### PR TITLE
fix: 修复短消息触发标题生成时 AI 产生幻觉的问题

### DIFF
--- a/apps/electron/src/main/lib/chat-service.ts
+++ b/apps/electron/src/main/lib/chat-service.ts
@@ -387,7 +387,10 @@ export function stopAllGenerations(): void {
 // ===== 标题生成 =====
 
 /** 标题生成 Prompt */
-const TITLE_PROMPT = '根据用户的第一条消息，生成一个简短的对话标题（10字以内）。只输出标题，不要有任何其他内容、标点符号或引号。\n\n用户消息：'
+const TITLE_PROMPT = '根据用户的第一条消息，生成一个简短的对话标题（10字以内）。只输出标题，不要有任何其他内容、标点符号或引号。如果消息内容过短或无明确主题，直接使用原始消息作为标题。\n\n用户消息：'
+
+/** 短消息阈值：低于此长度直接使用原文作为标题 */
+const SHORT_MESSAGE_THRESHOLD = 4
 
 /** 最大标题长度 */
 const MAX_TITLE_LENGTH = 20
@@ -404,6 +407,14 @@ const MAX_TITLE_LENGTH = 20
 export async function generateTitle(input: GenerateTitleInput): Promise<string | null> {
   const { userMessage, channelId, modelId } = input
   console.log('[标题生成] 开始生成标题:', { channelId, modelId, userMessage: userMessage.slice(0, 50) })
+
+  // 短消息直接使用原文作为标题，避免 AI 幻觉
+  const trimmedMessage = userMessage.trim()
+  if (trimmedMessage.length <= SHORT_MESSAGE_THRESHOLD) {
+    const shortTitle = trimmedMessage.slice(0, MAX_TITLE_LENGTH)
+    console.log('[标题生成] 消息过短，直接使用原文作为标题:', shortTitle)
+    return shortTitle
+  }
 
   // 查找渠道
   const channels = listChannels()


### PR DESCRIPTION
## 问题

当用户第一条消息过短（如 "1"、"你好"）时，标题生成调用 AI 模型，模型无法从极短文本中提取有效语义，会编造与对话内容完全无关的随机标题。

实际案例（用户发送 "1"、"2"、"3"、"4"）：
- 标题显示为 "如何制作简历"
- 标题显示为 "如何制作披萨"
- 标题显示为 "如何学习编程"

## 根因

`chat-service.ts` 的 `generateTitle` 函数将用户消息拼接到 prompt 后直接发给 AI，当消息过短时 LLM 产生幻觉。

## 修复

- 当用户消息长度 ≤ 4 字符时，直接使用原文作为标题，跳过 AI 调用
- 优化 `TITLE_PROMPT`，增加兜底指令：消息过短时使用原始消息

## 测试

- [x] 发送 "1" → 标题为 "1"
- [x] 发送 "12345" → 标题由 AI 正常生成
- [x] 发送 "你好" → 标题为 "你好"
- [x] typecheck 通过