### PR TITLE
feat: Agent 输入框手动折叠功能

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -729,6 +729,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
               }
               disabled={!agentChannelId}
               autoFocusTrigger={sessionId}
+              collapsible
             />
 
             {/* Footer 工具栏 */}

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -22,6 +22,8 @@ import Underline from '@tiptap/extension-underline'
 import Link from '@tiptap/extension-link'
 import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
 import { common, createLowlight } from 'lowlight'
+import { ChevronsDownUp, ChevronsUpDown } from 'lucide-react'
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 
 // 创建 lowlight 实例，使用常见语言
@@ -166,6 +168,8 @@ interface RichTextInputProps {
   disabled?: boolean
   /** 自动聚焦触发器（当此值变化时自动聚焦，通常传入对话 ID） */
   autoFocusTrigger?: string | null
+  /** 是否支持手动折叠（内容较长时显示折叠按钮） */
+  collapsible?: boolean
   className?: string
 }
 
@@ -185,8 +189,11 @@ export function RichTextInput({
   className,
   disabled = false,
   autoFocusTrigger,
+  collapsible = false,
 }: RichTextInputProps): React.ReactElement {
   const [isExpanded, setIsExpanded] = useState(false)
+  // 手动折叠状态：用户主动折叠输入框
+  const [isManuallyCollapsed, setIsManuallyCollapsed] = useState(false)
   // 跟踪编辑器自己设置的值，用于区分外部设置和内部更新
   const lastEditorValueRef = useRef<string>('')
   // 跟踪 IME 输入状态（中文输入法等）
@@ -289,6 +296,7 @@ export function RichTextInput({
         lastEditorValueRef.current = ''
         onChange('')
         setIsExpanded(false)
+        setIsManuallyCollapsed(false)
       } else {
         const markdown = htmlToMarkdown(html)
         lastEditorValueRef.current = markdown
@@ -314,6 +322,7 @@ export function RichTextInput({
         editor.commands.clearContent()
         lastEditorValueRef.current = ''
         setIsExpanded(false)
+        setIsManuallyCollapsed(false)
       } else {
         const html = controllerValue
           .split(/\n\n+/)
@@ -355,16 +364,42 @@ export function RichTextInput({
     }
   }, [editor, disabled, autoFocusTrigger])
 
+  // 是否显示折叠按钮：启用 collapsible 且内容已自动扩展
+  const showCollapseToggle = collapsible && isExpanded
+
   return (
     <div
       className={cn(
         'relative w-full overflow-y-auto transition-[max-height] duration-200 ease-in-out',
-        isExpanded ? 'max-h-[500px]' : 'max-h-[200px]',
+        isManuallyCollapsed
+          ? 'max-h-[60px]'
+          : isExpanded ? 'max-h-[500px]' : 'max-h-[200px]',
         disabled && 'opacity-50 cursor-not-allowed',
         className
       )}
     >
       <EditorContent editor={editor} className="w-full" />
+      {/* 折叠/展开切换按钮 — sticky 悬浮在滚动区域内 */}
+      {showCollapseToggle && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              className="sticky bottom-1 float-right mr-2 z-10 p-0.5 rounded hover:bg-muted/80 text-muted-foreground/50 hover:text-muted-foreground transition-colors"
+              onClick={() => setIsManuallyCollapsed((prev) => !prev)}
+            >
+              {isManuallyCollapsed ? (
+                <ChevronsUpDown className="size-3.5" />
+              ) : (
+                <ChevronsDownUp className="size-3.5" />
+              )}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="top">
+            {isManuallyCollapsed ? '展开输入框' : '折叠输入框'}
+          </TooltipContent>
+        </Tooltip>
+      )}
       <style>{`
         .ProseMirror {
           outline: none;

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -56,7 +56,6 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import type { ActiveView } from '@/atoms/active-view'
 import type { ConversationMeta, AgentSessionMeta, WorkspaceCapabilities } from '@proma/shared'
 


### PR DESCRIPTION
## Summary
- Agent 模式下输入内容过长时，输入框自动扩展至 500px 会遮挡 AskUserBanner/PermissionBanner
- RichTextInput 新增 `collapsible` prop，内容超过 5 行时右下角显示 sticky 折叠按钮（带 Tooltip）
- 折叠后输入框缩至 60px，用户可操作上方横幅；发送消息后自动重置
- 修复 LeftSidebar.tsx 重复的 Tooltip 导入

## Test plan
- [ ] Agent 模式输入超过 5 行文本，确认右下角出现折叠按钮
- [ ] 点击折叠按钮，输入框缩小，AskUserBanner 可正常交互
- [ ] 点击展开按钮，输入框恢复正常大小
- [ ] 发送消息后折叠状态自动重置
- [ ] Hover 按钮显示 Tooltip 提示文字