### PR TITLE
feat: Chat 模式模块化工具系统

### DIFF
--- a/apps/electron/default-skills/tool-builder/SKILL.md
+++ b/apps/electron/default-skills/tool-builder/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: tool-builder
+description: 交互式创建和管理 Chat 模式的自定义 HTTP 工具。当用户想要创建新的 API 工具、配置 Chat 工具、添加自定义工具、管理自定义工具、或说"帮我创建一个 XX 工具"时使用此 Skill。也适用于调试、修复或删除已有的自定义工具。
+---
+
+# Tool Builder
+
+通过交互式对话帮助用户创建可在 Chat 模式中使用的自定义 HTTP API 工具。
+
+## 工作流程
+
+### 1. 需求收集
+
+向用户了解：
+- 工具用途（查天气、翻译、汇率等）
+- API 端点 URL 和认证方式
+- 需要哪些参数（名称、类型、是否必填）
+- HTTP 方法（GET/POST）
+- 响应中需要提取哪部分数据
+
+如果用户不确定具体 API，帮助推荐合适的公开 API。
+
+### 2. 构建配置
+
+根据收集的信息构建工具配置 JSON。配置文件位于 `~/.proma/chat-tools.json`。
+
+#### 配置文件结构
+
+```json
+{
+  "toolStates": {
+    "memory": { "enabled": true },
+    "web-search": { "enabled": false },
+    "custom-weather": { "enabled": true }
+  },
+  "toolCredentials": {},
+  "customTools": [
+    {
+      "id": "custom-weather",
+      "name": "天气查询",
+      "description": "查询指定城市的当前天气信息",
+      "params": [
+        { "name": "city", "type": "string", "description": "城市名称", "required": true }
+      ],
+      "category": "custom",
+      "executorType": "http",
+      "httpConfig": {
+        "urlTemplate": "https://wttr.in/{{city}}?format=j1",
+        "method": "GET",
+        "resultPath": "current_condition"
+      }
+    }
+  ]
+}
+```
+
+#### ChatToolMeta 字段说明
+
+| 字段 | 必填 | 说明 |
+|------|------|------|
+| `id` | 是 | 唯一标识，必须以 `custom-` 前缀 + slug 格式（如 `custom-weather`） |
+| `name` | 是 | 显示名称 |
+| `description` | 是 | 工具描述，AI 据此决定何时调用 |
+| `params` | 是 | 参数列表，每个含 `name`/`type`/`description`/`required` |
+| `category` | 是 | 固定为 `"custom"` |
+| `executorType` | 是 | 固定为 `"http"` |
+| `httpConfig` | 是 | HTTP 请求配置 |
+| `icon` | 否 | Lucide 图标名（如 `"Cloud"`、`"Languages"`） |
+| `systemPromptAppend` | 否 | 启用时注入的系统提示词 |
+
+#### httpConfig 字段说明
+
+| 字段 | 必填 | 说明 |
+|------|------|------|
+| `urlTemplate` | 是 | URL 模板，`{{paramName}}` 占位符会被参数值替换（自动 URL 编码） |
+| `method` | 是 | `"GET"` 或 `"POST"` |
+| `headers` | 否 | 请求头，常用于 API Key 认证：`{ "Authorization": "Bearer xxx" }` |
+| `bodyTemplate` | 否 | POST 请求体 JSON 模板，`{{paramName}}` 占位符会被替换（不编码） |
+| `resultPath` | 否 | 点号路径提取响应中的特定字段（如 `"data.results"`） |
+
+#### 参数类型
+
+`params[].type` 支持：`"string"` / `"number"` / `"boolean"`
+
+可选添加 `enum` 字段限制可选值：
+```json
+{ "name": "unit", "type": "string", "description": "温度单位", "enum": ["celsius", "fahrenheit"] }
+```
+
+### 3. 写入配置
+
+操作步骤：
+1. 读取 `~/.proma/chat-tools.json`（如不存在则创建）
+2. 将新工具追加到 `customTools` 数组（按 `id` 去重）
+3. 在 `toolStates` 中添加 `{ "enabled": true }` 使其默认启用
+4. 写回文件（保持 JSON 格式化）
+
+写入后应用会自动检测文件变化并刷新工具列表。
+
+### 4. 测试引导
+
+告知用户：
+- "工具已创建并启用，请切换到 Chat 模式测试"
+- "在 Chat 输入框左下角的工具选择器中应该能看到新工具"
+- "试着问一个需要用到这个工具的问题"
+- "如果有问题，回到 Agent 模式告诉我，我帮你调试"
+
+### 5. 调试修复
+
+用户反馈问题时，常见原因：
+- URL 模板错误 → 修正 `urlTemplate`
+- 参数映射不对 → 调整 `params` 定义
+- 响应格式变化 → 修改 `resultPath`
+- 认证失败 → 检查 `headers` 中的 API Key
+- 超时 → 检查 API 可达性
+
+修复后重新写入 `chat-tools.json`，应用自动刷新。
+
+### 6. 删除工具
+
+从 `customTools` 数组中移除对应工具，同时删除 `toolStates` 中的条目。
+
+## 完整示例：天气查询工具
+
+```json
+{
+  "id": "custom-weather",
+  "name": "天气查询",
+  "description": "查询指定城市的当前天气和温度信息。当用户询问天气时调用。",
+  "params": [
+    { "name": "city", "type": "string", "description": "城市名称（英文）", "required": true }
+  ],
+  "category": "custom",
+  "executorType": "http",
+  "httpConfig": {
+    "urlTemplate": "https://wttr.in/{{city}}?format=j1",
+    "method": "GET",
+    "resultPath": "current_condition"
+  }
+}
+```
+
+## 完整示例：翻译工具（POST + API Key）
+
+```json
+{
+  "id": "custom-translate",
+  "name": "翻译",
+  "description": "将文本翻译为目标语言。当用户需要翻译时调用。",
+  "params": [
+    { "name": "text", "type": "string", "description": "要翻译的文本", "required": true },
+    { "name": "target_lang", "type": "string", "description": "目标语言代码", "required": true, "enum": ["EN", "ZH", "JA", "KO", "FR", "DE", "ES"] }
+  ],
+  "category": "custom",
+  "executorType": "http",
+  "httpConfig": {
+    "urlTemplate": "https://api.example.com/translate",
+    "method": "POST",
+    "headers": { "Authorization": "Bearer YOUR_API_KEY" },
+    "bodyTemplate": "{\"text\": \"{{text}}\", \"target_lang\": \"{{target_lang}}\"}",
+    "resultPath": "translations.0.text"
+  }
+}
+```

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -10,6 +10,7 @@ import { stopAllAgents } from './lib/agent-service'
 import { stopAllGenerations } from './lib/chat-service'
 import { initAutoUpdater, cleanupUpdater } from './lib/updater/auto-updater'
 import { startWorkspaceWatcher, stopWorkspaceWatcher } from './lib/workspace-watcher'
+import { startChatToolsWatcher, stopChatToolsWatcher } from './lib/chat-tools-watcher'
 import { getIsQuitting, setQuitting, isUpdating } from './lib/app-lifecycle'
 
 let mainWindow: BrowserWindow | null = null
@@ -182,6 +183,9 @@ app.whenReady().then(async () => {
     startWorkspaceWatcher(mainWindow)
   }
 
+  // 启动 Chat 工具配置文件监听（Agent 创建工具后自动通知渲染进程）
+  startChatToolsWatcher()
+
   // 生产环境下初始化自动更新
   if (app.isPackaged && mainWindow) {
     initAutoUpdater(mainWindow)
@@ -223,6 +227,8 @@ app.on('before-quit', () => {
   cleanupUpdater()
   // 停止工作区文件监听
   stopWorkspaceWatcher()
+  // 停止 Chat 工具配置文件监听
+  stopChatToolsWatcher()
   // Clean up system tray before quitting
   destroyTray()
 })

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -5,7 +5,7 @@
  */
 
 import { ipcMain, nativeTheme, shell, dialog, BrowserWindow } from 'electron'
-import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, MEMORY_IPC_CHANNELS } from '@proma/shared'
+import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, MEMORY_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS } from '@proma/shared'
 import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS } from '../types'
 import type {
   RuntimeStatus,
@@ -52,6 +52,9 @@ import type {
   SystemPromptCreateInput,
   SystemPromptUpdateInput,
   MemoryConfig,
+  ChatToolInfo,
+  ChatToolState,
+  ChatToolMeta,
 } from '@proma/shared'
 import type { UserProfile, AppSettings } from '../types'
 import { getRuntimeStatus, getGitRepoStatus } from './lib/runtime-init'
@@ -117,6 +120,8 @@ import {
   setWorkspacePermissionMode,
 } from './lib/agent-workspace-manager'
 import { getMemoryConfig, setMemoryConfig } from './lib/memory-service'
+import { getAllToolInfos } from './lib/chat-tool-registry'
+import { updateToolState, updateToolCredentials, getToolCredentials, addCustomTool, deleteCustomTool } from './lib/chat-tool-config'
 import {
   getSystemPromptConfig,
   createSystemPrompt,
@@ -785,6 +790,111 @@ export function registerIpcHandlers(): void {
         const msg = error instanceof Error ? error.message : String(error)
         return { success: false, message: `连接失败: ${msg}` }
       }
+    }
+  )
+
+  // ===== Chat 工具管理 =====
+
+  // 获取所有工具信息
+  ipcMain.handle(
+    CHAT_TOOL_IPC_CHANNELS.GET_ALL_TOOLS,
+    async (): Promise<ChatToolInfo[]> => {
+      return getAllToolInfos()
+    }
+  )
+
+  // 获取工具凭据
+  ipcMain.handle(
+    CHAT_TOOL_IPC_CHANNELS.GET_TOOL_CREDENTIALS,
+    async (_, toolId: string): Promise<Record<string, string>> => {
+      return getToolCredentials(toolId)
+    }
+  )
+
+  // 更新工具开关状态
+  ipcMain.handle(
+    CHAT_TOOL_IPC_CHANNELS.UPDATE_TOOL_STATE,
+    async (_, toolId: string, state: ChatToolState): Promise<void> => {
+      updateToolState(toolId, state)
+    }
+  )
+
+  // 更新工具凭据
+  ipcMain.handle(
+    CHAT_TOOL_IPC_CHANNELS.UPDATE_TOOL_CREDENTIALS,
+    async (_, toolId: string, credentials: Record<string, string>): Promise<void> => {
+      updateToolCredentials(toolId, credentials)
+    }
+  )
+
+  // 创建自定义工具
+  ipcMain.handle(
+    CHAT_TOOL_IPC_CHANNELS.CREATE_CUSTOM_TOOL,
+    async (_, meta: ChatToolMeta): Promise<void> => {
+      addCustomTool(meta)
+    }
+  )
+
+  // 删除自定义工具
+  ipcMain.handle(
+    CHAT_TOOL_IPC_CHANNELS.DELETE_CUSTOM_TOOL,
+    async (_, toolId: string): Promise<void> => {
+      deleteCustomTool(toolId)
+    }
+  )
+
+  // 测试工具连接
+  ipcMain.handle(
+    CHAT_TOOL_IPC_CHANNELS.TEST_TOOL,
+    async (_, toolId: string): Promise<{ success: boolean; message: string }> => {
+      // 记忆工具复用现有测试逻辑
+      if (toolId === 'memory') {
+        const config = getMemoryConfig()
+        if (!config.apiKey) {
+          return { success: false, message: '请先填写 API Key' }
+        }
+        try {
+          const { searchMemory } = await import('./lib/memos-client')
+          const result = await searchMemory(
+            { apiKey: config.apiKey, userId: config.userId?.trim() || 'proma-user', baseUrl: config.baseUrl },
+            'test connection',
+            1,
+          )
+          return { success: true, message: `连接成功，已检索到 ${result.facts.length} 条事实、${result.preferences.length} 条偏好` }
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error)
+          return { success: false, message: `连接失败: ${msg}` }
+        }
+      }
+      // 联网搜索工具测试
+      if (toolId === 'web-search') {
+        const { getToolCredentials: getCredentials } = await import('./lib/chat-tool-config')
+        const credentials = getCredentials('web-search')
+        if (!credentials.apiKey) {
+          return { success: false, message: '请先填写 Tavily API Key' }
+        }
+        try {
+          const response = await fetch('https://api.tavily.com/search', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              api_key: credentials.apiKey,
+              query: 'test connection',
+              search_depth: 'basic',
+              max_results: 1,
+            }),
+          })
+          if (!response.ok) {
+            const errorText = await response.text()
+            return { success: false, message: `API 请求失败 (${response.status}): ${errorText}` }
+          }
+          return { success: true, message: '连接成功，Tavily 搜索 API 可用' }
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error)
+          return { success: false, message: `连接失败: ${msg}` }
+        }
+      }
+      return { success: false, message: `工具 ${toolId} 不支持测试` }
     }
   )
 

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -99,6 +99,7 @@ import {
   getAgentSessionMessages,
   updateAgentSessionMeta,
   deleteAgentSession,
+  migrateChatToAgentSession,
 } from './lib/agent-session-manager'
 import { runAgent, stopAgent, generateAgentTitle, saveFilesToAgentSession, copyFolderToSession } from './lib/agent-service'
 import { permissionService } from './lib/agent-permission-service'
@@ -569,6 +570,14 @@ export function registerIpcHandlers(): void {
       // 清理 AskUser 服务中的待处理请求
       askUserService.clearSessionPending(id)
       return deleteAgentSession(id)
+    }
+  )
+
+  // 迁移 Chat 对话记录到 Agent 会话
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.MIGRATE_CHAT_TO_AGENT,
+    async (_, conversationId: string, agentSessionId: string): Promise<void> => {
+      migrateChatToAgentSession(conversationId, agentSessionId)
     }
   )
 

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -18,6 +18,7 @@ import {
 } from './config-paths'
 import { getAgentWorkspace } from './agent-workspace-manager'
 import type { AgentSessionMeta, AgentMessage } from '@proma/shared'
+import { getConversationMessages } from './conversation-manager'
 
 /**
  * 会话索引文件格式
@@ -223,4 +224,42 @@ export function deleteAgentSession(id: string): void {
   }
 
   console.log(`[Agent 会话] 已删除会话: ${removed.title} (${removed.id})`)
+}
+
+/**
+ * 迁移 Chat 对话记录到 Agent 会话
+ *
+ * 读取 Chat 对话的消息，转换为 AgentMessage 格式，
+ * 追加到目标 Agent 会话的 JSONL 文件中。
+ *
+ * 仅迁移 user 和 assistant 角色的消息文本内容，
+ * 工具活动、推理、附件等 Chat 特有字段不迁移。
+ */
+export function migrateChatToAgentSession(conversationId: string, agentSessionId: string): void {
+  const chatMessages = getConversationMessages(conversationId)
+
+  if (chatMessages.length === 0) {
+    console.log(`[Agent 会话] Chat 对话无消息，跳过迁移 (${conversationId})`)
+    return
+  }
+
+  let count = 0
+  for (const cm of chatMessages) {
+    // 仅迁移 user 和 assistant 消息
+    if (cm.role !== 'user' && cm.role !== 'assistant') continue
+    if (!cm.content.trim()) continue
+
+    const agentMsg: AgentMessage = {
+      id: randomUUID(),
+      role: cm.role,
+      content: cm.content,
+      createdAt: cm.createdAt,
+      model: cm.role === 'assistant' ? cm.model : undefined,
+    }
+
+    appendAgentMessage(agentSessionId, agentMsg)
+    count++
+  }
+
+  console.log(`[Agent 会话] 已迁移 ${count} 条消息到 Agent 会话 (${conversationId} → ${agentSessionId})`)
 }

--- a/apps/electron/src/main/lib/chat-service.ts
+++ b/apps/electron/src/main/lib/chat-service.ts
@@ -34,8 +34,8 @@ import { executeToolCalls } from './chat-tool-executor'
 /** 活跃的 AbortController 映射（conversationId → controller） */
 const activeControllers = new Map<string, AbortController>()
 
-/** 最大工具续接轮数（防止无限循环） */
-const MAX_TOOL_ROUNDS = 5
+/** 最大工具续接轮数（防止无限循环，每轮可含多个工具调用） */
+const MAX_TOOL_ROUNDS = 20
 
 // ===== 平台相关：图片附件读取器 =====
 
@@ -269,9 +269,44 @@ export async function sendMessage(
     // 9. 工具续接循环
     let continuationMessages: ContinuationMessage[] = []
     let round = 0
+    /** 标记最近一轮是否执行了工具（用于判断是否需要最终响应轮） */
+    let pendingToolResults = false
+
+    /** 流式事件处理器（工具轮和最终响应轮复用） */
+    const handleStreamEvent = (event: { type: string; delta?: string; toolCallId?: string; toolName?: string }): void => {
+      switch (event.type) {
+        case 'chunk':
+          accumulatedContent += event.delta ?? ''
+          webContents.send(CHAT_IPC_CHANNELS.STREAM_CHUNK, {
+            conversationId,
+            delta: event.delta,
+          })
+          break
+        case 'reasoning':
+          accumulatedReasoning += event.delta ?? ''
+          webContents.send(CHAT_IPC_CHANNELS.STREAM_REASONING, {
+            conversationId,
+            delta: event.delta,
+          })
+          break
+        case 'tool_call_start':
+          accumulatedToolActivities.push({
+            toolCallId: event.toolCallId!,
+            toolName: event.toolName!,
+            type: 'start',
+          })
+          webContents.send(CHAT_IPC_CHANNELS.STREAM_TOOL_ACTIVITY, {
+            conversationId,
+            activity: { type: 'start', toolName: event.toolName!, toolCallId: event.toolCallId! },
+          })
+          break
+        // done 事件在外部处理
+      }
+    }
 
     while (round < MAX_TOOL_ROUNDS) {
       round++
+      pendingToolResults = false
 
       const request = adapter.buildStreamRequest({
         baseUrl: channel.baseUrl,
@@ -287,41 +322,12 @@ export async function sendMessage(
         continuationMessages: continuationMessages.length > 0 ? continuationMessages : undefined,
       })
 
-      const { content, reasoning, toolCalls, stopReason } = await streamSSE({
+      const { content, toolCalls, stopReason } = await streamSSE({
         request,
         adapter,
         signal: controller.signal,
         fetchFn,
-        onEvent: (event) => {
-          switch (event.type) {
-            case 'chunk':
-              accumulatedContent += event.delta
-              webContents.send(CHAT_IPC_CHANNELS.STREAM_CHUNK, {
-                conversationId,
-                delta: event.delta,
-              })
-              break
-            case 'reasoning':
-              accumulatedReasoning += event.delta
-              webContents.send(CHAT_IPC_CHANNELS.STREAM_REASONING, {
-                conversationId,
-                delta: event.delta,
-              })
-              break
-            case 'tool_call_start':
-              accumulatedToolActivities.push({
-                toolCallId: event.toolCallId,
-                toolName: event.toolName,
-                type: 'start',
-              })
-              webContents.send(CHAT_IPC_CHANNELS.STREAM_TOOL_ACTIVITY, {
-                conversationId,
-                activity: { type: 'start', toolName: event.toolName, toolCallId: event.toolCallId },
-              })
-              break
-            // done 事件在外部处理
-          }
-        },
+        onEvent: handleStreamEvent,
       })
 
       // 如果没有工具调用或不是 tool_use 停止，退出循环
@@ -355,8 +361,37 @@ export async function sendMessage(
         { role: 'assistant' as const, content, toolCalls },
         { role: 'tool' as const, results: toolResults },
       ]
+      pendingToolResults = true
 
       // 注意：不重置 accumulatedContent/accumulatedReasoning，跨轮次持续累积
+    }
+
+    // 10. 最终响应轮：如果因达到 MAX_TOOL_ROUNDS 退出但仍有待处理的工具结果，
+    // 再发起一次 API 调用（不传 tools）让模型基于工具结果生成最终文本回复
+    if (pendingToolResults && continuationMessages.length > 0) {
+      console.log(`[聊天服务] 工具轮次已达上限 (${MAX_TOOL_ROUNDS})，发起最终响应轮`)
+
+      const finalRequest = adapter.buildStreamRequest({
+        baseUrl: channel.baseUrl,
+        apiKey,
+        modelId,
+        history: enrichedHistory,
+        userMessage: enrichedUserMessage,
+        systemMessage: effectiveSystemMessage,
+        attachments,
+        readImageAttachments: getImageAttachmentData,
+        thinkingEnabled,
+        // 不传 tools，强制模型生成文本回复而非继续调用工具
+        continuationMessages,
+      })
+
+      await streamSSE({
+        request: finalRequest,
+        adapter,
+        signal: controller.signal,
+        fetchFn,
+        onEvent: handleStreamEvent,
+      })
     }
 
     // 10. 保存 assistant 消息（空内容不保存）

--- a/apps/electron/src/main/lib/chat-tool-config.ts
+++ b/apps/electron/src/main/lib/chat-tool-config.ts
@@ -1,0 +1,116 @@
+/**
+ * Chat 工具配置服务
+ *
+ * 管理 ~/.proma/chat-tools.json 的读写。
+ * 存储工具开关状态和非记忆工具的凭据。
+ * 记忆凭据保留在 memory.json（Chat + Agent 共用）。
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { getChatToolsConfigPath } from './config-paths'
+import type { ChatToolsFileConfig, ChatToolState, ChatToolMeta } from '@proma/shared'
+
+/** 默认配置 */
+const DEFAULT_CONFIG: ChatToolsFileConfig = {
+  toolStates: {
+    memory: { enabled: true },
+    'web-search': { enabled: false },
+  },
+  toolCredentials: {},
+  customTools: [],
+}
+
+/**
+ * 读取工具配置
+ */
+export function getChatToolsConfig(): ChatToolsFileConfig {
+  const filePath = getChatToolsConfigPath()
+
+  if (!existsSync(filePath)) {
+    return structuredClone(DEFAULT_CONFIG)
+  }
+
+  try {
+    const raw = readFileSync(filePath, 'utf-8')
+    const data = JSON.parse(raw) as Partial<ChatToolsFileConfig>
+    return {
+      toolStates: { ...DEFAULT_CONFIG.toolStates, ...data.toolStates },
+      toolCredentials: data.toolCredentials ?? {},
+      customTools: data.customTools ?? [],
+    }
+  } catch (error) {
+    console.error('[Chat 工具配置] 读取失败:', error)
+    return structuredClone(DEFAULT_CONFIG)
+  }
+}
+
+/**
+ * 保存工具配置
+ */
+export function saveChatToolsConfig(config: ChatToolsFileConfig): void {
+  const filePath = getChatToolsConfigPath()
+  try {
+    writeFileSync(filePath, JSON.stringify(config, null, 2), 'utf-8')
+    console.log('[Chat 工具配置] 已保存')
+  } catch (error) {
+    console.error('[Chat 工具配置] 保存失败:', error)
+    throw new Error('保存 Chat 工具配置失败')
+  }
+}
+
+/**
+ * 更新单个工具的开关状态
+ */
+export function updateToolState(toolId: string, state: ChatToolState): void {
+  const config = getChatToolsConfig()
+  config.toolStates[toolId] = state
+  saveChatToolsConfig(config)
+}
+
+/**
+ * 更新工具凭据
+ */
+export function updateToolCredentials(toolId: string, credentials: Record<string, string>): void {
+  const config = getChatToolsConfig()
+  config.toolCredentials[toolId] = credentials
+  saveChatToolsConfig(config)
+}
+
+/**
+ * 获取工具开关状态（不存在时返回默认关闭）
+ */
+export function getToolState(toolId: string): ChatToolState {
+  const config = getChatToolsConfig()
+  return config.toolStates[toolId] ?? { enabled: false }
+}
+
+/**
+ * 获取工具凭据
+ */
+export function getToolCredentials(toolId: string): Record<string, string> {
+  const config = getChatToolsConfig()
+  return config.toolCredentials[toolId] ?? {}
+}
+
+/**
+ * 添加自定义工具
+ */
+export function addCustomTool(meta: ChatToolMeta): void {
+  const config = getChatToolsConfig()
+  // 去重
+  config.customTools = config.customTools.filter((t) => t.id !== meta.id)
+  config.customTools.push(meta)
+  config.toolStates[meta.id] = { enabled: false }
+  saveChatToolsConfig(config)
+}
+
+/**
+ * 删除自定义工具
+ */
+export function deleteCustomTool(toolId: string): void {
+  const config = getChatToolsConfig()
+  config.customTools = config.customTools.filter((t) => t.id !== toolId)
+  delete config.toolStates[toolId]
+  delete config.toolCredentials[toolId]
+  saveChatToolsConfig(config)
+}

--- a/apps/electron/src/main/lib/chat-tool-executor.ts
+++ b/apps/electron/src/main/lib/chat-tool-executor.ts
@@ -1,0 +1,78 @@
+/**
+ * Chat 工具统一执行器
+ *
+ * 统一分发工具调用到对应的执行模块。
+ * 替代 chat-service.ts 中硬编码的 if/else 分支。
+ */
+
+import type { ToolCall, ToolResult } from '@proma/core'
+import type { WebContents } from 'electron'
+import { CHAT_IPC_CHANNELS } from '@proma/shared'
+import { isMemoryToolCall, executeMemoryTool } from './chat-tools/memory-tool'
+import { isWebSearchToolCall, executeWebSearchTool } from './chat-tools/web-search-tool'
+import { isCustomHttpToolCall, executeHttpTool } from './chat-tools/http-tool-executor'
+import { getChatToolsConfig } from './chat-tool-config'
+
+/** 工具执行上下文 */
+export interface ToolExecutionContext {
+  /** webContents 用于推送工具活动事件 */
+  webContents: WebContents
+  /** 对话 ID */
+  conversationId: string
+}
+
+/**
+ * 执行工具调用列表
+ *
+ * 依次执行每个工具调用，推送活动事件给前端，返回所有结果。
+ *
+ * @param toolCalls 模型返回的工具调用列表
+ * @param context 执行上下文
+ * @returns 工具执行结果列表
+ */
+export async function executeToolCalls(
+  toolCalls: ToolCall[],
+  context: ToolExecutionContext,
+): Promise<ToolResult[]> {
+  const results: ToolResult[] = []
+
+  for (const tc of toolCalls) {
+    let result: ToolResult
+
+    if (isMemoryToolCall(tc.name)) {
+      result = await executeMemoryTool(tc)
+    } else if (isWebSearchToolCall(tc.name)) {
+      result = await executeWebSearchTool(tc)
+    } else if (isCustomHttpToolCall(tc.name)) {
+      const config = getChatToolsConfig()
+      const meta = config.customTools.find((t) => t.id === tc.name)
+      result = meta
+        ? await executeHttpTool(tc, meta)
+        : { toolCallId: tc.id, content: `自定义工具未找到: ${tc.name}`, isError: true }
+    } else {
+      // 未知工具
+      console.warn(`[Chat 工具执行器] 未知工具: ${tc.name}`)
+      result = {
+        toolCallId: tc.id,
+        content: `未知工具: ${tc.name}`,
+        isError: true,
+      }
+    }
+
+    results.push(result)
+
+    // 推送工具结果事件给前端
+    context.webContents.send(CHAT_IPC_CHANNELS.STREAM_TOOL_ACTIVITY, {
+      conversationId: context.conversationId,
+      activity: {
+        type: 'result',
+        toolName: tc.name,
+        toolCallId: tc.id,
+        result: result.content,
+        isError: result.isError,
+      },
+    })
+  }
+
+  return results
+}

--- a/apps/electron/src/main/lib/chat-tool-executor.ts
+++ b/apps/electron/src/main/lib/chat-tool-executor.ts
@@ -11,6 +11,7 @@ import { CHAT_IPC_CHANNELS } from '@proma/shared'
 import { isMemoryToolCall, executeMemoryTool } from './chat-tools/memory-tool'
 import { isWebSearchToolCall, executeWebSearchTool } from './chat-tools/web-search-tool'
 import { isCustomHttpToolCall, executeHttpTool } from './chat-tools/http-tool-executor'
+import { isAgentRecommendToolCall, executeAgentRecommendTool } from './chat-tools/agent-recommend-tool'
 import { getChatToolsConfig } from './chat-tool-config'
 
 /** 工具执行上下文 */
@@ -43,6 +44,8 @@ export async function executeToolCalls(
       result = await executeMemoryTool(tc)
     } else if (isWebSearchToolCall(tc.name)) {
       result = await executeWebSearchTool(tc)
+    } else if (isAgentRecommendToolCall(tc.name)) {
+      result = await executeAgentRecommendTool(tc)
     } else if (isCustomHttpToolCall(tc.name)) {
       const config = getChatToolsConfig()
       const meta = config.customTools.find((t) => t.id === tc.name)

--- a/apps/electron/src/main/lib/chat-tool-registry.ts
+++ b/apps/electron/src/main/lib/chat-tool-registry.ts
@@ -1,0 +1,200 @@
+/**
+ * Chat 工具注册表
+ *
+ * 管理所有可用的 Chat 工具：
+ * - 内置工具（记忆、联网搜索）
+ * - 自定义工具（用户配置的 HTTP 工具）
+ *
+ * 提供统一接口获取启用的工具定义和系统提示词。
+ */
+
+import type { ToolDefinition, ToolParameterProperty } from '@proma/core'
+import type { ChatToolInfo, ChatToolMeta } from '@proma/shared'
+import { getChatToolsConfig } from './chat-tool-config'
+import {
+  MEMORY_TOOL_META,
+  MEMORY_TOOL_DEFINITIONS,
+  isMemoryAvailable,
+} from './chat-tools/memory-tool'
+import {
+  WEB_SEARCH_TOOL_META,
+  WEB_SEARCH_TOOL_DEFINITIONS,
+  isWebSearchAvailable,
+} from './chat-tools/web-search-tool'
+import { getMemoryConfig } from './memory-service'
+
+// ===== 内置工具注册 =====
+
+/** 内置工具列表（元数据 + 获取 ToolDefinition 的方法） */
+interface BuiltinToolEntry {
+  meta: ChatToolMeta
+  getDefinitions: () => ToolDefinition[]
+  checkAvailable: () => boolean
+}
+
+/** 所有内置工具 */
+const BUILTIN_TOOLS: BuiltinToolEntry[] = [
+  {
+    meta: MEMORY_TOOL_META,
+    getDefinitions: () => MEMORY_TOOL_DEFINITIONS,
+    checkAvailable: isMemoryAvailable,
+  },
+  {
+    meta: WEB_SEARCH_TOOL_META,
+    getDefinitions: () => WEB_SEARCH_TOOL_DEFINITIONS,
+    checkAvailable: isWebSearchAvailable,
+  },
+]
+
+// ===== 自定义工具转换 =====
+
+/**
+ * 将 ChatToolMeta 转换为 ToolDefinition（Provider API 格式）
+ *
+ * 将简化的 params 格式映射为 JSON Schema。
+ */
+function convertMetaToDefinition(meta: ChatToolMeta): ToolDefinition {
+  const properties: Record<string, ToolParameterProperty> = {}
+  const required: string[] = []
+
+  for (const param of meta.params) {
+    const prop: ToolParameterProperty = {
+      type: param.type,
+      description: param.description,
+    }
+    if (param.enum && param.enum.length > 0) {
+      prop.enum = param.enum
+    }
+    properties[param.name] = prop
+
+    if (param.required) {
+      required.push(param.name)
+    }
+  }
+
+  return {
+    name: meta.id,
+    description: meta.description,
+    parameters: {
+      type: 'object',
+      properties,
+      required: required.length > 0 ? required : undefined,
+    },
+  }
+}
+
+// ===== 公开接口 =====
+
+/** 获取启用工具的返回结果 */
+export interface EnabledToolsResult {
+  /** 合并后的工具定义列表 */
+  tools: ToolDefinition[] | undefined
+  /** 合并后的系统提示词追加 */
+  systemPromptAppend: string | undefined
+}
+
+/**
+ * 获取当前启用的工具定义
+ *
+ * 根据前端传入的 enabledToolIds 和配置文件中的开关状态，
+ * 返回最终要注入到 API 请求中的工具定义和系统提示词。
+ *
+ * @param enabledToolIds 前端传入的启用工具 ID 列表
+ * @returns 合并后的工具定义和系统提示词
+ */
+export function getEnabledTools(enabledToolIds?: string[]): EnabledToolsResult {
+  // 未传入 enabledToolIds 时使用配置文件的开关状态
+  const config = getChatToolsConfig()
+  const memoryConfig = getMemoryConfig()
+
+  const allDefinitions: ToolDefinition[] = []
+  const systemPromptParts: string[] = []
+
+  for (const entry of BUILTIN_TOOLS) {
+    const toolId = entry.meta.id
+    const state = config.toolStates[toolId]
+
+    // 检查工具是否启用（前端开关 + 配置开关）
+    const isEnabledByUser = enabledToolIds ? enabledToolIds.includes(toolId) : (state?.enabled ?? false)
+    if (!isEnabledByUser) continue
+
+    // 记忆工具额外检查全局记忆配置的 enabled 状态
+    if (toolId === 'memory') {
+      if (!memoryConfig.enabled || !memoryConfig.apiKey) continue
+    }
+
+    // 检查工具是否可用（凭据已配置）
+    if (!entry.checkAvailable()) continue
+
+    // 收集工具定义
+    allDefinitions.push(...entry.getDefinitions())
+
+    // 收集系统提示词
+    if (entry.meta.systemPromptAppend) {
+      systemPromptParts.push(entry.meta.systemPromptAppend)
+    }
+  }
+
+  // 自定义工具
+  for (const customMeta of config.customTools) {
+    const toolId = customMeta.id
+    const isEnabledByUser = enabledToolIds
+      ? enabledToolIds.includes(toolId)
+      : (config.toolStates[toolId]?.enabled ?? false)
+    if (!isEnabledByUser) continue
+
+    // 自定义工具不需要凭据检查，httpConfig 即为配置
+    allDefinitions.push(convertMetaToDefinition(customMeta))
+
+    if (customMeta.systemPromptAppend) {
+      systemPromptParts.push(customMeta.systemPromptAppend)
+    }
+  }
+
+  return {
+    tools: allDefinitions.length > 0 ? allDefinitions : undefined,
+    systemPromptAppend: systemPromptParts.length > 0 ? systemPromptParts.join('\n') : undefined,
+  }
+}
+
+/**
+ * 获取所有工具信息（供前端展示）
+ *
+ * 返回所有内置 + 自定义工具的元数据、开关状态和可用性。
+ */
+export function getAllToolInfos(): ChatToolInfo[] {
+  const config = getChatToolsConfig()
+  const memoryConfig = getMemoryConfig()
+  const infos: ChatToolInfo[] = []
+
+  // 内置工具
+  for (const entry of BUILTIN_TOOLS) {
+    const toolId = entry.meta.id
+    const state = config.toolStates[toolId]
+
+    // 记忆工具的 enabled 还受全局记忆配置影响
+    let enabled = state?.enabled ?? false
+    if (toolId === 'memory') {
+      enabled = enabled && memoryConfig.enabled
+    }
+
+    infos.push({
+      meta: entry.meta,
+      enabled,
+      available: entry.checkAvailable(),
+    })
+  }
+
+  // 自定义工具
+  for (const customMeta of config.customTools) {
+    const state = config.toolStates[customMeta.id]
+
+    infos.push({
+      meta: customMeta,
+      enabled: state?.enabled ?? false,
+      available: !!customMeta.httpConfig,
+    })
+  }
+
+  return infos
+}

--- a/apps/electron/src/main/lib/chat-tool-registry.ts
+++ b/apps/electron/src/main/lib/chat-tool-registry.ts
@@ -21,6 +21,11 @@ import {
   WEB_SEARCH_TOOL_DEFINITIONS,
   isWebSearchAvailable,
 } from './chat-tools/web-search-tool'
+import {
+  AGENT_RECOMMEND_TOOL_META,
+  AGENT_RECOMMEND_TOOL_DEFINITIONS,
+  isAgentRecommendAvailable,
+} from './chat-tools/agent-recommend-tool'
 import { getMemoryConfig } from './memory-service'
 
 // ===== 内置工具注册 =====
@@ -43,6 +48,11 @@ const BUILTIN_TOOLS: BuiltinToolEntry[] = [
     meta: WEB_SEARCH_TOOL_META,
     getDefinitions: () => WEB_SEARCH_TOOL_DEFINITIONS,
     checkAvailable: isWebSearchAvailable,
+  },
+  {
+    meta: AGENT_RECOMMEND_TOOL_META,
+    getDefinitions: () => AGENT_RECOMMEND_TOOL_DEFINITIONS,
+    checkAvailable: isAgentRecommendAvailable,
   },
 ]
 

--- a/apps/electron/src/main/lib/chat-tools-watcher.ts
+++ b/apps/electron/src/main/lib/chat-tools-watcher.ts
@@ -1,0 +1,66 @@
+/**
+ * Chat 工具配置文件监听器
+ *
+ * 监听 ~/.proma/chat-tools.json 的变化，
+ * 当 Agent 通过文件系统修改配置后自动通知渲染进程刷新工具列表。
+ *
+ * 使用 node:fs.watch + debounce 防抖，避免高频写入导致多次通知。
+ */
+
+import { watch, existsSync } from 'node:fs'
+import type { FSWatcher } from 'node:fs'
+import { BrowserWindow } from 'electron'
+import { CHAT_TOOL_IPC_CHANNELS } from '@proma/shared'
+import { getChatToolsConfigPath } from './config-paths'
+
+/** debounce 延迟（ms） */
+const DEBOUNCE_MS = 500
+
+let watcher: FSWatcher | null = null
+
+/**
+ * 启动 chat-tools.json 文件监听
+ *
+ * 文件变化时向所有窗口广播 CUSTOM_TOOL_CHANGED 事件。
+ */
+export function startChatToolsWatcher(): void {
+  const filePath = getChatToolsConfigPath()
+
+  if (!existsSync(filePath)) {
+    console.log('[Chat 工具监听] 配置文件不存在，跳过:', filePath)
+    return
+  }
+
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null
+
+  try {
+    watcher = watch(filePath, (_eventType) => {
+      if (debounceTimer) clearTimeout(debounceTimer)
+      debounceTimer = setTimeout(() => {
+        const windows = BrowserWindow.getAllWindows()
+        for (const win of windows) {
+          if (!win.isDestroyed()) {
+            win.webContents.send(CHAT_TOOL_IPC_CHANNELS.CUSTOM_TOOL_CHANGED)
+          }
+        }
+        console.log('[Chat 工具监听] 配置变更，已通知渲染进程')
+        debounceTimer = null
+      }, DEBOUNCE_MS)
+    })
+
+    console.log('[Chat 工具监听] 已启动')
+  } catch (err) {
+    console.error('[Chat 工具监听] 启动失败:', err)
+  }
+}
+
+/**
+ * 停止 chat-tools.json 文件监听
+ */
+export function stopChatToolsWatcher(): void {
+  if (watcher) {
+    watcher.close()
+    watcher = null
+    console.log('[Chat 工具监听] 已停止')
+  }
+}

--- a/apps/electron/src/main/lib/chat-tools/agent-recommend-tool.ts
+++ b/apps/electron/src/main/lib/chat-tools/agent-recommend-tool.ts
@@ -1,0 +1,141 @@
+/**
+ * Agent 模式推荐工具模块（Chat 模式）
+ *
+ * 智能识别适合 Agent 模式的任务，推荐用户切换。
+ * 工具本身不执行切换，只产出推荐数据（reason + suggestedPrompt），
+ * 由渲染进程的 AgentRecommendBanner 负责展示和执行迁移。
+ */
+
+import type { ToolCall, ToolResult, ToolDefinition } from '@proma/core'
+import type { ChatToolMeta } from '@proma/shared'
+
+// ===== 工具元数据 =====
+
+export const AGENT_RECOMMEND_TOOL_META: ChatToolMeta = {
+  id: 'agent-mode-recommend',
+  name: 'Agent 模式推荐',
+  description: '智能识别适合 Agent 模式的任务，推荐用户切换',
+  params: [
+    { name: 'reason', type: 'string', description: '推荐理由', required: true },
+    { name: 'suggestedPrompt', type: 'string', description: '建议的 Agent 初始提示词', required: true },
+  ],
+  icon: 'Sparkles',
+  category: 'builtin',
+  executorType: 'builtin',
+  systemPromptAppend: `
+<agent_mode_recommendation>
+你有能力推荐用户切换到 Agent 模式。**请积极主动地识别适合 Agent 模式的任务**，在回复用户之前先调用 suggest_agent_mode 工具。
+
+## Agent 模式的能力
+
+Agent 模式拥有以下 Chat 模式不具备的能力：
+- **文件读写**：直接浏览、创建、编辑用户本地文件和项目代码
+- **命令行操作**：执行 shell 命令、运行测试、安装依赖、构建项目
+- **MCP 服务器**：连接数据库、调用外部 API、获取实时数据
+- **Skills 技能**：使用专业技能完成特定任务（如创建幻灯片、分析数据、生成图表）
+- **多步骤编排**：自主规划和执行复杂的多步骤任务，支持试错和迭代
+- **深度研究**：通过 MCP 和 Skills 进行系统化的信息搜集、对比分析和结构化输出
+
+## 推荐判断基准
+
+当用户的任务符合以下**任一**场景时，就应该推荐切换：
+
+1. **研究调研类任务**：产品调研、技术选型、竞品分析、行业报告、市场分析等需要系统化搜集和整理信息的任务
+2. **内容创作与输出**：撰写长文档、报告、方案、教程等需要结构化输出的任务
+3. **文件操作意图**：阅读/创建/修改代码、文档、配置文件，生成项目结构等
+4. **编程开发任务**：写代码、调试、重构、添加功能、写测试等软件开发工作
+5. **系统操作需求**：执行命令行操作、安装软件、运行脚本、管理进程等
+6. **外部能力需求**：访问数据库、调用 API、获取实时数据、使用开发工具等
+7. **数据处理分析**：数据清洗、统计分析、生成图表、制作可视化等
+8. **复杂多步任务**：任何需要拆分为多个子步骤、涉及规划和迭代的任务
+
+### 典型推荐示例
+
+- "帮我做个 XX 产品/技术的调研" → 推荐（深度研究 + 结构化输出）
+- "帮我写一个 React 组件" → 推荐（文件创建 + 代码编写）
+- "分析一下这个项目的代码" → 推荐（文件读取 + 代码分析）
+- "帮我整理一份报告" → 推荐（内容创作 + 结构化输出）
+- "搭建一个新项目" → 推荐（文件创建 + 命令行 + 多步骤）
+
+### 不推荐的场景
+
+仅以下简单任务不需要推荐：简短问答、解释概念、翻译短文、日常闲聊、简单计算
+
+## 推荐要求
+
+- **reason 必须具体说明 Agent 模式如何帮助用户更好地实现他们的目标**。结合用户的具体任务描述 Agent 会怎样做。例如："你想做桌面端 AI 产品调研，Agent 模式可以通过 MCP 和 Skills 系统化地搜集各产品信息、自动整理对比分析，并输出结构化的调研报告文档。"
+- suggestedPrompt 应概括用户的核心任务需求，作为 Agent 会话的起始提示
+- 每轮对话最多推荐一次，避免反复打扰
+</agent_mode_recommendation>`,
+}
+
+// ===== 工具定义（ToolDefinition 格式，传给 Provider） =====
+
+export const AGENT_RECOMMEND_TOOL_DEFINITIONS: ToolDefinition[] = [
+  {
+    name: 'suggest_agent_mode',
+    description: 'Proactively recommend switching to Agent mode when the task involves research, coding, file operations, command execution, content creation, data analysis, or any multi-step work. Call this before responding whenever the task would meaningfully benefit from Agent capabilities.',
+    parameters: {
+      type: 'object',
+      properties: {
+        reason: {
+          type: 'string',
+          description: 'Specific explanation of how Agent mode can better help the user achieve their goal',
+        },
+        suggestedPrompt: {
+          type: 'string',
+          description: 'Suggested initial prompt for the Agent session, summarizing the user\'s core task',
+        },
+      },
+      required: ['reason', 'suggestedPrompt'],
+    },
+  },
+]
+
+// ===== 可用性检查 =====
+
+/**
+ * Agent 推荐工具始终可用（无需外部凭据）
+ */
+export function isAgentRecommendAvailable(): boolean {
+  return true
+}
+
+// ===== 工具执行 =====
+
+/** 推荐工具名称集合 */
+const AGENT_RECOMMEND_TOOL_NAMES = new Set(['suggest_agent_mode'])
+
+/**
+ * 判断是否为 Agent 推荐工具调用
+ */
+export function isAgentRecommendToolCall(toolName: string): boolean {
+  return AGENT_RECOMMEND_TOOL_NAMES.has(toolName)
+}
+
+/**
+ * 执行 Agent 推荐工具调用
+ *
+ * 返回结构化 JSON 数据，供渲染进程解析并展示推荐横幅。
+ */
+export async function executeAgentRecommendTool(toolCall: ToolCall): Promise<ToolResult> {
+  const reason = toolCall.arguments.reason as string | undefined
+  const suggestedPrompt = toolCall.arguments.suggestedPrompt as string | undefined
+
+  if (!reason || !suggestedPrompt) {
+    return {
+      toolCallId: toolCall.id,
+      content: '参数缺失: reason 和 suggestedPrompt 均为必填',
+      isError: true,
+    }
+  }
+
+  return {
+    toolCallId: toolCall.id,
+    content: JSON.stringify({
+      type: 'agent_recommendation',
+      reason,
+      suggestedPrompt,
+    }),
+  }
+}

--- a/apps/electron/src/main/lib/chat-tools/http-tool-executor.ts
+++ b/apps/electron/src/main/lib/chat-tools/http-tool-executor.ts
@@ -1,0 +1,150 @@
+/**
+ * HTTP 工具执行器（自定义工具用）
+ *
+ * 根据 ChatToolMeta 中的 httpConfig 配置执行 HTTP 请求。
+ * 支持 URL/Body 模板占位符替换、超时控制、响应路径提取。
+ */
+
+import type { ToolCall, ToolResult } from '@proma/core'
+import type { ChatToolMeta, ChatToolHttpConfig } from '@proma/shared'
+import { getChatToolsConfig } from '../chat-tool-config'
+
+/** HTTP 请求超时（30 秒） */
+const HTTP_TIMEOUT_MS = 30_000
+
+/**
+ * 判断是否为自定义 HTTP 工具调用
+ *
+ * 通过查找 customTools 配置判断 toolName 是否属于自定义工具。
+ */
+export function isCustomHttpToolCall(toolName: string): boolean {
+  const config = getChatToolsConfig()
+  return config.customTools.some((t) => t.id === toolName)
+}
+
+/**
+ * 替换模板中的 {{paramName}} 占位符
+ *
+ * @param template 模板字符串
+ * @param args 参数键值对
+ * @param urlEncode 是否对值做 URL 编码
+ */
+function replaceTemplatePlaceholders(
+  template: string,
+  args: Record<string, unknown>,
+  urlEncode: boolean,
+): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (_match, paramName: string) => {
+    const value = args[paramName]
+    const str = value != null ? String(value) : ''
+    return urlEncode ? encodeURIComponent(str) : str
+  })
+}
+
+/**
+ * 通过点号路径提取嵌套对象的值
+ *
+ * @param obj 源对象
+ * @param path 点号路径（如 "data.results"）
+ * @returns 提取的值，路径不存在时返回 undefined
+ */
+function extractByPath(obj: unknown, path: string): unknown {
+  const parts = path.split('.')
+  let current: unknown = obj
+
+  for (const part of parts) {
+    if (current == null || typeof current !== 'object') return undefined
+    current = (current as Record<string, unknown>)[part]
+  }
+
+  return current
+}
+
+/**
+ * 执行自定义 HTTP 工具调用
+ *
+ * @param toolCall 模型返回的工具调用
+ * @param meta 工具元数据（包含 httpConfig）
+ * @returns 工具执行结果
+ */
+export async function executeHttpTool(toolCall: ToolCall, meta: ChatToolMeta): Promise<ToolResult> {
+  const httpConfig = meta.httpConfig
+
+  if (!httpConfig) {
+    return {
+      toolCallId: toolCall.id,
+      content: `工具 ${meta.id} 缺少 HTTP 配置`,
+      isError: true,
+    }
+  }
+
+  try {
+    const result = await executeHttpRequest(toolCall.arguments, httpConfig)
+    return {
+      toolCallId: toolCall.id,
+      content: typeof result === 'string' ? result : JSON.stringify(result, null, 2),
+    }
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error)
+    console.error(`[HTTP 工具] ${meta.id} 执行失败:`, error)
+    return {
+      toolCallId: toolCall.id,
+      content: `HTTP 请求失败: ${msg}`,
+      isError: true,
+    }
+  }
+}
+
+/**
+ * 执行 HTTP 请求
+ */
+async function executeHttpRequest(
+  args: Record<string, unknown>,
+  config: ChatToolHttpConfig,
+): Promise<unknown> {
+  // URL 占位符替换（URL 编码）
+  const url = replaceTemplatePlaceholders(config.urlTemplate, args, true)
+
+  // 请求头
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...config.headers,
+  }
+
+  // 请求配置
+  const fetchInit: RequestInit = {
+    method: config.method,
+    headers,
+    signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
+  }
+
+  // POST 请求体
+  if (config.method === 'POST' && config.bodyTemplate) {
+    fetchInit.body = replaceTemplatePlaceholders(config.bodyTemplate, args, false)
+  }
+
+  const response = await fetch(url, fetchInit)
+
+  if (!response.ok) {
+    const errorText = await response.text()
+    throw new Error(`HTTP ${response.status}: ${errorText}`)
+  }
+
+  // 解析响应
+  const contentType = response.headers.get('content-type') || ''
+  let data: unknown
+
+  if (contentType.includes('application/json')) {
+    data = await response.json()
+  } else {
+    data = await response.text()
+  }
+
+  // 路径提取
+  if (config.resultPath && typeof data === 'object' && data !== null) {
+    const extracted = extractByPath(data, config.resultPath)
+    return extracted !== undefined ? extracted : data
+  }
+
+  return data
+}

--- a/apps/electron/src/main/lib/chat-tools/memory-tool.ts
+++ b/apps/electron/src/main/lib/chat-tools/memory-tool.ts
@@ -1,0 +1,136 @@
+/**
+ * 记忆工具模块（Chat 模式）
+ *
+ * 从 chat-service.ts 提取的记忆工具定义和执行逻辑。
+ * 凭据通过 getMemoryConfig() 从 memory.json 读取（Chat + Agent 共用）。
+ */
+
+import type { ToolCall, ToolResult, ToolDefinition } from '@proma/core'
+import type { ChatToolMeta } from '@proma/shared'
+import { getMemoryConfig } from '../memory-service'
+import { searchMemory, addMemory, formatSearchResult } from '../memos-client'
+
+// ===== 工具元数据 =====
+
+export const MEMORY_TOOL_META: ChatToolMeta = {
+  id: 'memory',
+  name: '记忆',
+  description: '跨会话记忆能力，记住用户偏好和重要信息',
+  params: [
+    { name: 'query', type: 'string', description: '搜索查询', required: true },
+  ],
+  icon: 'Brain',
+  category: 'builtin',
+  executorType: 'builtin',
+  systemPromptAppend: `
+<memory_instructions>
+你拥有跨会话的记忆能力。
+
+**recall_memory — 回忆：**
+在你觉得过去的经历可能对当前有帮助时主动调用：
+- 用户提到"之前"、"上次"等回溯性表述
+- 当前任务可能和过去做过的事情有关
+
+**add_memory — 记住：**
+当对话中发生值得记住的事时调用：
+- 用户分享了工作方式或偏好
+- 一起做了重要决定
+- 解决了棘手问题
+
+自然地运用记忆，不要提及"记忆系统"等内部概念。
+</memory_instructions>`,
+}
+
+// ===== 工具定义（ToolDefinition 格式，传给 Provider） =====
+
+export const MEMORY_TOOL_DEFINITIONS: ToolDefinition[] = [
+  {
+    name: 'recall_memory',
+    description: 'Search user memories (facts and preferences). Use this to recall relevant context about the user before responding.',
+    parameters: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Search query for memory retrieval' },
+      },
+      required: ['query'],
+    },
+  },
+  {
+    name: 'add_memory',
+    description: 'Store a conversation message pair for long-term memory. Call this after meaningful exchanges worth remembering.',
+    parameters: {
+      type: 'object',
+      properties: {
+        userMessage: { type: 'string', description: 'The user message to store' },
+        assistantMessage: { type: 'string', description: 'The assistant response to store' },
+      },
+      required: ['userMessage'],
+    },
+  },
+]
+
+// ===== 可用性检查 =====
+
+/**
+ * 检查记忆工具是否可用（凭据已配置）
+ */
+export function isMemoryAvailable(): boolean {
+  const config = getMemoryConfig()
+  return !!config.apiKey
+}
+
+// ===== 工具执行 =====
+
+/** 记忆工具名称集合 */
+const MEMORY_TOOL_NAMES = new Set(['recall_memory', 'add_memory'])
+
+/**
+ * 判断是否为记忆工具调用
+ */
+export function isMemoryToolCall(toolName: string): boolean {
+  return MEMORY_TOOL_NAMES.has(toolName)
+}
+
+/**
+ * 执行记忆工具调用
+ */
+export async function executeMemoryTool(toolCall: ToolCall): Promise<ToolResult> {
+  const memoryConfig = getMemoryConfig()
+  const credentials = {
+    apiKey: memoryConfig.apiKey,
+    userId: memoryConfig.userId?.trim() || 'proma-user',
+    baseUrl: memoryConfig.baseUrl,
+  }
+
+  try {
+    if (toolCall.name === 'recall_memory') {
+      const query = toolCall.arguments.query as string
+      const result = await searchMemory(credentials, query)
+      return {
+        toolCallId: toolCall.id,
+        content: formatSearchResult(result),
+      }
+    } else if (toolCall.name === 'add_memory') {
+      const userMessage = toolCall.arguments.userMessage as string
+      const assistantMessage = toolCall.arguments.assistantMessage as string | undefined
+      await addMemory(credentials, { userMessage, assistantMessage })
+      return {
+        toolCallId: toolCall.id,
+        content: 'Memory stored successfully.',
+      }
+    }
+    return {
+      toolCallId: toolCall.id,
+      content: `未知记忆工具: ${toolCall.name}`,
+      isError: true,
+    }
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error)
+    console.error(`[记忆工具] 执行失败 (${toolCall.name}):`, error)
+    return {
+      toolCallId: toolCall.id,
+      content: `Tool execution failed: ${msg}`,
+      isError: true,
+    }
+  }
+}

--- a/apps/electron/src/main/lib/chat-tools/web-search-tool.ts
+++ b/apps/electron/src/main/lib/chat-tools/web-search-tool.ts
@@ -1,0 +1,174 @@
+/**
+ * 联网搜索工具模块（Chat 模式）
+ *
+ * 基于 Tavily Search API 提供实时联网搜索能力。
+ * 凭据存储在 ~/.proma/chat-tools.json 的 toolCredentials 中。
+ */
+
+import type { ToolCall, ToolResult, ToolDefinition } from '@proma/core'
+import type { ChatToolMeta } from '@proma/shared'
+import { getToolCredentials } from '../chat-tool-config'
+
+// ===== 工具元数据 =====
+
+export const WEB_SEARCH_TOOL_META: ChatToolMeta = {
+  id: 'web-search',
+  name: '联网搜索',
+  description: '实时搜索互联网获取最新信息',
+  params: [
+    { name: 'query', type: 'string', description: '搜索查询', required: true },
+  ],
+  icon: 'Globe',
+  category: 'builtin',
+  executorType: 'builtin',
+  systemPromptAppend: `
+<web_search_instructions>
+你拥有联网搜索能力。
+
+**web_search — 搜索：**
+当用户询问你不确定或可能过时的信息时主动调用：
+- 时事新闻、最新数据、实时信息
+- 你不确定的事实性问题
+- 用户明确要求搜索或查找信息
+
+搜索时使用简洁明确的关键词，返回结果后综合整理回答用户。
+</web_search_instructions>`,
+}
+
+// ===== 工具定义（ToolDefinition 格式，传给 Provider） =====
+
+export const WEB_SEARCH_TOOL_DEFINITIONS: ToolDefinition[] = [
+  {
+    name: 'web_search',
+    description: 'Search the internet for real-time information. Use this when the user asks about current events, recent data, or information you are unsure about.',
+    parameters: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Search query string' },
+      },
+      required: ['query'],
+    },
+  },
+]
+
+// ===== 可用性检查 =====
+
+/**
+ * 检查搜索工具是否可用（API Key 已配置）
+ */
+export function isWebSearchAvailable(): boolean {
+  const credentials = getToolCredentials('web-search')
+  return !!credentials.apiKey
+}
+
+// ===== 工具执行 =====
+
+/** 搜索工具名称集合 */
+const WEB_SEARCH_TOOL_NAMES = new Set(['web_search'])
+
+/**
+ * 判断是否为搜索工具调用
+ */
+export function isWebSearchToolCall(toolName: string): boolean {
+  return WEB_SEARCH_TOOL_NAMES.has(toolName)
+}
+
+/** Tavily API 搜索结果类型 */
+interface TavilySearchResult {
+  title: string
+  url: string
+  content: string
+  score: number
+}
+
+interface TavilySearchResponse {
+  results: TavilySearchResult[]
+  answer?: string
+}
+
+/**
+ * 执行联网搜索工具调用
+ */
+export async function executeWebSearchTool(toolCall: ToolCall): Promise<ToolResult> {
+  const credentials = getToolCredentials('web-search')
+
+  if (!credentials.apiKey) {
+    return {
+      toolCallId: toolCall.id,
+      content: '搜索工具未配置 API Key',
+      isError: true,
+    }
+  }
+
+  try {
+    const query = toolCall.arguments.query as string | undefined
+
+    if (!query) {
+      return {
+        toolCallId: toolCall.id,
+        content: '搜索参数缺失: query',
+        isError: true,
+      }
+    }
+
+    const response = await fetch('https://api.tavily.com/search', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        api_key: credentials.apiKey,
+        query,
+        search_depth: 'basic',
+        max_results: 5,
+        include_answer: true,
+      }),
+    })
+
+    if (!response.ok) {
+      const errorText = await response.text()
+      return {
+        toolCallId: toolCall.id,
+        content: `搜索请求失败 (${response.status}): ${errorText}`,
+        isError: true,
+      }
+    }
+
+    const data = await response.json() as TavilySearchResponse
+    return {
+      toolCallId: toolCall.id,
+      content: formatSearchResults(data),
+    }
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error)
+    console.error(`[联网搜索] 执行失败:`, error)
+    return {
+      toolCallId: toolCall.id,
+      content: `Search failed: ${msg}`,
+      isError: true,
+    }
+  }
+}
+
+/**
+ * 格式化搜索结果为 LLM 可读文本
+ */
+function formatSearchResults(data: TavilySearchResponse): string {
+  const parts: string[] = []
+
+  if (data.answer) {
+    parts.push(`**概要：** ${data.answer}`)
+    parts.push('')
+  }
+
+  if (data.results && data.results.length > 0) {
+    parts.push('**搜索结果：**')
+    for (const result of data.results) {
+      parts.push(`- [${result.title}](${result.url})`)
+      parts.push(`  ${result.content.slice(0, 300)}`)
+      parts.push('')
+    }
+  } else {
+    parts.push('未找到相关结果。')
+  }
+
+  return parts.join('\n')
+}

--- a/apps/electron/src/main/lib/config-paths.ts
+++ b/apps/electron/src/main/lib/config-paths.ts
@@ -166,6 +166,15 @@ export function getMemoryConfigPath(): string {
 }
 
 /**
+ * 获取 Chat 工具配置文件路径
+ *
+ * @returns ~/.proma/chat-tools.json
+ */
+export function getChatToolsConfigPath(): string {
+  return join(getConfigDir(), 'chat-tools.json')
+}
+
+/**
  * 获取 Agent 会话索引文件路径
  *
  * @returns ~/.proma/agent-sessions.json

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -6,7 +6,7 @@
  */
 
 import { contextBridge, ipcRenderer } from 'electron'
-import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, MEMORY_IPC_CHANNELS } from '@proma/shared'
+import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, MEMORY_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS } from '@proma/shared'
 import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS } from '../types'
 import type {
   RuntimeStatus,
@@ -62,6 +62,9 @@ import type {
   SystemPromptCreateInput,
   SystemPromptUpdateInput,
   MemoryConfig,
+  ChatToolInfo,
+  ChatToolState,
+  ChatToolMeta,
 } from '@proma/shared'
 import type { UserProfile, AppSettings } from '../types'
 
@@ -336,6 +339,32 @@ export interface ElectronAPI {
 
   /** 测试记忆连接 */
   testMemoryConnection: () => Promise<{ success: boolean; message: string }>
+
+  // ===== Chat 工具管理 =====
+
+  /** 获取所有工具信息 */
+  getChatTools: () => Promise<ChatToolInfo[]>
+
+  /** 获取工具凭据 */
+  getChatToolCredentials: (toolId: string) => Promise<Record<string, string>>
+
+  /** 更新工具开关状态 */
+  updateChatToolState: (toolId: string, state: ChatToolState) => Promise<void>
+
+  /** 更新工具凭据 */
+  updateChatToolCredentials: (toolId: string, credentials: Record<string, string>) => Promise<void>
+
+  /** 创建自定义工具 */
+  createCustomChatTool: (meta: ChatToolMeta) => Promise<void>
+
+  /** 删除自定义工具 */
+  deleteCustomChatTool: (toolId: string) => Promise<void>
+
+  /** 监听自定义工具配置变更 */
+  onCustomToolChanged: (callback: () => void) => () => void
+
+  /** 测试工具连接 */
+  testChatTool: (toolId: string) => Promise<{ success: boolean; message: string }>
 
   // ===== AskUserQuestion 交互式问答 =====
 
@@ -771,6 +800,41 @@ const electronAPI: ElectronAPI = {
 
   testMemoryConnection: () => {
     return ipcRenderer.invoke(MEMORY_IPC_CHANNELS.TEST_CONNECTION)
+  },
+
+  // Chat 工具管理
+  getChatTools: () => {
+    return ipcRenderer.invoke(CHAT_TOOL_IPC_CHANNELS.GET_ALL_TOOLS)
+  },
+
+  getChatToolCredentials: (toolId: string) => {
+    return ipcRenderer.invoke(CHAT_TOOL_IPC_CHANNELS.GET_TOOL_CREDENTIALS, toolId)
+  },
+
+  updateChatToolState: (toolId: string, state: ChatToolState) => {
+    return ipcRenderer.invoke(CHAT_TOOL_IPC_CHANNELS.UPDATE_TOOL_STATE, toolId, state)
+  },
+
+  updateChatToolCredentials: (toolId: string, credentials: Record<string, string>) => {
+    return ipcRenderer.invoke(CHAT_TOOL_IPC_CHANNELS.UPDATE_TOOL_CREDENTIALS, toolId, credentials)
+  },
+
+  createCustomChatTool: (meta: ChatToolMeta) => {
+    return ipcRenderer.invoke(CHAT_TOOL_IPC_CHANNELS.CREATE_CUSTOM_TOOL, meta)
+  },
+
+  deleteCustomChatTool: (toolId: string) => {
+    return ipcRenderer.invoke(CHAT_TOOL_IPC_CHANNELS.DELETE_CUSTOM_TOOL, toolId)
+  },
+
+  onCustomToolChanged: (callback: () => void) => {
+    const listener = (): void => callback()
+    ipcRenderer.on(CHAT_TOOL_IPC_CHANNELS.CUSTOM_TOOL_CHANGED, listener)
+    return () => { ipcRenderer.removeListener(CHAT_TOOL_IPC_CHANNELS.CUSTOM_TOOL_CHANGED, listener) }
+  },
+
+  testChatTool: (toolId: string) => {
+    return ipcRenderer.invoke(CHAT_TOOL_IPC_CHANNELS.TEST_TOOL, toolId)
   },
 
   // AskUserQuestion 交互式问答

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -257,6 +257,9 @@ export interface ElectronAPI {
   /** 删除 Agent 会话 */
   deleteAgentSession: (id: string) => Promise<void>
 
+  /** 迁移 Chat 对话记录到 Agent 会话 */
+  migrateChatToAgent: (conversationId: string, agentSessionId: string) => Promise<void>
+
   /** 生成 Agent 会话标题 */
   generateAgentTitle: (input: AgentGenerateTitleInput) => Promise<string | null>
 
@@ -687,6 +690,10 @@ const electronAPI: ElectronAPI = {
 
   deleteAgentSession: (id: string) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.DELETE_SESSION, id)
+  },
+
+  migrateChatToAgent: (conversationId: string, agentSessionId: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.MIGRATE_CHAT_TO_AGENT, conversationId, agentSessionId)
   },
 
   generateAgentTitle: (input: AgentGenerateTitleInput) => {

--- a/apps/electron/src/renderer/atoms/chat-atoms.ts
+++ b/apps/electron/src/renderer/atoms/chat-atoms.ts
@@ -203,3 +203,18 @@ export const currentConversationDraftAtom = atom(
     })
   }
 )
+
+// ===== Agent 模式推荐 =====
+
+/** Agent 模式推荐数据（由 suggest_agent_mode 工具结果写入） */
+export interface AgentRecommendation {
+  /** 推荐理由（AI 生成，描述 Agent 如何帮助用户） */
+  reason: string
+  /** 建议的 Agent 初始提示词 */
+  suggestedPrompt: string
+  /** 来源对话 ID（用于对话切换时清除） */
+  conversationId: string
+}
+
+/** 待处理的 Agent 模式推荐（工具结果写入，用户操作/关闭/切换对话时清除） */
+export const pendingAgentRecommendationAtom = atom<AgentRecommendation | null>(null)

--- a/apps/electron/src/renderer/atoms/chat-tool-atoms.ts
+++ b/apps/electron/src/renderer/atoms/chat-tool-atoms.ts
@@ -1,0 +1,43 @@
+/**
+ * Chat Tool Atoms - Chat 工具状态管理
+ *
+ * 管理 Chat 模式下可用工具的列表和开关状态：
+ * - chatToolsAtom: 从主进程加载的所有工具信息
+ * - enabledToolIdsAtom: 用户在 ChatInput 中切换的工具开关
+ * - activeToolIdsAtom: 当前实际启用的工具 ID（交集）
+ */
+
+import { atom } from 'jotai'
+import { atomWithStorage } from 'jotai/utils'
+import type { ChatToolInfo } from '@proma/shared'
+
+/** 从主进程加载的所有工具列表 */
+export const chatToolsAtom = atom<ChatToolInfo[]>([])
+
+/**
+ * 用户在 ChatInput 工具栏中切换的工具 ID 集合
+ *
+ * localStorage 持久化，默认包含 'memory'（记忆工具默认开启）
+ */
+export const enabledToolIdsAtom = atomWithStorage<string[]>(
+  'proma-enabled-tool-ids',
+  ['memory'],
+)
+
+/**
+ * 派生：当前实际启用的工具 ID 列表
+ *
+ * 交集条件：用户开关打开 AND 工具已配置可用
+ */
+export const activeToolIdsAtom = atom<string[]>((get) => {
+  const allTools = get(chatToolsAtom)
+  const enabledIds = get(enabledToolIdsAtom)
+  return allTools
+    .filter((t) => enabledIds.includes(t.meta.id) && t.available)
+    .map((t) => t.meta.id)
+})
+
+/** 派生：是否有任何工具启用 */
+export const hasActiveToolsAtom = atom<boolean>((get) => {
+  return get(activeToolIdsAtom).length > 0
+})

--- a/apps/electron/src/renderer/atoms/settings-tab.ts
+++ b/apps/electron/src/renderer/atoms/settings-tab.ts
@@ -11,7 +11,7 @@
 
 import { atom } from 'jotai'
 
-export type SettingsTab = 'general' | 'channels' | 'proxy' | 'appearance' | 'about' | 'agent' | 'prompts' | 'memory'
+export type SettingsTab = 'general' | 'channels' | 'proxy' | 'appearance' | 'about' | 'agent' | 'prompts' | 'tools'
 
 /** 当前设置标签页（不持久化，每次打开设置默认显示渠道） */
 export const settingsTabAtom = atom<SettingsTab>('channels')

--- a/apps/electron/src/renderer/components/chat/AgentRecommendBanner.tsx
+++ b/apps/electron/src/renderer/components/chat/AgentRecommendBanner.tsx
@@ -1,0 +1,145 @@
+/**
+ * AgentRecommendBanner — Agent 模式推荐横幅
+ *
+ * 当 AI 通过 suggest_agent_mode 工具推荐切换到 Agent 模式时，
+ * 在 ChatInput 上方展示推荐横幅（与 AskUserBanner 同风格同位置）。
+ * 用户可点击"切换到 Agent 模式"按钮迁移，或点击 × 关闭。
+ *
+ * 迁移流程：
+ * 1. 清除推荐状态（先清再切换，避免 ChatView 副作用）
+ * 2. 创建 Agent 会话（绑定默认工作区）
+ * 3. 将 Chat 对话历史复制到新 Agent 会话
+ * 4. 切换到默认工作区 + Agent 模式
+ * 5. 在 Agent 输入区显示建议提示（prompt suggestion）
+ */
+
+import * as React from 'react'
+import { useAtom, useStore } from 'jotai'
+import { toast } from 'sonner'
+import { Sparkles, X, ArrowRight } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { pendingAgentRecommendationAtom } from '@/atoms/chat-atoms'
+import {
+  agentChannelIdAtom,
+  agentWorkspacesAtom,
+  agentSessionsAtom,
+  currentAgentSessionIdAtom,
+  currentAgentWorkspaceIdAtom,
+  agentPromptSuggestionsAtom,
+} from '@/atoms/agent-atoms'
+import { activeViewAtom } from '@/atoms/active-view'
+import { appModeAtom } from '@/atoms/app-mode'
+
+export function AgentRecommendBanner(): React.ReactElement | null {
+  const [recommendation, setRecommendation] = useAtom(pendingAgentRecommendationAtom)
+  const store = useStore()
+  const [migrating, setMigrating] = React.useState(false)
+
+  if (!recommendation) return null
+
+  const handleDismiss = (): void => {
+    setRecommendation(null)
+  }
+
+  const handleMigrate = async (): Promise<void> => {
+    if (migrating) return
+
+    const agentChannelId = store.get(agentChannelIdAtom)
+    if (!agentChannelId) {
+      toast.error('请先在设置中配置 Agent 渠道')
+      return
+    }
+
+    // 保存推荐数据后立即清除，避免模式切换时 ChatView 副作用
+    const { conversationId, suggestedPrompt } = recommendation
+    setRecommendation(null)
+
+    setMigrating(true)
+    try {
+      const workspaces = store.get(agentWorkspacesAtom)
+      const defaultWorkspaceId = workspaces[0]?.id ?? null
+
+      // 1. 创建 Agent 会话
+      const session = await window.electronAPI.createAgentSession(
+        undefined,
+        agentChannelId,
+        defaultWorkspaceId ?? undefined,
+      )
+
+      // 2. 迁移 Chat 对话记录到新 Agent 会话
+      await window.electronAPI.migrateChatToAgent(conversationId, session.id)
+
+      // 3. 刷新会话列表
+      const sessions = await window.electronAPI.listAgentSessions()
+      store.set(agentSessionsAtom, sessions)
+
+      // 4. 切换到默认工作区（确保 AgentView 能正确显示新会话）
+      if (defaultWorkspaceId) {
+        store.set(currentAgentWorkspaceIdAtom, defaultWorkspaceId)
+        window.electronAPI.updateSettings({
+          agentWorkspaceId: defaultWorkspaceId,
+        }).catch(console.error)
+      }
+
+      // 5. 切换到新会话 + 设置建议提示 + 切换模式
+      store.set(currentAgentSessionIdAtom, session.id)
+
+      // 在 Agent 输入区显示建议提示（用户点击后发送，而非自动发送）
+      store.set(agentPromptSuggestionsAtom, (prev) => {
+        const map = new Map(prev)
+        map.set(session.id, suggestedPrompt)
+        return map
+      })
+
+      store.set(activeViewAtom, 'conversations')
+      store.set(appModeAtom, 'agent')
+    } catch (error) {
+      console.error('[AgentRecommendBanner] 迁移失败:', error)
+      toast.error('切换到 Agent 模式失败')
+    } finally {
+      setMigrating(false)
+    }
+  }
+
+  return (
+    <div className="mx-4 mb-3 rounded-xl bg-card shadow-lg overflow-hidden animate-in slide-in-from-bottom-2 duration-200">
+      {/* 头部 */}
+      <div className="px-4 pt-3 pb-2">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Sparkles className="size-4 text-primary" />
+            <span className="text-sm font-medium text-foreground">推荐使用 Agent 模式</span>
+          </div>
+          <button
+            type="button"
+            className="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+            onClick={handleDismiss}
+          >
+            <X className="size-3.5" />
+          </button>
+        </div>
+      </div>
+
+      {/* 推荐理由 */}
+      <div className="px-4 pb-3">
+        <p className="text-sm text-foreground/80 leading-relaxed">
+          {recommendation.reason}
+        </p>
+      </div>
+
+      {/* 操作按钮 */}
+      <div className="flex items-center justify-end px-4 pb-3">
+        <Button
+          variant="default"
+          size="sm"
+          onClick={handleMigrate}
+          disabled={migrating}
+          className="h-7 px-3 text-xs"
+        >
+          {migrating ? '切换中...' : '切换到 Agent 模式'}
+          {!migrating && <ArrowRight className="size-3 ml-1" />}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatInput.tsx
@@ -18,6 +18,7 @@ import { CornerDownLeft, Square, Lightbulb, Paperclip } from 'lucide-react'
 import { ModelSelector } from './ModelSelector'
 import { ClearContextButton } from './ClearContextButton'
 import { ContextSettingsPopover } from './ContextSettingsPopover'
+import { ToolSelectorPopover } from './ToolSelectorPopover'
 import { AttachmentPreviewItem } from './AttachmentPreviewItem'
 import { RichTextInput } from '@/components/ai-elements/rich-text-input'
 import { SpeechButton } from '@/components/ai-elements/speech-button'
@@ -304,6 +305,8 @@ export function ChatInput({ onSend, onStop, onClearContext }: ChatInputProps): R
               </Tooltip>
 
               <SpeechButton onTranscript={handleSpeechTranscript} />
+
+              <ToolSelectorPopover />
 
               <ContextSettingsPopover />
 

--- a/apps/electron/src/renderer/components/chat/ChatMessageItem.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessageItem.tsx
@@ -37,6 +37,7 @@ import { getModelLogo } from '@/lib/model-logo'
 import { userProfileAtom } from '@/atoms/user-profile'
 import type { ChatMessage } from '@proma/shared'
 import type { InlineEditSubmitPayload } from './InlineEditForm'
+import { ChatToolActivityIndicator } from './ChatToolActivityIndicator'
 
 // 重导出供外部使用
 export type { InlineEditSubmitPayload } from './InlineEditForm'
@@ -159,6 +160,11 @@ export function ChatMessageItem({
         <MessageContent>
           {message.role === 'assistant' ? (
             <>
+              {/* 工具活动记录（历史消息） */}
+              {message.toolActivities && message.toolActivities.length > 0 && (
+                <ChatToolActivityIndicator activities={message.toolActivities} />
+              )}
+
               {/* 推理折叠区域 */}
               {message.reasoning && (
                 <Reasoning

--- a/apps/electron/src/renderer/components/chat/ChatMessages.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessages.tsx
@@ -14,9 +14,10 @@
 
 import * as React from 'react'
 import { useAtomValue } from 'jotai'
-import { MessageSquare, Loader2, Brain, CheckCircle2, XCircle } from 'lucide-react'
+import { MessageSquare, Loader2 } from 'lucide-react'
 import { ChatMessageItem, formatMessageTime } from './ChatMessageItem'
 import type { InlineEditSubmitPayload } from './ChatMessageItem'
+import { ChatToolActivityIndicator } from './ChatToolActivityIndicator'
 import { ParallelChatMessages } from './ParallelChatMessages'
 import {
   Message,
@@ -55,65 +56,7 @@ import {
 } from '@/atoms/chat-atoms'
 import { getModelLogo } from '@/lib/model-logo'
 import { userProfileAtom } from '@/atoms/user-profile'
-import type { ChatMessage, ChatToolActivity } from '@proma/shared'
-import { cn } from '@/lib/utils'
-
-// ===== 记忆工具活动指示器 =====
-
-/** 工具名称到中文标签的映射 */
-const TOOL_LABELS: Record<string, { running: string; done: string }> = {
-  recall_memory: { running: '正在回忆…', done: '回忆完成' },
-  add_memory: { running: '正在记住…', done: '已记住' },
-}
-
-function MemoryToolIndicator({ activities }: { activities: ChatToolActivity[] }): React.ReactElement | null {
-  if (activities.length === 0) return null
-
-  // 合并同一个 toolCallId 的 start/result 事件
-  const merged = new Map<string, { toolName: string; done: boolean; isError?: boolean }>()
-  for (const a of activities) {
-    const existing = merged.get(a.toolCallId)
-    if (a.type === 'start') {
-      merged.set(a.toolCallId, { toolName: a.toolName, done: false })
-    } else if (a.type === 'result') {
-      merged.set(a.toolCallId, {
-        toolName: existing?.toolName ?? a.toolName,
-        done: true,
-        isError: a.isError,
-      })
-    }
-  }
-
-  const items = Array.from(merged.values())
-  if (items.length === 0) return null
-
-  return (
-    <div className="space-y-1 mb-2">
-      {items.map((item, i) => {
-        const label = TOOL_LABELS[item.toolName] ?? { running: item.toolName, done: item.toolName }
-        return (
-          <div
-            key={i}
-            className={cn(
-              'flex items-center gap-1.5 text-xs text-muted-foreground',
-              'animate-in fade-in slide-in-from-left-2 duration-200',
-            )}
-          >
-            {!item.done ? (
-              <Loader2 className="size-3 animate-spin text-primary" />
-            ) : item.isError ? (
-              <XCircle className="size-3 text-destructive" />
-            ) : (
-              <CheckCircle2 className="size-3 text-green-500" />
-            )}
-            <Brain className="size-3" />
-            <span>{item.done ? (item.isError ? `${label.done}（失败）` : label.done) : label.running}</span>
-          </div>
-        )
-      })}
-    </div>
-  )
-}
+import type { ChatMessage } from '@proma/shared'
 
 // ===== 滚动到顶部加载更多 =====
 
@@ -390,8 +333,8 @@ export function ChatMessages({
                   }
                 />
                 <MessageContent>
-                  {/* 记忆工具活动指示器 */}
-                  <MemoryToolIndicator activities={toolActivities} />
+                  {/* 工具活动指示器 */}
+                  <ChatToolActivityIndicator activities={toolActivities} />
 
                   {/* 推理内容（如果有） */}
                   {smoothReasoning && (

--- a/apps/electron/src/renderer/components/chat/ChatToolActivityIndicator.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatToolActivityIndicator.tsx
@@ -1,0 +1,124 @@
+/**
+ * ChatToolActivityIndicator - 工具活动指示器
+ *
+ * 展示工具调用的状态（进行中/完成/失败），
+ * 已完成的工具活动可点击展开查看结果详情。
+ * 同时用于流式临时消息和历史持久化消息。
+ */
+
+import * as React from 'react'
+import { Loader2, Brain, Globe, Wrench, CheckCircle2, XCircle, ChevronRight } from 'lucide-react'
+import {
+  Collapsible,
+  CollapsibleTrigger,
+  CollapsibleContent,
+} from '@/components/ui/collapsible'
+import { MessageResponse } from '@/components/ai-elements/message'
+import type { ChatToolActivity } from '@proma/shared'
+import { cn } from '@/lib/utils'
+
+/** 工具名称到中文标签的映射 */
+const TOOL_LABELS: Record<string, { running: string; done: string }> = {
+  recall_memory: { running: '正在回忆…', done: '回忆完成' },
+  add_memory: { running: '正在记住…', done: '已记住' },
+  web_search: { running: '正在搜索…', done: '搜索完成' },
+}
+
+/** 根据工具名称返回对应图标 */
+function getToolIcon(toolName: string): React.ReactElement {
+  if (toolName === 'recall_memory' || toolName === 'add_memory') {
+    return <Brain className="size-3" />
+  }
+  if (toolName === 'web_search') {
+    return <Globe className="size-3" />
+  }
+  return <Wrench className="size-3" />
+}
+
+export function ChatToolActivityIndicator({ activities }: { activities: ChatToolActivity[] }): React.ReactElement | null {
+  if (activities.length === 0) return null
+
+  // 合并同一个 toolCallId 的 start/result 事件
+  const merged = new Map<string, { toolName: string; done: boolean; isError?: boolean; result?: string }>()
+  for (const a of activities) {
+    const existing = merged.get(a.toolCallId)
+    if (a.type === 'start') {
+      merged.set(a.toolCallId, { toolName: a.toolName, done: false })
+    } else if (a.type === 'result') {
+      merged.set(a.toolCallId, {
+        toolName: existing?.toolName ?? a.toolName,
+        done: true,
+        isError: a.isError,
+        result: a.result,
+      })
+    }
+  }
+
+  const items = Array.from(merged.entries())
+  if (items.length === 0) return null
+
+  return (
+    <div className="space-y-1 mb-2">
+      {items.map(([callId, item]) => {
+        const label = TOOL_LABELS[item.toolName] ?? { running: item.toolName, done: item.toolName }
+        const hasResult = item.done && item.result
+
+        // 已完成且有结果的工具活动，可展开查看详情
+        if (hasResult) {
+          return (
+            <ToolActivityCollapsible key={callId} item={item} label={label} />
+          )
+        }
+
+        return (
+          <div
+            key={callId}
+            className={cn(
+              'flex items-center gap-1.5 text-xs text-muted-foreground',
+              'animate-in fade-in slide-in-from-left-2 duration-200',
+            )}
+          >
+            {!item.done ? (
+              <Loader2 className="size-3 animate-spin text-primary" />
+            ) : item.isError ? (
+              <XCircle className="size-3 text-destructive" />
+            ) : (
+              <CheckCircle2 className="size-3 text-green-500" />
+            )}
+            {getToolIcon(item.toolName)}
+            <span>{item.done ? (item.isError ? `${label.done}（失败）` : label.done) : label.running}</span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+/** 可展开的工具活动项 */
+function ToolActivityCollapsible({
+  item,
+  label,
+}: {
+  item: { toolName: string; done: boolean; isError?: boolean; result?: string }
+  label: { running: string; done: string }
+}): React.ReactElement {
+  return (
+    <Collapsible>
+      <CollapsibleTrigger className="group flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer w-full text-left">
+        {item.isError ? (
+          <XCircle className="size-3 text-destructive shrink-0" />
+        ) : (
+          <CheckCircle2 className="size-3 text-green-500 shrink-0" />
+        )}
+        {getToolIcon(item.toolName)}
+        <span>{item.isError ? `${label.done}（失败）` : label.done}</span>
+        <ChevronRight className="size-3 ml-auto transition-transform group-data-[state=open]:rotate-90 shrink-0" />
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="mt-1 ml-5 rounded-lg bg-muted/50 p-3 text-xs text-muted-foreground max-h-60 overflow-y-auto">
+          <MessageResponse>{item.result ?? ''}</MessageResponse>
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}

--- a/apps/electron/src/renderer/components/chat/ChatToolActivityIndicator.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatToolActivityIndicator.tsx
@@ -7,7 +7,7 @@
  */
 
 import * as React from 'react'
-import { Loader2, Brain, Globe, Wrench, CheckCircle2, XCircle, ChevronRight } from 'lucide-react'
+import { Loader2, Brain, Globe, Wrench, Sparkles, CheckCircle2, XCircle, ChevronRight } from 'lucide-react'
 import {
   Collapsible,
   CollapsibleTrigger,
@@ -22,6 +22,7 @@ const TOOL_LABELS: Record<string, { running: string; done: string }> = {
   recall_memory: { running: '正在回忆…', done: '回忆完成' },
   add_memory: { running: '正在记住…', done: '已记住' },
   web_search: { running: '正在搜索…', done: '搜索完成' },
+  suggest_agent_mode: { running: '正在分析任务适配性…', done: '已推荐 Agent 模式' },
 }
 
 /** 根据工具名称返回对应图标 */
@@ -31,6 +32,9 @@ function getToolIcon(toolName: string): React.ReactElement {
   }
   if (toolName === 'web_search') {
     return <Globe className="size-3" />
+  }
+  if (toolName === 'suggest_agent_mode') {
+    return <Sparkles className="size-3" />
   }
   return <Wrench className="size-3" />
 }

--- a/apps/electron/src/renderer/components/chat/ChatView.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatView.tsx
@@ -38,6 +38,7 @@ import {
   currentChatErrorAtom,
 } from '@/atoms/chat-atoms'
 import { resolvedSystemMessageAtom, promptSidebarOpenAtom } from '@/atoms/system-prompt-atoms'
+import { activeToolIdsAtom } from '@/atoms/chat-tool-atoms'
 import { cn } from '@/lib/utils'
 import type { ConversationStreamState } from '@/atoms/chat-atoms'
 import type {
@@ -69,6 +70,7 @@ export function ChatView(): React.ReactElement {
   const isStreaming = useAtomValue(streamingAtom)
   const resolvedSystemMessage = useAtomValue(resolvedSystemMessageAtom)
   const promptSidebarOpen = useAtomValue(promptSidebarOpenAtom)
+  const activeToolIds = useAtomValue(activeToolIdsAtom)
   const [inlineEditingMessageId, setInlineEditingMessageId] = React.useState<string | null>(null)
 
   // 首条消息标题生成相关 ref（支持多对话并行）
@@ -369,6 +371,7 @@ export function ChatView(): React.ReactElement {
       attachments: savedAttachments.length > 0 ? savedAttachments : undefined,
       thinkingEnabled: thinkingEnabled || undefined,
       systemMessage: resolvedSystemMessage,
+      enabledToolIds: activeToolIds.length > 0 ? activeToolIds : undefined,
     }
 
     // 乐观更新：立即在 UI 中显示用户消息
@@ -401,6 +404,7 @@ export function ChatView(): React.ReactElement {
     contextDividers,
     thinkingEnabled,
     resolvedSystemMessage,
+    activeToolIds,
     setChatStreamErrors,
     setPendingAttachments,
     setStreamingStates,

--- a/apps/electron/src/renderer/components/chat/ChatView.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatView.tsx
@@ -18,6 +18,7 @@ import { MessageSquare, AlertCircle, X } from 'lucide-react'
 import { ChatHeader } from './ChatHeader'
 import { ChatMessages } from './ChatMessages'
 import { ChatInput } from './ChatInput'
+import { AgentRecommendBanner } from './AgentRecommendBanner'
 import { PromptEditorSidebar } from './PromptEditorSidebar'
 import type { InlineEditSubmitPayload } from './ChatMessageItem'
 import {
@@ -36,6 +37,7 @@ import {
   INITIAL_MESSAGE_LIMIT,
   chatStreamErrorsAtom,
   currentChatErrorAtom,
+  pendingAgentRecommendationAtom,
 } from '@/atoms/chat-atoms'
 import { resolvedSystemMessageAtom, promptSidebarOpenAtom } from '@/atoms/system-prompt-atoms'
 import { activeToolIdsAtom } from '@/atoms/chat-tool-atoms'
@@ -71,6 +73,7 @@ export function ChatView(): React.ReactElement {
   const resolvedSystemMessage = useAtomValue(resolvedSystemMessageAtom)
   const promptSidebarOpen = useAtomValue(promptSidebarOpenAtom)
   const activeToolIds = useAtomValue(activeToolIdsAtom)
+  const setPendingRecommendation = useSetAtom(pendingAgentRecommendationAtom)
   const [inlineEditingMessageId, setInlineEditingMessageId] = React.useState<string | null>(null)
 
   // 首条消息标题生成相关 ref（支持多对话并行）
@@ -84,6 +87,7 @@ export function ChatView(): React.ReactElement {
 
   React.useEffect(() => {
     setInlineEditingMessageId(null)
+    setPendingRecommendation(null)
   }, [currentConversationId])
 
   // 加载当前对话最近消息 + 上下文分隔线
@@ -244,6 +248,27 @@ export function ChatView(): React.ReactElement {
           ...s,
           toolActivities: [...s.toolActivities, event.activity],
         }))
+
+        // 检测 Agent 推荐工具结果，写入推荐 atom
+        if (
+          event.activity.type === 'result'
+          && event.activity.toolName === 'suggest_agent_mode'
+          && event.activity.result
+          && !event.activity.isError
+        ) {
+          try {
+            const parsed = JSON.parse(event.activity.result) as { type?: string; reason?: string; suggestedPrompt?: string }
+            if (parsed.type === 'agent_recommendation' && parsed.reason && parsed.suggestedPrompt) {
+              setPendingRecommendation({
+                reason: parsed.reason,
+                suggestedPrompt: parsed.suggestedPrompt,
+                conversationId: event.conversationId,
+              })
+            }
+          } catch {
+            // JSON 解析失败，忽略
+          }
+        }
       }
     )
 
@@ -664,6 +689,9 @@ export function ChatView(): React.ReactElement {
               </button>
             </div>
           )}
+
+          {/* Agent 模式推荐横幅 */}
+          <AgentRecommendBanner />
 
           {/* 底部：输入框 */}
           <ChatInput

--- a/apps/electron/src/renderer/components/chat/ToolSelectorPopover.tsx
+++ b/apps/electron/src/renderer/components/chat/ToolSelectorPopover.tsx
@@ -1,0 +1,151 @@
+/**
+ * ToolSelectorPopover - 工具选择器弹出层
+ *
+ * 在 ChatInput footer 中显示工具开关列表。
+ * 用户可以快速启用/禁用工具（记忆、联网搜索等）。
+ * 类似 ContextSettingsPopover 的交互方式。
+ */
+
+import { useState } from 'react'
+import { useAtom, useAtomValue } from 'jotai'
+import { Button } from '@/components/ui/button'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import { Switch } from '@/components/ui/switch'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import { Wrench, Brain, Globe, Settings } from 'lucide-react'
+import { chatToolsAtom, enabledToolIdsAtom, hasActiveToolsAtom } from '@/atoms/chat-tool-atoms'
+import { settingsTabAtom } from '@/atoms/settings-tab'
+import { activeViewAtom } from '@/atoms/active-view'
+
+/** 工具 ID 到图标的映射 */
+function getToolIcon(iconName?: string): React.ReactElement {
+  switch (iconName) {
+    case 'Brain':
+      return <Brain className="size-4" />
+    case 'Globe':
+      return <Globe className="size-4" />
+    default:
+      return <Wrench className="size-4" />
+  }
+}
+
+export function ToolSelectorPopover(): React.ReactElement {
+  const [open, setOpen] = useState(false)
+  const tools = useAtomValue(chatToolsAtom)
+  const [enabledIds, setEnabledIds] = useAtom(enabledToolIdsAtom)
+  const hasActiveTools = useAtomValue(hasActiveToolsAtom)
+  const [, setActiveView] = useAtom(activeViewAtom)
+  const [, setSettingsTab] = useAtom(settingsTabAtom)
+
+  /** 切换工具开关 */
+  const toggleTool = (toolId: string): void => {
+    if (enabledIds.includes(toolId)) {
+      setEnabledIds(enabledIds.filter((id) => id !== toolId))
+    } else {
+      setEnabledIds([...enabledIds, toolId])
+    }
+  }
+
+  /** 跳转到设置页工具 tab */
+  const goToToolSettings = (): void => {
+    setOpen(false)
+    setActiveView('settings')
+    setSettingsTab('tools')
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Tooltip open={open ? false : undefined}>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className={cn(
+                'size-[30px] rounded-full',
+                hasActiveTools ? 'text-blue-500' : 'text-foreground/60 hover:text-foreground',
+              )}
+            >
+              <Wrench className="size-5" />
+            </Button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="top">
+          <p>工具</p>
+        </TooltipContent>
+      </Tooltip>
+      <PopoverContent className="w-64" side="top" align="center">
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-xs font-medium">工具</span>
+          </div>
+
+          {/* 工具列表 */}
+          {tools.length === 0 ? (
+            <p className="text-xs text-muted-foreground py-2">加载中...</p>
+          ) : (
+            <div className="space-y-1">
+              {tools.map((tool) => {
+                const isEnabled = enabledIds.includes(tool.meta.id)
+                const canToggle = tool.available
+
+                return (
+                  <div
+                    key={tool.meta.id}
+                    className="flex items-center justify-between py-1.5 px-1 rounded-md hover:bg-muted/50"
+                  >
+                    <div className="flex items-center gap-2 min-w-0">
+                      <span className={cn(
+                        'shrink-0',
+                        !canToggle && 'opacity-40',
+                      )}>
+                        {getToolIcon(tool.meta.icon)}
+                      </span>
+                      <span className={cn(
+                        'text-sm truncate',
+                        !canToggle && 'text-muted-foreground',
+                      )}>
+                        {tool.meta.name}
+                      </span>
+                      {!canToggle && (
+                        <span className="text-[10px] text-muted-foreground shrink-0">
+                          需配置
+                        </span>
+                      )}
+                    </div>
+                    <Switch
+                      checked={isEnabled && canToggle}
+                      onCheckedChange={() => toggleTool(tool.meta.id)}
+                      disabled={!canToggle}
+                      className="scale-75"
+                    />
+                  </div>
+                )
+              })}
+            </div>
+          )}
+
+          {/* 管理工具链接 */}
+          <button
+            type="button"
+            onClick={goToToolSettings}
+            className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors w-full pt-1 border-t border-border/50"
+          >
+            <Settings className="size-3" />
+            <span>管理工具</span>
+          </button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
+++ b/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
@@ -9,7 +9,7 @@
 import * as React from 'react'
 import { useAtom, useAtomValue } from 'jotai'
 import { cn } from '@/lib/utils'
-import { Settings, Radio, Palette, Info, Plug, Globe, BookOpen, Brain } from 'lucide-react'
+import { Settings, Radio, Palette, Info, Plug, Globe, BookOpen, Wrench } from 'lucide-react'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { settingsTabAtom } from '@/atoms/settings-tab'
 import type { SettingsTab } from '@/atoms/settings-tab'
@@ -23,7 +23,7 @@ import { AppearanceSettings } from './AppearanceSettings'
 import { AboutSettings } from './AboutSettings'
 import { AgentSettings } from './AgentSettings'
 import { PromptSettings } from './PromptSettings'
-import { MemorySettings } from './MemorySettings'
+import { ToolSettings } from './ToolSettings'
 
 /** 设置 Tab 定义 */
 interface TabItem {
@@ -42,7 +42,7 @@ const BASE_TABS: TabItem[] = [
 
 /** Agent 模式专属 Tab */
 const AGENT_TAB: TabItem = { id: 'agent', label: '配置', icon: <Plug size={16} /> }
-const MEMORY_TAB: TabItem = { id: 'memory', label: '记忆', icon: <Brain size={16} /> }
+const TOOLS_TAB: TabItem = { id: 'tools', label: '工具', icon: <Wrench size={16} /> }
 
 /** 尾部 Tabs */
 const TAIL_TABS: TabItem[] = [
@@ -63,8 +63,8 @@ function renderTabContent(tab: SettingsTab): React.ReactElement {
       return <ProxySettings />
     case 'agent':
       return <AgentSettings />
-    case 'memory':
-      return <MemorySettings />
+    case 'tools':
+      return <ToolSettings />
     case 'appearance':
       return <AppearanceSettings />
     case 'about':
@@ -78,12 +78,12 @@ export function SettingsPanel(): React.ReactElement {
   const hasUpdate = useAtomValue(hasUpdateAtom)
   const hasEnvironmentIssues = useAtomValue(hasEnvironmentIssuesAtom)
 
-  // Agent 模式时在渠道后插入 Agent Tab，记忆 tab 两种模式都显示
+  // Agent 模式时在渠道后插入 Agent Tab，工具 tab 两种模式都显示
   const tabs = React.useMemo(() => {
     if (appMode === 'agent') {
-      return [...BASE_TABS, AGENT_TAB, MEMORY_TAB, ...TAIL_TABS]
+      return [...BASE_TABS, AGENT_TAB, TOOLS_TAB, ...TAIL_TABS]
     }
-    return [...BASE_TABS, MEMORY_TAB, ...TAIL_TABS]
+    return [...BASE_TABS, TOOLS_TAB, ...TAIL_TABS]
   }, [appMode])
 
   return (

--- a/apps/electron/src/renderer/components/settings/ToolSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/ToolSettings.tsx
@@ -1,0 +1,285 @@
+/**
+ * ToolSettings - 工具设置页
+ *
+ * Chat 模式工具统一管理 tab。
+ * 内嵌 MemorySettings（记忆工具）+ 联网搜索工具配置。
+ */
+
+import * as React from 'react'
+import { useSetAtom, useAtomValue } from 'jotai'
+import { toast } from 'sonner'
+import { ExternalLink, Eye, EyeOff, Loader2, CheckCircle2, XCircle, Trash2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Switch } from '@/components/ui/switch'
+import { Input } from '@/components/ui/input'
+import { MemorySettings } from './MemorySettings'
+import { SettingsSection, SettingsCard } from './primitives'
+import { chatToolsAtom } from '@/atoms/chat-tool-atoms'
+
+/** 刷新全局工具列表 atom */
+async function refreshChatTools(setter: (tools: Awaited<ReturnType<typeof window.electronAPI.getChatTools>>) => void): Promise<void> {
+  try {
+    const tools = await window.electronAPI.getChatTools()
+    setter(tools)
+  } catch (err) {
+    console.error('[ToolSettings] 刷新工具列表失败:', err)
+  }
+}
+
+/** 联网搜索工具设置区域 */
+function WebSearchSettings(): React.ReactElement {
+  const [apiKey, setApiKey] = React.useState('')
+  const [showApiKey, setShowApiKey] = React.useState(false)
+  const [enabled, setEnabled] = React.useState(false)
+  const [loading, setLoading] = React.useState(true)
+  const [testing, setTesting] = React.useState(false)
+  const [testResult, setTestResult] = React.useState<{ success: boolean; message: string } | null>(null)
+  const setChatTools = useSetAtom(chatToolsAtom)
+
+  // 已保存的 API Key（用于判断是否有变更）
+  const savedApiKeyRef = React.useRef('')
+
+  // 从主进程加载当前配置 + 凭据
+  React.useEffect(() => {
+    Promise.all([
+      window.electronAPI.getChatTools(),
+      window.electronAPI.getChatToolCredentials('web-search'),
+    ]).then(([tools, credentials]) => {
+      const searchTool = tools.find((t) => t.meta.id === 'web-search')
+      if (searchTool) {
+        setEnabled(searchTool.enabled)
+      }
+      if (credentials.apiKey) {
+        setApiKey(credentials.apiKey)
+        savedApiKeyRef.current = credentials.apiKey
+      }
+    }).catch((err: unknown) => {
+      console.error('[联网搜索设置] 加载失败:', err)
+    }).finally(() => {
+      setLoading(false)
+    })
+  }, [])
+
+  /** 静默保存 API Key（blur 时触发） */
+  const handleBlurSave = React.useCallback(async (): Promise<void> => {
+    const trimmed = apiKey.trim()
+    if (trimmed === savedApiKeyRef.current) return
+    try {
+      await window.electronAPI.updateChatToolCredentials('web-search', { apiKey: trimmed })
+      savedApiKeyRef.current = trimmed
+      // 刷新全局工具列表（available 状态可能变化）
+      await refreshChatTools(setChatTools)
+      toast.success('联网搜索设置已保存')
+    } catch (error) {
+      console.error('[联网搜索设置] 保存失败:', error)
+    }
+  }, [apiKey, setChatTools])
+
+  const handleToggle = async (checked: boolean): Promise<void> => {
+    try {
+      await window.electronAPI.updateChatToolState('web-search', { enabled: checked })
+      setEnabled(checked)
+      await refreshChatTools(setChatTools)
+    } catch (error) {
+      console.error('[联网搜索设置] 切换失败:', error)
+    }
+  }
+
+  const handleTest = async (): Promise<void> => {
+    // 先保存可能的变更
+    const trimmed = apiKey.trim()
+    if (trimmed !== savedApiKeyRef.current) {
+      try {
+        await window.electronAPI.updateChatToolCredentials('web-search', { apiKey: trimmed })
+        savedApiKeyRef.current = trimmed
+        await refreshChatTools(setChatTools)
+      } catch (error) {
+        console.error('[联网搜索设置] 保存失败:', error)
+      }
+    }
+
+    setTesting(true)
+    setTestResult(null)
+    try {
+      const result = await window.electronAPI.testChatTool('web-search')
+      setTestResult(result)
+    } catch (error) {
+      setTestResult({ success: false, message: error instanceof Error ? error.message : String(error) })
+    } finally {
+      setTesting(false)
+    }
+  }
+
+  if (loading) {
+    return <div className="text-sm text-muted-foreground py-8 text-center">加载中...</div>
+  }
+
+  return (
+    <SettingsSection
+      title="联网搜索"
+      description="启用后 AI 可以实时搜索互联网获取最新信息"
+      action={
+        <Switch
+          checked={enabled}
+          onCheckedChange={handleToggle}
+        />
+      }
+    >
+      <SettingsCard divided={false}>
+        <div className="space-y-4 p-4">
+          {/* 引导说明 */}
+          <div className="rounded-lg bg-muted/50 p-3 space-y-2 text-sm text-muted-foreground">
+            <p>联网搜索由 <span className="font-medium text-foreground">Tavily</span> 提供，启用后 AI 可以搜索互联网获取实时信息。</p>
+            <p className="text-xs">配置步骤：</p>
+            <ol className="text-xs list-decimal list-inside space-y-1">
+              <li>
+                访问{' '}
+                <a
+                  href="https://tavily.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary hover:underline inline-flex items-center gap-0.5"
+                >
+                  Tavily 官网
+                  <ExternalLink size={10} />
+                </a>
+                {' '}注册账号
+              </li>
+              <li>在控制台获取 API Key（免费额度每月 1000 次搜索）</li>
+              <li>将 API Key 填入下方，然后开启开关</li>
+            </ol>
+          </div>
+
+          <div className="space-y-1.5">
+            <div className="flex items-center justify-between">
+              <label className="text-sm font-medium">API Key</label>
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={testing || !apiKey.trim()}
+                onClick={handleTest}
+              >
+                {testing ? <><Loader2 size={14} className="animate-spin mr-1.5" />测试中...</> : '测试连接'}
+              </Button>
+            </div>
+            <div className="relative">
+              <Input
+                type={showApiKey ? 'text' : 'password'}
+                placeholder="tvly-..."
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                onBlur={handleBlurSave}
+                className="pr-10"
+              />
+              <button
+                type="button"
+                onClick={() => setShowApiKey(!showApiKey)}
+                className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-muted-foreground hover:text-foreground transition-colors"
+                tabIndex={-1}
+              >
+                {showApiKey ? <EyeOff size={16} /> : <Eye size={16} />}
+              </button>
+            </div>
+          </div>
+
+          {testResult && (
+            <div className={`flex items-start gap-2 rounded-lg p-3 text-sm ${testResult.success ? 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' : 'bg-destructive/10 text-destructive'}`}>
+              {testResult.success ? <CheckCircle2 size={16} className="mt-0.5 shrink-0" /> : <XCircle size={16} className="mt-0.5 shrink-0" />}
+              <span>{testResult.message}</span>
+            </div>
+          )}
+        </div>
+      </SettingsCard>
+    </SettingsSection>
+  )
+}
+
+/** 自定义工具列表区域 */
+function CustomToolsSection(): React.ReactElement | null {
+  const tools = useAtomValue(chatToolsAtom)
+  const setChatTools = useSetAtom(chatToolsAtom)
+
+  const customTools = tools.filter((t) => t.meta.category === 'custom')
+  if (customTools.length === 0) return null
+
+  const handleToggle = async (toolId: string, checked: boolean): Promise<void> => {
+    try {
+      await window.electronAPI.updateChatToolState(toolId, { enabled: checked })
+      await refreshChatTools(setChatTools)
+    } catch (error) {
+      console.error('[自定义工具] 切换失败:', error)
+    }
+  }
+
+  const handleDelete = async (toolId: string, toolName: string): Promise<void> => {
+    try {
+      await window.electronAPI.deleteCustomChatTool(toolId)
+      await refreshChatTools(setChatTools)
+      toast.success(`已删除工具: ${toolName}`)
+    } catch (error) {
+      console.error('[自定义工具] 删除失败:', error)
+      toast.error('删除工具失败')
+    }
+  }
+
+  return (
+    <SettingsSection
+      title="自定义工具"
+      description="通过 Agent 模式创建的 HTTP API 工具"
+    >
+      <SettingsCard divided>
+        {customTools.map((tool) => (
+          <div key={tool.meta.id} className="flex items-center justify-between p-4">
+            <div className="flex-1 min-w-0 mr-4">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium">{tool.meta.name}</span>
+                {tool.meta.httpConfig && (
+                  <span className="text-xs text-muted-foreground font-mono">
+                    {tool.meta.httpConfig.method}
+                  </span>
+                )}
+              </div>
+              <p className="text-xs text-muted-foreground mt-0.5 truncate">
+                {tool.meta.description}
+              </p>
+              {tool.meta.httpConfig && (
+                <p className="text-xs text-muted-foreground/60 mt-0.5 truncate font-mono">
+                  {tool.meta.httpConfig.urlTemplate}
+                </p>
+              )}
+            </div>
+            <div className="flex items-center gap-2 shrink-0">
+              <Switch
+                checked={tool.enabled}
+                onCheckedChange={(checked) => handleToggle(tool.meta.id, checked)}
+              />
+              <Button
+                size="icon"
+                variant="ghost"
+                className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                onClick={() => handleDelete(tool.meta.id, tool.meta.name)}
+              >
+                <Trash2 size={14} />
+              </Button>
+            </div>
+          </div>
+        ))}
+      </SettingsCard>
+    </SettingsSection>
+  )
+}
+
+export function ToolSettings(): React.ReactElement {
+  return (
+    <div className="space-y-8">
+      {/* 记忆工具（复用现有 MemorySettings 组件） */}
+      <MemorySettings />
+
+      {/* 联网搜索工具 */}
+      <WebSearchSettings />
+
+      {/* 自定义工具 */}
+      <CustomToolsSection />
+    </div>
+  )
+}

--- a/packages/core/src/providers/openai-adapter.ts
+++ b/packages/core/src/providers/openai-adapter.ts
@@ -240,9 +240,11 @@ export class OpenAIAdapter implements ProviderAdapter {
             })
           }
           if (tc.function?.arguments) {
+            // tc.id 仅在首个 chunk 中存在，后续 delta 不携带 id
+            // 使用空字符串让 SSE reader 通过 currentToolCallId 关联
             events.push({
               type: 'tool_call_delta',
-              toolCallId: tc.id || `tc_${tc.index ?? 0}`,
+              toolCallId: tc.id || '',
               argumentsDelta: tc.function.arguments,
             })
           }

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -524,6 +524,8 @@ export const AGENT_IPC_CHANNELS = {
   UPDATE_TITLE: 'agent:update-title',
   /** 删除会话 */
   DELETE_SESSION: 'agent:delete-session',
+  /** 迁移 Chat 对话记录到 Agent 会话 */
+  MIGRATE_CHAT_TO_AGENT: 'agent:migrate-chat-to-agent',
 
   // 工作区管理
   /** 获取工作区列表 */

--- a/packages/shared/src/types/chat-tool.ts
+++ b/packages/shared/src/types/chat-tool.ts
@@ -1,0 +1,110 @@
+/**
+ * Chat Tool 模块化系统类型定义
+ *
+ * Chat 模式的工具（function calling）注册、配置、执行相关的共享类型。
+ * 记忆凭据保留在 memory.json（Chat + Agent 共用），
+ * chat-tools.json 管理工具开关和非记忆工具凭据。
+ */
+
+// ===== 工具元数据 =====
+
+/** 工具参数定义（简化格式，供用户/Agent 创建） */
+export interface ChatToolParam {
+  /** 参数名 */
+  name: string
+  /** 参数类型 */
+  type: 'string' | 'number' | 'boolean'
+  /** 参数描述 */
+  description: string
+  /** 是否必填 */
+  required?: boolean
+  /** 可选值枚举 */
+  enum?: string[]
+}
+
+/** HTTP 执行器配置（自定义工具用） */
+export interface ChatToolHttpConfig {
+  /** 请求 URL 模板，支持 {{param}} 占位符 */
+  urlTemplate: string
+  /** HTTP 方法 */
+  method: 'GET' | 'POST'
+  /** 请求头 */
+  headers?: Record<string, string>
+  /** 请求体模板（JSON 字符串，支持 {{param}} 占位符） */
+  bodyTemplate?: string
+  /** 响应结果提取的 JSONPath（可选，默认取全部） */
+  resultPath?: string
+}
+
+/** 工具元数据（描述一个工具"是什么"） */
+export interface ChatToolMeta {
+  /** 工具唯一标识（slug 格式） */
+  id: string
+  /** 显示名称 */
+  name: string
+  /** 描述（同时作为 LLM 的 tool description） */
+  description: string
+  /** 参数列表 */
+  params: ChatToolParam[]
+  /** 图标名称（lucide 图标名，可选） */
+  icon?: string
+  /** 工具类别 */
+  category: 'builtin' | 'custom'
+  /** 系统提示词追加（启用时注入） */
+  systemPromptAppend?: string
+  /** 执行器类型：builtin 由代码处理，http 由配置的 endpoint 处理 */
+  executorType: 'builtin' | 'http'
+  /** HTTP 执行器配置（executorType === 'http' 时使用） */
+  httpConfig?: ChatToolHttpConfig
+}
+
+// ===== 配置持久化 =====
+
+/** 单个工具的开关配置 */
+export interface ChatToolState {
+  /** 是否启用 */
+  enabled: boolean
+}
+
+/** 配置文件结构（~/.proma/chat-tools.json） */
+export interface ChatToolsFileConfig {
+  /** 各工具的开关状态，key 为工具 id */
+  toolStates: Record<string, ChatToolState>
+  /** 非记忆工具的凭据，key 为工具 id */
+  toolCredentials: Record<string, Record<string, string>>
+  /** 自定义工具定义列表 */
+  customTools: ChatToolMeta[]
+}
+
+// ===== 渲染进程交互 =====
+
+/** 渲染进程看到的完整工具信息 */
+export interface ChatToolInfo {
+  /** 工具元数据 */
+  meta: ChatToolMeta
+  /** 开关状态 */
+  enabled: boolean
+  /** 工具是否可用（凭据已配置） */
+  available: boolean
+}
+
+// ===== IPC 通道 =====
+
+export const CHAT_TOOL_IPC_CHANNELS = {
+  /** 获取所有可用工具信息 */
+  GET_ALL_TOOLS: 'chat-tool:get-all-tools',
+  /** 获取工具凭据 */
+  GET_TOOL_CREDENTIALS: 'chat-tool:get-credentials',
+  /** 更新单个工具的开关状态 */
+  UPDATE_TOOL_STATE: 'chat-tool:update-state',
+  /** 更新工具凭据 */
+  UPDATE_TOOL_CREDENTIALS: 'chat-tool:update-credentials',
+  /** 测试工具连接 */
+  TEST_TOOL: 'chat-tool:test',
+  /** 创建自定义工具 */
+  CREATE_CUSTOM_TOOL: 'chat-tool:create-custom',
+  /** 删除自定义工具 */
+  DELETE_CUSTOM_TOOL: 'chat-tool:delete-custom',
+  /** 自定义工具配置变更通知（文件监听触发） */
+  CUSTOM_TOOL_CHANGED: 'chat-tool:custom-tool-changed',
+} as const

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -79,6 +79,8 @@ export interface ChatMessage {
   stopped?: boolean
   /** 文件附件列表 */
   attachments?: FileAttachment[]
+  /** 工具活动记录（assistant 消息，工具调用历史） */
+  toolActivities?: ChatToolActivity[]
 }
 
 // ===== 对话相关 =====
@@ -156,6 +158,8 @@ export interface ChatSendInput {
   attachments?: FileAttachment[]
   /** 是否启用思考模式 */
   thinkingEnabled?: boolean
+  /** 本次请求启用的工具 ID 列表（由前端工具选择器决定） */
+  enabledToolIds?: string[]
 }
 
 // ===== 标题生成 =====

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -35,3 +35,6 @@ export * from './github'
 
 // 系统提示词相关类型
 export * from './system-prompt'
+
+// Chat 工具（function calling）相关类型
+export * from './chat-tool'


### PR DESCRIPTION
## Summary

- 实现 Chat 模式的可插拔工具架构，包含注册表（chat-tool-registry）、统一执行器（chat-tool-executor）、共享类型（ChatToolMeta/ChatToolsFileConfig）和完整的 IPC 4 层通信
- 内置记忆工具（memory-tool）和联网搜索工具（web-search-tool），均从 chat-service.ts 解耦为独立模块；新增自定义 HTTP 工具执行器（http-tool-executor）支持用户配置的 API 工具
- 前端新增 ToolSelectorPopover 工具选择器、ChatToolActivityIndicator 工具活动指示器、ToolSettings 设置页（含自定义工具管理），以及 chat-tools.json 文件监听自动刷新机制
- 新增 Tool Builder Skill 引导 Agent 交互式创建自定义 Chat 工具
- 修复 OpenAI adapter tool_call_delta ID 不匹配问题

## Test plan
- [ ] 开启记忆工具 + 联网搜索工具，验证 Chat 对话中工具调用和活动指示器正常
- [ ] 通过 Agent Tool Builder Skill 创建自定义 HTTP 工具，验证渲染进程自动刷新
- [ ] 设置页工具 Tab 验证开关/删除/API Key 配置功能
- [ ] `bun run typecheck` 全项目通过