### PR TITLE
fix: 飞书默认工作区设置不生效及 UI 优化

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -151,7 +151,7 @@ import {
   getReleaseByTag,
 } from './lib/github-release-service'
 import { watchAttachedDirectory, unwatchAttachedDirectory } from './lib/workspace-watcher'
-import { getFeishuConfig, saveFeishuConfig } from './lib/feishu-config'
+import { getFeishuConfig, saveFeishuConfig, getDecryptedAppSecret } from './lib/feishu-config'
 import { feishuBridge } from './lib/feishu-bridge'
 import { presenceService } from './lib/feishu-presence'
 
@@ -1453,6 +1453,14 @@ export function registerIpcHandlers(): void {
     FEISHU_IPC_CHANNELS.GET_CONFIG,
     async (): Promise<FeishuConfig> => {
       return getFeishuConfig()
+    }
+  )
+
+  // 获取解密后的 App Secret
+  ipcMain.handle(
+    FEISHU_IPC_CHANNELS.GET_DECRYPTED_SECRET,
+    async (): Promise<string> => {
+      return getDecryptedAppSecret()
     }
   )
 

--- a/apps/electron/src/main/lib/feishu-bridge.ts
+++ b/apps/electron/src/main/lib/feishu-bridge.ts
@@ -86,8 +86,7 @@ class FeishuBridge {
   async start(): Promise<void> {
     const config = getFeishuConfig()
     if (!config.enabled || !config.appId || !config.appSecret) {
-      console.log('[飞书 Bridge] 未配置或未启用，跳过启动')
-      return
+      throw new Error('请先配置 App ID 和 App Secret')
     }
 
     this.updateStatus({ status: 'connecting' })

--- a/apps/electron/src/main/lib/feishu-config.ts
+++ b/apps/electron/src/main/lib/feishu-config.ts
@@ -93,11 +93,13 @@ export function getFeishuConfig(): FeishuConfig {
  */
 export function saveFeishuConfig(input: FeishuConfigInput): FeishuConfig {
   const configPath = getFeishuConfigPath()
+  const current = getFeishuConfig()
 
   const config: FeishuConfig = {
     enabled: input.enabled,
     appId: input.appId.trim(),
-    appSecret: input.appSecret ? encryptSecret(input.appSecret) : '',
+    // 空字符串时保留原值（UI 端留空表示不修改）
+    appSecret: input.appSecret ? encryptSecret(input.appSecret) : current.appSecret,
     defaultWorkspaceId: input.defaultWorkspaceId,
   }
 

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -512,6 +512,8 @@ export interface ElectronAPI {
 
   /** 获取飞书配置 */
   getFeishuConfig: () => Promise<FeishuConfig>
+  /** 获取解密后的 App Secret */
+  getDecryptedFeishuSecret: () => Promise<string>
   /** 保存飞书配置（appSecret 为明文） */
   saveFeishuConfig: (input: FeishuConfigInput) => Promise<FeishuConfig>
   /** 测试飞书连接 */
@@ -1089,6 +1091,10 @@ const electronAPI: ElectronAPI = {
 
   getFeishuConfig: () => {
     return ipcRenderer.invoke(FEISHU_IPC_CHANNELS.GET_CONFIG)
+  },
+
+  getDecryptedFeishuSecret: () => {
+    return ipcRenderer.invoke(FEISHU_IPC_CHANNELS.GET_DECRYPTED_SECRET)
   },
 
   saveFeishuConfig: (input: FeishuConfigInput) => {

--- a/apps/electron/src/renderer/components/settings/FeishuSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/FeishuSettings.tsx
@@ -7,6 +7,7 @@
 
 import * as React from 'react'
 import { useAtomValue } from 'jotai'
+import { toast } from 'sonner'
 import { Loader2, CheckCircle2, XCircle, ExternalLink } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { SettingsSection } from './primitives/SettingsSection'
@@ -67,16 +68,17 @@ export function FeishuSettings(): React.ReactElement {
 
   // UI 状态
   const [loading, setLoading] = React.useState(true)
-  const [saving, setSaving] = React.useState(false)
-  const [savingDefaults, setSavingDefaults] = React.useState(false)
   const [testing, setTesting] = React.useState(false)
   const [testResult, setTestResult] = React.useState<FeishuTestResult | null>(null)
 
   // 加载配置
   React.useEffect(() => {
-    window.electronAPI.getFeishuConfig().then((config) => {
+    Promise.all([
+      window.electronAPI.getFeishuConfig(),
+      window.electronAPI.getDecryptedFeishuSecret().catch(() => ''),
+    ]).then(([config, secret]) => {
       setAppId(config.appId ?? '')
-      // appSecret 不回显（加密态），留空表示不修改
+      if (secret) setAppSecret(secret)
       setDefaultWorkspaceId(config.defaultWorkspaceId ?? '')
       setLoading(false)
     }).catch(() => setLoading(false))
@@ -88,11 +90,10 @@ export function FeishuSettings(): React.ReactElement {
     [workspaces]
   )
 
-  // 保存配置
+  // 保存配置（乐观更新）
   const handleSave = React.useCallback(async () => {
     if (!appId.trim()) return
 
-    setSaving(true)
     try {
       await window.electronAPI.saveFeishuConfig({
         enabled: true,
@@ -100,14 +101,14 @@ export function FeishuSettings(): React.ReactElement {
         appSecret: appSecret || '', // 空字符串时主进程保留原值
         defaultWorkspaceId: defaultWorkspaceId || undefined,
       })
-    } finally {
-      setSaving(false)
+      toast.success('飞书配置已保存')
+    } catch {
+      toast.error('保存飞书配置失败')
     }
   }, [appId, appSecret, defaultWorkspaceId])
 
-  // 保存默认配置
+  // 保存默认配置（乐观更新）
   const handleSaveDefaults = React.useCallback(async () => {
-    setSavingDefaults(true)
     try {
       await window.electronAPI.saveFeishuConfig({
         enabled: true,
@@ -115,8 +116,9 @@ export function FeishuSettings(): React.ReactElement {
         appSecret: '', // 空字符串 → 主进程保留原值
         defaultWorkspaceId: defaultWorkspaceId || undefined,
       })
-    } finally {
-      setSavingDefaults(false)
+      toast.success('默认配置已保存')
+    } catch {
+      toast.error('保存默认配置失败')
     }
   }, [appId, defaultWorkspaceId])
 
@@ -143,8 +145,14 @@ export function FeishuSettings(): React.ReactElement {
   const handleToggleBridge = React.useCallback(async () => {
     if (bridgeState.status === 'connected' || bridgeState.status === 'connecting') {
       await window.electronAPI.stopFeishuBridge()
+      toast.success('飞书 Bridge 已停止')
     } else {
-      await window.electronAPI.startFeishuBridge()
+      try {
+        await window.electronAPI.startFeishuBridge()
+        toast.success('飞书 Bridge 启动中...')
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : '启动飞书 Bridge 失败')
+      }
     }
   }, [bridgeState.status])
 
@@ -210,7 +218,7 @@ export function FeishuSettings(): React.ReactElement {
             label="App Secret"
             value={appSecret}
             onChange={setAppSecret}
-            placeholder="输入新的 App Secret（留空保留原值）"
+            placeholder="输入 App Secret"
           />
         </SettingsCard>
 
@@ -227,10 +235,9 @@ export function FeishuSettings(): React.ReactElement {
           <Button
             size="sm"
             onClick={handleSave}
-            disabled={saving || !appId.trim()}
+            disabled={!appId.trim()}
           >
-            {saving && <Loader2 size={14} className="animate-spin" />}
-            <span>{saving ? '保存中...' : '保存配置'}</span>
+            保存配置
           </Button>
         </div>
 
@@ -263,7 +270,7 @@ export function FeishuSettings(): React.ReactElement {
           />
           {workspaceOptions.length > 0 && (
             <SettingsSelect
-              label="默认工作区"
+              label="默认工作区（可在飞书内通过 /workspaces 选择）"
               value={defaultWorkspaceId}
               onValueChange={setDefaultWorkspaceId}
               options={workspaceOptions}
@@ -276,10 +283,8 @@ export function FeishuSettings(): React.ReactElement {
           <Button
             size="sm"
             onClick={handleSaveDefaults}
-            disabled={savingDefaults}
           >
-            {savingDefaults && <Loader2 size={14} className="animate-spin" />}
-            <span>{savingDefaults ? '保存中...' : '保存默认配置'}</span>
+            保存默认配置
           </Button>
         </div>
       </SettingsSection>

--- a/packages/shared/src/types/feishu.ts
+++ b/packages/shared/src/types/feishu.ts
@@ -105,6 +105,8 @@ export const FEISHU_IPC_CHANNELS = {
   GET_CONFIG: 'feishu:get-config',
   /** 保存飞书配置 */
   SAVE_CONFIG: 'feishu:save-config',
+  /** 获取解密后的 App Secret */
+  GET_DECRYPTED_SECRET: 'feishu:get-decrypted-secret',
   /** 测试飞书连接 */
   TEST_CONNECTION: 'feishu:test-connection',
   /** 启动 Bridge */


### PR DESCRIPTION
## 问题修复

修复飞书集成三个关键问题：

1. **App Secret 保存 Bug**：保存默认工作区配置时，主进程误删现有加密密钥，导致 Bridge 无法启动
2. **启动失败无提示**：点击启动 Bridge 按钮失败时无任何反馈，用户无法诊断问题
3. **App Secret 无法查看**：已保存的密钥无法回显或查看

## 核心改动

- `feishuConfig.saveFeishuConfig()`：空字符串时保留现有加密密钥
- `FeishuBridge.start()`：配置缺失时抛出明确错误信息
- 新增 `GET_DECRYPTED_SECRET` IPC 通道供渲染进程读取解密后的密钥
- UI 改为乐观更新，成功/失败时通过 Sonner toast 提示