### PR TITLE
fix: 修复聊天发送后向上滚动的 Bug

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -621,7 +621,7 @@ export function AgentMessages({ sessionId, messages, streaming, streamState, ses
   )
 
   return (
-    <Conversation className={ready ? `${streaming ? '' : 'cv-ready '}opacity-100 transition-opacity duration-200` : 'opacity-0'}>
+    <Conversation className={ready ? 'cv-ready opacity-100 transition-opacity duration-200' : 'opacity-0'}>
       <ConversationContent>
         {messages.length === 0 && !streaming ? (
           <EmptyState />

--- a/apps/electron/src/renderer/components/chat/ChatMessages.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessages.tsx
@@ -291,7 +291,7 @@ export function ChatMessages({
   const dividerSet = new Set(contextDividers)
 
   return (
-    <Conversation className={ready ? `${streaming ? '' : 'cv-ready '}opacity-100 transition-opacity duration-200` : 'opacity-0'}>
+    <Conversation className={ready ? 'cv-ready opacity-100 transition-opacity duration-200' : 'opacity-0'}>
       {/* 滚动到顶部时自动加载更多历史 */}
       <ScrollTopLoader
         hasMore={hasMore}


### PR DESCRIPTION
## Summary

修复了 Chat 和 Agent 模式中，发送消息后会向上滚动的 UI Bug。

## 问题分析

`cv-ready` CSS 类控制 `content-visibility: auto` 优化的启用。当流式生成停止时，该类被重新应用，导致浏览器重新计算消息尺寸。即使使用 `contain-intrinsic-size: auto` 缓存尺寸，class 的反复切换也会触发布局抖动，scroll 位置微移 1px 足以让 `StickToBottom` 误认为用户主动滚动而解除粘性，后续新消息不再自动滚动到底部。

## 解决方案

移除对 `streaming` 状态的依赖，始终应用 `cv-ready` 类。由于流式消息元素没有 `data-message-id`，不受 `content-visibility: auto` 影响，而历史消息的尺寸缓存保持稳定，避免重复的布局重算。

## 修改文件

- `apps/electron/src/renderer/components/chat/ChatMessages.tsx`（L294）
- `apps/electron/src/renderer/components/agent/AgentMessages.tsx`（L624）