### PR TITLE
fix: 缩小迷你地图触发区域，仅右上角响应悬浮

### DIFF
--- a/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
@@ -94,7 +94,7 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
 
   return (
     <div
-      className="absolute right-0 top-0 bottom-0 z-10 flex items-start"
+      className="absolute right-0 top-0 z-10 flex items-start"
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >


### PR DESCRIPTION
## Summary
- 移除迷你地图外层容器的 `bottom-0`，使触发区域由内容自然撑开
- 修复鼠标在右下角移动也会意外触发迷你地图弹出的问题

## Test plan
- [ ] 鼠标移到右上角迷你地图条区域，确认弹出面板正常显示
- [ ] 鼠标在右下角移动，确认不再意外触发迷你地图
- [ ] 点击弹出面板中的消息项，确认跳转正常