### PR TITLE
feat: 支持 Agent 会话跨工作区迁移

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -55,6 +55,7 @@ import type {
   ChatToolInfo,
   ChatToolState,
   ChatToolMeta,
+  MoveSessionToWorkspaceInput,
 } from '@proma/shared'
 import type { UserProfile, AppSettings } from '../types'
 import { getRuntimeStatus, getGitRepoStatus } from './lib/runtime-init'
@@ -100,8 +101,9 @@ import {
   updateAgentSessionMeta,
   deleteAgentSession,
   migrateChatToAgentSession,
+  moveSessionToWorkspace,
 } from './lib/agent-session-manager'
-import { runAgent, stopAgent, generateAgentTitle, saveFilesToAgentSession, copyFolderToSession } from './lib/agent-service'
+import { runAgent, stopAgent, generateAgentTitle, saveFilesToAgentSession, copyFolderToSession, isAgentSessionActive } from './lib/agent-service'
 import { permissionService } from './lib/agent-permission-service'
 import { askUserService } from './lib/agent-ask-user-service'
 import { getAgentSessionWorkspacePath, getAgentWorkspacesDir, getWorkspaceSkillsDir } from './lib/config-paths'
@@ -590,6 +592,17 @@ export function registerIpcHandlers(): void {
       const current = sessions.find((s) => s.id === id)
       if (!current) throw new Error(`Agent 会话不存在: ${id}`)
       return updateAgentSessionMeta(id, { pinned: !current.pinned })
+    }
+  )
+
+  // 迁移 Agent 会话到另一个工作区
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.MOVE_SESSION_TO_WORKSPACE,
+    async (_, input: MoveSessionToWorkspaceInput): Promise<AgentSessionMeta> => {
+      if (isAgentSessionActive(input.sessionId)) {
+        throw new Error('会话正在运行中，请停止后再迁移')
+      }
+      return moveSessionToWorkspace(input.sessionId, input.targetWorkspaceId)
     }
   )
 

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -115,6 +115,13 @@ export function stopAgent(sessionId: string): void {
   orchestrator.stop(sessionId)
 }
 
+/**
+ * 检查指定会话是否正在运行
+ */
+export function isAgentSessionActive(sessionId: string): boolean {
+  return orchestrator.isActive(sessionId)
+}
+
 /** 中止所有活跃的 Agent 会话（应用退出时调用） */
 export function stopAllAgents(): void {
   orchestrator.stopAll()

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -8,13 +8,15 @@
  * 照搬 conversation-manager.ts 的模式。
  */
 
-import { readFileSync, writeFileSync, appendFileSync, existsSync, unlinkSync, rmSync } from 'node:fs'
+import { readFileSync, writeFileSync, appendFileSync, existsSync, unlinkSync, rmSync, renameSync } from 'node:fs'
 import { randomUUID } from 'node:crypto'
+import { join } from 'node:path'
 import {
   getAgentSessionsIndexPath,
   getAgentSessionsDir,
   getAgentSessionMessagesPath,
   getAgentSessionWorkspacePath,
+  getAgentWorkspacePath,
 } from './config-paths'
 import { getAgentWorkspace } from './agent-workspace-manager'
 import type { AgentSessionMeta, AgentMessage } from '@proma/shared'
@@ -224,6 +226,63 @@ export function deleteAgentSession(id: string): void {
   }
 
   console.log(`[Agent 会话] 已删除会话: ${removed.title} (${removed.id})`)
+}
+
+/**
+ * 迁移 Agent 会话到另一个工作区
+ *
+ * 操作步骤：
+ * 1. 验证会话和目标工作区存在
+ * 2. 源 == 目标 → no-op
+ * 3. 移动会话工作目录到目标工作区
+ * 4. 更新元数据（workspaceId + 清空 sdkSessionId）
+ * 5. JSONL 消息文件保持原位（全局目录）
+ */
+export function moveSessionToWorkspace(sessionId: string, targetWorkspaceId: string): AgentSessionMeta {
+  const index = readIndex()
+  const idx = index.sessions.findIndex((s) => s.id === sessionId)
+  if (idx === -1) {
+    throw new Error(`Agent 会话不存在: ${sessionId}`)
+  }
+
+  const session = index.sessions[idx]!
+
+  // 源 == 目标 → 直接返回
+  if (session.workspaceId === targetWorkspaceId) return session
+
+  const targetWs = getAgentWorkspace(targetWorkspaceId)
+  if (!targetWs) {
+    throw new Error(`目标工作区不存在: ${targetWorkspaceId}`)
+  }
+
+  // 移动工作目录（如果源工作区存在）
+  if (session.workspaceId) {
+    const sourceWs = getAgentWorkspace(session.workspaceId)
+    if (sourceWs) {
+      const srcDir = join(getAgentWorkspacePath(sourceWs.slug), sessionId)
+      if (existsSync(srcDir)) {
+        const destDir = join(getAgentWorkspacePath(targetWs.slug), sessionId)
+        renameSync(srcDir, destDir)
+        console.log(`[Agent 会话] 已移动工作目录: ${srcDir} → ${destDir}`)
+      }
+    }
+  }
+
+  // 确保目标工作区下有 session 目录
+  getAgentSessionWorkspacePath(targetWs.slug, sessionId)
+
+  // 更新元数据
+  const updated: AgentSessionMeta = {
+    ...session,
+    workspaceId: targetWorkspaceId,
+    sdkSessionId: undefined, // SDK 上下文与工作区 cwd 绑定，必须清空
+    updatedAt: Date.now(),
+  }
+  index.sessions[idx] = updated
+  writeIndex(index)
+
+  console.log(`[Agent 会话] 已迁移会话到工作区: ${updated.title} → ${targetWs.name}`)
+  return updated
 }
 
 /**

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -65,6 +65,7 @@ import type {
   ChatToolInfo,
   ChatToolState,
   ChatToolMeta,
+  MoveSessionToWorkspaceInput,
 } from '@proma/shared'
 import type { UserProfile, AppSettings } from '../types'
 
@@ -262,6 +263,9 @@ export interface ElectronAPI {
 
   /** 切换 Agent 会话置顶状态 */
   togglePinAgentSession: (id: string) => Promise<AgentSessionMeta>
+
+  /** 迁移 Agent 会话到另一个工作区 */
+  moveAgentSessionToWorkspace: (input: MoveSessionToWorkspaceInput) => Promise<AgentSessionMeta>
 
   /** 生成 Agent 会话标题 */
   generateAgentTitle: (input: AgentGenerateTitleInput) => Promise<string | null>
@@ -707,6 +711,10 @@ const electronAPI: ElectronAPI = {
 
   togglePinAgentSession: (id: string) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.TOGGLE_PIN, id)
+  },
+
+  moveAgentSessionToWorkspace: (input: MoveSessionToWorkspaceInput) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.MOVE_SESSION_TO_WORKSPACE, input)
   },
 
   generateAgentTitle: (input: AgentGenerateTitleInput) => {

--- a/apps/electron/src/renderer/components/agent/MoveSessionDialog.tsx
+++ b/apps/electron/src/renderer/components/agent/MoveSessionDialog.tsx
@@ -1,0 +1,118 @@
+/**
+ * MoveSessionDialog - 迁移会话到另一个工作区的对话框
+ */
+
+import * as React from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Button } from '@/components/ui/button'
+import type { AgentWorkspace, AgentSessionMeta } from '@proma/shared'
+
+interface MoveSessionDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  sessionId: string
+  currentWorkspaceId: string | undefined
+  workspaces: AgentWorkspace[]
+  onMoved: (updatedSession: AgentSessionMeta) => void
+}
+
+export function MoveSessionDialog({
+  open,
+  onOpenChange,
+  sessionId,
+  currentWorkspaceId,
+  workspaces,
+  onMoved,
+}: MoveSessionDialogProps): React.ReactElement {
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = React.useState<string>('')
+  const [moving, setMoving] = React.useState(false)
+
+  // 过滤掉当前工作区
+  const availableWorkspaces = React.useMemo(
+    () => workspaces.filter((ws) => ws.id !== currentWorkspaceId),
+    [workspaces, currentWorkspaceId]
+  )
+
+  // 打开时重置选择
+  React.useEffect(() => {
+    if (open) {
+      setSelectedWorkspaceId('')
+      setMoving(false)
+    }
+  }, [open])
+
+  const handleConfirm = async (): Promise<void> => {
+    if (!selectedWorkspaceId || moving) return
+
+    setMoving(true)
+    try {
+      const updated = await window.electronAPI.moveAgentSessionToWorkspace({
+        sessionId,
+        targetWorkspaceId: selectedWorkspaceId,
+      })
+      onMoved(updated)
+      onOpenChange(false)
+    } catch (error) {
+      console.error('[迁移会话] 迁移失败:', error)
+      setMoving(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>迁移到其他工作区</DialogTitle>
+          <DialogDescription>
+            选择目标工作区，会话将完整迁移过去。
+          </DialogDescription>
+        </DialogHeader>
+
+        {availableWorkspaces.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-2">
+            没有其他可用的工作区，请先创建新的工作区。
+          </p>
+        ) : (
+          <Select value={selectedWorkspaceId} onValueChange={setSelectedWorkspaceId}>
+            <SelectTrigger>
+              <SelectValue placeholder="选择目标工作区" />
+            </SelectTrigger>
+            <SelectContent>
+              {availableWorkspaces.map((ws) => (
+                <SelectItem key={ws.id} value={ws.id}>
+                  {ws.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={moving}>
+            取消
+          </Button>
+          <Button
+            onClick={handleConfirm}
+            disabled={!selectedWorkspaceId || moving || availableWorkspaces.length === 0}
+          >
+            {moving ? '迁移中...' : '确认迁移'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -10,7 +10,7 @@
 
 import * as React from 'react'
 import { useAtom, useSetAtom, useAtomValue } from 'jotai'
-import { Pin, PinOff, Settings, Plus, Trash2, Pencil, ChevronDown, ChevronRight, Plug, Zap, PanelLeftClose, PanelLeftOpen } from 'lucide-react'
+import { Pin, PinOff, Settings, Plus, Trash2, Pencil, ChevronDown, ChevronRight, Plug, Zap, PanelLeftClose, PanelLeftOpen, ArrowRightLeft } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { ModeSwitcher } from './ModeSwitcher'
@@ -52,6 +52,7 @@ import { hasUpdateAtom } from '@/atoms/updater'
 import { hasEnvironmentIssuesAtom } from '@/atoms/environment'
 import { promptConfigAtom, selectedPromptIdAtom, conversationPromptIdAtom } from '@/atoms/system-prompt-atoms'
 import { WorkspaceSelector } from '@/components/agent/WorkspaceSelector'
+import { MoveSessionDialog } from '@/components/agent/MoveSessionDialog'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -148,6 +149,8 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   const [hoveredId, setHoveredId] = React.useState<string | null>(null)
   /** 待删除对话 ID，非空时显示确认弹窗 */
   const [pendingDeleteId, setPendingDeleteId] = React.useState<string | null>(null)
+  /** 待迁移会话 ID，非空时显示迁移对话框 */
+  const [moveTargetId, setMoveTargetId] = React.useState<string | null>(null)
   /** 置顶区域展开/收起 */
   const [pinnedExpanded, setPinnedExpanded] = React.useState(true)
   /** Agent 置顶区域展开/收起 */
@@ -441,6 +444,21 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     }
   }
 
+  /** 迁移会话到另一个工作区后的回调 */
+  const handleSessionMoved = (updatedSession: AgentSessionMeta): void => {
+    setAgentSessions((prev) =>
+      prev.map((s) => (s.id === updatedSession.id ? updatedSession : s))
+    )
+    // 如果迁移的是当前选中的会话，取消选中并关闭标签页
+    if (currentAgentSessionId === updatedSession.id) {
+      const tabResult = closeTab(tabs, layout, updatedSession.id)
+      setTabs(tabResult.tabs)
+      setLayout(tabResult.layout)
+      setCurrentAgentSessionId(null)
+    }
+    setMoveTargetId(null)
+  }
+
   /** Agent 会话按工作区过滤 */
   const filteredAgentSessions = React.useMemo(
     () => agentSessions.filter((s) => s.workspaceId === currentWorkspaceId),
@@ -484,6 +502,18 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>
+  )
+
+  // 迁移会话对话框（collapsed/expanded 共享）
+  const moveDialog = (
+    <MoveSessionDialog
+      open={moveTargetId !== null}
+      onOpenChange={(open) => { if (!open) setMoveTargetId(null) }}
+      sessionId={moveTargetId ?? ''}
+      currentWorkspaceId={currentWorkspaceId ?? undefined}
+      workspaces={workspaces}
+      onMoved={handleSessionMoved}
+    />
   )
 
   // ===== 折叠状态：精简图标视图 =====
@@ -555,6 +585,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         </div>
 
         {deleteDialog}
+        {moveDialog}
       </div>
     )
   }
@@ -678,6 +709,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                 showPinIcon={false}
                 onSelect={() => handleSelectAgentSession(session.id, session.title)}
                 onRequestDelete={() => handleRequestDelete(session.id)}
+                onRequestMove={() => setMoveTargetId(session.id)}
                 onRename={handleAgentRename}
                 onTogglePin={handleTogglePinAgent}
                 onMouseEnter={() => setHoveredId(session.id)}
@@ -735,6 +767,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                     showPinIcon={!!session.pinned}
                     onSelect={() => handleSelectAgentSession(session.id, session.title)}
                     onRequestDelete={() => handleRequestDelete(session.id)}
+                    onRequestMove={() => setMoveTargetId(session.id)}
                     onRename={handleAgentRename}
                     onTogglePin={handleTogglePinAgent}
                     onMouseEnter={() => setHoveredId(session.id)}
@@ -792,6 +825,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       </div>
 
       {deleteDialog}
+      {moveDialog}
     </div>
   )
 }
@@ -925,36 +959,48 @@ function ConversationItem({
         'flex items-center gap-0.5 flex-shrink-0 transition-all duration-100',
         hovered && !editing ? 'opacity-100' : 'opacity-0 pointer-events-none'
       )}>
-        <button
-          onClick={(e) => {
-            e.stopPropagation()
-            onTogglePin(conversation.id)
-          }}
-          className="p-1 rounded-md text-foreground/30 hover:bg-foreground/[0.08] hover:text-foreground/60 transition-colors"
-          title={isPinned ? '取消置顶' : '置顶对话'}
-        >
-          {isPinned ? <PinOff size={13} /> : <Pin size={13} />}
-        </button>
-        <button
-          onClick={(e) => {
-            e.stopPropagation()
-            startEdit()
-          }}
-          className="p-1 rounded-md text-foreground/30 hover:bg-foreground/[0.08] hover:text-foreground/60 transition-colors"
-          title="重命名"
-        >
-          <Pencil size={13} />
-        </button>
-        <button
-          onClick={(e) => {
-            e.stopPropagation()
-            onRequestDelete()
-          }}
-          className="p-1 rounded-md text-foreground/30 hover:bg-destructive/10 hover:text-destructive transition-colors"
-          title="删除对话"
-        >
-          <Trash2 size={13} />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onTogglePin(conversation.id)
+              }}
+              className="p-1 rounded-md text-foreground/30 hover:bg-foreground/[0.08] hover:text-foreground/60 transition-colors"
+            >
+              {isPinned ? <PinOff size={13} /> : <Pin size={13} />}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{isPinned ? '取消置顶' : '置顶对话'}</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                startEdit()
+              }}
+              className="p-1 rounded-md text-foreground/30 hover:bg-foreground/[0.08] hover:text-foreground/60 transition-colors"
+            >
+              <Pencil size={13} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">重命名</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onRequestDelete()
+              }}
+              className="p-1 rounded-md text-foreground/30 hover:bg-destructive/10 hover:text-destructive transition-colors"
+            >
+              <Trash2 size={13} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">删除对话</TooltipContent>
+        </Tooltip>
       </div>
     </div>
   )
@@ -970,6 +1016,7 @@ interface AgentSessionItemProps {
   showPinIcon?: boolean
   onSelect: () => void
   onRequestDelete: () => void
+  onRequestMove: () => void
   onRename: (id: string, newTitle: string) => Promise<void>
   onTogglePin: (id: string) => Promise<void>
   onMouseEnter: () => void
@@ -984,6 +1031,7 @@ function AgentSessionItem({
   showPinIcon,
   onSelect,
   onRequestDelete,
+  onRequestMove,
   onRename,
   onTogglePin,
   onMouseEnter,
@@ -1079,36 +1127,64 @@ function AgentSessionItem({
         'flex items-center gap-0.5 flex-shrink-0 transition-all duration-100',
         hovered && !editing ? 'opacity-100' : 'opacity-0 pointer-events-none'
       )}>
-        <button
-          onClick={(e) => {
-            e.stopPropagation()
-            onTogglePin(session.id)
-          }}
-          className="p-1 rounded-md text-foreground/30 hover:bg-foreground/[0.08] hover:text-foreground/60 transition-colors"
-          title={session.pinned ? '取消置顶' : '置顶会话'}
-        >
-          {session.pinned ? <PinOff size={13} /> : <Pin size={13} />}
-        </button>
-        <button
-          onClick={(e) => {
-            e.stopPropagation()
-            startEdit()
-          }}
-          className="p-1 rounded-md text-foreground/30 hover:bg-foreground/[0.08] hover:text-foreground/60 transition-colors"
-          title="重命名"
-        >
-          <Pencil size={13} />
-        </button>
-        <button
-          onClick={(e) => {
-            e.stopPropagation()
-            onRequestDelete()
-          }}
-          className="p-1 rounded-md text-foreground/30 hover:bg-destructive/10 hover:text-destructive transition-colors"
-          title="删除会话"
-        >
-          <Trash2 size={13} />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onTogglePin(session.id)
+              }}
+              className="p-1 rounded-md text-foreground/30 hover:bg-foreground/[0.08] hover:text-foreground/60 transition-colors"
+            >
+              {session.pinned ? <PinOff size={13} /> : <Pin size={13} />}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{session.pinned ? '取消置顶' : '置顶会话'}</TooltipContent>
+        </Tooltip>
+        {!running && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onRequestMove()
+                }}
+                className="p-1 rounded-md text-foreground/30 hover:bg-foreground/[0.08] hover:text-foreground/60 transition-colors"
+              >
+                <ArrowRightLeft size={13} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">迁移到其他工作区</TooltipContent>
+          </Tooltip>
+        )}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                startEdit()
+              }}
+              className="p-1 rounded-md text-foreground/30 hover:bg-foreground/[0.08] hover:text-foreground/60 transition-colors"
+            >
+              <Pencil size={13} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">重命名</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onRequestDelete()
+              }}
+              className="p-1 rounded-md text-foreground/30 hover:bg-destructive/10 hover:text-destructive transition-colors"
+            >
+              <Trash2 size={13} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">删除会话</TooltipContent>
+        </Tooltip>
       </div>
     </div>
   )

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -434,6 +434,18 @@ export interface AgentSendInput {
   workspaceId?: string
 }
 
+// ===== 会话迁移输入 =====
+
+/**
+ * 迁移会话到另一个工作区的输入参数
+ */
+export interface MoveSessionToWorkspaceInput {
+  /** 要迁移的会话 ID */
+  sessionId: string
+  /** 目标工作区 ID */
+  targetWorkspaceId: string
+}
+
 // ===== 后台任务管理 =====
 
 /**
@@ -638,6 +650,8 @@ export const AGENT_IPC_CHANNELS = {
   MIGRATE_CHAT_TO_AGENT: 'agent:migrate-chat-to-agent',
   /** 切换会话置顶状态 */
   TOGGLE_PIN: 'agent:toggle-pin',
+  /** 迁移会话到另一个工作区 */
+  MOVE_SESSION_TO_WORKSPACE: 'agent:move-session-to-workspace',
 
   // 工作区管理
   /** 获取工作区列表 */


### PR DESCRIPTION
## Summary
- 新增 Agent 会话跨工作区迁移功能，用户可将会话从工作区 A 完整迁移到工作区 B
- 迁移包括元数据更新（workspaceId）、工作目录移动、SDK 上下文清理
- 侧边栏会话 hover 按钮组新增迁移按钮，运行中会话自动隐藏该按钮
- Chat/Agent 模式所有 hover 操作按钮从 title 属性升级为 ShadcnUI Tooltip 组件

## 改动文件
- `packages/shared/src/types/agent.ts` — 新增 IPC 常量 + `MoveSessionToWorkspaceInput` 接口
- `apps/electron/src/main/lib/agent-session-manager.ts` — 新增 `moveSessionToWorkspace()` 核心迁移函数
- `apps/electron/src/main/lib/agent-service.ts` — 新增 `isAgentSessionActive()` 活跃状态检查
- `apps/electron/src/main/ipc.ts` — 注册迁移 IPC handler
- `apps/electron/src/preload/index.ts` — 桥接 `moveAgentSessionToWorkspace` API
- `apps/electron/src/renderer/components/agent/MoveSessionDialog.tsx` — 新建迁移对话框组件
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 集成迁移按钮 + Tooltip 升级

## Test plan
- [ ] 创建两个工作区 A 和 B，在 A 中创建会话并发送消息
- [ ] hover 会话项，点击迁移按钮，选择工作区 B，确认迁移
- [ ] 验证会话从 A 列表消失，切换到 B 后出现，消息完整保留
- [ ] 验证运行中的会话不显示迁移按钮
- [ ] 验证 hover 按钮的 Tooltip 在 Chat 和 Agent 模式下均正常显示