### PR TITLE
feat: Skills 分组显示 + 启用/禁用开关 + Agent 工具推荐默认开启

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -104,7 +104,7 @@ import {
 import { runAgent, stopAgent, generateAgentTitle, saveFilesToAgentSession, copyFolderToSession } from './lib/agent-service'
 import { permissionService } from './lib/agent-permission-service'
 import { askUserService } from './lib/agent-ask-user-service'
-import { getAgentSessionWorkspacePath, getAgentWorkspacesDir } from './lib/config-paths'
+import { getAgentSessionWorkspacePath, getAgentWorkspacesDir, getWorkspaceSkillsDir } from './lib/config-paths'
 import {
   listAgentWorkspaces,
   createAgentWorkspace,
@@ -113,10 +113,11 @@ import {
   ensureDefaultWorkspace,
   getWorkspaceMcpConfig,
   saveWorkspaceMcpConfig,
-  getWorkspaceSkills,
+  getAllWorkspaceSkills,
   getWorkspaceCapabilities,
   getAgentWorkspace,
   deleteWorkspaceSkill,
+  toggleWorkspaceSkill,
   getWorkspacePermissionMode,
   setWorkspacePermissionMode,
 } from './lib/agent-workspace-manager'
@@ -668,11 +669,19 @@ export function registerIpcHandlers(): void {
     }
   )
 
-  // 获取工作区 Skill 列表
+  // 获取工作区 Skill 列表（含活跃和不活跃，设置页 UI 用）
   ipcMain.handle(
     AGENT_IPC_CHANNELS.GET_SKILLS,
     async (_, workspaceSlug: string): Promise<SkillMeta[]> => {
-      return getWorkspaceSkills(workspaceSlug)
+      return getAllWorkspaceSkills(workspaceSlug)
+    }
+  )
+
+  // 获取工作区 Skills 目录绝对路径
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.GET_SKILLS_DIR,
+    async (_, workspaceSlug: string): Promise<string> => {
+      return getWorkspaceSkillsDir(workspaceSlug)
     }
   )
 
@@ -681,6 +690,14 @@ export function registerIpcHandlers(): void {
     AGENT_IPC_CHANNELS.DELETE_SKILL,
     async (_, workspaceSlug: string, skillSlug: string): Promise<void> => {
       return deleteWorkspaceSkill(workspaceSlug, skillSlug)
+    }
+  )
+
+  // 切换工作区 Skill 启用/禁用
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.TOGGLE_SKILL,
+    async (_, workspaceSlug: string, skillSlug: string, enabled: boolean): Promise<void> => {
+      return toggleWorkspaceSkill(workspaceSlug, skillSlug, enabled)
     }
   )
 

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -8,7 +8,7 @@
  * 照搬 agent-session-manager.ts 的 readIndex/writeIndex 模式。
  */
 
-import { readFileSync, writeFileSync, existsSync, readdirSync, cpSync, rmSync, mkdirSync, statSync } from 'node:fs'
+import { readFileSync, writeFileSync, existsSync, readdirSync, cpSync, rmSync, mkdirSync, statSync, renameSync } from 'node:fs'
 import { randomUUID } from 'node:crypto'
 import { join } from 'node:path'
 import {
@@ -16,6 +16,7 @@ import {
   getAgentWorkspacePath,
   getWorkspaceMcpPath,
   getWorkspaceSkillsDir,
+  getInactiveSkillsDir,
   getDefaultSkillsDir,
 } from './config-paths'
 import type { AgentWorkspace, McpServerEntry, WorkspaceMcpConfig, SkillMeta, WorkspaceCapabilities, PromaPermissionMode } from '@proma/shared'
@@ -321,40 +322,20 @@ export function saveWorkspaceMcpConfig(workspaceSlug: string, config: WorkspaceM
  *
  * 遍历 skills/{slug}/SKILL.md，解析 YAML frontmatter 提取元数据。
  */
+/**
+ * 扫描工作区活跃 Skills 目录
+ *
+ * 仅返回 skills/ 下的活跃 Skill，供 prompt builder 和 capabilities 使用。
+ */
 export function getWorkspaceSkills(workspaceSlug: string): SkillMeta[] {
-  const skillsDir = getWorkspaceSkillsDir(workspaceSlug)
-  const skills: SkillMeta[] = []
-
-  try {
-    const entries = readdirSync(skillsDir, { withFileTypes: true })
-
-    for (const entry of entries) {
-      const isDir = entry.isDirectory() || (entry.isSymbolicLink() && statSync(join(skillsDir, entry.name)).isDirectory())
-      if (!isDir) continue
-
-      const skillMdPath = join(skillsDir, entry.name, 'SKILL.md')
-      if (!existsSync(skillMdPath)) continue
-
-      try {
-        const content = readFileSync(skillMdPath, 'utf-8')
-        const meta = parseSkillFrontmatter(content, entry.name)
-        skills.push(meta)
-      } catch {
-        console.warn(`[Agent 工作区] 解析 Skill 失败: ${entry.name}`)
-      }
-    }
-  } catch {
-    // skills 目录可能不存在
-  }
-
-  return skills
+  return scanSkillsInDir(getWorkspaceSkillsDir(workspaceSlug), true)
 }
 
 /**
  * 解析 SKILL.md 的 YAML frontmatter
  */
-function parseSkillFrontmatter(content: string, slug: string): SkillMeta {
-  const meta: SkillMeta = { slug, name: slug }
+function parseSkillFrontmatter(content: string, slug: string, enabled: boolean): SkillMeta {
+  const meta: SkillMeta = { slug, name: slug, enabled }
 
   const fmMatch = content.match(/^---\s*\n([\s\S]*?)\n---/)
   if (!fmMatch) return meta
@@ -410,6 +391,78 @@ export function deleteWorkspaceSkill(workspaceSlug: string, skillSlug: string): 
 
   rmSync(skillPath, { recursive: true, force: true })
   console.log(`[Agent 工作区] 已删除 Skill: ${workspaceSlug}/${skillSlug}`)
+}
+
+/**
+ * 扫描指定目录下的 Skills
+ *
+ * 通用扫描逻辑，供 getWorkspaceSkills 和 getAllWorkspaceSkills 复用。
+ */
+function scanSkillsInDir(dir: string, enabled: boolean): SkillMeta[] {
+  const skills: SkillMeta[] = []
+
+  try {
+    const entries = readdirSync(dir, { withFileTypes: true })
+
+    for (const entry of entries) {
+      const isDir = entry.isDirectory() || (entry.isSymbolicLink() && statSync(join(dir, entry.name)).isDirectory())
+      if (!isDir) continue
+
+      const skillMdPath = join(dir, entry.name, 'SKILL.md')
+      if (!existsSync(skillMdPath)) continue
+
+      try {
+        const content = readFileSync(skillMdPath, 'utf-8')
+        const meta = parseSkillFrontmatter(content, entry.name, enabled)
+        skills.push(meta)
+      } catch {
+        console.warn(`[Agent 工作区] 解析 Skill 失败: ${entry.name}`)
+      }
+    }
+  } catch {
+    // 目录可能不存在
+  }
+
+  return skills
+}
+
+/**
+ * 获取工作区所有 Skills（含活跃和不活跃）
+ *
+ * 同时扫描 skills/ 和 skills-inactive/ 目录，返回带 enabled 标记的完整列表。
+ * 用于设置页 UI 展示。
+ */
+export function getAllWorkspaceSkills(workspaceSlug: string): SkillMeta[] {
+  const activeSkills = scanSkillsInDir(getWorkspaceSkillsDir(workspaceSlug), true)
+  const inactiveSkills = scanSkillsInDir(getInactiveSkillsDir(workspaceSlug), false)
+  return [...activeSkills, ...inactiveSkills]
+}
+
+/**
+ * 切换工作区 Skill 的启用/禁用状态
+ *
+ * 在 skills/ 和 skills-inactive/ 之间移动文件夹。
+ */
+export function toggleWorkspaceSkill(workspaceSlug: string, skillSlug: string, enabled: boolean): void {
+  const activeDir = getWorkspaceSkillsDir(workspaceSlug)
+  const inactiveDir = getInactiveSkillsDir(workspaceSlug)
+
+  const srcDir = enabled ? inactiveDir : activeDir
+  const destDir = enabled ? activeDir : inactiveDir
+
+  const srcPath = join(srcDir, skillSlug)
+  const destPath = join(destDir, skillSlug)
+
+  if (!existsSync(srcPath)) {
+    throw new Error(`Skill 不存在: ${skillSlug}`)
+  }
+
+  if (existsSync(destPath)) {
+    throw new Error(`目标目录已存在同名 Skill: ${skillSlug}`)
+  }
+
+  renameSync(srcPath, destPath)
+  console.log(`[Agent 工作区] Skill ${enabled ? '启用' : '禁用'}: ${workspaceSlug}/${skillSlug}`)
 }
 
 // ===== 权限模式管理 =====

--- a/apps/electron/src/main/lib/config-paths.ts
+++ b/apps/electron/src/main/lib/config-paths.ts
@@ -286,6 +286,25 @@ export function getWorkspaceSkillsDir(slug: string): string {
 }
 
 /**
+ * 获取工作区不活跃 Skills 目录路径
+ *
+ * 禁用的 Skill 会被移动到此目录，Agent SDK 不会扫描该目录。
+ * 如果目录不存在则自动创建。
+ *
+ * @param slug 工作区 slug
+ * @returns ~/.proma/agent-workspaces/{slug}/skills-inactive/
+ */
+export function getInactiveSkillsDir(slug: string): string {
+  const dir = join(getAgentWorkspacePath(slug), 'skills-inactive')
+
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+
+  return dir
+}
+
+/**
  * 获取默认 Skills 模板目录路径
  *
  * 新建工作区时自动复制此目录的内容到工作区 skills/ 下。

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -308,11 +308,17 @@ export interface ElectronAPI {
   /** 测试 MCP 服务器连接 */
   testMcpServer: (name: string, entry: import('@proma/shared').McpServerEntry) => Promise<{ success: boolean; message: string }>
 
-  /** 获取工作区 Skill 列表 */
+  /** 获取工作区 Skill 列表（含活跃和不活跃） */
   getWorkspaceSkills: (workspaceSlug: string) => Promise<SkillMeta[]>
+
+  /** 获取工作区 Skills 目录绝对路径 */
+  getWorkspaceSkillsDir: (workspaceSlug: string) => Promise<string>
 
   /** 删除工作区 Skill */
   deleteWorkspaceSkill: (workspaceSlug: string, skillSlug: string) => Promise<void>
+
+  /** 切换工作区 Skill 启用/禁用 */
+  toggleWorkspaceSkill: (workspaceSlug: string, skillSlug: string, enabled: boolean) => Promise<void>
 
   /** 订阅 Agent 流式事件（返回清理函数） */
   onAgentStreamEvent: (callback: (event: AgentStreamEvent) => void) => () => void
@@ -762,8 +768,16 @@ const electronAPI: ElectronAPI = {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.GET_SKILLS, workspaceSlug)
   },
 
+  getWorkspaceSkillsDir: (workspaceSlug: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.GET_SKILLS_DIR, workspaceSlug)
+  },
+
   deleteWorkspaceSkill: (workspaceSlug: string, skillSlug: string) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.DELETE_SKILL, workspaceSlug, skillSlug)
+  },
+
+  toggleWorkspaceSkill: (workspaceSlug: string, skillSlug: string, enabled: boolean) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.TOGGLE_SKILL, workspaceSlug, skillSlug, enabled)
   },
 
   onAgentStreamEvent: (callback: (event: AgentStreamEvent) => void) => {

--- a/apps/electron/src/renderer/atoms/chat-tool-atoms.ts
+++ b/apps/electron/src/renderer/atoms/chat-tool-atoms.ts
@@ -14,14 +14,32 @@ import type { ChatToolInfo } from '@proma/shared'
 /** 从主进程加载的所有工具列表 */
 export const chatToolsAtom = atom<ChatToolInfo[]>([])
 
+// 一次性迁移：为已有用户补充 agent-mode-recommend 默认开启
+const MIGRATION_KEY = 'proma-tool-migration-agent-recommend'
+if (typeof localStorage !== 'undefined' && !localStorage.getItem(MIGRATION_KEY)) {
+  const stored = localStorage.getItem('proma-enabled-tool-ids')
+  if (stored) {
+    try {
+      const ids = JSON.parse(stored) as string[]
+      if (Array.isArray(ids) && !ids.includes('agent-mode-recommend')) {
+        ids.push('agent-mode-recommend')
+        localStorage.setItem('proma-enabled-tool-ids', JSON.stringify(ids))
+      }
+    } catch {
+      // 解析失败忽略
+    }
+  }
+  localStorage.setItem(MIGRATION_KEY, '1')
+}
+
 /**
  * 用户在 ChatInput 工具栏中切换的工具 ID 集合
  *
- * localStorage 持久化，默认包含 'memory'（记忆工具默认开启）
+ * localStorage 持久化，默认包含 'memory' 和 'agent-mode-recommend'
  */
 export const enabledToolIdsAtom = atomWithStorage<string[]>(
   'proma-enabled-tool-ids',
-  ['memory'],
+  ['memory', 'agent-mode-recommend'],
 )
 
 /**

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -12,6 +12,7 @@ import * as React from 'react'
 import { useAtom, useSetAtom, useAtomValue } from 'jotai'
 import { Pin, PinOff, Settings, Plus, Trash2, Pencil, ChevronDown, ChevronRight, Plug, Zap } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { ModeSwitcher } from './ModeSwitcher'
 import { activeViewAtom } from '@/atoms/active-view'
 import { appModeAtom } from '@/atoms/app-mode'
@@ -558,24 +559,29 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       {/* Agent 模式：工作区能力指示器 */}
       {mode === 'agent' && capabilities && (
         <div className="px-3 pb-1">
-          <button
-            onClick={() => { setSettingsTab('agent'); handleItemClick('settings') }}
-            className="w-full flex items-center gap-3 px-3 py-2 rounded-[10px] text-[12px] text-foreground/50 hover:bg-foreground/[0.04] hover:text-foreground/70 transition-colors titlebar-no-drag"
-          >
-            <div className="flex items-center gap-2.5 flex-1 min-w-0">
-              <span className="flex items-center gap-1">
-                <Plug size={13} className="text-foreground/40" />
-                <span className="tabular-nums">{capabilities.mcpServers.filter((s) => s.enabled).length}</span>
-                <span className="text-foreground/30">MCP</span>
-              </span>
-              <span className="text-foreground/20">·</span>
-              <span className="flex items-center gap-1">
-                <Zap size={13} className="text-foreground/40" />
-                <span className="tabular-nums">{capabilities.skills.length}</span>
-                <span className="text-foreground/30">Skills</span>
-              </span>
-            </div>
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={() => { setSettingsTab('agent'); handleItemClick('settings') }}
+                className="w-full flex items-center gap-3 px-3 py-2 rounded-[10px] text-[12px] text-foreground/50 hover:bg-foreground/[0.04] hover:text-foreground/70 transition-colors titlebar-no-drag"
+              >
+                <div className="flex items-center gap-2.5 flex-1 min-w-0">
+                  <span className="flex items-center gap-1">
+                    <Plug size={13} className="text-foreground/40" />
+                    <span className="tabular-nums">{capabilities.mcpServers.filter((s) => s.enabled).length}</span>
+                    <span className="text-foreground/30">MCP</span>
+                  </span>
+                  <span className="text-foreground/20">·</span>
+                  <span className="flex items-center gap-1">
+                    <Zap size={13} className="text-foreground/40" />
+                    <span className="tabular-nums">{capabilities.skills.length}</span>
+                    <span className="text-foreground/30">Skills</span>
+                  </span>
+                </div>
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="right">点击配置 MCP 与 Skills</TooltipContent>
+          </Tooltip>
         </div>
       )}
 

--- a/apps/electron/src/renderer/components/settings/AgentSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AgentSettings.tsx
@@ -10,9 +10,11 @@
 
 import * as React from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
-import { Plus, Plug, Pencil, Trash2, Sparkles, FolderOpen, MessageSquare, ShieldCheck } from 'lucide-react'
+import { Plus, Plug, Pencil, Trash2, Sparkles, FolderOpen, MessageSquare, ShieldCheck, ChevronDown, ChevronRight } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
 import {
   agentWorkspacesAtom,
   currentAgentWorkspaceIdAtom,
@@ -61,6 +63,7 @@ export function AgentSettings(): React.ReactElement {
   // MCP 配置
   const [mcpConfig, setMcpConfig] = React.useState<WorkspaceMcpConfig>({ servers: {} })
   const [skills, setSkills] = React.useState<SkillMeta[]>([])
+  const [skillsDir, setSkillsDir] = React.useState('')
   const [loading, setLoading] = React.useState(true)
 
   /** 加载 MCP 配置和 Skills */
@@ -71,12 +74,14 @@ export function AgentSettings(): React.ReactElement {
     }
 
     try {
-      const [config, skillList] = await Promise.all([
+      const [config, skillList, dir] = await Promise.all([
         window.electronAPI.getWorkspaceMcpConfig(workspaceSlug),
         window.electronAPI.getWorkspaceSkills(workspaceSlug),
+        window.electronAPI.getWorkspaceSkillsDir(workspaceSlug),
       ])
       setMcpConfig(config)
       setSkills(skillList)
+      setSkillsDir(dir)
     } catch (error) {
       console.error('[Agent 设置] 加载工作区配置失败:', error)
     } finally {
@@ -256,6 +261,17 @@ ${skillList}
     }
   }
 
+  /** 切换 Skill 启用/禁用 */
+  const handleToggleSkill = async (skillSlug: string, enabled: boolean): Promise<void> => {
+    try {
+      await window.electronAPI.toggleWorkspaceSkill(workspaceSlug, skillSlug, enabled)
+      setSkills((prev) => prev.map((s) => s.slug === skillSlug ? { ...s, enabled } : s))
+      bumpCapabilitiesVersion((v) => v + 1)
+    } catch (error) {
+      console.error('[Agent 设置] 切换 Skill 状态失败:', error)
+    }
+  }
+
   /** 表单保存回调 */
   const handleFormSaved = (): void => {
     setViewMode('list')
@@ -340,6 +356,19 @@ ${skillList}
       <SettingsSection
         title="Skills"
         description="将 SKILL.md 放入工作区 skills/ 目录即可被 Agent 自动发现"
+        action={skillsDir ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={() => window.electronAPI.openFile(skillsDir)}
+                className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+              >
+                <FolderOpen size={16} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>打开 Skills 目录</TooltipContent>
+          </Tooltip>
+        ) : undefined}
       >
         {loading ? (
           <div className="text-sm text-muted-foreground py-8 text-center">加载中...</div>
@@ -350,29 +379,13 @@ ${skillList}
             </div>
           </SettingsCard>
         ) : (
-          <SettingsCard>
-            {skills.map((skill) => (
-              <SettingsRow
-                key={skill.slug}
-                label={skill.name}
-                icon={<Sparkles size={18} className="text-amber-500" />}
-                description={skill.description ?? skill.slug}
-                className="group"
-              >
-                <button
-                  onClick={() => handleDeleteSkill(skill.slug, skill.name)}
-                  className="p-1.5 rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors opacity-0 group-hover:opacity-100"
-                  title="删除"
-                >
-                  <Trash2 size={14} />
-                </button>
-              </SettingsRow>
-            ))}
-          </SettingsCard>
+          <SkillGroupedList
+            skills={skills}
+            skillsDir={skillsDir}
+            onDelete={handleDeleteSkill}
+            onToggle={handleToggleSkill}
+          />
         )}
-        <p className="text-xs text-muted-foreground px-1">
-          路径: ~/.proma/agent-workspaces/{workspaceSlug}/skills/
-        </p>
 
         <Button
           size="sm"
@@ -446,5 +459,235 @@ function McpServerRow({ name, entry, onEdit, onDelete, onToggle }: McpServerRowP
         />
       </div>
     </SettingsRow>
+  )
+}
+
+// ===== Skills 分组列表子组件 =====
+
+/** 分组结果 */
+interface SkillGroup {
+  prefix: string
+  skills: SkillMeta[]
+}
+
+/** 按前缀对 Skills 分组 */
+function groupSkillsByPrefix(skills: SkillMeta[]): SkillGroup[] {
+  const prefixMap = new Map<string, SkillMeta[]>()
+
+  for (const skill of skills) {
+    const dashIdx = skill.slug.indexOf('-')
+    const prefix = dashIdx > 0 ? skill.slug.slice(0, dashIdx) : ''
+    const key = prefix || skill.slug
+    const list = prefixMap.get(key) ?? []
+    list.push(skill)
+    prefixMap.set(key, list)
+  }
+
+  const groups: SkillGroup[] = []
+  const standalone: SkillMeta[] = []
+
+  for (const [prefix, list] of prefixMap) {
+    if (list.length >= 2) {
+      groups.push({ prefix, skills: list })
+    } else {
+      standalone.push(...list)
+    }
+  }
+
+  // 独立 skill 合为一个无前缀组
+  if (standalone.length > 0) {
+    groups.push({ prefix: '', skills: standalone })
+  }
+
+  return groups
+}
+
+/** 从 slug 中移除前缀得到短名称 */
+function shortName(slug: string, prefix: string): string {
+  if (!prefix) return slug
+  return slug.startsWith(prefix + '-') ? slug.slice(prefix.length + 1) : slug
+}
+
+interface SkillGroupedListProps {
+  skills: SkillMeta[]
+  skillsDir: string
+  onDelete: (slug: string, name: string) => void
+  onToggle: (slug: string, enabled: boolean) => void
+}
+
+function SkillGroupedList({ skills, skillsDir, onDelete, onToggle }: SkillGroupedListProps): React.ReactElement {
+  const groups = React.useMemo(() => groupSkillsByPrefix(skills), [skills])
+  const [expandedGroups, setExpandedGroups] = React.useState<Set<string>>(new Set())
+  const [expandedSkill, setExpandedSkill] = React.useState<string | null>(null)
+
+  const toggleGroup = (prefix: string) => {
+    setExpandedGroups((prev) => {
+      const next = new Set(prev)
+      if (next.has(prefix)) next.delete(prefix)
+      else next.add(prefix)
+      return next
+    })
+  }
+
+  const openSkillFolder = (slug: string) => {
+    if (skillsDir) {
+      window.electronAPI.openFile(`${skillsDir}/${slug}`)
+    }
+  }
+
+  return (
+    <div className="space-y-2 min-w-0">
+      {groups.map((group) =>
+        group.prefix ? (
+          <SkillGroupCard
+            key={group.prefix}
+            group={group}
+            expanded={expandedGroups.has(group.prefix)}
+            expandedSkill={expandedSkill}
+            onToggle={() => toggleGroup(group.prefix)}
+            onExpandSkill={(slug) => setExpandedSkill(expandedSkill === slug ? null : slug)}
+            onDelete={onDelete}
+            onToggleEnabled={onToggle}
+            onOpenFolder={openSkillFolder}
+          />
+        ) : (
+          /* 独立 skill 不分组，平铺展示 */
+          <SettingsCard key="__standalone__">
+            {group.skills.map((skill) => (
+              <SkillItemRow
+                key={skill.slug}
+                skill={skill}
+                displayName={skill.name}
+                expanded={expandedSkill === skill.slug}
+                onToggleExpand={() => setExpandedSkill(expandedSkill === skill.slug ? null : skill.slug)}
+                onDelete={() => onDelete(skill.slug, skill.name)}
+                onToggleEnabled={(enabled) => onToggle(skill.slug, enabled)}
+                onOpenFolder={() => openSkillFolder(skill.slug)}
+              />
+            ))}
+          </SettingsCard>
+        )
+      )}
+    </div>
+  )
+}
+
+interface SkillGroupCardProps {
+  group: SkillGroup
+  expanded: boolean
+  expandedSkill: string | null
+  onToggle: () => void
+  onExpandSkill: (slug: string) => void
+  onDelete: (slug: string, name: string) => void
+  onToggleEnabled: (slug: string, enabled: boolean) => void
+  onOpenFolder: (slug: string) => void
+}
+
+function SkillGroupCard({ group, expanded, expandedSkill, onToggle, onExpandSkill, onDelete, onToggleEnabled, onOpenFolder }: SkillGroupCardProps): React.ReactElement {
+  return (
+    <SettingsCard divided={false}>
+      {/* 分组头部 */}
+      <button
+        onClick={onToggle}
+        className="w-full flex items-center gap-3 px-4 py-2.5 text-left hover:bg-muted/30 transition-colors min-w-0"
+      >
+        {expanded
+          ? <ChevronDown size={14} className="text-muted-foreground flex-shrink-0" />
+          : <ChevronRight size={14} className="text-muted-foreground flex-shrink-0" />
+        }
+        <Sparkles size={16} className="text-amber-500 flex-shrink-0" />
+        <span className="text-sm font-medium text-foreground flex-1 min-w-0 truncate">{group.prefix}</span>
+        <span className="text-xs px-1.5 py-0.5 rounded-md bg-muted text-muted-foreground font-medium tabular-nums flex-shrink-0">
+          {group.skills.length}
+        </span>
+      </button>
+
+      {/* 展开的子项 */}
+      {expanded && (
+        <div className="overflow-hidden">
+          {group.skills.map((skill) => (
+            <SkillItemRow
+              key={skill.slug}
+              skill={skill}
+              displayName={shortName(skill.slug, group.prefix)}
+              expanded={expandedSkill === skill.slug}
+              onToggleExpand={() => onExpandSkill(skill.slug)}
+              onDelete={() => onDelete(skill.slug, skill.name)}
+              onToggleEnabled={(enabled) => onToggleEnabled(skill.slug, enabled)}
+              onOpenFolder={() => onOpenFolder(skill.slug)}
+              indent
+            />
+          ))}
+        </div>
+      )}
+    </SettingsCard>
+  )
+}
+
+interface SkillItemRowProps {
+  skill: SkillMeta
+  displayName: string
+  expanded: boolean
+  onToggleExpand: () => void
+  onDelete: () => void
+  onToggleEnabled: (enabled: boolean) => void
+  onOpenFolder: () => void
+  indent?: boolean
+}
+
+function SkillItemRow({ skill, displayName, expanded, onToggleExpand, onDelete, onToggleEnabled, onOpenFolder, indent }: SkillItemRowProps): React.ReactElement {
+  return (
+    <div className={cn('group border-t border-border/50 overflow-hidden', !skill.enabled && 'opacity-50')}>
+      <div className={cn('flex items-center gap-2 px-4 py-2', indent && 'pl-8')}>
+        {indent && <Sparkles size={14} className="text-amber-400/60 flex-shrink-0" />}
+        {!indent && <Sparkles size={16} className="text-amber-500 flex-shrink-0" />}
+
+        {/* 名称 + 可展开描述 */}
+        <button
+          onClick={onToggleExpand}
+          className="flex-1 min-w-0 text-left overflow-hidden"
+        >
+          <div className="text-sm font-medium text-foreground truncate">{displayName}</div>
+          {expanded && skill.description && (
+            <div className="text-xs text-muted-foreground mt-1 break-words">
+              {skill.description}
+            </div>
+          )}
+          {!expanded && skill.description && (
+            <div className="text-xs text-muted-foreground truncate">{skill.description}</div>
+          )}
+        </button>
+
+        {/* 操作按钮 */}
+        <div className="flex items-center gap-1 flex-shrink-0">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={onOpenFolder}
+                className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors opacity-0 group-hover:opacity-100"
+              >
+                <FolderOpen size={14} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>打开文件夹</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={onDelete}
+                className="p-1.5 rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors opacity-0 group-hover:opacity-100"
+              >
+                <Trash2 size={14} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>删除</TooltipContent>
+          </Tooltip>
+          <Switch
+            checked={skill.enabled}
+            onCheckedChange={onToggleEnabled}
+          />
+        </div>
+      </div>
+    </div>
   )
 }

--- a/apps/electron/src/renderer/components/ui/scroll-area.tsx
+++ b/apps/electron/src/renderer/components/ui/scroll-area.tsx
@@ -12,7 +12,7 @@ const ScrollArea = React.forwardRef<
     className={cn("relative overflow-hidden", className)}
     {...props}
   >
-    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit] [&>div]:!block">
       {children}
     </ScrollAreaPrimitive.Viewport>
     <ScrollBar />

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -300,6 +300,7 @@ export interface SkillMeta {
   name: string
   description?: string
   icon?: string
+  enabled: boolean
 }
 
 /** 工作区能力摘要（MCP + Skill 计数） */
@@ -568,8 +569,12 @@ export const AGENT_IPC_CHANNELS = {
   TEST_MCP_SERVER: 'agent:test-mcp-server',
   /** 获取工作区 Skill 列表 */
   GET_SKILLS: 'agent:get-skills',
+  /** 获取工作区 Skills 目录绝对路径 */
+  GET_SKILLS_DIR: 'agent:get-skills-dir',
   /** 删除工作区 Skill */
   DELETE_SKILL: 'agent:delete-skill',
+  /** 切换工作区 Skill 启用/禁用 */
+  TOGGLE_SKILL: 'agent:toggle-skill',
 
   // 流式事件（主进程 → 渲染进程推送）
   /** Agent 流式事件 */


### PR DESCRIPTION
## Summary
- **Skills 分组显示**：按 slug 前缀自动分组折叠，节省设置面板空间；支持展开描述、打开文件夹
- **Skills 启用/禁用**：通过在 `skills/` 和 `skills-inactive/` 目录间移动实现，禁用的 Skill 不会被 Agent SDK 发现，节省 Token
- **MCP/Skills Tooltip**：侧边栏按钮悬浮显示「点击配置 MCP 与 Skills」
- **ScrollArea 溢出修复**：Radix Viewport 内部 `display: table` 导致内容超出容器，加 `[&>div]:!block` 修复
- **Chat 工具推荐默认开启**：`agent-mode-recommend` 工具默认启用，含已有用户一次性 localStorage 迁移

## Test plan
- [ ] Agent 设置 → Skills 列表按前缀分组显示，可展开/收起
- [ ] 点击 Switch 关闭某 Skill → 文件从 `skills/` 移到 `skills-inactive/`，行变淡
- [ ] 重新开启 → 文件移回 `skills/`，侧边栏计数同步更新
- [ ] 点击文件夹按钮 → Finder 打开对应目录
- [ ] Settings 页面内容不溢出右边界
- [ ] Chat 模式默认显示 Agent 推荐工具已开启