### PR TITLE
fix: 消除 Chat/Agent 消息完成后的 UI 跳动

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -162,9 +162,21 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   React.useEffect(() => {
     window.electronAPI
       .getAgentSessionMessages(sessionId)
-      .then(setMessages)
+      .then((msgs) => {
+        setMessages(msgs)
+
+        // 消息加载完成后，清除已完成的流式状态（running=false 的过渡气泡）
+        // 在同一个微任务中执行，确保 React 在一次渲染中同时显示持久化消息并移除流式气泡
+        setStreamingStates((prev) => {
+          const state = prev.get(sessionId)
+          if (!state || state.running) return prev  // 仍在运行中，不清除
+          const map = new Map(prev)
+          map.delete(sessionId)
+          return map
+        })
+      })
       .catch(console.error)
-  }, [sessionId, refreshVersion])
+  }, [sessionId, refreshVersion, setStreamingStates])
 
   // 自动发送 pending prompt（从设置页"对话完成配置"触发）
   React.useEffect(() => {

--- a/apps/electron/src/renderer/components/chat/ChatView.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatView.tsx
@@ -96,9 +96,19 @@ export function ChatView({ conversationId }: ChatViewProps): React.ReactElement 
       .then((result) => {
         setMessages(result.messages)
         setHasMoreMessages(result.hasMore)
+
+        // 消息加载完成后，清除已完成的流式状态（streaming=false 的过渡气泡）
+        // 在同一个微任务中执行，确保 React 在一次渲染中同时显示持久化消息并移除流式气泡
+        setStreamingStates((prev) => {
+          const state = prev.get(conversationId)
+          if (!state || state.streaming) return prev  // 仍在流式中，不清除
+          const map = new Map(prev)
+          map.delete(conversationId)
+          return map
+        })
       })
       .catch(console.error)
-  }, [conversationId, refreshVersion])
+  }, [conversationId, refreshVersion, setStreamingStates])
 
   // 从对话元数据加载分隔线
   React.useEffect(() => {

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -193,17 +193,8 @@ export function useGlobalAgentListeners(): void {
             })
             .catch(console.error)
 
-          // 延迟移除流式状态 — 等待消息重新加载完成后再清除流式气泡
-          // 防止消息闪烁（流式内容消失 → 持久化消息尚未加载）
-          setTimeout(() => {
-            if (isNewStreamRunning()) return
-            store.set(agentStreamingStatesAtom, (prev) => {
-              if (!prev.has(data.sessionId)) return prev
-              const map = new Map(prev)
-              map.delete(data.sessionId)
-              return map
-            })
-          }, 300)
+          // 注意：流式状态的完全清除由 AgentView 在消息加载完成后执行，
+          // 确保不会出现「气泡消失 → 持久化消息尚未加载」的空档闪烁
         }
 
         // 通知 AgentView 重新加载消息（无论是否为当前会话）

--- a/apps/electron/src/renderer/hooks/useGlobalChatListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalChatListeners.ts
@@ -94,8 +94,10 @@ export function useGlobalChatListeners(): void {
     // ===== 3. 流式完成 =====
     const cleanupComplete = window.electronAPI.onStreamComplete(
       (event: StreamCompleteEvent) => {
-        // 清理 Map 中的流式状态
-        removeState(event.conversationId)
+        // 标记 streaming=false，但保留 content/reasoning 作为过渡气泡
+        // 流式状态的完全清除由 ChatView 在消息加载完成后执行（见 chatMessageRefreshAtom 的 useEffect），
+        // 确保不会出现「气泡消失 → 持久化消息尚未加载」的空档闪烁
+        updateState(event.conversationId, (s) => ({ ...s, streaming: false }))
 
         // 递增消息刷新版本号，通知 ChatView 重新加载消息
         store.set(chatMessageRefreshAtom, (prev) => {
@@ -141,8 +143,8 @@ export function useGlobalChatListeners(): void {
       (event: StreamErrorEvent) => {
         console.error('[GlobalChatListeners] 流式错误:', event.error)
 
-        // 清理 Map 中的流式状态
-        removeState(event.conversationId)
+        // 标记 streaming=false，保留内容作为过渡（与完成逻辑一致）
+        updateState(event.conversationId, (s) => ({ ...s, streaming: false }))
 
         // 存储错误消息，供 UI 显示
         store.set(chatStreamErrorsAtom, (prev) => {
@@ -152,6 +154,7 @@ export function useGlobalChatListeners(): void {
         })
 
         // 递增消息刷新版本号，通知 ChatView 重新加载消息
+        // 流式状态的完全清除由 ChatView 在消息加载完成后执行
         store.set(chatMessageRefreshAtom, (prev) => {
           const map = new Map(prev)
           map.set(event.conversationId, (prev.get(event.conversationId) ?? 0) + 1)


### PR DESCRIPTION
## Summary
- 流式完成后不再立即清除流式状态（`removeState`），改为先标记 `streaming=false` 保留内容作为过渡气泡
- 持久化消息通过 IPC 加载完成后，在同一个 `.then()` 回调中同步清除流式状态
- 利用 React 18 自动批处理，确保「显示持久化消息 + 移除流式气泡」在单次渲染中完成，消除视觉空档
- Chat 模式和 Agent 模式统一采用相同策略

## Test plan
- [ ] Chat 模式：发送消息，观察助手回复完成后是否还有跳动
- [ ] Agent 模式：发送消息，观察助手回复完成后是否还有跳动
- [ ] Chat 模式：流式输出过程中切换到设置页再切回，消息不丢失
- [ ] Agent 模式：停止生成后，已输出内容正常保留并持久化
- [ ] 流式错误场景：错误提示正常显示，无闪烁