### PR TITLE
feat: Agent 会话置顶 + 统一内联操作按钮

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -567,6 +567,17 @@ export function registerIpcHandlers(): void {
     }
   )
 
+  // 切换 Agent 会话置顶状态
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.TOGGLE_PIN,
+    async (_, id: string): Promise<AgentSessionMeta> => {
+      const sessions = listAgentSessions()
+      const current = sessions.find((s) => s.id === id)
+      if (!current) throw new Error(`Agent 会话不存在: ${id}`)
+      return updateAgentSessionMeta(id, { pinned: !current.pinned })
+    }
+  )
+
   // ===== Agent 工作区管理相关 =====
 
   // 确保默认工作区存在

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -159,7 +159,7 @@ export function appendAgentMessage(id: string, message: AgentMessage): void {
  */
 export function updateAgentSessionMeta(
   id: string,
-  updates: Partial<Pick<AgentSessionMeta, 'title' | 'channelId' | 'sdkSessionId' | 'workspaceId'>>,
+  updates: Partial<Pick<AgentSessionMeta, 'title' | 'channelId' | 'sdkSessionId' | 'workspaceId' | 'pinned'>>,
 ): AgentSessionMeta {
   const index = readIndex()
   const idx = index.sessions.findIndex((s) => s.id === id)

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -254,6 +254,9 @@ export interface ElectronAPI {
   /** 删除 Agent 会话 */
   deleteAgentSession: (id: string) => Promise<void>
 
+  /** 切换 Agent 会话置顶状态 */
+  togglePinAgentSession: (id: string) => Promise<AgentSessionMeta>
+
   /** 生成 Agent 会话标题 */
   generateAgentTitle: (input: AgentGenerateTitleInput) => Promise<string | null>
 
@@ -658,6 +661,10 @@ const electronAPI: ElectronAPI = {
 
   deleteAgentSession: (id: string) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.DELETE_SESSION, id)
+  },
+
+  togglePinAgentSession: (id: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.TOGGLE_PIN, id)
   },
 
   generateAgentTitle: (input: AgentGenerateTitleInput) => {

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -205,6 +205,8 @@ export interface AgentSessionMeta {
   sdkSessionId?: string
   /** 所属工作区 ID */
   workspaceId?: string
+  /** 是否置顶 */
+  pinned?: boolean
   /** 创建时间戳 */
   createdAt: number
   /** 更新时间戳 */
@@ -524,6 +526,8 @@ export const AGENT_IPC_CHANNELS = {
   UPDATE_TITLE: 'agent:update-title',
   /** 删除会话 */
   DELETE_SESSION: 'agent:delete-session',
+  /** 切换会话置顶状态 */
+  TOGGLE_PIN: 'agent:toggle-pin',
 
   // 工作区管理
   /** 获取工作区列表 */


### PR DESCRIPTION
## Summary
- Agent 模式新增会话置顶功能，置顶会话跨所有工作区显示，UI 不区分工作区
- 完整 IPC 四层架构实现：`AgentSessionMeta.pinned` → `AGENT_IPC_CHANNELS.TOGGLE_PIN` → Preload 桥接 → 渲染层
- Chat/Agent 两种模式的列表项交互统一为 hover 内联操作按钮（置顶/重命名/删除），移除右键上下文菜单

## Test plan
- [ ] Agent 模式下右键会话不再弹出菜单，hover 时显示三个内联按钮
- [ ] 点击 Pin 按钮置顶会话，置顶区域正确显示
- [ ] 切换工作区后，置顶区域仍显示所有被置顶的会话
- [ ] 点击 PinOff 按钮取消置顶，会话从置顶区域消失
- [ ] Chat 模式下列表项交互与 Agent 模式一致（内联按钮）
- [ ] 重命名和删除功能正常（双击编辑 + hover 按钮）
- [ ] `bun run typecheck` 通过