### PR TITLE
refactor: 工作区选择器改为垂直列表展示

### DIFF
--- a/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
@@ -1,19 +1,14 @@
 /**
  * WorkspaceSelector — Agent 工作区切换器
  *
- * 下拉选择器，展示所有工作区，支持新建、重命名、删除和切换。
+ * 垂直列表展示所有工作区，支持新建、重命名、删除和切换。
  * 切换工作区后持久化到 settings。
  */
 
 import * as React from 'react'
 import { useAtom } from 'jotai'
-import { FolderOpen, Plus, Check, ChevronDown, Pencil, Trash2 } from 'lucide-react'
+import { FolderOpen, Plus, Pencil, Trash2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -33,7 +28,6 @@ import type { AgentWorkspace } from '@proma/shared'
 export function WorkspaceSelector(): React.ReactElement {
   const [workspaces, setWorkspaces] = useAtom(agentWorkspacesAtom)
   const [currentWorkspaceId, setCurrentWorkspaceId] = useAtom(currentAgentWorkspaceIdAtom)
-  const [open, setOpen] = React.useState(false)
 
   // 新建状态
   const [creating, setCreating] = React.useState(false)
@@ -48,13 +42,10 @@ export function WorkspaceSelector(): React.ReactElement {
   // 删除确认状态
   const [deleteTargetId, setDeleteTargetId] = React.useState<string | null>(null)
 
-  const currentWorkspace = workspaces.find((w) => w.id === currentWorkspaceId)
-
   /** 切换工作区 */
   const handleSelect = (workspace: AgentWorkspace): void => {
     if (editingId) return // 编辑中不切换
     setCurrentWorkspaceId(workspace.id)
-    setOpen(false)
 
     window.electronAPI.updateSettings({
       agentWorkspaceId: workspace.id,
@@ -83,7 +74,6 @@ export function WorkspaceSelector(): React.ReactElement {
       setWorkspaces((prev) => [workspace, ...prev])
       setCurrentWorkspaceId(workspace.id)
       setCreating(false)
-      setOpen(false)
 
       window.electronAPI.updateSettings({
         agentWorkspaceId: workspace.id,
@@ -178,117 +168,89 @@ export function WorkspaceSelector(): React.ReactElement {
 
   return (
     <>
-      <DropdownMenu open={open} onOpenChange={setOpen}>
-        <DropdownMenuTrigger asChild>
-          <button
-            className={cn(
-              'w-full flex items-center gap-2 px-3 py-2 rounded-[10px] text-[13px] transition-colors duration-100 titlebar-no-drag',
-              'text-foreground/70 bg-foreground/[0.03] hover:bg-foreground/[0.06] border border-foreground/[0.06]',
-            )}
-          >
-            <FolderOpen size={14} className="flex-shrink-0 text-foreground/50" />
-            <span className="flex-1 text-left truncate">
-              {currentWorkspace?.name || '选择工作区'}
-            </span>
-            <ChevronDown size={12} className="flex-shrink-0 text-foreground/40" />
-          </button>
-        </DropdownMenuTrigger>
-
-        <DropdownMenuContent
-          align="start"
-          side="bottom"
-          className="w-[var(--radix-dropdown-menu-trigger-width)] p-1"
-        >
-          {/* 工作区列表 */}
-          <div className="max-h-[200px] overflow-y-auto">
-            {workspaces.map((ws) => (
-              <div
-                key={ws.id}
-                onClick={() => handleSelect(ws)}
-                className={cn(
-                  'group w-full flex items-center gap-2 px-2.5 py-1.5 rounded-md text-[13px] transition-colors duration-100 text-left cursor-pointer',
-                  ws.id === currentWorkspaceId
-                    ? 'bg-primary/10 text-foreground'
-                    : 'text-foreground/70 hover:bg-foreground/[0.04]',
-                )}
-              >
-                <FolderOpen size={13} className="flex-shrink-0 text-foreground/40" />
-
-                {editingId === ws.id ? (
-                  <input
-                    ref={editInputRef}
-                    value={editName}
-                    onChange={(e) => setEditName(e.target.value)}
-                    onKeyDown={handleRenameKeyDown}
-                    onBlur={handleRename}
-                    onClick={(e) => e.stopPropagation()}
-                    className="flex-1 bg-transparent text-[13px] text-foreground border-b border-primary/50 outline-none px-0.5"
-                    maxLength={50}
-                  />
-                ) : (
-                  <>
-                    <span className="flex-1 truncate">{ws.name}</span>
-
-                    {/* 操作按钮 - hover 时显示 */}
-                    <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
-                      <button
-                        onClick={(e) => handleStartRename(e, ws)}
-                        className="p-0.5 rounded hover:bg-foreground/[0.08] text-foreground/40 hover:text-foreground/70"
-                        title="重命名"
-                      >
-                        <Pencil size={12} />
-                      </button>
-                      {canDelete(ws) && (
-                        <button
-                          onClick={(e) => handleStartDelete(e, ws.id)}
-                          className="p-0.5 rounded hover:bg-destructive/10 text-foreground/40 hover:text-destructive"
-                          title="删除"
-                        >
-                          <Trash2 size={12} />
-                        </button>
-                      )}
-                    </div>
-
-                    {/* 选中勾 - 没有操作按钮时显示 */}
-                    {ws.id === currentWorkspaceId && (
-                      <Check size={13} className="flex-shrink-0 text-primary group-hover:hidden" />
-                    )}
-                  </>
-                )}
-              </div>
-            ))}
-          </div>
-
-          {/* 分隔线 */}
-          <div className="my-1 border-t border-foreground/[0.06]" />
-
-          {/* 新建工作区 */}
-          {creating ? (
-            <div className="px-2 py-1">
-              <input
-                ref={createInputRef}
-                value={newName}
-                onChange={(e) => setNewName(e.target.value)}
-                onKeyDown={handleCreateKeyDown}
-                onBlur={() => {
-                  if (!newName.trim()) setCreating(false)
-                }}
-                placeholder="工作区名称..."
-                className="w-full bg-transparent text-[13px] text-foreground border-b border-primary/50 outline-none px-0.5 py-1"
-                maxLength={50}
-              />
-            </div>
-          ) : (
+      <div className="flex flex-col gap-0.5">
+        {/* 工作区列表（可滚动） */}
+        <div className="max-h-[120px] overflow-y-auto scrollbar-none flex flex-col gap-0.5">
+          {workspaces.map((ws) => (
             <div
-              onClick={handleStartCreate}
-              className="w-full flex items-center gap-2 px-2.5 py-1.5 rounded-md text-[13px] text-foreground/50 hover:bg-foreground/[0.04] hover:text-foreground/70 transition-colors duration-100 cursor-pointer"
+              key={ws.id}
+              onClick={() => handleSelect(ws)}
+              className={cn(
+                'group w-full flex items-center gap-2 px-2.5 py-[5px] rounded-md text-[13px] transition-colors duration-100 cursor-pointer titlebar-no-drag',
+                ws.id === currentWorkspaceId
+                  ? 'bg-foreground/[0.08] text-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
+                  : 'text-foreground/70 hover:bg-foreground/[0.04]',
+              )}
             >
-              <Plus size={13} />
-              <span>新建工作区</span>
+              <FolderOpen size={13} className="flex-shrink-0 text-foreground/40" />
+
+              {editingId === ws.id ? (
+                <input
+                  ref={editInputRef}
+                  value={editName}
+                  onChange={(e) => setEditName(e.target.value)}
+                  onKeyDown={handleRenameKeyDown}
+                  onBlur={handleRename}
+                  onClick={(e) => e.stopPropagation()}
+                  className="flex-1 min-w-0 bg-transparent text-[13px] text-foreground border-b border-primary/50 outline-none px-0.5"
+                  maxLength={50}
+                />
+              ) : (
+                <>
+                  <span className="flex-1 min-w-0 truncate">{ws.name}</span>
+
+                  {/* 操作按钮 — hover 时显示 */}
+                  <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0">
+                    <button
+                      onClick={(e) => handleStartRename(e, ws)}
+                      className="p-0.5 rounded hover:bg-foreground/[0.08] text-foreground/30 hover:text-foreground/60 transition-colors"
+                      title="重命名"
+                    >
+                      <Pencil size={12} />
+                    </button>
+                    {canDelete(ws) && (
+                      <button
+                        onClick={(e) => handleStartDelete(e, ws.id)}
+                        className="p-0.5 rounded hover:bg-destructive/10 text-foreground/30 hover:text-destructive transition-colors"
+                        title="删除"
+                      >
+                        <Trash2 size={12} />
+                      </button>
+                    )}
+                  </div>
+                </>
+              )}
             </div>
-          )}
-        </DropdownMenuContent>
-      </DropdownMenu>
+          ))}
+        </div>
+
+        {/* 新建工作区 */}
+        {creating ? (
+          <div className="flex items-center gap-2 px-2.5 py-[5px]">
+            <FolderOpen size={13} className="flex-shrink-0 text-foreground/40" />
+            <input
+              ref={createInputRef}
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              onKeyDown={handleCreateKeyDown}
+              onBlur={() => {
+                if (!newName.trim()) setCreating(false)
+              }}
+              placeholder="工作区名称..."
+              className="flex-1 min-w-0 bg-transparent text-[13px] text-foreground border-b border-primary/50 outline-none px-0.5"
+              maxLength={50}
+            />
+          </div>
+        ) : (
+          <button
+            onClick={handleStartCreate}
+            className="w-full flex items-center gap-2 px-2.5 py-[5px] rounded-md text-[13px] text-foreground/40 hover:bg-foreground/[0.04] hover:text-foreground/60 transition-colors duration-100 titlebar-no-drag"
+          >
+            <Plus size={13} />
+            <span>新建工作区</span>
+          </button>
+        )}
+      </div>
 
       {/* 删除确认弹窗 */}
       <AlertDialog


### PR DESCRIPTION
## Summary
- 将 Agent 模式的 WorkspaceSelector 从 DropdownMenu 改为直接展示的垂直列表
- 用户无需点击即可看到所有工作区并快速切换，类似 VS Code 文件目录风格
- 操作按钮（重命名/删除）hover 时内联显示，与会话列表项交互模式一致
- 保留全部 CRUD 功能：选择、新建、重命名、删除

## Test plan
- [ ] 切换到 Agent 模式，确认侧边栏显示垂直工作区列表
- [ ] 点击不同工作区，确认切换正常，会话列表跟随过滤
- [ ] hover 工作区项，确认铅笔/垃圾桶按钮显示
- [ ] 点击铅笔按钮重命名，Enter 确认 / Esc 取消
- [ ] 点击垃圾桶按钮删除，确认弹窗正常
- [ ] 点击"+ 新建工作区"，内联 input 创建新工作区
- [ ] 多个工作区时确认滚动正常（max-h-[120px]）