### PR TITLE
feat: Agent Teams 完整 UI — 状态跟踪、进度可视化、通信时间线

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -55,6 +55,7 @@ import type {
   ChatToolInfo,
   ChatToolState,
   ChatToolMeta,
+  AgentTeamData,
 } from '@proma/shared'
 import type { UserProfile, AppSettings } from '../types'
 import { getRuntimeStatus, getGitRepoStatus } from './lib/runtime-init'
@@ -104,6 +105,7 @@ import {
 import { runAgent, stopAgent, generateAgentTitle, saveFilesToAgentSession, copyFolderToSession } from './lib/agent-service'
 import { permissionService } from './lib/agent-permission-service'
 import { askUserService } from './lib/agent-ask-user-service'
+import { getAgentTeamData, readAgentOutputFile } from './lib/agent-team-reader'
 import { getAgentSessionWorkspacePath, getAgentWorkspacesDir, getWorkspaceSkillsDir } from './lib/config-paths'
 import {
   listAgentWorkspaces,
@@ -950,6 +952,24 @@ export function registerIpcHandlers(): void {
           event: { type: 'ask_user_resolved', requestId },
         })
       }
+    }
+  )
+
+  // ===== Agent Teams 数据 =====
+
+  // 获取 Team 聚合数据（团队配置 + 任务列表 + 收件箱）
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.GET_TEAM_DATA,
+    async (_, sdkSessionId: string): Promise<AgentTeamData | null> => {
+      return getAgentTeamData(sdkSessionId)
+    }
+  )
+
+  // 读取 Teammate 输出文件内容
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.GET_AGENT_OUTPUT,
+    async (_, filePath: string): Promise<string> => {
+      return readAgentOutputFile(filePath)
     }
   )
 

--- a/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
@@ -72,6 +72,8 @@ interface SDKToolProgressMessage {
   tool_name: string
   parent_tool_use_id: string | null
   elapsed_time_seconds?: number
+  /** Agent Teams: 所属 teammate 任务 ID */
+  task_id?: string
 }
 
 type SDKMessage =
@@ -338,6 +340,18 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
         this.translatePromptSuggestion(message, events)
         break
 
+      case 'tool_use_summary': {
+        const summaryMsg = message as { type: 'tool_use_summary'; summary?: string; preceding_tool_use_ids?: string[] }
+        if (summaryMsg.summary) {
+          events.push({
+            type: 'tool_use_summary',
+            summary: summaryMsg.summary,
+            precedingToolUseIds: summaryMsg.preceding_tool_use_ids ?? [],
+          })
+        }
+        break
+      }
+
       default:
         console.log(`[ClaudeAgentAdapter] 忽略消息类型: ${message.type}`)
         break
@@ -453,6 +467,8 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
         toolUseId: msg.parent_tool_use_id || msg.tool_use_id,
         elapsedSeconds: msg.elapsed_time_seconds,
         turnId: turnId.value || undefined,
+        // Agent Teams: 透传 taskId 和 toolName（区分 teammate 内的工具进度 vs 普通工具计时）
+        ...(msg.task_id && { taskId: msg.task_id, lastToolName: msg.tool_name }),
       })
     }
 
@@ -515,19 +531,55 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
     const msg = message as {
       type: 'system'; subtype?: string; status?: string
       task_id?: string; tool_use_id?: string; description?: string; task_type?: string
+      // Agent Teams: task_progress 扩展字段
+      last_tool_name?: string; usage?: { total_tokens?: number; tool_uses?: number; duration_ms?: number }
+      // Agent Teams: task_notification 扩展字段
+      summary?: string; output_file?: string
     }
 
     if (msg.subtype === 'compact_boundary') {
       events.push({ type: 'compact_complete' })
     } else if (msg.subtype === 'status' && msg.status === 'compacting') {
       events.push({ type: 'compacting' })
-    } else if (msg.subtype === 'task_started' && msg.task_id && msg.description) {
+    } else if (msg.subtype === 'task_started' && msg.task_id) {
       events.push({
         type: 'task_started',
         taskId: msg.task_id,
         toolUseId: msg.tool_use_id,
-        description: msg.description,
+        description: msg.description || `Task ${msg.task_id}`,
         taskType: msg.task_type,
+        turnId: turnId.value || undefined,
+      })
+    } else if (msg.subtype === 'task_progress' && msg.task_id) {
+      // Agent Teams: teammate 任务进度（区别于 tool_progress 的计时事件）
+      events.push({
+        type: 'task_progress',
+        taskId: msg.task_id,
+        toolUseId: msg.tool_use_id || msg.task_id,
+        // 不设 elapsedSeconds — system task_progress 无真实计时，避免覆盖 tool_progress 的值
+        description: msg.description,
+        lastToolName: msg.last_tool_name,
+        usage: msg.usage ? {
+          totalTokens: msg.usage.total_tokens ?? 0,
+          toolUses: msg.usage.tool_uses ?? 0,
+          durationMs: msg.usage.duration_ms ?? 0,
+        } : undefined,
+        turnId: turnId.value || undefined,
+      })
+    } else if (msg.subtype === 'task_notification' && msg.task_id) {
+      // Agent Teams: teammate 任务完成/失败/停止
+      events.push({
+        type: 'task_notification',
+        taskId: msg.task_id,
+        toolUseId: msg.tool_use_id,
+        status: (msg.status as 'completed' | 'failed' | 'stopped') || 'completed',
+        summary: msg.summary || '',
+        outputFile: msg.output_file,
+        usage: msg.usage ? {
+          totalTokens: msg.usage.total_tokens ?? 0,
+          toolUses: msg.usage.tool_uses ?? 0,
+          durationMs: msg.usage.duration_ms ?? 0,
+        } : undefined,
         turnId: turnId.value || undefined,
       })
     }

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -39,6 +39,16 @@ import { permissionService } from './agent-permission-service'
 import { askUserService } from './agent-ask-user-service'
 import { getMemoryConfig } from './memory-service'
 import { searchMemory, addMemory, formatSearchResult } from './memos-client'
+import {
+  findTeamLeadInboxPath,
+  pollInboxWithRetry,
+  markInboxAsRead,
+  formatInboxPrompt,
+  formatSummaryFallbackPrompt,
+  areAllWorkersIdle,
+  INBOX_RETRY_CONFIG,
+  type TaskNotificationSummary,
+} from './agent-team-reader'
 
 // ===== 类型定义 =====
 
@@ -145,6 +155,19 @@ const MAX_AUTO_RETRIES = 3
 /** 计算重试延迟（指数退避：1s, 2s, 4s） */
 function getRetryDelayMs(attempt: number): number {
   return Math.min(1000 * Math.pow(2, attempt - 1), 8000)
+}
+
+/**
+ * 可中断的定时器
+ *
+ * 等待指定毫秒，如果 signal 被中止则立即 resolve。
+ */
+function timerWithAbort(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (signal.aborted) { resolve(); return }
+    const tid = setTimeout(resolve, ms)
+    signal.addEventListener('abort', () => { clearTimeout(tid); resolve() }, { once: true })
+  })
 }
 
 /**
@@ -778,7 +801,9 @@ export class AgentOrchestrator {
         env: sdkEnv,
         ...(maxTurns != null && { maxTurns }),
         sdkPermissionMode: permissionMode === 'auto' ? 'bypassPermissions' : 'default',
-        allowDangerouslySkipPermissions: permissionMode === 'auto',
+        // 始终为 true：Worker 子代理使用 SDK 内部 mailbox 通信，
+        // 若不跳过权限检查会导致 Worker 阻塞超时并提前停止
+        allowDangerouslySkipPermissions: true,
         ...(canUseTool && { canUseTool }),
         ...(permissionMode !== 'auto' && { allowedTools: [...SAFE_TOOLS] }),
         systemPrompt: {
@@ -805,6 +830,7 @@ export class AgentOrchestrator {
           console.error(`[Agent SDK stderr] ${data}`)
         },
         onSessionId: (sdkSessionId: string) => {
+          capturedSdkSessionId = sdkSessionId
           if (sdkSessionId !== existingSdkSessionId) {
             try {
               updateAgentSessionMeta(sessionId, { sdkSessionId })
@@ -825,9 +851,18 @@ export class AgentOrchestrator {
 
       console.log(`[Agent 编排] 开始通过 Adapter 遍历事件流...`)
 
-      // 14. 遍历 Adapter 产出的 AgentEvent 流（含自动重试）
+      // 14. 遍历 Adapter 产出的 AgentEvent 流（含自动重试 + Watchdog 死锁检测）
       let lastRetryableError: string | undefined
       let retrySucceeded = false
+
+      // Agent Teams 追踪
+      const startedTaskIds = new Set<string>()
+      const completedTaskIds = new Set<string>()
+      const taskNotificationSummaries: TaskNotificationSummary[] = []
+      /** 捕获到的 SDK session ID（用于 auto-resume 的 inbox 查找） */
+      let capturedSdkSessionId = existingSdkSessionId
+      /** Watchdog 触发标记（死锁被检测到时设为 true） */
+      let abortedByWatchdog = false
 
       for (let attempt = 1; attempt <= MAX_AUTO_RETRIES + 1; attempt++) {
         // 非首次尝试：等待 + 发送重试事件到 UI
@@ -865,7 +900,83 @@ export class AgentOrchestrator {
         let shouldRetryFromTypedError = false
 
         try {
-          for await (const event of this.adapter.query(queryOptions)) {
+          // 获取异步迭代器（手动 .next() 以支持 Promise.race 中断）
+          const queryIterable = this.adapter.query(queryOptions)
+          const queryIterator = queryIterable[Symbol.asyncIterator]()
+
+          // Watchdog 控制器（用于死锁检测后中断事件循环）
+          const loopAbort = new AbortController()
+          abortedByWatchdog = false
+
+          // 启动 Watchdog（每 5 秒检查是否所有 Worker 已 idle 但 Task 工具仍在等待）
+          const WATCHDOG_INTERVAL_MS = 5_000
+          const watchdogDone = (async () => {
+            while (!loopAbort.signal.aborted) {
+              await timerWithAbort(WATCHDOG_INTERVAL_MS, loopAbort.signal)
+              if (loopAbort.signal.aborted) break
+
+              // 仅在有 Worker 启动且未全部完成时检查
+              if (
+                startedTaskIds.size > 0 &&
+                completedTaskIds.size < startedTaskIds.size &&
+                capturedSdkSessionId
+              ) {
+                const allIdle = await areAllWorkersIdle(capturedSdkSessionId, startedTaskIds.size)
+                if (allIdle) {
+                  console.log(
+                    `[Agent 编排] Watchdog: 所有 ${startedTaskIds.size} 个 Worker 已 idle，` +
+                    `Task 工具仍在等待 — 中断以触发 auto-resume`,
+                  )
+                  abortedByWatchdog = true
+                  loopAbort.abort()
+                  break
+                }
+              }
+            }
+          })()
+
+          // 手动事件循环：Promise.race（事件 vs Watchdog 中断）
+          let pendingNext: Promise<IteratorResult<AgentEvent>> | null = null
+          // Teams 活跃时延迟 complete 事件，避免前端提前标记 teammates 为 stopped
+          let deferredCompleteEvent: AgentEvent | null = null
+
+          while (!loopAbort.signal.aborted) {
+            if (!pendingNext) {
+              pendingNext = queryIterator.next()
+            }
+
+            const abortPromise = new Promise<null>((resolve) => {
+              if (loopAbort.signal.aborted) { resolve(null); return }
+              loopAbort.signal.addEventListener('abort', () => resolve(null), { once: true })
+            })
+
+            const raceResult = await Promise.race([
+              pendingNext.then((r) => ({ kind: 'event' as const, result: r })),
+              abortPromise.then(() => ({ kind: 'abort' as const, result: null })),
+            ])
+
+            if (raceResult.kind === 'abort') {
+              // Watchdog 触发：终止事件循环，但不中止 SDK 会话
+              // 注意：pending .next() 可能因 SDK 阻塞而永远不返回，
+              // 因此 .return() 也会排队挂起 — 不能 await，用超时保护
+              pendingNext?.catch(() => {})  // 防止未处理 rejection
+              pendingNext = null
+              const returnPromise = queryIterator.return?.(undefined as never).catch(() => {})
+              // 最多等 1 秒，超时则放弃（generator 稍后 GC 清理）
+              await Promise.race([
+                returnPromise,
+                new Promise<void>((r) => setTimeout(r, 1000)),
+              ])
+              console.log(`[Agent 编排] Watchdog 中断：已退出事件循环`)
+              break
+            }
+
+            const iterResult = raceResult.result
+            if (!iterResult || iterResult.done) break
+
+            pendingNext = null
+            const event = iterResult.value
+
             // typed_error：判断是否可自动重试
             if (event.type === 'typed_error') {
               if (isAutoRetryableTypedError(event.error) && attempt <= MAX_AUTO_RETRIES) {
@@ -878,7 +989,7 @@ export class AgentOrchestrator {
                 accumulatedText = ''
                 accumulatedEvents.length = 0
                 shouldRetryFromTypedError = true
-                break  // 跳出 for-await，进入下一次 retry 循环
+                break  // 跳出事件循环，进入下一次 retry 循环
               }
 
               // 不可重试 → 走原有终止逻辑
@@ -916,6 +1027,9 @@ export class AgentOrchestrator {
               }
 
               this.eventBus.emit(sessionId, event)
+              // 清理 Watchdog
+              if (!loopAbort.signal.aborted) loopAbort.abort()
+              await watchdogDone
               try { updateAgentSessionMeta(sessionId, {}) } catch { /* 忽略 */ }
               callbacks.onComplete(getAgentSessionMessages(sessionId))
               return
@@ -926,7 +1040,39 @@ export class AgentOrchestrator {
               accumulatedText += event.text
             }
             accumulatedEvents.push(event)
-            this.eventBus.emit(sessionId, event)
+
+            // Agent Teams: 当有 teammate 活跃时，延迟 complete 事件
+            // 避免前端收到 complete → 标记所有 teammates 为 stopped → 建议不渲染
+            if (event.type === 'complete' && startedTaskIds.size > 0) {
+              console.log(`[Agent 编排] 延迟 complete 事件（${startedTaskIds.size} 个 teammate 活跃）`)
+              deferredCompleteEvent = event
+              // 不发射到 eventBus，继续等待 auto-resume
+            } else {
+              this.eventBus.emit(sessionId, event)
+            }
+
+            // Agent Teams: 追踪 teammate 任务状态
+            if (event.type === 'task_started') {
+              startedTaskIds.add(event.taskId)
+            } else if (event.type === 'task_notification') {
+              completedTaskIds.add(event.taskId)
+              if (event.summary) {
+                taskNotificationSummaries.push({
+                  taskId: event.taskId,
+                  status: event.status,
+                  summary: event.summary,
+                  outputFile: event.outputFile,
+                })
+              }
+            }
+          }
+
+          // 清理 Watchdog（事件循环正常结束或被 Watchdog 中断）
+          if (!loopAbort.signal.aborted) loopAbort.abort()
+          await watchdogDone
+
+          if (abortedByWatchdog) {
+            console.log(`[Agent 编排] Watchdog 中断了事件循环，将触发 auto-resume`)
           }
 
           // typed_error break 触发了 → 继续循环
@@ -943,7 +1089,88 @@ export class AgentOrchestrator {
 
           // 15. 持久化 assistant 消息
           this.persistAssistantMessage(sessionId, accumulatedText, accumulatedEvents, resolvedModel)
+
+          // 16. Agent Teams Auto-Resume：teammates 完成后自动收集结果并汇总
+          //     触发条件：有 teammate 启动过（正常完成或 Watchdog 中断均适用）
+          console.log(`[Agent 编排] Auto-resume 条件检查: startedTasks=${startedTaskIds.size}, sdkSession=${!!capturedSdkSessionId}, active=${this.activeSessions.has(sessionId)}`)
+          if (startedTaskIds.size > 0 && capturedSdkSessionId && this.activeSessions.has(sessionId)) {
+            console.log(`[Agent 编排] Agent Teams 检测到 ${startedTaskIds.size} 个 teammate，启动 auto-resume`)
+
+            // 通知前端：正在收集 teammate 结果
+            this.eventBus.emit(sessionId, {
+              type: 'waiting_resume',
+              message: '正在收集 teammate 工作结果...',
+            })
+
+            // 构造 resume prompt（优先 inbox，fallback 到 summaries）
+            let resumePrompt: string | null = null
+
+            const inboxInfo = await findTeamLeadInboxPath(capturedSdkSessionId)
+            console.log(`[Agent 编排] Inbox 查找结果: ${inboxInfo ? `team=${inboxInfo.teamName}` : '未找到 team'}`)
+            if (inboxInfo) {
+              const unreadMessages = await pollInboxWithRetry(
+                inboxInfo.inboxPath,
+                INBOX_RETRY_CONFIG,
+              )
+              if (unreadMessages.length > 0) {
+                await markInboxAsRead(inboxInfo.inboxPath)
+                resumePrompt = formatInboxPrompt(unreadMessages)
+                console.log(`[Agent 编排] 使用 ${unreadMessages.length} 条 inbox 消息构建 resume prompt`)
+              }
+            }
+
+            // Fallback：用 task_notification summaries
+            if (!resumePrompt && taskNotificationSummaries.length > 0) {
+              console.log(`[Agent 编排] Inbox 为空，使用 ${taskNotificationSummaries.length} 条 task summaries 作为 fallback`)
+              resumePrompt = formatSummaryFallbackPrompt(taskNotificationSummaries)
+            }
+
+            if (resumePrompt && this.activeSessions.has(sessionId)) {
+              const resumeMessageId = randomUUID()
+              this.eventBus.emit(sessionId, { type: 'resume_start', messageId: resumeMessageId })
+
+              // 创建 resume 查询（使用相同的 SDK session ID）
+              let resumeText = ''
+              const resumeEvents: AgentEvent[] = []
+
+              try {
+                const resumeOptions: ClaudeAgentQueryOptions = {
+                  ...queryOptions,
+                  prompt: resumePrompt,
+                  resumeSessionId: capturedSdkSessionId,
+                }
+
+                for await (const event of this.adapter.query(resumeOptions)) {
+                  if (!this.activeSessions.has(sessionId)) break
+
+                  if (event.type === 'text_delta') {
+                    resumeText += event.text
+                  }
+                  resumeEvents.push(event)
+                  this.eventBus.emit(sessionId, event)
+                }
+
+                // 持久化 resume 助手消息
+                if (resumeText || resumeEvents.length > 0) {
+                  this.persistAssistantMessage(sessionId, resumeText, resumeEvents, resolvedModel)
+                }
+
+                console.log(`[Agent 编排] Auto-resume 完成，输出 ${resumeText.length} 字符`)
+              } catch (resumeError) {
+                console.error('[Agent 编排] Auto-resume 失败:', resumeError)
+                // 已流式的部分内容已保存，继续完成流程
+              }
+            } else if (!resumePrompt) {
+              console.log('[Agent 编排] 无可用的 resume 内容（inbox 和 summaries 均为空）')
+            }
+          }
           try { updateAgentSessionMeta(sessionId, {}) } catch { /* 忽略 */ }
+
+          // 发射延迟的 complete 事件（auto-resume 已完成，前端可安全处理）
+          if (deferredCompleteEvent) {
+            console.log(`[Agent 编排] 发射延迟的 complete 事件`)
+            this.eventBus.emit(sessionId, deferredCompleteEvent)
+          }
 
           // 发送完成信号
           callbacks.onComplete(getAgentSessionMessages(sessionId))

--- a/apps/electron/src/main/lib/agent-permission-service.ts
+++ b/apps/electron/src/main/lib/agent-permission-service.ts
@@ -121,6 +121,11 @@ export class AgentPermissionService {
 
       const allow = (): PermissionResult => ({ behavior: 'allow' as const, updatedInput: input })
 
+      // Worker（子代理）的工具调用自动批准，避免 UI 等待导致超时死锁
+      if (options.agentID) {
+        return allow()
+      }
+
       // 自动模式：全部允许（理论上不会到这里，auto 模式使用 bypassPermissions）
       if (mode === 'auto') return allow()
 

--- a/apps/electron/src/main/lib/agent-team-reader.ts
+++ b/apps/electron/src/main/lib/agent-team-reader.ts
@@ -1,0 +1,351 @@
+/**
+ * Agent Team Reader — 读取 Agent Teams 文件系统数据
+ *
+ * 职责：
+ * - 扫描 ~/.claude/teams/ 查找 team 配置
+ * - 读取 ~/.claude/tasks/ 中的任务列表
+ * - 读取 agent 收件箱消息
+ * - 轮询 inbox 带重试（用于 auto-resume）
+ * - 格式化 resume prompt
+ */
+
+import { readdir, readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+import type {
+  TeamConfig,
+  TaskItem,
+  ParsedMailboxMessage,
+  AgentTeamData,
+} from '@proma/shared'
+
+const TEAMS_DIR = join(homedir(), '.claude', 'teams')
+const TASKS_DIR = join(homedir(), '.claude', 'tasks')
+
+// ===== 收件箱消息类型 =====
+
+interface InboxMessage {
+  from: string
+  text: string
+  summary?: string
+  timestamp?: string
+  read?: boolean
+}
+
+// ===== Inbox 重试配置 =====
+
+interface InboxRetryConfig {
+  maxAttempts: number
+  delayMs: number
+}
+
+export const INBOX_RETRY_CONFIG: InboxRetryConfig = {
+  maxAttempts: 5,
+  delayMs: 2000,
+}
+
+// ===== 核心函数 =====
+
+/**
+ * 通过 SDK sessionId 查找对应的 team 名称和 inbox 路径
+ */
+export async function findTeamLeadInboxPath(
+  sdkSessionId: string,
+): Promise<{ teamName: string; inboxPath: string } | null> {
+  let teamEntries: string[]
+  try {
+    teamEntries = await readdir(TEAMS_DIR)
+  } catch {
+    return null
+  }
+
+  for (const teamName of teamEntries) {
+    const configPath = join(TEAMS_DIR, teamName, 'config.json')
+    try {
+      const raw = await readFile(configPath, 'utf-8')
+      const config = JSON.parse(raw) as { leadSessionId?: string }
+      if (config.leadSessionId === sdkSessionId) {
+        const inboxPath = join(TEAMS_DIR, teamName, 'inboxes', 'team-lead.json')
+        return { teamName, inboxPath }
+      }
+    } catch {
+      continue
+    }
+  }
+  return null
+}
+
+/**
+ * 读取 team-lead 收件箱中未读的消息（排除系统类型）
+ */
+async function readUnreadTeamLeadMessages(inboxPath: string): Promise<InboxMessage[]> {
+  try {
+    const raw = await readFile(inboxPath, 'utf-8')
+    const messages: InboxMessage[] = JSON.parse(raw)
+    return messages.filter((m) => {
+      if (m.read) return false
+      // 跳过纯系统通知
+      try {
+        const parsed = JSON.parse(m.text) as Record<string, unknown>
+        const t = parsed.type
+        if (
+          t === 'idle_notification' ||
+          t === 'shutdown_request' ||
+          t === 'shutdown_approved' ||
+          t === 'permission_request'
+        ) {
+          return false
+        }
+      } catch {
+        // 不是 JSON，保留
+      }
+      return true
+    })
+  } catch {
+    return []
+  }
+}
+
+/**
+ * 将收件箱中所有消息标记为已读
+ */
+export async function markInboxAsRead(inboxPath: string): Promise<void> {
+  try {
+    const raw = await readFile(inboxPath, 'utf-8')
+    const messages: InboxMessage[] = JSON.parse(raw)
+    const updated = messages.map((m) => ({ ...m, read: true }))
+    await writeFile(inboxPath, JSON.stringify(updated, null, 2), 'utf-8')
+  } catch {
+    // 忽略错误
+  }
+}
+
+/**
+ * 带重试的 inbox 轮询
+ *
+ * Workers 写入 inbox 有时序延迟，需要多次尝试。
+ */
+export async function pollInboxWithRetry(
+  inboxPath: string,
+  config: InboxRetryConfig,
+): Promise<InboxMessage[]> {
+  for (let attempt = 1; attempt <= config.maxAttempts; attempt++) {
+    const messages = await readUnreadTeamLeadMessages(inboxPath)
+    if (messages.length > 0) {
+      console.log(`[Team Reader] Inbox 轮询 ${attempt}/${config.maxAttempts}: 找到 ${messages.length} 条消息`)
+      return messages
+    }
+    if (attempt < config.maxAttempts) {
+      console.log(`[Team Reader] Inbox 轮询 ${attempt}/${config.maxAttempts}: 空，${config.delayMs}ms 后重试`)
+      await new Promise<void>((resolve) => setTimeout(resolve, config.delayMs))
+    }
+  }
+  console.log(`[Team Reader] Inbox 轮询: ${config.maxAttempts} 次尝试用尽，仍为空`)
+  return []
+}
+
+/**
+ * 格式化未读收件箱消息，作为 auto-resume 的 prompt
+ */
+export function formatInboxPrompt(messages: InboxMessage[]): string {
+  const sections = messages.map((m) => {
+    const header = `**来自 ${m.from}**${m.summary ? `（${m.summary}）` : ''}:`
+    let body = m.text
+    try {
+      const parsed = JSON.parse(m.text) as Record<string, unknown>
+      if (typeof parsed.content === 'string') body = parsed.content
+    } catch { /* 非 JSON */ }
+    return `${header}\n${body}`
+  })
+  return (
+    `[系统通知] 你的工作者 Agent 已完成任务，以下是他们发送的完整工作结果：\n\n` +
+    sections.join('\n\n---\n\n') +
+    `\n\n请基于以上工作结果，向用户提供完整、详尽的最终回复。`
+  )
+}
+
+/** task_notification 收集的摘要（用作 inbox 为空时的 fallback） */
+export interface TaskNotificationSummary {
+  taskId: string
+  status: string
+  summary: string
+  outputFile?: string
+}
+
+/**
+ * 用 task_notification 的 summaries 构造 fallback resume prompt
+ */
+export function formatSummaryFallbackPrompt(summaries: TaskNotificationSummary[]): string {
+  const sections = summaries.map((s) => {
+    const statusLabel = s.status === 'completed' ? '已完成' : s.status
+    return `- **Task ${s.taskId}** (${statusLabel}): ${s.summary}`
+  })
+  return (
+    `[系统通知] 你的工作者 Agent 已完成任务。以下是各任务的完成摘要：\n\n` +
+    sections.join('\n') +
+    `\n\n请基于以上任务摘要，向用户提供完整、详尽的最终回复。`
+  )
+}
+
+/**
+ * 检测所有工作者 Agent 是否已进入 idle 状态
+ *
+ * 用于 Watchdog 死锁检测：Task 工具仍在等待但 Workers 已停止工作。
+ */
+export async function areAllWorkersIdle(
+  sdkSessionId: string,
+  startedCount: number,
+): Promise<boolean> {
+  if (startedCount === 0) return false
+  const inboxInfo = await findTeamLeadInboxPath(sdkSessionId)
+  if (!inboxInfo) return false
+  try {
+    const raw = await readFile(inboxInfo.inboxPath, 'utf-8')
+    const messages: InboxMessage[] = JSON.parse(raw)
+    const idleWorkers = new Set<string>()
+    for (const msg of messages) {
+      try {
+        const parsed = JSON.parse(msg.text) as Record<string, unknown>
+        if (parsed.type === 'idle_notification') {
+          idleWorkers.add(msg.from)
+        }
+      } catch { /* 非 JSON */ }
+    }
+    return idleWorkers.size >= startedCount
+  } catch {
+    return false
+  }
+}
+
+// ===== Team 数据聚合（IPC 用） =====
+
+/**
+ * 通过 SDK sessionId 获取 Team 聚合数据
+ *
+ * 供 IPC handler 调用，返回完整的团队信息 + 任务列表 + 收件箱消息。
+ */
+export async function getAgentTeamData(sdkSessionId: string): Promise<AgentTeamData | null> {
+  let teamEntries: string[]
+  try {
+    teamEntries = await readdir(TEAMS_DIR)
+  } catch {
+    return null
+  }
+
+  for (const teamName of teamEntries) {
+    const configPath = join(TEAMS_DIR, teamName, 'config.json')
+    try {
+      const raw = await readFile(configPath, 'utf-8')
+      const config: TeamConfig = JSON.parse(raw)
+      if (config.leadSessionId === sdkSessionId) {
+        const tasks = await readTasksForTeam(teamName)
+        const inboxes = await readInboxesForTeam(teamName)
+        return { teamName, team: config, tasks, inboxes }
+      }
+    } catch {
+      continue
+    }
+  }
+
+  return null
+}
+
+/**
+ * 读取指定 team 的任务列表
+ */
+async function readTasksForTeam(teamName: string): Promise<TaskItem[]> {
+  const tasksDir = join(TASKS_DIR, teamName)
+  let files: string[]
+  try {
+    files = await readdir(tasksDir)
+  } catch {
+    return []
+  }
+
+  const jsonFiles = files
+    .filter((f) => f.endsWith('.json') && !f.startsWith('.'))
+    .sort((a, b) => {
+      const na = parseInt(a, 10)
+      const nb = parseInt(b, 10)
+      if (!isNaN(na) && !isNaN(nb)) return na - nb
+      return a.localeCompare(b)
+    })
+
+  const tasks: TaskItem[] = []
+  for (const file of jsonFiles) {
+    try {
+      const raw = await readFile(join(tasksDir, file), 'utf-8')
+      const task: TaskItem = JSON.parse(raw)
+      tasks.push(task)
+    } catch {
+      continue
+    }
+  }
+
+  return tasks
+}
+
+/**
+ * 读取指定 team 的所有 agent 收件箱消息
+ */
+async function readInboxesForTeam(teamName: string): Promise<Record<string, ParsedMailboxMessage[]>> {
+  const inboxesDir = join(TEAMS_DIR, teamName, 'inboxes')
+  let files: string[]
+  try {
+    files = await readdir(inboxesDir)
+  } catch {
+    return {}
+  }
+
+  const result: Record<string, ParsedMailboxMessage[]> = {}
+
+  for (const file of files) {
+    if (!file.endsWith('.json') || file.startsWith('.')) continue
+    const agentName = file.replace(/\.json$/, '')
+    try {
+      const raw = await readFile(join(inboxesDir, file), 'utf-8')
+      const messages: InboxMessage[] = JSON.parse(raw)
+      result[agentName] = messages.map(parseMailboxMessage)
+    } catch {
+      continue
+    }
+  }
+
+  return result
+}
+
+/**
+ * 解析收件箱消息类型
+ */
+function parseMailboxMessage(msg: InboxMessage): ParsedMailboxMessage {
+  try {
+    const parsed = JSON.parse(msg.text) as Record<string, unknown>
+    if (parsed && typeof parsed === 'object' && typeof parsed.type === 'string') {
+      const msgType = parsed.type
+      if (msgType === 'idle_notification') return { ...msg, parsedType: 'idle_notification' }
+      if (msgType === 'shutdown_request') return { ...msg, parsedType: 'shutdown_request' }
+      if (msgType === 'shutdown_approved') return { ...msg, parsedType: 'shutdown_approved' }
+      if (msgType === 'task_assignment') return { ...msg, parsedType: 'task_assignment' }
+    }
+  } catch {
+    // 不是 JSON
+  }
+  return { ...msg, parsedType: 'text' }
+}
+
+/**
+ * 读取 Teammate 输出文件内容
+ *
+ * 安全性：仅允许读取 ~/.claude/ 目录下的文件。
+ */
+export async function readAgentOutputFile(filePath: string): Promise<string> {
+  const claudeDir = join(homedir(), '.claude')
+  if (!filePath.startsWith(claudeDir)) {
+    throw new Error('不允许读取 ~/.claude/ 目录之外的文件')
+  }
+  try {
+    return await readFile(filePath, 'utf-8')
+  } catch {
+    return ''
+  }
+}

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -65,6 +65,7 @@ import type {
   ChatToolInfo,
   ChatToolState,
   ChatToolMeta,
+  AgentTeamData,
 } from '@proma/shared'
 import type { UserProfile, AppSettings } from '../types'
 
@@ -382,6 +383,14 @@ export interface ElectronAPI {
 
   /** 响应 AskUser 请求 */
   respondAskUser: (response: AskUserResponse) => Promise<void>
+
+  // ===== Agent Teams 数据 =====
+
+  /** 获取 Team 聚合数据（团队配置 + 任务列表 + 收件箱） */
+  getAgentTeamData: (sdkSessionId: string) => Promise<AgentTeamData | null>
+
+  /** 读取 Teammate 输出文件内容 */
+  getAgentOutput: (filePath: string) => Promise<string>
 
   // ===== Agent 附件 =====
 
@@ -868,6 +877,15 @@ const electronAPI: ElectronAPI = {
   // AskUserQuestion 交互式问答
   respondAskUser: (response: AskUserResponse) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.ASK_USER_RESPOND, response)
+  },
+
+  // Agent Teams 数据
+  getAgentTeamData: (sdkSessionId: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.GET_TEAM_DATA, sdkSessionId)
+  },
+
+  getAgentOutput: (filePath: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.GET_AGENT_OUTPUT, filePath)
   },
 
   // 工作区文件变化通知

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -7,7 +7,7 @@
 
 import { atom } from 'jotai'
 import { atomFamily } from 'jotai/utils'
-import type { AgentSessionMeta, AgentMessage, AgentEvent, AgentWorkspace, AgentPendingFile, RetryAttempt, PromaPermissionMode, PermissionRequest, AskUserRequest, ThinkingConfig, AgentEffort } from '@proma/shared'
+import type { AgentSessionMeta, AgentMessage, AgentEvent, AgentWorkspace, AgentPendingFile, RetryAttempt, PromaPermissionMode, PermissionRequest, AskUserRequest, ThinkingConfig, AgentEffort, TaskUsage, AgentTeamData } from '@proma/shared'
 
 /** 活动状态 */
 export type ActivityStatus = 'pending' | 'running' | 'completed' | 'error' | 'backgrounded'
@@ -49,6 +49,48 @@ export interface SubAgentEntry {
   childActivities: ToolActivity[]
 }
 
+/** Teammate 状态枚举 */
+export type TeammateStatus = 'running' | 'completed' | 'failed' | 'stopped'
+
+/** 单个 teammate 的实时状态（Agent Teams 功能） */
+export interface TeammateState {
+  /** SDK task_id */
+  taskId: string
+  /** 关联的 tool_use_id（Task 工具调用 ID） */
+  toolUseId?: string
+  /** 任务描述（spawn 时 Claude 给出的说明） */
+  description: string
+  /** 任务类型（SDK 内部类型，如 in_process_teammate） */
+  taskType?: string
+  /** 在当前对话中的序号（从 1 开始） */
+  index: number
+  /** 当前状态 */
+  status: TeammateStatus
+  /** 最近一次 task_progress 的描述（实时思考内容） */
+  progressDescription?: string
+  /** 当前正在运行的工具名 */
+  currentToolName?: string
+  /** 当前工具已运行秒数 */
+  currentToolElapsedSeconds?: number
+  /** 当前工具 toolUseId */
+  currentToolUseId?: string
+  /** 已使用的工具历史记录（最近 N 个，去重） */
+  toolHistory: string[]
+  /** 完成时的摘要 */
+  summary?: string
+  /** 完成时输出文件路径 */
+  outputFile?: string
+  /** 累计用量 */
+  usage?: TaskUsage
+  /** 开始时间戳 */
+  startedAt: number
+  /** 结束时间戳 */
+  endedAt?: number
+}
+
+/** 工具历史最大记录数 */
+const MAX_TOOL_HISTORY = 20
+
 /** 侧面板活跃 Tab */
 export type SidePanelTab = 'team' | 'files'
 
@@ -77,6 +119,10 @@ export interface AgentStreamState {
     /** 是否已失败 */
     failed: boolean
   }
+  /** Agent Teams: teammate 状态列表 */
+  teammates: TeammateState[]
+  /** 是否等待 auto-resume（teammate 结果收集中） */
+  waitingResume?: boolean
 }
 
 /** 从 ToolActivity 派生状态 */
@@ -221,6 +267,265 @@ export function buildTeamActivityEntries(activities: ToolActivity[]): SubAgentEn
   return entries
 }
 
+// ============================================================================
+// Team Overview — 从 ToolActivity 提取丰富的团队信息
+// ============================================================================
+
+/** 团队全景信息（从工具调用事件提取） */
+export interface TeamOverview {
+  /** 团队名称（来自 TeamCreate） */
+  teamName?: string
+  /** 团队描述 */
+  teamDescription?: string
+  /** 任务看板项（来自 TaskCreate + TaskUpdate） */
+  tasks: TeamTaskItem[]
+  /** Agent 条目（来自 Agent tool_start） */
+  agents: TeamAgentInfo[]
+}
+
+/** 团队任务项 */
+export interface TeamTaskItem {
+  /** 任务编号（从 result 中解析） */
+  taskNumber?: string
+  /** 任务主题 */
+  subject: string
+  /** 任务描述 */
+  description?: string
+  /** 进行中标签 */
+  activeForm?: string
+  /** 被哪些任务阻塞 */
+  blockedBy: string[]
+  /** 状态（来自 TaskUpdate） */
+  status?: string
+  /** 工具调用 ID */
+  toolUseId: string
+}
+
+/** 团队 Agent 条目 */
+export interface TeamAgentInfo {
+  /** Agent 名称 */
+  name: string
+  /** 描述/角色 */
+  description: string
+  /** 所属团队 */
+  teamName?: string
+  /** Agent 类型 */
+  subagentType?: string
+  /** 是否后台运行 */
+  isBackground?: boolean
+  /** 对应的 toolUseId */
+  toolUseId: string
+  /** Agent 工具状态 */
+  status: ActivityStatus
+  /** 关联的 TeammateState（通过 toolUseId 匹配） */
+  teammate?: TeammateState
+}
+
+/**
+ * 从 ToolActivity[] 和 TeammateState[] 提取团队全景信息
+ *
+ * 解析 TeamCreate、TaskCreate、TaskUpdate、Agent 工具调用，
+ * 构建团队名称 + Task Board + Agent 列表。
+ */
+export function extractTeamOverview(
+  activities: ToolActivity[],
+  teammates: TeammateState[],
+): TeamOverview | null {
+  let teamName: string | undefined
+  let teamDescription: string | undefined
+  const tasks: TeamTaskItem[] = []
+  const agents: TeamAgentInfo[] = []
+
+  // 按 toolUseId 建立 TeammateState 快速查找表
+  const teammateByToolUseId = new Map<string, TeammateState>()
+  for (const tm of teammates) {
+    if (tm.toolUseId) teammateByToolUseId.set(tm.toolUseId, tm)
+  }
+
+  for (const a of activities) {
+    switch (a.toolName) {
+      case 'TeamCreate': {
+        if (typeof a.input.team_name === 'string') teamName = a.input.team_name
+        if (typeof a.input.description === 'string') teamDescription = a.input.description
+        break
+      }
+
+      case 'TaskCreate': {
+        const subject = typeof a.input.subject === 'string' ? a.input.subject : ''
+        if (!subject) break
+        // 从 result 中解析任务编号（如 "Task #1 created successfully"）
+        let taskNumber: string | undefined
+        if (a.result) {
+          const match = a.result.match(/(?:Task\s+)?#(\d+)/i)
+          if (match) taskNumber = match[1]
+        }
+        tasks.push({
+          taskNumber,
+          subject,
+          description: typeof a.input.description === 'string' ? a.input.description : undefined,
+          activeForm: typeof a.input.activeForm === 'string' ? a.input.activeForm : undefined,
+          blockedBy: [],
+          toolUseId: a.toolUseId,
+        })
+        break
+      }
+
+      case 'TaskUpdate': {
+        const taskId = typeof a.input.taskId === 'string' ? a.input.taskId : undefined
+        if (!taskId) break
+        // 找到匹配的 task，合并数据
+        const task = tasks.find((t) => t.taskNumber === taskId)
+        if (task) {
+          if (Array.isArray(a.input.addBlockedBy)) {
+            for (const dep of a.input.addBlockedBy) {
+              if (typeof dep === 'string' && !task.blockedBy.includes(dep)) {
+                task.blockedBy.push(dep)
+              }
+            }
+          }
+          if (typeof a.input.status === 'string') {
+            task.status = a.input.status
+          }
+        }
+        break
+      }
+
+      case 'Agent': {
+        const name = typeof a.input.name === 'string' ? a.input.name : ''
+        const desc = typeof a.input.description === 'string'
+          ? a.input.description
+          : typeof a.input.prompt === 'string'
+            ? a.input.prompt
+            : ''
+        if (!name && !desc) break
+        agents.push({
+          name: name || 'Agent',
+          description: desc,
+          teamName: typeof a.input.team_name === 'string' ? a.input.team_name : undefined,
+          subagentType: typeof a.input.subagent_type === 'string' ? a.input.subagent_type : undefined,
+          isBackground: a.input.run_in_background === true,
+          toolUseId: a.toolUseId,
+          status: getActivityStatus(a),
+          teammate: teammateByToolUseId.get(a.toolUseId),
+        })
+        break
+      }
+
+      default:
+        break
+    }
+  }
+
+  // 无任何团队信息则返回 null
+  if (!teamName && tasks.length === 0 && agents.length === 0) return null
+
+  return { teamName, teamDescription, tasks, agents }
+}
+
+/**
+ * 从持久化消息中重建 Team 数据
+ *
+ * 页面刷新后，从 JSONL 加载的 AgentMessage.events 中提取
+ * ToolActivity[] 和 TeammateState[]，用于填充缓存 atoms。
+ */
+export function rebuildTeamDataFromMessages(messages: AgentMessage[]): {
+  toolActivities: ToolActivity[]
+  teammates: TeammateState[]
+  overview: TeamOverview | null
+} | null {
+  // 收集所有 assistant 消息中的 events
+  const allEvents: AgentEvent[] = []
+  for (const msg of messages) {
+    if (msg.events) allEvents.push(...msg.events)
+  }
+  if (allEvents.length === 0) return null
+
+  // 重建 ToolActivity[]
+  const toolActivities: ToolActivity[] = []
+  for (const event of allEvents) {
+    if (event.type === 'tool_start') {
+      toolActivities.push({
+        toolUseId: event.toolUseId,
+        toolName: event.toolName,
+        input: event.input ?? {},
+        intent: event.intent,
+        displayName: event.displayName,
+        done: false,
+        parentToolUseId: event.parentToolUseId,
+      })
+    } else if (event.type === 'tool_result') {
+      const idx = toolActivities.findIndex((t) => t.toolUseId === event.toolUseId)
+      if (idx >= 0) {
+        toolActivities[idx] = {
+          ...toolActivities[idx]!,
+          result: event.result,
+          isError: event.isError,
+          done: true,
+        }
+      }
+    }
+  }
+
+  // 重建 TeammateState[]
+  const teammates: TeammateState[] = []
+  for (const event of allEvents) {
+    if (event.type === 'task_started') {
+      teammates.push({
+        taskId: event.taskId,
+        toolUseId: event.toolUseId,
+        description: event.description,
+        taskType: event.taskType,
+        index: teammates.length + 1,
+        status: 'running',
+        toolHistory: [],
+        startedAt: Date.now(),
+      })
+    } else if (event.type === 'task_progress' && event.taskId) {
+      const idx = teammates.findIndex((t) => t.taskId === event.taskId)
+      if (idx >= 0) {
+        const tm = teammates[idx]!
+        teammates[idx] = {
+          ...tm,
+          progressDescription: event.description ?? tm.progressDescription,
+          usage: event.usage ?? tm.usage,
+          ...(event.lastToolName && {
+            currentToolName: event.lastToolName,
+            currentToolElapsedSeconds: event.elapsedSeconds,
+            toolHistory: appendToolHistory(tm.toolHistory, event.lastToolName),
+          }),
+        }
+      }
+    } else if (event.type === 'task_notification') {
+      const idx = teammates.findIndex((t) => t.taskId === event.taskId)
+      if (idx >= 0) {
+        const tm = teammates[idx]!
+        teammates[idx] = {
+          ...tm,
+          status: event.status,
+          summary: event.summary,
+          outputFile: event.outputFile,
+          endedAt: Date.now(),
+          ...(event.usage && { usage: event.usage }),
+          currentToolName: undefined,
+          currentToolElapsedSeconds: undefined,
+          currentToolUseId: undefined,
+        }
+      }
+    }
+  }
+
+  // 检查是否有团队活动
+  const hasTeamActivity = toolActivities.some((a) =>
+    a.toolName === 'TeamCreate' || a.toolName === 'TaskCreate' ||
+    a.toolName === 'Agent' || a.toolName === 'Task',
+  ) || teammates.length > 0
+
+  if (!hasTeamActivity) return null
+
+  const overview = extractTeamOverview(toolActivities, teammates)
+  return { toolActivities, teammates, overview }
+}
+
 /** 待自动发送的 Agent 提示（从设置页"对话完成配置"触发） */
 export interface AgentPendingPrompt {
   sessionId: string
@@ -264,18 +569,50 @@ export const agentSidePanelTabMapAtom = atom<Map<string, SidePanelTab>>(new Map(
  */
 export const cachedTeamActivitiesAtom = atom<Map<string, SubAgentEntry[]>>(new Map())
 
+/**
+ * Teammate 状态缓存 — 以 sessionId 为 key
+ *
+ * 流式完成后保存 teammates 快照，确保切换会话后面板数据不丢失。
+ */
+export const cachedTeammateStatesAtom = atom<Map<string, TeammateState[]>>(new Map())
+
+/**
+ * TeamOverview 缓存 — 以 sessionId 为 key
+ *
+ * 流式完成后保存 TeamOverview 快照，确保切换 tab 后团队全景数据不丢失。
+ */
+export const cachedTeamOverviewsAtom = atom<Map<string, TeamOverview>>(new Map())
+
+/**
+ * 轮询数据缓存 — 以 sessionId 为 key
+ *
+ * 缓存文件系统轮询得到的 AgentTeamData（tasks + inboxes），
+ * 防止组件卸载后通信时间线等数据丢失。
+ */
+export const cachedPolledTeamDataAtom = atom<Map<string, AgentTeamData>>(new Map())
+
+/**
+ * 已关闭 Team 面板的 sessionId 集合
+ *
+ * 用户主动关闭 Team 活动面板后，阻止 derived atoms 返回数据。
+ * 当新一轮流式请求开始时自动清除（允许新 Team 数据显示）。
+ */
+export const dismissedTeamSessionIdsAtom = atom<Set<string>>(new Set<string>())
+
 /** 当前会话是否有 Team/Task 活动（派生只读原子，同时检查流式状态和缓存） */
 export const hasTeamActivityAtom = atom<boolean>((get) => {
   const currentId = get(currentAgentSessionIdAtom)
   if (!currentId) return false
+  if (get(dismissedTeamSessionIdsAtom).has(currentId)) return false
   // 优先检查流式状态
   const state = get(agentStreamingStatesAtom).get(currentId)
   if (state) {
-    return state.toolActivities.some(
+    const hasActivity = state.toolActivities.some(
       (a) => a.toolName === 'Task' || a.toolName === 'Agent'
     )
+    if (hasActivity) return true
   }
-  // 回退到缓存
+  // 回退到缓存（流式状态无 Team 活动或不存在时）
   const cached = get(cachedTeamActivitiesAtom).get(currentId)
   return cached !== undefined && cached.length > 0
 })
@@ -284,6 +621,7 @@ export const hasTeamActivityAtom = atom<boolean>((get) => {
 export const teamActivityEntriesAtom = atom<SubAgentEntry[]>((get) => {
   const currentId = get(currentAgentSessionIdAtom)
   if (!currentId) return []
+  if (get(dismissedTeamSessionIdsAtom).has(currentId)) return []
   // 优先使用流式状态
   const state = get(agentStreamingStatesAtom).get(currentId)
   if (state && state.toolActivities.length > 0) {
@@ -298,6 +636,42 @@ export const teamActivityEntriesAtom = atom<SubAgentEntry[]>((get) => {
 export const teamActivityCountAtom = atom<number>((get) => {
   const entries = get(teamActivityEntriesAtom)
   return entries.filter((e) => e.status === 'running' || e.status === 'backgrounded').length
+})
+
+/** 当前会话的 teammate 状态列表（派生只读原子，优先流式状态，回退缓存） */
+export const teammateStatesAtom = atom<TeammateState[]>((get) => {
+  const currentId = get(currentAgentSessionIdAtom)
+  if (!currentId) return []
+  if (get(dismissedTeamSessionIdsAtom).has(currentId)) return []
+  // 优先使用流式状态中的 teammates
+  const state = get(agentStreamingStatesAtom).get(currentId)
+  if (state && state.teammates.length > 0) return state.teammates
+  // 回退到缓存
+  return get(cachedTeammateStatesAtom).get(currentId) ?? []
+})
+
+/** 是否有 teammate 活动（综合检查流式状态和缓存） */
+export const hasTeammatesAtom = atom<boolean>((get) => {
+  return get(teammateStatesAtom).length > 0
+})
+
+/** 运行中的 teammate 数量 */
+export const runningTeammateCountAtom = atom<number>((get) => {
+  return get(teammateStatesAtom).filter((t) => t.status === 'running').length
+})
+
+/** 团队全景信息（派生只读原子，从 toolActivities + teammates 提取，回退到缓存） */
+export const teamOverviewAtom = atom<TeamOverview | null>((get) => {
+  const currentId = get(currentAgentSessionIdAtom)
+  if (!currentId) return null
+  if (get(dismissedTeamSessionIdsAtom).has(currentId)) return null
+  const state = get(agentStreamingStatesAtom).get(currentId)
+  if (state) {
+    const overview = extractTeamOverview(state.toolActivities, state.teammates)
+    if (overview) return overview
+  }
+  // 回退到缓存（流式状态无 Team 数据或不存在时）
+  return get(cachedTeamOverviewsAtom).get(currentId) ?? null
 })
 
 // ===== 权限系统 Atoms =====
@@ -422,6 +796,16 @@ export const agentRunningSessionIdsAtom = atom<Set<string>>((get) => {
 })
 
 /**
+ * 追加工具名到历史记录（不可变版本）
+ * 相同工具不连续重复，超出上限则删除最旧的
+ */
+function appendToolHistory(history: string[], toolName: string): string[] {
+  if (history[history.length - 1] === toolName) return history
+  const next = [...history, toolName]
+  return next.length > MAX_TOOL_HISTORY ? next.slice(next.length - MAX_TOOL_HISTORY) : next
+}
+
+/**
  * 处理 AgentEvent 并更新流式状态（纯函数）
  */
 export function applyAgentEvent(
@@ -488,27 +872,82 @@ export function applyAgentEvent(
       }
 
     case 'task_progress':
-      return {
-        ...prev,
-        toolActivities: prev.toolActivities.map((t) =>
-          t.toolUseId === event.toolUseId
-            ? { ...t, elapsedSeconds: event.elapsedSeconds }
-            : t
-        ),
+      // Teams 级别的 teammate 进度（带 taskId）
+      if (event.taskId) {
+        const tmIdx = prev.teammates.findIndex((t) => t.taskId === event.taskId)
+        if (tmIdx >= 0) {
+          const tm = prev.teammates[tmIdx]!
+          const updatedTm: TeammateState = {
+            ...tm,
+            progressDescription: event.description ?? tm.progressDescription,
+            usage: event.usage ?? tm.usage,
+            // 更新当前工具名和计时（来自 tool_progress 或 system task_progress）
+            ...(event.lastToolName && {
+              currentToolName: event.lastToolName,
+              currentToolElapsedSeconds: event.elapsedSeconds ?? tm.currentToolElapsedSeconds,
+              currentToolUseId: event.toolUseId,
+              toolHistory: appendToolHistory(tm.toolHistory, event.lastToolName),
+            }),
+            // 无 lastToolName 但有真实 elapsedSeconds 时仅更新计时
+            ...(!event.lastToolName && event.elapsedSeconds != null && {
+              currentToolElapsedSeconds: event.elapsedSeconds,
+            }),
+            // 主对话仍在运行时，收到进度说明 teammate 实际仍在工作，重置 stopped/failed
+            // 主对话已结束时（running: false），不重置（防止建议信息等后续事件错误唤醒）
+            ...(prev.running && (tm.status === 'stopped' || tm.status === 'failed')
+              ? { status: 'running' as const, endedAt: undefined }
+              : {}),
+          }
+          const nextTeammates = [...prev.teammates]
+          nextTeammates[tmIdx] = updatedTm
+          return { ...prev, teammates: nextTeammates }
+        }
       }
+      // 普通 tool 计时语义（仅当有真实 elapsedSeconds 时更新）
+      if (event.elapsedSeconds != null) {
+        return {
+          ...prev,
+          toolActivities: prev.toolActivities.map((t) =>
+            t.toolUseId === event.toolUseId
+              ? { ...t, elapsedSeconds: event.elapsedSeconds! }
+              : t
+          ),
+        }
+      }
+      return prev
 
     case 'task_started': {
       // 查找匹配 toolUseId 的 ToolActivity，更新 intent 和 taskId
-      if (!event.toolUseId) return prev
-      const idx = prev.toolActivities.findIndex((t) => t.toolUseId === event.toolUseId)
-      if (idx < 0) return prev
+      let nextActivities = prev.toolActivities
+      if (event.toolUseId) {
+        const idx = prev.toolActivities.findIndex((t) => t.toolUseId === event.toolUseId)
+        if (idx >= 0) {
+          nextActivities = prev.toolActivities.map((t) =>
+            t.toolUseId === event.toolUseId
+              ? { ...t, intent: event.description, taskId: event.taskId }
+              : t
+          )
+        }
+      }
+      // 去重：已有同 taskId 的 teammate 时仅更新 activities
+      if (prev.teammates.some((t) => t.taskId === event.taskId)) {
+        return { ...prev, toolActivities: nextActivities }
+      }
+      // 创建 TeammateState
+      const newTeammate: TeammateState = {
+        taskId: event.taskId,
+        toolUseId: event.toolUseId,
+        description: event.description,
+        taskType: event.taskType,
+        index: prev.teammates.length + 1,
+        status: 'running',
+        toolHistory: [],
+        startedAt: Date.now(),
+      }
       return {
         ...prev,
-        toolActivities: prev.toolActivities.map((t) =>
-          t.toolUseId === event.toolUseId
-            ? { ...t, intent: event.description, taskId: event.taskId }
-            : t
-        ),
+        toolActivities: nextActivities,
+        teammates: [...prev.teammates, newTeammate],
       }
     }
 
@@ -525,11 +964,62 @@ export function applyAgentEvent(
     case 'shell_killed':
       return prev
 
+    case 'task_notification': {
+      // Agent Teams: teammate 完成/失败/停止
+      const nextTeammates = [...prev.teammates]
+      let tmIdx = nextTeammates.findIndex((t) => t.taskId === event.taskId)
+      if (tmIdx < 0) {
+        // task_started 丢失时的兜底：从 notification 补创 teammate
+        nextTeammates.push({
+          taskId: event.taskId,
+          toolUseId: event.toolUseId,
+          description: event.summary || event.taskId,
+          index: nextTeammates.length + 1,
+          status: 'running',
+          toolHistory: [],
+          startedAt: Date.now(),
+        })
+        tmIdx = nextTeammates.length - 1
+      }
+      nextTeammates[tmIdx] = {
+        ...nextTeammates[tmIdx]!,
+        status: event.status,
+        summary: event.summary,
+        outputFile: event.outputFile,
+        endedAt: Date.now(),
+        ...(event.usage && { usage: event.usage }),
+        // 任务结束后清除实时工具状态
+        currentToolName: undefined,
+        currentToolElapsedSeconds: undefined,
+        currentToolUseId: undefined,
+      }
+      return { ...prev, teammates: nextTeammates }
+    }
+
+    case 'tool_use_summary':
+      // 工具使用摘要 — 目前不影响流式状态，仅用于 UI 展示
+      return prev
+
+    case 'waiting_resume':
+      return { ...prev, waitingResume: true }
+
+    case 'resume_start':
+      return { ...prev, waitingResume: false }
+
     case 'complete':
       // 成功完成 — 清除 retrying，但保持 running: true
       // 等待 STREAM_COMPLETE IPC 回调通过删除流式状态来控制 UI 就绪状态
       // 这避免了用户在后端尚未完成清理时就能发送新消息的竞态条件
-      return { ...prev, retrying: undefined }
+      // 同时将仍 running 的 teammates 标记为 stopped（兜底）
+      return {
+        ...prev,
+        retrying: undefined,
+        teammates: prev.teammates.map((tm) =>
+          tm.status === 'running'
+            ? { ...tm, status: 'stopped' as const, endedAt: Date.now(), currentToolName: undefined, currentToolElapsedSeconds: undefined, currentToolUseId: undefined }
+            : tm
+        ),
+      }
 
     case 'typed_error':
       // 处理类型化错误（TypedError）

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -44,6 +44,12 @@ import {
   agentMessageRefreshAtom,
   agentSessionsAtom,
   currentAgentSessionIdAtom,
+  cachedTeamOverviewsAtom,
+  cachedTeammateStatesAtom,
+  cachedTeamActivitiesAtom,
+  dismissedTeamSessionIdsAtom,
+  buildTeamActivityEntries,
+  rebuildTeamDataFromMessages,
 } from '@/atoms/agent-atoms'
 import type { AgentContextStatus } from '@/atoms/agent-atoms'
 import { activeViewAtom } from '@/atoms/active-view'
@@ -152,6 +158,33 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       .then((msgs) => {
         setMessages(msgs)
 
+        // 从持久化消息中重建 Team 数据并填充缓存（页面刷新后恢复）
+        const teamData = rebuildTeamDataFromMessages(msgs)
+        if (teamData) {
+          if (teamData.overview) {
+            store.set(cachedTeamOverviewsAtom, (prev) => {
+              const map = new Map(prev)
+              map.set(sessionId, teamData.overview!)
+              return map
+            })
+          }
+          if (teamData.teammates.length > 0) {
+            store.set(cachedTeammateStatesAtom, (prev) => {
+              const map = new Map(prev)
+              map.set(sessionId, teamData.teammates)
+              return map
+            })
+          }
+          const entries = buildTeamActivityEntries(teamData.toolActivities)
+          if (entries.length > 0) {
+            store.set(cachedTeamActivitiesAtom, (prev) => {
+              const map = new Map(prev)
+              map.set(sessionId, entries)
+              return map
+            })
+          }
+        }
+
         // 消息加载完成后，清除已完成的流式状态（running=false 的过渡气泡）
         // 在同一个微任务中执行，确保 React 在一次渲染中同时显示持久化消息并移除流式气泡
         setStreamingStates((prev) => {
@@ -163,7 +196,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         })
       })
       .catch(console.error)
-  }, [sessionId, refreshVersion, setStreamingStates])
+  }, [sessionId, refreshVersion, setStreamingStates, store])
 
   // 自动发送 pending prompt（从设置页"对话完成配置"触发）
   React.useEffect(() => {
@@ -184,6 +217,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           running: true,
           content: '',
           toolActivities: [],
+          teammates: [],
           model: agentModelId || undefined,
           startedAt: Date.now(),
         })
@@ -506,6 +540,14 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       })
     }
 
+    // 新一轮对话开始时，解除 Team 面板关闭状态（允许新 Team 数据显示）
+    store.set(dismissedTeamSessionIdsAtom, (prev: Set<string>) => {
+      if (!prev.has(sessionId)) return prev
+      const next = new Set(prev)
+      next.delete(sessionId)
+      return next
+    })
+
     // 初始化流式状态
     setStreamingStates((prev) => {
       const map = new Map(prev)
@@ -513,6 +555,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         running: true,
         content: '',
         toolActivities: [],
+        teammates: [],
         model: agentModelId || undefined,
       })
       return map
@@ -572,6 +615,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         running: true,
         content: '',
         toolActivities: [],
+        teammates: [],
         model: agentModelId || undefined,
         startedAt: Date.now(),
       }
@@ -624,6 +668,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         running: true,
         content: '',
         toolActivities: [],
+        teammates: [],
         model: agentModelId || undefined,
       })
       return map
@@ -664,6 +709,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           running: true,
           content: '',
           toolActivities: [],
+          teammates: [],
           model: agentModelId || undefined,
         })
         return map

--- a/apps/electron/src/renderer/components/agent/TeamActivityPanel.tsx
+++ b/apps/electron/src/renderer/components/agent/TeamActivityPanel.tsx
@@ -1,25 +1,1006 @@
 /**
- * TeamActivityPanel — Team/Task 子代理活动面板（Placeholder）
+ * TeamActivityPanel — Agent Teams 活动面板
  *
- * TODO: 完成 Agent Teams UI 展示
- * - 按 team_name 分组展示子代理活动
- * - 实时状态、计时器、子工具活动展开
+ * 展示团队全景：Team 头部 + Task Board + Agent 卡片列表 + 通信时间线。
+ * 从 toolActivities 中提取 TeamCreate/TaskCreate/Agent 工具调用的丰富数据。
+ * 通过轮询 getAgentTeamData 读取 Agent 间 inbox 通信消息。
  */
 
-import { Bot } from 'lucide-react'
+import { useState, useEffect, useMemo, useCallback, Fragment } from 'react'
+import { useAtomValue, useSetAtom, useStore } from 'jotai'
+import { toast } from 'sonner'
+import Markdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import {
+  teamOverviewAtom,
+  teammateStatesAtom,
+  hasTeammatesAtom,
+  agentSessionsAtom,
+  agentStreamingStatesAtom,
+  dismissedTeamSessionIdsAtom,
+  cachedPolledTeamDataAtom,
+  type TeamOverview,
+  type TeamTaskItem,
+  type TeamAgentInfo,
+  type TeammateState,
+  type ActivityStatus,
+} from '@/atoms/agent-atoms'
+import { formatElapsed } from './ToolActivityItem'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { Badge } from '@/components/ui/badge'
+import { Separator } from '@/components/ui/separator'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import type { ParsedMailboxMessage, AgentTeamData, TaskItem } from '@proma/shared'
+import {
+  Users,
+  Loader2,
+  CheckCircle2,
+  XCircle,
+  StopCircle,
+  ChevronDown,
+  Clock,
+  Wrench,
+  Zap,
+  FileText,
+  Bot,
+  ListChecks,
+  ArrowRight,
+  Circle,
+  Lock,
+  MessageSquare,
+  Send,
+  X,
+} from 'lucide-react'
 
 interface TeamActivityPanelProps {
   sessionId: string
 }
 
-export function TeamActivityPanel({ sessionId: _sessionId }: TeamActivityPanelProps): React.ReactElement {
+export function TeamActivityPanel({ sessionId }: TeamActivityPanelProps): React.ReactElement {
+  const overview = useAtomValue(teamOverviewAtom)
+  const teammates = useAtomValue(teammateStatesAtom)
+  const hasTeammates = useAtomValue(hasTeammatesAtom)
+  const setDismissed = useSetAtom(dismissedTeamSessionIdsAtom)
+  const [expandedId, setExpandedId] = useState<string | null>(null)
+
+  // 关闭 Team 面板
+  const handleDismiss = useCallback(() => {
+    setDismissed((prev: Set<string>) => new Set([...prev, sessionId]))
+    toast.success('Team 活动面板已关闭', {
+      description: '发送新消息时会自动恢复显示',
+    })
+  }, [sessionId, setDismissed])
+
+  // 基础 agent 列表（来自 tool events）
+  const rawAgentEntries = overview?.agents ?? []
+
+  // 轮询文件系统数据（task 状态 + inbox 通信消息）
+  const sessions = useAtomValue(agentSessionsAtom)
+  const session = sessions.find((s) => s.id === sessionId)
+  const sdkSessionId = session?.sdkSessionId
+  const streamState = useAtomValue(agentStreamingStatesAtom).get(sessionId)
+  const isStreaming = streamState?.running ?? false
+  const store = useStore()
+  const cachedPolled = useAtomValue(cachedPolledTeamDataAtom).get(sessionId)
+  const [polledData, setPolledDataLocal] = useState<AgentTeamData | null>(cachedPolled ?? null)
+
+  // 更新 polledData 同时写入缓存（防止组件卸载后数据丢失）
+  const setPolledData = useCallback((data: AgentTeamData) => {
+    setPolledDataLocal(data)
+    store.set(cachedPolledTeamDataAtom, (prev) => {
+      const map = new Map(prev)
+      map.set(sessionId, data)
+      return map
+    })
+  }, [sessionId, store])
+
+  useEffect(() => {
+    if (!sdkSessionId || !hasTeammates) return
+    const poll = async (): Promise<void> => {
+      try {
+        const data = await window.electronAPI.getAgentTeamData(sdkSessionId)
+        if (data) setPolledData(data)
+      } catch {
+        // 轮询错误不影响 UI
+      }
+    }
+    poll()
+    if (!isStreaming) return
+    const id = setInterval(poll, 2000)
+    return () => clearInterval(id)
+  }, [sdkSessionId, hasTeammates, isStreaming, setPolledData])
+
+  // 用文件系统的真实 task 状态合并 overview tasks
+  const mergedTasks = useMemo(() => {
+    if (!overview?.tasks.length) return overview?.tasks ?? []
+    if (!polledData?.tasks.length) return overview.tasks
+    return overview.tasks.map((t) => {
+      const polledTask = polledData.tasks.find((pt) =>
+        pt.subject === t.subject || (t.taskNumber && pt.id === t.taskNumber),
+      )
+      if (!polledTask) return t
+      return { ...t, status: polledTask.status }
+    })
+  }, [overview?.tasks, polledData?.tasks])
+
+  // 用文件系统 task 状态推算 agent 完成情况
+  const agentEntries = useMemo(() => {
+    if (!rawAgentEntries.length || !polledData?.tasks.length) return rawAgentEntries
+    return rawAgentEntries.map((agent) => {
+      // 已确认完成的保持不变；stopped/failed 允许被 polled data 修正为 completed
+      if (agent.teammate && agent.teammate.status === 'completed') return agent
+      // 按 owner 名称匹配文件系统 task
+      const ownedTask = polledData.tasks.find((pt) => pt.owner === agent.name)
+      if (ownedTask?.status === 'completed') {
+        const updatedTm: TeammateState = agent.teammate
+          ? { ...agent.teammate, status: 'completed', endedAt: agent.teammate.endedAt ?? Date.now() }
+          : {
+              taskId: `polled-${agent.toolUseId}`,
+              description: agent.description,
+              index: 0,
+              status: 'completed',
+              toolHistory: [],
+              startedAt: Date.now(),
+              endedAt: Date.now(),
+            }
+        return { ...agent, teammate: updatedTm, status: 'completed' as ActivityStatus }
+      }
+      return agent
+    })
+  }, [rawAgentEntries, polledData?.tasks])
+
+  // 空状态
+  if (!overview && !hasTeammates) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="flex flex-col items-center gap-2.5 text-muted-foreground/60">
+          <Bot className="size-8" />
+          <p className="text-xs">暂无 Team 活动</p>
+          <p className="text-[11px]">发送复杂任务时 Agent 会自动创建 teammates</p>
+        </div>
+      </div>
+    )
+  }
+
+  const hasAgents = agentEntries.length > 0
+  const displayTeammates = hasAgents ? [] : teammates
+
+  const runningCount = hasAgents
+    ? agentEntries.filter((a) => a.teammate?.status === 'running' || a.status === 'running').length
+    : teammates.filter((t) => t.status === 'running').length
+  const doneCount = hasAgents
+    ? agentEntries.filter((a) => {
+        const s = a.teammate?.status ?? (a.status === 'completed' || a.status === 'error' ? a.status : undefined)
+        return s === 'completed' || s === 'stopped' || s === 'failed' || s === 'error'
+      }).length
+    : teammates.filter((t) => t.status !== 'running').length
+  const totalCount = hasAgents ? agentEntries.length : teammates.length
+
   return (
-    <div className="flex h-full items-center justify-center">
-      <div className="flex flex-col items-center gap-2.5 text-muted-foreground/60">
-        <Bot className="size-8" />
-        <p className="text-xs">Team 活动面板</p>
-        <p className="text-[11px]">UI 待完成</p>
+    <div className="flex h-full flex-col">
+      {/* Team 头部 */}
+      {overview?.teamName && (
+        <div className="border-b px-3 py-2.5">
+          <div className="flex items-center gap-2">
+            <Users className="size-3.5 text-primary" />
+            <span className="text-xs font-semibold">{overview.teamName}</span>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={handleDismiss}
+                  className="ml-auto rounded-md p-0.5 text-muted-foreground/40 hover:text-muted-foreground/70 hover:bg-foreground/[0.05] transition-colors"
+                >
+                  <X className="size-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="left" className="text-xs">关闭 Team 面板</TooltipContent>
+            </Tooltip>
+          </div>
+          {overview.teamDescription && (
+            <p className="mt-1 text-[11px] text-muted-foreground/70 leading-relaxed">
+              {overview.teamDescription}
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* 摘要栏 */}
+      <div className="flex items-center gap-2 border-b px-3 py-1.5">
+        <span className="text-[11px] text-muted-foreground">{totalCount} 个 Agent</span>
+        <div className="ml-auto flex items-center gap-1.5">
+          {runningCount > 0 && (
+            <Badge variant="secondary" className="h-4.5 gap-1 rounded-full px-1.5 text-[10px] bg-blue-500/10 text-blue-600 dark:text-blue-400">
+              <Loader2 className="size-2 animate-spin" />
+              {runningCount}
+            </Badge>
+          )}
+          {doneCount > 0 && (
+            <Badge variant="secondary" className="h-4.5 gap-1 rounded-full px-1.5 text-[10px] bg-green-500/10 text-green-600 dark:text-green-400">
+              <CheckCircle2 className="size-2" />
+              {doneCount}
+            </Badge>
+          )}
+          {/* 无 Team 头部时在摘要栏显示关闭按钮 */}
+          {!overview?.teamName && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={handleDismiss}
+                  className="rounded-md p-0.5 text-muted-foreground/40 hover:text-muted-foreground/70 hover:bg-foreground/[0.05] transition-colors"
+                >
+                  <X className="size-3" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="left" className="text-xs">关闭 Team 面板</TooltipContent>
+            </Tooltip>
+          )}
+        </div>
+      </div>
+
+      <ScrollArea className="flex-1">
+        <div className="flex flex-col gap-2 p-2">
+          {/* Task Board */}
+          {mergedTasks.length > 0 && (
+            <TaskBoard tasks={mergedTasks} />
+          )}
+
+          {/* Agent 卡片（有 overview 时） */}
+          {hasAgents && agentEntries.map((agent) => (
+            <AgentCard
+              key={agent.toolUseId}
+              agent={agent}
+              expanded={expandedId === agent.toolUseId}
+              onToggle={() => setExpandedId(expandedId === agent.toolUseId ? null : agent.toolUseId)}
+            />
+          ))}
+
+          {/* 回退：TeammateState 卡片（无 overview 时） */}
+          {!hasAgents && displayTeammates.map((tm) => (
+            <TeammateCard
+              key={tm.taskId}
+              teammate={tm}
+              expanded={expandedId === tm.taskId}
+              onToggle={() => setExpandedId(expandedId === tm.taskId ? null : tm.taskId)}
+            />
+          ))}
+
+          {/* Agent 通信时间线 */}
+          <MailboxTimeline inboxes={polledData?.inboxes ?? {}} />
+        </div>
+      </ScrollArea>
+    </div>
+  )
+}
+
+// ============================================================================
+// TaskBoard — 任务看板
+// ============================================================================
+
+function TaskBoard({ tasks }: { tasks: TeamTaskItem[] }): React.ReactElement {
+  const completedCount = tasks.filter((t) => t.status === 'completed').length
+  const progress = tasks.length > 0 ? (completedCount / tasks.length) * 100 : 0
+
+  return (
+    <div className="rounded-lg bg-foreground/[0.03] dark:bg-foreground/[0.05] px-3 py-2.5">
+      <div className="flex items-center gap-2 mb-2">
+        <ListChecks className="size-3 text-muted-foreground/60" />
+        <span className="text-[11px] font-medium text-muted-foreground">Task Board</span>
+        <span className="text-[10px] text-muted-foreground/50 ml-auto">
+          {completedCount}/{tasks.length}
+        </span>
+      </div>
+
+      {/* 进度条 */}
+      <div className="h-1 rounded-full bg-foreground/[0.06] dark:bg-foreground/[0.1] mb-2 overflow-hidden">
+        <div
+          className="h-full rounded-full bg-green-500/60 transition-all duration-500"
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+
+      {/* 任务列表 */}
+      <div className="flex flex-col gap-1">
+        {tasks.map((task) => (
+          <TaskRow key={task.toolUseId} task={task} />
+        ))}
       </div>
     </div>
   )
+}
+
+function TaskRow({ task }: { task: TeamTaskItem }): React.ReactElement {
+  const isCompleted = task.status === 'completed'
+  const isBlocked = task.blockedBy.length > 0 && !isCompleted
+
+  return (
+    <div className="flex items-start gap-1.5 py-0.5">
+      {/* 状态图标 */}
+      {isCompleted ? (
+        <CheckCircle2 className="size-3 text-green-500 mt-0.5 shrink-0" />
+      ) : isBlocked ? (
+        <Lock className="size-3 text-yellow-500/70 mt-0.5 shrink-0" />
+      ) : task.status === 'in_progress' ? (
+        <Loader2 className="size-3 text-blue-500 animate-spin mt-0.5 shrink-0" />
+      ) : (
+        <Circle className="size-3 text-muted-foreground/30 mt-0.5 shrink-0" />
+      )}
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-1">
+          {task.taskNumber && (
+            <span className="text-[10px] font-mono text-muted-foreground/50">#{task.taskNumber}</span>
+          )}
+          <span className={cn(
+            'text-[11px] truncate',
+            isCompleted && 'line-through text-muted-foreground/50',
+          )}>
+            {task.subject}
+          </span>
+        </div>
+        {isBlocked && (
+          <span className="text-[9px] text-yellow-600/60 dark:text-yellow-400/60">
+            等待 #{task.blockedBy.join(', #')}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
+// MailboxTimeline — Agent 间通信消息时间线
+// ============================================================================
+
+/** 系统消息类型（过滤但计数） */
+const SYSTEM_MESSAGE_TYPES = new Set(['idle_notification', 'shutdown_request', 'shutdown_approved'])
+
+/** 带接收者信息的消息 */
+interface TimelineMessage extends ParsedMailboxMessage {
+  recipient: string
+}
+
+function MailboxTimeline({ inboxes }: { inboxes: Record<string, ParsedMailboxMessage[]> }): React.ReactElement | null {
+  const [collapsed, setCollapsed] = useState(false)
+
+  // 合并所有 inbox 消息，附加接收者名称，按时间排序
+  const { messages, systemCount } = useMemo(() => {
+    const all: TimelineMessage[] = []
+    let sysCount = 0
+
+    for (const [recipient, msgs] of Object.entries(inboxes)) {
+      for (const msg of msgs) {
+        if (SYSTEM_MESSAGE_TYPES.has(msg.parsedType)) {
+          sysCount++
+          continue
+        }
+        all.push({ ...msg, recipient })
+      }
+    }
+
+    // 按时间排序
+    all.sort((a, b) => {
+      if (a.timestamp && b.timestamp) return new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+      if (a.timestamp) return -1
+      if (b.timestamp) return 1
+      return 0
+    })
+
+    return { messages: all, systemCount: sysCount }
+  }, [inboxes])
+
+  // 无消息时不显示
+  if (messages.length === 0 && systemCount === 0) return null
+
+  return (
+    <div className="rounded-lg bg-foreground/[0.03] dark:bg-foreground/[0.05] px-3 py-2.5">
+      {/* 折叠头部 */}
+      <button
+        type="button"
+        onClick={() => setCollapsed(!collapsed)}
+        className="flex w-full items-center gap-2"
+      >
+        <MessageSquare className="size-3 text-muted-foreground/60" />
+        <span className="text-[11px] font-medium text-muted-foreground">Agent 通信</span>
+        <span className="text-[10px] text-muted-foreground/50 ml-auto">
+          {messages.length} 条消息
+          {systemCount > 0 && (
+            <span className="text-muted-foreground/40"> · {systemCount} 系统</span>
+          )}
+        </span>
+        <ChevronDown className={cn(
+          'size-3 text-muted-foreground/40 transition-transform duration-200',
+          collapsed && '-rotate-90',
+        )} />
+      </button>
+
+      {/* 消息列表 */}
+      {!collapsed && messages.length > 0 && (
+        <div className="mt-2 flex flex-col gap-1.5">
+          {messages.map((msg, i) => (
+            <MailboxMessageRow key={i} message={msg} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function MailboxMessageRow({ message }: { message: TimelineMessage }): React.ReactElement {
+  const isTaskAssignment = message.parsedType === 'task_assignment'
+
+  // 提取可读内容
+  let displayText = message.summary ?? message.text
+  try {
+    const parsed = JSON.parse(message.text) as Record<string, unknown>
+    if (typeof parsed.content === 'string') displayText = parsed.content
+  } catch {
+    // 非 JSON，使用原文
+  }
+
+  return (
+    <div className="flex items-start gap-2 rounded-md bg-foreground/[0.02] dark:bg-foreground/[0.04] px-2.5 py-2">
+      {/* 消息类型图标 */}
+      {isTaskAssignment ? (
+        <Send className="size-3 text-blue-500 mt-0.5 shrink-0" />
+      ) : (
+        <MessageSquare className="size-3 text-muted-foreground/50 mt-0.5 shrink-0" />
+      )}
+
+      <div className="flex-1 min-w-0">
+        {/* 发送者 → 接收者 */}
+        <div className="flex items-center gap-1 mb-0.5">
+          <span className={cn(
+            'text-[10px] font-medium',
+            isTaskAssignment ? 'text-blue-600 dark:text-blue-400' : 'text-muted-foreground/70',
+          )}>
+            {message.from}
+          </span>
+          <ArrowRight className="size-2 text-muted-foreground/30" />
+          <span className="text-[10px] text-muted-foreground/50">{message.recipient}</span>
+          {message.timestamp && (
+            <span className="ml-auto text-[9px] text-muted-foreground/40">
+              {new Date(message.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}
+            </span>
+          )}
+        </div>
+
+        {/* 消息内容 */}
+        <p className="text-[11px] text-muted-foreground/70 leading-relaxed line-clamp-3 break-all">
+          {displayText}
+        </p>
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
+// AgentCard — Agent 信息 + TeammateState 实时数据
+// ============================================================================
+
+interface AgentCardProps {
+  agent: TeamAgentInfo
+  expanded: boolean
+  onToggle: () => void
+}
+
+function AgentCard({ agent, expanded, onToggle }: AgentCardProps): React.ReactElement {
+  const tm = agent.teammate
+  const isRunning = tm?.status === 'running' || (!tm && agent.status === 'running')
+  const elapsed = useTeammateElapsed(tm ?? null)
+
+  return (
+    <div className={cn(
+      'rounded-lg transition-colors',
+      'bg-foreground/[0.03] dark:bg-foreground/[0.05]',
+      expanded && 'bg-foreground/[0.05] dark:bg-foreground/[0.07]',
+    )}>
+      <button
+        type="button"
+        onClick={onToggle}
+        className="group flex w-full flex-col gap-1.5 px-3 py-2.5 text-left hover:bg-foreground/[0.02] dark:hover:bg-foreground/[0.03] rounded-lg transition-colors"
+      >
+        {/* 头部：名称 + 类型 + 状态 */}
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-medium">{agent.name}</span>
+          {agent.subagentType && agent.subagentType !== 'general-purpose' && (
+            <Badge variant="outline" className="h-4 rounded-full px-1.5 text-[9px] text-muted-foreground/60">
+              {agent.subagentType}
+            </Badge>
+          )}
+          {agent.isBackground && (
+            <Badge variant="outline" className="h-4 rounded-full px-1.5 text-[9px] text-muted-foreground/60">
+              后台
+            </Badge>
+          )}
+          <div className="ml-auto flex items-center gap-1.5">
+            <TeammateStatusBadge status={tm?.status} activityStatus={agent.status} />
+            <ChevronDown className={cn(
+              'size-3 text-muted-foreground/40 transition-transform duration-200',
+              expanded && 'rotate-180',
+            )} />
+          </div>
+        </div>
+
+        {/* 任务描述 */}
+        <p className={cn('text-[11px] text-muted-foreground/70 leading-relaxed', !expanded && 'line-clamp-2')}>
+          {agent.description}
+        </p>
+
+        {/* 运行中：当前工具 + 进度描述 + 工具链 */}
+        {isRunning && tm && (
+          <div className="flex flex-col gap-1.5">
+            {/* 当前工具（高亮卡片） */}
+            {tm.currentToolName && (
+              <div className="flex items-center gap-1.5 rounded-md bg-blue-500/5 dark:bg-blue-500/10 px-2 py-1">
+                <Wrench className="size-2.5 text-blue-500 animate-pulse" />
+                <span className="text-[11px] text-blue-600 dark:text-blue-400 font-mono truncate flex-1">
+                  {tm.currentToolName}
+                </span>
+                {tm.currentToolElapsedSeconds != null && tm.currentToolElapsedSeconds > 0 && (
+                  <span className="text-[10px] tabular-nums text-muted-foreground/50">
+                    {formatElapsed(tm.currentToolElapsedSeconds)}
+                  </span>
+                )}
+              </div>
+            )}
+            {/* 进度描述（2 行） */}
+            {tm.progressDescription && (
+              <p className="text-[11px] text-muted-foreground/60 italic leading-relaxed line-clamp-2">
+                {tm.progressDescription}
+              </p>
+            )}
+            {/* 工具链（最近 5 个工具） */}
+            {tm.toolHistory.length > 0 && (
+              <div className="flex items-center gap-1 flex-wrap">
+                {tm.toolHistory.slice(-5).map((tool, i, arr) => (
+                  <Fragment key={`${tool}-${i}`}>
+                    <span className="text-[10px] font-mono text-muted-foreground/50 bg-foreground/[0.04] dark:bg-foreground/[0.06] rounded px-1 py-0.5">
+                      {tool}
+                    </span>
+                    {i < arr.length - 1 && (
+                      <span className="text-[9px] text-muted-foreground/30">→</span>
+                    )}
+                  </Fragment>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* 已完成：摘要 */}
+        {!expanded && tm?.status === 'completed' && tm.summary && (
+          <p className="text-[11px] text-green-700/70 dark:text-green-400/70 line-clamp-2">
+            {tm.summary}
+          </p>
+        )}
+
+        {/* 底部统计 */}
+        <div className="flex items-center gap-3 text-[10px] text-muted-foreground/50">
+          {elapsed && (
+            <span className="flex items-center gap-1">
+              <Clock className="size-2.5" />
+              {elapsed}
+            </span>
+          )}
+          {tm?.usage && (
+            <>
+              <span className="flex items-center gap-1">
+                <Wrench className="size-2.5" />
+                {tm.usage.toolUses}
+              </span>
+              <span className="flex items-center gap-1">
+                <Zap className="size-2.5" />
+                {formatTokens(tm.usage.totalTokens)}
+              </span>
+            </>
+          )}
+          {tm && tm.toolHistory.length > 0 && (
+            <span className="ml-auto text-[10px] text-muted-foreground/40">
+              {tm.toolHistory.length} 个工具
+            </span>
+          )}
+        </div>
+      </button>
+
+      {/* 展开详情 */}
+      {expanded && <AgentDetail agent={agent} />}
+    </div>
+  )
+}
+
+function AgentDetail({ agent }: { agent: TeamAgentInfo }): React.ReactElement {
+  const tm = agent.teammate
+  const hasSummary = !!tm?.summary
+  const hasProgress = tm?.status === 'running' && !!tm.progressDescription
+  const hasToolHistory = tm && tm.toolHistory.length > 0
+  const hasOutput = !!tm?.outputFile
+  const hasUsage = !!tm?.usage
+  const hasAnyContent = hasSummary || hasProgress || hasToolHistory || hasOutput || hasUsage
+
+  return (
+    <div className="flex flex-col gap-2.5 px-3 pb-3">
+      <Separator />
+
+      {/* 工作摘要 */}
+      {hasSummary && (
+        <DetailSection title="工作摘要" borderColor="border-l-green-500">
+          <MarkdownContent content={tm!.summary!} />
+        </DetailSection>
+      )}
+
+      {/* 当前进度（运行中） */}
+      {hasProgress && (
+        <DetailSection title="当前进度" borderColor="border-l-blue-500">
+          <p className="text-[11px] text-muted-foreground/70 leading-relaxed">
+            {tm!.progressDescription}
+          </p>
+        </DetailSection>
+      )}
+
+      {/* 使用量统计 */}
+      {hasUsage && (
+        <DetailSection title="使用量" borderColor="border-l-violet-500">
+          <div className="flex items-center gap-4 text-[11px] text-muted-foreground/70">
+            <span className="flex items-center gap-1">
+              <Wrench className="size-2.5" />
+              {tm!.usage!.toolUses} 次工具调用
+            </span>
+            <span className="flex items-center gap-1">
+              <Zap className="size-2.5" />
+              {formatTokens(tm!.usage!.totalTokens)} tokens
+            </span>
+            {tm!.usage!.durationMs > 0 && (
+              <span className="flex items-center gap-1">
+                <Clock className="size-2.5" />
+                {formatElapsed(tm!.usage!.durationMs / 1000)}
+              </span>
+            )}
+          </div>
+        </DetailSection>
+      )}
+
+      {/* 工具使用历史 */}
+      {hasToolHistory && (
+        <ToolHistorySection toolHistory={tm!.toolHistory} />
+      )}
+
+      {/* 产出文件 */}
+      {hasOutput && (
+        <OutputFileSection filePath={tm!.outputFile!} />
+      )}
+
+      {/* 无详细数据时的提示 */}
+      {!hasAnyContent && (
+        <p className="text-[11px] text-muted-foreground/40 text-center py-2">
+          {tm?.status === 'running'
+            ? '等待 Agent 返回进度数据...'
+            : agent.status === 'running'
+              ? 'Agent 正在初始化...'
+              : '暂无详细数据'}
+        </p>
+      )}
+    </div>
+  )
+}
+
+// ============================================================================
+// TeammateCard — 回退方案（无 overview 时使用）
+// ============================================================================
+
+interface TeammateCardProps {
+  teammate: TeammateState
+  expanded: boolean
+  onToggle: () => void
+}
+
+function TeammateCard({ teammate, expanded, onToggle }: TeammateCardProps): React.ReactElement {
+  const isRunning = teammate.status === 'running'
+  const elapsed = useTeammateElapsed(teammate)
+
+  return (
+    <div className={cn(
+      'rounded-lg transition-colors',
+      'bg-foreground/[0.03] dark:bg-foreground/[0.05]',
+      expanded && 'bg-foreground/[0.05] dark:bg-foreground/[0.07]',
+    )}>
+      <button
+        type="button"
+        onClick={onToggle}
+        className="group flex w-full flex-col gap-1.5 px-3 py-2.5 text-left hover:bg-foreground/[0.02] dark:hover:bg-foreground/[0.03] rounded-lg transition-colors"
+      >
+        <div className="flex items-center gap-2">
+          <span className="text-[11px] font-mono text-muted-foreground/70">#{teammate.index}</span>
+          <TeammateStatusBadge status={teammate.status} />
+          <ChevronDown className={cn(
+            'ml-auto size-3 text-muted-foreground/40 transition-transform duration-200',
+            expanded && 'rotate-180',
+          )} />
+        </div>
+
+        <p className={cn('text-xs leading-relaxed', !expanded && 'line-clamp-2')}>{teammate.description}</p>
+
+        {isRunning && (
+          <div className="flex flex-col gap-1.5">
+            {teammate.currentToolName && (
+              <div className="flex items-center gap-1.5 rounded-md bg-blue-500/5 dark:bg-blue-500/10 px-2 py-1">
+                <Wrench className="size-2.5 text-blue-500 animate-pulse" />
+                <span className="text-[11px] text-blue-600 dark:text-blue-400 font-mono truncate flex-1">
+                  {teammate.currentToolName}
+                </span>
+                {teammate.currentToolElapsedSeconds != null && teammate.currentToolElapsedSeconds > 0 && (
+                  <span className="text-[10px] tabular-nums text-muted-foreground/50">
+                    {formatElapsed(teammate.currentToolElapsedSeconds)}
+                  </span>
+                )}
+              </div>
+            )}
+            {teammate.progressDescription && (
+              <p className="text-[11px] text-muted-foreground/60 italic leading-relaxed line-clamp-2">
+                {teammate.progressDescription}
+              </p>
+            )}
+            {teammate.toolHistory.length > 0 && (
+              <div className="flex items-center gap-1 flex-wrap">
+                {teammate.toolHistory.slice(-5).map((tool, i, arr) => (
+                  <Fragment key={`${tool}-${i}`}>
+                    <span className="text-[10px] font-mono text-muted-foreground/50 bg-foreground/[0.04] dark:bg-foreground/[0.06] rounded px-1 py-0.5">
+                      {tool}
+                    </span>
+                    {i < arr.length - 1 && (
+                      <span className="text-[9px] text-muted-foreground/30">→</span>
+                    )}
+                  </Fragment>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {!expanded && teammate.status === 'completed' && teammate.summary && (
+          <p className="text-[11px] text-green-700/70 dark:text-green-400/70 line-clamp-2">
+            {teammate.summary}
+          </p>
+        )}
+
+        <div className="flex items-center gap-3 text-[10px] text-muted-foreground/50">
+          {elapsed && (
+            <span className="flex items-center gap-1">
+              <Clock className="size-2.5" />
+              {elapsed}
+            </span>
+          )}
+          {teammate.usage && (
+            <>
+              <span className="flex items-center gap-1">
+                <Wrench className="size-2.5" />
+                {teammate.usage.toolUses}
+              </span>
+              <span className="flex items-center gap-1">
+                <Zap className="size-2.5" />
+                {formatTokens(teammate.usage.totalTokens)}
+              </span>
+            </>
+          )}
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="flex flex-col gap-2.5 px-3 pb-3">
+          <Separator />
+          {teammate.summary && (
+            <DetailSection title="工作摘要" borderColor="border-l-green-500">
+              <MarkdownContent content={teammate.summary} />
+            </DetailSection>
+          )}
+          {teammate.status === 'running' && teammate.progressDescription && (
+            <DetailSection title="当前进度" borderColor="border-l-blue-500">
+              <p className="text-[11px] text-muted-foreground/70 leading-relaxed">
+                {teammate.progressDescription}
+              </p>
+            </DetailSection>
+          )}
+          {teammate.usage && (
+            <DetailSection title="使用量" borderColor="border-l-violet-500">
+              <div className="flex items-center gap-4 text-[11px] text-muted-foreground/70">
+                <span className="flex items-center gap-1">
+                  <Wrench className="size-2.5" />
+                  {teammate.usage.toolUses} 次工具调用
+                </span>
+                <span className="flex items-center gap-1">
+                  <Zap className="size-2.5" />
+                  {formatTokens(teammate.usage.totalTokens)} tokens
+                </span>
+                {teammate.usage.durationMs > 0 && (
+                  <span className="flex items-center gap-1">
+                    <Clock className="size-2.5" />
+                    {formatElapsed(teammate.usage.durationMs / 1000)}
+                  </span>
+                )}
+              </div>
+            </DetailSection>
+          )}
+          {teammate.toolHistory.length > 0 && (
+            <ToolHistorySection toolHistory={teammate.toolHistory} />
+          )}
+          {teammate.outputFile && (
+            <OutputFileSection filePath={teammate.outputFile} />
+          )}
+          {!teammate.summary && !teammate.usage && teammate.toolHistory.length === 0 && !teammate.outputFile && (
+            <p className="text-[11px] text-muted-foreground/40 text-center py-2">
+              {teammate.status === 'running' ? '等待 Agent 返回进度数据...' : '暂无详细数据'}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ============================================================================
+// 共享子组件
+// ============================================================================
+
+function TeammateStatusBadge({
+  status,
+  activityStatus,
+}: {
+  status?: TeammateState['status']
+  activityStatus?: string
+}): React.ReactElement {
+  const s = status ?? (activityStatus === 'completed' ? 'completed' : activityStatus === 'error' ? 'failed' : 'running')
+  switch (s) {
+    case 'running':
+      return (
+        <Badge variant="secondary" className="h-4 gap-1 rounded-full px-1.5 text-[10px] bg-blue-500/10 text-blue-600 dark:text-blue-400">
+          <Loader2 className="size-2 animate-spin" />
+          运行中
+        </Badge>
+      )
+    case 'completed':
+      return (
+        <Badge variant="secondary" className="h-4 gap-1 rounded-full px-1.5 text-[10px] bg-green-500/10 text-green-600 dark:text-green-400">
+          <CheckCircle2 className="size-2" />
+          已完成
+        </Badge>
+      )
+    case 'failed':
+      return (
+        <Badge variant="secondary" className="h-4 gap-1 rounded-full px-1.5 text-[10px] bg-red-500/10 text-red-600 dark:text-red-400">
+          <XCircle className="size-2" />
+          失败
+        </Badge>
+      )
+    case 'stopped':
+      return (
+        <Badge variant="secondary" className="h-4 gap-1 rounded-full px-1.5 text-[10px] bg-yellow-500/10 text-yellow-600 dark:text-yellow-400">
+          <StopCircle className="size-2" />
+          已停止
+        </Badge>
+      )
+    default:
+      return (
+        <Badge variant="secondary" className="h-4 gap-1 rounded-full px-1.5 text-[10px] bg-muted text-muted-foreground/60">
+          <Circle className="size-2" />
+          等待中
+        </Badge>
+      )
+  }
+}
+
+function DetailSection({
+  title,
+  borderColor,
+  children,
+}: {
+  title: string
+  borderColor?: string
+  children: React.ReactNode
+}): React.ReactElement {
+  return (
+    <div className={cn('rounded-md border-l-2 bg-foreground/[0.02] dark:bg-foreground/[0.04] px-3 py-2', borderColor)}>
+      <p className="text-[10px] font-medium text-muted-foreground/60 mb-1.5">{title}</p>
+      {children}
+    </div>
+  )
+}
+
+function ToolHistorySection({ toolHistory }: { toolHistory: string[] }): React.ReactElement {
+  const counts = new Map<string, number>()
+  for (const tool of toolHistory) {
+    counts.set(tool, (counts.get(tool) ?? 0) + 1)
+  }
+  const sorted = Array.from(counts.entries()).sort((a, b) => b[1] - a[1])
+
+  return (
+    <DetailSection title="工具使用" borderColor="border-l-muted-foreground/30">
+      <div className="flex flex-wrap gap-1 mb-2">
+        {sorted.map(([tool, count]) => (
+          <Badge
+            key={tool}
+            variant="secondary"
+            className="h-4 gap-0.5 rounded-full px-1.5 text-[10px] bg-foreground/[0.04] dark:bg-foreground/[0.06]"
+          >
+            {tool}
+            {count > 1 && <span className="text-muted-foreground/50">×{count}</span>}
+          </Badge>
+        ))}
+      </div>
+      <p className="text-[10px] text-muted-foreground/40 font-mono leading-relaxed break-all">
+        {toolHistory.join(' → ')}
+      </p>
+    </DetailSection>
+  )
+}
+
+function OutputFileSection({ filePath }: { filePath: string }): React.ReactElement {
+  const [content, setContent] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    setLoading(true)
+    window.electronAPI
+      .getAgentOutput(filePath)
+      .then((text) => setContent(text))
+      .catch(() => setContent(null))
+      .finally(() => setLoading(false))
+  }, [filePath])
+
+  return (
+    <DetailSection title="产出文件" borderColor="border-l-amber-500">
+      <div className="flex items-center gap-1.5 mb-1.5">
+        <FileText className="size-2.5 text-muted-foreground/50" />
+        <span className="text-[10px] font-mono text-muted-foreground/50 truncate">{filePath}</span>
+      </div>
+      {loading ? (
+        <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground/50">
+          <Loader2 className="size-2.5 animate-spin" />
+          加载中...
+        </div>
+      ) : content ? (
+        <div className="max-h-[200px] overflow-auto rounded bg-foreground/[0.02] dark:bg-foreground/[0.04] p-2">
+          <MarkdownContent content={content} />
+        </div>
+      ) : (
+        <p className="text-[10px] text-muted-foreground/40">无法读取文件内容</p>
+      )}
+    </DetailSection>
+  )
+}
+
+function MarkdownContent({ content }: { content: string }): React.ReactElement {
+  return (
+    <div className="prose dark:prose-invert max-w-none text-[11px] prose-p:my-0.5 prose-li:leading-relaxed prose-pre:my-0 [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
+      <Markdown remarkPlugins={[remarkGfm]}>{content}</Markdown>
+    </div>
+  )
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function formatTokens(tokens: number): string {
+  if (tokens < 1000) return `${tokens}`
+  if (tokens < 1_000_000) return `${(tokens / 1000).toFixed(1)}K`
+  return `${(tokens / 1_000_000).toFixed(1)}M`
+}
+
+/** 实时耗时 — 支持 TeammateState 或 null */
+function useTeammateElapsed(teammate: TeammateState | null): string | null {
+  const [now, setNow] = useState(Date.now())
+
+  useEffect(() => {
+    if (!teammate || teammate.status !== 'running') return
+    const timer = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(timer)
+  }, [teammate?.status])
+
+  if (!teammate) return null
+  const endTime = teammate.endedAt ?? now
+  const durationMs = endTime - teammate.startedAt
+  const seconds = Math.max(0, durationMs / 1000)
+  return formatElapsed(seconds)
 }

--- a/apps/electron/src/renderer/components/ui/sheet.tsx
+++ b/apps/electron/src/renderer/components/ui/sheet.tsx
@@ -1,0 +1,138 @@
+import * as React from "react"
+import * as SheetPrimitive from "@radix-ui/react-dialog"
+import { cva, type VariantProps } from "class-variance-authority"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Sheet = SheetPrimitive.Root
+
+const SheetTrigger = SheetPrimitive.Trigger
+
+const SheetClose = SheetPrimitive.Close
+
+const SheetPortal = SheetPrimitive.Portal
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
+
+const sheetVariants = cva(
+  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
+  {
+    variants: {
+      side: {
+        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        bottom:
+          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+        right:
+          "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+      },
+    },
+    defaultVariants: {
+      side: "right",
+    },
+  }
+)
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Content>,
+  SheetContentProps
+>(({ side = "right", className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content
+      ref={ref}
+      className={cn(sheetVariants({ side }), className)}
+      {...props}
+    >
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </SheetPrimitive.Close>
+      {children}
+    </SheetPrimitive.Content>
+  </SheetPortal>
+))
+SheetContent.displayName = SheetPrimitive.Content.displayName
+
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+SheetHeader.displayName = "SheetHeader"
+
+const SheetFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+SheetFooter.displayName = "SheetFooter"
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold text-foreground", className)}
+    {...props}
+  />
+))
+SheetTitle.displayName = SheetPrimitive.Title.displayName
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+SheetDescription.displayName = SheetPrimitive.Description.displayName
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -21,7 +21,10 @@ import {
   agentSidePanelOpenMapAtom,
   agentSidePanelTabMapAtom,
   cachedTeamActivitiesAtom,
+  cachedTeammateStatesAtom,
+  cachedTeamOverviewsAtom,
   buildTeamActivityEntries,
+  extractTeamOverview,
   applyAgentEvent,
 } from '@/atoms/agent-atoms'
 import {
@@ -47,6 +50,7 @@ export function useGlobalAgentListeners(): void {
             running: true,
             content: '',
             toolActivities: [],
+            teammates: [],
             model: undefined,
             startedAt: Date.now(),
           }
@@ -56,8 +60,11 @@ export function useGlobalAgentListeners(): void {
           return map
         })
 
-        // 自动打开侧面板：检测到 Agent/Task 工具启动时
-        if (event.type === 'tool_start' && (event.toolName === 'Agent' || event.toolName === 'Task')) {
+        // 自动打开侧面板：检测到 Agent/Task 工具启动或 teammate 任务开始时
+        if (
+          (event.type === 'tool_start' && (event.toolName === 'Agent' || event.toolName === 'Task')) ||
+          event.type === 'task_started'
+        ) {
           store.set(agentSidePanelOpenMapAtom, (prev) => {
             const map = new Map(prev)
             map.set(sessionId, true)
@@ -87,7 +94,7 @@ export function useGlobalAgentListeners(): void {
           store.set(backgroundTasksAtomFamily(sessionId), (prev) =>
             prev.map((t) =>
               t.toolUseId === event.toolUseId
-                ? { ...t, elapsedSeconds: event.elapsedSeconds }
+                ? { ...t, elapsedSeconds: event.elapsedSeconds ?? t.elapsedSeconds }
                 : t
             )
           )
@@ -189,6 +196,27 @@ export function useGlobalAgentListeners(): void {
             store.set(cachedTeamActivitiesAtom, (prev) => {
               const map = new Map(prev)
               map.set(data.sessionId, teamEntries)
+              return map
+            })
+          }
+        }
+
+        // 缓存 Teammate 状态数据（Agent Teams 功能）
+        if (streamState && streamState.teammates.length > 0) {
+          store.set(cachedTeammateStatesAtom, (prev) => {
+            const map = new Map(prev)
+            map.set(data.sessionId, streamState.teammates)
+            return map
+          })
+        }
+
+        // 缓存 TeamOverview 快照（确保切换 tab 后团队全景数据不丢失）
+        if (streamState && streamState.toolActivities.length > 0) {
+          const overview = extractTeamOverview(streamState.toolActivities, streamState.teammates)
+          if (overview) {
+            store.set(cachedTeamOverviewsAtom, (prev) => {
+              const map = new Map(prev)
+              map.set(data.sessionId, overview)
               return map
             })
           }

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -215,6 +215,16 @@ export interface AgentEventUsage {
   contextWindow?: number
 }
 
+/** Teammate 任务用量统计 */
+export interface TaskUsage {
+  /** 总 Token 数 */
+  totalTokens: number
+  /** 工具调用次数 */
+  toolUses: number
+  /** 运行耗时（毫秒） */
+  durationMs: number
+}
+
 /**
  * 重试尝试记录
  *
@@ -265,9 +275,12 @@ export type AgentEvent =
   // 后台任务
   | { type: 'task_backgrounded'; toolUseId: string; taskId: string; intent?: string; turnId?: string }
   | { type: 'task_started'; taskId: string; toolUseId?: string; description: string; taskType?: string; turnId?: string }
-  | { type: 'task_progress'; toolUseId: string; elapsedSeconds: number; turnId?: string }
+  | { type: 'task_progress'; toolUseId: string; elapsedSeconds?: number; turnId?: string; taskId?: string; description?: string; lastToolName?: string; usage?: TaskUsage }
+  | { type: 'task_notification'; taskId: string; toolUseId?: string; status: 'completed' | 'failed' | 'stopped'; summary: string; outputFile?: string; usage?: TaskUsage; turnId?: string }
   | { type: 'shell_backgrounded'; toolUseId: string; shellId: string; intent?: string; command?: string; turnId?: string }
   | { type: 'shell_killed'; shellId: string; turnId?: string }
+  // 工具使用摘要
+  | { type: 'tool_use_summary'; summary: string; precedingToolUseIds: string[] }
   // 控制流
   | { type: 'complete'; stopReason?: string; usage?: AgentEventUsage }
   | { type: 'error'; message: string }
@@ -290,6 +303,9 @@ export type AgentEvent =
   | { type: 'ask_user_resolved'; requestId: string }
   // 提示建议
   | { type: 'prompt_suggestion'; suggestion: string }
+  // Auto-Resume（Teams 完成后自动收集结果）
+  | { type: 'waiting_resume'; message: string }
+  | { type: 'resume_start'; messageId: string }
 
 // ===== Agent 会话管理 =====
 
@@ -617,6 +633,86 @@ export interface PermissionResponse {
   alwaysAllow: boolean
 }
 
+// ===== Agent Teams 数据类型 =====
+
+/** Team 配置（~/.claude/teams/{name}/config.json） */
+export interface TeamConfig {
+  /** 团队名称 */
+  name: string
+  /** 团队描述 */
+  description?: string
+  /** 创建时间戳 */
+  createdAt: number
+  /** 领导 Agent ID */
+  leadAgentId?: string
+  /** 领导 Agent 的 SDK 会话 ID */
+  leadSessionId?: string
+  /** 团队成员列表 */
+  members: TeamMember[]
+}
+
+/** Team 成员 */
+export interface TeamMember {
+  /** Agent ID */
+  agentId: string
+  /** 显示名称 */
+  name: string
+  /** Agent 类型（如 'general-purpose', 'Explore'） */
+  agentType: string
+  /** 使用的模型 */
+  model?: string
+  /** 颜色标识 */
+  color?: string
+  /** 加入时间戳 */
+  joinedAt?: number
+}
+
+/** 任务项（~/.claude/tasks/{teamName}/） */
+export interface TaskItem {
+  /** 任务 ID */
+  id: string
+  /** 任务标题 */
+  subject: string
+  /** 任务描述 */
+  description?: string
+  /** 进行中的显示文本 */
+  activeForm?: string
+  /** 负责人 Agent 名称 */
+  owner?: string
+  /** 任务状态 */
+  status: 'pending' | 'in_progress' | 'completed'
+  /** 阻塞的任务 ID 列表 */
+  blocks: string[]
+  /** 被阻塞的任务 ID 列表 */
+  blockedBy: string[]
+}
+
+/** 解析后的收件箱消息 */
+export interface ParsedMailboxMessage {
+  /** 发送者名称 */
+  from: string
+  /** 消息文本 */
+  text: string
+  /** 摘要 */
+  summary?: string
+  /** 时间戳 */
+  timestamp?: string
+  /** 解析后的消息类型 */
+  parsedType: 'idle_notification' | 'shutdown_request' | 'shutdown_approved' | 'task_assignment' | 'text'
+}
+
+/** Agent Team 聚合数据（IPC 返回） */
+export interface AgentTeamData {
+  /** 团队名称 */
+  teamName: string
+  /** 团队配置 */
+  team: TeamConfig
+  /** 任务列表 */
+  tasks: TaskItem[]
+  /** 收件箱消息（agent 名称 → 消息列表） */
+  inboxes: Record<string, ParsedMailboxMessage[]>
+}
+
 // ===== IPC 通道常量 =====
 
 /**
@@ -732,4 +828,10 @@ export const AGENT_IPC_CHANNELS = {
   // AskUserQuestion 交互式问答
   /** AskUser 响应（渲染进程 → 主进程） */
   ASK_USER_RESPOND: 'agent:ask-user:respond',
+
+  // Agent Teams 数据
+  /** 获取 Team 聚合数据（sdkSessionId → AgentTeamData | null） */
+  GET_TEAM_DATA: 'agent:get-team-data',
+  /** 读取 Teammate 输出文件（filePath → string） */
+  GET_AGENT_OUTPUT: 'agent:get-agent-output',
 } as const


### PR DESCRIPTION
## Summary

- 实现 Agent Teams 完整 UI 支持：状态跟踪修复（5 项断点）、进度可视化增强、通信时间线、数据持久化
- 修复 `task_started`/`task_notification`/`task_progress` 事件管线中的数据丢失问题
- AgentCard 运行态展示当前工具（高亮）+ 进度描述 + 工具链 + 使用量统计
- polledData 缓存到 Jotai atom 层，组件卸载后通信时间线不丢失
- 自愈逻辑加 `prev.running` 守卫，防止建议信息错误唤醒已停止的 teammate

## Test plan
- [ ] `bun run typecheck` 通过
- [ ] `bun run dev`，发送触发 Agent Teams 的复杂任务
- [ ] Worker 运行中可见：当前工具名（蓝色高亮）+ 进度描述 + 工具链
- [ ] Worker 完成后 Agent 卡片显示 ✅ 已完成（不卡在"运行中"）
- [ ] Task Board 进度条正确反映完成比例
- [ ] 摘要栏计数准确（包含 stopped/failed）
- [ ] 点击 AgentCard 展开有使用量统计、工具历史、产出文件等内容
- [ ] MailboxTimeline 显示 Agent 间通信消息
- [ ] 关闭 Team 面板后 Sonner toast 提醒，发新消息自动恢复
- [ ] 页面刷新/切换 tab 后状态保持
- [ ] Agent 完成后建议信息不会错误唤醒已停止的 teammate