### PR TITLE
fix: 修复思考计时器切换 Tab 后从 0s 重新计时

### DIFF
--- a/apps/electron/src/renderer/atoms/chat-atoms.ts
+++ b/apps/electron/src/renderer/atoms/chat-atoms.ts
@@ -38,6 +38,8 @@ export interface ConversationStreamState {
   model?: string
   /** 记忆工具活动列表（流式期间累积） */
   toolActivities: ChatToolActivity[]
+  /** 流式开始时间戳（用于思考计时持久化） */
+  startedAt?: number
 }
 
 /**

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -561,6 +561,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         toolActivities: [],
         teammates: [],
         model: agentModelId || undefined,
+        startedAt: Date.now(),
       })
       return map
     })
@@ -675,6 +676,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         toolActivities: [],
         teammates: [],
         model: agentModelId || undefined,
+        startedAt: Date.now(),
       })
       return map
     })
@@ -716,6 +718,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           toolActivities: [],
           teammates: [],
           model: agentModelId || undefined,
+          startedAt: Date.now(),
         })
         return map
       })

--- a/apps/electron/src/renderer/components/chat/ChatMessages.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessages.tsx
@@ -125,6 +125,8 @@ interface ChatMessagesProps {
   streamingReasoning: string
   /** 流式消息绑定的模型 */
   streamingModel: string | null
+  /** 流式开始时间戳 */
+  startedAt?: number
   /** 工具活动列表 */
   toolActivities: ChatToolActivity[]
   /** 上下文分隔线 */
@@ -170,6 +172,7 @@ export function ChatMessages({
   streamingContent,
   streamingReasoning,
   streamingModel,
+  startedAt,
   toolActivities,
   contextDividers,
   hasMore,
@@ -269,6 +272,7 @@ export function ChatMessages({
         streaming={streaming}
         streamingContent={smoothContent}
         streamingReasoning={smoothReasoning}
+        startedAt={startedAt}
         contextDividers={contextDividers}
         onDeleteDivider={onDeleteDivider}
         onDeleteMessage={onDeleteMessage}
@@ -362,7 +366,7 @@ export function ChatMessages({
                     </>
                   ) : (
                     /* 等待首个 chunk 时的加载动画（仅流式中且无推理时显示） */
-                    streaming && !smoothReasoning && <MessageLoading />
+                    streaming && !smoothReasoning && <MessageLoading startedAt={startedAt} />
                   )}
                 </MessageContent>
               </Message>

--- a/apps/electron/src/renderer/components/chat/ChatView.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatView.tsx
@@ -248,6 +248,7 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
         reasoning: '',
         model: selectedModel.modelId,
         toolActivities: [],
+        startedAt: Date.now(),
       })
       return map
     })
@@ -497,6 +498,7 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
             streamingContent={streamingContent}
             streamingReasoning={streamingReasoning}
             streamingModel={streamingModel}
+            startedAt={streamState?.startedAt}
             toolActivities={toolActivities}
             contextDividers={contextDividers}
             hasMore={hasMoreMessages}

--- a/apps/electron/src/renderer/components/chat/ParallelChatMessages.tsx
+++ b/apps/electron/src/renderer/components/chat/ParallelChatMessages.tsx
@@ -44,6 +44,8 @@ interface ParallelChatMessagesProps {
   streaming: boolean
   streamingContent: string
   streamingReasoning: string
+  /** 流式开始时间戳 */
+  startedAt?: number
   contextDividers?: string[]
   onDeleteDivider?: (messageId: string) => void
   onDeleteMessage?: (messageId: string) => Promise<void>
@@ -133,6 +135,7 @@ interface MessageColumnProps {
   streaming?: boolean
   streamingContent?: string
   streamingReasoning?: string
+  startedAt?: number
 }
 
 function MessageColumn({
@@ -148,6 +151,7 @@ function MessageColumn({
   streaming = false,
   streamingContent = '',
   streamingReasoning = '',
+  startedAt,
 }: MessageColumnProps): React.ReactElement {
   const streamingModel = useAtomValue(streamingModelAtom)
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -217,7 +221,7 @@ function MessageColumn({
                   {streaming && <StreamingIndicator />}
                 </>
               ) : (
-                streaming && !streamingReasoning && <MessageLoading />
+                streaming && !streamingReasoning && <MessageLoading startedAt={startedAt} />
               )}
             </MessageContent>
           </Message>
@@ -232,6 +236,7 @@ export function ParallelChatMessages({
   streaming,
   streamingContent,
   streamingReasoning,
+  startedAt,
   contextDividers = [],
   onDeleteDivider,
   onDeleteMessage,
@@ -310,6 +315,7 @@ export function ParallelChatMessages({
               streaming={streaming}
               streamingContent={streamingContent}
               streamingReasoning={streamingReasoning}
+              startedAt={startedAt}
             />
           </div>
         </div>
@@ -378,6 +384,7 @@ export function ParallelChatMessages({
                   streaming={index === segments.length - 1 ? streaming : false}
                   streamingContent={index === segments.length - 1 ? streamingContent : ''}
                   streamingReasoning={index === segments.length - 1 ? streamingReasoning : ''}
+                  startedAt={index === segments.length - 1 ? startedAt : undefined}
                 />
               </div>
             </div>

--- a/apps/electron/src/renderer/hooks/useGlobalChatListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalChatListeners.ts
@@ -53,6 +53,7 @@ export function useGlobalChatListeners(): void {
           reasoning: '',
           model: undefined,
           toolActivities: [],
+          startedAt: Date.now(),
         }
         const next = updater(current)
         const map = new Map(prev)


### PR DESCRIPTION
## Summary
- Agent 和 Chat 模式的流式状态初始化时缺少 `startedAt` 时间戳，导致 `LoadingIndicator` 在 Tab 切换重新挂载后无法恢复正确的已用时间，始终从 0s 重新计时
- 在所有流式状态初始化点添加 `startedAt: Date.now()`，使时间戳持久化在 Jotai atom Map 中，Tab 切换后组件能从 atom 读取原始时间戳，计算出正确的 elapsed time

## 改动范围
| 模式 | 文件 | 改动 |
|------|------|------|
| Agent | `AgentView.tsx` | `handleSend`/`handleRetry`/`handleRetryInNewSession` 添加 `startedAt` |
| Chat | `chat-atoms.ts` | `ConversationStreamState` 接口添加 `startedAt` 字段 |
| Chat | `ChatView.tsx` | `handleSend` 添加 `startedAt`，传递给 `ChatMessages` |
| Chat | `ChatMessages.tsx` | 接收并传递 `startedAt` 到 `MessageLoading` 和 `ParallelChatMessages` |
| Chat | `ParallelChatMessages.tsx` | `startedAt` 透传到 `MessageColumn` → `MessageLoading` |
| Chat | `useGlobalChatListeners.ts` | 默认流式状态添加 `startedAt` |

## Test plan
- [ ] Agent 模式：发送消息后切换到其他 Tab 再切回，验证计时器不从 0s 重新开始
- [ ] Chat 模式：发送消息后切换到其他 Tab 再切回，验证计时器不从 0s 重新开始
- [ ] 并排模式（ParallelChatMessages）同样验证计时器持久化
- [ ] 验证新发送消息时计时器正常从 0s 开始