### PR TITLE
fix: Agent 新建会话重命名时附加文件夹丢失

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -422,9 +422,9 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   /** 重命名 Agent 会话标题 */
   const handleAgentRename = async (id: string, newTitle: string): Promise<void> => {
     try {
-      await window.electronAPI.updateAgentSessionTitle(id, newTitle)
+      const updated = await window.electronAPI.updateAgentSessionTitle(id, newTitle)
       setAgentSessions((prev) =>
-        prev.map((s) => (s.id === id ? { ...s, title: newTitle, updatedAt: Date.now() } : s))
+        prev.map((s) => (s.id === updated.id ? updated : s))
       )
       // 同步更新标签页标题
       setTabs((prev) => updateTabTitle(prev, id, newTitle))


### PR DESCRIPTION
## 问题描述

在 Agent 模式下，当按照以下步骤操作时，附加的文件夹会丢失：

1. 新建一个 Agent 会话（未进行任何对话操作）
2. 附加文件夹到该会话
3. 直接修改会话名称
4. 回车确认后，附加的文件夹丢失

## 复现条件

- ✅ 新建会话 → 附加文件夹 → 重命名会话 → **文件夹丢失**
- ❌ 新建会话 → 进行对话 → 附加文件夹 → 重命名会话 → **文件夹保留** （这个情况本来就正常，不是我们此次修复内容）

关键点：在新建会话后，如果没有进行任何对话操作就直接附加文件夹并重命名，会导致文件夹丢失。

## 修复方案

修复了会话重命名时工作区 ID 丢失的问题，确保重命名操作正确保留会话的 workspaceId。

## 测试

- [x] 新建会话 → 附加文件夹 → 重命名 → 文件夹保留 （本次修复场景）
- [x] 新建会话 → 对话 → 附加文件夹 → 重命名 → 文件夹保留 （这种情况修复前就正常）