### PR TITLE
fix: 兼容 SSE 无空格数据行格式，修复 Kimi API

### DIFF
--- a/packages/core/src/providers/sse-reader.ts
+++ b/packages/core/src/providers/sse-reader.ts
@@ -96,9 +96,15 @@ export async function streamSSE(options: StreamSSEOptions): Promise<StreamSSERes
       buffer = lines.pop() || ''
 
       for (const line of lines) {
-        if (!line.startsWith('data: ')) continue
-
-        const data = line.slice(6).trim()
+        // SSE 规范：冒号后的空格是可选的，兼容 "data: {...}" 和 "data:{...}" 两种格式
+        let data: string
+        if (line.startsWith('data: ')) {
+          data = line.slice(6).trim()
+        } else if (line.startsWith('data:')) {
+          data = line.slice(5).trim()
+        } else {
+          continue
+        }
         if (data === '[DONE]' || !data) continue
 
         // 4. 委托给 adapter 解析供应商特定 JSON


### PR DESCRIPTION
修复 SSE 流式解析器对 Kimi API 响应格式的兼容性问题。

Kimi API 返回的 SSE 数据行格式为 `data:{...}`（冒号后无空格），但原有代码只匹配 `data: {...}`（带空格）的格式，导致所有 Kimi 数据行被跳过，流式输出为空。

本修复使 SSE 读取器兼容两种格式，遵循 SSE 规范（冒号后的空格为可选）。这不仅修复 Kimi 的流式响应，也增强了对其他类似格式的提供商的兼容性。

## 变更
- `packages/core/src/providers/sse-reader.ts`：修复 SSE 数据行前缀检测逻辑