### PR TITLE
fix: 修复 TypeScript 严格模式下的类型检查错误

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -647,15 +647,17 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(
     AGENT_IPC_CHANNELS.OPEN_FOLDER_DIALOG,
     async (): Promise<{ path: string; name: string } | null> => {
-      const win = BrowserWindow.getFocusedWindow()
-      const result = await dialog.showOpenDialog(win ?? BrowserWindow.getAllWindows()[0], {
+      const win = BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0]
+      if (!win) return null
+
+      const result = await dialog.showOpenDialog(win, {
         properties: ['openDirectory'],
         title: '选择文件夹',
       })
 
       if (result.canceled || result.filePaths.length === 0) return null
 
-      const folderPath = result.filePaths[0]
+      const folderPath = result.filePaths[0]!
       const name = folderPath.split('/').filter(Boolean).pop() || 'folder'
       return { path: folderPath, name }
     }

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -966,7 +966,7 @@ async function runAgentInternal(
         // 衔接上下文：有 SDK session ID 则 resume
         ...(existingSdkSessionId ? { resume: existingSdkSessionId } : {}),
         // MCP 服务器（每次 query 都从磁盘读取最新配置，支持回合间动态更新）
-        ...(Object.keys(mcpServers).length > 0 && { mcpServers }),
+        ...(Object.keys(mcpServers).length > 0 && { mcpServers: mcpServers as Record<string, import('@anthropic-ai/claude-agent-sdk').McpServerConfig> }),
         // Skill 插件（SDK 自动发现 skills/ 目录下的 SKILL.md）
         ...(workspaceSlug && { plugins: [{ type: 'local' as const, path: getAgentWorkspacePath(workspaceSlug) }] }),
         stderr: (data: string) => {

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -168,7 +168,7 @@ export function updateAgentSessionMeta(
     throw new Error(`Agent 会话不存在: ${id}`)
   }
 
-  const existing = index.sessions[idx]
+  const existing = index.sessions[idx]!
   const updated: AgentSessionMeta = {
     ...existing,
     ...updates,
@@ -193,7 +193,7 @@ export function deleteAgentSession(id: string): void {
     throw new Error(`Agent 会话不存在: ${id}`)
   }
 
-  const removed = index.sessions.splice(idx, 1)[0]
+  const removed = index.sessions.splice(idx, 1)[0]!
   writeIndex(index)
 
   // 删除消息文件

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -177,7 +177,7 @@ export function updateAgentWorkspace(
     throw new Error(`Agent 工作区不存在: ${id}`)
   }
 
-  const existing = index.workspaces[idx]
+  const existing = index.workspaces[idx]!
   const updated: AgentWorkspace = {
     ...existing,
     name: updates.name,
@@ -202,7 +202,7 @@ export function deleteAgentWorkspace(id: string): void {
     throw new Error(`Agent 工作区不存在: ${id}`)
   }
 
-  const removed = index.workspaces.splice(idx, 1)[0]
+  const removed = index.workspaces.splice(idx, 1)[0]!
   writeIndex(index)
 
   console.log(`[Agent 工作区] 已删除工作区索引: ${removed.name} (slug: ${removed.slug}，目录已保留)`)
@@ -359,6 +359,8 @@ function parseSkillFrontmatter(content: string, slug: string): SkillMeta {
   if (!fmMatch) return meta
 
   const yaml = fmMatch[1]
+  if (!yaml) return meta
+
   for (const line of yaml.split('\n')) {
     const colonIdx = line.indexOf(':')
     if (colonIdx === -1) continue

--- a/apps/electron/src/main/lib/attachment-service.ts
+++ b/apps/electron/src/main/lib/attachment-service.ts
@@ -200,8 +200,8 @@ export function deleteConversationAttachments(conversationId: string): void {
 export async function openFileDialog(): Promise<FileDialogResult> {
   // macOS 上必须传入父窗口，否则对话框可能出现在应用窗口后面
   const parentWindow = BrowserWindow.getFocusedWindow()
-  const dialogOptions = {
-    properties: ['openFile', 'multiSelections'] as const,
+  const dialogOptions: Electron.OpenDialogOptions = {
+    properties: ['openFile', 'multiSelections'],
     filters: FILE_FILTERS,
   }
 

--- a/apps/electron/src/main/lib/channel-manager.ts
+++ b/apps/electron/src/main/lib/channel-manager.ts
@@ -192,7 +192,7 @@ export function updateChannel(id: string, input: ChannelUpdateInput): Channel {
     throw new Error(`渠道不存在: ${id}`)
   }
 
-  const existing = config.channels[index]
+  const existing = config.channels[index]!
 
   const updated: Channel = {
     ...existing,
@@ -223,7 +223,7 @@ export function deleteChannel(id: string): void {
     throw new Error(`渠道不存在: ${id}`)
   }
 
-  const removed = config.channels.splice(index, 1)[0]
+  const removed = config.channels.splice(index, 1)[0]!
   writeConfig(config)
 
   console.log(`[渠道管理] 已删除渠道: ${removed.name} (${removed.id})`)

--- a/apps/electron/src/main/lib/conversation-manager.ts
+++ b/apps/electron/src/main/lib/conversation-manager.ts
@@ -227,7 +227,7 @@ export function updateConversationMeta(
     throw new Error(`对话不存在: ${id}`)
   }
 
-  const existing = index.conversations[idx]
+  const existing = index.conversations[idx]!
   const updated: ConversationMeta = {
     ...existing,
     ...updates,
@@ -256,7 +256,7 @@ export function deleteConversation(id: string): void {
     throw new Error(`对话不存在: ${id}`)
   }
 
-  const removed = index.conversations.splice(idx, 1)[0]
+  const removed = index.conversations.splice(idx, 1)[0]!
   writeIndex(index)
 
   // 删除消息文件

--- a/apps/electron/src/main/lib/git-bash-detector.ts
+++ b/apps/electron/src/main/lib/git-bash-detector.ts
@@ -48,7 +48,7 @@ function verifyBashPath(bashPath: string): string | null {
     const versionMatch = output.match(/version\s+(\S+)/)
     if (versionMatch?.[1]) {
       // 提取主版本号（如 "5.2.15(1)-release" → "5.2.15"）
-      const cleanVersion = versionMatch[1].split('(')[0]
+      const cleanVersion = versionMatch[1]!.split('(')[0]!
       return cleanVersion
     }
 

--- a/apps/electron/src/main/lib/git-detector.ts
+++ b/apps/electron/src/main/lib/git-detector.ts
@@ -67,7 +67,7 @@ function getGitVersion(gitPath: string): string | null {
     if (result.status === 0 && result.stdout) {
       // git version 2.39.0 -> 2.39.0
       const match = result.stdout.match(/git version (\d+\.\d+\.\d+)/)
-      return match ? match[1] : result.stdout.trim()
+      return match ? match[1]! : result.stdout.trim()
     }
   } catch {
     // 执行失败

--- a/apps/electron/src/main/lib/system-proxy-detector.ts
+++ b/apps/electron/src/main/lib/system-proxy-detector.ts
@@ -59,7 +59,7 @@ async function detectMacOSProxy(): Promise<SystemProxyDetectResult> {
       } else if (serviceList.includes('Ethernet')) {
         networkService = 'Ethernet'
       } else if (serviceList.length > 0) {
-        networkService = serviceList[0]
+        networkService = serviceList[0]!
       }
     } catch {
       // 如果获取服务列表失败，使用默认的 Wi-Fi

--- a/apps/electron/src/main/tray.ts
+++ b/apps/electron/src/main/tray.ts
@@ -18,7 +18,7 @@ function getTrayIconPath(): string {
 function showMainWindow(): void {
   const windows = BrowserWindow.getAllWindows()
   if (windows.length === 0) return
-  const mainWindow = windows[0]
+  const mainWindow = windows[0]!
   if (mainWindow.isMinimized()) {
     mainWindow.restore()
   }

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -343,6 +343,10 @@ export interface ElectronAPI {
   getLatestRelease: () => Promise<GitHubRelease | null>
   listReleases: (options?: GitHubReleaseListOptions) => Promise<GitHubRelease[]>
   getReleaseByTag: (tag: string) => Promise<GitHubRelease | null>
+
+  // 工作区文件变化通知
+  onCapabilitiesChanged: (callback: () => void) => () => void
+  onWorkspaceFilesChanged: (callback: () => void) => () => void
 }
 
 /**

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -82,7 +82,7 @@ function mergeTodoWrites(activities: ToolActivity[]): ToolActivity[] {
 
   if (todoWrites.length === 0) return activities
 
-  const latest = todoWrites[todoWrites.length - 1]
+  const latest = todoWrites[todoWrites.length - 1]!
   const allDone = todoWrites.every((t) => t.done)
 
   const merged: ToolActivity = {
@@ -376,7 +376,7 @@ export const currentAgentErrorAtom = atom<string | null>((get) => {
 export const agentSessionDraftsAtom = atom<Map<string, string>>(new Map())
 
 /** 当前 Agent 会话的草稿内容（派生读写原子） */
-export const currentAgentSessionDraftAtom = atom<string>(
+export const currentAgentSessionDraftAtom = atom(
   (get) => {
     const currentId = get(currentAgentSessionIdAtom)
     if (!currentId) return ''

--- a/apps/electron/src/renderer/atoms/chat-atoms.ts
+++ b/apps/electron/src/renderer/atoms/chat-atoms.ts
@@ -172,7 +172,7 @@ export const currentChatErrorAtom = atom<string | null>((get) => {
 export const conversationDraftsAtom = atom<Map<string, string>>(new Map())
 
 /** 当前对话的草稿内容（派生读写原子） */
-export const currentConversationDraftAtom = atom<string>(
+export const currentConversationDraftAtom = atom(
   (get) => {
     const currentId = get(currentConversationIdAtom)
     if (!currentId) return ''

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -81,10 +81,10 @@ function extractToolActivities(events: AgentMessage['events']): ToolActivity[] {
       const existingIdx = activities.findIndex((t) => t.toolUseId === event.toolUseId)
       if (existingIdx >= 0) {
         activities[existingIdx] = {
-          ...activities[existingIdx],
+          ...activities[existingIdx]!,
           input: event.input,
-          intent: event.intent || activities[existingIdx].intent,
-          displayName: event.displayName || activities[existingIdx].displayName,
+          intent: event.intent || activities[existingIdx]!.intent,
+          displayName: event.displayName || activities[existingIdx]!.displayName,
         }
       } else {
         activities.push({
@@ -101,7 +101,7 @@ function extractToolActivities(events: AgentMessage['events']): ToolActivity[] {
       const idx = activities.findIndex((t) => t.toolUseId === event.toolUseId)
       if (idx >= 0) {
         activities[idx] = {
-          ...activities[idx],
+          ...activities[idx]!,
           result: event.result,
           isError: event.isError,
           done: true,
@@ -110,17 +110,17 @@ function extractToolActivities(events: AgentMessage['events']): ToolActivity[] {
     } else if (event.type === 'task_backgrounded') {
       const idx = activities.findIndex((t) => t.toolUseId === event.toolUseId)
       if (idx >= 0) {
-        activities[idx] = { ...activities[idx], isBackground: true, taskId: event.taskId }
+        activities[idx] = { ...activities[idx]!, isBackground: true, taskId: event.taskId }
       }
     } else if (event.type === 'shell_backgrounded') {
       const idx = activities.findIndex((t) => t.toolUseId === event.toolUseId)
       if (idx >= 0) {
-        activities[idx] = { ...activities[idx], isBackground: true, shellId: event.shellId }
+        activities[idx] = { ...activities[idx]!, isBackground: true, shellId: event.shellId }
       }
     } else if (event.type === 'task_progress') {
       const idx = activities.findIndex((t) => t.toolUseId === event.toolUseId)
       if (idx >= 0) {
-        activities[idx] = { ...activities[idx], elapsedSeconds: event.elapsedSeconds }
+        activities[idx] = { ...activities[idx]!, elapsedSeconds: event.elapsedSeconds }
       }
     }
   }
@@ -140,12 +140,12 @@ function parseAttachedFiles(content: string): { files: AttachedFileRef[]; text: 
   if (!match) return { files: [], text: content }
 
   const files: AttachedFileRef[] = []
-  const lines = match[1].split('\n')
+  const lines = match[1]!.split('\n')
   for (const line of lines) {
     // 格式: - filename: /path/to/file
     const lineMatch = line.match(/^-\s+(.+?):\s+(.+)$/)
     if (lineMatch) {
-      files.push({ filename: lineMatch[1].trim(), path: lineMatch[2].trim() })
+      files.push({ filename: lineMatch[1]!.trim(), path: lineMatch[2]!.trim() })
     }
   }
 

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -52,7 +52,7 @@ function fileToBase64(file: File): Promise<string> {
     const reader = new FileReader()
     reader.onload = () => {
       const result = reader.result as string
-      const base64 = result.split(',')[1]
+      const base64 = result.split(',')[1]!
       resolve(base64)
     }
     reader.onerror = reject

--- a/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
@@ -159,9 +159,9 @@ export function WorkspaceSelector(): React.ReactElement {
 
       // 如果删除的是当前工作区，切换到第一个剩余的
       if (deleteTargetId === currentWorkspaceId && remaining.length > 0) {
-        setCurrentWorkspaceId(remaining[0].id)
+        setCurrentWorkspaceId(remaining[0]!.id)
         window.electronAPI.updateSettings({
-          agentWorkspaceId: remaining[0].id,
+          agentWorkspaceId: remaining[0]!.id,
         }).catch(console.error)
       }
     } catch (error) {

--- a/apps/electron/src/renderer/components/ai-elements/speech-button.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/speech-button.tsx
@@ -64,7 +64,7 @@ interface SpeechRecognitionErrorEvent extends Event {
 
 /** 获取 SpeechRecognition 构造函数 */
 function getSpeechRecognition(): (new () => SpeechRecognitionInstance) | null {
-  const win = window as Record<string, unknown>
+  const win = window as unknown as Record<string, unknown>
   return (win.SpeechRecognition ?? win.webkitSpeechRecognition ?? null) as
     | (new () => SpeechRecognitionInstance)
     | null

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -195,7 +195,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         setConversations(list)
         // 默认加载最近一条对话（按 updatedAt 降序，首条即最新）
         if (list.length > 0) {
-          setCurrentConversationId(list[0].id)
+          setCurrentConversationId(list[0]!.id)
         }
       })
       .catch(console.error)

--- a/apps/electron/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatInput.tsx
@@ -56,7 +56,7 @@ function fileToBase64(file: File): Promise<string> {
     reader.onload = () => {
       const result = reader.result as string
       // 去掉 data:xxx;base64, 前缀
-      const base64 = result.split(',')[1]
+      const base64 = result.split(',')[1]!
       resolve(base64)
     }
     reader.onerror = reject
@@ -171,8 +171,8 @@ export function ChatInput({ onSend, onStop, onClearContext }: ChatInputProps): R
 
   /** 语音识别结果 */
   const handleSpeechTranscript = React.useCallback((text: string): void => {
-    setContent((prev) => prev + (prev ? ' ' : '') + text)
-  }, [])
+    setContent(content + (content ? ' ' : '') + text)
+  }, [content, setContent])
 
   /** 粘贴文件回调 */
   const handlePasteFiles = React.useCallback((files: File[]): void => {

--- a/apps/electron/src/renderer/components/chat/ChatMessages.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessages.tsx
@@ -301,7 +301,7 @@ export function ChatMessages({
             {(streaming || smoothContent || smoothReasoning) && (
               <Message from="assistant">
                 <MessageHeader
-                  model={streamingModel}
+                  model={streamingModel ?? undefined}
                   time={formatMessageTime(Date.now())}
                   logo={
                     <img

--- a/apps/electron/src/renderer/components/chat/ChatView.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatView.tsx
@@ -546,7 +546,7 @@ export function ChatView(): React.ReactElement {
   const handleClearContext = React.useCallback((): void => {
     if (!currentConversationId || currentMessages.length === 0) return
 
-    const lastMessage = currentMessages[currentMessages.length - 1]
+    const lastMessage = currentMessages[currentMessages.length - 1]!
     const lastMessageId = lastMessage.id
 
     let newDividers: string[]

--- a/apps/electron/src/renderer/components/chat/ContextSettingsPopover.tsx
+++ b/apps/electron/src/renderer/components/chat/ContextSettingsPopover.tsx
@@ -36,7 +36,7 @@ function getContextLengthLabel(value: ContextLengthValue): string {
 
 /** 将滑块位置转换为实际值 */
 function sliderPositionToValue(position: number): ContextLengthValue {
-  return CONTEXT_LENGTH_OPTIONS[position]
+  return CONTEXT_LENGTH_OPTIONS[position]!
 }
 
 /** 将实际值转换为滑块位置 */
@@ -53,7 +53,7 @@ export function ContextSettingsPopover(): React.ReactElement {
   const maxSliderPosition = CONTEXT_LENGTH_OPTIONS.length - 1
 
   const handleSliderChange = (values: number[]): void => {
-    const newValue = sliderPositionToValue(values[0])
+    const newValue = sliderPositionToValue(values[0]!)
     // 暂不允许选择 infinite
     if (newValue === 'infinite') {
       return

--- a/apps/electron/src/renderer/components/chat/InlineEditForm.tsx
+++ b/apps/electron/src/renderer/components/chat/InlineEditForm.tsx
@@ -21,7 +21,7 @@ function fileToBase64(file: File): Promise<string> {
     const reader = new FileReader()
     reader.onload = () => {
       const result = reader.result as string
-      resolve(result.split(',')[1])
+      resolve(result.split(',')[1]!)
     }
     reader.onerror = reject
     reader.readAsDataURL(file)

--- a/apps/electron/src/renderer/components/chat/ParallelChatMessages.tsx
+++ b/apps/electron/src/renderer/components/chat/ParallelChatMessages.tsx
@@ -194,7 +194,7 @@ function MessageColumn({
         {side === 'assistant' && (streaming || streamingContent || streamingReasoning) && (
           <Message from="assistant">
             <MessageHeader
-              model={streamingModel}
+              model={streamingModel ?? undefined}
               time={formatMessageTime(Date.now())}
               logo={
                 <img

--- a/apps/electron/src/renderer/components/settings/AboutSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AboutSettings.tsx
@@ -374,7 +374,7 @@ function ShellEnvironmentCard(): React.ReactElement | null {
         <EnvironmentCheckCard
           name="Git Bash"
           status={shell.gitBash?.available ? 'success' : 'error'}
-          version={shell.gitBash?.version}
+          version={shell.gitBash?.version ?? undefined}
           requirement="Git for Windows 自带"
           downloadUrl="https://git-scm.com/download/win"
           statusText={

--- a/apps/electron/src/renderer/components/settings/ChannelSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelSettings.tsx
@@ -116,7 +116,7 @@ export function ChannelSettings(): React.ReactElement {
       currentAgentChannel.provider !== 'anthropic' // 选择的不是 Anthropic 渠道
 
     if (shouldAutoSelect && availableAnthropicChannels.length > 0) {
-      await handleSelectAgentProvider(availableAnthropicChannels[0].id)
+      await handleSelectAgentProvider(availableAnthropicChannels[0]!.id)
     }
   }
 

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -96,7 +96,7 @@ function AgentSettingsInitializer(): null {
           const exists = workspaces.some((w) => w.id === settings.agentWorkspaceId)
           setCurrentWorkspaceId(exists ? settings.agentWorkspaceId! : workspaces[0]?.id ?? null)
         } else if (workspaces.length > 0) {
-          setCurrentWorkspaceId(workspaces[0].id)
+          setCurrentWorkspaceId(workspaces[0]!.id)
         }
       }).catch(console.error)
     }).catch(console.error)


### PR DESCRIPTION
## 问题描述

项目 tsconfig 启用了 `strict: true` 和 `noUncheckedIndexedAccess: true`，但代码中存在大量未适配的类型安全问题，导致 `bun run typecheck` 报出约 54 个类型错误，`bun run electron:build` 的 renderer 构建也因 `tailwindcss-animate` 依赖缺失而失败。

## 修复内容

**构建依赖**：`tailwindcss-animate` 未安装，`bun install` 补全即可。

**类型修复**（28 个文件，+55 -47 行）：

- 数组索引访问在 `findIndex` / `length > 0` 检查后添加 `!` 非空断言，适配 `noUncheckedIndexedAccess`
- `ElectronAPI` 接口补充 `onCapabilitiesChanged` / `onWorkspaceFilesChanged` 方法声明（实现已有，接口遗漏）
- Jotai 派生读写 atom 移除 `<string>` 类型参数，匹配 v2 的 `atom(getter, setter)` 签名
- `attachment-service.ts` 的 `as const` 元组改为显式 `Electron.OpenDialogOptions` 类型
- `agent-service.ts` 的 mcpServers 添加 SDK 类型断言
- 零散的 `null` / `undefined` 类型不匹配修复

## 验证

- [x] `bun run typecheck` 通过（0 errors）
- [x] `bun run electron:build` 构建成功
- [x] `bun run dev` 开发模式正常启动

Co-Authored-By: Claude <noreply@anthropic.com>