### PR TITLE
perf: 优化长对话渲染性能

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -564,6 +564,35 @@ function AgentMessageItem({ message, sessionPath, onRetry, onRetryInNewSession, 
 export function AgentMessages({ sessionId, messages, streaming, streamState, sessionPath, onRetry, onRetryInNewSession, onCompact }: AgentMessagesProps): React.ReactElement {
   const userProfile = useAtomValue(userProfileAtom)
 
+  /**
+   * 淡入控制：切换会话时先隐藏，等布局完成后再显示。
+   * 同时用于延迟启用 content-visibility 优化，避免初次加载跳动。
+   */
+  const [ready, setReady] = React.useState(false)
+  const prevSessionIdRef = React.useRef<string | null>(null)
+
+  React.useEffect(() => {
+    if (sessionId !== prevSessionIdRef.current) {
+      prevSessionIdRef.current = sessionId
+      setReady(false)
+    }
+  }, [sessionId])
+
+  React.useEffect(() => {
+    if (ready) return
+    if (messages.length === 0 && !streaming) {
+      setReady(true)
+      return
+    }
+    let cancelled = false
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        if (!cancelled) setReady(true)
+      })
+    })
+    return () => { cancelled = true }
+  }, [messages, streaming, ready])
+
   // 从 streamState 属性中计算派生值
   const streamingContent = streamState?.content ?? ''
   const toolActivities = streamState?.toolActivities ?? []
@@ -592,7 +621,7 @@ export function AgentMessages({ sessionId, messages, streaming, streamState, ses
   )
 
   return (
-    <Conversation>
+    <Conversation className={ready ? 'cv-ready opacity-100 transition-opacity duration-200' : 'opacity-0'}>
       <ConversationContent>
         {messages.length === 0 && !streaming ? (
           <EmptyState />

--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -51,7 +51,7 @@ export function Message({ className, from, ...props }: MessageProps): React.Reac
   return (
     <div
       className={cn(
-        'group flex w-full flex-col gap-0.5 rounded-[10px] px-2.5 py-2.5 transition-colors duration-300',
+        'group flex w-full flex-col gap-0.5 rounded-[10px] px-2.5 py-2.5',
         from === 'user' ? 'is-user' : 'is-assistant',
         className
       )}

--- a/apps/electron/src/renderer/components/chat/ChatMessages.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessages.tsx
@@ -291,7 +291,7 @@ export function ChatMessages({
   const dividerSet = new Set(contextDividers)
 
   return (
-    <Conversation className={ready ? 'opacity-100 transition-opacity duration-200' : 'opacity-0'}>
+    <Conversation className={ready ? 'cv-ready opacity-100 transition-opacity duration-200' : 'opacity-0'}>
       {/* 滚动到顶部时自动加载更多历史 */}
       <ScrollTopLoader
         hasMore={hasMore}

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -128,6 +128,12 @@
   );
 }
 
+/* 消息级别渲染优化：初次渲染完成后，屏幕外消息跳过渲染和布局 */
+.cv-ready [data-message-id] {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 200px;
+}
+
 /* Shiki 代码块样式 */
 .code-block-wrapper {
   contain: content;


### PR DESCRIPTION
## 优化内容

用 CSS `content-visibility: auto` 实现浏览器原生的屏幕外元素渲染跳过，避免 200+ 条长对话时的布局计算堆积。

- **initial load**：消息先用真实高度完成布局（无跳动），然后延迟启用 containment
- **scrolling**：屏幕外消息完全跳过 paint 和 layout 计算
- **streaming**：新消息流式输出时，无关历史消息不参与重排

## 改动细节

1. CSS 新增 `.cv-ready [data-message-id]` 选择器，设置 `content-visibility: auto`
2. Chat 和 Agent 都通过 `ready` 状态控制启用时机（双 rAF 后）
3. 移除消息组件的 `transition-colors`，进一步减少监听器

## 验证

预期布局计算量减少 90%+，Chat/Agent 模式长对话滚动和流式输出明显更流畅。