### PR TITLE
fix(agent): 修复 runtimeStatusCache 未就绪时 node 路径降级导致 spawn ENOENT

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -18,6 +18,7 @@ import { randomUUID } from 'node:crypto'
 import { homedir } from 'node:os'
 import { join, dirname } from 'node:path'
 import { existsSync, mkdirSync, symlinkSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
 import { createRequire } from 'node:module'
 import { app } from 'electron'
 import type { AgentSendInput, AgentEvent, AgentMessage, AgentGenerateTitleInput, AgentProviderAdapter, TypedError, RetryAttempt } from '@proma/shared'
@@ -222,7 +223,11 @@ function resolveSDKCliPath(): string {
 /**
  * 获取 Agent SDK 运行时可执行文件
  *
- * 优先级：Node.js → Bun → 降级到字符串 'node'
+ * 优先级：Node.js → Bun → which node 同步查找 → 字符串 'node'
+ *
+ * 当 runtimeStatusCache 尚未初始化时（应用启动竞态），
+ * 降级到 'node' 字符串可能因 Electron 进程 PATH 不含 node 而触发 ENOENT。
+ * 此时用 which/where 同步查找作为兜底，避免 SDK spawn 失败。
  */
 function getAgentExecutable(): { type: 'node' | 'bun'; path: string } {
   const status = getRuntimeStatus()
@@ -233,6 +238,20 @@ function getAgentExecutable(): { type: 'node' | 'bun'; path: string } {
 
   if (status?.bun?.available && status.bun.path) {
     return { type: 'bun', path: status.bun.path }
+  }
+
+  // runtimeStatusCache 未就绪时，同步查找 node 路径
+  try {
+    const cmd = process.platform === 'win32' ? 'where' : 'which'
+    const nodePath = execFileSync(cmd, ['node'], { encoding: 'utf-8', timeout: 2000 })
+      .trim()
+      .split('\n')[0]
+    if (nodePath && existsSync(nodePath)) {
+      console.warn(`[Agent 编排] runtimeStatusCache 未就绪，同步查找 node: ${nodePath}`)
+      return { type: 'node', path: nodePath }
+    }
+  } catch {
+    // 忽略查找失败，继续降级
   }
 
   return { type: 'node', path: 'node' }


### PR DESCRIPTION
## 问题

部分用户偶发 `Claude Code executable not found at .../cli.js` 报错。

**根因**：`getAgentExecutable()` 在 `runtimeStatusCache` 为 `null` 时（`initializeRuntime()` 竞态窗口）降级到裸字符串 `'node'`。Electron 进程的 `PATH` 不保证包含 node 路径，导致 `spawn('node', [cliPath, ...])` 触发 `ENOENT`。

SDK 的错误处理会将 ENOENT 误导性地显示为 cli.js 不存在（实际是 node 二进制找不到），增加排查难度。

**为什么不稳定**：只在应用启动后、`initializeRuntime()` 完成前的短暂竞态窗口内触发，所以不是持续性问题。

## 修复

在 `'node'` 兜底之前，新增 `which`/`where` 同步查找：

```typescript
// runtimeStatusCache 未就绪时，同步查找 node 路径
try {
  const cmd = process.platform === 'win32' ? 'where' : 'which'
  const nodePath = execFileSync(cmd, ['node'], { encoding: 'utf-8', timeout: 2000 })
    .trim()
    .split('\n')[0]
  if (nodePath && existsSync(nodePath)) {
    return { type: 'node', path: nodePath }
  }
} catch { /* 忽略，继续降级 */ }
```

优先级链变为：**Node.js（缓存）→ Bun（缓存）→ which node 同步查找 → 'node' 字符串**

## 影响范围

- 仅在 `runtimeStatusCache` 未就绪的竞态窗口才会执行同步查找（正常路径无影响）
- 同步查找有 2 秒超时兜底，不会无限阻塞

🤖 Generated with [Claude Code](https://claude.com/claude-code)