### PR TITLE
feat: Agent 建议芯片 UI 替代 placeholder

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -16,7 +16,7 @@
 import * as React from 'react'
 import { useAtom, useAtomValue, useSetAtom, useStore } from 'jotai'
 import { toast } from 'sonner'
-import { Bot, CornerDownLeft, Square, Settings, Paperclip, FolderPlus, AlertCircle, X, FolderOpen, Copy, Check } from 'lucide-react'
+import { Bot, CornerDownLeft, Square, Settings, Paperclip, FolderPlus, AlertCircle, X, FolderOpen, Copy, Check, Sparkles } from 'lucide-react'
 import { AgentMessages } from './AgentMessages'
 import { AgentHeader } from './AgentHeader'
 import { ContextUsageBadge } from './ContextUsageBadge'
@@ -583,7 +583,7 @@ export function AgentView(): React.ReactElement {
     }
   }, [agentError])
 
-  const canSend = (inputContent.trim().length > 0 || pendingFiles.length > 0 || pendingFolderRefs.length > 0 || !!suggestion) && agentChannelId !== null && !streaming
+  const canSend = (inputContent.trim().length > 0 || pendingFiles.length > 0 || pendingFolderRefs.length > 0) && agentChannelId !== null && !streaming
 
   // 无当前会话 → 引导文案
   if (!currentSessionId) {
@@ -691,6 +691,32 @@ export function AgentView(): React.ReactElement {
               </div>
             )}
 
+            {/* Agent 建议提示 */}
+            {suggestion && !streaming && (
+              <div className="px-3 pb-1.5">
+                <button
+                  type="button"
+                  className="group flex items-start gap-2 w-full rounded-lg border border-dashed border-primary/30 bg-primary/[0.03] px-3 py-2.5 text-left text-sm transition-colors hover:border-primary/50 hover:bg-primary/[0.06]"
+                  onClick={handleSend}
+                >
+                  <Sparkles className="size-4 shrink-0 mt-0.5 text-primary/60 group-hover:text-primary/80" />
+                  <span className="flex-1 min-w-0 text-foreground/80 group-hover:text-foreground line-clamp-3">{suggestion}</span>
+                  <X
+                    className="size-3.5 shrink-0 mt-0.5 text-muted-foreground/40 hover:text-foreground transition-colors"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      setPromptSuggestions((prev) => {
+                        if (!currentSessionId || !prev.has(currentSessionId)) return prev
+                        const map = new Map(prev)
+                        map.delete(currentSessionId)
+                        return map
+                      })
+                    }}
+                  />
+                </button>
+              </div>
+            )}
+
             <RichTextInput
               value={inputContent}
               onChange={setInputContent}
@@ -698,12 +724,9 @@ export function AgentView(): React.ReactElement {
               onPasteFiles={handlePasteFiles}
               placeholder={
                 agentChannelId
-                  ? suggestion
-                    ? `${suggestion} (Proma Agent 提供，按下回车自动发送，或手动输入)`
-                    : '输入消息... (Enter 发送，Shift+Enter 换行)'
+                  ? '输入消息... (Enter 发送，Shift+Enter 换行)'
                   : '请先在设置中选择 Agent 供应商'
               }
-              suggestionActive={!!suggestion && inputContent.trim().length === 0}
               disabled={!agentChannelId}
               autoFocusTrigger={currentSessionId}
             />


### PR DESCRIPTION
## Summary
- Agent 完成运行后的 prompt suggestion 改为输入框上方的可点击虚线边框芯片，替代之前不可靠的 TipTap placeholder 方案
- 点击芯片发送建议，右侧 X 可关闭，用户手动输入发送时自动清除
- 仅修改 `AgentView.tsx` 一个文件

## Test plan
- [ ] Agent 运行完成后，输入框上方出现虚线边框的建议芯片
- [ ] 点击芯片，建议内容作为消息发送
- [ ] 点击 X 按钮，芯片消失且不发送
- [ ] 用户在输入框手动输入消息并发送后，建议芯片被清除
- [ ] Agent 流式运行中不显示芯片（streaming 状态下隐藏）