### PR TITLE
fix(agent): isolate sdk base URL normalization and config dir

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -27,12 +27,12 @@ import type { ClaudeAgentQueryOptions } from './adapters/claude-agent-adapter'
 import { isPromptTooLongError } from './adapters/claude-agent-adapter'
 import { AgentEventBus } from './agent-event-bus'
 import { decryptApiKey, getChannelById, listChannels } from './channel-manager'
-import { getAdapter, fetchTitle } from '@proma/core'
+import { getAdapter, fetchTitle, normalizeAnthropicBaseUrlForSdk } from '@proma/core'
 import { getFetchFn } from './proxy-fetch'
 import { getEffectiveProxyUrl } from './proxy-settings-service'
 import { appendAgentMessage, updateAgentSessionMeta, getAgentSessionMeta, getAgentSessionMessages } from './agent-session-manager'
 import { getAgentWorkspace, getWorkspaceMcpConfig, ensurePluginManifest, getWorkspacePermissionMode } from './agent-workspace-manager'
-import { getAgentWorkspacePath, getAgentSessionWorkspacePath } from './config-paths'
+import { getAgentWorkspacePath, getAgentSessionWorkspacePath, getSdkConfigDir } from './config-paths'
 import { getRuntimeStatus } from './runtime-init'
 import { getSettings } from './settings-service'
 import { buildSystemPromptAppend, buildDynamicContext } from './agent-prompt-builder'
@@ -387,15 +387,14 @@ export class AgentOrchestrator {
       CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1',
       // 启用 Tasks 功能
       CLAUDE_CODE_ENABLE_TASKS: 'true',
+      // 配置隔离：让 SDK 使用独立的配置目录，不读取用户的 ~/.claude.json
+      CLAUDE_CONFIG_DIR: getSdkConfigDir(),
     }
 
     // 显式控制 ANTHROPIC_BASE_URL：仅在用户配置了自定义 Base URL 时注入
+    // 使用统一的 normalizeAnthropicBaseUrlForSdk 规范化，SDK 内部会自动拼接 /v1/messages
     if (baseUrl && baseUrl !== DEFAULT_ANTHROPIC_URL) {
-      sdkEnv.ANTHROPIC_BASE_URL = baseUrl
-        .trim()
-        .replace(/\/+$/, '')
-        .replace(/\/v\d+\/messages$/, '')
-        .replace(/\/v\d+$/, '')
+      sdkEnv.ANTHROPIC_BASE_URL = normalizeAnthropicBaseUrlForSdk(baseUrl)
     }
 
     const proxyUrl = await getEffectiveProxyUrl()
@@ -681,8 +680,9 @@ export class AgentOrchestrator {
     delete process.env.ANTHROPIC_AUTH_TOKEN
     delete process.env.ANTHROPIC_BASE_URL
     process.env.ANTHROPIC_API_KEY = apiKey
-    if (channel.baseUrl) {
-      process.env.ANTHROPIC_BASE_URL = channel.baseUrl
+    // 使用与 buildSdkEnv 相同的规范化逻辑，确保 process.env 和 sdkEnv 中的 URL 一致
+    if (channel.baseUrl && channel.baseUrl !== 'https://api.anthropic.com') {
+      process.env.ANTHROPIC_BASE_URL = normalizeAnthropicBaseUrlForSdk(channel.baseUrl)
     }
 
     const sdkEnv = await this.buildSdkEnv(apiKey, channel.baseUrl)

--- a/apps/electron/src/main/lib/channel-manager.ts
+++ b/apps/electron/src/main/lib/channel-manager.ts
@@ -23,38 +23,10 @@ import type {
 } from '@proma/shared'
 import { getFetchFn } from './proxy-fetch'
 import { getEffectiveProxyUrl } from './proxy-settings-service'
+import { normalizeAnthropicBaseUrl, normalizeBaseUrl } from '@proma/core'
 
 /** 当前配置版本 */
 const CONFIG_VERSION = 1
-
-// ===== URL 规范化工具 =====
-
-/**
- * 规范化 Anthropic Base URL
- *
- * 处理逻辑：
- * - 去除尾部斜杠
- * - 确保包含 /v1（如果用户没填则自动补上）
- * - 如果已经包含 /v1 则不重复添加
- *
- * 最终结果类似 https://api.anthropic.com/v1
- */
-function normalizeAnthropicBaseUrl(baseUrl: string): string {
-  let url = baseUrl.trim().replace(/\/+$/, '')
-  // 去除用户误填的 /messages 后缀，避免后续拼接时路径重复
-  url = url.replace(/\/messages$/, '')
-  if (!url.match(/\/v\d+$/)) {
-    url = `${url}/v1`
-  }
-  return url
-}
-
-/**
- * 规范化通用 Base URL（去除尾部斜杠）
- */
-function normalizeBaseUrl(baseUrl: string): string {
-  return baseUrl.trim().replace(/\/+$/, '')
-}
 
 /**
  * 读取渠道配置文件

--- a/apps/electron/src/main/lib/config-paths.ts
+++ b/apps/electron/src/main/lib/config-paths.ts
@@ -395,3 +395,24 @@ export function getAgentSessionWorkspacePath(workspaceSlug: string, sessionId: s
 
   return dir
 }
+
+/**
+ * 获取 SDK 隔离配置目录路径
+ *
+ * 用于设置 CLAUDE_CONFIG_DIR 环境变量，让 SDK 读取独立的配置文件，
+ * 而不是用户的 ~/.claude.json，实现 Proma 与 Claude Code CLI 的配置隔离。
+ *
+ * 如果目录不存在则自动创建。
+ *
+ * @returns ~/.proma/sdk-config/
+ */
+export function getSdkConfigDir(): string {
+  const dir = join(getConfigDir(), 'sdk-config')
+
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+    console.log(`[配置] 已创建 SDK 配置目录: ${dir}`)
+  }
+
+  return dir
+}

--- a/packages/core/src/providers/url-utils.ts
+++ b/packages/core/src/providers/url-utils.ts
@@ -2,12 +2,15 @@
  * URL 规范化工具
  *
  * 各供应商 Base URL 的规范化处理。
+ * 所有 Anthropic URL 规范化逻辑统一收口在此文件，避免分散重复。
  */
 
 /**
- * 规范化 Anthropic Base URL
+ * 规范化 Anthropic Base URL（用于 Proma Chat 直接调用 API）
  *
  * 去除尾部斜杠，去除误填的 /messages 后缀，如果没有版本路径则追加 /v1。
+ * 结果用于直接拼接 /messages 发起请求。
+ *
  * 例如：
  * - "https://api.anthropic.com" → "https://api.anthropic.com/v1"
  * - "https://api.anthropic.com/v1" → 不变
@@ -17,12 +20,32 @@
  */
 export function normalizeAnthropicBaseUrl(baseUrl: string): string {
   let url = baseUrl.trim().replace(/\/+$/, '')
-  // 去除用户误填的 /messages 后缀，避免后续拼接时路径重复
   url = url.replace(/\/messages$/, '')
   if (!url.match(/\/v\d+$/)) {
     url = `${url}/v1`
   }
   return url
+}
+
+/**
+ * 规范化 Anthropic Base URL（用于 Agent SDK 环境变量 ANTHROPIC_BASE_URL）
+ *
+ * SDK 内部会自动拼接 /v1/messages，所以这里需要去除用户误填的路径后缀，
+ * 只保留根路径。
+ *
+ * 例如：
+ * - "https://api.anthropic.com" → "https://api.anthropic.com"
+ * - "https://api.anthropic.com/v1" → "https://api.anthropic.com"
+ * - "https://api.anthropic.com/v1/messages" → "https://api.anthropic.com"
+ * - "https://gateway.example.com/anthropic/v1/messages" → "https://gateway.example.com/anthropic"
+ * - "https://gateway.example.com/anthropic/" → "https://gateway.example.com/anthropic"
+ */
+export function normalizeAnthropicBaseUrlForSdk(baseUrl: string): string {
+  return baseUrl
+    .trim()
+    .replace(/\/+$/, '')
+    .replace(/\/v\d+\/messages$/, '')
+    .replace(/\/v\d+$/, '')
 }
 
 /**


### PR DESCRIPTION
## What
- unify Agent SDK base URL normalization for both `sdkEnv` and `process.env`
- centralize Anthropic URL normalization in `@proma/core`
- isolate Claude Agent SDK config with `CLAUDE_CONFIG_DIR`

## Why
Proma needs to tolerate Anthropic-compatible channel URLs like root path, `/v1`, and `/v1/messages` without requiring the same exact path shape as the underlying Claude Code SDK.

## Changes
- add `normalizeAnthropicBaseUrlForSdk()` for Agent SDK env injection
- reuse core URL helpers in `channel-manager.ts`
- inject normalized `ANTHROPIC_BASE_URL` into both `sdkEnv` and `process.env`
- point the SDK at `~/.proma/sdk-config` via `CLAUDE_CONFIG_DIR`

## Verification
- `bun run typecheck`
- `bun run --filter='@proma/electron' build:main`
- manual local Proma validation by the user after starting the app successfully
