### PR TITLE
fix: 去掉 Agent 错误消息的未知错误前缀

### DIFF
--- a/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
@@ -195,7 +195,7 @@ function mapSDKErrorToTypedError(
 
   const mapped = errorMap[errorCode] || {
     code: 'unknown_error' as ErrorCode,
-    title: '未知错误',
+    title: '',
     message: detailedMessage || errorCode,
     canRetry: false,
   }


### PR DESCRIPTION
## Summary
- Agent 模式下未映射的 SDK 错误码（如第三方 API 返回的无效 API key、模型不存在、余额不足等）fallback title 从 `'未知错误'` 改为空字符串
- 下游 `agent-orchestrator.ts` 的三元拼接逻辑 `title ? \`${title}: ${message}\` : message` 自动跳过空 title，直接展示 SDK 原始错误消息
- 已映射的 4 种错误（认证失败、账单错误、频率限制、服务繁忙）不受影响，仍保留中文 title

**修改前**：`未知错误: Invalid API key · Fix external API key`
**修改后**：`Invalid API key · Fix external API key`

## Test plan
- [ ] 使用无效 API Key 触发认证错误，确认不显示"未知错误"前缀
- [ ] 使用不存在的模型代码触发错误，确认直接显示原始消息
- [ ] 触发 rate_limited 等已映射错误，确认仍显示中文 title（如"请求频率限制"）