### PR TITLE
feat: 纤细滚动条 + 消息导航迷你地图

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentHeader.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentHeader.tsx
@@ -86,14 +86,20 @@ export function AgentHeader(): React.ReactElement | null {
           </button>
         </div>
       ) : (
-        <button
-          type="button"
-          onClick={startEdit}
-          className="titlebar-no-drag group flex items-center gap-1.5 text-sm font-medium text-foreground hover:text-foreground/80 transition-colors truncate flex-1 min-w-0"
-        >
-          <span className="truncate">{session.title}</span>
-          <Pencil className="size-3 opacity-40 group-hover:opacity-70 transition-opacity flex-shrink-0" />
-        </button>
+        <div className="flex items-center gap-1.5 flex-1 min-w-0">
+          <span className="truncate text-sm font-medium text-foreground">
+            {session.title}
+          </span>
+          <button
+            type="button"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={startEdit}
+            className="titlebar-no-drag p-1 text-muted-foreground hover:text-foreground transition-colors"
+            aria-label="编辑标题"
+          >
+            <Pencil className="size-3.5" />
+          </button>
+        </div>
       )}
     </div>
   )

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -820,52 +820,54 @@ export function AgentView(): React.ReactElement {
         </div>
       </div>
 
-      {/* 文件浏览器侧栏 — 始终渲染同一个切换按钮 */}
-      {sessionPath && (
-        <div
-          className={cn(
-            'relative flex-shrink-0 transition-[width] duration-300 ease-in-out overflow-hidden',
-            fileBrowserOpen ? 'w-[300px] border-l' : 'w-10'
-          )}
-        >
-          {/* 切换按钮 — 始终固定在右上角，同一个 DOM 元素 */}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                className="absolute right-2.5 top-2.5 z-10 h-7 w-7"
-                onClick={() => setFileBrowserOpen((prev) => !prev)}
-              >
-                <FolderOpen
-                  className={cn(
-                    'size-3.5 absolute transition-all duration-200',
-                    fileBrowserOpen ? 'opacity-0 rotate-90 scale-75' : 'opacity-100 rotate-0 scale-100'
-                  )}
-                />
-                <X
-                  className={cn(
-                    'size-3.5 absolute transition-all duration-200',
-                    fileBrowserOpen ? 'opacity-100 rotate-0 scale-100' : 'opacity-0 -rotate-90 scale-75'
-                  )}
-                />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="left">
-              <p>{fileBrowserOpen ? '关闭文件浏览器' : '打开文件浏览器'}</p>
-            </TooltipContent>
-          </Tooltip>
+      {/* 文件浏览器侧栏 — 始终渲染 w-10 占位，避免切换模式时布局跳动 */}
+      <div
+        className={cn(
+          'relative flex-shrink-0 transition-[width] duration-300 ease-in-out overflow-hidden titlebar-drag-region',
+          sessionPath && fileBrowserOpen ? 'w-[300px] border-l' : 'w-10'
+        )}
+      >
+        {sessionPath && (
+          <>
+            {/* 切换按钮 — 始终固定在右上角，同一个 DOM 元素 */}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="absolute right-2.5 top-2.5 z-10 h-7 w-7 titlebar-no-drag"
+                  onClick={() => setFileBrowserOpen((prev) => !prev)}
+                >
+                  <FolderOpen
+                    className={cn(
+                      'size-3.5 absolute transition-all duration-200',
+                      fileBrowserOpen ? 'opacity-0 rotate-90 scale-75' : 'opacity-100 rotate-0 scale-100'
+                    )}
+                  />
+                  <X
+                    className={cn(
+                      'size-3.5 absolute transition-all duration-200',
+                      fileBrowserOpen ? 'opacity-100 rotate-0 scale-100' : 'opacity-0 -rotate-90 scale-75'
+                    )}
+                  />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="left">
+                <p>{fileBrowserOpen ? '关闭文件浏览器' : '打开文件浏览器'}</p>
+              </TooltipContent>
+            </Tooltip>
 
-          {/* FileBrowser 内容 — 收起时隐藏 */}
-          <div className={cn(
-            'w-[300px] h-full transition-opacity duration-300',
-            fileBrowserOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'
-          )}>
-            <FileBrowser rootPath={sessionPath} />
-          </div>
-        </div>
-      )}
+            {/* FileBrowser 内容 — 收起时隐藏 */}
+            <div className={cn(
+              'w-[300px] h-full transition-opacity duration-300 titlebar-no-drag',
+              fileBrowserOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'
+            )}>
+              <FileBrowser rootPath={sessionPath} />
+            </div>
+          </>
+        )}
+      </div>
     </div>
   )
 }

--- a/apps/electron/src/renderer/components/ai-elements/conversation.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/conversation.tsx
@@ -25,7 +25,7 @@ export type ConversationProps = ComponentProps<typeof StickToBottom>
 export function Conversation({ className, ...props }: ConversationProps): React.ReactElement {
   return (
     <StickToBottom
-      className={cn('relative flex-1 overflow-y-hidden scrollbar-thin', className)}
+      className={cn('relative flex-1 overflow-y-hidden scrollbar-none', className)}
       initial="instant"
       resize="smooth"
       role="log"

--- a/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
@@ -1,0 +1,164 @@
+/**
+ * ScrollMinimap — 消息导航迷你地图
+ *
+ * 在消息区域右上角显示短横杠代表每条消息的位置，
+ * 悬浮时弹出消息预览列表，点击可跳转到对应消息。
+ * 必须放在 StickToBottom（Conversation）内部使用。
+ */
+
+import * as React from 'react'
+import { AlertTriangle } from 'lucide-react'
+import { useStickToBottomContext } from 'use-stick-to-bottom'
+import { UserAvatar } from '@/components/chat/UserAvatar'
+import { getModelLogo } from '@/lib/model-logo'
+import { cn } from '@/lib/utils'
+
+export interface MinimapItem {
+  id: string
+  role: 'user' | 'assistant' | 'status'
+  preview: string
+  avatar?: string
+  model?: string
+}
+
+interface ScrollMinimapProps {
+  items: MinimapItem[]
+}
+
+/** 最少消息数才显示迷你地图 */
+const MIN_ITEMS = 4
+
+export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement | null {
+  const { scrollRef } = useStickToBottomContext()
+  const [hovered, setHovered] = React.useState(false)
+  const [visibleIds, setVisibleIds] = React.useState<Set<string>>(new Set())
+  const closeTimerRef = React.useRef<ReturnType<typeof setTimeout>>()
+  const [canScroll, setCanScroll] = React.useState(false)
+
+  React.useEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+
+    const update = (): void => {
+      const { scrollTop, scrollHeight, clientHeight } = el
+      setCanScroll(scrollHeight > clientHeight + 10)
+      if (scrollHeight <= 0) return
+
+      const nodes = el.querySelectorAll<HTMLElement>('[data-message-id]')
+      const ids = new Set<string>()
+      for (const node of nodes) {
+        const top = node.offsetTop
+        const bottom = top + node.offsetHeight
+        if (bottom > scrollTop && top < scrollTop + clientHeight) {
+          const id = node.getAttribute('data-message-id')
+          if (id) ids.add(id)
+        }
+      }
+      setVisibleIds(ids)
+    }
+
+    update()
+    el.addEventListener('scroll', update, { passive: true })
+    const observer = new ResizeObserver(update)
+    observer.observe(el)
+
+    return () => {
+      el.removeEventListener('scroll', update)
+      observer.disconnect()
+    }
+  }, [scrollRef, items])
+
+  const handleMouseEnter = (): void => {
+    if (closeTimerRef.current) clearTimeout(closeTimerRef.current)
+    setHovered(true)
+  }
+
+  const handleMouseLeave = (): void => {
+    closeTimerRef.current = setTimeout(() => setHovered(false), 150)
+  }
+
+  const scrollToMessage = React.useCallback((id: string) => {
+    const el = scrollRef.current
+    if (!el) return
+    const target = el.querySelector(`[data-message-id="${id}"]`)
+    target?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  }, [scrollRef])
+
+  if (items.length < MIN_ITEMS || !canScroll) return null
+
+  // 迷你地图高度：紧凑排列在右上角，每条消息占 6px
+  const stripHeight = Math.min(items.length * 6, 120)
+
+  return (
+    <div
+      className="absolute right-0 top-0 bottom-0 z-10 flex items-start"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      {/* 悬浮弹出面板 */}
+      {hovered && (
+        <div className="mt-3 mr-1 w-[260px] rounded-lg border bg-popover shadow-lg animate-in fade-in-0 zoom-in-95 duration-150">
+          <div className="max-h-[30vh] overflow-y-auto scrollbar-none p-2 space-y-0.5">
+            {items.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                className={cn(
+                  'flex items-start gap-2 w-full rounded-md px-2 py-1.5 text-left transition-colors hover:bg-accent',
+                  visibleIds.has(item.id) && 'bg-accent/50'
+                )}
+                onClick={() => scrollToMessage(item.id)}
+              >
+                <ItemIcon item={item} />
+                <span className="text-xs text-popover-foreground/80 line-clamp-2 flex-1 min-w-0">
+                  {item.preview || '(空消息)'}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* 迷你地图条 — 集中在右上角 */}
+      <div className="relative mt-3 flex-shrink-0" style={{ width: 24, height: stripHeight }}>
+        {items.map((item, i) => {
+          const top = ((i + 0.5) / items.length) * 100
+          const isVisible = visibleIds.has(item.id)
+          return (
+            <div
+              key={item.id}
+              className={cn(
+                'absolute left-1 h-[2px] w-[20px] rounded-full transition-colors',
+                isVisible
+                  ? 'bg-primary/60'
+                  : item.role === 'user'
+                    ? 'bg-muted-foreground/25'
+                    : 'bg-muted-foreground/45'
+              )}
+              style={{ top: `${top}%` }}
+            />
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function ItemIcon({ item }: { item: MinimapItem }): React.ReactElement {
+  if (item.role === 'user' && item.avatar) {
+    return <UserAvatar avatar={item.avatar} size={16} className="mt-0.5" />
+  }
+  if ((item.role === 'assistant') && item.model) {
+    return (
+      <img
+        src={getModelLogo(item.model)}
+        alt=""
+        className="size-4 shrink-0 mt-0.5 rounded-[20%] object-cover"
+      />
+    )
+  }
+  if (item.role === 'status') {
+    return <AlertTriangle className="size-4 shrink-0 mt-0.5 text-destructive" />
+  }
+  return <div className="size-4 shrink-0 mt-0.5 rounded-[20%] bg-muted" />
+}

--- a/apps/electron/src/renderer/components/chat/ChatHeader.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatHeader.tsx
@@ -6,16 +6,12 @@
 
 import * as React from 'react'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
-import { Pencil, Check, X, Columns2, Pin } from 'lucide-react'
-import { Button } from '@/components/ui/button'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
-import { cn } from '@/lib/utils'
+import { Pencil, Check, X, Pin, Columns2 } from 'lucide-react'
 import { currentConversationAtom, conversationsAtom, parallelModeAtom } from '@/atoms/chat-atoms'
 import { SystemPromptSelector } from './SystemPromptSelector'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
 
 export function ChatHeader(): React.ReactElement | null {
   const conversation = useAtomValue(currentConversationAtom)
@@ -26,8 +22,6 @@ export function ChatHeader(): React.ReactElement | null {
   const inputRef = React.useRef<HTMLInputElement>(null)
 
   if (!conversation) return null
-
-  const isPinned = !!conversation.pinned
 
   /** 进入编辑模式 */
   const startEdit = (): void => {
@@ -53,18 +47,6 @@ export function ChatHeader(): React.ReactElement | null {
       console.error('[ChatHeader] 更新标题失败:', error)
     }
     setEditing(false)
-  }
-
-  /** 切换置顶状态 */
-  const handleTogglePin = async (): Promise<void> => {
-    try {
-      const updated = await window.electronAPI.togglePinConversation(conversation.id)
-      setConversations((prev) =>
-        prev.map((c) => (c.id === updated.id ? updated : c))
-      )
-    } catch (error) {
-      console.error('[ChatHeader] 切换置顶失败:', error)
-    }
   }
 
   /** 键盘事件 */
@@ -124,48 +106,39 @@ export function ChatHeader(): React.ReactElement | null {
         </div>
       )}
 
-      {/* 右上角按钮组 — 绝对定位，与 Agent 侧统一 */}
-      <div className="absolute right-2.5 top-2.5 z-10 flex items-center gap-1 titlebar-no-drag">
+      {/* 右侧按钮组 */}
+      <div className="flex items-center gap-1 titlebar-no-drag ml-auto">
         <SystemPromptSelector />
-
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
               type="button"
               variant="ghost"
               size="icon"
-              className={cn(
-                'h-7 w-7',
-                isPinned && 'bg-accent text-accent-foreground'
-              )}
-              onClick={handleTogglePin}
+              className={cn('h-7 w-7', conversation.pinned && 'bg-accent text-accent-foreground')}
+              onClick={async () => {
+                const updated = await window.electronAPI.togglePinConversation(conversation.id)
+                setConversations((prev) => prev.map((c) => (c.id === updated.id ? updated : c)))
+              }}
             >
               <Pin className="size-3.5" />
             </Button>
           </TooltipTrigger>
-          <TooltipContent side="bottom">
-            <p>{isPinned ? '取消置顶' : '置顶对话'}</p>
-          </TooltipContent>
+          <TooltipContent side="bottom"><p>{conversation.pinned ? '取消置顶' : '置顶对话'}</p></TooltipContent>
         </Tooltip>
-
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
               type="button"
               variant="ghost"
               size="icon"
-              className={cn(
-                'h-7 w-7',
-                parallelMode && 'bg-accent text-accent-foreground'
-              )}
+              className={cn('h-7 w-7', parallelMode && 'bg-accent text-accent-foreground')}
               onClick={() => setParallelMode(!parallelMode)}
             >
               <Columns2 className="size-3.5" />
             </Button>
           </TooltipTrigger>
-          <TooltipContent side="bottom">
-            <p>{parallelMode ? '关闭并排模式' : '并排模式'}</p>
-          </TooltipContent>
+          <TooltipContent side="bottom"><p>{parallelMode ? '关闭并排模式' : '并排模式'}</p></TooltipContent>
         </Tooltip>
       </div>
     </div>

--- a/apps/electron/src/renderer/components/chat/ChatMessages.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessages.tsx
@@ -239,6 +239,18 @@ export function ChatMessages({
     }
   }, [parallelMode, hasMore, handleLoadMore])
 
+  // 迷你地图数据（必须在所有条件分支之前调用，遵守 hooks 规则）
+  const minimapItems: MinimapItem[] = React.useMemo(
+    () => messages.map((m) => ({
+      id: m.id,
+      role: m.role as MinimapItem['role'],
+      preview: m.content.slice(0, 80),
+      avatar: m.role === 'user' ? userProfile.avatar : undefined,
+      model: m.model,
+    })),
+    [messages, userProfile.avatar]
+  )
+
   // 并排模式
   if (parallelMode) {
     return (
@@ -262,18 +274,6 @@ export function ChatMessages({
 
   // 标准消息列表模式
   const dividerSet = new Set(contextDividers)
-
-  // 迷你地图数据
-  const minimapItems: MinimapItem[] = React.useMemo(
-    () => messages.map((m) => ({
-      id: m.id,
-      role: m.role as MinimapItem['role'],
-      preview: m.content.slice(0, 80),
-      avatar: m.role === 'user' ? userProfile.avatar : undefined,
-      model: m.model,
-    })),
-    [messages, userProfile.avatar]
-  )
 
   return (
     <Conversation className={ready ? 'opacity-100 transition-opacity duration-200' : 'opacity-0'}>

--- a/apps/electron/src/renderer/components/chat/ChatMessages.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessages.tsx
@@ -31,6 +31,8 @@ import {
   ConversationContent,
   ConversationScrollButton,
 } from '@/components/ai-elements/conversation'
+import { ScrollMinimap } from '@/components/ai-elements/scroll-minimap'
+import type { MinimapItem } from '@/components/ai-elements/scroll-minimap'
 import { useStickToBottomContext } from 'use-stick-to-bottom'
 import { ContextDivider } from '@/components/ai-elements/context-divider'
 import {
@@ -51,6 +53,7 @@ import {
   currentConversationIdAtom,
 } from '@/atoms/chat-atoms'
 import { getModelLogo } from '@/lib/model-logo'
+import { userProfileAtom } from '@/atoms/user-profile'
 import type { ChatMessage } from '@proma/shared'
 
 // ===== 滚动到顶部加载更多 =====
@@ -162,6 +165,7 @@ export function ChatMessages({
   onLoadMore,
 }: ChatMessagesProps): React.ReactElement {
   const messages = useAtomValue(currentMessagesAtom)
+  const userProfile = useAtomValue(userProfileAtom)
   const streaming = useAtomValue(streamingAtom)
   const streamingContent = useAtomValue(streamingContentAtom)
   const streamingReasoning = useAtomValue(streamingReasoningAtom)
@@ -259,6 +263,18 @@ export function ChatMessages({
   // 标准消息列表模式
   const dividerSet = new Set(contextDividers)
 
+  // 迷你地图数据
+  const minimapItems: MinimapItem[] = React.useMemo(
+    () => messages.map((m) => ({
+      id: m.id,
+      role: m.role as MinimapItem['role'],
+      preview: m.content.slice(0, 80),
+      avatar: m.role === 'user' ? userProfile.avatar : undefined,
+      model: m.model,
+    })),
+    [messages, userProfile.avatar]
+  )
+
   return (
     <Conversation className={ready ? 'opacity-100 transition-opacity duration-200' : 'opacity-0'}>
       {/* 滚动到顶部时自动加载更多历史 */}
@@ -275,18 +291,20 @@ export function ChatMessages({
             {/* 已有消息 + 分隔线 */}
             {messages.map((msg: ChatMessage) => (
               <React.Fragment key={msg.id}>
-                <ChatMessageItem
-                  message={msg}
-                  isStreaming={false}
-                  isLastAssistant={false}
-                  allMessages={messages}
-                  onDeleteMessage={onDeleteMessage}
-                  onResendMessage={onResendMessage}
-                  onStartInlineEdit={onStartInlineEdit}
-                  onSubmitInlineEdit={onSubmitInlineEdit}
-                  onCancelInlineEdit={onCancelInlineEdit}
-                  isInlineEditing={msg.id === inlineEditingMessageId}
-                />
+                <div data-message-id={msg.id}>
+                  <ChatMessageItem
+                    message={msg}
+                    isStreaming={false}
+                    isLastAssistant={false}
+                    allMessages={messages}
+                    onDeleteMessage={onDeleteMessage}
+                    onResendMessage={onResendMessage}
+                    onStartInlineEdit={onStartInlineEdit}
+                    onSubmitInlineEdit={onSubmitInlineEdit}
+                    onCancelInlineEdit={onCancelInlineEdit}
+                    isInlineEditing={msg.id === inlineEditingMessageId}
+                  />
+                </div>
                 {/* 分隔线 */}
                 {dividerSet.has(msg.id) && (
                   <ContextDivider
@@ -339,6 +357,7 @@ export function ChatMessages({
           </>
         )}
       </ConversationContent>
+      <ScrollMinimap items={minimapItems} />
       <ConversationScrollButton />
     </Conversation>
   )

--- a/apps/electron/src/renderer/components/chat/ChatView.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatView.tsx
@@ -612,10 +612,9 @@ export function ChatView(): React.ReactElement {
     <div className="flex h-full overflow-hidden">
       {/* 主内容区域 */}
       <div className="flex flex-col h-full flex-1 min-w-0">
-        <div className="flex flex-col h-full w-full max-w-[min(72rem,100%)] mx-auto overflow-hidden">
-          {/* 头部：对话标题 + 并排模式切换 */}
-          <ChatHeader />
-
+        {/* Header 在 max-w 外，按钮可到达最右侧 */}
+        <ChatHeader />
+        <div className="flex flex-col flex-1 w-full max-w-[min(72rem,100%)] mx-auto overflow-hidden min-h-0">
           {/* 中间：消息区域 */}
           <ChatMessages
             onDeleteMessage={handleDeleteMessage}
@@ -661,11 +660,11 @@ export function ChatView(): React.ReactElement {
 
       {/* 提示词编辑侧栏 */}
       <div className={cn(
-        'flex-shrink-0 transition-[width] duration-300 ease-in-out overflow-hidden',
-        promptSidebarOpen ? 'w-[300px] border-l' : 'w-0'
+        'relative flex-shrink-0 transition-[width] duration-300 ease-in-out overflow-hidden titlebar-drag-region',
+        promptSidebarOpen ? 'w-[300px] border-l' : 'w-10'
       )}>
         <div className={cn(
-          'w-[300px] h-full transition-opacity duration-200',
+          'w-[300px] h-full transition-opacity duration-200 titlebar-no-drag',
           promptSidebarOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'
         )}>
           <PromptEditorSidebar />

--- a/apps/electron/src/renderer/components/chat/ParallelChatMessages.tsx
+++ b/apps/electron/src/renderer/components/chat/ParallelChatMessages.tsx
@@ -173,7 +173,7 @@ function MessageColumn({
   return (
     <div
       ref={scrollRef}
-      className="flex-1 min-h-0 overflow-y-auto scrollbar-thin overscroll-contain"
+      className="flex-1 min-h-0 overflow-y-auto scrollbar-none overscroll-contain"
     >
       <div className="flex flex-col gap-6 p-4">
         {messages.map((message) => (

--- a/apps/electron/src/renderer/components/chat/SystemPromptSelector.tsx
+++ b/apps/electron/src/renderer/components/chat/SystemPromptSelector.tsx
@@ -46,7 +46,7 @@ export function SystemPromptSelector(): React.ReactElement {
           title={tooltipText}
           className="inline-flex items-center justify-center h-7 w-7 rounded-md text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
         >
-          <BookOpen className="size-3.5" />
+          <BookOpen className="size-4" />
         </button>
       </DropdownMenuTrigger>
 


### PR DESCRIPTION
## Summary
- 用纤细滚动条（scrollbar-thin）替代隐藏滚动条，提升长消息拖动效率
- 新增 ScrollMinimap 组件：右上角短横杠表示消息位置，悬浮弹出预览列表，点击跳转对应消息
- 集成到 Chat 和 Agent 两种模式的消息区域

## Changes
- `globals.css`: 新增 `.scrollbar-thin` CSS 类
- `conversation.tsx` / `ParallelChatMessages.tsx`: `scrollbar-none` → `scrollbar-thin`
- `scroll-minimap.tsx`: 新增 ScrollMinimap 组件（迷你地图导航）
- `ChatMessages.tsx` / `AgentMessages.tsx`: 集成 ScrollMinimap，添加 `data-message-id` 属性