### PR TITLE
feat: Agent 侧面板文件拖拽上传区域

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -49,20 +49,7 @@ import type { AgentContextStatus } from '@/atoms/agent-atoms'
 import { activeViewAtom } from '@/atoms/active-view'
 import { tabsAtom, splitLayoutAtom, openTab } from '@/atoms/tab-atoms'
 import type { AgentSendInput, AgentMessage, AgentPendingFile, AgentSavedFile, ModelOption } from '@proma/shared'
-
-/** 将 File 对象转为 base64 字符串 */
-function fileToBase64(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader()
-    reader.onload = () => {
-      const result = reader.result as string
-      const base64 = result.split(',')[1]!
-      resolve(base64)
-    }
-    reader.onerror = reject
-    reader.readAsDataURL(file)
-  })
-}
+import { fileToBase64 } from '@/lib/file-utils'
 
 export function AgentView({ sessionId }: { sessionId: string }): React.ReactElement {
   const [messages, setMessages] = React.useState<AgentMessage[]>([])

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -9,13 +9,13 @@
  */
 
 import * as React from 'react'
-import { useAtom, useAtomValue } from 'jotai'
-import { PanelRight, X, Users, FolderOpen } from 'lucide-react'
+import { useAtom, useAtomValue, useSetAtom } from 'jotai'
+import { PanelRight, X, Users, FolderOpen, ExternalLink, RefreshCw } from 'lucide-react'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
-import { FileBrowser } from '@/components/file-browser'
+import { FileBrowser, FileDropZone } from '@/components/file-browser'
 import { TeamActivityPanel } from './TeamActivityPanel'
 import {
   agentSidePanelOpenAtom,
@@ -23,6 +23,8 @@ import {
   hasTeamActivityAtom,
   teamActivityCountAtom,
   workspaceFilesVersionAtom,
+  currentAgentWorkspaceIdAtom,
+  agentWorkspacesAtom,
 } from '@/atoms/agent-atoms'
 import type { SidePanelTab } from '@/atoms/agent-atoms'
 
@@ -37,7 +39,30 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
   const hasTeamActivity = useAtomValue(hasTeamActivityAtom)
   const runningCount = useAtomValue(teamActivityCountAtom)
   const filesVersion = useAtomValue(workspaceFilesVersionAtom)
+  const setFilesVersion = useSetAtom(workspaceFilesVersionAtom)
   const hasFileChanges = filesVersion > 0
+
+  // 派生当前工作区 slug（用于 FileDropZone IPC 调用）
+  const currentWorkspaceId = useAtomValue(currentAgentWorkspaceIdAtom)
+  const workspaces = useAtomValue(agentWorkspacesAtom)
+  const workspaceSlug = workspaces.find((w) => w.id === currentWorkspaceId)?.slug ?? null
+
+  // 文件上传完成后递增版本号，触发 FileBrowser 刷新
+  const handleFilesUploaded = React.useCallback(() => {
+    setFilesVersion((prev) => prev + 1)
+  }, [setFilesVersion])
+
+  // 手动刷新文件列表
+  const handleRefresh = React.useCallback(() => {
+    setFilesVersion((prev) => prev + 1)
+  }, [setFilesVersion])
+
+  // 面包屑：显示根路径最后两段
+  const breadcrumb = React.useMemo(() => {
+    if (!sessionPath) return ''
+    const parts = sessionPath.split('/').filter(Boolean)
+    return parts.length > 2 ? `.../${parts.slice(-2).join('/')}` : sessionPath
+  }, [sessionPath])
 
   // 自动打开：文件变化时（仅在有 sessionPath 时）
   const prevFilesVersionRef = React.useRef(filesVersion)
@@ -139,8 +164,45 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
 
             {/* File Browser Tab */}
             <TabsContent value="files" className="flex-1 overflow-hidden m-0 data-[state=active]:flex data-[state=active]:flex-col">
-              {sessionPath ? (
-                <FileBrowser rootPath={sessionPath} />
+              {sessionPath && workspaceSlug ? (
+                <>
+                  {/* 工具栏：路径面包屑 + 打开文件夹 + 刷新 */}
+                  <div className="flex items-center gap-1 px-3 h-[36px] border-b flex-shrink-0">
+                    <span className="text-xs text-muted-foreground truncate flex-1" title={sessionPath}>
+                      {breadcrumb}
+                    </span>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="h-6 w-6 flex-shrink-0"
+                      onClick={() => window.electronAPI.openFile(sessionPath).catch(console.error)}
+                      title="在 Finder 中打开"
+                    >
+                      <ExternalLink className="size-3" />
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="h-6 w-6 flex-shrink-0"
+                      onClick={handleRefresh}
+                      title="刷新"
+                    >
+                      <RefreshCw className="size-3" />
+                    </Button>
+                  </div>
+                  {/* 文件拖拽上传区域 */}
+                  <FileDropZone
+                    workspaceSlug={workspaceSlug}
+                    sessionId={sessionId}
+                    onFilesUploaded={handleFilesUploaded}
+                  />
+                  {/* 文件浏览器（隐藏内置工具栏） */}
+                  <div className="flex-1 min-h-0">
+                    <FileBrowser rootPath={sessionPath} hideToolbar />
+                  </div>
+                </>
               ) : (
                 <div className="flex h-full items-center justify-center text-xs text-muted-foreground">
                   请选择工作区

--- a/apps/electron/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatInput.tsx
@@ -35,6 +35,7 @@ import {
 } from '@/atoms/chat-atoms'
 import type { PendingAttachment } from '@/atoms/chat-atoms'
 import { cn } from '@/lib/utils'
+import { fileToBase64 } from '@/lib/file-utils'
 
 interface ChatInputProps {
   /** 当前对话 ID */
@@ -51,23 +52,6 @@ interface ChatInputProps {
   onStop: () => void
   /** 清除上下文回调 */
   onClearContext?: () => void
-}
-
-/**
- * 将 File 对象转为 base64 字符串
- */
-function fileToBase64(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader()
-    reader.onload = () => {
-      const result = reader.result as string
-      // 去掉 data:xxx;base64, 前缀
-      const base64 = result.split(',')[1]!
-      resolve(base64)
-    }
-    reader.onerror = reject
-    reader.readAsDataURL(file)
-  })
 }
 
 export function ChatInput({ conversationId, streaming, pendingAttachments, onSetPendingAttachments, onSend, onStop, onClearContext }: ChatInputProps): React.ReactElement {

--- a/apps/electron/src/renderer/components/chat/InlineEditForm.tsx
+++ b/apps/electron/src/renderer/components/chat/InlineEditForm.tsx
@@ -14,19 +14,7 @@ import { MessageAction } from '@/components/ai-elements/message'
 import { AttachmentPreviewItem } from './AttachmentPreviewItem'
 import { cn } from '@/lib/utils'
 import type { ChatMessage, FileAttachment } from '@proma/shared'
-
-/** 文件转 base64（模块级纯函数） */
-function fileToBase64(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader()
-    reader.onload = () => {
-      const result = reader.result as string
-      resolve(result.split(',')[1]!)
-    }
-    reader.onerror = reject
-    reader.readAsDataURL(file)
-  })
-}
+import { fileToBase64 } from '@/lib/file-utils'
 
 interface NewInlineAttachment {
   filename: string

--- a/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
@@ -50,9 +50,11 @@ interface ContextMenuState {
 
 interface FileBrowserProps {
   rootPath: string
+  /** 隐藏内置顶部工具栏（面包屑 + 按钮），由外部自行渲染 */
+  hideToolbar?: boolean
 }
 
-export function FileBrowser({ rootPath }: FileBrowserProps): React.ReactElement {
+export function FileBrowser({ rootPath, hideToolbar }: FileBrowserProps): React.ReactElement {
   const [entries, setEntries] = React.useState<FileEntry[]>([])
   const [loading, setLoading] = React.useState(false)
   const [error, setError] = React.useState<string | null>(null)
@@ -150,32 +152,34 @@ export function FileBrowser({ rootPath }: FileBrowserProps): React.ReactElement 
 
   return (
     <div className="flex flex-col h-full bg-background">
-      {/* 顶部工具栏 */}
-      <div className="flex items-center gap-1 px-3 pr-10 h-[48px] border-b flex-shrink-0">
-        <span className="text-xs text-muted-foreground truncate flex-1" title={rootPath}>
-          {breadcrumb}
-        </span>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className="h-7 w-7 flex-shrink-0"
-          onClick={() => window.electronAPI.openFile(rootPath).catch(console.error)}
-          title="在 Finder 中打开"
-        >
-          <ExternalLink className="size-3.5" />
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className="h-7 w-7 flex-shrink-0"
-          onClick={loadRoot}
-          disabled={loading}
-        >
-          <RefreshCw className={cn('size-3.5', loading && 'animate-spin')} />
-        </Button>
-      </div>
+      {/* 顶部工具栏（可由外部接管） */}
+      {!hideToolbar && (
+        <div className="flex items-center gap-1 px-3 pr-10 h-[48px] border-b flex-shrink-0">
+          <span className="text-xs text-muted-foreground truncate flex-1" title={rootPath}>
+            {breadcrumb}
+          </span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 flex-shrink-0"
+            onClick={() => window.electronAPI.openFile(rootPath).catch(console.error)}
+            title="在 Finder 中打开"
+          >
+            <ExternalLink className="size-3.5" />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 flex-shrink-0"
+            onClick={loadRoot}
+            disabled={loading}
+          >
+            <RefreshCw className={cn('size-3.5', loading && 'animate-spin')} />
+          </Button>
+        </div>
+      )}
 
       {/* 文件树 */}
       <ScrollArea className="flex-1">

--- a/apps/electron/src/renderer/components/file-browser/FileDropZone.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileDropZone.tsx
@@ -1,0 +1,208 @@
+/**
+ * FileDropZone — 文件拖拽上传区域
+ *
+ * 引导用户通过拖拽或点击将文件添加到 Agent 会话目录。
+ * 文件上传后直接保存到会话工作区，FileBrowser 通过版本号自动刷新。
+ */
+
+import * as React from 'react'
+import { toast } from 'sonner'
+import { Upload, File, FolderPlus, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { fileToBase64 } from '@/lib/file-utils'
+
+interface FileDropZoneProps {
+  /** 当前工作区 slug（用于 IPC 调用） */
+  workspaceSlug: string
+  /** 当前会话 ID */
+  sessionId: string
+  /** 上传成功后的回调（触发文件浏览器刷新） */
+  onFilesUploaded: () => void
+}
+
+export function FileDropZone({ workspaceSlug, sessionId, onFilesUploaded }: FileDropZoneProps): React.ReactElement {
+  const [isDragOver, setIsDragOver] = React.useState(false)
+  const [isUploading, setIsUploading] = React.useState(false)
+
+  /** 保存文件到会话目录 */
+  const saveFiles = React.useCallback(async (files: globalThis.File[]): Promise<void> => {
+    if (files.length === 0) return
+
+    setIsUploading(true)
+    try {
+      const fileEntries: Array<{ filename: string; data: string }> = []
+      for (const file of files) {
+        const base64 = await fileToBase64(file)
+        fileEntries.push({ filename: file.name, data: base64 })
+      }
+
+      await window.electronAPI.saveFilesToAgentSession({
+        workspaceSlug,
+        sessionId,
+        files: fileEntries,
+      })
+
+      onFilesUploaded()
+      toast.success(`已添加 ${files.length} 个文件`)
+    } catch (error) {
+      console.error('[FileDropZone] 文件上传失败:', error)
+      toast.error('文件上传失败')
+    } finally {
+      setIsUploading(false)
+    }
+  }, [workspaceSlug, sessionId, onFilesUploaded])
+
+  // ===== 拖拽处理 =====
+
+  const handleDragOver = React.useCallback((e: React.DragEvent): void => {
+    e.preventDefault()
+    e.stopPropagation()
+    setIsDragOver(true)
+  }, [])
+
+  const handleDragLeave = React.useCallback((e: React.DragEvent): void => {
+    e.preventDefault()
+    e.stopPropagation()
+    setIsDragOver(false)
+  }, [])
+
+  const handleDrop = React.useCallback(async (e: React.DragEvent): Promise<void> => {
+    e.preventDefault()
+    e.stopPropagation()
+    setIsDragOver(false)
+
+    const items = Array.from(e.dataTransfer.items)
+    const regularFiles: globalThis.File[] = []
+    let hasFolders = false
+
+    for (const item of items) {
+      if (item.kind !== 'file') continue
+      const entry = item.webkitGetAsEntry?.()
+      if (entry?.isDirectory) {
+        hasFolders = true
+      } else {
+        const file = item.getAsFile()
+        if (file) regularFiles.push(file)
+      }
+    }
+
+    if (hasFolders) {
+      toast.info('不支持拖拽文件夹', { description: '请使用「选择文件夹」按钮' })
+    }
+
+    if (regularFiles.length > 0) {
+      await saveFiles(regularFiles)
+    }
+  }, [saveFiles])
+
+  // ===== 按钮点击处理 =====
+
+  const handleSelectFiles = React.useCallback(async (): Promise<void> => {
+    try {
+      const result = await window.electronAPI.openFileDialog()
+      if (result.files.length === 0) return
+
+      setIsUploading(true)
+      const fileEntries = result.files.map((f) => ({
+        filename: f.filename,
+        data: f.data,
+      }))
+
+      await window.electronAPI.saveFilesToAgentSession({
+        workspaceSlug,
+        sessionId,
+        files: fileEntries,
+      })
+
+      onFilesUploaded()
+      toast.success(`已添加 ${result.files.length} 个文件`)
+    } catch (error) {
+      console.error('[FileDropZone] 选择文件失败:', error)
+      toast.error('文件上传失败')
+    } finally {
+      setIsUploading(false)
+    }
+  }, [workspaceSlug, sessionId, onFilesUploaded])
+
+  const handleSelectFolder = React.useCallback(async (): Promise<void> => {
+    try {
+      const result = await window.electronAPI.openFolderDialog()
+      if (!result) return
+
+      setIsUploading(true)
+      await window.electronAPI.copyFolderToSession({
+        sourcePath: result.path,
+        workspaceSlug,
+        sessionId,
+      })
+
+      onFilesUploaded()
+      toast.success(`已添加文件夹「${result.name}」`)
+    } catch (error) {
+      console.error('[FileDropZone] 选择文件夹失败:', error)
+      toast.error('文件夹上传失败')
+    } finally {
+      setIsUploading(false)
+    }
+  }, [workspaceSlug, sessionId, onFilesUploaded])
+
+  return (
+    <div className="flex-shrink-0 px-3 pt-3 pb-1">
+      <div
+        className={cn(
+          'relative flex flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed px-3 py-4',
+          'transition-colors duration-200 cursor-default',
+          isDragOver
+            ? 'border-primary bg-primary/5'
+            : 'border-muted-foreground/20 hover:border-muted-foreground/40',
+          isUploading && 'pointer-events-none opacity-60',
+        )}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+      >
+        {isUploading ? (
+          <>
+            <Loader2 className="size-5 text-muted-foreground animate-spin" />
+            <span className="text-xs text-muted-foreground">正在上传...</span>
+          </>
+        ) : (
+          <>
+            <Upload className={cn(
+              'size-5 transition-colors',
+              isDragOver ? 'text-primary' : 'text-muted-foreground/60',
+            )} />
+            <p className="text-xs text-muted-foreground text-center leading-relaxed">
+              将文件拖拽到此处
+              <br />
+              <span className="text-[10px] text-muted-foreground/60">供 Agent 读取和处理</span>
+            </p>
+            <div className="flex items-center gap-1.5">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="h-6 text-[11px] px-2 gap-1"
+                onClick={handleSelectFiles}
+              >
+                <File className="size-3" />
+                选择文件
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="h-6 text-[11px] px-2 gap-1"
+                onClick={handleSelectFolder}
+              >
+                <FolderPlus className="size-3" />
+                选择文件夹
+              </Button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/file-browser/index.ts
+++ b/apps/electron/src/renderer/components/file-browser/index.ts
@@ -3,3 +3,4 @@
  */
 
 export * from './FileBrowser'
+export * from './FileDropZone'

--- a/apps/electron/src/renderer/lib/file-utils.ts
+++ b/apps/electron/src/renderer/lib/file-utils.ts
@@ -1,0 +1,17 @@
+/**
+ * 文件处理工具函数
+ */
+
+/** 将 File 对象转为 base64 字符串 */
+export function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      const result = reader.result as string
+      const base64 = result.split(',')[1]!
+      resolve(base64)
+    }
+    reader.onerror = reject
+    reader.readAsDataURL(file)
+  })
+}


### PR DESCRIPTION
## Summary
- 在 Agent 模式右侧面板「文件」Tab 新增 FileDropZone 组件，支持拖拽文件/点击上传到会话目录
- 工具栏（路径面包屑 + 打开文件夹 + 刷新）提升到 DropZone 上方，FileBrowser 隐藏内置工具栏
- 提取 `fileToBase64` 共享工具函数到 `renderer/lib/file-utils.ts`，消除 AgentView / ChatInput / InlineEditForm 三处重复

## Test plan
- [ ] 进入 Agent 模式，选择工作区，打开右侧面板「文件」Tab
- [ ] 拖拽文件到 DropZone → 文件出现在下方 FileBrowser 树中
- [ ] 点击「选择文件」按钮 → 文件对话框 → 文件出现在树中
- [ ] 点击「选择文件夹」按钮 → 文件夹对话框 → 文件夹层级正确显示
- [ ] 拖拽文件夹 → toast 提示使用按钮
- [ ] 工具栏：面包屑路径正确、打开 Finder 正常、刷新按钮正常
- [ ] FileBrowser 右键删除文件 → 确认弹窗 → 删除成功
- [ ] Chat 模式附件上传、消息编辑附件功能不受影响