### PR TITLE
feat(agent): workspace files directory with shared folder access

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -30,8 +30,10 @@ import type {
   AgentWorkspace,
   AgentGenerateTitleInput,
   AgentSaveFilesInput,
+  AgentSaveWorkspaceFilesInput,
   AgentSavedFile,
   AgentAttachDirectoryInput,
+  WorkspaceAttachDirectoryInput,
   GetTaskOutputInput,
   GetTaskOutputResult,
   StopTaskInput,
@@ -115,11 +117,11 @@ import {
   migrateChatToAgentSession,
   moveSessionToWorkspace,
 } from './lib/agent-session-manager'
-import { runAgent, stopAgent, generateAgentTitle, saveFilesToAgentSession, isAgentSessionActive } from './lib/agent-service'
+import { runAgent, stopAgent, generateAgentTitle, saveFilesToAgentSession, saveFilesToWorkspaceFiles, isAgentSessionActive } from './lib/agent-service'
 import { permissionService } from './lib/agent-permission-service'
 import { askUserService } from './lib/agent-ask-user-service'
 import { getAgentTeamData, readAgentOutputFile } from './lib/agent-team-reader'
-import { getAgentSessionWorkspacePath, getAgentWorkspacesDir, getWorkspaceSkillsDir } from './lib/config-paths'
+import { getAgentSessionWorkspacePath, getAgentWorkspacesDir, getWorkspaceSkillsDir, getWorkspaceFilesDir } from './lib/config-paths'
 import {
   listAgentWorkspaces,
   createAgentWorkspace,
@@ -135,6 +137,9 @@ import {
   toggleWorkspaceSkill,
   getWorkspacePermissionMode,
   setWorkspacePermissionMode,
+  getWorkspaceAttachedDirectories,
+  attachWorkspaceDirectory,
+  detachWorkspaceDirectory,
 } from './lib/agent-workspace-manager'
 import { getMemoryConfig, setMemoryConfig } from './lib/memory-service'
 import { getAllToolInfos } from './lib/chat-tool-registry'
@@ -1041,6 +1046,22 @@ export function registerIpcHandlers(): void {
     }
   )
 
+  // 保存文件到工作区文件目录
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.SAVE_FILES_TO_WORKSPACE,
+    async (_, input: AgentSaveWorkspaceFilesInput): Promise<AgentSavedFile[]> => {
+      return saveFilesToWorkspaceFiles(input)
+    }
+  )
+
+  // 获取工作区文件目录路径
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.GET_WORKSPACE_FILES_PATH,
+    async (_, workspaceSlug: string): Promise<string> => {
+      return getWorkspaceFilesDir(workspaceSlug)
+    }
+  )
+
   // 打开文件夹选择对话框
   ipcMain.handle(
     AGENT_IPC_CHANNELS.OPEN_FOLDER_DIALOG,
@@ -1092,6 +1113,34 @@ export function registerIpcHandlers(): void {
       // 停止附加目录文件监听
       unwatchAttachedDirectory(input.directoryPath)
       return updated
+    }
+  )
+
+  // 附加外部目录到工作区（所有会话可访问）
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.ATTACH_WORKSPACE_DIRECTORY,
+    async (_, input: WorkspaceAttachDirectoryInput): Promise<string[]> => {
+      const updated = attachWorkspaceDirectory(input.workspaceSlug, input.directoryPath)
+      watchAttachedDirectory(input.directoryPath)
+      return updated
+    }
+  )
+
+  // 移除工作区的附加目录
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.DETACH_WORKSPACE_DIRECTORY,
+    async (_, input: WorkspaceAttachDirectoryInput): Promise<string[]> => {
+      const updated = detachWorkspaceDirectory(input.workspaceSlug, input.directoryPath)
+      unwatchAttachedDirectory(input.directoryPath)
+      return updated
+    }
+  )
+
+  // 获取工作区附加目录列表
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.GET_WORKSPACE_DIRECTORIES,
+    async (_, workspaceSlug: string): Promise<string[]> => {
+      return getWorkspaceAttachedDirectories(workspaceSlug)
     }
   )
 

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -33,7 +33,8 @@ import { getFetchFn } from './proxy-fetch'
 import { getEffectiveProxyUrl } from './proxy-settings-service'
 import { appendAgentMessage, updateAgentSessionMeta, getAgentSessionMeta, getAgentSessionMessages } from './agent-session-manager'
 import { getAgentWorkspace, getWorkspaceMcpConfig, ensurePluginManifest, getWorkspacePermissionMode } from './agent-workspace-manager'
-import { getAgentWorkspacePath, getAgentSessionWorkspacePath, getSdkConfigDir } from './config-paths'
+import { getAgentWorkspacePath, getAgentSessionWorkspacePath, getSdkConfigDir, getWorkspaceFilesDir } from './config-paths'
+import { getWorkspaceAttachedDirectories } from './agent-workspace-manager'
 import { getRuntimeStatus } from './runtime-init'
 import { getSettings } from './settings-service'
 import { buildSystemPromptAppend, buildDynamicContext } from './agent-prompt-builder'
@@ -885,7 +886,23 @@ export class AgentOrchestrator {
         resumeSessionId: existingSdkSessionId,
         ...(Object.keys(mcpServers).length > 0 && { mcpServers }),
         ...(workspaceSlug && { plugins: [{ type: 'local' as const, path: getAgentWorkspacePath(workspaceSlug) }] }),
-        ...(additionalDirectories && additionalDirectories.length > 0 && { additionalDirectories }),
+        // 合并用户附加目录 + 工作区附加目录 + 工作区文件目录
+        ...(() => {
+          const allDirs = [...(additionalDirectories || [])]
+          if (workspaceSlug) {
+            // 工作区级附加目录
+            const workspaceDirs = getWorkspaceAttachedDirectories(workspaceSlug)
+            for (const dir of workspaceDirs) {
+              if (!allDirs.includes(dir)) allDirs.push(dir)
+            }
+            // 工作区文件目录
+            const wsFilesDir = getWorkspaceFilesDir(workspaceSlug)
+            if (!allDirs.includes(wsFilesDir)) {
+              allDirs.push(wsFilesDir)
+            }
+          }
+          return allDirs.length > 0 ? { additionalDirectories: allDirs } : {}
+        })(),
         // SDK 0.2.52+ 新增选项（从 settings 读取）
         ...(appSettings.agentThinking && { thinking: appSettings.agentThinking }),
         ...(appSettings.agentEffort && { effort: appSettings.agentEffort }),

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -19,13 +19,14 @@ import type {
   AgentSendInput,
   AgentGenerateTitleInput,
   AgentSaveFilesInput,
+  AgentSaveWorkspaceFilesInput,
   AgentSavedFile,
   AgentStreamEvent,
 } from '@proma/shared'
 import { ClaudeAgentAdapter } from './adapters/claude-agent-adapter'
 import { AgentEventBus } from './agent-event-bus'
 import { AgentOrchestrator } from './agent-orchestrator'
-import { getAgentSessionWorkspacePath } from './config-paths'
+import { getAgentSessionWorkspacePath, getWorkspaceFilesDir } from './config-paths'
 
 // ===== 实例创建 =====
 
@@ -227,6 +228,46 @@ export function saveFilesToAgentSession(input: AgentSaveFilesInput): AgentSavedF
     const actualFilename = targetPath.slice(sessionDir.length + 1)
     results.push({ filename: actualFilename, targetPath })
     console.log(`[Agent 服务] 文件已保存: ${targetPath} (${buffer.length} bytes)`)
+  }
+
+  return results
+}
+
+/**
+ * 保存文件到工作区文件目录
+ *
+ * 将 base64 编码的文件写入工作区 workspace-files/ 目录，所有会话均可访问。
+ */
+export function saveFilesToWorkspaceFiles(input: AgentSaveWorkspaceFilesInput): AgentSavedFile[] {
+  const wsFilesDir = getWorkspaceFilesDir(input.workspaceSlug)
+  const results: AgentSavedFile[] = []
+  const usedPaths = new Set<string>()
+
+  for (const file of input.files) {
+    let targetPath = join(wsFilesDir, file.filename)
+
+    // 防止同名文件覆盖
+    if (usedPaths.has(targetPath) || existsSync(targetPath)) {
+      const dotIdx = file.filename.lastIndexOf('.')
+      const baseName = dotIdx > 0 ? file.filename.slice(0, dotIdx) : file.filename
+      const ext = dotIdx > 0 ? file.filename.slice(dotIdx) : ''
+      let counter = 1
+      let candidate = join(wsFilesDir, `${baseName}-${counter}${ext}`)
+      while (usedPaths.has(candidate) || existsSync(candidate)) {
+        counter++
+        candidate = join(wsFilesDir, `${baseName}-${counter}${ext}`)
+      }
+      targetPath = candidate
+    }
+    usedPaths.add(targetPath)
+
+    mkdirSync(dirname(targetPath), { recursive: true })
+    const buffer = Buffer.from(file.data, 'base64')
+    writeFileSync(targetPath, buffer)
+
+    const actualFilename = targetPath.slice(wsFilesDir.length + 1)
+    results.push({ filename: actualFilename, targetPath })
+    console.log(`[Agent 服务] 工作区文件已保存: ${targetPath} (${buffer.length} bytes)`)
   }
 
   return results

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -470,6 +470,7 @@ export function toggleWorkspaceSkill(workspaceSlug: string, skillSlug: string, e
 /** 工作区配置文件格式 */
 interface WorkspaceConfig {
   permissionMode?: PromaPermissionMode
+  attachedDirectories?: string[]
 }
 
 /**
@@ -523,4 +524,43 @@ export function setWorkspacePermissionMode(workspaceSlug: string, mode: PromaPer
   const updated: WorkspaceConfig = { ...config, permissionMode: mode }
   writeWorkspaceConfig(workspaceSlug, updated)
   console.log(`[Agent 工作区] 权限模式已更新: ${workspaceSlug} → ${mode}`)
+}
+
+// ===== 工作区级附加目录管理 =====
+
+/**
+ * 获取工作区附加目录列表
+ */
+export function getWorkspaceAttachedDirectories(workspaceSlug: string): string[] {
+  const config = readWorkspaceConfig(workspaceSlug)
+  return config.attachedDirectories ?? []
+}
+
+/**
+ * 附加目录到工作区（所有会话可访问）
+ */
+export function attachWorkspaceDirectory(workspaceSlug: string, directoryPath: string): string[] {
+  const config = readWorkspaceConfig(workspaceSlug)
+  const existing = config.attachedDirectories ?? []
+
+  if (existing.includes(directoryPath)) {
+    return existing
+  }
+
+  const updated = [...existing, directoryPath]
+  writeWorkspaceConfig(workspaceSlug, { ...config, attachedDirectories: updated })
+  console.log(`[Agent 工作区] 已附加工作区目录: ${directoryPath} → ${workspaceSlug}`)
+  return updated
+}
+
+/**
+ * 从工作区移除附加目录
+ */
+export function detachWorkspaceDirectory(workspaceSlug: string, directoryPath: string): string[] {
+  const config = readWorkspaceConfig(workspaceSlug)
+  const existing = config.attachedDirectories ?? []
+  const updated = existing.filter((d) => d !== directoryPath)
+  writeWorkspaceConfig(workspaceSlug, { ...config, attachedDirectories: updated })
+  console.log(`[Agent 工作区] 已移除工作区目录: ${directoryPath} ← ${workspaceSlug}`)
+  return updated
 }

--- a/apps/electron/src/main/lib/config-paths.ts
+++ b/apps/electron/src/main/lib/config-paths.ts
@@ -286,6 +286,25 @@ export function getWorkspaceSkillsDir(slug: string): string {
 }
 
 /**
+ * 获取工作区文件目录路径
+ *
+ * 工作区内所有会话可访问的文件存放于此。
+ * 如果目录不存在则自动创建。
+ *
+ * @param slug 工作区 slug
+ * @returns ~/.proma/agent-workspaces/{slug}/workspace-files/
+ */
+export function getWorkspaceFilesDir(slug: string): string {
+  const dir = join(getAgentWorkspacePath(slug), 'workspace-files')
+
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+
+  return dir
+}
+
+/**
  * 获取工作区不活跃 Skills 目录路径
  *
  * 禁用的 Skill 会被移动到此目录，Agent SDK 不会扫描该目录。

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -38,8 +38,10 @@ import type {
   AgentWorkspace,
   AgentGenerateTitleInput,
   AgentSaveFilesInput,
+  AgentSaveWorkspaceFilesInput,
   AgentSavedFile,
   AgentAttachDirectoryInput,
+  WorkspaceAttachDirectoryInput,
   GetTaskOutputInput,
   GetTaskOutputResult,
   StopTaskInput,
@@ -419,6 +421,12 @@ export interface ElectronAPI {
   /** 保存文件到 Agent session 工作目录 */
   saveFilesToAgentSession: (input: AgentSaveFilesInput) => Promise<AgentSavedFile[]>
 
+  /** 保存文件到工作区文件目录 */
+  saveFilesToWorkspaceFiles: (input: AgentSaveWorkspaceFilesInput) => Promise<AgentSavedFile[]>
+
+  /** 获取工作区文件目录路径 */
+  getWorkspaceFilesPath: (workspaceSlug: string) => Promise<string>
+
   /** 打开文件夹选择对话框 */
   openFolderDialog: () => Promise<{ path: string; name: string } | null>
 
@@ -427,6 +435,15 @@ export interface ElectronAPI {
 
   /** 移除会话的附加目录 */
   detachDirectory: (input: AgentAttachDirectoryInput) => Promise<string[]>
+
+  /** 附加外部目录到工作区（所有会话可访问） */
+  attachWorkspaceDirectory: (input: WorkspaceAttachDirectoryInput) => Promise<string[]>
+
+  /** 移除工作区的附加目录 */
+  detachWorkspaceDirectory: (input: WorkspaceAttachDirectoryInput) => Promise<string[]>
+
+  /** 获取工作区附加目录列表 */
+  getWorkspaceDirectories: (workspaceSlug: string) => Promise<string[]>
 
   // ===== Agent 文件系统操作 =====
 
@@ -995,6 +1012,14 @@ const electronAPI: ElectronAPI = {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.SAVE_FILES_TO_SESSION, input)
   },
 
+  saveFilesToWorkspaceFiles: (input: AgentSaveWorkspaceFilesInput) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.SAVE_FILES_TO_WORKSPACE, input)
+  },
+
+  getWorkspaceFilesPath: (workspaceSlug: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.GET_WORKSPACE_FILES_PATH, workspaceSlug)
+  },
+
   openFolderDialog: () => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.OPEN_FOLDER_DIALOG)
   },
@@ -1005,6 +1030,18 @@ const electronAPI: ElectronAPI = {
 
   detachDirectory: (input: AgentAttachDirectoryInput) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.DETACH_DIRECTORY, input)
+  },
+
+  attachWorkspaceDirectory: (input: WorkspaceAttachDirectoryInput) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.ATTACH_WORKSPACE_DIRECTORY, input)
+  },
+
+  detachWorkspaceDirectory: (input: WorkspaceAttachDirectoryInput) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.DETACH_WORKSPACE_DIRECTORY, input)
+  },
+
+  getWorkspaceDirectories: (workspaceSlug: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.GET_WORKSPACE_DIRECTORIES, workspaceSlug)
   },
 
   // Agent 文件系统操作

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -1169,6 +1169,13 @@ export const agentSessionDraftsAtom = atom<Map<string, string>>(new Map())
  */
 export const agentAttachedDirectoriesMapAtom = atom<Map<string, string[]>>(new Map())
 
+/**
+ * 工作区级附加目录列表（按 workspaceId 存储）
+ *
+ * 工作区内所有会话共享这些附加目录。
+ */
+export const workspaceAttachedDirectoriesMapAtom = atom<Map<string, string[]>>(new Map())
+
 /** 当前 Agent 会话的草稿内容（派生读写原子） */
 export const currentAgentSessionDraftAtom = atom(
   (get) => {

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -10,7 +10,7 @@
 
 import * as React from 'react'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
-import { PanelRight, X, Users, FolderOpen, ExternalLink, RefreshCw, ChevronRight, Folder, FileText, MoreHorizontal, FolderSearch, Pencil, FolderInput } from 'lucide-react'
+import { PanelRight, X, Users, FolderOpen, ExternalLink, RefreshCw, ChevronRight, Folder, FileText, MoreHorizontal, FolderSearch, Pencil, FolderInput, Info, FolderHeart } from 'lucide-react'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -33,6 +33,7 @@ import {
   currentAgentWorkspaceIdAtom,
   agentWorkspacesAtom,
   agentAttachedDirectoriesMapAtom,
+  workspaceAttachedDirectoriesMapAtom,
 } from '@/atoms/agent-atoms'
 import type { SidePanelTab } from '@/atoms/agent-atoms'
 import type { FileEntry } from '@proma/shared'
@@ -106,10 +107,29 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
   const workspaces = useAtomValue(agentWorkspacesAtom)
   const workspaceSlug = workspaces.find((w) => w.id === currentWorkspaceId)?.slug ?? null
 
-  // 附加目录列表
+  // 附加目录列表（会话级）
   const attachedDirsMap = useAtomValue(agentAttachedDirectoriesMapAtom)
   const setAttachedDirsMap = useSetAtom(agentAttachedDirectoriesMapAtom)
   const attachedDirs = attachedDirsMap.get(sessionId) ?? []
+
+  // 附加目录列表（工作区级）
+  const wsAttachedDirsMap = useAtomValue(workspaceAttachedDirectoriesMapAtom)
+  const setWsAttachedDirsMap = useSetAtom(workspaceAttachedDirectoriesMapAtom)
+  const wsAttachedDirs = currentWorkspaceId ? (wsAttachedDirsMap.get(currentWorkspaceId) ?? []) : []
+
+  // 加载工作区级附加目录
+  React.useEffect(() => {
+    if (!workspaceSlug || !currentWorkspaceId) return
+    window.electronAPI.getWorkspaceDirectories(workspaceSlug)
+      .then((dirs) => {
+        setWsAttachedDirsMap((prev) => {
+          const map = new Map(prev)
+          map.set(currentWorkspaceId, dirs)
+          return map
+        })
+      })
+      .catch(console.error)
+  }, [workspaceSlug, currentWorkspaceId, setWsAttachedDirsMap])
 
   const handleAttachFolder = React.useCallback(async () => {
     try {
@@ -150,6 +170,48 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
     }
   }, [sessionId, setAttachedDirsMap])
 
+  // 工作区级附加文件夹
+  const handleAttachWorkspaceFolder = React.useCallback(async () => {
+    if (!workspaceSlug || !currentWorkspaceId) return
+    try {
+      const result = await window.electronAPI.openFolderDialog()
+      if (!result) return
+
+      const updated = await window.electronAPI.attachWorkspaceDirectory({
+        workspaceSlug,
+        directoryPath: result.path,
+      })
+      setWsAttachedDirsMap((prev) => {
+        const map = new Map(prev)
+        map.set(currentWorkspaceId, updated)
+        return map
+      })
+    } catch (error) {
+      console.error('[SidePanel] 附加工作区文件夹失败:', error)
+    }
+  }, [workspaceSlug, currentWorkspaceId, setWsAttachedDirsMap])
+
+  const handleDetachWorkspaceDirectory = React.useCallback(async (dirPath: string) => {
+    if (!workspaceSlug || !currentWorkspaceId) return
+    try {
+      const updated = await window.electronAPI.detachWorkspaceDirectory({
+        workspaceSlug,
+        directoryPath: dirPath,
+      })
+      setWsAttachedDirsMap((prev) => {
+        const map = new Map(prev)
+        if (updated.length > 0) {
+          map.set(currentWorkspaceId, updated)
+        } else {
+          map.delete(currentWorkspaceId)
+        }
+        return map
+      })
+    } catch (error) {
+      console.error('[SidePanel] 移除工作区附加目录失败:', error)
+    }
+  }, [workspaceSlug, currentWorkspaceId, setWsAttachedDirsMap])
+
   // 文件上传完成后递增版本号，触发 FileBrowser 刷新
   const handleFilesUploaded = React.useCallback(() => {
     setFilesVersion((prev) => prev + 1)
@@ -166,6 +228,16 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
     const parts = sessionPath.split('/').filter(Boolean)
     return parts.length > 2 ? `.../${parts.slice(-2).join('/')}` : sessionPath
   }, [sessionPath])
+
+  // 工作区文件目录路径
+  const [workspaceFilesPath, setWorkspaceFilesPath] = React.useState<string | null>(null)
+  React.useEffect(() => {
+    if (!workspaceSlug) {
+      setWorkspaceFilesPath(null)
+      return
+    }
+    window.electronAPI.getWorkspaceFilesPath(workspaceSlug).then(setWorkspaceFilesPath).catch(() => setWorkspaceFilesPath(null))
+  }, [workspaceSlug])
 
   // 自动打开：文件变化时（仅在有 sessionPath 时）
   const prevFilesVersionRef = React.useRef(filesVersion)
@@ -268,11 +340,20 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
             {/* File Browser Tab */}
             <TabsContent value="files" className="flex-1 overflow-hidden m-0 data-[state=active]:flex data-[state=active]:flex-col">
               {sessionPath && workspaceSlug ? (
-                <>
-                  {/* 工具栏：工作区目录标签 + 路径 + 按钮 */}
-                  <div className="flex items-center gap-1 px-3 h-[36px] border-b flex-shrink-0">
-                    <span className="text-[11px] font-medium text-muted-foreground shrink-0">工作区目录</span>
-                    <span className="text-[11px] text-muted-foreground/60 truncate flex-1" title={sessionPath}>
+                <div className="flex-1 min-h-0 overflow-y-auto">
+                  {/* ===== 会话文件区 ===== */}
+                  <div className="flex items-center gap-1 px-3 h-[32px] flex-shrink-0">
+                    <FolderOpen className="size-3 text-muted-foreground" />
+                    <span className="text-[11px] font-medium text-muted-foreground">会话文件</span>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Info className="size-3 text-muted-foreground/50 cursor-help" />
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom" className="max-w-[200px]">
+                        <p>当前会话的专属文件，仅本次对话的 Agent 可以访问</p>
+                      </TooltipContent>
+                    </Tooltip>
+                    <span className="text-[10px] text-muted-foreground/50 truncate flex-1" title={sessionPath}>
                       {breadcrumb}
                     </span>
                     <Tooltip>
@@ -281,14 +362,14 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                           type="button"
                           variant="ghost"
                           size="icon"
-                          className="h-6 w-6 flex-shrink-0"
+                          className="h-5 w-5 flex-shrink-0"
                           onClick={() => window.electronAPI.openFile(sessionPath).catch(console.error)}
                         >
-                          <ExternalLink className="size-3" />
+                          <ExternalLink className="size-2.5" />
                         </Button>
                       </TooltipTrigger>
                       <TooltipContent side="bottom">
-                        <p>在 Finder 中打开工作区文件夹</p>
+                        <p>在 Finder 中打开</p>
                       </TooltipContent>
                     </Tooltip>
                     <Tooltip>
@@ -297,10 +378,10 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                           type="button"
                           variant="ghost"
                           size="icon"
-                          className="h-6 w-6 flex-shrink-0"
+                          className="h-5 w-5 flex-shrink-0"
                           onClick={handleRefresh}
                         >
-                          <RefreshCw className="size-3" />
+                          <RefreshCw className="size-2.5" />
                         </Button>
                       </TooltipTrigger>
                       <TooltipContent side="bottom">
@@ -308,27 +389,82 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                       </TooltipContent>
                     </Tooltip>
                   </div>
-                  {/* 可滚动内容区：附加目录 + 文件浏览器 + 拖拽上传 */}
-                  <div className="flex-1 min-h-0 overflow-y-auto">
-                    {/* 附加目录列表（可展开目录树） */}
-                    {attachedDirs.length > 0 && (
+                  {/* 附加目录列表（可展开目录树） */}
+                  {attachedDirs.length > 0 && (
+                    <AttachedDirsSection
+                      attachedDirs={attachedDirs}
+                      onDetach={handleDetachDirectory}
+                      refreshVersion={filesVersion}
+                    />
+                  )}
+                  {/* 会话文件浏览器 */}
+                  <FileBrowser rootPath={sessionPath} hideToolbar embedded />
+                  {/* 会话文件拖拽上传区域 */}
+                  <FileDropZone
+                    workspaceSlug={workspaceSlug}
+                    sessionId={sessionId}
+                    target="session"
+                    onFilesUploaded={handleFilesUploaded}
+                    onAttachFolder={handleAttachFolder}
+                  />
+
+                  {/* ===== 分隔线 ===== */}
+                  <div className="mx-3 my-3 border-t border-dashed border-muted-foreground/20" />
+
+                  {/* ===== 工作区文件区 ===== */}
+                  <div className="bg-muted/30 rounded-lg mx-2 mb-2 pb-1">
+                    <div className="flex items-center gap-1 px-2 h-[32px] flex-shrink-0">
+                      <FolderHeart className="size-3 text-primary/70" />
+                      <span className="text-[11px] font-medium text-primary/70">工作区文件</span>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Info className="size-3 text-primary/40 cursor-help" />
+                        </TooltipTrigger>
+                        <TooltipContent side="bottom" className="max-w-[220px]">
+                          <p>工作区内所有会话可访问的文件和文件夹，每个新对话都可以自动读取</p>
+                        </TooltipContent>
+                      </Tooltip>
+                      <div className="flex-1" />
+                      {workspaceFilesPath && (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon"
+                              className="h-5 w-5 flex-shrink-0"
+                              onClick={() => window.electronAPI.openFile(workspaceFilesPath).catch(console.error)}
+                            >
+                              <ExternalLink className="size-2.5" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom">
+                            <p>在 Finder 中打开工作区文件目录</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      )}
+                    </div>
+                    {/* 工作区级附加目录 */}
+                    {wsAttachedDirs.length > 0 && (
                       <AttachedDirsSection
-                        attachedDirs={attachedDirs}
-                        onDetach={handleDetachDirectory}
+                        attachedDirs={wsAttachedDirs}
+                        onDetach={handleDetachWorkspaceDirectory}
                         refreshVersion={filesVersion}
                       />
                     )}
-                    {/* 文件浏览器（嵌入模式，不自带滚动） */}
-                    <FileBrowser rootPath={sessionPath} hideToolbar embedded />
-                    {/* 文件拖拽上传区域 */}
+                    {/* 工作区文件浏览器 */}
+                    {workspaceFilesPath && (
+                      <FileBrowser rootPath={workspaceFilesPath} hideToolbar embedded />
+                    )}
+                    {/* 工作区文件拖拽上传区域 */}
                     <FileDropZone
                       workspaceSlug={workspaceSlug}
-                      sessionId={sessionId}
+                      target="workspace"
                       onFilesUploaded={handleFilesUploaded}
-                      onAttachFolder={handleAttachFolder}
+                      onAttachFolder={handleAttachWorkspaceFolder}
                     />
                   </div>
-                </>
+                </div>
               ) : (
                 <div className="flex h-full items-center justify-center text-xs text-muted-foreground">
                   请选择工作区

--- a/apps/electron/src/renderer/components/file-browser/FileDropZone.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileDropZone.tsx
@@ -1,8 +1,8 @@
 /**
  * FileDropZone — 文件拖拽上传区域
  *
- * 引导用户通过拖拽或点击将文件添加到 Agent 会话目录。
- * 文件上传后直接保存到会话工作区，FileBrowser 通过版本号自动刷新。
+ * 引导用户通过拖拽或点击将文件添加到 Agent 会话目录或工作区文件目录。
+ * 文件上传后直接保存到目标目录，FileBrowser 通过版本号自动刷新。
  */
 
 import * as React from 'react'
@@ -16,19 +16,23 @@ import { fileToBase64 } from '@/lib/file-utils'
 interface FileDropZoneProps {
   /** 当前工作区 slug（用于 IPC 调用） */
   workspaceSlug: string
-  /** 当前会话 ID */
-  sessionId: string
+  /** 当前会话 ID（session 模式必传） */
+  sessionId?: string
+  /** 上传目标：session（会话目录）或 workspace（工作区文件目录） */
+  target?: 'session' | 'workspace'
   /** 上传成功后的回调（触发文件浏览器刷新） */
   onFilesUploaded: () => void
   /** 附加文件夹回调 */
   onAttachFolder?: () => void
 }
 
-export function FileDropZone({ workspaceSlug, sessionId, onFilesUploaded, onAttachFolder }: FileDropZoneProps): React.ReactElement {
+export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onFilesUploaded, onAttachFolder }: FileDropZoneProps): React.ReactElement {
   const [isDragOver, setIsDragOver] = React.useState(false)
   const [isUploading, setIsUploading] = React.useState(false)
 
-  /** 保存文件到会话目录 */
+  const isWorkspace = target === 'workspace'
+
+  /** 保存文件到目标目录 */
   const saveFiles = React.useCallback(async (files: globalThis.File[]): Promise<void> => {
     if (files.length === 0) return
 
@@ -40,11 +44,18 @@ export function FileDropZone({ workspaceSlug, sessionId, onFilesUploaded, onAtta
         fileEntries.push({ filename: file.name, data: base64 })
       }
 
-      await window.electronAPI.saveFilesToAgentSession({
-        workspaceSlug,
-        sessionId,
-        files: fileEntries,
-      })
+      if (isWorkspace) {
+        await window.electronAPI.saveFilesToWorkspaceFiles({
+          workspaceSlug,
+          files: fileEntries,
+        })
+      } else {
+        await window.electronAPI.saveFilesToAgentSession({
+          workspaceSlug,
+          sessionId: sessionId!,
+          files: fileEntries,
+        })
+      }
 
       onFilesUploaded()
       toast.success(`已添加 ${files.length} 个文件`)
@@ -54,7 +65,7 @@ export function FileDropZone({ workspaceSlug, sessionId, onFilesUploaded, onAtta
     } finally {
       setIsUploading(false)
     }
-  }, [workspaceSlug, sessionId, onFilesUploaded])
+  }, [workspaceSlug, sessionId, isWorkspace, onFilesUploaded])
 
   // ===== 拖拽处理 =====
 
@@ -91,7 +102,7 @@ export function FileDropZone({ workspaceSlug, sessionId, onFilesUploaded, onAtta
     }
 
     if (hasFolders) {
-      toast.info('不支持拖拽文件夹', { description: '请使用输入框工具栏的「附加文件夹」按钮' })
+      toast.info('不支持拖拽文件夹', { description: '请使用「附加文件夹」按钮' })
     }
 
     if (regularFiles.length > 0) {
@@ -112,11 +123,18 @@ export function FileDropZone({ workspaceSlug, sessionId, onFilesUploaded, onAtta
         data: f.data,
       }))
 
-      await window.electronAPI.saveFilesToAgentSession({
-        workspaceSlug,
-        sessionId,
-        files: fileEntries,
-      })
+      if (isWorkspace) {
+        await window.electronAPI.saveFilesToWorkspaceFiles({
+          workspaceSlug,
+          files: fileEntries,
+        })
+      } else {
+        await window.electronAPI.saveFilesToAgentSession({
+          workspaceSlug,
+          sessionId: sessionId!,
+          files: fileEntries,
+        })
+      }
 
       onFilesUploaded()
       toast.success(`已添加 ${result.files.length} 个文件`)
@@ -126,7 +144,7 @@ export function FileDropZone({ workspaceSlug, sessionId, onFilesUploaded, onAtta
     } finally {
       setIsUploading(false)
     }
-  }, [workspaceSlug, sessionId, onFilesUploaded])
+  }, [workspaceSlug, sessionId, isWorkspace, onFilesUploaded])
 
   return (
     <div className="flex-shrink-0 px-3 pt-3 pb-1">
@@ -155,9 +173,11 @@ export function FileDropZone({ workspaceSlug, sessionId, onFilesUploaded, onAtta
               isDragOver ? 'text-primary' : 'text-muted-foreground/60',
             )} />
             <p className="text-xs text-muted-foreground text-center leading-relaxed">
-              将文件拖拽到此处
+              拖拽文件到此处
               <br />
-              <span className="text-[10px] text-muted-foreground/60">供 Agent 读取和处理</span>
+              <span className="text-[10px] text-muted-foreground/60">
+                {isWorkspace ? '工作区内所有会话可访问' : '供 Agent 读取和处理'}
+              </span>
             </p>
             <div className="flex items-center gap-1.5">
               <Tooltip>
@@ -174,7 +194,7 @@ export function FileDropZone({ workspaceSlug, sessionId, onFilesUploaded, onAtta
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent side="bottom">
-                  <p>将文件放入 Agent 工作文件夹</p>
+                  <p>{isWorkspace ? '添加文件到工作区文件目录' : '将文件放入 Agent 工作文件夹'}</p>
                 </TooltipContent>
               </Tooltip>
               {onAttachFolder && (
@@ -192,7 +212,7 @@ export function FileDropZone({ workspaceSlug, sessionId, onFilesUploaded, onAtta
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent side="bottom">
-                    <p>告知 Agent 你想处理的文件夹</p>
+                    <p>{isWorkspace ? '附加文件夹供工作区所有会话访问' : '告知 Agent 你想处理的文件夹'}</p>
                   </TooltipContent>
                 </Tooltip>
               )}

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -584,10 +584,24 @@ export interface AgentSavedFile {
   targetPath: string
 }
 
+/** Agent 文件保存到工作区文件目录的输入 */
+export interface AgentSaveWorkspaceFilesInput {
+  workspaceSlug: string
+  files: Array<{ filename: string; data: string }>
+}
+
 /** 附加/分离目录的输入参数 */
 export interface AgentAttachDirectoryInput {
   /** 会话 ID */
   sessionId: string
+  /** 目录的绝对路径 */
+  directoryPath: string
+}
+
+/** 工作区级附加/分离目录的输入参数 */
+export interface WorkspaceAttachDirectoryInput {
+  /** 工作区 slug */
+  workspaceSlug: string
   /** 目录的绝对路径 */
   directoryPath: string
 }
@@ -832,12 +846,22 @@ export const AGENT_IPC_CHANNELS = {
   // 附件
   /** 保存文件到 Agent session 工作目录 */
   SAVE_FILES_TO_SESSION: 'agent:save-files-to-session',
+  /** 保存文件到工作区文件目录 */
+  SAVE_FILES_TO_WORKSPACE: 'agent:save-files-to-workspace',
+  /** 获取工作区文件目录路径 */
+  GET_WORKSPACE_FILES_PATH: 'agent:get-workspace-files-path',
   /** 打开文件夹选择对话框 */
   OPEN_FOLDER_DIALOG: 'agent:open-folder-dialog',
   /** 附加外部目录到 Agent 会话 */
   ATTACH_DIRECTORY: 'agent:attach-directory',
   /** 移除会话的附加目录 */
   DETACH_DIRECTORY: 'agent:detach-directory',
+  /** 附加外部目录到工作区（所有会话共享） */
+  ATTACH_WORKSPACE_DIRECTORY: 'agent:attach-workspace-directory',
+  /** 移除工作区的附加目录 */
+  DETACH_WORKSPACE_DIRECTORY: 'agent:detach-workspace-directory',
+  /** 获取工作区附加目录列表 */
+  GET_WORKSPACE_DIRECTORIES: 'agent:get-workspace-directories',
 
   // 文件系统操作
   /** 获取 session 工作路径 */


### PR DESCRIPTION
## Summary

Add workspace-level file management allowing all sessions in a workspace to access shared files and folders. This feature complements session-level file uploads with workspace-level sharing, plus workspace-level attached directories that all sessions inherit.

## Changes

- **Workspace Files Directory**: New `~/.proma/agent-workspaces/{slug}/workspace-files/` for storing files accessible to all sessions
- **File Management**: UI reorganization with session files (top) and workspace files (sticky bottom) clearly separated with tooltips
- **Workspace Attached Directories**: All sessions automatically inherit attached directories configured at the workspace level
- **SDK Integration**: Both workspace files and workspace-level attached directories auto-inject into Agent SDK's `additionalDirectories`
- **Naming**: Internal "shared" terminology renamed to "workspace-files" to avoid confusion with Agent SDK

## Architecture

- Session files: `{sessionId}/` (isolated per session)
- Workspace files: `workspace-files/` (shared across all sessions)
- Session attached dirs: Per-session configuration
- Workspace attached dirs: Per-workspace configuration, inherited by all sessions