### PR TITLE
fix: support symlinked skill directories in workspace

### DIFF
--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -8,7 +8,7 @@
  * 照搬 agent-session-manager.ts 的 readIndex/writeIndex 模式。
  */
 
-import { readFileSync, writeFileSync, existsSync, readdirSync, cpSync, rmSync, mkdirSync } from 'node:fs'
+import { readFileSync, writeFileSync, existsSync, readdirSync, cpSync, rmSync, mkdirSync, statSync } from 'node:fs'
 import { randomUUID } from 'node:crypto'
 import { join } from 'node:path'
 import {
@@ -329,7 +329,8 @@ export function getWorkspaceSkills(workspaceSlug: string): SkillMeta[] {
     const entries = readdirSync(skillsDir, { withFileTypes: true })
 
     for (const entry of entries) {
-      if (!entry.isDirectory()) continue
+      const isDir = entry.isDirectory() || (entry.isSymbolicLink() && statSync(join(skillsDir, entry.name)).isDirectory())
+      if (!isDir) continue
 
       const skillMdPath = join(skillsDir, entry.name, 'SKILL.md')
       if (!existsSync(skillMdPath)) continue


### PR DESCRIPTION
## Problem

`getWorkspaceSkills()` uses `readdirSync()` with `{ withFileTypes: true }` and checks `entry.isDirectory()` to filter skill directories. However, Node.js `Dirent.isDirectory()` returns `false` for symbolic links, causing symlinked skill folders to be silently skipped.

This prevents users from sharing skills across tools (e.g., Claude Code ↔ Proma) via symlinks.

## Fix

Add an `isSymbolicLink()` check with `statSync()` to follow symlinks and correctly identify the directories they point to:

```typescript
const isDir = entry.isDirectory() || (entry.isSymbolicLink() && statSync(join(skillsDir, entry.name)).isDirectory())
```

## Verification

Tested locally — symlinked skill directories are now correctly discovered and loaded.