### PR TITLE
feat: Agent 权限系统 + AskUserQuestion 交互式问答

### DIFF
--- a/apps/electron/src/main/lib/agent-permission-service.ts
+++ b/apps/electron/src/main/lib/agent-permission-service.ts
@@ -89,26 +89,26 @@ export class AgentPermissionService {
 
       // 自动模式：全部允许（理论上不会到这里，auto 模式使用 bypassPermissions）
       if (mode === 'auto') {
-        return { behavior: 'allow' as const, updatedInput: {} }
+        return { behavior: 'allow' as const, updatedInput: input }
       }
 
       // 智能模式：只读工具自动允许
       if (mode === 'smart') {
         if (this.isReadOnlyTool(toolName, input)) {
-          return { behavior: 'allow' as const, updatedInput: {} }
+          return { behavior: 'allow' as const, updatedInput: input }
         }
         if (this.isWhitelisted(sessionId, toolName, input)) {
-          return { behavior: 'allow' as const, updatedInput: {} }
+          return { behavior: 'allow' as const, updatedInput: input }
         }
       }
 
       // 监督模式：安全工具自动允许 + 检查白名单
       if (mode === 'supervised') {
         if (this.isReadOnlyTool(toolName, input)) {
-          return { behavior: 'allow' as const, updatedInput: {} }
+          return { behavior: 'allow' as const, updatedInput: input }
         }
         if (this.isWhitelisted(sessionId, toolName, input)) {
-          return { behavior: 'allow' as const, updatedInput: {} }
+          return { behavior: 'allow' as const, updatedInput: input }
         }
       }
 
@@ -148,7 +148,7 @@ export class AgentPermissionService {
 
     pending.resolve(
       behavior === 'allow'
-        ? { behavior: 'allow' as const, updatedInput: {} }
+        ? { behavior: 'allow' as const, updatedInput: pending.request.toolInput }
         : { behavior: 'deny' as const, message: '用户拒绝了此操作' }
     )
     this.pendingPermissions.delete(requestId)

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -19,6 +19,7 @@ import {
   getDefaultSkillsDir,
 } from './config-paths'
 import type { AgentWorkspace, WorkspaceMcpConfig, SkillMeta, WorkspaceCapabilities, PromaPermissionMode } from '@proma/shared'
+import { PROMA_PERMISSION_MODE_ORDER } from '@proma/shared'
 
 /**
  * 工作区索引文件格式
@@ -458,7 +459,13 @@ function writeWorkspaceConfig(workspaceSlug: string, config: WorkspaceConfig): v
  */
 export function getWorkspacePermissionMode(workspaceSlug: string): PromaPermissionMode {
   const config = readWorkspaceConfig(workspaceSlug)
-  return config.permissionMode ?? 'smart'
+  const mode = config.permissionMode
+  // 校验：无效值回退到 'smart'
+  if (mode && !PROMA_PERMISSION_MODE_ORDER.includes(mode as PromaPermissionMode)) {
+    console.warn(`[Agent 工作区] 无效的权限模式: ${mode}，回退到 smart`)
+    return 'smart'
+  }
+  return (mode as PromaPermissionMode) ?? 'smart'
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Agent 权限系统**：实现 auto/smart/supervised 三模式权限控制，支持工具分类（安全/只读/危险）、会话级白名单、PermissionBanner 交互式审批 UI
- **AskUserQuestion 交互式问答**：通过 `canUseTool` 拦截 + `updatedInput` 注入答案，在渲染进程展示选项按钮/自由文本/多选 UI，用户回答后注入答案回传 SDK
- **安全修复**：`hasDangerousStructure` 新增命令链接检测（`&&`、`;`、`$()`、反引号），`isWhitelisted` 对白名单命令重新验证完整命令安全性
- **关键 Bug 修复**：`updatedInput` 是替换语义，之前返回 `{}` 会清空工具原始输入，导致 smart/supervised 模式下用户点"允许"后 Write/Bash 等工具静默失败

### 架构

```
LLM tool_use → SDK canUseTool 回调
  → AgentPermissionService（权限判断）
  → AgentAskUserService（问答拦截）
  → IPC → 渲染进程 Jotai atom
  → PermissionBanner / AskUserBanner UI
  → 用户操作 → IPC 回传 → resolve Promise
```

### 变更文件

| 文件 | 说明 |
|------|------|
| `packages/shared/src/types/agent.ts` | 新增权限/问答类型、IPC 通道、AgentEvent 变体 |
| `packages/shared/src/constants/permission-rules.ts` | 工具分类规则 + 安全修复 |
| `apps/electron/src/main/lib/agent-permission-service.ts` | 权限服务（canUseTool + 白名单 + updatedInput 修复） |
| `apps/electron/src/main/lib/agent-ask-user-service.ts` | AskUser 问答服务（Promise+Map 模式） |
| `apps/electron/src/main/lib/agent-service.ts` | 集成权限/问答服务 |
| `apps/electron/src/main/lib/agent-workspace-manager.ts` | 权限模式配置校验 |
| `apps/electron/src/main/ipc.ts` | IPC handler 注册 |
| `apps/electron/src/preload/index.ts` | Preload bridge 扩展 |
| `apps/electron/src/renderer/atoms/agent-atoms.ts` | Jotai 状态管理 |
| `apps/electron/src/renderer/components/agent/AgentView.tsx` | IPC 订阅 + UI 渲染 |
| `apps/electron/src/renderer/components/agent/AskUserBanner.tsx` | 交互式问答 UI 组件 |

## Test plan

- [ ] smart 模式下 Agent 写入文件 → PermissionBanner → 点"允许" → 文件成功创建
- [ ] smart 模式下 Agent 执行 Bash → 允许后命令正确执行（非空输出）
- [ ] "总是允许"后同类操作自动放行
- [ ] AskUserQuestion 弹出交互式 UI（选项按钮 + 自由文本 + 多选）
- [ ] 用户选择后 Agent 收到正确答案继续执行
- [ ] Enter 键在自由文本输入框中触发提交
- [ ] 会话切换/结束时清理 pending 请求
- [ ] auto 模式下权限自动放行、AskUserQuestion 降级为文本输出
- [ ] 无效权限模式配置（如 "write"）回退到 smart
- [ ] `bun run typecheck` 全部通过