### PR TITLE
feat: 添加 Agent 会话归档和搜索功能

### DIFF
--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -159,7 +159,7 @@ export function appendAgentMessage(id: string, message: AgentMessage): void {
  */
 export function updateAgentSessionMeta(
   id: string,
-  updates: Partial<Pick<AgentSessionMeta, 'title' | 'channelId' | 'sdkSessionId' | 'workspaceId'>>,
+  updates: Partial<Pick<AgentSessionMeta, 'title' | 'channelId' | 'sdkSessionId' | 'workspaceId' | 'archived'>>,
 ): AgentSessionMeta {
   const index = readIndex()
   const idx = index.sessions.findIndex((s) => s.id === id)

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -444,6 +444,55 @@ export const currentAgentSessionDraftAtom = atom(
   }
 )
 
+// ===== 会话归档与搜索 =====
+
+/** 归档视图切换 */
+export const showArchivedSessionsAtom = atom<boolean>(false)
+
+/** 会话搜索关键词 */
+export const sessionSearchKeywordAtom = atom<string>('')
+
+/** 获取活跃会话（按工作区过滤 + 排除归档） */
+export const activeAgentSessionsAtom = atom((get) => {
+  const sessions = get(agentSessionsAtom)
+  const currentWorkspaceId = get(currentAgentWorkspaceIdAtom)
+  return sessions.filter(
+    (s) => s.workspaceId === currentWorkspaceId && !s.archived,
+  )
+})
+
+/** 获取归档会话 */
+export const archivedAgentSessionsAtom = atom((get) => {
+  const sessions = get(agentSessionsAtom)
+  const currentWorkspaceId = get(currentAgentWorkspaceIdAtom)
+  return sessions.filter(
+    (s) => s.workspaceId === currentWorkspaceId && s.archived,
+  )
+})
+
+/** 过滤后的会话列表（结合工作区、归档状态、搜索关键词） */
+export const filteredAgentSessionsAtom = atom((get) => {
+  const sessions = get(agentSessionsAtom)
+  const currentWorkspaceId = get(currentAgentWorkspaceIdAtom)
+  const showArchived = get(showArchivedSessionsAtom)
+  const keyword = get(sessionSearchKeywordAtom)
+
+  return sessions.filter((s) => {
+    // 工作区筛选
+    if (s.workspaceId !== currentWorkspaceId) return false
+
+    // 归档状态筛选
+    if (showArchived !== !!s.archived) return false
+
+    // 关键词搜索
+    if (keyword.trim()) {
+      return s.title.toLowerCase().includes(keyword.toLowerCase())
+    }
+
+    return true
+  })
+})
+
 // ===== 后台任务管理 =====
 
 /**

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -174,6 +174,8 @@ export interface AgentSessionMeta {
   createdAt: number
   /** 更新时间戳 */
   updatedAt: number
+  /** 是否已归档 */
+  archived?: boolean
 }
 
 /**
@@ -396,6 +398,8 @@ export const AGENT_IPC_CHANNELS = {
   UPDATE_TITLE: 'agent:update-title',
   /** 删除会话 */
   DELETE_SESSION: 'agent:delete-session',
+  /** 切换归档状态 */
+  TOGGLE_ARCHIVE: 'agent:toggle-archive',
 
   // 工作区管理
   /** 获取工作区列表 */


### PR DESCRIPTION
## 功能描述

本 PR 为 Agent 模式添加会话归档和搜索功能，提升会话管理体验。

## 主要改动

### 类型定义 (packages/shared/src/types/agent.ts)
- 在 `AgentSessionMeta` 类型中添加 `archived?: boolean` 字段支持会话归档
- 在 `AGENT_IPC_CHANNELS` 常量中添加 `TOGGLE_ARCHIVE: 'agent:toggle-archive'` 通道

### 主进程 (apps/electron/src/main)
- **ipc.ts**: 新增 `TOGGLE_ARCHIVE` IPC 处理器，切换会话归档状态
- **agent-session-manager.ts**: `updateAgentSessionMeta` 函数支持更新 `archived` 字段

### Preload 桥接 (apps/electron/src/preload/index.ts)
- 暴露 `toggleArchiveAgentSession(id: string)` API 供渲染进程调用

### 前端状态管理 (apps/electron/src/renderer/atoms/agent-atoms.ts)
- `showArchivedSessionsAtom`: 控制归档/活跃会话视图切换
- `sessionSearchKeywordAtom`: 会话搜索关键词状态
- `activeAgentSessionsAtom`: 派生 atom，获取当前工作区的活跃会话
- `archivedAgentSessionsAtom`: 派生 atom，获取当前工作区的归档会话
- `filteredAgentSessionsAtom`: 组合过滤（工作区 + 归档状态 + 关键词搜索）

### UI 界面 (apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx)
- **归档切换**: 侧边栏顶部添加"活跃"和"归档"切换按钮
- **搜索功能**: 支持按会话标题实时搜索
- **快捷操作**: 会话项悬停时显示归档/取消归档图标按钮（通过 `extraButton` 实现，与删除按钮并排）
- **空状态**: 根据当前视图显示对应的空状态提示

## 测试清单

- [ ] 归档/取消归档会话功能正常
- [ ] 归档视图和活跃视图切换正常
- [ ] 搜索功能可按标题过滤会话
- [ ] 归档状态持久化（重启应用后保留）
- [ ] 切换工作区时会话列表正确过滤

联系方式：david.liu1888888@gmail.com