### PR TITLE
实时上下文用量展示+无限上下文自动压缩（阈值设定 和 文本截断）

### DIFF
--- a/apps/electron/src/main/lib/channel-manager.ts
+++ b/apps/electron/src/main/lib/channel-manager.ts
@@ -436,6 +436,21 @@ interface AnthropicModelItem {
   id: string
   display_name?: string
   type?: string
+  context_window?: number
+  max_input_tokens?: number
+}
+
+function parsePositiveInt(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    return Math.floor(value)
+  }
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10)
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed
+    }
+  }
+  return undefined
 }
 
 /**
@@ -472,6 +487,7 @@ async function fetchAnthropicModels(baseUrl: string, apiKey: string): Promise<Fe
   const models: ChannelModel[] = items.map((item) => ({
     id: item.id,
     name: item.display_name || item.id,
+    contextWindow: parsePositiveInt(item.context_window) ?? parsePositiveInt(item.max_input_tokens),
     enabled: true,
   }))
 
@@ -488,6 +504,10 @@ async function fetchAnthropicModels(baseUrl: string, apiKey: string): Promise<Fe
 interface OpenAIModelItem {
   id: string
   owned_by?: string
+  context_window?: number
+  context_length?: number
+  max_context_tokens?: number
+  input_token_limit?: number
 }
 
 /**
@@ -521,6 +541,10 @@ async function fetchOpenAICompatibleModels(baseUrl: string, apiKey: string): Pro
   const models: ChannelModel[] = items.map((item) => ({
     id: item.id,
     name: item.id,
+    contextWindow: parsePositiveInt(item.context_window)
+      ?? parsePositiveInt(item.context_length)
+      ?? parsePositiveInt(item.max_context_tokens)
+      ?? parsePositiveInt(item.input_token_limit),
     enabled: true,
   }))
 
@@ -542,6 +566,7 @@ interface GoogleModelItem {
   displayName?: string
   description?: string
   supportedGenerationMethods?: string[]
+  inputTokenLimit?: number | string
 }
 
 /**
@@ -580,6 +605,7 @@ async function fetchGoogleModels(baseUrl: string, apiKey: string): Promise<Fetch
     return {
       id,
       name: item.displayName || id,
+      contextWindow: parsePositiveInt(item.inputTokenLimit),
       enabled: true,
     }
   })

--- a/apps/electron/src/main/lib/model-context-window-cache.ts
+++ b/apps/electron/src/main/lib/model-context-window-cache.ts
@@ -1,0 +1,24 @@
+/**
+ * 模型上下文窗口缓存
+ *
+ * 用于跨服务复用“服务端回传”的 contextWindow（例如 Agent SDK result modelUsage）。
+ * 键统一按小写 modelId 存储。
+ */
+
+const modelContextWindowCache = new Map<string, number>()
+
+function normalizeModelId(modelId: string): string {
+  return modelId.trim().toLowerCase()
+}
+
+export function setModelContextWindow(modelId: string, contextWindow: number): void {
+  if (!modelId) return
+  if (!Number.isFinite(contextWindow) || contextWindow <= 0) return
+  modelContextWindowCache.set(normalizeModelId(modelId), Math.floor(contextWindow))
+}
+
+export function getModelContextWindow(modelId: string): number | undefined {
+  if (!modelId) return undefined
+  return modelContextWindowCache.get(normalizeModelId(modelId))
+}
+

--- a/apps/electron/src/renderer/atoms/chat-atoms.ts
+++ b/apps/electron/src/renderer/atoms/chat-atoms.ts
@@ -115,6 +115,12 @@ export const contextLengthAtom = atomWithStorage<ContextLengthValue>(
   20,
 )
 
+/** 无限上下文触发阈值（占模型窗口百分比，默认 75） */
+export const infiniteContextThresholdAtom = atomWithStorage<number>(
+  'proma-infinite-context-threshold',
+  75,
+)
+
 /** 并排模式 */
 export const parallelModeAtom = atom<boolean>(false)
 

--- a/apps/electron/src/renderer/components/chat/ChatView.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatView.tsx
@@ -6,7 +6,7 @@
  * - 订阅流式 IPC 事件（chunk, reasoning, complete, error）
  * - 管理 streaming 状态和累积内容
  * - 处理消息删除、上下文清除/删除
- * - 传递 contextLength 和 contextDividers 到 sendMessage
+ * - 传递 contextLength / infiniteThreshold / contextDividers 到 sendMessage
  * - 无当前对话时显示引导文案
  *
  * 布局：三段式 ChatHeader | ChatMessages | ChatInput
@@ -26,6 +26,7 @@ import {
   selectedModelAtom,
   conversationsAtom,
   contextLengthAtom,
+  infiniteContextThresholdAtom,
   contextDividersAtom,
   thinkingEnabledAtom,
   pendingAttachmentsAtom,
@@ -54,6 +55,7 @@ export function ChatView(): React.ReactElement {
   const [selectedModel, setSelectedModel] = useAtom(selectedModelAtom)
   const setConversations = useSetAtom(conversationsAtom)
   const contextLength = useAtomValue(contextLengthAtom)
+  const infiniteContextThreshold = useAtomValue(infiniteContextThresholdAtom)
   const [contextDividers, setContextDividers] = useAtom(contextDividersAtom)
   const thinkingEnabled = useAtomValue(thinkingEnabledAtom)
   const [pendingAttachments, setPendingAttachments] = useAtom(pendingAttachmentsAtom)
@@ -298,7 +300,8 @@ export function ChatView(): React.ReactElement {
       channelId: selectedModel.channelId,
       modelId: selectedModel.modelId,
       contextLength,
-      contextDividers,
+      infiniteContextThreshold,
+      contextDividers: options?.contextDividersOverride ?? contextDividers,
       attachments: savedAttachments.length > 0 ? savedAttachments : undefined,
       thinkingEnabled: thinkingEnabled || undefined,
     }

--- a/packages/shared/src/types/channel.ts
+++ b/packages/shared/src/types/channel.ts
@@ -60,6 +60,8 @@ export interface ChannelModel {
   id: string
   /** 模型显示名称 */
   name: string
+  /** 上下文窗口（token），可选 */
+  contextWindow?: number
   /** 是否启用 */
   enabled: boolean
 }

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -150,6 +150,8 @@ export interface ChatSendInput {
   systemMessage?: string
   /** 上下文长度（轮数），'infinite' 表示全部包含 */
   contextLength?: number | 'infinite'
+  /** infinite 模式下的上下文预算阈值（占模型窗口百分比，10-95） */
+  infiniteContextThreshold?: number
   /** 上下文分隔线对应的消息 ID 列表 */
   contextDividers?: string[]
   /** 文件附件列表 */


### PR DESCRIPTION

![Xnip2026-02-10_20-57-36](https://github.com/user-attachments/assets/67dba912-8818-41b6-ba56-043d75aae59e)


## 变更概述
本 PR 实现聊天场景下的无限上下文能力与实时上下文用量展示，提升长对话可持续性与可观测性。

## 主要改动
- 支持选择 `∞` 上下文模式
- 新增自动压缩阈值（默认 75%，支持自定义）
- 阈值输入仅在 `∞` 模式下可编辑，其他模式置灰禁用
- 在主进程实现 `∞` 模式自动压缩：
  - 保留最近原文上下文
  - 超预算历史压缩为摘要并注入 system
- 上下文窗口优先级：
  1. 模型配置 `contextWindow`
  2. 运行时服务端回传缓存
  3. heuristics 兜底
- 输入区新增实时上下文用量显示（当前估算 / 最大上下文），并在高占用时警示

## 验证
- shared typecheck 通过
- electron main/preload/renderer 构建通过
