### PR TITLE
feat: Nano Banana 生图工具 (Gemini Image Generation)

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -441,6 +441,35 @@ export function registerIpcHandlers(): void {
     }
   )
 
+  // 另存图片到用户选择的位置（原生 Save As 对话框）
+  ipcMain.handle(
+    CHAT_IPC_CHANNELS.SAVE_IMAGE_AS,
+    async (event, localPath: string, defaultFilename: string): Promise<boolean> => {
+      const { dialog, BrowserWindow } = await import('electron')
+      const { writeFileSync } = await import('node:fs')
+      const { extname: pathExtname } = await import('node:path')
+
+      const win = BrowserWindow.fromWebContents(event.sender)
+      const ext = pathExtname(defaultFilename).replace('.', '').toLowerCase()
+      const filterMap: Record<string, string> = { jpg: 'JPEG', jpeg: 'JPEG', png: 'PNG', gif: 'GIF', webp: 'WebP', bmp: 'BMP' }
+      const filterName = filterMap[ext] ?? 'Image'
+
+      const result = await dialog.showSaveDialog(win ?? BrowserWindow.getFocusedWindow()!, {
+        defaultPath: defaultFilename,
+        filters: [
+          { name: `${filterName} 图片`, extensions: [ext || 'png'] },
+          { name: '所有文件', extensions: ['*'] },
+        ],
+      })
+
+      if (result.canceled || !result.filePath) return false
+
+      const base64 = readAttachmentAsBase64(localPath)
+      writeFileSync(result.filePath, Buffer.from(base64, 'base64'))
+      return true
+    }
+  )
+
   // 删除附件
   ipcMain.handle(
     CHAT_IPC_CHANNELS.DELETE_ATTACHMENT,

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -996,6 +996,35 @@ export function registerIpcHandlers(): void {
           return { success: false, message: `连接失败: ${msg}` }
         }
       }
+      // Nano Banana 生图工具测试
+      if (toolId === 'nano-banana') {
+        const { getToolCredentials: getCredentials } = await import('./lib/chat-tool-config')
+        const credentials = getCredentials('nano-banana')
+        if (!credentials.apiKey) {
+          return { success: false, message: '请先填写 Gemini API Key' }
+        }
+        try {
+          const baseUrl = credentials.baseUrl?.trim() || 'https://generativelanguage.googleapis.com'
+          const model = credentials.model?.trim() || 'gemini-3.1-flash-image-preview'
+          const url = `${baseUrl}/v1beta/models/${model}:generateContent?key=${credentials.apiKey}`
+          const response = await fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              contents: [{ role: 'user', parts: [{ text: 'Hi' }] }],
+              generationConfig: { maxOutputTokens: 10 },
+            }),
+          })
+          if (!response.ok) {
+            const errorText = await response.text()
+            return { success: false, message: `API 请求失败 (${response.status}): ${errorText.slice(0, 200)}` }
+          }
+          return { success: true, message: `连接成功，模型 ${model} 可用` }
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error)
+          return { success: false, message: `连接失败: ${msg}` }
+        }
+      }
       return { success: false, message: `工具 ${toolId} 不支持测试` }
     }
   )

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -545,6 +545,23 @@ export class AgentOrchestrator {
   }
 
   /**
+   * 注入 SDK 内置生图工具（Nano Banana）
+   */
+  private async injectNanoBananaTools(
+    sdk: typeof import('@anthropic-ai/claude-agent-sdk'),
+    mcpServers: Record<string, Record<string, unknown>>,
+    sessionId: string,
+    agentCwd?: string,
+  ): Promise<void> {
+    try {
+      const { injectNanoBananaMcpServer } = await import('./chat-tools/nano-banana-mcp')
+      await injectNanoBananaMcpServer(sdk, mcpServers, sessionId, agentCwd)
+    } catch (err) {
+      console.error(`[Agent 编排] 注入 Nano Banana MCP 失败:`, err)
+    }
+  }
+
+  /**
    * 生成 Agent 会话标题
    *
    * 使用 Provider 适配器系统，支持所有渠道。任何错误返回 null。
@@ -798,9 +815,10 @@ export class AgentOrchestrator {
         }
       }
 
-      // 10. 构建 MCP 服务器配置 + 记忆工具 + 自定义工具
+      // 10. 构建 MCP 服务器配置 + 记忆工具 + 生图工具 + 自定义工具
       const mcpServers = this.buildMcpServers(workspaceSlug)
       await this.injectMemoryTools(sdk, mcpServers)
+      await this.injectNanoBananaTools(sdk, mcpServers, sessionId, agentCwd)
 
       // 合并外部注入的自定义 MCP 服务器（如飞书群聊工具）
       if (customMcpServers) {

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -21,6 +21,7 @@ import {
 import { getAgentWorkspace } from './agent-workspace-manager'
 import type { AgentSessionMeta, AgentMessage } from '@proma/shared'
 import { getConversationMessages } from './conversation-manager'
+import { clearNanoBananaAgentHistory } from './chat-tools/nano-banana-mcp'
 
 /**
  * 会话索引文件格式
@@ -226,6 +227,9 @@ export function deleteAgentSession(id: string): void {
   }
 
   console.log(`[Agent 会话] 已删除会话: ${removed.title} (${removed.id})`)
+
+  // 清理 Nano Banana 生图历史
+  clearNanoBananaAgentHistory(id)
 }
 
 /**

--- a/apps/electron/src/main/lib/chat-service.ts
+++ b/apps/electron/src/main/lib/chat-service.ts
@@ -248,6 +248,7 @@ export async function sendMessage(
   let accumulatedContent = ''
   let accumulatedReasoning = ''
   const accumulatedToolActivities: ChatToolActivity[] = []
+  const accumulatedGeneratedAttachments: FileAttachment[] = []
 
   try {
     // 7. 获取适配器
@@ -336,9 +337,15 @@ export async function sendMessage(
       }
 
       // 执行工具调用（通过统一执行器）
+      // 提取前一轮对话的附件（用于参考图支持）
+      const lastUserMsg = fullHistory.filter((m) => m.role === 'user').at(-1)
+      const lastAssistantMsg = fullHistory.filter((m) => m.role === 'assistant').at(-1)
       const toolResults = await executeToolCalls(toolCalls, {
         webContents,
         conversationId,
+        currentAttachments: attachments,
+        previousUserAttachments: lastUserMsg?.attachments,
+        previousAssistantAttachments: lastAssistantMsg?.attachments,
       })
 
       // 累积工具结果到持久化数据
@@ -352,6 +359,10 @@ export async function sendMessage(
             result: tr.content,
             isError: tr.isError,
           })
+          // 收集工具生成的附件（如生图工具的图片）
+          if (tr.generatedAttachments) {
+            accumulatedGeneratedAttachments.push(...tr.generatedAttachments)
+          }
         }
       }
 
@@ -394,9 +405,9 @@ export async function sendMessage(
       })
     }
 
-    // 10. 保存 assistant 消息（空内容不保存）
+    // 10. 保存 assistant 消息（空内容不保存，除非有生成的附件）
     const assistantMsgId = randomUUID()
-    if (accumulatedContent.trim()) {
+    if (accumulatedContent.trim() || accumulatedGeneratedAttachments.length > 0) {
       const assistantMsg: ChatMessage = {
         id: assistantMsgId,
         role: 'assistant',
@@ -405,6 +416,7 @@ export async function sendMessage(
         model: modelId,
         reasoning: accumulatedReasoning || undefined,
         toolActivities: accumulatedToolActivities.length > 0 ? accumulatedToolActivities : undefined,
+        attachments: accumulatedGeneratedAttachments.length > 0 ? accumulatedGeneratedAttachments : undefined,
       }
       appendMessage(conversationId, assistantMsg)
 
@@ -415,13 +427,13 @@ export async function sendMessage(
         // 索引更新失败不影响主流程
       }
     } else {
-      console.warn(`[聊天服务] 模型返回空内容，跳过保存 (对话 ${conversationId})`)
+      console.warn(`[聊天服务] 模型返回空内容且无生成附件，跳过保存 (对话 ${conversationId})`)
     }
 
     webContents.send(CHAT_IPC_CHANNELS.STREAM_COMPLETE, {
       conversationId,
       model: modelId,
-      messageId: accumulatedContent.trim() ? assistantMsgId : undefined,
+      messageId: (accumulatedContent.trim() || accumulatedGeneratedAttachments.length > 0) ? assistantMsgId : undefined,
     })
   } catch (error) {
     // 被中止的请求：保存已输出的部分内容，通知前端停止

--- a/apps/electron/src/main/lib/chat-tool-config.ts
+++ b/apps/electron/src/main/lib/chat-tool-config.ts
@@ -15,6 +15,7 @@ const DEFAULT_CONFIG: ChatToolsFileConfig = {
   toolStates: {
     memory: { enabled: true },
     'web-search': { enabled: false },
+    'nano-banana': { enabled: false },
   },
   toolCredentials: {},
   customTools: [],

--- a/apps/electron/src/main/lib/chat-tool-executor.ts
+++ b/apps/electron/src/main/lib/chat-tool-executor.ts
@@ -7,11 +7,14 @@
 
 import type { ToolCall, ToolResult } from '@proma/core'
 import type { WebContents } from 'electron'
+import type { FileAttachment } from '@proma/shared'
 import { CHAT_IPC_CHANNELS } from '@proma/shared'
 import { isMemoryToolCall, executeMemoryTool } from './chat-tools/memory-tool'
 import { isWebSearchToolCall, executeWebSearchTool } from './chat-tools/web-search-tool'
 import { isCustomHttpToolCall, executeHttpTool } from './chat-tools/http-tool-executor'
 import { isAgentRecommendToolCall, executeAgentRecommendTool } from './chat-tools/agent-recommend-tool'
+import { isNanoBananaToolCall, executeNanoBananaTool } from './chat-tools/nano-banana-tool'
+import type { NanoBananaContext } from './chat-tools/nano-banana-tool'
 import { getChatToolsConfig } from './chat-tool-config'
 
 /** 工具执行上下文 */
@@ -20,6 +23,12 @@ export interface ToolExecutionContext {
   webContents: WebContents
   /** 对话 ID */
   conversationId: string
+  /** 当前用户消息的附件列表 */
+  currentAttachments?: FileAttachment[]
+  /** 前一轮用户消息的附件 */
+  previousUserAttachments?: FileAttachment[]
+  /** 前一轮助手消息的附件 */
+  previousAssistantAttachments?: FileAttachment[]
 }
 
 /**
@@ -46,6 +55,14 @@ export async function executeToolCalls(
       result = await executeWebSearchTool(tc)
     } else if (isAgentRecommendToolCall(tc.name)) {
       result = await executeAgentRecommendTool(tc)
+    } else if (isNanoBananaToolCall(tc.name)) {
+      const nanoBananaContext: NanoBananaContext = {
+        conversationId: context.conversationId,
+        currentAttachments: context.currentAttachments,
+        previousUserAttachments: context.previousUserAttachments,
+        previousAssistantAttachments: context.previousAssistantAttachments,
+      }
+      result = await executeNanoBananaTool(tc, nanoBananaContext)
     } else if (isCustomHttpToolCall(tc.name)) {
       const config = getChatToolsConfig()
       const meta = config.customTools.find((t) => t.id === tc.name)

--- a/apps/electron/src/main/lib/chat-tool-registry.ts
+++ b/apps/electron/src/main/lib/chat-tool-registry.ts
@@ -26,6 +26,11 @@ import {
   AGENT_RECOMMEND_TOOL_DEFINITIONS,
   isAgentRecommendAvailable,
 } from './chat-tools/agent-recommend-tool'
+import {
+  NANO_BANANA_TOOL_META,
+  NANO_BANANA_TOOL_DEFINITIONS,
+  isNanoBananaAvailable,
+} from './chat-tools/nano-banana-tool'
 import { getMemoryConfig } from './memory-service'
 
 // ===== 内置工具注册 =====
@@ -53,6 +58,11 @@ const BUILTIN_TOOLS: BuiltinToolEntry[] = [
     meta: AGENT_RECOMMEND_TOOL_META,
     getDefinitions: () => AGENT_RECOMMEND_TOOL_DEFINITIONS,
     checkAvailable: isAgentRecommendAvailable,
+  },
+  {
+    meta: NANO_BANANA_TOOL_META,
+    getDefinitions: () => NANO_BANANA_TOOL_DEFINITIONS,
+    checkAvailable: isNanoBananaAvailable,
   },
 ]
 

--- a/apps/electron/src/main/lib/chat-tools/nano-banana-mcp.ts
+++ b/apps/electron/src/main/lib/chat-tools/nano-banana-mcp.ts
@@ -1,0 +1,374 @@
+/**
+ * Nano Banana MCP Server（Agent 模式）
+ *
+ * 基于 Gemini Image Generation API 的内置 MCP 服务器。
+ * 通过 sdk.createSdkMcpServer() 创建，注入到每个 Agent 会话。
+ * 支持文生图、多轮连续修改。凭据复用 chat-tools.json 配置。
+ */
+
+import { randomUUID } from 'node:crypto'
+import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'node:fs'
+import { extname, resolve, isAbsolute, join } from 'node:path'
+import { getToolState, getToolCredentials } from '../chat-tool-config'
+import { saveAttachment, isImageAttachment } from '../attachment-service'
+
+// ===== Gemini API 类型（REST API 使用 camelCase） =====
+
+interface GeminiInlineData {
+  mimeType: string
+  data: string
+}
+
+interface GeminiPart {
+  text?: string
+  inlineData?: GeminiInlineData
+  /** Gemini 多轮对话必需：模型生成图片时附带的签名，回传时原样保留 */
+  thoughtSignature?: string
+  /** snake_case 兼容（部分 API 版本） */
+  thought_signature?: string
+}
+
+interface GeminiContent {
+  role: 'user' | 'model'
+  parts: GeminiPart[]
+}
+
+interface GeminiCandidate {
+  content: {
+    parts: GeminiPart[]
+    role: string
+  }
+}
+
+interface GeminiResponse {
+  candidates?: GeminiCandidate[]
+  error?: { message: string; code: number }
+}
+
+// ===== 多轮对话历史（按 sessionId 隔离） =====
+
+const sessionHistory = new Map<string, GeminiContent[]>()
+
+// ===== 默认配置 =====
+
+const DEFAULT_BASE_URL = 'https://generativelanguage.googleapis.com'
+const DEFAULT_MODEL = 'gemini-3.1-flash-image-preview'
+
+// ===== MCP 内容块类型 =====
+
+interface McpTextContent {
+  type: 'text'
+  text: string
+  [key: string]: unknown
+}
+
+interface McpImageContent {
+  type: 'image'
+  data: string
+  mimeType: string
+  [key: string]: unknown
+}
+
+type McpContent = McpTextContent | McpImageContent
+
+interface McpToolResult {
+  content: McpContent[]
+  [key: string]: unknown
+}
+
+// ===== Gemini API 调用 =====
+
+/** 已知图片扩展名 → MIME 类型映射 */
+const EXT_TO_MIME: Record<string, string> = {
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.bmp': 'image/bmp',
+}
+
+/**
+ * 从文件路径列表读取参考图，转换为 GeminiPart[]
+ *
+ * 支持绝对路径和相对路径（相对于 cwd 解析）。
+ * 跳过不存在、非图片、读取失败的文件。
+ */
+function readReferenceImages(paths: string[], cwd?: string): GeminiPart[] {
+  const parts: GeminiPart[] = []
+  for (const rawPath of paths) {
+    try {
+      // 相对路径 → 基于 cwd 解析为绝对路径
+      const filePath = isAbsolute(rawPath) ? rawPath : resolve(cwd ?? process.cwd(), rawPath)
+
+      if (!existsSync(filePath)) {
+        console.warn(`[Nano Banana MCP] 参考图不存在: ${filePath}`)
+        continue
+      }
+      const ext = extname(filePath).toLowerCase()
+      const mimeType = EXT_TO_MIME[ext]
+      if (!mimeType || !isImageAttachment(mimeType)) {
+        console.warn(`[Nano Banana MCP] 非图片文件，跳过: ${filePath}`)
+        continue
+      }
+      const data = readFileSync(filePath).toString('base64')
+      parts.push({ inlineData: { mimeType, data } })
+    } catch (error) {
+      console.warn(`[Nano Banana MCP] 读取参考图失败: ${rawPath}`, error)
+    }
+  }
+  return parts
+}
+
+/**
+ * Gemini 多轮对话中，模型响应包含 thoughtSignature 后，
+ * 后续所有 user 消息的 text part 也必须携带 thoughtSignature。
+ * 使用 Gemini 官方提供的跳过验证占位符。
+ * @see https://ai.google.dev/gemini-api/docs/thought-signatures
+ */
+const DUMMY_THOUGHT_SIGNATURE = 'skip_thought_signature_validator'
+
+/** 检查对话历史中是否存在 thoughtSignature */
+function historyHasThoughtSignature(history: GeminiContent[]): boolean {
+  return history.some((c) =>
+    c.parts.some((p) => p.thoughtSignature || p.thought_signature),
+  )
+}
+
+/**
+ * 构建 Gemini API 请求体
+ */
+function buildGeminiRequest(
+  prompt: string,
+  referenceImageParts: GeminiPart[],
+  history: GeminiContent[],
+  options: { aspectRatio?: string; imageSize?: string },
+): Record<string, unknown> {
+  // 多轮对话中 model 响应含 thoughtSignature 时，新 user 的 text part 也必须带签名
+  const needsSignature = history.length > 0 && historyHasThoughtSignature(history)
+
+  const userParts: GeminiPart[] = [
+    ...referenceImageParts,
+    {
+      text: prompt,
+      ...(needsSignature && { thoughtSignature: DUMMY_THOUGHT_SIGNATURE }),
+    },
+  ]
+
+  const contents: GeminiContent[] = [
+    ...history,
+    { role: 'user', parts: userParts },
+  ]
+
+  const generationConfig: Record<string, unknown> = {
+    responseModalities: ['TEXT', 'IMAGE'],
+  }
+
+  const imageConfig: Record<string, unknown> = {}
+  if (options.aspectRatio && options.aspectRatio !== '1:1') {
+    imageConfig.aspectRatio = options.aspectRatio
+  }
+  if (options.imageSize && options.imageSize !== 'auto') {
+    imageConfig.imageSize = options.imageSize
+  }
+  if (Object.keys(imageConfig).length > 0) {
+    generationConfig.imageConfig = imageConfig
+  }
+
+  return { contents, generationConfig }
+}
+
+/**
+ * 调用 Gemini Image Generation API 并返回 MCP 工具结果
+ */
+async function callGeminiAndBuildResult(
+  prompt: string,
+  sessionId: string,
+  options: { aspectRatio?: string; imageSize?: string; referenceImagePaths?: string[]; cwd?: string },
+): Promise<McpToolResult> {
+  const credentials = getToolCredentials('nano-banana')
+  const baseUrl = credentials.baseUrl?.trim() || DEFAULT_BASE_URL
+  const model = credentials.model?.trim() || DEFAULT_MODEL
+
+  // 获取会话历史
+  const history = sessionHistory.get(sessionId) ?? []
+
+  // 读取参考图
+  const referenceImageParts = options.referenceImagePaths?.length
+    ? readReferenceImages(options.referenceImagePaths, options.cwd)
+    : []
+  if (referenceImageParts.length > 0) {
+    console.log(`[Nano Banana MCP] 加载了 ${referenceImageParts.length} 张参考图`)
+  }
+
+  // 构建请求
+  const requestBody = buildGeminiRequest(prompt, referenceImageParts, history, options)
+  const url = `${baseUrl}/v1beta/models/${model}:generateContent?key=${credentials.apiKey}`
+
+  console.log(`[Nano Banana MCP] 调用 Gemini API: model=${model}, prompt="${prompt.slice(0, 50)}..."`)
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(requestBody),
+  })
+
+  if (!response.ok) {
+    const errorText = await response.text()
+    console.error(`[Nano Banana MCP] API 请求失败 (${response.status}):`, errorText)
+    return {
+      content: [{ type: 'text' as const, text: `Gemini API 请求失败 (${response.status}): ${errorText.slice(0, 200)}` }],
+    }
+  }
+
+  const data = (await response.json()) as GeminiResponse
+
+  if (data.error) {
+    return {
+      content: [{ type: 'text' as const, text: `Gemini API 错误: ${data.error.message}` }],
+    }
+  }
+
+  if (!data.candidates || data.candidates.length === 0) {
+    return {
+      content: [{ type: 'text' as const, text: '未生成任何内容' }],
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- candidates[0] 已通过上方 length 检查
+  const parts = data.candidates![0]!.content.parts
+  console.log(`[Nano Banana MCP] 响应包含 ${parts.length} 个 parts，类型:`,
+    parts.map((p) => p.inlineData ? `image(${p.inlineData.mimeType})` : `text(${(p.text ?? '').slice(0, 30)})`))
+
+  const mcpContent: McpContent[] = []
+  const textParts: string[] = []
+  const savedWorkspacePaths: string[] = []
+
+  // 解析响应：提取图片和文本
+  for (const part of parts) {
+    if (part.inlineData) {
+      // 保存图片到附件目录（供 UI 渲染）
+      const ext = part.inlineData.mimeType === 'image/jpeg' ? '.jpg' : '.png'
+      const filename = `nano-banana-${randomUUID().slice(0, 8)}${ext}`
+      const result = saveAttachment({
+        conversationId: sessionId,
+        filename,
+        mediaType: part.inlineData.mimeType,
+        data: part.inlineData.data,
+      })
+
+      // 同时保存到 Agent 工作 session 目录（供 Agent 直接引用）
+      if (options.cwd) {
+        try {
+          const imgDir = join(options.cwd, 'generated-images')
+          mkdirSync(imgDir, { recursive: true })
+          const workspacePath = join(imgDir, filename)
+          writeFileSync(workspacePath, Buffer.from(part.inlineData.data, 'base64'))
+          savedWorkspacePaths.push(workspacePath)
+        } catch (err) {
+          console.warn(`[Nano Banana MCP] 保存图片到工作目录失败:`, err)
+        }
+      }
+
+      // MCP image content block（供 SDK/模型查看）
+      mcpContent.push({
+        type: 'image' as const,
+        data: part.inlineData.data,
+        mimeType: part.inlineData.mimeType,
+      })
+
+      // 嵌入附件标记（供前端 UI 解析渲染）
+      const attachmentMeta = JSON.stringify({
+        localPath: result.attachment.localPath,
+        filename: result.attachment.filename,
+        mediaType: result.attachment.mediaType,
+      })
+      textParts.push(`[PROMA_IMAGE_ATTACHMENT:${attachmentMeta}]`)
+    } else if (part.text) {
+      textParts.push(part.text)
+    }
+  }
+
+  // 更新会话历史（保留原始 parts 含 thoughtSignature，多轮编辑必需）
+  const userContent: GeminiContent = { role: 'user', parts: [...referenceImageParts, { text: prompt }] }
+  const modelContent: GeminiContent = { role: 'model', parts }
+  const updatedHistory = [...history, userContent, modelContent]
+  sessionHistory.set(sessionId, updatedHistory)
+
+  // 在图片内容块之后追加文本摘要
+  const imageCount = mcpContent.filter((c) => c.type === 'image').length
+  const pathInfo = savedWorkspacePaths.length > 0
+    ? `\n图片已保存到工作目录:\n${savedWorkspacePaths.map((p) => `- ${p}`).join('\n')}`
+    : ''
+  const summaryText = imageCount > 0
+    ? `图片已生成（${imageCount} 张）${pathInfo}\n${textParts.join('\n')}`
+    : textParts.join('\n') || '未生成图片内容'
+
+  mcpContent.push({ type: 'text' as const, text: summaryText })
+
+  return { content: mcpContent }
+}
+
+// ===== MCP Server 注入 =====
+
+/**
+ * 注入 Nano Banana MCP Server 到 Agent 会话
+ *
+ * 参照 injectMemoryTools 模式，检查配置后创建 SDK MCP Server。
+ */
+export async function injectNanoBananaMcpServer(
+  sdk: typeof import('@anthropic-ai/claude-agent-sdk'),
+  mcpServers: Record<string, Record<string, unknown>>,
+  sessionId: string,
+  agentCwd?: string,
+): Promise<void> {
+  // 检查工具是否启用且有凭据
+  const toolState = getToolState('nano-banana')
+  const credentials = getToolCredentials('nano-banana')
+  if (!toolState.enabled || !credentials.apiKey) return
+
+  const { z } = await import('zod')
+
+  const server = sdk.createSdkMcpServer({
+    name: 'nano-banana',
+    version: '1.0.0',
+    tools: [
+      sdk.tool(
+        'generate_image',
+        'Generate or edit images using AI (Gemini Image Generation). Supports text-to-image, reference image editing, and iterative multi-turn editing. Use English prompts for best results. Previous generations are automatically used as context for subsequent calls. When the user uploads images (listed in <attached_files>) or mentions image files via @file:{path}, pass their absolute file paths via referenceImagePaths to use them as reference for editing.',
+        {
+          prompt: z.string().describe('Detailed description of the image to generate or the edits to make. English descriptions work best.'),
+          referenceImagePaths: z.array(z.string()).optional().describe('File paths of reference images for editing. Can be absolute paths or relative paths (resolved from cwd). Extract from <attached_files> entries or @file:{path} mentions when the user wants to edit uploaded/referenced images.'),
+          aspectRatio: z.enum(['1:1', '16:9', '4:3', '9:16', '3:4']).optional().describe('Aspect ratio (default 1:1)'),
+          imageSize: z.enum(['auto', '1K', '2K', '4K']).optional().describe('Resolution (default auto)'),
+        },
+        async (args) => {
+          try {
+            return await callGeminiAndBuildResult(args.prompt, sessionId, {
+              aspectRatio: args.aspectRatio,
+              imageSize: args.imageSize,
+              referenceImagePaths: args.referenceImagePaths,
+              cwd: agentCwd,
+            })
+          } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error)
+            console.error(`[Nano Banana MCP] 执行失败:`, error)
+            return { content: [{ type: 'text' as const, text: `图片生成失败: ${msg}` }] }
+          }
+        },
+      ),
+    ],
+  })
+
+  mcpServers['nano-banana'] = server as unknown as Record<string, unknown>
+  console.log(`[Nano Banana MCP] 已注入内置生图工具 (nano-banana)`)
+}
+
+// ===== 清理 =====
+
+/**
+ * 清除 Agent 会话的生图历史（会话删除时调用）
+ */
+export function clearNanoBananaAgentHistory(sessionId: string): void {
+  sessionHistory.delete(sessionId)
+}

--- a/apps/electron/src/main/lib/chat-tools/nano-banana-tool.ts
+++ b/apps/electron/src/main/lib/chat-tools/nano-banana-tool.ts
@@ -194,6 +194,21 @@ function collectReferenceImages(context: NanoBananaContext): GeminiPart[] {
 }
 
 /**
+ * Gemini 多轮对话中，模型响应包含 thoughtSignature 后，
+ * 后续所有 user 消息的 text part 也必须携带 thoughtSignature。
+ * 使用 Gemini 官方提供的跳过验证占位符。
+ * @see https://ai.google.dev/gemini-api/docs/thought-signatures
+ */
+const DUMMY_THOUGHT_SIGNATURE = 'skip_thought_signature_validator'
+
+/** 检查对话历史中是否存在 thoughtSignature */
+function historyHasThoughtSignature(history: GeminiContent[]): boolean {
+  return history.some((c) =>
+    c.parts.some((p) => p.thoughtSignature || p.thought_signature),
+  )
+}
+
+/**
  * 构建 Gemini API 请求体
  */
 function buildGeminiRequest(
@@ -205,10 +220,15 @@ function buildGeminiRequest(
     imageSize?: string
   },
 ): Record<string, unknown> {
-  // 当前用户输入：参考图 + 文字提示
+  // 多轮对话中 model 响应含 thoughtSignature 时，新 user 的 text part 也必须带签名
+  const needsSignature = history.length > 0 && historyHasThoughtSignature(history)
+
   const userParts: GeminiPart[] = [
     ...referenceImageParts,
-    { text: prompt },
+    {
+      text: prompt,
+      ...(needsSignature && { thoughtSignature: DUMMY_THOUGHT_SIGNATURE }),
+    },
   ]
 
   // 合并历史 + 当前用户消息

--- a/apps/electron/src/main/lib/chat-tools/nano-banana-tool.ts
+++ b/apps/electron/src/main/lib/chat-tools/nano-banana-tool.ts
@@ -1,0 +1,385 @@
+/**
+ * Nano Banana 生图工具模块（Chat 模式）
+ *
+ * 基于 Gemini Image Generation API 提供 AI 生图能力。
+ * 支持文生图、参考图编辑、多轮连续修改。
+ * 凭据存储在 ~/.proma/chat-tools.json 的 toolCredentials 中。
+ */
+
+import type { ToolCall, ToolResult, ToolDefinition } from '@proma/core'
+import type { ChatToolMeta, FileAttachment } from '@proma/shared'
+import { randomUUID } from 'node:crypto'
+import { getToolCredentials } from '../chat-tool-config'
+import { saveAttachment, readAttachmentAsBase64, isImageAttachment } from '../attachment-service'
+
+// ===== Gemini API 类型（REST API 使用 camelCase） =====
+
+interface GeminiInlineData {
+  mimeType: string
+  data: string
+}
+
+interface GeminiPart {
+  text?: string
+  inlineData?: GeminiInlineData
+  /** Gemini 多轮对话必需：模型生成图片时附带的签名，回传时原样保留 */
+  thoughtSignature?: string
+  /** snake_case 兼容（部分 API 版本） */
+  thought_signature?: string
+}
+
+interface GeminiContent {
+  role: 'user' | 'model'
+  parts: GeminiPart[]
+}
+
+interface GeminiCandidate {
+  content: {
+    parts: GeminiPart[]
+    role: string
+  }
+}
+
+interface GeminiResponse {
+  candidates?: GeminiCandidate[]
+  error?: { message: string; code: number }
+}
+
+// ===== 多轮对话历史 =====
+
+/** 每个 conversationId 对应的 Gemini 对话历史 */
+const conversationHistory = new Map<string, GeminiContent[]>()
+
+// ===== 工具执行上下文 =====
+
+/** Nano Banana 工具执行所需的额外上下文 */
+export interface NanoBananaContext {
+  /** 对话 ID（用于保存附件和管理对话历史） */
+  conversationId: string
+  /** 当前用户消息的附件列表 */
+  currentAttachments?: FileAttachment[]
+  /** 前一轮用户消息的附件 */
+  previousUserAttachments?: FileAttachment[]
+  /** 前一轮助手消息的附件 */
+  previousAssistantAttachments?: FileAttachment[]
+}
+
+// ===== 默认配置 =====
+
+const DEFAULT_BASE_URL = 'https://generativelanguage.googleapis.com'
+const DEFAULT_MODEL = 'gemini-3.1-flash-image-preview'
+
+// ===== 工具元数据 =====
+
+export const NANO_BANANA_TOOL_META: ChatToolMeta = {
+  id: 'nano-banana',
+  name: 'Nano Banana',
+  description: 'AI 图片生成与编辑（基于 Gemini Image Generation）',
+  params: [
+    { name: 'prompt', type: 'string', description: '图片生成/编辑描述', required: true },
+  ],
+  icon: 'ImagePlus',
+  category: 'builtin',
+  executorType: 'builtin',
+  systemPromptAppend: `
+<nano_banana_instructions>
+你拥有 AI 图片生成和编辑能力（Nano Banana）。
+
+**generate_image — 生成/编辑图片：**
+当用户需要创建或修改图片时调用：
+- 用户要求画画、生成图片、创作插图
+- 用户上传了图片并要求修改、编辑、调整
+- 用户想要基于描述生成视觉内容
+
+**参数说明：**
+- prompt: 详细描述想要生成的图片内容，用英文描述效果最佳
+- aspectRatio: 可选宽高比 "1:1"(默认) / "16:9" / "4:3" / "9:16" / "3:4"
+- imageSize: 可选分辨率 "auto"(默认) / "1K" / "2K" / "4K"
+- useReferenceImages: 当用户上传了参考图或要求修改之前生成的图片时设为 true
+
+**使用技巧：**
+- 生成新图片时用详细的英文描述
+- 编辑图片时设置 useReferenceImages: true，并在 prompt 中描述要做的修改
+- 支持连续修改：多次调用时会自动保持上下文
+</nano_banana_instructions>`,
+}
+
+// ===== 工具定义（ToolDefinition 格式，传给 Provider） =====
+
+export const NANO_BANANA_TOOL_DEFINITIONS: ToolDefinition[] = [
+  {
+    name: 'generate_image',
+    description: 'Generate or edit images using AI. Supports text-to-image generation, reference image editing, and iterative modifications with context.',
+    parameters: {
+      type: 'object',
+      properties: {
+        prompt: {
+          type: 'string',
+          description: 'Detailed description of the image to generate or the edits to make. English descriptions work best.',
+        },
+        aspectRatio: {
+          type: 'string',
+          description: 'Aspect ratio of the generated image',
+          enum: ['1:1', '16:9', '4:3', '9:16', '3:4'],
+        },
+        imageSize: {
+          type: 'string',
+          description: 'Resolution of the generated image',
+          enum: ['auto', '1K', '2K', '4K'],
+        },
+        useReferenceImages: {
+          type: 'string',
+          description: 'Set to "true" to use uploaded reference images or previously generated images for editing',
+          enum: ['true', 'false'],
+        },
+      },
+      required: ['prompt'],
+    },
+  },
+]
+
+// ===== 可用性检查 =====
+
+/**
+ * 检查 Nano Banana 工具是否可用（API Key 已配置）
+ */
+export function isNanoBananaAvailable(): boolean {
+  const credentials = getToolCredentials('nano-banana')
+  return !!credentials.apiKey
+}
+
+// ===== 工具执行 =====
+
+/** 工具名称集合 */
+const NANO_BANANA_TOOL_NAMES = new Set(['generate_image'])
+
+/**
+ * 判断是否为 Nano Banana 工具调用
+ */
+export function isNanoBananaToolCall(toolName: string): boolean {
+  return NANO_BANANA_TOOL_NAMES.has(toolName)
+}
+
+/**
+ * 收集参考图的 base64 数据
+ *
+ * 按时间从早到晚排列：前一轮用户附件 → 前一轮助手附件 → 当前用户附件
+ */
+function collectReferenceImages(context: NanoBananaContext): GeminiPart[] {
+  const parts: GeminiPart[] = []
+
+  const allAttachments: FileAttachment[] = [
+    ...(context.previousUserAttachments ?? []),
+    ...(context.previousAssistantAttachments ?? []),
+    ...(context.currentAttachments ?? []),
+  ]
+
+  for (const attachment of allAttachments) {
+    if (!isImageAttachment(attachment.mediaType)) continue
+
+    try {
+      const base64 = readAttachmentAsBase64(attachment.localPath)
+      parts.push({
+        inlineData: {
+          mimeType: attachment.mediaType,
+          data: base64,
+        },
+      })
+    } catch (error) {
+      console.warn(`[Nano Banana] 读取参考图失败: ${attachment.localPath}`, error)
+    }
+  }
+
+  return parts
+}
+
+/**
+ * 构建 Gemini API 请求体
+ */
+function buildGeminiRequest(
+  prompt: string,
+  referenceImageParts: GeminiPart[],
+  history: GeminiContent[],
+  options: {
+    aspectRatio?: string
+    imageSize?: string
+  },
+): Record<string, unknown> {
+  // 当前用户输入：参考图 + 文字提示
+  const userParts: GeminiPart[] = [
+    ...referenceImageParts,
+    { text: prompt },
+  ]
+
+  // 合并历史 + 当前用户消息
+  const contents: GeminiContent[] = [
+    ...history,
+    { role: 'user', parts: userParts },
+  ]
+
+  const generationConfig: Record<string, unknown> = {
+    responseModalities: ['TEXT', 'IMAGE'],
+  }
+
+  // 图片配置
+  const imageConfig: Record<string, unknown> = {}
+  if (options.aspectRatio && options.aspectRatio !== '1:1') {
+    imageConfig.aspectRatio = options.aspectRatio
+  }
+  if (options.imageSize && options.imageSize !== 'auto') {
+    imageConfig.imageSize = options.imageSize
+  }
+  if (Object.keys(imageConfig).length > 0) {
+    generationConfig.imageConfig = imageConfig
+  }
+
+  return { contents, generationConfig }
+}
+
+/**
+ * 执行 Nano Banana 工具调用
+ */
+export async function executeNanoBananaTool(
+  toolCall: ToolCall,
+  context: NanoBananaContext,
+): Promise<ToolResult> {
+  const credentials = getToolCredentials('nano-banana')
+
+  if (!credentials.apiKey) {
+    return {
+      toolCallId: toolCall.id,
+      content: 'Nano Banana 未配置 API Key',
+      isError: true,
+    }
+  }
+
+  try {
+    const prompt = toolCall.arguments.prompt as string
+    const aspectRatio = toolCall.arguments.aspectRatio as string | undefined
+    const imageSize = toolCall.arguments.imageSize as string | undefined
+    const useReferenceImages = toolCall.arguments.useReferenceImages === 'true'
+
+    if (!prompt) {
+      return {
+        toolCallId: toolCall.id,
+        content: '参数缺失: prompt',
+        isError: true,
+      }
+    }
+
+    const baseUrl = credentials.baseUrl?.trim() || DEFAULT_BASE_URL
+    const model = credentials.model?.trim() || DEFAULT_MODEL
+
+    // 收集参考图
+    const referenceImageParts = useReferenceImages ? collectReferenceImages(context) : []
+
+    // 获取对话历史
+    const history = conversationHistory.get(context.conversationId) ?? []
+
+    // 构建请求
+    const requestBody = buildGeminiRequest(prompt, referenceImageParts, history, {
+      aspectRatio,
+      imageSize,
+    })
+
+    const url = `${baseUrl}/v1beta/models/${model}:generateContent?key=${credentials.apiKey}`
+
+    console.log(`[Nano Banana] 调用 Gemini API: model=${model}, prompt="${prompt.slice(0, 50)}..."`)
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(requestBody),
+    })
+
+    if (!response.ok) {
+      const errorText = await response.text()
+      console.error(`[Nano Banana] API 请求失败 (${response.status}):`, errorText)
+      return {
+        toolCallId: toolCall.id,
+        content: `Gemini API 请求失败 (${response.status}): ${errorText.slice(0, 200)}`,
+        isError: true,
+      }
+    }
+
+    const data = (await response.json()) as GeminiResponse
+
+    if (data.error) {
+      return {
+        toolCallId: toolCall.id,
+        content: `Gemini API 错误: ${data.error.message}`,
+        isError: true,
+      }
+    }
+
+    if (!data.candidates || data.candidates.length === 0) {
+      return {
+        toolCallId: toolCall.id,
+        content: '未生成任何内容',
+        isError: true,
+      }
+    }
+
+    const parts = data.candidates![0].content.parts
+    console.log(`[Nano Banana] 响应包含 ${parts.length} 个 parts，类型:`, parts.map((p) => p.inlineData ? `image(${p.inlineData.mimeType})` : `text(${(p.text ?? '').slice(0, 30)})`))
+    const generatedAttachments: FileAttachment[] = []
+    const textParts: string[] = []
+
+    // 解析响应：提取图片和文本
+    for (const part of parts) {
+      if (part.inlineData) {
+        // 保存生成的图片为附件
+        const ext = part.inlineData.mimeType === 'image/jpeg' ? '.jpg' : '.png'
+        const result = saveAttachment({
+          conversationId: context.conversationId,
+          filename: `nano-banana-${randomUUID().slice(0, 8)}${ext}`,
+          mediaType: part.inlineData.mimeType,
+          data: part.inlineData.data,
+        })
+        generatedAttachments.push(result.attachment)
+      } else if (part.text) {
+        textParts.push(part.text)
+      }
+    }
+
+    // 更新对话历史（用于多轮连续修改）
+    // 注意：必须原样保留 model 响应中的 parts（含 thoughtSignature），否则多轮编辑会报错
+    const userContent: GeminiContent = {
+      role: 'user',
+      parts: [...referenceImageParts, { text: prompt }],
+    }
+    const modelContent: GeminiContent = {
+      role: 'model',
+      parts, // 直接使用原始响应 parts，保留 thoughtSignature 等元数据
+    }
+    const updatedHistory = [...history, userContent, modelContent]
+    conversationHistory.set(context.conversationId, updatedHistory)
+
+    // 构建返回结果
+    const imageCount = generatedAttachments.length
+    const resultText = imageCount > 0
+      ? `图片已成功生成（${imageCount} 张）${textParts.length > 0 ? `\n\n${textParts.join('\n')}` : ''}`
+      : textParts.join('\n') || '未生成图片内容'
+
+    return {
+      toolCallId: toolCall.id,
+      content: resultText,
+      generatedAttachments: generatedAttachments.length > 0 ? generatedAttachments : undefined,
+    }
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error)
+    console.error(`[Nano Banana] 执行失败:`, error)
+    return {
+      toolCallId: toolCall.id,
+      content: `图片生成失败: ${msg}`,
+      isError: true,
+    }
+  }
+}
+
+/**
+ * 清除对话的生图历史（对话删除时调用）
+ */
+export function clearNanoBananaHistory(conversationId: string): void {
+  conversationHistory.delete(conversationId)
+}

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -198,6 +198,9 @@ export interface ElectronAPI {
   /** 读取附件（返回 base64 字符串） */
   readAttachment: (localPath: string) => Promise<string>
 
+  /** 另存图片到用户选择的位置（原生 Save As 对话框） */
+  saveImageAs: (localPath: string, defaultFilename: string) => Promise<boolean>
+
   /** 删除附件 */
   deleteAttachment: (localPath: string) => Promise<void>
 
@@ -700,6 +703,10 @@ const electronAPI: ElectronAPI = {
 
   readAttachment: (localPath: string) => {
     return ipcRenderer.invoke(CHAT_IPC_CHANNELS.READ_ATTACHMENT, localPath)
+  },
+
+  saveImageAs: (localPath: string, defaultFilename: string) => {
+    return ipcRenderer.invoke(CHAT_IPC_CHANNELS.SAVE_IMAGE_AS, localPath, defaultFilename)
   },
 
   deleteAttachment: (localPath: string) => {

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -27,6 +27,8 @@ export interface ToolActivity {
   taskId?: string
   shellId?: string
   isBackground?: boolean
+  /** MCP 工具返回的图片附件 */
+  imageAttachments?: Array<{ localPath: string; filename: string; mediaType: string }>
 }
 
 /** 活动分组（Task 子代理） */
@@ -856,7 +858,7 @@ export function applyAgentEvent(
         ...prev,
         toolActivities: prev.toolActivities.map((t) =>
           t.toolUseId === event.toolUseId
-            ? { ...t, result: event.result, isError: event.isError, done: true }
+            ? { ...t, result: event.result, isError: event.isError, done: true, imageAttachments: event.imageAttachments }
             : t
         ),
       }

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -7,7 +7,7 @@
 
 import * as React from 'react'
 import { useAtomValue } from 'jotai'
-import { Bot, FileText, FileImage, RotateCw, AlertTriangle, ChevronDown, ChevronRight, Plus, Minimize2 } from 'lucide-react'
+import { Bot, FileText, FileImage, RotateCw, AlertTriangle, ChevronDown, ChevronRight, Plus, Minimize2, Download } from 'lucide-react'
 import {
   Message,
   MessageHeader,
@@ -80,6 +80,62 @@ function AssistantLogo({ model }: { model?: string }): React.ReactElement {
   )
 }
 
+/** 单张工具结果图片（内联显示） */
+function InlineImage({ attachment }: { attachment: { localPath: string; filename: string; mediaType: string } }): React.ReactElement {
+  const [imageSrc, setImageSrc] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    window.electronAPI
+      .readAttachment(attachment.localPath)
+      .then((base64) => {
+        setImageSrc(`data:${attachment.mediaType};base64,${base64}`)
+      })
+      .catch((error) => {
+        console.error('[InlineImage] 读取附件失败:', error)
+      })
+  }, [attachment.localPath, attachment.mediaType])
+
+  const handleSave = React.useCallback((): void => {
+    window.electronAPI.saveImageAs(attachment.localPath, attachment.filename)
+  }, [attachment.localPath, attachment.filename])
+
+  if (!imageSrc) {
+    return <div className="size-[280px] rounded-lg bg-muted/30 animate-pulse shrink-0" />
+  }
+
+  return (
+    <div className="relative group inline-block">
+      <img
+        src={imageSrc}
+        alt={attachment.filename}
+        className="size-[280px] rounded-lg object-cover shrink-0"
+      />
+      <button
+        type="button"
+        onClick={handleSave}
+        className="absolute bottom-2 right-2 p-1.5 rounded-md bg-black/50 text-white opacity-0 group-hover:opacity-100 transition-opacity hover:bg-black/70"
+        title="保存图片"
+      >
+        <Download className="size-4" />
+      </button>
+    </div>
+  )
+}
+
+/** 从工具活动中提取并内联显示所有生成的图片 */
+function ToolResultInlineImages({ activities }: { activities: ToolActivity[] }): React.ReactElement | null {
+  const allImages = activities.flatMap((a) => a.imageAttachments ?? [])
+  if (allImages.length === 0) return null
+
+  return (
+    <div className="flex flex-wrap gap-2 mb-3">
+      {allImages.map((img, i) => (
+        <InlineImage key={`${img.localPath}-${i}`} attachment={img} />
+      ))}
+    </div>
+  )
+}
+
 /** 从持久化事件中提取工具活动列表 */
 function extractToolActivities(events: AgentMessage['events']): ToolActivity[] {
   if (!events) return []
@@ -114,6 +170,7 @@ function extractToolActivities(events: AgentMessage['events']): ToolActivity[] {
           result: event.result,
           isError: event.isError,
           done: true,
+          imageAttachments: event.imageAttachments,
         }
       }
     } else if (event.type === 'task_backgrounded') {
@@ -436,6 +493,7 @@ function AgentMessageItem({ message, onRetry, onRetryInNewSession, onCompact }: 
               <ToolActivityList activities={toolActivities} />
             </div>
           )}
+          <ToolResultInlineImages activities={toolActivities} />
           {message.content && (
             <MessageResponse>{message.content}</MessageResponse>
           )}
@@ -564,6 +622,7 @@ export function AgentMessages({ sessionId, messages, streaming, streamState, onR
                       <BackgroundTasksPanel tasks={backgroundTasks} />
                     </div>
                   )}
+                  <ToolResultInlineImages activities={toolActivities} />
                   {smoothContent ? (
                     <>
                       <MessageResponse>{smoothContent}</MessageResponse>

--- a/apps/electron/src/renderer/components/agent/ToolActivityItem.tsx
+++ b/apps/electron/src/renderer/components/agent/ToolActivityItem.tsx
@@ -31,6 +31,8 @@ import {
   MessageCircleDashed,
   Plus,
   Users,
+  ImagePlus,
+  Download,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import {
@@ -75,6 +77,7 @@ const TOOL_ICONS: Record<string, React.ComponentType<{ className?: string }>> = 
   TaskList: ListTodo,
   TeamCreate: Users,
   Agent: Users,
+  generate_image: ImagePlus,
 }
 
 function getToolIcon(toolName: string): React.ComponentType<{ className?: string }> {
@@ -293,6 +296,11 @@ function getInputSummary(toolName: string, input: Record<string, unknown>): stri
     }
     if (typeof desc === 'string') return desc.length > 80 ? desc.slice(0, 80) + '…' : desc
     if (typeof agentName === 'string') return agentName
+  }
+  // generate_image (Nano Banana MCP)：显示 prompt
+  if (toolName === 'generate_image') {
+    const prompt = input.prompt
+    if (typeof prompt === 'string') return prompt.length > 80 ? prompt.slice(0, 80) + '…' : prompt
   }
   return null
 }
@@ -531,6 +539,49 @@ function ActivityGroupRow({ group, index = 0, animate = false, onOpenDetails, de
   )
 }
 
+// ===== 工具结果图片 =====
+
+function ToolResultImage({ attachment }: { attachment: { localPath: string; filename: string; mediaType: string } }): React.ReactElement {
+  const [imageSrc, setImageSrc] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    window.electronAPI
+      .readAttachment(attachment.localPath)
+      .then((base64) => {
+        setImageSrc(`data:${attachment.mediaType};base64,${base64}`)
+      })
+      .catch((error) => {
+        console.error('[ToolResultImage] 读取附件失败:', error)
+      })
+  }, [attachment.localPath, attachment.mediaType])
+
+  const handleSave = React.useCallback((): void => {
+    window.electronAPI.saveImageAs(attachment.localPath, attachment.filename)
+  }, [attachment.localPath, attachment.filename])
+
+  if (!imageSrc) {
+    return <div className="size-[120px] rounded-md bg-muted/30 animate-pulse" />
+  }
+
+  return (
+    <div className="relative group inline-block">
+      <img
+        src={imageSrc}
+        alt={attachment.filename}
+        className="max-w-[240px] max-h-[240px] rounded-md object-cover"
+      />
+      <button
+        type="button"
+        onClick={handleSave}
+        className="absolute bottom-1.5 right-1.5 p-1 rounded-md bg-black/50 text-white opacity-0 group-hover:opacity-100 transition-opacity hover:bg-black/70"
+        title="保存图片"
+      >
+        <Download className="size-3.5" />
+      </button>
+    </div>
+  )
+}
+
 // ===== 详情面板 =====
 
 function ActivityDetails({ activity, onClose }: { activity: ToolActivity; onClose: () => void }): React.ReactElement {
@@ -583,6 +634,16 @@ function ActivityDetails({ activity, onClose }: { activity: ToolActivity; onClos
             >
               {activity.result.length > 2000 ? activity.result.slice(0, 2000) + '\n… [截断]' : activity.result}
             </pre>
+          </div>
+        )}
+        {activity.imageAttachments && activity.imageAttachments.length > 0 && (
+          <div>
+            <div className="text-[10px] font-medium text-foreground/40 mb-1">生成图片</div>
+            <div className="flex flex-wrap gap-2">
+              {activity.imageAttachments.map((img, i) => (
+                <ToolResultImage key={i} attachment={img} />
+              ))}
+            </div>
           </div>
         )}
       </div>

--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -22,7 +22,7 @@ import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkMath from 'remark-math'
 import rehypeKatex from 'rehype-katex'
-import { ChevronDown, ChevronUp, Paperclip, FileText, Sparkles, Server } from 'lucide-react'
+import { ChevronDown, ChevronUp, Paperclip, FileText, Sparkles, Server, Download } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import {
@@ -507,6 +507,17 @@ function MessageAttachmentImage({ attachment, isSingle = false }: MessageAttachm
       })
   }, [attachment.localPath, attachment.mediaType])
 
+  /** 保存图片到本地 */
+  const handleSave = React.useCallback((): void => {
+    if (!imageSrc) return
+    const link = document.createElement('a')
+    link.href = imageSrc
+    link.download = attachment.filename
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+  }, [imageSrc, attachment.filename])
+
   if (!imageSrc) {
     return (
       <div className={cn(
@@ -516,7 +527,7 @@ function MessageAttachmentImage({ attachment, isSingle = false }: MessageAttachm
     )
   }
 
-  return isSingle ? (
+  const imgElement = isSingle ? (
     <img
       src={imageSrc}
       alt={attachment.filename}
@@ -528,6 +539,20 @@ function MessageAttachmentImage({ attachment, isSingle = false }: MessageAttachm
       alt={attachment.filename}
       className="size-[280px] rounded-lg object-cover shrink-0"
     />
+  )
+
+  return (
+    <div className="relative group inline-block">
+      {imgElement}
+      <button
+        type="button"
+        onClick={handleSave}
+        className="absolute bottom-2 right-2 p-1.5 rounded-md bg-black/50 text-white opacity-0 group-hover:opacity-100 transition-opacity hover:bg-black/70"
+        title="保存图片"
+      >
+        <Download className="size-4" />
+      </button>
+    </div>
   )
 }
 

--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -509,14 +509,8 @@ function MessageAttachmentImage({ attachment, isSingle = false }: MessageAttachm
 
   /** 保存图片到本地 */
   const handleSave = React.useCallback((): void => {
-    if (!imageSrc) return
-    const link = document.createElement('a')
-    link.href = imageSrc
-    link.download = attachment.filename
-    document.body.appendChild(link)
-    link.click()
-    document.body.removeChild(link)
-  }, [imageSrc, attachment.filename])
+    window.electronAPI.saveImageAs(attachment.localPath, attachment.filename)
+  }, [attachment.localPath, attachment.filename])
 
   if (!imageSrc) {
     return (

--- a/apps/electron/src/renderer/components/chat/ChatMessageItem.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessageItem.tsx
@@ -192,6 +192,11 @@ export function ChatMessageItem({
               ) : message.stopped ? (
                 <MessageStopped />
               ) : null}
+
+              {/* 生成的图片附件（如 Nano Banana 生图结果） */}
+              {message.attachments && message.attachments.length > 0 && (
+                <MessageAttachments attachments={message.attachments} />
+              )}
             </>
           ) : (
             /* 用户消息 - 附件 + 可折叠文本 / 原地编辑 */

--- a/apps/electron/src/renderer/components/chat/ToolSelectorPopover.tsx
+++ b/apps/electron/src/renderer/components/chat/ToolSelectorPopover.tsx
@@ -21,7 +21,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
-import { Wrench, Brain, Globe, Settings } from 'lucide-react'
+import { Wrench, Brain, Globe, Settings, ImagePlus } from 'lucide-react'
 import { chatToolsAtom, enabledToolIdsAtom, hasActiveToolsAtom } from '@/atoms/chat-tool-atoms'
 import { settingsTabAtom } from '@/atoms/settings-tab'
 import { activeViewAtom } from '@/atoms/active-view'
@@ -33,6 +33,8 @@ function getToolIcon(iconName?: string): React.ReactElement {
       return <Brain className="size-4" />
     case 'Globe':
       return <Globe className="size-4" />
+    case 'ImagePlus':
+      return <ImagePlus className="size-4" />
     default:
       return <Wrench className="size-4" />
   }

--- a/apps/electron/src/renderer/components/settings/AgentSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AgentSettings.tsx
@@ -10,7 +10,7 @@
 
 import * as React from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
-import { Plus, Plug, Pencil, Trash2, Sparkles, FolderOpen, MessageSquare, ShieldCheck, ChevronDown, ChevronRight } from 'lucide-react'
+import { Plus, Plug, Pencil, Trash2, Sparkles, FolderOpen, MessageSquare, ShieldCheck, ChevronDown, ChevronRight, Brain, ImagePlus, Settings } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
@@ -31,6 +31,8 @@ import {
 } from '@/atoms/agent-atoms'
 import { activeViewAtom } from '@/atoms/active-view'
 import { appModeAtom } from '@/atoms/app-mode'
+import { chatToolsAtom } from '@/atoms/chat-tool-atoms'
+import { settingsTabAtom } from '@/atoms/settings-tab'
 import type { McpServerEntry, SkillMeta, WorkspaceMcpConfig, ThinkingConfig, AgentEffort } from '@proma/shared'
 import { SettingsSection, SettingsCard, SettingsRow, SettingsSegmentedControl, SettingsInput } from './primitives'
 import { McpServerForm } from './McpServerForm'
@@ -311,6 +313,9 @@ ${skillList}
     <div className="space-y-8">
       {/* 区块零：Agent 高级设置 */}
       <AgentAdvancedSettings />
+
+      {/* 区块零点五：内置工具状态 */}
+      <BuiltinAgentTools />
 
       {/* 区块一：MCP 服务器 */}
       <SettingsSection
@@ -739,6 +744,94 @@ function effortToValue(effort: AgentEffort | undefined): string {
 function valueToEffort(value: string): AgentEffort | undefined {
   if (value === 'default') return undefined
   return value as AgentEffort
+}
+
+/** 内置 Agent 工具状态展示 */
+function BuiltinAgentTools(): React.ReactElement {
+  const tools = useAtomValue(chatToolsAtom)
+  const setActiveView = useSetAtom(activeViewAtom)
+  const setSettingsTab = useSetAtom(settingsTabAtom)
+
+  const memoryTool = tools.find((t) => t.meta.id === 'memory')
+  const nanoBananaTool = tools.find((t) => t.meta.id === 'nano-banana')
+
+  /** 跳转到工具设置页 */
+  const goToToolSettings = (): void => {
+    setActiveView('settings')
+    setSettingsTab('tools')
+  }
+
+  interface BuiltinToolItem {
+    id: string
+    name: string
+    description: string
+    icon: React.ReactElement
+    enabled: boolean
+    available: boolean
+  }
+
+  const builtinTools: BuiltinToolItem[] = [
+    {
+      id: 'memory',
+      name: '记忆',
+      description: '长期记忆存储与检索',
+      icon: <Brain className="size-4" />,
+      enabled: memoryTool?.enabled ?? false,
+      available: memoryTool?.available ?? false,
+    },
+    {
+      id: 'nano-banana',
+      name: 'Nano Banana',
+      description: 'AI 图片生成与编辑',
+      icon: <ImagePlus className="size-4" />,
+      enabled: nanoBananaTool?.enabled ?? false,
+      available: nanoBananaTool?.available ?? false,
+    },
+  ]
+
+  return (
+    <SettingsSection
+      title="内置工具"
+      description="启用后自动注入到 Agent 会话，在工具设置中配置"
+      action={
+        <Button size="sm" variant="outline" onClick={goToToolSettings}>
+          <Settings size={14} />
+          <span>配置</span>
+        </Button>
+      }
+    >
+      <SettingsCard divided>
+        {builtinTools.map((tool) => {
+          const isActive = tool.enabled && tool.available
+          return (
+            <div key={tool.id} className="flex items-center justify-between p-4">
+              <div className="flex items-center gap-3 min-w-0">
+                <span className={cn('shrink-0', !isActive && 'opacity-40')}>
+                  {tool.icon}
+                </span>
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className={cn('text-sm font-medium', !isActive && 'text-muted-foreground')}>
+                      {tool.name}
+                    </span>
+                    <span className={cn(
+                      'text-[10px] px-1.5 py-0.5 rounded-full',
+                      isActive
+                        ? 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400'
+                        : 'bg-muted text-muted-foreground',
+                    )}>
+                      {isActive ? '已启用' : !tool.available ? '需配置' : '未启用'}
+                    </span>
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-0.5">{tool.description}</p>
+                </div>
+              </div>
+            </div>
+          )
+        })}
+      </SettingsCard>
+    </SettingsSection>
+  )
 }
 
 function AgentAdvancedSettings(): React.ReactElement {

--- a/apps/electron/src/renderer/components/settings/ToolSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/ToolSettings.tsx
@@ -194,6 +194,201 @@ function WebSearchSettings(): React.ReactElement {
   )
 }
 
+/** Nano Banana 生图工具设置区域 */
+function NanoBananaSettings(): React.ReactElement {
+  const [apiKey, setApiKey] = React.useState('')
+  const [baseUrl, setBaseUrl] = React.useState('')
+  const [model, setModel] = React.useState('')
+  const [showApiKey, setShowApiKey] = React.useState(false)
+  const [enabled, setEnabled] = React.useState(false)
+  const [loading, setLoading] = React.useState(true)
+  const [testing, setTesting] = React.useState(false)
+  const [testResult, setTestResult] = React.useState<{ success: boolean; message: string } | null>(null)
+  const setChatTools = useSetAtom(chatToolsAtom)
+
+  const savedCredentialsRef = React.useRef({ apiKey: '', baseUrl: '', model: '' })
+
+  React.useEffect(() => {
+    Promise.all([
+      window.electronAPI.getChatTools(),
+      window.electronAPI.getChatToolCredentials('nano-banana'),
+    ]).then(([tools, credentials]) => {
+      const tool = tools.find((t) => t.meta.id === 'nano-banana')
+      if (tool) setEnabled(tool.enabled)
+      if (credentials.apiKey) setApiKey(credentials.apiKey)
+      if (credentials.baseUrl) setBaseUrl(credentials.baseUrl)
+      if (credentials.model) setModel(credentials.model)
+      savedCredentialsRef.current = {
+        apiKey: credentials.apiKey || '',
+        baseUrl: credentials.baseUrl || '',
+        model: credentials.model || '',
+      }
+    }).catch((err: unknown) => {
+      console.error('[Nano Banana 设置] 加载失败:', err)
+    }).finally(() => {
+      setLoading(false)
+    })
+  }, [])
+
+  /** 静默保存凭据（blur 时触发） */
+  const handleBlurSave = React.useCallback(async (): Promise<void> => {
+    const current = { apiKey: apiKey.trim(), baseUrl: baseUrl.trim(), model: model.trim() }
+    const saved = savedCredentialsRef.current
+    if (current.apiKey === saved.apiKey && current.baseUrl === saved.baseUrl && current.model === saved.model) return
+    try {
+      await window.electronAPI.updateChatToolCredentials('nano-banana', current)
+      savedCredentialsRef.current = current
+      await refreshChatTools(setChatTools)
+      toast.success('Nano Banana 设置已保存')
+    } catch (error) {
+      console.error('[Nano Banana 设置] 保存失败:', error)
+    }
+  }, [apiKey, baseUrl, model, setChatTools])
+
+  const handleToggle = async (checked: boolean): Promise<void> => {
+    try {
+      await window.electronAPI.updateChatToolState('nano-banana', { enabled: checked })
+      setEnabled(checked)
+      await refreshChatTools(setChatTools)
+    } catch (error) {
+      console.error('[Nano Banana 设置] 切换失败:', error)
+    }
+  }
+
+  const handleTest = async (): Promise<void> => {
+    // 先保存可能的变更
+    const current = { apiKey: apiKey.trim(), baseUrl: baseUrl.trim(), model: model.trim() }
+    const saved = savedCredentialsRef.current
+    if (current.apiKey !== saved.apiKey || current.baseUrl !== saved.baseUrl || current.model !== saved.model) {
+      try {
+        await window.electronAPI.updateChatToolCredentials('nano-banana', current)
+        savedCredentialsRef.current = current
+        await refreshChatTools(setChatTools)
+      } catch (error) {
+        console.error('[Nano Banana 设置] 保存失败:', error)
+      }
+    }
+
+    setTesting(true)
+    setTestResult(null)
+    try {
+      const result = await window.electronAPI.testChatTool('nano-banana')
+      setTestResult(result)
+    } catch (error) {
+      setTestResult({ success: false, message: error instanceof Error ? error.message : String(error) })
+    } finally {
+      setTesting(false)
+    }
+  }
+
+  if (loading) {
+    return <div className="text-sm text-muted-foreground py-8 text-center">加载中...</div>
+  }
+
+  return (
+    <SettingsSection
+      title="Nano Banana"
+      description="启用后 AI 可以生成和编辑图片（基于 Gemini Image Generation）"
+      action={
+        <Switch
+          checked={enabled}
+          onCheckedChange={handleToggle}
+        />
+      }
+    >
+      <SettingsCard divided={false}>
+        <div className="space-y-4 p-4">
+          {/* 引导说明 */}
+          <div className="rounded-lg bg-muted/50 p-3 space-y-2 text-sm text-muted-foreground">
+            <p>Nano Banana 基于 <span className="font-medium text-foreground">Gemini Image Generation</span> 提供 AI 图片生成与编辑能力。</p>
+            <p className="text-xs">配置步骤：</p>
+            <ol className="text-xs list-decimal list-inside space-y-1">
+              <li>
+                访问{' '}
+                <a
+                  href="https://aistudio.google.com/apikey"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary hover:underline inline-flex items-center gap-0.5"
+                >
+                  Google AI Studio
+                  <ExternalLink size={10} />
+                </a>
+                {' '}获取 Gemini API Key
+              </li>
+              <li>将 API Key 填入下方，可选修改 API 地址和模型</li>
+              <li>开启开关即可在对话中使用生图能力</li>
+            </ol>
+          </div>
+
+          <div className="space-y-1.5">
+            <div className="flex items-center justify-between">
+              <label className="text-sm font-medium">API Key</label>
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={testing || !apiKey.trim()}
+                onClick={handleTest}
+              >
+                {testing ? <><Loader2 size={14} className="animate-spin mr-1.5" />测试中...</> : '测试连接'}
+              </Button>
+            </div>
+            <div className="relative">
+              <Input
+                type={showApiKey ? 'text' : 'password'}
+                placeholder="AIza..."
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                onBlur={handleBlurSave}
+                className="pr-10"
+              />
+              <button
+                type="button"
+                onClick={() => setShowApiKey(!showApiKey)}
+                className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-muted-foreground hover:text-foreground transition-colors"
+                tabIndex={-1}
+              >
+                {showApiKey ? <EyeOff size={16} /> : <Eye size={16} />}
+              </button>
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium">API 地址</label>
+            <Input
+              type="text"
+              placeholder="https://generativelanguage.googleapis.com"
+              value={baseUrl}
+              onChange={(e) => setBaseUrl(e.target.value)}
+              onBlur={handleBlurSave}
+            />
+            <p className="text-xs text-muted-foreground">留空则使用 Gemini 官方地址</p>
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium">模型</label>
+            <Input
+              type="text"
+              placeholder="gemini-3.1-flash-image-preview"
+              value={model}
+              onChange={(e) => setModel(e.target.value)}
+              onBlur={handleBlurSave}
+            />
+            <p className="text-xs text-muted-foreground">留空则使用默认模型 gemini-3.1-flash-image-preview</p>
+          </div>
+
+          {testResult && (
+            <div className={`flex items-start gap-2 rounded-lg p-3 text-sm ${testResult.success ? 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' : 'bg-destructive/10 text-destructive'}`}>
+              {testResult.success ? <CheckCircle2 size={16} className="mt-0.5 shrink-0" /> : <XCircle size={16} className="mt-0.5 shrink-0" />}
+              <span>{testResult.message}</span>
+            </div>
+          )}
+        </div>
+      </SettingsCard>
+    </SettingsSection>
+  )
+}
+
 /** 自定义工具列表区域 */
 function CustomToolsSection(): React.ReactElement | null {
   const tools = useAtomValue(chatToolsAtom)
@@ -277,6 +472,9 @@ export function ToolSettings(): React.ReactElement {
 
       {/* 联网搜索工具 */}
       <WebSearchSettings />
+
+      {/* Nano Banana 生图工具 */}
+      <NanoBananaSettings />
 
       {/* 自定义工具 */}
       <CustomToolsSection />

--- a/packages/core/src/providers/types.ts
+++ b/packages/core/src/providers/types.ts
@@ -69,6 +69,8 @@ export interface ToolResult {
   content: string
   /** 是否出错 */
   isError?: boolean
+  /** 工具生成的附件（如生图工具的图片），附加到 assistant 消息展示 */
+  generatedAttachments?: FileAttachment[]
 }
 
 /**

--- a/packages/shared/src/agent/tool-matching.ts
+++ b/packages/shared/src/agent/tool-matching.ts
@@ -7,7 +7,7 @@
  * 无可变队列、栈或顺序依赖的状态。
  */
 
-import type { AgentEvent } from '../types/agent'
+import type { AgentEvent, AgentToolResultImage } from '../types/agent'
 
 // ============================================================================
 // Tool Index — 追加式、顺序无关的查找表
@@ -189,22 +189,24 @@ export function extractToolResults(
       const toolUseId = block.tool_use_id
       const entry = toolIndex.getEntry(toolUseId)
 
-      const resultStr = serializeResult(block.content)
+      // 从原始 content 中提取图片和文本（在 JSON 序列化之前，避免标记被转义）
+      const { text: cleanedResult, images } = extractFromMcpContent(block.content)
       const isError = block.is_error ?? isToolResultError(block.content)
 
       events.push({
         type: 'tool_result',
         toolUseId,
         toolName: entry?.name,
-        result: resultStr,
+        result: cleanedResult,
         isError,
         input: entry?.input,
         turnId,
         parentToolUseId: sdkParentToolUseId ?? undefined,
+        imageAttachments: images.length > 0 ? images : undefined,
       })
 
       if (entry) {
-        const bgEvents = detectBackgroundEvents(toolUseId, entry, resultStr, isError, turnId)
+        const bgEvents = detectBackgroundEvents(toolUseId, entry, cleanedResult, isError, turnId)
         events.push(...bgEvents)
       }
     }
@@ -212,22 +214,24 @@ export function extractToolResults(
     const toolUseId = sdkParentToolUseId ?? `fallback-${turnId ?? 'unknown'}`
     const entry = toolIndex.getEntry(toolUseId)
 
-    const resultStr = serializeResult(toolUseResultValue)
+    // 从原始值中提取图片和文本
+    const { text: cleanedResult, images } = extractFromMcpContent(toolUseResultValue)
     const isError = isToolResultError(toolUseResultValue)
 
     events.push({
       type: 'tool_result',
       toolUseId,
       toolName: entry?.name,
-      result: resultStr,
+      result: cleanedResult,
       isError,
       input: entry?.input,
       turnId,
       parentToolUseId: undefined,
+      imageAttachments: images.length > 0 ? images : undefined,
     })
 
     if (entry) {
-      const bgEvents = detectBackgroundEvents(toolUseId, entry, resultStr, isError, turnId)
+      const bgEvents = detectBackgroundEvents(toolUseId, entry, cleanedResult, isError, turnId)
       events.push(...bgEvents)
     }
   }
@@ -249,6 +253,56 @@ function extractIntent(toolBlock: ToolUseBlock): string | undefined {
   return intent
 }
 
+/** MCP 内容块类型（用于从 tool_result 中提取图片） */
+interface McpContentBlock {
+  type: string
+  text?: string
+  data?: string
+  mimeType?: string
+  [key: string]: unknown
+}
+
+/**
+ * 从 MCP 工具结果的原始 content 中预提取图片附件和文本。
+ *
+ * MCP tool_result 的 content 可能是：
+ * - string：普通文本结果
+ * - Array<McpContentBlock>：包含 text / image 内容块
+ *
+ * 此函数在 JSON 序列化之前处理，避免 [PROMA_IMAGE_ATTACHMENT:...] 标记被转义、
+ * 以及 image 块的巨大 base64 数据被序列化到显示文本中。
+ */
+function extractFromMcpContent(content: unknown): { text: string; images: AgentToolResultImage[] } {
+  // 字符串直接返回，交给后续 parseToolResultImages 处理
+  if (typeof content === 'string') {
+    return { text: content, images: [] }
+  }
+
+  // 非数组情况：走普通序列化
+  if (!Array.isArray(content)) {
+    return { text: serializeResult(content), images: [] }
+  }
+
+  const blocks = content as McpContentBlock[]
+  const textParts: string[] = []
+  const images: AgentToolResultImage[] = []
+
+  for (const block of blocks) {
+    if (block.type === 'text' && typeof block.text === 'string') {
+      textParts.push(block.text)
+    }
+    // 跳过 image 块（base64 数据不需要序列化到显示文本）
+    // 图片信息通过 text 块中的 [PROMA_IMAGE_ATTACHMENT:...] 标记携带
+  }
+
+  const rawText = textParts.join('\n')
+  // 从合并的文本中解析图片标记
+  const parsed = parseToolResultImages(rawText)
+  images.push(...parsed.images)
+
+  return { text: parsed.text, images }
+}
+
 /** 将工具结果值序列化为字符串 */
 export function serializeResult(value: unknown): string {
   if (typeof value === 'string') return value
@@ -258,6 +312,26 @@ export function serializeResult(value: unknown): string {
   } catch {
     return '[结果包含不可序列化的数据]'
   }
+}
+
+/** 从序列化结果中解析图片附件标记 */
+interface ParsedToolResult {
+  text: string
+  images: AgentToolResultImage[]
+}
+
+export function parseToolResultImages(raw: string): ParsedToolResult {
+  const images: AgentToolResultImage[] = []
+  const cleaned = raw.replace(
+    /\[PROMA_IMAGE_ATTACHMENT:(\{[^}]+\})\]/g,
+    (_, json: string) => {
+      try {
+        images.push(JSON.parse(json) as AgentToolResultImage)
+      } catch { /* 忽略解析失败 */ }
+      return ''
+    },
+  )
+  return { text: cleaned.trim(), images }
 }
 
 /** 检查工具结果是否指示错误 */

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -264,6 +264,16 @@ export interface RetryAttempt {
 /**
  * Agent 事件类型
  *
+/** MCP 工具结果中的图片附件 */
+export interface AgentToolResultImage {
+  localPath: string
+  filename: string
+  mediaType: string
+}
+
+/**
+ * Agent 事件流类型
+ *
  * 从 SDK 消息转换而来的扁平事件流，用于驱动 UI 渲染。
  */
 export type AgentEvent =
@@ -272,7 +282,7 @@ export type AgentEvent =
   | { type: 'text_complete'; text: string; isIntermediate: boolean; turnId?: string; parentToolUseId?: string }
   // 工具执行
   | { type: 'tool_start'; toolName: string; toolUseId: string; input: Record<string, unknown>; intent?: string; displayName?: string; turnId?: string; parentToolUseId?: string }
-  | { type: 'tool_result'; toolUseId: string; toolName?: string; result: string; isError: boolean; input?: Record<string, unknown>; turnId?: string; parentToolUseId?: string }
+  | { type: 'tool_result'; toolUseId: string; toolName?: string; result: string; isError: boolean; input?: Record<string, unknown>; turnId?: string; parentToolUseId?: string; imageAttachments?: AgentToolResultImage[] }
   // 后台任务
   | { type: 'task_backgrounded'; toolUseId: string; taskId: string; intent?: string; turnId?: string }
   | { type: 'task_started'; taskId: string; toolUseId?: string; description: string; taskType?: string; turnId?: string }

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -324,6 +324,8 @@ export const CHAT_IPC_CHANNELS = {
   SAVE_ATTACHMENT: 'chat:save-attachment',
   /** 读取附件（返回 base64） */
   READ_ATTACHMENT: 'chat:read-attachment',
+  /** 另存图片到用户选择的位置（原生 Save As 对话框） */
+  SAVE_IMAGE_AS: 'chat:save-image-as',
   /** 删除附件 */
   DELETE_ATTACHMENT: 'chat:delete-attachment',
   /** 打开文件选择对话框 */


### PR DESCRIPTION
## Summary

实现 Nano Banana 生图工具，基于 Gemini Image Generation API，作为 Chat 模式的内置工具与 Tavily 搜索和记忆工具并列。

## Changes

- 新增 `nano-banana-tool.ts`：Gemini API 集成，支持文生图、参考图编辑、多轮连续修改
- 扩展 `ToolResult` 接口支持 `generatedAttachments` 字段
- 工具注册、执行、配置、IPC 端点集成
- Chat 设置页新增 Nano Banana 配置区块（API Key、地址、模型）
- Assistant 消息渲染生成的图片附件，右下角悬浮下载按钮

## Test Plan

- [ ] 配置 Gemini API Key 并启用工具
- [ ] 测试文生图：发送"画一只猫" → LLM 调用 generate_image → 图片内联显示
- [ ] 测试参考图编辑：上传参考图 + 发送修改描述 → 显示编辑后图片
- [ ] 测试多轮连续修改：继续对话时保持上下文修改历史
- [ ] 验证右下角悬浮下载按钮可见且能正常保存