### PR TITLE
feat: 工作区支持右键重命名和删除

### DIFF
--- a/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
@@ -1,19 +1,36 @@
 /**
  * WorkspaceSelector — Agent 工作区切换器
  *
- * 下拉选择器，展示所有工作区，支持新建和切换。
+ * 下拉选择器，展示所有工作区，支持新建、重命名、删除和切换。
  * 切换工作区后持久化到 settings。
  */
 
 import * as React from 'react'
-import { useAtom, useSetAtom } from 'jotai'
-import { FolderOpen, Plus, Check, ChevronDown } from 'lucide-react'
+import { useAtom } from 'jotai'
+import { FolderOpen, Plus, Check, ChevronDown, Pencil, Trash2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from '@/components/ui/context-menu'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import {
   agentWorkspacesAtom,
   currentAgentWorkspaceIdAtom,
@@ -24,33 +41,43 @@ export function WorkspaceSelector(): React.ReactElement {
   const [workspaces, setWorkspaces] = useAtom(agentWorkspacesAtom)
   const [currentWorkspaceId, setCurrentWorkspaceId] = useAtom(currentAgentWorkspaceIdAtom)
   const [open, setOpen] = React.useState(false)
+
+  // 新建状态
   const [creating, setCreating] = React.useState(false)
   const [newName, setNewName] = React.useState('')
-  const inputRef = React.useRef<HTMLInputElement>(null)
+  const createInputRef = React.useRef<HTMLInputElement>(null)
+
+  // 重命名状态
+  const [editingId, setEditingId] = React.useState<string | null>(null)
+  const [editName, setEditName] = React.useState('')
+  const editInputRef = React.useRef<HTMLInputElement>(null)
+
+  // 删除确认状态
+  const [deleteTargetId, setDeleteTargetId] = React.useState<string | null>(null)
 
   const currentWorkspace = workspaces.find((w) => w.id === currentWorkspaceId)
 
   /** 切换工作区 */
   const handleSelect = (workspace: AgentWorkspace): void => {
+    if (editingId) return // 编辑中不切换
     setCurrentWorkspaceId(workspace.id)
     setOpen(false)
 
-    // 持久化到设置
     window.electronAPI.updateSettings({
       agentWorkspaceId: workspace.id,
     }).catch(console.error)
   }
 
-  /** 开始新建 */
+  // ===== 新建 =====
+
   const handleStartCreate = (): void => {
     setCreating(true)
     setNewName('')
     requestAnimationFrame(() => {
-      inputRef.current?.focus()
+      createInputRef.current?.focus()
     })
   }
 
-  /** 提交新建 */
   const handleCreate = async (): Promise<void> => {
     const trimmed = newName.trim()
     if (!trimmed) {
@@ -65,7 +92,6 @@ export function WorkspaceSelector(): React.ReactElement {
       setCreating(false)
       setOpen(false)
 
-      // 持久化到设置
       window.electronAPI.updateSettings({
         agentWorkspaceId: workspace.id,
       }).catch(console.error)
@@ -74,8 +100,7 @@ export function WorkspaceSelector(): React.ReactElement {
     }
   }
 
-  /** 键盘事件 */
-  const handleKeyDown = (e: React.KeyboardEvent): void => {
+  const handleCreateKeyDown = (e: React.KeyboardEvent): void => {
     if (e.key === 'Enter') {
       e.preventDefault()
       handleCreate()
@@ -84,79 +109,210 @@ export function WorkspaceSelector(): React.ReactElement {
     }
   }
 
+  // ===== 重命名 =====
+
+  const handleStartRename = (ws: AgentWorkspace): void => {
+    setEditingId(ws.id)
+    setEditName(ws.name)
+    requestAnimationFrame(() => {
+      editInputRef.current?.focus()
+      editInputRef.current?.select()
+    })
+  }
+
+  const handleRename = async (): Promise<void> => {
+    if (!editingId) return
+    const trimmed = editName.trim()
+
+    if (!trimmed) {
+      setEditingId(null)
+      return
+    }
+
+    try {
+      const updated = await window.electronAPI.updateAgentWorkspace(editingId, { name: trimmed })
+      setWorkspaces((prev) => prev.map((w) => (w.id === updated.id ? updated : w)))
+    } catch (error) {
+      console.error('[WorkspaceSelector] 重命名工作区失败:', error)
+    } finally {
+      setEditingId(null)
+    }
+  }
+
+  const handleRenameKeyDown = (e: React.KeyboardEvent): void => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      handleRename()
+    } else if (e.key === 'Escape') {
+      setEditingId(null)
+    }
+  }
+
+  // ===== 删除 =====
+
+  const handleConfirmDelete = async (): Promise<void> => {
+    if (!deleteTargetId) return
+
+    try {
+      await window.electronAPI.deleteAgentWorkspace(deleteTargetId)
+      const remaining = workspaces.filter((w) => w.id !== deleteTargetId)
+      setWorkspaces(remaining)
+
+      // 如果删除的是当前工作区，切换到第一个剩余的
+      if (deleteTargetId === currentWorkspaceId && remaining.length > 0) {
+        setCurrentWorkspaceId(remaining[0].id)
+        window.electronAPI.updateSettings({
+          agentWorkspaceId: remaining[0].id,
+        }).catch(console.error)
+      }
+    } catch (error) {
+      console.error('[WorkspaceSelector] 删除工作区失败:', error)
+    } finally {
+      setDeleteTargetId(null)
+    }
+  }
+
+  /** 是否可以删除该工作区 */
+  const canDelete = (ws: AgentWorkspace): boolean => {
+    return ws.slug !== 'default' && workspaces.length > 1
+  }
+
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <button
-          className={cn(
-            'w-full flex items-center gap-2 px-3 py-2 rounded-[10px] text-[13px] transition-colors duration-100 titlebar-no-drag',
-            'text-foreground/70 bg-foreground/[0.03] hover:bg-foreground/[0.06] border border-foreground/[0.06]',
-          )}
-        >
-          <FolderOpen size={14} className="flex-shrink-0 text-foreground/50" />
-          <span className="flex-1 text-left truncate">
-            {currentWorkspace?.name || '选择工作区'}
-          </span>
-          <ChevronDown size={12} className="flex-shrink-0 text-foreground/40" />
-        </button>
-      </PopoverTrigger>
-
-      <PopoverContent
-        align="start"
-        side="bottom"
-        className="w-[var(--radix-popover-trigger-width)] p-1"
-      >
-        {/* 工作区列表 */}
-        <div className="max-h-[200px] overflow-y-auto">
-          {workspaces.map((ws) => (
-            <button
-              key={ws.id}
-              onClick={() => handleSelect(ws)}
-              className={cn(
-                'w-full flex items-center gap-2 px-2.5 py-1.5 rounded-md text-[13px] transition-colors duration-100 text-left',
-                ws.id === currentWorkspaceId
-                  ? 'bg-primary/10 text-foreground'
-                  : 'text-foreground/70 hover:bg-foreground/[0.04]',
-              )}
-            >
-              <FolderOpen size={13} className="flex-shrink-0 text-foreground/40" />
-              <span className="flex-1 truncate">{ws.name}</span>
-              {ws.id === currentWorkspaceId && (
-                <Check size={13} className="flex-shrink-0 text-primary" />
-              )}
-            </button>
-          ))}
-        </div>
-
-        {/* 分隔线 */}
-        <div className="my-1 border-t border-foreground/[0.06]" />
-
-        {/* 新建工作区 */}
-        {creating ? (
-          <div className="px-2 py-1">
-            <input
-              ref={inputRef}
-              value={newName}
-              onChange={(e) => setNewName(e.target.value)}
-              onKeyDown={handleKeyDown}
-              onBlur={() => {
-                if (!newName.trim()) setCreating(false)
-              }}
-              placeholder="工作区名称..."
-              className="w-full bg-transparent text-[13px] text-foreground border-b border-primary/50 outline-none px-0.5 py-1"
-              maxLength={50}
-            />
-          </div>
-        ) : (
+    <>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
           <button
-            onClick={handleStartCreate}
-            className="w-full flex items-center gap-2 px-2.5 py-1.5 rounded-md text-[13px] text-foreground/50 hover:bg-foreground/[0.04] hover:text-foreground/70 transition-colors duration-100"
+            className={cn(
+              'w-full flex items-center gap-2 px-3 py-2 rounded-[10px] text-[13px] transition-colors duration-100 titlebar-no-drag',
+              'text-foreground/70 bg-foreground/[0.03] hover:bg-foreground/[0.06] border border-foreground/[0.06]',
+            )}
           >
-            <Plus size={13} />
-            <span>新建工作区</span>
+            <FolderOpen size={14} className="flex-shrink-0 text-foreground/50" />
+            <span className="flex-1 text-left truncate">
+              {currentWorkspace?.name || '选择工作区'}
+            </span>
+            <ChevronDown size={12} className="flex-shrink-0 text-foreground/40" />
           </button>
-        )}
-      </PopoverContent>
-    </Popover>
+        </PopoverTrigger>
+
+        <PopoverContent
+          align="start"
+          side="bottom"
+          className="w-[var(--radix-popover-trigger-width)] p-1"
+        >
+          {/* 工作区列表 */}
+          <div className="max-h-[200px] overflow-y-auto">
+            {workspaces.map((ws) => (
+              <ContextMenu key={ws.id}>
+                <ContextMenuTrigger asChild>
+                  <button
+                    onClick={() => handleSelect(ws)}
+                    className={cn(
+                      'w-full flex items-center gap-2 px-2.5 py-1.5 rounded-md text-[13px] transition-colors duration-100 text-left',
+                      ws.id === currentWorkspaceId
+                        ? 'bg-primary/10 text-foreground'
+                        : 'text-foreground/70 hover:bg-foreground/[0.04]',
+                    )}
+                  >
+                    <FolderOpen size={13} className="flex-shrink-0 text-foreground/40" />
+                    {editingId === ws.id ? (
+                      <input
+                        ref={editInputRef}
+                        value={editName}
+                        onChange={(e) => setEditName(e.target.value)}
+                        onKeyDown={handleRenameKeyDown}
+                        onBlur={handleRename}
+                        onClick={(e) => e.stopPropagation()}
+                        className="flex-1 bg-transparent text-[13px] text-foreground border-b border-primary/50 outline-none px-0.5"
+                        maxLength={50}
+                      />
+                    ) : (
+                      <span className="flex-1 truncate">{ws.name}</span>
+                    )}
+                    {ws.id === currentWorkspaceId && editingId !== ws.id && (
+                      <Check size={13} className="flex-shrink-0 text-primary" />
+                    )}
+                  </button>
+                </ContextMenuTrigger>
+
+                <ContextMenuContent className="w-40">
+                  <ContextMenuItem
+                    onClick={() => handleStartRename(ws)}
+                  >
+                    <Pencil size={14} className="mr-2" />
+                    重命名
+                  </ContextMenuItem>
+                  {canDelete(ws) && (
+                    <>
+                      <ContextMenuSeparator />
+                      <ContextMenuItem
+                        onClick={() => setDeleteTargetId(ws.id)}
+                        className="text-destructive focus:text-destructive"
+                      >
+                        <Trash2 size={14} className="mr-2" />
+                        删除工作区
+                      </ContextMenuItem>
+                    </>
+                  )}
+                </ContextMenuContent>
+              </ContextMenu>
+            ))}
+          </div>
+
+          {/* 分隔线 */}
+          <div className="my-1 border-t border-foreground/[0.06]" />
+
+          {/* 新建工作区 */}
+          {creating ? (
+            <div className="px-2 py-1">
+              <input
+                ref={createInputRef}
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                onKeyDown={handleCreateKeyDown}
+                onBlur={() => {
+                  if (!newName.trim()) setCreating(false)
+                }}
+                placeholder="工作区名称..."
+                className="w-full bg-transparent text-[13px] text-foreground border-b border-primary/50 outline-none px-0.5 py-1"
+                maxLength={50}
+              />
+            </div>
+          ) : (
+            <button
+              onClick={handleStartCreate}
+              className="w-full flex items-center gap-2 px-2.5 py-1.5 rounded-md text-[13px] text-foreground/50 hover:bg-foreground/[0.04] hover:text-foreground/70 transition-colors duration-100"
+            >
+              <Plus size={13} />
+              <span>新建工作区</span>
+            </button>
+          )}
+        </PopoverContent>
+      </Popover>
+
+      {/* 删除确认弹窗 */}
+      <AlertDialog
+        open={deleteTargetId !== null}
+        onOpenChange={(v) => { if (!v) setDeleteTargetId(null) }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>确认删除工作区</AlertDialogTitle>
+            <AlertDialogDescription>
+              删除后工作区配置将被移除，但目录文件会保留。确定要删除吗？
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>取消</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleConfirmDelete}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              删除
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   )
 }


### PR DESCRIPTION
在 WorkspaceSelector 的 Popover 列表中，为每个工作区项添加 ContextMenu：
- 重命名：行内编辑，Enter 提交 / Escape 取消
- 删除：AlertDialog 确认后删除，自动切换到剩余工作区
- 保护：默认工作区和最后一个工作区不可删除