### PR TITLE
fix: 分屏模式下 Header 控件状态隔离

### DIFF
--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -250,11 +250,11 @@ export const workspaceFilesVersionAtom = atom(0)
 
 // ===== 侧面板 Atoms =====
 
-/** 侧面板是否打开 */
-export const agentSidePanelOpenAtom = atom(false)
+/** 侧面板是否打开（per-session Map） */
+export const agentSidePanelOpenMapAtom = atom<Map<string, boolean>>(new Map())
 
-/** 侧面板当前活跃 Tab */
-export const agentSidePanelTabAtom = atom<SidePanelTab>('team')
+/** 侧面板当前活跃 Tab（per-session Map） */
+export const agentSidePanelTabMapAtom = atom<Map<string, SidePanelTab>>(new Map())
 
 /**
  * Team 活动缓存 — 以 sessionId 为 key

--- a/apps/electron/src/renderer/atoms/chat-atoms.ts
+++ b/apps/electron/src/renderer/atoms/chat-atoms.ts
@@ -10,7 +10,7 @@ import { atomWithStorage } from 'jotai/utils'
 import type { ConversationMeta, ChatMessage, FileAttachment, ChatToolActivity } from '@proma/shared'
 
 /** 选中的模型信息 */
-interface SelectedModel {
+export interface SelectedModel {
   channelId: string
   modelId: string
 }
@@ -225,3 +225,18 @@ export interface AgentRecommendation {
 
 /** 待处理的 Agent 模式推荐（工具结果写入，用户操作/关闭/切换对话时清除） */
 export const pendingAgentRecommendationAtom = atom<AgentRecommendation | null>(null)
+
+// ===== Per-conversation 设置 Map =====
+// 分屏时每个 ChatView 实例独立控制，缺省时使用全局默认值
+
+/** 每个对话的模型选择 */
+export const conversationModelsAtom = atom<Map<string, SelectedModel | null>>(new Map())
+
+/** 每个对话的上下文长度 */
+export const conversationContextLengthAtom = atom<Map<string, ContextLengthValue>>(new Map())
+
+/** 每个对话的思考模式 */
+export const conversationThinkingEnabledAtom = atom<Map<string, boolean>>(new Map())
+
+/** 每个对话的并排模式 */
+export const conversationParallelModeAtom = atom<Map<string, boolean>>(new Map())

--- a/apps/electron/src/renderer/atoms/system-prompt-atoms.ts
+++ b/apps/electron/src/renderer/atoms/system-prompt-atoms.ts
@@ -74,3 +74,35 @@ export const resolvedSystemMessageAtom = atom<string | undefined>((get) => {
 
   return message
 })
+
+// ===== Per-conversation 系统提示词 =====
+
+/** 每个对话选中的提示词 ID（分屏时独立） */
+export const conversationPromptIdAtom = atom<Map<string, string>>(new Map())
+
+/** 根据 promptId 解析 systemMessage（纯函数，不依赖全局 atom） */
+export function resolveSystemMessage(
+  promptId: string,
+  config: SystemPromptConfig,
+  userName: string,
+): string | undefined {
+  const prompt = config.prompts.find((p) => p.id === promptId)
+  if (!prompt) return undefined
+
+  let message = prompt.content
+
+  if (config.appendDateTimeAndUserName) {
+    const now = new Date()
+    const dateTimeStr = now.toLocaleString('zh-CN', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      weekday: 'long',
+    })
+    message += `\n\n---\n当前时间: ${dateTimeStr}\n用户名: ${userName}`
+  }
+
+  return message
+}

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -48,6 +48,7 @@ import {
 import type { AgentContextStatus } from '@/atoms/agent-atoms'
 import { activeViewAtom } from '@/atoms/active-view'
 import { tabsAtom, splitLayoutAtom, openTab } from '@/atoms/tab-atoms'
+import { AgentSessionProvider } from '@/contexts/session-context'
 import type { AgentSendInput, AgentMessage, AgentPendingFile, AgentSavedFile, ModelOption } from '@proma/shared'
 
 /** 将 File 对象转为 base64 字符串 */
@@ -696,6 +697,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const canSend = (inputContent.trim().length > 0 || pendingFiles.length > 0 || pendingFolderRefs.length > 0) && agentChannelId !== null && !streaming
 
   return (
+    <AgentSessionProvider sessionId={sessionId}>
     <div className="flex h-full overflow-hidden">
       {/* 主内容区域 */}
       <div className="flex flex-col h-full flex-1 min-w-0 max-w-[min(72rem,100%)] mx-auto">
@@ -924,5 +926,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       {/* 侧面板（Team Activity + File Browser） */}
       <SidePanel sessionId={sessionId} sessionPath={sessionPath} />
     </div>
+    </AgentSessionProvider>
   )
 }

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -9,7 +9,7 @@
  */
 
 import * as React from 'react'
-import { useAtom, useAtomValue } from 'jotai'
+import { useAtomValue, useSetAtom } from 'jotai'
 import { PanelRight, X, Users, FolderOpen } from 'lucide-react'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import { Button } from '@/components/ui/button'
@@ -18,10 +18,11 @@ import { cn } from '@/lib/utils'
 import { FileBrowser } from '@/components/file-browser'
 import { TeamActivityPanel } from './TeamActivityPanel'
 import {
-  agentSidePanelOpenAtom,
-  agentSidePanelTabAtom,
-  hasTeamActivityAtom,
-  teamActivityCountAtom,
+  agentSidePanelOpenMapAtom,
+  agentSidePanelTabMapAtom,
+  agentStreamingStatesAtom,
+  cachedTeamActivitiesAtom,
+  buildTeamActivityEntries,
   workspaceFilesVersionAtom,
 } from '@/atoms/agent-atoms'
 import type { SidePanelTab } from '@/atoms/agent-atoms'
@@ -32,10 +33,60 @@ interface SidePanelProps {
 }
 
 export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.ReactElement {
-  const [isOpen, setIsOpen] = useAtom(agentSidePanelOpenAtom)
-  const [activeTab, setActiveTab] = useAtom(agentSidePanelTabAtom)
-  const hasTeamActivity = useAtomValue(hasTeamActivityAtom)
-  const runningCount = useAtomValue(teamActivityCountAtom)
+  // per-session 侧面板状态
+  const sidePanelOpenMap = useAtomValue(agentSidePanelOpenMapAtom)
+  const setSidePanelOpenMap = useSetAtom(agentSidePanelOpenMapAtom)
+  const sidePanelTabMap = useAtomValue(agentSidePanelTabMapAtom)
+  const setSidePanelTabMap = useSetAtom(agentSidePanelTabMapAtom)
+
+  const isOpen = sidePanelOpenMap.get(sessionId) ?? false
+  const activeTab = sidePanelTabMap.get(sessionId) ?? 'team'
+
+  const setIsOpen = React.useCallback((value: boolean | ((prev: boolean) => boolean)) => {
+    setSidePanelOpenMap((prev) => {
+      const map = new Map(prev)
+      const current = map.get(sessionId) ?? false
+      map.set(sessionId, typeof value === 'function' ? value(current) : value)
+      return map
+    })
+  }, [sessionId, setSidePanelOpenMap])
+
+  const setActiveTab = React.useCallback((tab: SidePanelTab) => {
+    setSidePanelTabMap((prev) => {
+      const map = new Map(prev)
+      map.set(sessionId, tab)
+      return map
+    })
+  }, [sessionId, setSidePanelTabMap])
+
+  // 直接用 sessionId 计算 team 活动（不依赖 currentAgentSessionIdAtom）
+  const streamingStates = useAtomValue(agentStreamingStatesAtom)
+  const cachedActivities = useAtomValue(cachedTeamActivitiesAtom)
+
+  const hasTeamActivity = React.useMemo(() => {
+    const state = streamingStates.get(sessionId)
+    if (state) {
+      return state.toolActivities.some(
+        (a) => a.toolName === 'Task' || a.toolName === 'Agent'
+      )
+    }
+    const cached = cachedActivities.get(sessionId)
+    return cached !== undefined && cached.length > 0
+  }, [sessionId, streamingStates, cachedActivities])
+
+  const runningCount = React.useMemo(() => {
+    const state = streamingStates.get(sessionId)
+    if (state && state.toolActivities.length > 0) {
+      const entries = buildTeamActivityEntries(state.toolActivities)
+      return entries.filter((e) => e.status === 'running' || e.status === 'backgrounded').length
+    }
+    const cached = cachedActivities.get(sessionId)
+    if (cached) {
+      return cached.filter((e) => e.status === 'running' || e.status === 'backgrounded').length
+    }
+    return 0
+  }, [sessionId, streamingStates, cachedActivities])
+
   const filesVersion = useAtomValue(workspaceFilesVersionAtom)
   const hasFileChanges = filesVersion > 0
 

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -22,6 +22,10 @@ import {
   currentConversationIdAtom,
   selectedModelAtom,
   streamingConversationIdsAtom,
+  conversationModelsAtom,
+  conversationContextLengthAtom,
+  conversationThinkingEnabledAtom,
+  conversationParallelModeAtom,
 } from '@/atoms/chat-atoms'
 import {
   agentSessionsAtom,
@@ -31,6 +35,8 @@ import {
   currentAgentWorkspaceIdAtom,
   agentWorkspacesAtom,
   workspaceCapabilitiesVersionAtom,
+  agentSidePanelOpenMapAtom,
+  agentSidePanelTabMapAtom,
 } from '@/atoms/agent-atoms'
 import {
   tabsAtom,
@@ -44,7 +50,7 @@ import {
 import { userProfileAtom } from '@/atoms/user-profile'
 import { hasUpdateAtom } from '@/atoms/updater'
 import { hasEnvironmentIssuesAtom } from '@/atoms/environment'
-import { promptConfigAtom, selectedPromptIdAtom } from '@/atoms/system-prompt-atoms'
+import { promptConfigAtom, selectedPromptIdAtom, conversationPromptIdAtom } from '@/atoms/system-prompt-atoms'
 import { WorkspaceSelector } from '@/components/agent/WorkspaceSelector'
 import {
   AlertDialog,
@@ -172,6 +178,32 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   const [layout, setLayout] = useAtom(splitLayoutAtom)
   const activeTabId = useAtomValue(activeTabIdAtom)
   const [sidebarCollapsed, setSidebarCollapsed] = useAtom(sidebarCollapsedAtom)
+
+  // per-conversation/session Map atoms（删除时清理）
+  const setConvModels = useSetAtom(conversationModelsAtom)
+  const setConvContextLength = useSetAtom(conversationContextLengthAtom)
+  const setConvThinking = useSetAtom(conversationThinkingEnabledAtom)
+  const setConvParallel = useSetAtom(conversationParallelModeAtom)
+  const setConvPromptId = useSetAtom(conversationPromptIdAtom)
+  const setAgentSidePanelOpen = useSetAtom(agentSidePanelOpenMapAtom)
+  const setAgentSidePanelTab = useSetAtom(agentSidePanelTabMapAtom)
+
+  /** 清理 per-conversation/session Map atoms 条目 */
+  const cleanupMapAtoms = React.useCallback((id: string) => {
+    const deleteKey = <T,>(prev: Map<string, T>): Map<string, T> => {
+      if (!prev.has(id)) return prev
+      const map = new Map(prev)
+      map.delete(id)
+      return map
+    }
+    setConvModels(deleteKey)
+    setConvContextLength(deleteKey)
+    setConvThinking(deleteKey)
+    setConvParallel(deleteKey)
+    setConvPromptId(deleteKey)
+    setAgentSidePanelOpen(deleteKey)
+    setAgentSidePanelTab(deleteKey)
+  }, [setConvModels, setConvContextLength, setConvThinking, setConvParallel, setConvPromptId, setAgentSidePanelOpen, setAgentSidePanelTab])
 
   const currentWorkspaceSlug = React.useMemo(() => {
     if (!currentWorkspaceId) return null
@@ -319,6 +351,9 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     const tabResult = closeTab(tabs, layout, pendingDeleteId)
     setTabs(tabResult.tabs)
     setLayout(tabResult.layout)
+
+    // 清理 per-conversation/session Map atoms 条目
+    cleanupMapAtoms(pendingDeleteId)
 
     if (mode === 'agent') {
       // Agent 模式：删除 Agent 会话

--- a/apps/electron/src/renderer/components/chat/ChatHeader.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatHeader.tsx
@@ -5,9 +5,10 @@
  */
 
 import * as React from 'react'
-import { useAtom, useSetAtom } from 'jotai'
+import { useSetAtom } from 'jotai'
 import { Pencil, Check, X, Pin, Columns2 } from 'lucide-react'
-import { conversationsAtom, parallelModeAtom } from '@/atoms/chat-atoms'
+import { conversationsAtom } from '@/atoms/chat-atoms'
+import { useConversationParallelMode } from '@/hooks/useConversationSettings'
 import type { ConversationMeta } from '@proma/shared'
 import { SystemPromptSelector } from './SystemPromptSelector'
 import { Button } from '@/components/ui/button'
@@ -20,7 +21,7 @@ interface ChatHeaderProps {
 
 export function ChatHeader({ conversation }: ChatHeaderProps): React.ReactElement | null {
   const setConversations = useSetAtom(conversationsAtom)
-  const [parallelMode, setParallelMode] = useAtom(parallelModeAtom)
+  const [parallelMode, setParallelMode] = useConversationParallelMode()
   const [editing, setEditing] = React.useState(false)
   const [editTitle, setEditTitle] = React.useState('')
   const inputRef = React.useRef<HTMLInputElement>(null)

--- a/apps/electron/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatInput.tsx
@@ -13,7 +13,7 @@
  */
 
 import * as React from 'react'
-import { useAtom, useAtomValue, useSetAtom } from 'jotai'
+import { useAtomValue, useSetAtom } from 'jotai'
 import { CornerDownLeft, Square, Lightbulb, Paperclip } from 'lucide-react'
 import { ModelSelector } from './ModelSelector'
 import { ClearContextButton } from './ClearContextButton'
@@ -29,11 +29,13 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import {
-  selectedModelAtom,
-  thinkingEnabledAtom,
   conversationDraftsAtom,
 } from '@/atoms/chat-atoms'
 import type { PendingAttachment } from '@/atoms/chat-atoms'
+import {
+  useConversationModel,
+  useConversationThinkingEnabled,
+} from '@/hooks/useConversationSettings'
 import { cn } from '@/lib/utils'
 
 interface ChatInputProps {
@@ -87,8 +89,8 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
     })
   }, [conversationId, setDraftsMap])
 
-  const selectedModel = useAtomValue(selectedModelAtom)
-  const [thinkingEnabled, setThinkingEnabled] = useAtom(thinkingEnabledAtom)
+  const [selectedModel] = useConversationModel()
+  const [thinkingEnabled, setThinkingEnabled] = useConversationThinkingEnabled()
   const setPendingAttachments = onSetPendingAttachments
   const [isDragOver, setIsDragOver] = React.useState(false)
 

--- a/apps/electron/src/renderer/components/chat/ChatMessages.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessages.tsx
@@ -42,9 +42,7 @@ import {
   ReasoningContent,
 } from '@/components/ai-elements/reasoning'
 import { useSmoothStream } from '@proma/ui'
-import {
-  parallelModeAtom,
-} from '@/atoms/chat-atoms'
+import { useConversationParallelMode } from '@/hooks/useConversationSettings'
 import { getModelLogo } from '@/lib/model-logo'
 import { userProfileAtom } from '@/atoms/user-profile'
 import type { ChatMessage, ChatToolActivity } from '@proma/shared'
@@ -195,7 +193,7 @@ export function ChatMessages({
     content: streamingReasoning,
     isStreaming: streaming,
   })
-  const parallelMode = useAtomValue(parallelModeAtom)
+  const [parallelMode] = useConversationParallelMode()
 
   /** 是否正在加载更多历史 */
   const [loadingMore, setLoadingMore] = React.useState(false)

--- a/apps/electron/src/renderer/components/chat/ChatView.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatView.tsx
@@ -14,7 +14,7 @@
  */
 
 import * as React from 'react'
-import { useAtom, useAtomValue, useSetAtom } from 'jotai'
+import { useAtomValue, useSetAtom } from 'jotai'
 import { AlertCircle, X } from 'lucide-react'
 import { ChatHeader } from './ChatHeader'
 import { ChatMessages } from './ChatMessages'
@@ -25,17 +25,23 @@ import type { InlineEditSubmitPayload } from './ChatMessageItem'
 import {
   conversationsAtom,
   streamingStatesAtom,
-  selectedModelAtom,
-  contextLengthAtom,
-  thinkingEnabledAtom,
   chatStreamErrorsAtom,
   chatMessageRefreshAtom,
   pendingAgentRecommendationAtom,
+  conversationModelsAtom,
   INITIAL_MESSAGE_LIMIT,
 } from '@/atoms/chat-atoms'
 import type { PendingAttachment } from '@/atoms/chat-atoms'
-import { resolvedSystemMessageAtom, promptSidebarOpenAtom } from '@/atoms/system-prompt-atoms'
+import { promptConfigAtom, promptSidebarOpenAtom, conversationPromptIdAtom, resolveSystemMessage, selectedPromptIdAtom } from '@/atoms/system-prompt-atoms'
 import { activeToolIdsAtom } from '@/atoms/chat-tool-atoms'
+import { userProfileAtom } from '@/atoms/user-profile'
+import { ConversationProvider } from '@/contexts/session-context'
+import {
+  useConversationModel,
+  useConversationContextLength,
+  useConversationThinkingEnabled,
+  useConversationPromptId,
+} from '@/hooks/useConversationSettings'
 import { registerPendingTitle } from '@/hooks/useGlobalChatListeners'
 import { cn } from '@/lib/utils'
 import type {
@@ -50,6 +56,14 @@ interface ChatViewProps {
 }
 
 export function ChatView({ conversationId }: ChatViewProps): React.ReactElement {
+  return (
+    <ConversationProvider conversationId={conversationId}>
+      <ChatViewInner conversationId={conversationId} />
+    </ConversationProvider>
+  )
+}
+
+function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
   // ===== 本地状态（每个实例独立） =====
   const [messages, setMessages] = React.useState<ChatMessage[]>([])
   const [contextDividers, setContextDividers] = React.useState<string[]>([])
@@ -57,17 +71,22 @@ export function ChatView({ conversationId }: ChatViewProps): React.ReactElement 
   const [hasMoreMessages, setHasMoreMessages] = React.useState(false)
   const [inlineEditingMessageId, setInlineEditingMessageId] = React.useState<string | null>(null)
 
+  // ===== Per-conversation hooks（分屏独立） =====
+  const [selectedModel, setSelectedModel] = useConversationModel()
+  const [contextLength] = useConversationContextLength()
+  const [thinkingEnabled] = useConversationThinkingEnabled()
+  const [conversationPromptId] = useConversationPromptId()
+
   // ===== 全局 atoms（Map 结构，按 conversationId 读取） =====
   const conversations = useAtomValue(conversationsAtom)
   const streamingStates = useAtomValue(streamingStatesAtom)
   const setStreamingStates = useSetAtom(streamingStatesAtom)
-  const [selectedModel, setSelectedModel] = useAtom(selectedModelAtom)
-  const contextLength = useAtomValue(contextLengthAtom)
-  const thinkingEnabled = useAtomValue(thinkingEnabledAtom)
+  const setConversationModels = useSetAtom(conversationModelsAtom)
   const setChatStreamErrors = useSetAtom(chatStreamErrorsAtom)
   const chatStreamErrors = useAtomValue(chatStreamErrorsAtom)
   const refreshMap = useAtomValue(chatMessageRefreshAtom)
-  const resolvedSystemMessage = useAtomValue(resolvedSystemMessageAtom)
+  const promptConfig = useAtomValue(promptConfigAtom)
+  const userProfile = useAtomValue(userProfileAtom)
   const promptSidebarOpen = useAtomValue(promptSidebarOpenAtom)
   const activeToolIds = useAtomValue(activeToolIdsAtom)
   const setPendingRecommendation = useSetAtom(pendingAgentRecommendationAtom)
@@ -119,15 +138,19 @@ export function ChatView({ conversationId }: ChatViewProps): React.ReactElement 
     }
   }, [conversation?.contextDividers])
 
-  // 从对话元数据恢复模型/渠道选择
+  // 从对话元数据恢复模型/渠道选择（写入 per-conversation Map）
   React.useEffect(() => {
     if (conversation?.modelId && conversation?.channelId) {
-      setSelectedModel({
-        channelId: conversation.channelId,
-        modelId: conversation.modelId,
+      setConversationModels((prev) => {
+        const map = new Map(prev)
+        map.set(conversationId, {
+          channelId: conversation.channelId,
+          modelId: conversation.modelId,
+        })
+        return map
       })
     }
-  }, [conversation?.modelId, conversation?.channelId, setSelectedModel])
+  }, [conversationId, conversation?.modelId, conversation?.channelId, setConversationModels])
 
   const syncContextDividers = React.useCallback(async (
     convId: string,
@@ -237,7 +260,7 @@ export function ChatView({ conversationId }: ChatViewProps): React.ReactElement 
       contextDividers: options?.contextDividersOverride ?? contextDividers,
       attachments: savedAttachments.length > 0 ? savedAttachments : undefined,
       thinkingEnabled: thinkingEnabled || undefined,
-      systemMessage: resolvedSystemMessage,
+      systemMessage: resolveSystemMessage(conversationPromptId, promptConfig, userProfile.userName),
       enabledToolIds: activeToolIds.length > 0 ? activeToolIds : undefined,
     }
 
@@ -270,7 +293,9 @@ export function ChatView({ conversationId }: ChatViewProps): React.ReactElement 
     contextLength,
     contextDividers,
     thinkingEnabled,
-    resolvedSystemMessage,
+    conversationPromptId,
+    promptConfig,
+    userProfile.userName,
     activeToolIds,
     setChatStreamErrors,
     setStreamingStates,

--- a/apps/electron/src/renderer/components/chat/ContextSettingsPopover.tsx
+++ b/apps/electron/src/renderer/components/chat/ContextSettingsPopover.tsx
@@ -6,7 +6,6 @@
  */
 
 import { useState } from 'react'
-import { useAtom } from 'jotai'
 import { Button } from '@/components/ui/button'
 import {
   Popover,
@@ -22,10 +21,10 @@ import {
 import { cn } from '@/lib/utils'
 import { Settings2 } from 'lucide-react'
 import {
-  contextLengthAtom,
   CONTEXT_LENGTH_OPTIONS,
   type ContextLengthValue,
 } from '@/atoms/chat-atoms'
+import { useConversationContextLength } from '@/hooks/useConversationSettings'
 
 /** 上下文长度滑块标签 */
 function getContextLengthLabel(value: ContextLengthValue): string {
@@ -47,7 +46,7 @@ function valueToSliderPosition(value: ContextLengthValue): number {
 
 export function ContextSettingsPopover(): React.ReactElement {
   const [open, setOpen] = useState(false)
-  const [contextLength, setContextLength] = useAtom(contextLengthAtom)
+  const [contextLength, setContextLength] = useConversationContextLength()
 
   const sliderPosition = valueToSliderPosition(contextLength)
   const maxSliderPosition = CONTEXT_LENGTH_OPTIONS.length - 1

--- a/apps/electron/src/renderer/components/chat/ModelSelector.tsx
+++ b/apps/electron/src/renderer/components/chat/ModelSelector.tsx
@@ -9,7 +9,7 @@
  */
 
 import * as React from 'react'
-import { useAtom, useAtomValue, useSetAtom } from 'jotai'
+import { useAtomValue, useSetAtom } from 'jotai'
 import { ChevronDown, Cpu, Search } from 'lucide-react'
 import {
   Dialog,
@@ -18,10 +18,10 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import {
-  selectedModelAtom,
-  currentConversationIdAtom,
   conversationsAtom,
 } from '@/atoms/chat-atoms'
+import { useConversationModelOptional } from '@/hooks/useConversationSettings'
+import { useConversationIdOptional } from '@/contexts/session-context'
 import { getModelLogo, getChannelLogo } from '@/lib/model-logo'
 import { cn } from '@/lib/utils'
 import type { Channel, ModelOption } from '@proma/shared'
@@ -79,15 +79,15 @@ export function ModelSelector({
   externalSelectedModel,
   onModelSelect,
 }: ModelSelectorProps = {}): React.ReactElement {
-  const [internalSelectedModel, setInternalSelectedModel] = useAtom(selectedModelAtom)
-  const currentConversationId = useAtomValue(currentConversationIdAtom)
+  const [conversationModel, setConversationModel] = useConversationModelOptional()
+  const conversationId = useConversationIdOptional()
   const setConversations = useSetAtom(conversationsAtom)
   const [channels, setChannels] = React.useState<Channel[]>([])
   const [open, setOpen] = React.useState(false)
   const [search, setSearch] = React.useState('')
 
-  // 外部模型优先，否则用内部 atom
-  const selectedModel = externalSelectedModel !== undefined ? externalSelectedModel : internalSelectedModel
+  // 外部模型优先 → per-conversation 模型
+  const selectedModel = externalSelectedModel !== undefined ? externalSelectedModel : conversationModel
 
   // 加载渠道列表
   React.useEffect(() => {
@@ -167,13 +167,16 @@ export function ModelSelector({
       return
     }
 
-    setInternalSelectedModel({ channelId: option.channelId, modelId: option.modelId })
+    // Chat 模式：写入 per-conversation Map
+    if (setConversationModel) {
+      setConversationModel({ channelId: option.channelId, modelId: option.modelId })
+    }
     setOpen(false)
 
     // 将模型/渠道选择保存到当前对话元数据
-    if (currentConversationId) {
+    if (conversationId) {
       window.electronAPI
-        .updateConversationModel(currentConversationId, option.modelId, option.channelId)
+        .updateConversationModel(conversationId, option.modelId, option.channelId)
         .then((updated) => {
           setConversations((prev) =>
             prev.map((c) => (c.id === updated.id ? updated : c))

--- a/apps/electron/src/renderer/components/chat/SystemPromptSelector.tsx
+++ b/apps/electron/src/renderer/components/chat/SystemPromptSelector.tsx
@@ -15,15 +15,15 @@ import {
 } from '@/components/ui/dropdown-menu'
 import {
   promptConfigAtom,
-  selectedPromptIdAtom,
   defaultPromptIdAtom,
   promptSidebarOpenAtom,
 } from '@/atoms/system-prompt-atoms'
+import { useConversationPromptId } from '@/hooks/useConversationSettings'
 import { cn } from '@/lib/utils'
 
 export function SystemPromptSelector(): React.ReactElement {
   const [config, setConfig] = useAtom(promptConfigAtom)
-  const [selectedId, setSelectedId] = useAtom(selectedPromptIdAtom)
+  const [selectedId, setSelectedId] = useConversationPromptId()
   const defaultPromptId = useAtomValue(defaultPromptIdAtom)
   const setPromptSidebarOpen = useSetAtom(promptSidebarOpenAtom)
   const [open, setOpen] = React.useState(false)

--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -10,7 +10,7 @@
  */
 
 import * as React from 'react'
-import { useAtom, useAtomValue } from 'jotai'
+import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import {
   tabsAtom,
   splitLayoutAtom,
@@ -21,6 +21,17 @@ import {
   focusTab,
   reorderTabs,
 } from '@/atoms/tab-atoms'
+import {
+  conversationModelsAtom,
+  conversationContextLengthAtom,
+  conversationThinkingEnabledAtom,
+  conversationParallelModeAtom,
+} from '@/atoms/chat-atoms'
+import {
+  agentSidePanelOpenMapAtom,
+  agentSidePanelTabMapAtom,
+} from '@/atoms/agent-atoms'
+import { conversationPromptIdAtom } from '@/atoms/system-prompt-atoms'
 import { TabBarItem } from './TabBarItem'
 import { SplitModeToggle } from './SplitModeToggle'
 
@@ -30,6 +41,34 @@ export function TabBar(): React.ReactElement {
   const activeTabId = useAtomValue(activeTabIdAtom)
   const streamingMap = useAtomValue(tabStreamingMapAtom)
   const scrollRef = React.useRef<HTMLDivElement>(null)
+
+  // per-conversation/session Map atoms（用于关闭标签时清理）
+  const setConvModels = useSetAtom(conversationModelsAtom)
+  const setConvContextLength = useSetAtom(conversationContextLengthAtom)
+  const setConvThinking = useSetAtom(conversationThinkingEnabledAtom)
+  const setConvParallel = useSetAtom(conversationParallelModeAtom)
+  const setConvPromptId = useSetAtom(conversationPromptIdAtom)
+  const setAgentSidePanelOpen = useSetAtom(agentSidePanelOpenMapAtom)
+  const setAgentSidePanelTab = useSetAtom(agentSidePanelTabMapAtom)
+
+  /** 清理关闭标签对应的 per-conversation/session Map atoms 条目 */
+  const cleanupMapAtoms = React.useCallback((tabId: string) => {
+    const deleteKey = <T,>(prev: Map<string, T>): Map<string, T> => {
+      if (!prev.has(tabId)) return prev
+      const map = new Map(prev)
+      map.delete(tabId)
+      return map
+    }
+    // Chat per-conversation atoms
+    setConvModels(deleteKey)
+    setConvContextLength(deleteKey)
+    setConvThinking(deleteKey)
+    setConvParallel(deleteKey)
+    setConvPromptId(deleteKey)
+    // Agent per-session atoms
+    setAgentSidePanelOpen(deleteKey)
+    setAgentSidePanelTab(deleteKey)
+  }, [setConvModels, setConvContextLength, setConvThinking, setConvParallel, setConvPromptId, setAgentSidePanelOpen, setAgentSidePanelTab])
 
   // 拖拽状态
   const dragState = React.useRef<{
@@ -50,7 +89,9 @@ export function TabBar(): React.ReactElement {
       setTimeout(() => setLayout(result.layout), 0)
       return result.tabs
     })
-  }, [layout, setTabs, setLayout])
+    // 清理 per-conversation/session Map atoms 条目，防止内存泄漏
+    cleanupMapAtoms(tabId)
+  }, [layout, setTabs, setLayout, cleanupMapAtoms])
 
   const handleDragStart = React.useCallback((tabId: string, e: React.PointerEvent) => {
     if (e.button !== 0) return // 只处理左键

--- a/apps/electron/src/renderer/contexts/session-context.tsx
+++ b/apps/electron/src/renderer/contexts/session-context.tsx
@@ -1,0 +1,60 @@
+/**
+ * Session Context — 为 ChatView / AgentView 提供 conversationId / sessionId
+ *
+ * 避免逐层 props 透传，子组件通过 useConversationId() / useAgentSessionId() 获取。
+ */
+
+import * as React from 'react'
+
+// ===== Conversation（Chat 模式）=====
+
+const ConversationContext = React.createContext<string | null>(null)
+
+export function ConversationProvider({
+  conversationId,
+  children,
+}: {
+  conversationId: string
+  children: React.ReactNode
+}): React.ReactElement {
+  return (
+    <ConversationContext.Provider value={conversationId}>
+      {children}
+    </ConversationContext.Provider>
+  )
+}
+
+export function useConversationId(): string {
+  const id = React.useContext(ConversationContext)
+  if (!id) throw new Error('useConversationId 必须在 ConversationProvider 内使用')
+  return id
+}
+
+/** 可选版本：在 Provider 外返回 null（用于 ModelSelector 等双模式组件） */
+export function useConversationIdOptional(): string | null {
+  return React.useContext(ConversationContext)
+}
+
+// ===== Agent Session =====
+
+const AgentSessionContext = React.createContext<string | null>(null)
+
+export function AgentSessionProvider({
+  sessionId,
+  children,
+}: {
+  sessionId: string
+  children: React.ReactNode
+}): React.ReactElement {
+  return (
+    <AgentSessionContext.Provider value={sessionId}>
+      {children}
+    </AgentSessionContext.Provider>
+  )
+}
+
+export function useAgentSessionId(): string {
+  const id = React.useContext(AgentSessionContext)
+  if (!id) throw new Error('useAgentSessionId 必须在 AgentSessionProvider 内使用')
+  return id
+}

--- a/apps/electron/src/renderer/hooks/useConversationSettings.ts
+++ b/apps/electron/src/renderer/hooks/useConversationSettings.ts
@@ -1,0 +1,125 @@
+/**
+ * useConversationSettings — per-conversation 设置读写 hooks
+ *
+ * 从 Map atoms 中按 conversationId 读取，缺省时返回全局默认值。
+ * 通过 ConversationContext 获取 conversationId，避免 props 透传。
+ */
+
+import * as React from 'react'
+import { useAtomValue, useSetAtom } from 'jotai'
+import { useConversationId, useConversationIdOptional } from '@/contexts/session-context'
+import {
+  selectedModelAtom,
+  contextLengthAtom,
+  thinkingEnabledAtom,
+  conversationModelsAtom,
+  conversationContextLengthAtom,
+  conversationThinkingEnabledAtom,
+  conversationParallelModeAtom,
+} from '@/atoms/chat-atoms'
+import type { SelectedModel, ContextLengthValue } from '@/atoms/chat-atoms'
+import {
+  selectedPromptIdAtom,
+  conversationPromptIdAtom,
+} from '@/atoms/system-prompt-atoms'
+
+// ===== 通用 Map 读写辅助 =====
+
+type MapAtom<T> = ReturnType<typeof import('jotai').atom<Map<string, T>>>
+
+function useMapValue<T>(mapAtom: MapAtom<T>, key: string, defaultValue: T): T {
+  const map = useAtomValue(mapAtom)
+  return map.get(key) ?? defaultValue
+}
+
+function useMapSetter<T>(
+  mapAtom: MapAtom<T>,
+  key: string,
+): (value: T | ((prev: T) => T)) => void {
+  const setMap = useSetAtom(mapAtom)
+  return React.useCallback(
+    (value: T | ((prev: T) => T)) => {
+      setMap((prev) => {
+        const map = new Map(prev)
+        if (typeof value === 'function') {
+          const current = map.get(key)
+          map.set(key, (value as (prev: T) => T)(current as T))
+        } else {
+          map.set(key, value)
+        }
+        return map
+      })
+    },
+    [key, setMap],
+  )
+}
+
+// ===== Per-conversation Hooks =====
+
+/** 每个对话独立的模型选择 */
+export function useConversationModel(): [SelectedModel | null, (m: SelectedModel | null) => void] {
+  const conversationId = useConversationId()
+  const defaultModel = useAtomValue(selectedModelAtom)
+  const value = useMapValue(conversationModelsAtom, conversationId, defaultModel)
+  const setter = useMapSetter(conversationModelsAtom, conversationId)
+  return [value, setter]
+}
+
+/** 可选版本：在 Provider 外返回 null（ModelSelector 双模式用） */
+export function useConversationModelOptional(): [SelectedModel | null, ((m: SelectedModel | null) => void) | null] {
+  const conversationId = useConversationIdOptional()
+  const defaultModel = useAtomValue(selectedModelAtom)
+  const map = useAtomValue(conversationModelsAtom)
+  const setMap = useSetAtom(conversationModelsAtom)
+
+  const value = conversationId ? (map.get(conversationId) ?? defaultModel) : null
+
+  const setter = React.useCallback(
+    (model: SelectedModel | null) => {
+      if (!conversationId) return
+      setMap((prev) => {
+        const m = new Map(prev)
+        m.set(conversationId, model)
+        return m
+      })
+    },
+    [conversationId, setMap],
+  )
+
+  return [value, conversationId ? setter : null]
+}
+
+/** 每个对话独立的上下文长度 */
+export function useConversationContextLength(): [ContextLengthValue, (v: ContextLengthValue) => void] {
+  const conversationId = useConversationId()
+  const defaultLength = useAtomValue(contextLengthAtom)
+  const value = useMapValue(conversationContextLengthAtom, conversationId, defaultLength)
+  const setter = useMapSetter(conversationContextLengthAtom, conversationId)
+  return [value, setter]
+}
+
+/** 每个对话独立的思考模式 */
+export function useConversationThinkingEnabled(): [boolean, (v: boolean) => void] {
+  const conversationId = useConversationId()
+  const defaultEnabled = useAtomValue(thinkingEnabledAtom)
+  const value = useMapValue(conversationThinkingEnabledAtom, conversationId, defaultEnabled)
+  const setter = useMapSetter(conversationThinkingEnabledAtom, conversationId)
+  return [value, setter]
+}
+
+/** 每个对话独立的并排模式 */
+export function useConversationParallelMode(): [boolean, (v: boolean) => void] {
+  const conversationId = useConversationId()
+  const value = useMapValue(conversationParallelModeAtom, conversationId, false)
+  const setter = useMapSetter(conversationParallelModeAtom, conversationId)
+  return [value, setter]
+}
+
+/** 每个对话独立的系统提示词 ID */
+export function useConversationPromptId(): [string, (v: string) => void] {
+  const conversationId = useConversationId()
+  const defaultPromptId = useAtomValue(selectedPromptIdAtom)
+  const value = useMapValue(conversationPromptIdAtom, conversationId, defaultPromptId)
+  const setter = useMapSetter(conversationPromptIdAtom, conversationId)
+  return [value, setter]
+}

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -18,9 +18,8 @@ import {
   allPendingAskUserRequestsAtom,
   agentPromptSuggestionsAtom,
   backgroundTasksAtomFamily,
-  agentSidePanelOpenAtom,
-  agentSidePanelTabAtom,
-  currentAgentSessionIdAtom,
+  agentSidePanelOpenMapAtom,
+  agentSidePanelTabMapAtom,
   cachedTeamActivitiesAtom,
   buildTeamActivityEntries,
   applyAgentEvent,
@@ -59,11 +58,16 @@ export function useGlobalAgentListeners(): void {
 
         // 自动打开侧面板：检测到 Agent/Task 工具启动时
         if (event.type === 'tool_start' && (event.toolName === 'Agent' || event.toolName === 'Task')) {
-          const currentSessionId = store.get(currentAgentSessionIdAtom)
-          if (sessionId === currentSessionId) {
-            store.set(agentSidePanelOpenAtom, true)
-            store.set(agentSidePanelTabAtom, 'team')
-          }
+          store.set(agentSidePanelOpenMapAtom, (prev) => {
+            const map = new Map(prev)
+            map.set(sessionId, true)
+            return map
+          })
+          store.set(agentSidePanelTabMapAtom, (prev) => {
+            const map = new Map(prev)
+            map.set(sessionId, 'team')
+            return map
+          })
         }
 
         // 处理后台任务事件


### PR DESCRIPTION
## Summary

- 将全局 Jotai atoms 改为 per-conversation/session Map atoms，解决分屏模式下多面板共享状态的问题
- Chat 模式：模型选择、上下文长度、思考模式、并排模式、系统提示词现在各面板独立
- Agent 模式：侧面板开关和 Tab 选择现在各面板独立

## 实现方式

- 新增 `ConversationProvider` / `AgentSessionProvider` React Context 传递 conversationId/sessionId
- 新增 `useConversationSettings` hooks 封装 per-conversation 状态读写（fallback 到全局默认值）
- 原有 `atomWithStorage` atoms 保留作为新对话的默认值模板
- TabBar / LeftSidebar 关闭标签时自动清理 Map 条目，防止内存泄漏

## 涉及文件

- 新增：`contexts/session-context.tsx`、`hooks/useConversationSettings.ts`
- atoms：`chat-atoms.ts`（+4 Map atoms）、`system-prompt-atoms.ts`（+Map + 纯函数）、`agent-atoms.ts`（Map 化侧面板 atoms）
- Chat 组件：ChatView、ChatHeader、ChatInput、ChatMessages、ModelSelector、ContextSettingsPopover、SystemPromptSelector
- Agent 组件：AgentView、SidePanel
- 全局：useGlobalAgentListeners、TabBar、LeftSidebar

## Test plan

- [ ] Chat 模式分屏：切换一个面板的模型/上下文长度/思考模式/并排模式/系统提示词，另一个面板不受影响
- [ ] Agent 模式分屏：打开/关闭一个面板的侧面板、切换 Tab，另一个面板不受影响
- [ ] 新建对话仍继承上次使用的模型/上下文长度等默认值
- [ ] 关闭标签页后重新打开同一对话，状态正常
- [ ] 删除对话/会话时 Map 条目被正确清理