### PR TITLE
feat: 飞书 IM 集成 — 通过飞书机器人控制 Proma Agent

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -40,6 +40,7 @@
     "@anthropic-ai/claude-agent-sdk": "0.2.66",
     "@emoji-mart/data": "^1.2.1",
     "@emoji-mart/react": "^1.1.1",
+    "@larksuiteoapi/node-sdk": "^1.59.0",
     "@proma/core": "workspace:*",
     "@proma/shared": "workspace:*",
     "@proma/ui": "workspace:*",

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -22,6 +22,8 @@ import { initAutoUpdater, cleanupUpdater } from './lib/updater/auto-updater'
 import { startWorkspaceWatcher, stopWorkspaceWatcher } from './lib/workspace-watcher'
 import { startChatToolsWatcher, stopChatToolsWatcher } from './lib/chat-tools-watcher'
 import { getIsQuitting, setQuitting } from './lib/app-lifecycle'
+import { feishuBridge } from './lib/feishu-bridge'
+import { getFeishuConfig } from './lib/feishu-config'
 
 let mainWindow: BrowserWindow | null = null
 
@@ -201,6 +203,14 @@ app.whenReady().then(async () => {
     initAutoUpdater(mainWindow)
   }
 
+  // 飞书 Bridge 自动启动（配置启用时）
+  const feishuConfig = getFeishuConfig()
+  if (feishuConfig.enabled && feishuConfig.appId && feishuConfig.appSecret) {
+    feishuBridge.start().catch((err) => {
+      console.error('[飞书 Bridge] 自动启动失败:', err)
+    })
+  }
+
   app.on('activate', () => {
     // 直接检查 mainWindow 引用，避免 getAllWindows() 包含 DevTools 等其他窗口导致误判
     if (!mainWindow || mainWindow.isDestroyed()) {
@@ -233,6 +243,8 @@ app.on('before-quit', () => {
   stopWorkspaceWatcher()
   // 停止 Chat 工具配置文件监听
   stopChatToolsWatcher()
+  // 停止飞书 Bridge
+  feishuBridge.stop()
   // Clean up system tray before quitting
   destroyTray()
 })

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -5,7 +5,7 @@
  */
 
 import { ipcMain, nativeTheme, shell, dialog, BrowserWindow } from 'electron'
-import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, MEMORY_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS } from '@proma/shared'
+import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, MEMORY_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS } from '@proma/shared'
 import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS } from '../types'
 import type {
   RuntimeStatus,
@@ -58,6 +58,13 @@ import type {
   ChatToolMeta,
   AgentTeamData,
   MoveSessionToWorkspaceInput,
+  FeishuConfigInput,
+  FeishuConfig,
+  FeishuBridgeState,
+  FeishuTestResult,
+  FeishuChatBinding,
+  FeishuPresenceReport,
+  FeishuNotifyMode,
 } from '@proma/shared'
 import type { UserProfile, AppSettings } from '../types'
 import { getRuntimeStatus, getGitRepoStatus } from './lib/runtime-init'
@@ -144,6 +151,9 @@ import {
   getReleaseByTag,
 } from './lib/github-release-service'
 import { watchAttachedDirectory, unwatchAttachedDirectory } from './lib/workspace-watcher'
+import { getFeishuConfig, saveFeishuConfig } from './lib/feishu-config'
+import { feishuBridge } from './lib/feishu-bridge'
+import { presenceService } from './lib/feishu-presence'
 
 /**
  * 注册 IPC 处理器
@@ -1433,6 +1443,87 @@ export function registerIpcHandlers(): void {
     GITHUB_RELEASE_IPC_CHANNELS.GET_RELEASE_BY_TAG,
     async (_, tag: string): Promise<GitHubRelease | null> => {
       return getReleaseByTag(tag)
+    }
+  )
+
+  // ===== 飞书集成 =====
+
+  // 获取飞书配置
+  ipcMain.handle(
+    FEISHU_IPC_CHANNELS.GET_CONFIG,
+    async (): Promise<FeishuConfig> => {
+      return getFeishuConfig()
+    }
+  )
+
+  // 保存飞书配置
+  ipcMain.handle(
+    FEISHU_IPC_CHANNELS.SAVE_CONFIG,
+    async (_, input: FeishuConfigInput): Promise<FeishuConfig> => {
+      const config = saveFeishuConfig(input)
+      // 配置变更后自动重启或停止 Bridge
+      if (input.enabled && input.appId && input.appSecret) {
+        await feishuBridge.restart()
+      } else if (!input.enabled) {
+        feishuBridge.stop()
+      }
+      return config
+    }
+  )
+
+  // 测试飞书连接
+  ipcMain.handle(
+    FEISHU_IPC_CHANNELS.TEST_CONNECTION,
+    async (_, appId: string, appSecret: string): Promise<FeishuTestResult> => {
+      return feishuBridge.testConnection(appId, appSecret)
+    }
+  )
+
+  // 启动飞书 Bridge
+  ipcMain.handle(
+    FEISHU_IPC_CHANNELS.START_BRIDGE,
+    async (): Promise<void> => {
+      await feishuBridge.start()
+    }
+  )
+
+  // 停止飞书 Bridge
+  ipcMain.handle(
+    FEISHU_IPC_CHANNELS.STOP_BRIDGE,
+    async (): Promise<void> => {
+      feishuBridge.stop()
+    }
+  )
+
+  // 获取飞书 Bridge 状态
+  ipcMain.handle(
+    FEISHU_IPC_CHANNELS.GET_STATUS,
+    async (): Promise<FeishuBridgeState> => {
+      return feishuBridge.getStatus()
+    }
+  )
+
+  // 获取活跃绑定列表
+  ipcMain.handle(
+    FEISHU_IPC_CHANNELS.LIST_BINDINGS,
+    async (): Promise<FeishuChatBinding[]> => {
+      return feishuBridge.listBindings()
+    }
+  )
+
+  // 上报用户在场状态
+  ipcMain.handle(
+    FEISHU_IPC_CHANNELS.REPORT_PRESENCE,
+    async (_, report: FeishuPresenceReport): Promise<void> => {
+      presenceService.updatePresence(report)
+    }
+  )
+
+  // 设置会话通知模式
+  ipcMain.handle(
+    FEISHU_IPC_CHANNELS.SET_SESSION_NOTIFY,
+    async (_, sessionId: string, mode: FeishuNotifyMode): Promise<void> => {
+      feishuBridge.setSessionNotifyMode(sessionId, mode)
     }
   )
 

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -12,6 +12,7 @@
 
 import { join, dirname } from 'node:path'
 import { writeFileSync, mkdirSync, existsSync } from 'node:fs'
+import { BrowserWindow } from 'electron'
 import type { WebContents } from 'electron'
 import { AGENT_IPC_CHANNELS } from '@proma/shared'
 import type {
@@ -31,6 +32,9 @@ import { getAgentSessionWorkspacePath } from './config-paths'
 const eventBus = new AgentEventBus()
 const adapter = new ClaudeAgentAdapter()
 const orchestrator = new AgentOrchestrator(adapter, eventBus)
+
+/** 导出 EventBus 供飞书 Bridge 等外部服务订阅事件 */
+export { eventBus as agentEventBus }
 
 /**
  * 会话 → webContents 映射
@@ -93,6 +97,67 @@ export async function runAgent(
   } finally {
     // 仅在 orchestrator 已完成此会话时清理映射
     // 避免被拒绝的请求误删仍在运行的会话映射
+    if (!orchestrator.isActive(input.sessionId)) {
+      sessionWebContents.delete(input.sessionId)
+    }
+  }
+}
+
+/**
+ * 无渲染进程的 Agent 运行（供飞书 Bridge 等外部调用方使用）
+ *
+ * 如果桌面窗口存在，同时注册 webContents 以便事件同步到桌面端 UI。
+ * 事件同时通过 EventBus listeners 分发给飞书 Bridge。
+ */
+export async function runAgentHeadless(
+  input: AgentSendInput,
+  callbacks: {
+    onError: (error: string) => void
+    onComplete: () => void
+    onTitleUpdated: (title: string) => void
+  },
+): Promise<void> {
+  // 尝试注册主窗口 webContents，让流式事件同步推送到桌面端
+  const win = BrowserWindow.getAllWindows()[0]
+  const wc = win && !win.isDestroyed() ? win.webContents : null
+  if (wc) {
+    sessionWebContents.set(input.sessionId, wc)
+  }
+
+  try {
+    await orchestrator.sendMessage(input, {
+      onError: (error) => {
+        callbacks.onError(error)
+        // 同步到渲染进程
+        if (wc && !wc.isDestroyed()) {
+          wc.send(AGENT_IPC_CHANNELS.STREAM_ERROR, {
+            sessionId: input.sessionId,
+            error,
+          })
+        }
+      },
+      onComplete: (messages) => {
+        callbacks.onComplete()
+        // 同步到渲染进程
+        if (wc && !wc.isDestroyed()) {
+          wc.send(AGENT_IPC_CHANNELS.STREAM_COMPLETE, {
+            sessionId: input.sessionId,
+            messages,
+          })
+        }
+      },
+      onTitleUpdated: (title) => {
+        callbacks.onTitleUpdated(title)
+        // 同步到渲染进程
+        if (wc && !wc.isDestroyed()) {
+          wc.send(AGENT_IPC_CHANNELS.TITLE_UPDATED, {
+            sessionId: input.sessionId,
+            title,
+          })
+        }
+      },
+    })
+  } finally {
     if (!orchestrator.isActive(input.sessionId)) {
       sessionWebContents.delete(input.sessionId)
     }

--- a/apps/electron/src/main/lib/config-paths.ts
+++ b/apps/electron/src/main/lib/config-paths.ts
@@ -358,6 +358,15 @@ export function seedDefaultSkills(): void {
 }
 
 /**
+ * 获取飞书配置文件路径
+ *
+ * @returns ~/.proma/feishu.json
+ */
+export function getFeishuConfigPath(): string {
+  return join(getConfigDir(), 'feishu.json')
+}
+
+/**
  * 获取指定 Agent 会话的工作路径
  *
  * 在工作区目录下创建以 sessionId 命名的子文件夹，

--- a/apps/electron/src/main/lib/feishu-bridge.ts
+++ b/apps/electron/src/main/lib/feishu-bridge.ts
@@ -1,0 +1,862 @@
+/**
+ * 飞书 Bridge 服务
+ *
+ * 核心职责：
+ * - 通过 WebSocket 长连接接收飞书消息
+ * - 路由命令或转发用户消息到 Agent/Chat 服务
+ * - 监听 AgentEventBus 事件，累积完整回复后发送到飞书
+ * - 管理聊天绑定（chatId ↔ sessionId）
+ * - 智能通知路由：桌面发起的会话根据在场状态决定是否发飞书通知
+ */
+
+import { BrowserWindow } from 'electron'
+import type {
+  AgentEvent,
+  AgentSendInput,
+  FeishuBridgeState,
+  FeishuChatBinding,
+  FeishuTestResult,
+  FeishuNotifyMode,
+  FeishuNotificationSentPayload,
+} from '@proma/shared'
+import { FEISHU_IPC_CHANNELS, AGENT_IPC_CHANNELS } from '@proma/shared'
+import { getFeishuConfig, getDecryptedAppSecret } from './feishu-config'
+import { agentEventBus, runAgentHeadless, stopAgent } from './agent-service'
+import { createAgentSession, listAgentSessions, getAgentSessionMeta } from './agent-session-manager'
+import { listAgentWorkspaces, getAgentWorkspace } from './agent-workspace-manager'
+import { getSettings } from './settings-service'
+import { presenceService } from './feishu-presence'
+import {
+  buildAgentReplyCard,
+  buildNotificationCard,
+  buildErrorCard,
+  buildSessionListCard,
+  buildWorkspaceSwitchedCard,
+  buildWorkspaceListCard,
+  buildHelpCard,
+  accumulateToolSummary,
+  splitLongContent,
+} from './feishu-message'
+import type { ToolSummary, FormattedAgentResult, WorkspaceListItem } from './feishu-message'
+
+// ===== 类型定义 =====
+
+/** 会话累积缓冲 */
+interface SessionBuffer {
+  text: string
+  toolSummaries: Map<string, ToolSummary>
+  startedAt: number
+}
+
+// ===== 单例 Bridge =====
+
+class FeishuBridge {
+  /** SDK Client（发消息用） */
+  private client: InstanceType<typeof import('@larksuiteoapi/node-sdk').Client> | null = null
+  /** WebSocket Client */
+  private wsClient: InstanceType<typeof import('@larksuiteoapi/node-sdk').WSClient> | null = null
+
+  /** 连接状态 */
+  private status: FeishuBridgeState = { status: 'disconnected', activeBindings: 0 }
+
+  /** chatId → 绑定信息 */
+  private chatBindings = new Map<string, FeishuChatBinding>()
+  /** sessionId → chatId（反向索引） */
+  private sessionToChat = new Map<string, string>()
+  /** sessionId → 文本累积缓冲 */
+  private sessionBuffers = new Map<string, SessionBuffer>()
+  /** sessionId → 通知模式 */
+  private sessionNotifyModes = new Map<string, FeishuNotifyMode>()
+  /** 默认通知目标 chatId（最后一个与 Bot 交互的飞书聊天） */
+  private defaultNotifyChatId: string | null = null
+
+  /** 消息去重（防止 SDK WebSocket 重复投递） */
+  private recentMessageIds = new Set<string>()
+  /** 事件去重（防止网关超时重投） */
+  private recentEventIds = new Set<string>()
+  /** chatId 级处理锁（防止 bot 回复触发的事件重入） */
+  private processingChats = new Set<string>()
+  private static readonly DEDUP_MAX = 200
+
+  /** EventBus 监听器取消函数 */
+  private eventBusUnsubscribe: (() => void) | null = null
+
+  // ===== 生命周期 =====
+
+  async start(): Promise<void> {
+    const config = getFeishuConfig()
+    if (!config.enabled || !config.appId || !config.appSecret) {
+      console.log('[飞书 Bridge] 未配置或未启用，跳过启动')
+      return
+    }
+
+    this.updateStatus({ status: 'connecting' })
+
+    try {
+      const appSecret = getDecryptedAppSecret()
+      const lark = await import('@larksuiteoapi/node-sdk')
+
+      // 创建 SDK Client
+      this.client = new lark.Client({
+        appId: config.appId,
+        appSecret,
+        appType: lark.AppType.SelfBuild,
+      })
+
+      // 创建事件分发器
+      // 重要：回调必须立即返回，不能 await 长时间操作
+      // SDK 需要回调返回后发送 ACK 给飞书网关，否则网关会超时重投事件
+      const eventDispatcher = new lark.EventDispatcher({}).register({
+        'im.message.receive_v1': (data: Record<string, unknown>) => {
+          this.handleFeishuMessage(data).catch((error) => {
+            console.error('[飞书 Bridge] 处理消息异常:', error)
+          })
+        },
+      })
+
+      // 创建 WebSocket 长连接
+      this.wsClient = new lark.WSClient({
+        appId: config.appId,
+        appSecret,
+        loggerLevel: lark.LoggerLevel.warn,
+      })
+
+      await this.wsClient.start({ eventDispatcher })
+
+      // 注册 EventBus 监听器
+      this.eventBusUnsubscribe = agentEventBus.on((sessionId, event) => {
+        this.handleAgentEvent(sessionId, event)
+      })
+
+      this.updateStatus({ status: 'connected', connectedAt: Date.now() })
+      console.log('[飞书 Bridge] 已连接')
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      this.updateStatus({ status: 'error', errorMessage: message })
+      console.error('[飞书 Bridge] 启动失败:', error)
+    }
+  }
+
+  stop(): void {
+    // 取消 EventBus 监听
+    this.eventBusUnsubscribe?.()
+    this.eventBusUnsubscribe = null
+
+    // 清理 WebSocket
+    if (this.wsClient) {
+      // SDK WSClient 没有显式的 stop 方法，清空引用让 GC 回收
+      this.wsClient = null
+    }
+    this.client = null
+
+    // 清理状态
+    this.chatBindings.clear()
+    this.sessionToChat.clear()
+    this.sessionBuffers.clear()
+    this.sessionNotifyModes.clear()
+    this.recentMessageIds.clear()
+    this.recentEventIds.clear()
+    this.processingChats.clear()
+    this.defaultNotifyChatId = null
+
+    this.updateStatus({ status: 'disconnected', activeBindings: 0 })
+    console.log('[飞书 Bridge] 已停止')
+  }
+
+  async restart(): Promise<void> {
+    this.stop()
+    await this.start()
+  }
+
+  // ===== 状态查询 =====
+
+  getStatus(): FeishuBridgeState {
+    return { ...this.status }
+  }
+
+  listBindings(): FeishuChatBinding[] {
+    return Array.from(this.chatBindings.values())
+  }
+
+  setSessionNotifyMode(sessionId: string, mode: FeishuNotifyMode): void {
+    this.sessionNotifyModes.set(sessionId, mode)
+  }
+
+  // ===== 连接测试 =====
+
+  async testConnection(appId: string, appSecret: string): Promise<FeishuTestResult> {
+    try {
+      const lark = await import('@larksuiteoapi/node-sdk')
+      const client = new lark.Client({
+        appId,
+        appSecret,
+        appType: lark.AppType.SelfBuild,
+      })
+
+      // 通过获取 tenant_access_token 来验证凭证
+      const resp = await client.auth.tenantAccessToken.internal({
+        data: {
+          app_id: appId,
+          app_secret: appSecret,
+        },
+      })
+
+      if (resp.code === 0) {
+        return {
+          success: true,
+          message: '连接成功',
+          botName: `App ${appId.slice(0, 8)}...`,
+        }
+      }
+
+      return {
+        success: false,
+        message: `飞书 API 错误: ${resp.msg ?? '未知错误'} (code: ${resp.code})`,
+      }
+    } catch (error) {
+      return {
+        success: false,
+        message: `连接失败: ${error instanceof Error ? error.message : String(error)}`,
+      }
+    }
+  }
+
+  // ===== 飞书消息处理 =====
+
+  private async handleFeishuMessage(data: Record<string, unknown>): Promise<void> {
+    if (!this.client) return
+
+    // 事件级去重（飞书网关超时重投时 event_id 相同）
+    const eventId = data.event_id as string | undefined
+    if (eventId && this.recentEventIds.has(eventId)) {
+      console.log('[飞书 Bridge] 跳过重复事件 (event_id):', eventId)
+      return
+    }
+    if (eventId) {
+      this.addToDedup(this.recentEventIds, eventId)
+    }
+
+    // 解析消息
+    const message = (data as { message?: Record<string, unknown> }).message
+    if (!message) return
+
+    const sender = (data as { sender?: Record<string, unknown> }).sender
+
+    // 过滤非用户消息（Bot 自己发的消息 sender_type 不是 "user"）
+    const senderType = (sender?.sender_type as string) ?? ''
+    if (senderType !== 'user') {
+      return
+    }
+
+    // 消息级去重（同一条消息被不同 event 包裹时 message_id 相同）
+    const messageId = message.message_id as string
+    if (messageId && this.recentMessageIds.has(messageId)) {
+      console.log('[飞书 Bridge] 跳过重复消息 (message_id):', messageId)
+      return
+    }
+    if (messageId) {
+      this.addToDedup(this.recentMessageIds, messageId)
+    }
+
+    const chatId = message.chat_id as string
+    const messageType = message.message_type as string
+    const chatType = message.chat_type as string
+    const userId = (sender?.sender_id as Record<string, unknown>)?.open_id as string ?? 'unknown'
+
+    // chatId 级处理锁：同一聊天同时只处理一条消息，防止 bot 回复被重入处理
+    if (this.processingChats.has(chatId)) {
+      console.log('[飞书 Bridge] 跳过重入消息 (chatId lock):', chatId)
+      return
+    }
+
+    // 群聊中仅处理 @Bot 的消息
+    if (chatType === 'group') {
+      const mentions = message.mentions as Array<Record<string, unknown>> | undefined
+      const hasBotMention = mentions?.some(
+        (m) => (m as Record<string, unknown>).id?.toString()?.includes('app_id') ||
+               (m as Record<string, unknown>).key !== undefined
+      ) ?? false
+      if (!hasBotMention && mentions?.length === 0) {
+        return
+      }
+    }
+
+    // 记录最近交互的 chatId 作为默认通知目标
+    this.defaultNotifyChatId = chatId
+
+    // 仅处理文本消息
+    if (messageType !== 'text') {
+      await this.sendTextMessage(chatId, '目前仅支持文本消息。')
+      return
+    }
+
+    const content = JSON.parse(message.content as string) as { text?: string }
+    let text = content.text?.trim() ?? ''
+
+    // 去除 @Bot 的占位符（如 @_user_1）
+    text = text.replace(/@_user_\d+/g, '').trim()
+
+    if (!text) return
+
+    // 加锁：防止命令回复触发的事件被重入处理
+    this.processingChats.add(chatId)
+    try {
+      // 命令路由
+      if (text.startsWith('/')) {
+        await this.handleCommand(chatId, userId, text)
+        return
+      }
+
+      // 普通文本 → 转发到会话
+      await this.handleUserMessage(chatId, userId, text)
+    } finally {
+      this.processingChats.delete(chatId)
+    }
+  }
+
+  private async handleCommand(chatId: string, userId: string, text: string): Promise<void> {
+    const [command, ...args] = text.split(/\s+/)
+    const arg = args.join(' ').trim()
+
+    switch (command?.toLowerCase()) {
+      case '/help':
+        await this.sendCard(chatId, buildHelpCard())
+        break
+
+      case '/new':
+        await this.createNewSession(chatId, userId, 'agent', arg || undefined)
+        break
+
+      case '/chat':
+        await this.updateBindingMode(chatId, userId, 'chat')
+        break
+
+      case '/agent':
+        await this.updateBindingMode(chatId, userId, 'agent')
+        break
+
+      case '/list':
+        await this.handleListCommand(chatId, userId)
+        break
+
+      case '/stop':
+        await this.handleStopCommand(chatId)
+        break
+
+      case '/switch': {
+        if (!arg) {
+          await this.sendTextMessage(chatId, '用法: /switch <序号>（先用 /list 查看）')
+          return
+        }
+        await this.handleSwitchCommand(chatId, userId, arg)
+        break
+      }
+
+      case '/workspace': {
+        await this.handleWorkspaceCommand(chatId, userId, arg || undefined)
+        break
+      }
+
+      default:
+        await this.sendTextMessage(chatId, `未知命令: ${command}。输入 /help 查看帮助。`)
+    }
+  }
+
+  // ===== 会话管理 =====
+
+  private async createNewSession(
+    chatId: string,
+    userId: string,
+    mode: 'agent' | 'chat',
+    title?: string,
+    overrideWorkspaceId?: string,
+  ): Promise<void> {
+    const config = getFeishuConfig()
+    const appSettings = getSettings()
+
+    // 选择工作区：显式指定 > 飞书配置 > 应用设置 > 第一个工作区
+    let workspaceId = overrideWorkspaceId ?? config.defaultWorkspaceId ?? appSettings.agentWorkspaceId
+    if (!workspaceId) {
+      const workspaces = await listAgentWorkspaces()
+      workspaceId = workspaces[0]?.id
+    }
+
+    if (!workspaceId) {
+      await this.sendTextMessage(chatId, '请先在 Proma 设置中创建工作区。')
+      return
+    }
+
+    // 渠道/模型：直接复用 Proma 应用当前设置
+    const channelId = appSettings.agentChannelId
+    if (!channelId) {
+      await this.sendTextMessage(chatId, '请先在 Proma Agent 设置中选择渠道。')
+      return
+    }
+
+    // 创建会话（使用默认标题，首次对话完成后会自动生成标题）
+    const session = await createAgentSession(
+      title,
+      channelId,
+      workspaceId,
+    )
+
+    // 绑定
+    const binding: FeishuChatBinding = {
+      chatId,
+      userId,
+      sessionId: session.id,
+      workspaceId,
+      channelId,
+      modelId: appSettings.agentModelId ?? undefined,
+      mode,
+      createdAt: Date.now(),
+    }
+    this.chatBindings.set(chatId, binding)
+    this.sessionToChat.set(session.id, chatId)
+    this.updateStatus({ activeBindings: this.chatBindings.size })
+
+    // 通知渲染进程刷新会话列表（复用 TITLE_UPDATED 通道触发列表刷新）
+    const windows = BrowserWindow.getAllWindows()
+    if (windows.length > 0 && !windows[0]!.isDestroyed()) {
+      windows[0]!.webContents.send(AGENT_IPC_CHANNELS.TITLE_UPDATED, {
+        sessionId: session.id,
+        title: session.title,
+      })
+    }
+
+    const modeLabel = mode === 'agent' ? 'Agent' : 'Chat'
+    await this.sendTextMessage(chatId, `✅ 已创建 ${modeLabel} 会话 (${session.id.slice(0, 8)})`)
+  }
+
+  private async updateBindingMode(chatId: string, _userId: string, mode: 'agent' | 'chat'): Promise<void> {
+    const binding = this.chatBindings.get(chatId)
+    if (binding) {
+      binding.mode = mode
+      const modeLabel = mode === 'agent' ? 'Agent' : 'Chat'
+      await this.sendTextMessage(chatId, `已切换到 ${modeLabel} 模式`)
+    } else {
+      const modeLabel = mode === 'agent' ? 'Agent' : 'Chat'
+      await this.sendTextMessage(chatId, `当前没有会话。直接发送消息将自动创建 ${modeLabel} 会话，或使用 /new 创建。`)
+    }
+  }
+
+  private async handleListCommand(chatId: string, _userId: string): Promise<void> {
+    const sessions = listAgentSessions()
+    const workspaces = listAgentWorkspaces()
+    const binding = this.chatBindings.get(chatId)
+    const currentWorkspaceId = binding?.workspaceId
+
+    // 每个工作区最多展示最近 5 个会话
+    const MAX_SESSIONS_PER_WS = 5
+
+    // 为所有会话建立全局序号映射（序号 = 全局排序位置，从 1 开始）
+    const sessionIndexMap = new Map<string, number>()
+    sessions.forEach((s, i) => sessionIndexMap.set(s.id, i + 1))
+
+    // 按工作区分组
+    const wsItems: WorkspaceListItem[] = workspaces.map((ws) => {
+      const wsSessions = sessions
+        .filter((s) => s.workspaceId === ws.id)
+        .slice(0, MAX_SESSIONS_PER_WS)
+        .map((s) => ({
+          id: s.id,
+          title: s.title,
+          active: binding?.sessionId === s.id,
+          index: sessionIndexMap.get(s.id) ?? 0,
+        }))
+
+      return { id: ws.id, name: ws.name, sessions: wsSessions }
+    })
+
+    // 未归属工作区的会话
+    const orphanSessions = sessions
+      .filter((s) => !s.workspaceId || !workspaces.some((w) => w.id === s.workspaceId))
+      .slice(0, MAX_SESSIONS_PER_WS)
+      .map((s) => ({
+        id: s.id,
+        title: s.title,
+        active: binding?.sessionId === s.id,
+        index: sessionIndexMap.get(s.id) ?? 0,
+      }))
+
+    if (orphanSessions.length > 0) {
+      wsItems.push({ id: '', name: '未分配工作区', sessions: orphanSessions })
+    }
+
+    await this.sendCard(chatId, buildSessionListCard(wsItems, currentWorkspaceId))
+  }
+
+  private async handleStopCommand(chatId: string): Promise<void> {
+    const binding = this.chatBindings.get(chatId)
+    if (!binding) {
+      await this.sendTextMessage(chatId, '当前没有绑定的会话。')
+      return
+    }
+
+    stopAgent(binding.sessionId)
+    await this.sendTextMessage(chatId, '✅ 已停止 Agent')
+  }
+
+  private async handleSwitchCommand(chatId: string, userId: string, arg: string): Promise<void> {
+    const sessions = listAgentSessions()
+
+    // 支持序号（如 /switch 1）和 ID 前缀两种方式
+    const index = Number(arg)
+    const match = Number.isInteger(index) && index >= 1 && index <= sessions.length
+      ? sessions[index - 1]
+      : sessions.find((s) => s.id.startsWith(arg))
+
+    if (!match) {
+      await this.sendTextMessage(chatId, `未找到会话。使用 /list 查看可用会话。`)
+      return
+    }
+
+    // 清理旧绑定的反向索引
+    const oldBinding = this.chatBindings.get(chatId)
+    if (oldBinding) {
+      this.sessionToChat.delete(oldBinding.sessionId)
+    }
+
+    const appSettings = getSettings()
+    const config = getFeishuConfig()
+    const binding: FeishuChatBinding = {
+      chatId,
+      userId,
+      sessionId: match.id,
+      workspaceId: match.workspaceId ?? config.defaultWorkspaceId ?? appSettings.agentWorkspaceId ?? '',
+      channelId: match.channelId ?? appSettings.agentChannelId ?? '',
+      modelId: appSettings.agentModelId ?? undefined,
+      mode: 'agent',
+      createdAt: Date.now(),
+    }
+    this.chatBindings.set(chatId, binding)
+    this.sessionToChat.set(match.id, chatId)
+    this.updateStatus({ activeBindings: this.chatBindings.size })
+
+    await this.sendTextMessage(chatId, `✅ 已切换到会话: ${match.title} (${match.id.slice(0, 8)})`)
+  }
+
+  private async handleWorkspaceCommand(chatId: string, _userId: string, arg?: string): Promise<void> {
+    const workspaces = listAgentWorkspaces()
+    const binding = this.chatBindings.get(chatId)
+    const currentWorkspaceId = binding?.workspaceId
+
+    // 无参数 → 列出所有工作区供选择
+    if (!arg) {
+      const items = workspaces.map((w, i) => ({
+        index: i + 1,
+        name: w.name,
+        isCurrent: w.id === currentWorkspaceId,
+      }))
+      await this.sendCard(chatId, buildWorkspaceListCard(items))
+      return
+    }
+
+    // 支持序号（如 /workspace 1）和名称两种方式
+    const index = Number(arg)
+    const match = Number.isInteger(index) && index >= 1 && index <= workspaces.length
+      ? workspaces[index - 1]
+      : workspaces.find(
+          (w) => w.name.toLowerCase() === arg.toLowerCase() || w.slug === arg.toLowerCase(),
+        )
+
+    if (!match) {
+      const available = workspaces.map((w, i) => `${i + 1}. ${w.name}`).join(', ')
+      await this.sendTextMessage(chatId, `未找到工作区 "${arg}"。可用: ${available}`)
+      return
+    }
+
+    // 清理旧绑定（切换工作区后需要用户选择或新建会话）
+    if (binding) {
+      this.sessionToChat.delete(binding.sessionId)
+      this.chatBindings.delete(chatId)
+      this.updateStatus({ activeBindings: this.chatBindings.size })
+    }
+
+    // 更新飞书配置的默认工作区（下次自动创建会话时使用）
+    const { updateFeishuConfigPartial } = await import('./feishu-config')
+    updateFeishuConfigPartial({ defaultWorkspaceId: match.id })
+
+    // 列出该工作区下最近 10 条会话（序号为全局排序位置）
+    const sessions = listAgentSessions()
+    const recentSessions = sessions
+      .filter((s) => s.workspaceId === match.id)
+      .slice(0, 10)
+      .map((s) => ({
+        id: s.id,
+        title: s.title,
+        index: sessions.indexOf(s) + 1,
+      }))
+
+    await this.sendCard(chatId, buildWorkspaceSwitchedCard(match.name, recentSessions))
+  }
+
+  // ===== 用户消息处理 =====
+
+  private async handleUserMessage(chatId: string, userId: string, text: string): Promise<void> {
+    let binding = this.chatBindings.get(chatId)
+
+    // 自动创建会话
+    if (!binding) {
+      await this.createNewSession(chatId, userId, 'agent')
+      binding = this.chatBindings.get(chatId)
+      if (!binding) return
+    }
+
+    // 初始化缓冲
+    this.sessionBuffers.set(binding.sessionId, {
+      text: '',
+      toolSummaries: new Map(),
+      startedAt: Date.now(),
+    })
+
+    // 发送思考中指示
+    const prefix = this.resolveContextPrefix(chatId)
+    await this.sendTextMessage(chatId, `${prefix}⏳ Agent 处理中...`)
+
+    if (binding.mode === 'agent') {
+      // Agent 模式 — fire-and-forget，不阻塞事件回调
+      const input: AgentSendInput = {
+        sessionId: binding.sessionId,
+        userMessage: text,
+        channelId: binding.channelId,
+        modelId: binding.modelId,
+        workspaceId: binding.workspaceId,
+      }
+
+      runAgentHeadless(input, {
+        onError: (error) => {
+          const errPrefix = this.resolveContextPrefix(chatId)
+          this.sendCard(chatId, buildErrorCard(`${errPrefix}${error}`)).catch(console.error)
+          this.sessionBuffers.delete(binding!.sessionId)
+        },
+        onComplete: () => {
+          // complete 事件由 EventBus listener 处理
+        },
+        onTitleUpdated: (_title) => {
+          // 标题更新可选通知
+        },
+      }).catch((error) => {
+        console.error('[飞书 Bridge] Agent 运行异常:', error)
+      })
+    } else {
+      // Chat 模式 — TODO: Phase 4 实现
+      await this.sendTextMessage(chatId, 'Chat 模式暂未实现，请使用 /agent 切换到 Agent 模式。')
+      this.sessionBuffers.delete(binding.sessionId)
+    }
+  }
+
+  // ===== EventBus 事件处理 =====
+
+  private handleAgentEvent(sessionId: string, event: AgentEvent): void {
+    // 对于飞书发起的会话，缓冲由 handleUserMessage 初始化
+    // 对于桌面发起的会话，complete 事件时检查是否需要通知
+    const buffer = this.sessionBuffers.get(sessionId)
+
+    if (buffer) {
+      if (event.type === 'text_delta') {
+        buffer.text += event.text
+      }
+      accumulateToolSummary(buffer.toolSummaries, event)
+    }
+
+    if (event.type === 'complete') {
+      if (buffer) {
+        // 飞书发起的会话 → 发送完整回复
+        this.handleFeishuSessionComplete(sessionId)
+      } else {
+        // 桌面发起的会话 → 检查是否需要发送通知
+        this.handleDesktopSessionComplete(sessionId)
+      }
+    } else if (event.type === 'error') {
+      const chatId = this.sessionToChat.get(sessionId)
+      if (chatId) {
+        const prefix = this.resolveContextPrefix(chatId)
+        this.sendCard(chatId, buildErrorCard(`${prefix}${event.message}`)).catch(console.error)
+      }
+      this.sessionBuffers.delete(sessionId)
+    }
+  }
+
+  /** 飞书发起的会话完成：发送完整回复到飞书 */
+  private handleFeishuSessionComplete(sessionId: string): void {
+    const buffer = this.sessionBuffers.get(sessionId)
+    if (!buffer) return
+
+    const duration = (Date.now() - buffer.startedAt) / 1000
+    const toolSummaries = Array.from(buffer.toolSummaries.values())
+    const result: FormattedAgentResult = {
+      text: buffer.text,
+      toolSummaries,
+      duration,
+    }
+
+    const chatId = this.sessionToChat.get(sessionId)
+    if (chatId) {
+      this.sendAgentReply(chatId, result).catch(console.error)
+    }
+
+    this.sessionBuffers.delete(sessionId)
+  }
+
+  /**
+   * 桌面发起的会话完成：根据通知模式和在场状态决定是否发飞书通知
+   *
+   * - off → 不发
+   * - always → 发
+   * - auto → 用户不在场时才发
+   */
+  private handleDesktopSessionComplete(sessionId: string): void {
+    if (!this.client || !this.defaultNotifyChatId) return
+
+    const mode = this.sessionNotifyModes.get(sessionId) ?? 'auto'
+
+    if (mode === 'off') return
+    if (mode === 'auto' && presenceService.isUserPresent(sessionId)) return
+
+    // 需要发通知 → 发送简短通知卡片
+    this.sendDesktopNotification(sessionId).catch(console.error)
+  }
+
+  /** 向飞书发送桌面会话完成通知，并通知渲染进程 */
+  private async sendDesktopNotification(sessionId: string): Promise<void> {
+    if (!this.defaultNotifyChatId) return
+
+    // 获取会话标题
+    const sessions = await listAgentSessions()
+    const session = sessions.find((s) => s.id === sessionId)
+    const title = session?.title ?? '未命名会话'
+    const preview = '任务已完成，请在 Proma 中查看详情。'
+
+    // 发送通知卡片到飞书
+    const card = buildNotificationCard(title, preview, [], 0)
+    await this.sendCard(this.defaultNotifyChatId, card)
+
+    // 通知渲染进程（用于 Sonner toast + 桌面通知）
+    const payload: FeishuNotificationSentPayload = {
+      sessionId,
+      sessionTitle: title,
+      preview,
+    }
+    const windows = BrowserWindow.getAllWindows()
+    if (windows.length > 0 && !windows[0]!.isDestroyed()) {
+      windows[0]!.webContents.send(FEISHU_IPC_CHANNELS.NOTIFICATION_SENT, payload)
+    }
+  }
+
+  private async sendAgentReply(chatId: string, result: FormattedAgentResult): Promise<void> {
+    const prefix = this.resolveContextPrefix(chatId)
+
+    if (!result.text.trim()) {
+      await this.sendTextMessage(chatId, `${prefix}✅ Agent 已完成（无文本输出）`)
+      return
+    }
+
+    // 在正文前追加上下文前缀
+    const prefixedResult: FormattedAgentResult = {
+      ...result,
+      text: `${prefix}\n${result.text}`,
+    }
+    const chunks = splitLongContent(prefixedResult.text)
+
+    if (chunks.length === 1) {
+      // 单条卡片
+      await this.sendCard(chatId, buildAgentReplyCard(prefixedResult))
+    } else {
+      // 多条消息
+      for (let i = 0; i < chunks.length; i++) {
+        const chunkResult: FormattedAgentResult = {
+          text: chunks[i]!,
+          toolSummaries: i === chunks.length - 1 ? result.toolSummaries : [],
+          duration: i === chunks.length - 1 ? result.duration : 0,
+        }
+        await this.sendCard(chatId, buildAgentReplyCard(chunkResult))
+      }
+    }
+  }
+
+  // ===== 飞书 API =====
+
+  /** 向去重集合添加 ID，保持集合大小不超过上限 */
+  private addToDedup(set: Set<string>, id: string): void {
+    set.add(id)
+    if (set.size > FeishuBridge.DEDUP_MAX) {
+      const first = set.values().next().value as string
+      set.delete(first)
+    }
+  }
+
+  /**
+   * 解析消息上下文前缀：[工作区名称]->[会话名称]：
+   *
+   * 用于在每条回复的飞书消息开头标注来源，方便用户区分。
+   */
+  private resolveContextPrefix(chatId: string): string {
+    const binding = this.chatBindings.get(chatId)
+    if (!binding) return ''
+
+    const workspace = binding.workspaceId ? getAgentWorkspace(binding.workspaceId) : undefined
+    const session = getAgentSessionMeta(binding.sessionId)
+
+    const wsName = workspace?.name ?? '默认工作区'
+    const sessName = session?.title ?? binding.sessionId.slice(0, 8)
+
+    return `[${wsName}]->[${sessName}]：`
+  }
+
+  private async sendTextMessage(chatId: string, text: string): Promise<void> {
+    if (!this.client) return
+
+    try {
+      const resp = await this.client.im.message.create({
+        params: { receive_id_type: 'chat_id' },
+        data: {
+          receive_id: chatId,
+          msg_type: 'text',
+          content: JSON.stringify({ text }),
+        },
+      })
+      // 将 Bot 发出的消息 ID 加入去重集合，防止回环
+      const sentId = (resp?.data as Record<string, unknown>)?.message_id as string | undefined
+      if (sentId) this.addToDedup(this.recentMessageIds, sentId)
+    } catch (error) {
+      console.error('[飞书 Bridge] 发送文本消息失败:', error)
+    }
+  }
+
+  private async sendCard(chatId: string, card: Record<string, unknown>): Promise<void> {
+    if (!this.client) return
+
+    try {
+      const resp = await this.client.im.message.create({
+        params: { receive_id_type: 'chat_id' },
+        data: {
+          receive_id: chatId,
+          msg_type: 'interactive',
+          content: JSON.stringify(card),
+        },
+      })
+      // 将 Bot 发出的消息 ID 加入去重集合，防止回环
+      const sentId = (resp?.data as Record<string, unknown>)?.message_id as string | undefined
+      if (sentId) this.addToDedup(this.recentMessageIds, sentId)
+    } catch (error) {
+      console.error('[飞书 Bridge] 发送卡片消息失败:', error)
+    }
+  }
+
+  // ===== 状态更新与广播 =====
+
+  private updateStatus(partial: Partial<FeishuBridgeState>): void {
+    this.status = { ...this.status, ...partial }
+
+    // 广播到渲染进程
+    const windows = BrowserWindow.getAllWindows()
+    if (windows.length > 0 && !windows[0]!.isDestroyed()) {
+      windows[0]!.webContents.send(FEISHU_IPC_CHANNELS.STATUS_CHANGED, this.status)
+    }
+  }
+}
+
+// ===== 导出单例 =====
+
+export const feishuBridge = new FeishuBridge()

--- a/apps/electron/src/main/lib/feishu-config.ts
+++ b/apps/electron/src/main/lib/feishu-config.ts
@@ -1,0 +1,131 @@
+/**
+ * 飞书配置管理
+ *
+ * 负责飞书 Bot 配置的 CRUD 操作、App Secret 加密/解密。
+ * 使用 Electron safeStorage 进行加密（与渠道 API Key 相同模式）。
+ * 数据持久化到 ~/.proma/feishu.json。
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { safeStorage } from 'electron'
+import { getFeishuConfigPath } from './config-paths'
+import type { FeishuConfig, FeishuConfigInput } from '@proma/shared'
+
+/** 默认配置 */
+const DEFAULT_CONFIG: FeishuConfig = {
+  enabled: false,
+  appId: '',
+  appSecret: '',
+}
+
+// ===== 加密/解密 =====
+
+/**
+ * 加密 App Secret
+ *
+ * 使用 Electron safeStorage 加密，底层使用 OS 级加密。
+ *
+ * @returns base64 编码的加密字符串
+ */
+function encryptSecret(plainSecret: string): string {
+  if (!safeStorage.isEncryptionAvailable()) {
+    console.warn('[飞书配置] safeStorage 加密不可用，将以明文存储')
+    return plainSecret
+  }
+
+  const encrypted = safeStorage.encryptString(plainSecret)
+  return encrypted.toString('base64')
+}
+
+/**
+ * 解密 App Secret
+ *
+ * @returns 明文 App Secret
+ */
+function decryptSecret(encryptedSecret: string): string {
+  if (!encryptedSecret) return ''
+
+  if (!safeStorage.isEncryptionAvailable()) {
+    return encryptedSecret
+  }
+
+  try {
+    const buffer = Buffer.from(encryptedSecret, 'base64')
+    return safeStorage.decryptString(buffer)
+  } catch (error) {
+    console.error('[飞书配置] 解密 App Secret 失败:', error)
+    throw new Error('解密 App Secret 失败')
+  }
+}
+
+// ===== 配置 CRUD =====
+
+/**
+ * 读取飞书配置
+ *
+ * 返回的 appSecret 是加密后的，不要直接使用。
+ * 需要明文 Secret 请调用 getDecryptedAppSecret()。
+ */
+export function getFeishuConfig(): FeishuConfig {
+  const configPath = getFeishuConfigPath()
+
+  if (!existsSync(configPath)) {
+    return { ...DEFAULT_CONFIG }
+  }
+
+  try {
+    const raw = readFileSync(configPath, 'utf-8')
+    const data = JSON.parse(raw) as Partial<FeishuConfig>
+    return {
+      ...DEFAULT_CONFIG,
+      ...data,
+    }
+  } catch (error) {
+    console.error('[飞书配置] 读取配置文件失败:', error)
+    return { ...DEFAULT_CONFIG }
+  }
+}
+
+/**
+ * 保存飞书配置
+ *
+ * 接收明文 App Secret，自动加密后存储。
+ */
+export function saveFeishuConfig(input: FeishuConfigInput): FeishuConfig {
+  const configPath = getFeishuConfigPath()
+
+  const config: FeishuConfig = {
+    enabled: input.enabled,
+    appId: input.appId.trim(),
+    appSecret: input.appSecret ? encryptSecret(input.appSecret) : '',
+    defaultWorkspaceId: input.defaultWorkspaceId,
+  }
+
+  writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8')
+  console.log('[飞书配置] 配置已保存')
+
+  return config
+}
+
+/**
+ * 获取解密后的 App Secret
+ *
+ * 用于实际连接飞书 API 时使用。
+ */
+export function getDecryptedAppSecret(): string {
+  const config = getFeishuConfig()
+  return decryptSecret(config.appSecret)
+}
+
+/**
+ * 更新飞书配置的部分字段
+ *
+ * 不会修改 appId 和 appSecret，仅更新其他字段。
+ */
+export function updateFeishuConfigPartial(updates: Partial<Omit<FeishuConfig, 'appId' | 'appSecret'>>): FeishuConfig {
+  const current = getFeishuConfig()
+  const updated: FeishuConfig = { ...current, ...updates }
+  const configPath = getFeishuConfigPath()
+  writeFileSync(configPath, JSON.stringify(updated, null, 2), 'utf-8')
+  return updated
+}

--- a/apps/electron/src/main/lib/feishu-message.ts
+++ b/apps/electron/src/main/lib/feishu-message.ts
@@ -1,0 +1,364 @@
+/**
+ * 飞书消息格式化
+ *
+ * 将 Agent 事件转换为飞书消息卡片格式。
+ */
+
+import type { AgentEvent } from '@proma/shared'
+
+/** 工具活动摘要 */
+export interface ToolSummary {
+  toolName: string
+  count: number
+  hasError: boolean
+}
+
+/** Agent 完成后的格式化结果 */
+export interface FormattedAgentResult {
+  text: string
+  toolSummaries: ToolSummary[]
+  duration: number
+}
+
+/**
+ * 构建 Agent 回复的飞书交互卡片
+ */
+export function buildAgentReplyCard(result: FormattedAgentResult): Record<string, unknown> {
+  const toolLine = formatToolSummaryLine(result.toolSummaries, result.duration)
+  const content = truncateForFeishu(result.text)
+
+  return {
+    config: { wide_screen_mode: true },
+    header: {
+      title: { tag: 'plain_text', content: 'Proma Agent' },
+      template: 'blue',
+    },
+    elements: [
+      { tag: 'markdown', content },
+      ...(toolLine ? [
+        { tag: 'hr' },
+        {
+          tag: 'note',
+          elements: [{ tag: 'plain_text', content: toolLine }],
+        },
+      ] : []),
+    ],
+  }
+}
+
+/**
+ * 构建桌面端通知的飞书摘要卡片（非飞书发起的会话）
+ */
+export function buildNotificationCard(
+  sessionTitle: string,
+  preview: string,
+  toolSummaries: ToolSummary[],
+  duration: number,
+): Record<string, unknown> {
+  const toolLine = formatToolSummaryLine(toolSummaries, duration)
+
+  return {
+    config: { wide_screen_mode: true },
+    header: {
+      title: { tag: 'plain_text', content: 'Proma 任务完成' },
+      template: 'green',
+    },
+    elements: [
+      {
+        tag: 'markdown',
+        content: `**会话**: ${sessionTitle}\n\n${preview.slice(0, 200)}${preview.length > 200 ? '...' : ''}`,
+      },
+      ...(toolLine ? [
+        { tag: 'hr' },
+        {
+          tag: 'note',
+          elements: [{ tag: 'plain_text', content: `${toolLine} | 在 Proma 中查看完整回复` }],
+        },
+      ] : []),
+    ],
+  }
+}
+
+/**
+ * 构建错误卡片
+ */
+export function buildErrorCard(errorMessage: string): Record<string, unknown> {
+  return {
+    config: { wide_screen_mode: true },
+    header: {
+      title: { tag: 'plain_text', content: 'Proma 错误' },
+      template: 'red',
+    },
+    elements: [
+      { tag: 'markdown', content: errorMessage },
+    ],
+  }
+}
+
+/** 工作区及其会话的列表项 */
+export interface WorkspaceListItem {
+  id: string
+  name: string
+  sessions: Array<{ id: string; title: string; active: boolean; index: number }>
+}
+
+/**
+ * 构建会话列表卡片（/list 命令）
+ *
+ * 按工作区分组展示，每个工作区下显示最近会话。
+ */
+export function buildSessionListCard(
+  workspaces: WorkspaceListItem[],
+  currentWorkspaceId?: string,
+): Record<string, unknown> {
+  const elements: Array<Record<string, unknown>> = []
+
+  for (const ws of workspaces) {
+    const isCurrent = ws.id === currentWorkspaceId
+    const wsLabel = isCurrent ? `📂 **${ws.name}**（当前）` : `📁 ${ws.name}`
+
+    if (ws.sessions.length === 0) {
+      elements.push({
+        tag: 'markdown',
+        content: `${wsLabel}\n  暂无会话`,
+      })
+    } else {
+      const lines = ws.sessions.map((s) => {
+        const prefix = s.active ? '▶ ' : '  '
+        return `${prefix}**${s.index}.** ${s.title}`
+      })
+      elements.push({
+        tag: 'markdown',
+        content: `${wsLabel}\n${lines.join('\n')}`,
+      })
+    }
+  }
+
+  if (elements.length === 0) {
+    elements.push({ tag: 'markdown', content: '暂无工作区和会话' })
+  }
+
+  // 用分割线隔开每个工作区
+  const withDividers: Array<Record<string, unknown>> = []
+  for (let i = 0; i < elements.length; i++) {
+    if (i > 0) withDividers.push({ tag: 'hr' })
+    withDividers.push(elements[i]!)
+  }
+
+  // 底部提示
+  withDividers.push({ tag: 'hr' })
+  withDividers.push({
+    tag: 'note',
+    elements: [{ tag: 'plain_text', content: '使用 /switch <序号> 切换会话 | /new 创建新会话' }],
+  })
+
+  return {
+    config: { wide_screen_mode: true },
+    header: {
+      title: { tag: 'plain_text', content: '工作区与会话' },
+      template: 'blue',
+    },
+    elements: withDividers,
+  }
+}
+
+/**
+ * 构建工作区切换结果卡片（/workspace 命令）
+ *
+ * 显示切换成功 + 该工作区下最近会话列表，引导用户 /switch 或 /new。
+ */
+export function buildWorkspaceSwitchedCard(
+  workspaceName: string,
+  sessions: Array<{ id: string; title: string; index: number }>,
+): Record<string, unknown> {
+  const elements: Array<Record<string, unknown>> = []
+
+  elements.push({
+    tag: 'markdown',
+    content: `📂 已切换到工作区: **${workspaceName}**`,
+  })
+
+  if (sessions.length > 0) {
+    elements.push({ tag: 'hr' })
+    const lines = sessions.map(
+      (s) => `  **${s.index}.** ${s.title}`,
+    )
+    elements.push({
+      tag: 'markdown',
+      content: `**最近会话**\n${lines.join('\n')}`,
+    })
+  }
+
+  elements.push({ tag: 'hr' })
+  elements.push({
+    tag: 'note',
+    elements: [{
+      tag: 'plain_text',
+      content: sessions.length > 0
+        ? '使用 /switch <序号> 继续已有会话 | 直接发消息或 /new 创建新会话'
+        : '直接发送消息或 /new 创建新会话',
+    }],
+  })
+
+  return {
+    config: { wide_screen_mode: true },
+    header: {
+      title: { tag: 'plain_text', content: '切换工作区' },
+      template: 'green',
+    },
+    elements,
+  }
+}
+
+/**
+ * 构建工作区列表卡片（/workspace 无参数时）
+ */
+export function buildWorkspaceListCard(
+  workspaces: Array<{ index: number; name: string; isCurrent: boolean }>,
+): Record<string, unknown> {
+  const lines = workspaces.map((w) =>
+    w.isCurrent
+      ? `▶ **${w.index}.** ${w.name}（当前）`
+      : `  **${w.index}.** ${w.name}`,
+  )
+
+  return {
+    config: { wide_screen_mode: true },
+    header: {
+      title: { tag: 'plain_text', content: '选择工作区' },
+      template: 'blue',
+    },
+    elements: [
+      {
+        tag: 'markdown',
+        content: lines.length > 0 ? lines.join('\n') : '暂无工作区',
+      },
+      { tag: 'hr' },
+      {
+        tag: 'note',
+        elements: [{ tag: 'plain_text', content: '使用 /workspace <序号或名称> 切换工作区' }],
+      },
+    ],
+  }
+}
+
+/**
+ * 构建帮助卡片（/help 命令）
+ */
+export function buildHelpCard(): Record<string, unknown> {
+  return {
+    config: { wide_screen_mode: true },
+    header: {
+      title: { tag: 'plain_text', content: 'Proma Bot 命令' },
+      template: 'blue',
+    },
+    elements: [
+      {
+        tag: 'markdown',
+        content: [
+          '`/help` — 显示帮助',
+          '`/new [标题]` — 创建新 Agent 会话',
+          '`/chat` — 切换到 Chat 模式',
+          '`/agent` — 切换到 Agent 模式',
+          '`/list` — 列出所有会话',
+          '`/stop` — 停止当前 Agent',
+          '`/switch <序号>` — 切换到已有会话',
+          '`/workspace <名称>` — 设置工作区',
+          '',
+          '直接发送文本会自动创建或发送到当前会话。',
+        ].join('\n'),
+      },
+    ],
+  }
+}
+
+// ===== 工具函数 =====
+
+/**
+ * 格式化工具调用摘要行
+ */
+function formatToolSummaryLine(summaries: ToolSummary[], durationSeconds: number): string {
+  if (summaries.length === 0 && durationSeconds === 0) return ''
+
+  const parts: string[] = []
+
+  if (summaries.length > 0) {
+    const toolParts = summaries.map((s) => `${s.toolName} x${s.count}`)
+    parts.push(`🔧 ${toolParts.join(', ')}`)
+  }
+
+  if (durationSeconds > 0) {
+    parts.push(`⏱ ${Math.round(durationSeconds)}s`)
+  }
+
+  return parts.join(' | ')
+}
+
+/**
+ * 截断文本以适应飞书卡片大小限制
+ *
+ * 飞书卡片约 30KB 限制，保守取 25000 字符。
+ */
+function truncateForFeishu(text: string, maxLength = 25000): string {
+  if (text.length <= maxLength) return text
+  return text.slice(0, maxLength) + '\n\n... [内容过长，请在 Proma 中查看完整回复]'
+}
+
+/**
+ * 将飞书消息内容拆分为多段（超长消息）
+ */
+export function splitLongContent(text: string, maxLength = 25000): string[] {
+  if (text.length <= maxLength) return [text]
+
+  const chunks: string[] = []
+  let remaining = text
+
+  while (remaining.length > 0) {
+    if (remaining.length <= maxLength) {
+      chunks.push(remaining)
+      break
+    }
+
+    // 尝试在段落边界拆分
+    let splitIndex = remaining.lastIndexOf('\n\n', maxLength)
+    if (splitIndex < maxLength * 0.5) {
+      // 如果段落边界太靠前，退而在行边界拆分
+      splitIndex = remaining.lastIndexOf('\n', maxLength)
+    }
+    if (splitIndex < maxLength * 0.5) {
+      // 如果行边界也太靠前，硬拆
+      splitIndex = maxLength
+    }
+
+    chunks.push(remaining.slice(0, splitIndex))
+    remaining = remaining.slice(splitIndex).trimStart()
+  }
+
+  return chunks
+}
+
+/**
+ * 从 AgentEvent 中提取工具名称（用于累积工具摘要）
+ */
+export function accumulateToolSummary(
+  summaries: Map<string, ToolSummary>,
+  event: AgentEvent,
+): void {
+  if (event.type === 'tool_start') {
+    const existing = summaries.get(event.toolName)
+    if (existing) {
+      existing.count++
+    } else {
+      summaries.set(event.toolName, {
+        toolName: event.toolName,
+        count: 1,
+        hasError: false,
+      })
+    }
+  } else if (event.type === 'tool_result' && event.isError && event.toolName) {
+    const existing = summaries.get(event.toolName)
+    if (existing) {
+      existing.hasError = true
+    }
+  }
+}

--- a/apps/electron/src/main/lib/feishu-presence.ts
+++ b/apps/electron/src/main/lib/feishu-presence.ts
@@ -1,0 +1,73 @@
+/**
+ * 飞书在场检测服务
+ *
+ * 接收渲染进程上报的用户活动状态，结合窗口状态和系统空闲时间，
+ * 判断用户是否正在「关注」某个会话。
+ *
+ * 在场 = 不需要发飞书通知；离开 = 需要发飞书通知。
+ */
+
+import { BrowserWindow, powerMonitor } from 'electron'
+import type { FeishuPresenceReport } from '@proma/shared'
+
+/** 内部在场状态 */
+interface PresenceState {
+  /** 当前查看的会话 ID */
+  activeSessionId: string | null
+  /** 最后交互时间 */
+  lastInteractionAt: number
+}
+
+/** 系统空闲超时（秒） */
+const SYSTEM_IDLE_TIMEOUT = 120
+/** 窗口失焦超时（毫秒） */
+const FOCUS_LOST_TIMEOUT = 30_000
+
+class PresenceService {
+  private state: PresenceState = {
+    activeSessionId: null,
+    lastInteractionAt: Date.now(),
+  }
+
+  /** 更新在场状态（渲染进程上报） */
+  updatePresence(report: FeishuPresenceReport): void {
+    this.state.activeSessionId = report.activeSessionId
+    this.state.lastInteractionAt = report.lastInteractionAt
+  }
+
+  /**
+   * 判断用户是否「在场」观察某个会话
+   *
+   * 不在场的条件（任一满足）：
+   * - 窗口最小化
+   * - 窗口失焦超过 30 秒
+   * - 系统空闲超过 2 分钟
+   * - 当前查看的不是这个会话（后台会话）
+   */
+  isUserPresent(sessionId: string): boolean {
+    const win = BrowserWindow.getAllWindows()[0]
+    if (!win || win.isDestroyed()) return false
+
+    // 窗口最小化 → 不在场
+    if (win.isMinimized()) return false
+
+    // 窗口失焦超过 30 秒 → 不在场
+    if (!win.isFocused() && Date.now() - this.state.lastInteractionAt > FOCUS_LOST_TIMEOUT) {
+      return false
+    }
+
+    // 系统空闲超过 2 分钟 → 不在场
+    try {
+      if (powerMonitor.getSystemIdleTime() > SYSTEM_IDLE_TIMEOUT) return false
+    } catch {
+      // powerMonitor 可能在某些环境下不可用
+    }
+
+    // 当前查看的不是这个会话 → 不在场
+    if (this.state.activeSessionId !== sessionId) return false
+
+    return true
+  }
+}
+
+export const presenceService = new PresenceService()

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -6,7 +6,7 @@
  */
 
 import { contextBridge, ipcRenderer } from 'electron'
-import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, MEMORY_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS } from '@proma/shared'
+import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, MEMORY_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS } from '@proma/shared'
 import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS } from '../types'
 import type {
   RuntimeStatus,
@@ -68,6 +68,14 @@ import type {
   ChatToolMeta,
   AgentTeamData,
   MoveSessionToWorkspaceInput,
+  FeishuConfig,
+  FeishuConfigInput,
+  FeishuBridgeState,
+  FeishuTestResult,
+  FeishuChatBinding,
+  FeishuPresenceReport,
+  FeishuNotifyMode,
+  FeishuNotificationSentPayload,
 } from '@proma/shared'
 import type { UserProfile, AppSettings } from '../types'
 
@@ -499,6 +507,31 @@ export interface ElectronAPI {
   // 工作区文件变化通知
   onCapabilitiesChanged: (callback: () => void) => () => void
   onWorkspaceFilesChanged: (callback: () => void) => () => void
+
+  // ===== 飞书集成 =====
+
+  /** 获取飞书配置 */
+  getFeishuConfig: () => Promise<FeishuConfig>
+  /** 保存飞书配置（appSecret 为明文） */
+  saveFeishuConfig: (input: FeishuConfigInput) => Promise<FeishuConfig>
+  /** 测试飞书连接 */
+  testFeishuConnection: (appId: string, appSecret: string) => Promise<FeishuTestResult>
+  /** 启动飞书 Bridge */
+  startFeishuBridge: () => Promise<void>
+  /** 停止飞书 Bridge */
+  stopFeishuBridge: () => Promise<void>
+  /** 获取飞书 Bridge 状态 */
+  getFeishuStatus: () => Promise<FeishuBridgeState>
+  /** 获取活跃绑定列表 */
+  listFeishuBindings: () => Promise<FeishuChatBinding[]>
+  /** 上报用户在场状态 */
+  reportFeishuPresence: (report: FeishuPresenceReport) => Promise<void>
+  /** 设置会话通知模式 */
+  setFeishuSessionNotify: (sessionId: string, mode: FeishuNotifyMode) => Promise<void>
+  /** 订阅飞书 Bridge 状态变化 */
+  onFeishuStatusChanged: (callback: (state: FeishuBridgeState) => void) => () => void
+  /** 订阅飞书通知已发送事件 */
+  onFeishuNotificationSent: (callback: (payload: FeishuNotificationSentPayload) => void) => () => void
 }
 
 /**
@@ -1050,6 +1083,56 @@ const electronAPI: ElectronAPI = {
 
   getReleaseByTag: (tag) => {
     return ipcRenderer.invoke(GITHUB_RELEASE_IPC_CHANNELS.GET_RELEASE_BY_TAG, tag)
+  },
+
+  // ===== 飞书集成 =====
+
+  getFeishuConfig: () => {
+    return ipcRenderer.invoke(FEISHU_IPC_CHANNELS.GET_CONFIG)
+  },
+
+  saveFeishuConfig: (input: FeishuConfigInput) => {
+    return ipcRenderer.invoke(FEISHU_IPC_CHANNELS.SAVE_CONFIG, input)
+  },
+
+  testFeishuConnection: (appId: string, appSecret: string) => {
+    return ipcRenderer.invoke(FEISHU_IPC_CHANNELS.TEST_CONNECTION, appId, appSecret)
+  },
+
+  startFeishuBridge: () => {
+    return ipcRenderer.invoke(FEISHU_IPC_CHANNELS.START_BRIDGE)
+  },
+
+  stopFeishuBridge: () => {
+    return ipcRenderer.invoke(FEISHU_IPC_CHANNELS.STOP_BRIDGE)
+  },
+
+  getFeishuStatus: () => {
+    return ipcRenderer.invoke(FEISHU_IPC_CHANNELS.GET_STATUS)
+  },
+
+  listFeishuBindings: () => {
+    return ipcRenderer.invoke(FEISHU_IPC_CHANNELS.LIST_BINDINGS)
+  },
+
+  reportFeishuPresence: (report: FeishuPresenceReport) => {
+    return ipcRenderer.invoke(FEISHU_IPC_CHANNELS.REPORT_PRESENCE, report)
+  },
+
+  setFeishuSessionNotify: (sessionId: string, mode: FeishuNotifyMode) => {
+    return ipcRenderer.invoke(FEISHU_IPC_CHANNELS.SET_SESSION_NOTIFY, sessionId, mode)
+  },
+
+  onFeishuStatusChanged: (callback: (state: FeishuBridgeState) => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, state: FeishuBridgeState): void => callback(state)
+    ipcRenderer.on(FEISHU_IPC_CHANNELS.STATUS_CHANGED, listener)
+    return () => { ipcRenderer.removeListener(FEISHU_IPC_CHANNELS.STATUS_CHANGED, listener) }
+  },
+
+  onFeishuNotificationSent: (callback: (payload: FeishuNotificationSentPayload) => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, payload: FeishuNotificationSentPayload): void => callback(payload)
+    ipcRenderer.on(FEISHU_IPC_CHANNELS.NOTIFICATION_SENT, listener)
+    return () => { ipcRenderer.removeListener(FEISHU_IPC_CHANNELS.NOTIFICATION_SENT, listener) }
   },
 }
 

--- a/apps/electron/src/renderer/atoms/feishu-atoms.ts
+++ b/apps/electron/src/renderer/atoms/feishu-atoms.ts
@@ -1,0 +1,23 @@
+/**
+ * 飞书集成 Jotai 状态
+ *
+ * 管理飞书 Bridge 连接状态和 per-session 通知模式。
+ */
+
+import { atom } from 'jotai'
+import type { FeishuBridgeState, FeishuNotifyMode } from '@proma/shared'
+
+/** 飞书 Bridge 连接状态 */
+export const feishuBridgeStateAtom = atom<FeishuBridgeState>({
+  status: 'disconnected',
+  activeBindings: 0,
+})
+
+/** 全局默认通知模式 */
+export const feishuDefaultNotifyModeAtom = atom<FeishuNotifyMode>('auto')
+
+/** per-session 通知模式 Map<sessionId, FeishuNotifyMode> */
+export const sessionFeishuNotifyModeAtom = atom<Map<string, FeishuNotifyMode>>(new Map())
+
+/** 飞书是否已连接（derived atom） */
+export const feishuConnectedAtom = atom((get) => get(feishuBridgeStateAtom).status === 'connected')

--- a/apps/electron/src/renderer/atoms/settings-tab.ts
+++ b/apps/electron/src/renderer/atoms/settings-tab.ts
@@ -11,7 +11,7 @@
 
 import { atom } from 'jotai'
 
-export type SettingsTab = 'general' | 'channels' | 'proxy' | 'appearance' | 'about' | 'agent' | 'prompts' | 'tools'
+export type SettingsTab = 'general' | 'channels' | 'proxy' | 'appearance' | 'about' | 'agent' | 'prompts' | 'tools' | 'feishu'
 
 /** 当前设置标签页（不持久化，每次打开设置默认显示渠道） */
 export const settingsTabAtom = atom<SettingsTab>('channels')

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -30,6 +30,7 @@ import { RichTextInput } from '@/components/ai-elements/rich-text-input'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
+import { FeishuNotifyToggle } from '@/components/chat/FeishuNotifyToggle'
 import {
   agentStreamingStatesAtom,
   agentChannelIdAtom,
@@ -906,6 +907,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
                       isProcessing={streaming}
                       onCompact={handleCompact}
                     />
+                    <FeishuNotifyToggle sessionId={sessionId} />
                   </>
                 )}
               </div>

--- a/apps/electron/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatInput.tsx
@@ -36,6 +36,7 @@ import {
   useConversationModel,
   useConversationThinkingEnabled,
 } from '@/hooks/useConversationSettings'
+import { FeishuNotifyToggle } from './FeishuNotifyToggle'
 import { cn } from '@/lib/utils'
 import { fileToBase64 } from '@/lib/file-utils'
 
@@ -307,6 +308,8 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
                   <p>{thinkingEnabled ? '关闭思考模式' : '开启思考模式'}</p>
                 </TooltipContent>
               </Tooltip>
+
+              <FeishuNotifyToggle sessionId={conversationId} />
 
               <SpeechButton onTranscript={handleSpeechTranscript} />
 

--- a/apps/electron/src/renderer/components/chat/FeishuNotifyToggle.tsx
+++ b/apps/electron/src/renderer/components/chat/FeishuNotifyToggle.tsx
@@ -1,0 +1,85 @@
+/**
+ * FeishuNotifyToggle — 飞书通知模式切换按钮
+ *
+ * 三态循环：auto → always → off → auto
+ * 仅在飞书 Bridge 已连接时显示。
+ */
+
+import * as React from 'react'
+import { useAtomValue, useSetAtom } from 'jotai'
+import { MessageSquare } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { feishuConnectedAtom, sessionFeishuNotifyModeAtom, feishuDefaultNotifyModeAtom } from '@/atoms/feishu-atoms'
+import { cn } from '@/lib/utils'
+import type { FeishuNotifyMode } from '@proma/shared'
+
+/** 模式循环顺序 */
+const MODE_CYCLE: FeishuNotifyMode[] = ['auto', 'always', 'off']
+
+/** 模式配置 */
+const MODE_CONFIG: Record<FeishuNotifyMode, { color: string; tooltip: string }> = {
+  auto: { color: 'text-foreground/60 hover:text-foreground', tooltip: '飞书通知: 智能 (离开时发送)' },
+  always: { color: 'text-blue-500', tooltip: '飞书通知: 始终发送' },
+  off: { color: 'text-foreground/30', tooltip: '飞书通知: 已关闭' },
+}
+
+interface FeishuNotifyToggleProps {
+  sessionId: string
+}
+
+export function FeishuNotifyToggle({ sessionId }: FeishuNotifyToggleProps): React.ReactElement | null {
+  const isConnected = useAtomValue(feishuConnectedAtom)
+  const defaultMode = useAtomValue(feishuDefaultNotifyModeAtom)
+  const notifyModes = useAtomValue(sessionFeishuNotifyModeAtom)
+  const setNotifyModes = useSetAtom(sessionFeishuNotifyModeAtom)
+
+  const currentMode = notifyModes.get(sessionId) ?? defaultMode
+
+  const handleClick = React.useCallback(() => {
+    const currentIndex = MODE_CYCLE.indexOf(currentMode)
+    const nextMode = MODE_CYCLE[(currentIndex + 1) % MODE_CYCLE.length]!
+
+    // 更新 atom
+    setNotifyModes((prev) => {
+      const map = new Map(prev)
+      map.set(sessionId, nextMode)
+      return map
+    })
+
+    // 同步到主进程
+    window.electronAPI.setFeishuSessionNotify(sessionId, nextMode).catch(console.error)
+  }, [sessionId, currentMode, setNotifyModes])
+
+  // 仅在飞书 Bridge 已连接时显示
+  if (!isConnected) return null
+
+  const config = MODE_CONFIG[currentMode]
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className={cn(
+            'size-[30px] rounded-full',
+            config.color,
+            currentMode === 'off' && 'line-through',
+          )}
+          onClick={handleClick}
+        >
+          <MessageSquare className="size-5" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="top">
+        <p>{config.tooltip}</p>
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/apps/electron/src/renderer/components/settings/FeishuSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/FeishuSettings.tsx
@@ -1,0 +1,436 @@
+/**
+ * FeishuSettings - 飞书集成设置页
+ *
+ * 配置飞书 Bot 连接、默认参数、查看连接状态。
+ * 包含创建飞书 Bot 的完整引导流程。
+ */
+
+import * as React from 'react'
+import { useAtomValue } from 'jotai'
+import { Loader2, CheckCircle2, XCircle, ExternalLink } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { SettingsSection } from './primitives/SettingsSection'
+import { SettingsCard } from './primitives/SettingsCard'
+import { SettingsInput } from './primitives/SettingsInput'
+import { SettingsSecretInput } from './primitives/SettingsSecretInput'
+import { SettingsSelect } from './primitives/SettingsSelect'
+import { SettingsSegmentedControl } from './primitives/SettingsSegmentedControl'
+import { SettingsRow } from './primitives/SettingsRow'
+import { feishuBridgeStateAtom } from '@/atoms/feishu-atoms'
+import { agentWorkspacesAtom } from '@/atoms/agent-atoms'
+import { cn } from '@/lib/utils'
+import type { FeishuTestResult } from '@proma/shared'
+
+/** 连接状态颜色映射 */
+const STATUS_CONFIG = {
+  disconnected: { color: 'bg-gray-400', label: '未连接' },
+  connecting: { color: 'bg-yellow-400 animate-pulse', label: '连接中...' },
+  connected: { color: 'bg-green-500', label: '已连接' },
+  error: { color: 'bg-red-500', label: '连接错误' },
+} as const
+
+/** 通知模式选项 */
+const NOTIFY_MODE_OPTIONS = [
+  { value: 'auto', label: '智能' },
+  { value: 'always', label: '始终' },
+  { value: 'off', label: '关闭' },
+]
+
+/** 安全地用系统浏览器打开链接 */
+function openLink(url: string): void {
+  window.electronAPI.openExternal(url)
+}
+
+/** 可点击的外部链接组件 */
+function Link({ href, children }: { href: string; children: React.ReactNode }): React.ReactElement {
+  return (
+    <button
+      type="button"
+      className="inline-flex items-center gap-1 text-primary hover:underline cursor-pointer"
+      onClick={() => openLink(href)}
+    >
+      {children}
+      <ExternalLink className="size-3 flex-shrink-0" />
+    </button>
+  )
+}
+
+export function FeishuSettings(): React.ReactElement {
+  const bridgeState = useAtomValue(feishuBridgeStateAtom)
+  const workspaces = useAtomValue(agentWorkspacesAtom)
+
+  // 表单状态
+  const [appId, setAppId] = React.useState('')
+  const [appSecret, setAppSecret] = React.useState('')
+  const [defaultWorkspaceId, setDefaultWorkspaceId] = React.useState('')
+  const [defaultNotifyMode, setDefaultNotifyMode] = React.useState('auto')
+
+  // UI 状态
+  const [loading, setLoading] = React.useState(true)
+  const [saving, setSaving] = React.useState(false)
+  const [savingDefaults, setSavingDefaults] = React.useState(false)
+  const [testing, setTesting] = React.useState(false)
+  const [testResult, setTestResult] = React.useState<FeishuTestResult | null>(null)
+
+  // 加载配置
+  React.useEffect(() => {
+    window.electronAPI.getFeishuConfig().then((config) => {
+      setAppId(config.appId ?? '')
+      // appSecret 不回显（加密态），留空表示不修改
+      setDefaultWorkspaceId(config.defaultWorkspaceId ?? '')
+      setLoading(false)
+    }).catch(() => setLoading(false))
+  }, [])
+
+  // 工作区选项
+  const workspaceOptions = React.useMemo(
+    () => workspaces.map((w) => ({ value: w.id, label: w.name })),
+    [workspaces]
+  )
+
+  // 保存配置
+  const handleSave = React.useCallback(async () => {
+    if (!appId.trim()) return
+
+    setSaving(true)
+    try {
+      await window.electronAPI.saveFeishuConfig({
+        enabled: true,
+        appId: appId.trim(),
+        appSecret: appSecret || '', // 空字符串时主进程保留原值
+        defaultWorkspaceId: defaultWorkspaceId || undefined,
+      })
+    } finally {
+      setSaving(false)
+    }
+  }, [appId, appSecret, defaultWorkspaceId])
+
+  // 保存默认配置
+  const handleSaveDefaults = React.useCallback(async () => {
+    setSavingDefaults(true)
+    try {
+      await window.electronAPI.saveFeishuConfig({
+        enabled: true,
+        appId: appId.trim(),
+        appSecret: '', // 空字符串 → 主进程保留原值
+        defaultWorkspaceId: defaultWorkspaceId || undefined,
+      })
+    } finally {
+      setSavingDefaults(false)
+    }
+  }, [appId, defaultWorkspaceId])
+
+  // 测试连接
+  const handleTestConnection = React.useCallback(async () => {
+    if (!appId.trim() || !appSecret.trim()) {
+      setTestResult({ success: false, message: '请填写 App ID 和 App Secret' })
+      return
+    }
+
+    setTesting(true)
+    setTestResult(null)
+    try {
+      const result = await window.electronAPI.testFeishuConnection(appId.trim(), appSecret.trim())
+      setTestResult(result)
+    } catch (err) {
+      setTestResult({ success: false, message: `测试失败: ${err instanceof Error ? err.message : String(err)}` })
+    } finally {
+      setTesting(false)
+    }
+  }, [appId, appSecret])
+
+  // 启动/停止 Bridge
+  const handleToggleBridge = React.useCallback(async () => {
+    if (bridgeState.status === 'connected' || bridgeState.status === 'connecting') {
+      await window.electronAPI.stopFeishuBridge()
+    } else {
+      await window.electronAPI.startFeishuBridge()
+    }
+  }, [bridgeState.status])
+
+  const statusConfig = STATUS_CONFIG[bridgeState.status]
+  const isConnected = bridgeState.status === 'connected' || bridgeState.status === 'connecting'
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Loader2 size={24} className="animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-8">
+      {/* 连接状态 */}
+      <SettingsSection
+        title="飞书集成"
+        description="连接飞书机器人，在飞书中控制 Proma Agent"
+      >
+        <SettingsCard>
+          <SettingsRow
+            label="Bridge 状态"
+            description={bridgeState.errorMessage ?? undefined}
+          >
+            <div className="flex items-center gap-3">
+              <div className="flex items-center gap-2">
+                <span className={cn('w-2 h-2 rounded-full', statusConfig.color)} />
+                <span className="text-sm text-muted-foreground">{statusConfig.label}</span>
+              </div>
+              <Button
+                size="sm"
+                variant={isConnected ? 'destructive' : 'default'}
+                onClick={handleToggleBridge}
+                disabled={!appId}
+              >
+                {isConnected ? '停止' : '启动'}
+              </Button>
+            </div>
+          </SettingsRow>
+          {bridgeState.activeBindings > 0 && (
+            <SettingsRow label="活跃绑定" description="当前连接的飞书聊天数">
+              <span className="text-sm font-medium">{bridgeState.activeBindings}</span>
+            </SettingsRow>
+          )}
+        </SettingsCard>
+      </SettingsSection>
+
+      {/* Bot 配置 */}
+      <SettingsSection
+        title="Bot 配置"
+        description="从飞书开发者平台获取应用凭证"
+      >
+        <SettingsCard>
+          <SettingsInput
+            label="App ID"
+            value={appId}
+            onChange={setAppId}
+            placeholder="cli_xxxxxxxxxx"
+          />
+          <SettingsSecretInput
+            label="App Secret"
+            value={appSecret}
+            onChange={setAppSecret}
+            placeholder="输入新的 App Secret（留空保留原值）"
+          />
+        </SettingsCard>
+
+        <div className="flex items-center gap-3 mt-3">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={handleTestConnection}
+            disabled={testing || !appId.trim() || !appSecret.trim()}
+          >
+            {testing && <Loader2 size={14} className="animate-spin" />}
+            <span>{testing ? '测试中...' : '测试连接'}</span>
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleSave}
+            disabled={saving || !appId.trim()}
+          >
+            {saving && <Loader2 size={14} className="animate-spin" />}
+            <span>{saving ? '保存中...' : '保存配置'}</span>
+          </Button>
+        </div>
+
+        {testResult && (
+          <div className={cn(
+            'mt-3 p-3 rounded-lg flex items-start gap-2 text-sm',
+            testResult.success ? 'bg-green-500/10 text-green-700 dark:text-green-400' : 'bg-red-500/10 text-red-700 dark:text-red-400'
+          )}>
+            {testResult.success
+              ? <CheckCircle2 size={16} className="flex-shrink-0 mt-0.5" />
+              : <XCircle size={16} className="flex-shrink-0 mt-0.5" />
+            }
+            <span>{testResult.message}{testResult.botName && ` — ${testResult.botName}`}</span>
+          </div>
+        )}
+      </SettingsSection>
+
+      {/* 默认配置 */}
+      <SettingsSection
+        title="默认配置"
+        description="飞书发起新会话时使用的默认设置"
+      >
+        <SettingsCard>
+          <SettingsSegmentedControl
+            label="默认通知模式"
+            description="智能: 离开时才发飞书 | 始终: 总是发 | 关闭: 从不发"
+            value={defaultNotifyMode}
+            onValueChange={setDefaultNotifyMode}
+            options={NOTIFY_MODE_OPTIONS}
+          />
+          {workspaceOptions.length > 0 && (
+            <SettingsSelect
+              label="默认工作区"
+              value={defaultWorkspaceId}
+              onValueChange={setDefaultWorkspaceId}
+              options={workspaceOptions}
+              placeholder="选择工作区"
+            />
+          )}
+        </SettingsCard>
+
+        <div className="flex items-center mt-3">
+          <Button
+            size="sm"
+            onClick={handleSaveDefaults}
+            disabled={savingDefaults}
+          >
+            {savingDefaults && <Loader2 size={14} className="animate-spin" />}
+            <span>{savingDefaults ? '保存中...' : '保存默认配置'}</span>
+          </Button>
+        </div>
+      </SettingsSection>
+
+      {/* 创建飞书 Bot 引导 */}
+      <SettingsSection
+        title="创建飞书 Bot"
+        description="首次使用？按以下步骤在飞书开放平台创建机器人应用"
+      >
+        <SettingsCard divided={false}>
+          <div className="px-4 py-4 space-y-5 text-sm">
+            {/* 步骤 1 */}
+            <div className="space-y-1.5">
+              <div className="flex items-center gap-2">
+                <span className="flex-shrink-0 w-5 h-5 rounded-full bg-primary/10 text-primary text-xs font-semibold flex items-center justify-center">1</span>
+                <span className="font-medium text-foreground">创建自建应用</span>
+              </div>
+              <p className="pl-7 text-muted-foreground">
+                前往{' '}
+                <Link href="https://open.feishu.cn/app">飞书开放平台</Link>
+                {' '}（海外版：
+                <Link href="https://open.larksuite.com/app">Lark 开放平台</Link>
+                ），点击「创建自建应用」，填写应用名称和描述。
+              </p>
+            </div>
+
+            {/* 步骤 2 */}
+            <div className="space-y-1.5">
+              <div className="flex items-center gap-2">
+                <span className="flex-shrink-0 w-5 h-5 rounded-full bg-primary/10 text-primary text-xs font-semibold flex items-center justify-center">2</span>
+                <span className="font-medium text-foreground">获取凭证</span>
+              </div>
+              <p className="pl-7 text-muted-foreground">
+                进入应用详情页，在「凭证与基础信息」中找到{' '}
+                <span className="text-foreground font-medium">App ID</span> 和{' '}
+                <span className="text-foreground font-medium">App Secret</span>，
+                复制到上方的配置表单中。
+              </p>
+            </div>
+
+            {/* 步骤 3 */}
+            <div className="space-y-1.5">
+              <div className="flex items-center gap-2">
+                <span className="flex-shrink-0 w-5 h-5 rounded-full bg-primary/10 text-primary text-xs font-semibold flex items-center justify-center">3</span>
+                <span className="font-medium text-foreground">启用机器人能力</span>
+              </div>
+              <p className="pl-7 text-muted-foreground">
+                进入「添加应用能力」页面，启用「机器人」能力。
+                这样应用才能接收和发送飞书消息。
+              </p>
+            </div>
+
+            {/* 步骤 4 */}
+            <div className="space-y-1.5">
+              <div className="flex items-center gap-2">
+                <span className="flex-shrink-0 w-5 h-5 rounded-full bg-primary/10 text-primary text-xs font-semibold flex items-center justify-center">4</span>
+                <span className="font-medium text-foreground">配置权限</span>
+              </div>
+              <div className="pl-7 space-y-1.5 text-muted-foreground">
+                <p>
+                  进入「权限管理」页面
+                  ，逐个复制搜索，添加以下权限（也可通过批量开通接口一键添加）：
+                </p>
+                <div className="bg-muted/50 rounded-md p-3 font-mono text-xs space-y-0.5">
+                  <div><span className="text-foreground/70">im:message</span> — 获取与发送单聊、群组消息</div>
+                  <div><span className="text-foreground/70">im:message:send_as_bot</span> — 以机器人身份发送消息</div>
+                  <div><span className="text-foreground/70">im:chat:readonly</span> — 获取群组信息</div>
+                  <div><span className="text-foreground/70">im:resource</span> — 获取消息中的资源文件</div>
+                </div>
+              </div>
+            </div>
+
+            {/* 步骤 5 */}
+            <div className="space-y-1.5">
+              <div className="flex items-center gap-2">
+                <span className="flex-shrink-0 w-5 h-5 rounded-full bg-primary/10 text-primary text-xs font-semibold flex items-center justify-center">5</span>
+                <span className="font-medium text-foreground">配置事件订阅（关键步骤）</span>
+              </div>
+              <div className="pl-7 space-y-1.5 text-muted-foreground">
+                <p>
+                  进入「事件与回调」页面：
+                </p>
+                <ol className="list-decimal pl-4 space-y-1">
+                  <li>
+                    事件订阅方式选择{' '}
+                    <span className="text-foreground font-medium">「使用长连接接收事件」</span>
+                    （而非 Webhook，无需公网 IP）
+                  </li>
+                  <li>
+                    添加事件{' '}
+                    <code className="bg-muted/50 px-1.5 py-0.5 rounded text-xs text-foreground/80">im.message.receive_v1</code>
+                    {' '}（接收消息）
+                  </li>
+                </ol>
+              </div>
+            </div>
+
+            {/* 步骤 6 */}
+            <div className="space-y-1.5">
+              <div className="flex items-center gap-2">
+                <span className="flex-shrink-0 w-5 h-5 rounded-full bg-primary/10 text-primary text-xs font-semibold flex items-center justify-center">6</span>
+                <span className="font-medium text-foreground">发布应用</span>
+              </div>
+              <p className="pl-7 text-muted-foreground">
+                进入「版本管理与发布」→ 创建版本 → 提交审核。
+                需要企业管理员在{' '}
+                <Link href="https://feishu.cn/admin">管理后台</Link>
+                {' '}审核通过后，机器人才能正常使用。
+              </p>
+            </div>
+
+            {/* 提示 */}
+            <div className="pl-7 p-3 rounded-lg bg-amber-500/10 text-amber-700 dark:text-amber-400 text-xs">
+              版本审核通过并发布后，在飞书中搜索机器人名称添加到聊天，
+              即可通过飞书向 Proma Agent 发送指令。
+            </div>
+          </div>
+        </SettingsCard>
+      </SettingsSection>
+
+      {/* 飞书命令使用说明 */}
+      <SettingsSection
+        title="飞书命令"
+        description="在飞书中向 Bot 发送以下命令"
+      >
+        <SettingsCard divided={false}>
+          <div className="px-4 py-3 space-y-2 text-sm text-muted-foreground">
+            <div className="grid grid-cols-[100px_1fr] gap-y-1.5 gap-x-4">
+              <code className="text-foreground/80 font-mono">/help</code>
+              <span>显示帮助</span>
+              <code className="text-foreground/80 font-mono">/new</code>
+              <span>创建新 Agent 会话</span>
+              {/* <code className="text-foreground/80 font-mono">/chat</code>
+              <span>切换到 Chat 模式</span> */}
+              <code className="text-foreground/80 font-mono">/agent</code>
+              <span>切换到 Agent 模式</span>
+              <code className="text-foreground/80 font-mono">/list</code>
+              <span>列出所有会话</span>
+              <code className="text-foreground/80 font-mono">/stop</code>
+              <span>停止当前 Agent</span>
+              <code className="text-foreground/80 font-mono">/switch</code>
+              <span>切换到已有会话（序号）</span>
+              <code className="text-foreground/80 font-mono">/workspace</code>
+              <span>设置默认工作区</span>
+            </div>
+            <p className="pt-2 text-xs">
+              直接发送文本会自动创建新会话或发送到当前绑定的会话。
+            </p>
+          </div>
+        </SettingsCard>
+      </SettingsSection>
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
+++ b/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
@@ -9,7 +9,7 @@
 import * as React from 'react'
 import { useAtom, useAtomValue } from 'jotai'
 import { cn } from '@/lib/utils'
-import { Settings, Radio, Palette, Info, Plug, Globe, BookOpen, Wrench } from 'lucide-react'
+import { Settings, Radio, Palette, Info, Plug, Globe, BookOpen, Wrench, MessageSquare } from 'lucide-react'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { settingsTabAtom } from '@/atoms/settings-tab'
 import type { SettingsTab } from '@/atoms/settings-tab'
@@ -24,6 +24,7 @@ import { AboutSettings } from './AboutSettings'
 import { AgentSettings } from './AgentSettings'
 import { PromptSettings } from './PromptSettings'
 import { ToolSettings } from './ToolSettings'
+import { FeishuSettings } from './FeishuSettings'
 
 /** 设置 Tab 定义 */
 interface TabItem {
@@ -43,6 +44,7 @@ const BASE_TABS: TabItem[] = [
 /** Agent 模式专属 Tab */
 const AGENT_TAB: TabItem = { id: 'agent', label: '配置', icon: <Plug size={16} /> }
 const TOOLS_TAB: TabItem = { id: 'tools', label: '工具', icon: <Wrench size={16} /> }
+const FEISHU_TAB: TabItem = { id: 'feishu', label: '飞书', icon: <MessageSquare size={16} /> }
 
 /** 尾部 Tabs */
 const TAIL_TABS: TabItem[] = [
@@ -69,6 +71,8 @@ function renderTabContent(tab: SettingsTab): React.ReactElement {
       return <AppearanceSettings />
     case 'about':
       return <AboutSettings />
+    case 'feishu':
+      return <FeishuSettings />
   }
 }
 
@@ -81,9 +85,9 @@ export function SettingsPanel(): React.ReactElement {
   // Agent 模式时在渠道后插入 Agent Tab，工具 tab 两种模式都显示
   const tabs = React.useMemo(() => {
     if (appMode === 'agent') {
-      return [...BASE_TABS, AGENT_TAB, TOOLS_TAB, ...TAIL_TABS]
+      return [...BASE_TABS, AGENT_TAB, TOOLS_TAB, FEISHU_TAB, ...TAIL_TABS]
     }
-    return [...BASE_TABS, TOOLS_TAB, ...TAIL_TABS]
+    return [...BASE_TABS, TOOLS_TAB, FEISHU_TAB, ...TAIL_TABS]
   }, [appMode])
 
   return (

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -20,6 +20,7 @@ import {
   agentModelIdAtom,
   agentWorkspacesAtom,
   currentAgentWorkspaceIdAtom,
+  currentAgentSessionIdAtom,
   workspaceCapabilitiesVersionAtom,
   workspaceFilesVersionAtom,
   agentPermissionModeAtom,
@@ -38,6 +39,9 @@ import { useGlobalChatListeners } from './hooks/useGlobalChatListeners'
 import { tabsAtom, splitLayoutAtom } from './atoms/tab-atoms'
 import type { TabItem, SplitLayoutState } from './atoms/tab-atoms'
 import { chatToolsAtom } from './atoms/chat-tool-atoms'
+import { feishuBridgeStateAtom } from './atoms/feishu-atoms'
+import { currentConversationIdAtom } from './atoms/chat-atoms'
+import type { FeishuBridgeState, FeishuNotificationSentPayload } from '@proma/shared'
 import { Toaster } from './components/ui/sonner'
 import { toast } from 'sonner'
 import { diffCapabilities } from '@proma/shared'
@@ -289,6 +293,65 @@ function ChatToolInitializer(): null {
   return null
 }
 
+/**
+ * 飞书集成初始化组件
+ *
+ * - 订阅飞书 Bridge 状态变化
+ * - 定期上报用户在场状态（用于智能通知路由）
+ * - 监听通知已发送事件（显示 Sonner + 桌面通知）
+ */
+function FeishuInitializer(): null {
+  const store = useStore()
+
+  useEffect(() => {
+    // 加载初始状态
+    window.electronAPI.getFeishuStatus()
+      .then((state: FeishuBridgeState) => store.set(feishuBridgeStateAtom, state))
+      .catch((err: unknown) => console.error('[FeishuInitializer] 加载状态失败:', err))
+
+    // 订阅状态变化
+    const cleanupStatus = window.electronAPI.onFeishuStatusChanged((state: FeishuBridgeState) => {
+      store.set(feishuBridgeStateAtom, state)
+    })
+
+    // 订阅通知已发送事件 → Sonner + 桌面通知
+    const cleanupNotif = window.electronAPI.onFeishuNotificationSent((payload: FeishuNotificationSentPayload) => {
+      toast('已发送到飞书', {
+        description: `${payload.sessionTitle}: ${payload.preview.slice(0, 60)}`,
+        duration: 3000,
+      })
+      // 桌面通知
+      if (Notification.permission === 'granted') {
+        new Notification('Proma → 飞书', {
+          body: `${payload.sessionTitle} 的回复已发送到飞书`,
+        })
+      }
+    })
+
+    // 定期上报在场状态（5 秒间隔 + 焦点变化时即时上报）
+    const reportPresence = (): void => {
+      const activeSessionId = store.get(currentAgentSessionIdAtom) ?? store.get(currentConversationIdAtom)
+      window.electronAPI.reportFeishuPresence({
+        activeSessionId,
+        lastInteractionAt: Date.now(),
+      }).catch(() => { /* 忽略 */ })
+    }
+    const interval = setInterval(reportPresence, 5000)
+    window.addEventListener('focus', reportPresence)
+    window.addEventListener('blur', reportPresence)
+
+    return () => {
+      cleanupStatus()
+      cleanupNotif()
+      clearInterval(interval)
+      window.removeEventListener('focus', reportPresence)
+      window.removeEventListener('blur', reportPresence)
+    }
+  }, [store])
+
+  return null
+}
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ThemeInitializer />
@@ -298,6 +361,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     <AgentListenersInitializer />
     <ChatToolInitializer />
     <UpdaterInitializer />
+    <FeishuInitializer />
     <App />
     <UpdateDialog />
     <Toaster position="top-right" />

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "proma",
@@ -25,6 +24,7 @@
         "@anthropic-ai/claude-agent-sdk": "0.2.66",
         "@emoji-mart/data": "^1.2.1",
         "@emoji-mart/react": "^1.1.1",
+        "@larksuiteoapi/node-sdk": "^1.59.0",
         "@proma/core": "workspace:*",
         "@proma/shared": "workspace:*",
         "@proma/ui": "workspace:*",
@@ -321,6 +321,8 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@larksuiteoapi/node-sdk": ["@larksuiteoapi/node-sdk@1.59.0", "", { "dependencies": { "axios": "~1.13.3", "lodash.identity": "^3.0.0", "lodash.merge": "^4.6.2", "lodash.pickby": "^4.6.0", "protobufjs": "^7.2.6", "qs": "^6.14.2", "ws": "^8.19.0" } }, "sha512-sBpkruTvZDOxnVtoTbepWKRX0j1Y1ZElQYu0x7+v088sI9pcpbVp6ZzCGn62dhrKPatzNyCJyzYCPXPYQWccrA=="],
+
     "@malept/cross-spawn-promise": ["@malept/cross-spawn-promise@2.0.0", "", { "dependencies": { "cross-spawn": "^7.0.1" } }, "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg=="],
 
     "@malept/flatpak-bundler": ["@malept/flatpak-bundler@0.4.0", "", { "dependencies": { "debug": "^4.1.1", "fs-extra": "^9.0.0", "lodash": "^4.17.15", "tmp-promise": "^3.0.2" } }, "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q=="],
@@ -346,6 +348,26 @@
     "@proma/shared": ["@proma/shared@workspace:packages/shared"],
 
     "@proma/ui": ["@proma/ui@workspace:packages/ui"],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.4", "", {}, "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.0", "", {}, "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.0", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1", "@protobufjs/inquire": "^1.1.0" } }, "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.0", "", {}, "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
@@ -705,6 +727,8 @@
 
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
 
+    "axios": ["axios@1.13.6", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^1.1.0" } }, "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ=="],
+
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
@@ -1019,6 +1043,8 @@
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
+    "follow-redirects": ["follow-redirects@1.15.11", "", {}, "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="],
+
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
@@ -1253,13 +1279,21 @@
 
     "lodash.flatten": ["lodash.flatten@4.4.0", "", {}, "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g=="],
 
+    "lodash.identity": ["lodash.identity@3.0.0", "", {}, "sha512-AupTIzdLQxJS5wIYUQlgGyk2XRTfGXA+MCghDHqZk0pzUNYvd3EESS6dkChNauNYVIutcb0dfHw1ri9Q1yPV8Q=="],
+
     "lodash.isequal": ["lodash.isequal@4.5.0", "", {}, "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="],
 
     "lodash.isplainobject": ["lodash.isplainobject@4.0.6", "", {}, "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="],
 
+    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
+
+    "lodash.pickby": ["lodash.pickby@4.6.0", "", {}, "sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q=="],
+
     "lodash.union": ["lodash.union@4.6.0", "", {}, "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw=="],
 
     "log-symbols": ["log-symbols@4.1.0", "", { "dependencies": { "chalk": "^4.1.0", "is-unicode-supported": "^0.1.0" } }, "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg=="],
+
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
@@ -1579,7 +1613,11 @@
 
     "prosemirror-view": ["prosemirror-view@1.41.5", "", { "dependencies": { "prosemirror-model": "^1.20.0", "prosemirror-state": "^1.0.0", "prosemirror-transform": "^1.1.0" } }, "sha512-UDQbIPnDrjE8tqUBbPmCOZgtd75htE6W3r0JCmY9bL6W1iemDM37MZEKC49d+tdQ0v/CKx4gjxLoLsfkD2NiZA=="],
 
+    "protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
+
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "pump": ["pump@3.0.3", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA=="],
 
@@ -1587,7 +1625,7 @@
 
     "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
 
-    "qs": ["qs@6.14.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ=="],
+    "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
@@ -1925,6 +1963,8 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
+    "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+
     "xmlbuilder": ["xmlbuilder@15.1.1", "", {}, "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="],
 
     "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
@@ -2057,6 +2097,8 @@
 
     "body-parser/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "body-parser/qs": ["qs@6.14.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ=="],
+
     "builder-util/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "builder-util-runtime/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
@@ -2110,6 +2152,8 @@
     "encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "express/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "express/qs": ["qs@6.14.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ=="],
 
     "extract-zip/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -2182,6 +2226,8 @@
     "path-scurry/minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
     "postcss-nested/postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="],
+
+    "protobufjs/@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
 
     "read-binary-file-arch/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -2296,6 +2342,8 @@
     "make-fetch-happen/https-proxy-agent/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "node-gyp/glob/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
+    "protobufjs/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "tailwindcss/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 

--- a/packages/shared/src/types/feishu.ts
+++ b/packages/shared/src/types/feishu.ts
@@ -1,0 +1,126 @@
+/**
+ * 飞书集成相关类型定义
+ *
+ * 包含飞书 Bot 配置、Bridge 连接状态、聊天绑定、
+ * 通知模式、IPC 通道常量。
+ */
+
+// ===== 飞书 Bot 配置 =====
+
+/** 飞书 Bot 应用配置（持久化到 ~/.proma/feishu.json） */
+export interface FeishuConfig {
+  /** 是否启用飞书集成 */
+  enabled: boolean
+  /** 飞书应用 App ID */
+  appId: string
+  /** 飞书应用 App Secret（safeStorage 加密后的 base64 字符串） */
+  appSecret: string
+  /** 默认绑定的工作区 ID */
+  defaultWorkspaceId?: string
+}
+
+/** 飞书配置保存输入（App Secret 为明文，主进程负责加密） */
+export interface FeishuConfigInput {
+  enabled: boolean
+  appId: string
+  /** 明文 App Secret */
+  appSecret: string
+  defaultWorkspaceId?: string
+}
+
+// ===== Bridge 连接状态 =====
+
+/** 飞书 Bridge 连接状态 */
+export type FeishuBridgeStatus = 'disconnected' | 'connecting' | 'connected' | 'error'
+
+/** 飞书 Bridge 状态详情 */
+export interface FeishuBridgeState {
+  status: FeishuBridgeStatus
+  /** 上次连接成功时间 */
+  connectedAt?: number
+  /** 错误信息 */
+  errorMessage?: string
+  /** 当前活跃的聊天绑定数量 */
+  activeBindings: number
+}
+
+// ===== 聊天绑定 =====
+
+/** 飞书聊天 → Proma 会话绑定（内存态，不持久化） */
+export interface FeishuChatBinding {
+  /** 飞书 chat_id（单聊或群聊） */
+  chatId: string
+  /** 飞书用户 open_id */
+  userId: string
+  /** 绑定的 Proma 会话 ID */
+  sessionId: string
+  /** 绑定的工作区 ID */
+  workspaceId: string
+  /** 渠道 ID */
+  channelId: string
+  /** 模型 ID */
+  modelId?: string
+  /** 会话模式 */
+  mode: 'agent' | 'chat'
+  /** 创建时间 */
+  createdAt: number
+}
+
+// ===== 通知模式 =====
+
+/** 飞书通知模式（per-session） */
+export type FeishuNotifyMode = 'auto' | 'always' | 'off'
+
+// ===== 连接测试 =====
+
+/** 飞书连接测试结果 */
+export interface FeishuTestResult {
+  success: boolean
+  message: string
+  /** Bot 名称（测试成功时返回） */
+  botName?: string
+}
+
+// ===== 在场状态上报 =====
+
+/** 渲染进程上报的用户在场状态 */
+export interface FeishuPresenceReport {
+  /** 当前正在查看的会话 ID */
+  activeSessionId: string | null
+  /** 最后交互时间戳 */
+  lastInteractionAt: number
+}
+
+/** 飞书通知已发送的事件载荷 */
+export interface FeishuNotificationSentPayload {
+  sessionId: string
+  sessionTitle: string
+  preview: string
+}
+
+// ===== IPC 通道常量 =====
+
+export const FEISHU_IPC_CHANNELS = {
+  /** 获取飞书配置 */
+  GET_CONFIG: 'feishu:get-config',
+  /** 保存飞书配置 */
+  SAVE_CONFIG: 'feishu:save-config',
+  /** 测试飞书连接 */
+  TEST_CONNECTION: 'feishu:test-connection',
+  /** 启动 Bridge */
+  START_BRIDGE: 'feishu:start-bridge',
+  /** 停止 Bridge */
+  STOP_BRIDGE: 'feishu:stop-bridge',
+  /** 获取 Bridge 状态 */
+  GET_STATUS: 'feishu:get-status',
+  /** Bridge 状态变化（主进程 → 渲染进程推送） */
+  STATUS_CHANGED: 'feishu:status-changed',
+  /** 获取活跃绑定列表 */
+  LIST_BINDINGS: 'feishu:list-bindings',
+  /** 渲染进程 → 主进程：上报用户在场状态 */
+  REPORT_PRESENCE: 'feishu:report-presence',
+  /** 渲染进程 → 主进程：设置某会话的通知模式 */
+  SET_SESSION_NOTIFY: 'feishu:set-session-notify',
+  /** 主进程 → 渲染进程：飞书通知已发送 */
+  NOTIFICATION_SENT: 'feishu:notification-sent',
+} as const

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -38,3 +38,6 @@ export * from './system-prompt'
 
 // Chat 工具（function calling）相关类型
 export * from './chat-tool'
+
+// 飞书集成相关类型
+export * from './feishu'


### PR DESCRIPTION
## Summary

- 新增飞书（Lark）机器人集成，通过飞书 IM 直接控制 Proma Agent
- 支持 WebSocket 长连接方式接收飞书消息，无需公网 IP
- 实现智能通知路由：用户离开桌面端时自动将 Agent 完成结果推送到飞书

## 功能详情

### 飞书 Bridge 核心
- `feishu-bridge.ts`：WebSocket 连接管理、消息路由、命令解析、Agent/Chat 集成
- `feishu-message.ts`：Agent 事件 → 飞书交互卡片格式化（支持工具摘要、长消息分割）
- `feishu-config.ts`：配置 CRUD，App Secret 使用 Electron safeStorage 加密存储
- `feishu-presence.ts`：用户在场检测服务（窗口焦点 + 系统空闲 + 会话切换）

### 飞书命令
- `/help` — 显示帮助
- `/new [标题]` — 创建新 Agent 会话
- `/agent` / `/chat` — 切换模式
- `/list` — 按工作区分组列出会话（带序号）
- `/switch <序号>` — 切换到已有会话
- `/workspace [序号/名称]` — 查看/切换工作区
- `/stop` — 停止当前 Agent
- 直接发送文本自动创建或转发到当前会话

### 智能通知
- 三种模式：智能（离开时发送）/ 始终 / 关闭
- 输入框旁飞书通知开关按钮（仅 Bridge 连接时显示）
- 通知发出后显示 Sonner toast + 桌面通知双重反馈

### Settings UI
- 完整的飞书设置页：连接状态、Bot 配置、测试连接、默认配置
- 创建飞书 Bot 的分步引导流程
- 飞书命令使用说明

## 新增文件
- `packages/shared/src/types/feishu.ts` — 类型定义 + IPC 通道常量
- `apps/electron/src/main/lib/feishu-bridge.ts` — Bridge 核心
- `apps/electron/src/main/lib/feishu-config.ts` — 配置管理
- `apps/electron/src/main/lib/feishu-message.ts` — 消息格式化
- `apps/electron/src/main/lib/feishu-presence.ts` — 在场检测
- `apps/electron/src/renderer/components/settings/FeishuSettings.tsx` — 设置页
- `apps/electron/src/renderer/components/chat/FeishuNotifyToggle.tsx` — 通知开关
- `apps/electron/src/renderer/atoms/feishu-atoms.ts` — Jotai 状态

## Test plan
- [ ] Settings → 飞书 Tab → 输入 App ID/Secret → 测试连接成功
- [ ] 启用后状态指示器变为绿色「已连接」
- [ ] 飞书发送消息 → Proma 创建会话 → Agent 执行 → 飞书收到回复卡片
- [ ] `/list`、`/switch`、`/workspace`、`/stop`、`/help` 命令正常工作
- [ ] 智能通知：离开桌面端 → Agent 完成 → 飞书收到通知
- [ ] 在场不通知：盯着 Proma → Agent 完成 → 不发飞书
- [ ] 手动开关 always 模式 → 无论在不在场都发飞书
- [ ] 斜杠命令不会误触发新 Agent 会话