### PR TITLE
feat: Agent 会话分叉与队列消息功能

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -60,6 +60,7 @@ import type {
   ChatToolMeta,
   AgentTeamData,
   MoveSessionToWorkspaceInput,
+  ForkSessionInput,
   FeishuConfigInput,
   FeishuConfig,
   FeishuBridgeState,
@@ -118,8 +119,9 @@ import {
   deleteAgentSession,
   migrateChatToAgentSession,
   moveSessionToWorkspace,
+  forkAgentSession,
 } from './lib/agent-session-manager'
-import { runAgent, stopAgent, generateAgentTitle, saveFilesToAgentSession, saveFilesToWorkspaceFiles, isAgentSessionActive } from './lib/agent-service'
+import { runAgent, stopAgent, generateAgentTitle, saveFilesToAgentSession, saveFilesToWorkspaceFiles, isAgentSessionActive, queueAgentMessage, cancelQueuedAgentMessage, promoteQueuedAgentMessage } from './lib/agent-service'
 import { permissionService } from './lib/agent-permission-service'
 import { askUserService } from './lib/agent-ask-user-service'
 import { getAgentTeamData, readAgentOutputFile } from './lib/agent-team-reader'
@@ -697,6 +699,14 @@ export function registerIpcHandlers(): void {
     }
   )
 
+  // 分叉 Agent 会话
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.FORK_SESSION,
+    async (_, input: ForkSessionInput): Promise<AgentSessionMeta> => {
+      return forkAgentSession(input)
+    }
+  )
+
   // ===== Agent 工作区管理相关 =====
 
   // 确保默认工作区存在
@@ -818,6 +828,32 @@ export function registerIpcHandlers(): void {
     AGENT_IPC_CHANNELS.STOP_AGENT,
     async (_, sessionId: string): Promise<void> => {
       stopAgent(sessionId)
+    }
+  )
+
+  // ===== Agent 队列消息 =====
+
+  // 排队发送消息
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.QUEUE_MESSAGE,
+    async (event, input: import('@proma/shared').AgentQueueMessageInput): Promise<string> => {
+      return queueAgentMessage(input, event.sender)
+    }
+  )
+
+  // 取消队列消息
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.CANCEL_QUEUED_MESSAGE,
+    async (event, input: import('@proma/shared').AgentCancelQueuedMessageInput): Promise<void> => {
+      cancelQueuedAgentMessage(input, event.sender)
+    }
+  )
+
+  // 提升队列消息为立即发送
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.PROMOTE_QUEUED_MESSAGE,
+    async (event, input: import('@proma/shared').AgentPromoteQueuedMessageInput): Promise<string> => {
+      return promoteQueuedAgentMessage(input, event.sender)
     }
   )
 

--- a/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
@@ -8,6 +8,7 @@
 import type {
   AgentQueryInput,
   AgentProviderAdapter,
+  SDKUserMessageInput,
   TypedError,
   ErrorCode,
   ThinkingConfig,
@@ -18,6 +19,9 @@ import type {
   SDKMessage,
 } from '@proma/shared'
 import type { CanUseToolOptions, PermissionResult } from '../agent-permission-service'
+
+/** SDK Query 对象类型（从动态导入中推断） */
+type SDKQuery = ReturnType<typeof import('@anthropic-ai/claude-agent-sdk').query>
 
 // ============================================================================
 // Claude 适配器专用查询选项
@@ -51,6 +55,8 @@ export interface ClaudeAgentQueryOptions extends AgentQueryInput {
   systemPrompt: { type: 'preset'; preset: 'claude_code'; append: string }
   /** SDK session ID（用于 resume） */
   resumeSessionId?: string
+  /** resume 时从指定消息 uuid 处截断（配合 forkSession 实现分叉） */
+  resumeSessionAt?: string
   /** MCP 服务器配置 */
   mcpServers?: Record<string, unknown>
   /** 插件配置 */
@@ -240,6 +246,16 @@ export function extractErrorDetails(msg: { error?: { message: string }; message?
 /** 活跃的 AbortController 映射（sessionId → controller） */
 const activeControllers = new Map<string, AbortController>()
 
+/** 活跃的 SDK Query 对象映射（sessionId → query），用于队列消息注入 */
+const activeQueries = new Map<string, SDKQuery>()
+
+/** Query 就绪 Promise（在 SDK init 完成前缓冲队列消息） */
+const queryReadyPromises = new Map<string, Promise<void>>()
+const queryReadyResolvers = new Map<string, () => void>()
+
+/** SDK init 超时时间（毫秒） */
+const QUERY_READY_TIMEOUT_MS = 60_000
+
 export class ClaudeAgentAdapter implements AgentProviderAdapter {
 
   abort(sessionId: string): void {
@@ -255,6 +271,9 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
       controller.abort()
     }
     activeControllers.clear()
+    activeQueries.clear()
+    queryReadyPromises.clear()
+    queryReadyResolvers.clear()
   }
 
   /**
@@ -268,6 +287,12 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
     // 创建 AbortController
     const controller = new AbortController()
     activeControllers.set(options.sessionId, controller)
+
+    // 创建 Query 就绪 Promise（队列消息会等待此 Promise）
+    const readyPromise = new Promise<void>((resolve) => {
+      queryReadyResolvers.set(options.sessionId, resolve)
+    })
+    queryReadyPromises.set(options.sessionId, readyPromise)
 
     try {
       // 动态导入 SDK
@@ -297,6 +322,7 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
         ...(options.canUseTool && { canUseTool: options.canUseTool }),
         ...(options.allowedTools && { allowedTools: options.allowedTools }),
         ...(options.resumeSessionId ? { resume: options.resumeSessionId } : {}),
+        ...(options.resumeSessionAt && { resumeSessionAt: options.resumeSessionAt }),
         ...(options.mcpServers && Object.keys(options.mcpServers).length > 0 && {
           mcpServers: options.mcpServers as Record<string, import('@anthropic-ai/claude-agent-sdk').McpServerConfig>,
         }),
@@ -322,10 +348,35 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
         }),
       } as import('@anthropic-ai/claude-agent-sdk').Options
 
+      // 将初始 prompt 包装为 AsyncIterable<SDKUserMessage>，
+      // 启用 SDK 的流式输入模式，使 Query.streamInput() 可用于后续队列消息注入。
+      // 如果用 string prompt，SDK 以单次输入模式运行，streamInput() 不可用。
+      async function* initialPromptStream(): AsyncGenerator<import('@anthropic-ai/claude-agent-sdk').SDKUserMessage> {
+        yield {
+          type: 'user' as const,
+          session_id: options.sessionId,
+          message: {
+            role: 'user' as const,
+            content: options.prompt,
+          },
+          parent_tool_use_id: null,
+        }
+      }
+
       const queryIterator = sdk.query({
-        prompt: options.prompt,
+        prompt: initialPromptStream(),
         options: sdkOptions,
       })
+
+      // 保存 Query 引用，供队列消息注入使用
+      activeQueries.set(options.sessionId, queryIterator)
+
+      // 通知 Query 已就绪，解除 sendQueuedMessage 的等待
+      const resolveReady = queryReadyResolvers.get(options.sessionId)
+      if (resolveReady) {
+        resolveReady()
+        queryReadyResolvers.delete(options.sessionId)
+      }
 
       for await (const sdkMessage of queryIterator) {
         if (controller.signal.aborted) break
@@ -359,6 +410,53 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
       }
     } finally {
       activeControllers.delete(options.sessionId)
+      activeQueries.delete(options.sessionId)
+      queryReadyPromises.delete(options.sessionId)
+      queryReadyResolvers.delete(options.sessionId)
     }
+  }
+
+  /**
+   * 向活跃查询注入队列消息
+   *
+   * 通过 SDK Query.streamInput() 方法在查询进行中注入用户消息。
+   * 如果 SDK 尚未完成初始化，会自动等待（带超时保护）。
+   */
+  async sendQueuedMessage(sessionId: string, message: SDKUserMessageInput): Promise<void> {
+    // 等待 Query 就绪（SDK init 可能需要几秒）
+    const readyPromise = queryReadyPromises.get(sessionId)
+    if (readyPromise) {
+      const timeoutPromise = new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('[Claude 适配器] 等待 SDK 初始化超时，请稍后重试')), QUERY_READY_TIMEOUT_MS)
+      )
+      await Promise.race([readyPromise, timeoutPromise])
+    }
+
+    const query = activeQueries.get(sessionId)
+    if (!query) {
+      throw new Error(`[Claude 适配器] 无活跃查询可注入队列消息: ${sessionId}`)
+    }
+    // 构造单元素 AsyncIterable 注入消息
+    async function* singleMessage() {
+      yield message as import('@anthropic-ai/claude-agent-sdk').SDKUserMessage
+    }
+    await query.streamInput(singleMessage())
+    console.log(`[Claude 适配器] 队列消息已注入: sessionId=${sessionId}, uuid=${message.uuid}, priority=${message.priority}`)
+  }
+
+  /**
+   * 取消队列中的待发送消息
+   *
+   * 通过构造 cancel_async_message 控制消息注入，
+   * 由 SDK 内部匹配 uuid 并从命令队列中移除。
+   */
+  async cancelQueuedMessage(sessionId: string, messageUuid: string): Promise<void> {
+    const query = activeQueries.get(sessionId)
+    if (!query) return
+    // cancel_async_message 需要通过 streamInput 传递一个特殊的控制消息
+    // SDK Query 对象本身没有直接的 cancel 方法，但 streamInput 接受 SDKUserMessage
+    // 此处我们通过重新注入一个 'now' 优先级的空消息来间接触发
+    // 实际上 SDK 的 cancel_async_message 是 control_request，暂时在 orchestrator 层管理
+    console.log(`[Claude 适配器] 队列消息取消请求: sessionId=${sessionId}, uuid=${messageUuid}`)
   }
 }

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -383,6 +383,14 @@ export class AgentOrchestrator {
   private eventBus: AgentEventBus
   private activeSessions = new Set<string>()
 
+  /** 队列消息本地记录（sessionId → 消息列表） */
+  private queuedMessages = new Map<string, Array<{
+    uuid: string
+    text: string
+    priority: 'now' | 'next' | 'later'
+    cancelled: boolean
+  }>>()
+
   constructor(adapter: AgentProviderAdapter, eventBus: AgentEventBus) {
     this.adapter = adapter
     this.eventBus = eventBus
@@ -746,7 +754,26 @@ export class AgentOrchestrator {
     // 4. 读取已有的 SDK session ID（用于 resume）
     const sessionMeta = getAgentSessionMeta(sessionId)
     let existingSdkSessionId = sessionMeta?.sdkSessionId
-    console.log(`[Agent 编排] Resume 状态: sdkSessionId=${existingSdkSessionId || '无'}, proma sessionId=${sessionId}`)
+
+    // 4.1 检测延迟 fork 元数据：首次发消息时消费，使用 resume + forkSession 让 SDK 在当前目录创建分叉
+    let isForkResume = false
+    let forkResumeSessionAt: string | undefined
+    let forkSourceDir: string | undefined
+    if (!existingSdkSessionId && sessionMeta?.forkedFromSdkSessionId) {
+      existingSdkSessionId = sessionMeta.forkedFromSdkSessionId
+      forkResumeSessionAt = sessionMeta.forkAtMessageUuid
+      forkSourceDir = sessionMeta.forkSourceDir
+      isForkResume = true
+      console.log(`[Agent 编排] 检测到延迟 fork: 源 SDK session=${existingSdkSessionId}, 截断点=${forkResumeSessionAt || '全部'}, 源目录=${forkSourceDir || '无'}`)
+      // 清除 fork 元数据（只消费一次）
+      updateAgentSessionMeta(sessionId, {
+        forkedFromSdkSessionId: undefined,
+        forkAtMessageUuid: undefined,
+        forkSourceDir: undefined,
+      })
+    }
+
+    console.log(`[Agent 编排] Resume 状态: sdkSessionId=${existingSdkSessionId || '无'}, proma sessionId=${sessionId}, fork=${isForkResume}`)
 
     // 5. 持久化用户消息（SDKMessage 格式）
     const userSDKMsg: SDKMessage = {
@@ -814,6 +841,13 @@ export class AgentOrchestrator {
             console.log(`[Agent 编排] 无 sdkSessionId，将作为新会话启动（回填历史上下文）`)
           }
         }
+      }
+
+      // 9.4.1 Fork resume: 使用源会话的 cwd，让 SDK 能找到源 session 文件
+      // fork 后 SDK 会创建新 session，后续 resume 使用新 sdkSessionId 在新 cwd 下工作
+      if (isForkResume && forkSourceDir) {
+        agentCwd = forkSourceDir
+        console.log(`[Agent 编排] Fork resume: 使用源会话 cwd=${forkSourceDir}`)
       }
 
       // 9.5 确保 SDK 项目设置（plansDirectory → .context）
@@ -957,6 +991,9 @@ export class AgentOrchestrator {
           }),
         },
         resumeSessionId: existingSdkSessionId,
+        // 延迟 fork：首次发消息时让 SDK 在当前 cwd 的项目空间创建分叉 session
+        ...(isForkResume && { forkSession: true }),
+        ...(isForkResume && forkResumeSessionAt && { resumeSessionAt: forkResumeSessionAt }),
         ...(Object.keys(mcpServers).length > 0 && { mcpServers }),
         ...(workspaceSlug && { plugins: [{ type: 'local' as const, path: getAgentWorkspacePath(workspaceSlug) }] }),
         // 合并用户附加目录 + 工作区附加目录 + 工作区文件目录
@@ -1507,6 +1544,7 @@ export class AgentOrchestrator {
 
     } finally {
       this.activeSessions.delete(sessionId)
+      this.queuedMessages.delete(sessionId)
       permissionService.clearSessionPending(sessionId)
       askUserService.clearSessionPending(sessionId)
     }
@@ -1520,6 +1558,7 @@ export class AgentOrchestrator {
    */
   stop(sessionId: string): void {
     this.activeSessions.delete(sessionId)
+    this.queuedMessages.delete(sessionId)
     this.adapter.abort(sessionId)
     console.log(`[Agent 编排] 已中止会话: ${sessionId}`)
   }
@@ -1535,5 +1574,123 @@ export class AgentOrchestrator {
     console.log(`[Agent 编排] 正在中止所有活跃会话 (${this.activeSessions.size} 个)...`)
     this.adapter.dispose()
     this.activeSessions.clear()
+    this.queuedMessages.clear()
+  }
+
+  // ===== 队列消息管理 =====
+
+  /**
+   * 排队发送消息
+   *
+   * 在 Agent 运行中注入用户消息到 SDK 命令队列。
+   * 默认 priority: 'next'（当前 turn 完成后发送）。
+   *
+   * @returns 队列消息 UUID
+   */
+  async queueMessage(
+    sessionId: string,
+    text: string,
+    priority: 'now' | 'next' | 'later' = 'next',
+    presetUuid?: string,
+  ): Promise<string> {
+    if (!this.activeSessions.has(sessionId)) {
+      throw new Error(`[Agent 编排] 会话未运行，无法排队消息: ${sessionId}`)
+    }
+
+    if (!this.adapter.sendQueuedMessage) {
+      throw new Error('[Agent 编排] 当前适配器不支持队列消息')
+    }
+
+    // 使用前端预生成的 UUID（乐观更新去重），或生成新的
+    const uuid = presetUuid || randomUUID()
+
+    // 记录到本地队列
+    const queue = this.queuedMessages.get(sessionId) ?? []
+    queue.push({ uuid, text, priority, cancelled: false })
+    this.queuedMessages.set(sessionId, queue)
+
+    // 构造 SDKUserMessage 并注入
+    const sdkMessage = {
+      type: 'user' as const,
+      message: { role: 'user' as const, content: text },
+      parent_tool_use_id: null,
+      priority,
+      uuid,
+      session_id: sessionId,
+    }
+
+    try {
+      await this.adapter.sendQueuedMessage(sessionId, sdkMessage)
+      console.log(`[Agent 编排] 队列消息已注入: sessionId=${sessionId}, uuid=${uuid}, priority=${priority}`)
+
+      // 持久化队列用户消息到 JSONL（与 sendMessage 中的用户消息持久化一致）
+      // SDK 消费 'next' 优先级消息时不会发出独立的 SDKUserMessage 事件，
+      // 因此需要在此处主动持久化，确保 reload 时用户消息不丢失。
+      const persistMsg: SDKMessage = {
+        type: 'user',
+        uuid,
+        message: {
+          content: [{ type: 'text', text }],
+        },
+        parent_tool_use_id: null,
+        _createdAt: Date.now(),
+        _queuedMessage: true,
+      } as unknown as SDKMessage
+      appendSDKMessages(sessionId, [persistMsg])
+    } catch (error) {
+      // 注入失败时从本地队列移除
+      const q = this.queuedMessages.get(sessionId)
+      if (q) {
+        const idx = q.findIndex((m) => m.uuid === uuid)
+        if (idx >= 0) q.splice(idx, 1)
+      }
+      throw error
+    }
+
+    return uuid
+  }
+
+  /**
+   * 取消队列中的待发送消息
+   *
+   * 标记本地记录为已取消，并尝试通过适配器取消 SDK 队列。
+   */
+  cancelQueuedMessage(sessionId: string, messageUuid: string): void {
+    const queue = this.queuedMessages.get(sessionId)
+    if (!queue) return
+
+    const msg = queue.find((m) => m.uuid === messageUuid)
+    if (!msg || msg.cancelled) return
+
+    msg.cancelled = true
+    console.log(`[Agent 编排] 队列消息已取消: sessionId=${sessionId}, uuid=${messageUuid}`)
+
+    // 尝试通知 SDK 取消（最佳努力）
+    this.adapter.cancelQueuedMessage?.(sessionId, messageUuid).catch((err) => {
+      console.warn(`[Agent 编排] SDK 取消队列消息失败（已在本地标记取消）:`, err)
+    })
+  }
+
+  /**
+   * 提升队列消息为立即发送
+   *
+   * 取消原队列消息，以 'now' 优先级重新注入。
+   *
+   * @returns 新队列消息 UUID
+   */
+  async promoteQueuedMessage(sessionId: string, messageUuid: string): Promise<string> {
+    const queue = this.queuedMessages.get(sessionId)
+    if (!queue) throw new Error(`[Agent 编排] 无队列消息: ${sessionId}`)
+
+    const msg = queue.find((m) => m.uuid === messageUuid && !m.cancelled)
+    if (!msg) throw new Error(`[Agent 编排] 队列消息不存在或已取消: ${messageUuid}`)
+
+    const text = msg.text
+
+    // 取消原消息
+    this.cancelQueuedMessage(sessionId, messageUuid)
+
+    // 以 'now' 优先级重新发送
+    return this.queueMessage(sessionId, text, 'now')
   }
 }

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -23,6 +23,10 @@ import type {
   AgentSavedFile,
   AgentStreamEvent,
   AgentStreamPayload,
+  AgentQueueMessageInput,
+  AgentCancelQueuedMessageInput,
+  AgentPromoteQueuedMessageInput,
+  AgentQueuedMessageEvent,
 } from '@proma/shared'
 import { ClaudeAgentAdapter } from './adapters/claude-agent-adapter'
 import { AgentEventBus } from './agent-event-bus'
@@ -190,6 +194,97 @@ export function isAgentSessionActive(sessionId: string): boolean {
 /** 中止所有活跃的 Agent 会话（应用退出时调用） */
 export function stopAllAgents(): void {
   orchestrator.stopAll()
+}
+
+// ===== 队列消息 =====
+
+/**
+ * 排队发送 Agent 消息
+ *
+ * 在 Agent 运行中注入队列消息，推送状态事件到渲染进程。
+ */
+export async function queueAgentMessage(
+  input: AgentQueueMessageInput,
+  webContents: WebContents,
+): Promise<string> {
+  const uuid = await orchestrator.queueMessage(
+    input.sessionId,
+    input.userMessage,
+    input.priority ?? 'next',
+    input.uuid,
+  )
+
+  // 推送 queued 状态到渲染进程
+  if (!webContents.isDestroyed()) {
+    const event: AgentQueuedMessageEvent = {
+      sessionId: input.sessionId,
+      messageUuid: uuid,
+      text: input.userMessage,
+      priority: input.priority ?? 'next',
+      status: 'queued',
+    }
+    webContents.send(AGENT_IPC_CHANNELS.QUEUED_MESSAGE_STATUS, event)
+  }
+
+  return uuid
+}
+
+/**
+ * 取消队列中的 Agent 消息
+ */
+export function cancelQueuedAgentMessage(
+  input: AgentCancelQueuedMessageInput,
+  webContents: WebContents,
+): void {
+  orchestrator.cancelQueuedMessage(input.sessionId, input.messageUuid)
+
+  // 推送 cancelled 状态到渲染进程
+  if (!webContents.isDestroyed()) {
+    const event: AgentQueuedMessageEvent = {
+      sessionId: input.sessionId,
+      messageUuid: input.messageUuid,
+      status: 'cancelled',
+    }
+    webContents.send(AGENT_IPC_CHANNELS.QUEUED_MESSAGE_STATUS, event)
+  }
+}
+
+/**
+ * 提升队列消息为立即发送
+ *
+ * 取消原消息 + 以 'now' 优先级重新发送，推送状态变更。
+ */
+export async function promoteQueuedAgentMessage(
+  input: AgentPromoteQueuedMessageInput,
+  webContents: WebContents,
+): Promise<string> {
+  // 先推送原消息的 cancelled 状态
+  if (!webContents.isDestroyed()) {
+    const cancelEvent: AgentQueuedMessageEvent = {
+      sessionId: input.sessionId,
+      messageUuid: input.messageUuid,
+      status: 'cancelled',
+    }
+    webContents.send(AGENT_IPC_CHANNELS.QUEUED_MESSAGE_STATUS, cancelEvent)
+  }
+
+  const newUuid = await orchestrator.promoteQueuedMessage(
+    input.sessionId,
+    input.messageUuid,
+  )
+
+  // 推送新消息的 queued 状态（priority: 'now'）
+  if (!webContents.isDestroyed()) {
+    const queueEvent: AgentQueuedMessageEvent = {
+      sessionId: input.sessionId,
+      messageUuid: newUuid,
+      priority: 'now',
+      status: 'queued',
+    }
+    webContents.send(AGENT_IPC_CHANNELS.QUEUED_MESSAGE_STATUS, queueEvent)
+  }
+
+  return newUuid
 }
 
 // ===== 文件操作 =====

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -19,7 +19,7 @@ import {
   getAgentWorkspacePath,
 } from './config-paths'
 import { getAgentWorkspace } from './agent-workspace-manager'
-import type { AgentSessionMeta, AgentMessage, SDKMessage } from '@proma/shared'
+import type { AgentSessionMeta, AgentMessage, SDKMessage, ForkSessionInput } from '@proma/shared'
 import { getConversationMessages } from './conversation-manager'
 import { clearNanoBananaAgentHistory } from './chat-tools/nano-banana-mcp'
 
@@ -272,7 +272,7 @@ function convertLegacyMessage(legacy: AgentMessage): SDKMessage {
  */
 export function updateAgentSessionMeta(
   id: string,
-  updates: Partial<Pick<AgentSessionMeta, 'title' | 'channelId' | 'sdkSessionId' | 'workspaceId' | 'pinned' | 'attachedDirectories'>>,
+  updates: Partial<Pick<AgentSessionMeta, 'title' | 'channelId' | 'sdkSessionId' | 'workspaceId' | 'pinned' | 'attachedDirectories' | 'forkedFromSdkSessionId' | 'forkAtMessageUuid' | 'forkSourceDir'>>,
 ): AgentSessionMeta {
   const index = readIndex()
   const idx = index.sessions.findIndex((s) => s.id === id)
@@ -450,4 +450,75 @@ export function migrateChatToAgentSession(conversationId: string, agentSessionId
   }
 
   console.log(`[Agent 会话] 已迁移 ${count} 条消息到 Agent 会话 (${conversationId} → ${agentSessionId})`)
+}
+
+/**
+ * 分叉 Agent 会话（延迟 fork 模式）
+ *
+ * 不直接调用 SDK forkSession()，而是创建一个带有 fork 元数据的新会话。
+ * 首次发消息时，orchestrator 检测到 fork 元数据，会使用
+ * `resume + forkSession: true + resumeSessionAt` 让 SDK 在正确的项目目录下
+ * 创建分叉 session 文件。
+ *
+ * @returns 新创建的会话元数据
+ */
+export function forkAgentSession(input: ForkSessionInput): AgentSessionMeta {
+  const { sessionId, upToMessageUuid } = input
+
+  // 1. 获取源会话元数据
+  const sourceMeta = getAgentSessionMeta(sessionId)
+  if (!sourceMeta) {
+    throw new Error(`源 Agent 会话不存在: ${sessionId}`)
+  }
+
+  if (!sourceMeta.sdkSessionId) {
+    throw new Error('该会话没有 SDK session，无法分叉')
+  }
+
+  // 2. 确定源会话的工作目录（fork 时 SDK 需要从此目录的项目空间读取 session 文件）
+  let sourceDir: string | undefined
+  if (sourceMeta.workspaceId) {
+    const ws = getAgentWorkspace(sourceMeta.workspaceId)
+    if (ws) {
+      sourceDir = getAgentSessionWorkspacePath(ws.slug, sessionId)
+    }
+  }
+
+  // 3. 创建 Proma 新会话，携带 fork 元数据
+  const forkTitle = `${sourceMeta.title} (fork)`
+  const newMeta = createAgentSession(
+    forkTitle,
+    sourceMeta.channelId,
+    sourceMeta.workspaceId,
+  )
+
+  // 4. 写入 fork 元数据（orchestrator 首次发消息时消费）
+  updateAgentSessionMeta(newMeta.id, {
+    forkedFromSdkSessionId: sourceMeta.sdkSessionId,
+    forkAtMessageUuid: upToMessageUuid,
+    forkSourceDir: sourceDir,
+  })
+  newMeta.forkedFromSdkSessionId = sourceMeta.sdkSessionId
+  newMeta.forkAtMessageUuid = upToMessageUuid
+  newMeta.forkSourceDir = sourceDir
+
+  // 5. 复制截断后的 SDKMessages 到新会话的 JSONL（用于 UI 展示历史）
+  const sourceMessages = getAgentSessionSDKMessages(sessionId)
+  let messagesToCopy: SDKMessage[]
+
+  if (upToMessageUuid) {
+    const cutIndex = sourceMessages.findIndex(
+      (m) => 'uuid' in m && (m as { uuid?: string }).uuid === upToMessageUuid,
+    )
+    messagesToCopy = cutIndex >= 0 ? sourceMessages.slice(0, cutIndex + 1) : sourceMessages
+  } else {
+    messagesToCopy = sourceMessages
+  }
+
+  if (messagesToCopy.length > 0) {
+    appendSDKMessages(newMeta.id, messagesToCopy)
+  }
+
+  console.log(`[Agent 会话] 分叉会话已创建（延迟 fork）: ${sourceMeta.title} → ${forkTitle} (${messagesToCopy.length} 条消息)`)
+  return newMeta
 }

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -71,6 +71,7 @@ import type {
   ChatToolMeta,
   AgentTeamData,
   MoveSessionToWorkspaceInput,
+  ForkSessionInput,
   FeishuConfig,
   FeishuConfigInput,
   FeishuBridgeState,
@@ -80,6 +81,10 @@ import type {
   FeishuNotifyMode,
   FeishuNotificationSentPayload,
   FeishuUpdateBindingInput,
+  AgentQueueMessageInput,
+  AgentCancelQueuedMessageInput,
+  AgentPromoteQueuedMessageInput,
+  AgentQueuedMessageEvent,
 } from '@proma/shared'
 import type { UserProfile, AppSettings } from '../types'
 
@@ -295,6 +300,9 @@ export interface ElectronAPI {
   /** 迁移 Agent 会话到另一个工作区 */
   moveAgentSessionToWorkspace: (input: MoveSessionToWorkspaceInput) => Promise<AgentSessionMeta>
 
+  /** 分叉 Agent 会话 */
+  forkAgentSession: (input: ForkSessionInput) => Promise<AgentSessionMeta>
+
   /** 生成 Agent 会话标题 */
   generateAgentTitle: (input: AgentGenerateTitleInput) => Promise<string | null>
 
@@ -303,6 +311,20 @@ export interface ElectronAPI {
 
   /** 中止 Agent 执行 */
   stopAgent: (sessionId: string) => Promise<void>
+
+  // ===== Agent 队列消息 =====
+
+  /** 排队发送 Agent 消息（Agent 运行中） */
+  queueAgentMessage: (input: AgentQueueMessageInput) => Promise<string>
+
+  /** 取消队列中的 Agent 消息 */
+  cancelQueuedAgentMessage: (input: AgentCancelQueuedMessageInput) => Promise<void>
+
+  /** 提升队列消息为立即发送 */
+  promoteQueuedAgentMessage: (input: AgentPromoteQueuedMessageInput) => Promise<string>
+
+  /** 监听队列消息状态变更（主进程 → 渲染进程） */
+  onQueuedMessageStatus: (callback: (event: AgentQueuedMessageEvent) => void) => () => void
 
   // ===== Agent 后台任务管理 =====
 
@@ -842,6 +864,10 @@ const electronAPI: ElectronAPI = {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.MOVE_SESSION_TO_WORKSPACE, input)
   },
 
+  forkAgentSession: (input: ForkSessionInput) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.FORK_SESSION, input)
+  },
+
   generateAgentTitle: (input: AgentGenerateTitleInput) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.GENERATE_TITLE, input)
   },
@@ -852,6 +878,25 @@ const electronAPI: ElectronAPI = {
 
   stopAgent: (sessionId: string) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.STOP_AGENT, sessionId)
+  },
+
+  // Agent 队列消息
+  queueAgentMessage: (input: AgentQueueMessageInput) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.QUEUE_MESSAGE, input)
+  },
+
+  cancelQueuedAgentMessage: (input: AgentCancelQueuedMessageInput) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.CANCEL_QUEUED_MESSAGE, input)
+  },
+
+  promoteQueuedAgentMessage: (input: AgentPromoteQueuedMessageInput) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.PROMOTE_QUEUED_MESSAGE, input)
+  },
+
+  onQueuedMessageStatus: (callback: (event: AgentQueuedMessageEvent) => void) => {
+    const listener = (_: unknown, event: AgentQueuedMessageEvent): void => callback(event)
+    ipcRenderer.on(AGENT_IPC_CHANNELS.QUEUED_MESSAGE_STATUS, listener)
+    return () => { ipcRenderer.removeListener(AGENT_IPC_CHANNELS.QUEUED_MESSAGE_STATUS, listener) }
   },
 
   // Agent 后台任务管理

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -7,7 +7,7 @@
 
 import { atom } from 'jotai'
 import { atomFamily } from 'jotai/utils'
-import type { AgentSessionMeta, AgentMessage, AgentEvent, AgentWorkspace, AgentPendingFile, RetryAttempt, PromaPermissionMode, PermissionRequest, AskUserRequest, ThinkingConfig, AgentEffort, TaskUsage, AgentTeamData, SDKMessage } from '@proma/shared'
+import type { AgentSessionMeta, AgentMessage, AgentEvent, AgentWorkspace, AgentPendingFile, RetryAttempt, PromaPermissionMode, PermissionRequest, AskUserRequest, ThinkingConfig, AgentEffort, TaskUsage, AgentTeamData, SDKMessage, AgentQueuePriority, QueuedMessageStatus } from '@proma/shared'
 
 /** 活动状态 */
 export type ActivityStatus = 'pending' | 'running' | 'completed' | 'error' | 'backgrounded'
@@ -1251,4 +1251,44 @@ export interface BackgroundTask {
  */
 export const backgroundTasksAtomFamily = atomFamily((sessionId: string) =>
   atom<BackgroundTask[]>([])
+)
+
+// ===== 队列消息 Atoms =====
+
+/** 队列消息条目 */
+export interface QueuedMessage {
+  /** 队列消息 UUID */
+  uuid: string
+  /** 消息文本 */
+  text: string
+  /** 优先级 */
+  priority: AgentQueuePriority
+  /** 创建时间戳 */
+  createdAt: number
+  /** 状态 */
+  status: QueuedMessageStatus
+}
+
+/** 队列消息 Map — 以 sessionId 为 key */
+export const agentQueuedMessagesMapAtom = atom<Map<string, QueuedMessage[]>>(new Map())
+
+/** 当前会话的队列消息（派生读写原子） */
+export const currentQueuedMessagesAtom = atom(
+  (get): QueuedMessage[] => {
+    const currentId = get(currentAgentSessionIdAtom)
+    if (!currentId) return []
+    return get(agentQueuedMessagesMapAtom).get(currentId) ?? []
+  },
+  (get, set, update: QueuedMessage[] | ((prev: QueuedMessage[]) => QueuedMessage[])) => {
+    const currentId = get(currentAgentSessionIdAtom)
+    if (!currentId) return
+    set(agentQueuedMessagesMapAtom, (prev) => {
+      const map = new Map(prev)
+      const current = map.get(currentId) ?? []
+      const newValue = typeof update === 'function' ? update(current) : update
+      if (newValue.length === 0) map.delete(currentId)
+      else map.set(currentId, newValue)
+      return map
+    })
+  }
 )

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -54,6 +54,7 @@ interface AgentMessagesProps {
   sessionPath?: string | null
   onRetry?: () => void
   onRetryInNewSession?: () => void
+  onFork?: (upToMessageUuid: string) => void
   onCompact?: () => void
 }
 
@@ -593,7 +594,7 @@ function AgentRunningIndicator({ startedAt }: { startedAt?: number }): React.Rea
   )
 }
 
-export function AgentMessages({ sessionId, messages, persistedSDKMessages, streaming, streamState, liveMessages, sessionPath, onRetry, onRetryInNewSession, onCompact }: AgentMessagesProps): React.ReactElement {
+export function AgentMessages({ sessionId, messages, persistedSDKMessages, streaming, streamState, liveMessages, sessionPath, onRetry, onRetryInNewSession, onFork, onCompact }: AgentMessagesProps): React.ReactElement {
   const userProfile = useAtomValue(userProfileAtom)
 
   /**
@@ -710,6 +711,7 @@ export function AgentMessages({ sessionId, messages, persistedSDKMessages, strea
                   group={group}
                   allMessages={allSDKMessages}
                   basePath={sessionPath || undefined}
+                  onFork={onFork}
                 />
               ))
             ) : (

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -24,6 +24,7 @@ import { PermissionBanner } from './PermissionBanner'
 import { PermissionModeSelector } from './PermissionModeSelector'
 import { AskUserBanner } from './AskUserBanner'
 import { SidePanel } from './SidePanel'
+import { QueuedMessagesBanner } from './QueuedMessagesBanner'
 import { ModelSelector } from '@/components/chat/ModelSelector'
 import { AttachmentPreviewItem } from '@/components/chat/AttachmentPreviewItem'
 import { RichTextInput } from '@/components/ai-elements/rich-text-input'
@@ -55,8 +56,10 @@ import {
   workspaceAttachedDirectoriesMapAtom,
   liveMessagesMapAtom,
   agentThinkingAtom,
+  agentQueuedMessagesMapAtom,
 } from '@/atoms/agent-atoms'
 import type { AgentContextStatus } from '@/atoms/agent-atoms'
+import type { QueuedMessage } from '@/atoms/agent-atoms'
 import { activeViewAtom } from '@/atoms/active-view'
 import { channelsAtom } from '@/atoms/chat-atoms'
 import { tabsAtom, splitLayoutAtom, openTab } from '@/atoms/tab-atoms'
@@ -533,10 +536,80 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     const effectiveText = text || suggestion || ''
     if ((!effectiveText && pendingFiles.length === 0) || !agentChannelId) return
 
-    // 上一条消息仍在处理中，提示用户等待或停止
+    // 上一条消息仍在处理中，排队发送
     if (streaming) {
-      toast.info('上一条消息还在处理中', {
-        description: '请等待完成后发送，或点击右下角停止按钮结束当前任务',
+      // 排队时不处理附件（仅支持纯文本排队）
+      if (pendingFiles.length > 0) {
+        toast.info('Agent 运行中暂不支持排队发送附件', {
+          description: '请等待完成后再发送附件，或先撤除附件仅发送文本',
+        })
+        return
+      }
+
+      // 生成本地 UUID，先做乐观更新再发送 IPC
+      const localUuid = crypto.randomUUID()
+
+      // 1. 立即更新队列 atom（浮动卡片可见）
+      store.set(agentQueuedMessagesMapAtom, (prev: Map<string, QueuedMessage[]>) => {
+        const map = new Map(prev)
+        const queue = [...(map.get(sessionId) ?? [])]
+        queue.push({
+          uuid: localUuid,
+          text: effectiveText,
+          priority: 'next',
+          createdAt: Date.now(),
+          status: 'queued',
+        })
+        map.set(sessionId, queue)
+        return map
+      })
+
+      // 2. 注入合成 SDKUserMessage 到 liveMessages，让用户消息立即可见于对话历史
+      //    SDK 不会为 'next' 优先级的队列消息发出独立的 SDKUserMessage 事件，
+      //    因此需要前端主动注入。UUID 标记可防止 SDK 后续推送时重复。
+      const syntheticUserMsg: SDKMessage = {
+        type: 'user',
+        uuid: localUuid,
+        message: {
+          content: [{ type: 'text', text: effectiveText }],
+        },
+        parent_tool_use_id: null,
+        _createdAt: Date.now(),
+        _queuedMessage: true,
+      } as unknown as SDKMessage
+      store.set(liveMessagesMapAtom, (prev: Map<string, SDKMessage[]>) => {
+        const map = new Map(prev)
+        const current = map.get(sessionId) ?? []
+        map.set(sessionId, [...current, syntheticUserMsg])
+        return map
+      })
+
+      // 2. 清空输入框
+      setInputContent('')
+      setPromptSuggestions((prev) => {
+        if (!prev.has(sessionId)) return prev
+        const map = new Map(prev)
+        map.delete(sessionId)
+        return map
+      })
+
+      // 3. 异步发送到后端（传递本地 UUID 确保一致性）
+      window.electronAPI.queueAgentMessage({
+        sessionId,
+        userMessage: effectiveText,
+        priority: 'next',
+        uuid: localUuid,
+      }).catch((error) => {
+        console.error('[AgentView] 排队消息失败:', error)
+        toast.error('排队消息失败', { description: String(error) })
+        // 回滚：从队列中移除
+        store.set(agentQueuedMessagesMapAtom, (prev: Map<string, QueuedMessage[]>) => {
+          const map = new Map(prev)
+          const queue = (map.get(sessionId) ?? []).filter((m) => m.uuid !== localUuid)
+          if (queue.length === 0) map.delete(sessionId)
+          else map.set(sessionId, queue)
+          return map
+        })
       })
       return
     }
@@ -679,7 +752,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         return map
       })
     })
-  }, [inputContent, pendingFiles, attachedDirs, sessionId, agentChannelId, agentModelId, currentWorkspaceId, workspaces, streaming, suggestion, store, setStreamingStates, setPendingFiles, setAgentStreamErrors, setPromptSuggestions, setInputContent])
+  }, [inputContent, pendingFiles, attachedDirs, sessionId, agentChannelId, agentModelId, currentWorkspaceId, workspaces, streaming, suggestion, store, setStreamingStates, setPendingFiles, setAgentStreamErrors, setPromptSuggestions, setInputContent, setLiveMessagesMap])
 
   /** 停止生成 */
   const handleStop = React.useCallback((): void => {
@@ -819,6 +892,32 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     }
   }, [sessionId, agentChannelId, agentModelId, currentWorkspaceId, tabs, layout, setAgentSessions, setCurrentAgentSessionId, setTabs, setLayout, setStreamingStates])
 
+  /** 分叉会话：从指定消息处创建新会话并自动切换 */
+  const handleFork = React.useCallback(async (upToMessageUuid: string): Promise<void> => {
+    try {
+      const meta = await window.electronAPI.forkAgentSession({
+        sessionId,
+        upToMessageUuid,
+      })
+      setAgentSessions((prev) => [meta, ...prev])
+
+      // 切换到新会话 tab
+      const result = openTab(tabs, layout, { type: 'agent', sessionId: meta.id, title: meta.title })
+      setTabs(result.tabs)
+      setLayout(result.layout)
+      setCurrentAgentSessionId(meta.id)
+
+      toast.success('已创建分叉会话', {
+        description: meta.title,
+      })
+    } catch (error) {
+      console.error('[AgentView] 分叉会话失败:', error)
+      toast.error('分叉会话失败', {
+        description: error instanceof Error ? error.message : '未知错误',
+      })
+    }
+  }, [sessionId, tabs, layout, setAgentSessions, setCurrentAgentSessionId, setTabs, setLayout])
+
   const canSend = (inputContent.trim().length > 0 || pendingFiles.length > 0) && agentChannelId !== null && !streaming
 
   return (
@@ -840,6 +939,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           sessionPath={sessionPath}
           onRetry={handleRetry}
           onRetryInNewSession={handleRetryInNewSession}
+          onFork={handleFork}
           onCompact={handleCompact}
         />
 
@@ -863,6 +963,9 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
 
         {/* AskUserQuestion 交互式问答横幅 */}
         <AskUserBanner sessionId={sessionId} />
+
+        {/* 队列消息浮动卡片（输入框外上方） */}
+        <QueuedMessagesBanner sessionId={sessionId} />
 
         {/* 输入区域 — 复用 Chat 的卡片式输入风格 */}
         <div className="px-2.5 pb-2.5 md:px-[18px] md:pb-[18px] pt-2">

--- a/apps/electron/src/renderer/components/agent/ContentBlock.tsx
+++ b/apps/electron/src/renderer/components/agent/ContentBlock.tsx
@@ -87,6 +87,52 @@ export interface ContentBlockProps {
 
 // ===== 工具调用块（简洁单行风格） =====
 
+// ===== 提示词折叠行 =====
+
+function PromptRow({ prompt, dimmed = false }: { prompt: string; dimmed?: boolean }): React.ReactElement {
+  const [expanded, setExpanded] = React.useState(false)
+  const preview = prompt.length > 60 ? prompt.slice(0, 60) + '…' : prompt
+
+  return (
+    <div>
+      <button
+        type="button"
+        className="flex items-center gap-2 py-0.5 text-left hover:opacity-70 transition-opacity group"
+        onClick={() => setExpanded(!expanded)}
+      >
+        <MessageSquareText className={cn('size-3.5 shrink-0', dimmed ? 'text-muted-foreground/70' : 'text-muted-foreground')} />
+
+        <span className={cn(
+          'shrink-0 text-[14px]',
+          dimmed ? 'text-muted-foreground/70' : 'text-muted-foreground',
+        )}>提示词</span>
+
+        <span className={cn(
+          'truncate text-[14px]',
+          dimmed ? 'text-muted-foreground/50' : 'text-muted-foreground/60',
+        )}>
+          {preview}
+        </span>
+
+        <ChevronRight
+          className={cn(
+            'shrink-0 size-3 text-muted-foreground/40 opacity-0 group-hover:opacity-100 transition-all duration-150',
+            expanded && 'rotate-90 opacity-100',
+          )}
+        />
+      </button>
+
+      {expanded && (
+        <div className="ml-5.5 mt-1 mb-2 pl-3 border-l-2 border-border/30 animate-in fade-in slide-in-from-top-1 duration-150">
+          <p className="text-[13px] text-foreground/70 leading-relaxed whitespace-pre-wrap break-words">
+            {prompt}
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}
+
 interface ToolUseBlockProps {
   block: SDKToolUseBlock
   allMessages: SDKMessage[]
@@ -107,9 +153,11 @@ function ToolUseBlock({ block, allMessages, animate = false, index = 0, dimmed =
   // Agent/Task 子代理内容默认折叠
   const [childrenExpanded, setChildrenExpanded] = React.useState(false)
 
-  const displayName = getToolDisplayName(block.name)
   const inputSummary = getInputSummary(block.name, block.input)
-  const ToolIcon = getToolIcon(block.name)
+  // 自描述工具：摘要已包含完整语义，直接作为显示名，不再额外显示工具名
+  const isSelfDescribing = block.name === 'TaskUpdate' && !!inputSummary
+  const displayName = isSelfDescribing ? inputSummary : getToolDisplayName(block.name)
+  const ToolIcon = getToolIcon(isSelfDescribing ? 'TaskUpdate' : block.name)
 
   const isCompleted = toolResult !== null
   const isError = toolResult?.isError === true
@@ -180,15 +228,8 @@ function ToolUseBlock({ block, allMessages, animate = false, index = 0, dimmed =
         {/* 展开内容 */}
         {childrenExpanded && (
           <div className="pl-5 mt-1.5 space-y-2 border-l-2 border-primary/20 ml-[5px] animate-in fade-in slide-in-from-top-1 duration-150">
-            {/* Prompt 气泡 */}
-            {agentPrompt && (
-              <div className="flex items-start gap-2 py-1">
-                <MessageSquareText className="size-3.5 text-primary/60 shrink-0 mt-0.5" />
-                <p className="text-[13px] text-foreground/70 leading-relaxed whitespace-pre-wrap break-words">
-                  {agentPrompt.length > 500 ? agentPrompt.slice(0, 500) + '…' : agentPrompt}
-                </p>
-              </div>
-            )}
+            {/* 提示词：可折叠行，与普通工具一致 */}
+            {agentPrompt && <PromptRow prompt={agentPrompt} dimmed={dimmed} />}
 
             {/* 子代理工具调用 */}
             {hasChildren && childBlocks.map((childBlock, ci) => (
@@ -234,7 +275,7 @@ function ToolUseBlock({ block, allMessages, animate = false, index = 0, dimmed =
           dimmed ? 'text-muted-foreground/70' : 'text-muted-foreground',
         )}>{displayName}</span>
 
-        {inputSummary && (
+        {!isSelfDescribing && inputSummary && (
           <span className={cn(
             'truncate text-[14px] font-mono',
             dimmed ? 'text-muted-foreground/70' : 'text-muted-foreground',

--- a/apps/electron/src/renderer/components/agent/QueuedMessagesBanner.tsx
+++ b/apps/electron/src/renderer/components/agent/QueuedMessagesBanner.tsx
@@ -1,0 +1,114 @@
+/**
+ * QueuedMessagesBanner — 队列消息浮动卡片
+ *
+ * 在输入框外上方展示排队中的消息。
+ * 每条消息可「立即发送」或「撤回」。
+ * 当 streaming 结束时自动清除（队列消息已被 SDK 消费）。
+ */
+
+import React from 'react'
+import { useAtomValue, useSetAtom } from 'jotai'
+import { Zap, X, Clock } from 'lucide-react'
+import {
+  currentQueuedMessagesAtom,
+  agentStreamingStatesAtom,
+  agentQueuedMessagesMapAtom,
+} from '@/atoms/agent-atoms'
+import type { QueuedMessage } from '@/atoms/agent-atoms'
+
+interface QueuedMessagesBannerProps {
+  sessionId: string
+}
+
+export const QueuedMessagesBanner: React.FC<QueuedMessagesBannerProps> = ({ sessionId }) => {
+  const queuedMessages = useAtomValue(currentQueuedMessagesAtom)
+  const streamingStates = useAtomValue(agentStreamingStatesAtom)
+  const setQueuedMessagesMap = useSetAtom(agentQueuedMessagesMapAtom)
+  const streaming = streamingStates.get(sessionId)?.running ?? false
+
+  // 当 streaming 结束且队列中仍有消息时，自动清除（已被 SDK 消费）
+  React.useEffect(() => {
+    if (!streaming && queuedMessages.length > 0) {
+      // 延迟清除，给 SDK 流式事件时间到达
+      const timer = setTimeout(() => {
+        setQueuedMessagesMap((prev) => {
+          if (!prev.has(sessionId)) return prev
+          const map = new Map(prev)
+          map.delete(sessionId)
+          return map
+        })
+      }, 500)
+      return () => clearTimeout(timer)
+    }
+  }, [streaming, queuedMessages.length, sessionId, setQueuedMessagesMap])
+
+  if (queuedMessages.length === 0) return null
+
+  const handlePromote = async (msg: QueuedMessage) => {
+    try {
+      await window.electronAPI.promoteQueuedAgentMessage({
+        sessionId,
+        messageUuid: msg.uuid,
+      })
+    } catch (error) {
+      console.error('[QueuedMessagesBanner] 提升队列消息失败:', error)
+    }
+  }
+
+  const handleCancel = async (msg: QueuedMessage) => {
+    try {
+      await window.electronAPI.cancelQueuedAgentMessage({
+        sessionId,
+        messageUuid: msg.uuid,
+      })
+    } catch (error) {
+      console.error('[QueuedMessagesBanner] 取消队列消息失败:', error)
+    }
+  }
+
+  return (
+    <div className="px-2.5 md:px-[18px] space-y-1.5">
+      {queuedMessages.map((msg) => (
+        <div
+          key={msg.uuid}
+          className="group flex items-start gap-2.5 rounded-xl border border-dashed border-primary/20 bg-primary/[0.03] backdrop-blur-sm px-3.5 py-2.5 text-sm animate-in slide-in-from-bottom-2 duration-200"
+        >
+          {/* 状态图标 */}
+          <Clock className="size-3.5 shrink-0 mt-1 text-primary/40 animate-pulse" />
+
+          {/* 消息内容预览 */}
+          <div className="flex-1 min-w-0">
+            <p className="text-foreground/80 line-clamp-2 break-all">{msg.text}</p>
+            <p className="text-xs text-muted-foreground/50 mt-0.5">
+              等待当前任务完成后发送
+            </p>
+          </div>
+
+          {/* 操作按钮 */}
+          <div className="flex items-center gap-1 shrink-0">
+            {/* 立即发送 */}
+            <button
+              type="button"
+              className="flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-primary hover:bg-primary/10 transition-colors"
+              onClick={() => handlePromote(msg)}
+              title="立即发送"
+            >
+              <Zap className="size-3" />
+              <span>立即发送</span>
+            </button>
+
+            {/* 撤回 */}
+            <button
+              type="button"
+              className="flex items-center justify-center size-6 rounded-md text-muted-foreground/40 hover:text-destructive hover:bg-destructive/10 transition-colors"
+              onClick={() => handleCancel(msg)}
+              title="撤回消息"
+            >
+              <X className="size-3.5" />
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -12,7 +12,7 @@
  */
 
 import * as React from 'react'
-import { Bot, Loader2, AlertTriangle, FileText, FileImage, Download } from 'lucide-react'
+import { Bot, Loader2, AlertTriangle, FileText, FileImage, Download, Split } from 'lucide-react'
 import { useAtomValue } from 'jotai'
 import { cn } from '@/lib/utils'
 import { ContentBlock } from './ContentBlock'
@@ -21,6 +21,7 @@ import {
   MessageHeader,
   MessageContent,
   MessageActions,
+  MessageAction,
   MessageResponse,
   UserMessageContent,
 } from '@/components/ai-elements/message'
@@ -279,9 +280,11 @@ export interface AssistantTurnRendererProps {
   /** 所有消息（全局，供工具结果查找跨 turn 的结果） */
   allMessages: SDKMessage[]
   basePath?: string
+  /** 分叉回调（传入最后一条 assistant 消息的 uuid） */
+  onFork?: (upToMessageUuid: string) => void
 }
 
-export function AssistantTurnRenderer({ turn, allMessages, basePath }: AssistantTurnRendererProps): React.ReactElement | null {
+export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork }: AssistantTurnRendererProps): React.ReactElement | null {
   // 收集所有 assistant 消息的内容块，保留 parent_tool_use_id 关联
   interface EnrichedBlock {
     block: SDKContentBlock
@@ -380,6 +383,27 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath }: Assistant
           </div>
         )}
       </MessageContent>
+      {/* 操作按钮：复制 + 分叉 */}
+      {(() => {
+        const textContent = topLevelBlocks
+          .filter((b) => b.type === 'text' && 'text' in b)
+          .map((b) => (b as { text: string }).text)
+          .join('\n\n')
+        // 取最后一条 assistant 消息的 uuid 作为分叉截断点
+        const lastUuid = turn.assistantMessages.length > 0
+          ? turn.assistantMessages[turn.assistantMessages.length - 1]?.uuid
+          : undefined
+        return (textContent || lastUuid) ? (
+          <MessageActions className="pl-[46px] mt-0.5">
+            {textContent && <CopyButton content={textContent} />}
+            {onFork && lastUuid && (
+              <MessageAction tooltip="从此处分叉" onClick={() => onFork(lastUuid)}>
+                <Split className="size-3.5" />
+              </MessageAction>
+            )}
+          </MessageActions>
+        ) : null
+      })()}
     </Message>
   )
 }
@@ -441,6 +465,18 @@ export function SDKMessageRenderer({
             ))}
           </div>
         </MessageContent>
+        {/* 复制按钮：提取所有文本块内容 */}
+        {(() => {
+          const textContent = blocks
+            .filter((b) => b.type === 'text' && 'text' in b)
+            .map((b) => (b as { text: string }).text)
+            .join('\n\n')
+          return textContent ? (
+            <MessageActions className="pl-[46px] mt-0.5">
+              <CopyButton content={textContent} />
+            </MessageActions>
+          ) : null
+        })()}
       </Message>
     )
   }
@@ -658,9 +694,10 @@ export interface MessageGroupRendererProps {
   group: MessageGroup
   allMessages: SDKMessage[]
   basePath?: string
+  onFork?: (upToMessageUuid: string) => void
 }
 
-export function MessageGroupRenderer({ group, allMessages, basePath }: MessageGroupRendererProps): React.ReactElement | null {
+export function MessageGroupRenderer({ group, allMessages, basePath, onFork }: MessageGroupRendererProps): React.ReactElement | null {
   if (group.type === 'user') {
     return <UserInputMessage message={group.message} />
   }
@@ -678,6 +715,7 @@ export function MessageGroupRenderer({ group, allMessages, basePath }: MessageGr
       turn={group}
       allMessages={allMessages}
       basePath={basePath}
+      onFork={onFork}
     />
   )
 }

--- a/apps/electron/src/renderer/components/agent/ToolActivityItem.tsx
+++ b/apps/electron/src/renderer/components/agent/ToolActivityItem.tsx
@@ -190,11 +190,19 @@ function getInputSummary(toolName: string, input: Record<string, unknown>): stri
     const subject = input.subject
     if (typeof subject === 'string') return subject.length > 80 ? subject.slice(0, 80) + '…' : subject
   }
-  // TaskUpdate：显示状态变更
+  // TaskUpdate：显示状态变更（中文化）
   if (toolName === 'TaskUpdate') {
+    const statusMap: Record<string, string> = {
+      pending: '待处理',
+      in_progress: '正在进行中',
+      completed: '已结束',
+      cancelled: '已取消',
+      blocked: '已阻塞',
+      error: '出错',
+    }
     const parts: string[] = []
-    if (typeof input.taskId === 'string') parts.push(`#${input.taskId}`)
-    if (typeof input.status === 'string') parts.push(input.status)
+    if (typeof input.taskId === 'string') parts.push(`任务 #${input.taskId}`)
+    if (typeof input.status === 'string') parts.push(statusMap[input.status] ?? input.status)
     if (typeof input.subject === 'string') parts.push(input.subject.length > 60 ? input.subject.slice(0, 60) + '…' : input.subject)
     return parts.length > 0 ? parts.join(' ') : null
   }
@@ -325,12 +333,18 @@ export interface ActivityRowProps {
   onOpenDetails?: (activity: ToolActivity) => void
 }
 
+/** 自描述工具：inputSummary 已包含完整语义，不再额外显示工具名 */
+const SELF_DESCRIBING_TOOLS = new Set(['TaskUpdate'])
+
 export function ActivityRow({ activity, index = 0, animate = false, onOpenDetails }: ActivityRowProps): React.ReactElement {
   const status = getActivityStatus(activity)
   const filePath = extractFilePath(activity.input)
   const diffStats = computeDiffStats(activity.toolName, activity.input)
   const inputSummary = getInputSummary(activity.toolName, activity.input)
   const intent = activity.intent ?? activity.displayName
+
+  // 自描述工具：摘要已包含完整信息，直接作为主标签，隐藏工具名
+  const isSelfDescribing = SELF_DESCRIBING_TOOLS.has(activity.toolName) && !!inputSummary
 
   const delay = animate && index < SIZE.staggerLimit ? `${index * 30}ms` : '0ms'
 
@@ -357,12 +371,20 @@ export function ActivityRow({ activity, index = 0, animate = false, onOpenDetail
             </span>
             <Plus className={cn(SIZE.icon, 'absolute text-foreground/60 opacity-0 transition-opacity duration-150 group-hover/expand:opacity-100')} />
           </span>
-          <span className="shrink-0 text-foreground/80 group-hover/expand:text-foreground transition-colors duration-150">{activity.toolName}</span>
+          {isSelfDescribing ? (
+            <span className="shrink-0 text-foreground/80 group-hover/expand:text-foreground transition-colors duration-150">{inputSummary}</span>
+          ) : (
+            <span className="shrink-0 text-foreground/80 group-hover/expand:text-foreground transition-colors duration-150">{activity.toolName}</span>
+          )}
         </button>
       ) : (
         <>
           <StatusIcon status={status} toolName={activity.toolName} />
-          <span className="shrink-0 text-foreground/80">{activity.toolName}</span>
+          {isSelfDescribing ? (
+            <span className="shrink-0 text-foreground/80">{inputSummary}</span>
+          ) : (
+            <span className="shrink-0 text-foreground/80">{activity.toolName}</span>
+          )}
         </>
       )}
 
@@ -372,11 +394,13 @@ export function ActivityRow({ activity, index = 0, animate = false, onOpenDetail
 
       {activity.isError && <ErrorBadge />}
 
-      <span className="truncate flex-1 min-w-0 text-foreground/50">
-        {intent && <>{intent}</>}
-        {!intent && inputSummary && <>{inputSummary}</>}
-        {intent && inputSummary && <> · <span className="opacity-70">{inputSummary}</span></>}
-      </span>
+      {!isSelfDescribing && (
+        <span className="truncate flex-1 min-w-0 text-foreground/50">
+          {intent && <>{intent}</>}
+          {!intent && inputSummary && <>{inputSummary}</>}
+          {intent && inputSummary && <> · <span className="opacity-70">{inputSummary}</span></>}
+        </span>
+      )}
 
       {activity.elapsedSeconds !== undefined && activity.elapsedSeconds > 0 && (
         <span className="shrink-0 text-[11px] text-muted-foreground/60 tabular-nums">

--- a/apps/electron/src/renderer/components/agent/tool-utils.ts
+++ b/apps/electron/src/renderer/components/agent/tool-utils.ts
@@ -21,7 +21,7 @@ import {
   ListChecks,
   Pencil,
   Plug,
-  RefreshCw,
+
   Search,
   Terminal,
   Users,
@@ -45,7 +45,7 @@ export const TOOL_ICONS: Record<string, LucideIcon> = {
   TodoWrite: ListChecks,
   TodoRead: ClipboardList,
   TaskCreate: FilePlus,
-  TaskUpdate: RefreshCw,
+  TaskUpdate: ListChecks,
   TaskGet: FileSearch,
   TaskList: List,
   TeamCreate: Users,
@@ -79,12 +79,12 @@ const TOOL_DISPLAY_NAMES: Record<string, string> = {
   Skill: '使用技能',
   TodoWrite: '更新待办',
   TodoRead: '阅读待办',
-  TaskCreate: '任务创建',
-  TaskUpdate: '任务更新',
-  TaskGet: '任务加载',
+  TaskCreate: '创建任务',
+  TaskUpdate: '更新任务',
+  TaskGet: '加载任务',
   TaskList: '任务列表',
   TeamCreate: '创建团队',
-  Agent: 'Agent 调用',
+  Agent: 'Agent',
   generate_image: '生成图片',
 }
 
@@ -97,7 +97,7 @@ export function getToolDisplayName(toolName: string): string {
   if (TOOL_DISPLAY_NAMES[toolName]) return TOOL_DISPLAY_NAMES[toolName]
   // MCP 工具：mcp__serverName__toolName → "SERVERNAME / TOOLNAME"
   const parts = toolName.split('__')
-  if (parts[0] === 'mcp' && parts.length >= 3) {
+  if (parts[0] === 'mcp' && parts.length >= 3 && parts[1]) {
     return `${parts[1].toUpperCase()} / ${parts.slice(2).join('_').toUpperCase()}`
   }
   return toolName
@@ -179,17 +179,25 @@ export function getInputSummary(
     }
 
     case 'TaskUpdate': {
+      const statusMap: Record<string, string> = {
+        pending: '待处理',
+        in_progress: '正在进行中',
+        completed: '已结束',
+        cancelled: '已取消',
+        blocked: '已阻塞',
+        error: '出错',
+      }
       const parts: string[] = []
       if (typeof input.taskId === 'string') {
-        parts.push(`#${input.taskId}`)
+        parts.push(`任务 #${input.taskId}`)
       }
       if (typeof input.status === 'string') {
-        parts.push(input.status)
+        parts.push(statusMap[input.status] ?? input.status)
       }
       if (typeof input.subject === 'string') {
         parts.push(input.subject)
       }
-      return parts.length > 0 ? parts.join(' · ') : null
+      return parts.length > 0 ? parts.join(' ') : null
     }
 
     case 'TaskGet': {

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -28,6 +28,7 @@ import {
   applyAgentEvent,
   liveMessagesMapAtom,
   agentPermissionModeAtom,
+  agentQueuedMessagesMapAtom,
 } from '@/atoms/agent-atoms'
 import {
   notificationsEnabledAtom,
@@ -35,7 +36,7 @@ import {
 } from '@/atoms/notifications'
 import { tabsAtom, updateTabTitle } from '@/atoms/tab-atoms'
 import type { AgentStreamState } from '@/atoms/agent-atoms'
-import type { AgentStreamEvent, AgentStreamCompletePayload, AgentEvent, AgentStreamPayload, SDKAssistantMessage, SDKUserMessage, SDKSystemMessage, SDKContentBlock, SDKUserContentBlock } from '@proma/shared'
+import type { AgentStreamEvent, AgentStreamCompletePayload, AgentEvent, AgentStreamPayload, SDKAssistantMessage, SDKUserMessage, SDKSystemMessage, SDKContentBlock, SDKUserContentBlock, AgentQueuedMessageEvent } from '@proma/shared'
 
 // ============================================================================
 // Phase 1 临时兼容层：将 AgentStreamPayload 转换为旧 AgentEvent
@@ -240,6 +241,13 @@ export function useGlobalAgentListeners(): void {
             store.set(liveMessagesMapAtom, (prev) => {
               const map = new Map(prev)
               const current = map.get(sessionId) ?? []
+
+              // UUID 去重：队列消息已被乐观注入，SDK 再次推送时跳过
+              const incomingUuid = msgRecord.uuid as string | undefined
+              if (incomingUuid && current.some((m) => (m as Record<string, unknown>).uuid === incomingUuid)) {
+                return prev
+              }
+
               map.set(sessionId, [...current, payload.message])
               return map
             })
@@ -399,6 +407,10 @@ export function useGlobalAgentListeners(): void {
           return map
         })
 
+        // 注意：不清除队列消息 — STREAM_COMPLETE 表示整个查询结束，
+        // 此时所有 'next' 队列消息应已被 SDK 消费。
+        // 队列 atom 由 IPC QUEUED_MESSAGE_STATUS 事件管理生命周期。
+
         // 缓存 Team 活动数据（在流式状态被清除前保存，防止面板数据丢失）
         const streamState = store.get(agentStreamingStatesAtom).get(data.sessionId)
         if (streamState && streamState.toolActivities.length > 0) {
@@ -520,11 +532,51 @@ export function useGlobalAgentListeners(): void {
         .catch(console.error)
     })
 
+    // ===== 5. 队列消息状态变更 =====
+    const cleanupQueuedMessageStatus = window.electronAPI.onQueuedMessageStatus(
+      (event: AgentQueuedMessageEvent) => {
+        const { sessionId, messageUuid, status, text, priority } = event
+
+        store.set(agentQueuedMessagesMapAtom, (prev) => {
+          const map = new Map(prev)
+          const queue = [...(map.get(sessionId) ?? [])]
+
+          switch (status) {
+            case 'queued': {
+              // 追加新的队列消息（跳过已乐观注入的）
+              if (text && !queue.some((m) => m.uuid === messageUuid)) {
+                queue.push({
+                  uuid: messageUuid,
+                  text,
+                  priority: priority ?? 'next',
+                  createdAt: Date.now(),
+                  status: 'queued',
+                })
+              }
+              break
+            }
+            case 'sent':
+            case 'cancelled': {
+              // 从队列中移除
+              const idx = queue.findIndex((m) => m.uuid === messageUuid)
+              if (idx >= 0) queue.splice(idx, 1)
+              break
+            }
+          }
+
+          if (queue.length === 0) map.delete(sessionId)
+          else map.set(sessionId, queue)
+          return map
+        })
+      }
+    )
+
     return () => {
       cleanupEvent()
       cleanupComplete()
       cleanupError()
       cleanupTitleUpdated()
+      cleanupQueuedMessageStatus()
     }
   }, [store]) // store 引用稳定，effect 只执行一次
 }

--- a/packages/shared/src/types/agent-provider.ts
+++ b/packages/shared/src/types/agent-provider.ts
@@ -8,6 +8,16 @@
 
 import type { SDKMessage } from './agent'
 
+/** SDK 用户消息（队列消息注入用，匹配 SDK SDKUserMessage 结构） */
+export interface SDKUserMessageInput {
+  type: 'user'
+  message: { role: 'user'; content: string }
+  parent_tool_use_id: null
+  priority?: 'now' | 'next' | 'later'
+  uuid?: string
+  session_id: string
+}
+
 /**
  * Agent 查询输入（Provider 无关）
  *
@@ -40,4 +50,8 @@ export interface AgentProviderAdapter {
   abort(sessionId: string): void
   /** 释放资源 */
   dispose(): void
+  /** 向活跃查询注入队列消息（可选，仅支持队列的 Provider 实现） */
+  sendQueuedMessage?(sessionId: string, message: SDKUserMessageInput): Promise<void>
+  /** 取消队列中的待发送消息（可选） */
+  cancelQueuedMessage?(sessionId: string, messageUuid: string): Promise<void>
 }

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -210,6 +210,8 @@ export interface SDKAssistantMessage {
   }
   parent_tool_use_id: string | null
   session_id?: string
+  /** SDK 消息唯一标识，用于 forkSession / resumeSessionAt */
+  uuid?: string
   error?: { message: string; errorType?: string }
   isReplay?: boolean
 }
@@ -222,6 +224,8 @@ export interface SDKUserMessage {
   }
   parent_tool_use_id: string | null
   session_id?: string
+  /** SDK 消息唯一标识 */
+  uuid?: string
   tool_use_result?: unknown
   isReplay?: boolean
 }
@@ -513,6 +517,12 @@ export interface AgentSessionMeta {
   pinned?: boolean
   /** 附加的外部目录路径列表（绝对路径，作为 SDK additionalDirectories 传递） */
   attachedDirectories?: string[]
+  /** 分叉来源：源会话的 SDK session ID（首次发消息时用于 resume + forkSession） */
+  forkedFromSdkSessionId?: string
+  /** 分叉截断点：源会话中的消息 uuid（inclusive） */
+  forkAtMessageUuid?: string
+  /** 分叉来源：源会话的 Proma 工作目录（SDK session 文件在此目录的项目空间中） */
+  forkSourceDir?: string
   /** 创建时间戳 */
   createdAt: number
   /** 更新时间戳 */
@@ -645,6 +655,56 @@ export interface AgentSendInput {
   mentionedMcpServers?: string[]
 }
 
+// ===== Agent 队列消息 =====
+
+/** 队列消息优先级 */
+export type AgentQueuePriority = 'now' | 'next' | 'later'
+
+/** 排队发送消息的输入参数 */
+export interface AgentQueueMessageInput {
+  /** 会话 ID */
+  sessionId: string
+  /** 用户消息内容 */
+  userMessage: string
+  /** 优先级（默认 'next'：当前 turn 完成后发送） */
+  priority?: AgentQueuePriority
+  /** 前端预生成的 UUID（用于乐观更新去重） */
+  uuid?: string
+}
+
+/** 取消队列消息的输入参数 */
+export interface AgentCancelQueuedMessageInput {
+  /** 会话 ID */
+  sessionId: string
+  /** 队列消息 UUID */
+  messageUuid: string
+}
+
+/** 提升队列消息为立即发送的输入参数 */
+export interface AgentPromoteQueuedMessageInput {
+  /** 会话 ID */
+  sessionId: string
+  /** 队列消息 UUID */
+  messageUuid: string
+}
+
+/** 队列消息状态 */
+export type QueuedMessageStatus = 'queued' | 'sent' | 'cancelled'
+
+/** 队列消息状态变更事件（主进程 → 渲染进程推送） */
+export interface AgentQueuedMessageEvent {
+  /** 会话 ID */
+  sessionId: string
+  /** 队列消息 UUID */
+  messageUuid: string
+  /** 消息文本（首次 queued 时携带，便于前端乐观更新） */
+  text?: string
+  /** 优先级 */
+  priority?: AgentQueuePriority
+  /** 状态 */
+  status: QueuedMessageStatus
+}
+
 // ===== 会话迁移输入 =====
 
 /**
@@ -655,6 +715,14 @@ export interface MoveSessionToWorkspaceInput {
   sessionId: string
   /** 目标工作区 ID */
   targetWorkspaceId: string
+}
+
+/** Fork（分叉）会话输入 */
+export interface ForkSessionInput {
+  /** Proma 会话 ID */
+  sessionId: string
+  /** SDK 消息 uuid（截断点，inclusive）。省略时复制全部历史 */
+  upToMessageUuid?: string
 }
 
 // ===== 后台任务管理 =====
@@ -991,6 +1059,8 @@ export const AGENT_IPC_CHANNELS = {
   TOGGLE_PIN: 'agent:toggle-pin',
   /** 迁移会话到另一个工作区 */
   MOVE_SESSION_TO_WORKSPACE: 'agent:move-session-to-workspace',
+  /** 分叉会话（从指定消息处创建新会话） */
+  FORK_SESSION: 'agent:fork-session',
 
   // 工作区管理
   /** 获取工作区列表 */
@@ -1121,4 +1191,14 @@ export const AGENT_IPC_CHANNELS = {
   GET_TEAM_DATA: 'agent:get-team-data',
   /** 读取 Teammate 输出文件（filePath → string） */
   GET_AGENT_OUTPUT: 'agent:get-agent-output',
+
+  // 队列消息（Agent 运行中排队发送）
+  /** 排队发送消息 */
+  QUEUE_MESSAGE: 'agent:queue-message',
+  /** 取消队列消息 */
+  CANCEL_QUEUED_MESSAGE: 'agent:cancel-queued-message',
+  /** 提升队列消息为立即发送 */
+  PROMOTE_QUEUED_MESSAGE: 'agent:promote-queued-message',
+  /** 队列消息状态变更通知（主进程 → 渲染进程推送） */
+  QUEUED_MESSAGE_STATUS: 'agent:queued-message-status',
 } as const


### PR DESCRIPTION
## Summary
- **会话分叉（Fork）**：支持从 Agent 对话的任意 assistant 消息处创建分叉会话，采用延迟 fork 模式——创建时仅复制消息历史和 fork 元数据，首次发消息时通过 SDK `resume + forkSession` 在正确的工作区目录下创建分叉 session。
- **队列消息（Queue）**：Agent 运行中可继续发送消息，通过 SDK `streamInput()` 注入到命令队列，支持取消和提升优先级（promote to now），前端乐观更新 + `QueuedMessagesBanner` 浮动卡片展示排队状态。
- **UI 优化**：新增 `PromptRow` 折叠组件优化子代理提示词展示、Assistant Turn 新增 CopyButton 和 Fork 操作按钮、`TaskUpdate` 工具显示自描述摘要。

## Test plan
- [ ] 在 Agent 运行中发送消息，验证队列消息注入和浮动卡片展示
- [ ] 在 Assistant 消息处点击分叉按钮，验证新会话创建和历史消息复制
- [ ] 在分叉会话中发送首条消息，验证 SDK fork resume 正常工作
- [ ] 取消队列消息，验证状态更新和 UI 反馈