### PR TITLE
feat: 添加教程系统

### DIFF
--- a/apps/electron/electron-builder.yml
+++ b/apps/electron/electron-builder.yml
@@ -38,6 +38,9 @@ extraResources:
     to: default-skills
     filter:
       - "**/*"
+  # 教程文件（教程查看器 + 欢迎对话使用）
+  - from: ../../tutorial/tutorial-1.md
+    to: tutorial-1.md
 
 # ============================================
 # macOS 配置

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -98,6 +98,7 @@ import {
   openFileDialog,
 } from './lib/attachment-service'
 import { extractTextFromAttachment } from './lib/document-parser'
+import { getTutorialContent, createWelcomeConversation } from './lib/tutorial-service'
 import { getUserProfile, updateUserProfile } from './lib/user-profile-service'
 import { getSettings, updateSettings } from './lib/settings-service'
 import { checkEnvironment } from './lib/environment-checker'
@@ -339,6 +340,22 @@ export function registerIpcHandlers(): void {
       const current = conversations.find((c) => c.id === id)
       if (!current) throw new Error(`对话不存在: ${id}`)
       return updateConversationMeta(id, { pinned: !current.pinned })
+    }
+  )
+
+  // 获取教程内容
+  ipcMain.handle(
+    CHAT_IPC_CHANNELS.GET_TUTORIAL_CONTENT,
+    async (): Promise<string | null> => {
+      return getTutorialContent()
+    }
+  )
+
+  // 创建欢迎对话（含教程附件）
+  ipcMain.handle(
+    CHAT_IPC_CHANNELS.CREATE_WELCOME_CONVERSATION,
+    async (): Promise<ConversationMeta | null> => {
+      return createWelcomeConversation()
     }
   )
 

--- a/apps/electron/src/main/lib/settings-service.ts
+++ b/apps/electron/src/main/lib/settings-service.ts
@@ -31,20 +31,11 @@ export function getSettings(): AppSettings {
     const raw = readFileSync(filePath, 'utf-8')
     const data = JSON.parse(raw) as Partial<AppSettings>
     return {
+      ...data,
       themeMode: data.themeMode || DEFAULT_THEME_MODE,
-      agentChannelId: data.agentChannelId,
-      agentModelId: data.agentModelId,
-      agentWorkspaceId: data.agentWorkspaceId,
       onboardingCompleted: data.onboardingCompleted ?? false,
       environmentCheckSkipped: data.environmentCheckSkipped ?? false,
-      lastEnvironmentCheck: data.lastEnvironmentCheck,
       notificationsEnabled: data.notificationsEnabled ?? true,
-      tabState: data.tabState,
-      agentPermissionMode: data.agentPermissionMode,
-      agentThinking: data.agentThinking,
-      agentEffort: data.agentEffort,
-      agentMaxBudgetUsd: data.agentMaxBudgetUsd,
-      agentMaxTurns: data.agentMaxTurns,
     }
   } catch (error) {
     console.error('[设置] 读取失败:', error)

--- a/apps/electron/src/main/lib/tutorial-service.ts
+++ b/apps/electron/src/main/lib/tutorial-service.ts
@@ -1,0 +1,126 @@
+/**
+ * 教程服务
+ *
+ * 负责读取教程内容和创建欢迎对话。
+ */
+
+import { readFileSync, existsSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+import { app } from 'electron'
+import { createConversation, appendMessage } from './conversation-manager'
+import { getConversationAttachmentsDir } from './config-paths'
+import type { ConversationMeta, FileAttachment, ChatMessage } from '@proma/shared'
+
+/**
+ * 获取教程文件路径
+ *
+ * 开发模式：从 monorepo 根目录读取
+ * 生产模式：从 extraResources 读取
+ */
+function getTutorialFilePath(): string {
+  if (app.isPackaged) {
+    return join(process.resourcesPath, 'tutorial-1.md')
+  }
+  // 开发模式：app.getAppPath() → apps/electron/
+  return join(app.getAppPath(), '../../tutorial/tutorial-1.md')
+}
+
+/**
+ * 读取教程内容
+ *
+ * @returns 教程 markdown 文本，读取失败返回 null
+ */
+export function getTutorialContent(): string | null {
+  const filePath = getTutorialFilePath()
+
+  if (!existsSync(filePath)) {
+    console.warn('[教程服务] 教程文件不存在:', filePath)
+    return null
+  }
+
+  try {
+    return readFileSync(filePath, 'utf-8')
+  } catch (error) {
+    console.error('[教程服务] 读取教程文件失败:', error)
+    return null
+  }
+}
+
+/**
+ * 创建欢迎对话
+ *
+ * 创建一个预填教程内容的 Chat 对话：
+ * 1. 创建对话
+ * 2. 将教程文件保存为附件
+ * 3. 追加 user 消息（携带教程附件）
+ * 4. 追加 assistant 欢迎消息
+ *
+ * @returns 对话元数据，失败返回 null
+ */
+export function createWelcomeConversation(): ConversationMeta | null {
+  const tutorialContent = getTutorialContent()
+  if (!tutorialContent) {
+    console.warn('[教程服务] 无法读取教程内容，跳过创建欢迎对话')
+    return null
+  }
+
+  try {
+    // 1. 创建对话
+    const meta = createConversation('了解 Proma')
+
+    // 2. 保存教程文件为附件
+    const attachmentId = randomUUID()
+    const attachmentFilename = 'Proma 使用教程.md'
+    const localPath = `${meta.id}/${attachmentId}.md`
+    const dir = getConversationAttachmentsDir(meta.id)
+    const fullPath = join(dir, `${attachmentId}.md`)
+
+    // 去掉图片标记，保留纯文本（图片在 Chat 上下文中无意义）
+    const cleanedContent = tutorialContent.replace(/!\[.*?\]\(.*?\)\n*/g, '')
+    writeFileSync(fullPath, cleanedContent, 'utf-8')
+
+    const attachment: FileAttachment = {
+      id: attachmentId,
+      filename: attachmentFilename,
+      mediaType: 'text/markdown',
+      localPath,
+      size: Buffer.byteLength(cleanedContent, 'utf-8'),
+    }
+
+    // 3. 追加 user 消息（携带教程附件）
+    const now = Date.now()
+    const userMessage: ChatMessage = {
+      id: randomUUID(),
+      role: 'user',
+      content: '请帮我了解 Proma 的功能和使用方式，我附上了完整的使用教程作为参考。',
+      createdAt: now,
+      attachments: [attachment],
+    }
+    appendMessage(meta.id, userMessage)
+
+    // 4. 追加 assistant 欢迎消息
+    const assistantMessage: ChatMessage = {
+      id: randomUUID(),
+      role: 'assistant',
+      content: `你好，欢迎使用 Proma！我已经阅读了完整的使用教程。你可以向我提问来快速了解 Proma，比如：
+
+- Proma 可以做什么？
+- 如何配置 AI 供应商渠道？
+- Chat 和 Agent 模式有什么区别？
+- 什么是 Skills 和 MCP？
+- 如何远程使用 Proma？
+
+直接输入你的问题并发送吧！`,
+      createdAt: now + 1,
+      model: 'Proma',
+    }
+    appendMessage(meta.id, assistantMessage)
+
+    console.log(`[教程服务] 已创建欢迎对话: ${meta.id}`)
+    return meta
+  } catch (error) {
+    console.error('[教程服务] 创建欢迎对话失败:', error)
+    return null
+  }
+}

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -155,6 +155,14 @@ export interface ElectronAPI {
   /** 切换对话置顶状态 */
   togglePinConversation: (id: string) => Promise<ConversationMeta>
 
+  // ===== 教程 =====
+
+  /** 获取教程内容 */
+  getTutorialContent: () => Promise<string | null>
+
+  /** 创建欢迎对话（含教程附件） */
+  createWelcomeConversation: () => Promise<ConversationMeta | null>
+
   // ===== 消息发送 =====
 
   /** 发送消息（触发 AI 流式响应） */
@@ -618,6 +626,15 @@ const electronAPI: ElectronAPI = {
 
   togglePinConversation: (id: string) => {
     return ipcRenderer.invoke(CHAT_IPC_CHANNELS.TOGGLE_PIN, id)
+  },
+
+  // 教程
+  getTutorialContent: () => {
+    return ipcRenderer.invoke(CHAT_IPC_CHANNELS.GET_TUTORIAL_CONTENT)
+  },
+
+  createWelcomeConversation: () => {
+    return ipcRenderer.invoke(CHAT_IPC_CHANNELS.CREATE_WELCOME_CONVERSATION)
   },
 
   // 消息发送

--- a/apps/electron/src/renderer/App.tsx
+++ b/apps/electron/src/renderer/App.tsx
@@ -1,13 +1,18 @@
 import * as React from 'react'
 import { useSetAtom } from 'jotai'
+import { useStore } from 'jotai'
 import { AppShell } from './components/app-shell/AppShell'
 import { OnboardingView } from './components/onboarding/OnboardingView'
+import { TutorialBanner } from './components/tutorial/TutorialBanner'
 import { TooltipProvider } from './components/ui/tooltip'
 import { environmentCheckResultAtom } from './atoms/environment'
+import { conversationsAtom } from './atoms/chat-atoms'
+import { tabsAtom, splitLayoutAtom, openTab } from './atoms/tab-atoms'
 import type { AppShellContextType } from './contexts/AppShellContext'
 
 export default function App(): React.ReactElement {
   const setEnvironmentResult = useSetAtom(environmentCheckResultAtom)
+  const store = useStore()
   const [isLoading, setIsLoading] = React.useState(true)
   const [showOnboarding, setShowOnboarding] = React.useState(false)
 
@@ -36,9 +41,31 @@ export default function App(): React.ReactElement {
     initialize()
   }, [setEnvironmentResult])
 
-  // 完成 onboarding 回调
-  const handleOnboardingComplete = () => {
+  // 完成 onboarding 回调：创建欢迎对话
+  const handleOnboardingComplete = async () => {
     setShowOnboarding(false)
+
+    try {
+      const meta = await window.electronAPI.createWelcomeConversation()
+      if (meta) {
+        // 添加到对话列表
+        const conversations = store.get(conversationsAtom)
+        store.set(conversationsAtom, [meta, ...conversations])
+
+        // 打开对话标签页
+        const tabs = store.get(tabsAtom)
+        const layout = store.get(splitLayoutAtom)
+        const result = openTab(tabs, layout, {
+          type: 'chat',
+          sessionId: meta.id,
+          title: meta.title,
+        })
+        store.set(tabsAtom, result.tabs)
+        store.set(splitLayoutAtom, result.layout)
+      }
+    } catch (error) {
+      console.error('[App] 创建欢迎对话失败:', error)
+    }
   }
 
   // 加载中状态
@@ -69,6 +96,7 @@ export default function App(): React.ReactElement {
   return (
     <TooltipProvider delayDuration={200}>
       <AppShell contextValue={contextValue} />
+      <TutorialBanner />
     </TooltipProvider>
   )
 }

--- a/apps/electron/src/renderer/atoms/settings-tab.ts
+++ b/apps/electron/src/renderer/atoms/settings-tab.ts
@@ -11,7 +11,7 @@
 
 import { atom } from 'jotai'
 
-export type SettingsTab = 'general' | 'channels' | 'proxy' | 'appearance' | 'about' | 'agent' | 'prompts' | 'tools' | 'feishu'
+export type SettingsTab = 'general' | 'channels' | 'proxy' | 'appearance' | 'about' | 'agent' | 'prompts' | 'tools' | 'feishu' | 'tutorial'
 
 /** 当前设置标签页（不持久化，每次打开设置默认显示渠道） */
 export const settingsTabAtom = atom<SettingsTab>('channels')

--- a/apps/electron/src/renderer/components/onboarding/OnboardingView.tsx
+++ b/apps/electron/src/renderer/components/onboarding/OnboardingView.tsx
@@ -6,7 +6,7 @@
 
 import { useState, useEffect } from 'react'
 import { useSetAtom } from 'jotai'
-import { RefreshCw, Info } from 'lucide-react'
+import { RefreshCw, Info, GraduationCap } from 'lucide-react'
 import type { EnvironmentCheckResult } from '@proma/shared'
 import { Button } from '@/components/ui/button'
 import { Alert, AlertDescription } from '@/components/ui/alert'
@@ -20,7 +20,15 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet'
+import { ScrollArea } from '@/components/ui/scroll-area'
 import { EnvironmentCheckCard } from '@/components/environment/EnvironmentCheckCard'
+import { TutorialViewer } from '@/components/tutorial/TutorialViewer'
 import {
   environmentCheckResultAtom,
   isCheckingEnvironmentAtom,
@@ -41,6 +49,7 @@ export function OnboardingView({ onComplete }: OnboardingViewProps) {
   const [result, setResult] = useState<EnvironmentCheckResult | null>(null)
   const [isChecking, setCheckingState] = useState(true)
   const [showSkipDialog, setShowSkipDialog] = useState(false)
+  const [showTutorial, setShowTutorial] = useState(false)
 
   // 执行环境检测
   const checkEnvironment = async () => {
@@ -149,6 +158,22 @@ export function OnboardingView({ onComplete }: OnboardingViewProps) {
         )}
       </div>
 
+      {/* 教程入口 */}
+      <div className="w-full max-w-2xl mb-8">
+        <button
+          onClick={() => setShowTutorial(true)}
+          className="w-full rounded-xl bg-gradient-to-r from-primary/5 via-primary/10 to-primary/5 border border-primary/15 p-4 flex items-center gap-4 hover:from-primary/10 hover:via-primary/15 hover:to-primary/10 transition-colors text-left"
+        >
+          <div className="w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center flex-shrink-0">
+            <GraduationCap size={20} className="text-primary" />
+          </div>
+          <div className="flex-1">
+            <h3 className="text-sm font-semibold text-foreground">查看使用教程</h3>
+            <p className="text-xs text-muted-foreground mt-0.5">了解 Proma 的全部功能和使用技巧</p>
+          </div>
+        </button>
+      </div>
+
       {/* 底部操作栏 */}
       <div className="flex gap-4">
         <Button
@@ -197,6 +222,23 @@ export function OnboardingView({ onComplete }: OnboardingViewProps) {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {/* 教程 Sheet */}
+      <Sheet open={showTutorial} onOpenChange={setShowTutorial}>
+        <SheetContent side="right" className="w-[560px] sm:max-w-[560px] p-0">
+          <SheetHeader className="px-6 pt-6 pb-4 border-b">
+            <SheetTitle className="flex items-center gap-2">
+              <GraduationCap size={18} className="text-primary" />
+              Proma 使用教程
+            </SheetTitle>
+          </SheetHeader>
+          <ScrollArea className="h-[calc(100vh-80px)]">
+            <div className="px-6 py-4">
+              <TutorialViewer />
+            </div>
+          </ScrollArea>
+        </SheetContent>
+      </Sheet>
     </div>
   )
 }

--- a/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
+++ b/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
@@ -9,7 +9,7 @@
 import * as React from 'react'
 import { useAtom, useAtomValue } from 'jotai'
 import { cn } from '@/lib/utils'
-import { Settings, Radio, Palette, Info, Plug, Globe, BookOpen, Wrench, MessageSquare } from 'lucide-react'
+import { Settings, Radio, Palette, Info, Plug, Globe, BookOpen, Wrench, MessageSquare, GraduationCap } from 'lucide-react'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { settingsTabAtom } from '@/atoms/settings-tab'
 import type { SettingsTab } from '@/atoms/settings-tab'
@@ -25,6 +25,7 @@ import { AgentSettings } from './AgentSettings'
 import { PromptSettings } from './PromptSettings'
 import { ToolSettings } from './ToolSettings'
 import { FeishuSettings } from './FeishuSettings'
+import { TutorialViewer } from '../tutorial/TutorialViewer'
 
 /** 设置 Tab 定义 */
 interface TabItem {
@@ -45,6 +46,7 @@ const BASE_TABS: TabItem[] = [
 const AGENT_TAB: TabItem = { id: 'agent', label: '配置', icon: <Plug size={16} /> }
 const TOOLS_TAB: TabItem = { id: 'tools', label: '工具', icon: <Wrench size={16} /> }
 const FEISHU_TAB: TabItem = { id: 'feishu', label: '飞书', icon: <MessageSquare size={16} /> }
+const TUTORIAL_TAB: TabItem = { id: 'tutorial', label: '教程', icon: <GraduationCap size={16} /> }
 
 /** 尾部 Tabs */
 const TAIL_TABS: TabItem[] = [
@@ -73,6 +75,8 @@ function renderTabContent(tab: SettingsTab): React.ReactElement {
       return <AboutSettings />
     case 'feishu':
       return <FeishuSettings />
+    case 'tutorial':
+      return <TutorialViewer />
   }
 }
 
@@ -85,9 +89,9 @@ export function SettingsPanel(): React.ReactElement {
   // Agent 模式时在渠道后插入 Agent Tab，工具 tab 两种模式都显示
   const tabs = React.useMemo(() => {
     if (appMode === 'agent') {
-      return [...BASE_TABS, AGENT_TAB, TOOLS_TAB, FEISHU_TAB, ...TAIL_TABS]
+      return [...BASE_TABS, AGENT_TAB, TOOLS_TAB, FEISHU_TAB, TUTORIAL_TAB, ...TAIL_TABS]
     }
-    return [...BASE_TABS, TOOLS_TAB, FEISHU_TAB, ...TAIL_TABS]
+    return [...BASE_TABS, TOOLS_TAB, FEISHU_TAB, TUTORIAL_TAB, ...TAIL_TABS]
   }, [appMode])
 
   return (

--- a/apps/electron/src/renderer/components/tutorial/TutorialBanner.tsx
+++ b/apps/electron/src/renderer/components/tutorial/TutorialBanner.tsx
@@ -1,0 +1,111 @@
+/**
+ * TutorialBanner - 教程推荐横幅
+ *
+ * 固定在右下角的浮动卡片，引导用户查看教程。
+ * - 不区分新老用户，使用 tutorialBannerDismissed 字段控制
+ * - 用户点击「立即学习」或「稍后再学」后永不再显示
+ * - 明确告知教程的下次访问位置：设置 > 教程
+ */
+
+import * as React from 'react'
+import { useSetAtom } from 'jotai'
+import { GraduationCap, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { activeViewAtom } from '@/atoms/active-view'
+import { settingsTabAtom } from '@/atoms/settings-tab'
+
+export function TutorialBanner(): React.ReactElement | null {
+  const [visible, setVisible] = React.useState(false)
+  const [dismissed, setDismissed] = React.useState(true)
+  const setActiveView = useSetAtom(activeViewAtom)
+  const setSettingsTab = useSetAtom(settingsTabAtom)
+
+  // 初始化：从主进程读取 settings 判断是否需要显示
+  React.useEffect(() => {
+    window.electronAPI
+      .getSettings()
+      .then((settings) => {
+        if (!settings.tutorialBannerDismissed) {
+          setDismissed(false)
+          // 延迟 1.5 秒显示，避免页面加载时的干扰
+          setTimeout(() => setVisible(true), 1500)
+        }
+      })
+      .catch(console.error)
+  }, [])
+
+  // 关闭横幅并持久化
+  const handleDismiss = async () => {
+    setVisible(false)
+    await window.electronAPI.updateSettings({ tutorialBannerDismissed: true })
+  }
+
+  // 立即学习：跳转到设置教程页并关闭横幅
+  const handleLearnNow = async () => {
+    setSettingsTab('tutorial')
+    setActiveView('settings')
+    await handleDismiss()
+  }
+
+  // 稍后再学：关闭横幅
+  const handleLater = async () => {
+    await handleDismiss()
+  }
+
+  if (dismissed) return null
+
+  return (
+    <div
+      className={`fixed bottom-6 right-6 z-[100] w-[340px] transition-all duration-500 ease-out ${
+        visible
+          ? 'translate-x-0 opacity-100'
+          : 'translate-x-8 opacity-0 pointer-events-none'
+      }`}
+    >
+      <div className="relative rounded-2xl bg-gradient-to-br from-primary/5 via-background to-primary/10 border border-primary/15 shadow-lg shadow-primary/5 backdrop-blur-sm p-5">
+        {/* 关闭按钮 */}
+        <button
+          onClick={handleLater}
+          className="absolute top-3 right-3 p-1 rounded-lg text-muted-foreground/50 hover:text-muted-foreground hover:bg-foreground/5 transition-colors"
+        >
+          <X size={14} />
+        </button>
+
+        {/* 图标 + 标题 */}
+        <div className="flex items-center gap-3 mb-3">
+          <div className="w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center flex-shrink-0">
+            <GraduationCap size={20} className="text-primary" />
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold text-foreground">Proma 使用教程</h3>
+            <p className="text-xs text-muted-foreground mt-0.5">了解 Proma 的全部功能和使用技巧</p>
+          </div>
+        </div>
+
+        {/* 操作按钮 */}
+        <div className="flex items-center gap-2">
+          <Button
+            size="sm"
+            onClick={handleLearnNow}
+            className="flex-1 h-8 text-xs"
+          >
+            立即学习
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={handleLater}
+            className="h-8 text-xs text-muted-foreground"
+          >
+            稍后再学
+          </Button>
+        </div>
+
+        {/* 提示文字 */}
+        <p className="text-[11px] text-muted-foreground/60 mt-3 text-center">
+          你可以随时在 设置 &gt; 教程 中查看完整教程
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/tutorial/TutorialViewer.tsx
+++ b/apps/electron/src/renderer/components/tutorial/TutorialViewer.tsx
@@ -1,0 +1,93 @@
+/**
+ * TutorialViewer - 教程查看器
+ *
+ * 通过 IPC 从主进程获取教程 markdown 内容并渲染。
+ * 复用 react-markdown + remarkGfm 渲染栈。
+ * 支持外部图片、代码块高亮、链接跳转。
+ */
+
+import * as React from 'react'
+import Markdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { Loader2 } from 'lucide-react'
+import { CodeBlock } from '@proma/ui'
+
+export function TutorialViewer(): React.ReactElement {
+  const [content, setContent] = React.useState<string | null>(null)
+  const [loading, setLoading] = React.useState(true)
+
+  React.useEffect(() => {
+    window.electronAPI
+      .getTutorialContent()
+      .then((text) => {
+        setContent(text)
+      })
+      .catch((err: unknown) => {
+        console.error('[TutorialViewer] 加载教程失败:', err)
+      })
+      .finally(() => setLoading(false))
+  }, [])
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        <span className="ml-2 text-sm text-muted-foreground">加载教程中...</span>
+      </div>
+    )
+  }
+
+  if (!content) {
+    return (
+      <div className="text-center py-20 text-muted-foreground">
+        <p className="text-sm">暂未找到教程内容</p>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className="prose dark:prose-invert max-w-none text-[14px]
+        prose-p:my-2 prose-p:leading-[1.75] prose-li:leading-[1.75]
+        prose-headings:my-3 prose-pre:my-0
+        prose-img:rounded-xl prose-img:shadow-md prose-img:max-w-full
+        prose-blockquote:border-primary/30 prose-blockquote:text-muted-foreground
+        [&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
+    >
+      <Markdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          a: ({ href, children: linkChildren, ...linkProps }) => (
+            <a
+              {...linkProps}
+              href={href}
+              onClick={(e) => {
+                e.preventDefault()
+                if (href && (href.startsWith('http://') || href.startsWith('https://'))) {
+                  window.electronAPI.openExternal(href)
+                }
+              }}
+              title={href}
+              className="text-primary hover:underline cursor-pointer"
+            >
+              {linkChildren}
+            </a>
+          ),
+          pre: ({ children: preChildren }) => {
+            return <CodeBlock>{preChildren}</CodeBlock>
+          },
+          img: ({ src, alt }) => (
+            <img
+              src={src}
+              alt={alt || ''}
+              className="rounded-xl shadow-md max-w-full"
+              loading="lazy"
+            />
+          ),
+        }}
+      >
+        {content}
+      </Markdown>
+    </div>
+  )
+}

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -42,6 +42,8 @@ export interface AppSettings {
   agentMaxBudgetUsd?: number
   /** Agent 最大轮次（0 或 undefined = SDK 默认） */
   agentMaxTurns?: number
+  /** 教程推荐横幅是否已关闭 */
+  tutorialBannerDismissed?: boolean
 }
 
 /** 持久化的标签页状态 */

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -335,6 +335,12 @@ export const CHAT_IPC_CHANNELS = {
   /** 切换对话置顶状态 */
   TOGGLE_PIN: 'chat:toggle-pin',
 
+  // 教程
+  /** 获取教程内容 */
+  GET_TUTORIAL_CONTENT: 'chat:get-tutorial-content',
+  /** 创建欢迎对话（含教程附件） */
+  CREATE_WELCOME_CONVERSATION: 'chat:create-welcome-conversation',
+
   // 流式事件（主进程 → 渲染进程推送）
   /** 内容片段 */
   STREAM_CHUNK: 'chat:stream:chunk',

--- a/tutorial/tutorial-1.md
+++ b/tutorial/tutorial-1.md
@@ -1,4 +1,12 @@
-# 在这个系列开始之前（推荐看）
+# Proma 教程
+
+编辑时间：2026年3月9日
+编辑时版本：v0.7.0
+作者：Erlich Liu
+
+## 在开始之前（推荐看）
+
+![Proma 海报](https://img.erlich.fun/personal-blog/uPic/pb.png)
 
 大家好，感谢大家关注开源通用 Agent 项目 Proma，我是 Proma 的开发者 Erlich。在正式开始关于 Proma 的使用教程前，我想先简单做个本次系列教程的介绍。
 


### PR DESCRIPTION
## Summary
- 新增教程查看器组件（TutorialViewer），通过 IPC 从主进程读取教程 markdown 渲染
- 新增右下角浮动推荐横幅（TutorialBanner），引导用户查看教程，关闭后永不再显示
- 设置面板新增「教程」标签页，用户可随时查看完整教程
- Onboarding 页面添加教程入口卡片，点击打开 Sheet 侧栏预览教程
- 完成 Onboarding 时自动创建欢迎对话，教程以附件方式附加，预填欢迎消息
- 修复 settings-service 逐字段映射导致新增字段丢失的问题，改用展开运算符

## 涉及文件
| 文件 | 变更 |
|------|------|
| `apps/electron/src/main/lib/tutorial-service.ts` | 新建：教程内容读取 + 欢迎对话创建 |
| `apps/electron/src/renderer/components/tutorial/TutorialViewer.tsx` | 新建：教程渲染组件 |
| `apps/electron/src/renderer/components/tutorial/TutorialBanner.tsx` | 新建：右下角推荐横幅 |
| `packages/shared/src/types/chat.ts` | 添加教程 IPC 通道常量 |
| `apps/electron/src/types/settings.ts` | 添加 tutorialBannerDismissed 字段 |
| `apps/electron/src/main/ipc.ts` | 注册教程 IPC handler |
| `apps/electron/src/preload/index.ts` | 暴露教程 API |
| `apps/electron/src/renderer/App.tsx` | 挂载 Banner + 创建欢迎对话 |
| `apps/electron/src/renderer/components/settings/SettingsPanel.tsx` | 添加教程标签页 |
| `apps/electron/src/renderer/components/onboarding/OnboardingView.tsx` | 添加教程入口 + Sheet |
| `apps/electron/src/main/lib/settings-service.ts` | 修复字段丢失问题 |
| `apps/electron/electron-builder.yml` | 添加教程文件到 extraResources |

## Test plan
- [ ] 清除 `~/.proma/settings.json` 中的 `onboardingCompleted` → 重启 → 验证 Onboarding 教程入口 + Sheet 弹窗
- [ ] 完成 Onboarding → 验证欢迎对话自动创建（含教程附件 + 欢迎消息，模型显示 Proma）
- [ ] 验证右下角横幅出现 → 点击「立即学习」跳转设置教程页 → 横幅永不再显示
- [ ] 验证 设置 > 教程 标签页完整渲染教程内容
- [ ] 重启应用 → 验证 `tutorialBannerDismissed` 不被丢失