### PR TITLE
feat: Agent 侧面板框架 + SDK Agent 工具支持

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -56,6 +56,7 @@
     "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-toast": "^1.2.15",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tiptap/extension-code-block-lowlight": "^3.19.0",

--- a/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
@@ -22,6 +22,7 @@ import {
   ToolIndex,
   extractToolStarts,
   extractToolResults,
+  SUBAGENT_TOOL_NAMES,
   type ContentBlock,
 } from '@proma/shared'
 import type { CanUseToolOptions, PermissionResult } from '../agent-permission-service'
@@ -293,7 +294,7 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
           activeParentTools,
         )
         for (const evt of toolStartEvents) {
-          if (evt.type === 'tool_start' && evt.toolName === 'Task') {
+          if (evt.type === 'tool_start' && SUBAGENT_TOOL_NAMES.has(evt.toolName)) {
             activeParentTools.add(evt.toolUseId)
           }
         }
@@ -402,7 +403,7 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
         emittedToolStarts, turnId.value || undefined, activeParentTools,
       )
       for (const evt of streamEvents) {
-        if (evt.type === 'tool_start' && evt.toolName === 'Task') {
+        if (evt.type === 'tool_start' && SUBAGENT_TOOL_NAMES.has(evt.toolName)) {
           activeParentTools.add(evt.toolUseId)
         }
       }
@@ -430,7 +431,7 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
         msg.tool_use_result, toolIndex, turnId.value || undefined,
       )
       for (const evt of resultEvents) {
-        if (evt.type === 'tool_result' && evt.toolName === 'Task') {
+        if (evt.type === 'tool_result' && evt.toolName && SUBAGENT_TOOL_NAMES.has(evt.toolName)) {
           activeParentTools.delete(evt.toolUseId)
         }
       }
@@ -468,7 +469,7 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
         emittedToolStarts, turnId.value || undefined, activeParentTools,
       )
       for (const evt of progressEvents) {
-        if (evt.type === 'tool_start' && evt.toolName === 'Task') {
+        if (evt.type === 'tool_start' && SUBAGENT_TOOL_NAMES.has(evt.toolName)) {
           activeParentTools.add(evt.toolUseId)
         }
       }

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -35,6 +35,23 @@ export interface ActivityGroup {
   children: ToolActivity[]
 }
 
+/** 子代理条目（从 ToolActivity 派生，用于侧面板展示 — TODO: 完善 Team UI 时启用） */
+export interface SubAgentEntry {
+  toolUseId: string
+  toolName: 'Task' | 'Agent'
+  subagentType?: string
+  description: string
+  teamName?: string
+  status: ActivityStatus
+  elapsedSeconds?: number
+  isBackground?: boolean
+  taskId?: string
+  childActivities: ToolActivity[]
+}
+
+/** 侧面板活跃 Tab */
+export type SidePanelTab = 'team' | 'files'
+
 /** Agent 会话的流式状态 */
 export interface AgentStreamState {
   running: boolean
@@ -148,6 +165,62 @@ export function isActivityGroup(item: ActivityGroup | ToolActivity): item is Act
   return 'parent' in item && 'children' in item
 }
 
+/**
+ * 从 ToolActivity[] 构建 SubAgentEntry[]
+ *
+ * 将 Task/Agent 提取为顶层条目，
+ * 其子活动（parentToolUseId 匹配）嵌套在 childActivities 中。
+ */
+export function buildTeamActivityEntries(activities: ToolActivity[]): SubAgentEntry[] {
+  const subAgentIds = new Set<string>()
+  const entries: SubAgentEntry[] = []
+
+  // 第一遍：收集所有 Task/Agent 的 toolUseId
+  for (const a of activities) {
+    if (a.toolName === 'Task' || a.toolName === 'Agent') {
+      subAgentIds.add(a.toolUseId)
+    }
+  }
+
+  if (subAgentIds.size === 0) return []
+
+  // 第二遍：按 parentToolUseId 分组子活动
+  const childrenMap = new Map<string, ToolActivity[]>()
+  for (const a of activities) {
+    if (a.parentToolUseId && subAgentIds.has(a.parentToolUseId)) {
+      const children = childrenMap.get(a.parentToolUseId) ?? []
+      children.push(a)
+      childrenMap.set(a.parentToolUseId, children)
+    }
+  }
+
+  // 第三遍：构建 SubAgentEntry
+  for (const a of activities) {
+    if (a.toolName !== 'Task' && a.toolName !== 'Agent') continue
+
+    const description = typeof a.input.description === 'string'
+      ? a.input.description
+      : typeof a.input.prompt === 'string'
+        ? a.input.prompt
+        : a.intent ?? a.toolName
+
+    entries.push({
+      toolUseId: a.toolUseId,
+      toolName: a.toolName as 'Task' | 'Agent',
+      subagentType: typeof a.input.subagent_type === 'string' ? a.input.subagent_type : undefined,
+      description,
+      teamName: typeof a.input.team_name === 'string' ? a.input.team_name : undefined,
+      status: getActivityStatus(a),
+      elapsedSeconds: a.elapsedSeconds,
+      isBackground: a.isBackground,
+      taskId: a.taskId,
+      childActivities: childrenMap.get(a.toolUseId) ?? [],
+    })
+  }
+
+  return entries
+}
+
 /** 待自动发送的 Agent 提示（从设置页"对话完成配置"触发） */
 export interface AgentPendingPrompt {
   sessionId: string
@@ -174,6 +247,58 @@ export const workspaceCapabilitiesVersionAtom = atom(0)
 
 /** 工作区文件版本号 — 文件变化时自增，触发文件浏览器重新加载 */
 export const workspaceFilesVersionAtom = atom(0)
+
+// ===== 侧面板 Atoms =====
+
+/** 侧面板是否打开 */
+export const agentSidePanelOpenAtom = atom(false)
+
+/** 侧面板当前活跃 Tab */
+export const agentSidePanelTabAtom = atom<SidePanelTab>('team')
+
+/**
+ * Team 活动缓存 — 以 sessionId 为 key
+ *
+ * 流式完成后 agentStreamingStatesAtom 会被清除，
+ * 此缓存在清除前保存 Team 活动数据，确保面板内容不丢失。
+ */
+export const cachedTeamActivitiesAtom = atom<Map<string, SubAgentEntry[]>>(new Map())
+
+/** 当前会话是否有 Team/Task 活动（派生只读原子，同时检查流式状态和缓存） */
+export const hasTeamActivityAtom = atom<boolean>((get) => {
+  const currentId = get(currentAgentSessionIdAtom)
+  if (!currentId) return false
+  // 优先检查流式状态
+  const state = get(agentStreamingStatesAtom).get(currentId)
+  if (state) {
+    return state.toolActivities.some(
+      (a) => a.toolName === 'Task' || a.toolName === 'Agent'
+    )
+  }
+  // 回退到缓存
+  const cached = get(cachedTeamActivitiesAtom).get(currentId)
+  return cached !== undefined && cached.length > 0
+})
+
+/** 当前会话的 Team 活动数据（派生只读原子，同时读取流式状态和缓存） */
+export const teamActivityEntriesAtom = atom<SubAgentEntry[]>((get) => {
+  const currentId = get(currentAgentSessionIdAtom)
+  if (!currentId) return []
+  // 优先使用流式状态
+  const state = get(agentStreamingStatesAtom).get(currentId)
+  if (state && state.toolActivities.length > 0) {
+    const entries = buildTeamActivityEntries(state.toolActivities)
+    if (entries.length > 0) return entries
+  }
+  // 回退到缓存
+  return get(cachedTeamActivitiesAtom).get(currentId) ?? []
+})
+
+/** 运行中的子代理数量（用于 badge 指示器） */
+export const teamActivityCountAtom = atom<number>((get) => {
+  const entries = get(teamActivityEntriesAtom)
+  return entries.filter((e) => e.status === 'running' || e.status === 'backgrounded').length
+})
 
 // ===== 权限系统 Atoms =====
 

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -16,14 +16,14 @@
 import * as React from 'react'
 import { useAtom, useAtomValue, useSetAtom, useStore } from 'jotai'
 import { toast } from 'sonner'
-import { Bot, CornerDownLeft, Square, Settings, Paperclip, FolderPlus, AlertCircle, X, FolderOpen, Copy, Check, Sparkles } from 'lucide-react'
+import { Bot, CornerDownLeft, Square, Settings, Paperclip, FolderPlus, X, Copy, Check, Sparkles } from 'lucide-react'
 import { AgentMessages } from './AgentMessages'
 import { AgentHeader } from './AgentHeader'
 import { ContextUsageBadge } from './ContextUsageBadge'
 import { PermissionBanner } from './PermissionBanner'
 import { PermissionModeSelector } from './PermissionModeSelector'
 import { AskUserBanner } from './AskUserBanner'
-import { FileBrowser } from '@/components/file-browser'
+import { SidePanel } from './SidePanel'
 import { ModelSelector } from '@/components/chat/ModelSelector'
 import { AttachmentPreviewItem } from '@/components/chat/AttachmentPreviewItem'
 import { RichTextInput } from '@/components/ai-elements/rich-text-input'
@@ -108,7 +108,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       return map
     })
   }, [sessionId, setDraftsMap])
-  const [fileBrowserOpen, setFileBrowserOpen] = React.useState(false)
   const [sessionPath, setSessionPath] = React.useState<string | null>(null)
   const [isDragOver, setIsDragOver] = React.useState(false)
   const [pendingFolderRefs, setPendingFolderRefs] = React.useState<AgentSavedFile[]>([])
@@ -922,54 +921,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         </div>
       </div>
 
-      {/* 文件浏览器侧栏 — 始终渲染 w-10 占位，避免切换模式时布局跳动 */}
-      <div
-        className={cn(
-          'relative flex-shrink-0 transition-[width] duration-300 ease-in-out overflow-hidden titlebar-drag-region',
-          sessionPath && fileBrowserOpen ? 'w-[300px] border-l' : 'w-10'
-        )}
-      >
-        {sessionPath && (
-          <>
-            {/* 切换按钮 — 始终固定在右上角，同一个 DOM 元素 */}
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="absolute right-2.5 top-2.5 z-10 h-7 w-7 titlebar-no-drag"
-                  onClick={() => setFileBrowserOpen((prev) => !prev)}
-                >
-                  <FolderOpen
-                    className={cn(
-                      'size-3.5 absolute transition-all duration-200',
-                      fileBrowserOpen ? 'opacity-0 rotate-90 scale-75' : 'opacity-100 rotate-0 scale-100'
-                    )}
-                  />
-                  <X
-                    className={cn(
-                      'size-3.5 absolute transition-all duration-200',
-                      fileBrowserOpen ? 'opacity-100 rotate-0 scale-100' : 'opacity-0 -rotate-90 scale-75'
-                    )}
-                  />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="left">
-                <p>{fileBrowserOpen ? '关闭文件浏览器' : '打开文件浏览器'}</p>
-              </TooltipContent>
-            </Tooltip>
-
-            {/* FileBrowser 内容 — 收起时隐藏 */}
-            <div className={cn(
-              'w-[300px] h-full transition-opacity duration-300 titlebar-no-drag',
-              fileBrowserOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'
-            )}>
-              <FileBrowser rootPath={sessionPath} />
-            </div>
-          </>
-        )}
-      </div>
+      {/* 侧面板（Team Activity + File Browser） */}
+      <SidePanel sessionId={sessionId} sessionPath={sessionPath} />
     </div>
   )
 }

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -1,0 +1,155 @@
+/**
+ * SidePanel — Agent 侧面板容器
+ *
+ * 包含 Team Activity 和 File Browser 两个 Tab。
+ * 面板可自动打开（检测到 Team/Task 活动或文件变化）
+ * 或由用户手动切换。
+ *
+ * 切换按钮在面板关闭时显示活动指示点。
+ */
+
+import * as React from 'react'
+import { useAtom, useAtomValue } from 'jotai'
+import { PanelRight, X, Users, FolderOpen } from 'lucide-react'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import { FileBrowser } from '@/components/file-browser'
+import { TeamActivityPanel } from './TeamActivityPanel'
+import {
+  agentSidePanelOpenAtom,
+  agentSidePanelTabAtom,
+  hasTeamActivityAtom,
+  teamActivityCountAtom,
+  workspaceFilesVersionAtom,
+} from '@/atoms/agent-atoms'
+import type { SidePanelTab } from '@/atoms/agent-atoms'
+
+interface SidePanelProps {
+  sessionId: string
+  sessionPath: string | null
+}
+
+export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.ReactElement {
+  const [isOpen, setIsOpen] = useAtom(agentSidePanelOpenAtom)
+  const [activeTab, setActiveTab] = useAtom(agentSidePanelTabAtom)
+  const hasTeamActivity = useAtomValue(hasTeamActivityAtom)
+  const runningCount = useAtomValue(teamActivityCountAtom)
+  const filesVersion = useAtomValue(workspaceFilesVersionAtom)
+  const hasFileChanges = filesVersion > 0
+
+  // 自动打开：文件变化时（仅在有 sessionPath 时）
+  const prevFilesVersionRef = React.useRef(filesVersion)
+  React.useEffect(() => {
+    if (filesVersion > prevFilesVersionRef.current && sessionPath) {
+      setIsOpen(true)
+      // 仅在当前无 team 活动时切换到文件 tab
+      if (!hasTeamActivity) {
+        setActiveTab('files')
+      }
+    }
+    prevFilesVersionRef.current = filesVersion
+  }, [filesVersion, sessionPath, hasTeamActivity, setIsOpen, setActiveTab])
+
+  // 面板是否可显示内容（需要有 sessionPath 或 team 活动）
+  const hasContent = sessionPath || hasTeamActivity
+
+  return (
+    <div
+      className={cn(
+        'relative flex-shrink-0 transition-[width] duration-300 ease-in-out overflow-hidden titlebar-drag-region',
+        hasContent && isOpen ? 'w-[320px] border-l' : 'w-10',
+      )}
+    >
+      {/* 切换按钮 — 始终固定在右上角 */}
+      {hasContent && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="absolute right-2.5 top-2.5 z-10 h-7 w-7 titlebar-no-drag"
+              onClick={() => setIsOpen((prev) => !prev)}
+            >
+              <PanelRight
+                className={cn(
+                  'size-3.5 absolute transition-all duration-200',
+                  isOpen ? 'opacity-0 rotate-90 scale-75' : 'opacity-100 rotate-0 scale-100',
+                )}
+              />
+              <X
+                className={cn(
+                  'size-3.5 absolute transition-all duration-200',
+                  isOpen ? 'opacity-100 rotate-0 scale-100' : 'opacity-0 -rotate-90 scale-75',
+                )}
+              />
+              {/* 活动指示点（面板关闭时显示） */}
+              {!isOpen && (hasTeamActivity || hasFileChanges) && (
+                <span className="absolute -top-0.5 -right-0.5 size-2 rounded-full bg-primary animate-pulse" />
+              )}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="left">
+            <p>{isOpen ? '关闭侧面板' : '打开侧面板'}</p>
+          </TooltipContent>
+        </Tooltip>
+      )}
+
+      {/* 面板内容 */}
+      {hasContent && (
+        <div
+          className={cn(
+            'w-[320px] h-full flex flex-col transition-opacity duration-300 titlebar-no-drag',
+            isOpen ? 'opacity-100' : 'opacity-0 pointer-events-none',
+          )}
+        >
+          <Tabs
+            value={activeTab}
+            onValueChange={(v) => setActiveTab(v as SidePanelTab)}
+            className="flex flex-col h-full"
+          >
+            {/* Tab 切换栏 */}
+            <div className="flex items-center gap-1 px-2 pr-10 h-[48px] border-b flex-shrink-0">
+              <TabsList className="h-8 bg-muted/50">
+                <TabsTrigger value="team" className="text-xs h-7 px-3 gap-1.5">
+                  <Users className="size-3" />
+                  Team
+                  {runningCount > 0 && (
+                    <span className="ml-0.5 px-1.5 py-0.5 rounded-full text-[10px] bg-primary text-primary-foreground leading-none">
+                      {runningCount}
+                    </span>
+                  )}
+                </TabsTrigger>
+                <TabsTrigger value="files" className="text-xs h-7 px-3 gap-1.5">
+                  <FolderOpen className="size-3" />
+                  文件
+                  {hasFileChanges && (
+                    <span className="ml-0.5 size-1.5 rounded-full bg-primary" />
+                  )}
+                </TabsTrigger>
+              </TabsList>
+            </div>
+
+            {/* Team Activity Tab */}
+            <TabsContent value="team" className="flex-1 overflow-hidden m-0 data-[state=active]:flex data-[state=active]:flex-col">
+              <TeamActivityPanel sessionId={sessionId} />
+            </TabsContent>
+
+            {/* File Browser Tab */}
+            <TabsContent value="files" className="flex-1 overflow-hidden m-0 data-[state=active]:flex data-[state=active]:flex-col">
+              {sessionPath ? (
+                <FileBrowser rootPath={sessionPath} />
+              ) : (
+                <div className="flex h-full items-center justify-center text-xs text-muted-foreground">
+                  请选择工作区
+                </div>
+              )}
+            </TabsContent>
+          </Tabs>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/agent/TeamActivityPanel.tsx
+++ b/apps/electron/src/renderer/components/agent/TeamActivityPanel.tsx
@@ -1,0 +1,25 @@
+/**
+ * TeamActivityPanel — Team/Task 子代理活动面板（Placeholder）
+ *
+ * TODO: 完成 Agent Teams UI 展示
+ * - 按 team_name 分组展示子代理活动
+ * - 实时状态、计时器、子工具活动展开
+ */
+
+import { Bot } from 'lucide-react'
+
+interface TeamActivityPanelProps {
+  sessionId: string
+}
+
+export function TeamActivityPanel({ sessionId: _sessionId }: TeamActivityPanelProps): React.ReactElement {
+  return (
+    <div className="flex h-full items-center justify-center">
+      <div className="flex flex-col items-center gap-2.5 text-muted-foreground/60">
+        <Bot className="size-8" />
+        <p className="text-xs">Team 活动面板</p>
+        <p className="text-[11px]">UI 待完成</p>
+      </div>
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/agent/ToolActivityItem.tsx
+++ b/apps/electron/src/renderer/components/agent/ToolActivityItem.tsx
@@ -74,6 +74,7 @@ const TOOL_ICONS: Record<string, React.ComponentType<{ className?: string }>> = 
   TaskGet: ListTodo,
   TaskList: ListTodo,
   TeamCreate: Users,
+  Agent: Users,
 }
 
 function getToolIcon(toolName: string): React.ComponentType<{ className?: string }> {
@@ -181,7 +182,7 @@ function ErrorBadge(): React.ReactElement {
 
 // ===== 格式化耗时 =====
 
-function formatElapsed(seconds: number): string {
+export function formatElapsed(seconds: number): string {
   if (seconds < 60) return `${seconds.toFixed(1)}s`
   const m = Math.floor(seconds / 60)
   const s = Math.round(seconds % 60)
@@ -283,6 +284,16 @@ function getInputSummary(toolName: string, input: Record<string, unknown>): stri
       return name
     }
   }
+  // Agent：显示 name + description
+  if (toolName === 'Agent') {
+    const agentName = input.name
+    const desc = input.description ?? input.prompt
+    if (typeof agentName === 'string' && typeof desc === 'string') {
+      return `${agentName} · ${desc.length > 60 ? desc.slice(0, 60) + '…' : desc}`
+    }
+    if (typeof desc === 'string') return desc.length > 80 ? desc.slice(0, 80) + '…' : desc
+    if (typeof agentName === 'string') return agentName
+  }
   return null
 }
 
@@ -341,14 +352,14 @@ function TodoList({ items }: { items: TodoItem[] }): React.ReactElement {
 
 // ===== 活动行 =====
 
-interface ActivityRowProps {
+export interface ActivityRowProps {
   activity: ToolActivity
   index?: number
   animate?: boolean
   onOpenDetails?: (activity: ToolActivity) => void
 }
 
-function ActivityRow({ activity, index = 0, animate = false, onOpenDetails }: ActivityRowProps): React.ReactElement {
+export function ActivityRow({ activity, index = 0, animate = false, onOpenDetails }: ActivityRowProps): React.ReactElement {
   const status = getActivityStatus(activity)
   const filePath = extractFilePath(activity.input)
   const diffStats = computeDiffStats(activity.toolName, activity.input)

--- a/apps/electron/src/renderer/components/ui/tabs.tsx
+++ b/apps/electron/src/renderer/components/ui/tabs.tsx
@@ -1,0 +1,53 @@
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow",
+      className
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -18,6 +18,11 @@ import {
   allPendingAskUserRequestsAtom,
   agentPromptSuggestionsAtom,
   backgroundTasksAtomFamily,
+  agentSidePanelOpenAtom,
+  agentSidePanelTabAtom,
+  currentAgentSessionIdAtom,
+  cachedTeamActivitiesAtom,
+  buildTeamActivityEntries,
   applyAgentEvent,
 } from '@/atoms/agent-atoms'
 import {
@@ -51,6 +56,15 @@ export function useGlobalAgentListeners(): void {
           map.set(sessionId, next)
           return map
         })
+
+        // 自动打开侧面板：检测到 Agent/Task 工具启动时
+        if (event.type === 'tool_start' && (event.toolName === 'Agent' || event.toolName === 'Task')) {
+          const currentSessionId = store.get(currentAgentSessionIdAtom)
+          if (sessionId === currentSessionId) {
+            store.set(agentSidePanelOpenAtom, true)
+            store.set(agentSidePanelTabAtom, 'team')
+          }
+        }
 
         // 处理后台任务事件
         if (event.type === 'task_backgrounded') {
@@ -162,6 +176,19 @@ export function useGlobalAgentListeners(): void {
           map.set(data.sessionId, { ...current, running: false })
           return map
         })
+
+        // 缓存 Team 活动数据（在流式状态被清除前保存，防止面板数据丢失）
+        const streamState = store.get(agentStreamingStatesAtom).get(data.sessionId)
+        if (streamState && streamState.toolActivities.length > 0) {
+          const teamEntries = buildTeamActivityEntries(streamState.toolActivities)
+          if (teamEntries.length > 0) {
+            store.set(cachedTeamActivitiesAtom, (prev) => {
+              const map = new Map(prev)
+              map.set(data.sessionId, teamEntries)
+              return map
+            })
+          }
+        }
 
         /** 竞态保护：检查该会话是否已有新的流式请求正在运行 */
         const isNewStreamRunning = (): boolean => {

--- a/bun.lock
+++ b/bun.lock
@@ -40,6 +40,7 @@
         "@radix-ui/react-slider": "^1.3.6",
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-switch": "^1.2.6",
+        "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-toast": "^1.2.15",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@tiptap/extension-code-block-lowlight": "^3.19.0",
@@ -400,6 +401,8 @@
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
 
     "@radix-ui/react-switch": ["@radix-ui/react-switch@1.2.6", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-use-size": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ=="],
+
+    "@radix-ui/react-tabs": ["@radix-ui/react-tabs@1.1.13", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-roving-focus": "1.1.11", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A=="],
 
     "@radix-ui/react-toast": ["@radix-ui/react-toast@1.2.15", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-visually-hidden": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g=="],
 

--- a/packages/shared/src/agent/tool-matching.ts
+++ b/packages/shared/src/agent/tool-matching.ts
@@ -87,6 +87,13 @@ export interface TextBlock {
 export type ContentBlock = ToolUseBlock | ToolResultBlock | TextBlock | { type: string }
 
 // ============================================================================
+// 子代理工具名称
+// ============================================================================
+
+/** 子代理工具名称集合 — 这些工具派生并行子代理，不应互相嵌套 */
+export const SUBAGENT_TOOL_NAMES = new Set(['Task', 'Agent'])
+
+// ============================================================================
 // 纯提取函数
 // ============================================================================
 
@@ -110,11 +117,11 @@ export function extractToolStarts(
     toolIndex.register(toolBlock.id, toolBlock.name, toolBlock.input)
 
     // 确定父级：SDK 的 parent_tool_use_id 是权威来源
-    // 推断仅适用于非 Task 工具 — 并行 Task 是同级关系，不应互相嵌套
+    // 推断仅适用于非子代理工具 — 并行 Task/Agent 是同级关系，不应互相嵌套
     let parentToolUseId: string | undefined
     if (sdkParentToolUseId) {
       parentToolUseId = sdkParentToolUseId
-    } else if (toolBlock.name !== 'Task' && activeParentTools && activeParentTools.size === 1) {
+    } else if (!SUBAGENT_TOOL_NAMES.has(toolBlock.name) && activeParentTools && activeParentTools.size === 1) {
       const [singleActiveParent] = activeParentTools
       if (toolBlock.id !== singleActiveParent) {
         parentToolUseId = singleActiveParent
@@ -275,9 +282,10 @@ function detectBackgroundEvents(
 ): AgentEvent[] {
   const events: AgentEvent[] = []
 
-  // 后台 Task 检测
-  if (entry.name === 'Task' && !isError && resultStr && entry.input.run_in_background === true) {
-    const agentIdMatch = resultStr.match(/agentId:\s*([a-zA-Z0-9_-]+)/)
+  // 后台 Task/Agent 检测
+  if (SUBAGENT_TOOL_NAMES.has(entry.name) && !isError && resultStr && entry.input.run_in_background === true) {
+    // 匹配 agentId / agent_id，ID 可能包含 @ 等特殊字符
+    const agentIdMatch = resultStr.match(/(?:agentId|agent_id):\s*([^\s\n]+)/)
     if (agentIdMatch?.[1]) {
       // 优先使用 _intent，回退到 description（任务名称）
       const intentValue = (typeof entry.input._intent === 'string' && entry.input._intent)


### PR DESCRIPTION
## Summary
- 新增 Tab 式复合侧面板（Team | 文件），替换原 FileBrowser 独立侧栏
- Team tab 暂为 placeholder（UI 待完成），文件浏览器功能不变
- `tool-matching.ts` 新增 `SUBAGENT_TOOL_NAMES` 集合，统一 `Task` 和 `Agent` 工具的处理逻辑
- 修正后台任务检测：支持 `Agent` 工具 + 修正 `agent_id:` 格式的正则匹配
- `claude-agent-adapter.ts` 的 `activeParentTools` 追踪统一使用 `SUBAGENT_TOOL_NAMES`
- `ToolActivityItem` 为 `Agent` 工具添加图标映射和摘要显示
- 检测到 Agent/Task 工具启动时自动展开侧面板到 Team tab

## Test plan
- [ ] `bun run typecheck` 通过
- [ ] `bun run dev` 正常启动
- [ ] Agent 模式下发送消息，侧面板切换按钮可见
- [ ] 手动切换 Team / 文件 tab
- [ ] Agent 触发 Task/Agent 工具时侧面板自动展开
- [ ] 文件浏览器功能正常（选择工作区后可浏览文件）