### PR TITLE
fix: 修复代理配置重启后丢失的问题

### DIFF
--- a/apps/electron/src/main/lib/proxy-settings-service.ts
+++ b/apps/electron/src/main/lib/proxy-settings-service.ts
@@ -5,7 +5,7 @@
  * 配置文件存储在 ~/.proma/proxy-settings.json。
  */
 
-import { existsSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import type { ProxyConfig } from '@proma/shared'
 import { getProxySettingsPath } from './config-paths'
 import { detectSystemProxy } from './system-proxy-detector'
@@ -33,9 +33,8 @@ export async function getProxySettings(): Promise<ProxyConfig> {
   }
 
   try {
-    const file = Bun.file(configPath)
-    const config = (await file.json()) as ProxyConfig
-    return config
+    const raw = readFileSync(configPath, 'utf-8')
+    return JSON.parse(raw) as ProxyConfig
   } catch (error) {
     console.error('[代理配置] 读取配置失败:', error)
     return DEFAULT_PROXY_CONFIG
@@ -51,7 +50,7 @@ export async function saveProxySettings(config: ProxyConfig): Promise<void> {
   const configPath = getProxySettingsPath()
 
   try {
-    await Bun.write(configPath, JSON.stringify(config, null, 2))
+    writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8')
     console.log('[代理配置] 配置已保存:', config)
   } catch (error) {
     console.error('[代理配置] 保存配置失败:', error)


### PR DESCRIPTION
## 问题

代理设置开启后，重启应用代理配置会丢失，每次都回退到默认关闭状态。

## 原因

`proxy-settings-service.ts` 是 `main/lib/` 中唯一使用 `Bun.file` / `Bun.write` 的文件。Electron 主进程运行在 Node.js 运行时中，`Bun` 全局对象不可用，导致读写操作在 try/catch 中静默失败，每次启动都返回默认配置（`enabled: false`）。

## 修复

将 `Bun.file` / `Bun.write` 替换为 `readFileSync` / `writeFileSync`（`node:fs`），与其他服务（settings-service、channel-manager 等）保持一致。

## 变更文件

- `apps/electron/src/main/lib/proxy-settings-service.ts`