### PR TITLE
feat: add usage statistics visualization (closes #13)

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -76,6 +76,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",
+    "recharts": "^3.7.0",
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^2.5.5",

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -5,7 +5,7 @@
  */
 
 import { ipcMain, nativeTheme, shell, dialog, BrowserWindow } from 'electron'
-import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, MEMORY_IPC_CHANNELS } from '@proma/shared'
+import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, MEMORY_IPC_CHANNELS, USAGE_IPC_CHANNELS } from '@proma/shared'
 import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS } from '../types'
 import type {
   RuntimeStatus,
@@ -52,6 +52,8 @@ import type {
   SystemPromptCreateInput,
   SystemPromptUpdateInput,
   MemoryConfig,
+  UsageQueryRange,
+  UsageSummary,
 } from '@proma/shared'
 import type { UserProfile, AppSettings } from '../types'
 import { getRuntimeStatus, getGitRepoStatus } from './lib/runtime-init'
@@ -117,6 +119,7 @@ import {
   setWorkspacePermissionMode,
 } from './lib/agent-workspace-manager'
 import { getMemoryConfig, setMemoryConfig } from './lib/memory-service'
+import { getUsageSummary, clearUsageStats } from './lib/usage-stats-service'
 import {
   getSystemPromptConfig,
   createSystemPrompt,
@@ -1019,6 +1022,24 @@ export function registerIpcHandlers(): void {
     GITHUB_RELEASE_IPC_CHANNELS.GET_RELEASE_BY_TAG,
     async (_, tag: string): Promise<GitHubRelease | null> => {
       return getReleaseByTag(tag)
+    }
+  )
+
+  // ===== 用量统计 =====
+
+  // 查询用量汇总
+  ipcMain.handle(
+    USAGE_IPC_CHANNELS.GET_SUMMARY,
+    async (_, range?: UsageQueryRange): Promise<UsageSummary> => {
+      return getUsageSummary(range)
+    }
+  )
+
+  // 清除用量记录
+  ipcMain.handle(
+    USAGE_IPC_CHANNELS.CLEAR,
+    async (): Promise<void> => {
+      clearUsageStats()
     }
   )
 

--- a/apps/electron/src/main/lib/config-paths.ts
+++ b/apps/electron/src/main/lib/config-paths.ts
@@ -166,6 +166,15 @@ export function getMemoryConfigPath(): string {
 }
 
 /**
+ * 获取用量统计文件路径
+ *
+ * @returns ~/.proma/usage-stats.json
+ */
+export function getUsageStatsPath(): string {
+  return join(getConfigDir(), 'usage-stats.json')
+}
+
+/**
  * 获取 Agent 会话索引文件路径
  *
  * @returns ~/.proma/agent-sessions.json

--- a/apps/electron/src/main/lib/usage-stats-service.ts
+++ b/apps/electron/src/main/lib/usage-stats-service.ts
@@ -1,0 +1,174 @@
+/**
+ * 用量统计服务
+ *
+ * 管理 Token 用量记录的读写和聚合查询。
+ * 数据存储在 ~/.proma/usage-stats.json，JSON 格式。
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { randomUUID } from 'node:crypto'
+import type { ProviderType, UsageRecord, UsageQueryRange, UsageSummary, DailyUsage, ModelUsage } from '@proma/shared'
+import { getUsageStatsPath } from './config-paths'
+
+// ===== 存储结构 =====
+
+/** 用量统计文件结构 */
+interface UsageStatsFile {
+  version: number
+  records: UsageRecord[]
+}
+
+/** 默认空数据 */
+const DEFAULT_STATS: UsageStatsFile = {
+  version: 1,
+  records: [],
+}
+
+// ===== 读写操作 =====
+
+/** 读取用量统计文件 */
+function readStats(): UsageStatsFile {
+  const filePath = getUsageStatsPath()
+
+  if (!existsSync(filePath)) {
+    return { ...DEFAULT_STATS, records: [] }
+  }
+
+  try {
+    const raw = readFileSync(filePath, 'utf-8')
+    const data = JSON.parse(raw) as Partial<UsageStatsFile>
+    return {
+      version: data.version ?? 1,
+      records: data.records ?? [],
+    }
+  } catch (error) {
+    console.warn('[用量统计] 读取失败，使用默认值:', error)
+    return { ...DEFAULT_STATS, records: [] }
+  }
+}
+
+/** 写入用量统计文件 */
+function writeStats(stats: UsageStatsFile): void {
+  const filePath = getUsageStatsPath()
+  writeFileSync(filePath, JSON.stringify(stats, null, 2), 'utf-8')
+}
+
+// ===== 公开 API =====
+
+/**
+ * 记录一条 Token 用量
+ */
+export function recordUsage(input: {
+  channelId: string
+  provider: ProviderType
+  modelId: string
+  inputTokens: number
+  outputTokens: number
+  mode: 'chat' | 'agent'
+}): void {
+  const stats = readStats()
+
+  const record: UsageRecord = {
+    id: randomUUID(),
+    timestamp: Date.now(),
+    channelId: input.channelId,
+    provider: input.provider,
+    modelId: input.modelId,
+    inputTokens: input.inputTokens,
+    outputTokens: input.outputTokens,
+    mode: input.mode,
+  }
+
+  stats.records.push(record)
+  writeStats(stats)
+}
+
+/**
+ * 查询用量汇总
+ *
+ * @param range 时间范围（可选，默认最近 30 天）
+ */
+export function getUsageSummary(range?: UsageQueryRange): UsageSummary {
+  const stats = readStats()
+
+  // 默认最近 30 天
+  const now = Date.now()
+  const from = range?.from ?? now - 30 * 24 * 60 * 60 * 1000
+  const to = range?.to ?? now
+
+  // 过滤范围内的记录
+  const filtered = stats.records.filter(
+    (r) => r.timestamp >= from && r.timestamp <= to
+  )
+
+  // 按日期聚合
+  const dailyMap = new Map<string, DailyUsage>()
+  for (const r of filtered) {
+    const date = new Date(r.timestamp).toISOString().slice(0, 10)
+    const existing = dailyMap.get(date)
+    if (existing) {
+      existing.inputTokens += r.inputTokens
+      existing.outputTokens += r.outputTokens
+      existing.requestCount += 1
+    } else {
+      dailyMap.set(date, {
+        date,
+        inputTokens: r.inputTokens,
+        outputTokens: r.outputTokens,
+        requestCount: 1,
+      })
+    }
+  }
+
+  // 按模型聚合
+  const modelMap = new Map<string, ModelUsage>()
+  for (const r of filtered) {
+    const key = `${r.provider}:${r.modelId}`
+    const existing = modelMap.get(key)
+    if (existing) {
+      existing.inputTokens += r.inputTokens
+      existing.outputTokens += r.outputTokens
+      existing.requestCount += 1
+    } else {
+      modelMap.set(key, {
+        modelId: r.modelId,
+        provider: r.provider,
+        inputTokens: r.inputTokens,
+        outputTokens: r.outputTokens,
+        requestCount: 1,
+      })
+    }
+  }
+
+  // 每日数据按日期排序
+  const daily = [...dailyMap.values()].sort((a, b) => a.date.localeCompare(b.date))
+
+  // 模型数据按总 token 降序
+  const byModel = [...modelMap.values()].sort(
+    (a, b) => (b.inputTokens + b.outputTokens) - (a.inputTokens + a.outputTokens)
+  )
+
+  // 总计
+  let totalInputTokens = 0
+  let totalOutputTokens = 0
+  for (const r of filtered) {
+    totalInputTokens += r.inputTokens
+    totalOutputTokens += r.outputTokens
+  }
+
+  return {
+    daily,
+    byModel,
+    totalInputTokens,
+    totalOutputTokens,
+    totalRequests: filtered.length,
+  }
+}
+
+/**
+ * 清除所有用量记录
+ */
+export function clearUsageStats(): void {
+  writeStats({ ...DEFAULT_STATS, records: [] })
+  console.log('[用量统计] 已清除所有记录')
+}

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -6,7 +6,7 @@
  */
 
 import { contextBridge, ipcRenderer } from 'electron'
-import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, MEMORY_IPC_CHANNELS } from '@proma/shared'
+import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, MEMORY_IPC_CHANNELS, USAGE_IPC_CHANNELS } from '@proma/shared'
 import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS } from '../types'
 import type {
   RuntimeStatus,
@@ -62,6 +62,8 @@ import type {
   SystemPromptCreateInput,
   SystemPromptUpdateInput,
   MemoryConfig,
+  UsageQueryRange,
+  UsageSummary,
 } from '@proma/shared'
 import type { UserProfile, AppSettings } from '../types'
 
@@ -417,6 +419,14 @@ export interface ElectronAPI {
   getLatestRelease: () => Promise<GitHubRelease | null>
   listReleases: (options?: GitHubReleaseListOptions) => Promise<GitHubRelease[]>
   getReleaseByTag: (tag: string) => Promise<GitHubRelease | null>
+
+  // ===== 用量统计 =====
+
+  /** 查询用量汇总 */
+  getUsageSummary: (range?: UsageQueryRange) => Promise<UsageSummary>
+
+  /** 清除用量记录 */
+  clearUsageStats: () => Promise<void>
 
   // 工作区文件变化通知
   onCapabilitiesChanged: (callback: () => void) => () => void
@@ -874,6 +884,14 @@ const electronAPI: ElectronAPI = {
 
   getReleaseByTag: (tag) => {
     return ipcRenderer.invoke(GITHUB_RELEASE_IPC_CHANNELS.GET_RELEASE_BY_TAG, tag)
+  },
+
+  // 用量统计
+  getUsageSummary: (range?) => {
+    return ipcRenderer.invoke(USAGE_IPC_CHANNELS.GET_SUMMARY, range)
+  },
+  clearUsageStats: () => {
+    return ipcRenderer.invoke(USAGE_IPC_CHANNELS.CLEAR)
   },
 }
 

--- a/apps/electron/src/renderer/atoms/settings-tab.ts
+++ b/apps/electron/src/renderer/atoms/settings-tab.ts
@@ -7,11 +7,12 @@
  * - proxy: 代理配置
  * - appearance: 外观设置
  * - about: 关于
+ * - usage: 用量统计
  */
 
 import { atom } from 'jotai'
 
-export type SettingsTab = 'general' | 'channels' | 'proxy' | 'appearance' | 'about' | 'agent' | 'prompts' | 'memory'
+export type SettingsTab = 'general' | 'channels' | 'proxy' | 'appearance' | 'about' | 'agent' | 'prompts' | 'memory' | 'usage'
 
 /** 当前设置标签页（不持久化，每次打开设置默认显示渠道） */
 export const settingsTabAtom = atom<SettingsTab>('channels')

--- a/apps/electron/src/renderer/atoms/usage-atoms.ts
+++ b/apps/electron/src/renderer/atoms/usage-atoms.ts
@@ -1,0 +1,14 @@
+/**
+ * Usage Atoms - 用量统计状态
+ *
+ * 管理用量统计数据的加载和缓存。
+ */
+
+import { atom } from 'jotai'
+import type { UsageSummary } from '@proma/shared'
+
+/** 用量汇总数据 */
+export const usageSummaryAtom = atom<UsageSummary | null>(null)
+
+/** 用量数据加载状态 */
+export const usageLoadingAtom = atom<boolean>(false)

--- a/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
+++ b/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
@@ -9,7 +9,7 @@
 import * as React from 'react'
 import { useAtom, useAtomValue } from 'jotai'
 import { cn } from '@/lib/utils'
-import { Settings, Radio, Palette, Info, Plug, Globe, BookOpen, Brain } from 'lucide-react'
+import { Settings, Radio, Palette, Info, Plug, Globe, BookOpen, Brain, BarChart3 } from 'lucide-react'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { settingsTabAtom } from '@/atoms/settings-tab'
 import type { SettingsTab } from '@/atoms/settings-tab'
@@ -24,6 +24,7 @@ import { AboutSettings } from './AboutSettings'
 import { AgentSettings } from './AgentSettings'
 import { PromptSettings } from './PromptSettings'
 import { MemorySettings } from './MemorySettings'
+import { UsageSettings } from './UsageSettings'
 
 /** 设置 Tab 定义 */
 interface TabItem {
@@ -43,6 +44,7 @@ const BASE_TABS: TabItem[] = [
 /** Agent 模式专属 Tab */
 const AGENT_TAB: TabItem = { id: 'agent', label: '配置', icon: <Plug size={16} /> }
 const MEMORY_TAB: TabItem = { id: 'memory', label: '记忆', icon: <Brain size={16} /> }
+const USAGE_TAB: TabItem = { id: 'usage', label: '用量', icon: <BarChart3 size={16} /> }
 
 /** 尾部 Tabs */
 const TAIL_TABS: TabItem[] = [
@@ -67,6 +69,8 @@ function renderTabContent(tab: SettingsTab): React.ReactElement {
       return <MemorySettings />
     case 'appearance':
       return <AppearanceSettings />
+    case 'usage':
+      return <UsageSettings />
     case 'about':
       return <AboutSettings />
   }
@@ -81,9 +85,9 @@ export function SettingsPanel(): React.ReactElement {
   // Agent 模式时在渠道后插入 Agent Tab，记忆 tab 两种模式都显示
   const tabs = React.useMemo(() => {
     if (appMode === 'agent') {
-      return [...BASE_TABS, AGENT_TAB, MEMORY_TAB, ...TAIL_TABS]
+      return [...BASE_TABS, AGENT_TAB, MEMORY_TAB, USAGE_TAB, ...TAIL_TABS]
     }
-    return [...BASE_TABS, MEMORY_TAB, ...TAIL_TABS]
+    return [...BASE_TABS, MEMORY_TAB, USAGE_TAB, ...TAIL_TABS]
   }, [appMode])
 
   return (

--- a/apps/electron/src/renderer/components/settings/UsageSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/UsageSettings.tsx
@@ -1,0 +1,293 @@
+/**
+ * UsageSettings - 用量统计页
+ *
+ * 展示 Token 消耗的可视化统计数据：
+ * - 总览数字（今日/本月 Token 总量）
+ * - 最近 30 天趋势图表（AreaChart）
+ * - 按模型分布明细
+ *
+ * 使用 recharts 绘制图表，遵循 SettingsSection/SettingsCard 视觉规范。
+ */
+
+import * as React from 'react'
+import { useAtom } from 'jotai'
+import { Loader2, Trash2, ArrowUpRight, ArrowDownRight } from 'lucide-react'
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts'
+import { Button } from '@/components/ui/button'
+import { SettingsSection, SettingsCard } from './primitives'
+import { usageSummaryAtom, usageLoadingAtom } from '@/atoms/usage-atoms'
+import type { UsageSummary, DailyUsage } from '@proma/shared'
+
+// ===== 工具函数 =====
+
+/** 格式化 token 数为可读字符串 */
+function formatTokens(count: number): string {
+  if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`
+  if (count >= 1_000) return `${(count / 1_000).toFixed(1)}K`
+  return String(count)
+}
+
+/** 格式化日期为短格式 (MM-DD) */
+function formatDate(dateStr: string): string {
+  return dateStr.slice(5) // "2024-03-01" → "03-01"
+}
+
+/** 获取今日日期字符串 */
+function getToday(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
+// ===== 子组件 =====
+
+/** 统计数字卡片 */
+function StatItem({ label, value, sub }: {
+  label: string
+  value: string
+  sub?: string
+}): React.ReactElement {
+  return (
+    <div className="flex-1 min-w-0">
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p className="text-2xl font-bold text-foreground mt-1">{value}</p>
+      {sub && <p className="text-xs text-muted-foreground mt-0.5">{sub}</p>}
+    </div>
+  )
+}
+
+/** 自定义 Tooltip */
+function ChartTooltip({ active, payload, label }: {
+  active?: boolean
+  payload?: Array<{ value: number; dataKey: string }>
+  label?: string
+}): React.ReactElement | null {
+  if (!active || !payload || payload.length === 0) return null
+
+  return (
+    <div className="rounded-lg bg-popover border border-border/50 shadow-md px-3 py-2 text-sm">
+      <p className="text-muted-foreground mb-1">{label}</p>
+      {payload.map((entry) => (
+        <div key={entry.dataKey} className="flex items-center gap-2">
+          {entry.dataKey === 'inputTokens' ? (
+            <ArrowUpRight size={12} className="text-blue-500" />
+          ) : (
+            <ArrowDownRight size={12} className="text-emerald-500" />
+          )}
+          <span className="text-foreground font-medium">
+            {formatTokens(entry.value)}
+          </span>
+          <span className="text-muted-foreground">
+            {entry.dataKey === 'inputTokens' ? '输入' : '输出'}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ===== 主组件 =====
+
+export function UsageSettings(): React.ReactElement {
+  const [summary, setSummary] = useAtom(usageSummaryAtom)
+  const [loading, setLoading] = useAtom(usageLoadingAtom)
+
+  /** 加载用量数据 */
+  const loadData = React.useCallback(async () => {
+    setLoading(true)
+    try {
+      const data = await window.electronAPI.getUsageSummary()
+      setSummary(data)
+    } catch (error) {
+      console.error('[用量统计] 加载失败:', error)
+    } finally {
+      setLoading(false)
+    }
+  }, [setSummary, setLoading])
+
+  React.useEffect(() => {
+    loadData()
+  }, [loadData])
+
+  /** 清除用量记录 */
+  const handleClear = React.useCallback(async () => {
+    try {
+      await window.electronAPI.clearUsageStats()
+      setSummary(null)
+    } catch (error) {
+      console.error('[用量统计] 清除失败:', error)
+    }
+  }, [setSummary])
+
+  if (loading && !summary) {
+    return (
+      <div className="text-sm text-muted-foreground py-8 text-center">
+        <Loader2 size={16} className="animate-spin inline mr-2" />
+        加载中...
+      </div>
+    )
+  }
+
+  // 计算今日数据
+  const today = getToday()
+  const todayData = summary?.daily.find((d) => d.date === today)
+  const todayTotal = todayData ? todayData.inputTokens + todayData.outputTokens : 0
+
+  return (
+    <div className="space-y-6">
+      {/* 总览 */}
+      <SettingsSection
+        title="用量统计"
+        description="查看 Token 消耗和 API 调用情况"
+        action={
+          summary && summary.totalRequests > 0 ? (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={handleClear}
+              className="text-muted-foreground"
+            >
+              <Trash2 size={14} className="mr-1.5" />
+              清除
+            </Button>
+          ) : undefined
+        }
+      >
+        <SettingsCard divided={false}>
+          <div className="flex gap-6 p-4">
+            <StatItem
+              label="今日消耗"
+              value={formatTokens(todayTotal)}
+              sub={todayData ? `${todayData.requestCount} 次请求` : '暂无数据'}
+            />
+            <StatItem
+              label="近 30 天总计"
+              value={formatTokens((summary?.totalInputTokens ?? 0) + (summary?.totalOutputTokens ?? 0))}
+              sub={`${summary?.totalRequests ?? 0} 次请求`}
+            />
+            <StatItem
+              label="输入 / 输出"
+              value={`${formatTokens(summary?.totalInputTokens ?? 0)} / ${formatTokens(summary?.totalOutputTokens ?? 0)}`}
+            />
+          </div>
+        </SettingsCard>
+      </SettingsSection>
+
+      {/* 趋势图表 */}
+      {summary && summary.daily.length > 0 && (
+        <SettingsSection title="近 30 天趋势">
+          <SettingsCard divided={false}>
+            <div className="p-4">
+              <ResponsiveContainer width="100%" height={220}>
+                <AreaChart
+                  data={summary.daily}
+                  margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
+                >
+                  <defs>
+                    <linearGradient id="inputGradient" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="5%" stopColor="hsl(217, 91%, 60%)" stopOpacity={0.3} />
+                      <stop offset="95%" stopColor="hsl(217, 91%, 60%)" stopOpacity={0} />
+                    </linearGradient>
+                    <linearGradient id="outputGradient" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="5%" stopColor="hsl(160, 84%, 39%)" stopOpacity={0.3} />
+                      <stop offset="95%" stopColor="hsl(160, 84%, 39%)" stopOpacity={0} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid
+                    strokeDasharray="3 3"
+                    stroke="hsl(var(--border))"
+                    opacity={0.5}
+                  />
+                  <XAxis
+                    dataKey="date"
+                    tickFormatter={formatDate}
+                    tick={{ fontSize: 11, fill: 'hsl(var(--muted-foreground))' }}
+                    axisLine={false}
+                    tickLine={false}
+                  />
+                  <YAxis
+                    tickFormatter={formatTokens}
+                    tick={{ fontSize: 11, fill: 'hsl(var(--muted-foreground))' }}
+                    axisLine={false}
+                    tickLine={false}
+                    width={45}
+                  />
+                  <Tooltip content={<ChartTooltip />} />
+                  <Area
+                    type="monotone"
+                    dataKey="inputTokens"
+                    stroke="hsl(217, 91%, 60%)"
+                    fill="url(#inputGradient)"
+                    strokeWidth={2}
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="outputTokens"
+                    stroke="hsl(160, 84%, 39%)"
+                    fill="url(#outputGradient)"
+                    strokeWidth={2}
+                  />
+                </AreaChart>
+              </ResponsiveContainer>
+              <div className="flex items-center justify-center gap-6 mt-3 text-xs text-muted-foreground">
+                <div className="flex items-center gap-1.5">
+                  <span className="w-3 h-0.5 rounded-full bg-blue-500" />
+                  输入 Token
+                </div>
+                <div className="flex items-center gap-1.5">
+                  <span className="w-3 h-0.5 rounded-full bg-emerald-500" />
+                  输出 Token
+                </div>
+              </div>
+            </div>
+          </SettingsCard>
+        </SettingsSection>
+      )}
+
+      {/* 模型分布 */}
+      {summary && summary.byModel.length > 0 && (
+        <SettingsSection title="按模型分布">
+          <SettingsCard>
+            {summary.byModel.map((model) => {
+              const total = model.inputTokens + model.outputTokens
+              return (
+                <div key={`${model.provider}:${model.modelId}`} className="flex items-center justify-between px-4 py-3">
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium text-foreground truncate">
+                      {model.modelId}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {model.provider} · {model.requestCount} 次请求
+                    </p>
+                  </div>
+                  <div className="text-right shrink-0 ml-4">
+                    <p className="text-sm font-medium text-foreground">
+                      {formatTokens(total)}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {formatTokens(model.inputTokens)} 入 / {formatTokens(model.outputTokens)} 出
+                    </p>
+                  </div>
+                </div>
+              )
+            })}
+          </SettingsCard>
+        </SettingsSection>
+      )}
+
+      {/* 空状态 */}
+      {summary && summary.totalRequests === 0 && (
+        <div className="rounded-lg bg-muted/50 p-6 text-center text-sm text-muted-foreground">
+          <p>暂无用量数据</p>
+          <p className="mt-1 text-xs">开始对话后，Token 用量将自动记录在这里</p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/core",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "license": "Apache-2.0",
   "description": "proma core types,storage and core logic with agents",
   "type": "module",

--- a/packages/core/src/providers/openai-adapter.ts
+++ b/packages/core/src/providers/openai-adapter.ts
@@ -60,6 +60,12 @@ interface OpenAIChunkData {
     }
     finish_reason?: string | null
   }>
+  /** 流式末尾的 usage 信息（需开启 stream_options） */
+  usage?: {
+    prompt_tokens?: number
+    completion_tokens?: number
+    total_tokens?: number
+  }
 }
 
 /** OpenAI 标题响应 */
@@ -192,6 +198,7 @@ export class OpenAIAdapter implements ProviderAdapter {
       model: input.modelId,
       messages,
       stream: true,
+      stream_options: { include_usage: true },
     }
 
     // 工具定义
@@ -253,6 +260,15 @@ export class OpenAIAdapter implements ProviderAdapter {
       const finishReason = chunk.choices?.[0]?.finish_reason
       if (finishReason === 'tool_calls') {
         events.push({ type: 'done', stopReason: 'tool_use' })
+      }
+
+      // 流式末尾的 usage 信息（stream_options.include_usage 开启时）
+      if (chunk.usage) {
+        events.push({
+          type: 'usage',
+          inputTokens: chunk.usage.prompt_tokens ?? 0,
+          outputTokens: chunk.usage.completion_tokens ?? 0,
+        })
       }
 
       return events

--- a/packages/core/src/providers/types.ts
+++ b/packages/core/src/providers/types.ts
@@ -123,6 +123,13 @@ export interface StreamToolCallDeltaEvent {
   argumentsDelta: string
 }
 
+/** Token 用量事件 */
+export interface StreamUsageEvent {
+  type: 'usage'
+  inputTokens: number
+  outputTokens: number
+}
+
 /** 所有流式事件的联合类型 */
 export type StreamEvent =
   | StreamChunkEvent
@@ -131,6 +138,7 @@ export type StreamEvent =
   | StreamDoneEvent
   | StreamToolCallStartEvent
   | StreamToolCallDeltaEvent
+  | StreamUsageEvent
 
 /** 流式事件回调函数 */
 export type StreamEventCallback = (event: StreamEvent) => void

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/shared",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "license": "Apache-2.0",
   "description": "Shared types, configs and utilities for proma",
   "type": "module",

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -59,6 +59,14 @@ export interface FileDialogResult {
  */
 export type MessageRole = 'user' | 'assistant' | 'system'
 
+/** Token 用量信息 */
+export interface MessageUsage {
+  /** 输入 token 数 */
+  inputTokens: number
+  /** 输出 token 数 */
+  outputTokens: number
+}
+
 /**
  * 聊天消息
  */
@@ -79,6 +87,8 @@ export interface ChatMessage {
   stopped?: boolean
   /** 文件附件列表 */
   attachments?: FileAttachment[]
+  /** Token 用量（assistant 消息，如果 Provider 返回了用量数据） */
+  usage?: MessageUsage
 }
 
 // ===== 对话相关 =====

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -35,3 +35,6 @@ export * from './github'
 
 // 系统提示词相关类型
 export * from './system-prompt'
+
+// 用量统计相关类型
+export * from './usage'

--- a/packages/shared/src/types/usage.ts
+++ b/packages/shared/src/types/usage.ts
@@ -1,0 +1,94 @@
+/**
+ * 用量统计相关类型定义
+ *
+ * 包含用量记录、查询参数、汇总结果等类型，
+ * 以及用量统计模块的 IPC 通道常量。
+ */
+
+import type { ProviderType } from './channel'
+
+// ===== 用量记录 =====
+
+/** 单次 API 调用的 Token 用量记录 */
+export interface UsageRecord {
+  /** 记录唯一标识 */
+  id: string
+  /** 时间戳 */
+  timestamp: number
+  /** 渠道 ID */
+  channelId: string
+  /** 供应商类型 */
+  provider: ProviderType
+  /** 模型 ID */
+  modelId: string
+  /** 输入 token 数 */
+  inputTokens: number
+  /** 输出 token 数 */
+  outputTokens: number
+  /** 来源模式 */
+  mode: 'chat' | 'agent'
+}
+
+// ===== 查询参数 =====
+
+/** 用量查询时间范围 */
+export interface UsageQueryRange {
+  /** 起始时间戳 */
+  from: number
+  /** 结束时间戳 */
+  to: number
+}
+
+// ===== 汇总结果 =====
+
+/** 每日用量汇总 */
+export interface DailyUsage {
+  /** 日期字符串 (YYYY-MM-DD) */
+  date: string
+  /** 当日输入 token 总数 */
+  inputTokens: number
+  /** 当日输出 token 总数 */
+  outputTokens: number
+  /** 当日请求次数 */
+  requestCount: number
+}
+
+/** 按模型汇总的用量 */
+export interface ModelUsage {
+  /** 模型 ID */
+  modelId: string
+  /** 供应商类型 */
+  provider: ProviderType
+  /** 输入 token 总数 */
+  inputTokens: number
+  /** 输出 token 总数 */
+  outputTokens: number
+  /** 请求次数 */
+  requestCount: number
+}
+
+/** 用量统计汇总 */
+export interface UsageSummary {
+  /** 查询范围内的每日用量 */
+  daily: DailyUsage[]
+  /** 按模型汇总 */
+  byModel: ModelUsage[]
+  /** 总输入 token */
+  totalInputTokens: number
+  /** 总输出 token */
+  totalOutputTokens: number
+  /** 总请求次数 */
+  totalRequests: number
+}
+
+// ===== IPC 通道常量 =====
+
+/** 用量统计 IPC 通道 */
+export const USAGE_IPC_CHANNELS = {
+  /** 记录一条用量（主进程内部调用，不暴露给渲染进程） */
+  RECORD: 'usage:record',
+  /** 查询用量汇总 */
+  GET_SUMMARY: 'usage:get-summary',
+  /** 清除用量记录 */
+  CLEAR: 'usage:clear',
+} as const


### PR DESCRIPTION
## Summary

Closes #13

Complete implementation of token usage statistics tracking and visualization, split into 3 logical commits:

### Commit 1: Token Capture Layer
Capture token usage from all provider SSE streaming responses:
- **Anthropic**: parse `message_start.usage` + `message_delta.usage`
- **OpenAI/DeepSeek/Custom**: enable `stream_options`, parse final usage chunk
- **Google**: parse `usageMetadata` from stream response
- Accumulate usage across tool-use rounds in chat-service, persist to `ChatMessage.usage`

### Commit 2: Storage Service + IPC
Data persistence and IPC layer for usage tracking:
- `UsageRecord` / `UsageSummary` types + `USAGE_IPC_CHANNELS` constants
- `usage-stats-service.ts`: read/write `~/.proma/usage-stats.json` with daily + per-model aggregation
- Register IPC handlers, expose APIs through preload bridge
- Call `recordUsage()` after message persistence in chat-service

### Commit 3: UI Visualization
Settings panel with recharts dashboard:
- Summary cards: today / 30-day token totals
- 30-day trend AreaChart (input/output tokens with gradients)
- Per-model usage distribution list
- Empty state placeholder
- Register "用量" tab in SettingsPanel navigation

### Files Changed (16 files)

**packages/core/** (4 files)
- `providers/types.ts` — `StreamUsageEvent` type
- `providers/sse-reader.ts` — `TokenUsage` interface, accumulation in `StreamSSEResult`
- `providers/anthropic-adapter.ts` — Anthropic usage parsing
- `providers/openai-adapter.ts` — OpenAI usage parsing
- `providers/google-adapter.ts` — Google usage parsing

**packages/shared/** (2 files)
- `types/usage.ts` — Usage types and IPC channel constants
- `types/chat.ts` — `MessageUsage` on `ChatMessage`

**apps/electron/** (10 files)
- `main/lib/usage-stats-service.ts` — Storage service (new)
- `main/lib/config-paths.ts` — `getUsageStatsPath()`
- `main/lib/chat-service.ts` — Usage accumulation + `recordUsage()` call
- `main/ipc.ts` — IPC handler registration
- `preload/index.ts` — Preload bridge APIs
- `renderer/atoms/usage-atoms.ts` — Jotai atoms (new)
- `renderer/atoms/settings-tab.ts` — Add 'usage' tab type
- `renderer/components/settings/UsageSettings.tsx` — Dashboard UI (new)
- `renderer/components/settings/SettingsPanel.tsx` — Tab registration
- `package.json` — recharts dependency

### Design Decisions

- **Additive token accumulation** works correctly across all 3 providers (Anthropic sends split events, OpenAI/Google send totals once)
- **Optional `usage?` field** on ChatMessage — fully backward compatible with existing JSONL data
- **4-layer IPC pattern** followed: shared types → main handler → preload bridge → renderer atoms
- **SettingsSection/SettingsCard primitives** — consistent visual style with existing settings pages
- **recharts AreaChart** — lightweight, React-native charting with HSL theme integration

## Test plan

- [ ] `bun run typecheck` passes across all packages ✅
- [ ] Test with Anthropic provider — usage events captured from `message_start` / `message_delta`
- [ ] Test with OpenAI-compatible provider — `stream_options` works, usage returned
- [ ] Test with Google Gemini — `usageMetadata` parsed correctly
- [ ] Verify chat functionality unaffected (backward compatible)
- [ ] Open Settings → 用量 tab — empty state shown initially
- [ ] After conversations, verify stats populate correctly
- [ ] Verify 30-day trend chart renders with correct data
- [ ] Verify per-model distribution shows all used models
- [ ] Test "清除" button clears all usage data

🤖 Generated with [Claude Code](https://claude.com/claude-code)