### PR TITLE
feat: Chat 消息 Action Bar 添加切换到 Agent 模式按钮

### DIFF
--- a/apps/electron/src/renderer/components/chat/AgentRecommendBanner.tsx
+++ b/apps/electron/src/renderer/components/chat/AgentRecommendBanner.tsx
@@ -29,6 +29,7 @@ import {
 } from '@/atoms/agent-atoms'
 import { activeViewAtom } from '@/atoms/active-view'
 import { appModeAtom } from '@/atoms/app-mode'
+import { tabsAtom, splitLayoutAtom, openTab } from '@/atoms/tab-atoms'
 
 export function AgentRecommendBanner(): React.ReactElement | null {
   const [recommendation, setRecommendation] = useAtom(pendingAgentRecommendationAtom)
@@ -81,18 +82,34 @@ export function AgentRecommendBanner(): React.ReactElement | null {
         }).catch(console.error)
       }
 
-      // 5. 切换到新会话 + 设置建议提示 + 切换模式
+      // 5. 切换模式
+      store.set(appModeAtom, 'agent')
+      store.set(activeViewAtom, 'conversations')
+
+      // 6. 打开 Agent 会话 Tab 并激活
+      const sessionTitle = session.title ?? '新 Agent 会话'
+      const tabs = store.get(tabsAtom)
+      const layout = store.get(splitLayoutAtom)
+      const result = openTab(tabs, layout, {
+        type: 'agent',
+        sessionId: session.id,
+        title: sessionTitle,
+      })
+      store.set(tabsAtom, result.tabs)
+      store.set(splitLayoutAtom, result.layout)
       store.set(currentAgentSessionIdAtom, session.id)
 
-      // 在 Agent 输入区显示建议提示（用户点击后发送，而非自动发送）
+      // 7. 在 Agent 输入区显示建议提示（用户点击后发送，而非自动发送）
       store.set(agentPromptSuggestionsAtom, (prev) => {
         const map = new Map(prev)
         map.set(session.id, suggestedPrompt)
         return map
       })
 
-      store.set(activeViewAtom, 'conversations')
-      store.set(appModeAtom, 'agent')
+      // 8. 通知用户
+      toast.success('已切换到 Agent 模式', {
+        description: '对话历史已迁移到新的 Agent 会话',
+      })
     } catch (error) {
       console.error('[AgentRecommendBanner] 迁移失败:', error)
       toast.error('切换到 Agent 模式失败')

--- a/apps/electron/src/renderer/components/chat/ChatMessageItem.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessageItem.tsx
@@ -30,6 +30,7 @@ import {
   ReasoningContent,
 } from '@/components/ai-elements/reasoning'
 import { CopyButton } from './CopyButton'
+import { MigrateToAgentButton } from './MigrateToAgentButton'
 import { DeleteMessageDialog } from './DeleteMessageDialog'
 import { InlineEditForm } from './InlineEditForm'
 import { UserAvatar } from './UserAvatar'
@@ -67,6 +68,8 @@ export function formatMessageTime(timestamp: number): string {
 interface ChatMessageItemProps {
   /** 消息数据 */
   message: ChatMessage
+  /** 当前对话 ID（用于迁移到 Agent 模式） */
+  conversationId?: string
   /** 是否正在流式生成中 */
   isStreaming?: boolean
   /** 是否为最后一条 assistant 消息（用于显示 StreamingIndicator） */
@@ -93,6 +96,7 @@ interface ChatMessageItemProps {
 
 export function ChatMessageItem({
   message,
+  conversationId,
   isStreaming = false,
   isLastAssistant = false,
   onDeleteMessage,
@@ -212,6 +216,9 @@ export function ChatMessageItem({
         {(message.content || (message.attachments && message.attachments.length > 0)) && !isStreaming && !isInlineEditing && (
           <MessageActions className="pl-[46px] mt-0.5">
             <CopyButton content={message.content} />
+            {message.role === 'assistant' && conversationId && (
+              <MigrateToAgentButton conversationId={conversationId} />
+            )}
             {message.role === 'user' && onResendMessage && (
               <MessageAction
                 tooltip="重新发送"

--- a/apps/electron/src/renderer/components/chat/ChatMessages.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessages.tsx
@@ -269,6 +269,7 @@ export function ChatMessages({
     return (
       <ParallelChatMessages
         messages={messages}
+        conversationId={conversationId}
         streaming={streaming}
         streamingContent={smoothContent}
         streamingReasoning={smoothReasoning}
@@ -308,6 +309,7 @@ export function ChatMessages({
                 <div data-message-id={msg.id}>
                   <ChatMessageItem
                     message={msg}
+                    conversationId={conversationId}
                     isStreaming={false}
                     isLastAssistant={false}
                     allMessages={messages}

--- a/apps/electron/src/renderer/components/chat/MigrateToAgentButton.tsx
+++ b/apps/electron/src/renderer/components/chat/MigrateToAgentButton.tsx
@@ -1,0 +1,114 @@
+/**
+ * MigrateToAgentButton — 切换到 Agent 模式按钮
+ *
+ * 常驻在助手消息 Action Bar 中，点击后：
+ * 1. 创建 Agent 会话（绑定默认工作区）
+ * 2. 迁移当前 Chat 对话历史到新 Agent 会话
+ * 3. 打开 Agent 会话 Tab 并自动激活
+ * 4. 通过 Sonner 通知用户已完成切换
+ */
+
+import * as React from 'react'
+import { useStore } from 'jotai'
+import { toast } from 'sonner'
+import { Bot, Loader2 } from 'lucide-react'
+import { MessageAction } from '@/components/ai-elements/message'
+import {
+  agentChannelIdAtom,
+  agentWorkspacesAtom,
+  agentSessionsAtom,
+  currentAgentSessionIdAtom,
+  currentAgentWorkspaceIdAtom,
+} from '@/atoms/agent-atoms'
+import { tabsAtom, splitLayoutAtom, openTab } from '@/atoms/tab-atoms'
+import { activeViewAtom } from '@/atoms/active-view'
+import { appModeAtom } from '@/atoms/app-mode'
+
+interface MigrateToAgentButtonProps {
+  /** 当前对话 ID */
+  conversationId: string
+}
+
+export function MigrateToAgentButton({ conversationId }: MigrateToAgentButtonProps): React.ReactElement {
+  const store = useStore()
+  const [migrating, setMigrating] = React.useState(false)
+
+  const handleMigrate = async (): Promise<void> => {
+    if (migrating) return
+
+    const agentChannelId = store.get(agentChannelIdAtom)
+    if (!agentChannelId) {
+      toast.error('请先在设置中配置 Agent 渠道')
+      return
+    }
+
+    setMigrating(true)
+    try {
+      const workspaces = store.get(agentWorkspacesAtom)
+      const defaultWorkspaceId = workspaces[0]?.id ?? null
+
+      // 1. 创建 Agent 会话
+      const session = await window.electronAPI.createAgentSession(
+        undefined,
+        agentChannelId,
+        defaultWorkspaceId ?? undefined,
+      )
+
+      // 2. 迁移 Chat 对话记录到新 Agent 会话
+      await window.electronAPI.migrateChatToAgent(conversationId, session.id)
+
+      // 3. 刷新会话列表
+      const sessions = await window.electronAPI.listAgentSessions()
+      store.set(agentSessionsAtom, sessions)
+
+      // 4. 切换到默认工作区
+      if (defaultWorkspaceId) {
+        store.set(currentAgentWorkspaceIdAtom, defaultWorkspaceId)
+        window.electronAPI.updateSettings({
+          agentWorkspaceId: defaultWorkspaceId,
+        }).catch(console.error)
+      }
+
+      // 5. 切换到 Agent 模式
+      store.set(appModeAtom, 'agent')
+      store.set(activeViewAtom, 'conversations')
+
+      // 6. 打开 Agent 会话 Tab 并激活
+      const sessionTitle = session.title ?? '新 Agent 会话'
+      const tabs = store.get(tabsAtom)
+      const layout = store.get(splitLayoutAtom)
+      const result = openTab(tabs, layout, {
+        type: 'agent',
+        sessionId: session.id,
+        title: sessionTitle,
+      })
+      store.set(tabsAtom, result.tabs)
+      store.set(splitLayoutAtom, result.layout)
+      store.set(currentAgentSessionIdAtom, session.id)
+
+      // 7. 通知用户
+      toast.success('已切换到 Agent 模式', {
+        description: '对话历史已迁移到新的 Agent 会话',
+      })
+    } catch (error) {
+      console.error('[MigrateToAgentButton] 迁移失败:', error)
+      toast.error('切换到 Agent 模式失败')
+    } finally {
+      setMigrating(false)
+    }
+  }
+
+  return (
+    <MessageAction
+      tooltip={migrating ? '切换中...' : '切换到 Agent 模式'}
+      onClick={() => { void handleMigrate() }}
+      disabled={migrating}
+    >
+      {migrating ? (
+        <Loader2 className="size-3.5 animate-spin" />
+      ) : (
+        <Bot className="size-3.5" />
+      )}
+    </MessageAction>
+  )
+}

--- a/apps/electron/src/renderer/components/chat/ParallelChatMessages.tsx
+++ b/apps/electron/src/renderer/components/chat/ParallelChatMessages.tsx
@@ -41,6 +41,8 @@ interface MessageSegment {
 
 interface ParallelChatMessagesProps {
   messages: ChatMessage[]
+  /** 当前对话 ID（用于迁移到 Agent 模式） */
+  conversationId?: string
   streaming: boolean
   streamingContent: string
   streamingReasoning: string
@@ -124,6 +126,8 @@ function segmentMessages(
 interface MessageColumnProps {
   messages: ChatMessage[]
   allMessages: ChatMessage[]
+  /** 当前对话 ID（用于迁移到 Agent 模式） */
+  conversationId?: string
   onDeleteMessage?: (messageId: string) => Promise<void>
   onResendMessage?: (message: ChatMessage) => Promise<void>
   onStartInlineEdit?: (message: ChatMessage) => void
@@ -141,6 +145,7 @@ interface MessageColumnProps {
 function MessageColumn({
   messages,
   allMessages,
+  conversationId,
   onDeleteMessage,
   onResendMessage,
   onStartInlineEdit,
@@ -184,6 +189,7 @@ function MessageColumn({
           <ChatMessageItem
             key={message.id}
             message={message}
+            conversationId={conversationId}
             allMessages={allMessages}
             onDeleteMessage={onDeleteMessage}
             onResendMessage={onResendMessage}
@@ -233,6 +239,7 @@ function MessageColumn({
 
 export function ParallelChatMessages({
   messages,
+  conversationId,
   streaming,
   streamingContent,
   streamingReasoning,
@@ -285,6 +292,7 @@ export function ParallelChatMessages({
             <MessageColumn
               messages={userMessages}
               allMessages={messages}
+              conversationId={conversationId}
               onDeleteMessage={onDeleteMessage}
               onResendMessage={onResendMessage}
               onStartInlineEdit={onStartInlineEdit}
@@ -305,6 +313,7 @@ export function ParallelChatMessages({
             <MessageColumn
               messages={assistantMessages}
               allMessages={messages}
+              conversationId={conversationId}
               onDeleteMessage={onDeleteMessage}
               onResendMessage={onResendMessage}
               onStartInlineEdit={onStartInlineEdit}
@@ -352,6 +361,7 @@ export function ParallelChatMessages({
                 <MessageColumn
                   messages={segment.userMessages}
                   allMessages={messages}
+                  conversationId={conversationId}
                   onDeleteMessage={onDeleteMessage}
                   onResendMessage={onResendMessage}
                   onStartInlineEdit={onStartInlineEdit}
@@ -374,6 +384,7 @@ export function ParallelChatMessages({
                 <MessageColumn
                   messages={segment.assistantMessages}
                   allMessages={messages}
+                  conversationId={conversationId}
                   onDeleteMessage={onDeleteMessage}
                   onResendMessage={onResendMessage}
                   onStartInlineEdit={onStartInlineEdit}


### PR DESCRIPTION
## 概述
在 Chat 模式下，用户现在可以直接从任意助手消息点击"切换到 Agent 模式"按钮，自动创建 Agent 会话、迁移对话历史，并切换到 Agent 模式。

## 实现细节
- **MigrateToAgentButton.tsx**: 新增独立按钮组件，使用 Bot 图标，集成完整的迁移流程（创建会话 → 迁移历史 → 打开 Tab → 显示 toast）
- **ChatMessageItem**: Assistant 消息 Action Bar 中 CopyButton 后添加迁移按钮
- **ChatMessages/ParallelChatMessages**: 传递 conversationId prop，支持标准和并排两种模式
- **AgentRecommendBanner**: 更新为使用 Tab 系统，添加 Sonner toast 用户通知

## 用户体验
- 点击按钮后自动打开新 Agent 会话 Tab 并激活
- Toast 通知："已切换到 Agent 模式，对话历史已迁移到新的 Agent 会话"
- 迁移中显示 Loader2 旋转动画，确保用户知晓操作进行中