### PR TITLE
feat: 纤细滚动条替代隐藏滚动条

### DIFF
--- a/apps/electron/src/renderer/components/ai-elements/conversation.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/conversation.tsx
@@ -25,7 +25,7 @@ export type ConversationProps = ComponentProps<typeof StickToBottom>
 export function Conversation({ className, ...props }: ConversationProps): React.ReactElement {
   return (
     <StickToBottom
-      className={cn('relative flex-1 overflow-y-hidden scrollbar-none', className)}
+      className={cn('relative flex-1 overflow-y-hidden scrollbar-thin', className)}
       initial="instant"
       resize="smooth"
       role="log"

--- a/apps/electron/src/renderer/components/chat/ParallelChatMessages.tsx
+++ b/apps/electron/src/renderer/components/chat/ParallelChatMessages.tsx
@@ -173,7 +173,7 @@ function MessageColumn({
   return (
     <div
       ref={scrollRef}
-      className="flex-1 min-h-0 overflow-y-auto scrollbar-none overscroll-contain"
+      className="flex-1 min-h-0 overflow-y-auto scrollbar-thin overscroll-contain"
     >
       <div className="flex flex-col gap-6 p-4">
         {messages.map((message) => (

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -86,6 +86,30 @@
   display: none;
 }
 
+/* 纤细滚动条 */
+.scrollbar-thin,
+.scrollbar-thin > * {
+  scrollbar-width: thin;
+  scrollbar-color: hsl(var(--muted-foreground) / 0.3) transparent;
+}
+.scrollbar-thin::-webkit-scrollbar,
+.scrollbar-thin > *::-webkit-scrollbar {
+  width: 6px;
+}
+.scrollbar-thin::-webkit-scrollbar-track,
+.scrollbar-thin > *::-webkit-scrollbar-track {
+  background: transparent;
+}
+.scrollbar-thin::-webkit-scrollbar-thumb,
+.scrollbar-thin > *::-webkit-scrollbar-thumb {
+  background-color: hsl(var(--muted-foreground) / 0.3);
+  border-radius: 3px;
+}
+.scrollbar-thin::-webkit-scrollbar-thumb:hover,
+.scrollbar-thin > *::-webkit-scrollbar-thumb:hover {
+  background-color: hsl(var(--muted-foreground) / 0.5);
+}
+
 /* 滚动区域上下渐隐遮罩 */
 .mask-fade-y {
   mask-image: linear-gradient(


### PR DESCRIPTION
## Summary
- 将对话区域和并排模式的 `scrollbar-none` 替换为 `scrollbar-thin`
- 添加 6px 宽度的半透明纤细滚动条样式，提升内容浏览体验

## Changes
- `conversation.tsx`: scrollbar-none → scrollbar-thin
- `ParallelChatMessages.tsx`: scrollbar-none → scrollbar-thin
- `globals.css`: 新增 `.scrollbar-thin` 样式（支持 webkit 和标准属性）