### PR TITLE
fix: 取消自动下载/安装更新，改为引导用户手动下载

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -21,7 +21,7 @@ import { stopAllGenerations } from './lib/chat-service'
 import { initAutoUpdater, cleanupUpdater } from './lib/updater/auto-updater'
 import { startWorkspaceWatcher, stopWorkspaceWatcher } from './lib/workspace-watcher'
 import { startChatToolsWatcher, stopChatToolsWatcher } from './lib/chat-tools-watcher'
-import { getIsQuitting, setQuitting, isUpdating } from './lib/app-lifecycle'
+import { getIsQuitting, setQuitting } from './lib/app-lifecycle'
 
 let mainWindow: BrowserWindow | null = null
 
@@ -223,12 +223,6 @@ app.on('window-all-closed', () => {
 app.on('before-quit', () => {
   // 标记正在退出，让 close 事件不再阻止关闭
   setQuitting()
-
-  // 正在安装更新时，让 electron-updater 控制退出流程，不做额外操作
-  if (isUpdating()) {
-    console.log('[应用] 正在安装更新，跳过额外清理')
-    return
-  }
 
   // 中止所有活跃的 Agent 和 Chat 子进程
   stopAllAgents()

--- a/apps/electron/src/main/lib/app-lifecycle.ts
+++ b/apps/electron/src/main/lib/app-lifecycle.ts
@@ -1,14 +1,11 @@
 /**
  * 应用生命周期共享状态
  *
- * 抽取退出/更新标志为独立模块，避免 index.ts ↔ auto-updater.ts 循环依赖。
+ * 抽取退出标志为独立模块，避免循环依赖。
  */
 
 /** 是否正在退出应用（用于区分关闭窗口和退出应用） */
 let _isQuitting = false
-
-/** 是否正在安装更新（防止 before-quit 中额外操作破坏安装流程） */
-let _isUpdating = false
 
 export function getIsQuitting(): boolean {
   return _isQuitting
@@ -16,12 +13,4 @@ export function getIsQuitting(): boolean {
 
 export function setQuitting(value = true): void {
   _isQuitting = value
-}
-
-export function isUpdating(): boolean {
-  return _isUpdating
-}
-
-export function setUpdating(value: boolean): void {
-  _isUpdating = value
 }

--- a/apps/electron/src/main/lib/updater/auto-updater.ts
+++ b/apps/electron/src/main/lib/updater/auto-updater.ts
@@ -1,22 +1,16 @@
 /**
  * 自动更新核心模块
  *
- * 封装 electron-updater，提供后台静默检查/下载 + 状态推送。
- * 仅在打包后的生产环境中工作。
+ * 仅检测新版本并通知用户，不做自动下载/安装。
+ * 用户通过 GitHub Releases 页面手动下载覆盖安装。
  *
- * 参考 craft-agents-oss 的 auto-update.ts 模式：
- * - 设置 electron-updater 日志
- * - installUpdate 使用 isInstalling 防重复 + setUpdating 标志
- * - 直接调用 quitAndInstall（不包裹 setImmediate）
- * - 备份定时器确保退出
+ * 仅在打包后的生产环境中工作。
  */
 
-import { app } from 'electron'
 import { autoUpdater } from 'electron-updater'
 import type { BrowserWindow } from 'electron'
 import type { UpdateStatus } from './updater-types'
 import { UPDATER_IPC_CHANNELS } from './updater-types'
-import { setQuitting, setUpdating } from '../app-lifecycle'
 
 /** 当前更新状态 */
 let currentStatus: UpdateStatus = { status: 'idle' }
@@ -26,9 +20,6 @@ let win: BrowserWindow | null = null
 
 /** 定时检查定时器 */
 let checkInterval: ReturnType<typeof setInterval> | null = null
-
-/** 是否正在执行安装（防重复点击） */
-let isInstalling = false
 
 /** 更新状态并推送给渲染进程 */
 function setStatus(status: UpdateStatus): void {
@@ -47,76 +38,6 @@ export async function checkForUpdates(): Promise<void> {
     await autoUpdater.checkForUpdates()
   } catch (err) {
     console.error('[更新] 检查更新失败:', err)
-    setStatus({
-      status: 'error',
-      error: err instanceof Error ? err.message : String(err),
-    })
-  }
-}
-
-/** 手动触发下载更新 */
-export async function downloadUpdate(): Promise<void> {
-  try {
-    await autoUpdater.downloadUpdate()
-  } catch (err) {
-    console.error('[更新] 下载更新失败:', err)
-    setStatus({
-      status: 'error',
-      error: err instanceof Error ? err.message : String(err),
-    })
-  }
-}
-
-/**
- * 退出并安装更新
- *
- * 参考 craft-agents-oss 模式：
- * 1. 防重复点击
- * 2. 设置 installing 状态给 UI 反馈
- * 3. 设置 isUpdating 标志，让 before-quit 不做额外操作
- * 4. 设置 isQuitting 标志，确保 macOS close handler 不阻止关闭
- * 5. 直接调用 quitAndInstall（不清理子进程，由 before-quit 统一处理）
- * 6. 备份定时器确保应用退出
- */
-export function installUpdate(): void {
-  if (isInstalling) {
-    console.log('[更新] 已在安装中，忽略重复调用')
-    return
-  }
-  isInstalling = true
-
-  try {
-    console.log('[更新] 准备安装更新...')
-    setStatus({ status: 'installing' })
-
-    // 标记正在更新，让 before-quit 知道不要强制退出
-    setUpdating(true)
-    // 标记正在退出，确保 macOS close handler 不阻止关闭
-    setQuitting()
-
-    // 清理定时器
-    cleanupUpdater()
-
-    // isSilent=true: Windows NSIS 静默安装，不弹出安装向导
-    // isForceRunAfter=true: 安装完成后自动重新打开应用
-    console.log('[更新] 调用 autoUpdater.quitAndInstall(true, true)')
-    autoUpdater.quitAndInstall(true, true)
-
-    // 3 秒后备 app.quit()，以防 quitAndInstall 未能触发退出
-    setTimeout(() => {
-      console.log('[更新] 后备: 3 秒超时，调用 app.quit()')
-      app.quit()
-    }, 3_000)
-
-    // 5 秒终极后备 app.exit(0)，强制退出
-    setTimeout(() => {
-      console.log('[更新] 终极后备: 5 秒超时，调用 app.exit(0)')
-      app.exit(0)
-    }, 5_000)
-  } catch (err) {
-    console.error('[更新] 安装更新失败:', err)
-    isInstalling = false
-    setUpdating(false)
     setStatus({
       status: 'error',
       error: err instanceof Error ? err.message : String(err),
@@ -148,9 +69,9 @@ export function initAutoUpdater(mainWindow: BrowserWindow): void {
     debug: (...args: unknown[]) => console.log('[更新-updater:debug]', ...args),
   }
 
-  // 配置：后台静默下载，退出时自动安装
-  autoUpdater.autoDownload = true
-  autoUpdater.autoInstallOnAppQuit = true
+  // 禁用自动下载和自动安装，仅做版本检测
+  autoUpdater.autoDownload = false
+  autoUpdater.autoInstallOnAppQuit = false
 
   // 监听更新事件
   autoUpdater.on('checking-for-update', () => {
@@ -174,37 +95,12 @@ export function initAutoUpdater(mainWindow: BrowserWindow): void {
     setStatus({ status: 'not-available' })
   })
 
-  autoUpdater.on('download-progress', (progress) => {
-    setStatus({
-      status: 'downloading',
-      progress: {
-        percent: progress.percent,
-        transferred: progress.transferred,
-        total: progress.total,
-      },
-    })
-  })
-
-  autoUpdater.on('update-downloaded', (info) => {
-    console.log('[更新] 更新已下载完成:', info.version)
-    setStatus({
-      status: 'downloaded',
-      version: info.version,
-      releaseNotes: typeof info.releaseNotes === 'string'
-        ? info.releaseNotes
-        : undefined,
-    })
-  })
-
   autoUpdater.on('error', (err) => {
     console.error('[更新] 更新出错:', err)
-    // 安装过程中的 error 不覆盖 installing 状态，避免干扰退出流程
-    if (!isInstalling) {
-      setStatus({
-        status: 'error',
-        error: err.message,
-      })
-    }
+    setStatus({
+      status: 'error',
+      error: err.message,
+    })
   })
 
   // 启动后延迟 10 秒首次检查
@@ -228,5 +124,5 @@ export function initAutoUpdater(mainWindow: BrowserWindow): void {
     win = null
   })
 
-  console.log('[更新] 自动更新模块已初始化')
+  console.log('[更新] 版本检测模块已初始化（仅检测，不自动下载/安装）')
 }

--- a/apps/electron/src/main/lib/updater/updater-ipc.ts
+++ b/apps/electron/src/main/lib/updater/updater-ipc.ts
@@ -2,6 +2,7 @@
  * 自动更新 IPC 处理器
  *
  * 注册更新相关的 IPC 通道，供渲染进程调用。
+ * 仅支持检查更新和获取状态，不提供下载/安装功能。
  */
 
 import { ipcMain } from 'electron'
@@ -9,8 +10,6 @@ import { UPDATER_IPC_CHANNELS } from './updater-types'
 import type { UpdateStatus } from './updater-types'
 import {
   checkForUpdates,
-  downloadUpdate,
-  installUpdate,
   getUpdateStatus,
 } from './auto-updater'
 
@@ -23,22 +22,6 @@ export function registerUpdaterIpc(): void {
     UPDATER_IPC_CHANNELS.CHECK_FOR_UPDATES,
     async (): Promise<void> => {
       await checkForUpdates()
-    }
-  )
-
-  // 下载更新
-  ipcMain.handle(
-    UPDATER_IPC_CHANNELS.DOWNLOAD_UPDATE,
-    async (): Promise<void> => {
-      await downloadUpdate()
-    }
-  )
-
-  // 安装更新（退出并安装）
-  ipcMain.handle(
-    UPDATER_IPC_CHANNELS.INSTALL_UPDATE,
-    async (): Promise<void> => {
-      installUpdate()
     }
   )
 

--- a/apps/electron/src/main/lib/updater/updater-types.ts
+++ b/apps/electron/src/main/lib/updater/updater-types.ts
@@ -1,28 +1,21 @@
 /**
  * 自动更新相关类型定义
+ *
+ * 仅检测新版本并通知用户，不做自动下载/安装。
+ * 用户通过 GitHub Releases 页面手动下载覆盖安装。
  */
-
-/** 更新进度信息 */
-export interface UpdateProgress {
-  percent: number
-  transferred: number
-  total: number
-}
 
 /** 更新状态 */
 export interface UpdateStatus {
-  status: 'idle' | 'checking' | 'available' | 'not-available' | 'downloading' | 'downloaded' | 'installing' | 'error'
+  status: 'idle' | 'checking' | 'available' | 'not-available' | 'error'
   version?: string
   releaseNotes?: string
-  progress?: UpdateProgress
   error?: string
 }
 
 /** 更新 IPC 通道常量 */
 export const UPDATER_IPC_CHANNELS = {
   CHECK_FOR_UPDATES: 'updater:check',
-  DOWNLOAD_UPDATE: 'updater:download',
-  INSTALL_UPDATE: 'updater:install',
   GET_STATUS: 'updater:get-status',
   ON_STATUS_CHANGED: 'updater:status-changed',
 } as const

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -431,25 +431,21 @@ export interface ElectronAPI {
   /** 设置默认提示词 */
   setDefaultPrompt: (id: string | null) => Promise<void>
 
-  // ===== 自动更新相关（可选，仅在 updater 模块存在时可用） =====
+  // ===== 版本检测相关（仅检测，不自动下载/安装） =====
 
   /** 更新 API */
   updater?: {
     checkForUpdates: () => Promise<void>
-    downloadUpdate: () => Promise<void>
-    installUpdate: () => Promise<void>
     getStatus: () => Promise<{
-      status: 'idle' | 'checking' | 'available' | 'not-available' | 'downloading' | 'downloaded' | 'installing' | 'error'
+      status: 'idle' | 'checking' | 'available' | 'not-available' | 'error'
       version?: string
       releaseNotes?: string
-      progress?: { percent: number; transferred: number; total: number }
       error?: string
     }>
     onStatusChanged: (callback: (status: {
-      status: 'idle' | 'checking' | 'available' | 'not-available' | 'downloading' | 'downloaded' | 'installing' | 'error'
+      status: 'idle' | 'checking' | 'available' | 'not-available' | 'error'
       version?: string
       releaseNotes?: string
-      progress?: { percent: number; transferred: number; total: number }
       error?: string
     }) => void) => () => void
   }
@@ -942,11 +938,9 @@ const electronAPI: ElectronAPI = {
     return ipcRenderer.invoke(SYSTEM_PROMPT_IPC_CHANNELS.SET_DEFAULT, id)
   },
 
-  // 自动更新（updater 模块为可选，bridge 始终暴露，IPC 调用失败时由渲染进程处理）
+  // 自动更新（仅版本检测，不自动下载/安装）
   updater: {
     checkForUpdates: () => ipcRenderer.invoke('updater:check'),
-    downloadUpdate: () => ipcRenderer.invoke('updater:download'),
-    installUpdate: () => ipcRenderer.invoke('updater:install'),
     getStatus: () => ipcRenderer.invoke('updater:get-status'),
     onStatusChanged: (callback) => {
       const listener = (_event: Electron.IpcRendererEvent, status: Parameters<typeof callback>[0]): void => callback(status)

--- a/apps/electron/src/renderer/atoms/updater.ts
+++ b/apps/electron/src/renderer/atoms/updater.ts
@@ -2,34 +2,27 @@
  * 自动更新状态原子
  *
  * 管理应用更新状态，订阅主进程推送的更新事件。
+ * 仅检测新版本并通知，不自动下载/安装。
  * 优雅降级：如果 window.electronAPI.updater 不存在（开源构建），状态保持 idle。
  */
 
 import { atom } from 'jotai'
 
-/** 更新进度信息 */
-interface UpdateProgress {
-  percent: number
-  transferred: number
-  total: number
-}
-
 /** 更新状态 */
 export interface UpdateStatus {
-  status: 'idle' | 'checking' | 'available' | 'not-available' | 'downloading' | 'downloaded' | 'installing' | 'error'
+  status: 'idle' | 'checking' | 'available' | 'not-available' | 'error'
   version?: string
   releaseNotes?: string
-  progress?: UpdateProgress
   error?: string
 }
 
 /** 更新状态 atom */
 export const updateStatusAtom = atom<UpdateStatus>({ status: 'idle' })
 
-/** 是否有可用更新（available 或 downloaded 状态） */
+/** 是否有可用更新 */
 export const hasUpdateAtom = atom((get) => {
   const { status } = get(updateStatusAtom)
-  return status === 'available' || status === 'downloaded'
+  return status === 'available'
 })
 
 /** updater 是否可用 */
@@ -65,9 +58,4 @@ export function initializeUpdater(
 /** 手动检查更新 */
 export async function checkForUpdates(): Promise<void> {
   await window.electronAPI?.updater?.checkForUpdates()
-}
-
-/** 安装更新并重启 */
-export async function installUpdate(): Promise<void> {
-  await window.electronAPI?.updater?.installUpdate()
 }

--- a/apps/electron/src/renderer/components/settings/AboutSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AboutSettings.tsx
@@ -1,19 +1,20 @@
 /**
  * AboutSettings - 关于页面
  *
- * 显示应用版本号等基本信息，以及自动更新状态和控制。
+ * 显示应用版本号等基本信息，以及版本检测状态。
+ * 检测到新版本后引导用户去 GitHub Releases 手动下载。
  */
 
 import * as React from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
-import { RefreshCw, Download, Loader2, CheckCircle2, AlertCircle, Info, Terminal, ChevronDown, ChevronUp } from 'lucide-react'
+import { RefreshCw, Loader2, CheckCircle2, AlertCircle, Info, Terminal, ChevronDown, ChevronUp, ExternalLink } from 'lucide-react'
 import type { EnvironmentCheckResult, RuntimeStatus } from '@proma/shared'
 import {
   SettingsSection,
   SettingsCard,
   SettingsRow,
 } from './primitives'
-import { updateStatusAtom, updaterAvailableAtom, checkForUpdates, installUpdate } from '@/atoms/updater'
+import { updateStatusAtom, updaterAvailableAtom, checkForUpdates } from '@/atoms/updater'
 import {
   environmentCheckResultAtom,
   hasEnvironmentIssuesAtom,
@@ -27,6 +28,8 @@ import { VersionHistory } from './VersionHistory'
 /** 从 package.json 构建时由 Vite define 注入 */
 declare const __APP_VERSION__: string
 const APP_VERSION = __APP_VERSION__
+
+const GITHUB_RELEASES_URL = 'https://github.com/ErlichLiu/Proma/releases'
 
 /** 更新状态卡片 */
 function UpdateCard(): React.ReactElement | null {
@@ -49,14 +52,14 @@ function UpdateCard(): React.ReactElement | null {
     }
   }
 
-  const handleInstall = async (): Promise<void> => {
-    await installUpdate()
+  const handleGoToDownload = (): void => {
+    const url = release?.html_url || GITHUB_RELEASES_URL
+    window.electronAPI.openExternal(url)
   }
 
   // 当检测到新版本时，获取完整的 release 信息
   React.useEffect(() => {
     if (status.status === 'available' && status.version && !release) {
-      // 从 GitHub 获取完整的 release 信息
       window.electronAPI
         .getReleaseByTag(`v${status.version}`)
         .then((r) => {
@@ -82,21 +85,13 @@ function UpdateCard(): React.ReactElement | null {
           <StatusText status={status.status} version={status.version} error={status.error} />
 
           {/* 操作按钮 */}
-          {status.status === 'installing' ? (
+          {status.status === 'available' ? (
             <button
-              disabled
-              className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground opacity-50 cursor-not-allowed"
-            >
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              正在安装...
-            </button>
-          ) : status.status === 'downloaded' ? (
-            <button
-              onClick={handleInstall}
+              onClick={handleGoToDownload}
               className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
             >
-              <Download className="h-3.5 w-3.5" />
-              立即安装
+              <ExternalLink className="h-3.5 w-3.5" />
+              前往下载
             </button>
           ) : (
             <button
@@ -115,23 +110,8 @@ function UpdateCard(): React.ReactElement | null {
         </div>
       </SettingsRow>
 
-      {/* 下载进度条 */}
-      {status.status === 'downloading' && status.progress && (
-        <div className="px-4 pb-4 -mt-2">
-          <div className="w-full h-1.5 bg-secondary rounded-full overflow-hidden">
-            <div
-              className="h-full bg-primary rounded-full transition-all duration-300"
-              style={{ width: `${Math.round(status.progress.percent)}%` }}
-            />
-          </div>
-          <p className="text-xs text-muted-foreground mt-1">
-            下载中 {Math.round(status.progress.percent)}%
-          </p>
-        </div>
-      )}
-
-      {/* Release Notes（新版本可用或已下载时显示） */}
-      {(status.status === 'available' || status.status === 'downloaded') && hasReleaseNotes && (
+      {/* Release Notes（新版本可用时显示） */}
+      {status.status === 'available' && hasReleaseNotes && (
         <div className="px-4 pb-4 border-t">
           <button
             onClick={() => setShowReleaseNotes(!showReleaseNotes)}
@@ -172,24 +152,8 @@ function StatusText({ status, version, error }: {
     case 'available':
       return (
         <span className="text-xs text-primary flex items-center gap-1">
-          <Download className="h-3 w-3" />
+          <ExternalLink className="h-3 w-3" />
           新版本 v{version} 可用
-        </span>
-      )
-    case 'downloading':
-      return <span className="text-xs text-muted-foreground">正在下载更新...</span>
-    case 'downloaded':
-      return (
-        <span className="text-xs text-green-600 dark:text-green-400 flex items-center gap-1">
-          <CheckCircle2 className="h-3 w-3" />
-          v{version} 已就绪，重启后生效
-        </span>
-      )
-    case 'installing':
-      return (
-        <span className="text-xs text-primary flex items-center gap-1">
-          <Loader2 className="h-3 w-3 animate-spin" />
-          正在安装更新，即将重启...
         </span>
       )
     case 'not-available':

--- a/apps/electron/src/renderer/components/settings/UpdateDialog.tsx
+++ b/apps/electron/src/renderer/components/settings/UpdateDialog.tsx
@@ -1,13 +1,13 @@
 /**
- * UpdateDialog - 全局更新弹窗
+ * UpdateDialog - 新版本通知弹窗
  *
- * 当检测到更新下载完成时自动弹出，提供安装和手动下载两条路径。
+ * 当检测到新版本时自动弹出，引导用户前往 GitHub Releases 下载。
  * 同一版本只弹一次，用户关闭后不再重复弹出。
  */
 
 import * as React from 'react'
 import { useAtomValue } from 'jotai'
-import { Loader2, ExternalLink } from 'lucide-react'
+import { ExternalLink } from 'lucide-react'
 import type { GitHubRelease } from '@proma/shared'
 import {
   AlertDialog,
@@ -19,7 +19,7 @@ import {
   AlertDialogCancel,
   AlertDialogAction,
 } from '@/components/ui/alert-dialog'
-import { updateStatusAtom, installUpdate } from '@/atoms/updater'
+import { updateStatusAtom } from '@/atoms/updater'
 import { ReleaseNotesViewer } from './ReleaseNotesViewer'
 
 const GITHUB_RELEASES_URL = 'https://github.com/ErlichLiu/Proma/releases'
@@ -33,10 +33,10 @@ export function UpdateDialog(): React.ReactElement | null {
   // 记录已弹出过的版本号，同一版本不重复弹出
   const shownVersionRef = React.useRef<string | null>(null)
 
-  // 当状态变为 downloaded 且是新版本时，自动弹出
+  // 当状态变为 available 且是新版本时，自动弹出
   React.useEffect(() => {
     if (
-      updateStatus.status === 'downloaded' &&
+      updateStatus.status === 'available' &&
       updateStatus.version &&
       shownVersionRef.current !== updateStatus.version
     ) {
@@ -58,14 +58,11 @@ export function UpdateDialog(): React.ReactElement | null {
     }
   }, [updateStatus.status, updateStatus.version])
 
-  const isInstalling = updateStatus.status === 'installing'
-
-  const handleInstall = async (e: React.MouseEvent): Promise<void> => {
+  const handleGoToDownload = (e: React.MouseEvent): void => {
     e.preventDefault()
-    await installUpdate()
+    const url = release?.html_url || GITHUB_RELEASES_URL
+    window.electronAPI.openExternal(url)
   }
-
-  const githubUrl = release?.html_url || GITHUB_RELEASES_URL
 
   if (!dialogVersion) return null
 
@@ -75,7 +72,7 @@ export function UpdateDialog(): React.ReactElement | null {
         <AlertDialogHeader>
           <AlertDialogTitle>发现新版本</AlertDialogTitle>
           <AlertDialogDescription>
-            v{dialogVersion} 已下载完成，是否立即安装？
+            v{dialogVersion} 已发布，请前往下载页面获取最新版本覆盖安装。
           </AlertDialogDescription>
         </AlertDialogHeader>
 
@@ -86,36 +83,13 @@ export function UpdateDialog(): React.ReactElement | null {
           </div>
         )}
 
-        {/* 手动下载提示 */}
-        <p className="text-xs text-muted-foreground">
-          如果自动更新失败，请前往{' '}
-          <a
-            href={githubUrl}
-            onClick={(e) => {
-              e.preventDefault()
-              window.electronAPI.openExternal(githubUrl)
-            }}
-            className="inline-flex items-center gap-0.5 text-primary hover:underline"
-          >
-            GitHub Release
-            <ExternalLink className="h-3 w-3" />
-          </a>
-          {' '}页面下载最新版本覆盖安装。
-        </p>
-
         <AlertDialogFooter>
-          <AlertDialogCancel disabled={isInstalling}>
-            稍后提醒
+          <AlertDialogCancel>
+            稍后再说
           </AlertDialogCancel>
-          <AlertDialogAction onClick={handleInstall} disabled={isInstalling}>
-            {isInstalling ? (
-              <>
-                <Loader2 className="h-4 w-4 animate-spin mr-1.5" />
-                正在安装...
-              </>
-            ) : (
-              '立即安装'
-            )}
+          <AlertDialogAction onClick={handleGoToDownload}>
+            <ExternalLink className="h-4 w-4 mr-1.5" />
+            前往下载
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/apps/electron/src/renderer/vite-env.d.ts
+++ b/apps/electron/src/renderer/vite-env.d.ts
@@ -6,27 +6,17 @@ declare module '*.css' {
   export default content
 }
 
-/** 更新进度信息 */
-interface UpdateProgress {
-  percent: number
-  transferred: number
-  total: number
-}
-
 /** 更新状态（与 updater-types.ts 保持一致） */
 interface UpdateStatus {
-  status: 'idle' | 'checking' | 'available' | 'not-available' | 'downloading' | 'downloaded' | 'error'
+  status: 'idle' | 'checking' | 'available' | 'not-available' | 'error'
   version?: string
   releaseNotes?: string
-  progress?: UpdateProgress
   error?: string
 }
 
-/** 更新 API（可选，仅在 updater 模块存在时可用） */
+/** 更新 API（仅版本检测，不自动下载/安装） */
 interface UpdaterAPI {
   checkForUpdates: () => Promise<void>
-  downloadUpdate: () => Promise<void>
-  installUpdate: () => Promise<void>
   getStatus: () => Promise<UpdateStatus>
   onStatusChanged: (callback: (status: UpdateStatus) => void) => () => void
 }


### PR DESCRIPTION
## Summary
- 禁用 electron-updater 的自动下载和自动安装（`autoDownload: false`, `autoInstallOnAppQuit: false`）
- 保留版本检测和通知功能（启动后 10 秒首检，每 4 小时定检）
- 检测到新版本后弹窗引导用户前往 GitHub Releases 页面手动下载覆盖安装
- 移除所有下载/安装相关代码（IPC 通道、preload 桥接、renderer atoms、UI 组件中的进度条和安装按钮）
- 清理 `app-lifecycle.ts` 中不再需要的 `isUpdating`/`setUpdating` 标志

## 背景
electron-updater 在 macOS 上的自动安装长期存在不稳定问题：
- MacUpdater 通过本地 localhost 代理服务器将 ZIP 转交 Squirrel.Mac 处理，这个代理环节是大多数失败的根源
- 从 Big Sur 到 Ventura，每个新版 macOS 都可能导致 `quitAndInstall()` 静默失败
- 该问题在 electron-builder 仓库有大量 issue 报告，且被标记为 "not planned"

## Test plan
- [ ] 启动应用后 10 秒自动检查更新，设置页显示检测结果
- [ ] 手动点击"检查更新"按钮可触发检测
- [ ] 检测到新版本时弹出通知弹窗，显示版本号和更新日志
- [ ] 点击"前往下载"按钮打开 GitHub Releases 页面
- [ ] 设置页 UpdateCard 中"前往下载"按钮正常工作
- [ ] 已是最新版本时显示"已是最新版本"状态
- [ ] 确认不再有自动下载行为（检查 electron-updater 日志）