### PR TITLE
feat: Agent 附加文件夹（additionalDirectories）

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -31,7 +31,7 @@ import type {
   AgentGenerateTitleInput,
   AgentSaveFilesInput,
   AgentSavedFile,
-  AgentCopyFolderInput,
+  AgentAttachDirectoryInput,
   GetTaskOutputInput,
   GetTaskOutputResult,
   StopTaskInput,
@@ -97,13 +97,14 @@ import { detectSystemProxy } from './lib/system-proxy-detector'
 import {
   listAgentSessions,
   createAgentSession,
+  getAgentSessionMeta,
   getAgentSessionMessages,
   updateAgentSessionMeta,
   deleteAgentSession,
   migrateChatToAgentSession,
   moveSessionToWorkspace,
 } from './lib/agent-session-manager'
-import { runAgent, stopAgent, generateAgentTitle, saveFilesToAgentSession, copyFolderToSession, isAgentSessionActive } from './lib/agent-service'
+import { runAgent, stopAgent, generateAgentTitle, saveFilesToAgentSession, isAgentSessionActive } from './lib/agent-service'
 import { permissionService } from './lib/agent-permission-service'
 import { askUserService } from './lib/agent-ask-user-service'
 import { getAgentSessionWorkspacePath, getAgentWorkspacesDir, getWorkspaceSkillsDir } from './lib/config-paths'
@@ -996,11 +997,33 @@ export function registerIpcHandlers(): void {
     }
   )
 
-  // 复制文件夹到 Agent session 工作目录
+  // 附加外部目录到 Agent 会话
   ipcMain.handle(
-    AGENT_IPC_CHANNELS.COPY_FOLDER_TO_SESSION,
-    async (_, input: AgentCopyFolderInput): Promise<AgentSavedFile[]> => {
-      return copyFolderToSession(input)
+    AGENT_IPC_CHANNELS.ATTACH_DIRECTORY,
+    async (_, input: AgentAttachDirectoryInput): Promise<string[]> => {
+      const meta = getAgentSessionMeta(input.sessionId)
+      if (!meta) throw new Error(`会话不存在: ${input.sessionId}`)
+
+      const existing = meta.attachedDirectories ?? []
+      if (existing.includes(input.directoryPath)) return existing
+
+      const updated = [...existing, input.directoryPath]
+      updateAgentSessionMeta(input.sessionId, { attachedDirectories: updated })
+      return updated
+    }
+  )
+
+  // 移除会话的附加目录
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.DETACH_DIRECTORY,
+    async (_, input: AgentAttachDirectoryInput): Promise<string[]> => {
+      const meta = getAgentSessionMeta(input.sessionId)
+      if (!meta) throw new Error(`会话不存在: ${input.sessionId}`)
+
+      const existing = meta.attachedDirectories ?? []
+      const updated = existing.filter((d) => d !== input.directoryPath)
+      updateAgentSessionMeta(input.sessionId, { attachedDirectories: updated })
+      return updated
     }
   )
 

--- a/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
@@ -155,6 +155,8 @@ export interface ClaudeAgentQueryOptions extends AgentQueryInput {
   forkSession?: boolean
   /** 指定 SDK 会话 ID（替代自动生成，与 AgentQueryInput.sessionId 区分） */
   sdkSessionId?: string
+  /** 附加的外部目录（SDK additionalDirectories） */
+  additionalDirectories?: string[]
 }
 
 // ============================================================================
@@ -647,6 +649,9 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
         ...(options.persistSession != null && { persistSession: options.persistSession }),
         ...(options.forkSession != null && { forkSession: options.forkSession }),
         ...(options.sdkSessionId && { sessionId: options.sdkSessionId }),
+        ...(options.additionalDirectories && options.additionalDirectories.length > 0 && {
+          additionalDirectories: options.additionalDirectories,
+        }),
       } as import('@anthropic-ai/claude-agent-sdk').Options
 
       const queryIterator = sdk.query({

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -566,7 +566,7 @@ export class AgentOrchestrator {
    * 通过 EventBus 分发 AgentEvent，通过 callbacks 发送控制信号。
    */
   async sendMessage(input: AgentSendInput, callbacks: SessionCallbacks): Promise<void> {
-    const { sessionId, userMessage, channelId, modelId, workspaceId } = input
+    const { sessionId, userMessage, channelId, modelId, workspaceId, additionalDirectories } = input
     const stderrChunks: string[] = []
 
     // 0. 并发保护
@@ -794,6 +794,7 @@ export class AgentOrchestrator {
         resumeSessionId: existingSdkSessionId,
         ...(Object.keys(mcpServers).length > 0 && { mcpServers }),
         ...(workspaceSlug && { plugins: [{ type: 'local' as const, path: getAgentWorkspacePath(workspaceSlug) }] }),
+        ...(additionalDirectories && additionalDirectories.length > 0 && { additionalDirectories }),
         // SDK 0.2.52+ 新增选项（从 settings 读取）
         ...(appSettings.agentThinking && { thinking: appSettings.agentThinking }),
         ...(appSettings.agentEffort && { effort: appSettings.agentEffort }),

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -5,14 +5,13 @@
  * - 创建 AgentOrchestrator / EventBus / Adapter 实例
  * - 注册 EventBus IPC 转发中间件（webContents.send）
  * - 导出 IPC handler 调用的薄包装函数
- * - 文件操作（saveFilesToAgentSession / copyFolderToSession）
+ * - 文件操作（saveFilesToAgentSession）
  *
  * 所有业务逻辑已委托给 AgentOrchestrator。
  */
 
 import { join, dirname } from 'node:path'
 import { writeFileSync, mkdirSync, existsSync } from 'node:fs'
-import { cp, readdir } from 'node:fs/promises'
 import type { WebContents } from 'electron'
 import { AGENT_IPC_CHANNELS } from '@proma/shared'
 import type {
@@ -20,7 +19,6 @@ import type {
   AgentGenerateTitleInput,
   AgentSaveFilesInput,
   AgentSavedFile,
-  AgentCopyFolderInput,
   AgentStreamEvent,
 } from '@proma/shared'
 import { ClaudeAgentAdapter } from './adapters/claude-agent-adapter'
@@ -166,39 +164,5 @@ export function saveFilesToAgentSession(input: AgentSaveFilesInput): AgentSavedF
     console.log(`[Agent 服务] 文件已保存: ${targetPath} (${buffer.length} bytes)`)
   }
 
-  return results
-}
-
-/**
- * 复制文件夹到 Agent session 工作目录（异步版本）
- *
- * 使用异步 fs.cp 递归复制整个文件夹，返回所有复制的文件列表。
- */
-export async function copyFolderToSession(input: AgentCopyFolderInput): Promise<AgentSavedFile[]> {
-  const { sourcePath, workspaceSlug, sessionId } = input
-  const sessionDir = getAgentSessionWorkspacePath(workspaceSlug, sessionId)
-
-  const folderName = sourcePath.split('/').filter(Boolean).pop() || 'folder'
-  const targetDir = join(sessionDir, folderName)
-
-  await cp(sourcePath, targetDir, { recursive: true })
-  console.log(`[Agent 服务] 文件夹已复制: ${sourcePath} → ${targetDir}`)
-
-  const results: AgentSavedFile[] = []
-  const collectFiles = async (dir: string, relativeTo: string): Promise<void> => {
-    const items = await readdir(dir, { withFileTypes: true })
-    for (const item of items) {
-      const fullPath = join(dir, item.name)
-      if (item.isDirectory()) {
-        await collectFiles(fullPath, relativeTo)
-      } else {
-        const relPath = fullPath.slice(relativeTo.length + 1)
-        results.push({ filename: relPath, targetPath: fullPath })
-      }
-    }
-  }
-  await collectFiles(targetDir, sessionDir)
-
-  console.log(`[Agent 服务] 文件夹复制完成，共 ${results.length} 个文件`)
   return results
 }

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -162,7 +162,7 @@ export function appendAgentMessage(id: string, message: AgentMessage): void {
  */
 export function updateAgentSessionMeta(
   id: string,
-  updates: Partial<Pick<AgentSessionMeta, 'title' | 'channelId' | 'sdkSessionId' | 'workspaceId' | 'pinned'>>,
+  updates: Partial<Pick<AgentSessionMeta, 'title' | 'channelId' | 'sdkSessionId' | 'workspaceId' | 'pinned' | 'attachedDirectories'>>,
 ): AgentSessionMeta {
   const index = readIndex()
   const idx = index.sessions.findIndex((s) => s.id === id)

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -39,7 +39,7 @@ import type {
   AgentGenerateTitleInput,
   AgentSaveFilesInput,
   AgentSavedFile,
-  AgentCopyFolderInput,
+  AgentAttachDirectoryInput,
   GetTaskOutputInput,
   GetTaskOutputResult,
   StopTaskInput,
@@ -395,8 +395,11 @@ export interface ElectronAPI {
   /** 打开文件夹选择对话框 */
   openFolderDialog: () => Promise<{ path: string; name: string } | null>
 
-  /** 复制文件夹到 Agent session 工作目录 */
-  copyFolderToSession: (input: AgentCopyFolderInput) => Promise<AgentSavedFile[]>
+  /** 附加外部目录到 Agent 会话 */
+  attachDirectory: (input: AgentAttachDirectoryInput) => Promise<string[]>
+
+  /** 移除会话的附加目录 */
+  detachDirectory: (input: AgentAttachDirectoryInput) => Promise<string[]>
 
   // ===== Agent 文件系统操作 =====
 
@@ -900,8 +903,12 @@ const electronAPI: ElectronAPI = {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.OPEN_FOLDER_DIALOG)
   },
 
-  copyFolderToSession: (input: AgentCopyFolderInput) => {
-    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.COPY_FOLDER_TO_SESSION, input)
+  attachDirectory: (input: AgentAttachDirectoryInput) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.ATTACH_DIRECTORY, input)
+  },
+
+  detachDirectory: (input: AgentAttachDirectoryInput) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.DETACH_DIRECTORY, input)
   },
 
   // Agent 文件系统操作

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -669,6 +669,13 @@ export const currentAgentErrorAtom = atom<string | null>((get) => {
  */
 export const agentSessionDraftsAtom = atom<Map<string, string>>(new Map())
 
+/**
+ * 会话附加目录 Map — 以 sessionId 为 key
+ * 存储每个会话通过"附加文件夹"功能关联的外部目录路径列表。
+ * 这些路径作为 SDK additionalDirectories 参数传递。
+ */
+export const agentAttachedDirectoriesMapAtom = atom<Map<string, string[]>>(new Map())
+
 /** 当前 Agent 会话的草稿内容（派生读写原子） */
 export const currentAgentSessionDraftAtom = atom(
   (get) => {

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -44,12 +44,13 @@ import {
   agentMessageRefreshAtom,
   agentSessionsAtom,
   currentAgentSessionIdAtom,
+  agentAttachedDirectoriesMapAtom,
 } from '@/atoms/agent-atoms'
 import type { AgentContextStatus } from '@/atoms/agent-atoms'
 import { activeViewAtom } from '@/atoms/active-view'
 import { tabsAtom, splitLayoutAtom, openTab } from '@/atoms/tab-atoms'
 import { AgentSessionProvider } from '@/contexts/session-context'
-import type { AgentSendInput, AgentMessage, AgentPendingFile, AgentSavedFile, ModelOption } from '@proma/shared'
+import type { AgentSendInput, AgentMessage, AgentPendingFile, ModelOption } from '@proma/shared'
 import { fileToBase64 } from '@/lib/file-utils'
 
 export function AgentView({ sessionId }: { sessionId: string }): React.ReactElement {
@@ -81,6 +82,9 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const setCurrentAgentSessionId = useSetAtom(currentAgentSessionIdAtom)
   const [tabs, setTabs] = useAtom(tabsAtom)
   const [layout, setLayout] = useAtom(splitLayoutAtom)
+  const setAttachedDirsMap = useSetAtom(agentAttachedDirectoriesMapAtom)
+  const attachedDirsMap = useAtomValue(agentAttachedDirectoriesMapAtom)
+  const attachedDirs = attachedDirsMap.get(sessionId) ?? []
 
   const draftsMap = useAtomValue(agentSessionDraftsAtom)
   const setDraftsMap = useSetAtom(agentSessionDraftsAtom)
@@ -98,8 +102,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   }, [sessionId, setDraftsMap])
   const [sessionPath, setSessionPath] = React.useState<string | null>(null)
   const [isDragOver, setIsDragOver] = React.useState(false)
-  const [pendingFolderRefs, setPendingFolderRefs] = React.useState<AgentSavedFile[]>([])
-  const [isUploadingFolder, setIsUploadingFolder] = React.useState(false)
   const [dragFolderWarning, setDragFolderWarning] = React.useState(false)
   const [errorCopied, setErrorCopied] = React.useState(false)
 
@@ -164,6 +166,25 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       })
       .catch(console.error)
   }, [sessionId, refreshVersion, setStreamingStates])
+
+  // 从会话元数据初始化附加目录
+  const sessions = useAtomValue(agentSessionsAtom)
+  React.useEffect(() => {
+    const meta = sessions.find((s) => s.id === sessionId)
+    const dirs = meta?.attachedDirectories ?? []
+    setAttachedDirsMap((prev) => {
+      const existing = prev.get(sessionId)
+      // 避免不必要的更新
+      if (JSON.stringify(existing) === JSON.stringify(dirs)) return prev
+      const map = new Map(prev)
+      if (dirs.length > 0) {
+        map.set(sessionId, dirs)
+      } else {
+        map.delete(sessionId)
+      }
+      return map
+    })
+  }, [sessionId, sessions, setAttachedDirsMap])
 
   // 自动发送 pending prompt（从设置页"对话完成配置"触发）
   React.useEffect(() => {
@@ -298,40 +319,29 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     }
   }, [setPendingFiles])
 
-  /** 打开文件夹选择对话框 */
-  const handleOpenFolderDialog = React.useCallback(async (): Promise<void> => {
-    if (!currentWorkspaceId || isUploadingFolder) return
-
-    const workspace = workspaces.find((w) => w.id === currentWorkspaceId)
-    if (!workspace) return
-
+  /** 附加文件夹（不复制，仅记录路径） */
+  const handleAttachFolder = React.useCallback(async (): Promise<void> => {
     try {
       const result = await window.electronAPI.openFolderDialog()
       if (!result) return
 
-      setIsUploadingFolder(true)
-      console.log(`[AgentView] 开始复制文件夹: ${result.path}`)
-
-      const saved = await window.electronAPI.copyFolderToSession({
-        sourcePath: result.path,
-        workspaceSlug: workspace.slug,
+      const updated = await window.electronAPI.attachDirectory({
         sessionId,
+        directoryPath: result.path,
       })
 
-      setPendingFolderRefs((prev) => [...prev, ...saved])
-      console.log(`[AgentView] 文件夹复制成功，共 ${saved.length} 个文件`)
-    } catch (error) {
-      console.error('[AgentView] 文件夹选择失败:', error)
-      // 显示错误提示
-      setAgentStreamErrors((prev) => {
+      setAttachedDirsMap((prev) => {
         const map = new Map(prev)
-        map.set(sessionId, `文件夹上传失败: ${error instanceof Error ? error.message : '未知错误'}`)
+        map.set(sessionId, updated)
         return map
       })
-    } finally {
-      setIsUploadingFolder(false)
+
+      toast.success(`已附加目录: ${result.name}`)
+    } catch (error) {
+      console.error('[AgentView] 附加文件夹失败:', error)
+      toast.error('附加文件夹失败')
     }
-  }, [sessionId, currentWorkspaceId, workspaces, isUploadingFolder, setAgentStreamErrors])
+  }, [sessionId, setAttachedDirsMap])
 
   /** 移除待发送文件 */
   const handleRemoveFile = React.useCallback((id: string): void => {
@@ -422,7 +432,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     const text = inputContent.trim()
     // 如果输入为空但有建议，使用建议内容
     const effectiveText = text || suggestion || ''
-    if ((!effectiveText && pendingFiles.length === 0 && pendingFolderRefs.length === 0) || !agentChannelId) return
+    if ((!effectiveText && pendingFiles.length === 0) || !agentChannelId) return
 
     // 上一条消息仍在处理中，提示用户等待或停止
     if (streaming) {
@@ -478,13 +488,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       setPendingFiles([])
     }
 
-    // 1b. 如果有 pending 文件夹引用（已复制到 session 目录）
-    if (pendingFolderRefs.length > 0) {
-      const refs = pendingFolderRefs.map((f) => `- ${f.filename}: ${f.targetPath}`).join('\n')
-      fileReferences += `<attached_files>\n${refs}\n</attached_files>\n\n`
-      setPendingFolderRefs([])
-    }
-
     // 2. 构建最终消息
     const finalMessage = fileReferences + effectiveText
 
@@ -533,6 +536,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       channelId: agentChannelId,
       modelId: agentModelId || undefined,
       workspaceId: currentWorkspaceId || undefined,
+      ...(attachedDirs.length > 0 && { additionalDirectories: attachedDirs }),
     }
 
     setInputContent('')
@@ -546,7 +550,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         return map
       })
     })
-  }, [inputContent, pendingFiles, pendingFolderRefs, sessionId, agentChannelId, agentModelId, currentWorkspaceId, workspaces, streaming, suggestion, store, setStreamingStates, setPendingFiles, setAgentStreamErrors, setPromptSuggestions, setInputContent])
+  }, [inputContent, pendingFiles, attachedDirs, sessionId, agentChannelId, agentModelId, currentWorkspaceId, workspaces, streaming, suggestion, store, setStreamingStates, setPendingFiles, setAgentStreamErrors, setPromptSuggestions, setInputContent])
 
   /** 停止生成 */
   const handleStop = React.useCallback((): void => {
@@ -681,7 +685,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     }
   }, [sessionId, agentChannelId, agentModelId, currentWorkspaceId, tabs, layout, setAgentSessions, setCurrentAgentSessionId, setTabs, setLayout, setStreamingStates])
 
-  const canSend = (inputContent.trim().length > 0 || pendingFiles.length > 0 || pendingFolderRefs.length > 0) && agentChannelId !== null && !streaming
+  const canSend = (inputContent.trim().length > 0 || pendingFiles.length > 0) && agentChannelId !== null && !streaming
 
   return (
     <AgentSessionProvider sessionId={sessionId}>
@@ -705,7 +709,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         {dragFolderWarning && (
           <div className="mx-4 mb-2 px-4 py-2.5 rounded-lg bg-amber-500/10 text-amber-600 dark:text-amber-400 text-sm flex items-center gap-2">
             <FolderPlus className="size-4 shrink-0" />
-            <span className="flex-1">不支持拖拽文件夹，请使用"添加文件夹"按钮</span>
+            <span className="flex-1">不支持拖拽文件夹，请使用"附加文件夹"按钮</span>
             <button
               type="button"
               className="shrink-0 p-0.5 rounded hover:bg-amber-500/10 transition-colors"
@@ -760,23 +764,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
                     onRemove={() => handleRemoveFile(file.id)}
                   />
                 ))}
-              </div>
-            )}
-
-            {/* 文件夹引用预览区域 */}
-            {pendingFolderRefs.length > 0 && (
-              <div className="flex flex-wrap gap-1.5 px-3 pb-1.5">
-                <div className="flex items-center gap-1.5 px-2.5 py-1 rounded-md bg-muted text-xs text-muted-foreground">
-                  <FolderPlus className="size-3.5" />
-                  <span>已附加 {pendingFolderRefs.length} 个文件</span>
-                  <button
-                    type="button"
-                    className="ml-1 text-muted-foreground/60 hover:text-foreground transition-colors"
-                    onClick={() => setPendingFolderRefs([])}
-                  >
-                    ×
-                  </button>
-                </div>
               </div>
             )}
 
@@ -848,15 +835,14 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
                           type="button"
                           variant="ghost"
                           size="icon"
-                          className="size-[30px] rounded-full text-foreground/60 hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed"
-                          onClick={handleOpenFolderDialog}
-                          disabled={isUploadingFolder}
+                          className="size-[30px] rounded-full text-foreground/60 hover:text-foreground"
+                          onClick={handleAttachFolder}
                         >
                           <FolderPlus className="size-5" />
                         </Button>
                       </TooltipTrigger>
                       <TooltipContent side="top">
-                        <p>{isUploadingFolder ? '正在上传文件夹...' : '添加文件夹'}</p>
+                        <p>附加文件夹</p>
                       </TooltipContent>
                     </Tooltip>
                     <PermissionModeSelector />

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -268,26 +268,38 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                     <span className="text-[11px] text-muted-foreground/60 truncate flex-1" title={sessionPath}>
                       {breadcrumb}
                     </span>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      className="h-6 w-6 flex-shrink-0"
-                      onClick={() => window.electronAPI.openFile(sessionPath).catch(console.error)}
-                      title="在 Finder 中打开"
-                    >
-                      <ExternalLink className="size-3" />
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      className="h-6 w-6 flex-shrink-0"
-                      onClick={handleRefresh}
-                      title="刷新"
-                    >
-                      <RefreshCw className="size-3" />
-                    </Button>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          className="h-6 w-6 flex-shrink-0"
+                          onClick={() => window.electronAPI.openFile(sessionPath).catch(console.error)}
+                        >
+                          <ExternalLink className="size-3" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom">
+                        <p>在 Finder 中打开工作区文件夹</p>
+                      </TooltipContent>
+                    </Tooltip>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          className="h-6 w-6 flex-shrink-0"
+                          onClick={handleRefresh}
+                        >
+                          <RefreshCw className="size-3" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom">
+                        <p>刷新文件列表</p>
+                      </TooltipContent>
+                    </Tooltip>
                   </div>
                   {/* 附加目录列表 */}
                   {attachedDirs.length > 0 && (

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -243,9 +243,10 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
             <TabsContent value="files" className="flex-1 overflow-hidden m-0 data-[state=active]:flex data-[state=active]:flex-col">
               {sessionPath && workspaceSlug ? (
                 <>
-                  {/* 工具栏：路径面包屑 + 打开文件夹 + 刷新 */}
+                  {/* 工具栏：工作区目录标签 + 路径 + 按钮 */}
                   <div className="flex items-center gap-1 px-3 h-[36px] border-b flex-shrink-0">
-                    <span className="text-xs text-muted-foreground truncate flex-1" title={sessionPath}>
+                    <span className="text-[11px] font-medium text-muted-foreground shrink-0">工作区目录</span>
+                    <span className="text-[11px] text-muted-foreground/60 truncate flex-1" title={sessionPath}>
                       {breadcrumb}
                     </span>
                     <Button

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -26,6 +26,7 @@ import {
   workspaceFilesVersionAtom,
   currentAgentWorkspaceIdAtom,
   agentWorkspacesAtom,
+  agentAttachedDirectoriesMapAtom,
 } from '@/atoms/agent-atoms'
 import type { SidePanelTab } from '@/atoms/agent-atoms'
 
@@ -98,6 +99,31 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
   const workspaces = useAtomValue(agentWorkspacesAtom)
   const workspaceSlug = workspaces.find((w) => w.id === currentWorkspaceId)?.slug ?? null
 
+  // 附加目录列表
+  const attachedDirsMap = useAtomValue(agentAttachedDirectoriesMapAtom)
+  const setAttachedDirsMap = useSetAtom(agentAttachedDirectoriesMapAtom)
+  const attachedDirs = attachedDirsMap.get(sessionId) ?? []
+
+  const handleDetachDirectory = React.useCallback(async (dirPath: string) => {
+    try {
+      const updated = await window.electronAPI.detachDirectory({
+        sessionId,
+        directoryPath: dirPath,
+      })
+      setAttachedDirsMap((prev) => {
+        const map = new Map(prev)
+        if (updated.length > 0) {
+          map.set(sessionId, updated)
+        } else {
+          map.delete(sessionId)
+        }
+        return map
+      })
+    } catch (error) {
+      console.error('[SidePanel] 移除附加目录失败:', error)
+    }
+  }, [sessionId, setAttachedDirsMap])
+
   // 文件上传完成后递增版本号，触发 FileBrowser 刷新
   const handleFilesUploaded = React.useCallback(() => {
     setFilesVersion((prev) => prev + 1)
@@ -129,7 +155,7 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
   }, [filesVersion, sessionPath, hasTeamActivity, setIsOpen, setActiveTab])
 
   // 面板是否可显示内容（需要有 sessionPath 或 team 活动）
-  const hasContent = sessionPath || hasTeamActivity
+  const hasContent = sessionPath || hasTeamActivity || attachedDirs.length > 0
 
   return (
     <div
@@ -243,6 +269,35 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                       <RefreshCw className="size-3" />
                     </Button>
                   </div>
+                  {/* 附加目录列表 */}
+                  {attachedDirs.length > 0 && (
+                    <div className="px-3 pt-2.5 pb-1 space-y-1 flex-shrink-0">
+                      <div className="text-[11px] font-medium text-muted-foreground mb-1">附加目录（Agent 可以读取并操作此文件夹）</div>
+                      {attachedDirs.map((dir) => {
+                        const dirName = dir.split('/').filter(Boolean).pop() || dir
+                        return (
+                          <div
+                            key={dir}
+                            className="flex items-center gap-2 px-2.5 py-1.5 rounded-lg bg-muted/50 group"
+                          >
+                            <FolderOpen className="size-3.5 text-amber-500 shrink-0" />
+                            <span className="text-xs truncate flex-1" title={dir}>
+                              {dirName}
+                            </span>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon"
+                              className="h-5 w-5 opacity-0 group-hover:opacity-100 transition-opacity"
+                              onClick={() => handleDetachDirectory(dir)}
+                            >
+                              <X className="size-3" />
+                            </Button>
+                          </div>
+                        )
+                      })}
+                    </div>
+                  )}
                   {/* 文件拖拽上传区域 */}
                   <FileDropZone
                     workspaceSlug={workspaceSlug}

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -104,6 +104,25 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
   const setAttachedDirsMap = useSetAtom(agentAttachedDirectoriesMapAtom)
   const attachedDirs = attachedDirsMap.get(sessionId) ?? []
 
+  const handleAttachFolder = React.useCallback(async () => {
+    try {
+      const result = await window.electronAPI.openFolderDialog()
+      if (!result) return
+
+      const updated = await window.electronAPI.attachDirectory({
+        sessionId,
+        directoryPath: result.path,
+      })
+      setAttachedDirsMap((prev) => {
+        const map = new Map(prev)
+        map.set(sessionId, updated)
+        return map
+      })
+    } catch (error) {
+      console.error('[SidePanel] 附加文件夹失败:', error)
+    }
+  }, [sessionId, setAttachedDirsMap])
+
   const handleDetachDirectory = React.useCallback(async (dirPath: string) => {
     try {
       const updated = await window.electronAPI.detachDirectory({
@@ -304,6 +323,7 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                     workspaceSlug={workspaceSlug}
                     sessionId={sessionId}
                     onFilesUploaded={handleFilesUploaded}
+                    onAttachFolder={handleAttachFolder}
                   />
                   {/* 文件浏览器（隐藏内置工具栏） */}
                   <div className="flex-1 min-h-0">

--- a/apps/electron/src/renderer/components/file-browser/FileDropZone.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileDropZone.tsx
@@ -9,6 +9,7 @@ import * as React from 'react'
 import { toast } from 'sonner'
 import { Upload, File, FolderPlus, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { fileToBase64 } from '@/lib/file-utils'
 
@@ -159,27 +160,41 @@ export function FileDropZone({ workspaceSlug, sessionId, onFilesUploaded, onAtta
               <span className="text-[10px] text-muted-foreground/60">供 Agent 读取和处理</span>
             </p>
             <div className="flex items-center gap-1.5">
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="h-6 text-[11px] px-2 gap-1"
-                onClick={handleSelectFiles}
-              >
-                <File className="size-3" />
-                选择文件
-              </Button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-6 text-[11px] px-2 gap-1"
+                    onClick={handleSelectFiles}
+                  >
+                    <File className="size-3" />
+                    选择文件
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  <p>将文件放入 Agent 工作文件夹</p>
+                </TooltipContent>
+              </Tooltip>
               {onAttachFolder && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="h-6 text-[11px] px-2 gap-1"
-                  onClick={onAttachFolder}
-                >
-                  <FolderPlus className="size-3" />
-                  附加文件夹
-                </Button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-6 text-[11px] px-2 gap-1"
+                      onClick={onAttachFolder}
+                    >
+                      <FolderPlus className="size-3" />
+                      附加文件夹
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    <p>告知 Agent 你想处理的文件夹</p>
+                  </TooltipContent>
+                </Tooltip>
               )}
             </div>
           </>

--- a/apps/electron/src/renderer/components/file-browser/FileDropZone.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileDropZone.tsx
@@ -7,7 +7,7 @@
 
 import * as React from 'react'
 import { toast } from 'sonner'
-import { Upload, File, Loader2 } from 'lucide-react'
+import { Upload, File, FolderPlus, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { fileToBase64 } from '@/lib/file-utils'
@@ -19,9 +19,11 @@ interface FileDropZoneProps {
   sessionId: string
   /** 上传成功后的回调（触发文件浏览器刷新） */
   onFilesUploaded: () => void
+  /** 附加文件夹回调 */
+  onAttachFolder?: () => void
 }
 
-export function FileDropZone({ workspaceSlug, sessionId, onFilesUploaded }: FileDropZoneProps): React.ReactElement {
+export function FileDropZone({ workspaceSlug, sessionId, onFilesUploaded, onAttachFolder }: FileDropZoneProps): React.ReactElement {
   const [isDragOver, setIsDragOver] = React.useState(false)
   const [isUploading, setIsUploading] = React.useState(false)
 
@@ -167,6 +169,18 @@ export function FileDropZone({ workspaceSlug, sessionId, onFilesUploaded }: File
                 <File className="size-3" />
                 选择文件
               </Button>
+              {onAttachFolder && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-6 text-[11px] px-2 gap-1"
+                  onClick={onAttachFolder}
+                >
+                  <FolderPlus className="size-3" />
+                  附加文件夹
+                </Button>
+              )}
             </div>
           </>
         )}

--- a/apps/electron/src/renderer/components/file-browser/FileDropZone.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileDropZone.tsx
@@ -7,7 +7,7 @@
 
 import * as React from 'react'
 import { toast } from 'sonner'
-import { Upload, File, FolderPlus, Loader2 } from 'lucide-react'
+import { Upload, File, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { fileToBase64 } from '@/lib/file-utils'
@@ -88,7 +88,7 @@ export function FileDropZone({ workspaceSlug, sessionId, onFilesUploaded }: File
     }
 
     if (hasFolders) {
-      toast.info('不支持拖拽文件夹', { description: '请使用「选择文件夹」按钮' })
+      toast.info('不支持拖拽文件夹', { description: '请使用输入框工具栏的「附加文件夹」按钮' })
     }
 
     if (regularFiles.length > 0) {
@@ -120,28 +120,6 @@ export function FileDropZone({ workspaceSlug, sessionId, onFilesUploaded }: File
     } catch (error) {
       console.error('[FileDropZone] 选择文件失败:', error)
       toast.error('文件上传失败')
-    } finally {
-      setIsUploading(false)
-    }
-  }, [workspaceSlug, sessionId, onFilesUploaded])
-
-  const handleSelectFolder = React.useCallback(async (): Promise<void> => {
-    try {
-      const result = await window.electronAPI.openFolderDialog()
-      if (!result) return
-
-      setIsUploading(true)
-      await window.electronAPI.copyFolderToSession({
-        sourcePath: result.path,
-        workspaceSlug,
-        sessionId,
-      })
-
-      onFilesUploaded()
-      toast.success(`已添加文件夹「${result.name}」`)
-    } catch (error) {
-      console.error('[FileDropZone] 选择文件夹失败:', error)
-      toast.error('文件夹上传失败')
     } finally {
       setIsUploading(false)
     }
@@ -188,16 +166,6 @@ export function FileDropZone({ workspaceSlug, sessionId, onFilesUploaded }: File
               >
                 <File className="size-3" />
                 选择文件
-              </Button>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="h-6 text-[11px] px-2 gap-1"
-                onClick={handleSelectFolder}
-              >
-                <FolderPlus className="size-3" />
-                选择文件夹
               </Button>
             </div>
           </>

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/shared",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "license": "Apache-2.0",
   "description": "Shared types, configs and utilities for proma",
   "type": "module",

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -312,6 +312,8 @@ export interface AgentSessionMeta {
   workspaceId?: string
   /** 是否置顶 */
   pinned?: boolean
+  /** 附加的外部目录路径列表（绝对路径，作为 SDK additionalDirectories 传递） */
+  attachedDirectories?: string[]
   /** 创建时间戳 */
   createdAt: number
   /** 更新时间戳 */
@@ -432,6 +434,8 @@ export interface AgentSendInput {
   modelId?: string
   /** 工作区 ID（用于确定 cwd） */
   workspaceId?: string
+  /** 附加的外部目录（绝对路径，传递给 SDK additionalDirectories） */
+  additionalDirectories?: string[]
 }
 
 // ===== 会话迁移输入 =====
@@ -541,11 +545,12 @@ export interface AgentSavedFile {
   targetPath: string
 }
 
-/** Agent 复制文件夹到 session 的输入 */
-export interface AgentCopyFolderInput {
-  sourcePath: string
-  workspaceSlug: string
+/** 附加/分离目录的输入参数 */
+export interface AgentAttachDirectoryInput {
+  /** 会话 ID */
   sessionId: string
+  /** 目录的绝对路径 */
+  directoryPath: string
 }
 
 // ===== AskUserQuestion 交互式问答类型 =====
@@ -710,8 +715,10 @@ export const AGENT_IPC_CHANNELS = {
   SAVE_FILES_TO_SESSION: 'agent:save-files-to-session',
   /** 打开文件夹选择对话框 */
   OPEN_FOLDER_DIALOG: 'agent:open-folder-dialog',
-  /** 复制文件夹到 session 工作目录 */
-  COPY_FOLDER_TO_SESSION: 'agent:copy-folder-to-session',
+  /** 附加外部目录到 Agent 会话 */
+  ATTACH_DIRECTORY: 'agent:attach-directory',
+  /** 移除会话的附加目录 */
+  DETACH_DIRECTORY: 'agent:detach-directory',
 
   // 文件系统操作
   /** 获取 session 工作路径 */


### PR DESCRIPTION
## Summary
- 将 Agent 模式的「添加文件夹」（复制整个目录）改为「附加文件夹」（仅记录路径），利用 Claude Agent SDK 原生的 `additionalDirectories` 选项让 Agent 直接访问外部目录
- 右侧文件面板新增附加目录列表区域，显示已附加目录并支持 hover 删除
- 附加目录持久化到 `AgentSessionMeta`，重启应用后仍保留

## Test plan
- [ ] Agent 模式点击 FolderPlus 按钮 → 选择文件夹 → 确认路径被记录（不复制文件）
- [ ] 右侧文件面板 → Files 标签页 → 可见附加目录列表及说明文字
- [ ] hover 目录行显示删除按钮，点击移除目录
- [ ] 发送消息后 Agent 能读取附加目录中的文件
- [ ] 重启应用 → 同一会话的附加目录列表仍在
- [ ] FileDropZone 不再显示「选择文件夹」按钮