### PR TITLE
fix: 流式消息在切换模型后显示错误模型

### DIFF
--- a/apps/electron/src/renderer/atoms/chat-atoms.ts
+++ b/apps/electron/src/renderer/atoms/chat-atoms.ts
@@ -35,6 +35,7 @@ export interface ConversationStreamState {
   streaming: boolean
   content: string
   reasoning: string
+  model?: string
 }
 
 /**
@@ -91,6 +92,15 @@ export const streamingReasoningAtom = atom<string>(
     const currentId = get(currentConversationIdAtom)
     if (!currentId) return ''
     return get(streamingStatesAtom).get(currentId)?.reasoning ?? ''
+  },
+)
+
+/** 当前对话流式消息绑定的模型（发送时快照） */
+export const streamingModelAtom = atom<string | null>(
+  (get) => {
+    const currentId = get(currentConversationIdAtom)
+    if (!currentId) return null
+    return get(streamingStatesAtom).get(currentId)?.model ?? null
   },
 )
 

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -32,7 +32,7 @@ import {
   agentStreamingAtom,
   agentStreamingContentAtom,
   agentToolActivitiesAtom,
-  agentModelIdAtom,
+  agentStreamingModelAtom,
 } from '@/atoms/agent-atoms'
 import { userProfileAtom } from '@/atoms/user-profile'
 import type { AgentMessage } from '@proma/shared'
@@ -231,7 +231,7 @@ export function AgentMessages(): React.ReactElement {
   const streaming = useAtomValue(agentStreamingAtom)
   const streamingContent = useAtomValue(agentStreamingContentAtom)
   const toolActivities = useAtomValue(agentToolActivitiesAtom)
-  const agentModelId = useAtomValue(agentModelIdAtom)
+  const agentStreamingModel = useAtomValue(agentStreamingModelAtom)
 
   const { displayedContent: smoothContent } = useSmoothStream({
     content: streamingContent,
@@ -252,9 +252,9 @@ export function AgentMessages(): React.ReactElement {
             {(streaming || smoothContent || toolActivities.length > 0) && (
               <Message from="assistant">
                 <MessageHeader
-                  model={agentModelId || undefined}
+                  model={agentStreamingModel}
                   time={formatMessageTime(Date.now())}
-                  logo={<AssistantLogo model={agentModelId || undefined} />}
+                  logo={<AssistantLogo model={agentStreamingModel} />}
                 />
                 <MessageContent>
                   {toolActivities.length > 0 && (

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -185,7 +185,7 @@ export function AgentView(): React.ReactElement {
       updater: (prev: AgentStreamState) => AgentStreamState,
     ): void => {
       setStreamingStates((prev) => {
-        const current = prev.get(sessionId) ?? { running: true, content: '', toolActivities: [] }
+        const current = prev.get(sessionId) ?? { running: true, content: '', toolActivities: [], model: undefined }
         const next = updater(current)
         const map = new Map(prev)
         map.set(sessionId, next)
@@ -296,7 +296,12 @@ export function AgentView(): React.ReactElement {
       // 初始化流式状态
       setStreamingStates((prev) => {
         const map = new Map(prev)
-        map.set(currentSessionId, { running: true, content: '', toolActivities: [] })
+        map.set(currentSessionId, {
+          running: true,
+          content: '',
+          toolActivities: [],
+          model: agentModelId || undefined,
+        })
         return map
       })
 
@@ -575,7 +580,12 @@ export function AgentView(): React.ReactElement {
     // 初始化流式状态
     setStreamingStates((prev) => {
       const map = new Map(prev)
-      map.set(currentSessionId, { running: true, content: '', toolActivities: [] })
+      map.set(currentSessionId, {
+        running: true,
+        content: '',
+        toolActivities: [],
+        model: agentModelId || undefined,
+      })
       return map
     })
 
@@ -631,7 +641,12 @@ export function AgentView(): React.ReactElement {
     // 初始化流式状态
     setStreamingStates((prev) => {
       const map = new Map(prev)
-      const current = prev.get(currentSessionId) ?? { running: true, content: '', toolActivities: [] }
+      const current = prev.get(currentSessionId) ?? {
+        running: true,
+        content: '',
+        toolActivities: [],
+        model: agentModelId || undefined,
+      }
       map.set(currentSessionId, { ...current, running: true })
       return map
     })

--- a/apps/electron/src/renderer/components/chat/ChatMessages.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessages.tsx
@@ -44,9 +44,9 @@ import {
   streamingAtom,
   streamingContentAtom,
   streamingReasoningAtom,
+  streamingModelAtom,
   contextDividersAtom,
   parallelModeAtom,
-  selectedModelAtom,
   hasMoreMessagesAtom,
   currentConversationIdAtom,
 } from '@/atoms/chat-atoms'
@@ -177,7 +177,7 @@ export function ChatMessages({
   })
   const contextDividers = useAtomValue(contextDividersAtom)
   const parallelMode = useAtomValue(parallelModeAtom)
-  const selectedModel = useAtomValue(selectedModelAtom)
+  const streamingModel = useAtomValue(streamingModelAtom)
   const hasMore = useAtomValue(hasMoreMessagesAtom)
   const currentConversationId = useAtomValue(currentConversationIdAtom)
 
@@ -301,11 +301,11 @@ export function ChatMessages({
             {(streaming || smoothContent || smoothReasoning) && (
               <Message from="assistant">
                 <MessageHeader
-                  model={selectedModel?.modelId}
+                  model={streamingModel}
                   time={formatMessageTime(Date.now())}
                   logo={
                     <img
-                      src={getModelLogo(selectedModel?.modelId ?? '')}
+                      src={getModelLogo(streamingModel ?? '')}
                       alt="AI"
                       className="size-[35px] rounded-[25%] object-cover"
                     />

--- a/apps/electron/src/renderer/components/chat/ChatView.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatView.tsx
@@ -120,7 +120,7 @@ export function ChatView(): React.ReactElement {
       updater: (prev: ConversationStreamState) => ConversationStreamState
     ): void => {
       setStreamingStates((prev) => {
-        const current = prev.get(convId) ?? { streaming: false, content: '', reasoning: '' }
+        const current = prev.get(convId) ?? { streaming: false, content: '', reasoning: '', model: undefined }
         const next = updater(current)
         const map = new Map(prev)
         map.set(convId, next)
@@ -324,7 +324,12 @@ export function ChatView(): React.ReactElement {
     // 初始化当前对话的流式状态
     setStreamingStates((prev) => {
       const map = new Map(prev)
-      map.set(currentConversationId, { streaming: true, content: '', reasoning: '' })
+      map.set(currentConversationId, {
+        streaming: true,
+        content: '',
+        reasoning: '',
+        model: selectedModel.modelId,
+      })
       return map
     })
 

--- a/apps/electron/src/renderer/components/chat/ParallelChatMessages.tsx
+++ b/apps/electron/src/renderer/components/chat/ParallelChatMessages.tsx
@@ -28,7 +28,7 @@ import {
   ReasoningTrigger,
   ReasoningContent,
 } from '@/components/ai-elements/reasoning'
-import { selectedModelAtom } from '@/atoms/chat-atoms'
+import { streamingModelAtom } from '@/atoms/chat-atoms'
 import { getModelLogo } from '@/lib/model-logo'
 import type { ChatMessage } from '@proma/shared'
 
@@ -149,7 +149,7 @@ function MessageColumn({
   streamingContent = '',
   streamingReasoning = '',
 }: MessageColumnProps): React.ReactElement {
-  const selectedModel = useAtomValue(selectedModelAtom)
+  const streamingModel = useAtomValue(streamingModelAtom)
   const scrollRef = useRef<HTMLDivElement>(null)
 
   // 消息加载后自动滚动到底部（两列都滚到最新消息）
@@ -194,11 +194,11 @@ function MessageColumn({
         {side === 'assistant' && (streaming || streamingContent || streamingReasoning) && (
           <Message from="assistant">
             <MessageHeader
-              model={selectedModel?.modelId}
+              model={streamingModel}
               time={formatMessageTime(Date.now())}
               logo={
                 <img
-                  src={getModelLogo(selectedModel?.modelId ?? '')}
+                  src={getModelLogo(streamingModel ?? '')}
                   alt="AI"
                   className="size-[35px] rounded-[25%] object-cover"
                 />


### PR DESCRIPTION
## Summary
修复了发送消息后，切换模型导致流式临时卡片显示错误模型的问题。

**核心改动：**
在流式状态（ChatStreamState 和 AgentStreamState）中新增 `model` 字段，在发送消息时快照当前选中的模型 ID，流式临时卡片从快照字段读取模型而非实时选中的模型。

## Test Plan
- [x] Chat 模式：发送消息后切换模型，确认流式卡片显示发送时的模型而非新模型
- [x] Agent 模式：发送消息后切换模型，确认流式消息头显示发送时的模型
- [x] 多对话并行流式：在并排模式下同时向两个对话发送消息（使用不同模型），确认各自显示正确模型