### PR TITLE
feat: 删除会话支持 Enter 键快捷删除

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -533,7 +533,14 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         open={pendingDeleteId !== null}
         onOpenChange={(open) => { if (!open) setPendingDeleteId(null) }}
       >
-        <AlertDialogContent>
+        <AlertDialogContent
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              handleConfirmDelete()
+            }
+          }}
+        >
           <AlertDialogHeader>
             <AlertDialogTitle>确认删除对话</AlertDialogTitle>
             <AlertDialogDescription>


### PR DESCRIPTION
## Summary

在删除会话的确认对话框中，修改了键盘快捷键支持。
先前的`esc`和`enter`都只能取消删除，关闭对话框，现在把`enter`修改成确认删除。

**改动：**
- 在 AlertDialogContent 上添加 onKeyDown 事件处理
- 按 Enter 键直接触发删除操作
- Escape 键保持默认行为（关闭对话框）

**影响范围：**
- Chat 模式删除对话
- Agent 模式删除会话

## Test Plan
- [x] Chat 模式和 Agent 模式：右键删除对话，按 Enter 键确认删除
- [x] Escape 键正常关闭对话框