### PR TITLE
修复设置页黑屏：MCP 配置 servers 字段缺失时崩溃

### DIFF
--- a/apps/electron/src/main/lib/agent-prompt-builder.ts
+++ b/apps/electron/src/main/lib/agent-prompt-builder.ts
@@ -58,9 +58,27 @@ export function buildSystemPromptAppend(ctx: SystemPromptContext): string {
 - 会话目录: ~/.proma/agent-workspaces/${ctx.workspaceSlug}/sessions/${ctx.sessionId}/
 
 ### MCP 配置格式
-mcp.json 结构：
-\`{servers: { "名称": { type, command/url, args, env, headers, enabled }}}\`
-其中 stdio 类型使用 command/args/env，http/sse 类型使用 url/headers。
+mcp.json 的顶层 key 必须是 \`servers\`（不是 mcpServers），示例：
+\`\`\`json
+{
+  "servers": {
+    "my-stdio-server": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@example/mcp-server"],
+      "env": { "API_KEY": "xxx" },
+      "enabled": true
+    },
+    "my-http-server": {
+      "type": "http",
+      "url": "https://example.com/mcp",
+      "headers": { "Authorization": "Bearer xxx" },
+      "enabled": true
+    }
+  }
+}
+\`\`\`
+**重要：顶层 key 是 \`servers\`，绝对不要写成 \`mcpServers\` 或其他名称。**
 
 ### Skill 格式
 每个 Skill 是 skills/{slug}/ 目录下的 SKILL.md 文件：

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -291,7 +291,8 @@ export function getWorkspaceMcpConfig(workspaceSlug: string): WorkspaceMcpConfig
 
   try {
     const raw = readFileSync(mcpPath, 'utf-8')
-    return JSON.parse(raw) as WorkspaceMcpConfig
+    const parsed = JSON.parse(raw) as Partial<WorkspaceMcpConfig>
+    return { servers: parsed.servers ?? {} }
   } catch (error) {
     console.error('[Agent 工作区] 读取 MCP 配置失败:', error)
     return { servers: {} }

--- a/apps/electron/src/renderer/components/settings/AgentSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AgentSettings.tsx
@@ -278,7 +278,7 @@ ${skillList}
     )
   }
 
-  const serverEntries = Object.entries(mcpConfig.servers)
+  const serverEntries = Object.entries(mcpConfig.servers ?? {})
 
   // 列表视图
   return (


### PR DESCRIPTION
## Summary
- **后端**：`getWorkspaceMcpConfig()` 使用 `Partial<WorkspaceMcpConfig>` 安全解析 JSON，确保 `servers` 字段始终为有效对象（`parsed.servers ?? {}`）
- **前端**：`AgentSettings.tsx` 中 `Object.entries(mcpConfig.servers)` 添加 `?? {}` 防御性保护，防止 `undefined`/`null` 导致崩溃
- **提示词**：强化 Agent 系统提示词中的 MCP 配置格式说明，提供完整 JSON 示例并明确强调顶层 key 必须是 `servers`（不是 `mcpServers`），避免 Agent 生成错误格式的配置文件

## Root Cause
Agent 通过对话生成 MCP 配置时，受 Claude Agent SDK 参数名 `mcpServers` 影响，将 `mcp.json` 的顶层 key 误写为 `mcpServers`。后端 `JSON.parse()` 使用不安全的类型断言 `as WorkspaceMcpConfig`，未校验 `servers` 字段是否存在。前端 `Object.entries(mcpConfig.servers)` 接收到 `undefined` 后抛出 `TypeError: Cannot convert undefined or null to object`，导致设置页白屏。

## Test plan
- [ ] 手动将 `~/.proma/agent-workspaces/{slug}/mcp.json` 内容改为 `{}`（空对象），打开设置页确认不崩溃
- [ ] 手动将内容改为 `{"mcpServers": {...}}`（错误 key），打开设置页确认不崩溃
- [ ] 通过 Agent 对话让其配置 MCP 服务器，确认生成的 `mcp.json` 使用正确的 `servers` key

🤖 Generated with [Claude Code](https://claude.com/claude-code)