### PR TITLE
feat: 输入框支持 / 触发 Skill 和 $ 触发 MCP 快速调用

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -847,13 +847,14 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
               onPasteFiles={handlePasteFiles}
               placeholder={
                 agentChannelId
-                  ? '输入消息... (Enter 发送，Shift+Enter 换行，@ 引用文件)'
+                  ? '输入消息... (Enter 发送，Shift+Enter 换行，@ 引用文件，/ Skill，$ MCP)'
                   : '请先在设置中选择 Agent 供应商'
               }
               disabled={!agentChannelId}
               autoFocusTrigger={sessionId}
               collapsible
               workspacePath={sessionPath}
+              workspaceSlug={workspaces.find((w) => w.id === currentWorkspaceId)?.slug ?? null}
               attachedDirs={attachedDirs}
             />
 

--- a/apps/electron/src/renderer/components/agent/McpMentionList.tsx
+++ b/apps/electron/src/renderer/components/agent/McpMentionList.tsx
@@ -1,0 +1,102 @@
+/**
+ * McpMentionList — $ 触发的 MCP Server 下拉列表
+ *
+ * 显示当前工作区的 MCP Server 列表，支持键盘导航。
+ * 通过 React.useImperativeHandle 暴露 onKeyDown 给 TipTap Suggestion。
+ */
+
+import * as React from 'react'
+import { Server } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+export interface McpMentionItem {
+  id: string
+  name: string
+  type: string
+  enabled: boolean
+}
+
+export interface McpMentionListProps {
+  items: McpMentionItem[]
+  selectedIndex: number
+  onSelect: (item: McpMentionItem) => void
+}
+
+export interface McpMentionRef {
+  onKeyDown: (props: { event: KeyboardEvent }) => boolean
+}
+
+export const McpMentionList = React.forwardRef<McpMentionRef, McpMentionListProps>(
+  function McpMentionList({ items, selectedIndex, onSelect }, ref) {
+    const [localIndex, setLocalIndex] = React.useState(selectedIndex)
+    const containerRef = React.useRef<HTMLDivElement>(null)
+
+    React.useEffect(() => {
+      setLocalIndex(0)
+    }, [items])
+
+    React.useEffect(() => {
+      const container = containerRef.current
+      if (!container) return
+      const item = container.children[localIndex] as HTMLElement | undefined
+      item?.scrollIntoView({ block: 'nearest' })
+    }, [localIndex])
+
+    React.useImperativeHandle(ref, () => ({
+      onKeyDown: ({ event }) => {
+        if (event.key === 'ArrowUp') {
+          setLocalIndex((prev) => (prev <= 0 ? items.length - 1 : prev - 1))
+          return true
+        }
+        if (event.key === 'ArrowDown') {
+          setLocalIndex((prev) => (prev >= items.length - 1 ? 0 : prev + 1))
+          return true
+        }
+        if (event.key === 'Enter') {
+          const item = items[localIndex]
+          if (item) onSelect(item)
+          return true
+        }
+        if (event.key === 'Escape') {
+          return true
+        }
+        return false
+      },
+    }))
+
+    if (items.length === 0) {
+      return (
+        <div className="rounded-lg border bg-popover p-2 shadow-lg text-[11px] text-muted-foreground">
+          无匹配 MCP 服务
+        </div>
+      )
+    }
+
+    return (
+      <div
+        ref={containerRef}
+        className="rounded-lg border bg-popover shadow-lg overflow-y-auto max-h-[240px] min-w-[240px]"
+      >
+        {items.map((item, index) => (
+          <button
+            key={item.id}
+            type="button"
+            className={cn(
+              'w-full flex items-center gap-2 px-2.5 py-1.5 text-left text-xs hover:bg-accent transition-colors',
+              index === localIndex && 'bg-accent text-accent-foreground',
+            )}
+            onClick={() => onSelect(item)}
+          >
+            <Server className="size-3.5 text-emerald-500 flex-shrink-0" />
+            <div className="flex flex-col min-w-0 flex-1">
+              <span className="truncate font-medium">{item.name}</span>
+              <span className="truncate text-[10px] text-muted-foreground/70">
+                {item.type} · {item.enabled ? '已启用' : '已禁用'}
+              </span>
+            </div>
+          </button>
+        ))}
+      </div>
+    )
+  },
+)

--- a/apps/electron/src/renderer/components/agent/SkillMentionList.tsx
+++ b/apps/electron/src/renderer/components/agent/SkillMentionList.tsx
@@ -1,0 +1,102 @@
+/**
+ * SkillMentionList — / 触发的 Skill 下拉列表
+ *
+ * 显示当前工作区的 Skill 列表，支持键盘导航。
+ * 通过 React.useImperativeHandle 暴露 onKeyDown 给 TipTap Suggestion。
+ */
+
+import * as React from 'react'
+import { Sparkles } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type { SkillMeta } from '@proma/shared'
+
+export interface SkillMentionItem {
+  id: string
+  name: string
+  description?: string
+}
+
+export interface SkillMentionListProps {
+  items: SkillMentionItem[]
+  selectedIndex: number
+  onSelect: (item: SkillMentionItem) => void
+}
+
+export interface SkillMentionRef {
+  onKeyDown: (props: { event: KeyboardEvent }) => boolean
+}
+
+export const SkillMentionList = React.forwardRef<SkillMentionRef, SkillMentionListProps>(
+  function SkillMentionList({ items, selectedIndex, onSelect }, ref) {
+    const [localIndex, setLocalIndex] = React.useState(selectedIndex)
+    const containerRef = React.useRef<HTMLDivElement>(null)
+
+    React.useEffect(() => {
+      setLocalIndex(0)
+    }, [items])
+
+    React.useEffect(() => {
+      const container = containerRef.current
+      if (!container) return
+      const item = container.children[localIndex] as HTMLElement | undefined
+      item?.scrollIntoView({ block: 'nearest' })
+    }, [localIndex])
+
+    React.useImperativeHandle(ref, () => ({
+      onKeyDown: ({ event }) => {
+        if (event.key === 'ArrowUp') {
+          setLocalIndex((prev) => (prev <= 0 ? items.length - 1 : prev - 1))
+          return true
+        }
+        if (event.key === 'ArrowDown') {
+          setLocalIndex((prev) => (prev >= items.length - 1 ? 0 : prev + 1))
+          return true
+        }
+        if (event.key === 'Enter') {
+          const item = items[localIndex]
+          if (item) onSelect(item)
+          return true
+        }
+        if (event.key === 'Escape') {
+          return true
+        }
+        return false
+      },
+    }))
+
+    if (items.length === 0) {
+      return (
+        <div className="rounded-lg border bg-popover p-2 shadow-lg text-[11px] text-muted-foreground">
+          无匹配 Skill
+        </div>
+      )
+    }
+
+    return (
+      <div
+        ref={containerRef}
+        className="rounded-lg border bg-popover shadow-lg overflow-y-auto max-h-[240px] min-w-[240px]"
+      >
+        {items.map((item, index) => (
+          <button
+            key={item.id}
+            type="button"
+            className={cn(
+              'w-full flex items-center gap-2 px-2.5 py-1.5 text-left text-xs hover:bg-accent transition-colors',
+              index === localIndex && 'bg-accent text-accent-foreground',
+            )}
+            onClick={() => onSelect(item)}
+          >
+            <Sparkles className="size-3.5 text-violet-500 flex-shrink-0" />
+            <div className="flex flex-col min-w-0 flex-1">
+              <span className="truncate font-medium">{item.name}</span>
+              {item.description && (
+                <span className="truncate text-[10px] text-muted-foreground/70">{item.description}</span>
+              )}
+            </div>
+          </button>
+        ))}
+      </div>
+    )
+  },
+)

--- a/apps/electron/src/renderer/components/agent/mcp-mention-suggestion.tsx
+++ b/apps/electron/src/renderer/components/agent/mcp-mention-suggestion.tsx
@@ -1,0 +1,105 @@
+/**
+ * McpMentionSuggestion — TipTap Mention Suggestion 配置（$ 触发）
+ *
+ * 输入 $ 后异步获取当前工作区的 MCP Server 列表，弹出 McpMentionList 浮动列表。
+ */
+
+import type React from 'react'
+import { ReactRenderer } from '@tiptap/react'
+import type { SuggestionOptions } from '@tiptap/suggestion'
+import { McpMentionList } from './McpMentionList'
+import type { McpMentionRef, McpMentionItem } from './McpMentionList'
+
+/**
+ * 创建 MCP $ 引用的 Suggestion 配置
+ *
+ * @param workspaceSlugRef 当前工作区 slug 引用
+ * @param mentionActiveRef 是否正在 mention 模式（用于阻止 Enter 发送消息）
+ */
+export function createMcpMentionSuggestion(
+  workspaceSlugRef: React.RefObject<string | null>,
+  mentionActiveRef: React.MutableRefObject<boolean>,
+): Omit<SuggestionOptions<McpMentionItem>, 'editor'> {
+  return {
+    char: '$',
+    allowSpaces: false,
+
+    items: async ({ query }): Promise<McpMentionItem[]> => {
+      const slug = workspaceSlugRef.current
+      if (!slug) return []
+
+      try {
+        const caps = await window.electronAPI.getWorkspaceCapabilities(slug)
+        const q = (query ?? '').toLowerCase()
+        return caps.mcpServers
+          .filter((s) => !q || s.name.toLowerCase().includes(q))
+          .map((s) => ({ id: s.name, name: s.name, type: s.type, enabled: s.enabled }))
+      } catch {
+        return []
+      }
+    },
+
+    render: () => {
+      let renderer: ReactRenderer<McpMentionRef> | null = null
+      let popup: HTMLDivElement | null = null
+
+      return {
+        onStart(props) {
+          mentionActiveRef.current = true
+          renderer = new ReactRenderer(McpMentionList, {
+            props: {
+              items: props.items,
+              selectedIndex: 0,
+              onSelect: (item: McpMentionItem) => {
+                props.command({ id: item.id, label: item.name })
+              },
+            },
+            editor: props.editor,
+          })
+
+          popup = document.createElement('div')
+          popup.style.position = 'absolute'
+          popup.style.zIndex = '9999'
+          document.body.appendChild(popup)
+          popup.appendChild(renderer.element)
+
+          const rect = props.clientRect?.()
+          if (rect && popup) {
+            popup.style.left = `${rect.left}px`
+            requestAnimationFrame(() => {
+              if (!popup) return
+              const popupHeight = popup.offsetHeight
+              popup.style.top = `${rect.top - popupHeight - 4}px`
+            })
+          }
+        },
+
+        onUpdate(props) {
+          renderer?.updateProps({ items: props.items })
+
+          const rect = props.clientRect?.()
+          if (rect && popup) {
+            popup.style.left = `${rect.left}px`
+            requestAnimationFrame(() => {
+              if (!popup) return
+              const popupHeight = popup.offsetHeight
+              popup.style.top = `${rect.top - popupHeight - 4}px`
+            })
+          }
+        },
+
+        onKeyDown(props) {
+          return renderer?.ref?.onKeyDown({ event: props.event }) ?? false
+        },
+
+        onExit() {
+          mentionActiveRef.current = false
+          popup?.remove()
+          popup = null
+          renderer?.destroy()
+          renderer = null
+        },
+      }
+    },
+  }
+}

--- a/apps/electron/src/renderer/components/agent/skill-mention-suggestion.tsx
+++ b/apps/electron/src/renderer/components/agent/skill-mention-suggestion.tsx
@@ -1,0 +1,106 @@
+/**
+ * SkillMentionSuggestion — TipTap Mention Suggestion 配置（/ 触发）
+ *
+ * 输入 / 后异步获取当前工作区的 Skill 列表，弹出 SkillMentionList 浮动列表。
+ */
+
+import type React from 'react'
+import { ReactRenderer } from '@tiptap/react'
+import type { SuggestionOptions } from '@tiptap/suggestion'
+import { SkillMentionList } from './SkillMentionList'
+import type { SkillMentionRef, SkillMentionItem } from './SkillMentionList'
+
+/**
+ * 创建 Skill / 引用的 Suggestion 配置
+ *
+ * @param workspaceSlugRef 当前工作区 slug 引用
+ * @param mentionActiveRef 是否正在 mention 模式（用于阻止 Enter 发送消息）
+ */
+export function createSkillMentionSuggestion(
+  workspaceSlugRef: React.RefObject<string | null>,
+  mentionActiveRef: React.MutableRefObject<boolean>,
+): Omit<SuggestionOptions<SkillMentionItem>, 'editor'> {
+  return {
+    char: '/',
+    allowSpaces: false,
+
+    items: async ({ query }): Promise<SkillMentionItem[]> => {
+      const slug = workspaceSlugRef.current
+      if (!slug) return []
+
+      try {
+        const caps = await window.electronAPI.getWorkspaceCapabilities(slug)
+        const q = (query ?? '').toLowerCase()
+        return caps.skills
+          .filter((s) => s.enabled)
+          .filter((s) => !q || s.name.toLowerCase().includes(q) || (s.slug ?? '').toLowerCase().includes(q))
+          .map((s) => ({ id: s.slug, name: s.name, description: s.description }))
+      } catch {
+        return []
+      }
+    },
+
+    render: () => {
+      let renderer: ReactRenderer<SkillMentionRef> | null = null
+      let popup: HTMLDivElement | null = null
+
+      return {
+        onStart(props) {
+          mentionActiveRef.current = true
+          renderer = new ReactRenderer(SkillMentionList, {
+            props: {
+              items: props.items,
+              selectedIndex: 0,
+              onSelect: (item: SkillMentionItem) => {
+                props.command({ id: item.id, label: item.name })
+              },
+            },
+            editor: props.editor,
+          })
+
+          popup = document.createElement('div')
+          popup.style.position = 'absolute'
+          popup.style.zIndex = '9999'
+          document.body.appendChild(popup)
+          popup.appendChild(renderer.element)
+
+          const rect = props.clientRect?.()
+          if (rect && popup) {
+            popup.style.left = `${rect.left}px`
+            requestAnimationFrame(() => {
+              if (!popup) return
+              const popupHeight = popup.offsetHeight
+              popup.style.top = `${rect.top - popupHeight - 4}px`
+            })
+          }
+        },
+
+        onUpdate(props) {
+          renderer?.updateProps({ items: props.items })
+
+          const rect = props.clientRect?.()
+          if (rect && popup) {
+            popup.style.left = `${rect.left}px`
+            requestAnimationFrame(() => {
+              if (!popup) return
+              const popupHeight = popup.offsetHeight
+              popup.style.top = `${rect.top - popupHeight - 4}px`
+            })
+          }
+        },
+
+        onKeyDown(props) {
+          return renderer?.ref?.onKeyDown({ event: props.event }) ?? false
+        },
+
+        onExit() {
+          mentionActiveRef.current = false
+          popup?.remove()
+          popup = null
+          renderer?.destroy()
+          renderer = null
+        },
+      }
+    },
+  }
+}

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -5,7 +5,7 @@
  *
  * 功能：
  * - StarterKit + Placeholder + Underline + Link + CodeBlockLowlight
- * - 可选 Mention 扩展（@ 引用文件）
+ * - 可选 Mention 扩展（@ 引用文件、/ 触发 Skill、$ 触发 MCP）
  * - htmlToMarkdown 转换
  * - IME composition 处理
  * - Enter 提交 / Shift+Enter 换行
@@ -26,6 +26,8 @@ import { ChevronsDownUp, ChevronsUpDown } from 'lucide-react'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { createFileMentionSuggestion } from '@/components/file-browser/file-mention-suggestion'
+import { createSkillMentionSuggestion } from '@/components/agent/skill-mention-suggestion'
+import { createMcpMentionSuggestion } from '@/components/agent/mcp-mention-suggestion'
 
 // 创建 lowlight 实例，使用常见语言
 const lowlight = createLowlight(common)
@@ -111,10 +113,14 @@ function htmlToMarkdown(html: string): string {
       case 'h6': return `###### ${children}\n\n`
       case 'hr': return '---\n\n'
       case 'span': {
-        // Mention 节点：转换为 @file:路径 格式
-        if (el.getAttribute('data-type') === 'mention') {
-          const filePath = el.getAttribute('data-id') || ''
-          return `@file:${filePath}`
+        // Mention 节点：根据 data-mention-suggestion-char 区分类型
+        const dataType = el.getAttribute('data-type')
+        const dataId = el.getAttribute('data-id') || ''
+        const suggestionChar = el.getAttribute('data-mention-suggestion-char') || '@'
+        if (dataType === 'mention') {
+          if (suggestionChar === '/') return `/skill:${dataId}`
+          if (suggestionChar === '$') return `$mcp:${dataId}`
+          return `@file:${dataId}`
         }
         return children
       }
@@ -181,6 +187,8 @@ interface RichTextInputProps {
   collapsible?: boolean
   /** 工作区根路径（启用 @ 引用文件功能时需要） */
   workspacePath?: string | null
+  /** 工作区 slug（启用 / Skill 和 $ MCP 功能时需要） */
+  workspaceSlug?: string | null
   /** 附加目录路径列表（@ 引用时一并搜索） */
   attachedDirs?: string[]
   className?: string
@@ -204,6 +212,7 @@ export function RichTextInput({
   autoFocusTrigger,
   collapsible = false,
   workspacePath,
+  workspaceSlug,
   attachedDirs = [],
 }: RichTextInputProps): React.ReactElement {
   const [isExpanded, setIsExpanded] = useState(false)
@@ -227,10 +236,25 @@ export function RichTextInput({
   // 附加目录路径引用（给 Suggestion 使用）
   const attachedDirsRef = useRef<string[]>(attachedDirs)
   attachedDirsRef.current = attachedDirs
+  // 工作区 slug 引用（给 Skill/MCP Suggestion 使用）
+  const workspaceSlugRef = useRef<string | null>(workspaceSlug ?? null)
+  workspaceSlugRef.current = workspaceSlug ?? null
 
   // Mention Suggestion 配置（稳定引用，不随 workspacePath 变化重建）
   const mentionSuggestion = useMemo(
     () => createFileMentionSuggestion(workspacePathRef, mentionActiveRef, attachedDirsRef),
+    [],
+  )
+
+  // Skill Suggestion 配置（/ 触发）
+  const skillSuggestion = useMemo(
+    () => createSkillMentionSuggestion(workspaceSlugRef, mentionActiveRef),
+    [],
+  )
+
+  // MCP Suggestion 配置（$ 触发）
+  const mcpSuggestion = useMemo(
+    () => createMcpMentionSuggestion(workspaceSlugRef, mentionActiveRef),
     [],
   )
 
@@ -260,13 +284,33 @@ export function RichTextInput({
         placeholder,
         emptyEditorClass: 'is-editor-empty',
       }),
-      // @ 引用文件（始终加载扩展，workspacePathRef 内部控制是否搜索）
-      // 不能条件加载，因为 useEditor 不会在 workspacePath 变化时重建扩展
+      // Mention 扩展：@ 引用文件、/ 触发 Skill、$ 触发 MCP
+      // TipTap v3 原生支持 suggestions 数组，一个实例处理多个触发字符
       Mention.configure({
-        HTMLAttributes: {
-          class: 'mention-chip',
+        HTMLAttributes: {},
+        renderHTML({ options, node, suggestion }) {
+          const char = suggestion?.char ?? node.attrs.mentionSuggestionChar ?? '@'
+          const label = node.attrs.label ?? node.attrs.id
+          let chipClass = 'mention-chip'
+          if (char === '/') chipClass = 'skill-mention-chip'
+          else if (char === '$') chipClass = 'mcp-mention-chip'
+          return [
+            'span',
+            {
+              'data-type': 'mention',
+              'data-id': node.attrs.id,
+              'data-label': node.attrs.label,
+              'data-mention-suggestion-char': char,
+              class: chipClass,
+            },
+            `${char}${label}`,
+          ]
         },
-        suggestion: mentionSuggestion,
+        suggestions: [
+          mentionSuggestion,
+          skillSuggestion,
+          mcpSuggestion,
+        ],
       }),
     ],
     content: value || '',
@@ -466,6 +510,24 @@ export function RichTextInput({
         .mention-chip {
           background-color: hsl(var(--primary) / 0.1);
           color: hsl(var(--primary));
+          border-radius: 4px;
+          padding: 1px 4px;
+          font-size: 13px;
+          font-weight: 500;
+          white-space: nowrap;
+        }
+        .skill-mention-chip {
+          background-color: hsl(270 60% 60% / 0.15);
+          color: hsl(270 60% 50%);
+          border-radius: 4px;
+          padding: 1px 4px;
+          font-size: 13px;
+          font-weight: 500;
+          white-space: nowrap;
+        }
+        .mcp-mention-chip {
+          background-color: hsl(160 60% 45% / 0.15);
+          color: hsl(160 60% 35%);
           border-radius: 4px;
           padding: 1px 4px;
           font-size: 13px;

--- a/apps/electron/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatInput.tsx
@@ -31,6 +31,10 @@ import {
 import {
   conversationDraftsAtom,
 } from '@/atoms/chat-atoms'
+import {
+  agentWorkspacesAtom,
+  currentAgentWorkspaceIdAtom,
+} from '@/atoms/agent-atoms'
 import type { PendingAttachment } from '@/atoms/chat-atoms'
 import {
   useConversationModel,
@@ -76,6 +80,9 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
 
   const [selectedModel] = useConversationModel()
   const [thinkingEnabled, setThinkingEnabled] = useConversationThinkingEnabled()
+  const workspaces = useAtomValue(agentWorkspacesAtom)
+  const currentWorkspaceId = useAtomValue(currentAgentWorkspaceIdAtom)
+  const currentWorkspaceSlug = workspaces.find((w) => w.id === currentWorkspaceId)?.slug ?? null
   const setPendingAttachments = onSetPendingAttachments
   const [isDragOver, setIsDragOver] = React.useState(false)
 
@@ -257,11 +264,12 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
             onPasteFiles={handlePasteFiles}
             placeholder={
               selectedModel
-                ? '输入消息... (Enter 发送，Shift+Enter 换行。支持拖放文件和直接粘贴图片)'
+                ? '输入消息... (Enter 发送，Shift+Enter 换行，@ 引用文件，/ 调用 Skill，$ 调用 MCP)'
                 : '请先选择模型'
             }
             disabled={!selectedModel}
             autoFocusTrigger={conversationId}
+            workspaceSlug={currentWorkspaceSlug}
           />
 
           {/* Footer 工具栏 — Cherry Studio: padding 5px 8px, height 40px, gap 16px */}


### PR DESCRIPTION
## 改动说明

在 Agent 和 Chat 模式的输入框中新增两个快捷触发功能：

- **`/` 触发 Skill 列表** — 紫色标签，从当前工作区异步加载已启用的 Skill，支持模糊搜索和键盘导航
- **`$` 触发 MCP Server 列表** — 绿色标签，从当前工作区加载 MCP 服务列表

### 实现方式

基于 TipTap v3 Mention 扩展的原生 `suggestions` 数组，将 `@`（文件引用）、`/`（Skill）、`$`（MCP）三个触发器统一在一个 Mention 实例中，互不冲突。

### 改动文件

- `SkillMentionList.tsx` + `skill-mention-suggestion.tsx` — Skill 下拉列表组件和触发配置
- `McpMentionList.tsx` + `mcp-mention-suggestion.tsx` — MCP 下拉列表组件和触发配置
- `rich-text-input.tsx` — 集成 `suggestions` 数组，添加样式
- `AgentView.tsx` — 传递 `workspaceSlug` 给输入框
- `ChatInput.tsx` — Chat 模式同样支持，读取当前 Agent 工作区数据；更新 placeholder 提示

### 构建状态

TypeScript 类型检查和 Vite 构建均通过，零错误。