### PR TITLE
fix: 用户消息折叠按钮对齐与间距修复

### DIFF
--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -307,7 +307,7 @@ export const UserMessageContent = React.memo(
     }, [])
 
     return (
-      <div className={cn('relative rounded-[10px] bg-foreground/[0.045] dark:bg-foreground/[0.08] px-3.5 py-2.5', className)} {...props}>
+      <div className={cn('relative rounded-[10px] bg-foreground/[0.045] dark:bg-foreground/[0.08] px-3.5 py-2.5', shouldCollapse && !isExpanded && 'pb-6', className)} {...props}>
         <div
           ref={contentRef}
           className={cn(
@@ -325,7 +325,7 @@ export const UserMessageContent = React.memo(
             className={cn(
               'flex items-center gap-1 text-xs text-foreground/40 hover:text-foreground/70 transition-colors mt-1',
               !isExpanded &&
-                'absolute bottom-0 left-0 right-0 pt-4 bg-gradient-to-t from-foreground/[0.045] dark:from-foreground/[0.08] to-transparent'
+                'absolute bottom-0 left-0 right-0 px-3.5 pb-2.5 pt-4 rounded-b-[10px] bg-gradient-to-t from-foreground/[0.045] dark:from-foreground/[0.08] to-transparent'
             )}
           >
             {isExpanded ? (

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -56,7 +56,6 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import type { ActiveView } from '@/atoms/active-view'
 import type { ConversationMeta, AgentSessionMeta, WorkspaceCapabilities } from '@proma/shared'
 


### PR DESCRIPTION
## Summary
- 折叠按钮添加 `px-3.5` 内边距，使展开/收起按钮与消息文字左对齐
- 折叠状态容器增加 `pb-6` 底部间距，避免按钮悬浮遮挡文字内容
- 渐变遮罩添加 `rounded-b-[10px]` 匹配容器圆角
- 移除 LeftSidebar 重复的 Tooltip 导入（修复编译报错）

## Test plan
- [ ] 发送超过 4 行的长消息，确认折叠按钮与消息文字左对齐
- [ ] 确认折叠状态下按钮与文字之间有适当间距
- [ ] 点击展开/收起按钮功能正常
- [ ] Chat 和 Agent 模式均测试