### PR TITLE
fix: 修复用户消息重复发送给 API 的 bug

### DIFF
--- a/apps/electron/src/main/lib/chat-service.ts
+++ b/apps/electron/src/main/lib/chat-service.ts
@@ -211,7 +211,10 @@ export async function sendMessage(
     return
   }
 
-  // 3. 追加用户消息到 JSONL
+  // 3. 先读取历史消息（在追加用户消息之前，避免 adapter 重复发送当前消息）
+  const fullHistory = getConversationMessages(conversationId)
+
+  // 4. 追加用户消息到 JSONL
   const userMsg: ChatMessage = {
     id: randomUUID(),
     role: 'user',
@@ -221,11 +224,8 @@ export async function sendMessage(
   }
   appendMessage(conversationId, userMsg)
 
-  // 4. 从磁盘读取完整消息历史（不依赖前端传入，确保上下文完整）
-  const fullHistory = getConversationMessages(conversationId)
+  // 5. 过滤历史并提取文档附件文本
   const filteredHistory = filterHistory(fullHistory, contextDividers, contextLength)
-
-  // 5. 提取文档附件文本，注入到消息内容中
   const enrichedHistory = await enrichHistoryWithDocuments(filteredHistory)
   const enrichedUserMessage = await enrichMessageWithDocuments(userMessage, attachments)
 


### PR DESCRIPTION
## 问题描述

`chat-service.ts` 的 `sendMessage()` 中，用户消息先通过 `appendMessage()` 写入 JSONL，
然后 `getConversationMessages()` 从磁盘读回完整历史（此时已包含刚写入的用户消息）。
这个 history 连同 `userMessage` 一起传给 adapter 的 `buildStreamRequest()`。

而所有 adapter（Anthropic / OpenAI / Google）都会先遍历 `history` 转为消息数组，
再追加 `userMessage` 作为当前消息。由于 history 中已经包含了当前用户消息，
最终 API 请求体中用户消息出现了两次。

**影响范围**：所有 Provider（Anthropic、OpenAI、DeepSeek、Google、Custom）均受影响，
每次聊天都会多发送一次用户消息，浪费 input token 并可能影响 AI 回复质量。

## 修复方式

将 `getConversationMessages()` 移到 `appendMessage()` 之前调用，
确保读取的历史不包含当前用户消息。

## 验证方式

在 adapter 的 `buildStreamRequest` 中添加临时日志，确认修复后最后两条消息不再都是 user 角色：

- 修复前：最后两条角色: [user, user]（重复）
- 修复后：最后两条角色: [assistant, user]（正常）
