### PR TITLE
fix: 修复全项目类型检查错误

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -67,6 +67,7 @@
     "@tiptap/extension-underline": "^3.19.0",
     "@tiptap/react": "^3.19.0",
     "@tiptap/starter-kit": "^3.19.0",
+    "@tiptap/suggestion": "^3.19.0",
     "chokidar": "^5.0.0",
     "class-variance-authority": "0.7.1",
     "clsx": "^2.1.1",

--- a/apps/electron/src/main/lib/chat-tools/nano-banana-tool.ts
+++ b/apps/electron/src/main/lib/chat-tools/nano-banana-tool.ts
@@ -332,7 +332,8 @@ export async function executeNanoBananaTool(
       }
     }
 
-    if (!data.candidates || data.candidates.length === 0) {
+    const candidate = data.candidates?.[0]
+    if (!candidate) {
       return {
         toolCallId: toolCall.id,
         content: '未生成任何内容',
@@ -340,7 +341,7 @@ export async function executeNanoBananaTool(
       }
     }
 
-    const parts = data.candidates![0].content.parts
+    const parts = candidate.content.parts
     console.log(`[Nano Banana] 响应包含 ${parts.length} 个 parts，类型:`, parts.map((p) => p.inlineData ? `image(${p.inlineData.mimeType})` : `text(${(p.text ?? '').slice(0, 30)})`))
     const generatedAttachments: FileAttachment[] = []
     const textParts: string[] = []

--- a/bun.lock
+++ b/bun.lock
@@ -51,6 +51,7 @@
         "@tiptap/extension-underline": "^3.19.0",
         "@tiptap/react": "^3.19.0",
         "@tiptap/starter-kit": "^3.19.0",
+        "@tiptap/suggestion": "^3.19.0",
         "chokidar": "^5.0.0",
         "class-variance-authority": "0.7.1",
         "clsx": "^2.1.1",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,5 +5,4 @@
 export * from './types/index'
 export * from './config/index'
 export * from './utils/index'
-export * from './agent/index'
 export * from './constants/permission-rules'


### PR DESCRIPTION
## Summary
- 移除 `@proma/shared` 中对空 `agent/index.ts` 模块的 re-export，修复 `@proma/core` 的 TS2306 错误
- 修复 `nano-banana-tool.ts` 中 `data.candidates` 可能为 undefined 的类型安全问题
- 添加 `@tiptap/suggestion` 为直接依赖，解决 `mention-suggestions.tsx` 和 `file-mention-suggestion.tsx` 的模块找不到及隐式 any 类型错误

## Test plan
- [x] `bun run typecheck` 全部通过（4 个包均无错误）
- [x] `bun run electron:build` 构建成功