### PR TITLE
fix: 隔离 Agent SDK 认证凭证，防止本地环境变量干扰

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {
@@ -37,7 +37,7 @@
     "dist:debug": "bun run scripts/dist.ts --current-arch --verbose"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.2.63",
+    "@anthropic-ai/claude-agent-sdk": "0.2.66",
     "@emoji-mart/data": "^1.2.1",
     "@emoji-mart/react": "^1.1.1",
     "@proma/core": "workspace:*",

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -1,6 +1,16 @@
 import { app, BrowserWindow, Menu, screen, shell } from 'electron'
 import { join } from 'path'
 import { existsSync } from 'fs'
+
+// 清理本地环境中的 ANTHROPIC_* 变量，防止干扰应用的认证流程
+// Electron 桌面应用通过渠道系统管理 API Key，不应受终端环境变量影响
+// 注意：此操作必须在 initializeRuntime()（loadShellEnv）之前执行
+for (const key of Object.keys(process.env)) {
+  if (key.startsWith('ANTHROPIC_')) {
+    delete process.env[key]
+  }
+}
+
 import { createApplicationMenu } from './menu'
 import { registerIpcHandlers } from './ipc'
 import { createTray, destroyTray } from './tray'

--- a/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
@@ -618,6 +618,10 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
         abortController: controller,
         env: options.env,
         systemPrompt: options.systemPrompt,
+        // 不加载 user 级别的 ~/.claude/settings.json，防止其中的 env 字段
+        // （如 ANTHROPIC_AUTH_TOKEN、ANTHROPIC_BASE_URL）覆盖我们注入的凭证。
+        // 保留 project 级别以支持 CLAUDE.md 加载。
+        settingSources: ['project'],
 
         // 条件字段
         ...(options.canUseTool && { canUseTool: options.canUseTool }),

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -305,8 +305,21 @@ export class AgentOrchestrator {
     baseUrl: string | undefined,
   ): Promise<Record<string, string | undefined>> {
     const DEFAULT_ANTHROPIC_URL = 'https://api.anthropic.com'
+
+    // 从 process.env 继承系统变量，但清理所有 ANTHROPIC_ 前缀的变量，
+    // 防止本地开发环境（如 ANTHROPIC_AUTH_TOKEN、ANTHROPIC_API_KEY、
+    // ANTHROPIC_BASE_URL 等）干扰 SDK 的认证和请求目标。
+    // 即使 index.ts 启动时已清理过一次，initializeRuntime() 中的
+    // loadShellEnv() 可能从 shell 配置文件（~/.zshrc 等）重新注入这些变量。
+    const cleanEnv: Record<string, string | undefined> = {}
+    for (const [key, value] of Object.entries(process.env)) {
+      if (!key.startsWith('ANTHROPIC_')) {
+        cleanEnv[key] = value
+      }
+    }
+
     const sdkEnv: Record<string, string | undefined> = {
-      ...process.env,
+      ...cleanEnv,
       ANTHROPIC_API_KEY: apiKey,
       // 提升输出 token 上限，避免 "exceeded 32000 output token maximum" 错误
       CLAUDE_CODE_MAX_OUTPUT_TOKENS: '64000',
@@ -316,14 +329,13 @@ export class AgentOrchestrator {
       CLAUDE_CODE_ENABLE_TASKS: 'true',
     }
 
+    // 显式控制 ANTHROPIC_BASE_URL：仅在用户配置了自定义 Base URL 时注入
     if (baseUrl && baseUrl !== DEFAULT_ANTHROPIC_URL) {
       sdkEnv.ANTHROPIC_BASE_URL = baseUrl
         .trim()
         .replace(/\/+$/, '')
         .replace(/\/v\d+\/messages$/, '')
         .replace(/\/v\d+$/, '')
-    } else {
-      delete sdkEnv.ANTHROPIC_BASE_URL
     }
 
     const proxyUrl = await getEffectiveProxyUrl()
@@ -603,6 +615,16 @@ export class AgentOrchestrator {
     }
 
     // 3. 构建环境变量
+    // 同步凭证到 process.env（SDK in-process 代码可能直接读取 process.env）
+    // 先清理再注入，确保 SDK 无论从 env 选项还是 process.env 都拿到正确值
+    delete process.env.ANTHROPIC_API_KEY
+    delete process.env.ANTHROPIC_AUTH_TOKEN
+    delete process.env.ANTHROPIC_BASE_URL
+    process.env.ANTHROPIC_API_KEY = apiKey
+    if (channel.baseUrl) {
+      process.env.ANTHROPIC_BASE_URL = channel.baseUrl
+    }
+
     const sdkEnv = await this.buildSdkEnv(apiKey, channel.baseUrl)
 
     // 4. 读取已有的 SDK session ID（用于 resume）

--- a/bun.lock
+++ b/bun.lock
@@ -19,9 +19,9 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.5.0",
+      "version": "0.6.1",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.2.63",
+        "@anthropic-ai/claude-agent-sdk": "0.2.66",
         "@emoji-mart/data": "^1.2.1",
         "@emoji-mart/react": "^1.1.1",
         "@proma/core": "workspace:*",
@@ -138,7 +138,7 @@
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.63", "", { "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-ZNiaQb/v6xkbrGt3dtq5J0DGY+AaOhoehUyposa3msvlAlkTHWNGR+NhbCcTE0ML1U91xhPqMAAwZIUqrlkKyQ=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.66", "", { "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-hJL+j35yIkhcryR0kkszLz00lsEWBMu3qx8hazIHh55QV2nnZ6cn3p6oi04/VT84J9YU90jfmDffTQ66RD7YZg=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.71.2", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-TGNDEUuEstk/DKu0/TflXAEt+p+p/WhTlFzEnoosvbaDU2LTjm42igSdlL0VijrKpWejtOKxX0b8A7uc+XiSAQ=="],
 


### PR DESCRIPTION
## Summary

Agent SDK 子进程会从多个来源获取认证信息（环境变量 + `~/.claude/settings.json`），导致用户本地开发环境中的 `ANTHROPIC_*` 变量覆盖应用通过渠道系统注入的凭证，表现为"无效的令牌"错误。

### 根本原因

1. **环境变量污染**：用户 shell 配置文件（`~/.zshrc`/`.bashrc`）中定义的 `ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL` 等变量会被 Electron 进程继承。即使启动时清理了，`initializeRuntime()` 中的 `loadShellEnv()` 也可能重新注入。

2. **settings.json 覆盖**：`~/.claude/settings.json` 的 `env` 字段（如 `ANTHROPIC_AUTH_TOKEN`、`ANTHROPIC_BASE_URL`）会在 SDK CLI 子进程启动时被读取，优先级高于通过 `env` 选项传递的环境变量。

### 修复方案（三层防护）

| 层级 | 位置 | 作用 |
|------|------|------|
| 1 | `index.ts` 启动时 | 清理 `process.env` 中所有 `ANTHROPIC_*` 变量 |
| 2 | `buildSdkEnv()` | 构建 SDK 环境时再次过滤 `ANTHROPIC_*`，防止 `loadShellEnv()` 重新注入 |
| 3 | `claude-agent-adapter.ts` | SDK 选项添加 `settingSources: ['project']`，阻止 CLI 子进程加载 `~/.claude/settings.json` |

### 其他改动

- 升级 `@anthropic-ai/claude-agent-sdk` 0.2.63 → 0.2.66（修复 MCP/hooks/canUseTool stdin 关闭问题）
- `buildSdkEnv` 中移除 `else { delete sdkEnv.ANTHROPIC_BASE_URL }`（已由过滤逻辑处理）
- SDK 调用前同步凭证到 `process.env`（参考 craft-agents-oss 模式）

## Test plan

- [ ] 在本地 `~/.zshrc` 中设置 `export ANTHROPIC_API_KEY=sk-invalid-test`，启动应用，验证 Agent 模式仍能使用渠道配置的正确 API Key
- [ ] 在 `~/.claude/settings.json` 中配置 `env.ANTHROPIC_BASE_URL` 指向无效地址，验证 Agent 请求不受影响
- [ ] 验证 Agent 模式正常流式输出、工具调用、resume 等功能不受影响
- [ ] 验证 CLAUDE.md 仍能正常加载（`settingSources` 保留了 `'project'`）