### PR TITLE
feat: 支持 Agent @ 引用工作区和附加目录文件

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -52,6 +52,7 @@ import {
   buildTeamActivityEntries,
   rebuildTeamDataFromMessages,
   agentAttachedDirectoriesMapAtom,
+  workspaceAttachedDirectoriesMapAtom,
 } from '@/atoms/agent-atoms'
 import type { AgentContextStatus } from '@/atoms/agent-atoms'
 import { activeViewAtom } from '@/atoms/active-view'
@@ -92,6 +93,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const setAttachedDirsMap = useSetAtom(agentAttachedDirectoriesMapAtom)
   const attachedDirsMap = useAtomValue(agentAttachedDirectoriesMapAtom)
   const attachedDirs = attachedDirsMap.get(sessionId) ?? []
+  const wsAttachedDirsMap = useAtomValue(workspaceAttachedDirectoriesMapAtom)
+  const wsAttachedDirs = currentWorkspaceId ? (wsAttachedDirsMap.get(currentWorkspaceId) ?? []) : []
 
   const draftsMap = useAtomValue(agentSessionDraftsAtom)
   const setDraftsMap = useSetAtom(agentSessionDraftsAtom)
@@ -108,6 +111,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     })
   }, [sessionId, setDraftsMap])
   const [sessionPath, setSessionPath] = React.useState<string | null>(null)
+  const [workspaceFilesPath, setWorkspaceFilesPath] = React.useState<string | null>(null)
   const [isDragOver, setIsDragOver] = React.useState(false)
   const [dragFolderWarning, setDragFolderWarning] = React.useState(false)
   const [errorCopied, setErrorCopied] = React.useState(false)
@@ -149,6 +153,33 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       .then(setSessionPath)
       .catch(() => setSessionPath(null))
   }, [sessionId, currentWorkspaceId])
+
+  // 获取工作区共享文件目录路径（@ 引用时需要搜索）
+  const workspaceSlug = workspaces.find((w) => w.id === currentWorkspaceId)?.slug ?? null
+  React.useEffect(() => {
+    if (!workspaceSlug) {
+      setWorkspaceFilesPath(null)
+      return
+    }
+    window.electronAPI
+      .getWorkspaceFilesPath(workspaceSlug)
+      .then(setWorkspaceFilesPath)
+      .catch(() => setWorkspaceFilesPath(null))
+  }, [workspaceSlug])
+
+  // 合并工作区文件目录、工作区级附加目录和会话级附加目录，供 @ 引用搜索
+  const allAttachedDirs = React.useMemo(() => {
+    const dirs = [...attachedDirs]
+    // 添加工作区级附加目录
+    for (const d of wsAttachedDirs) {
+      if (!dirs.includes(d)) dirs.push(d)
+    }
+    // 添加工作区共享文件目录
+    if (workspaceFilesPath && !dirs.includes(workspaceFilesPath)) {
+      dirs.unshift(workspaceFilesPath)
+    }
+    return dirs
+  }, [attachedDirs, wsAttachedDirs, workspaceFilesPath])
 
   // 监听消息刷新版本号
   const refreshMap = useAtomValue(agentMessageRefreshAtom)
@@ -866,8 +897,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
               autoFocusTrigger={sessionId}
               collapsible
               workspacePath={sessionPath}
-              workspaceSlug={workspaces.find((w) => w.id === currentWorkspaceId)?.slug ?? null}
-              attachedDirs={attachedDirs}
+              workspaceSlug={workspaceSlug}
+              attachedDirs={allAttachedDirs}
             />
 
             {/* Footer 工具栏 */}

--- a/apps/electron/src/renderer/components/file-browser/FileMentionList.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileMentionList.tsx
@@ -73,7 +73,7 @@ export const FileMentionList = React.forwardRef<FileMentionRef, FileMentionListP
     return (
       <div
         ref={containerRef}
-        className="rounded-lg border bg-popover shadow-lg overflow-y-auto max-h-[200px] min-w-[200px]"
+        className="rounded-lg border bg-popover shadow-lg overflow-y-auto max-h-[280px] min-w-[200px]"
       >
         {items.map((item, index) => (
           <button

--- a/apps/electron/src/renderer/components/file-browser/file-mention-suggestion.tsx
+++ b/apps/electron/src/renderer/components/file-browser/file-mention-suggestion.tsx
@@ -39,7 +39,7 @@ export function createFileMentionSuggestion(
         const result = await window.electronAPI.searchWorkspaceFiles(
           wsPath,
           query ?? '',
-          8,
+          20,
           additionalPaths.length > 0 ? additionalPaths : undefined,
         )
         return result.entries


### PR DESCRIPTION
## 功能说明

Agent 模式下 @ 引用文件时现已支持完整的文件搜索范围：

1. **工作区级附加目录**：用户在工作区中添加的目录下的文件现可被搜索到
2. **工作区共享文件目录**：workspace-files 路径中的文件可跨会话被引用
3. **会话级附加目录**：保持原有的会话特定附加目录搜索
4. **改进搜索体验**：增加搜索结果限制至 20 个，扩大文件列表显示高度至 280px，支持滚动查看

## 修改详情

- `AgentView.tsx`：读取工作区级附加目录和共享文件目录，合并后传给文件搜索功能
- `FileMentionList.tsx`：增大列表容器高度以改进滚动体验
- `file-mention-suggestion.tsx`：提高搜索结果限制

## 测试

在 Agent 模式输入框中输入 `@` 时，现可查看并引用工作区所有配置的附加目录中的文件。