### PR TITLE
修复 MCP stdio 服务器 spawn npx ENOENT

### DIFF
--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -593,11 +593,16 @@ export async function runAgent(
         if (!entry.enabled) continue
 
         if (entry.type === 'stdio' && entry.command) {
+          // 合并系统 PATH 到 MCP 服务器环境，确保 npx/node 等工具可被找到
+          const mergedEnv: Record<string, string> = {
+            ...(process.env.PATH && { PATH: process.env.PATH }),
+            ...entry.env,
+          }
           mcpServers[name] = {
             type: 'stdio',
             command: entry.command,
             ...(entry.args && entry.args.length > 0 && { args: entry.args }),
-            ...(entry.env && Object.keys(entry.env).length > 0 && { env: entry.env }),
+            ...(Object.keys(mergedEnv).length > 0 && { env: mergedEnv }),
           }
         } else if ((entry.type === 'http' || entry.type === 'sse') && entry.url) {
           mcpServers[name] = {


### PR DESCRIPTION
## Summary
- 构建 MCP stdio 服务器配置时，将 `process.env.PATH`（已被 `shell-env.ts` 增强，包含 `/opt/homebrew/bin`、`~/.nvm/...` 等）合并到 MCP 子进程环境
- 用户自定义的 `env` 配置优先级更高（后合并可覆盖）

## Root Cause
Electron 从 Dock 启动时不继承 shell PATH。`shell-env.ts` 已将完整的 shell PATH 加载到 `process.env.PATH`，但 `agent-service.ts` 构建 MCP 服务器配置时未将其合并到 MCP 子进程的 `env` 中，导致 SDK 启动 MCP 子进程时找不到 `npx`/`node`。

## Test plan
- [ ] 配置 npx 类型的 MCP 服务器（如 `npx -y @anthropic-ai/mcp-server-fetch`），确认 Agent 可正常调用

🤖 Generated with [Claude Code](https://claude.com/claude-code)