### PR TITLE
Fix chat tool state sync and memory tool invocation

### DIFF
--- a/apps/electron/src/main/lib/chat-tool-config.ts
+++ b/apps/electron/src/main/lib/chat-tool-config.ts
@@ -14,6 +14,7 @@ import type { ChatToolsFileConfig, ChatToolState, ChatToolMeta } from '@proma/sh
 const DEFAULT_CONFIG: ChatToolsFileConfig = {
   toolStates: {
     memory: { enabled: true },
+    'agent-mode-recommend': { enabled: true },
     'web-search': { enabled: false },
     'nano-banana': { enabled: false },
   },

--- a/apps/electron/src/main/lib/chat-tool-registry.ts
+++ b/apps/electron/src/main/lib/chat-tool-registry.ts
@@ -31,7 +31,6 @@ import {
   NANO_BANANA_TOOL_DEFINITIONS,
   isNanoBananaAvailable,
 } from './chat-tools/nano-banana-tool'
-import { getMemoryConfig } from './memory-service'
 
 // ===== 内置工具注册 =====
 
@@ -125,7 +124,6 @@ export interface EnabledToolsResult {
 export function getEnabledTools(enabledToolIds?: string[]): EnabledToolsResult {
   // 未传入 enabledToolIds 时使用配置文件的开关状态
   const config = getChatToolsConfig()
-  const memoryConfig = getMemoryConfig()
 
   const allDefinitions: ToolDefinition[] = []
   const systemPromptParts: string[] = []
@@ -137,11 +135,6 @@ export function getEnabledTools(enabledToolIds?: string[]): EnabledToolsResult {
     // 检查工具是否启用（前端开关 + 配置开关）
     const isEnabledByUser = enabledToolIds ? enabledToolIds.includes(toolId) : (state?.enabled ?? false)
     if (!isEnabledByUser) continue
-
-    // 记忆工具额外检查全局记忆配置的 enabled 状态
-    if (toolId === 'memory') {
-      if (!memoryConfig.enabled || !memoryConfig.apiKey) continue
-    }
 
     // 检查工具是否可用（凭据已配置）
     if (!entry.checkAvailable()) continue
@@ -184,7 +177,6 @@ export function getEnabledTools(enabledToolIds?: string[]): EnabledToolsResult {
  */
 export function getAllToolInfos(): ChatToolInfo[] {
   const config = getChatToolsConfig()
-  const memoryConfig = getMemoryConfig()
   const infos: ChatToolInfo[] = []
 
   // 内置工具
@@ -192,15 +184,9 @@ export function getAllToolInfos(): ChatToolInfo[] {
     const toolId = entry.meta.id
     const state = config.toolStates[toolId]
 
-    // 记忆工具的 enabled 还受全局记忆配置影响
-    let enabled = state?.enabled ?? false
-    if (toolId === 'memory') {
-      enabled = enabled && memoryConfig.enabled
-    }
-
     infos.push({
       meta: entry.meta,
-      enabled,
+      enabled: state?.enabled ?? false,
       available: entry.checkAvailable(),
     })
   }

--- a/apps/electron/src/renderer/atoms/chat-tool-atoms.ts
+++ b/apps/electron/src/renderer/atoms/chat-tool-atoms.ts
@@ -2,56 +2,25 @@
  * Chat Tool Atoms - Chat 工具状态管理
  *
  * 管理 Chat 模式下可用工具的列表和开关状态：
- * - chatToolsAtom: 从主进程加载的所有工具信息
- * - enabledToolIdsAtom: 用户在 ChatInput 中切换的工具开关
- * - activeToolIdsAtom: 当前实际启用的工具 ID（交集）
+ * - chatToolsAtom: 从主进程加载的所有工具信息（唯一状态源，来自 chat-tools.json）
+ * - activeToolIdsAtom: 当前实际启用的工具 ID（enabled AND available）
  */
 
 import { atom } from 'jotai'
-import { atomWithStorage } from 'jotai/utils'
 import type { ChatToolInfo } from '@proma/shared'
 
-/** 从主进程加载的所有工具列表 */
+/** 从主进程加载的所有工具列表（唯一状态源） */
 export const chatToolsAtom = atom<ChatToolInfo[]>([])
-
-// 一次性迁移：为已有用户补充 agent-mode-recommend 默认开启
-const MIGRATION_KEY = 'proma-tool-migration-agent-recommend'
-if (typeof localStorage !== 'undefined' && !localStorage.getItem(MIGRATION_KEY)) {
-  const stored = localStorage.getItem('proma-enabled-tool-ids')
-  if (stored) {
-    try {
-      const ids = JSON.parse(stored) as string[]
-      if (Array.isArray(ids) && !ids.includes('agent-mode-recommend')) {
-        ids.push('agent-mode-recommend')
-        localStorage.setItem('proma-enabled-tool-ids', JSON.stringify(ids))
-      }
-    } catch {
-      // 解析失败忽略
-    }
-  }
-  localStorage.setItem(MIGRATION_KEY, '1')
-}
-
-/**
- * 用户在 ChatInput 工具栏中切换的工具 ID 集合
- *
- * localStorage 持久化，默认包含 'memory' 和 'agent-mode-recommend'
- */
-export const enabledToolIdsAtom = atomWithStorage<string[]>(
-  'proma-enabled-tool-ids',
-  ['memory', 'agent-mode-recommend'],
-)
 
 /**
  * 派生：当前实际启用的工具 ID 列表
  *
- * 交集条件：用户开关打开 AND 工具已配置可用
+ * 条件：后端配置开关打开 AND 工具已配置可用
  */
 export const activeToolIdsAtom = atom<string[]>((get) => {
   const allTools = get(chatToolsAtom)
-  const enabledIds = get(enabledToolIdsAtom)
   return allTools
-    .filter((t) => enabledIds.includes(t.meta.id) && t.available)
+    .filter((t) => t.enabled && t.available)
     .map((t) => t.meta.id)
 })
 

--- a/apps/electron/src/renderer/components/chat/ToolSelectorPopover.tsx
+++ b/apps/electron/src/renderer/components/chat/ToolSelectorPopover.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useState } from 'react'
-import { useAtom, useAtomValue } from 'jotai'
+import { useAtomValue, useSetAtom } from 'jotai'
 import { Button } from '@/components/ui/button'
 import {
   Popover,
@@ -22,7 +22,7 @@ import {
 } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { Wrench, Brain, Globe, Settings, ImagePlus } from 'lucide-react'
-import { chatToolsAtom, enabledToolIdsAtom, hasActiveToolsAtom } from '@/atoms/chat-tool-atoms'
+import { chatToolsAtom, hasActiveToolsAtom } from '@/atoms/chat-tool-atoms'
 import { settingsTabAtom } from '@/atoms/settings-tab'
 import { activeViewAtom } from '@/atoms/active-view'
 
@@ -43,17 +43,19 @@ function getToolIcon(iconName?: string): React.ReactElement {
 export function ToolSelectorPopover(): React.ReactElement {
   const [open, setOpen] = useState(false)
   const tools = useAtomValue(chatToolsAtom)
-  const [enabledIds, setEnabledIds] = useAtom(enabledToolIdsAtom)
+  const setChatTools = useSetAtom(chatToolsAtom)
   const hasActiveTools = useAtomValue(hasActiveToolsAtom)
-  const [, setActiveView] = useAtom(activeViewAtom)
-  const [, setSettingsTab] = useAtom(settingsTabAtom)
+  const setActiveView = useSetAtom(activeViewAtom)
+  const setSettingsTab = useSetAtom(settingsTabAtom)
 
-  /** 切换工具开关 */
-  const toggleTool = (toolId: string): void => {
-    if (enabledIds.includes(toolId)) {
-      setEnabledIds(enabledIds.filter((id) => id !== toolId))
-    } else {
-      setEnabledIds([...enabledIds, toolId])
+  /** 切换工具开关（通过 IPC 更新后端配置，再刷新 atom） */
+  const toggleTool = async (toolId: string, currentEnabled: boolean): Promise<void> => {
+    try {
+      await window.electronAPI.updateChatToolState(toolId, { enabled: !currentEnabled })
+      const updated = await window.electronAPI.getChatTools()
+      setChatTools(updated)
+    } catch (err) {
+      console.error('[ToolSelectorPopover] 切换工具失败:', err)
     }
   }
 
@@ -98,7 +100,7 @@ export function ToolSelectorPopover(): React.ReactElement {
           ) : (
             <div className="space-y-1">
               {tools.map((tool) => {
-                const isEnabled = enabledIds.includes(tool.meta.id)
+                const isEnabled = tool.enabled
                 const canToggle = tool.available
 
                 return (
@@ -127,7 +129,7 @@ export function ToolSelectorPopover(): React.ReactElement {
                     </div>
                     <Switch
                       checked={isEnabled && canToggle}
-                      onCheckedChange={() => toggleTool(tool.meta.id)}
+                      onCheckedChange={() => toggleTool(tool.meta.id, isEnabled)}
                       disabled={!canToggle}
                       className="scale-75"
                     />

--- a/apps/electron/src/renderer/components/settings/MemorySettings.tsx
+++ b/apps/electron/src/renderer/components/settings/MemorySettings.tsx
@@ -55,6 +55,8 @@ export function MemorySettings(): React.ReactElement {
     setSaving(true)
     try {
       await window.electronAPI.setMemoryConfig(updated)
+      // 同步记忆工具开关到 chat-tools.json（唯一状态源）
+      await window.electronAPI.updateChatToolState('memory', { enabled: updated.enabled })
       setConfig(updated)
       setApiKey(updated.apiKey)
       // 刷新全局工具列表（available/enabled 可能变化）


### PR DESCRIPTION
## Summary
Unified tool enabled state from dual-source (frontend localStorage + backend config) to single source (backend chat-tools.json). Fixed two bugs:
1. Memory tool not being invoked despite API key and switch enabled (silent failure from double-check logic)
2. Default enabled state always overriding user configuration

## Changes
- Remove `enabledToolIdsAtom` localStorage and use backend config as sole state source
- ToolSelectorPopover now updates backend via IPC instead of localStorage
- Remove redundant `memoryConfig.enabled` check in `getEnabledTools()`
- Sync MemorySettings toggle to both `memory.json` (credentials) and `chat-tools.json` (enabled state)