### PR TITLE
Transform SDK login error to user-friendly message

### DIFF
--- a/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
@@ -162,6 +162,26 @@ export interface ClaudeAgentQueryOptions extends AgentQueryInput {
 }
 
 // ============================================================================
+// SDK 错误消息友好化
+// ============================================================================
+
+/** 已知 SDK 错误 → 用户友好提示映射 */
+const FRIENDLY_ERROR_MESSAGES: Array<{ pattern: RegExp; message: string }> = [
+  {
+    pattern: /not logged in|please run \/login/i,
+    message: '请检查是否选择了正确的 Proma 供应渠道和模型',
+  },
+]
+
+/** 将 SDK 原始错误消息转换为用户友好的提示（无匹配则返回原文） */
+export function friendlyErrorMessage(raw: string): string {
+  for (const { pattern, message } of FRIENDLY_ERROR_MESSAGES) {
+    if (pattern.test(raw)) return message
+  }
+  return raw
+}
+
+// ============================================================================
 // 错误映射（从 agent-service.ts 迁移）
 // ============================================================================
 
@@ -296,7 +316,7 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
           if (isPromptTooLongError(detailedMessage, originalError)) {
             errorCode = 'prompt_too_long'
           }
-          const typedError = mapSDKErrorToTypedError(errorCode, detailedMessage, originalError)
+          const typedError = mapSDKErrorToTypedError(errorCode, friendlyErrorMessage(detailedMessage), originalError)
           events.push({ type: 'typed_error', error: typedError })
           break
         }
@@ -546,7 +566,7 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
     if (msg.subtype === 'success') {
       events.push({ type: 'complete', usage })
     } else {
-      const errorMsg = msg.errors ? msg.errors.join(', ') : 'Agent 查询失败'
+      const errorMsg = friendlyErrorMessage(msg.errors ? msg.errors.join(', ') : 'Agent 查询失败')
       events.push({ type: 'error', message: errorMsg })
       events.push({ type: 'complete', usage })
     }

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -25,7 +25,7 @@ import type { AgentSendInput, AgentEvent, AgentMessage, AgentGenerateTitleInput,
 import { SAFE_TOOLS } from '@proma/shared'
 import type { PermissionRequest, PromaPermissionMode, AskUserRequest } from '@proma/shared'
 import type { ClaudeAgentQueryOptions } from './adapters/claude-agent-adapter'
-import { isPromptTooLongError } from './adapters/claude-agent-adapter'
+import { isPromptTooLongError, friendlyErrorMessage } from './adapters/claude-agent-adapter'
 import { AgentEventBus } from './agent-event-bus'
 import { decryptApiKey, getChannelById, listChannels } from './channel-manager'
 import { getAdapter, fetchTitle, normalizeAnthropicBaseUrlForSdk } from '@proma/core'
@@ -1357,9 +1357,9 @@ export class AgentOrchestrator {
 
           let userFacingError: string
           if (apiError) {
-            userFacingError = `API 错误 (${apiError.statusCode}):\n${apiError.message}`
+            userFacingError = friendlyErrorMessage(`API 错误 (${apiError.statusCode}):\n${apiError.message}`)
           } else {
-            userFacingError = errorMessage
+            userFacingError = friendlyErrorMessage(errorMessage)
           }
 
           // 保存错误消息到 JSONL


### PR DESCRIPTION
## Summary

Replaced the technical "Not logged in · Please run /login" SDK error with a more helpful message: "请检查是否选择了正确的 Proma 供应渠道和模型" (Please check if you've selected the correct Proma channel and model).

## Implementation

- Added centralized `friendlyErrorMessage()` helper in adapter layer with extensible pattern-based mapping
- Applied transformation across both SDK event translation (typed_error, result errors) and orchestrator catch blocks
- Makes it easy to add additional error mappings in the future

## Files Changed

- `apps/electron/src/main/lib/adapters/claude-agent-adapter.ts`: Added error message mapping table and applied to error events
- `apps/electron/src/main/lib/agent-orchestrator.ts`: Applied friendly error message formatting to catch block exceptions