### PR TITLE
perf: 恢复丝滑流式输出体验

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -621,7 +621,7 @@ export function AgentMessages({ sessionId, messages, streaming, streamState, ses
   )
 
   return (
-    <Conversation className={ready ? 'cv-ready opacity-100 transition-opacity duration-200' : 'opacity-0'}>
+    <Conversation className={ready ? `${streaming ? '' : 'cv-ready '}opacity-100 transition-opacity duration-200` : 'opacity-0'}>
       <ConversationContent>
         {messages.length === 0 && !streaming ? (
           <EmptyState />

--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -206,9 +206,104 @@ interface MessageResponseProps {
   basePath?: string
 }
 
+/** 稳定引用的插件数组，避免 react-markdown 每帧重建插件管线 */
+const REMARK_PLUGINS = [remarkGfm, remarkMath]
+const REHYPE_PLUGINS = [rehypeKatex]
+
+// ===== Memo'd Markdown 子组件（稳定引用，避免 react-markdown 每帧重建组件映射） =====
+
+/** 外部链接渲染器 */
+const MarkdownLink = React.memo(function MarkdownLink({
+  href,
+  children: linkChildren,
+  ...linkProps
+}: React.AnchorHTMLAttributes<HTMLAnchorElement>): React.ReactElement {
+  return (
+    <a
+      {...linkProps}
+      href={href}
+      onClick={(e) => {
+        e.preventDefault()
+        if (href && (href.startsWith('http://') || href.startsWith('https://'))) {
+          window.electronAPI.openExternal(href)
+        }
+      }}
+      title={href}
+    >
+      {linkChildren}
+    </a>
+  )
+})
+
+/** 递归提取纯文本（children 可能是字符串数组） */
+function extractText(node: React.ReactNode): string {
+  if (typeof node === 'string') return node
+  if (typeof node === 'number') return String(node)
+  if (!node) return ''
+  if (Array.isArray(node)) return node.map(extractText).join('')
+  if (React.isValidElement(node)) {
+    return extractText((node.props as { children?: React.ReactNode }).children)
+  }
+  return ''
+}
+
+/** 代码块 / Mermaid 渲染器 */
+const MarkdownPre = React.memo(function MarkdownPre({
+  children: preChildren,
+}: { children?: React.ReactNode }): React.ReactElement {
+  const codeChild = React.Children.toArray(preChildren).find(
+    (child): child is React.ReactElement =>
+      React.isValidElement(child) && (child as React.ReactElement).type === 'code'
+  ) as React.ReactElement | undefined
+
+  if (codeChild) {
+    const codeProps = codeChild.props as { className?: string; children?: React.ReactNode }
+    if (codeProps.className?.includes('language-mermaid')) {
+      const mermaidCode = extractText(codeProps.children).replace(/\n$/, '')
+      return <MermaidBlock code={mermaidCode} />
+    }
+  }
+
+  return <CodeBlock>{preChildren}</CodeBlock>
+})
+
+/** 行内代码 / 文件路径渲染器 */
+const MarkdownInlineCode = React.memo(function MarkdownInlineCode({
+  children: codeChildren,
+  className: codeClassName,
+  basePath,
+  ...codeProps
+}: React.HTMLAttributes<HTMLElement> & { basePath?: string }): React.ReactElement {
+  if (codeClassName) {
+    return <code className={codeClassName} {...codeProps}>{codeChildren}</code>
+  }
+
+  const text = typeof codeChildren === 'string' ? codeChildren : ''
+
+  if (text) {
+    if (isAbsoluteFilePath(text)) {
+      return <FilePathChip filePath={text.trim()} />
+    }
+    if (basePath && isRelativeFilePath(text)) {
+      return <FilePathChip filePath={text.trim()} basePath={basePath} />
+    }
+  }
+
+  return <code {...codeProps}>{codeChildren}</code>
+})
+
 /** 使用 react-markdown 渲染 assistant 消息内容，代码块使用 Shiki 语法高亮 */
 export const MessageResponse = React.memo(
   function MessageResponse({ children, className, basePath }: MessageResponseProps): React.ReactElement {
+    // 稳定引用的 components 对象，避免 react-markdown 每帧重建组件映射
+    const components = React.useMemo(() => ({
+      a: MarkdownLink,
+      pre: MarkdownPre,
+      code: (props: React.HTMLAttributes<HTMLElement>) => (
+        <MarkdownInlineCode {...props} basePath={basePath} />
+      ),
+    }), [basePath])
+
     return (
       <div
         className={cn(
@@ -220,77 +315,9 @@ export const MessageResponse = React.memo(
         )}
       >
         <Markdown
-          remarkPlugins={[remarkGfm, remarkMath]}
-          rehypePlugins={[rehypeKatex]}
-          components={{
-            a: ({ href, children: linkChildren, ...linkProps }) => (
-              <a
-                {...linkProps}
-                href={href}
-                onClick={(e) => {
-                  e.preventDefault()
-                  if (href && (href.startsWith('http://') || href.startsWith('https://'))) {
-                    window.electronAPI.openExternal(href)
-                  }
-                }}
-                title={href}
-              >
-                {linkChildren}
-              </a>
-            ),
-            pre: ({ children: preChildren }) => {
-              // 检测子 <code> 元素的 className 是否包含 language-mermaid
-              const codeChild = React.Children.toArray(preChildren).find(
-                (child): child is React.ReactElement =>
-                  React.isValidElement(child) && (child as React.ReactElement).type === 'code'
-              ) as React.ReactElement | undefined
-
-              if (codeChild) {
-                const codeProps = codeChild.props as { className?: string; children?: React.ReactNode }
-                if (codeProps.className?.includes('language-mermaid')) {
-                  // 递归提取纯文本（children 可能是字符串数组）
-                  const extractText = (node: React.ReactNode): string => {
-                    if (typeof node === 'string') return node
-                    if (typeof node === 'number') return String(node)
-                    if (!node) return ''
-                    if (Array.isArray(node)) return node.map(extractText).join('')
-                    if (React.isValidElement(node)) {
-                      return extractText((node.props as { children?: React.ReactNode }).children)
-                    }
-                    return ''
-                  }
-                  const mermaidCode = extractText(codeProps.children).replace(/\n$/, '')
-                  return <MermaidBlock code={mermaidCode} />
-                }
-              }
-
-              return <CodeBlock>{preChildren}</CodeBlock>
-            },
-            code: ({ children: codeChildren, className: codeClassName, ...codeProps }) => {
-              // 仅处理行内代码（代码块内的 <code> 有 className="language-xxx"）
-              if (codeClassName) {
-                return <code className={codeClassName} {...codeProps}>{codeChildren}</code>
-              }
-
-              // 提取纯文本内容
-              const text = typeof codeChildren === 'string' ? codeChildren : ''
-
-              if (text) {
-                // 检测绝对文件路径
-                if (isAbsoluteFilePath(text)) {
-                  return <FilePathChip filePath={text.trim()} />
-                }
-
-                // 检测相对文件路径（需要 basePath）
-                if (basePath && isRelativeFilePath(text)) {
-                  return <FilePathChip filePath={text.trim()} basePath={basePath} />
-                }
-              }
-
-              // 默认渲染
-              return <code {...codeProps}>{codeChildren}</code>
-            },
-          }}
+          remarkPlugins={REMARK_PLUGINS}
+          rehypePlugins={REHYPE_PLUGINS}
+          components={components}
         >
           {children}
         </Markdown>

--- a/apps/electron/src/renderer/components/chat/ChatMessageItem.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessageItem.tsx
@@ -94,7 +94,7 @@ interface ChatMessageItemProps {
   isParallelMode?: boolean
 }
 
-export function ChatMessageItem({
+export const ChatMessageItem = React.memo(function ChatMessageItem({
   message,
   conversationId,
   isStreaming = false,
@@ -264,4 +264,4 @@ export function ChatMessageItem({
       />
     </>
   )
-}
+})

--- a/apps/electron/src/renderer/components/chat/ChatMessages.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessages.tsx
@@ -291,7 +291,7 @@ export function ChatMessages({
   const dividerSet = new Set(contextDividers)
 
   return (
-    <Conversation className={ready ? 'cv-ready opacity-100 transition-opacity duration-200' : 'opacity-0'}>
+    <Conversation className={ready ? `${streaming ? '' : 'cv-ready '}opacity-100 transition-opacity duration-200` : 'opacity-0'}>
       {/* 滚动到顶部时自动加载更多历史 */}
       <ScrollTopLoader
         hasMore={hasMore}

--- a/packages/ui/src/hooks/useSmoothStream.ts
+++ b/packages/ui/src/hooks/useSmoothStream.ts
@@ -4,19 +4,13 @@
  * 将后端推送的流式文本（可能每秒几十次更新）转化为
  * 平滑的逐字渲染效果，类似打字机。
  *
- * 核心设计目标：**稳定、有序的输出节奏**
- * - 无论 chunk 到达节奏如何，用户看到的都是均匀的文字流
- * - 基础速率恒定（2字符/帧），积压时平缓加速追赶，不会突变
- * - 双缓冲机制：rAF 持续积累字符，React setState 按节拍刷新，
- *   避免高频 Markdown 重解析导致的帧率下降
- *
  * 核心机制：
  * 1. 新增 delta 通过 Intl.Segmenter 拆分为字符粒度后入队
- * 2. requestAnimationFrame 驱动渲染循环，持续将字符从队列移入缓冲区
- * 3. 每帧恒定基础速率 + 积压平缓追赶（线性加速，无突变）
- * 4. React setState 按 renderInterval 节拍触发（默认 ~30fps），
- *    将缓冲区内容一次性刷新到 UI，减少 Markdown 重解析频率
- * 5. 流结束时一次性输出剩余内容
+ * 2. requestAnimationFrame 驱动渲染循环
+ * 3. 每帧动态计算渲染字符数（队列长时加速追赶，短时放慢）
+ * 4. 流结束后加速但渐进排空队列（不一次性 dump，避免跳动）
+ *
+ * 参考 Cherry Studio 的 useSmoothStream 实现。
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react'
@@ -26,27 +20,14 @@ interface UseSmoothStreamOptions {
   content: string
   /** 是否正在流式输出中 */
   isStreaming: boolean
-  /**
-   * React setState 触发间隔（ms），控制 Markdown 重解析频率。
-   * 默认 36（约 28fps），在视觉流畅与渲染性能之间取得平衡。
-   * rAF 循环仍然每帧运行（~16ms），字符在缓冲区中持续积累。
-   */
-  renderInterval?: number
+  /** 每帧最小间隔（ms），默认 10 */
+  minDelay?: number
 }
 
 interface UseSmoothStreamReturn {
   /** 平滑后的显示内容 */
   displayedContent: string
 }
-
-// ===== 速率常量 =====
-
-/** 基础每帧输出字符数（保持稳定节奏） */
-const BASE_RATE = 2
-/** 队列积压超过此值时开始平缓加速追赶 */
-const CATCHUP_THRESHOLD = 40
-/** 追赶加速因子（越大越平缓，8 = 每积压 8 字符加速 1 字符/帧） */
-const CATCHUP_DIVISOR = 8
 
 /** 多语言字符分割器（正确处理中文、日文等多字节字符） */
 const segmenter = new Intl.Segmenter(
@@ -77,7 +58,7 @@ function segmentText(text: string): string[] {
 export function useSmoothStream({
   content,
   isStreaming,
-  renderInterval = 36,
+  minDelay = 10,
 }: UseSmoothStreamOptions): UseSmoothStreamReturn {
   const [displayedContent, setDisplayedContent] = useState(content)
 
@@ -85,14 +66,12 @@ export function useSmoothStream({
   const chunkQueueRef = useRef<string[]>([])
   // rAF ID
   const rafRef = useRef<number | null>(null)
-  // 已提交到 React state 的文本
-  const committedRef = useRef(content)
-  // rAF 循环中累积的缓冲文本（尚未提交到 state）
-  const bufferRef = useRef(content)
+  // 已渲染到 UI 的文本
+  const displayedRef = useRef(content)
   // 上一次收到的完整内容（用于计算 delta）
   const prevContentRef = useRef(content)
-  // 上次 React setState 时间
-  const lastCommitTimeRef = useRef(0)
+  // 上次渲染时间
+  const lastRenderTimeRef = useRef(0)
   // 流是否结束
   const streamDoneRef = useRef(!isStreaming)
 
@@ -119,42 +98,30 @@ export function useSmoothStream({
     } else {
       // 内容重置（用户重新发送等场景）
       chunkQueueRef.current = []
-      bufferRef.current = newContent
-      committedRef.current = newContent
+      displayedRef.current = newContent
       setDisplayedContent(newContent)
     }
 
     prevContentRef.current = newContent
   }, [content])
 
-  // 非流式状态时，直接显示完整内容（历史消息、编辑后的消息等）
+  // 非流式状态时，确保最终内容一致（安全网，不立即 flush 队列）
   useEffect(() => {
     if (!isStreaming) {
-      // 如果队列还有剩余，一次性输出
+      // 如果 rAF 循环仍在运行，让它自然排空队列
+      if (rafRef.current) return
+
+      // rAF 已停止：同步剩余内容
       if (chunkQueueRef.current.length > 0) {
-        bufferRef.current += chunkQueueRef.current.join('')
+        displayedRef.current += chunkQueueRef.current.join('')
         chunkQueueRef.current = []
       }
-      // 确保显示内容与实际内容一致
-      if (bufferRef.current !== content) {
-        bufferRef.current = content
+      if (displayedRef.current !== content) {
+        displayedRef.current = content
       }
-      committedRef.current = bufferRef.current
-      setDisplayedContent(committedRef.current)
+      setDisplayedContent(displayedRef.current)
     }
   }, [isStreaming, content])
-
-  /**
-   * 将缓冲区内容提交到 React state（触发 Markdown 重渲染）。
-   * 仅在缓冲区有新内容时才调用 setState。
-   */
-  const commitBuffer = useCallback((time: number) => {
-    if (bufferRef.current !== committedRef.current) {
-      committedRef.current = bufferRef.current
-      setDisplayedContent(committedRef.current)
-      lastCommitTimeRef.current = time
-    }
-  }, [])
 
   // 渲染循环
   const renderLoop = useCallback((currentTime: number) => {
@@ -162,11 +129,12 @@ export function useSmoothStream({
 
     // 队列为空
     if (queue.length === 0) {
-      // 提交缓冲区中剩余内容
-      commitBuffer(currentTime)
-
       if (streamDoneRef.current) {
-        // 流结束 + 队列空 → 停止循环
+        // 流结束 + 队列空 → 同步最终内容并停止
+        if (displayedRef.current !== prevContentRef.current) {
+          displayedRef.current = prevContentRef.current
+          setDisplayedContent(displayedRef.current)
+        }
         rafRef.current = null
         return
       }
@@ -175,45 +143,39 @@ export function useSmoothStream({
       return
     }
 
-    // ===== 计算本帧输出字符数：稳定基础速率 + 平缓追赶 =====
-    let count: number
-
-    if (streamDoneRef.current) {
-      // 流结束：一次性输出所有剩余
-      count = queue.length
-    } else if (queue.length > CATCHUP_THRESHOLD) {
-      // 积压较多：基础速率 + 线性追赶（平缓加速，不会突变）
-      const extra = Math.ceil((queue.length - CATCHUP_THRESHOLD) / CATCHUP_DIVISOR)
-      count = BASE_RATE + extra
-    } else {
-      // 正常流式：恒定基础速率，保持稳定节奏
-      count = Math.min(BASE_RATE, queue.length)
+    // 最小延迟控制
+    if (currentTime - lastRenderTimeRef.current < minDelay) {
+      rafRef.current = requestAnimationFrame(renderLoop)
+      return
     }
+    lastRenderTimeRef.current = currentTime
 
-    // 从队列取出字符，追加到缓冲区
+    // 动态计算本帧渲染字符数：除数越大缓冲越深、输出越匀
+    // 流式中 /8 保持较深缓冲（牺牲少许延迟换取丝滑），结束后 /4 加速排空
+    const divisor = streamDoneRef.current ? 4 : 8
+    const count = Math.max(1, Math.floor(queue.length / divisor))
+
+    // 取出字符并更新
     const chars = queue.splice(0, count)
-    bufferRef.current += chars.join('')
+    displayedRef.current += chars.join('')
+    setDisplayedContent(displayedRef.current)
 
-    // ===== 按节拍提交到 React state =====
-    // rAF 每帧（~16ms）移动字符到缓冲区，但 setState 按 renderInterval 节拍触发，
-    // 减少 Markdown 重解析频率（从 ~60fps 降到 ~28fps），显著降低 CPU 开销
-    if (currentTime - lastCommitTimeRef.current >= renderInterval) {
-      commitBuffer(currentTime)
-    }
-
-    // 还有内容或流未结束 → 继续下一帧
+    // 队列未空或流未结束 → 继续
     if (queue.length > 0 || !streamDoneRef.current) {
       rafRef.current = requestAnimationFrame(renderLoop)
     } else {
-      // 队列刚好清空：立即提交剩余缓冲
-      commitBuffer(currentTime)
+      // 队列刚排空 + 流已结束 → 同步最终内容并停止
+      if (displayedRef.current !== prevContentRef.current) {
+        displayedRef.current = prevContentRef.current
+        setDisplayedContent(displayedRef.current)
+      }
       rafRef.current = null
     }
-  }, [renderInterval, commitBuffer])
+  }, [minDelay])
 
-  // 启动/重启渲染循环
+  // 启动/重启渲染循环（流结束后也继续运行直到队列排空）
   useEffect(() => {
-    if (isStreaming && !rafRef.current) {
+    if ((isStreaming || chunkQueueRef.current.length > 0) && !rafRef.current) {
       rafRef.current = requestAnimationFrame(renderLoop)
     }
 


### PR DESCRIPTION
## Summary

恢复 v0.7.1 版本的流式输出体验。PR #120 引入的双缓冲 + 固定速率机制导致流式卡顿，本改动还原 v0.7.1 的动态速率算法，同时优化流结束时的排空策略。

## Changes

- **useSmoothStream**: 恢复 v0.7.1 算法（`queue.length / divisor` 动态速率）；流式中除数 8（深缓冲）、流结束后除数 4（加速排空）；流结束后继续运行直到队列排空，避免跳动
- **MessageResponse**: 提取 Markdown components 到 `useMemo`，添加 memo'd 子组件（MarkdownLink、MarkdownPre、MarkdownInlineCode）稳定引用
- **content-visibility**: 禁用流式期间的优化，仅流结束后启用（减少 Markdown re-parse）
- **ChatMessageItem**: 加 React.memo 防止历史消息在流式时重渲染
- **Chat & Agent**: 同时应用所有优化

## Test Plan

- 开发模式流式输出：验证匀速逐字打字机效果，无跳动
- 流结束：文字平滑加速输出完毕，无突变
- 长对话性能：流结束后 content-visibility 启用，屏幕外消息跳过渲染