### PR TITLE
feat: 文件浏览器侧栏丝滑开关过渡

### DIFF
--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -95,7 +95,12 @@ function mergeTodoWrites(activities: ToolActivity[]): ToolActivity[] {
  * 每层内 TodoWrite 合并去重并置底。
  */
 export function groupActivities(activities: ToolActivity[]): Array<ActivityGroup | ToolActivity> {
-  const processed = mergeTodoWrites(activities)
+  // 过滤幽灵条目：tool_progress 创建的空 input 条目，完成后仍无内容
+  const filtered = activities.filter((a) => {
+    if (a.done && Object.keys(a.input).length === 0 && !a.result) return false
+    return true
+  })
+  const processed = mergeTodoWrites(filtered)
 
   const parentIds = new Set<string>()
   for (const a of processed) {

--- a/apps/electron/src/renderer/components/agent/AgentHeader.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentHeader.tsx
@@ -1,28 +1,16 @@
 /**
  * AgentHeader — Agent 会话头部
  *
- * 显示会话标题（可点击编辑）+ 文件浏览器切换按钮。
+ * 显示会话标题（可点击编辑）。
  * 参照 ChatHeader 的编辑模式。
  */
 
 import * as React from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
-import { Pencil, Check, X, FolderOpen } from 'lucide-react'
-import { Button } from '@/components/ui/button'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
-import { cn } from '@/lib/utils'
+import { Pencil, Check, X } from 'lucide-react'
 import { currentAgentSessionAtom, agentSessionsAtom } from '@/atoms/agent-atoms'
 
-interface AgentHeaderProps {
-  onToggleFileBrowser: () => void
-  fileBrowserOpen: boolean
-}
-
-export function AgentHeader({ onToggleFileBrowser, fileBrowserOpen }: AgentHeaderProps): React.ReactElement | null {
+export function AgentHeader(): React.ReactElement | null {
   const session = useAtomValue(currentAgentSessionAtom)
   const setAgentSessions = useSetAtom(agentSessionsAtom)
   const [editing, setEditing] = React.useState(false)
@@ -107,27 +95,6 @@ export function AgentHeader({ onToggleFileBrowser, fileBrowserOpen }: AgentHeade
           <Pencil className="size-3 opacity-40 group-hover:opacity-70 transition-opacity flex-shrink-0" />
         </button>
       )}
-
-      {/* 文件浏览器切换 */}
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            className={cn(
-              'h-8 w-8 flex-shrink-0',
-              fileBrowserOpen && 'bg-accent text-accent-foreground'
-            )}
-            onClick={onToggleFileBrowser}
-          >
-            <FolderOpen className="size-4" />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">
-          <p>{fileBrowserOpen ? '关闭文件浏览器' : '打开文件浏览器'}</p>
-        </TooltipContent>
-      </Tooltip>
     </div>
   )
 }

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -13,7 +13,7 @@
 
 import * as React from 'react'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
-import { Bot, CornerDownLeft, Square, Settings, Paperclip, FolderPlus, AlertCircle, X } from 'lucide-react'
+import { Bot, CornerDownLeft, Square, Settings, Paperclip, FolderPlus, AlertCircle, X, FolderOpen } from 'lucide-react'
 import { AgentMessages } from './AgentMessages'
 import { AgentHeader } from './AgentHeader'
 import { ContextUsageBadge } from './ContextUsageBadge'
@@ -669,10 +669,7 @@ export function AgentView(): React.ReactElement {
       {/* 主内容区域 */}
       <div className="flex flex-col h-full flex-1 min-w-0 max-w-[min(72rem,100%)] mx-auto">
         {/* Agent Header */}
-        <AgentHeader
-          onToggleFileBrowser={() => setFileBrowserOpen((prev) => !prev)}
-          fileBrowserOpen={fileBrowserOpen}
-        />
+        <AgentHeader />
 
         {/* 消息区域 */}
         <AgentMessages />
@@ -857,13 +854,50 @@ export function AgentView(): React.ReactElement {
         </div>
       </div>
 
-      {/* 文件浏览器侧面板 */}
-      {fileBrowserOpen && sessionPath && (
-        <div className="w-[300px] border-l flex-shrink-0">
-          <FileBrowser
-            rootPath={sessionPath}
-            onClose={() => setFileBrowserOpen(false)}
-          />
+      {/* 文件浏览器侧栏 — 始终渲染同一个切换按钮 */}
+      {sessionPath && (
+        <div
+          className={cn(
+            'relative flex-shrink-0 transition-[width] duration-300 ease-in-out overflow-hidden',
+            fileBrowserOpen ? 'w-[300px] border-l' : 'w-10'
+          )}
+        >
+          {/* 切换按钮 — 始终固定在右上角，同一个 DOM 元素 */}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="absolute right-2.5 top-2.5 z-10 h-7 w-7"
+                onClick={() => setFileBrowserOpen((prev) => !prev)}
+              >
+                <FolderOpen
+                  className={cn(
+                    'size-3.5 absolute transition-all duration-200',
+                    fileBrowserOpen ? 'opacity-0 rotate-90 scale-75' : 'opacity-100 rotate-0 scale-100'
+                  )}
+                />
+                <X
+                  className={cn(
+                    'size-3.5 absolute transition-all duration-200',
+                    fileBrowserOpen ? 'opacity-100 rotate-0 scale-100' : 'opacity-0 -rotate-90 scale-75'
+                  )}
+                />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="left">
+              <p>{fileBrowserOpen ? '关闭文件浏览器' : '打开文件浏览器'}</p>
+            </TooltipContent>
+          </Tooltip>
+
+          {/* FileBrowser 内容 — 收起时隐藏 */}
+          <div className={cn(
+            'w-[300px] h-full transition-opacity duration-300',
+            fileBrowserOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'
+          )}>
+            <FileBrowser rootPath={sessionPath} />
+          </div>
         </div>
       )}
     </div>

--- a/apps/electron/src/renderer/components/agent/ToolActivityItem.tsx
+++ b/apps/electron/src/renderer/components/agent/ToolActivityItem.tsx
@@ -28,8 +28,8 @@ import {
   Loader2,
   Circle,
   ChevronRight,
-  ArrowUpRight,
   MessageCircleDashed,
+  Plus,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import {
@@ -290,6 +290,8 @@ function ActivityRow({ activity, index = 0, animate = false, onOpenDetails }: Ac
 
   const delay = animate && index < SIZE.staggerLimit ? `${index * 30}ms` : '0ms'
 
+  const canExpand = !!onOpenDetails && activity.done && !!(activity.result || Object.keys(activity.input).length > 0)
+
   return (
     <div
       className={cn(
@@ -299,9 +301,26 @@ function ActivityRow({ activity, index = 0, animate = false, onOpenDetails }: Ac
       )}
       style={animate ? { animationDelay: delay } : undefined}
     >
-      <StatusIcon status={status} toolName={activity.toolName} />
-
-      <span className="shrink-0 text-foreground/80">{activity.toolName}</span>
+      {canExpand ? (
+        <button
+          type="button"
+          className="group/expand shrink-0 flex items-center gap-2 cursor-pointer"
+          onClick={(e) => { e.stopPropagation(); onOpenDetails(activity) }}
+        >
+          <span className={cn(SIZE.icon, 'relative flex items-center justify-center')}>
+            <span className="transition-opacity duration-150 group-hover/expand:opacity-0">
+              <StatusIcon status={status} toolName={activity.toolName} />
+            </span>
+            <Plus className={cn(SIZE.icon, 'absolute text-foreground/60 opacity-0 transition-opacity duration-150 group-hover/expand:opacity-100')} />
+          </span>
+          <span className="shrink-0 text-foreground/80 group-hover/expand:text-foreground transition-colors duration-150">{activity.toolName}</span>
+        </button>
+      ) : (
+        <>
+          <StatusIcon status={status} toolName={activity.toolName} />
+          <span className="shrink-0 text-foreground/80">{activity.toolName}</span>
+        </>
+      )}
 
       {diffStats && <DiffBadges stats={diffStats} />}
 
@@ -319,16 +338,6 @@ function ActivityRow({ activity, index = 0, animate = false, onOpenDetails }: Ac
         <span className="shrink-0 text-[11px] text-muted-foreground/60 tabular-nums">
           {formatElapsed(activity.elapsedSeconds)}
         </span>
-      )}
-
-      {onOpenDetails && activity.done && (activity.result || Object.keys(activity.input).length > 0) && (
-        <button
-          type="button"
-          onClick={(e) => { e.stopPropagation(); onOpenDetails(activity) }}
-          className="shrink-0 p-0.5 rounded opacity-0 group-hover/row:opacity-100 transition-opacity hover:bg-muted/80"
-        >
-          <ArrowUpRight className="size-3 text-muted-foreground" />
-        </button>
       )}
     </div>
   )
@@ -443,7 +452,7 @@ function ActivityGroupRow({ group, index = 0, animate = false, onOpenDetails, de
 
 function ActivityDetails({ activity, onClose }: { activity: ToolActivity; onClose: () => void }): React.ReactElement {
   return (
-    <div className="mt-1 rounded-md border border-border/40 bg-muted/20 overflow-hidden animate-in fade-in slide-in-from-top-1 duration-150">
+    <div className="mt-1 rounded-md border border-border/40 bg-muted/20 overflow-hidden animate-in fade-in slide-in-from-top-2 duration-300 ease-out">
       <div className="flex items-center justify-between px-3 py-1.5 border-b border-border/30">
         <span className="text-[11px] font-medium text-foreground/50">{activity.toolName}</span>
         <button

--- a/apps/electron/src/renderer/components/agent/ToolActivityItem.tsx
+++ b/apps/electron/src/renderer/components/agent/ToolActivityItem.tsx
@@ -451,16 +451,32 @@ function ActivityGroupRow({ group, index = 0, animate = false, onOpenDetails, de
 // ===== 详情面板 =====
 
 function ActivityDetails({ activity, onClose }: { activity: ToolActivity; onClose: () => void }): React.ReactElement {
+  const [copied, setCopied] = React.useState(false)
+
+  const handleCopy = (): void => {
+    const parts: string[] = [`[${activity.toolName}]`]
+    if (Object.keys(activity.input).length > 0) {
+      parts.push('输入:\n' + formatInput(activity.input))
+    }
+    if (activity.result) {
+      parts.push('结果:\n' + (activity.result.length > 2000 ? activity.result.slice(0, 2000) + '\n… [截断]' : activity.result))
+    }
+    navigator.clipboard.writeText(parts.join('\n\n')).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    })
+  }
+
   return (
     <div className="mt-1 rounded-md border border-border/40 bg-muted/20 overflow-hidden animate-in fade-in slide-in-from-top-2 duration-300 ease-out">
       <div className="flex items-center justify-between px-3 py-1.5 border-b border-border/30">
         <span className="text-[11px] font-medium text-foreground/50">{activity.toolName}</span>
         <button
           type="button"
-          onClick={onClose}
+          onClick={handleCopy}
           className="text-[11px] text-foreground/40 hover:text-foreground transition-colors"
         >
-          收起
+          {copied ? '已复制' : '复制'}
         </button>
       </div>
 

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -15,6 +15,7 @@ import { cn } from '@/lib/utils'
 import { ModeSwitcher } from './ModeSwitcher'
 import { activeViewAtom } from '@/atoms/active-view'
 import { appModeAtom } from '@/atoms/app-mode'
+import { settingsTabAtom } from '@/atoms/settings-tab'
 import {
   conversationsAtom,
   currentConversationIdAtom,
@@ -129,6 +130,7 @@ function groupByDate<T extends { updatedAt: number }>(items: T[]): Array<{ label
 
 export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   const [activeView, setActiveView] = useAtom(activeViewAtom)
+  const setSettingsTab = useSetAtom(settingsTabAtom)
   const [activeItem, setActiveItem] = React.useState<SidebarItemId>('all-chats')
   const [conversations, setConversations] = useAtom(conversationsAtom)
   const [currentConversationId, setCurrentConversationId] = useAtom(currentConversationIdAtom)
@@ -491,7 +493,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       {mode === 'agent' && capabilities && (
         <div className="px-3 pb-1">
           <button
-            onClick={() => handleItemClick('settings')}
+            onClick={() => { setSettingsTab('agent'); handleItemClick('settings') }}
             className="w-full flex items-center gap-3 px-3 py-2 rounded-[10px] text-[12px] text-foreground/50 hover:bg-foreground/[0.04] hover:text-foreground/70 transition-colors titlebar-no-drag"
           >
             <div className="flex items-center gap-2.5 flex-1 min-w-0">

--- a/apps/electron/src/renderer/components/app-shell/MainContentPanel.tsx
+++ b/apps/electron/src/renderer/components/app-shell/MainContentPanel.tsx
@@ -2,7 +2,7 @@
  * MainContentPanel - 主内容面板
  *
  * 根据当前活跃视图显示不同内容：
- * - conversations: 根据 App 模式显示 Chat/Agent 内容
+ * - conversations: 根据 App 模式显示 Chat/Agent 内容（带滑动过渡）
  * - settings: 显示设置面板
  */
 
@@ -10,6 +10,7 @@ import * as React from 'react'
 import { useAtomValue } from 'jotai'
 import { appModeAtom } from '@/atoms/app-mode'
 import { activeViewAtom } from '@/atoms/active-view'
+import { cn } from '@/lib/utils'
 import { Panel } from './Panel'
 import { ChatView } from '@/components/chat'
 import { AgentView } from '@/components/agent'
@@ -19,17 +20,33 @@ export function MainContentPanel(): React.ReactElement {
   const mode = useAtomValue(appModeAtom)
   const activeView = useAtomValue(activeViewAtom)
 
-  /** 渲染对话视图内容 */
-  const renderConversations = (): React.ReactElement => {
-    return mode === 'chat' ? <ChatView /> : <AgentView />
-  }
-
   return (
     <Panel
       variant="grow"
       className="bg-white/95 dark:bg-zinc-900/95 backdrop-blur-xl rounded-2xl shadow-xl border border-border/50"
     >
-      {activeView === 'settings' ? <SettingsPanel /> : renderConversations()}
+      {activeView === 'settings' ? (
+        <SettingsPanel />
+      ) : (
+        <div className="relative h-full w-full overflow-hidden">
+          <div
+            className={cn(
+              'absolute inset-0 transition-transform duration-300 ease-in-out',
+              mode === 'chat' ? 'translate-x-0' : '-translate-x-full'
+            )}
+          >
+            <ChatView />
+          </div>
+          <div
+            className={cn(
+              'absolute inset-0 transition-transform duration-300 ease-in-out',
+              mode === 'agent' ? 'translate-x-0' : 'translate-x-full'
+            )}
+          >
+            <AgentView />
+          </div>
+        </div>
+      )}
     </Panel>
   )
 }

--- a/apps/electron/src/renderer/components/app-shell/MainContentPanel.tsx
+++ b/apps/electron/src/renderer/components/app-shell/MainContentPanel.tsx
@@ -2,7 +2,7 @@
  * MainContentPanel - 主内容面板
  *
  * 根据当前活跃视图显示不同内容：
- * - conversations: 根据 App 模式显示 Chat/Agent 内容（带滑动过渡）
+ * - conversations: 根据 App 模式显示 Chat/Agent 内容
  * - settings: 显示设置面板
  */
 
@@ -10,7 +10,6 @@ import * as React from 'react'
 import { useAtomValue } from 'jotai'
 import { appModeAtom } from '@/atoms/app-mode'
 import { activeViewAtom } from '@/atoms/active-view'
-import { cn } from '@/lib/utils'
 import { Panel } from './Panel'
 import { ChatView } from '@/components/chat'
 import { AgentView } from '@/components/agent'
@@ -20,33 +19,17 @@ export function MainContentPanel(): React.ReactElement {
   const mode = useAtomValue(appModeAtom)
   const activeView = useAtomValue(activeViewAtom)
 
+  /** 渲染对话视图内容 */
+  const renderConversations = (): React.ReactElement => {
+    return mode === 'chat' ? <ChatView /> : <AgentView />
+  }
+
   return (
     <Panel
       variant="grow"
       className="bg-white/95 dark:bg-zinc-900/95 backdrop-blur-xl rounded-2xl shadow-xl border border-border/50"
     >
-      {activeView === 'settings' ? (
-        <SettingsPanel />
-      ) : (
-        <div className="relative h-full w-full overflow-hidden">
-          <div
-            className={cn(
-              'absolute inset-0 transition-transform duration-300 ease-in-out',
-              mode === 'chat' ? 'translate-x-0' : '-translate-x-full'
-            )}
-          >
-            <ChatView />
-          </div>
-          <div
-            className={cn(
-              'absolute inset-0 transition-transform duration-300 ease-in-out',
-              mode === 'agent' ? 'translate-x-0' : 'translate-x-full'
-            )}
-          >
-            <AgentView />
-          </div>
-        </div>
-      )}
+      {activeView === 'settings' ? <SettingsPanel /> : renderConversations()}
     </Panel>
   )
 }

--- a/apps/electron/src/renderer/components/app-shell/ModeSwitcher.tsx
+++ b/apps/electron/src/renderer/components/app-shell/ModeSwitcher.tsx
@@ -22,7 +22,7 @@ export function ModeSwitcher(): React.ReactElement {
         <div
           className={cn(
             'absolute top-1 bottom-1 w-[calc(50%-4px)] rounded bg-background shadow-sm transition-transform duration-300 ease-in-out',
-            mode === 'chat' ? 'translate-x-0' : 'translate-x-[calc(100%+4px)]'
+            mode === 'chat' ? 'translate-x-0' : 'translate-x-full'
           )}
         />
         {modes.map(({ value, label }) => (

--- a/apps/electron/src/renderer/components/app-shell/ModeSwitcher.tsx
+++ b/apps/electron/src/renderer/components/app-shell/ModeSwitcher.tsx
@@ -1,5 +1,5 @@
 /**
- * ModeSwitcher - Chat/Agent 模式切换
+ * ModeSwitcher - Chat/Agent 模式切换（带滑动指示器）
  */
 
 import * as React from 'react'
@@ -17,15 +17,22 @@ export function ModeSwitcher(): React.ReactElement {
 
   return (
     <div className="px-2 pt-2">
-      <div className="flex rounded-lg bg-muted p-1">
+      <div className="relative flex rounded-lg bg-muted p-1">
+        {/* 滑动背景指示器 */}
+        <div
+          className={cn(
+            'absolute top-1 bottom-1 w-[calc(50%-4px)] rounded-md bg-background shadow-sm transition-transform duration-300 ease-in-out',
+            mode === 'chat' ? 'translate-x-0' : 'translate-x-[calc(100%+4px)]'
+          )}
+        />
         {modes.map(({ value, label }) => (
           <button
             key={value}
             onClick={() => setMode(value)}
             className={cn(
-              'flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+              'relative z-[1] flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors duration-200',
               mode === value
-                ? 'bg-background text-foreground shadow-sm'
+                ? 'text-foreground'
                 : 'text-muted-foreground hover:text-foreground'
             )}
           >

--- a/apps/electron/src/renderer/components/app-shell/ModeSwitcher.tsx
+++ b/apps/electron/src/renderer/components/app-shell/ModeSwitcher.tsx
@@ -21,7 +21,7 @@ export function ModeSwitcher(): React.ReactElement {
         {/* 滑动背景指示器 */}
         <div
           className={cn(
-            'absolute top-1 bottom-1 w-[calc(50%-4px)] rounded-md bg-background shadow-sm transition-transform duration-300 ease-in-out',
+            'absolute top-1 bottom-1 w-[calc(50%-4px)] rounded bg-background shadow-sm transition-transform duration-300 ease-in-out',
             mode === 'chat' ? 'translate-x-0' : 'translate-x-[calc(100%+4px)]'
           )}
         />

--- a/apps/electron/src/renderer/components/chat/ChatHeader.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatHeader.tsx
@@ -123,47 +123,48 @@ export function ChatHeader(): React.ReactElement | null {
         </div>
       )}
 
-      {/* 置顶按钮 */}
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            className={cn(
-              'h-8 w-8 flex-shrink-0 titlebar-no-drag',
-              isPinned && 'bg-accent text-accent-foreground'
-            )}
-            onClick={handleTogglePin}
-          >
-            <Pin className="size-4" />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">
-          <p>{isPinned ? '取消置顶' : '置顶对话'}</p>
-        </TooltipContent>
-      </Tooltip>
+      {/* 右上角按钮组 — 绝对定位，与 Agent 侧统一 */}
+      <div className="absolute right-2.5 top-2.5 z-10 flex items-center gap-1 titlebar-no-drag">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className={cn(
+                'h-7 w-7',
+                isPinned && 'bg-accent text-accent-foreground'
+              )}
+              onClick={handleTogglePin}
+            >
+              <Pin className="size-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            <p>{isPinned ? '取消置顶' : '置顶对话'}</p>
+          </TooltipContent>
+        </Tooltip>
 
-      {/* 并排模式切换 - 始终显示，避免编辑时高度跳动 */}
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            className={cn(
-              'h-8 w-8 flex-shrink-0 titlebar-no-drag',
-              parallelMode && 'bg-accent text-accent-foreground'
-            )}
-            onClick={() => setParallelMode(!parallelMode)}
-          >
-            <Columns2 className="size-4" />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">
-          <p>{parallelMode ? '关闭并排模式' : '并排模式'}</p>
-        </TooltipContent>
-      </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className={cn(
+                'h-7 w-7',
+                parallelMode && 'bg-accent text-accent-foreground'
+              )}
+              onClick={() => setParallelMode(!parallelMode)}
+            >
+              <Columns2 className="size-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            <p>{parallelMode ? '关闭并排模式' : '并排模式'}</p>
+          </TooltipContent>
+        </Tooltip>
+      </div>
     </div>
   )
 }

--- a/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
@@ -22,7 +22,6 @@ import {
   ChevronDown,
   Trash2,
   RefreshCw,
-  X,
   ExternalLink,
   FolderSearch,
 } from 'lucide-react'
@@ -51,10 +50,9 @@ interface ContextMenuState {
 
 interface FileBrowserProps {
   rootPath: string
-  onClose?: () => void
 }
 
-export function FileBrowser({ rootPath, onClose }: FileBrowserProps): React.ReactElement {
+export function FileBrowser({ rootPath }: FileBrowserProps): React.ReactElement {
   const [entries, setEntries] = React.useState<FileEntry[]>([])
   const [loading, setLoading] = React.useState(false)
   const [error, setError] = React.useState<string | null>(null)
@@ -153,7 +151,7 @@ export function FileBrowser({ rootPath, onClose }: FileBrowserProps): React.Reac
   return (
     <div className="flex flex-col h-full bg-background">
       {/* 顶部工具栏 */}
-      <div className="flex items-center gap-1 px-3 h-[48px] border-b flex-shrink-0">
+      <div className="flex items-center gap-1 px-3 pr-10 h-[48px] border-b flex-shrink-0">
         <span className="text-xs text-muted-foreground truncate flex-1" title={rootPath}>
           {breadcrumb}
         </span>
@@ -165,7 +163,7 @@ export function FileBrowser({ rootPath, onClose }: FileBrowserProps): React.Reac
           onClick={() => window.electronAPI.openFile(rootPath).catch(console.error)}
           title="在 Finder 中打开"
         >
-          <FolderOpen className="size-3.5" />
+          <ExternalLink className="size-3.5" />
         </Button>
         <Button
           type="button"
@@ -177,17 +175,6 @@ export function FileBrowser({ rootPath, onClose }: FileBrowserProps): React.Reac
         >
           <RefreshCw className={cn('size-3.5', loading && 'animate-spin')} />
         </Button>
-        {onClose && (
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            className="h-7 w-7 flex-shrink-0"
-            onClick={onClose}
-          >
-            <X className="size-3.5" />
-          </Button>
-        )}
       </div>
 
       {/* 文件树 */}


### PR DESCRIPTION
## Summary
- 将文件浏览器切换按钮从 AgentHeader 移至侧栏容器，绝对定位固定在右上角
- 收起时只显示文件夹图标，展开时通过 opacity/rotate/scale 动画交叉淡入为 X 关闭图标（同一个 DOM 元素）
- 侧栏宽度 300ms ease-in-out 平滑过渡，收起时内容 opacity-0 隐藏避免露出
- FileBrowser "在 Finder 中打开"改用 ExternalLink 图标，与切换按钮明确区分
- AgentHeader 简化为纯标题编辑组件，移除 fileBrowser 相关 props

## Test plan
- [ ] 点击文件夹按钮，侧栏平滑展开，图标变为 X
- [ ] 点击 X 按钮，侧栏平滑收起，图标变回文件夹
- [ ] 按钮位置和大小在展开/收起过程中保持不变
- [ ] 收起时不露出侧栏内容
- [ ] "在 Finder 中打开"按钮显示为 ExternalLink 图标

🤖 Generated with [Claude Code](https://claude.com/claude-code)