### PR TITLE
feat: Agent 权限模式感知的 AskUserQuestion 提示策略

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -703,6 +703,7 @@ export class AgentOrchestrator {
             workspaceName: workspace?.name,
             workspaceSlug,
             sessionId,
+            permissionMode,
           }),
         },
         resumeSessionId: existingSdkSessionId,

--- a/apps/electron/src/main/lib/agent-prompt-builder.ts
+++ b/apps/electron/src/main/lib/agent-prompt-builder.ts
@@ -8,6 +8,7 @@
  * - 动态 per-message 上下文（buildDynamicContext）：注入到用户消息前，每次实时读取磁盘
  */
 
+import type { PromaPermissionMode } from '@proma/shared'
 import { getUserProfile } from './user-profile-service'
 import { getWorkspaceMcpConfig, getWorkspaceSkills } from './agent-workspace-manager'
 import { getMemoryConfig } from './memory-service'
@@ -19,6 +20,7 @@ interface SystemPromptContext {
   workspaceName?: string
   workspaceSlug?: string
   sessionId: string
+  permissionMode: PromaPermissionMode
 }
 
 /**
@@ -94,6 +96,26 @@ description: 简要描述
 ---
 详细指令内容...
 \`\`\``)
+  }
+
+  // 不确定性处理策略（根据权限模式区分）
+  if (ctx.permissionMode === 'auto') {
+    sections.push(`## 不确定性处理
+
+当前用户使用的是自动模式（所有工具调用自动批准），此模式下 AskUserQuestion 工具不可用。
+
+**当你遇到不确定的情况时：**
+- **停下来，直接在回复文本中向用户提问**，等待用户回复后再继续
+- 列出你考虑的选项和各自的利弊，让用户决策
+- **绝对不要**调用 AskUserQuestion 工具，该工具在自动模式下会失败`)
+  } else {
+    sections.push(`## 不确定性处理
+
+**遇到不确定的部分时，尽可能多地使用 AskUserQuestion 工具来向用户提问：**
+- 提供清晰的选项列表，降低用户输入的复杂度
+- 每个选项附带简短说明，帮助用户快速决策
+- 拆分多个独立问题为多个 AskUserQuestion 调用，避免一次性提问过多
+- 特别是在触发 brainstorming / 头脑风暴类 Skill 时，**必须**通过 AskUserQuestion 逐步引导用户明确需求和方向，而非让用户自己大段输入`)
   }
 
   // 交互规范


### PR DESCRIPTION
## Summary
- Agent 系统提示词根据权限模式（auto/smart/supervised）注入不同的不确定性处理策略
- **auto 模式**：明确告知 AskUserQuestion 工具不可用，引导 Agent 直接在回复文本中向用户提问
- **smart/supervised 模式**：鼓励尽可能多地使用 AskUserQuestion 工具，提供选项降低用户输入复杂度，尤其在 brainstorming skill 触发时逐步引导

## Test plan
- [ ] auto 模式下 Agent 遇到不确定情况时不调用 AskUserQuestion，而是直接文本提问
- [ ] smart/supervised 模式下 Agent 积极使用 AskUserQuestion 提供选项式交互
- [ ] 触发 brainstorming skill 时 Agent 通过 AskUserQuestion 逐步引导需求