### PR TITLE
docs(readme): fix spelling and markdown formatting typos

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -18,9 +18,9 @@ Chat mode with multi-model switching and file attachment support.
 Agent mode with general-purpose agent capabilities. Supports the full Claude series, MiniMax M2.1, Kimi K2.5, Zhipu GLM, and third-party channels. Elegant, clean, smooth, and confident streaming output.
 ![Proma Agent Mode](https://img.erlich.fun/personal-blog/uPic/3ZHWyA.png)
 Built-in Brainstorming and office suite Skills with MCP support. Automatically helps you find and install Skills through conversation.
-![Proma Default Skills and Mcp](https://img.erlich.fun/personal-blog/uPic/PNBOSt.png)
+![Proma Default Skills and MCP](https://img.erlich.fun/personal-blog/uPic/PNBOSt.png)
 Full-protocol LLM channel support for all domestic and international providers, configured via Base URL + API Key.
-![Proma Mutili Provider Support](https://img.erlich.fun/personal-blog/uPic/uPPazd.png)
+![Proma Multi Provider Support](https://img.erlich.fun/personal-blog/uPic/uPPazd.png)
 
 ## Features
 
@@ -54,9 +54,9 @@ MiniMax, Kimi (Moonshot), and Zhipu GLM use dedicated API endpoints — these ar
 
 | Provider | Chat Mode | Agent Mode | Note |
 |----------|----------|----------|------|
-| MiniMax | `https://api.minimaxi.com/v1` | `https://api.minimaxi.com/anthropic`| Supports MiniMax Pro membership |
-| Kimi | `https://api.moonshot.cn/v1` | `https://api.moonshot.cn/anthropic`| Supports Moonshot developer plan |
-| Zhipu GLM | `https://open.bigmodel.cn/api/paas/v4` | `https://open.bigmodel.cn/api/anthropic`| Supports Zhipu developer plan |
+| MiniMax | `https://api.minimaxi.com/v1` | `https://api.minimaxi.com/anthropic` | Supports MiniMax Pro membership |
+| Kimi | `https://api.moonshot.cn/v1` | `https://api.moonshot.cn/anthropic` | Supports Moonshot developer plan |
+| Zhipu GLM | `https://open.bigmodel.cn/api/paas/v4` | `https://open.bigmodel.cn/api/anthropic` | Supports Zhipu developer plan |
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ Proma 的核心意义不在于替代任何一款软件，目前只实现了 Prom
 
 Proma 的聊天模式，支持多模型切换，支持附加文件对话。
 ![Proma Chat Mode](https://img.erlich.fun/personal-blog/uPic/tBXRKI.png)
-Proma Agent 模式，通用 Agent 能力，支持 Cladue 全系列、Minimax M2.1、Kimi K2.5、智谱 GLM 等模型，支持第三方渠道。优雅、简洁、丝滑、确信的流式输出。
+Proma Agent 模式，通用 Agent 能力，支持 Claude 全系列、Minimax M2.1、Kimi K2.5、智谱 GLM 等模型，支持第三方渠道。优雅、简洁、丝滑、确信的流式输出。
 ![Proma Agent Mode](https://img.erlich.fun/personal-blog/uPic/3ZHWyA.png)
 Proma Skills 和 MCP，默认内置 Brainstorming 和办公软件 Skill，支持通过对话就能自动帮助你寻找和安装 Skills。
 ![Proma Default Skills and Mcp](https://img.erlich.fun/personal-blog/uPic/PNBOSt.png)
-Proma 全协议大模型渠道支持，支持国内外所有渠道模型，通过 Base URL + API KEY 配置。
-![Proma Mutili Provider Support](https://img.erlich.fun/personal-blog/uPic/uPPazd.png)
+Proma 全协议大模型渠道支持，支持国内外所有渠道模型，通过 Base URL + API Key 配置。
+![Proma Multi Provider Support](https://img.erlich.fun/personal-blog/uPic/uPPazd.png)
 
 ## 特性
 


### PR DESCRIPTION
Closes #5

## What
- Fix objective spelling/casing issues in `README.md` and `README.en.md`
- Fix markdown table spacing consistency in `README.en.md`

## Why
- Improve documentation quality with no behavior or meaning changes

## Out of Scope
- No sentence rewrites
- No wording/flow improvements