### PR TITLE
feat: 改进会话排序与滚动恢复，并修复 Agent 启动退出问题

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -391,9 +391,12 @@ export class AgentOrchestrator {
     // ANTHROPIC_BASE_URL 等）干扰 SDK 的认证和请求目标。
     // 即使 index.ts 启动时已清理过一次，initializeRuntime() 中的
     // loadShellEnv() 可能从 shell 配置文件（~/.zshrc 等）重新注入这些变量。
+    // 另外，开发模式下如果 Proma 是从 Claude Code 会话里启动的，父进程会带上
+    // CLAUDECODE=1；若原样透传给 SDK 子进程，Claude Code CLI 会把它判定为嵌套会话，
+    // 直接退出并报 "Claude Code process exited with code 1"。
     const cleanEnv: Record<string, string | undefined> = {}
     for (const [key, value] of Object.entries(process.env)) {
-      if (!key.startsWith('ANTHROPIC_')) {
+      if (!key.startsWith('ANTHROPIC_') && key !== 'CLAUDECODE') {
         cleanEnv[key] = value
       }
     }

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -8,6 +8,7 @@
 import { atom } from 'jotai'
 import { atomFamily } from 'jotai/utils'
 import type { AgentSessionMeta, AgentMessage, AgentEvent, AgentWorkspace, AgentPendingFile, RetryAttempt, PromaPermissionMode, PermissionRequest, AskUserRequest, ThinkingConfig, AgentEffort, TaskUsage, AgentTeamData } from '@proma/shared'
+import type { ScrollMemoryState } from '@/lib/scroll-memory'
 
 /** 活动状态 */
 export type ActivityStatus = 'pending' | 'running' | 'completed' | 'error' | 'backgrounded'
@@ -560,6 +561,9 @@ export const agentSidePanelOpenMapAtom = atom<Map<string, boolean>>(new Map())
 
 /** 侧面板当前活跃 Tab（per-session Map） */
 export const agentSidePanelTabMapAtom = atom<Map<string, SidePanelTab>>(new Map())
+
+/** Agent 消息滚动位置（per-session） */
+export const agentScrollMemoryAtom = atom<Map<string, ScrollMemoryState>>(new Map())
 
 /**
  * Team 活动缓存 — 以 sessionId 为 key

--- a/apps/electron/src/renderer/atoms/chat-atoms.ts
+++ b/apps/electron/src/renderer/atoms/chat-atoms.ts
@@ -8,6 +8,8 @@
 import { atom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
 import type { ConversationMeta, ChatMessage, FileAttachment, ChatToolActivity } from '@proma/shared'
+import type { ScrollMemoryState } from '@/lib/scroll-memory'
+import { deleteMapEntry } from '@/lib/utils'
 
 /** 选中的模型信息 */
 export interface SelectedModel {
@@ -242,3 +244,96 @@ export const conversationThinkingEnabledAtom = atom<Map<string, boolean>>(new Ma
 
 /** 每个对话的并排模式 */
 export const conversationParallelModeAtom = atom<Map<string, boolean>>(new Map())
+
+/** 标准消息列表滚动位置（per-conversation） */
+export const conversationScrollMemoryAtom = atom<Map<string, ScrollMemoryState>>(new Map())
+
+/** 非底部阅读位置下，是否已加载完整历史（per-conversation） */
+export const conversationLoadedAllHistoryAtom = atom<Map<string, boolean>>(new Map())
+
+/** 非底部阅读位置下，是否需要首次直接加载完整历史（per-conversation） */
+export const conversationNeedsFullHistoryAtom = atom<Map<string, boolean>>(new Map())
+
+/** 标记某个对话已加载完整历史 */
+export const markConversationHistoryLoadedAtom = atom(
+  null,
+  (_get, set, conversationId: string) => {
+    set(conversationLoadedAllHistoryAtom, (prev) => {
+      const map = new Map(prev)
+      map.set(conversationId, true)
+      return map
+    })
+    set(conversationNeedsFullHistoryAtom, (prev) => deleteMapEntry(prev, conversationId))
+  }
+)
+
+/** 根据当前滚动状态同步历史加载需求 */
+export const updateConversationHistoryRequirementAtom = atom(
+  null,
+  (get, set, payload: { conversationId: string; scrollState: ScrollMemoryState }) => {
+    const { conversationId, scrollState } = payload
+
+    if (scrollState.atBottom) {
+      set(conversationNeedsFullHistoryAtom, (prev) => {
+        if (!prev.has(conversationId)) return prev
+        const map = new Map(prev)
+        map.delete(conversationId)
+        return map
+      })
+      return
+    }
+
+    const loadedAll = get(conversationLoadedAllHistoryAtom).get(conversationId) ?? false
+    if (loadedAll) return
+
+    set(conversationNeedsFullHistoryAtom, (prev) => {
+      if (prev.get(conversationId) === true) return prev
+      const map = new Map(prev)
+      map.set(conversationId, true)
+      return map
+    })
+  }
+)
+
+/** 指定对话是否应直接加载完整历史 */
+export const conversationShouldLoadFullHistoryAtom = atom((get) => (conversationId: string): boolean => {
+  return get(conversationNeedsFullHistoryAtom).get(conversationId) ?? false
+})
+
+/** 指定对话是否已加载完整历史 */
+export const conversationLoadedAllHistorySelectorAtom = atom((get) => (conversationId: string): boolean => {
+  return get(conversationLoadedAllHistoryAtom).get(conversationId) ?? false
+})
+
+/** 当前对话的标准滚动状态 */
+export const currentConversationScrollMemoryAtom = atom<ScrollMemoryState | null>((get) => {
+  const currentId = get(currentConversationIdAtom)
+  if (!currentId) return null
+  return get(conversationScrollMemoryAtom).get(currentId) ?? null
+})
+
+/** 当前对话是否记住了非底部阅读位置 */
+export const currentConversationHasHistoricScrollAtom = atom<boolean>((get) => {
+  const scrollState = get(currentConversationScrollMemoryAtom)
+  return scrollState !== null && !scrollState.atBottom
+})
+
+/** 指定对话是否记住了非底部阅读位置 */
+export const conversationHasHistoricScrollAtom = atom((get) => (conversationId: string): boolean => {
+  const scrollState = get(conversationScrollMemoryAtom).get(conversationId)
+  return scrollState !== undefined && !scrollState.atBottom
+})
+
+/** 当前对话是否应直接加载完整历史 */
+export const shouldLoadFullHistoryAtom = atom<boolean>((get) => {
+  const currentId = get(currentConversationIdAtom)
+  if (!currentId) return false
+  return get(conversationNeedsFullHistoryAtom).get(currentId) ?? false
+})
+
+/** 当前对话是否已加载完整历史 */
+export const currentConversationLoadedAllHistoryAtom = atom<boolean>((get) => {
+  const currentId = get(currentConversationIdAtom)
+  if (!currentId) return false
+  return get(conversationLoadedAllHistoryAtom).get(currentId) ?? false
+})

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -6,7 +6,7 @@
  */
 
 import * as React from 'react'
-import { useAtomValue } from 'jotai'
+import { useAtomValue, useSetAtom } from 'jotai'
 import { Bot, FileText, FileImage, RotateCw, AlertTriangle, ChevronDown, ChevronRight, Plus, Minimize2 } from 'lucide-react'
 import {
   Message,
@@ -35,7 +35,10 @@ import { ToolActivityList } from './ToolActivityItem'
 import { BackgroundTasksPanel } from './BackgroundTasksPanel'
 import { useBackgroundTasks } from '@/hooks/useBackgroundTasks'
 import { userProfileAtom } from '@/atoms/user-profile'
+import { agentScrollMemoryAtom } from '@/atoms/agent-atoms'
 import { cn } from '@/lib/utils'
+import { isScrollMemoryStateEqual } from '@/lib/scroll-memory'
+import type { ScrollMemoryState } from '@/lib/scroll-memory'
 import type { AgentMessage, RetryAttempt } from '@proma/shared'
 import type { ToolActivity, AgentStreamState } from '@/atoms/agent-atoms'
 
@@ -502,6 +505,11 @@ function AgentMessageItem({ message, onRetry, onRetryInNewSession, onCompact }: 
 
 export function AgentMessages({ sessionId, messages, streaming, streamState, onRetry, onRetryInNewSession, onCompact }: AgentMessagesProps): React.ReactElement {
   const userProfile = useAtomValue(userProfileAtom)
+  const scrollMemoryMap = useAtomValue(agentScrollMemoryAtom)
+  const setAgentScrollMemory = useSetAtom(agentScrollMemoryAtom)
+  const scrollMemory = scrollMemoryMap.get(sessionId) ?? null
+  const [ready, setReady] = React.useState(false)
+  const prevSessionIdRef = React.useRef<string | null>(null)
 
   // 从 streamState 属性中计算派生值
   const streamingContent = streamState?.content ?? ''
@@ -518,6 +526,50 @@ export function AgentMessages({ sessionId, messages, streaming, streamState, onR
     isStreaming: streaming,
   })
 
+  React.useEffect(() => {
+    if (sessionId !== prevSessionIdRef.current) {
+      prevSessionIdRef.current = sessionId
+      setReady(false)
+    }
+  }, [sessionId])
+
+  const handleScrollMemoryChange = React.useCallback((state: ScrollMemoryState): void => {
+    setAgentScrollMemory((prev) => {
+      const current = prev.get(sessionId)
+      if (current && isScrollMemoryStateEqual(current, state)) return prev
+
+      const map = new Map(prev)
+      map.set(sessionId, state)
+      return map
+    })
+  }, [sessionId, setAgentScrollMemory])
+
+  const handleRestoreComplete = React.useCallback((): void => {
+    setReady(true)
+  }, [])
+
+  React.useEffect(() => {
+    if (ready) return
+
+    if (messages.length === 0 && !streaming) {
+      setReady(true)
+      return
+    }
+
+    if (scrollMemory?.atBottom === false) return
+
+    let cancelled = false
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        if (!cancelled) setReady(true)
+      })
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [messages.length, streaming, ready, scrollMemory?.atBottom])
+
   // 迷你地图数据
   const minimapItems: MinimapItem[] = React.useMemo(
     () => messages.map((m) => ({
@@ -531,7 +583,14 @@ export function AgentMessages({ sessionId, messages, streaming, streamState, onR
   )
 
   return (
-    <Conversation>
+    <Conversation
+      className={ready ? 'opacity-100 transition-opacity duration-200' : 'opacity-0'}
+      scrollMemory={scrollMemory}
+      onScrollMemoryChange={handleScrollMemoryChange}
+      restoreKey={sessionId}
+      restoreVersion={messages.length}
+      onRestoreComplete={handleRestoreComplete}
+    >
       <ConversationContent>
         {messages.length === 0 && !streaming ? (
           <EmptyState />

--- a/apps/electron/src/renderer/components/agent/TeamActivityPanel.tsx
+++ b/apps/electron/src/renderer/components/agent/TeamActivityPanel.tsx
@@ -177,6 +177,38 @@ export function TeamActivityPanel({ sessionId }: TeamActivityPanelProps): React.
     : teammates.filter((t) => t.status !== 'running').length
   const totalCount = hasAgents ? agentEntries.length : teammates.length
 
+  const content = (
+    <div className="flex flex-col gap-2 p-2">
+      {/* Task Board */}
+      {mergedTasks.length > 0 && (
+        <TaskBoard tasks={mergedTasks} />
+      )}
+
+      {/* Agent 卡片（有 overview 时） */}
+      {hasAgents && agentEntries.map((agent) => (
+        <AgentCard
+          key={agent.toolUseId}
+          agent={agent}
+          expanded={expandedId === agent.toolUseId}
+          onToggle={() => setExpandedId(expandedId === agent.toolUseId ? null : agent.toolUseId)}
+        />
+      ))}
+
+      {/* 回退：TeammateState 卡片（无 overview 时） */}
+      {!hasAgents && displayTeammates.map((tm) => (
+        <TeammateCard
+          key={tm.taskId}
+          teammate={tm}
+          expanded={expandedId === tm.taskId}
+          onToggle={() => setExpandedId(expandedId === tm.taskId ? null : tm.taskId)}
+        />
+      ))}
+
+      {/* Agent 通信时间线 */}
+      <MailboxTimeline inboxes={polledData?.inboxes ?? {}} />
+    </div>
+  )
+
   return (
     <div className="flex h-full flex-col">
       {/* Team 头部 */}
@@ -241,35 +273,7 @@ export function TeamActivityPanel({ sessionId }: TeamActivityPanelProps): React.
       </div>
 
       <ScrollArea className="flex-1">
-        <div className="flex flex-col gap-2 p-2">
-          {/* Task Board */}
-          {mergedTasks.length > 0 && (
-            <TaskBoard tasks={mergedTasks} />
-          )}
-
-          {/* Agent 卡片（有 overview 时） */}
-          {hasAgents && agentEntries.map((agent) => (
-            <AgentCard
-              key={agent.toolUseId}
-              agent={agent}
-              expanded={expandedId === agent.toolUseId}
-              onToggle={() => setExpandedId(expandedId === agent.toolUseId ? null : agent.toolUseId)}
-            />
-          ))}
-
-          {/* 回退：TeammateState 卡片（无 overview 时） */}
-          {!hasAgents && displayTeammates.map((tm) => (
-            <TeammateCard
-              key={tm.taskId}
-              teammate={tm}
-              expanded={expandedId === tm.taskId}
-              onToggle={() => setExpandedId(expandedId === tm.taskId ? null : tm.taskId)}
-            />
-          ))}
-
-          {/* Agent 通信时间线 */}
-          <MailboxTimeline inboxes={polledData?.inboxes ?? {}} />
-        </div>
+        {content}
       </ScrollArea>
     </div>
   )
@@ -493,7 +497,7 @@ function AgentCard({ agent, expanded, onToggle }: AgentCardProps): React.ReactEl
 
   return (
     <div className={cn(
-      'rounded-lg transition-colors',
+      'overflow-hidden rounded-lg transition-colors',
       'bg-foreground/[0.03] dark:bg-foreground/[0.05]',
       expanded && 'bg-foreground/[0.05] dark:bg-foreground/[0.07]',
     )}>
@@ -620,10 +624,8 @@ function AgentDetail({ agent }: { agent: TeamAgentInfo }): React.ReactElement {
   const hasUsage = !!tm?.usage
   const hasAnyContent = hasSummary || hasProgress || hasToolHistory || hasOutput || hasUsage
 
-  return (
+  const detailContent = (
     <div className="flex flex-col gap-2.5 px-3 pb-3">
-      <Separator />
-
       {/* 工作摘要 */}
       {hasSummary && (
         <DetailSection title="工作摘要" borderColor="border-l-green-500">
@@ -674,7 +676,7 @@ function AgentDetail({ agent }: { agent: TeamAgentInfo }): React.ReactElement {
 
       {/* 无详细数据时的提示 */}
       {!hasAnyContent && (
-        <p className="text-[11px] text-muted-foreground/40 text-center py-2">
+        <p className="py-2 text-center text-[11px] text-muted-foreground/40">
           {tm?.status === 'running'
             ? '等待 Agent 返回进度数据...'
             : agent.status === 'running'
@@ -682,6 +684,15 @@ function AgentDetail({ agent }: { agent: TeamAgentInfo }): React.ReactElement {
               : '暂无详细数据'}
         </p>
       )}
+    </div>
+  )
+
+  return (
+    <div className="px-3 pb-3">
+      <Separator />
+      <ScrollArea className="mt-2 max-h-[min(24rem,50vh)] rounded-md bg-background/80 pr-2">
+        {detailContent}
+      </ScrollArea>
     </div>
   )
 }
@@ -702,7 +713,7 @@ function TeammateCard({ teammate, expanded, onToggle }: TeammateCardProps): Reac
 
   return (
     <div className={cn(
-      'rounded-lg transition-colors',
+      'overflow-hidden rounded-lg transition-colors',
       'bg-foreground/[0.03] dark:bg-foreground/[0.05]',
       expanded && 'bg-foreground/[0.05] dark:bg-foreground/[0.07]',
     )}>
@@ -788,51 +799,55 @@ function TeammateCard({ teammate, expanded, onToggle }: TeammateCardProps): Reac
       </button>
 
       {expanded && (
-        <div className="flex flex-col gap-2.5 px-3 pb-3">
+        <div className="px-3 pb-3">
           <Separator />
-          {teammate.summary && (
-            <DetailSection title="工作摘要" borderColor="border-l-green-500">
-              <MarkdownContent content={teammate.summary} />
-            </DetailSection>
-          )}
-          {teammate.status === 'running' && teammate.progressDescription && (
-            <DetailSection title="当前进度" borderColor="border-l-blue-500">
-              <p className="text-[11px] text-muted-foreground/70 leading-relaxed">
-                {teammate.progressDescription}
-              </p>
-            </DetailSection>
-          )}
-          {teammate.usage && (
-            <DetailSection title="使用量" borderColor="border-l-violet-500">
-              <div className="flex items-center gap-4 text-[11px] text-muted-foreground/70">
-                <span className="flex items-center gap-1">
-                  <Wrench className="size-2.5" />
-                  {teammate.usage.toolUses} 次工具调用
-                </span>
-                <span className="flex items-center gap-1">
-                  <Zap className="size-2.5" />
-                  {formatTokens(teammate.usage.totalTokens)} tokens
-                </span>
-                {teammate.usage.durationMs > 0 && (
-                  <span className="flex items-center gap-1">
-                    <Clock className="size-2.5" />
-                    {formatElapsed(teammate.usage.durationMs / 1000)}
-                  </span>
-                )}
-              </div>
-            </DetailSection>
-          )}
-          {teammate.toolHistory.length > 0 && (
-            <ToolHistorySection toolHistory={teammate.toolHistory} />
-          )}
-          {teammate.outputFile && (
-            <OutputFileSection filePath={teammate.outputFile} />
-          )}
-          {!teammate.summary && !teammate.usage && teammate.toolHistory.length === 0 && !teammate.outputFile && (
-            <p className="text-[11px] text-muted-foreground/40 text-center py-2">
-              {teammate.status === 'running' ? '等待 Agent 返回进度数据...' : '暂无详细数据'}
-            </p>
-          )}
+          <ScrollArea className="mt-2 max-h-[min(24rem,50vh)] rounded-md bg-background/80 pr-2">
+            <div className="flex flex-col gap-2.5 px-3 pb-3">
+              {teammate.summary && (
+                <DetailSection title="工作摘要" borderColor="border-l-green-500">
+                  <MarkdownContent content={teammate.summary} />
+                </DetailSection>
+              )}
+              {teammate.status === 'running' && teammate.progressDescription && (
+                <DetailSection title="当前进度" borderColor="border-l-blue-500">
+                  <p className="text-[11px] text-muted-foreground/70 leading-relaxed">
+                    {teammate.progressDescription}
+                  </p>
+                </DetailSection>
+              )}
+              {teammate.usage && (
+                <DetailSection title="使用量" borderColor="border-l-violet-500">
+                  <div className="flex items-center gap-4 text-[11px] text-muted-foreground/70">
+                    <span className="flex items-center gap-1">
+                      <Wrench className="size-2.5" />
+                      {teammate.usage.toolUses} 次工具调用
+                    </span>
+                    <span className="flex items-center gap-1">
+                      <Zap className="size-2.5" />
+                      {formatTokens(teammate.usage.totalTokens)} tokens
+                    </span>
+                    {teammate.usage.durationMs > 0 && (
+                      <span className="flex items-center gap-1">
+                        <Clock className="size-2.5" />
+                        {formatElapsed(teammate.usage.durationMs / 1000)}
+                      </span>
+                    )}
+                  </div>
+                </DetailSection>
+              )}
+              {teammate.toolHistory.length > 0 && (
+                <ToolHistorySection toolHistory={teammate.toolHistory} />
+              )}
+              {teammate.outputFile && (
+                <OutputFileSection filePath={teammate.outputFile} />
+              )}
+              {!teammate.summary && !teammate.usage && teammate.toolHistory.length === 0 && !teammate.outputFile && (
+                <p className="py-2 text-center text-[11px] text-muted-foreground/40">
+                  {teammate.status === 'running' ? '等待 Agent 返回进度数据...' : '暂无详细数据'}
+                </p>
+              )}
+            </div>
+          </ScrollArea>
         </div>
       )}
     </div>

--- a/apps/electron/src/renderer/components/ai-elements/conversation.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/conversation.tsx
@@ -11,26 +11,234 @@
  * - ConversationScrollButton — 滚动到底部按钮
  */
 
+import * as React from 'react'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
+import {
+  captureScrollMemory,
+  isScrollMemoryStateEqual,
+  resolveScrollMemory,
+} from '@/lib/scroll-memory'
+import type { ScrollMemoryState } from '@/lib/scroll-memory'
 import { ArrowDownIcon } from 'lucide-react'
 import type { ComponentProps } from 'react'
-import { useCallback } from 'react'
-import { StickToBottom, useStickToBottomContext } from 'use-stick-to-bottom'
+import {
+  StickToBottom,
+  useStickToBottomContext,
+} from 'use-stick-to-bottom'
 
 // ===== Conversation 根容器 =====
 
-export type ConversationProps = ComponentProps<typeof StickToBottom>
+export interface ConversationProps extends ComponentProps<typeof StickToBottom> {
+  scrollMemory?: ScrollMemoryState | null
+  onScrollMemoryChange?: (state: ScrollMemoryState) => void
+  restoreKey?: string
+  restoreVersion?: string | number
+  onRestoreComplete?: () => void
+}
 
-export function Conversation({ className, ...props }: ConversationProps): React.ReactElement {
+function ConversationScrollMemory({
+  scrollMemory,
+  onScrollMemoryChange,
+  restoreKey,
+  restoreVersion,
+  onRestoreComplete,
+}: Pick<ConversationProps, 'scrollMemory' | 'onScrollMemoryChange' | 'restoreKey' | 'restoreVersion' | 'onRestoreComplete'>): null {
+  const { scrollRef, stopScroll, scrollToBottom } = useStickToBottomContext()
+  const lastReportedStateRef = React.useRef<ScrollMemoryState | null>(null)
+  const suppressSaveRef = React.useRef(false)
+  const restoredCycleRef = React.useRef<string | null>(null)
+  const latestScrollMemoryRef = React.useRef<ScrollMemoryState | null | undefined>(scrollMemory)
+  const captureFrameRef = React.useRef<number | null>(null)
+
+  const reportScrollMemory = React.useCallback((container: HTMLElement): void => {
+    if (suppressSaveRef.current) return
+
+    const nextState = captureScrollMemory(container)
+    if (lastReportedStateRef.current && isScrollMemoryStateEqual(lastReportedStateRef.current, nextState)) {
+      return
+    }
+
+    lastReportedStateRef.current = nextState
+    onScrollMemoryChange?.(nextState)
+  }, [onScrollMemoryChange])
+
+  const scheduleScrollMemoryReport = React.useCallback((container: HTMLElement): void => {
+    if (captureFrameRef.current !== null) return
+
+    captureFrameRef.current = requestAnimationFrame(() => {
+      captureFrameRef.current = null
+      reportScrollMemory(container)
+    })
+  }, [reportScrollMemory])
+
+  React.useEffect(() => {
+    latestScrollMemoryRef.current = scrollMemory
+  }, [scrollMemory])
+
+  const restoreCycleToken = React.useMemo(() => {
+    if (!restoreKey) return null
+    return [restoreKey, restoreVersion ?? ''].join(':')
+  }, [restoreKey, restoreVersion])
+
+  React.useEffect(() => {
+    suppressSaveRef.current = restoreCycleToken !== null
+    restoredCycleRef.current = null
+  }, [restoreCycleToken])
+
+  React.useEffect(() => {
+    const el = scrollRef.current
+    if (!el || !onScrollMemoryChange) return
+
+    reportScrollMemory(el)
+    const handleScroll = (): void => {
+      scheduleScrollMemoryReport(el)
+    }
+
+    el.addEventListener('scroll', handleScroll, { passive: true })
+    return () => {
+      el.removeEventListener('scroll', handleScroll)
+      if (captureFrameRef.current !== null) {
+        cancelAnimationFrame(captureFrameRef.current)
+        captureFrameRef.current = null
+      }
+    }
+  }, [scrollRef, onScrollMemoryChange, reportScrollMemory, scheduleScrollMemoryReport, restoreKey])
+
+  React.useLayoutEffect(() => {
+    if (!restoreCycleToken) {
+      suppressSaveRef.current = false
+      return
+    }
+
+    if (restoredCycleRef.current === restoreCycleToken) return
+
+    const el = scrollRef.current
+    if (!el) return
+
+    const state = latestScrollMemoryRef.current
+    let cancelled = false
+
+    if (!state || state.atBottom) {
+      stopScroll()
+
+      requestAnimationFrame(() => {
+        const completeRestore = (): void => {
+          requestAnimationFrame(() => {
+            if (cancelled) return
+
+            restoredCycleRef.current = restoreCycleToken
+            suppressSaveRef.current = false
+            reportScrollMemory(el)
+            onRestoreComplete?.()
+          })
+        }
+
+        const result = scrollToBottom('instant')
+        if (typeof result === 'boolean') {
+          completeRestore()
+          return
+        }
+
+        void result.then(() => {
+          completeRestore()
+        })
+      })
+
+      return () => {
+        cancelled = true
+      }
+    }
+
+    stopScroll()
+
+    const hasMessageAnchors = (): boolean => {
+      return el.querySelector('[data-message-id]') !== null
+    }
+
+    const completeRestore = (): void => {
+      restoredCycleRef.current = restoreCycleToken
+      suppressSaveRef.current = false
+      reportScrollMemory(el)
+      onRestoreComplete?.()
+    }
+
+    const restore = (): void => {
+      if (cancelled || !hasMessageAnchors()) return
+
+      const latestState = latestScrollMemoryRef.current
+      if (!latestState) return
+
+      el.scrollTop = resolveScrollMemory(el, latestState)
+
+      requestAnimationFrame(() => {
+        if (cancelled || !hasMessageAnchors()) return
+
+        const finalState = latestScrollMemoryRef.current
+        if (!finalState) return
+
+        el.scrollTop = resolveScrollMemory(el, finalState)
+        completeRestore()
+      })
+    }
+
+    if (hasMessageAnchors()) {
+      requestAnimationFrame(restore)
+      return () => {
+        cancelled = true
+      }
+    }
+
+    const observer = new MutationObserver(() => {
+      if (!hasMessageAnchors()) return
+      observer.disconnect()
+      requestAnimationFrame(restore)
+    })
+
+    observer.observe(el, { childList: true, subtree: true })
+    return () => {
+      cancelled = true
+      observer.disconnect()
+    }
+  }, [restoreCycleToken, scrollRef, stopScroll, scrollToBottom, onScrollMemoryChange, onRestoreComplete])
+
+  return null
+}
+
+export function Conversation({
+  className,
+  scrollMemory,
+  onScrollMemoryChange,
+  restoreKey,
+  restoreVersion,
+  onRestoreComplete,
+  initial,
+  children,
+  ...props
+}: ConversationProps): React.ReactElement {
+  const initialBehavior = scrollMemory?.atBottom === false ? false : (initial ?? 'instant')
+
   return (
     <StickToBottom
       className={cn('relative flex-1 overflow-y-hidden scrollbar-none', className)}
-      initial="instant"
+      initial={initialBehavior}
       resize="smooth"
       role="log"
       {...props}
-    />
+    >
+      {(context) => (
+        <>
+          <ConversationScrollMemory
+            scrollMemory={scrollMemory}
+            onScrollMemoryChange={onScrollMemoryChange}
+            restoreKey={restoreKey}
+            restoreVersion={restoreVersion}
+            onRestoreComplete={onRestoreComplete}
+          />
+          {typeof children === 'function' ? children(context) : children}
+        </>
+      )}
+    </StickToBottom>
   )
 }
 
@@ -96,7 +304,7 @@ export function ConversationScrollButton({
 }: ConversationScrollButtonProps): React.ReactElement | null {
   const { isAtBottom, scrollToBottom } = useStickToBottomContext()
 
-  const handleScrollToBottom = useCallback(() => {
+  const handleScrollToBottom = React.useCallback(() => {
     scrollToBottom()
   }, [scrollToBottom])
 

--- a/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
@@ -25,6 +25,12 @@ interface ScrollMinimapProps {
   items: MinimapItem[]
 }
 
+interface ScrollMetrics {
+  scrollTop: number
+  scrollHeight: number
+  clientHeight: number
+}
+
 /** 最少消息数才显示迷你地图 */
 const MIN_ITEMS = 4
 /** 迷你地图最多渲染的横杠数 */
@@ -35,7 +41,12 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
   const [hovered, setHovered] = React.useState(false)
   const [visibleIds, setVisibleIds] = React.useState<Set<string>>(new Set())
   const closeTimerRef = React.useRef<ReturnType<typeof setTimeout>>()
-  const [canScroll, setCanScroll] = React.useState(false)
+  const updateFrameRef = React.useRef<number | null>(null)
+  const [scrollMetrics, setScrollMetrics] = React.useState<ScrollMetrics>({
+    scrollTop: 0,
+    scrollHeight: 0,
+    clientHeight: 0,
+  })
 
   React.useEffect(() => {
     const el = scrollRef.current
@@ -43,7 +54,14 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
 
     const update = (): void => {
       const { scrollTop, scrollHeight, clientHeight } = el
-      setCanScroll(scrollHeight > clientHeight + 10)
+      setScrollMetrics((prev) => (
+        prev.scrollTop === scrollTop
+        && prev.scrollHeight === scrollHeight
+        && prev.clientHeight === clientHeight
+          ? prev
+          : { scrollTop, scrollHeight, clientHeight }
+      ))
+
       if (scrollHeight <= 0) return
 
       const nodes = el.querySelectorAll<HTMLElement>('[data-message-id]')
@@ -59,16 +77,36 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
       setVisibleIds(ids)
     }
 
+    const scheduleUpdate = (): void => {
+      if (updateFrameRef.current !== null) return
+
+      updateFrameRef.current = requestAnimationFrame(() => {
+        updateFrameRef.current = null
+        update()
+      })
+    }
+
     update()
-    el.addEventListener('scroll', update, { passive: true })
-    const observer = new ResizeObserver(update)
+    el.addEventListener('scroll', scheduleUpdate, { passive: true })
+    const observer = new ResizeObserver(scheduleUpdate)
     observer.observe(el)
 
     return () => {
-      el.removeEventListener('scroll', update)
+      el.removeEventListener('scroll', scheduleUpdate)
       observer.disconnect()
+      if (updateFrameRef.current !== null) {
+        cancelAnimationFrame(updateFrameRef.current)
+        updateFrameRef.current = null
+      }
     }
   }, [scrollRef, items])
+
+  React.useEffect(() => {
+    return () => {
+      if (closeTimerRef.current) clearTimeout(closeTimerRef.current)
+      if (updateFrameRef.current !== null) cancelAnimationFrame(updateFrameRef.current)
+    }
+  }, [])
 
   const handleMouseEnter = (): void => {
     if (closeTimerRef.current) clearTimeout(closeTimerRef.current)
@@ -86,7 +124,10 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
     target?.scrollIntoView({ behavior: 'smooth', block: 'center' })
   }, [scrollRef])
 
-  if (items.length < MIN_ITEMS || !canScroll) return null
+  if (items.length < MIN_ITEMS) return null
+
+  const canScroll = scrollMetrics.scrollHeight > scrollMetrics.clientHeight + 10
+  if (!canScroll) return null
 
   // 迷你地图：超过 MAX_BARS 条时按比例采样，避免拥挤
   const barCount = Math.min(items.length, MAX_BARS)
@@ -100,8 +141,8 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
     >
       {/* 悬浮弹出面板 */}
       {hovered && (
-        <div className="mt-3 mr-1 w-[260px] rounded-lg border bg-popover shadow-lg animate-in fade-in-0 zoom-in-95 duration-150">
-          <div className="max-h-[30vh] overflow-y-auto scrollbar-none p-2 space-y-0.5">
+        <div className="mt-3 mr-1 max-h-[30vh] w-[260px] overflow-y-auto rounded-lg border bg-popover p-2 pr-3 shadow-lg animate-in fade-in-0 zoom-in-95 duration-150">
+          <div className="space-y-0.5">
             {items.map((item) => (
               <button
                 key={item.id}
@@ -123,7 +164,7 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
       )}
 
       {/* 迷你地图条 — 集中在右上角 */}
-      <div className="relative mt-3 flex-shrink-0" style={{ width: 24, height: stripHeight }}>
+      <div className="relative mt-3 flex-shrink-0" style={{ width: 18, height: stripHeight }}>
         {Array.from({ length: barCount }, (_, i) => {
           const start = Math.floor((i * items.length) / barCount)
           const end = Math.floor(((i + 1) * items.length) / barCount)
@@ -135,7 +176,7 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
             <div
               key={i}
               className={cn(
-                'absolute left-1 h-[2px] w-[20px] rounded-full transition-colors',
+                'absolute left-0 h-[2px] w-[16px] rounded-full transition-colors',
                 isVisible
                   ? 'bg-primary/60'
                   : hasUser
@@ -155,7 +196,7 @@ function ItemIcon({ item }: { item: MinimapItem }): React.ReactElement {
   if (item.role === 'user' && item.avatar) {
     return <UserAvatar avatar={item.avatar} size={16} className="mt-0.5" />
   }
-  if ((item.role === 'assistant') && item.model) {
+  if (item.role === 'assistant' && item.model) {
     return (
       <img
         src={getModelLogo(item.model)}

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -12,7 +12,7 @@ import * as React from 'react'
 import { useAtom, useSetAtom, useAtomValue } from 'jotai'
 import { toast } from 'sonner'
 import { Pin, PinOff, Settings, Plus, Trash2, Pencil, ChevronDown, ChevronRight, Plug, Zap, PanelLeftClose, PanelLeftOpen, ArrowRightLeft } from 'lucide-react'
-import { cn } from '@/lib/utils'
+import { cn, deleteMapEntry } from '@/lib/utils'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { ModeSwitcher } from './ModeSwitcher'
 import { activeViewAtom } from '@/atoms/active-view'
@@ -111,34 +111,67 @@ const ITEM_TO_VIEW: Record<SidebarItemId, ActiveView> = {
   settings: 'settings',
 }
 
-/** 日期分组标签 */
-type DateGroup = '今天' | '昨天' | '更早'
+type SidebarReorderSection = 'chat-pinned' | 'chat-normal' | 'agent-pinned' | 'agent-normal'
 
-/** 按 updatedAt 将项目分为 今天 / 昨天 / 更早 三组 */
-function groupByDate<T extends { updatedAt: number }>(items: T[]): Array<{ label: DateGroup; items: T[] }> {
-  const now = new Date()
-  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime()
-  const yesterdayStart = todayStart - 86_400_000
+interface SidebarOrderState {
+  chatPinned: string[]
+  chatNormal: string[]
+  agentPinned: string[]
+  agentNormal: string[]
+}
 
-  const today: T[] = []
-  const yesterday: T[] = []
-  const earlier: T[] = []
+function resolveOrderedIds(itemIds: string[], rememberedOrder: string[]): string[] {
+  const seen = new Set<string>()
+  const availableIds = new Set(itemIds)
+  const remembered = rememberedOrder.filter((id) => {
+    if (seen.has(id)) return false
+    if (!availableIds.has(id)) return false
+    seen.add(id)
+    return true
+  })
 
-  for (const item of items) {
-    if (item.updatedAt >= todayStart) {
-      today.push(item)
-    } else if (item.updatedAt >= yesterdayStart) {
-      yesterday.push(item)
-    } else {
-      earlier.push(item)
-    }
+  return [...remembered, ...itemIds.filter((id) => !seen.has(id))]
+}
+
+function orderItemsByIds<T extends { id: string }>(items: T[], rememberedOrder: string[]): T[] {
+  const resolvedIds = resolveOrderedIds(items.map((item) => item.id), rememberedOrder)
+  const itemMap = new Map(items.map((item) => [item.id, item]))
+  return resolvedIds.map((id) => itemMap.get(id)).filter((item): item is T => item !== undefined)
+}
+
+function moveItemToIndex(ids: string[], itemId: string, toIndex: number): string[] {
+  const fromIndex = ids.indexOf(itemId)
+  if (fromIndex === -1) return ids
+
+  const clampedIndex = Math.max(0, Math.min(toIndex, ids.length - 1))
+  if (fromIndex === clampedIndex) return ids
+
+  const next = [...ids]
+  const [moved] = next.splice(fromIndex, 1)
+  next.splice(clampedIndex, 0, moved!)
+  return next
+}
+
+function isStringArrayEqual(a: string[], b: string[]): boolean {
+  if (a === b) return true
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i += 1) {
+    if (a[i] !== b[i]) return false
   }
+  return true
+}
 
-  const groups: Array<{ label: DateGroup; items: T[] }> = []
-  if (today.length > 0) groups.push({ label: '今天', items: today })
-  if (yesterday.length > 0) groups.push({ label: '昨天', items: yesterday })
-  if (earlier.length > 0) groups.push({ label: '更早', items: earlier })
-  return groups
+function getSectionOrderKey(section: SidebarReorderSection): keyof SidebarOrderState {
+  switch (section) {
+    case 'chat-pinned':
+      return 'chatPinned'
+    case 'chat-normal':
+      return 'chatNormal'
+    case 'agent-pinned':
+      return 'agentPinned'
+    case 'agent-normal':
+      return 'agentNormal'
+  }
 }
 
 export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
@@ -148,6 +181,43 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   const [conversations, setConversations] = useAtom(conversationsAtom)
   const [currentConversationId, setCurrentConversationId] = useAtom(currentConversationIdAtom)
   const [hoveredId, setHoveredId] = React.useState<string | null>(null)
+  const [sidebarOrder, setSidebarOrder] = React.useState<SidebarOrderState>({
+    chatPinned: [],
+    chatNormal: [],
+    agentPinned: [],
+    agentNormal: [],
+  })
+  const dragStateRef = React.useRef<{
+    section: SidebarReorderSection
+    itemId: string
+    pointerId: number
+    startX: number
+    startY: number
+    dragging: boolean
+    moved: boolean
+  } | null>(null)
+  const suppressClickRef = React.useRef<string | null>(null)
+  const clearSuppressClickTimerRef = React.useRef<number | null>(null)
+  const suppressNextClick = React.useCallback((itemId: string): void => {
+    suppressClickRef.current = itemId
+    if (clearSuppressClickTimerRef.current !== null) {
+      window.clearTimeout(clearSuppressClickTimerRef.current)
+    }
+    clearSuppressClickTimerRef.current = window.setTimeout(() => {
+      suppressClickRef.current = null
+      clearSuppressClickTimerRef.current = null
+    }, 0)
+  }, [])
+
+  const shouldSuppressClick = React.useCallback((itemId: string): boolean => {
+    if (suppressClickRef.current !== itemId) return false
+    suppressClickRef.current = null
+    if (clearSuppressClickTimerRef.current !== null) {
+      window.clearTimeout(clearSuppressClickTimerRef.current)
+      clearSuppressClickTimerRef.current = null
+    }
+    return true
+  }, [])
   /** 待删除对话 ID，非空时显示确认弹窗 */
   const [pendingDeleteId, setPendingDeleteId] = React.useState<string | null>(null)
   /** 待迁移会话 ID，非空时显示迁移对话框 */
@@ -194,12 +264,8 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
 
   /** 清理 per-conversation/session Map atoms 条目 */
   const cleanupMapAtoms = React.useCallback((id: string) => {
-    const deleteKey = <T,>(prev: Map<string, T>): Map<string, T> => {
-      if (!prev.has(id)) return prev
-      const map = new Map(prev)
-      map.delete(id)
-      return map
-    }
+    const deleteKey = <T,>(prev: Map<string, T>): Map<string, T> => deleteMapEntry(prev, id)
+
     setConvModels(deleteKey)
     setConvContextLength(deleteKey)
     setConvThinking(deleteKey)
@@ -225,9 +291,13 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       .catch(console.error)
   }, [currentWorkspaceSlug, mode, activeView, capabilitiesVersion])
 
-  /** 置顶对话列表 */
-  const pinnedConversations = React.useMemo(
+  const chatPinnedConversations = React.useMemo(
     () => conversations.filter((c) => c.pinned),
+    [conversations]
+  )
+
+  const chatNormalConversations = React.useMemo(
+    () => conversations.filter((c) => !c.pinned),
     [conversations]
   )
 
@@ -237,11 +307,119 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     [agentSessions]
   )
 
-  /** 对话按日期分组 */
-  const conversationGroups = React.useMemo(
-    () => groupByDate(conversations),
-    [conversations]
+  const normalAgentSessions = React.useMemo(
+    () => agentSessions.filter((s) => !s.pinned && s.workspaceId === currentWorkspaceId),
+    [agentSessions, currentWorkspaceId]
   )
+
+  const pinnedConversations = React.useMemo(
+    () => orderItemsByIds(chatPinnedConversations, sidebarOrder.chatPinned),
+    [chatPinnedConversations, sidebarOrder.chatPinned]
+  )
+
+  const normalConversations = React.useMemo(
+    () => orderItemsByIds(chatNormalConversations, sidebarOrder.chatNormal),
+    [chatNormalConversations, sidebarOrder.chatNormal]
+  )
+
+  const orderedPinnedAgentSessions = React.useMemo(
+    () => orderItemsByIds(pinnedAgentSessions, sidebarOrder.agentPinned),
+    [pinnedAgentSessions, sidebarOrder.agentPinned]
+  )
+
+  const orderedNormalAgentSessions = React.useMemo(
+    () => orderItemsByIds(normalAgentSessions, sidebarOrder.agentNormal),
+    [normalAgentSessions, sidebarOrder.agentNormal]
+  )
+
+  const applySidebarReorder = React.useCallback((section: SidebarReorderSection, itemId: string, toIndex: number): void => {
+    setSidebarOrder((prev) => {
+      const key = getSectionOrderKey(section)
+      const nextOrder = moveItemToIndex(prev[key], itemId, toIndex)
+      if (nextOrder === prev[key]) return prev
+      return {
+        ...prev,
+        [key]: nextOrder,
+      }
+    })
+  }, [])
+
+  const startSidebarDrag = React.useCallback((section: SidebarReorderSection, itemId: string, pointerId: number, startX: number, startY: number): void => {
+    dragStateRef.current = {
+      section,
+      itemId,
+      pointerId,
+      startX,
+      startY,
+      dragging: false,
+      moved: false,
+    }
+  }, [])
+
+  const markSidebarDragging = React.useCallback((section: SidebarReorderSection, itemId: string, clientX: number, clientY: number): boolean => {
+    const current = dragStateRef.current
+    if (!current || current.section !== section || current.itemId !== itemId) return false
+
+    const dx = Math.abs(clientX - current.startX)
+    const dy = Math.abs(clientY - current.startY)
+    if (!current.dragging && Math.max(dx, dy) > 5) {
+      current.dragging = true
+    }
+
+    return current.dragging
+  }, [])
+
+  const handleSidebarReorderHover = React.useCallback((section: SidebarReorderSection, itemId: string, toIndex: number): void => {
+    const current = dragStateRef.current
+    if (!current || current.section !== section || current.itemId !== itemId) return
+    current.dragging = true
+    current.moved = true
+    applySidebarReorder(section, itemId, toIndex)
+  }, [applySidebarReorder])
+
+  const finishSidebarDrag = React.useCallback((section: SidebarReorderSection, itemId: string): boolean => {
+    const current = dragStateRef.current
+    if (!current || current.section !== section || current.itemId !== itemId) return false
+    const didDrag = current.dragging || current.moved
+    dragStateRef.current = null
+    return didDrag
+  }, [])
+
+  const cancelSidebarDrag = React.useCallback((section: SidebarReorderSection, itemId: string): void => {
+    const current = dragStateRef.current
+    if (!current || current.section !== section || current.itemId !== itemId) return
+    dragStateRef.current = null
+  }, [])
+
+  React.useEffect(() => {
+    setSidebarOrder((prev) => {
+      const next: SidebarOrderState = {
+        chatPinned: resolveOrderedIds(chatPinnedConversations.map((item) => item.id), prev.chatPinned),
+        chatNormal: resolveOrderedIds(chatNormalConversations.map((item) => item.id), prev.chatNormal),
+        agentPinned: resolveOrderedIds(pinnedAgentSessions.map((item) => item.id), prev.agentPinned),
+        agentNormal: resolveOrderedIds(normalAgentSessions.map((item) => item.id), prev.agentNormal),
+      }
+
+      if (
+        isStringArrayEqual(prev.chatPinned, next.chatPinned)
+        && isStringArrayEqual(prev.chatNormal, next.chatNormal)
+        && isStringArrayEqual(prev.agentPinned, next.agentPinned)
+        && isStringArrayEqual(prev.agentNormal, next.agentNormal)
+      ) {
+        return prev
+      }
+
+      return next
+    })
+  }, [chatPinnedConversations, chatNormalConversations, pinnedAgentSessions, normalAgentSessions])
+
+  React.useEffect(() => {
+    return () => {
+      if (clearSuppressClickTimerRef.current !== null) {
+        window.clearTimeout(clearSuppressClickTimerRef.current)
+      }
+    }
+  }, [])
 
   // 初始加载对话列表 + 用户档案 + Agent 会话
   React.useEffect(() => {
@@ -289,6 +467,10 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         selectedModel?.channelId,
       )
       setConversations((prev) => [meta, ...prev])
+      setSidebarOrder((prev) => ({
+        ...prev,
+        chatNormal: [meta.id, ...prev.chatNormal.filter((id) => id !== meta.id)],
+      }))
       // 打开新标签页
       const result = openTab(tabs, layout, { type: 'chat', sessionId: meta.id, title: meta.title })
       setTabs(result.tabs)
@@ -397,6 +579,17 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         currentWorkspaceId || undefined,
       )
       setAgentSessions((prev) => [meta, ...prev])
+      if (meta.pinned) {
+        setSidebarOrder((prev) => ({
+          ...prev,
+          agentPinned: [meta.id, ...prev.agentPinned.filter((id) => id !== meta.id)],
+        }))
+      } else if (meta.workspaceId === currentWorkspaceId) {
+        setSidebarOrder((prev) => ({
+          ...prev,
+          agentNormal: [meta.id, ...prev.agentNormal.filter((id) => id !== meta.id)],
+        }))
+      }
       // 打开新标签页
       const result = openTab(tabs, layout, { type: 'agent', sessionId: meta.id, title: meta.title })
       setTabs(result.tabs)
@@ -462,18 +655,6 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       description: `已迁移到「${targetWorkspaceName}」，请切换工作区查看`,
     })
   }
-
-  /** Agent 会话按工作区过滤 */
-  const filteredAgentSessions = React.useMemo(
-    () => agentSessions.filter((s) => s.workspaceId === currentWorkspaceId),
-    [agentSessions, currentWorkspaceId]
-  )
-
-  /** Agent 会话按日期分组 */
-  const agentSessionGroups = React.useMemo(
-    () => groupByDate(filteredAgentSessions),
-    [filteredAgentSessions]
-  )
 
   // 删除确认弹窗（collapsed/expanded 共享）
   const deleteDialog = (
@@ -661,7 +842,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       {mode === 'chat' && pinnedExpanded && pinnedConversations.length > 0 && (
         <div className="px-3 pt-1 pb-1">
           <div className="flex flex-col gap-0.5 pl-1 border-l-2 border-primary/20 ml-2">
-            {pinnedConversations.map((conv) => (
+            {pinnedConversations.map((conv, index) => (
               <ConversationItem
                 key={`pinned-${conv.id}`}
                 conversation={conv}
@@ -669,16 +850,63 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                 hovered={conv.id === hoveredId}
                 streaming={streamingIds.has(conv.id)}
                 showPinIcon={false}
+                reorderSection="chat-pinned"
+                reorderIndex={index}
                 onSelect={() => handleSelectConversation(conv.id, conv.title)}
                 onRequestDelete={() => handleRequestDelete(conv.id)}
                 onRename={handleRename}
                 onTogglePin={handleTogglePin}
                 onMouseEnter={() => setHoveredId(conv.id)}
                 onMouseLeave={() => setHoveredId(null)}
+                onDragStart={startSidebarDrag}
+                onDragMove={markSidebarDragging}
+                onDragHover={handleSidebarReorderHover}
+                onDragFinish={finishSidebarDrag}
+                onDragCancel={cancelSidebarDrag}
+                onSuppressClick={suppressNextClick}
+                shouldSuppressClick={shouldSuppressClick}
               />
             ))}
           </div>
         </div>
+      )}
+
+      {mode === 'chat' && normalConversations.length > 0 && (
+        <div className="flex-1 overflow-y-auto px-3 pt-2 pb-3 scrollbar-none">
+          <div className="flex flex-col gap-0.5">
+            {normalConversations.map((conv, index) => (
+              <ConversationItem
+                key={conv.id}
+                conversation={conv}
+                active={conv.id === activeTabId}
+                hovered={conv.id === hoveredId}
+                streaming={streamingIds.has(conv.id)}
+                showPinIcon={false}
+                reorderSection="chat-normal"
+                reorderIndex={index}
+                onSelect={() => handleSelectConversation(conv.id, conv.title)}
+                onRequestDelete={() => handleRequestDelete(conv.id)}
+                onRename={handleRename}
+                onTogglePin={handleTogglePin}
+                onMouseEnter={() => setHoveredId(conv.id)}
+                onMouseLeave={() => setHoveredId(null)}
+                onDragStart={startSidebarDrag}
+                onDragMove={markSidebarDragging}
+                onDragHover={handleSidebarReorderHover}
+                onDragFinish={finishSidebarDrag}
+                onDragCancel={cancelSidebarDrag}
+                onSuppressClick={suppressNextClick}
+                shouldSuppressClick={shouldSuppressClick}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Agent 模式：导航菜单（置顶区域） */}
+
+      {mode === 'chat' && normalConversations.length === 0 && (
+        <div className="flex-1 overflow-y-auto px-3 pt-2 pb-3 scrollbar-none" />
       )}
 
       {/* Agent 模式：导航菜单（置顶区域） */}
@@ -703,7 +931,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       {mode === 'agent' && pinnedAgentExpanded && pinnedAgentSessions.length > 0 && (
         <div className="px-3 pt-1 pb-1">
           <div className="flex flex-col gap-0.5 pl-1 border-l-2 border-primary/20 ml-2">
-            {pinnedAgentSessions.map((session) => (
+            {orderedPinnedAgentSessions.map((session, index) => (
               <AgentSessionItem
                 key={`pinned-${session.id}`}
                 session={session}
@@ -711,6 +939,8 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                 hovered={session.id === hoveredId}
                 running={agentRunningIds.has(session.id)}
                 showPinIcon={false}
+                reorderSection="agent-pinned"
+                reorderIndex={index}
                 onSelect={() => handleSelectAgentSession(session.id, session.title)}
                 onRequestDelete={() => handleRequestDelete(session.id)}
                 onRequestMove={() => setMoveTargetId(session.id)}
@@ -718,71 +948,56 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                 onTogglePin={handleTogglePinAgent}
                 onMouseEnter={() => setHoveredId(session.id)}
                 onMouseLeave={() => setHoveredId(null)}
+                onDragStart={startSidebarDrag}
+                onDragMove={markSidebarDragging}
+                onDragHover={handleSidebarReorderHover}
+                onDragFinish={finishSidebarDrag}
+                onDragCancel={cancelSidebarDrag}
+                onSuppressClick={suppressNextClick}
+                shouldSuppressClick={shouldSuppressClick}
               />
             ))}
           </div>
         </div>
       )}
 
-      {/* 列表区域：根据模式切换 */}
-      <div className="flex-1 overflow-y-auto px-3 pt-2 pb-3 scrollbar-none">
-        {mode === 'chat' ? (
-          /* Chat 模式：对话按日期分组 */
-          conversationGroups.map((group) => (
-            <div key={group.label} className="mb-1">
-              <div className="px-3 pt-2 pb-1 text-[11px] font-medium text-foreground/40 select-none">
-                {group.label}
-              </div>
-              <div className="flex flex-col gap-0.5">
-                {group.items.map((conv) => (
-                  <ConversationItem
-                    key={conv.id}
-                    conversation={conv}
-                    active={conv.id === activeTabId}
-                    hovered={conv.id === hoveredId}
-                    streaming={streamingIds.has(conv.id)}
-                    showPinIcon={!!conv.pinned}
-                    onSelect={() => handleSelectConversation(conv.id, conv.title)}
-                    onRequestDelete={() => handleRequestDelete(conv.id)}
-                    onRename={handleRename}
-                    onTogglePin={handleTogglePin}
-                    onMouseEnter={() => setHoveredId(conv.id)}
-                    onMouseLeave={() => setHoveredId(null)}
-                  />
-                ))}
-              </div>
-            </div>
-          ))
-        ) : (
-          /* Agent 模式：Agent 会话按日期分组 */
-          agentSessionGroups.map((group) => (
-            <div key={group.label} className="mb-1">
-              <div className="px-3 pt-2 pb-1 text-[11px] font-medium text-foreground/40 select-none">
-                {group.label}
-              </div>
-              <div className="flex flex-col gap-0.5">
-                {group.items.map((session) => (
-                  <AgentSessionItem
-                    key={session.id}
-                    session={session}
-                    active={session.id === activeTabId}
-                    hovered={session.id === hoveredId}
-                    running={agentRunningIds.has(session.id)}
-                    showPinIcon={!!session.pinned}
-                    onSelect={() => handleSelectAgentSession(session.id, session.title)}
-                    onRequestDelete={() => handleRequestDelete(session.id)}
-                    onRequestMove={() => setMoveTargetId(session.id)}
-                    onRename={handleAgentRename}
-                    onTogglePin={handleTogglePinAgent}
-                    onMouseEnter={() => setHoveredId(session.id)}
-                    onMouseLeave={() => setHoveredId(null)}
-                  />
-                ))}
-              </div>
-            </div>
-          ))
-        )}
-      </div>
+      {mode === 'agent' && (
+        <div className="flex-1 overflow-y-auto px-3 pt-2 pb-3 scrollbar-none">
+          <div className="flex flex-col gap-0.5">
+            {orderedNormalAgentSessions.map((session, index) => (
+              <AgentSessionItem
+                key={session.id}
+                session={session}
+                active={session.id === activeTabId}
+                hovered={session.id === hoveredId}
+                running={agentRunningIds.has(session.id)}
+                showPinIcon={false}
+                reorderSection="agent-normal"
+                reorderIndex={index}
+                onSelect={() => handleSelectAgentSession(session.id, session.title)}
+                onRequestDelete={() => handleRequestDelete(session.id)}
+                onRequestMove={() => setMoveTargetId(session.id)}
+                onRename={handleAgentRename}
+                onTogglePin={handleTogglePinAgent}
+                onMouseEnter={() => setHoveredId(session.id)}
+                onMouseLeave={() => setHoveredId(null)}
+                onDragStart={startSidebarDrag}
+                onDragMove={markSidebarDragging}
+                onDragHover={handleSidebarReorderHover}
+                onDragFinish={finishSidebarDrag}
+                onDragCancel={cancelSidebarDrag}
+                onSuppressClick={suppressNextClick}
+                shouldSuppressClick={shouldSuppressClick}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {mode === 'agent' && orderedNormalAgentSessions.length === 0 && (
+        <div className="flex-1 overflow-y-auto px-3 pt-2 pb-3 scrollbar-none" />
+      )}
+
 
       {/* Agent 模式：工作区能力指示器 */}
       {mode === 'agent' && capabilities && (
@@ -843,12 +1058,137 @@ interface ConversationItemProps {
   streaming: boolean
   /** 是否在标题旁显示 Pin 图标 */
   showPinIcon: boolean
+  reorderSection: SidebarReorderSection
+  reorderIndex: number
   onSelect: () => void
   onRequestDelete: () => void
   onRename: (id: string, newTitle: string) => Promise<void>
   onTogglePin: (id: string) => Promise<void>
   onMouseEnter: () => void
   onMouseLeave: () => void
+  onDragStart: (section: SidebarReorderSection, itemId: string, pointerId: number, startX: number, startY: number) => void
+  onDragMove: (section: SidebarReorderSection, itemId: string, clientX: number, clientY: number) => boolean
+  onDragHover: (section: SidebarReorderSection, itemId: string, toIndex: number) => void
+  onDragFinish: (section: SidebarReorderSection, itemId: string) => boolean
+  onDragCancel: (section: SidebarReorderSection, itemId: string) => void
+  onSuppressClick: (itemId: string) => void
+  shouldSuppressClick: (itemId: string) => boolean
+}
+
+interface DragHoverTarget {
+  section: SidebarReorderSection
+  index: number
+}
+
+function getSidebarHoverTarget(clientX: number, clientY: number): DragHoverTarget | null {
+  const target = document.elementFromPoint(clientX, clientY)?.closest<HTMLElement>('[data-sidebar-section][data-sidebar-index]')
+  if (!target) return null
+
+  const section = target.dataset.sidebarSection as SidebarReorderSection | undefined
+  const indexValue = target.dataset.sidebarIndex
+  if (!section || !indexValue) return null
+
+  const index = Number(indexValue)
+  if (Number.isNaN(index)) return null
+
+  return { section, index }
+}
+
+function shouldIgnoreSidebarPointerDown(target: HTMLElement | null): boolean {
+  if (!target) return false
+  return target.closest('[data-sidebar-action="true"], input') !== null
+}
+
+function stopSidebarActionPointerDown(e: React.PointerEvent | React.MouseEvent): void {
+  e.stopPropagation()
+}
+
+function stopSidebarActionClick(e: React.MouseEvent): void {
+  e.stopPropagation()
+}
+
+function stopSidebarActionKeyDown(e: React.KeyboardEvent): void {
+  e.stopPropagation()
+}
+
+function cancelSidebarItemClickIfNeeded(
+  e: React.MouseEvent,
+  itemId: string,
+  shouldSuppressClick: (itemId: string) => boolean,
+): boolean {
+  if (!shouldSuppressClick(itemId)) return false
+  e.preventDefault()
+  e.stopPropagation()
+  return true
+}
+
+function cleanupSidebarPointerListeners(cleanupRef: React.MutableRefObject<(() => void) | null>): void {
+  cleanupRef.current?.()
+  cleanupRef.current = null
+}
+
+function startSidebarPointerDrag(options: {
+  section: SidebarReorderSection
+  itemId: string
+  pointerId: number
+  startX: number
+  startY: number
+  onDragStart: (section: SidebarReorderSection, itemId: string, pointerId: number, startX: number, startY: number) => void
+  onDragMove: (section: SidebarReorderSection, itemId: string, clientX: number, clientY: number) => boolean
+  onDragHover: (section: SidebarReorderSection, itemId: string, toIndex: number) => void
+  onDragFinish: (section: SidebarReorderSection, itemId: string) => boolean
+  onDragCancel: (section: SidebarReorderSection, itemId: string) => void
+  onSuppressClick: (itemId: string) => void
+  cleanupRef: React.MutableRefObject<(() => void) | null>
+}): void {
+  const {
+    section,
+    itemId,
+    pointerId,
+    startX,
+    startY,
+    onDragStart,
+    onDragMove,
+    onDragHover,
+    onDragFinish,
+    onDragCancel,
+    onSuppressClick,
+    cleanupRef,
+  } = options
+
+  cleanupSidebarPointerListeners(cleanupRef)
+  onDragStart(section, itemId, pointerId, startX, startY)
+
+  const handleMove = (me: PointerEvent): void => {
+    if (!onDragMove(section, itemId, me.clientX, me.clientY)) return
+    me.preventDefault()
+    const hoverTarget = getSidebarHoverTarget(me.clientX, me.clientY)
+    if (!hoverTarget || hoverTarget.section !== section) return
+    onDragHover(section, itemId, hoverTarget.index)
+  }
+
+  const stop = (): void => {
+    document.removeEventListener('pointermove', handleMove)
+    document.removeEventListener('pointerup', handleUp)
+    document.removeEventListener('pointercancel', handleCancel)
+    cleanupRef.current = null
+  }
+
+  const handleUp = (): void => {
+    const didDrag = onDragFinish(section, itemId)
+    if (didDrag) onSuppressClick(itemId)
+    stop()
+  }
+
+  const handleCancel = (): void => {
+    onDragCancel(section, itemId)
+    stop()
+  }
+
+  cleanupRef.current = stop
+  document.addEventListener('pointermove', handleMove)
+  document.addEventListener('pointerup', handleUp)
+  document.addEventListener('pointercancel', handleCancel)
 }
 
 function ConversationItem({
@@ -857,24 +1197,36 @@ function ConversationItem({
   hovered,
   streaming,
   showPinIcon,
+  reorderSection,
+  reorderIndex,
   onSelect,
   onRequestDelete,
   onRename,
   onTogglePin,
   onMouseEnter,
   onMouseLeave,
+  onDragStart,
+  onDragMove,
+  onDragHover,
+  onDragFinish,
+  onDragCancel,
+  onSuppressClick,
+  shouldSuppressClick,
 }: ConversationItemProps): React.ReactElement {
   const [editing, setEditing] = React.useState(false)
   const [editTitle, setEditTitle] = React.useState('')
   const inputRef = React.useRef<HTMLInputElement>(null)
   const justStartedEditing = React.useRef(false)
+  const dragCleanupRef = React.useRef<(() => void) | null>(null)
 
-  /** 进入编辑模式 */
+  React.useEffect(() => {
+    return () => cleanupSidebarPointerListeners(dragCleanupRef)
+  }, [])
+
   const startEdit = (): void => {
     setEditTitle(conversation.title)
     setEditing(true)
     justStartedEditing.current = true
-    // 延迟聚焦，等待 ContextMenu 完全关闭后再 focus
     setTimeout(() => {
       justStartedEditing.current = false
       inputRef.current?.focus()
@@ -882,9 +1234,7 @@ function ConversationItem({
     }, 300)
   }
 
-  /** 保存标题 */
   const saveTitle = async (): Promise<void> => {
-    // ContextMenu 关闭导致的 blur，忽略
     if (justStartedEditing.current) return
     const trimmed = editTitle.trim()
     if (!trimmed || trimmed === conversation.title) {
@@ -895,14 +1245,41 @@ function ConversationItem({
     setEditing(false)
   }
 
-  /** 键盘事件 */
   const handleKeyDown = (e: React.KeyboardEvent): void => {
     if (e.key === 'Enter') {
       e.preventDefault()
-      saveTitle()
+      void saveTitle()
     } else if (e.key === 'Escape') {
       setEditing(false)
     }
+  }
+
+  const handleClick = (e: React.MouseEvent): void => {
+    if (cancelSidebarItemClickIfNeeded(e, conversation.id, shouldSuppressClick)) return
+    if (editing) {
+      e.preventDefault()
+      return
+    }
+    onSelect()
+  }
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>): void => {
+    if (e.button !== 0 || editing || shouldIgnoreSidebarPointerDown(e.target as HTMLElement | null)) return
+
+    startSidebarPointerDrag({
+      section: reorderSection,
+      itemId: conversation.id,
+      pointerId: e.pointerId,
+      startX: e.clientX,
+      startY: e.clientY,
+      onDragStart,
+      onDragMove,
+      onDragHover,
+      onDragFinish,
+      onDragCancel,
+      onSuppressClick,
+      cleanupRef: dragCleanupRef,
+    })
   }
 
   const isPinned = !!conversation.pinned
@@ -911,7 +1288,10 @@ function ConversationItem({
     <div
       role="button"
       tabIndex={0}
-      onClick={onSelect}
+      data-sidebar-section={reorderSection}
+      data-sidebar-index={reorderIndex}
+      onClick={handleClick}
+      onPointerDown={handlePointerDown}
       onDoubleClick={(e) => {
         e.stopPropagation()
         startEdit()
@@ -919,7 +1299,7 @@ function ConversationItem({
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       className={cn(
-        'w-full flex items-center gap-2 px-3 py-[7px] rounded-[10px] transition-colors duration-100 titlebar-no-drag text-left',
+        'w-full flex items-center gap-2 px-3 py-[7px] rounded-[10px] transition-colors duration-100 titlebar-no-drag text-left select-none',
         active
           ? 'bg-foreground/[0.08] dark:bg-foreground/[0.08] shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
           : 'hover:bg-foreground/[0.04] dark:hover:bg-foreground/[0.04]'
@@ -932,8 +1312,9 @@ function ConversationItem({
             value={editTitle}
             onChange={(e) => setEditTitle(e.target.value)}
             onKeyDown={handleKeyDown}
-            onBlur={saveTitle}
+            onBlur={() => { void saveTitle() }}
             onClick={(e) => e.stopPropagation()}
+            onPointerDown={stopSidebarActionPointerDown}
             className="w-full bg-transparent text-[13px] leading-5 text-foreground border-b border-primary/50 outline-none px-0 py-0"
             maxLength={100}
           />
@@ -942,14 +1323,12 @@ function ConversationItem({
             'truncate text-[13px] leading-5 flex items-center gap-1.5',
             active ? 'text-foreground' : 'text-foreground/80'
           )}>
-            {/* 流式输出绿色呼吸点指示器 */}
             {streaming && (
               <span className="relative flex-shrink-0 size-2">
                 <span className="absolute inset-0 rounded-full bg-green-500/60 animate-ping" />
                 <span className="relative block size-2 rounded-full bg-green-500" />
               </span>
             )}
-            {/* 置顶标记 */}
             {showPinIcon && (
               <Pin size={11} className="flex-shrink-0 text-primary/60" />
             )}
@@ -958,7 +1337,6 @@ function ConversationItem({
         )}
       </div>
 
-      {/* 操作按钮组（hover 时可见） */}
       <div className={cn(
         'flex items-center gap-0.5 flex-shrink-0 transition-all duration-100',
         hovered && !editing ? 'opacity-100' : 'opacity-0 pointer-events-none'
@@ -966,10 +1344,13 @@ function ConversationItem({
         <Tooltip>
           <TooltipTrigger asChild>
             <button
+              data-sidebar-action="true"
+              onPointerDown={stopSidebarActionPointerDown}
               onClick={(e) => {
-                e.stopPropagation()
-                onTogglePin(conversation.id)
+                stopSidebarActionClick(e)
+                void onTogglePin(conversation.id)
               }}
+              onKeyDown={stopSidebarActionKeyDown}
               className="p-1 rounded-md text-foreground/30 hover:bg-foreground/[0.08] hover:text-foreground/60 transition-colors"
             >
               {isPinned ? <PinOff size={13} /> : <Pin size={13} />}
@@ -980,10 +1361,13 @@ function ConversationItem({
         <Tooltip>
           <TooltipTrigger asChild>
             <button
+              data-sidebar-action="true"
+              onPointerDown={stopSidebarActionPointerDown}
               onClick={(e) => {
-                e.stopPropagation()
+                stopSidebarActionClick(e)
                 startEdit()
               }}
+              onKeyDown={stopSidebarActionKeyDown}
               className="p-1 rounded-md text-foreground/30 hover:bg-foreground/[0.08] hover:text-foreground/60 transition-colors"
             >
               <Pencil size={13} />
@@ -994,10 +1378,13 @@ function ConversationItem({
         <Tooltip>
           <TooltipTrigger asChild>
             <button
+              data-sidebar-action="true"
+              onPointerDown={stopSidebarActionPointerDown}
               onClick={(e) => {
-                e.stopPropagation()
+                stopSidebarActionClick(e)
                 onRequestDelete()
               }}
+              onKeyDown={stopSidebarActionKeyDown}
               className="p-1 rounded-md text-foreground/30 hover:bg-destructive/10 hover:text-destructive transition-colors"
             >
               <Trash2 size={13} />
@@ -1018,6 +1405,8 @@ interface AgentSessionItemProps {
   hovered: boolean
   running: boolean
   showPinIcon?: boolean
+  reorderSection: SidebarReorderSection
+  reorderIndex: number
   onSelect: () => void
   onRequestDelete: () => void
   onRequestMove: () => void
@@ -1025,6 +1414,13 @@ interface AgentSessionItemProps {
   onTogglePin: (id: string) => Promise<void>
   onMouseEnter: () => void
   onMouseLeave: () => void
+  onDragStart: (section: SidebarReorderSection, itemId: string, pointerId: number, startX: number, startY: number) => void
+  onDragMove: (section: SidebarReorderSection, itemId: string, clientX: number, clientY: number) => boolean
+  onDragHover: (section: SidebarReorderSection, itemId: string, toIndex: number) => void
+  onDragFinish: (section: SidebarReorderSection, itemId: string) => boolean
+  onDragCancel: (section: SidebarReorderSection, itemId: string) => void
+  onSuppressClick: (itemId: string) => void
+  shouldSuppressClick: (itemId: string) => boolean
 }
 
 function AgentSessionItem({
@@ -1033,6 +1429,8 @@ function AgentSessionItem({
   hovered,
   running,
   showPinIcon,
+  reorderSection,
+  reorderIndex,
   onSelect,
   onRequestDelete,
   onRequestMove,
@@ -1040,11 +1438,23 @@ function AgentSessionItem({
   onTogglePin,
   onMouseEnter,
   onMouseLeave,
+  onDragStart,
+  onDragMove,
+  onDragHover,
+  onDragFinish,
+  onDragCancel,
+  onSuppressClick,
+  shouldSuppressClick,
 }: AgentSessionItemProps): React.ReactElement {
   const [editing, setEditing] = React.useState(false)
   const [editTitle, setEditTitle] = React.useState('')
   const inputRef = React.useRef<HTMLInputElement>(null)
   const justStartedEditing = React.useRef(false)
+  const dragCleanupRef = React.useRef<(() => void) | null>(null)
+
+  React.useEffect(() => {
+    return () => cleanupSidebarPointerListeners(dragCleanupRef)
+  }, [])
 
   const startEdit = (): void => {
     setEditTitle(session.title)
@@ -1071,17 +1481,48 @@ function AgentSessionItem({
   const handleKeyDown = (e: React.KeyboardEvent): void => {
     if (e.key === 'Enter') {
       e.preventDefault()
-      saveTitle()
+      void saveTitle()
     } else if (e.key === 'Escape') {
       setEditing(false)
     }
+  }
+
+  const handleClick = (e: React.MouseEvent): void => {
+    if (cancelSidebarItemClickIfNeeded(e, session.id, shouldSuppressClick)) return
+    if (editing) {
+      e.preventDefault()
+      return
+    }
+    onSelect()
+  }
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>): void => {
+    if (e.button !== 0 || editing || shouldIgnoreSidebarPointerDown(e.target as HTMLElement | null)) return
+
+    startSidebarPointerDrag({
+      section: reorderSection,
+      itemId: session.id,
+      pointerId: e.pointerId,
+      startX: e.clientX,
+      startY: e.clientY,
+      onDragStart,
+      onDragMove,
+      onDragHover,
+      onDragFinish,
+      onDragCancel,
+      onSuppressClick,
+      cleanupRef: dragCleanupRef,
+    })
   }
 
   return (
     <div
       role="button"
       tabIndex={0}
-      onClick={onSelect}
+      data-sidebar-section={reorderSection}
+      data-sidebar-index={reorderIndex}
+      onClick={handleClick}
+      onPointerDown={handlePointerDown}
       onDoubleClick={(e) => {
         e.stopPropagation()
         startEdit()
@@ -1089,7 +1530,7 @@ function AgentSessionItem({
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       className={cn(
-        'w-full flex items-center gap-2 px-3 py-[7px] rounded-[10px] transition-colors duration-100 titlebar-no-drag text-left',
+        'w-full flex items-center gap-2 px-3 py-[7px] rounded-[10px] transition-colors duration-100 titlebar-no-drag text-left select-none',
         active
           ? 'bg-foreground/[0.08] dark:bg-foreground/[0.08] shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
           : 'hover:bg-foreground/[0.04] dark:hover:bg-foreground/[0.04]'
@@ -1102,8 +1543,9 @@ function AgentSessionItem({
             value={editTitle}
             onChange={(e) => setEditTitle(e.target.value)}
             onKeyDown={handleKeyDown}
-            onBlur={saveTitle}
+            onBlur={() => { void saveTitle() }}
             onClick={(e) => e.stopPropagation()}
+            onPointerDown={stopSidebarActionPointerDown}
             className="w-full bg-transparent text-[13px] leading-5 text-foreground border-b border-primary/50 outline-none px-0 py-0"
             maxLength={100}
           />
@@ -1126,7 +1568,6 @@ function AgentSessionItem({
         )}
       </div>
 
-      {/* 操作按钮组（hover 时可见） */}
       <div className={cn(
         'flex items-center gap-0.5 flex-shrink-0 transition-all duration-100',
         hovered && !editing ? 'opacity-100' : 'opacity-0 pointer-events-none'
@@ -1134,10 +1575,13 @@ function AgentSessionItem({
         <Tooltip>
           <TooltipTrigger asChild>
             <button
+              data-sidebar-action="true"
+              onPointerDown={stopSidebarActionPointerDown}
               onClick={(e) => {
-                e.stopPropagation()
-                onTogglePin(session.id)
+                stopSidebarActionClick(e)
+                void onTogglePin(session.id)
               }}
+              onKeyDown={stopSidebarActionKeyDown}
               className="p-1 rounded-md text-foreground/30 hover:bg-foreground/[0.08] hover:text-foreground/60 transition-colors"
             >
               {session.pinned ? <PinOff size={13} /> : <Pin size={13} />}
@@ -1149,10 +1593,13 @@ function AgentSessionItem({
           <Tooltip>
             <TooltipTrigger asChild>
               <button
+                data-sidebar-action="true"
+                onPointerDown={stopSidebarActionPointerDown}
                 onClick={(e) => {
-                  e.stopPropagation()
+                  stopSidebarActionClick(e)
                   onRequestMove()
                 }}
+                onKeyDown={stopSidebarActionKeyDown}
                 className="p-1 rounded-md text-foreground/30 hover:bg-foreground/[0.08] hover:text-foreground/60 transition-colors"
               >
                 <ArrowRightLeft size={13} />
@@ -1164,10 +1611,13 @@ function AgentSessionItem({
         <Tooltip>
           <TooltipTrigger asChild>
             <button
+              data-sidebar-action="true"
+              onPointerDown={stopSidebarActionPointerDown}
               onClick={(e) => {
-                e.stopPropagation()
+                stopSidebarActionClick(e)
                 startEdit()
               }}
+              onKeyDown={stopSidebarActionKeyDown}
               className="p-1 rounded-md text-foreground/30 hover:bg-foreground/[0.08] hover:text-foreground/60 transition-colors"
             >
               <Pencil size={13} />
@@ -1178,10 +1628,13 @@ function AgentSessionItem({
         <Tooltip>
           <TooltipTrigger asChild>
             <button
+              data-sidebar-action="true"
+              onPointerDown={stopSidebarActionPointerDown}
               onClick={(e) => {
-                e.stopPropagation()
+                stopSidebarActionClick(e)
                 onRequestDelete()
               }}
+              onKeyDown={stopSidebarActionKeyDown}
               className="p-1 rounded-md text-foreground/30 hover:bg-destructive/10 hover:text-destructive transition-colors"
             >
               <Trash2 size={13} />

--- a/apps/electron/src/renderer/components/chat/ChatMessages.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessages.tsx
@@ -13,7 +13,7 @@
  */
 
 import * as React from 'react'
-import { useAtomValue } from 'jotai'
+import { useAtomValue, useSetAtom } from 'jotai'
 import { MessageSquare, Loader2 } from 'lucide-react'
 import { ChatMessageItem, formatMessageTime } from './ChatMessageItem'
 import type { InlineEditSubmitPayload } from './ChatMessageItem'
@@ -44,7 +44,14 @@ import {
 import { useSmoothStream } from '@proma/ui'
 import { useConversationParallelMode } from '@/hooks/useConversationSettings'
 import { getModelLogo } from '@/lib/model-logo'
+import {
+  conversationScrollMemoryAtom,
+  conversationLoadedAllHistorySelectorAtom,
+  updateConversationHistoryRequirementAtom,
+} from '@/atoms/chat-atoms'
 import { userProfileAtom } from '@/atoms/user-profile'
+import { isScrollMemoryStateEqual } from '@/lib/scroll-memory'
+import type { ScrollMemoryState } from '@/lib/scroll-memory'
 import type { ChatMessage, ChatToolActivity } from '@proma/shared'
 
 // ===== 滚动到顶部加载更多 =====
@@ -187,7 +194,6 @@ export function ChatMessages({
 }: ChatMessagesProps): React.ReactElement {
   const userProfile = useAtomValue(userProfileAtom)
 
-  // 平滑流式输出：将高频更新转为逐字渲染
   const { displayedContent: smoothContent } = useSmoothStream({
     content: streamingContent,
     isStreaming: streaming,
@@ -197,46 +203,8 @@ export function ChatMessages({
     isStreaming: streaming,
   })
   const [parallelMode] = useConversationParallelMode()
-
-  /** 是否正在加载更多历史 */
   const [loadingMore, setLoadingMore] = React.useState(false)
 
-  /**
-   * 淡入控制：切换对话时先隐藏，等 StickToBottom 定位完成后再显示。
-   * 避免 "先看到顶部消息再跳到底部" 的闪烁。
-   */
-  const [ready, setReady] = React.useState(false)
-  const prevConversationIdRef = React.useRef<string | null>(null)
-
-  // 对话切换时立即隐藏
-  React.useEffect(() => {
-    if (conversationId !== prevConversationIdRef.current) {
-      prevConversationIdRef.current = conversationId
-      setReady(false)
-    }
-  }, [conversationId])
-
-  // 消息渲染 + StickToBottom 定位完成后淡入
-  React.useEffect(() => {
-    if (ready) return
-
-    // 空对话直接显示
-    if (messages.length === 0 && !streaming) {
-      setReady(true)
-      return
-    }
-
-    // 双 rAF：确保 DOM 渲染和 StickToBottom 滚动都完成
-    let cancelled = false
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        if (!cancelled) setReady(true)
-      })
-    })
-    return () => { cancelled = true }
-  }, [messages, streaming, ready])
-
-  /** 加载更多历史消息 */
   const handleLoadMore = React.useCallback(async () => {
     if (!onLoadMore || loadingMore || !hasMore) return
 
@@ -245,14 +213,12 @@ export function ChatMessages({
     setLoadingMore(false)
   }, [onLoadMore, loadingMore, hasMore])
 
-  // 并排模式：自动加载全部历史消息（并排视图需要完整上下文）
   React.useEffect(() => {
     if (parallelMode && hasMore) {
       handleLoadMore()
     }
   }, [parallelMode, hasMore, handleLoadMore])
 
-  // 迷你地图数据（必须在所有条件分支之前调用，遵守 hooks 规则）
   const minimapItems: MinimapItem[] = React.useMemo(
     () => messages.map((m) => ({
       id: m.id,
@@ -264,7 +230,6 @@ export function ChatMessages({
     [messages, userProfile.avatar]
   )
 
-  // 并排模式
   if (parallelMode) {
     return (
       <ParallelChatMessages
@@ -287,23 +252,170 @@ export function ChatMessages({
     )
   }
 
-  // 标准消息列表模式
+  return (
+    <StandardChatMessages
+      conversationId={conversationId}
+      messages={messages}
+      streaming={streaming}
+      smoothContent={smoothContent}
+      smoothReasoning={smoothReasoning}
+      streamingModel={streamingModel}
+      startedAt={startedAt}
+      toolActivities={toolActivities}
+      contextDividers={contextDividers}
+      hasMore={hasMore}
+      loadingMore={loadingMore}
+      minimapItems={minimapItems}
+      onDeleteMessage={onDeleteMessage}
+      onResendMessage={onResendMessage}
+      onStartInlineEdit={onStartInlineEdit}
+      onSubmitInlineEdit={onSubmitInlineEdit}
+      onCancelInlineEdit={onCancelInlineEdit}
+      inlineEditingMessageId={inlineEditingMessageId}
+      onDeleteDivider={onDeleteDivider}
+      onLoadMore={handleLoadMore}
+    />
+  )
+}
+
+interface StandardChatMessagesProps {
+  conversationId: string
+  messages: ChatMessage[]
+  streaming: boolean
+  smoothContent: string
+  smoothReasoning: string
+  streamingModel: string | null
+  startedAt?: number
+  toolActivities: ChatToolActivity[]
+  contextDividers: string[]
+  hasMore: boolean
+  loadingMore: boolean
+  minimapItems: MinimapItem[]
+  onDeleteMessage?: (messageId: string) => Promise<void>
+  onResendMessage?: (message: ChatMessage) => Promise<void>
+  onStartInlineEdit?: (message: ChatMessage) => void
+  onSubmitInlineEdit?: (message: ChatMessage, payload: InlineEditSubmitPayload) => Promise<void>
+  onCancelInlineEdit?: () => void
+  inlineEditingMessageId?: string | null
+  onDeleteDivider?: (messageId: string) => void
+  onLoadMore: () => Promise<void>
+}
+
+function StandardChatMessages({
+  conversationId,
+  messages,
+  streaming,
+  smoothContent,
+  smoothReasoning,
+  streamingModel,
+  startedAt,
+  toolActivities,
+  contextDividers,
+  hasMore,
+  loadingMore,
+  minimapItems,
+  onDeleteMessage,
+  onResendMessage,
+  onStartInlineEdit,
+  onSubmitInlineEdit,
+  onCancelInlineEdit,
+  inlineEditingMessageId,
+  onDeleteDivider,
+  onLoadMore,
+}: StandardChatMessagesProps): React.ReactElement {
+  const scrollMemoryMap = useAtomValue(conversationScrollMemoryAtom)
+  const loadedAllHistorySelector = useAtomValue(conversationLoadedAllHistorySelectorAtom)
+  const setConversationScrollMemory = useSetAtom(conversationScrollMemoryAtom)
+  const setHistoryRequirement = useSetAtom(updateConversationHistoryRequirementAtom)
+  const scrollMemory = scrollMemoryMap.get(conversationId) ?? null
+  const loadedAllHistory = loadedAllHistorySelector(conversationId)
+  const [ready, setReady] = React.useState(false)
+  const prevConversationIdRef = React.useRef<string | null>(null)
+
+  React.useEffect(() => {
+    if (conversationId !== prevConversationIdRef.current) {
+      prevConversationIdRef.current = conversationId
+      setReady(false)
+    }
+  }, [conversationId])
+
+  const handleScrollMemoryChange = React.useCallback((state: ScrollMemoryState): void => {
+    setConversationScrollMemory((prev) => {
+      const current = prev.get(conversationId)
+      if (current && isScrollMemoryStateEqual(current, state)) return prev
+
+      const map = new Map(prev)
+      map.set(conversationId, state)
+      return map
+    })
+
+    setHistoryRequirement({ conversationId, scrollState: state })
+  }, [conversationId, setConversationScrollMemory, setHistoryRequirement])
+
+  const handleRestoreComplete = React.useCallback((): void => {
+    setReady(true)
+  }, [])
+
+  React.useEffect(() => {
+    if (ready) return
+
+    const waitingFullHistory = scrollMemory?.atBottom === false && !loadedAllHistory
+    if (waitingFullHistory) return
+
+    if (messages.length === 0 && !streaming) {
+      setReady(true)
+      return
+    }
+
+    if (scrollMemory?.atBottom === false) return
+
+    let cancelled = false
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        if (!cancelled) setReady(true)
+      })
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [messages.length, streaming, ready, scrollMemory?.atBottom, loadedAllHistory])
+
+  const waitingFullHistory = scrollMemory?.atBottom === false && !loadedAllHistory
+  if (waitingFullHistory) {
+    return <div className="flex-1 min-h-0" />
+  }
+
   const dividerSet = new Set(contextDividers)
+  const standardMinimapItems = [...minimapItems]
+  if (streaming || smoothContent || smoothReasoning) {
+    standardMinimapItems.push({
+      id: `streaming-${conversationId}`,
+      role: 'assistant',
+      preview: smoothContent || smoothReasoning || '(生成中)',
+      model: streamingModel ?? undefined,
+    })
+  }
 
   return (
-    <Conversation className={ready ? 'opacity-100 transition-opacity duration-200' : 'opacity-0'}>
-      {/* 滚动到顶部时自动加载更多历史 */}
+    <Conversation
+      className={ready ? 'opacity-100 transition-opacity duration-200' : 'opacity-0'}
+      scrollMemory={scrollMemory}
+      onScrollMemoryChange={handleScrollMemoryChange}
+      restoreKey={conversationId}
+      restoreVersion={messages.length}
+      onRestoreComplete={handleRestoreComplete}
+    >
       <ScrollTopLoader
-        hasMore={hasMore}
+        hasMore={loadedAllHistory ? false : hasMore}
         loading={loadingMore}
-        onLoadMore={handleLoadMore}
+        onLoadMore={onLoadMore}
       />
       <ConversationContent>
         {messages.length === 0 && !streaming ? (
           <EmptyState />
         ) : (
           <>
-            {/* 已有消息 + 分隔线 */}
             {messages.map((msg: ChatMessage) => (
               <React.Fragment key={msg.id}>
                 <div data-message-id={msg.id}>
@@ -321,7 +433,6 @@ export function ChatMessages({
                     isInlineEditing={msg.id === inlineEditingMessageId}
                   />
                 </div>
-                {/* 分隔线 */}
                 {dividerSet.has(msg.id) && (
                   <ContextDivider
                     messageId={msg.id}
@@ -331,7 +442,6 @@ export function ChatMessages({
               </React.Fragment>
             ))}
 
-            {/* 正在生成 / 停止后等待磁盘消息加载的临时 assistant 消息 */}
             {(streaming || smoothContent || smoothReasoning) && (
               <Message from="assistant">
                 <MessageHeader
@@ -346,10 +456,8 @@ export function ChatMessages({
                   }
                 />
                 <MessageContent>
-                  {/* 工具活动指示器 */}
                   <ChatToolActivityIndicator activities={toolActivities} />
 
-                  {/* 推理内容（如果有） */}
                   {smoothReasoning && (
                     <Reasoning
                       isStreaming={streaming && !smoothContent}
@@ -360,14 +468,12 @@ export function ChatMessages({
                     </Reasoning>
                   )}
 
-                  {/* 流式内容（经过平滑处理） */}
                   {smoothContent ? (
                     <>
                       <MessageResponse>{smoothContent}</MessageResponse>
                       {streaming && <StreamingIndicator />}
                     </>
                   ) : (
-                    /* 等待首个 chunk 时的加载动画（仅流式中且无推理时显示） */
                     streaming && !smoothReasoning && <MessageLoading startedAt={startedAt} />
                   )}
                 </MessageContent>
@@ -376,7 +482,7 @@ export function ChatMessages({
           </>
         )}
       </ConversationContent>
-      <ScrollMinimap items={minimapItems} />
+      <ScrollMinimap items={standardMinimapItems} />
       <ConversationScrollButton />
     </Conversation>
   )

--- a/apps/electron/src/renderer/components/chat/ChatView.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatView.tsx
@@ -29,6 +29,9 @@ import {
   chatMessageRefreshAtom,
   pendingAgentRecommendationAtom,
   conversationModelsAtom,
+  conversationShouldLoadFullHistoryAtom,
+  conversationLoadedAllHistorySelectorAtom,
+  markConversationHistoryLoadedAtom,
   INITIAL_MESSAGE_LIMIT,
 } from '@/atoms/chat-atoms'
 import type { PendingAttachment } from '@/atoms/chat-atoms'
@@ -89,12 +92,18 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
   const userProfile = useAtomValue(userProfileAtom)
   const promptSidebarOpen = useAtomValue(promptSidebarOpenAtom)
   const activeToolIds = useAtomValue(activeToolIdsAtom)
+  const shouldLoadFullHistoryForConversation = useAtomValue(conversationShouldLoadFullHistoryAtom)
+  const loadedAllHistoryForConversation = useAtomValue(conversationLoadedAllHistorySelectorAtom)
+  const setMarkConversationHistoryLoaded = useSetAtom(markConversationHistoryLoadedAtom)
   const setPendingRecommendation = useSetAtom(pendingAgentRecommendationAtom)
 
   // ===== 从 Map 派生当前对话状态 =====
   const conversation = conversations.find((c) => c.id === conversationId) ?? null
   const streamState = streamingStates.get(conversationId)
   const isStreaming = streamState?.streaming ?? false
+  const shouldLoadFullHistory = shouldLoadFullHistoryForConversation(conversationId)
+  const loadedAllHistory = loadedAllHistoryForConversation(conversationId)
+  const shouldLoadAllMessages = shouldLoadFullHistory || loadedAllHistory
   const streamingContent = streamState?.content ?? ''
   const streamingReasoning = streamState?.reasoning ?? ''
   const streamingModel = streamState?.model ?? null
@@ -110,24 +119,41 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
 
   // ===== 加载消息 + 上下文分隔线 =====
   React.useEffect(() => {
-    window.electronAPI
-      .getRecentMessages(conversationId, INITIAL_MESSAGE_LIMIT)
-      .then((result) => {
-        setMessages(result.messages)
-        setHasMoreMessages(result.hasMore)
+    const loadMessages = async (): Promise<void> => {
+      const result = shouldLoadAllMessages
+        ? {
+            messages: await window.electronAPI.getConversationMessages(conversationId),
+            hasMore: false,
+          }
+        : await window.electronAPI.getRecentMessages(conversationId, INITIAL_MESSAGE_LIMIT)
 
-        // 消息加载完成后，清除已完成的流式状态（streaming=false 的过渡气泡）
-        // 在同一个微任务中执行，确保 React 在一次渲染中同时显示持久化消息并移除流式气泡
-        setStreamingStates((prev) => {
-          const state = prev.get(conversationId)
-          if (!state || state.streaming) return prev  // 仍在流式中，不清除
-          const map = new Map(prev)
-          map.delete(conversationId)
-          return map
-        })
+      setMessages(result.messages)
+      setHasMoreMessages(result.hasMore)
+
+      if (shouldLoadAllMessages && !loadedAllHistory) {
+        setMarkConversationHistoryLoaded(conversationId)
+      }
+
+      // 消息加载完成后，清除已完成的流式状态（streaming=false 的过渡气泡）
+      // 在同一个微任务中执行，确保 React 在一次渲染中同时显示持久化消息并移除流式气泡
+      setStreamingStates((prev) => {
+        const state = prev.get(conversationId)
+        if (!state || state.streaming) return prev  // 仍在流式中，不清除
+        const map = new Map(prev)
+        map.delete(conversationId)
+        return map
       })
-      .catch(console.error)
-  }, [conversationId, refreshVersion, setStreamingStates])
+    }
+
+    loadMessages().catch(console.error)
+  }, [
+    conversationId,
+    refreshVersion,
+    shouldLoadAllMessages,
+    loadedAllHistory,
+    setMarkConversationHistoryLoaded,
+    setStreamingStates,
+  ])
 
   // 从对话元数据加载分隔线
   React.useEffect(() => {
@@ -481,7 +507,8 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
     const allMessages = await window.electronAPI.getConversationMessages(conversationId)
     setMessages(allMessages)
     setHasMoreMessages(false)
-  }, [conversationId])
+    setMarkConversationHistoryLoaded(conversationId)
+  }, [conversationId, setMarkConversationHistoryLoaded])
 
   return (
     <div className="flex h-full overflow-hidden">
@@ -501,7 +528,7 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
             startedAt={streamState?.startedAt}
             toolActivities={toolActivities}
             contextDividers={contextDividers}
-            hasMore={hasMoreMessages}
+            hasMore={loadedAllHistory ? false : hasMoreMessages}
             onDeleteMessage={handleDeleteMessage}
             onResendMessage={handleResendMessage}
             onStartInlineEdit={handleStartInlineEdit}

--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -32,6 +32,7 @@ import {
   agentSidePanelTabMapAtom,
 } from '@/atoms/agent-atoms'
 import { conversationPromptIdAtom } from '@/atoms/system-prompt-atoms'
+import { deleteMapEntry } from '@/lib/utils'
 import { TabBarItem } from './TabBarItem'
 import { SplitModeToggle } from './SplitModeToggle'
 
@@ -41,6 +42,74 @@ export function TabBar(): React.ReactElement {
   const activeTabId = useAtomValue(activeTabIdAtom)
   const streamingMap = useAtomValue(tabStreamingMapAtom)
   const scrollRef = React.useRef<HTMLDivElement>(null)
+  const suppressClickRef = React.useRef<string | null>(null)
+  const suppressClickTimerRef = React.useRef<number | null>(null)
+
+  const suppressNextClick = React.useCallback((tabId: string): void => {
+    suppressClickRef.current = tabId
+    if (suppressClickTimerRef.current !== null) {
+      window.clearTimeout(suppressClickTimerRef.current)
+    }
+    suppressClickTimerRef.current = window.setTimeout(() => {
+      suppressClickRef.current = null
+      suppressClickTimerRef.current = null
+    }, 0)
+  }, [])
+
+  const shouldSuppressClick = React.useCallback((tabId: string): boolean => {
+    if (suppressClickRef.current !== tabId) return false
+    suppressClickRef.current = null
+    if (suppressClickTimerRef.current !== null) {
+      window.clearTimeout(suppressClickTimerRef.current)
+      suppressClickTimerRef.current = null
+    }
+    return true
+  }, [])
+
+  React.useEffect(() => {
+    return () => {
+      if (suppressClickTimerRef.current !== null) {
+        window.clearTimeout(suppressClickTimerRef.current)
+      }
+    }
+  }, [])
+
+  const getTabIndexFromPointer = React.useCallback((clientX: number, fallbackIndex: number): number => {
+    const elements = Array.from(scrollRef.current?.querySelectorAll<HTMLElement>('[data-tab-id]') ?? [])
+    for (let index = 0; index < elements.length; index += 1) {
+      const element = elements[index]!
+      const rect = element.getBoundingClientRect()
+      if (clientX < rect.left + rect.width / 2) {
+        return index
+      }
+    }
+    return elements.length > 0 ? elements.length - 1 : fallbackIndex
+  }, [])
+
+  const handleTabDragMove = React.useCallback((clientX: number): void => {
+    const current = dragState.current
+    if (!current) return
+
+    const dx = Math.abs(clientX - current.startX)
+    if (!current.dragging && dx > 5) {
+      current.dragging = true
+    }
+    if (!current.dragging) return
+
+    const fromIndex = tabs.findIndex((t) => t.id === current.tabId)
+    if (fromIndex === -1) return
+
+    const toIndex = getTabIndexFromPointer(clientX, fromIndex)
+    if (fromIndex === toIndex) return
+
+    setTabs((prev) => {
+      const latestFromIndex = prev.findIndex((t) => t.id === current.tabId)
+      if (latestFromIndex === -1) return prev
+      const latestToIndex = Math.max(0, Math.min(toIndex, prev.length - 1))
+      if (latestFromIndex === latestToIndex) return prev
+      return reorderTabs(prev, latestFromIndex, latestToIndex)
+    })
+  }, [getTabIndexFromPointer, setTabs, tabs])
 
   // per-conversation/session Map atoms（用于关闭标签时清理）
   const setConvModels = useSetAtom(conversationModelsAtom)
@@ -53,12 +122,8 @@ export function TabBar(): React.ReactElement {
 
   /** 清理关闭标签对应的 per-conversation/session Map atoms 条目 */
   const cleanupMapAtoms = React.useCallback((tabId: string) => {
-    const deleteKey = <T,>(prev: Map<string, T>): Map<string, T> => {
-      if (!prev.has(tabId)) return prev
-      const map = new Map(prev)
-      map.delete(tabId)
-      return map
-    }
+    const deleteKey = <T,>(prev: Map<string, T>): Map<string, T> => deleteMapEntry(prev, tabId)
+
     // Chat per-conversation atoms
     setConvModels(deleteKey)
     setConvContextLength(deleteKey)
@@ -75,7 +140,6 @@ export function TabBar(): React.ReactElement {
     dragging: boolean
     tabId: string
     startX: number
-    startIndex: number
   } | null>(null)
 
   const handleActivate = React.useCallback((tabId: string) => {
@@ -94,7 +158,7 @@ export function TabBar(): React.ReactElement {
   }, [layout, setTabs, setLayout, cleanupMapAtoms])
 
   const handleDragStart = React.useCallback((tabId: string, e: React.PointerEvent) => {
-    if (e.button !== 0) return // 只处理左键
+    if (e.button !== 0) return
     const idx = tabs.findIndex((t) => t.id === tabId)
     if (idx === -1) return
 
@@ -102,24 +166,39 @@ export function TabBar(): React.ReactElement {
       dragging: false,
       tabId,
       startX: e.clientX,
-      startIndex: idx,
     }
 
     const handleMove = (me: PointerEvent): void => {
-      if (!dragState.current) return
-      const dx = Math.abs(me.clientX - dragState.current.startX)
-      if (dx > 5) dragState.current.dragging = true
+      handleTabDragMove(me.clientX)
     }
 
     const handleUp = (): void => {
+      const didDrag = dragState.current?.dragging ?? false
       document.removeEventListener('pointermove', handleMove)
       document.removeEventListener('pointerup', handleUp)
+      document.removeEventListener('pointercancel', handleUp)
       dragState.current = null
+      if (didDrag) suppressNextClick(tabId)
     }
 
     document.addEventListener('pointermove', handleMove)
     document.addEventListener('pointerup', handleUp)
-  }, [tabs])
+    document.addEventListener('pointercancel', handleUp)
+  }, [handleTabDragMove, suppressNextClick, tabs])
+
+  const handleTabClick = React.useCallback((tabId: string) => {
+    if (shouldSuppressClick(tabId)) return
+    handleActivate(tabId)
+  }, [handleActivate, shouldSuppressClick])
+
+  const handleCloseClick = React.useCallback((tabId: string, e: React.MouseEvent): void => {
+    e.stopPropagation()
+    handleClose(tabId)
+  }, [handleClose])
+
+  const handleMiddleClick = React.useCallback((tabId: string) => {
+    handleClose(tabId)
+  }, [handleClose])
 
   // 水平滚动支持
   const handleWheel = React.useCallback((e: React.WheelEvent) => {
@@ -138,7 +217,7 @@ export function TabBar(): React.ReactElement {
         className="flex items-end shrink min-w-0 max-w-full overflow-x-auto scrollbar-none titlebar-no-drag"
         onWheel={handleWheel}
       >
-        {tabs.map((tab, _index) => (
+        {tabs.map((tab) => (
           <TabBarItem
             key={tab.id}
             id={tab.id}
@@ -146,9 +225,9 @@ export function TabBar(): React.ReactElement {
             title={tab.title}
             isActive={tab.id === activeTabId}
             isStreaming={streamingMap.get(tab.id) ?? false}
-            onActivate={() => handleActivate(tab.id)}
-            onClose={() => handleClose(tab.id)}
-            onMiddleClick={() => handleClose(tab.id)}
+            onActivate={() => handleTabClick(tab.id)}
+            onClose={(e) => handleCloseClick(tab.id, e)}
+            onMiddleClick={() => handleMiddleClick(tab.id)}
             onDragStart={(e) => handleDragStart(tab.id, e)}
           />
         ))}

--- a/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
@@ -17,40 +17,96 @@ export interface TabBarItemProps {
   isActive: boolean
   isStreaming: boolean
   onActivate: () => void
-  onClose: () => void
+  onClose: (e: React.MouseEvent) => void
   onMiddleClick: () => void
-  /** 拖拽相关 */
   onDragStart: (e: React.PointerEvent) => void
 }
 
-export function TabBarItem({
-  type,
-  title,
+function stopTabItemActionKeyDown(e: React.KeyboardEvent): void {
+  e.stopPropagation()
+}
+
+function stopTabItemActionClick(e: React.MouseEvent): void {
+  e.stopPropagation()
+}
+
+function stopTabItemActionPointerDown(e: React.PointerEvent): void {
+  e.stopPropagation()
+}
+
+function shouldIgnoreTabPointerDown(target: HTMLElement | null): boolean {
+  if (!target) return false
+  return target.closest('[data-tab-action="true"]') !== null
+}
+
+function handleTabItemMiddleMouseDown(e: React.MouseEvent, onMiddleClick: () => void): void {
+  if (e.button !== 1) return
+  e.preventDefault()
+  e.stopPropagation()
+  onMiddleClick()
+}
+
+function handleTabItemPointerDown(
+  e: React.PointerEvent,
+  onDragStart: (e: React.PointerEvent) => void,
+): void {
+  if (shouldIgnoreTabPointerDown(e.target as HTMLElement | null)) return
+  onDragStart(e)
+}
+
+function handleTabItemCloseKeyDown(
+  e: React.KeyboardEvent,
+  onClose: (e: React.MouseEvent) => void,
+): void {
+  stopTabItemActionKeyDown(e)
+  if (e.key !== 'Enter' && e.key !== ' ') return
+  e.preventDefault()
+  onClose(e as unknown as React.MouseEvent)
+}
+
+function handleTabItemCloseClick(
+  e: React.MouseEvent,
+  onClose: (e: React.MouseEvent) => void,
+): void {
+  stopTabItemActionClick(e)
+  onClose(e)
+}
+
+function TabBarItemCloseButton({
   isActive,
-  isStreaming,
-  onActivate,
   onClose,
+}: Pick<TabBarItemProps, 'isActive' | 'onClose'>): React.ReactElement {
+  return (
+    <span
+      role="button"
+      tabIndex={-1}
+      data-tab-action="true"
+      className={cn(
+        'size-4 rounded-sm flex items-center justify-center shrink-0',
+        'opacity-0 group-hover:opacity-100 hover:bg-muted-foreground/20 transition-opacity',
+        isActive && 'opacity-60',
+      )}
+      onPointerDown={stopTabItemActionPointerDown}
+      onClick={(e) => handleTabItemCloseClick(e, onClose)}
+      onKeyDown={(e) => handleTabItemCloseKeyDown(e, onClose)}
+    >
+      <X className="size-2.5" />
+    </span>
+  )
+}
+
+function TabBarItemRoot({
+  id,
+  isActive,
+  onActivate,
   onMiddleClick,
   onDragStart,
-}: TabBarItemProps): React.ReactElement {
-  const handleMouseDown = (e: React.MouseEvent): void => {
-    // 中键点击关闭
-    if (e.button === 1) {
-      e.preventDefault()
-      onMiddleClick()
-    }
-  }
-
-  const handleCloseClick = (e: React.MouseEvent): void => {
-    e.stopPropagation()
-    onClose()
-  }
-
-  const Icon = type === 'chat' ? MessageSquare : Bot
-
+  children,
+}: Pick<TabBarItemProps, 'id' | 'isActive' | 'onActivate' | 'onMiddleClick' | 'onDragStart'> & { children: React.ReactNode }): React.ReactElement {
   return (
     <button
       type="button"
+      data-tab-id={id}
       className={cn(
         'group relative flex items-center gap-1.5 px-3 h-[34px] min-w-[100px] max-w-[200px] shrink-0',
         'rounded-t-lg text-xs transition-colors select-none cursor-pointer',
@@ -60,16 +116,25 @@ export function TabBarItem({
           : 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
       )}
       onClick={onActivate}
-      onMouseDown={handleMouseDown}
-      onPointerDown={onDragStart}
+      onMouseDown={(e) => handleTabItemMiddleMouseDown(e, onMiddleClick)}
+      onPointerDown={(e) => handleTabItemPointerDown(e, onDragStart)}
     >
-      {/* 类型图标 */}
+      {children}
+    </button>
+  )
+}
+
+function TabBarItemContent({
+  type,
+  title,
+  isStreaming,
+}: Pick<TabBarItemProps, 'type' | 'title' | 'isStreaming'>): React.ReactElement {
+  const Icon = type === 'chat' ? MessageSquare : Bot
+
+  return (
+    <>
       <Icon className="size-3 shrink-0" />
-
-      {/* 标题 */}
       <span className="flex-1 min-w-0 truncate text-left">{title}</span>
-
-      {/* 流式指示器 */}
       {isStreaming && (
         <span
           className={cn(
@@ -78,23 +143,38 @@ export function TabBarItem({
           )}
         />
       )}
+    </>
+  )
+}
 
-      {/* 关闭按钮 */}
-      <span
-        role="button"
-        tabIndex={-1}
-        className={cn(
-          'size-4 rounded-sm flex items-center justify-center shrink-0',
-          'opacity-0 group-hover:opacity-100 hover:bg-muted-foreground/20 transition-opacity',
-          isActive && 'opacity-60',
-        )}
-        onClick={handleCloseClick}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') handleCloseClick(e as unknown as React.MouseEvent)
-        }}
-      >
-        <X className="size-2.5" />
-      </span>
-    </button>
+export function TabBarItem({
+  id,
+  type,
+  title,
+  isActive,
+  isStreaming,
+  onActivate,
+  onClose,
+  onMiddleClick,
+  onDragStart,
+}: TabBarItemProps): React.ReactElement {
+  return (
+    <TabBarItemRoot
+      id={id}
+      isActive={isActive}
+      onActivate={onActivate}
+      onMiddleClick={onMiddleClick}
+      onDragStart={onDragStart}
+    >
+      <TabBarItemContent
+        type={type}
+        title={title}
+        isStreaming={isStreaming}
+      />
+      <TabBarItemCloseButton
+        isActive={isActive}
+        onClose={onClose}
+      />
+    </TabBarItemRoot>
   )
 }

--- a/apps/electron/src/renderer/lib/scroll-memory.ts
+++ b/apps/electron/src/renderer/lib/scroll-memory.ts
@@ -1,0 +1,80 @@
+/**
+ * scroll-memory — 运行期滚动位置快照与恢复
+ *
+ * 基于消息锚点（message id + offset）保存阅读位置，
+ * 避免仅靠 scrollTop 在历史加载或新消息插入后出现位置失真。
+ */
+
+export interface ScrollMemoryState {
+  scrollTop: number
+  atBottom: boolean
+  anchorMessageId?: string
+  anchorOffset?: number
+}
+
+export const DEFAULT_SCROLL_MEMORY_STATE: ScrollMemoryState = {
+  scrollTop: 0,
+  atBottom: true,
+}
+
+/** 与 use-stick-to-bottom 内部 near-bottom 阈值保持一致 */
+export const STICK_TO_BOTTOM_OFFSET_PX = 70
+
+export function isScrollMemoryStateEqual(a: ScrollMemoryState, b: ScrollMemoryState): boolean {
+  return a.scrollTop === b.scrollTop
+    && a.atBottom === b.atBottom
+    && a.anchorMessageId === b.anchorMessageId
+    && a.anchorOffset === b.anchorOffset
+}
+
+export function clampScrollTop(container: HTMLElement, scrollTop: number): number {
+  const maxScrollTop = Math.max(0, container.scrollHeight - container.clientHeight)
+  return Math.min(Math.max(0, scrollTop), maxScrollTop)
+}
+
+export function captureScrollMemory(container: HTMLElement): ScrollMemoryState {
+  const scrollTop = clampScrollTop(container, container.scrollTop)
+  const maxScrollTop = Math.max(0, container.scrollHeight - container.clientHeight)
+  const atBottom = maxScrollTop - scrollTop <= STICK_TO_BOTTOM_OFFSET_PX
+
+  if (atBottom) {
+    return {
+      scrollTop,
+      atBottom: true,
+    }
+  }
+
+  const nodes = container.querySelectorAll<HTMLElement>('[data-message-id]')
+  for (const node of nodes) {
+    const top = node.offsetTop
+    const bottom = top + node.offsetHeight
+    if (bottom > scrollTop) {
+      return {
+        scrollTop,
+        atBottom: false,
+        anchorMessageId: node.dataset.messageId,
+        anchorOffset: scrollTop - top,
+      }
+    }
+  }
+
+  return {
+    scrollTop,
+    atBottom: false,
+  }
+}
+
+export function resolveScrollMemory(container: HTMLElement, state: ScrollMemoryState): number {
+  if (state.atBottom) {
+    return Math.max(0, container.scrollHeight - container.clientHeight)
+  }
+
+  if (state.anchorMessageId) {
+    const anchor = container.querySelector<HTMLElement>(`[data-message-id="${state.anchorMessageId}"]`)
+    if (anchor) {
+      return clampScrollTop(container, anchor.offsetTop + (state.anchorOffset ?? 0))
+    }
+  }
+
+  return clampScrollTop(container, state.scrollTop)
+}

--- a/apps/electron/src/renderer/lib/utils.ts
+++ b/apps/electron/src/renderer/lib/utils.ts
@@ -4,3 +4,11 @@ import { twMerge } from 'tailwind-merge'
 export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs))
 }
+
+export function deleteMapEntry<T>(map: Map<string, T>, key: string): Map<string, T> {
+  if (!map.has(key)) return map
+
+  const next = new Map(map)
+  next.delete(key)
+  return next
+}


### PR DESCRIPTION
## 概要

这次 PR 主要包含以下几类已经完成并实际使用过的修复：

1. 左侧侧边栏会话支持自由拖拽排序
2. 顶部标签栏支持自由拖拽排序
3. Chat / Agent 会话切换时的滚动位置恢复
4. 右侧展开详情区域的滚动条归位修正
5. 修复 Agent 模式在 Claude Code 环境下可能直接退出的问题

## 具体改动

### 1. 侧边栏会话自由拖拽
- 支持 Chat / Agent 会话在各自区域内自由排序
- 拖拽完成后抑制误点击
- 避免菜单按钮、输入框等交互和拖拽冲突

### 2. 顶部标签自由拖拽
- 支持顶部标签拖拽重排
- 保留关闭按钮和中键关闭逻辑
- 减少点击、关闭、拖拽之间的交互冲突

### 3. 会话滚动位置恢复
- 为 Chat / Agent 会话增加滚动位置记忆与恢复
- 切换会话后尽量回到原阅读位置，而不是直接跳到底部
- 减少切换时的闪动和错误跳动

### 4. 右侧展开区域滚动条修正
- 调整滚动容器归属
- 让展开后的白色详情区域自己承担滚动
- 修正滑块显示位置

### 5. Agent 启动稳定性修复
- 启动 Agent 子进程时过滤 `CLAUDECODE` 环境变量
- 避免在 Claude Code 环境下误判为嵌套会话，导致 `Claude Code process exited with code 1`

## 说明
- 这次 PR 只包含已经完成并确认过的 UI / 交互 / Agent 启动修复
- Chat 模式 system prompt 在 Anthropic 兼容链路下的未生效问题 **没有包含在这次 PR 中**
- 这个问题我会单独补充说明，不混入本次 PR

## 验证情况
- 已验证左侧会话拖拽排序
- 已验证顶部标签拖拽排序
- 已验证会话切换后的滚动位置保持
- 已验证右侧展开区域滑块位置修正
- 已验证 Agent 模式不再因环境变量问题直接退出