### PR TITLE
fix: 修复右键菜单重命名对话时立即退出编辑模式

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -597,19 +597,25 @@ function ConversationItem({
   const [editing, setEditing] = React.useState(false)
   const [editTitle, setEditTitle] = React.useState('')
   const inputRef = React.useRef<HTMLInputElement>(null)
+  const justStartedEditing = React.useRef(false)
 
   /** 进入编辑模式 */
   const startEdit = (): void => {
     setEditTitle(conversation.title)
     setEditing(true)
-    requestAnimationFrame(() => {
+    justStartedEditing.current = true
+    // 延迟聚焦，等待 ContextMenu 完全关闭后再 focus
+    setTimeout(() => {
+      justStartedEditing.current = false
       inputRef.current?.focus()
       inputRef.current?.select()
-    })
+    }, 300)
   }
 
   /** 保存标题 */
   const saveTitle = async (): Promise<void> => {
+    // ContextMenu 关闭导致的 blur，忽略
+    if (justStartedEditing.current) return
     const trimmed = editTitle.trim()
     if (!trimmed || trimmed === conversation.title) {
       setEditing(false)
@@ -758,17 +764,21 @@ function AgentSessionItem({
   const [editing, setEditing] = React.useState(false)
   const [editTitle, setEditTitle] = React.useState('')
   const inputRef = React.useRef<HTMLInputElement>(null)
+  const justStartedEditing = React.useRef(false)
 
   const startEdit = (): void => {
     setEditTitle(session.title)
     setEditing(true)
-    requestAnimationFrame(() => {
+    justStartedEditing.current = true
+    setTimeout(() => {
+      justStartedEditing.current = false
       inputRef.current?.focus()
       inputRef.current?.select()
-    })
+    }, 300)
   }
 
   const saveTitle = async (): Promise<void> => {
+    if (justStartedEditing.current) return
     const trimmed = editTitle.trim()
     if (!trimmed || trimmed === session.title) {
       setEditing(false)


### PR DESCRIPTION
## 问题

右键点击对话 → 选择"重命名"后，编辑模式立即退出，用户无法实际编辑标题。

## 根因

Radix UI 的 ContextMenu 在选中菜单项后自动关闭，关闭过程中会抢走 input 焦点，触发 `onBlur={saveTitle}`，导致编辑模式瞬间退出。

## 修复

- 添加 `justStartedEditing` ref 标记，在保护期内忽略 blur 事件
- 将 input 聚焦从 `requestAnimationFrame` 改为 `setTimeout(300ms)`，确保在 ContextMenu 完全关闭后再聚焦
- `ConversationItem` 和 `AgentSessionItem` 均已修复

## 测试

- [x] 右键对话 → 重命名 → 可正常编辑标题
- [x] 双击对话标题 → 可正常编辑
- [x] Enter 确认 / Escape 取消 正常工作
- [x] typecheck 通过