### PR TITLE
feat: Agent 运行时间与 Token 用量持久化及 UI 展示优化

### DIFF
--- a/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
@@ -51,8 +51,8 @@ export interface ClaudeAgentQueryOptions extends AgentQueryInput {
   ) => Promise<PermissionResult>
   /** 只读工具白名单 */
   allowedTools?: string[]
-  /** 系统提示词 */
-  systemPrompt: { type: 'preset'; preset: 'claude_code'; append: string }
+  /** 系统提示词（字符串为自定义提示词，对象为 claude_code preset） */
+  systemPrompt: string | { type: 'preset'; preset: 'claude_code'; append?: string }
   /** SDK session ID（用于 resume） */
   resumeSessionId?: string
   /** resume 时从指定消息 uuid 处截断（配合 forkSession 实现分叉） */

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -37,7 +37,7 @@ import { getAgentWorkspacePath, getAgentSessionWorkspacePath, getSdkConfigDir, g
 import { getWorkspaceAttachedDirectories } from './agent-workspace-manager'
 import { getRuntimeStatus } from './runtime-init'
 import { getSettings } from './settings-service'
-import { buildSystemPromptAppend, buildDynamicContext } from './agent-prompt-builder'
+import { buildSystemPrompt, buildDynamicContext } from './agent-prompt-builder'
 import { permissionService } from './agent-permission-service'
 import type { PermissionResult, CanUseToolOptions } from './agent-permission-service'
 import { askUserService } from './agent-ask-user-service'
@@ -657,16 +657,18 @@ export class AgentOrchestrator {
   /**
    * 持久化累积的 SDKMessage（Phase 4: 直接存储原始 SDKMessage）
    *
-   * 只持久化 assistant 和 user 类型的消息（跳过 system、tool_progress 等临时消息）。
+   * 持久化 assistant、user 和 result 类型的消息（result 包含 token 用量和费用数据）。
+   * 跳过 system、tool_progress 等临时消息。
    */
   private persistSDKMessages(
     sessionId: string,
     accumulatedMessages: SDKMessage[],
+    durationMs?: number,
   ): void {
     if (accumulatedMessages.length === 0) return
 
     const toPersist = accumulatedMessages.filter(
-      (m) => m.type === 'assistant' || m.type === 'user'
+      (m) => m.type === 'assistant' || m.type === 'user' || m.type === 'result'
     )
 
     if (toPersist.length === 0) return
@@ -676,6 +678,10 @@ export class AgentOrchestrator {
     const withTimestamps = toPersist.map((m) => {
       const msg = m as Record<string, unknown>
       if (typeof msg._createdAt === 'number') return m
+      // 为 result 消息附加 _durationMs
+      if (m.type === 'result' && durationMs != null) {
+        return { ...m, _createdAt: now, _durationMs: durationMs } as unknown as SDKMessage
+      }
       return { ...m, _createdAt: now } as unknown as SDKMessage
     })
 
@@ -980,16 +986,16 @@ export class AgentOrchestrator {
         allowDangerouslySkipPermissions: true,
         ...(canUseTool && { canUseTool }),
         ...(permissionMode === 'acceptEdits' && { allowedTools: [...SAFE_TOOLS] }),
-        systemPrompt: {
-          type: 'preset',
-          preset: 'claude_code',
-          append: buildSystemPromptAppend({
+        systemPrompt: buildSystemPrompt({
             workspaceName: workspace?.name,
             workspaceSlug,
             sessionId,
             permissionMode,
+            memoryEnabled: (() => {
+              const mc = getMemoryConfig()
+              return !!(mc.enabled && mc.apiKey)
+            })(),
           }),
-        },
         resumeSessionId: existingSdkSessionId,
         // 延迟 fork：首次发消息时让 SDK 在当前 cwd 的项目空间创建分叉 session
         ...(isForkResume && { forkSession: true }),
@@ -1053,6 +1059,8 @@ export class AgentOrchestrator {
       // 14. 遍历 Adapter 产出的 AgentEvent 流（含自动重试 + Watchdog 死锁检测）
       let lastRetryableError: string | undefined
       let retrySucceeded = false
+      /** 查询开始时间戳（用于计算 durationMs） */
+      const queryStartedAt = Date.now()
 
       // Agent Teams 追踪
       const startedTaskIds = new Set<string>()
@@ -1090,7 +1098,7 @@ export class AgentOrchestrator {
 
           // 等待期间如果会话被中止，退出
           if (!this.activeSessions.has(sessionId)) {
-            this.persistSDKMessages(sessionId, accumulatedMessages)
+            this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
             callbacks.onComplete(getAgentSessionMessages(sessionId))
             return
           }
@@ -1190,14 +1198,14 @@ export class AgentOrchestrator {
                     ? `${typedError.title}: ${typedError.message}`
                     : typedError.message
                   console.log(`[Agent 编排] 可重试错误 (assistant error): ${typedError.code} - ${lastRetryableError}`)
-                  this.persistSDKMessages(sessionId, accumulatedMessages)
+                  this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
                   accumulatedMessages.length = 0
                   shouldRetryFromError = true
                   break
                 }
 
                 // 不可重试 → 终止
-                this.persistSDKMessages(sessionId, accumulatedMessages)
+                this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
 
                 const errorContent = typedError.title
                     ? `${typedError.title}: ${typedError.message}`
@@ -1238,10 +1246,11 @@ export class AgentOrchestrator {
               }
             }
 
-            // 累积 assistant 和 user 消息用于持久化
+            // 累积 assistant、user 和 result 消息用于持久化
             // - 跳过 replay 消息，避免 resume 时重复写入
             // - 对 user 消息，仅累积含 tool_result 的（初始用户消息已在步骤 5 手动持久化）
-            if (msg.type === 'assistant' || msg.type === 'user') {
+            // - result 消息包含 token 用量和费用数据
+            if (msg.type === 'assistant' || msg.type === 'user' || msg.type === 'result') {
               const msgRecord = msg as Record<string, unknown>
               if (!msgRecord.isReplay) {
                 if (msg.type === 'user') {
@@ -1305,7 +1314,7 @@ export class AgentOrchestrator {
           retrySucceeded = true
 
           // 15. 持久化 assistant 消息
-          this.persistSDKMessages(sessionId, accumulatedMessages)
+          this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
 
           // 16. Agent Teams Auto-Resume：teammates 完成后自动收集结果并汇总
           console.log(`[Agent 编排] Auto-resume 条件检查: startedTasks=${startedTaskIds.size}, sdkSession=${!!capturedSdkSessionId}, active=${this.activeSessions.has(sessionId)}`)
@@ -1368,7 +1377,7 @@ export class AgentOrchestrator {
 
                 // 持久化 resume 助手消息
                 if (resumeMessages.length > 0) {
-                  this.persistSDKMessages(sessionId, resumeMessages)
+                  this.persistSDKMessages(sessionId, resumeMessages, Date.now() - queryStartedAt)
                 }
 
                 console.log(`[Agent 编排] Auto-resume 完成`)
@@ -1418,7 +1427,7 @@ export class AgentOrchestrator {
           // 用户主动中止
           if (!this.activeSessions.has(sessionId)) {
             console.log(`[Agent 编排] 会话 ${sessionId} 已被用户中止`)
-            this.persistSDKMessages(sessionId, accumulatedMessages)
+            this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
             callbacks.onComplete(getAgentSessionMessages(sessionId))
             return
           }
@@ -1435,7 +1444,7 @@ export class AgentOrchestrator {
               : (error instanceof Error ? error.message : '未知错误')
             console.log(`[Agent 编排] 可重试错误 (catch): ${lastRetryableError}`)
             // 保存部分内容
-            this.persistSDKMessages(sessionId, accumulatedMessages)
+            this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
             accumulatedMessages.length = 0
             stderrChunks.length = 0
             continue  // 进入下一次 retry 循环
@@ -1448,7 +1457,7 @@ export class AgentOrchestrator {
           // 保存已累积的部分内容
           if (accumulatedMessages.length > 0) {
             try {
-              this.persistSDKMessages(sessionId, accumulatedMessages)
+              this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
               console.log(`[Agent 编排] 已保存部分执行结果 (${accumulatedMessages.length} 条消息)`)
             } catch (saveError) {
               console.error('[Agent 编排] 保存部分内容失败:', saveError)

--- a/apps/electron/src/main/lib/agent-prompt-builder.ts
+++ b/apps/electron/src/main/lib/agent-prompt-builder.ts
@@ -1,48 +1,58 @@
 /**
  * Agent 系统 Prompt 构建器
  *
- * 负责构建 Agent 的 system prompt 追加内容和每条消息的动态上下文。
+ * 负责构建 Agent 的完整系统提示词和每条消息的动态上下文。
  *
- * 设计策略（参考 Craft Agent OSS）：
- * - 静态 system prompt（buildSystemPromptAppend）：保持不变以利用 prompt caching
+ * 设计策略：
+ * - 静态 system prompt（buildSystemPrompt）：完整的自定义系统提示词，替代 claude_code preset 以大幅降低 token 消耗
  * - 动态 per-message 上下文（buildDynamicContext）：注入到用户消息前，每次实时读取磁盘
  */
 
 import type { PromaPermissionMode } from '@proma/shared'
 import { getUserProfile } from './user-profile-service'
 import { getWorkspaceMcpConfig, getWorkspaceSkills } from './agent-workspace-manager'
-import { getMemoryConfig } from './memory-service'
 
 // ===== 静态 System Prompt =====
 
-/** buildSystemPromptAppend 所需的上下文 */
+/** buildSystemPrompt 所需的上下文 */
 interface SystemPromptContext {
   workspaceName?: string
   workspaceSlug?: string
   sessionId: string
   permissionMode: PromaPermissionMode
+  /** 记忆服务是否已启用且配置了 API Key */
+  memoryEnabled: boolean
 }
 
 /**
- * 构建静态 system prompt 追加内容
+ * 构建完整的系统提示词
  *
- * 拼接 Agent 角色定义、用户信息、工作区结构说明和交互规范。
- * 内容保持稳定以利用 Anthropic prompt caching。
+ * 替代 claude_code preset，直接返回自定义系统提示词字符串。
+ * 相比 preset（~15-20K tokens），自定义版本仅 ~2K tokens，大幅降低每次请求的 token 消耗。
+ * 工具（Read/Write/Edit/Bash 等）由 SDK 独立注册，不受 systemPrompt 影响。
  */
-export function buildSystemPromptAppend(ctx: SystemPromptContext): string {
+export function buildSystemPrompt(ctx: SystemPromptContext): string {
   const profile = getUserProfile()
   const userName = profile.userName || '用户'
 
   const sections: string[] = []
 
   // Agent 角色定义
-  sections.push(`## Proma Agent
+  sections.push(`# Proma Agent
 
-你是 Proma Agent — 一个集成在 Proma 桌面应用中的通用AI助手，你有极强的自主性和主观能动性，由 Claude Agent SDK 驱动，你可以完成任何任务，并尽可能帮助用户完成更多的工作，尽最大的努力。
+你是 Proma Agent — 一个集成在 Proma 桌面应用中的通用AI助手，由 Claude Agent SDK 驱动。你有极强的自主性和主观能动性，可以完成任何任务，尽最大努力帮助用户。`)
 
-**CRITICAL — Skill 调用规则：**
-调用 Skill 工具时，\`skill\` 参数**必须**使用含命名空间前缀的完整名称（如 \`proma-workspace-${ctx.workspaceSlug}:brainstorming\`）。
-**绝对不可**使用不带前缀的短名称（如 \`brainstorming\`），否则会报 Unknown skill 错误。`)
+  // 工具使用指南（精简版，替代 claude_code preset 中的冗长说明）
+  sections.push(`## 工具使用指南
+
+- 读取文件用 Read，搜索文件名用 Glob，搜索内容用 Grep — 不要用 Bash 执行 cat/find/grep 等命令替代专用工具
+- 编辑已有文件用 Edit（精确字符串替换），创建新文件用 Write — Edit 的 old_string 必须是文件中唯一匹配的字符串
+- 执行 shell 命令用 Bash — 破坏性操作（rm、git push --force 等）前先确认
+- 使用 Agent 工具将独立子任务委托给子代理并行执行
+- 文本输出直接写在回复中，不要用 echo/printf
+- 当存在内置工具时，优先采用内置工具完成任务，避免滥用 MCP、shell 等过于通用的工具来完成简单任务
+- 复杂操作（如大规模重构、架构设计、头脑风暴等）优先考虑先委派相关的探索 SubAgent 来收集足够的消息或者调研，不确定的部分调用头脑风暴 Skill 来跟用户确认，最后进入 Plan 模式输出执行计划，确保每一步都在用户的掌控之下
+- 处理多个独立任务时，尽量并行调用工具以提高效率`)
 
   // 用户信息
   sections.push(`## 用户信息
@@ -54,42 +64,9 @@ export function buildSystemPromptAppend(ctx: SystemPromptContext): string {
     sections.push(`## 工作区
 
 - 工作区名称: ${ctx.workspaceName}
-- MCP 配置: ~/.proma/agent-workspaces/${ctx.workspaceSlug}/mcp.json
+- MCP 配置: ~/.proma/agent-workspaces/${ctx.workspaceSlug}/mcp.json（顶层 key 是 \`servers\`）
 - Skills 目录: ~/.proma/agent-workspaces/${ctx.workspaceSlug}/skills/
-- 会话目录: ~/.proma/agent-workspaces/${ctx.workspaceSlug}/sessions/${ctx.sessionId}/
-
-### MCP 配置格式
-mcp.json 的顶层 key 必须是 \`servers\`（不是 mcpServers），示例：
-\`\`\`json
-{
-  "servers": {
-    "my-stdio-server": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "@example/mcp-server"],
-      "env": { "API_KEY": "xxx" },
-      "enabled": true
-    },
-    "my-http-server": {
-      "type": "http",
-      "url": "https://example.com/mcp",
-      "headers": { "Authorization": "Bearer xxx" },
-      "enabled": true
-    }
-  }
-}
-\`\`\`
-**重要：顶层 key 是 \`servers\`，绝对不要写成 \`mcpServers\` 或其他名称。**
-
-### Skill 格式
-每个 Skill 是 skills/{slug}/ 目录下的 SKILL.md 文件：
-\`\`\`
----
-name: 显示名称
-description: 简要描述
----
-详细指令内容...
-\`\`\``)
+- 会话目录: ~/.proma/agent-workspaces/${ctx.workspaceSlug}/sessions/${ctx.sessionId}/`)
   }
 
   // 不确定性处理策略（根据权限模式区分）
@@ -123,13 +100,55 @@ description: 简要描述
 4. 用户确认执行后，再调用 ExitPlanMode 退出计划模式`)
   }
 
+  // 记忆系统指引（静态，利用 prompt caching）
+  if (ctx.memoryEnabled) {
+    sections.push(`## 记忆系统
+
+你拥有跨会话的记忆能力。这些记忆是你和用户之间共同的经历——你们一起讨论过的问题、一起做过的决定、一起踩过的坑。
+
+**重要：记忆工具是 MCP 工具，不是文件操作！**
+- 存储和回忆记忆必须通过 mcp__mem__recall_memory 和 mcp__mem__add_memory 工具调用
+- 绝对不要把记忆写入 MEMORY.md 或任何本地文件来替代记忆工具
+- 这两个工具连接的是云端记忆服务，能真正跨会话持久化
+
+**理解记忆的本质：**
+- 记忆是"我们一起经历过的事"，不是"关于用户的信息条目"
+- 回忆起过去的经历时，像老搭档一样自然地带入，而不是像在查档案
+- 例如：不要说"根据记忆记录，您偏好使用 Tailwind"，而是自然地按照那个偏好去做，就像你本来就知道一样
+
+**mcp__mem__recall_memory — 回忆过去：**
+在你觉得过去的经历可能对当前有帮助时主动调用：
+- 用户提到"之前"、"上次"、"我们讨论过"等回溯性表述
+- 当前任务可能和过去一起做过的事情有关联
+- 需要延续之前的讨论或决策
+
+**mcp__mem__add_memory — 记住这次经历：**
+当这次对话中发生了值得记住的事情时调用。想象一下：如果下次用户再来，你会希望自己还记得什么？
+- 我们一起做了一个重要决定（如选择了某个架构方案及原因）
+- 用户分享了他的工作方式或偏好（如"我习惯用 pnpm"、"缩进用 2 空格"）
+- 我们一起解决了一个棘手的问题（问题是什么、怎么解决的）
+- 用户的项目有了重要进展或变化
+- 用户明确说"记住这个"
+
+存储时的要点：
+- userMessage 写用户当时说了什么（精简），assistantMessage 写你们一起得出的结论或经历
+- 记的是经历和结论，不是对话流水账
+- 不值得记的：纯粹的代码搬运、一次性的 typo 修复、临时调试过程
+
+**核心原则：**
+- 自然地运用记忆，就像你本来就记得，不要提及"记忆系统"、"检索"等内部概念
+- 宁可少记也不要记一堆没用的，保持记忆都是有温度的、有价值的共同经历
+- 搜索时用简短精准的查询词`)
+  }
+
   // 交互规范
   sections.push(`## 交互规范
 
 1. 优先使用中文回复，保留技术术语
 2. 确认破坏性操作后再执行
 3. 使用 Markdown 格式化输出
-4. 自称 Proma Agent`)
+4. 自称 Proma Agent
+5. 回复简洁直接，不要冗长`)
 
   return sections.join('\n\n')
 }
@@ -202,48 +221,6 @@ export function buildDynamicContext(ctx: DynamicContext): string {
     if (wsLines.length > 0) {
       sections.push(`<workspace_state>\n${wsLines.join('\n')}\n</workspace_state>`)
     }
-  }
-
-  // 记忆系统使用指引（全局，不依赖工作区）
-  const memoryConfig = getMemoryConfig()
-  if (memoryConfig.enabled && memoryConfig.apiKey) {
-    sections.push(`<memory_instructions>
-你拥有跨会话的记忆能力。这些记忆是你和用户之间共同的经历——你们一起讨论过的问题、一起做过的决定、一起踩过的坑。它不是一个冷冰冰的用户档案数据库，而是你作为长期搭档积累下来的默契。
-
-**重要：记忆工具是 MCP 工具，不是文件操作！**
-- 存储和回忆记忆必须通过 mcp__mem__recall_memory 和 mcp__mem__add_memory 工具调用
-- 绝对不要把记忆写入 MEMORY.md 或任何本地文件来替代记忆工具
-- 这两个工具连接的是云端记忆服务，能真正跨会话持久化
-
-**理解记忆的本质：**
-- 记忆是"我们一起经历过的事"，不是"关于用户的信息条目"
-- 回忆起过去的经历时，像老搭档一样自然地带入，而不是像在查档案
-- 例如：不要说"根据记忆记录，您偏好使用 Tailwind"，而是自然地按照那个偏好去做，就像你本来就知道一样
-
-**mcp__mem__recall_memory — 回忆过去：**
-在你觉得过去的经历可能对当前有帮助时主动调用：
-- 用户提到"之前"、"上次"、"我们讨论过"等回溯性表述
-- 当前任务可能和过去一起做过的事情有关联
-- 需要延续之前的讨论或决策
-
-**mcp__mem__add_memory — 记住这次经历：**
-当这次对话中发生了值得记住的事情时调用。想象一下：如果下次用户再来，你会希望自己还记得什么？
-- 我们一起做了一个重要决定（如选择了某个架构方案及原因）
-- 用户分享了他的工作方式或偏好（如"我习惯用 pnpm"、"缩进用 2 空格"）
-- 我们一起解决了一个棘手的问题（问题是什么、怎么解决的）
-- 用户的项目有了重要进展或变化
-- 用户明确说"记住这个"
-
-存储时的要点：
-- userMessage 写用户当时说了什么（精简），assistantMessage 写你们一起得出的结论或经历
-- 记的是经历和结论，不是对话流水账
-- 不值得记的：纯粹的代码搬运、一次性的 typo 修复、临时调试过程
-
-**核心原则：**
-- 自然地运用记忆，就像你本来就记得，不要提及"记忆系统"、"检索"等内部概念
-- 宁可少记也不要记一堆没用的，保持记忆都是有温度的、有价值的共同经历
-- 搜索时用简短精准的查询词
-</memory_instructions>`)
   }
 
   // 工作目录

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -104,6 +104,14 @@ export interface AgentStreamState {
   model?: string
   /** 当前输入 token 数（上下文使用量） */
   inputTokens?: number
+  /** 输出 token 数 */
+  outputTokens?: number
+  /** 缓存读取 token 数 */
+  cacheReadTokens?: number
+  /** 缓存写入 token 数 */
+  cacheCreationTokens?: number
+  /** 费用（美元） */
+  costUsd?: number
   /** 模型上下文窗口大小 */
   contextWindow?: number
   /** 是否正在压缩上下文 */
@@ -1046,6 +1054,10 @@ export function applyAgentEvent(
       return {
         ...prev,
         inputTokens: event.usage.inputTokens,
+        ...(event.usage.outputTokens != null && { outputTokens: event.usage.outputTokens }),
+        ...(event.usage.cacheReadTokens != null && { cacheReadTokens: event.usage.cacheReadTokens }),
+        ...(event.usage.cacheCreationTokens != null && { cacheCreationTokens: event.usage.cacheCreationTokens }),
+        ...(event.usage.costUsd != null && { costUsd: event.usage.costUsd }),
         ...(event.usage.contextWindow && { contextWindow: event.usage.contextWindow }),
       }
 
@@ -1132,6 +1144,10 @@ export function applyAgentEvent(
 export interface AgentContextStatus {
   isCompacting: boolean
   inputTokens?: number
+  outputTokens?: number
+  cacheReadTokens?: number
+  cacheCreationTokens?: number
+  costUsd?: number
   contextWindow?: number
 }
 
@@ -1143,6 +1159,10 @@ export const agentContextStatusAtom = atom<AgentContextStatus>((get) => {
   return {
     isCompacting: state?.isCompacting ?? false,
     inputTokens: state?.inputTokens,
+    outputTokens: state?.outputTokens,
+    cacheReadTokens: state?.cacheReadTokens,
+    cacheCreationTokens: state?.cacheCreationTokens,
+    costUsd: state?.costUsd,
     contextWindow: state?.contextWindow,
   }
 })

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -36,8 +36,9 @@ import { userProfileAtom } from '@/atoms/user-profile'
 import { ScrollPositionManager } from '@/hooks/useScrollPositionMemory'
 import { cn } from '@/lib/utils'
 import { Spinner } from '@/components/ui/spinner'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { groupIntoTurns, MessageGroupRenderer } from './SDKMessageRenderer'
-import type { AgentMessage, RetryAttempt, SDKMessage } from '@proma/shared'
+import type { AgentMessage, AgentEventUsage, RetryAttempt, SDKMessage } from '@proma/shared'
 import type { ToolActivity, AgentStreamState } from '@/atoms/agent-atoms'
 
 /** AgentMessages 属性接口 */
@@ -507,10 +508,11 @@ function AgentMessageItem({ message, sessionPath, onRetry, onRetryInNewSession, 
             <MessageResponse basePath={sessionPath || undefined}>{message.content}</MessageResponse>
           )}
         </MessageContent>
-        {/* 操作按钮（hover 时可见） */}
-        {message.content && (
-          <MessageActions className="pl-[46px] mt-0.5">
-            <CopyButton content={message.content} />
+        {/* 操作栏：左侧靠左排列 */}
+        {(message.durationMs != null || message.content) && (
+          <MessageActions className="pl-[46px] mt-0.5 justify-start gap-2.5">
+            {message.durationMs != null && <DurationBadge durationMs={message.durationMs} usage={message.usage} />}
+            {message.content && <CopyButton content={message.content} />}
           </MessageActions>
         )}
       </Message>
@@ -565,6 +567,48 @@ function AgentMessageItem({ message, sessionPath, onRetry, onRetryInNewSession, 
   }
 
   return null
+}
+
+/** 格式化耗时（毫秒 → 可读字符串） */
+export function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  const seconds = ms / 1000
+  if (seconds < 60) return `${seconds.toFixed(1)}s`
+  const m = Math.floor(seconds / 60)
+  const s = seconds % 60
+  return `${m}m ${s.toFixed(0)}s`
+}
+
+/** 构建 usage tooltip 多行文本 */
+export function buildUsageTooltip(durationMs: number, usage?: AgentEventUsage): string {
+  const lines: string[] = []
+  lines.push(`耗时: ${formatDuration(durationMs)}`)
+
+  if (usage) {
+    const pureInput = usage.inputTokens - (usage.cacheReadTokens ?? 0) - (usage.cacheCreationTokens ?? 0)
+    if (pureInput > 0) lines.push(`输入: ${pureInput.toLocaleString()}`)
+    if (usage.outputTokens) lines.push(`输出: ${usage.outputTokens.toLocaleString()}`)
+    if (usage.cacheCreationTokens) lines.push(`缓存写入: ${usage.cacheCreationTokens.toLocaleString()}`)
+    if (usage.cacheReadTokens) lines.push(`缓存读取: ${usage.cacheReadTokens.toLocaleString()}`)
+  }
+
+  return lines.join('\n')
+}
+
+/** 耗时徽章 — 悬浮显示 token 用量明细 */
+export function DurationBadge({ durationMs, usage }: { durationMs: number; usage?: AgentEventUsage }): React.ReactElement {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="text-[15px] text-muted-foreground/60 tabular-nums font-light cursor-default">
+          {formatDuration(durationMs)}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top">
+        <p className="whitespace-pre-line text-left">{buildUsageTooltip(durationMs, usage)}</p>
+      </TooltipContent>
+    </Tooltip>
+  )
 }
 
 /** Agent 运行指示器 — Shimmer Spinner + 无括号的运行时间 */
@@ -736,12 +780,13 @@ export function AgentMessages({ sessionId, messages, persistedSDKMessages, strea
                 group={group}
                 allMessages={allSDKMessages}
                 basePath={sessionPath || undefined}
+                isStreaming
               />
             ))}
 
             {/* 有实时助手内容时：仅追加运行指示器 */}
             {hasLiveAssistantContent && (streaming || retrying) && (
-              <div className="pl-[46px]">
+              <div className="pl-[56px]">
                 {retrying && <RetryingNotice retrying={retrying} />}
                 {streaming && <AgentRunningIndicator startedAt={startedAt} />}
               </div>

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -1125,6 +1125,9 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
                 </Tooltip>
                 <ContextUsageBadge
                   inputTokens={contextStatus.inputTokens}
+                  outputTokens={contextStatus.outputTokens}
+                  cacheReadTokens={contextStatus.cacheReadTokens}
+                  cacheCreationTokens={contextStatus.cacheCreationTokens}
                   contextWindow={contextStatus.contextWindow}
                   isCompacting={contextStatus.isCompacting}
                   isProcessing={streaming}

--- a/apps/electron/src/renderer/components/agent/ContextUsageBadge.tsx
+++ b/apps/electron/src/renderer/components/agent/ContextUsageBadge.tsx
@@ -1,12 +1,12 @@
 /**
  * ContextUsageBadge — 上下文使用量徽章
  *
- * 常驻显示在输入框工具栏，展示当前 Agent 会话的 token 使用量和压缩状态：
- * - 有数据时显示 "Xk / Yk" token 计数（Y = contextWindow × 0.775 压缩阈值）
+ * 常驻显示在输入框工具栏，展示当前 Agent 会话的上下文占用情况：
+ * - 有数据时显示 "Xk / Yk"（已用 / 总窗口大小）
  * - 无数据时不显示（首次请求前无 usage 数据）
  * - 压缩中时显示 Loader2 旋转图标
- * - 使用量 ≥ 80% 阈值时显示琥珀色警告
- * - 压缩按钮始终可见（有 token 数据后），非警告状态时仅图标展示
+ * - 使用量接近压缩阈值（窗口 × 0.775 × 80%）时显示琥珀色警告
+ * - hover tooltip 显示 token 用量明细
  */
 
 import * as React from 'react'
@@ -16,11 +16,15 @@ import { cn } from '@/lib/utils'
 
 /** 压缩阈值比例（SDK 在 ~77.5% 窗口大小时自动压缩） */
 const COMPACT_THRESHOLD_RATIO = 0.775
-/** 显示警告的阈值（阈值的 80%） */
+/** 显示警告的阈值（压缩阈值的 80%） */
 const WARNING_RATIO = 0.80
 
 interface ContextUsageBadgeProps {
   inputTokens?: number
+  outputTokens?: number
+  cacheReadTokens?: number
+  cacheCreationTokens?: number
+  costUsd?: number
   contextWindow?: number
   isCompacting: boolean
   isProcessing: boolean
@@ -38,17 +42,56 @@ function formatTokens(tokens: number): string {
   return `${tokens}`
 }
 
+/** 构建多行 tooltip 文本 */
+function buildTooltipLines(props: {
+  inputTokens: number
+  outputTokens?: number
+  cacheReadTokens?: number
+  cacheCreationTokens?: number
+  contextWindow?: number
+  isWarning: boolean
+}): string {
+  const lines: string[] = []
+
+  // 纯输入 = 总上下文 - 缓存读取 - 缓存写入
+  const pureInput = props.inputTokens - (props.cacheReadTokens ?? 0) - (props.cacheCreationTokens ?? 0)
+
+  if (pureInput > 0) lines.push(`输入: ${pureInput.toLocaleString()}`)
+  if (props.outputTokens) lines.push(`输出: ${props.outputTokens.toLocaleString()}`)
+  if (props.cacheCreationTokens) lines.push(`缓存写入: ${props.cacheCreationTokens.toLocaleString()}`)
+  if (props.cacheReadTokens) lines.push(`缓存读取: ${props.cacheReadTokens.toLocaleString()}`)
+
+  if (props.contextWindow) {
+    lines.push(`上下文窗口: ${props.contextWindow.toLocaleString()}`)
+  }
+
+  if (props.isWarning) {
+    lines.push('点击手动压缩')
+  }
+
+  return lines.join('\n')
+}
+
 export function ContextUsageBadge({
   inputTokens,
+  outputTokens,
+  cacheReadTokens,
+  cacheCreationTokens,
   contextWindow,
   isCompacting,
   isProcessing,
   onCompact,
 }: ContextUsageBadgeProps): React.ReactElement | null {
   // 保留最近一次有效的 token 值，避免切换会话时闪烁消失
-  const stableRef = React.useRef<{ inputTokens: number; contextWindow?: number } | null>(null)
+  const stableRef = React.useRef<{
+    inputTokens: number
+    outputTokens?: number
+    cacheReadTokens?: number
+    cacheCreationTokens?: number
+    contextWindow?: number
+  } | null>(null)
   if (inputTokens && inputTokens > 0) {
-    stableRef.current = { inputTokens, contextWindow }
+    stableRef.current = { inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, contextWindow }
   }
 
   // 压缩中 → 始终显示 spinner
@@ -62,32 +105,42 @@ export function ContextUsageBadge({
   }
 
   // 使用稳定值：优先当前数据，回退到上次有效数据
-  const displayTokens = (inputTokens && inputTokens > 0) ? inputTokens : stableRef.current?.inputTokens
-  const displayWindow = (inputTokens && inputTokens > 0) ? contextWindow : stableRef.current?.contextWindow
+  const stable = stableRef.current
+  const hasCurrent = inputTokens != null && inputTokens > 0
+  const displayTokens = hasCurrent ? inputTokens : stable?.inputTokens
+  const displayWindow = hasCurrent ? contextWindow : stable?.contextWindow
+  const displayOutput = hasCurrent ? outputTokens : stable?.outputTokens
+  const displayCacheRead = hasCurrent ? cacheReadTokens : stable?.cacheReadTokens
+  const displayCacheCreation = hasCurrent ? cacheCreationTokens : stable?.cacheCreationTokens
 
   // 从未有过 usage 数据 → 不显示
   if (!displayTokens || displayTokens <= 0) return null
 
+  // 警告阈值：基于压缩阈值（contextWindow × 0.775 × 80%）
   const compactThreshold = displayWindow
     ? Math.floor(displayWindow * COMPACT_THRESHOLD_RATIO)
     : undefined
+  const isWarning = compactThreshold
+    ? displayTokens / compactThreshold >= WARNING_RATIO
+    : false
 
-  const usageRatio = compactThreshold
-    ? displayTokens / compactThreshold
-    : undefined
-
-  const isWarning = usageRatio !== undefined && usageRatio >= WARNING_RATIO
-
-  const displayText = compactThreshold
-    ? `${formatTokens(displayTokens)} / ${formatTokens(compactThreshold)}`
+  // 显示文本：已用 / 总窗口
+  const displayText = displayWindow
+    ? `${formatTokens(displayTokens)} / ${formatTokens(displayWindow)}`
     : formatTokens(displayTokens)
 
-  const tooltipText = displayWindow
-    ? `上下文: ${displayTokens.toLocaleString()} / ${compactThreshold!.toLocaleString()} tokens (窗口 ${displayWindow.toLocaleString()})${isWarning ? '\n点击手动压缩' : ''}`
-    : `上下文: ${displayTokens.toLocaleString()} tokens`
+  const tooltipText = buildTooltipLines({
+    inputTokens: displayTokens,
+    outputTokens: displayOutput,
+    cacheReadTokens: displayCacheRead,
+    cacheCreationTokens: displayCacheCreation,
+    contextWindow: displayWindow,
+    isWarning,
+  })
 
-  const percentText = usageRatio !== undefined
-    ? `${Math.round(usageRatio * 100)}%`
+  // 占用百分比（相对完整窗口）
+  const percentText = displayWindow
+    ? `${Math.round((displayTokens / displayWindow) * 100)}%`
     : undefined
 
   // 压缩按钮的 tooltip 文案
@@ -109,13 +162,13 @@ export function ContextUsageBadge({
             )}
           >
             <span>{displayText}</span>
-            {isWarning && percentText && (
-              <span className="font-medium">{percentText}</span>
+            {percentText && (
+              <span className={cn('tabular-nums', isWarning && 'font-medium')}>{percentText}</span>
             )}
           </span>
         </TooltipTrigger>
         <TooltipContent side="top">
-          <p className="whitespace-pre-line">{tooltipText}</p>
+          <p className="whitespace-pre-line text-left">{tooltipText}</p>
         </TooltipContent>
       </Tooltip>
 

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -16,6 +16,7 @@ import { Bot, Loader2, AlertTriangle, FileText, FileImage, Download, Split } fro
 import { useAtomValue } from 'jotai'
 import { cn } from '@/lib/utils'
 import { ContentBlock } from './ContentBlock'
+import { DurationBadge } from './AgentMessages'
 import {
   Message,
   MessageHeader,
@@ -36,6 +37,8 @@ import type {
   SDKUserMessage,
   SDKSystemMessage,
   SDKContentBlock,
+  SDKResultMessage,
+  AgentEventUsage,
 } from '@proma/shared'
 
 // ===== SDKMessageRenderer Props =====
@@ -87,6 +90,33 @@ function extractMeta(message: SDKMessage): MessageMeta {
   return {
     createdAt: typeof msg._createdAt === 'number' ? msg._createdAt : undefined,
   }
+}
+
+/** 从 turn 消息列表中提取 result 消息的耗时和用量数据 */
+function extractTurnUsage(turnMessages: SDKMessage[]): { durationMs?: number; usage?: AgentEventUsage } {
+  for (const msg of turnMessages) {
+    if (msg.type !== 'result') continue
+    const resultMsg = msg as SDKResultMessage
+    const raw = msg as Record<string, unknown>
+    const durationMs = typeof raw._durationMs === 'number' ? raw._durationMs : undefined
+    const u = resultMsg.usage
+    if (!u) return { durationMs }
+    const contextWindow = resultMsg.modelUsage
+      ? Object.values(resultMsg.modelUsage)[0]?.contextWindow
+      : undefined
+    return {
+      durationMs,
+      usage: {
+        inputTokens: u.input_tokens + (u.cache_read_input_tokens ?? 0) + (u.cache_creation_input_tokens ?? 0),
+        outputTokens: u.output_tokens,
+        cacheReadTokens: u.cache_read_input_tokens,
+        cacheCreationTokens: u.cache_creation_input_tokens,
+        costUsd: resultMsg.total_cost_usd,
+        contextWindow,
+      },
+    }
+  }
+  return {}
 }
 
 // ===== 辅助：从 user 消息中提取纯文本内容 =====
@@ -282,9 +312,11 @@ export interface AssistantTurnRendererProps {
   basePath?: string
   /** 分叉回调（传入最后一条 assistant 消息的 uuid） */
   onFork?: (upToMessageUuid: string) => void
+  /** 是否正在流式输出中（隐藏操作栏） */
+  isStreaming?: boolean
 }
 
-export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork }: AssistantTurnRendererProps): React.ReactElement | null {
+export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, isStreaming }: AssistantTurnRendererProps): React.ReactElement | null {
   // 收集所有 assistant 消息的内容块，保留 parent_tool_use_id 关联
   interface EnrichedBlock {
     block: SDKContentBlock
@@ -316,6 +348,9 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork }: A
 
   // 如果没有任何内容
   if (enrichedBlocks.length === 0 && !hasError) return null
+
+  // 从 turnMessages 中提取 result 消息的耗时和用量
+  const { durationMs, usage } = extractTurnUsage(turn.turnMessages)
 
   // 构建 Agent/Task tool_use → 子代理内容块映射
   const agentToolIds = new Set<string>()
@@ -383,18 +418,21 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork }: A
           </div>
         )}
       </MessageContent>
-      {/* 操作按钮：复制 + 分叉 */}
-      {(() => {
+      {/* 操作栏：左侧耗时标签 + 右侧操作按钮（流式输出中隐藏） */}
+      {!isStreaming && (() => {
         const textContent = topLevelBlocks
           .filter((b) => b.type === 'text' && 'text' in b)
           .map((b) => (b as { text: string }).text)
           .join('\n\n')
-        // 取最后一条 assistant 消息的 uuid 作为分叉截断点
         const lastUuid = turn.assistantMessages.length > 0
           ? turn.assistantMessages[turn.assistantMessages.length - 1]?.uuid
           : undefined
-        return (textContent || lastUuid) ? (
-          <MessageActions className="pl-[46px] mt-0.5">
+        const hasActions = !!(textContent || (onFork && lastUuid))
+        const hasDuration = durationMs != null
+        if (!hasDuration && !hasActions) return null
+        return (
+          <MessageActions className="pl-[46px] mt-0.5 justify-start">
+            {hasDuration && <DurationBadge durationMs={durationMs!} usage={usage} />}
             {textContent && <CopyButton content={textContent} />}
             {onFork && lastUuid && (
               <MessageAction tooltip="从此处分叉" onClick={() => onFork(lastUuid)}>
@@ -402,7 +440,7 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork }: A
               </MessageAction>
             )}
           </MessageActions>
-        ) : null
+        )
       })()}
     </Message>
   )
@@ -465,18 +503,6 @@ export function SDKMessageRenderer({
             ))}
           </div>
         </MessageContent>
-        {/* 复制按钮：提取所有文本块内容 */}
-        {(() => {
-          const textContent = blocks
-            .filter((b) => b.type === 'text' && 'text' in b)
-            .map((b) => (b as { text: string }).text)
-            .join('\n\n')
-          return textContent ? (
-            <MessageActions className="pl-[46px] mt-0.5">
-              <CopyButton content={textContent} />
-            </MessageActions>
-          ) : null
-        })()}
       </Message>
     )
   }
@@ -695,9 +721,11 @@ export interface MessageGroupRendererProps {
   allMessages: SDKMessage[]
   basePath?: string
   onFork?: (upToMessageUuid: string) => void
+  /** 是否正在流式输出中（隐藏操作栏） */
+  isStreaming?: boolean
 }
 
-export function MessageGroupRenderer({ group, allMessages, basePath, onFork }: MessageGroupRendererProps): React.ReactElement | null {
+export function MessageGroupRenderer({ group, allMessages, basePath, onFork, isStreaming }: MessageGroupRendererProps): React.ReactElement | null {
   if (group.type === 'user') {
     return <UserInputMessage message={group.message} />
   }
@@ -716,6 +744,7 @@ export function MessageGroupRenderer({ group, allMessages, basePath, onFork }: M
       allMessages={allMessages}
       basePath={basePath}
       onFork={onFork}
+      isStreaming={isStreaming}
     />
   )
 }

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -114,11 +114,19 @@ function payloadToLegacyEvents(payload: AgentStreamPayload): AgentEvent[] {
           })
         }
       }
-      // Usage
+      // Usage（保留完整字段用于详细展示）
       if (!aMsg.parent_tool_use_id && aMsg.message.usage) {
         const u = aMsg.message.usage
         const inputTokens = u.input_tokens + (u.cache_read_input_tokens ?? 0) + (u.cache_creation_input_tokens ?? 0)
-        events.push({ type: 'usage_update', usage: { inputTokens } })
+        events.push({
+          type: 'usage_update',
+          usage: {
+            inputTokens,
+            outputTokens: u.output_tokens,
+            cacheReadTokens: u.cache_read_input_tokens,
+            cacheCreationTokens: u.cache_creation_input_tokens,
+          },
+        })
       }
       return events
     }
@@ -145,15 +153,18 @@ function payloadToLegacyEvents(payload: AgentStreamPayload): AgentEvent[] {
     }
 
     case 'result': {
-      const rMsg = msg as { subtype: string; usage?: { input_tokens: number; output_tokens?: number }; modelUsage?: Record<string, { contextWindow?: number }> }
+      const rMsg = msg as { subtype: string; usage?: { input_tokens: number; output_tokens?: number; cache_read_input_tokens?: number; cache_creation_input_tokens?: number }; total_cost_usd?: number; modelUsage?: Record<string, { contextWindow?: number }> }
       const usage = rMsg.usage
       const contextWindow = rMsg.modelUsage ? Object.values(rMsg.modelUsage)[0]?.contextWindow : undefined
       return [{
         type: 'complete',
         stopReason: rMsg.subtype === 'success' ? 'end_turn' : 'error',
         usage: usage ? {
-          inputTokens: usage.input_tokens,
+          inputTokens: usage.input_tokens + (usage.cache_read_input_tokens ?? 0) + (usage.cache_creation_input_tokens ?? 0),
           outputTokens: usage.output_tokens,
+          cacheReadTokens: usage.cache_read_input_tokens,
+          cacheCreationTokens: usage.cache_creation_input_tokens,
+          costUsd: rMsg.total_cost_usd,
           contextWindow,
         } : undefined,
       }]

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -455,7 +455,7 @@ export type AgentEvent =
   | { type: 'retry_cleared' }  // 新增：重试成功，清除状态
   | { type: 'retry_failed'; finalAttempt: RetryAttempt }  // 新增：重试失败
   // Usage 更新
-  | { type: 'usage_update'; usage: { inputTokens: number; contextWindow?: number } }
+  | { type: 'usage_update'; usage: AgentEventUsage }
   // 上下文压缩
   | { type: 'compacting' }
   | { type: 'compact_complete' }
@@ -559,6 +559,10 @@ export interface AgentMessage {
   errorCanRetry?: boolean
   /** 错误恢复操作（status 消息） */
   errorActions?: RecoveryAction[]
+  /** 耗时（毫秒），assistant 消息从流式开始到完成的时间 */
+  durationMs?: number
+  /** Token 用量明细（assistant 消息完成时记录） */
+  usage?: AgentEventUsage
 }
 
 // ===== Agent 标题生成输入 =====


### PR DESCRIPTION
## Summary
- 新增 `AgentEventUsage` 类型，持久化每轮 Agent 的运行时间（`durationMs`）和完整 token 用量（输入/输出/缓存读写/费用）到 JSONL result 消息
- 修复 `inputTokens` 在 `usage_update`、`result→complete`、`extractTurnUsage` 三条路径计算不一致的问题（后两者未包含缓存 token，导致输入显示为 0）
- `ContextUsageBadge` 分母从压缩阈值（contextWindow × 0.775）改为完整 contextWindow，始终显示占用百分比
- `DurationBadge` 从独立 div 移入 MessageActions 操作栏左侧，悬浮 tooltip 显示 token 明细（输入→输出→缓存写入→缓存读取）
- 流式输出期间通过 `isStreaming` prop 隐藏操作栏，Agent 完成后才显示复制/分叉/耗时
- 修复 Agent Running 指示器与消息内容左侧未对齐（`pl-[46px]` → `pl-[56px]` 补偿 Message 组件的 `px-2.5`）
- 优化 agent-prompt-builder 系统提示词构建逻辑

## Test plan
- [ ] 发送 Agent 消息，验证流式输出期间不显示复制按钮和耗时标签
- [ ] Agent 完成后，验证操作栏显示耗时（如 "10.4s"）并悬浮显示完整 token 明细
- [ ] 验证输入框右下角 ContextUsageBadge 显示 "Xk / Yk" 其中 Y 为完整上下文窗口
- [ ] 切换会话后重新加载历史消息，验证耗时和 token 数据从 JSONL 正确恢复
- [ ] 验证 Agent Running 指示器与上方消息文本左侧对齐