### PR TITLE
feat: Tab 分屏视图 + ChatView/AgentView 参数化重构

### DIFF
--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -510,6 +510,13 @@ export const agentContextStatusAtom = atom<AgentContextStatus>((get) => {
  */
 export const agentStreamErrorsAtom = atom<Map<string, string>>(new Map())
 
+/**
+ * Agent 消息刷新版本 Map — 以 sessionId 为 key
+ * 全局监听器在流式完成/错误时递增版本号，
+ * AgentView 监听版本号变化来重新加载消息。
+ */
+export const agentMessageRefreshAtom = atom<Map<string, number>>(new Map())
+
 /** 当前 Agent 会话的错误消息（派生只读原子） */
 export const currentAgentErrorAtom = atom<string | null>((get) => {
   const currentId = get(currentAgentSessionIdAtom)

--- a/apps/electron/src/renderer/atoms/chat-atoms.ts
+++ b/apps/electron/src/renderer/atoms/chat-atoms.ts
@@ -204,6 +204,13 @@ export const currentConversationDraftAtom = atom(
   }
 )
 
+/**
+ * Chat 消息刷新版本 Map — 以 conversationId 为 key
+ * 全局监听器在流式完成/错误时递增版本号，
+ * ChatView 监听版本号变化来重新加载消息。
+ */
+export const chatMessageRefreshAtom = atom<Map<string, number>>(new Map())
+
 // ===== Agent 模式推荐 =====
 
 /** Agent 模式推荐数据（由 suggest_agent_mode 工具结果写入） */

--- a/apps/electron/src/renderer/atoms/tab-atoms.ts
+++ b/apps/electron/src/renderer/atoms/tab-atoms.ts
@@ -1,0 +1,253 @@
+/**
+ * Tab Atoms — 标签页和分屏布局状态管理
+ *
+ * 支持浏览器风格的多标签页 + 最多 4 面板分屏。
+ * 通过桥接 atom 与现有 currentConversationIdAtom / currentAgentSessionIdAtom 同步，
+ * 确保所有现有派生 atoms 无需修改。
+ */
+
+import { atom } from 'jotai'
+import { atomWithStorage } from 'jotai/utils'
+import {
+  streamingConversationIdsAtom,
+} from './chat-atoms'
+import {
+  agentRunningSessionIdsAtom,
+} from './agent-atoms'
+
+// ===== 类型定义 =====
+
+/** 标签页类型（Settings 不作为 Tab，保留独立视图） */
+export type TabType = 'chat' | 'agent'
+
+/** 标签页数据 */
+export interface TabItem {
+  /** 唯一标签 ID（直接使用 sessionId） */
+  id: string
+  /** 标签页类型 */
+  type: TabType
+  /** Chat conversationId 或 Agent sessionId */
+  sessionId: string
+  /** 标签页显示标题 */
+  title: string
+}
+
+/** 分屏布局模式 */
+export type SplitMode = 'single' | 'horizontal-2' | 'vertical-2' | 'grid-4'
+
+/** 分屏面板 */
+export interface SplitPanel {
+  /** 面板位置索引（0-3） */
+  index: number
+  /** 该面板激活的标签 ID（null = 空面板） */
+  activeTabId: string | null
+}
+
+/** 分屏布局状态 */
+export interface SplitLayoutState {
+  /** 布局模式 */
+  mode: SplitMode
+  /** 面板列表（1-4 个面板） */
+  panels: SplitPanel[]
+  /** 当前焦点面板索引 */
+  focusedPanelIndex: number
+}
+
+/** Tab 持久化数据（保存到 settings.json） */
+export interface PersistedTabState {
+  tabs: TabItem[]
+  splitLayout: SplitLayoutState
+}
+
+// ===== 默认值 =====
+
+const DEFAULT_SPLIT_LAYOUT: SplitLayoutState = {
+  mode: 'single',
+  panels: [{ index: 0, activeTabId: null }],
+  focusedPanelIndex: 0,
+}
+
+// ===== 核心 Atoms =====
+
+/** 所有打开的标签页列表（有序，控制 TabBar 显示顺序） */
+export const tabsAtom = atom<TabItem[]>([])
+
+/** 分屏布局状态 */
+export const splitLayoutAtom = atom<SplitLayoutState>(DEFAULT_SPLIT_LAYOUT)
+
+/** 侧边栏是否收起（持久化） */
+export const sidebarCollapsedAtom = atomWithStorage<boolean>(
+  'proma-sidebar-collapsed',
+  false,
+)
+
+// ===== 派生 Atoms =====
+
+/** 当前焦点面板的活跃标签 ID */
+export const activeTabIdAtom = atom<string | null>((get) => {
+  const layout = get(splitLayoutAtom)
+  const focusedPanel = layout.panels[layout.focusedPanelIndex]
+  return focusedPanel?.activeTabId ?? null
+})
+
+/** 当前焦点面板的活跃标签 */
+export const activeTabAtom = atom<TabItem | null>((get) => {
+  const activeId = get(activeTabIdAtom)
+  if (!activeId) return null
+  return get(tabsAtom).find((t) => t.id === activeId) ?? null
+})
+
+/** 标签是否在流式输出中（派生，从现有流式 atoms 计算） */
+export const tabStreamingMapAtom = atom<Map<string, boolean>>((get) => {
+  const tabs = get(tabsAtom)
+  const chatStreaming = get(streamingConversationIdsAtom)
+  const agentRunning = get(agentRunningSessionIdsAtom)
+  const map = new Map<string, boolean>()
+  for (const tab of tabs) {
+    if (tab.type === 'chat') {
+      map.set(tab.id, chatStreaming.has(tab.sessionId))
+    } else if (tab.type === 'agent') {
+      map.set(tab.id, agentRunning.has(tab.sessionId))
+    }
+  }
+  return map
+})
+
+// ===== 操作函数 =====
+
+/** 打开或聚焦标签页（如果已存在则聚焦，否则创建新标签） */
+export function openTab(
+  tabs: TabItem[],
+  layout: SplitLayoutState,
+  item: { type: TabType; sessionId: string; title: string },
+): { tabs: TabItem[]; layout: SplitLayoutState } {
+  const existingTab = tabs.find((t) => t.sessionId === item.sessionId && t.type === item.type)
+
+  if (existingTab) {
+    // 已存在 → 聚焦到该标签
+    const newLayout = focusTab(layout, existingTab.id)
+    return { tabs, layout: newLayout }
+  }
+
+  // 创建新标签
+  const newTab: TabItem = {
+    id: item.sessionId,
+    type: item.type,
+    sessionId: item.sessionId,
+    title: item.title,
+  }
+
+  const newTabs = [...tabs, newTab]
+
+  // 在焦点面板中激活新标签
+  const newPanels = layout.panels.map((panel, idx) =>
+    idx === layout.focusedPanelIndex
+      ? { ...panel, activeTabId: newTab.id }
+      : panel
+  )
+
+  return {
+    tabs: newTabs,
+    layout: { ...layout, panels: newPanels },
+  }
+}
+
+/** 关闭标签页 */
+export function closeTab(
+  tabs: TabItem[],
+  layout: SplitLayoutState,
+  tabId: string,
+): { tabs: TabItem[]; layout: SplitLayoutState } {
+  const tabIndex = tabs.findIndex((t) => t.id === tabId)
+  if (tabIndex === -1) return { tabs, layout }
+
+  const newTabs = tabs.filter((t) => t.id !== tabId)
+
+  // 更新所有面板：如果面板的活跃标签被关闭，切换到相邻标签
+  const newPanels = layout.panels.map((panel) => {
+    if (panel.activeTabId !== tabId) return panel
+
+    // 找到相邻标签（优先右侧，其次左侧）
+    let nextTabId: string | null = null
+    if (newTabs.length > 0) {
+      const nextIndex = Math.min(tabIndex, newTabs.length - 1)
+      nextTabId = newTabs[nextIndex]!.id
+    }
+
+    return { ...panel, activeTabId: nextTabId }
+  })
+
+  return {
+    tabs: newTabs,
+    layout: { ...layout, panels: newPanels },
+  }
+}
+
+/** 聚焦到指定标签（在焦点面板中激活） */
+export function focusTab(
+  layout: SplitLayoutState,
+  tabId: string,
+): SplitLayoutState {
+  // 先检查是否已在某个面板中激活
+  const panelIndex = layout.panels.findIndex((p) => p.activeTabId === tabId)
+  if (panelIndex >= 0) {
+    // 已在面板中 → 切换焦点到该面板
+    return { ...layout, focusedPanelIndex: panelIndex }
+  }
+
+  // 不在任何面板 → 在焦点面板中激活
+  const newPanels = layout.panels.map((panel, idx) =>
+    idx === layout.focusedPanelIndex
+      ? { ...panel, activeTabId: tabId }
+      : panel
+  )
+  return { ...layout, panels: newPanels }
+}
+
+/** 重排标签顺序 */
+export function reorderTabs(
+  tabs: TabItem[],
+  fromIndex: number,
+  toIndex: number,
+): TabItem[] {
+  if (fromIndex === toIndex) return tabs
+  const newTabs = [...tabs]
+  const [moved] = newTabs.splice(fromIndex, 1)
+  newTabs.splice(toIndex, 0, moved!)
+  return newTabs
+}
+
+/** 更新标签标题 */
+export function updateTabTitle(
+  tabs: TabItem[],
+  sessionId: string,
+  title: string,
+): TabItem[] {
+  return tabs.map((t) =>
+    t.sessionId === sessionId ? { ...t, title } : t
+  )
+}
+
+/** 设置分屏模式 */
+export function setSplitMode(
+  layout: SplitLayoutState,
+  mode: SplitMode,
+): SplitLayoutState {
+  const panelCount = mode === 'single' ? 1
+    : mode === 'horizontal-2' || mode === 'vertical-2' ? 2
+    : 4
+
+  // 保留现有面板，补充不足的
+  const panels: SplitPanel[] = []
+  for (let i = 0; i < panelCount; i++) {
+    panels.push(
+      layout.panels[i] ?? { index: i, activeTabId: null }
+    )
+  }
+
+  return {
+    mode,
+    panels: panels.map((p, i) => ({ ...p, index: i })),
+    focusedPanelIndex: Math.min(layout.focusedPanelIndex, panelCount - 1),
+  }
+}

--- a/apps/electron/src/renderer/components/agent/AgentHeader.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentHeader.tsx
@@ -8,10 +8,16 @@
 import * as React from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { Pencil, Check, X } from 'lucide-react'
-import { currentAgentSessionAtom, agentSessionsAtom } from '@/atoms/agent-atoms'
+import { agentSessionsAtom } from '@/atoms/agent-atoms'
 
-export function AgentHeader(): React.ReactElement | null {
-  const session = useAtomValue(currentAgentSessionAtom)
+/** AgentHeader 属性接口 */
+interface AgentHeaderProps {
+  sessionId: string
+}
+
+export function AgentHeader({ sessionId }: AgentHeaderProps): React.ReactElement | null {
+  const sessions = useAtomValue(agentSessionsAtom)
+  const session = sessions.find((s) => s.id === sessionId) ?? null
   const setAgentSessions = useSetAtom(agentSessionsAtom)
   const [editing, setEditing] = React.useState(false)
   const [editTitle, setEditTitle] = React.useState('')

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -33,20 +33,18 @@ import { getModelLogo } from '@/lib/model-logo'
 import { ToolActivityList } from './ToolActivityItem'
 import { BackgroundTasksPanel } from './BackgroundTasksPanel'
 import { useBackgroundTasks } from '@/hooks/useBackgroundTasks'
-import {
-  currentAgentMessagesAtom,
-  currentAgentSessionIdAtom,
-  agentStreamingAtom,
-  agentStreamingContentAtom,
-  agentToolActivitiesAtom,
-  agentStreamingModelAtom,
-  agentRetryingAtom,
-  agentStartedAtAtom,
-} from '@/atoms/agent-atoms'
 import { userProfileAtom } from '@/atoms/user-profile'
 import { cn } from '@/lib/utils'
 import type { AgentMessage, RetryAttempt } from '@proma/shared'
 import type { ToolActivity, AgentStreamState } from '@/atoms/agent-atoms'
+
+/** AgentMessages 属性接口 */
+interface AgentMessagesProps {
+  sessionId: string
+  messages: AgentMessage[]
+  streaming: boolean
+  streamState?: AgentStreamState
+}
 
 function EmptyState(): React.ReactElement {
   return (
@@ -469,19 +467,18 @@ function AgentMessageItem({ message }: { message: AgentMessage }): React.ReactEl
   return null
 }
 
-export function AgentMessages(): React.ReactElement {
-  const messages = useAtomValue(currentAgentMessagesAtom)
+export function AgentMessages({ sessionId, messages, streaming, streamState }: AgentMessagesProps): React.ReactElement {
   const userProfile = useAtomValue(userProfileAtom)
-  const currentSessionId = useAtomValue(currentAgentSessionIdAtom)
-  const streaming = useAtomValue(agentStreamingAtom)
-  const streamingContent = useAtomValue(agentStreamingContentAtom)
-  const toolActivities = useAtomValue(agentToolActivitiesAtom)
-  const agentStreamingModel = useAtomValue(agentStreamingModelAtom)
-  const retrying = useAtomValue(agentRetryingAtom)
-  const startedAt = useAtomValue(agentStartedAtAtom)
+
+  // 从 streamState 属性中计算派生值
+  const streamingContent = streamState?.content ?? ''
+  const toolActivities = streamState?.toolActivities ?? []
+  const agentStreamingModel = streamState?.model
+  const retrying = streamState?.retrying
+  const startedAt = streamState?.startedAt
 
   // 获取后台任务列表
-  const { tasks: backgroundTasks } = useBackgroundTasks(currentSessionId || '')
+  const { tasks: backgroundTasks } = useBackgroundTasks(sessionId)
 
   const { displayedContent: smoothContent } = useSmoothStream({
     content: streamingContent,

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -31,23 +31,19 @@ import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import {
-  currentAgentSessionIdAtom,
-  currentAgentMessagesAtom,
   agentStreamingStatesAtom,
-  agentStreamingAtom,
   agentChannelIdAtom,
   agentModelIdAtom,
   currentAgentWorkspaceIdAtom,
   agentPendingPromptAtom,
   agentPendingFilesAtom,
   agentWorkspacesAtom,
-  agentContextStatusAtom,
   agentStreamErrorsAtom,
-  currentAgentErrorAtom,
-  currentAgentSessionDraftAtom,
+  agentSessionDraftsAtom,
   agentPromptSuggestionsAtom,
-  currentAgentSuggestionAtom,
+  agentMessageRefreshAtom,
 } from '@/atoms/agent-atoms'
+import type { AgentContextStatus } from '@/atoms/agent-atoms'
 import { activeViewAtom } from '@/atoms/active-view'
 import type { AgentSendInput, AgentMessage, AgentPendingFile, AgentSavedFile, ModelOption } from '@proma/shared'
 
@@ -65,11 +61,12 @@ function fileToBase64(file: File): Promise<string> {
   })
 }
 
-export function AgentView(): React.ReactElement {
-  const currentSessionId = useAtomValue(currentAgentSessionIdAtom)
-  const [currentMessages, setCurrentMessages] = useAtom(currentAgentMessagesAtom)
+export function AgentView({ sessionId }: { sessionId: string }): React.ReactElement {
+  const [messages, setMessages] = React.useState<AgentMessage[]>([])
   const setStreamingStates = useSetAtom(agentStreamingStatesAtom)
-  const streaming = useAtomValue(agentStreamingAtom)
+  const streamingStates = useAtomValue(agentStreamingStatesAtom)
+  const streamState = streamingStates.get(sessionId)
+  const streaming = streamState?.running ?? false
   const [agentChannelId, setAgentChannelId] = useAtom(agentChannelIdAtom)
   const [agentModelId, setAgentModelId] = useAtom(agentModelIdAtom)
   const setActiveView = useSetAtom(activeViewAtom)
@@ -77,14 +74,33 @@ export function AgentView(): React.ReactElement {
   const [pendingPrompt, setPendingPrompt] = useAtom(agentPendingPromptAtom)
   const [pendingFiles, setPendingFiles] = useAtom(agentPendingFilesAtom)
   const workspaces = useAtomValue(agentWorkspacesAtom)
-  const contextStatus = useAtomValue(agentContextStatusAtom)
+  const contextStatus: AgentContextStatus = {
+    isCompacting: streamState?.isCompacting ?? false,
+    inputTokens: streamState?.inputTokens,
+    contextWindow: streamState?.contextWindow,
+  }
   const setAgentStreamErrors = useSetAtom(agentStreamErrorsAtom)
-  const agentError = useAtomValue(currentAgentErrorAtom)
+  const streamErrors = useAtomValue(agentStreamErrorsAtom)
+  const agentError = streamErrors.get(sessionId) ?? null
   const store = useStore()
-  const suggestion = useAtomValue(currentAgentSuggestionAtom)
+  const suggestionsMap = useAtomValue(agentPromptSuggestionsAtom)
+  const suggestion = suggestionsMap.get(sessionId) ?? null
   const setPromptSuggestions = useSetAtom(agentPromptSuggestionsAtom)
 
-  const [inputContent, setInputContent] = useAtom(currentAgentSessionDraftAtom)
+  const draftsMap = useAtomValue(agentSessionDraftsAtom)
+  const setDraftsMap = useSetAtom(agentSessionDraftsAtom)
+  const inputContent = draftsMap.get(sessionId) ?? ''
+  const setInputContent = React.useCallback((value: string) => {
+    setDraftsMap((prev) => {
+      const map = new Map(prev)
+      if (value.trim() === '') {
+        map.delete(sessionId)
+      } else {
+        map.set(sessionId, value)
+      }
+      return map
+    })
+  }, [sessionId, setDraftsMap])
   const [fileBrowserOpen, setFileBrowserOpen] = React.useState(false)
   const [sessionPath, setSessionPath] = React.useState<string | null>(null)
   const [isDragOver, setIsDragOver] = React.useState(false)
@@ -120,35 +136,33 @@ export function AgentView(): React.ReactElement {
 
   // 获取当前 session 的工作路径（文件浏览器需要）
   React.useEffect(() => {
-    if (!currentSessionId || !currentWorkspaceId) {
+    if (!currentWorkspaceId) {
       setSessionPath(null)
       return
     }
 
     window.electronAPI
-      .getAgentSessionPath(currentWorkspaceId, currentSessionId)
+      .getAgentSessionPath(currentWorkspaceId, sessionId)
       .then(setSessionPath)
       .catch(() => setSessionPath(null))
-  }, [currentSessionId, currentWorkspaceId])
+  }, [sessionId, currentWorkspaceId])
+
+  // 监听消息刷新版本号
+  const refreshMap = useAtomValue(agentMessageRefreshAtom)
+  const refreshVersion = refreshMap.get(sessionId) ?? 0
 
   // 加载当前会话消息
   React.useEffect(() => {
-    if (!currentSessionId) {
-      setCurrentMessages([])
-      return
-    }
-
     window.electronAPI
-      .getAgentSessionMessages(currentSessionId)
-      .then(setCurrentMessages)
+      .getAgentSessionMessages(sessionId)
+      .then(setMessages)
       .catch(console.error)
-
-  }, [currentSessionId, setCurrentMessages])
+  }, [sessionId, refreshVersion])
 
   // 自动发送 pending prompt（从设置页"对话完成配置"触发）
   React.useEffect(() => {
     if (!pendingPrompt) return
-    if (!currentSessionId || pendingPrompt.sessionId !== currentSessionId) return
+    if (pendingPrompt.sessionId !== sessionId) return
     if (!agentChannelId || streaming) return
 
     // 立即清除，防止重复执行
@@ -160,7 +174,7 @@ export function AgentView(): React.ReactElement {
       // 初始化流式状态
       setStreamingStates((prev) => {
         const map = new Map(prev)
-        map.set(currentSessionId, {
+        map.set(sessionId, {
           running: true,
           content: '',
           toolActivities: [],
@@ -177,11 +191,11 @@ export function AgentView(): React.ReactElement {
         content: prompt.message,
         createdAt: Date.now(),
       }
-      setCurrentMessages((prev) => [...prev, tempUserMsg])
+      setMessages((prev) => [...prev, tempUserMsg])
 
       // 发送消息
       const input: AgentSendInput = {
-        sessionId: currentSessionId,
+        sessionId,
         userMessage: prompt.message,
         channelId: agentChannelId,
         modelId: agentModelId || undefined,
@@ -191,14 +205,14 @@ export function AgentView(): React.ReactElement {
         console.error('[AgentView] 自动发送配置消息失败:', error)
         setStreamingStates((prev) => {
           const map = new Map(prev)
-          map.delete(currentSessionId)
+          map.delete(sessionId)
           return map
         })
       })
     }, 150)
 
     return () => clearTimeout(timer)
-  }, [pendingPrompt, currentSessionId, agentChannelId, agentModelId, currentWorkspaceId, streaming, setPendingPrompt, setStreamingStates, setCurrentMessages])
+  }, [pendingPrompt, sessionId, agentChannelId, agentModelId, currentWorkspaceId, streaming, setPendingPrompt, setStreamingStates])
 
   // ===== 附件处理 =====
 
@@ -280,7 +294,7 @@ export function AgentView(): React.ReactElement {
 
   /** 打开文件夹选择对话框 */
   const handleOpenFolderDialog = React.useCallback(async (): Promise<void> => {
-    if (!currentSessionId || !currentWorkspaceId || isUploadingFolder) return
+    if (!currentWorkspaceId || isUploadingFolder) return
 
     const workspace = workspaces.find((w) => w.id === currentWorkspaceId)
     if (!workspace) return
@@ -295,7 +309,7 @@ export function AgentView(): React.ReactElement {
       const saved = await window.electronAPI.copyFolderToSession({
         sourcePath: result.path,
         workspaceSlug: workspace.slug,
-        sessionId: currentSessionId,
+        sessionId,
       })
 
       setPendingFolderRefs((prev) => [...prev, ...saved])
@@ -305,13 +319,13 @@ export function AgentView(): React.ReactElement {
       // 显示错误提示
       setAgentStreamErrors((prev) => {
         const map = new Map(prev)
-        map.set(currentSessionId, `文件夹上传失败: ${error instanceof Error ? error.message : '未知错误'}`)
+        map.set(sessionId, `文件夹上传失败: ${error instanceof Error ? error.message : '未知错误'}`)
         return map
       })
     } finally {
       setIsUploadingFolder(false)
     }
-  }, [currentSessionId, currentWorkspaceId, workspaces, isUploadingFolder, setAgentStreamErrors])
+  }, [sessionId, currentWorkspaceId, workspaces, isUploadingFolder, setAgentStreamErrors])
 
   /** 移除待发送文件 */
   const handleRemoveFile = React.useCallback((id: string): void => {
@@ -402,7 +416,7 @@ export function AgentView(): React.ReactElement {
     const text = inputContent.trim()
     // 如果输入为空但有建议，使用建议内容
     const effectiveText = text || suggestion || ''
-    if ((!effectiveText && pendingFiles.length === 0 && pendingFolderRefs.length === 0) || !currentSessionId || !agentChannelId) return
+    if ((!effectiveText && pendingFiles.length === 0 && pendingFolderRefs.length === 0) || !agentChannelId) return
 
     // 上一条消息仍在处理中，提示用户等待或停止
     if (streaming) {
@@ -414,17 +428,17 @@ export function AgentView(): React.ReactElement {
 
     // 清除当前会话的错误消息
     setAgentStreamErrors((prev) => {
-      if (!prev.has(currentSessionId)) return prev
+      if (!prev.has(sessionId)) return prev
       const map = new Map(prev)
-      map.delete(currentSessionId)
+      map.delete(sessionId)
       return map
     })
 
     // 清除当前会话的提示建议
     setPromptSuggestions((prev) => {
-      if (!prev.has(currentSessionId)) return prev
+      if (!prev.has(sessionId)) return prev
       const map = new Map(prev)
-      map.delete(currentSessionId)
+      map.delete(sessionId)
       return map
     })
 
@@ -440,7 +454,7 @@ export function AgentView(): React.ReactElement {
         try {
           const saved = await window.electronAPI.saveFilesToAgentSession({
             workspaceSlug: workspace.slug,
-            sessionId: currentSessionId,
+            sessionId,
             files: filesToSave,
           })
           const refs = saved.map((f) => `- ${f.filename}: ${f.targetPath}`).join('\n')
@@ -470,9 +484,9 @@ export function AgentView(): React.ReactElement {
 
     // 防御性快照：将当前流式 assistant 内容保存到消息列表
     // 避免重置流式状态时丢失前一轮回复（竞态场景：complete 事件到达但 STREAM_COMPLETE 尚未到达）
-    const prevStream = store.get(agentStreamingStatesAtom).get(currentSessionId)
+    const prevStream = store.get(agentStreamingStatesAtom).get(sessionId)
     if (prevStream && prevStream.content && !prevStream.running) {
-      setCurrentMessages((prev) => {
+      setMessages((prev) => {
         // 仅在最后一条不是 assistant 消息时追加（避免重复）
         const lastMsg = prev[prev.length - 1]
         if (lastMsg?.role === 'assistant') return prev
@@ -489,7 +503,7 @@ export function AgentView(): React.ReactElement {
     // 初始化流式状态
     setStreamingStates((prev) => {
       const map = new Map(prev)
-      map.set(currentSessionId, {
+      map.set(sessionId, {
         running: true,
         content: '',
         toolActivities: [],
@@ -505,10 +519,10 @@ export function AgentView(): React.ReactElement {
       content: finalMessage,
       createdAt: Date.now(),
     }
-    setCurrentMessages((prev) => [...prev, tempUserMsg])
+    setMessages((prev) => [...prev, tempUserMsg])
 
     const input: AgentSendInput = {
-      sessionId: currentSessionId,
+      sessionId,
       userMessage: finalMessage,
       channelId: agentChannelId,
       modelId: agentModelId || undefined,
@@ -520,55 +534,53 @@ export function AgentView(): React.ReactElement {
     window.electronAPI.sendAgentMessage(input).catch((error) => {
       console.error('[AgentView] 发送消息失败:', error)
       setStreamingStates((prev) => {
-        if (!prev.has(currentSessionId)) return prev
+        if (!prev.has(sessionId)) return prev
         const map = new Map(prev)
-        map.delete(currentSessionId)
+        map.delete(sessionId)
         return map
       })
     })
-  }, [inputContent, pendingFiles, pendingFolderRefs, currentSessionId, agentChannelId, agentModelId, currentWorkspaceId, workspaces, streaming, suggestion, store, setStreamingStates, setCurrentMessages, setPendingFiles, setAgentStreamErrors, setPromptSuggestions])
+  }, [inputContent, pendingFiles, pendingFolderRefs, sessionId, agentChannelId, agentModelId, currentWorkspaceId, workspaces, streaming, suggestion, store, setStreamingStates, setPendingFiles, setAgentStreamErrors, setPromptSuggestions, setInputContent])
 
   /** 停止生成 */
   const handleStop = React.useCallback((): void => {
-    if (!currentSessionId) return
-
     setStreamingStates((prev) => {
-      const current = prev.get(currentSessionId)
+      const current = prev.get(sessionId)
       if (!current) return prev
       const map = new Map(prev)
-      map.set(currentSessionId, { ...current, running: false })
+      map.set(sessionId, { ...current, running: false })
       return map
     })
 
-    window.electronAPI.stopAgent(currentSessionId).catch(console.error)
-  }, [currentSessionId, setStreamingStates])
+    window.electronAPI.stopAgent(sessionId).catch(console.error)
+  }, [sessionId, setStreamingStates])
 
   /** 手动发送 /compact 命令 */
   const handleCompact = React.useCallback((): void => {
-    if (!currentSessionId || !agentChannelId || streaming) return
+    if (!agentChannelId || streaming) return
 
     // 初始化流式状态
     setStreamingStates((prev) => {
       const map = new Map(prev)
-      const current = prev.get(currentSessionId) ?? {
+      const current = prev.get(sessionId) ?? {
         running: true,
         content: '',
         toolActivities: [],
         model: agentModelId || undefined,
         startedAt: Date.now(),
       }
-      map.set(currentSessionId, { ...current, running: true, startedAt: current.startedAt ?? Date.now() })
+      map.set(sessionId, { ...current, running: true, startedAt: current.startedAt ?? Date.now() })
       return map
     })
 
     window.electronAPI.sendAgentMessage({
-      sessionId: currentSessionId,
+      sessionId,
       userMessage: '/compact',
       channelId: agentChannelId,
       modelId: agentModelId || undefined,
       workspaceId: currentWorkspaceId || undefined,
     }).catch(console.error)
-  }, [currentSessionId, agentChannelId, agentModelId, currentWorkspaceId, streaming, setStreamingStates])
+  }, [sessionId, agentChannelId, agentModelId, currentWorkspaceId, streaming, setStreamingStates])
 
   /** 复制错误信息到剪贴板 */
   const handleCopyError = React.useCallback(async (): Promise<void> => {
@@ -585,32 +597,20 @@ export function AgentView(): React.ReactElement {
 
   const canSend = (inputContent.trim().length > 0 || pendingFiles.length > 0 || pendingFolderRefs.length > 0) && agentChannelId !== null && !streaming
 
-  // 无当前会话 → 引导文案
-  if (!currentSessionId) {
-    return (
-      <div className="flex flex-col items-center justify-center h-full w-full max-w-[min(72rem,100%)] mx-auto gap-4 text-muted-foreground" style={{ zoom: 1.1 }}>
-        <div className="w-16 h-16 rounded-full bg-muted flex items-center justify-center">
-          <Bot size={32} className="text-muted-foreground/60" />
-        </div>
-        <div className="text-center space-y-2">
-          <h2 className="text-lg font-medium text-foreground">Agent 模式</h2>
-          <p className="text-sm max-w-[300px]">
-            从左侧点击"新会话"按钮创建一个 Agent 会话
-          </p>
-        </div>
-      </div>
-    )
-  }
-
   return (
     <div className="flex h-full overflow-hidden">
       {/* 主内容区域 */}
       <div className="flex flex-col h-full flex-1 min-w-0 max-w-[min(72rem,100%)] mx-auto">
         {/* Agent Header */}
-        <AgentHeader />
+        <AgentHeader sessionId={sessionId} />
 
         {/* 消息区域 */}
-        <AgentMessages />
+        <AgentMessages
+          sessionId={sessionId}
+          messages={messages}
+          streaming={streaming}
+          streamState={streamState}
+        />
 
         {/* 拖拽文件夹警告 */}
         {dragFolderWarning && (
@@ -628,10 +628,10 @@ export function AgentView(): React.ReactElement {
         )}
 
         {/* 权限请求横幅 */}
-        <PermissionBanner />
+        <PermissionBanner sessionId={sessionId} />
 
         {/* AskUserQuestion 交互式问答横幅 */}
-        <AskUserBanner />
+        <AskUserBanner sessionId={sessionId} />
 
         {/* 输入区域 — 复用 Chat 的卡片式输入风格 */}
         <div className="px-2.5 pb-2.5 md:px-[18px] md:pb-[18px] pt-2">
@@ -706,9 +706,9 @@ export function AgentView(): React.ReactElement {
                     onClick={(e) => {
                       e.stopPropagation()
                       setPromptSuggestions((prev) => {
-                        if (!currentSessionId || !prev.has(currentSessionId)) return prev
+                        if (!prev.has(sessionId)) return prev
                         const map = new Map(prev)
-                        map.delete(currentSessionId)
+                        map.delete(sessionId)
                         return map
                       })
                     }}
@@ -728,7 +728,7 @@ export function AgentView(): React.ReactElement {
                   : '请先在设置中选择 Agent 供应商'
               }
               disabled={!agentChannelId}
-              autoFocusTrigger={currentSessionId}
+              autoFocusTrigger={sessionId}
             />
 
             {/* Footer 工具栏 */}

--- a/apps/electron/src/renderer/components/agent/AskUserBanner.tsx
+++ b/apps/electron/src/renderer/components/agent/AskUserBanner.tsx
@@ -9,7 +9,7 @@ import * as React from 'react'
 import { useAtom } from 'jotai'
 import { Send } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { pendingAskUserRequestsAtom } from '@/atoms/agent-atoms'
+import { allPendingAskUserRequestsAtom } from '@/atoms/agent-atoms'
 import type { AskUserQuestion } from '@proma/shared'
 
 interface QuestionAnswer {
@@ -20,8 +20,14 @@ interface QuestionAnswer {
 
 const EMPTY_ANSWER: QuestionAnswer = { selected: [], customText: '', showCustom: false }
 
-export function AskUserBanner(): React.ReactElement | null {
-  const [requests, setRequests] = useAtom(pendingAskUserRequestsAtom)
+/** AskUserBanner 属性接口 */
+interface AskUserBannerProps {
+  sessionId: string
+}
+
+export function AskUserBanner({ sessionId }: AskUserBannerProps): React.ReactElement | null {
+  const [allRequests, setAllRequests] = useAtom(allPendingAskUserRequestsAtom)
+  const requests = allRequests.get(sessionId) ?? []
   const [answers, setAnswers] = React.useState<Map<number, QuestionAnswer>>(new Map())
   const [submitting, setSubmitting] = React.useState(false)
   const [activeTab, setActiveTab] = React.useState(0)
@@ -139,7 +145,14 @@ export function AskUserBanner(): React.ReactElement | null {
         }
       }
       await window.electronAPI.respondAskUser({ requestId: request.requestId, answers: answersRecord })
-      setRequests((prev) => prev.filter((r) => r.requestId !== request.requestId))
+      setAllRequests((prev) => {
+        const map = new Map(prev)
+        const current = map.get(sessionId) ?? []
+        const newValue = current.filter((r) => r.requestId !== request.requestId)
+        if (newValue.length === 0) map.delete(sessionId)
+        else map.set(sessionId, newValue)
+        return map
+      })
     } catch (error) {
       console.error('[AskUserBanner] 响应失败:', error)
     } finally {

--- a/apps/electron/src/renderer/components/agent/PermissionBanner.tsx
+++ b/apps/electron/src/renderer/components/agent/PermissionBanner.tsx
@@ -12,7 +12,7 @@ import * as React from 'react'
 import { useAtom } from 'jotai'
 import { Shield, ShieldAlert, Check, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { pendingPermissionRequestsAtom } from '@/atoms/agent-atoms'
+import { allPendingPermissionRequestsAtom } from '@/atoms/agent-atoms'
 import type { DangerLevel } from '@proma/shared'
 
 /** 危险等级对应的图标颜色 */
@@ -31,8 +31,14 @@ function formatToolName(toolName: string): string {
   return toolName
 }
 
-export function PermissionBanner(): React.ReactElement | null {
-  const [requests, setRequests] = useAtom(pendingPermissionRequestsAtom)
+/** PermissionBanner 属性接口 */
+interface PermissionBannerProps {
+  sessionId: string
+}
+
+export function PermissionBanner({ sessionId }: PermissionBannerProps): React.ReactElement | null {
+  const [allRequests, setAllRequests] = useAtom(allPendingPermissionRequestsAtom)
+  const requests = allRequests.get(sessionId) ?? []
   const [responding, setResponding] = React.useState(false)
   const respondRef = React.useRef<(behavior: 'allow' | 'deny', alwaysAllow?: boolean) => void>()
 
@@ -70,7 +76,14 @@ export function PermissionBanner(): React.ReactElement | null {
         alwaysAllow,
       })
       // 移除已响应的请求（FIFO 出队）
-      setRequests((prev) => prev.filter((r) => r.requestId !== request.requestId))
+      setAllRequests((prev) => {
+        const map = new Map(prev)
+        const current = map.get(sessionId) ?? []
+        const newValue = current.filter((r) => r.requestId !== request.requestId)
+        if (newValue.length === 0) map.delete(sessionId)
+        else map.set(sessionId, newValue)
+        return map
+      })
     } catch (error) {
       console.error('[PermissionBanner] 响应失败:', error)
     } finally {

--- a/apps/electron/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/electron/src/renderer/components/app-shell/AppShell.tsx
@@ -26,8 +26,8 @@ export function AppShell({ contextValue }: AppShellProps): React.ReactElement {
         {/* 左侧边栏：可折叠 */}
         <LeftSidebar />
 
-        {/* 右侧容器：relative z-[60] 使其在 z-50 拖动区域之上；titlebar-no-drag 标记非拖动区域 */}
-        <div className="flex-1 min-w-0 p-2 relative z-[60] titlebar-no-drag">
+        {/* 右侧容器：relative z-[60] 使其在 z-50 拖动区域之上 */}
+        <div className="flex-1 min-w-0 p-2 relative z-[60]">
           {/* 主内容区域（TabBar + SplitContainer） */}
           <MainArea />
         </div>

--- a/apps/electron/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/electron/src/renderer/components/app-shell/AppShell.tsx
@@ -1,14 +1,14 @@
 /**
  * AppShell - 应用主布局容器
  *
- * 布局结构：[LeftSidebar 280px] | [MainContentPanel 浮动效果]
+ * 布局结构：[LeftSidebar 可折叠] | [MainArea: TabBar + SplitContainer]
  *
- * MainContentPanel 根据当前 App 模式（Chat/Agent）自动渲染对应内容
+ * MainArea 支持多标签页 + 分屏，Settings 视图为独立覆盖。
  */
 
 import * as React from 'react'
 import { LeftSidebar } from './LeftSidebar'
-import { MainContentPanel } from './MainContentPanel'
+import { MainArea } from '@/components/tabs/MainArea'
 import { AppShellProvider, type AppShellContextType } from '@/contexts/AppShellContext'
 
 export interface AppShellProps {
@@ -23,13 +23,13 @@ export function AppShell({ contextValue }: AppShellProps): React.ReactElement {
       <div className="titlebar-drag-region fixed top-0 left-0 right-0 h-[50px] z-50" />
 
       <div className="h-screen w-screen flex overflow-hidden bg-gradient-to-br from-zinc-50 to-zinc-100 dark:from-zinc-950 dark:to-zinc-900">
-        {/* 左侧边栏：默认 280px，放大时可收缩到最小 180px */}
+        {/* 左侧边栏：可折叠 */}
         <LeftSidebar />
 
         {/* 右侧容器：relative z-[60] 使其在 z-50 拖动区域之上；titlebar-no-drag 标记非拖动区域 */}
         <div className="flex-1 min-w-0 p-2 relative z-[60] titlebar-no-drag">
-          {/* 主内容面板（根据模式自动切换内容） */}
-          <MainContentPanel />
+          {/* 主内容区域（TabBar + SplitContainer） */}
+          <MainArea />
         </div>
       </div>
     </AppShellProvider>

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -541,9 +541,9 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
             <TooltipTrigger asChild>
               <button
                 onClick={() => setSidebarCollapsed(true)}
-                className="mt-2.5 p-1.5 rounded-lg text-foreground/40 hover:bg-foreground/[0.04] hover:text-foreground/60 transition-colors titlebar-no-drag"
+                className="mt-2 size-10 flex items-center justify-center rounded-[10px] text-foreground/40 hover:bg-foreground/[0.04] hover:text-foreground/60 transition-colors titlebar-no-drag"
               >
-                <PanelLeftClose size={16} />
+                <PanelLeftClose size={18} />
               </button>
             </TooltipTrigger>
             <TooltipContent side="right">收起侧边栏</TooltipContent>

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -10,7 +10,7 @@
 
 import * as React from 'react'
 import { useAtom, useSetAtom, useAtomValue } from 'jotai'
-import { Pin, PinOff, Settings, Plus, Trash2, Pencil, ChevronDown, ChevronRight, Plug, Zap } from 'lucide-react'
+import { Pin, PinOff, Settings, Plus, Trash2, Pencil, ChevronDown, ChevronRight, Plug, Zap, PanelLeftClose, PanelLeftOpen } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { ModeSwitcher } from './ModeSwitcher'
 import { activeViewAtom } from '@/atoms/active-view'
@@ -31,6 +31,15 @@ import {
   agentWorkspacesAtom,
   workspaceCapabilitiesVersionAtom,
 } from '@/atoms/agent-atoms'
+import {
+  tabsAtom,
+  splitLayoutAtom,
+  activeTabIdAtom,
+  sidebarCollapsedAtom,
+  openTab,
+  closeTab,
+  updateTabTitle,
+} from '@/atoms/tab-atoms'
 import { userProfileAtom } from '@/atoms/user-profile'
 import { hasUpdateAtom } from '@/atoms/updater'
 import { hasEnvironmentIssuesAtom } from '@/atoms/environment'
@@ -46,6 +55,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import type { ActiveView } from '@/atoms/active-view'
 import type { ConversationMeta, AgentSessionMeta, WorkspaceCapabilities } from '@proma/shared'
 
@@ -157,6 +167,12 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   const [capabilities, setCapabilities] = React.useState<WorkspaceCapabilities | null>(null)
   const capabilitiesVersion = useAtomValue(workspaceCapabilitiesVersionAtom)
 
+  // Tab 状态
+  const [tabs, setTabs] = useAtom(tabsAtom)
+  const [layout, setLayout] = useAtom(splitLayoutAtom)
+  const activeTabId = useAtomValue(activeTabIdAtom)
+  const [sidebarCollapsed, setSidebarCollapsed] = useAtom(sidebarCollapsedAtom)
+
   const currentWorkspaceSlug = React.useMemo(() => {
     if (!currentWorkspaceId) return null
     return workspaces.find((w) => w.id === currentWorkspaceId)?.slug ?? null
@@ -197,10 +213,6 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       .listConversations()
       .then((list) => {
         setConversations(list)
-        // 默认加载最近一条对话（按 updatedAt 降序，首条即最新）
-        if (list.length > 0) {
-          setCurrentConversationId(list[0]!.id)
-        }
       })
       .catch(console.error)
     window.electronAPI
@@ -212,7 +224,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       .then(setAgentSessions)
       .catch(console.error)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [setConversations, setCurrentConversationId, setUserProfile, setAgentSessions])
+  }, [setConversations, setUserProfile, setAgentSessions])
 
   /** 处理导航项点击 */
   const handleItemClick = (item: SidebarItemId): void => {
@@ -241,6 +253,10 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         selectedModel?.channelId,
       )
       setConversations((prev) => [meta, ...prev])
+      // 打开新标签页
+      const result = openTab(tabs, layout, { type: 'chat', sessionId: meta.id, title: meta.title })
+      setTabs(result.tabs)
+      setLayout(result.layout)
       setCurrentConversationId(meta.id)
       // 确保在对话视图
       setActiveView('conversations')
@@ -254,8 +270,11 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     }
   }
 
-  /** 选择对话 */
-  const handleSelectConversation = (id: string): void => {
+  /** 选择对话（打开或聚焦标签页） */
+  const handleSelectConversation = (id: string, title: string): void => {
+    const result = openTab(tabs, layout, { type: 'chat', sessionId: id, title })
+    setTabs(result.tabs)
+    setLayout(result.layout)
     setCurrentConversationId(id)
     setActiveView('conversations')
     setActiveItem('all-chats')
@@ -273,6 +292,8 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       setConversations((prev) =>
         prev.map((c) => (c.id === updated.id ? updated : c))
       )
+      // 同步更新标签页标题
+      setTabs((prev) => updateTabTitle(prev, id, newTitle))
     } catch (error) {
       console.error('[侧边栏] 重命名对话失败:', error)
     }
@@ -293,6 +314,11 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   /** 确认删除对话 */
   const handleConfirmDelete = async (): Promise<void> => {
     if (!pendingDeleteId) return
+
+    // 关闭对应的标签页
+    const tabResult = closeTab(tabs, layout, pendingDeleteId)
+    setTabs(tabResult.tabs)
+    setLayout(tabResult.layout)
 
     if (mode === 'agent') {
       // Agent 模式：删除 Agent 会话
@@ -332,6 +358,10 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         currentWorkspaceId || undefined,
       )
       setAgentSessions((prev) => [meta, ...prev])
+      // 打开新标签页
+      const result = openTab(tabs, layout, { type: 'agent', sessionId: meta.id, title: meta.title })
+      setTabs(result.tabs)
+      setLayout(result.layout)
       setCurrentAgentSessionId(meta.id)
       setActiveView('conversations')
       setActiveItem('all-chats')
@@ -340,8 +370,11 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     }
   }
 
-  /** 选择 Agent 会话 */
-  const handleSelectAgentSession = (id: string): void => {
+  /** 选择 Agent 会话（打开或聚焦标签页） */
+  const handleSelectAgentSession = (id: string, title: string): void => {
+    const result = openTab(tabs, layout, { type: 'agent', sessionId: id, title })
+    setTabs(result.tabs)
+    setLayout(result.layout)
     setCurrentAgentSessionId(id)
     setActiveView('conversations')
     setActiveItem('all-chats')
@@ -354,6 +387,8 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       setAgentSessions((prev) =>
         prev.map((s) => (s.id === id ? { ...s, title: newTitle, updatedAt: Date.now() } : s))
       )
+      // 同步更新标签页标题
+      setTabs((prev) => updateTabTitle(prev, id, newTitle))
     } catch (error) {
       console.error('[侧边栏] 重命名 Agent 会话失败:', error)
     }
@@ -383,15 +418,137 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     [filteredAgentSessions]
   )
 
+  // 删除确认弹窗（collapsed/expanded 共享）
+  const deleteDialog = (
+    <AlertDialog
+      open={pendingDeleteId !== null}
+      onOpenChange={(open) => { if (!open) setPendingDeleteId(null) }}
+    >
+      <AlertDialogContent
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault()
+            handleConfirmDelete()
+          }
+        }}
+      >
+        <AlertDialogHeader>
+          <AlertDialogTitle>确认删除对话</AlertDialogTitle>
+          <AlertDialogDescription>
+            删除后将无法恢复，确定要删除这个对话吗？
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>取消</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleConfirmDelete}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            删除
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+
+  // ===== 折叠状态：精简图标视图 =====
+  if (sidebarCollapsed) {
+    return (
+      <div
+        className="h-full flex flex-col items-center bg-background transition-[width] duration-300"
+        style={{ width: 48, flexShrink: 0 }}
+      >
+        {/* 顶部留空，避开 macOS 红绿灯 */}
+        <div className="pt-[50px]" />
+
+        {/* 展开按钮 */}
+        <div className="pt-2">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={() => setSidebarCollapsed(false)}
+                className="p-2 rounded-[10px] text-foreground/60 hover:bg-foreground/[0.04] hover:text-foreground transition-colors titlebar-no-drag"
+              >
+                <PanelLeftOpen size={18} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="right">展开侧边栏</TooltipContent>
+          </Tooltip>
+        </div>
+
+        {/* 新对话/会话按钮 */}
+        <div className="pt-2">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={mode === 'agent' ? handleNewAgentSession : handleNewConversation}
+                className="p-2 rounded-[10px] text-foreground/70 bg-foreground/[0.04] hover:bg-foreground/[0.08] transition-colors titlebar-no-drag border border-dashed border-foreground/10 hover:border-foreground/20"
+              >
+                <Plus size={16} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="right">
+              {mode === 'agent' ? '新会话' : '新对话'}
+            </TooltipContent>
+          </Tooltip>
+        </div>
+
+        {/* 弹性空间 */}
+        <div className="flex-1" />
+
+        {/* 设置按钮 */}
+        <div className="pb-3">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={() => handleItemClick('settings')}
+                className={cn(
+                  'relative p-2 rounded-[10px] transition-colors titlebar-no-drag',
+                  activeItem === 'settings'
+                    ? 'bg-foreground/[0.08] text-foreground'
+                    : 'text-foreground/60 hover:bg-foreground/[0.04] hover:text-foreground'
+                )}
+              >
+                <Settings size={18} />
+                {(hasUpdate || hasEnvironmentIssues) && (
+                  <span className="absolute top-1.5 right-1.5 w-2 h-2 rounded-full bg-red-500" />
+                )}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="right">设置</TooltipContent>
+          </Tooltip>
+        </div>
+
+        {deleteDialog}
+      </div>
+    )
+  }
+
+  // ===== 展开状态：完整侧边栏 =====
   return (
     <div
-      className="h-full flex flex-col bg-background"
+      className="h-full flex flex-col bg-background transition-[width] duration-300"
       style={{ width: width ?? 280, minWidth: 180, flexShrink: 1 }}
     >
       {/* 顶部留空，避开 macOS 红绿灯 */}
       <div className="pt-[50px]">
-        {/* 模式切换器 */}
-        <ModeSwitcher />
+        {/* 模式切换器 + 折叠按钮 */}
+        <div className="flex items-start gap-1 pr-1">
+          <div className="flex-1 min-w-0">
+            <ModeSwitcher />
+          </div>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={() => setSidebarCollapsed(true)}
+                className="mt-2.5 p-1.5 rounded-lg text-foreground/40 hover:bg-foreground/[0.04] hover:text-foreground/60 transition-colors titlebar-no-drag"
+              >
+                <PanelLeftClose size={16} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="right">收起侧边栏</TooltipContent>
+          </Tooltip>
+        </div>
       </div>
 
       {/* Agent 模式：工作区选择器 */}
@@ -438,11 +595,11 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
               <ConversationItem
                 key={`pinned-${conv.id}`}
                 conversation={conv}
-                active={conv.id === currentConversationId}
+                active={conv.id === activeTabId}
                 hovered={conv.id === hoveredId}
                 streaming={streamingIds.has(conv.id)}
                 showPinIcon={false}
-                onSelect={() => handleSelectConversation(conv.id)}
+                onSelect={() => handleSelectConversation(conv.id, conv.title)}
                 onRequestDelete={() => handleRequestDelete(conv.id)}
                 onRename={handleRename}
                 onTogglePin={handleTogglePin}
@@ -480,11 +637,11 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
               <AgentSessionItem
                 key={`pinned-${session.id}`}
                 session={session}
-                active={session.id === currentAgentSessionId}
+                active={session.id === activeTabId}
                 hovered={session.id === hoveredId}
                 running={agentRunningIds.has(session.id)}
                 showPinIcon={false}
-                onSelect={() => handleSelectAgentSession(session.id)}
+                onSelect={() => handleSelectAgentSession(session.id, session.title)}
                 onRequestDelete={() => handleRequestDelete(session.id)}
                 onRename={handleAgentRename}
                 onTogglePin={handleTogglePinAgent}
@@ -510,11 +667,11 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                   <ConversationItem
                     key={conv.id}
                     conversation={conv}
-                    active={conv.id === currentConversationId}
+                    active={conv.id === activeTabId}
                     hovered={conv.id === hoveredId}
                     streaming={streamingIds.has(conv.id)}
                     showPinIcon={!!conv.pinned}
-                    onSelect={() => handleSelectConversation(conv.id)}
+                    onSelect={() => handleSelectConversation(conv.id, conv.title)}
                     onRequestDelete={() => handleRequestDelete(conv.id)}
                     onRename={handleRename}
                     onTogglePin={handleTogglePin}
@@ -537,11 +694,11 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                   <AgentSessionItem
                     key={session.id}
                     session={session}
-                    active={session.id === currentAgentSessionId}
+                    active={session.id === activeTabId}
                     hovered={session.id === hoveredId}
                     running={agentRunningIds.has(session.id)}
                     showPinIcon={!!session.pinned}
-                    onSelect={() => handleSelectAgentSession(session.id)}
+                    onSelect={() => handleSelectAgentSession(session.id, session.title)}
                     onRequestDelete={() => handleRequestDelete(session.id)}
                     onRename={handleAgentRename}
                     onTogglePin={handleTogglePinAgent}
@@ -594,36 +751,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         />
       </div>
 
-      {/* 删除确认弹窗 */}
-      <AlertDialog
-        open={pendingDeleteId !== null}
-        onOpenChange={(open) => { if (!open) setPendingDeleteId(null) }}
-      >
-        <AlertDialogContent
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              e.preventDefault()
-              handleConfirmDelete()
-            }
-          }}
-        >
-          <AlertDialogHeader>
-            <AlertDialogTitle>确认删除对话</AlertDialogTitle>
-            <AlertDialogDescription>
-              删除后将无法恢复，确定要删除这个对话吗？
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>取消</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleConfirmDelete}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              删除
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      {deleteDialog}
     </div>
   )
 }

--- a/apps/electron/src/renderer/components/app-shell/MainContentPanel.tsx
+++ b/apps/electron/src/renderer/components/app-shell/MainContentPanel.tsx
@@ -14,14 +14,28 @@ import { Panel } from './Panel'
 import { ChatView } from '@/components/chat'
 import { AgentView } from '@/components/agent'
 import { SettingsPanel } from '@/components/settings'
+import { currentConversationIdAtom } from '@/atoms/chat-atoms'
+import { currentAgentSessionIdAtom } from '@/atoms/agent-atoms'
 
+/**
+ * @deprecated 已被 MainArea（TabBar + SplitContainer）替代。
+ * 保留仅供参考，不再被 AppShell 使用。
+ */
 export function MainContentPanel(): React.ReactElement {
   const mode = useAtomValue(appModeAtom)
   const activeView = useAtomValue(activeViewAtom)
+  const conversationId = useAtomValue(currentConversationIdAtom)
+  const sessionId = useAtomValue(currentAgentSessionIdAtom)
 
   /** 渲染对话视图内容 */
-  const renderConversations = (): React.ReactElement => {
-    return mode === 'chat' ? <ChatView /> : <AgentView />
+  const renderConversations = (): React.ReactElement | null => {
+    if (mode === 'chat' && conversationId) {
+      return <ChatView conversationId={conversationId} />
+    }
+    if (mode === 'agent' && sessionId) {
+      return <AgentView sessionId={sessionId} />
+    }
+    return null
   }
 
   return (

--- a/apps/electron/src/renderer/components/chat/ChatHeader.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatHeader.tsx
@@ -5,16 +5,20 @@
  */
 
 import * as React from 'react'
-import { useAtom, useAtomValue, useSetAtom } from 'jotai'
+import { useAtom, useSetAtom } from 'jotai'
 import { Pencil, Check, X, Pin, Columns2 } from 'lucide-react'
-import { currentConversationAtom, conversationsAtom, parallelModeAtom } from '@/atoms/chat-atoms'
+import { conversationsAtom, parallelModeAtom } from '@/atoms/chat-atoms'
+import type { ConversationMeta } from '@proma/shared'
 import { SystemPromptSelector } from './SystemPromptSelector'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 
-export function ChatHeader(): React.ReactElement | null {
-  const conversation = useAtomValue(currentConversationAtom)
+interface ChatHeaderProps {
+  conversation: ConversationMeta | null
+}
+
+export function ChatHeader({ conversation }: ChatHeaderProps): React.ReactElement | null {
   const setConversations = useSetAtom(conversationsAtom)
   const [parallelMode, setParallelMode] = useAtom(parallelModeAtom)
   const [editing, setEditing] = React.useState(false)

--- a/apps/electron/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatInput.tsx
@@ -13,7 +13,7 @@
  */
 
 import * as React from 'react'
-import { useAtom, useAtomValue } from 'jotai'
+import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { CornerDownLeft, Square, Lightbulb, Paperclip } from 'lucide-react'
 import { ModelSelector } from './ModelSelector'
 import { ClearContextButton } from './ClearContextButton'
@@ -30,16 +30,21 @@ import {
 } from '@/components/ui/tooltip'
 import {
   selectedModelAtom,
-  streamingAtom,
   thinkingEnabledAtom,
-  pendingAttachmentsAtom,
-  currentConversationIdAtom,
-  currentConversationDraftAtom,
+  conversationDraftsAtom,
 } from '@/atoms/chat-atoms'
 import type { PendingAttachment } from '@/atoms/chat-atoms'
 import { cn } from '@/lib/utils'
 
 interface ChatInputProps {
+  /** 当前对话 ID */
+  conversationId: string
+  /** 是否正在流式生成 */
+  streaming: boolean
+  /** 待发送附件列表 */
+  pendingAttachments: PendingAttachment[]
+  /** 设置待发送附件 */
+  onSetPendingAttachments: React.Dispatch<React.SetStateAction<PendingAttachment[]>>
   /** 发送消息回调 */
   onSend: (content: string) => void
   /** 停止生成回调 */
@@ -65,13 +70,26 @@ function fileToBase64(file: File): Promise<string> {
   })
 }
 
-export function ChatInput({ onSend, onStop, onClearContext }: ChatInputProps): React.ReactElement {
-  const [content, setContent] = useAtom(currentConversationDraftAtom)
+export function ChatInput({ conversationId, streaming, pendingAttachments, onSetPendingAttachments, onSend, onStop, onClearContext }: ChatInputProps): React.ReactElement {
+  // 从 Map atom 读写草稿
+  const draftsMap = useAtomValue(conversationDraftsAtom)
+  const setDraftsMap = useSetAtom(conversationDraftsAtom)
+  const content = draftsMap.get(conversationId) ?? ''
+  const setContent = React.useCallback((value: string) => {
+    setDraftsMap((prev) => {
+      const map = new Map(prev)
+      if (value.trim() === '') {
+        map.delete(conversationId)
+      } else {
+        map.set(conversationId, value)
+      }
+      return map
+    })
+  }, [conversationId, setDraftsMap])
+
   const selectedModel = useAtomValue(selectedModelAtom)
-  const streaming = useAtomValue(streamingAtom)
   const [thinkingEnabled, setThinkingEnabled] = useAtom(thinkingEnabledAtom)
-  const [pendingAttachments, setPendingAttachments] = useAtom(pendingAttachmentsAtom)
-  const currentConversationId = useAtomValue(currentConversationIdAtom)
+  const setPendingAttachments = onSetPendingAttachments
   const [isDragOver, setIsDragOver] = React.useState(false)
 
   const canSend = (content.trim().length > 0 || pendingAttachments.length > 0)
@@ -256,7 +274,7 @@ export function ChatInput({ onSend, onStop, onClearContext }: ChatInputProps): R
                 : '请先选择模型'
             }
             disabled={!selectedModel}
-            autoFocusTrigger={currentConversationId}
+            autoFocusTrigger={conversationId}
           />
 
           {/* Footer 工具栏 — Cherry Studio: padding 5px 8px, height 40px, gap 16px */}

--- a/apps/electron/src/renderer/components/chat/ChatMessages.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessages.tsx
@@ -43,20 +43,11 @@ import {
 } from '@/components/ai-elements/reasoning'
 import { useSmoothStream } from '@proma/ui'
 import {
-  currentMessagesAtom,
-  streamingAtom,
-  streamingContentAtom,
-  streamingReasoningAtom,
-  streamingModelAtom,
-  streamingToolActivitiesAtom,
-  contextDividersAtom,
   parallelModeAtom,
-  hasMoreMessagesAtom,
-  currentConversationIdAtom,
 } from '@/atoms/chat-atoms'
 import { getModelLogo } from '@/lib/model-logo'
 import { userProfileAtom } from '@/atoms/user-profile'
-import type { ChatMessage } from '@proma/shared'
+import type { ChatMessage, ChatToolActivity } from '@proma/shared'
 
 // ===== 滚动到顶部加载更多 =====
 
@@ -124,6 +115,24 @@ function ScrollTopLoader({ hasMore, loading, onLoadMore }: ScrollTopLoaderProps)
 // ===== 主组件 =====
 
 interface ChatMessagesProps {
+  /** 当前对话 ID */
+  conversationId: string
+  /** 消息列表 */
+  messages: ChatMessage[]
+  /** 是否正在流式生成 */
+  streaming: boolean
+  /** 流式累积内容 */
+  streamingContent: string
+  /** 流式推理内容 */
+  streamingReasoning: string
+  /** 流式消息绑定的模型 */
+  streamingModel: string | null
+  /** 工具活动列表 */
+  toolActivities: ChatToolActivity[]
+  /** 上下文分隔线 */
+  contextDividers: string[]
+  /** 是否还有更多历史消息 */
+  hasMore: boolean
   /** 删除消息回调 */
   onDeleteMessage?: (messageId: string) => Promise<void>
   /** 重新发送消息回调 */
@@ -157,6 +166,15 @@ function EmptyState(): React.ReactElement {
 }
 
 export function ChatMessages({
+  conversationId,
+  messages,
+  streaming,
+  streamingContent,
+  streamingReasoning,
+  streamingModel,
+  toolActivities,
+  contextDividers,
+  hasMore,
   onDeleteMessage,
   onResendMessage,
   onStartInlineEdit,
@@ -166,14 +184,9 @@ export function ChatMessages({
   onDeleteDivider,
   onLoadMore,
 }: ChatMessagesProps): React.ReactElement {
-  const messages = useAtomValue(currentMessagesAtom)
   const userProfile = useAtomValue(userProfileAtom)
-  const streaming = useAtomValue(streamingAtom)
-  const streamingContent = useAtomValue(streamingContentAtom)
-  const streamingReasoning = useAtomValue(streamingReasoningAtom)
-  const toolActivities = useAtomValue(streamingToolActivitiesAtom)
 
-  // 平滑流式输出：将高频 atom 更新转为逐字渲染
+  // 平滑流式输出：将高频更新转为逐字渲染
   const { displayedContent: smoothContent } = useSmoothStream({
     content: streamingContent,
     isStreaming: streaming,
@@ -182,11 +195,7 @@ export function ChatMessages({
     content: streamingReasoning,
     isStreaming: streaming,
   })
-  const contextDividers = useAtomValue(contextDividersAtom)
   const parallelMode = useAtomValue(parallelModeAtom)
-  const streamingModel = useAtomValue(streamingModelAtom)
-  const hasMore = useAtomValue(hasMoreMessagesAtom)
-  const currentConversationId = useAtomValue(currentConversationIdAtom)
 
   /** 是否正在加载更多历史 */
   const [loadingMore, setLoadingMore] = React.useState(false)
@@ -200,11 +209,11 @@ export function ChatMessages({
 
   // 对话切换时立即隐藏
   React.useEffect(() => {
-    if (currentConversationId !== prevConversationIdRef.current) {
-      prevConversationIdRef.current = currentConversationId
+    if (conversationId !== prevConversationIdRef.current) {
+      prevConversationIdRef.current = conversationId
       setReady(false)
     }
-  }, [currentConversationId])
+  }, [conversationId])
 
   // 消息渲染 + StickToBottom 定位完成后淡入
   React.useEffect(() => {

--- a/apps/electron/src/renderer/components/chat/ChatView.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatView.tsx
@@ -1,20 +1,21 @@
 /**
- * ChatView - 主聊天视图容器
+ * ChatView - 主聊天视图容器（参数化版本）
  *
  * 职责：
- * - 加载当前对话消息和上下文分隔线
- * - 订阅流式 IPC 事件（chunk, reasoning, complete, error）
- * - 管理 streaming 状态和累积内容
- * - 处理消息删除、上下文清除/删除
- * - 传递 contextLength 和 contextDividers 到 sendMessage
- * - 无当前对话时显示引导文案
+ * - 接受 conversationId prop，不依赖全局单例 atom
+ * - 加载对话消息和上下文分隔线（本地 state）
+ * - 处理消息发送、删除、编辑、重发
+ * - 管理上下文清除/删除
+ * - 监听 chatMessageRefreshAtom 版本号变化自动重载消息
+ *
+ * 注意：流式 IPC 事件监听已迁移到 useGlobalChatListeners（全局挂载）
  *
  * 布局：三段式 ChatHeader | ChatMessages | ChatInput
  */
 
 import * as React from 'react'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
-import { MessageSquare, AlertCircle, X } from 'lucide-react'
+import { AlertCircle, X } from 'lucide-react'
 import { ChatHeader } from './ChatHeader'
 import { ChatMessages } from './ChatMessages'
 import { ChatInput } from './ChatInput'
@@ -22,284 +23,115 @@ import { AgentRecommendBanner } from './AgentRecommendBanner'
 import { PromptEditorSidebar } from './PromptEditorSidebar'
 import type { InlineEditSubmitPayload } from './ChatMessageItem'
 import {
-  currentConversationIdAtom,
-  currentConversationAtom,
-  currentMessagesAtom,
-  streamingAtom,
+  conversationsAtom,
   streamingStatesAtom,
   selectedModelAtom,
-  conversationsAtom,
   contextLengthAtom,
-  contextDividersAtom,
   thinkingEnabledAtom,
-  pendingAttachmentsAtom,
-  hasMoreMessagesAtom,
-  INITIAL_MESSAGE_LIMIT,
   chatStreamErrorsAtom,
-  currentChatErrorAtom,
+  chatMessageRefreshAtom,
   pendingAgentRecommendationAtom,
+  INITIAL_MESSAGE_LIMIT,
 } from '@/atoms/chat-atoms'
+import type { PendingAttachment } from '@/atoms/chat-atoms'
 import { resolvedSystemMessageAtom, promptSidebarOpenAtom } from '@/atoms/system-prompt-atoms'
 import { activeToolIdsAtom } from '@/atoms/chat-tool-atoms'
+import { registerPendingTitle } from '@/hooks/useGlobalChatListeners'
 import { cn } from '@/lib/utils'
-import type { ConversationStreamState } from '@/atoms/chat-atoms'
 import type {
+  ChatMessage,
   ChatSendInput,
-  GenerateTitleInput,
-  StreamChunkEvent,
-  StreamReasoningEvent,
-  StreamCompleteEvent,
-  StreamErrorEvent,
-  StreamToolActivityEvent,
   FileAttachment,
   AttachmentSaveInput,
 } from '@proma/shared'
 
-export function ChatView(): React.ReactElement {
-  const currentConversationId = useAtomValue(currentConversationIdAtom)
-  const currentConversation = useAtomValue(currentConversationAtom)
-  const [currentMessages, setCurrentMessages] = useAtom(currentMessagesAtom)
+interface ChatViewProps {
+  conversationId: string
+}
+
+export function ChatView({ conversationId }: ChatViewProps): React.ReactElement {
+  // ===== 本地状态（每个实例独立） =====
+  const [messages, setMessages] = React.useState<ChatMessage[]>([])
+  const [contextDividers, setContextDividers] = React.useState<string[]>([])
+  const [pendingAttachments, setPendingAttachments] = React.useState<PendingAttachment[]>([])
+  const [hasMoreMessages, setHasMoreMessages] = React.useState(false)
+  const [inlineEditingMessageId, setInlineEditingMessageId] = React.useState<string | null>(null)
+
+  // ===== 全局 atoms（Map 结构，按 conversationId 读取） =====
+  const conversations = useAtomValue(conversationsAtom)
+  const streamingStates = useAtomValue(streamingStatesAtom)
   const setStreamingStates = useSetAtom(streamingStatesAtom)
   const [selectedModel, setSelectedModel] = useAtom(selectedModelAtom)
-  const setConversations = useSetAtom(conversationsAtom)
   const contextLength = useAtomValue(contextLengthAtom)
-  const [contextDividers, setContextDividers] = useAtom(contextDividersAtom)
   const thinkingEnabled = useAtomValue(thinkingEnabledAtom)
-  const [pendingAttachments, setPendingAttachments] = useAtom(pendingAttachmentsAtom)
-  const setHasMoreMessages = useSetAtom(hasMoreMessagesAtom)
   const setChatStreamErrors = useSetAtom(chatStreamErrorsAtom)
-  const chatError = useAtomValue(currentChatErrorAtom)
-  const isStreaming = useAtomValue(streamingAtom)
+  const chatStreamErrors = useAtomValue(chatStreamErrorsAtom)
+  const refreshMap = useAtomValue(chatMessageRefreshAtom)
   const resolvedSystemMessage = useAtomValue(resolvedSystemMessageAtom)
   const promptSidebarOpen = useAtomValue(promptSidebarOpenAtom)
   const activeToolIds = useAtomValue(activeToolIdsAtom)
   const setPendingRecommendation = useSetAtom(pendingAgentRecommendationAtom)
-  const [inlineEditingMessageId, setInlineEditingMessageId] = React.useState<string | null>(null)
 
-  // 首条消息标题生成相关 ref（支持多对话并行）
-  const pendingTitleRef = React.useRef<Map<string, GenerateTitleInput>>(new Map())
+  // ===== 从 Map 派生当前对话状态 =====
+  const conversation = conversations.find((c) => c.id === conversationId) ?? null
+  const streamState = streamingStates.get(conversationId)
+  const isStreaming = streamState?.streaming ?? false
+  const streamingContent = streamState?.content ?? ''
+  const streamingReasoning = streamState?.reasoning ?? ''
+  const streamingModel = streamState?.model ?? null
+  const toolActivities = streamState?.toolActivities ?? []
+  const chatError = chatStreamErrors.get(conversationId) ?? null
+  const refreshVersion = refreshMap.get(conversationId) ?? 0
 
-  // 当前对话 ID 的 ref，供 IPC 回调使用（避免闭包捕获旧值）
-  const currentConvIdRef = React.useRef(currentConversationId)
-  React.useEffect(() => {
-    currentConvIdRef.current = currentConversationId
-  }, [currentConversationId])
-
+  // ===== 对话切换时重置状态 =====
   React.useEffect(() => {
     setInlineEditingMessageId(null)
     setPendingRecommendation(null)
-  }, [currentConversationId])
+  }, [conversationId, setPendingRecommendation])
 
-  // 加载当前对话最近消息 + 上下文分隔线
+  // ===== 加载消息 + 上下文分隔线 =====
   React.useEffect(() => {
-    if (!currentConversationId) {
-      setCurrentMessages([])
-      setContextDividers([])
-      setHasMoreMessages(false)
-      return
-    }
-
-    // 仅加载最近 N 条消息，避免大量消息导致渲染卡顿
     window.electronAPI
-      .getRecentMessages(currentConversationId, INITIAL_MESSAGE_LIMIT)
+      .getRecentMessages(conversationId, INITIAL_MESSAGE_LIMIT)
       .then((result) => {
-        setCurrentMessages(result.messages)
+        setMessages(result.messages)
         setHasMoreMessages(result.hasMore)
       })
       .catch(console.error)
+  }, [conversationId, refreshVersion])
 
-    // 从对话元数据加载分隔线
-    if (currentConversation?.contextDividers) {
-      setContextDividers(currentConversation.contextDividers)
+  // 从对话元数据加载分隔线
+  React.useEffect(() => {
+    if (conversation?.contextDividers) {
+      setContextDividers(conversation.contextDividers)
     } else {
       setContextDividers([])
     }
+  }, [conversation?.contextDividers])
 
-    // 从对话元数据恢复模型/渠道选择
-    if (currentConversation?.modelId && currentConversation?.channelId) {
-      setSelectedModel({
-        channelId: currentConversation.channelId,
-        modelId: currentConversation.modelId,
-      })
-    }
-  }, [currentConversationId, currentConversation?.contextDividers, currentConversation?.modelId, currentConversation?.channelId, setCurrentMessages, setContextDividers, setHasMoreMessages, setSelectedModel])
-
-  // 订阅流式 IPC 事件（全局，不按 conversationId 过滤）
+  // 从对话元数据恢复模型/渠道选择
   React.useEffect(() => {
-    /** 辅助函数：更新 Map 中某个对话的流式状态 */
-    const updateState = (
-      convId: string,
-      updater: (prev: ConversationStreamState) => ConversationStreamState
-    ): void => {
-      setStreamingStates((prev) => {
-        const current = prev.get(convId) ?? { streaming: false, content: '', reasoning: '', model: undefined, toolActivities: [] }
-        const next = updater(current)
-        const map = new Map(prev)
-        map.set(convId, next)
-        return map
+    if (conversation?.modelId && conversation?.channelId) {
+      setSelectedModel({
+        channelId: conversation.channelId,
+        modelId: conversation.modelId,
       })
     }
-
-    /** 辅助函数：从 Map 中移除某个对话的流式状态 */
-    const removeState = (convId: string): void => {
-      setStreamingStates((prev) => {
-        if (!prev.has(convId)) return prev
-        const map = new Map(prev)
-        map.delete(convId)
-        return map
-      })
-    }
-
-    const cleanupChunk = window.electronAPI.onStreamChunk(
-      (event: StreamChunkEvent) => {
-        updateState(event.conversationId, (s) => ({
-          ...s,
-          content: s.content + event.delta,
-        }))
-      }
-    )
-
-    const cleanupReasoning = window.electronAPI.onStreamReasoning(
-      (event: StreamReasoningEvent) => {
-        updateState(event.conversationId, (s) => ({
-          ...s,
-          reasoning: s.reasoning + event.delta,
-        }))
-      }
-    )
-
-    const cleanupComplete = window.electronAPI.onStreamComplete(
-      (event: StreamCompleteEvent) => {
-        // 清理 Map 中的流式状态
-        removeState(event.conversationId)
-
-        // 仅当完成的是当前对话时，重新加载消息
-        if (event.conversationId === currentConvIdRef.current) {
-          window.electronAPI
-            .getConversationMessages(event.conversationId)
-            .then((msgs) => {
-              setCurrentMessages(msgs)
-              setHasMoreMessages(false)
-            })
-            .catch(console.error)
-        }
-
-        // 刷新对话列表（updatedAt 已更新）
-        window.electronAPI
-          .listConversations()
-          .then(setConversations)
-          .catch(console.error)
-
-        // 第一条消息回复完成后，生成对话标题
-        const titleInput = pendingTitleRef.current.get(event.conversationId)
-        console.log('[ChatView] 流式完成 - conversationId:', event.conversationId, 'titleInput:', titleInput)
-        if (titleInput) {
-          pendingTitleRef.current.delete(event.conversationId)
-          console.log('[ChatView] 开始生成标题:', titleInput)
-          window.electronAPI.generateTitle(titleInput).then((title) => {
-            console.log('[ChatView] 标题生成结果:', title)
-            if (!title) return
-            window.electronAPI
-              .updateConversationTitle(event.conversationId, title)
-              .then((updated) => {
-                console.log('[ChatView] 标题更新成功:', updated.title)
-                setConversations((prev) =>
-                  prev.map((c) => (c.id === updated.id ? updated : c))
-                )
-              })
-              .catch(console.error)
-          }).catch((error) => {
-            console.error('[ChatView] 标题生成失败:', error)
-          })
-        }
-      }
-    )
-
-    const cleanupError = window.electronAPI.onStreamError(
-      (event: StreamErrorEvent) => {
-        console.error('[ChatView] 流式错误:', event.error)
-
-        // 清理 Map 中的流式状态
-        removeState(event.conversationId)
-
-        // 存储错误消息，供 UI 显示
-        setChatStreamErrors((prev) => {
-          const map = new Map(prev)
-          map.set(event.conversationId, event.error)
-          return map
-        })
-
-        // 仅当错误的是当前对话时，重新加载消息
-        if (event.conversationId === currentConvIdRef.current) {
-          window.electronAPI
-            .getConversationMessages(event.conversationId)
-            .then((msgs) => {
-              setCurrentMessages(msgs)
-              setHasMoreMessages(false)
-            })
-            .catch(console.error)
-        }
-      }
-    )
-
-    const cleanupToolActivity = window.electronAPI.onStreamToolActivity(
-      (event: StreamToolActivityEvent) => {
-        updateState(event.conversationId, (s) => ({
-          ...s,
-          toolActivities: [...s.toolActivities, event.activity],
-        }))
-
-        // 检测 Agent 推荐工具结果，写入推荐 atom
-        if (
-          event.activity.type === 'result'
-          && event.activity.toolName === 'suggest_agent_mode'
-          && event.activity.result
-          && !event.activity.isError
-        ) {
-          try {
-            const parsed = JSON.parse(event.activity.result) as { type?: string; reason?: string; suggestedPrompt?: string }
-            if (parsed.type === 'agent_recommendation' && parsed.reason && parsed.suggestedPrompt) {
-              setPendingRecommendation({
-                reason: parsed.reason,
-                suggestedPrompt: parsed.suggestedPrompt,
-                conversationId: event.conversationId,
-              })
-            }
-          } catch {
-            // JSON 解析失败，忽略
-          }
-        }
-      }
-    )
-
-    return () => {
-      cleanupChunk()
-      cleanupReasoning()
-      cleanupComplete()
-      cleanupError()
-      cleanupToolActivity()
-    }
-  }, [
-    setStreamingStates,
-    setCurrentMessages,
-    setConversations,
-    setHasMoreMessages,
-    setChatStreamErrors,
-  ])
+  }, [conversation?.modelId, conversation?.channelId, setSelectedModel])
 
   const syncContextDividers = React.useCallback(async (
-    conversationId: string,
-    messages: { id: string }[],
+    convId: string,
+    msgs: { id: string }[],
     currentDividers: string[],
   ): Promise<string[]> => {
-    const messageIdSet = new Set(messages.map((msg) => msg.id))
+    const messageIdSet = new Set(msgs.map((msg) => msg.id))
     const newDividers = currentDividers.filter((id) => messageIdSet.has(id))
     if (newDividers.length !== currentDividers.length) {
       setContextDividers(newDividers)
-      await window.electronAPI.updateContextDividers(conversationId, newDividers)
+      await window.electronAPI.updateContextDividers(convId, newDividers)
     }
     return newDividers
-  }, [setContextDividers])
+  }, [])
 
   /** 发送消息 */
   const handleSend = React.useCallback(async (
@@ -311,25 +143,25 @@ export function ChatView(): React.ReactElement {
       contextDividersOverride?: string[]
     },
   ): Promise<void> => {
-    if (!currentConversationId || !selectedModel) return
+    if (!selectedModel) return
 
     const consumePending = options?.consumePendingAttachments ?? true
 
     // 清除当前对话的错误消息
     setChatStreamErrors((prev) => {
-      if (!prev.has(currentConversationId)) return prev
+      if (!prev.has(conversationId)) return prev
       const map = new Map(prev)
-      map.delete(currentConversationId)
+      map.delete(conversationId)
       return map
     })
 
     // 判断是否为第一条消息（发送前历史为空）
-    const messageCountBeforeSend = options?.messageCountBeforeSend ?? currentMessages.length
+    const messageCountBeforeSend = options?.messageCountBeforeSend ?? messages.length
     const isFirstMessage = messageCountBeforeSend === 0
-    console.log('[ChatView] 发送消息 - isFirstMessage:', isFirstMessage, 'messageCountBeforeSend:', messageCountBeforeSend, 'conversationId:', currentConversationId)
+    console.log('[ChatView] 发送消息 - isFirstMessage:', isFirstMessage, 'messageCountBeforeSend:', messageCountBeforeSend, 'conversationId:', conversationId)
     if (isFirstMessage && content) {
-      console.log('[ChatView] 设置待生成标题:', { conversationId: currentConversationId, userMessage: content.slice(0, 50) })
-      pendingTitleRef.current.set(currentConversationId, {
+      console.log('[ChatView] 设置待生成标题:', { conversationId, userMessage: content.slice(0, 50) })
+      registerPendingTitle(conversationId, {
         userMessage: content,
         channelId: selectedModel.channelId,
         modelId: selectedModel.modelId,
@@ -350,7 +182,7 @@ export function ChatView(): React.ReactElement {
 
         try {
           const input: AttachmentSaveInput = {
-            conversationId: currentConversationId,
+            conversationId,
             filename: att.filename,
             mediaType: att.mediaType,
             data: base64Data,
@@ -375,7 +207,7 @@ export function ChatView(): React.ReactElement {
     // 初始化当前对话的流式状态
     setStreamingStates((prev) => {
       const map = new Map(prev)
-      map.set(currentConversationId, {
+      map.set(conversationId, {
         streaming: true,
         content: '',
         reasoning: '',
@@ -386,7 +218,7 @@ export function ChatView(): React.ReactElement {
     })
 
     const input: ChatSendInput = {
-      conversationId: currentConversationId,
+      conversationId,
       userMessage: content,
       messageHistory: [], // 后端已改为从磁盘读取完整历史，无需前端传入
       channelId: selectedModel.channelId,
@@ -400,7 +232,7 @@ export function ChatView(): React.ReactElement {
     }
 
     // 乐观更新：立即在 UI 中显示用户消息
-    setCurrentMessages((prev) => [
+    setMessages((prev) => [
       ...prev,
       {
         id: `temp-${Date.now()}`,
@@ -414,16 +246,16 @@ export function ChatView(): React.ReactElement {
     window.electronAPI.sendMessage(input).catch((error) => {
       console.error('[ChatView] 发送消息失败:', error)
       setStreamingStates((prev) => {
-        if (!prev.has(currentConversationId)) return prev
+        if (!prev.has(conversationId)) return prev
         const map = new Map(prev)
-        map.delete(currentConversationId)
+        map.delete(conversationId)
         return map
       })
     })
   }, [
-    currentConversationId,
+    conversationId,
     selectedModel,
-    currentMessages.length,
+    messages.length,
     pendingAttachments,
     contextLength,
     contextDividers,
@@ -431,9 +263,7 @@ export function ChatView(): React.ReactElement {
     resolvedSystemMessage,
     activeToolIds,
     setChatStreamErrors,
-    setPendingAttachments,
     setStreamingStates,
-    setCurrentMessages,
   ])
 
   /** 从某条消息起截断（包含该条） */
@@ -445,23 +275,15 @@ export function ChatView(): React.ReactElement {
     messageCountBeforeSend: number
     contextDividersAfterTruncate: string[]
   }> => {
-    if (!currentConversationId) {
-      return {
-        targetAttachments: [],
-        messageCountBeforeSend: 0,
-        contextDividersAfterTruncate: [],
-      }
-    }
-
-    const target = currentMessages.find((msg) => msg.id === messageId)
-    const targetIndex = currentMessages.findIndex((msg) => msg.id === messageId)
+    const target = messages.find((msg) => msg.id === messageId)
+    const targetIndex = messages.findIndex((msg) => msg.id === messageId)
     const targetAttachments = target?.attachments ?? []
     const updatedMessages = await window.electronAPI.truncateMessagesFrom(
-      currentConversationId,
+      conversationId,
       messageId,
       preserveFirstMessageAttachments,
     )
-    setCurrentMessages(updatedMessages)
+    setMessages(updatedMessages)
     setHasMoreMessages(false)
     if (inlineEditingMessageId && inlineEditingMessageId !== messageId) {
       const stillExists = updatedMessages.some((msg) => msg.id === inlineEditingMessageId)
@@ -469,59 +291,54 @@ export function ChatView(): React.ReactElement {
         setInlineEditingMessageId(null)
       }
     }
-    const contextDividersAfterTruncate = await syncContextDividers(currentConversationId, updatedMessages, contextDividers)
+    const contextDividersAfterTruncate = await syncContextDividers(conversationId, updatedMessages, contextDividers)
     return {
       targetAttachments,
       messageCountBeforeSend: targetIndex >= 0 ? targetIndex : updatedMessages.length,
       contextDividersAfterTruncate,
     }
   }, [
-    currentConversationId,
-    currentMessages,
+    conversationId,
+    messages,
     contextDividers,
-    setCurrentMessages,
-    setHasMoreMessages,
     inlineEditingMessageId,
     syncContextDividers,
   ])
 
   /** 停止生成 */
-  const handleStop = (): void => {
-    if (!currentConversationId) return
+  const handleStop = React.useCallback((): void => {
     // 标记 streaming=false（按钮即时变化），不清空内容
     // 内容保留在 UI 直到 onStreamComplete 原子性替换为磁盘消息，避免闪烁
     setStreamingStates((prev) => {
-      const current = prev.get(currentConversationId)
+      const current = prev.get(conversationId)
       if (!current) return prev
       const map = new Map(prev)
-      map.set(currentConversationId, { ...current, streaming: false })
+      map.set(conversationId, { ...current, streaming: false })
       return map
     })
-    window.electronAPI.stopGeneration(currentConversationId).catch(console.error)
-  }
+    window.electronAPI.stopGeneration(conversationId).catch(console.error)
+  }, [conversationId, setStreamingStates])
 
   /** 删除消息 */
-  const handleDeleteMessage = async (messageId: string): Promise<void> => {
-    if (!currentConversationId) return
-
+  const handleDeleteMessage = React.useCallback(async (messageId: string): Promise<void> => {
     try {
       const updatedMessages = await window.electronAPI.deleteMessage(
-        currentConversationId,
+        conversationId,
         messageId
       )
-      setCurrentMessages(updatedMessages)
+      setMessages(updatedMessages)
       if (inlineEditingMessageId === messageId) {
         setInlineEditingMessageId(null)
       }
-      await syncContextDividers(currentConversationId, updatedMessages, contextDividers)
+      await syncContextDividers(conversationId, updatedMessages, contextDividers)
     } catch (error) {
       console.error('[ChatView] 删除消息失败:', error)
     }
-  }
+  }, [conversationId, contextDividers, inlineEditingMessageId, syncContextDividers])
 
   /** 重新发送：从该用户消息分叉后，直接重发 */
   const handleResendMessage = React.useCallback(async (message: { id: string; content: string }): Promise<void> => {
-    if (!currentConversationId || isStreaming) return
+    if (isStreaming) return
 
     try {
       const truncated = await truncateFromMessage(message.id, true)
@@ -534,7 +351,7 @@ export function ChatView(): React.ReactElement {
     } catch (error) {
       console.error('[ChatView] 重新发送失败:', error)
     }
-  }, [currentConversationId, isStreaming, truncateFromMessage, handleSend])
+  }, [isStreaming, truncateFromMessage, handleSend])
 
   /** 开始原地编辑 */
   const handleStartInlineEdit = React.useCallback((message: { id: string }): void => {
@@ -552,7 +369,7 @@ export function ChatView(): React.ReactElement {
     message: { id: string; content: string },
     payload: InlineEditSubmitPayload,
   ): Promise<void> => {
-    if (!currentConversationId || isStreaming) return
+    if (isStreaming) return
     const trimmed = payload.content.trim()
     if (!trimmed && payload.keepExistingAttachments.length === 0 && payload.newAttachments.length === 0) return
 
@@ -569,7 +386,7 @@ export function ChatView(): React.ReactElement {
       const newSavedAttachments: FileAttachment[] = []
       for (const newAttachment of payload.newAttachments) {
         const input: AttachmentSaveInput = {
-          conversationId: currentConversationId,
+          conversationId,
           filename: newAttachment.filename,
           mediaType: newAttachment.mediaType,
           data: newAttachment.data,
@@ -588,13 +405,13 @@ export function ChatView(): React.ReactElement {
     } catch (error) {
       console.error('[ChatView] 原地编辑重发失败:', error)
     }
-  }, [currentConversationId, isStreaming, truncateFromMessage, handleSend])
+  }, [conversationId, isStreaming, truncateFromMessage, handleSend])
 
   /** 清除上下文（toggle 最后消息的分隔线） */
   const handleClearContext = React.useCallback((): void => {
-    if (!currentConversationId || currentMessages.length === 0) return
+    if (messages.length === 0) return
 
-    const lastMessage = currentMessages[currentMessages.length - 1]!
+    const lastMessage = messages[messages.length - 1]!
     const lastMessageId = lastMessage.id
 
     let newDividers: string[]
@@ -608,56 +425,44 @@ export function ChatView(): React.ReactElement {
 
     setContextDividers(newDividers)
     window.electronAPI
-      .updateContextDividers(currentConversationId, newDividers)
+      .updateContextDividers(conversationId, newDividers)
       .catch(console.error)
-  }, [currentConversationId, currentMessages, contextDividers, setContextDividers])
+  }, [conversationId, messages, contextDividers])
 
   /** 删除分隔线 */
   const handleDeleteDivider = React.useCallback((messageId: string): void => {
-    if (!currentConversationId) return
-
     const newDividers = contextDividers.filter((id) => id !== messageId)
     setContextDividers(newDividers)
     window.electronAPI
-      .updateContextDividers(currentConversationId, newDividers)
+      .updateContextDividers(conversationId, newDividers)
       .catch(console.error)
-  }, [currentConversationId, contextDividers, setContextDividers])
+  }, [conversationId, contextDividers])
 
   /** 加载全部历史消息（向上滚动时触发） */
   const handleLoadMore = React.useCallback(async (): Promise<void> => {
-    if (!currentConversationId) return
-
-    const allMessages = await window.electronAPI.getConversationMessages(currentConversationId)
-    setCurrentMessages(allMessages)
+    const allMessages = await window.electronAPI.getConversationMessages(conversationId)
+    setMessages(allMessages)
     setHasMoreMessages(false)
-  }, [currentConversationId, setCurrentMessages, setHasMoreMessages])
-
-  // 无当前对话 → 引导文案
-  if (!currentConversationId) {
-    return (
-      <div className="flex flex-col items-center justify-center h-full w-full max-w-[min(72rem,100%)] mx-auto gap-4 text-muted-foreground" style={{ zoom: 1.1 }}>
-        <div className="w-16 h-16 rounded-full bg-muted flex items-center justify-center">
-          <MessageSquare size={32} className="text-muted-foreground/60" />
-        </div>
-        <div className="text-center space-y-2">
-          <h2 className="text-lg font-medium text-foreground">开始对话</h2>
-          <p className="text-sm max-w-[300px]">
-            从左侧点击"新对话"按钮创建一个新对话
-          </p>
-        </div>
-      </div>
-    )
-  }
+  }, [conversationId])
 
   return (
     <div className="flex h-full overflow-hidden">
       {/* 主内容区域 */}
       <div className="flex flex-col h-full flex-1 min-w-0">
         {/* Header 在 max-w 外，按钮可到达最右侧 */}
-        <ChatHeader />
+        <ChatHeader conversation={conversation} />
         <div className="flex flex-col flex-1 w-full max-w-[min(72rem,100%)] mx-auto overflow-hidden min-h-0">
           {/* 中间：消息区域 */}
           <ChatMessages
+            conversationId={conversationId}
+            messages={messages}
+            streaming={isStreaming}
+            streamingContent={streamingContent}
+            streamingReasoning={streamingReasoning}
+            streamingModel={streamingModel}
+            toolActivities={toolActivities}
+            contextDividers={contextDividers}
+            hasMore={hasMoreMessages}
             onDeleteMessage={handleDeleteMessage}
             onResendMessage={handleResendMessage}
             onStartInlineEdit={handleStartInlineEdit}
@@ -677,10 +482,9 @@ export function ChatView(): React.ReactElement {
                 type="button"
                 className="shrink-0 p-0.5 rounded hover:bg-destructive/10 transition-colors"
                 onClick={() => {
-                  if (!currentConversationId) return
                   setChatStreamErrors((prev) => {
                     const map = new Map(prev)
-                    map.delete(currentConversationId)
+                    map.delete(conversationId)
                     return map
                   })
                 }}
@@ -695,6 +499,10 @@ export function ChatView(): React.ReactElement {
 
           {/* 底部：输入框 */}
           <ChatInput
+            conversationId={conversationId}
+            streaming={isStreaming}
+            pendingAttachments={pendingAttachments}
+            onSetPendingAttachments={setPendingAttachments}
             onSend={handleSend}
             onStop={handleStop}
             onClearContext={handleClearContext}

--- a/apps/electron/src/renderer/components/tabs/MainArea.tsx
+++ b/apps/electron/src/renderer/components/tabs/MainArea.tsx
@@ -24,7 +24,7 @@ export function MainArea(): React.ReactElement {
     return (
       <Panel
         variant="grow"
-        className="bg-white/95 dark:bg-zinc-900/95 backdrop-blur-xl rounded-2xl shadow-xl border border-border/50"
+        className="bg-white/95 dark:bg-zinc-900/95 backdrop-blur-xl rounded-2xl shadow-xl border border-border/50 titlebar-no-drag"
       >
         <SettingsPanel />
       </Panel>
@@ -39,7 +39,7 @@ export function MainArea(): React.ReactElement {
     >
       <TabBar />
       {tabs.length === 0 ? (
-        <div className="flex flex-col items-center justify-center flex-1 gap-4 text-muted-foreground" style={{ zoom: 1.1 }}>
+        <div className="flex flex-col items-center justify-center flex-1 gap-4 text-muted-foreground titlebar-no-drag" style={{ zoom: 1.1 }}>
           <div className="w-16 h-16 rounded-full bg-muted flex items-center justify-center">
             <MessageSquare size={32} className="text-muted-foreground/60" />
           </div>

--- a/apps/electron/src/renderer/components/tabs/MainArea.tsx
+++ b/apps/electron/src/renderer/components/tabs/MainArea.tsx
@@ -1,0 +1,58 @@
+/**
+ * MainArea — 主内容区域
+ *
+ * 替代原 MainContentPanel，组合 TabBar + SplitContainer。
+ * Settings 视图仍为独立全屏覆盖。
+ */
+
+import * as React from 'react'
+import { useAtomValue } from 'jotai'
+import { activeViewAtom } from '@/atoms/active-view'
+import { tabsAtom } from '@/atoms/tab-atoms'
+import { Panel } from '@/components/app-shell/Panel'
+import { SettingsPanel } from '@/components/settings'
+import { TabBar } from './TabBar'
+import { SplitContainer } from './SplitContainer'
+import { MessageSquare } from 'lucide-react'
+
+export function MainArea(): React.ReactElement {
+  const activeView = useAtomValue(activeViewAtom)
+  const tabs = useAtomValue(tabsAtom)
+
+  // Settings 视图覆盖整个右侧
+  if (activeView === 'settings') {
+    return (
+      <Panel
+        variant="grow"
+        className="bg-white/95 dark:bg-zinc-900/95 backdrop-blur-xl rounded-2xl shadow-xl border border-border/50"
+      >
+        <SettingsPanel />
+      </Panel>
+    )
+  }
+
+  // 标签视图
+  return (
+    <Panel
+      variant="grow"
+      className="bg-white/95 dark:bg-zinc-900/95 backdrop-blur-xl rounded-2xl shadow-xl border border-border/50"
+    >
+      <TabBar />
+      {tabs.length === 0 ? (
+        <div className="flex flex-col items-center justify-center flex-1 gap-4 text-muted-foreground" style={{ zoom: 1.1 }}>
+          <div className="w-16 h-16 rounded-full bg-muted flex items-center justify-center">
+            <MessageSquare size={32} className="text-muted-foreground/60" />
+          </div>
+          <div className="text-center space-y-2">
+            <h2 className="text-lg font-medium text-foreground">开始使用</h2>
+            <p className="text-sm max-w-[300px]">
+              从左侧选择或创建一个对话，它将以标签页的形式打开
+            </p>
+          </div>
+        </div>
+      ) : (
+        <SplitContainer />
+      )}
+    </Panel>
+  )
+}

--- a/apps/electron/src/renderer/components/tabs/SplitContainer.tsx
+++ b/apps/electron/src/renderer/components/tabs/SplitContainer.tsx
@@ -34,7 +34,7 @@ export function SplitContainer(): React.ReactElement {
 
   return (
     <div
-      className={isSplit ? 'flex-1 min-h-0 p-1.5' : 'flex-1 min-h-0'}
+      className={isSplit ? 'flex-1 min-h-0 p-1.5 titlebar-no-drag' : 'flex-1 min-h-0 titlebar-no-drag'}
       style={{
         display: 'grid',
         gap: isSplit ? 6 : 0,

--- a/apps/electron/src/renderer/components/tabs/SplitContainer.tsx
+++ b/apps/electron/src/renderer/components/tabs/SplitContainer.tsx
@@ -1,0 +1,56 @@
+/**
+ * SplitContainer — 分屏容器
+ *
+ * 使用 CSS Grid 实现 1-4 面板布局。
+ * 根据 splitLayoutAtom.mode 自动切换布局。
+ */
+
+import * as React from 'react'
+import { useAtomValue } from 'jotai'
+import { splitLayoutAtom } from '@/atoms/tab-atoms'
+import { SplitPanel } from './SplitPanel'
+import type { SplitMode } from '@/atoms/tab-atoms'
+
+/** 获取 CSS Grid 样式 */
+function getGridStyle(mode: SplitMode): React.CSSProperties {
+  switch (mode) {
+    case 'single':
+      return { gridTemplate: '"a" 1fr / 1fr' }
+    case 'horizontal-2':
+      return { gridTemplate: '"a b" 1fr / 1fr 1fr' }
+    case 'vertical-2':
+      return { gridTemplate: '"a" 1fr "b" 1fr / 1fr' }
+    case 'grid-4':
+      return { gridTemplate: '"a b" 1fr "c d" 1fr / 1fr 1fr' }
+  }
+}
+
+const GRID_AREAS = ['a', 'b', 'c', 'd']
+
+export function SplitContainer(): React.ReactElement {
+  const layout = useAtomValue(splitLayoutAtom)
+
+  const isSplit = layout.mode !== 'single'
+
+  return (
+    <div
+      className={isSplit ? 'flex-1 min-h-0 p-1.5' : 'flex-1 min-h-0'}
+      style={{
+        display: 'grid',
+        gap: isSplit ? 6 : 0,
+        ...getGridStyle(layout.mode),
+      }}
+    >
+      {layout.panels.map((panel, idx) => (
+        <SplitPanel
+          key={idx}
+          panel={panel}
+          panelIndex={idx}
+          gridArea={GRID_AREAS[idx]!}
+          isFocused={idx === layout.focusedPanelIndex}
+          showBorder={isSplit}
+        />
+      ))}
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/tabs/SplitModeToggle.tsx
+++ b/apps/electron/src/renderer/components/tabs/SplitModeToggle.tsx
@@ -83,7 +83,7 @@ export function SplitModeToggle(): React.ReactElement {
             <Button
               variant="ghost"
               size="icon"
-              className="size-[34px] shrink-0 rounded-none text-muted-foreground hover:text-foreground"
+              className="size-[34px] shrink-0 rounded-none text-muted-foreground hover:text-foreground titlebar-no-drag"
             >
               <LayoutIcon mode={layout.mode} />
             </Button>

--- a/apps/electron/src/renderer/components/tabs/SplitModeToggle.tsx
+++ b/apps/electron/src/renderer/components/tabs/SplitModeToggle.tsx
@@ -1,0 +1,122 @@
+/**
+ * SplitModeToggle — 分屏模式切换按钮
+ *
+ * 提供 Popover 选择布局模式：单面板 / 左右 / 上下 / 四格
+ */
+
+import * as React from 'react'
+import { useAtom } from 'jotai'
+import { splitLayoutAtom, setSplitMode } from '@/atoms/tab-atoms'
+import type { SplitMode } from '@/atoms/tab-atoms'
+import { cn } from '@/lib/utils'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { Button } from '@/components/ui/button'
+
+/** 布局模式图标 SVG */
+function LayoutIcon({ mode, className }: { mode: SplitMode; className?: string }): React.ReactElement {
+  const size = 16
+  const stroke = 'currentColor'
+  const fill = 'none'
+
+  switch (mode) {
+    case 'single':
+      return (
+        <svg width={size} height={size} viewBox="0 0 16 16" className={className}>
+          <rect x="2" y="2" width="12" height="12" rx="1.5" stroke={stroke} fill={fill} strokeWidth="1.2" />
+        </svg>
+      )
+    case 'horizontal-2':
+      return (
+        <svg width={size} height={size} viewBox="0 0 16 16" className={className}>
+          <rect x="2" y="2" width="12" height="12" rx="1.5" stroke={stroke} fill={fill} strokeWidth="1.2" />
+          <line x1="8" y1="2" x2="8" y2="14" stroke={stroke} strokeWidth="1.2" />
+        </svg>
+      )
+    case 'vertical-2':
+      return (
+        <svg width={size} height={size} viewBox="0 0 16 16" className={className}>
+          <rect x="2" y="2" width="12" height="12" rx="1.5" stroke={stroke} fill={fill} strokeWidth="1.2" />
+          <line x1="2" y1="8" x2="14" y2="8" stroke={stroke} strokeWidth="1.2" />
+        </svg>
+      )
+    case 'grid-4':
+      return (
+        <svg width={size} height={size} viewBox="0 0 16 16" className={className}>
+          <rect x="2" y="2" width="12" height="12" rx="1.5" stroke={stroke} fill={fill} strokeWidth="1.2" />
+          <line x1="8" y1="2" x2="8" y2="14" stroke={stroke} strokeWidth="1.2" />
+          <line x1="2" y1="8" x2="14" y2="8" stroke={stroke} strokeWidth="1.2" />
+        </svg>
+      )
+  }
+}
+
+const MODES: { mode: SplitMode; label: string }[] = [
+  { mode: 'single', label: '单面板' },
+  { mode: 'horizontal-2', label: '左右分屏' },
+  { mode: 'vertical-2', label: '上下分屏' },
+  { mode: 'grid-4', label: '四格分屏' },
+]
+
+export function SplitModeToggle(): React.ReactElement {
+  const [layout, setLayout] = useAtom(splitLayoutAtom)
+  const [open, setOpen] = React.useState(false)
+
+  const handleSelect = (mode: SplitMode): void => {
+    setLayout((prev) => setSplitMode(prev, mode))
+    setOpen(false)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-[34px] shrink-0 rounded-none text-muted-foreground hover:text-foreground"
+            >
+              <LayoutIcon mode={layout.mode} />
+            </Button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          <p>分屏模式</p>
+        </TooltipContent>
+      </Tooltip>
+      <PopoverContent side="bottom" align="end" className="w-auto p-1.5">
+        <div className="flex gap-1">
+          {MODES.map(({ mode, label }) => (
+            <Tooltip key={mode}>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className={cn(
+                    'size-8 rounded-md',
+                    layout.mode === mode && 'bg-accent text-accent-foreground'
+                  )}
+                  onClick={() => handleSelect(mode)}
+                >
+                  <LayoutIcon mode={mode} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                <p>{label}</p>
+              </TooltipContent>
+            </Tooltip>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/electron/src/renderer/components/tabs/SplitPanel.tsx
+++ b/apps/electron/src/renderer/components/tabs/SplitPanel.tsx
@@ -1,0 +1,57 @@
+/**
+ * SplitPanel — 单个分屏面板
+ *
+ * 包装面板内容，处理焦点切换和视觉指示。
+ */
+
+import * as React from 'react'
+import { useSetAtom } from 'jotai'
+import { splitLayoutAtom } from '@/atoms/tab-atoms'
+import { TabContent } from './TabContent'
+import { cn } from '@/lib/utils'
+import type { SplitPanel as SplitPanelType } from '@/atoms/tab-atoms'
+
+export interface SplitPanelProps {
+  panel: SplitPanelType
+  panelIndex: number
+  gridArea: string
+  isFocused: boolean
+  showBorder: boolean
+}
+
+export function SplitPanel({
+  panel,
+  panelIndex,
+  gridArea,
+  isFocused,
+  showBorder,
+}: SplitPanelProps): React.ReactElement {
+  const setLayout = useSetAtom(splitLayoutAtom)
+
+  const handleClick = React.useCallback(() => {
+    setLayout((prev) => ({
+      ...prev,
+      focusedPanelIndex: panelIndex,
+    }))
+  }, [panelIndex, setLayout])
+
+  return (
+    <div
+      className={cn(
+        'min-h-0 min-w-0 overflow-hidden',
+        showBorder && 'rounded-lg border border-border/60',
+        showBorder && isFocused && 'border-primary/40',
+      )}
+      style={{ gridArea }}
+      onClick={handleClick}
+    >
+      {panel.activeTabId ? (
+        <TabContent tabId={panel.activeTabId} />
+      ) : (
+        <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
+          从侧边栏选择一个会话
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -87,14 +87,14 @@ export function TabBar(): React.ReactElement {
     }
   }, [])
 
-  if (tabs.length === 0) return <div className="h-[34px]" />
+  if (tabs.length === 0) return <div className="h-[34px] titlebar-drag-region" />
 
   return (
     <div className="flex items-end h-[34px] bg-muted/30">
       {/* 标签区域（可滚动） */}
       <div
         ref={scrollRef}
-        className="flex items-end flex-1 min-w-0 overflow-x-auto scrollbar-none"
+        className="flex items-end shrink min-w-0 max-w-full overflow-x-auto scrollbar-none titlebar-no-drag"
         onWheel={handleWheel}
       >
         {tabs.map((tab, _index) => (
@@ -112,6 +112,9 @@ export function TabBar(): React.ReactElement {
           />
         ))}
       </div>
+
+      {/* 空白拖拽区域：支持拖动窗口 */}
+      <div className="flex-1 h-full titlebar-drag-region" />
 
       {/* 分屏模式切换 */}
       <SplitModeToggle />

--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -1,0 +1,120 @@
+/**
+ * TabBar — 顶部标签栏
+ *
+ * 显示所有打开的标签页，支持：
+ * - 点击切换标签
+ * - 中键关闭标签
+ * - 拖拽重排序
+ * - 溢出时水平滚动
+ * - 分屏模式切换按钮
+ */
+
+import * as React from 'react'
+import { useAtom, useAtomValue } from 'jotai'
+import {
+  tabsAtom,
+  splitLayoutAtom,
+  tabStreamingMapAtom,
+  activeTabIdAtom,
+  openTab,
+  closeTab,
+  focusTab,
+  reorderTabs,
+} from '@/atoms/tab-atoms'
+import { TabBarItem } from './TabBarItem'
+import { SplitModeToggle } from './SplitModeToggle'
+
+export function TabBar(): React.ReactElement {
+  const [tabs, setTabs] = useAtom(tabsAtom)
+  const [layout, setLayout] = useAtom(splitLayoutAtom)
+  const activeTabId = useAtomValue(activeTabIdAtom)
+  const streamingMap = useAtomValue(tabStreamingMapAtom)
+  const scrollRef = React.useRef<HTMLDivElement>(null)
+
+  // 拖拽状态
+  const dragState = React.useRef<{
+    dragging: boolean
+    tabId: string
+    startX: number
+    startIndex: number
+  } | null>(null)
+
+  const handleActivate = React.useCallback((tabId: string) => {
+    setLayout((prev) => focusTab(prev, tabId))
+  }, [setLayout])
+
+  const handleClose = React.useCallback((tabId: string) => {
+    setTabs((prevTabs) => {
+      const result = closeTab(prevTabs, layout, tabId)
+      // 需要同时更新 layout，使用 setTimeout 保证原子性
+      setTimeout(() => setLayout(result.layout), 0)
+      return result.tabs
+    })
+  }, [layout, setTabs, setLayout])
+
+  const handleDragStart = React.useCallback((tabId: string, e: React.PointerEvent) => {
+    if (e.button !== 0) return // 只处理左键
+    const idx = tabs.findIndex((t) => t.id === tabId)
+    if (idx === -1) return
+
+    dragState.current = {
+      dragging: false,
+      tabId,
+      startX: e.clientX,
+      startIndex: idx,
+    }
+
+    const handleMove = (me: PointerEvent): void => {
+      if (!dragState.current) return
+      const dx = Math.abs(me.clientX - dragState.current.startX)
+      if (dx > 5) dragState.current.dragging = true
+    }
+
+    const handleUp = (): void => {
+      document.removeEventListener('pointermove', handleMove)
+      document.removeEventListener('pointerup', handleUp)
+      dragState.current = null
+    }
+
+    document.addEventListener('pointermove', handleMove)
+    document.addEventListener('pointerup', handleUp)
+  }, [tabs])
+
+  // 水平滚动支持
+  const handleWheel = React.useCallback((e: React.WheelEvent) => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollLeft += e.deltaY
+    }
+  }, [])
+
+  if (tabs.length === 0) return <div className="h-[34px]" />
+
+  return (
+    <div className="flex items-end h-[34px] bg-muted/30">
+      {/* 标签区域（可滚动） */}
+      <div
+        ref={scrollRef}
+        className="flex items-end flex-1 min-w-0 overflow-x-auto scrollbar-none"
+        onWheel={handleWheel}
+      >
+        {tabs.map((tab, _index) => (
+          <TabBarItem
+            key={tab.id}
+            id={tab.id}
+            type={tab.type}
+            title={tab.title}
+            isActive={tab.id === activeTabId}
+            isStreaming={streamingMap.get(tab.id) ?? false}
+            onActivate={() => handleActivate(tab.id)}
+            onClose={() => handleClose(tab.id)}
+            onMiddleClick={() => handleClose(tab.id)}
+            onDragStart={(e) => handleDragStart(tab.id, e)}
+          />
+        ))}
+      </div>
+
+      {/* 分屏模式切换 */}
+      <SplitModeToggle />
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
@@ -1,0 +1,100 @@
+/**
+ * TabBarItem — 单个标签页 UI
+ *
+ * 显示：类型图标 + 标题 + 流式指示器 + 关闭按钮
+ * 支持：点击聚焦、中键关闭、拖拽重排
+ */
+
+import * as React from 'react'
+import { MessageSquare, Bot, X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type { TabType } from '@/atoms/tab-atoms'
+
+export interface TabBarItemProps {
+  id: string
+  type: TabType
+  title: string
+  isActive: boolean
+  isStreaming: boolean
+  onActivate: () => void
+  onClose: () => void
+  onMiddleClick: () => void
+  /** 拖拽相关 */
+  onDragStart: (e: React.PointerEvent) => void
+}
+
+export function TabBarItem({
+  type,
+  title,
+  isActive,
+  isStreaming,
+  onActivate,
+  onClose,
+  onMiddleClick,
+  onDragStart,
+}: TabBarItemProps): React.ReactElement {
+  const handleMouseDown = (e: React.MouseEvent): void => {
+    // 中键点击关闭
+    if (e.button === 1) {
+      e.preventDefault()
+      onMiddleClick()
+    }
+  }
+
+  const handleCloseClick = (e: React.MouseEvent): void => {
+    e.stopPropagation()
+    onClose()
+  }
+
+  const Icon = type === 'chat' ? MessageSquare : Bot
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        'group relative flex items-center gap-1.5 px-3 h-[34px] min-w-[100px] max-w-[200px] shrink-0',
+        'rounded-t-lg text-xs transition-colors select-none cursor-pointer',
+        'border-t border-l border-r border-transparent',
+        isActive
+          ? 'bg-background text-foreground border-border/50 shadow-sm'
+          : 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
+      )}
+      onClick={onActivate}
+      onMouseDown={handleMouseDown}
+      onPointerDown={onDragStart}
+    >
+      {/* 类型图标 */}
+      <Icon className="size-3 shrink-0" />
+
+      {/* 标题 */}
+      <span className="flex-1 min-w-0 truncate text-left">{title}</span>
+
+      {/* 流式指示器 */}
+      {isStreaming && (
+        <span
+          className={cn(
+            'size-1.5 rounded-full shrink-0 animate-pulse',
+            type === 'chat' ? 'bg-emerald-500' : 'bg-blue-500'
+          )}
+        />
+      )}
+
+      {/* 关闭按钮 */}
+      <span
+        role="button"
+        tabIndex={-1}
+        className={cn(
+          'size-4 rounded-sm flex items-center justify-center shrink-0',
+          'opacity-0 group-hover:opacity-100 hover:bg-muted-foreground/20 transition-opacity',
+          isActive && 'opacity-60',
+        )}
+        onClick={handleCloseClick}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') handleCloseClick(e as unknown as React.MouseEvent)
+        }}
+      >
+        <X className="size-2.5" />
+      </span>
+    </button>
+  )
+}

--- a/apps/electron/src/renderer/components/tabs/TabContent.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabContent.tsx
@@ -1,0 +1,35 @@
+/**
+ * TabContent — 标签内容渲染器
+ *
+ * 根据标签类型渲染参数化的 ChatView 或 AgentView。
+ * 直接传递 sessionId/conversationId prop，无需桥接全局 atoms。
+ */
+
+import * as React from 'react'
+import { useAtomValue } from 'jotai'
+import { tabsAtom } from '@/atoms/tab-atoms'
+import { ChatView } from '@/components/chat'
+import { AgentView } from '@/components/agent'
+
+export interface TabContentProps {
+  tabId: string
+}
+
+export function TabContent({ tabId }: TabContentProps): React.ReactElement {
+  const tabs = useAtomValue(tabsAtom)
+  const tab = tabs.find((t) => t.id === tabId)
+
+  if (!tab) {
+    return (
+      <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
+        标签页不存在
+      </div>
+    )
+  }
+
+  if (tab.type === 'chat') {
+    return <ChatView conversationId={tab.sessionId} key={tab.sessionId} />
+  }
+
+  return <AgentView sessionId={tab.sessionId} key={tab.sessionId} />
+}

--- a/apps/electron/src/renderer/components/tabs/index.ts
+++ b/apps/electron/src/renderer/components/tabs/index.ts
@@ -1,0 +1,7 @@
+export { MainArea } from './MainArea'
+export { TabBar } from './TabBar'
+export { TabBarItem } from './TabBarItem'
+export { TabContent } from './TabContent'
+export { SplitContainer } from './SplitContainer'
+export { SplitPanel } from './SplitPanel'
+export { SplitModeToggle } from './SplitModeToggle'

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -13,8 +13,7 @@ import {
   agentStreamingStatesAtom,
   agentStreamErrorsAtom,
   agentSessionsAtom,
-  currentAgentSessionIdAtom,
-  currentAgentMessagesAtom,
+  agentMessageRefreshAtom,
   allPendingPermissionRequestsAtom,
   allPendingAskUserRequestsAtom,
   agentPromptSuggestionsAtom,
@@ -25,6 +24,7 @@ import {
   notificationsEnabledAtom,
   sendDesktopNotification,
 } from '@/atoms/notifications'
+import { tabsAtom, updateTabTitle } from '@/atoms/tab-atoms'
 import type { AgentStreamState } from '@/atoms/agent-atoms'
 import type { AgentStreamEvent, AgentStreamCompletePayload } from '@proma/shared'
 
@@ -143,8 +143,6 @@ export function useGlobalAgentListeners(): void {
     // ===== 2. 流式完成 =====
     const cleanupComplete = window.electronAPI.onAgentStreamComplete(
       (data: AgentStreamCompletePayload) => {
-        const currentId = store.get(currentAgentSessionIdAtom)
-
         // 发送桌面通知
         const enabled = store.get(notificationsEnabledAtom)
         const sessions = store.get(agentSessionsAtom)
@@ -159,6 +157,15 @@ export function useGlobalAgentListeners(): void {
         const isNewStreamRunning = (): boolean => {
           const state = store.get(agentStreamingStatesAtom).get(data.sessionId)
           return state?.running === true
+        }
+
+        /** 递增消息刷新版本号，通知 AgentView 重新加载消息 */
+        const bumpRefresh = (): void => {
+          store.set(agentMessageRefreshAtom, (prev) => {
+            const map = new Map(prev)
+            map.set(data.sessionId, (prev.get(data.sessionId) ?? 0) + 1)
+            return map
+          })
         }
 
         const finalize = (): void => {
@@ -185,27 +192,11 @@ export function useGlobalAgentListeners(): void {
             .catch(console.error)
         }
 
-        if (data.sessionId === currentId) {
-          if (data.messages) {
-            // 同步路径：直接使用 payload 中已持久化的消息，消除异步 IPC 竞态窗口
-            if (!isNewStreamRunning()) {
-              store.set(currentAgentMessagesAtom, data.messages)
-            }
-            finalize()
-          } else {
-            // 降级路径：payload 无消息（兼容旧版主进程），异步重新加载
-            window.electronAPI
-              .getAgentSessionMessages(data.sessionId)
-              .then((messages) => {
-                if (isNewStreamRunning()) return
-                store.set(currentAgentMessagesAtom, messages)
-                finalize()
-              })
-              .catch(() => finalize())
-          }
-        } else {
-          finalize()
+        // 通知 AgentView 重新加载消息（无论是否为当前会话）
+        if (!isNewStreamRunning()) {
+          bumpRefresh()
         }
+        finalize()
       }
     )
 
@@ -221,20 +212,14 @@ export function useGlobalAgentListeners(): void {
           return map
         })
 
-        // 重新加载当前会话的消息
-        const currentId = store.get(currentAgentSessionIdAtom)
-        if (data.sessionId === currentId) {
-          window.electronAPI
-            .getAgentSessionMessages(data.sessionId)
-            .then((messages) => {
-              // 竞态保护：新流已启动时跳过消息覆盖
-              const state = store.get(agentStreamingStatesAtom).get(data.sessionId)
-              if (state?.running) return
-              store.set(currentAgentMessagesAtom, messages)
-            })
-            .catch((error) => {
-              console.error('[GlobalAgentListeners] 加载消息失败:', error)
-            })
+        // 递增消息刷新版本号，通知 AgentView 重新加载消息
+        const state = store.get(agentStreamingStatesAtom).get(data.sessionId)
+        if (!state?.running) {
+          store.set(agentMessageRefreshAtom, (prev) => {
+            const map = new Map(prev)
+            map.set(data.sessionId, (prev.get(data.sessionId) ?? 0) + 1)
+            return map
+          })
         }
       }
     )
@@ -244,7 +229,15 @@ export function useGlobalAgentListeners(): void {
       window.electronAPI
         .listAgentSessions()
         .then((sessions) => {
+          const prevSessions = store.get(agentSessionsAtom)
           store.set(agentSessionsAtom, sessions)
+          // 同步更新标签页标题（比较新旧标题，有变化才更新）
+          for (const session of sessions) {
+            const prev = prevSessions.find((s) => s.id === session.id)
+            if (prev && prev.title !== session.title) {
+              store.set(tabsAtom, (tabs) => updateTabTitle(tabs, session.id, session.title))
+            }
+          }
         })
         .catch(console.error)
     })

--- a/apps/electron/src/renderer/hooks/useGlobalChatListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalChatListeners.ts
@@ -1,0 +1,206 @@
+/**
+ * useGlobalChatListeners — 全局 Chat IPC 监听器
+ *
+ * 在应用顶层挂载，永不销毁。将所有 Chat 流式事件
+ * 写入对应 Jotai atoms，确保页面切换时不丢失事件。
+ *
+ * 参照 useGlobalAgentListeners 模式，使用 useStore() 直接操作 atoms。
+ */
+
+import { useEffect } from 'react'
+import { useStore } from 'jotai'
+import {
+  streamingStatesAtom,
+  chatStreamErrorsAtom,
+  conversationsAtom,
+  chatMessageRefreshAtom,
+  pendingAgentRecommendationAtom,
+} from '@/atoms/chat-atoms'
+import { tabsAtom, updateTabTitle } from '@/atoms/tab-atoms'
+import type { ConversationStreamState } from '@/atoms/chat-atoms'
+import type {
+  StreamChunkEvent,
+  StreamReasoningEvent,
+  StreamCompleteEvent,
+  StreamErrorEvent,
+  StreamToolActivityEvent,
+  GenerateTitleInput,
+} from '@proma/shared'
+
+/** 待生成标题的队列（按 conversationId 跟踪） */
+const pendingTitles = new Map<string, GenerateTitleInput>()
+
+/**
+ * 注册待生成标题信息（由 ChatView.handleSend 在首条消息时调用）
+ */
+export function registerPendingTitle(conversationId: string, input: GenerateTitleInput): void {
+  pendingTitles.set(conversationId, input)
+}
+
+export function useGlobalChatListeners(): void {
+  const store = useStore()
+
+  useEffect(() => {
+    /** 辅助函数：更新 Map 中某个对话的流式状态 */
+    const updateState = (
+      convId: string,
+      updater: (prev: ConversationStreamState) => ConversationStreamState
+    ): void => {
+      store.set(streamingStatesAtom, (prev) => {
+        const current = prev.get(convId) ?? {
+          streaming: false,
+          content: '',
+          reasoning: '',
+          model: undefined,
+          toolActivities: [],
+        }
+        const next = updater(current)
+        const map = new Map(prev)
+        map.set(convId, next)
+        return map
+      })
+    }
+
+    /** 辅助函数：从 Map 中移除某个对话的流式状态 */
+    const removeState = (convId: string): void => {
+      store.set(streamingStatesAtom, (prev) => {
+        if (!prev.has(convId)) return prev
+        const map = new Map(prev)
+        map.delete(convId)
+        return map
+      })
+    }
+
+    // ===== 1. 流式内容块 =====
+    const cleanupChunk = window.electronAPI.onStreamChunk(
+      (event: StreamChunkEvent) => {
+        updateState(event.conversationId, (s) => ({
+          ...s,
+          content: s.content + event.delta,
+        }))
+      }
+    )
+
+    // ===== 2. 流式推理内容 =====
+    const cleanupReasoning = window.electronAPI.onStreamReasoning(
+      (event: StreamReasoningEvent) => {
+        updateState(event.conversationId, (s) => ({
+          ...s,
+          reasoning: s.reasoning + event.delta,
+        }))
+      }
+    )
+
+    // ===== 3. 流式完成 =====
+    const cleanupComplete = window.electronAPI.onStreamComplete(
+      (event: StreamCompleteEvent) => {
+        // 清理 Map 中的流式状态
+        removeState(event.conversationId)
+
+        // 递增消息刷新版本号，通知 ChatView 重新加载消息
+        store.set(chatMessageRefreshAtom, (prev) => {
+          const map = new Map(prev)
+          map.set(event.conversationId, (prev.get(event.conversationId) ?? 0) + 1)
+          return map
+        })
+
+        // 刷新对话列表（updatedAt 已更新）
+        window.electronAPI
+          .listConversations()
+          .then((convs) => store.set(conversationsAtom, convs))
+          .catch(console.error)
+
+        // 第一条消息回复完成后，生成对话标题
+        const titleInput = pendingTitles.get(event.conversationId)
+        if (titleInput) {
+          pendingTitles.delete(event.conversationId)
+          console.log('[GlobalChatListeners] 开始生成标题:', titleInput)
+          window.electronAPI.generateTitle(titleInput).then((title) => {
+            console.log('[GlobalChatListeners] 标题生成结果:', title)
+            if (!title) return
+            window.electronAPI
+              .updateConversationTitle(event.conversationId, title)
+              .then((updated) => {
+                console.log('[GlobalChatListeners] 标题更新成功:', updated.title)
+                store.set(conversationsAtom, (prev) =>
+                  prev.map((c) => (c.id === updated.id ? updated : c))
+                )
+                // 同步更新标签页标题
+                store.set(tabsAtom, (prev) => updateTabTitle(prev, event.conversationId, title))
+              })
+              .catch(console.error)
+          }).catch((error) => {
+            console.error('[GlobalChatListeners] 标题生成失败:', error)
+          })
+        }
+      }
+    )
+
+    // ===== 4. 流式错误 =====
+    const cleanupError = window.electronAPI.onStreamError(
+      (event: StreamErrorEvent) => {
+        console.error('[GlobalChatListeners] 流式错误:', event.error)
+
+        // 清理 Map 中的流式状态
+        removeState(event.conversationId)
+
+        // 存储错误消息，供 UI 显示
+        store.set(chatStreamErrorsAtom, (prev) => {
+          const map = new Map(prev)
+          map.set(event.conversationId, event.error)
+          return map
+        })
+
+        // 递增消息刷新版本号，通知 ChatView 重新加载消息
+        store.set(chatMessageRefreshAtom, (prev) => {
+          const map = new Map(prev)
+          map.set(event.conversationId, (prev.get(event.conversationId) ?? 0) + 1)
+          return map
+        })
+      }
+    )
+
+    // ===== 5. 工具活动 =====
+    const cleanupToolActivity = window.electronAPI.onStreamToolActivity(
+      (event: StreamToolActivityEvent) => {
+        updateState(event.conversationId, (s) => ({
+          ...s,
+          toolActivities: [...s.toolActivities, event.activity],
+        }))
+
+        // 检测 Agent 推荐工具结果，写入推荐 atom
+        if (
+          event.activity.type === 'result'
+          && event.activity.toolName === 'suggest_agent_mode'
+          && event.activity.result
+          && !event.activity.isError
+        ) {
+          try {
+            const parsed = JSON.parse(event.activity.result) as {
+              type?: string
+              reason?: string
+              suggestedPrompt?: string
+            }
+            if (parsed.type === 'agent_recommendation' && parsed.reason && parsed.suggestedPrompt) {
+              store.set(pendingAgentRecommendationAtom, {
+                reason: parsed.reason,
+                suggestedPrompt: parsed.suggestedPrompt,
+                conversationId: event.conversationId,
+              })
+            }
+          } catch {
+            // JSON 解析失败，忽略
+          }
+        }
+      }
+    )
+
+    return () => {
+      cleanupChunk()
+      cleanupReasoning()
+      cleanupComplete()
+      cleanupError()
+      cleanupToolActivity()
+    }
+  }, [store]) // store 引用稳定，effect 只执行一次
+}

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -6,7 +6,7 @@
 
 import React, { useEffect } from 'react'
 import ReactDOM from 'react-dom/client'
-import { useSetAtom, useAtomValue } from 'jotai'
+import { useSetAtom, useAtomValue, useStore } from 'jotai'
 import App from './App'
 import {
   themeModeAtom,
@@ -29,6 +29,9 @@ import {
   initializeNotifications,
 } from './atoms/notifications'
 import { useGlobalAgentListeners } from './hooks/useGlobalAgentListeners'
+import { useGlobalChatListeners } from './hooks/useGlobalChatListeners'
+import { tabsAtom, splitLayoutAtom } from './atoms/tab-atoms'
+import type { TabItem, SplitLayoutState } from './atoms/tab-atoms'
 import { chatToolsAtom } from './atoms/chat-tool-atoms'
 import { Toaster } from './components/ui/sonner'
 import { toast } from 'sonner'
@@ -161,6 +164,17 @@ function NotificationsInitializer(): null {
 }
 
 /**
+ * Chat IPC 监听器初始化组件
+ *
+ * 全局挂载，永不销毁。确保 Chat 流式事件
+ * 在页面切换时不丢失。
+ */
+function ChatListenersInitializer(): null {
+  useGlobalChatListeners()
+  return null
+}
+
+/**
  * Agent IPC 监听器初始化组件
  *
  * 全局挂载，永不销毁。确保 Agent 流式事件、权限请求
@@ -207,6 +221,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     <ThemeInitializer />
     <AgentSettingsInitializer />
     <NotificationsInitializer />
+    <ChatListenersInitializer />
     <AgentListenersInitializer />
     <ChatToolInitializer />
     <UpdaterInitializer />

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -30,6 +30,26 @@ export interface AppSettings {
   lastEnvironmentCheck?: EnvironmentCheckResult
   /** 是否启用桌面通知 */
   notificationsEnabled?: boolean
+  /** 标签页持久化状态（重启恢复） */
+  tabState?: PersistedTabSettings
+}
+
+/** 持久化的标签页状态 */
+export interface PersistedTabSettings {
+  tabs: Array<{
+    id: string
+    type: 'chat' | 'agent'
+    sessionId: string
+    title: string
+  }>
+  splitLayout: {
+    mode: 'single' | 'horizontal-2' | 'vertical-2' | 'grid-4'
+    panels: Array<{
+      index: number
+      activeTabId: string | null
+    }>
+    focusedPanelIndex: number
+  }
 }
 
 /** 设置 IPC 通道 */


### PR DESCRIPTION
## Summary

- **Tab 标签页系统**：新增 TabBar、TabBarItem、TabContent 组件，支持多标签页切换、中键关闭、拖拽重排序、溢出滚动
- **分屏功能**：SplitContainer（CSS Grid 布局）+ SplitPanel + SplitModeToggle（单面板/左右/上下/四格），每个面板独立绑定标签页
- **ChatView/AgentView 参数化**：接受 `conversationId`/`sessionId` prop，消除全局单例 atom 冲突，支持多实例并存
  - 消息、分隔线、附件等改为 `useState` 本地管理
  - 流式状态从 Map atoms 按 ID 读取
  - 全局监听器改用 `chatMessageRefreshAtom`/`agentMessageRefreshAtom` 版本号模式通知视图刷新
- **子组件参数化**：ChatHeader、ChatMessages、ChatInput、AgentHeader、AgentMessages、PermissionBanner、AskUserBanner 全部接受 props
- **侧边栏折叠** + Tab 交互集成
- **UI 优化**：分屏边框完整显示（padding + border 替代 ring）、SplitModeToggle 添加 ShadcnUI Tooltip 指引

## Test plan
- [ ] 单标签页模式下 Chat/Agent 功能正常（发送、流式、停止、编辑、重发、删除）
- [ ] 多标签页切换不丢消息，流式输出在后台标签继续
- [ ] 分屏模式切换（单/左右/上下/四格）布局正确，边框完整
- [ ] 分屏中两个面板各自独立发消息、接收流式输出，互不干扰
- [ ] 侧边栏点击会话正确打开/聚焦标签页
- [ ] SplitModeToggle 按钮 hover 显示 Tooltip
- [ ] typecheck 通过