### PR TITLE
feat: MCP/Skill 配置变化时显示 toast 通知

### DIFF
--- a/apps/electron/src/renderer/lib/capabilities-toast.ts
+++ b/apps/electron/src/renderer/lib/capabilities-toast.ts
@@ -1,0 +1,44 @@
+import { toast } from 'sonner'
+import type { CapabilityChange } from '@proma/shared'
+
+/** 变化类型 → 中文描述 */
+const CHANGE_LABELS: Record<CapabilityChange['type'], string> = {
+  mcp_added: 'MCP 服务器已添加',
+  mcp_removed: 'MCP 服务器已移除',
+  mcp_enabled: 'MCP 服务器已启用',
+  mcp_disabled: 'MCP 服务器已禁用',
+  skill_added: 'Skill 已添加',
+  skill_removed: 'Skill 已移除',
+  skill_enabled: 'Skill 已启用',
+  skill_disabled: 'Skill 已禁用',
+}
+
+/**
+ * 显示能力变化 toast 通知。
+ *
+ * - 1-3 条变化：每条单独 toast
+ * - 4+ 条变化：合并为一条摘要 toast
+ */
+export function showCapabilityChangeToasts(changes: CapabilityChange[]): void {
+  if (changes.length === 0) return
+
+  if (changes.length <= 3) {
+    for (const change of changes) {
+      const label = CHANGE_LABELS[change.type]
+      const isPositive = change.type.endsWith('_added') || change.type.endsWith('_enabled')
+      if (isPositive) {
+        toast.success(`${label}: ${change.name}`)
+      } else {
+        toast.info(`${label}: ${change.name}`)
+      }
+    }
+  } else {
+    // 批量变化：合并为一条摘要
+    const mcpCount = changes.filter((c) => c.type.startsWith('mcp_')).length
+    const skillCount = changes.filter((c) => c.type.startsWith('skill_')).length
+    const parts: string[] = []
+    if (mcpCount > 0) parts.push(`${mcpCount} 个 MCP 服务器`)
+    if (skillCount > 0) parts.push(`${skillCount} 个 Skill`)
+    toast.info(`工作区配置已更新：${parts.join('、')}`)
+  }
+}

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -4,7 +4,7 @@
  * 挂载 React 应用，初始化主题系统。
  */
 
-import React, { useEffect } from 'react'
+import React, { useEffect, useRef } from 'react'
 import ReactDOM from 'react-dom/client'
 import { useSetAtom, useAtomValue, useStore } from 'jotai'
 import App from './App'
@@ -40,6 +40,9 @@ import type { TabItem, SplitLayoutState } from './atoms/tab-atoms'
 import { chatToolsAtom } from './atoms/chat-tool-atoms'
 import { Toaster } from './components/ui/sonner'
 import { toast } from 'sonner'
+import { diffCapabilities } from '@proma/shared'
+import type { WorkspaceCapabilities } from '@proma/shared'
+import { showCapabilityChangeToasts } from './lib/capabilities-toast'
 import { UpdateDialog } from './components/settings/UpdateDialog'
 import './styles/globals.css'
 import 'katex/dist/katex.min.css'
@@ -101,6 +104,15 @@ function AgentSettingsInitializer(): null {
   const setMaxBudget = useSetAtom(agentMaxBudgetUsdAtom)
   const setMaxTurns = useSetAtom(agentMaxTurnsAtom)
 
+  // 读取当前工作区信息（用于能力变化 diff）
+  const currentWorkspaceId = useAtomValue(currentAgentWorkspaceIdAtom)
+  const workspaces = useAtomValue(agentWorkspacesAtom)
+
+  // 缓存上一次工作区能力（用于 diff 检测变化）
+  const prevCapabilitiesRef = useRef<WorkspaceCapabilities | null>(null)
+  // 初次加载标记 — 应用启动或切换工作区时不显示 toast
+  const suppressToastRef = useRef(true)
+
   useEffect(() => {
     // 加载设置
     window.electronAPI.getSettings().then((settings) => {
@@ -140,9 +152,44 @@ function AgentSettingsInitializer(): null {
     }).catch(console.error)
   }, [setAgentChannelId, setAgentModelId, setAgentWorkspaces, setCurrentWorkspaceId, setPermissionMode, setThinking, setEffort, setMaxBudget, setMaxTurns])
 
+  // 工作区切换时重置能力缓存，预加载基线
+  useEffect(() => {
+    suppressToastRef.current = true
+    prevCapabilitiesRef.current = null
+
+    if (!currentWorkspaceId) return
+    const ws = workspaces.find((w) => w.id === currentWorkspaceId)
+    if (!ws) return
+
+    window.electronAPI
+      .getWorkspaceCapabilities(ws.slug)
+      .then((caps) => {
+        prevCapabilitiesRef.current = caps
+        suppressToastRef.current = false
+      })
+      .catch(console.error)
+  }, [currentWorkspaceId, workspaces])
+
   // 订阅主进程文件监听推送
   useEffect(() => {
     const unsubCapabilities = window.electronAPI.onCapabilitiesChanged(() => {
+      // 查找当前工作区 slug
+      const ws = workspaces.find((w) => w.id === currentWorkspaceId)
+      if (ws) {
+        window.electronAPI
+          .getWorkspaceCapabilities(ws.slug)
+          .then((newCaps) => {
+            const prevCaps = prevCapabilitiesRef.current
+            if (prevCaps && !suppressToastRef.current) {
+              const changes = diffCapabilities(prevCaps, newCaps)
+              showCapabilityChangeToasts(changes)
+            }
+            prevCapabilitiesRef.current = newCaps
+            suppressToastRef.current = false
+          })
+          .catch(console.error)
+      }
+
       bumpCapabilities((v) => v + 1)
     })
     const unsubFiles = window.electronAPI.onWorkspaceFilesChanged(() => {
@@ -153,7 +200,7 @@ function AgentSettingsInitializer(): null {
       unsubCapabilities()
       unsubFiles()
     }
-  }, [bumpCapabilities, bumpFiles])
+  }, [bumpCapabilities, bumpFiles, currentWorkspaceId, workspaces])
 
   return null
 }

--- a/packages/shared/src/utils/capabilities-diff.test.ts
+++ b/packages/shared/src/utils/capabilities-diff.test.ts
@@ -1,0 +1,110 @@
+import { test, expect, describe } from 'bun:test'
+import { diffCapabilities } from './capabilities-diff'
+import type { WorkspaceCapabilities } from '../types/agent'
+
+/** 构建测试用 WorkspaceCapabilities */
+function makeCaps(
+  mcpServers: Array<{ name: string; enabled: boolean }> = [],
+  skills: Array<{ slug: string; name: string; enabled: boolean }> = [],
+): WorkspaceCapabilities {
+  return {
+    mcpServers: mcpServers.map((s) => ({ ...s, type: 'stdio' as const })),
+    skills: skills.map((s) => ({ ...s })),
+  }
+}
+
+describe('diffCapabilities', () => {
+  test('无变化返回空数组', () => {
+    const caps = makeCaps(
+      [{ name: 'github', enabled: true }],
+      [{ slug: 'review', name: 'Code Review', enabled: true }],
+    )
+    expect(diffCapabilities(caps, caps)).toEqual([])
+  })
+
+  test('两个空 capabilities 返回空数组', () => {
+    const empty = makeCaps()
+    expect(diffCapabilities(empty, empty)).toEqual([])
+  })
+
+  // --- MCP 服务器 ---
+
+  test('检测 MCP 服务器新增', () => {
+    const prev = makeCaps()
+    const next = makeCaps([{ name: 'github', enabled: true }])
+    const changes = diffCapabilities(prev, next)
+    expect(changes).toEqual([{ type: 'mcp_added', name: 'github' }])
+  })
+
+  test('检测 MCP 服务器移除', () => {
+    const prev = makeCaps([{ name: 'github', enabled: true }])
+    const next = makeCaps()
+    const changes = diffCapabilities(prev, next)
+    expect(changes).toEqual([{ type: 'mcp_removed', name: 'github' }])
+  })
+
+  test('检测 MCP 服务器启用', () => {
+    const prev = makeCaps([{ name: 'github', enabled: false }])
+    const next = makeCaps([{ name: 'github', enabled: true }])
+    const changes = diffCapabilities(prev, next)
+    expect(changes).toEqual([{ type: 'mcp_enabled', name: 'github' }])
+  })
+
+  test('检测 MCP 服务器禁用', () => {
+    const prev = makeCaps([{ name: 'github', enabled: true }])
+    const next = makeCaps([{ name: 'github', enabled: false }])
+    const changes = diffCapabilities(prev, next)
+    expect(changes).toEqual([{ type: 'mcp_disabled', name: 'github' }])
+  })
+
+  // --- Skills ---
+
+  test('检测 Skill 新增', () => {
+    const prev = makeCaps()
+    const next = makeCaps([], [{ slug: 'review', name: 'Code Review', enabled: true }])
+    const changes = diffCapabilities(prev, next)
+    expect(changes).toEqual([{ type: 'skill_added', name: 'Code Review' }])
+  })
+
+  test('检测 Skill 移除', () => {
+    const prev = makeCaps([], [{ slug: 'review', name: 'Code Review', enabled: true }])
+    const next = makeCaps()
+    const changes = diffCapabilities(prev, next)
+    expect(changes).toEqual([{ type: 'skill_removed', name: 'Code Review' }])
+  })
+
+  test('检测 Skill 启用', () => {
+    const prev = makeCaps([], [{ slug: 'review', name: 'Code Review', enabled: false }])
+    const next = makeCaps([], [{ slug: 'review', name: 'Code Review', enabled: true }])
+    const changes = diffCapabilities(prev, next)
+    expect(changes).toEqual([{ type: 'skill_enabled', name: 'Code Review' }])
+  })
+
+  test('检测 Skill 禁用', () => {
+    const prev = makeCaps([], [{ slug: 'review', name: 'Code Review', enabled: true }])
+    const next = makeCaps([], [{ slug: 'review', name: 'Code Review', enabled: false }])
+    const changes = diffCapabilities(prev, next)
+    expect(changes).toEqual([{ type: 'skill_disabled', name: 'Code Review' }])
+  })
+
+  // --- 混合场景 ---
+
+  test('检测多个同时变化', () => {
+    const prev = makeCaps(
+      [{ name: 'github', enabled: true }, { name: 'slack', enabled: true }],
+      [{ slug: 'review', name: 'Code Review', enabled: true }],
+    )
+    const next = makeCaps(
+      [{ name: 'github', enabled: false }, { name: 'jira', enabled: true }],
+      [{ slug: 'review', name: 'Code Review', enabled: false }, { slug: 'test', name: 'Test Runner', enabled: true }],
+    )
+    const changes = diffCapabilities(prev, next)
+
+    expect(changes).toContainEqual({ type: 'mcp_disabled', name: 'github' })
+    expect(changes).toContainEqual({ type: 'mcp_added', name: 'jira' })
+    expect(changes).toContainEqual({ type: 'mcp_removed', name: 'slack' })
+    expect(changes).toContainEqual({ type: 'skill_disabled', name: 'Code Review' })
+    expect(changes).toContainEqual({ type: 'skill_added', name: 'Test Runner' })
+    expect(changes).toHaveLength(5)
+  })
+})

--- a/packages/shared/src/utils/capabilities-diff.ts
+++ b/packages/shared/src/utils/capabilities-diff.ts
@@ -1,0 +1,69 @@
+import type { WorkspaceCapabilities } from '../types/agent'
+
+/** 单条能力变化描述 */
+export interface CapabilityChange {
+  /** 变化类型 */
+  type:
+    | 'mcp_added'
+    | 'mcp_removed'
+    | 'mcp_enabled'
+    | 'mcp_disabled'
+    | 'skill_added'
+    | 'skill_removed'
+    | 'skill_enabled'
+    | 'skill_disabled'
+  /** 变化对象名称 */
+  name: string
+}
+
+/**
+ * 比较新旧 WorkspaceCapabilities，返回变化列表。
+ *
+ * - MCP 服务器：按 name 比较集合差异（added/removed）和 enabled 状态变化
+ * - Skills：按 slug 比较集合差异（added/removed）和 enabled 状态变化
+ */
+export function diffCapabilities(
+  prev: WorkspaceCapabilities,
+  next: WorkspaceCapabilities,
+): CapabilityChange[] {
+  const changes: CapabilityChange[] = []
+
+  // --- MCP 服务器 ---
+  const prevMcpMap = new Map(prev.mcpServers.map((s) => [s.name, s]))
+  const nextMcpMap = new Map(next.mcpServers.map((s) => [s.name, s]))
+
+  for (const [name, server] of nextMcpMap) {
+    const prevServer = prevMcpMap.get(name)
+    if (!prevServer) {
+      changes.push({ type: 'mcp_added', name })
+    } else if (prevServer.enabled !== server.enabled) {
+      changes.push({ type: server.enabled ? 'mcp_enabled' : 'mcp_disabled', name })
+    }
+  }
+  for (const name of prevMcpMap.keys()) {
+    if (!nextMcpMap.has(name)) {
+      changes.push({ type: 'mcp_removed', name })
+    }
+  }
+
+  // --- Skills ---
+  const prevSkillMap = new Map(prev.skills.map((s) => [s.slug, s]))
+  const nextSkillMap = new Map(next.skills.map((s) => [s.slug, s]))
+
+  for (const [slug, skill] of nextSkillMap) {
+    const prevSkill = prevSkillMap.get(slug)
+    if (!prevSkill) {
+      changes.push({ type: 'skill_added', name: skill.name })
+    } else if (prevSkill.enabled !== skill.enabled) {
+      changes.push({ type: skill.enabled ? 'skill_enabled' : 'skill_disabled', name: skill.name })
+    }
+  }
+  for (const [slug] of prevSkillMap) {
+    if (!nextSkillMap.has(slug)) {
+      const skill = prevSkillMap.get(slug)!
+      changes.push({ type: 'skill_removed', name: skill.name })
+    }
+  }
+
+  return changes
+}

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -6,3 +6,6 @@
 export function noop(): void {
   // no-op
 }
+
+export { diffCapabilities } from './capabilities-diff'
+export type { CapabilityChange } from './capabilities-diff'


### PR DESCRIPTION
## Summary
- Agent 模式下，当 MCP 服务器或 Skill 配置发生变化时（添加/删除/启用/禁用），自动弹出 sonner toast 通知
- 新增纯函数 `diffCapabilities()` 比较新旧 `WorkspaceCapabilities`，返回变化列表
- 在 `AgentSettingsInitializer` 中缓存上一次 capabilities，收到 `CAPABILITIES_CHANGED` 事件时 diff 并显示 toast
- 应用启动和切换工作区时抑制 toast，避免误报

## 改动文件
- `packages/shared/src/utils/capabilities-diff.ts` — diff 工具函数（纯函数，无副作用）
- `packages/shared/src/utils/capabilities-diff.test.ts` — 11 个单元测试
- `apps/electron/src/renderer/lib/capabilities-toast.ts` — toast 显示辅助函数
- `apps/electron/src/renderer/main.tsx` — AgentSettingsInitializer 集成

## Test plan
- [x] `bun test` 通过 11 个单元测试
- [x] `bun run build:renderer` 构建成功
- [ ] 启动应用，在 Agent 模式下让 Agent 添加 MCP 服务器，观察 toast 通知
- [ ] 在设置页面手动添加/删除/启禁用 MCP 或 Skill，观察 toast 通知
- [ ] 切换工作区时确认不会弹出错误的 toast