### PR TITLE
fix: Agent 文件树展开文件夹内文件变动不刷新

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -143,6 +143,7 @@ import {
   listReleases as listGitHubReleases,
   getReleaseByTag,
 } from './lib/github-release-service'
+import { watchAttachedDirectory, unwatchAttachedDirectory } from './lib/workspace-watcher'
 
 /**
  * 注册 IPC 处理器
@@ -531,7 +532,16 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(
     AGENT_IPC_CHANNELS.LIST_SESSIONS,
     async (): Promise<AgentSessionMeta[]> => {
-      return listAgentSessions()
+      const sessions = listAgentSessions()
+      // 启动所有已有附加目录的文件监听
+      for (const session of sessions) {
+        if (session.attachedDirectories) {
+          for (const dir of session.attachedDirectories) {
+            watchAttachedDirectory(dir)
+          }
+        }
+      }
+      return sessions
     }
   )
 
@@ -1030,6 +1040,8 @@ export function registerIpcHandlers(): void {
 
       const updated = [...existing, input.directoryPath]
       updateAgentSessionMeta(input.sessionId, { attachedDirectories: updated })
+      // 启动附加目录文件监听
+      watchAttachedDirectory(input.directoryPath)
       return updated
     }
   )
@@ -1044,6 +1056,8 @@ export function registerIpcHandlers(): void {
       const existing = meta.attachedDirectories ?? []
       const updated = existing.filter((d) => d !== input.directoryPath)
       updateAgentSessionMeta(input.sessionId, { attachedDirectories: updated })
+      // 停止附加目录文件监听
+      unwatchAttachedDirectory(input.directoryPath)
       return updated
     }
   )

--- a/apps/electron/src/main/lib/workspace-watcher.ts
+++ b/apps/electron/src/main/lib/workspace-watcher.ts
@@ -6,6 +6,8 @@
  * - mcp.json / skills/ 变化 → 推送 CAPABILITIES_CHANGED（侧边栏刷新）
  * - 其他文件变化 → 推送 WORKSPACE_FILES_CHANGED（文件浏览器刷新）
  *
+ * 同时支持监听附加目录（外部路径），变化时统一推送 WORKSPACE_FILES_CHANGED。
+ *
  * 所有事件均做 debounce 防抖，避免高频文件操作导致渲染进程风暴。
  */
 
@@ -20,12 +22,20 @@ const DEBOUNCE_MS = 500
 
 let watcher: FSWatcher | null = null
 
+/** 附加目录监听器：路径 → FSWatcher */
+const attachedWatchers = new Map<string, FSWatcher>()
+/** 附加目录防抖定时器 */
+let attachedFilesTimer: ReturnType<typeof setTimeout> | null = null
+/** 主窗口引用（供附加目录监听器使用） */
+let mainWin: BrowserWindow | null = null
+
 /**
  * 启动工作区文件监听
  *
  * @param win 主窗口引用，用于向渲染进程推送事件
  */
 export function startWorkspaceWatcher(win: BrowserWindow): void {
+  mainWin = win
   const watchDir = getAgentWorkspacesDir()
 
   if (!existsSync(watchDir)) {
@@ -83,5 +93,56 @@ export function stopWorkspaceWatcher(): void {
     watcher.close()
     watcher = null
     console.log('[工作区监听] 已停止')
+  }
+  // 同时清理所有附加目录监听器
+  for (const [dirPath, w] of attachedWatchers) {
+    w.close()
+    console.log('[附加目录监听] 已停止:', dirPath)
+  }
+  attachedWatchers.clear()
+  mainWin = null
+}
+
+/**
+ * 开始监听附加目录
+ * 当目录内文件变化时，推送 WORKSPACE_FILES_CHANGED 事件
+ */
+export function watchAttachedDirectory(dirPath: string): void {
+  if (attachedWatchers.has(dirPath)) return
+  if (!existsSync(dirPath)) {
+    console.warn('[附加目录监听] 目录不存在，跳过:', dirPath)
+    return
+  }
+
+  try {
+    const w = watch(dirPath, { recursive: true }, () => {
+      if (!mainWin || mainWin.isDestroyed()) return
+
+      // 统一防抖：所有附加目录变化合并为一次刷新
+      if (attachedFilesTimer) clearTimeout(attachedFilesTimer)
+      attachedFilesTimer = setTimeout(() => {
+        if (mainWin && !mainWin.isDestroyed()) {
+          mainWin.webContents.send(AGENT_IPC_CHANNELS.WORKSPACE_FILES_CHANGED)
+        }
+        attachedFilesTimer = null
+      }, DEBOUNCE_MS)
+    })
+
+    attachedWatchers.set(dirPath, w)
+    console.log('[附加目录监听] 已启动:', dirPath)
+  } catch (error) {
+    console.error('[附加目录监听] 启动失败:', dirPath, error)
+  }
+}
+
+/**
+ * 停止监听附加目录
+ */
+export function unwatchAttachedDirectory(dirPath: string): void {
+  const w = attachedWatchers.get(dirPath)
+  if (w) {
+    w.close()
+    attachedWatchers.delete(dirPath)
+    console.log('[附加目录监听] 已停止:', dirPath)
   }
 }

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -315,6 +315,7 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                       <AttachedDirsSection
                         attachedDirs={attachedDirs}
                         onDetach={handleDetachDirectory}
+                        refreshVersion={filesVersion}
                       />
                     )}
                     {/* 文件浏览器（嵌入模式，不自带滚动） */}
@@ -346,10 +347,12 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
 interface AttachedDirsSectionProps {
   attachedDirs: string[]
   onDetach: (dirPath: string) => void
+  /** 文件版本号，用于自动刷新已展开的目录 */
+  refreshVersion: number
 }
 
 /** 附加目录区域：统一管理所有子项的选中状态 */
-function AttachedDirsSection({ attachedDirs, onDetach }: AttachedDirsSectionProps): React.ReactElement {
+function AttachedDirsSection({ attachedDirs, onDetach, refreshVersion }: AttachedDirsSectionProps): React.ReactElement {
   const [selectedPaths, setSelectedPaths] = React.useState<Set<string>>(new Set())
 
   const handleSelect = React.useCallback((path: string, ctrlKey: boolean) => {
@@ -379,6 +382,7 @@ function AttachedDirsSection({ attachedDirs, onDetach }: AttachedDirsSectionProp
           onDetach={() => onDetach(dir)}
           selectedPaths={selectedPaths}
           onSelect={handleSelect}
+          refreshVersion={refreshVersion}
         />
       ))}
     </div>
@@ -392,15 +396,26 @@ interface AttachedDirTreeProps {
   onDetach: () => void
   selectedPaths: Set<string>
   onSelect: (path: string, ctrlKey: boolean) => void
+  /** 文件版本号，变化时已展开的目录自动重新加载 */
+  refreshVersion: number
 }
 
 /** 附加目录根节点：可展开/收起，带移除按钮 */
-function AttachedDirTree({ dirPath, onDetach, selectedPaths, onSelect }: AttachedDirTreeProps): React.ReactElement {
+function AttachedDirTree({ dirPath, onDetach, selectedPaths, onSelect, refreshVersion }: AttachedDirTreeProps): React.ReactElement {
   const [expanded, setExpanded] = React.useState(false)
   const [children, setChildren] = React.useState<FileEntry[]>([])
   const [loaded, setLoaded] = React.useState(false)
 
   const dirName = dirPath.split('/').filter(Boolean).pop() || dirPath
+
+  // 当 refreshVersion 变化时，已展开的目录自动重新加载
+  React.useEffect(() => {
+    if (expanded && loaded) {
+      window.electronAPI.listAttachedDirectory(dirPath)
+        .then((items) => setChildren(items))
+        .catch((err) => console.error('[AttachedDirTree] 刷新失败:', err))
+    }
+  }, [refreshVersion]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const toggleExpand = async (): Promise<void> => {
     if (!expanded && !loaded) {
@@ -451,7 +466,7 @@ function AttachedDirTree({ dirPath, onDetach, selectedPaths, onSelect }: Attache
         </div>
       )}
       {expanded && children.map((child) => (
-        <AttachedDirItem key={child.path} entry={child} depth={1} selectedPaths={selectedPaths} onSelect={onSelect} />
+        <AttachedDirItem key={child.path} entry={child} depth={1} selectedPaths={selectedPaths} onSelect={onSelect} refreshVersion={refreshVersion} />
       ))}
     </div>
   )
@@ -462,10 +477,12 @@ interface AttachedDirItemProps {
   depth: number
   selectedPaths: Set<string>
   onSelect: (path: string, ctrlKey: boolean) => void
+  /** 文件版本号，变化时已展开的目录自动重新加载 */
+  refreshVersion: number
 }
 
 /** 附加目录子项：递归可展开，支持选中 + 三点菜单（含重命名、移动） */
-function AttachedDirItem({ entry, depth, selectedPaths, onSelect }: AttachedDirItemProps): React.ReactElement {
+function AttachedDirItem({ entry, depth, selectedPaths, onSelect, refreshVersion }: AttachedDirItemProps): React.ReactElement {
   const [expanded, setExpanded] = React.useState(false)
   const [children, setChildren] = React.useState<FileEntry[]>([])
   const [loaded, setLoaded] = React.useState(false)
@@ -478,6 +495,15 @@ function AttachedDirItem({ entry, depth, selectedPaths, onSelect }: AttachedDirI
   const [currentPath, setCurrentPath] = React.useState(entry.path)
 
   const isSelected = selectedPaths.has(currentPath)
+
+  // 当 refreshVersion 变化时，已展开的文件夹自动重新加载子项
+  React.useEffect(() => {
+    if (expanded && loaded && entry.isDirectory) {
+      window.electronAPI.listAttachedDirectory(currentPath)
+        .then((items) => setChildren(items))
+        .catch((err) => console.error('[AttachedDirItem] 刷新子目录失败:', err))
+    }
+  }, [refreshVersion]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const toggleDir = async (): Promise<void> => {
     if (!entry.isDirectory) return
@@ -668,7 +694,7 @@ function AttachedDirItem({ entry, depth, selectedPaths, onSelect }: AttachedDirI
         </div>
       )}
       {expanded && children.map((child) => (
-        <AttachedDirItem key={child.path} entry={child} depth={depth + 1} selectedPaths={selectedPaths} onSelect={onSelect} />
+        <AttachedDirItem key={child.path} entry={child} depth={depth + 1} selectedPaths={selectedPaths} onSelect={onSelect} refreshVersion={refreshVersion} />
       ))}
     </>
   )

--- a/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
@@ -235,6 +235,7 @@ export function FileBrowser({ rootPath, hideToolbar, embedded }: FileBrowserProp
           selectedCount={selectedCount}
           renamingPath={renamingPath}
           moving={moving}
+          refreshVersion={filesVersion}
           onSelect={handleSelect}
           onShowInFolder={handleShowInFolder}
           onStartRename={handleStartRename}
@@ -324,6 +325,8 @@ interface FileTreeItemProps {
   selectedCount: number
   renamingPath: string | null
   moving: boolean
+  /** 文件版本号，变化时已展开的文件夹自动重新加载子项 */
+  refreshVersion: number
   onSelect: (entry: FileEntry, event: React.MouseEvent) => void
   onShowInFolder: (entry: FileEntry) => void
   onStartRename: (entry: FileEntry) => void
@@ -341,6 +344,7 @@ function FileTreeItem({
   selectedCount,
   renamingPath,
   moving,
+  refreshVersion,
   onSelect,
   onShowInFolder,
   onStartRename,
@@ -353,6 +357,15 @@ function FileTreeItem({
   const [expanded, setExpanded] = React.useState(false)
   const [children, setChildren] = React.useState<FileEntry[]>([])
   const [childrenLoaded, setChildrenLoaded] = React.useState(false)
+
+  // 当 refreshVersion 变化时，已展开的文件夹自动重新加载子项
+  React.useEffect(() => {
+    if (expanded && childrenLoaded && entry.isDirectory) {
+      window.electronAPI.listDirectory(entry.path)
+        .then((items) => setChildren(items))
+        .catch((err) => console.error('[FileTreeItem] 刷新子目录失败:', err))
+    }
+  }, [refreshVersion]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // 重命名编辑状态
   const [editName, setEditName] = React.useState('')
@@ -603,6 +616,7 @@ function FileTreeItem({
           selectedCount={selectedCount}
           renamingPath={renamingPath}
           moving={moving}
+          refreshVersion={refreshVersion}
           onSelect={onSelect}
           onShowInFolder={onShowInFolder}
           onStartRename={onStartRename}


### PR DESCRIPTION
## Summary
- 修复 Agent 模式右侧文件浏览器中，已展开文件夹内的文件变动（新增/删除/修改）不更新的问题
- 修复刷新按钮对已展开子文件夹无效的问题
- 新增附加目录的实时文件监听，文件变动后无需手动刷新

## 改动
- **FileBrowser.tsx**: `FileTreeItem` 新增 `refreshVersion` prop，当文件版本号变化时已展开的文件夹自动重新加载子项
- **SidePanel.tsx**: `AttachedDirTree`/`AttachedDirItem` 同步支持 `refreshVersion` 自动刷新
- **workspace-watcher.ts**: 新增 `watchAttachedDirectory()`/`unwatchAttachedDirectory()` 函数，对附加目录使用 `fs.watch` 递归监听
- **ipc.ts**: attach/detach 时启停附加目录监听，`LIST_SESSIONS` 时恢复已有附加目录的监听

## Test plan
- [ ] 在 Agent 模式下展开工作区文件夹，触发文件变动（Agent 创建文件），确认子文件夹内容自动更新
- [ ] 点击刷新按钮，确认已展开的子文件夹也正确刷新
- [ ] 附加外部目录后，在该目录中创建/删除文件，确认文件树自动更新
- [ ] 移除附加目录后再附加，确认监听正常工作
- [ ] 应用重启后，确认已有附加目录的文件监听自动恢复