### PR TITLE
fix: 移除 agent-orchestrator 多余闭合花括号，修复构建失败

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -840,7 +840,6 @@ export class AgentOrchestrator {
       if (existingSdkSessionId) {
         console.log(`[Agent 编排] 将直接使用已保存的 sdkSessionId 进行 resume: ${existingSdkSessionId}`)
       }
-      }
 
       // 10. 构建 MCP 服务器配置 + 记忆工具 + 生图工具 + 自定义工具
       const mcpServers = this.buildMcpServers(workspaceSlug)


### PR DESCRIPTION
## Summary
- 移除 `agent-orchestrator.ts` 第 843 行多余的 `}` 闭合花括号，该花括号提前关闭了 `try` 块，导致 esbuild 构建时报错 `Expected "finally" but found "const"`。

## Test plan
- [x] `bun run build:main` 构建通过