### PR TITLE
fix: 修复 Base URL 末尾含 /v1/messages 时路径重复导致请求失败

### DIFF
--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -739,8 +739,13 @@ async function runAgentInternal(
     ANTHROPIC_API_KEY: apiKey,
   }
   // 自定义 Base URL 时注入 ANTHROPIC_BASE_URL
+  // SDK 内部会自动拼接 /v1/messages，需要去除用户误填的路径后缀
   if (channel.baseUrl && channel.baseUrl !== DEFAULT_ANTHROPIC_URL) {
     sdkEnv.ANTHROPIC_BASE_URL = channel.baseUrl
+      .trim()
+      .replace(/\/+$/, '')
+      .replace(/\/v\d+\/messages$/, '')
+      .replace(/\/v\d+$/, '')
   } else {
     // 确保不会残留上一次的 Base URL
     delete sdkEnv.ANTHROPIC_BASE_URL

--- a/apps/electron/src/main/lib/channel-manager.ts
+++ b/apps/electron/src/main/lib/channel-manager.ts
@@ -41,6 +41,8 @@ const CONFIG_VERSION = 1
  */
 function normalizeAnthropicBaseUrl(baseUrl: string): string {
   let url = baseUrl.trim().replace(/\/+$/, '')
+  // 去除用户误填的 /messages 后缀，避免后续拼接时路径重复
+  url = url.replace(/\/messages$/, '')
   if (!url.match(/\/v\d+$/)) {
     url = `${url}/v1`
   }

--- a/apps/electron/src/renderer/components/settings/ChannelForm.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelForm.tsx
@@ -81,9 +81,11 @@ const PROVIDER_CHAT_PATHS: Record<ProviderType, string> = {
  * Anthropic 特殊处理：如果 baseUrl 已包含 /v1，则不重复添加。
  */
 function buildPreviewUrl(baseUrl: string, provider: ProviderType): string {
-  const trimmed = baseUrl.trim().replace(/\/+$/, '')
+  let trimmed = baseUrl.trim().replace(/\/+$/, '')
 
   if (provider === 'anthropic') {
+    // 去除用户误填的 /messages 后缀，与 normalizeAnthropicBaseUrl 保持一致
+    trimmed = trimmed.replace(/\/messages$/, '')
     if (trimmed.match(/\/v\d+$/)) {
       return `${trimmed}/messages`
     }

--- a/packages/core/src/providers/url-utils.ts
+++ b/packages/core/src/providers/url-utils.ts
@@ -7,14 +7,18 @@
 /**
  * 规范化 Anthropic Base URL
  *
- * 去除尾部斜杠，如果没有版本路径则追加 /v1。
+ * 去除尾部斜杠，去除误填的 /messages 后缀，如果没有版本路径则追加 /v1。
  * 例如：
  * - "https://api.anthropic.com" → "https://api.anthropic.com/v1"
  * - "https://api.anthropic.com/v1" → 不变
  * - "https://proxy.example.com/v2/" → "https://proxy.example.com/v2"
+ * - "https://proxy.example.com/v1/messages" → "https://proxy.example.com/v1"
+ * - "https://proxy.example.com/v1/messages/" → "https://proxy.example.com/v1"
  */
 export function normalizeAnthropicBaseUrl(baseUrl: string): string {
   let url = baseUrl.trim().replace(/\/+$/, '')
+  // 去除用户误填的 /messages 后缀，避免后续拼接时路径重复
+  url = url.replace(/\/messages$/, '')
   if (!url.match(/\/v\d+$/)) {
     url = `${url}/v1`
   }


### PR DESCRIPTION
## 问题

用户在渠道设置中填写完整 API 地址（如 `https://xxx/v1/messages`）时，
normalizeAnthropicBaseUrl 和 Agent SDK 会再次拼接路径，导致实际请求地址变为
`/v1/messages/messages` 或 `/v1/messages/v1/messages`，服务端返回 400/404。

## 修复

在四处 Base URL 处理逻辑中自动 strip 用户误填的 `/messages` 后缀：

- `packages/core/src/providers/url-utils.ts` — normalizeAnthropicBaseUrl
- `apps/electron/src/main/lib/channel-manager.ts` — 本地重复定义的同名函数
- `apps/electron/src/renderer/components/settings/ChannelForm.tsx` — buildPreviewUrl
- `apps/electron/src/main/lib/agent-service.ts` — Agent 模式 ANTHROPIC_BASE_URL 注入

## 覆盖场景

无论用户填 `https://xxx`、`https://xxx/v1`、`https://xxx/v1/messages` 三种写法，Chat 模式和 Agent 模式均能正确工作。