### PR TITLE
fix: 修复 TypeScript 类型检查错误

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -725,7 +725,10 @@ export class AgentOrchestrator {
       // 9.5 验证 sdkSessionId 是否仍然有效（SDK 0.2.53 listSessions）
       if (existingSdkSessionId) {
         try {
-          const sessions = await sdk.listSessions({ dir: agentCwd })
+          const listSessions = (sdk as unknown as {
+            listSessions: (opts: { dir: string }) => Promise<Array<{ sessionId: string }>>
+          }).listSessions
+          const sessions = await listSessions({ dir: agentCwd })
           const isValid = sessions.some((s: { sessionId: string }) => s.sessionId === existingSdkSessionId)
           if (!isValid) {
             console.log(`[Agent 编排] sdkSessionId 已失效 (${existingSdkSessionId})，将使用上下文注入`)

--- a/apps/electron/src/renderer/components/chat/ChatView.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatView.tsx
@@ -139,18 +139,20 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
   }, [conversation?.contextDividers])
 
   // 从对话元数据恢复模型/渠道选择（写入 per-conversation Map）
+  const conversationChannelId = conversation?.channelId
+  const conversationModelId = conversation?.modelId
   React.useEffect(() => {
-    if (conversation?.modelId && conversation?.channelId) {
+    if (conversationChannelId && conversationModelId) {
       setConversationModels((prev) => {
         const map = new Map(prev)
         map.set(conversationId, {
-          channelId: conversation.channelId,
-          modelId: conversation.modelId,
+          channelId: conversationChannelId,
+          modelId: conversationModelId,
         })
         return map
       })
     }
-  }, [conversationId, conversation?.modelId, conversation?.channelId, setConversationModels])
+  }, [conversationId, conversationChannelId, conversationModelId, setConversationModels])
 
   const syncContextDividers = React.useCallback(async (
     convId: string,


### PR DESCRIPTION
## Summary

- **ChatView.tsx**: `setConversationModels` 回调闭包内 `conversation.channelId` / `conversation.modelId` 被推断为 `string | undefined`，将可选属性提取为闭包外局部变量，让 TypeScript 正确收窄类型
- **agent-orchestrator.ts**: SDK `listSessions` 方法在类型定义中未导出，添加类型断言解决 TS2339 错误

修复后 `bun run typecheck` 全部通过（4 个包均为 exit code 0）。

## Test plan

- [x] `bun run typecheck` 无错误
- [x] `bun run build` 成功