### PR TITLE
feat: Agent 文件引用、附加目录增强与布局修复

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -61,6 +61,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tiptap/extension-code-block-lowlight": "^3.19.0",
     "@tiptap/extension-link": "^3.19.0",
+    "@tiptap/extension-mention": "^3.19.0",
     "@tiptap/extension-placeholder": "^3.19.0",
     "@tiptap/extension-underline": "^3.19.0",
     "@tiptap/react": "^3.19.0",

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -39,6 +39,7 @@ import type {
   SkillMeta,
   WorkspaceCapabilities,
   FileEntry,
+  FileSearchResult,
   EnvironmentCheckResult,
   ProxyConfig,
   SystemProxyDetectResult,
@@ -1146,6 +1147,202 @@ export function registerIpcHandlers(): void {
       }
 
       shell.showItemInFolder(safePath)
+    }
+  )
+
+  // 重命名文件/目录
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.RENAME_FILE,
+    async (_, filePath: string, newName: string): Promise<void> => {
+      const { renameSync } = await import('node:fs')
+      const { resolve, dirname, join } = await import('node:path')
+
+      const safePath = resolve(filePath)
+      const workspacesRoot = resolve(getAgentWorkspacesDir())
+      if (!safePath.startsWith(workspacesRoot)) {
+        throw new Error('访问路径超出 Agent 工作区范围')
+      }
+
+      const newPath = join(dirname(safePath), newName)
+      renameSync(safePath, newPath)
+      console.log(`[Agent 文件] 已重命名: ${safePath} → ${newPath}`)
+    }
+  )
+
+  // 移动文件/目录到目标目录
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.MOVE_FILE,
+    async (_, filePath: string, targetDir: string): Promise<void> => {
+      const { renameSync } = await import('node:fs')
+      const { resolve, basename, join } = await import('node:path')
+
+      const safePath = resolve(filePath)
+      const safeTarget = resolve(targetDir)
+      const workspacesRoot = resolve(getAgentWorkspacesDir())
+      if (!safePath.startsWith(workspacesRoot) || !safeTarget.startsWith(workspacesRoot)) {
+        throw new Error('访问路径超出 Agent 工作区范围')
+      }
+
+      const newPath = join(safeTarget, basename(safePath))
+      renameSync(safePath, newPath)
+      console.log(`[Agent 文件] 已移动: ${safePath} → ${newPath}`)
+    }
+  )
+
+  // 列出附加目录内容（无工作区路径限制，用于用户附加的外部目录）
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.LIST_ATTACHED_DIRECTORY,
+    async (_, dirPath: string): Promise<FileEntry[]> => {
+      const { readdirSync } = await import('node:fs')
+      const { resolve } = await import('node:path')
+
+      const safePath = resolve(dirPath)
+      const entries: FileEntry[] = []
+      const items = readdirSync(safePath, { withFileTypes: true })
+
+      for (const item of items) {
+        if (item.name.startsWith('.')) continue
+        const fullPath = resolve(safePath, item.name)
+        entries.push({
+          name: item.name,
+          path: fullPath,
+          isDirectory: item.isDirectory(),
+        })
+      }
+
+      entries.sort((a, b) => {
+        if (a.isDirectory !== b.isDirectory) return a.isDirectory ? -1 : 1
+        return a.name.localeCompare(b.name)
+      })
+
+      return entries
+    }
+  )
+
+  // 用系统默认应用打开附加目录文件（无工作区路径限制）
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.OPEN_ATTACHED_FILE,
+    async (_, filePath: string): Promise<void> => {
+      const { resolve } = await import('node:path')
+      await shell.openPath(resolve(filePath))
+    }
+  )
+
+  // 在文件管理器中显示附加目录文件（无工作区路径限制）
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.SHOW_ATTACHED_IN_FOLDER,
+    async (_, filePath: string): Promise<void> => {
+      const { resolve } = await import('node:path')
+      shell.showItemInFolder(resolve(filePath))
+    }
+  )
+
+  // 重命名附加目录文件/目录（无工作区路径限制）
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.RENAME_ATTACHED_FILE,
+    async (_, filePath: string, newName: string): Promise<void> => {
+      const { renameSync } = await import('node:fs')
+      const { resolve, dirname, join } = await import('node:path')
+
+      const safePath = resolve(filePath)
+      const newPath = join(dirname(safePath), newName)
+      renameSync(safePath, newPath)
+      console.log(`[附加目录] 已重命名: ${safePath} → ${newPath}`)
+    }
+  )
+
+  // 移动附加目录文件/目录（无工作区路径限制）
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.MOVE_ATTACHED_FILE,
+    async (_, filePath: string, targetDir: string): Promise<void> => {
+      const { renameSync } = await import('node:fs')
+      const { resolve, basename, join } = await import('node:path')
+
+      const safePath = resolve(filePath)
+      const newPath = join(resolve(targetDir), basename(safePath))
+      renameSync(safePath, newPath)
+      console.log(`[附加目录] 已移动: ${safePath} → ${newPath}`)
+    }
+  )
+
+  // 搜索工作区文件（用于 @ 引用，递归扫描，支持附加目录）
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.SEARCH_WORKSPACE_FILES,
+    async (_, rootPath: string, query: string, limit = 20, additionalPaths?: string[]): Promise<FileSearchResult> => {
+      const { readdirSync } = await import('node:fs')
+      const { resolve, relative } = await import('node:path')
+
+      const safeRoot = resolve(rootPath)
+      const ignoreDirs = new Set(['node_modules', '.git', 'dist', '.next', '__pycache__', '.venv', 'build', '.cache'])
+
+      // 递归收集文件（限制深度 5 层）
+      const allEntries: Array<{ name: string; path: string; type: 'file' | 'dir' }> = []
+
+      function scan(dir: string, depth: number, baseRoot: string): void {
+        if (depth > 5) return
+        try {
+          const items = readdirSync(dir, { withFileTypes: true })
+          for (const item of items) {
+            if (item.name.startsWith('.')) continue
+            if (item.isDirectory() && ignoreDirs.has(item.name)) continue
+
+            const fullPath = resolve(dir, item.name)
+            const relPath = relative(baseRoot, fullPath)
+            allEntries.push({
+              name: item.name,
+              path: relPath,
+              type: item.isDirectory() ? 'dir' : 'file',
+            })
+
+            if (item.isDirectory()) {
+              scan(fullPath, depth + 1, baseRoot)
+            }
+          }
+        } catch {
+          // 忽略无权限的目录
+        }
+      }
+
+      scan(safeRoot, 0, safeRoot)
+
+      // 扫描附加目录（外部路径）
+      if (additionalPaths && additionalPaths.length > 0) {
+        for (const addPath of additionalPaths) {
+          const addRoot = resolve(addPath)
+          scan(addRoot, 0, addRoot)
+        }
+      }
+
+      // 搜索匹配
+      const q = query.toLowerCase()
+      if (!q) {
+        return { entries: allEntries.slice(0, limit), total: allEntries.length }
+      }
+
+      const matched = allEntries.filter((entry) => {
+        const nameLower = entry.name.toLowerCase()
+        const pathLower = entry.path.toLowerCase()
+        if (nameLower.startsWith(q)) return true
+        if (nameLower.includes(q) || pathLower.includes(q)) return true
+        // 模糊匹配
+        let qi = 0
+        for (let i = 0; i < nameLower.length && qi < q.length; i++) {
+          if (nameLower[i] === q[qi]) qi++
+        }
+        return qi === q.length
+      })
+
+      // 排序：精确前缀优先，目录优先，路径短优先
+      matched.sort((a, b) => {
+        const aStartsWith = a.name.toLowerCase().startsWith(q) ? 0 : 1
+        const bStartsWith = b.name.toLowerCase().startsWith(q) ? 0 : 1
+        if (aStartsWith !== bStartsWith) return aStartsWith - bStartsWith
+        if (a.type === 'dir' && b.type !== 'dir') return -1
+        if (a.type !== 'dir' && b.type === 'dir') return 1
+        return a.path.length - b.path.length
+      })
+
+      return { entries: matched.slice(0, limit), total: matched.length }
     }
   )
 

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -47,6 +47,7 @@ import type {
   SkillMeta,
   WorkspaceCapabilities,
   FileEntry,
+  FileSearchResult,
   EnvironmentCheckResult,
   ProxyConfig,
   SystemProxyDetectResult,
@@ -426,6 +427,30 @@ export interface ElectronAPI {
 
   /** 在系统文件管理器中显示文件 */
   showInFolder: (filePath: string) => Promise<void>
+
+  /** 重命名文件/目录 */
+  renameFile: (filePath: string, newName: string) => Promise<void>
+
+  /** 移动文件/目录到目标目录 */
+  moveFile: (filePath: string, targetDir: string) => Promise<void>
+
+  /** 列出附加目录内容（无工作区路径限制） */
+  listAttachedDirectory: (dirPath: string) => Promise<FileEntry[]>
+
+  /** 用系统默认应用打开附加目录文件（无工作区路径限制） */
+  openAttachedFile: (filePath: string) => Promise<void>
+
+  /** 在文件管理器中显示附加目录文件（无工作区路径限制） */
+  showAttachedInFolder: (filePath: string) => Promise<void>
+
+  /** 重命名附加目录文件/目录（无工作区路径限制） */
+  renameAttachedFile: (filePath: string, newName: string) => Promise<void>
+
+  /** 移动附加目录文件/目录（无工作区路径限制） */
+  moveAttachedFile: (filePath: string, targetDir: string) => Promise<void>
+
+  /** 搜索工作区文件（用于 @ 引用，支持附加目录） */
+  searchWorkspaceFiles: (rootPath: string, query: string, limit?: number, additionalPaths?: string[]) => Promise<FileSearchResult>
 
   // ===== 系统提示词管理 =====
 
@@ -944,6 +969,38 @@ const electronAPI: ElectronAPI = {
 
   showInFolder: (filePath: string) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.SHOW_IN_FOLDER, filePath)
+  },
+
+  renameFile: (filePath: string, newName: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.RENAME_FILE, filePath, newName)
+  },
+
+  moveFile: (filePath: string, targetDir: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.MOVE_FILE, filePath, targetDir)
+  },
+
+  listAttachedDirectory: (dirPath: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.LIST_ATTACHED_DIRECTORY, dirPath)
+  },
+
+  openAttachedFile: (filePath: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.OPEN_ATTACHED_FILE, filePath)
+  },
+
+  showAttachedInFolder: (filePath: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.SHOW_ATTACHED_IN_FOLDER, filePath)
+  },
+
+  renameAttachedFile: (filePath: string, newName: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.RENAME_ATTACHED_FILE, filePath, newName)
+  },
+
+  moveAttachedFile: (filePath: string, targetDir: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.MOVE_ATTACHED_FILE, filePath, targetDir)
+  },
+
+  searchWorkspaceFiles: (rootPath: string, query: string, limit = 20, additionalPaths?: string[]) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.SEARCH_WORKSPACE_FILES, rootPath, query, limit, additionalPaths)
   },
 
   // 系统提示词管理

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -846,12 +846,14 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
               onPasteFiles={handlePasteFiles}
               placeholder={
                 agentChannelId
-                  ? '输入消息... (Enter 发送，Shift+Enter 换行)'
+                  ? '输入消息... (Enter 发送，Shift+Enter 换行，@ 引用文件)'
                   : '请先在设置中选择 Agent 供应商'
               }
               disabled={!agentChannelId}
               autoFocusTrigger={sessionId}
               collapsible
+              workspacePath={sessionPath}
+              attachedDirs={attachedDirs}
             />
 
             {/* Footer 工具栏 */}

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -10,10 +10,16 @@
 
 import * as React from 'react'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
-import { PanelRight, X, Users, FolderOpen, ExternalLink, RefreshCw } from 'lucide-react'
+import { PanelRight, X, Users, FolderOpen, ExternalLink, RefreshCw, ChevronRight, Folder, FileText, MoreHorizontal, FolderSearch, Pencil, FolderInput } from 'lucide-react'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import { cn } from '@/lib/utils'
 import { FileBrowser, FileDropZone } from '@/components/file-browser'
 import { TeamActivityPanel } from './TeamActivityPanel'
@@ -29,6 +35,7 @@ import {
   agentAttachedDirectoriesMapAtom,
 } from '@/atoms/agent-atoms'
 import type { SidePanelTab } from '@/atoms/agent-atoms'
+import type { FileEntry } from '@proma/shared'
 
 interface SidePanelProps {
   sessionId: string
@@ -303,34 +310,12 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                   </div>
                   {/* 可滚动内容区：附加目录 + 文件浏览器 + 拖拽上传 */}
                   <div className="flex-1 min-h-0 overflow-y-auto">
-                    {/* 附加目录列表 */}
+                    {/* 附加目录列表（可展开目录树） */}
                     {attachedDirs.length > 0 && (
-                      <div className="px-3 pt-2.5 pb-1 space-y-1 flex-shrink-0">
-                        <div className="text-[11px] font-medium text-muted-foreground mb-1">附加目录（Agent 可以读取并操作此文件夹）</div>
-                        {attachedDirs.map((dir) => {
-                          const dirName = dir.split('/').filter(Boolean).pop() || dir
-                          return (
-                            <div
-                              key={dir}
-                              className="flex items-center gap-2 px-2.5 py-1.5 rounded-lg bg-muted/50 group"
-                            >
-                              <FolderOpen className="size-3.5 text-amber-500 shrink-0" />
-                              <span className="text-xs truncate flex-1" title={dir}>
-                                {dirName}
-                              </span>
-                              <Button
-                                type="button"
-                                variant="ghost"
-                                size="icon"
-                                className="h-5 w-5 opacity-0 group-hover:opacity-100 transition-opacity"
-                                onClick={() => handleDetachDirectory(dir)}
-                              >
-                                <X className="size-3" />
-                              </Button>
-                            </div>
-                          )
-                        })}
-                      </div>
+                      <AttachedDirsSection
+                        attachedDirs={attachedDirs}
+                        onDetach={handleDetachDirectory}
+                      />
                     )}
                     {/* 文件浏览器（嵌入模式，不自带滚动） */}
                     <FileBrowser rootPath={sessionPath} hideToolbar embedded />
@@ -353,5 +338,338 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
         </div>
       )}
     </div>
+  )
+}
+
+// ===== 附加目录容器（管理选中状态） =====
+
+interface AttachedDirsSectionProps {
+  attachedDirs: string[]
+  onDetach: (dirPath: string) => void
+}
+
+/** 附加目录区域：统一管理所有子项的选中状态 */
+function AttachedDirsSection({ attachedDirs, onDetach }: AttachedDirsSectionProps): React.ReactElement {
+  const [selectedPaths, setSelectedPaths] = React.useState<Set<string>>(new Set())
+
+  const handleSelect = React.useCallback((path: string, ctrlKey: boolean) => {
+    setSelectedPaths((prev) => {
+      if (ctrlKey) {
+        // Ctrl+点击：切换选中
+        const next = new Set(prev)
+        if (next.has(path)) {
+          next.delete(path)
+        } else {
+          next.add(path)
+        }
+        return next
+      }
+      // 普通点击：单选
+      return new Set([path])
+    })
+  }, [])
+
+  return (
+    <div className="pt-2.5 pb-1 flex-shrink-0">
+      <div className="text-[11px] font-medium text-muted-foreground mb-1 px-3">附加目录（Agent 可以读取并操作此文件夹）</div>
+      {attachedDirs.map((dir) => (
+        <AttachedDirTree
+          key={dir}
+          dirPath={dir}
+          onDetach={() => onDetach(dir)}
+          selectedPaths={selectedPaths}
+          onSelect={handleSelect}
+        />
+      ))}
+    </div>
+  )
+}
+
+// ===== 附加目录树组件 =====
+
+interface AttachedDirTreeProps {
+  dirPath: string
+  onDetach: () => void
+  selectedPaths: Set<string>
+  onSelect: (path: string, ctrlKey: boolean) => void
+}
+
+/** 附加目录根节点：可展开/收起，带移除按钮 */
+function AttachedDirTree({ dirPath, onDetach, selectedPaths, onSelect }: AttachedDirTreeProps): React.ReactElement {
+  const [expanded, setExpanded] = React.useState(false)
+  const [children, setChildren] = React.useState<FileEntry[]>([])
+  const [loaded, setLoaded] = React.useState(false)
+
+  const dirName = dirPath.split('/').filter(Boolean).pop() || dirPath
+
+  const toggleExpand = async (): Promise<void> => {
+    if (!expanded && !loaded) {
+      try {
+        const items = await window.electronAPI.listAttachedDirectory(dirPath)
+        setChildren(items)
+        setLoaded(true)
+      } catch (err) {
+        console.error('[AttachedDirTree] 加载失败:', err)
+      }
+    }
+    setExpanded(!expanded)
+  }
+
+  return (
+    <div>
+      <div
+        className="flex items-center gap-1 py-1 px-2 cursor-pointer hover:bg-accent/50 group"
+        onClick={toggleExpand}
+      >
+        <ChevronRight
+          className={cn(
+            'size-3.5 text-muted-foreground flex-shrink-0 transition-transform duration-150',
+            expanded && 'rotate-90',
+          )}
+        />
+        {expanded ? (
+          <FolderOpen className="size-4 text-amber-500 flex-shrink-0" />
+        ) : (
+          <Folder className="size-4 text-amber-500 flex-shrink-0" />
+        )}
+        <span className="text-xs truncate flex-1" title={dirPath}>
+          {dirName}
+        </span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-5 w-5 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0"
+          onClick={(e) => { e.stopPropagation(); onDetach() }}
+        >
+          <X className="size-3" />
+        </Button>
+      </div>
+      {expanded && children.length === 0 && loaded && (
+        <div className="text-[11px] text-muted-foreground/50 py-1" style={{ paddingLeft: 48 }}>
+          空文件夹
+        </div>
+      )}
+      {expanded && children.map((child) => (
+        <AttachedDirItem key={child.path} entry={child} depth={1} selectedPaths={selectedPaths} onSelect={onSelect} />
+      ))}
+    </div>
+  )
+}
+
+interface AttachedDirItemProps {
+  entry: FileEntry
+  depth: number
+  selectedPaths: Set<string>
+  onSelect: (path: string, ctrlKey: boolean) => void
+}
+
+/** 附加目录子项：递归可展开，支持选中 + 三点菜单（含重命名、移动） */
+function AttachedDirItem({ entry, depth, selectedPaths, onSelect }: AttachedDirItemProps): React.ReactElement {
+  const [expanded, setExpanded] = React.useState(false)
+  const [children, setChildren] = React.useState<FileEntry[]>([])
+  const [loaded, setLoaded] = React.useState(false)
+  // 重命名状态
+  const [isRenaming, setIsRenaming] = React.useState(false)
+  const [renameValue, setRenameValue] = React.useState(entry.name)
+  const renameInputRef = React.useRef<HTMLInputElement>(null)
+  // 当前显示的名称和路径（重命名后更新）
+  const [currentName, setCurrentName] = React.useState(entry.name)
+  const [currentPath, setCurrentPath] = React.useState(entry.path)
+
+  const isSelected = selectedPaths.has(currentPath)
+
+  const toggleDir = async (): Promise<void> => {
+    if (!entry.isDirectory) return
+    if (!expanded && !loaded) {
+      try {
+        const items = await window.electronAPI.listAttachedDirectory(currentPath)
+        setChildren(items)
+        setLoaded(true)
+      } catch (err) {
+        console.error('[AttachedDirItem] 加载子目录失败:', err)
+      }
+    }
+    setExpanded(!expanded)
+  }
+
+  const handleClick = (e: React.MouseEvent): void => {
+    onSelect(currentPath, e.ctrlKey || e.metaKey)
+    if (entry.isDirectory) {
+      toggleDir()
+    }
+  }
+
+  const handleDoubleClick = (): void => {
+    if (!entry.isDirectory) {
+      window.electronAPI.openAttachedFile(currentPath).catch(console.error)
+    }
+  }
+
+  // 开始重命名
+  const startRename = (): void => {
+    setRenameValue(currentName)
+    setIsRenaming(true)
+    // 延迟聚焦，等待 DOM 渲染
+    setTimeout(() => renameInputRef.current?.select(), 50)
+  }
+
+  // 确认重命名
+  const confirmRename = async (): Promise<void> => {
+    const newName = renameValue.trim()
+    if (!newName || newName === currentName) {
+      setIsRenaming(false)
+      return
+    }
+    try {
+      await window.electronAPI.renameAttachedFile(currentPath, newName)
+      // 更新本地显示
+      const parentDir = currentPath.substring(0, currentPath.lastIndexOf('/'))
+      const newPath = `${parentDir}/${newName}`
+      // 更新选中状态中的路径
+      onSelect(newPath, false)
+      setCurrentName(newName)
+      setCurrentPath(newPath)
+    } catch (err) {
+      console.error('[AttachedDirItem] 重命名失败:', err)
+    }
+    setIsRenaming(false)
+  }
+
+  // 取消重命名
+  const cancelRename = (): void => {
+    setIsRenaming(false)
+    setRenameValue(currentName)
+  }
+
+  // 移动到文件夹
+  const handleMove = async (): Promise<void> => {
+    try {
+      const result = await window.electronAPI.openFolderDialog()
+      if (!result) return
+      await window.electronAPI.moveAttachedFile(currentPath, result.path)
+      // 移动后更新路径
+      const newPath = `${result.path}/${currentName}`
+      setCurrentPath(newPath)
+    } catch (err) {
+      console.error('[AttachedDirItem] 移动失败:', err)
+    }
+  }
+
+  const paddingLeft = 8 + depth * 16
+
+  return (
+    <>
+      <div
+        className={cn(
+          'flex items-center gap-1 py-1 pr-2 text-sm cursor-pointer group',
+          isSelected ? 'bg-accent' : 'hover:bg-accent/50',
+        )}
+        style={{ paddingLeft }}
+        onClick={handleClick}
+        onDoubleClick={handleDoubleClick}
+      >
+        {entry.isDirectory ? (
+          <ChevronRight
+            className={cn(
+              'size-3.5 text-muted-foreground flex-shrink-0 transition-transform duration-150',
+              expanded && 'rotate-90',
+            )}
+          />
+        ) : (
+          <span className="w-3.5 flex-shrink-0" />
+        )}
+        {entry.isDirectory ? (
+          expanded ? (
+            <FolderOpen className="size-4 text-amber-500 flex-shrink-0" />
+          ) : (
+            <Folder className="size-4 text-amber-500 flex-shrink-0" />
+          )
+        ) : (
+          <FileText className="size-4 text-muted-foreground flex-shrink-0" />
+        )}
+
+        {/* 名称：正常显示 / 重命名输入框 */}
+        {isRenaming ? (
+          <input
+            ref={renameInputRef}
+            className="text-xs flex-1 min-w-0 bg-background border border-primary rounded px-1 py-0.5 outline-none"
+            value={renameValue}
+            onChange={(e) => setRenameValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') confirmRename()
+              if (e.key === 'Escape') cancelRename()
+              e.stopPropagation()
+            }}
+            onBlur={confirmRename}
+            onClick={(e) => e.stopPropagation()}
+          />
+        ) : (
+          <span className="truncate text-xs flex-1">{currentName}</span>
+        )}
+
+        {/* 三点菜单按钮 */}
+        {isSelected && !isRenaming && (
+          <div
+            onClick={(e) => e.stopPropagation()}
+            onMouseDown={(e) => e.stopPropagation()}
+          >
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  className="h-6 w-6 rounded flex items-center justify-center hover:bg-accent/70"
+                >
+                  <MoreHorizontal className="size-3.5" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start" className="w-40 z-[9999] min-w-0 p-0.5">
+                <DropdownMenuItem
+                  className="text-xs py-1 [&>svg]:size-3.5"
+                  onSelect={() => window.electronAPI.showAttachedInFolder(currentPath).catch(console.error)}
+                >
+                  <FolderSearch />
+                  在文件夹中显示
+                </DropdownMenuItem>
+                {!entry.isDirectory && (
+                  <DropdownMenuItem
+                    className="text-xs py-1 [&>svg]:size-3.5"
+                    onSelect={() => window.electronAPI.openAttachedFile(currentPath).catch(console.error)}
+                  >
+                    <ExternalLink />
+                    打开文件
+                  </DropdownMenuItem>
+                )}
+                <DropdownMenuItem
+                  className="text-xs py-1 [&>svg]:size-3.5"
+                  onSelect={startRename}
+                >
+                  <Pencil />
+                  重命名
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  className="text-xs py-1 [&>svg]:size-3.5"
+                  onSelect={handleMove}
+                >
+                  <FolderInput />
+                  移动到...
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        )}
+      </div>
+      {expanded && children.length === 0 && loaded && (
+        <div
+          className="text-[11px] text-muted-foreground/50 py-1"
+          style={{ paddingLeft: paddingLeft + 24 }}
+        >
+          空文件夹
+        </div>
+      )}
+      {expanded && children.map((child) => (
+        <AttachedDirItem key={child.path} entry={child} depth={depth + 1} selectedPaths={selectedPaths} onSelect={onSelect} />
+      ))}
+    </>
   )
 }

--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -22,7 +22,7 @@ import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkMath from 'remark-math'
 import rehypeKatex from 'rehype-katex'
-import { ChevronDown, ChevronUp, Paperclip } from 'lucide-react'
+import { ChevronDown, ChevronUp, Paperclip, FileText } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import {
@@ -278,6 +278,46 @@ export const MessageResponse = React.memo(
 /** 折叠行数阈值 */
 const COLLAPSE_LINE_THRESHOLD = 4
 
+/** 将文本中的 @file:路径 替换为样式化 chip */
+const FILE_MENTION_RE = /@file:(\S+)/g
+
+function renderTextWithMentions(text: string): React.ReactNode {
+  const parts: React.ReactNode[] = []
+  let lastIndex = 0
+  let match: RegExpExecArray | null
+
+  // 重置 lastIndex（全局正则复用时需要）
+  FILE_MENTION_RE.lastIndex = 0
+
+  while ((match = FILE_MENTION_RE.exec(text)) !== null) {
+    // 添加 match 前的纯文本
+    if (match.index > lastIndex) {
+      parts.push(text.slice(lastIndex, match.index))
+    }
+    // 渲染 mention chip
+    const filePath = match[1] ?? ''
+    const fileName = filePath.split('/').pop() || filePath
+    parts.push(
+      <span
+        key={`mention-${match.index}`}
+        className="inline-flex items-center gap-0.5 bg-primary/10 text-primary rounded px-1 py-[1px] text-[13px] font-medium whitespace-nowrap align-baseline"
+        title={filePath}
+      >
+        <FileText className="size-3 inline shrink-0" />
+        {fileName}
+      </span>
+    )
+    lastIndex = match.index + match[0].length
+  }
+
+  // 添加剩余文本
+  if (lastIndex < text.length) {
+    parts.push(text.slice(lastIndex))
+  }
+
+  return parts.length > 0 ? parts : text
+}
+
 interface UserMessageContentProps extends HTMLAttributes<HTMLDivElement> {
   children: string
 }
@@ -319,7 +359,7 @@ export const UserMessageContent = React.memo(
             shouldCollapse && !isExpanded && 'max-h-[6.5em]'
           )}
         >
-          {children}
+          {renderTextWithMentions(children)}
         </div>
         {shouldCollapse && (
           <button

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -2,11 +2,10 @@
  * AI Elements - TipTap 富文本输入组件
  *
  * 独立受控组件，不依赖 PromptInput Provider。
- * 移植自 proma-frontend 的 ai-elements/rich-text-input.tsx，
- * 去掉了粘贴图片处理和 Backspace 删除附件逻辑。
  *
  * 功能：
  * - StarterKit + Placeholder + Underline + Link + CodeBlockLowlight
+ * - 可选 Mention 扩展（@ 引用文件）
  * - htmlToMarkdown 转换
  * - IME composition 处理
  * - Enter 提交 / Shift+Enter 换行
@@ -14,17 +13,19 @@
  * - 自动扩高
  */
 
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useMemo } from 'react'
 import { useEditor, EditorContent } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import Placeholder from '@tiptap/extension-placeholder'
 import Underline from '@tiptap/extension-underline'
 import Link from '@tiptap/extension-link'
 import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
+import Mention from '@tiptap/extension-mention'
 import { common, createLowlight } from 'lowlight'
 import { ChevronsDownUp, ChevronsUpDown } from 'lucide-react'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
+import { createFileMentionSuggestion } from '@/components/file-browser/file-mention-suggestion'
 
 // 创建 lowlight 实例，使用常见语言
 const lowlight = createLowlight(common)
@@ -109,6 +110,14 @@ function htmlToMarkdown(html: string): string {
       case 'h5': return `##### ${children}\n\n`
       case 'h6': return `###### ${children}\n\n`
       case 'hr': return '---\n\n'
+      case 'span': {
+        // Mention 节点：转换为 @file:路径 格式
+        if (el.getAttribute('data-type') === 'mention') {
+          const filePath = el.getAttribute('data-id') || ''
+          return `@file:${filePath}`
+        }
+        return children
+      }
       default: return children
     }
   }
@@ -170,6 +179,10 @@ interface RichTextInputProps {
   autoFocusTrigger?: string | null
   /** 是否支持手动折叠（内容较长时显示折叠按钮） */
   collapsible?: boolean
+  /** 工作区根路径（启用 @ 引用文件功能时需要） */
+  workspacePath?: string | null
+  /** 附加目录路径列表（@ 引用时一并搜索） */
+  attachedDirs?: string[]
   className?: string
 }
 
@@ -190,6 +203,8 @@ export function RichTextInput({
   disabled = false,
   autoFocusTrigger,
   collapsible = false,
+  workspacePath,
+  attachedDirs = [],
 }: RichTextInputProps): React.ReactElement {
   const [isExpanded, setIsExpanded] = useState(false)
   // 手动折叠状态：用户主动折叠输入框
@@ -204,6 +219,20 @@ export function RichTextInput({
   // 保持 onPasteFiles 引用最新
   const onPasteFilesRef = useRef(onPasteFiles)
   onPasteFilesRef.current = onPasteFiles
+  // Mention 活跃状态（阻止 Enter 发送消息）
+  const mentionActiveRef = useRef(false)
+  // 工作区路径引用（给 Suggestion 使用）
+  const workspacePathRef = useRef<string | null>(workspacePath ?? null)
+  workspacePathRef.current = workspacePath ?? null
+  // 附加目录路径引用（给 Suggestion 使用）
+  const attachedDirsRef = useRef<string[]>(attachedDirs)
+  attachedDirsRef.current = attachedDirs
+
+  // Mention Suggestion 配置（稳定引用，不随 workspacePath 变化重建）
+  const mentionSuggestion = useMemo(
+    () => createFileMentionSuggestion(workspacePathRef, mentionActiveRef, attachedDirsRef),
+    [],
+  )
 
   const editor = useEditor({
     extensions: [
@@ -230,6 +259,14 @@ export function RichTextInput({
       Placeholder.configure({
         placeholder,
         emptyEditorClass: 'is-editor-empty',
+      }),
+      // @ 引用文件（始终加载扩展，workspacePathRef 内部控制是否搜索）
+      // 不能条件加载，因为 useEditor 不会在 workspacePath 变化时重建扩展
+      Mention.configure({
+        HTMLAttributes: {
+          class: 'mention-chip',
+        },
+        suggestion: mentionSuggestion,
       }),
     ],
     content: value || '',
@@ -279,6 +316,11 @@ export function RichTextInput({
 
           // 检查是否正在输入中文（IME 组合输入）
           if (isComposingRef.current || event.isComposing) {
+            return false
+          }
+
+          // Mention 列表打开时，让 TipTap Mention 处理 Enter
+          if (mentionActiveRef.current) {
             return false
           }
 
@@ -420,6 +462,15 @@ export function RichTextInput({
         }
         .ProseMirror::-webkit-scrollbar {
           width: 3px;
+        }
+        .mention-chip {
+          background-color: hsl(var(--primary) / 0.1);
+          color: hsl(var(--primary));
+          border-radius: 4px;
+          padding: 1px 4px;
+          font-size: 13px;
+          font-weight: 500;
+          white-space: nowrap;
         }
       `}</style>
     </div>

--- a/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
@@ -2,14 +2,12 @@
  * FileBrowser — 通用文件浏览器面板
  *
  * 显示指定根路径下的文件树，支持：
- * - 文件夹懒加载展开
- * - 点击文件用系统默认应用打开
- * - 右键菜单：打开 / 在 Finder 中打开 / 在文件夹中显示 / 删除
+ * - 文件夹懒加载展开（Chevron 旋转动画）
+ * - 单击选中、Cmd/Ctrl+Click 多选
+ * - 选中后显示三点菜单（打开 / 在文件夹中显示 / 重命名 / 移动 / 删除）
  * - 文件/文件夹删除（带确认对话框）
+ * - 原位重命名（含同名检查）
  * - 自动刷新
- *
- * 注意：使用手动 onContextMenu + 定位弹出菜单而非 Radix ContextMenu，
- * 因为 Radix ContextMenu 在 Electron ScrollArea 内存在右键事件不触发的问题。
  */
 
 import * as React from 'react'
@@ -19,11 +17,13 @@ import {
   FolderOpen,
   FileText,
   ChevronRight,
-  ChevronDown,
   Trash2,
   RefreshCw,
   ExternalLink,
   FolderSearch,
+  MoreHorizontal,
+  FolderInput,
+  Pencil,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
@@ -37,16 +37,16 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import { cn } from '@/lib/utils'
 import { workspaceFilesVersionAtom } from '@/atoms/agent-atoms'
 import type { FileEntry } from '@proma/shared'
-
-/** 右键菜单状态 */
-interface ContextMenuState {
-  x: number
-  y: number
-  entry: FileEntry
-}
 
 interface FileBrowserProps {
   rootPath: string
@@ -62,11 +62,17 @@ export function FileBrowser({ rootPath, hideToolbar, embedded }: FileBrowserProp
   const [error, setError] = React.useState<string | null>(null)
   const filesVersion = useAtomValue(workspaceFilesVersionAtom)
 
+  // 选中状态
+  const [selectedPaths, setSelectedPaths] = React.useState<Set<string>>(new Set())
   // 删除确认状态
   const [deleteTarget, setDeleteTarget] = React.useState<FileEntry | null>(null)
-  // 右键菜单状态
-  const [contextMenu, setContextMenu] = React.useState<ContextMenuState | null>(null)
-  const menuRef = React.useRef<HTMLDivElement>(null)
+  const [deleteCount, setDeleteCount] = React.useState(1)
+  // 重命名状态
+  const [renamingPath, setRenamingPath] = React.useState<string | null>(null)
+  // 移动中状态
+  const [moving, setMoving] = React.useState(false)
+
+  const selectedCount = selectedPaths.size
 
   /** 加载根目录 */
   const loadRoot = React.useCallback(async () => {
@@ -89,62 +95,120 @@ export function FileBrowser({ rootPath, hideToolbar, embedded }: FileBrowserProp
     loadRoot()
   }, [loadRoot, filesVersion])
 
-  // 点击任意位置关闭右键菜单
-  React.useEffect(() => {
-    if (!contextMenu) return
-
-    const close = (): void => setContextMenu(null)
-    // 用 capture 阶段捕获，确保菜单关闭
-    window.addEventListener('mousedown', close)
-    window.addEventListener('contextmenu', close)
-    window.addEventListener('scroll', close, true)
-
-    return () => {
-      window.removeEventListener('mousedown', close)
-      window.removeEventListener('contextmenu', close)
-      window.removeEventListener('scroll', close, true)
+  /** 选中项 */
+  const handleSelect = React.useCallback((entry: FileEntry, event: React.MouseEvent) => {
+    const isMulti = event.metaKey || event.ctrlKey
+    if (isMulti) {
+      setSelectedPaths((prev) => {
+        const next = new Set(prev)
+        if (next.has(entry.path)) {
+          next.delete(entry.path)
+        } else {
+          next.add(entry.path)
+        }
+        return next
+      })
+    } else {
+      setSelectedPaths(new Set([entry.path]))
     }
-  }, [contextMenu])
-
-  /** 右键菜单回调 */
-  const handleContextMenu = React.useCallback((e: React.MouseEvent, entry: FileEntry): void => {
-    e.preventDefault()
-    e.stopPropagation()
-    setContextMenu({ x: e.clientX, y: e.clientY, entry })
   }, [])
 
-  /** 右键菜单操作：打开 */
-  const handleMenuOpen = (): void => {
-    if (!contextMenu) return
-    window.electronAPI.openFile(contextMenu.entry.path).catch(console.error)
-    setContextMenu(null)
-  }
+  /** 点击空白区域清空选中 */
+  const handleBackgroundClick = React.useCallback((e: React.MouseEvent) => {
+    // 只处理直接点击容器的情况
+    if (e.target === e.currentTarget) {
+      setSelectedPaths(new Set())
+    }
+  }, [])
 
-  /** 右键菜单操作：在文件夹中显示 */
-  const handleMenuShowInFolder = (): void => {
-    if (!contextMenu) return
-    window.electronAPI.showInFolder(contextMenu.entry.path).catch(console.error)
-    setContextMenu(null)
-  }
+  /** 在文件夹中显示 */
+  const handleShowInFolder = React.useCallback((entry: FileEntry) => {
+    window.electronAPI.showInFolder(entry.path).catch(console.error)
+  }, [])
 
-  /** 右键菜单操作：删除 */
-  const handleMenuDelete = (): void => {
-    if (!contextMenu) return
-    setDeleteTarget(contextMenu.entry)
-    setContextMenu(null)
-  }
+  /** 开始重命名 */
+  const handleStartRename = React.useCallback((entry: FileEntry) => {
+    setRenamingPath(entry.path)
+  }, [])
 
-  /** 删除文件/目录 */
-  const handleDelete = async (): Promise<void> => {
+  /** 取消重命名 */
+  const handleCancelRename = React.useCallback(() => {
+    setRenamingPath(null)
+  }, [])
+
+  /** 执行重命名 */
+  const handleRename = React.useCallback(async (filePath: string, newName: string): Promise<string | null> => {
+    // 同名检查
+    const parentDir = filePath.substring(0, filePath.lastIndexOf('/'))
+    try {
+      const siblings = await window.electronAPI.listDirectory(parentDir)
+      const conflict = siblings.some((s) => s.name === newName && s.path !== filePath)
+      if (conflict) {
+        return '同名文件已存在'
+      }
+    } catch {
+      // 无法列出目录，跳过检查
+    }
+
+    try {
+      await window.electronAPI.renameFile(filePath, newName)
+      await loadRoot()
+      setRenamingPath(null)
+      setSelectedPaths(new Set())
+      return null
+    } catch (err) {
+      return err instanceof Error ? err.message : '重命名失败'
+    }
+  }, [loadRoot])
+
+  /** 触发删除（支持多选） */
+  const handleRequestDelete = React.useCallback((entry: FileEntry) => {
+    setDeleteTarget(entry)
+    setDeleteCount(selectedCount > 1 ? selectedCount : 1)
+  }, [selectedCount])
+
+  /** 执行删除 */
+  const handleDelete = React.useCallback(async () => {
     if (!deleteTarget) return
     try {
-      await window.electronAPI.deleteFile(deleteTarget.path)
+      if (selectedPaths.size > 1) {
+        // 批量删除
+        for (const path of selectedPaths) {
+          await window.electronAPI.deleteFile(path)
+        }
+      } else {
+        await window.electronAPI.deleteFile(deleteTarget.path)
+      }
+      setSelectedPaths(new Set())
       await loadRoot()
     } catch (err) {
       console.error('[FileBrowser] 删除失败:', err)
     }
     setDeleteTarget(null)
-  }
+  }, [deleteTarget, selectedPaths, loadRoot])
+
+  /** 移动文件 */
+  const handleMove = React.useCallback(async (entry: FileEntry) => {
+    setMoving(true)
+    try {
+      const result = await window.electronAPI.openFolderDialog()
+      if (!result) return
+
+      if (selectedPaths.size > 1) {
+        for (const path of selectedPaths) {
+          await window.electronAPI.moveFile(path, result.path)
+        }
+      } else {
+        await window.electronAPI.moveFile(entry.path, result.path)
+      }
+      setSelectedPaths(new Set())
+      await loadRoot()
+    } catch (err) {
+      console.error('[FileBrowser] 移动失败:', err)
+    } finally {
+      setMoving(false)
+    }
+  }, [selectedPaths, loadRoot])
 
   // 显示根路径最后两段作为面包屑
   const breadcrumb = React.useMemo(() => {
@@ -153,7 +217,7 @@ export function FileBrowser({ rootPath, hideToolbar, embedded }: FileBrowserProp
   }, [rootPath])
 
   const fileTree = (
-    <div className="py-1">
+    <div className="py-1" onClick={handleBackgroundClick}>
       {error && (
         <div className="px-3 py-2 text-xs text-destructive">{error}</div>
       )}
@@ -167,7 +231,17 @@ export function FileBrowser({ rootPath, hideToolbar, embedded }: FileBrowserProp
           key={entry.path}
           entry={entry}
           depth={0}
-          onContextMenu={handleContextMenu}
+          selectedPaths={selectedPaths}
+          selectedCount={selectedCount}
+          renamingPath={renamingPath}
+          moving={moving}
+          onSelect={handleSelect}
+          onShowInFolder={handleShowInFolder}
+          onStartRename={handleStartRename}
+          onCancelRename={handleCancelRename}
+          onRename={handleRename}
+          onDelete={handleRequestDelete}
+          onMove={handleMove}
           onRefresh={loadRoot}
         />
       ))}
@@ -212,61 +286,20 @@ export function FileBrowser({ rootPath, hideToolbar, embedded }: FileBrowserProp
         </ScrollArea>
       )}
 
-      {/* 右键菜单（手动定位弹出层） */}
-      {contextMenu && (
-        <div
-          ref={menuRef}
-          className="fixed z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95"
-          style={{ left: contextMenu.x, top: contextMenu.y }}
-          onMouseDown={(e) => e.stopPropagation()}
-        >
-          {contextMenu.entry.isDirectory ? (
-            <button
-              type="button"
-              className="relative flex w-full cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground"
-              onClick={handleMenuOpen}
-            >
-              <FolderOpen className="size-3.5 mr-2" />
-              在 Finder 中打开
-            </button>
-          ) : (
-            <button
-              type="button"
-              className="relative flex w-full cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground"
-              onClick={handleMenuOpen}
-            >
-              <ExternalLink className="size-3.5 mr-2" />
-              打开
-            </button>
-          )}
-          <button
-            type="button"
-            className="relative flex w-full cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground"
-            onClick={handleMenuShowInFolder}
-          >
-            <FolderSearch className="size-3.5 mr-2" />
-            在文件夹中显示
-          </button>
-          <div className="-mx-1 my-1 h-px bg-border" />
-          <button
-            type="button"
-            className="relative flex w-full cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none text-destructive hover:bg-destructive/10 hover:text-destructive"
-            onClick={handleMenuDelete}
-          >
-            <Trash2 className="size-3.5 mr-2" />
-            删除
-          </button>
-        </div>
-      )}
-
       {/* 删除确认对话框 */}
       <AlertDialog open={!!deleteTarget} onOpenChange={(open) => { if (!open) setDeleteTarget(null) }}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>确认删除</AlertDialogTitle>
             <AlertDialogDescription>
-              确定要删除 <strong>{deleteTarget?.name}</strong> 吗？
-              {deleteTarget?.isDirectory && '（包含所有子文件）'}
+              {deleteCount > 1 ? (
+                <>确定要删除选中的 <strong>{deleteCount}</strong> 个项目吗？</>
+              ) : (
+                <>
+                  确定要删除 <strong>{deleteTarget?.name}</strong> 吗？
+                  {deleteTarget?.isDirectory && '（包含所有子文件）'}
+                </>
+              )}
               此操作不可撤销。
             </AlertDialogDescription>
           </AlertDialogHeader>
@@ -287,14 +320,48 @@ export function FileBrowser({ rootPath, hideToolbar, embedded }: FileBrowserProp
 interface FileTreeItemProps {
   entry: FileEntry
   depth: number
-  onContextMenu: (e: React.MouseEvent, entry: FileEntry) => void
+  selectedPaths: Set<string>
+  selectedCount: number
+  renamingPath: string | null
+  moving: boolean
+  onSelect: (entry: FileEntry, event: React.MouseEvent) => void
+  onShowInFolder: (entry: FileEntry) => void
+  onStartRename: (entry: FileEntry) => void
+  onCancelRename: () => void
+  onRename: (filePath: string, newName: string) => Promise<string | null>
+  onDelete: (entry: FileEntry) => void
+  onMove: (entry: FileEntry) => void
   onRefresh: () => Promise<void>
 }
 
-function FileTreeItem({ entry, depth, onContextMenu, onRefresh }: FileTreeItemProps): React.ReactElement {
+function FileTreeItem({
+  entry,
+  depth,
+  selectedPaths,
+  selectedCount,
+  renamingPath,
+  moving,
+  onSelect,
+  onShowInFolder,
+  onStartRename,
+  onCancelRename,
+  onRename,
+  onDelete,
+  onMove,
+  onRefresh,
+}: FileTreeItemProps): React.ReactElement {
   const [expanded, setExpanded] = React.useState(false)
   const [children, setChildren] = React.useState<FileEntry[]>([])
   const [childrenLoaded, setChildrenLoaded] = React.useState(false)
+
+  // 重命名编辑状态
+  const [editName, setEditName] = React.useState('')
+  const [renameError, setRenameError] = React.useState<string | null>(null)
+  const renameInputRef = React.useRef<HTMLInputElement>(null)
+  const justStartedEditing = React.useRef(false)
+
+  const isSelected = selectedPaths.has(entry.path)
+  const isRenaming = renamingPath === entry.path
 
   /** 展开/收起文件夹 */
   const toggleDir = async (): Promise<void> => {
@@ -313,16 +380,23 @@ function FileTreeItem({ entry, depth, onContextMenu, onRefresh }: FileTreeItemPr
     setExpanded(!expanded)
   }
 
-  /** 点击行为：文件 → 打开，文件夹 → 展开/收起 */
-  const handleClick = (): void => {
-    if (entry.isDirectory) {
+  /** 点击行为：选中 + 文件夹展开/收起 */
+  const handleClick = (e: React.MouseEvent): void => {
+    e.stopPropagation()
+    onSelect(entry, e)
+    if (entry.isDirectory && !e.metaKey && !e.ctrlKey) {
       toggleDir()
-    } else {
+    }
+  }
+
+  /** 双击打开文件 */
+  const handleDoubleClick = (): void => {
+    if (!entry.isDirectory) {
       window.electronAPI.openFile(entry.path).catch(console.error)
     }
   }
 
-  /** 删除后刷新父目录 */
+  /** 删除后刷新子目录 */
   const handleRefreshAfterDelete = async (): Promise<void> => {
     if (childrenLoaded) {
       try {
@@ -334,23 +408,88 @@ function FileTreeItem({ entry, depth, onContextMenu, onRefresh }: FileTreeItemPr
     }
   }
 
+  // 进入重命名编辑模式
+  React.useEffect(() => {
+    if (isRenaming) {
+      setEditName(entry.name)
+      setRenameError(null)
+      justStartedEditing.current = true
+      const timer = setTimeout(() => {
+        justStartedEditing.current = false
+        const input = renameInputRef.current
+        if (input) {
+          input.focus()
+          // 只选中文件名部分，不包括后缀
+          const lastDotIndex = entry.name.lastIndexOf('.')
+          if (lastDotIndex > 0 && !entry.isDirectory) {
+            input.setSelectionRange(0, lastDotIndex)
+          } else {
+            input.select()
+          }
+        }
+      }, 100)
+      return () => clearTimeout(timer)
+    }
+  }, [isRenaming, entry.name, entry.isDirectory])
+
+  /** 保存重命名 */
+  const saveRename = async (): Promise<void> => {
+    if (justStartedEditing.current) return
+
+    const trimmed = editName.trim()
+    if (!trimmed || trimmed === entry.name) {
+      onCancelRename()
+      return
+    }
+    const error = await onRename(entry.path, trimmed)
+    if (error) {
+      setRenameError(error)
+    }
+  }
+
+  /** 重命名键盘事件 */
+  const handleRenameKeyDown = (e: React.KeyboardEvent): void => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      void saveRename()
+    } else if (e.key === 'Escape') {
+      e.preventDefault()
+      onCancelRename()
+    }
+  }
+
+  /** 重命名失焦 */
+  const handleBlur = (): void => {
+    if (renameError) {
+      onCancelRename()
+      setRenameError(null)
+    } else {
+      void saveRename()
+    }
+  }
+
   const paddingLeft = 8 + depth * 16
+  const showMenu = isSelected && selectedCount > 0 && !isRenaming
 
   return (
     <>
       <div
-        className="flex items-center gap-1 py-1 pr-2 text-sm cursor-pointer hover:bg-accent/50 group"
+        className={cn(
+          'flex items-center gap-1 py-1 pr-2 text-sm cursor-pointer group',
+          isSelected ? 'bg-accent' : 'hover:bg-accent/50',
+        )}
         style={{ paddingLeft }}
         onClick={handleClick}
-        onContextMenu={(e) => onContextMenu(e, entry)}
+        onDoubleClick={handleDoubleClick}
       >
         {/* 展开/收起图标 */}
         {entry.isDirectory ? (
-          expanded ? (
-            <ChevronDown className="size-3.5 text-muted-foreground flex-shrink-0" />
-          ) : (
-            <ChevronRight className="size-3.5 text-muted-foreground flex-shrink-0" />
-          )
+          <ChevronRight
+            className={cn(
+              'size-3.5 text-muted-foreground flex-shrink-0 transition-transform duration-150',
+              expanded && 'rotate-90',
+            )}
+          />
         ) : (
           <span className="w-3.5 flex-shrink-0" />
         )}
@@ -366,17 +505,111 @@ function FileTreeItem({ entry, depth, onContextMenu, onRefresh }: FileTreeItemPr
           <FileText className="size-4 text-muted-foreground flex-shrink-0" />
         )}
 
-        {/* 文件名 */}
-        <span className="truncate text-xs flex-1">{entry.name}</span>
+        {/* 文件名 / 重命名输入框 */}
+        {isRenaming ? (
+          <div className="flex-1 min-w-0">
+            <input
+              ref={renameInputRef}
+              value={editName}
+              onChange={(e) => { setEditName(e.target.value); setRenameError(null) }}
+              onKeyDown={handleRenameKeyDown}
+              onBlur={handleBlur}
+              onClick={(e) => e.stopPropagation()}
+              className={cn(
+                'w-full bg-transparent text-xs border-b outline-none py-0.5',
+                renameError ? 'border-destructive' : 'border-primary/50',
+              )}
+              maxLength={255}
+            />
+            {renameError && (
+              <div className="text-[10px] text-destructive mt-0.5">{renameError}</div>
+            )}
+          </div>
+        ) : (
+          <span className="truncate text-xs flex-1">{entry.name}</span>
+        )}
+
+        {/* 三点菜单按钮 */}
+        {showMenu && (
+          <div
+            onClick={(e) => e.stopPropagation()}
+            onMouseDown={(e) => e.stopPropagation()}
+          >
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  className="h-6 w-6 rounded flex items-center justify-center hover:bg-accent/70"
+                >
+                  <MoreHorizontal className="size-3.5" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start" className="w-40 z-[9999] min-w-0 p-0.5">
+                {selectedCount === 1 && (
+                  <DropdownMenuItem
+                    className="text-xs py-1 [&>svg]:size-3.5"
+                    onSelect={() => onShowInFolder(entry)}
+                  >
+                    <FolderSearch />
+                    在文件夹中显示
+                  </DropdownMenuItem>
+                )}
+                <DropdownMenuItem
+                  className="text-xs py-1 [&>svg]:size-3.5"
+                  disabled={moving}
+                  onSelect={() => { void onMove(entry) }}
+                >
+                  <FolderInput />
+                  {selectedCount > 1 ? `移动选中 (${selectedCount})` : '移动到...'}
+                </DropdownMenuItem>
+                {selectedCount === 1 && (
+                  <DropdownMenuItem
+                    className="text-xs py-1 [&>svg]:size-3.5"
+                    onSelect={() => onStartRename(entry)}
+                  >
+                    <Pencil />
+                    重命名
+                  </DropdownMenuItem>
+                )}
+                <DropdownMenuSeparator className="my-0.5" />
+                <DropdownMenuItem
+                  className="text-xs py-1 [&>svg]:size-3.5 text-destructive"
+                  onSelect={() => onDelete(entry)}
+                >
+                  <Trash2 />
+                  {selectedCount > 1 ? `删除选中 (${selectedCount})` : '删除'}
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        )}
       </div>
 
       {/* 子项 */}
+      {expanded && children.length === 0 && childrenLoaded && (
+        <div
+          className="text-[11px] text-muted-foreground/50 py-1"
+          style={{ paddingLeft: paddingLeft + 24 }}
+        >
+          空文件夹
+        </div>
+      )}
       {expanded && children.map((child) => (
         <FileTreeItem
           key={child.path}
           entry={child}
           depth={depth + 1}
-          onContextMenu={onContextMenu}
+          selectedPaths={selectedPaths}
+          selectedCount={selectedCount}
+          renamingPath={renamingPath}
+          moving={moving}
+          onSelect={onSelect}
+          onShowInFolder={onShowInFolder}
+          onStartRename={onStartRename}
+          onCancelRename={onCancelRename}
+          onRename={onRename}
+          onDelete={onDelete}
+          onMove={onMove}
           onRefresh={handleRefreshAfterDelete}
         />
       ))}

--- a/apps/electron/src/renderer/components/file-browser/FileMentionList.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileMentionList.tsx
@@ -1,0 +1,105 @@
+/**
+ * FileMentionList — @ 引用文件下拉列表
+ *
+ * 显示文件搜索结果，支持键盘导航（上/下/Enter/Escape）。
+ * 通过 React.useImperativeHandle 暴露 onKeyDown 给 TipTap Suggestion。
+ */
+
+import * as React from 'react'
+import { Folder, FileText } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type { FileIndexEntry } from '@proma/shared'
+
+export interface FileMentionListProps {
+  items: FileIndexEntry[]
+  selectedIndex: number
+  onSelect: (item: FileIndexEntry) => void
+}
+
+export interface FileMentionRef {
+  onKeyDown: (props: { event: KeyboardEvent }) => boolean
+}
+
+export const FileMentionList = React.forwardRef<FileMentionRef, FileMentionListProps>(
+  function FileMentionList({ items, selectedIndex, onSelect }, ref) {
+    const [localIndex, setLocalIndex] = React.useState(selectedIndex)
+    const containerRef = React.useRef<HTMLDivElement>(null)
+
+    // items 变化时重置选中索引
+    React.useEffect(() => {
+      setLocalIndex(0)
+    }, [items])
+
+    // 滚动选中项到可见区域
+    React.useEffect(() => {
+      const container = containerRef.current
+      if (!container) return
+      const item = container.children[localIndex] as HTMLElement | undefined
+      item?.scrollIntoView({ block: 'nearest' })
+    }, [localIndex])
+
+    // 暴露键盘处理给 TipTap
+    React.useImperativeHandle(ref, () => ({
+      onKeyDown: ({ event }) => {
+        if (event.key === 'ArrowUp') {
+          setLocalIndex((prev) => (prev <= 0 ? items.length - 1 : prev - 1))
+          return true
+        }
+        if (event.key === 'ArrowDown') {
+          setLocalIndex((prev) => (prev >= items.length - 1 ? 0 : prev + 1))
+          return true
+        }
+        if (event.key === 'Enter') {
+          const item = items[localIndex]
+          if (item) onSelect(item)
+          return true
+        }
+        if (event.key === 'Escape') {
+          return true
+        }
+        return false
+      },
+    }))
+
+    // 无匹配结果
+    if (items.length === 0) {
+      return (
+        <div className="rounded-lg border bg-popover p-2 shadow-lg text-[11px] text-muted-foreground">
+          无匹配文件
+        </div>
+      )
+    }
+
+    return (
+      <div
+        ref={containerRef}
+        className="rounded-lg border bg-popover shadow-lg overflow-y-auto max-h-[200px] min-w-[200px]"
+      >
+        {items.map((item, index) => (
+          <button
+            key={item.path}
+            type="button"
+            className={cn(
+              'w-full flex items-center gap-1.5 px-2.5 py-1 text-left text-xs hover:bg-accent transition-colors',
+              index === localIndex && 'bg-accent text-accent-foreground',
+            )}
+            onClick={() => onSelect(item)}
+          >
+            {item.type === 'dir' ? (
+              <Folder className="size-3 text-amber-500 flex-shrink-0" />
+            ) : (
+              <FileText className="size-3 text-muted-foreground flex-shrink-0" />
+            )}
+            <span className="truncate flex-1">{item.name}</span>
+            {/* 显示相对路径（当路径不等于文件名时） */}
+            {item.path !== item.name && (
+              <span className="text-[10px] text-muted-foreground/60 truncate max-w-[120px]">
+                {item.path}
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+    )
+  },
+)

--- a/apps/electron/src/renderer/components/file-browser/file-mention-suggestion.tsx
+++ b/apps/electron/src/renderer/components/file-browser/file-mention-suggestion.tsx
@@ -1,0 +1,117 @@
+/**
+ * FileMentionSuggestion — TipTap Mention Suggestion 配置
+ *
+ * 工厂函数，创建用于 @ 引用文件的 TipTap Suggestion 配置。
+ * 输入 @ 后异步搜索工作区文件，弹出 FileMentionList 浮动列表。
+ */
+
+import type React from 'react'
+import { ReactRenderer } from '@tiptap/react'
+import type { SuggestionOptions } from '@tiptap/suggestion'
+import { FileMentionList } from './FileMentionList'
+import type { FileMentionRef } from './FileMentionList'
+import type { FileIndexEntry } from '@proma/shared'
+
+/**
+ * 创建文件 @ 引用的 Suggestion 配置
+ *
+ * @param workspacePathRef 当前工作区根路径引用
+ * @param mentionActiveRef 是否正在 mention 模式（用于阻止 Enter 发送消息）
+ * @param attachedDirsRef 附加目录路径列表引用（搜索时一并扫描）
+ */
+export function createFileMentionSuggestion(
+  workspacePathRef: React.RefObject<string | null>,
+  mentionActiveRef: React.MutableRefObject<boolean>,
+  attachedDirsRef?: React.RefObject<string[]>,
+): Omit<SuggestionOptions<FileIndexEntry>, 'editor'> {
+  return {
+    char: '@',
+    allowSpaces: false,
+
+    // 异步搜索文件
+    items: async ({ query }): Promise<FileIndexEntry[]> => {
+      const wsPath = workspacePathRef.current
+      if (!wsPath) return []
+
+      try {
+        const additionalPaths = attachedDirsRef?.current ?? []
+        const result = await window.electronAPI.searchWorkspaceFiles(
+          wsPath,
+          query ?? '',
+          8,
+          additionalPaths.length > 0 ? additionalPaths : undefined,
+        )
+        return result.entries
+      } catch {
+        return []
+      }
+    },
+
+    // 渲染下拉列表
+    render: () => {
+      let renderer: ReactRenderer<FileMentionRef> | null = null
+      let popup: HTMLDivElement | null = null
+
+      return {
+        onStart(props) {
+          mentionActiveRef.current = true
+          renderer = new ReactRenderer(FileMentionList, {
+            props: {
+              items: props.items,
+              selectedIndex: 0,
+              onSelect: (item: FileIndexEntry) => {
+                props.command({ id: item.path, label: item.name })
+              },
+            },
+            editor: props.editor,
+          })
+
+          // 创建浮动容器（向上弹出）
+          popup = document.createElement('div')
+          popup.style.position = 'absolute'
+          popup.style.zIndex = '9999'
+          document.body.appendChild(popup)
+          popup.appendChild(renderer.element)
+
+          // 定位到光标上方
+          const rect = props.clientRect?.()
+          if (rect && popup) {
+            popup.style.left = `${rect.left}px`
+            requestAnimationFrame(() => {
+              if (!popup) return
+              const popupHeight = popup.offsetHeight
+              popup.style.top = `${rect.top - popupHeight - 4}px`
+            })
+          }
+        },
+
+        onUpdate(props) {
+          renderer?.updateProps({ items: props.items })
+
+          // 重新定位
+          const rect = props.clientRect?.()
+          if (rect && popup) {
+            popup.style.left = `${rect.left}px`
+            requestAnimationFrame(() => {
+              if (!popup) return
+              const popupHeight = popup.offsetHeight
+              popup.style.top = `${rect.top - popupHeight - 4}px`
+            })
+          }
+        },
+
+        onKeyDown(props) {
+          return renderer?.ref?.onKeyDown({ event: props.event }) ?? false
+        },
+
+        onExit() {
+          mentionActiveRef.current = false
+          popup?.remove()
+          popup = null
+          renderer?.destroy()
+          renderer = null
+        },
+      }
+    },
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "proma",
@@ -19,7 +20,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.6.1",
+      "version": "0.6.3",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.66",
         "@emoji-mart/data": "^1.2.1",
@@ -45,6 +46,7 @@
         "@radix-ui/react-tooltip": "^1.2.8",
         "@tiptap/extension-code-block-lowlight": "^3.19.0",
         "@tiptap/extension-link": "^3.19.0",
+        "@tiptap/extension-mention": "^3.19.0",
         "@tiptap/extension-placeholder": "^3.19.0",
         "@tiptap/extension-underline": "^3.19.0",
         "@tiptap/react": "^3.19.0",
@@ -112,7 +114,7 @@
     },
     "packages/shared": {
       "name": "@proma/shared",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "devDependencies": {
         "typescript": "^5.0.0",
       },
@@ -545,6 +547,8 @@
 
     "@tiptap/extension-list-keymap": ["@tiptap/extension-list-keymap@3.19.0", "", { "peerDependencies": { "@tiptap/extension-list": "^3.19.0" } }, "sha512-bxgmAgA3RzBGA0GyTwS2CC1c+QjkJJq9hC+S6PSOWELGRiTbwDN3MANksFXLjntkTa0N5fOnL27vBHtMStURqw=="],
 
+    "@tiptap/extension-mention": ["@tiptap/extension-mention@3.20.0", "", { "peerDependencies": { "@tiptap/core": "^3.20.0", "@tiptap/pm": "^3.20.0", "@tiptap/suggestion": "^3.20.0" } }, "sha512-wUjsq7Za0JJdJzrGNG+g8nrCpek/85GQ0Rm9bka3PynIVRwus+xQqW6IyWVPBdl1BSkrbgMAUqtrfoh1ymznbg=="],
+
     "@tiptap/extension-ordered-list": ["@tiptap/extension-ordered-list@3.19.0", "", { "peerDependencies": { "@tiptap/extension-list": "^3.19.0" } }, "sha512-cxGsINquwHYE1kmhAcLNLHAofmoDEG6jbesR5ybl7tU5JwtKVO7S/xZatll2DU1dsDAXWPWEeeMl4e/9svYjCg=="],
 
     "@tiptap/extension-paragraph": ["@tiptap/extension-paragraph@3.19.0", "", { "peerDependencies": { "@tiptap/core": "^3.19.0" } }, "sha512-xWa6gj82l5+AzdYyrSk9P4ynySaDzg/SlR1FarXE5yPXibYzpS95IWaVR0m2Qaz7Rrk+IiYOTGxGRxcHLOelNg=="],
@@ -564,6 +568,8 @@
     "@tiptap/react": ["@tiptap/react@3.19.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "fast-equals": "^5.3.3", "use-sync-external-store": "^1.4.0" }, "optionalDependencies": { "@tiptap/extension-bubble-menu": "^3.19.0", "@tiptap/extension-floating-menu": "^3.19.0" }, "peerDependencies": { "@tiptap/core": "^3.19.0", "@tiptap/pm": "^3.19.0", "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0", "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0", "react": "^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-GQQMUUXMpNd8tRjc1jDK3tDRXFugJO7C928EqmeBcBzTKDrFIJ3QUoZKEPxUNb6HWhZ2WL7q00fiMzsv4DNSmg=="],
 
     "@tiptap/starter-kit": ["@tiptap/starter-kit@3.19.0", "", { "dependencies": { "@tiptap/core": "^3.19.0", "@tiptap/extension-blockquote": "^3.19.0", "@tiptap/extension-bold": "^3.19.0", "@tiptap/extension-bullet-list": "^3.19.0", "@tiptap/extension-code": "^3.19.0", "@tiptap/extension-code-block": "^3.19.0", "@tiptap/extension-document": "^3.19.0", "@tiptap/extension-dropcursor": "^3.19.0", "@tiptap/extension-gapcursor": "^3.19.0", "@tiptap/extension-hard-break": "^3.19.0", "@tiptap/extension-heading": "^3.19.0", "@tiptap/extension-horizontal-rule": "^3.19.0", "@tiptap/extension-italic": "^3.19.0", "@tiptap/extension-link": "^3.19.0", "@tiptap/extension-list": "^3.19.0", "@tiptap/extension-list-item": "^3.19.0", "@tiptap/extension-list-keymap": "^3.19.0", "@tiptap/extension-ordered-list": "^3.19.0", "@tiptap/extension-paragraph": "^3.19.0", "@tiptap/extension-strike": "^3.19.0", "@tiptap/extension-text": "^3.19.0", "@tiptap/extension-underline": "^3.19.0", "@tiptap/extensions": "^3.19.0", "@tiptap/pm": "^3.19.0" } }, "sha512-dTCkHEz+Y8ADxX7h+xvl6caAj+3nII/wMB1rTQchSuNKqJTOrzyUsCWm094+IoZmLT738wANE0fRIgziNHs/ug=="],
+
+    "@tiptap/suggestion": ["@tiptap/suggestion@3.20.0", "", { "peerDependencies": { "@tiptap/core": "^3.20.0", "@tiptap/pm": "^3.20.0" } }, "sha512-OA9Fe+1Q/Ex0ivTcpRcVFiLnNsVdIBmiEoctt/gu4H2ayCYmZ906veioXNdc1m/3MtVVUIuEnvwwsrOZXlfDEw=="],
 
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
 

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -536,6 +536,22 @@ export interface FileEntry {
   children?: FileEntry[]
 }
 
+/** 文件索引条目（用于 @ 引用搜索） */
+export interface FileIndexEntry {
+  /** 文件/目录名称 */
+  name: string
+  /** 相对于工作区的路径 */
+  path: string
+  /** 条目类型 */
+  type: 'file' | 'dir'
+}
+
+/** 文件搜索结果 */
+export interface FileSearchResult {
+  entries: FileIndexEntry[]
+  total: number
+}
+
 // ===== Agent 附件 =====
 
 /** Agent 待发送文件（UI 侧暂存） */
@@ -827,6 +843,22 @@ export const AGENT_IPC_CHANNELS = {
   OPEN_FILE: 'agent:open-file',
   /** 在系统文件管理器中显示文件 */
   SHOW_IN_FOLDER: 'agent:show-in-folder',
+  /** 重命名文件/目录 */
+  RENAME_FILE: 'agent:rename-file',
+  /** 移动文件/目录到目标目录 */
+  MOVE_FILE: 'agent:move-file',
+  /** 列出附加目录内容（无工作区路径限制） */
+  LIST_ATTACHED_DIRECTORY: 'agent:list-attached-directory',
+  /** 用系统默认应用打开附加目录文件（无工作区路径限制） */
+  OPEN_ATTACHED_FILE: 'agent:open-attached-file',
+  /** 在文件管理器中显示附加目录文件（无工作区路径限制） */
+  SHOW_ATTACHED_IN_FOLDER: 'agent:show-attached-in-folder',
+  /** 重命名附加目录文件/目录（无工作区路径限制） */
+  RENAME_ATTACHED_FILE: 'agent:rename-attached-file',
+  /** 移动附加目录文件/目录（无工作区路径限制） */
+  MOVE_ATTACHED_FILE: 'agent:move-attached-file',
+  /** 搜索工作区文件（用于 @ 引用） */
+  SEARCH_WORKSPACE_FILES: 'agent:search-workspace-files',
 
   // 标题自动生成通知（主进程 → 渲染进程推送）
   /** 标题已更新（首次对话完成后自动生成） */


### PR DESCRIPTION
## Summary

本 PR 在修复文件选项卡布局问题的基础上，完整实现了 Agent 文件引用（@ mention）和附加目录操作功能。

### 1. 文件选项卡布局修复
- FileDropZone 从附加目录与文件列表之间移至文件列表末尾，不再隔开文件夹和文件
- FileBrowser 新增 `embedded` 模式，嵌入时不自带 ScrollArea

### 2. @ 引用文件功能（新增）
- 新增 TipTap Mention 扩展集成（`FileMentionList` + `file-mention-suggestion`）
- 输入 `@` 后异步搜索工作区文件，弹出浮动下拉列表
- 支持键盘导航（上/下/Enter/Escape）和鼠标点击选择
- 搜索范围覆盖工作区文件 **和所有附加目录**（`additionalPaths` 透传到 IPC）
- Mention 扩展始终加载，通过 `workspacePathRef` 控制搜索（解决 TipTap `useEditor` 不重建扩展的问题）
- 下拉列表采用紧凑字号（`text-xs`），与整体 UI 协调

### 3. 附加目录树增强
- 目录树支持递归展开（`AttachedDirTree` + `AttachedDirItem`）
- 选中行为优化：单击单选（自动取消其他），Ctrl/Cmd+点击多选
- 选中状态提升到 `AttachedDirsSection` 统一管理，跨目录树联动
- 三点菜单新增：**重命名**（内联输入框）、**移动到文件夹**（系统对话框）
- 保留原有功能：在文件管理器中显示、打开文件、双击打开

### 4. 文件引用显示优化
- 用户消息中 `@file:路径` 渲染为样式化 chip 标签（文件图标 + 文件名）
- 悬停 tooltip 显示完整路径，视觉风格与输入框 `mention-chip` 一致

### 5. IPC 通道扩展
- 新增 `OPEN_ATTACHED_FILE` / `SHOW_ATTACHED_IN_FOLDER`（无工作区路径限制）
- 新增 `RENAME_ATTACHED_FILE` / `MOVE_ATTACHED_FILE`（附加目录文件操作）
- `SEARCH_WORKSPACE_FILES` 扩展 `additionalPaths` 参数，支持扫描附加目录
- Preload 桥接层同步更新所有新增 API

### 6. FileBrowser 工作区文件树增强
- 工作区文件树支持选中 + 三点菜单（重命名、移动、删除）
- 目录树上下文菜单与附加目录保持一致的交互风格

## 改动文件

| 文件 | 说明 |
|------|------|
| `packages/shared/src/types/agent.ts` | 新增 4 个附加目录 IPC 通道常量 |
| `apps/electron/src/main/ipc.ts` | 新增附加目录操作 IPC handler + 搜索扩展 `additionalPaths` |
| `apps/electron/src/preload/index.ts` | Preload 桥接新增 API 声明与实现 |
| `apps/electron/src/renderer/components/agent/AgentView.tsx` | 传递 `attachedDirs` 给 `RichTextInput` |
| `apps/electron/src/renderer/components/agent/SidePanel.tsx` | 附加目录树组件重构（选中管理、重命名、移动） |
| `apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx` | 集成 Mention 扩展 + `attachedDirsRef` |
| `apps/electron/src/renderer/components/ai-elements/message.tsx` | `@file:` 渲染为 chip 标签 |
| `apps/electron/src/renderer/components/file-browser/FileBrowser.tsx` | 文件树增强（选中 + 上下文菜单 + embedded 模式） |
| `apps/electron/src/renderer/components/file-browser/FileMentionList.tsx` | **新增** @ 引用下拉列表组件 |
| `apps/electron/src/renderer/components/file-browser/file-mention-suggestion.tsx` | **新增** TipTap Suggestion 配置工厂 |

## Test plan
- [x] 输入 `@` 弹出文件搜索列表，支持模糊匹配
- [x] @ 引用范围覆盖工作区文件和附加目录内文件
- [x] 选择文件后显示为 mention chip，发送后消息中显示为样式化标签
- [x] 附加目录文件/文件夹三点菜单：在文件管理器中显示、打开文件、重命名、移动到
- [x] 重命名：内联输入框，Enter 确认、Escape 取消、失焦自动保存
- [x] 移动到：打开系统文件夹选择对话框，确认后文件移动到目标目录
- [x] 单击选中一项自动取消其他，Ctrl/Cmd+点击支持多选
- [x] FileDropZone 位于文件列表末尾，不隔开文件夹和文件