### PR TITLE
feat: 窗口启动时默认最大化显示

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -107,8 +107,9 @@ function createWindow(): void {
     mainWindow.loadFile(join(__dirname, 'renderer', 'index.html'))
   }
 
-  // Show main window when ready
+  // 窗口就绪后最大化显示
   mainWindow.once('ready-to-show', () => {
+    mainWindow?.maximize()
     mainWindow?.show()
   })
 


### PR DESCRIPTION
## Summary
- 窗口 `ready-to-show` 时先调用 `maximize()` 再 `show()`，使应用启动即占满全屏
- 原有 `width: 1400, height: 900` 作为取消最大化后的回退尺寸保留

## Test plan
- [ ] 启动应用，确认窗口默认最大化
- [ ] 取消最大化后，窗口恢复到合理尺寸
- [ ] macOS 关闭窗口后通过 Dock 重新打开，确认仍为最大化