### PR TITLE
优化工具活动 UI + 修复 MCP npx ENOENT

### DIFF
--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -593,11 +593,16 @@ export async function runAgent(
         if (!entry.enabled) continue
 
         if (entry.type === 'stdio' && entry.command) {
+          // 合并系统 PATH 到 MCP 服务器环境，确保 npx/node 等工具可被找到
+          const mergedEnv: Record<string, string> = {
+            ...(process.env.PATH && { PATH: process.env.PATH }),
+            ...entry.env,
+          }
           mcpServers[name] = {
             type: 'stdio',
             command: entry.command,
             ...(entry.args && entry.args.length > 0 && { args: entry.args }),
-            ...(entry.env && Object.keys(entry.env).length > 0 && { env: entry.env }),
+            ...(Object.keys(mergedEnv).length > 0 && { env: mergedEnv }),
           }
         } else if ((entry.type === 'http' || entry.type === 'sse') && entry.url) {
           mcpServers[name] = {

--- a/apps/electron/src/renderer/components/agent/ToolActivityItem.tsx
+++ b/apps/electron/src/renderer/components/agent/ToolActivityItem.tsx
@@ -341,9 +341,11 @@ interface ActivityGroupRowProps {
   index?: number
   animate?: boolean
   onOpenDetails?: (activity: ToolActivity) => void
+  detailsId?: string | null
+  onCloseDetails?: () => void
 }
 
-function ActivityGroupRow({ group, index = 0, animate = false, onOpenDetails }: ActivityGroupRowProps): React.ReactElement {
+function ActivityGroupRow({ group, index = 0, animate = false, onOpenDetails, detailsId, onCloseDetails }: ActivityGroupRowProps): React.ReactElement {
   const [expanded, setExpanded] = React.useState(true)
   const { parent, children } = group
 
@@ -370,6 +372,7 @@ function ActivityGroupRow({ group, index = 0, animate = false, onOpenDetails }: 
   return (
     <div
       className={cn(
+        'w-full',
         animate && 'animate-in fade-in slide-in-from-left-2 duration-200 fill-mode-both',
       )}
       style={animate ? { animationDelay: delay } : undefined}
@@ -378,7 +381,7 @@ function ActivityGroupRow({ group, index = 0, animate = false, onOpenDetails }: 
         type="button"
         onClick={() => setExpanded(!expanded)}
         className={cn(
-          'w-full flex items-center gap-2 pl-1 text-[13px] rounded-md hover:text-foreground transition-colors cursor-pointer',
+          'w-full flex items-center gap-2 pl-1 text-left text-[13px] rounded-md hover:text-foreground transition-colors cursor-pointer',
           SIZE.row,
         )}
       >
@@ -418,13 +421,17 @@ function ActivityGroupRow({ group, index = 0, animate = false, onOpenDetails }: 
           )}
         >
           {children.map((child, ci) => (
-            <ActivityRow
-              key={child.toolUseId}
-              activity={child}
-              index={ci}
-              animate={animate}
-              onOpenDetails={onOpenDetails}
-            />
+            <React.Fragment key={child.toolUseId}>
+              <ActivityRow
+                activity={child}
+                index={ci}
+                animate={animate}
+                onOpenDetails={onOpenDetails}
+              />
+              {detailsId === child.toolUseId && (
+                <ActivityDetails activity={child} onClose={onCloseDetails ?? (() => {})} />
+              )}
+            </React.Fragment>
           ))}
         </div>
       )}
@@ -561,17 +568,15 @@ export function ToolActivityList({ activities, animate = false }: ToolActivityLi
       {grouped.map((item, i) => {
         if (isActivityGroup(item)) {
           return (
-            <React.Fragment key={item.parent.toolUseId}>
-              <ActivityGroupRow
-                group={item}
-                index={i}
-                animate={animate}
-                onOpenDetails={handleOpenDetails}
-              />
-              {detailsId && item.children.some((c) => c.toolUseId === detailsId) && detailActivity && (
-                <ActivityDetails activity={detailActivity} onClose={() => setDetailsId(null)} />
-              )}
-            </React.Fragment>
+            <ActivityGroupRow
+              key={item.parent.toolUseId}
+              group={item}
+              index={i}
+              animate={animate}
+              onOpenDetails={handleOpenDetails}
+              detailsId={detailsId}
+              onCloseDetails={() => setDetailsId(null)}
+            />
           )
         }
 


### PR DESCRIPTION
## Summary
- **工具活动 UI**：Task 分组行添加 `w-full` + `text-left`，修复按钮默认居中；详情面板从 group 外部移至子条目下方内联渲染
- **MCP PATH 注入**：构建 MCP stdio 服务器配置时，将 `process.env.PATH`（已被 `shell-env.ts` 增强）合并到 MCP 子进程环境，解决 Dock 启动时 `spawn npx ENOENT`

## Root Cause
1. HTML `<button>` 默认 `text-align: center`，导致 Task 分组标题居中
2. MCP 详情面板渲染在整个 group 下方，而非被点击的子条目下方
3. Electron 从 Dock 启动不继承 shell PATH，MCP 子进程 env 未包含增强后的 PATH

## Test plan
- [ ] 确认 Task 分组标题左对齐
- [ ] 点击子工具详情按钮，确认详情面板出现在该条目正下方
- [ ] 配置 npx 类型的 MCP 服务器，确认 Agent 可正常调用

🤖 Generated with [Claude Code](https://claude.com/claude-code)