### PR TITLE
feat: Agent Plan 模式指示、请求恢复、相对路径修复与 UI 优化

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -1146,6 +1146,20 @@ export function registerIpcHandlers(): void {
     }
   )
 
+  // ===== 待处理请求恢复 =====
+
+  // 获取所有待处理的交互请求快照（渲染进程重载后恢复状态）
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.GET_PENDING_REQUESTS,
+    async (): Promise<import('@proma/shared').PendingRequestsSnapshot> => {
+      return {
+        permissions: permissionService.getPendingRequests(),
+        askUsers: askUserService.getPendingRequests(),
+        exitPlans: exitPlanService.getPendingRequests(),
+      }
+    }
+  )
+
   // ===== Agent Teams 数据 =====
 
   // 获取 Team 聚合数据（团队配置 + 任务列表 + 收件箱）

--- a/apps/electron/src/main/lib/agent-ask-user-service.ts
+++ b/apps/electron/src/main/lib/agent-ask-user-service.ts
@@ -102,6 +102,13 @@ export class AgentAskUserService {
   }
 
   /**
+   * 获取当前所有待处理的 AskUser 请求（用于渲染进程重载后恢复状态）
+   */
+  getPendingRequests(): AskUserRequest[] {
+    return [...this.pendingRequests.values()].map((p) => p.request)
+  }
+
+  /**
    * 清除指定会话的所有待处理 AskUser 请求
    */
   clearSessionPending(sessionId: string): void {

--- a/apps/electron/src/main/lib/agent-exit-plan-service.ts
+++ b/apps/electron/src/main/lib/agent-exit-plan-service.ts
@@ -139,6 +139,13 @@ export class AgentExitPlanService {
   }
 
   /**
+   * 获取当前所有待处理的 ExitPlanMode 请求（用于渲染进程重载后恢复状态）
+   */
+  getPendingRequests(): ExitPlanModeRequest[] {
+    return [...this.pendingRequests.values()].map((p) => p.request)
+  }
+
+  /**
    * 清除指定会话的所有待处理请求
    */
   clearSessionPending(sessionId: string): void {

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -661,11 +661,12 @@ export class AgentOrchestrator {
   private persistSDKMessages(
     sessionId: string,
     accumulatedMessages: SDKMessage[],
+    durationMs?: number,
   ): void {
     if (accumulatedMessages.length === 0) return
 
     const toPersist = accumulatedMessages.filter(
-      (m) => m.type === 'assistant' || m.type === 'user'
+      (m) => m.type === 'assistant' || m.type === 'user' || m.type === 'result'
     )
 
     if (toPersist.length === 0) return
@@ -675,6 +676,10 @@ export class AgentOrchestrator {
     const withTimestamps = toPersist.map((m) => {
       const msg = m as Record<string, unknown>
       if (typeof msg._createdAt === 'number') return m
+      // 为 result 消息附加 _durationMs
+      if (m.type === 'result' && durationMs != null) {
+        return { ...m, _createdAt: now, _durationMs: durationMs } as unknown as SDKMessage
+      }
       return { ...m, _createdAt: now } as unknown as SDKMessage
     })
 
@@ -963,11 +968,19 @@ export class AgentOrchestrator {
             }
           : undefined
 
-      // 包装 canUseTool：优先拦截 ExitPlanMode，其余走基础逻辑
+      // 包装 canUseTool：优先拦截 EnterPlanMode/ExitPlanMode，其余走基础逻辑
       const canUseTool = async (toolName: string, input: Record<string, unknown>, options: CanUseToolOptions): Promise<PermissionResult> => {
         // ExitPlanMode 统一走 UI 审批
         if (toolName === 'ExitPlanMode') {
           return handleExitPlanMode(input, options.signal)
+        }
+        // EnterPlanMode：通知渲染进程 Agent 已进入 Plan 模式，然后放行
+        if (toolName === 'EnterPlanMode') {
+          this.eventBus.emit(sessionId, { kind: 'proma_event', event: { type: 'enter_plan_mode', sessionId } })
+          if (baseCanUseTool) {
+            return baseCanUseTool(toolName, input, options)
+          }
+          return { behavior: 'allow' as const, updatedInput: input }
         }
         // 有基础回调则委托
         if (baseCanUseTool) {
@@ -1081,6 +1094,8 @@ export class AgentOrchestrator {
       /** Watchdog 触发标记（死锁被检测到时设为 true） */
       let abortedByWatchdog = false
 
+      const queryStartedAt = Date.now()
+
       for (let attempt = 1; attempt <= MAX_AUTO_RETRIES + 1; attempt++) {
         // 非首次尝试：等待 + 发送重试事件到 UI
         if (attempt > 1) {
@@ -1108,7 +1123,7 @@ export class AgentOrchestrator {
 
           // 等待期间如果会话被中止，退出
           if (!this.activeSessions.has(sessionId)) {
-            this.persistSDKMessages(sessionId, accumulatedMessages)
+            this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
             callbacks.onComplete(getAgentSessionMessages(sessionId))
             return
           }
@@ -1208,14 +1223,14 @@ export class AgentOrchestrator {
                     ? `${typedError.title}: ${typedError.message}`
                     : typedError.message
                   console.log(`[Agent 编排] 可重试错误 (assistant error): ${typedError.code} - ${lastRetryableError}`)
-                  this.persistSDKMessages(sessionId, accumulatedMessages)
+                  this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
                   accumulatedMessages.length = 0
                   shouldRetryFromError = true
                   break
                 }
 
                 // 不可重试 → 终止
-                this.persistSDKMessages(sessionId, accumulatedMessages)
+                this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
 
                 const errorContent = typedError.title
                     ? `${typedError.title}: ${typedError.message}`
@@ -1259,7 +1274,7 @@ export class AgentOrchestrator {
             // 累积 assistant 和 user 消息用于持久化
             // - 跳过 replay 消息，避免 resume 时重复写入
             // - 对 user 消息，仅累积含 tool_result 的（初始用户消息已在步骤 5 手动持久化）
-            if (msg.type === 'assistant' || msg.type === 'user') {
+            if (msg.type === 'assistant' || msg.type === 'user' || msg.type === 'result') {
               const msgRecord = msg as Record<string, unknown>
               if (!msgRecord.isReplay) {
                 if (msg.type === 'user') {
@@ -1277,7 +1292,7 @@ export class AgentOrchestrator {
 
             // Turn 结束时：持久化累积消息
             if (msg.type === 'result') {
-              this.persistSDKMessages(sessionId, accumulatedMessages)
+              this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
               accumulatedMessages.length = 0
             }
 
@@ -1343,7 +1358,7 @@ export class AgentOrchestrator {
           retrySucceeded = true
 
           // 15. 持久化 assistant 消息
-          this.persistSDKMessages(sessionId, accumulatedMessages)
+          this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
 
           // 16. Agent Teams Auto-Resume：teammates 完成后自动收集结果并汇总
           console.log(`[Agent 编排] Auto-resume 条件检查: startedTasks=${startedTaskIds.size}, sdkSession=${!!capturedSdkSessionId}, active=${this.activeSessions.has(sessionId)}`)
@@ -1406,7 +1421,7 @@ export class AgentOrchestrator {
 
                 // 持久化 resume 助手消息
                 if (resumeMessages.length > 0) {
-                  this.persistSDKMessages(sessionId, resumeMessages)
+                  this.persistSDKMessages(sessionId, resumeMessages, Date.now() - queryStartedAt)
                 }
 
                 console.log(`[Agent 编排] Auto-resume 完成`)
@@ -1457,7 +1472,7 @@ export class AgentOrchestrator {
           if (!this.activeSessions.has(sessionId)) {
             const wasStoppedByUser = this.stoppedBySessions.delete(sessionId)
             console.log(`[Agent 编排] 会话 ${sessionId} 已被用户中止`)
-            this.persistSDKMessages(sessionId, accumulatedMessages)
+            this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
             callbacks.onComplete(getAgentSessionMessages(sessionId), { stoppedByUser: wasStoppedByUser })
             return
           }
@@ -1474,7 +1489,7 @@ export class AgentOrchestrator {
               : (error instanceof Error ? error.message : '未知错误')
             console.log(`[Agent 编排] 可重试错误 (catch): ${lastRetryableError}`)
             // 保存部分内容
-            this.persistSDKMessages(sessionId, accumulatedMessages)
+            this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
             accumulatedMessages.length = 0
             stderrChunks.length = 0
             continue  // 进入下一次 retry 循环
@@ -1487,7 +1502,7 @@ export class AgentOrchestrator {
           // 保存已累积的部分内容
           if (accumulatedMessages.length > 0) {
             try {
-              this.persistSDKMessages(sessionId, accumulatedMessages)
+              this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
               console.log(`[Agent 编排] 已保存部分执行结果 (${accumulatedMessages.length} 条消息)`)
             } catch (saveError) {
               console.error('[Agent 编排] 保存部分内容失败:', saveError)

--- a/apps/electron/src/main/lib/agent-permission-service.ts
+++ b/apps/electron/src/main/lib/agent-permission-service.ts
@@ -185,6 +185,13 @@ export class AgentPermissionService {
   }
 
   /**
+   * 获取当前所有待处理的权限请求（用于渲染进程重载后恢复状态）
+   */
+  getPendingRequests(): PermissionRequest[] {
+    return [...this.pendingPermissions.values()].map((p) => p.request)
+  }
+
+  /**
    * 清除指定会话的白名单（会话结束时调用）
    */
   clearSessionWhitelist(sessionId: string): void {

--- a/apps/electron/src/main/lib/agent-prompt-builder.ts
+++ b/apps/electron/src/main/lib/agent-prompt-builder.ts
@@ -52,7 +52,9 @@ export function buildSystemPrompt(ctx: SystemPromptContext): string {
 - 文本输出直接写在回复中，不要用 echo/printf
 - 当存在内置工具时，优先采用内置工具完成任务，避免滥用 MCP、shell 等过于通用的工具来完成简单任务
 - 复杂操作（如大规模重构、架构设计、头脑风暴等）优先考虑先委派相关的探索 SubAgent 来收集足够的消息或者调研，不确定的部分调用头脑风暴 Skill 来跟用户确认，最后进入 Plan 模式输出执行计划，确保每一步都在用户的掌控之下
-- 处理多个独立任务时，尽量并行调用工具以提高效率`)
+- 处理多个独立任务时，尽量并行调用工具以提高效率
+- 用户可能也会在工作区文件夹下添加文件或者附加文件作为长期上下文或者长期处理任务，要注意及时感知这些变化并利用起来
+`)
 
   // 用户信息
   sections.push(`## 用户信息
@@ -76,8 +78,6 @@ export function buildSystemPrompt(ctx: SystemPromptContext): string {
 当前用户使用的是${ctx.permissionMode === 'bypassPermissions' ? '完全自动模式（所有工具调用自动批准）' : '计划模式（仅规划不执行）'}。
 
 **⚠️ 严禁调用 AskUserQuestion 工具！**
-在当前模式下，AskUserQuestion 工具的弹窗不会显示给用户，调用后会直接导致请求失败并中断你的工作流。这是一个已知的技术限制，不是你能绕过的问题。
-
 **当你遇到不确定的情况时：**
 - **停下来，直接在回复文本中向用户提问**，等待用户回复后再继续
 - 列出你考虑的选项和各自的利弊，让用户决策
@@ -97,9 +97,9 @@ export function buildSystemPrompt(ctx: SystemPromptContext): string {
     sections.push(`## 计划模式
 
 你当前处于计划模式。规则：
-1. 将计划文件写入当前工作目录的 \`.context/\` 子目录（如 \`.context/my-plan.md\`）
+1. 将计划文件写入当前工作目录的 \`.context/plan/\` 子目录（如 \`.context/plan/my-plan.md\`）
 2. 完成计划后，**不要立即调用 ExitPlanMode**
-3. 先向用户展示计划摘要，然后等待用户确认后再退出计划模式
+3. 先向用户展示计划摘要，以及完整的计划文档的路径地址，然后等待用户确认后再退出计划模式
 4. 用户确认执行后，再调用 ExitPlanMode 退出计划模式`)
   }
 
@@ -149,9 +149,10 @@ export function buildSystemPrompt(ctx: SystemPromptContext): string {
 
 1. 优先使用中文回复，保留技术术语
 2. 确认破坏性操作后再执行
-3. 使用 Markdown 格式化输出
-4. 自称 Proma Agent
-5. 回复简洁直接，不要冗长`)
+3. 你可以经常性的维护一个 CLAUDE.md 文档，并积极更新
+4. 也推荐你可以在用户执行更长和更复杂的任务时，主动在当前目录下的 \`.context\` 目录中维护 note.md 和 todo.md 来帮助你记录和规划任务的细节和进展，保持对复杂任务的清晰掌控，并保证你可以及时回来更新
+5. 自称 Proma Agent
+6. 回复简洁直接，不要冗长`)
 
   return sections.join('\n\n')
 }

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -83,6 +83,7 @@ import type {
   FeishuNotificationSentPayload,
   FeishuUpdateBindingInput,
   AgentQueueMessageInput,
+  PendingRequestsSnapshot,
 } from '@proma/shared'
 import type { UserProfile, AppSettings } from '../types'
 
@@ -430,6 +431,9 @@ export interface ElectronAPI {
 
   /** 响应 ExitPlanMode 请求 */
   respondExitPlanMode: (response: ExitPlanModeResponse) => Promise<void>
+
+  /** 获取所有待处理的交互请求快照（渲染进程重载后恢复状态） */
+  getPendingRequests: () => Promise<PendingRequestsSnapshot>
 
   // ===== Agent Teams 数据 =====
 
@@ -1031,6 +1035,11 @@ const electronAPI: ElectronAPI = {
   // ExitPlanMode 计划审批
   respondExitPlanMode: (response: ExitPlanModeResponse) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.EXIT_PLAN_MODE_RESPOND, response)
+  },
+
+  // 待处理请求恢复
+  getPendingRequests: () => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.GET_PENDING_REQUESTS)
   },
 
   // Agent Teams 数据

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -765,6 +765,9 @@ export const pendingAskUserRequestsAtom = atom(
 /** 待处理的 ExitPlanMode 请求 Map — 以 sessionId 为 key */
 export const allPendingExitPlanRequestsAtom = atom<Map<string, readonly ExitPlanModeRequest[]>>(new Map())
 
+/** 当前处于 Plan 模式的会话 ID 集合 */
+export const agentPlanModeSessionsAtom = atom<Set<string>>(new Set<string>())
+
 export const currentAgentSessionAtom = atom<AgentSessionMeta | null>((get) => {
   const sessions = get(agentSessionsAtom)
   const currentId = get(currentAgentSessionIdAtom)

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -601,7 +601,7 @@ export function DurationBadge({ durationMs, usage }: { durationMs: number; usage
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span className="text-[15px] text-muted-foreground/60 tabular-nums font-light cursor-default">
+        <span className="text-[15px] tabular-nums font-light cursor-default">
           {formatDuration(durationMs)}
         </span>
       </TooltipTrigger>
@@ -632,7 +632,7 @@ function AgentRunningIndicator({ startedAt }: { startedAt?: number }): React.Rea
   }
 
   return (
-    <div className="flex items-center gap-2 py-1">
+    <div className="flex items-center gap-2 min-h-[28px]">
       <Spinner size="sm" className="text-primary/50" />
       <span className="text-[13px] font-light text-muted-foreground/50 tabular-nums">Agent Running {formatTime(elapsed)}</span>
     </div>
@@ -789,7 +789,7 @@ export function AgentMessages({ sessionId, messages, persistedSDKMessages, strea
 
             {/* 有实时助手内容时：仅追加运行指示器 */}
             {hasLiveAssistantContent && (streaming || retrying) && (
-              <div className="pl-[56px]">
+              <div className="pl-[46px] mt-0.5">
                 {retrying && <RetryingNotice retrying={retrying} />}
                 {streaming && <AgentRunningIndicator startedAt={startedAt} />}
               </div>

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -16,7 +16,7 @@
 import * as React from 'react'
 import { useAtom, useAtomValue, useSetAtom, useStore } from 'jotai'
 import { toast } from 'sonner'
-import { Bot, CornerDownLeft, Square, Settings, Paperclip, FolderPlus, X, Copy, Check, Sparkles, Brain } from 'lucide-react'
+import { Bot, CornerDownLeft, Square, Settings, Paperclip, FolderPlus, X, Copy, Check, Sparkles, Brain, Map as MapIcon } from 'lucide-react'
 import { AgentMessages } from './AgentMessages'
 import { AgentHeader } from './AgentHeader'
 import { ContextUsageBadge } from './ContextUsageBadge'
@@ -57,6 +57,7 @@ import {
   liveMessagesMapAtom,
   agentThinkingAtom,
   stoppedByUserSessionsAtom,
+  agentPlanModeSessionsAtom,
 } from '@/atoms/agent-atoms'
 import type { AgentContextStatus } from '@/atoms/agent-atoms'
 import { activeViewAtom } from '@/atoms/active-view'
@@ -97,6 +98,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const setAgentStreamErrors = useSetAtom(agentStreamErrorsAtom)
   const streamErrors = useAtomValue(agentStreamErrorsAtom)
   const agentError = streamErrors.get(sessionId) ?? null
+  const planModeSessions = useAtomValue(agentPlanModeSessionsAtom)
+  const isPlanMode = planModeSessions.has(sessionId)
   const store = useStore()
   const suggestionsMap = useAtomValue(agentPromptSuggestionsAtom)
   const suggestion = suggestionsMap.get(sessionId) ?? null
@@ -954,6 +957,15 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
 
         {/* AskUserQuestion 交互式问答横幅 */}
         <AskUserBanner sessionId={sessionId} />
+
+        {/* Plan 模式指示条 */}
+        {isPlanMode && (
+          <div className="mx-4 mb-2 flex items-center gap-2 px-3 py-2 rounded-lg bg-primary/5 text-primary text-sm animate-in fade-in slide-in-from-bottom-1 duration-200">
+            <MapIcon className="size-4 animate-pulse" />
+            <span className="font-medium">Agent 正在规划中...</span>
+            <span className="text-xs text-muted-foreground">完成后将请求你的审批</span>
+          </div>
+        )}
 
         {/* ExitPlanMode 计划审批横幅 */}
         <ExitPlanModeBanner sessionId={sessionId} />

--- a/apps/electron/src/renderer/components/agent/ExitPlanModeBanner.tsx
+++ b/apps/electron/src/renderer/components/agent/ExitPlanModeBanner.tsx
@@ -51,7 +51,7 @@ const PLAN_OPTIONS: PlanOption[] = [
   {
     action: 'deny',
     label: '拒绝计划',
-    description: 'Agent 将重新规划',
+    description: '直接拒绝，Agent 不会执行计划',
     icon: <X className="size-3.5" />,
     variant: 'destructive',
   },

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -431,7 +431,7 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, isS
         const hasDuration = durationMs != null
         if (!hasDuration && !hasActions) return null
         return (
-          <MessageActions className="pl-[46px] mt-0.5 justify-start">
+          <MessageActions className="pl-[46px] mt-0.5 min-h-[28px] justify-start animate-in fade-in duration-200">
             {hasDuration && <DurationBadge durationMs={durationMs!} usage={usage} />}
             {textContent && <CopyButton content={textContent} />}
             {onFork && lastUuid && (

--- a/apps/electron/src/renderer/components/agent/tool-utils.ts
+++ b/apps/electron/src/renderer/components/agent/tool-utils.ts
@@ -19,6 +19,8 @@ import {
   ImagePlus,
   List,
   ListChecks,
+  Map,
+  MapPinOff,
   Pencil,
   Plug,
 
@@ -50,6 +52,8 @@ export const TOOL_ICONS: Record<string, LucideIcon> = {
   TaskList: List,
   TeamCreate: Users,
   Agent: Bot,
+  EnterPlanMode: Map,
+  ExitPlanMode: MapPinOff,
   generate_image: ImagePlus,
 }
 
@@ -85,6 +89,8 @@ const TOOL_DISPLAY_NAMES: Record<string, string> = {
   TaskList: '任务列表',
   TeamCreate: '创建团队',
   Agent: 'Agent',
+  EnterPlanMode: '正在生成计划',
+  ExitPlanMode: '正在退出计划',
   generate_image: '生成图片',
 }
 

--- a/apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx
@@ -139,8 +139,8 @@ export function isRelativeFilePath(text: string): boolean {
   // 排除含空格或特殊字符的（太可能是其他内容）
   if (!/^[\w./@-]+$/.test(trimmed)) return false
 
-  // 排除以点开头的隐藏文件（如 .gitignore）——这些通常不是要预览的
-  if (trimmed.startsWith('.') && !trimmed.startsWith('./')) return false
+  // 排除以点开头的隐藏文件（如 .gitignore），但保留含子路径的目录相对路径（如 .context/file.md）
+  if (trimmed.startsWith('.') && !trimmed.startsWith('./') && !trimmed.includes('/')) return false
 
   return true
 }

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -30,6 +30,7 @@ import {
   liveMessagesMapAtom,
   agentPermissionModeAtom,
   stoppedByUserSessionsAtom,
+  agentPlanModeSessionsAtom,
 } from '@/atoms/agent-atoms'
 import {
   notificationsEnabledAtom,
@@ -60,6 +61,8 @@ function payloadToLegacyEvents(payload: AgentStreamPayload): AgentEvent[] {
         return [{ type: 'exit_plan_mode_request', request: evt.request }]
       case 'exit_plan_mode_resolved':
         return [{ type: 'exit_plan_mode_resolved', requestId: evt.requestId }]
+      case 'enter_plan_mode':
+        return [{ type: 'enter_plan_mode', sessionId: evt.sessionId }]
       case 'model_resolved':
         return [{ type: 'model_resolved', model: evt.model }]
       case 'permission_mode_changed':
@@ -254,6 +257,12 @@ export function useGlobalAgentListeners(): void {
         if (payload.kind === 'sdk_message') {
           const msgRecord = payload.message as Record<string, unknown>
           if (!msgRecord.isReplay) {
+            // 为实时消息补充 _createdAt 时间戳（与持久化时的逻辑一致），
+            // 避免 AssistantTurnRenderer 因缺少时间戳导致 header 时间消失
+            if (typeof msgRecord._createdAt !== 'number') {
+              msgRecord._createdAt = Date.now()
+            }
+
             store.set(liveMessagesMapAtom, (prev) => {
               const map = new Map(prev)
               const current = map.get(sessionId) ?? []
@@ -399,6 +408,13 @@ export function useGlobalAgentListeners(): void {
               map.set(sessionId, [...current, event.request])
               return map
             })
+            // 退出 Plan 模式指示状态
+            store.set(agentPlanModeSessionsAtom, (prev: Set<string>) => {
+              if (!prev.has(sessionId)) return prev
+              const next = new Set(prev)
+              next.delete(sessionId)
+              return next
+            })
             // 桌面通知
             const enabled = store.get(notificationsEnabledAtom)
             sendDesktopNotification(
@@ -406,6 +422,16 @@ export function useGlobalAgentListeners(): void {
               'Agent 已完成计划，等待你的审批',
               enabled
             )
+          } else if (event.type === 'enter_plan_mode') {
+            // 进入 Plan 模式
+            store.set(agentPlanModeSessionsAtom, (prev: Set<string>) => {
+              if (prev.has(sessionId)) return prev
+              const next = new Set(prev)
+              next.add(sessionId)
+              return next
+            })
+            // 同步更新权限模式选择器
+            store.set(agentPermissionModeAtom, 'plan')
           } else if (event.type === 'permission_mode_changed') {
             // 权限模式变更（如 Plan 模式退出时切换到完全自动）
             console.log(`[GlobalAgentListeners] 权限模式变更: ${event.mode}`)
@@ -446,6 +472,14 @@ export function useGlobalAgentListeners(): void {
             return next
           })
         }
+
+        // 清除 Plan 模式状态（防止异常退出时残留）
+        store.set(agentPlanModeSessionsAtom, (prev: Set<string>) => {
+          if (!prev.has(data.sessionId)) return prev
+          const next = new Set(prev)
+          next.delete(data.sessionId)
+          return next
+        })
 
         // 缓存 Team 活动数据（在流式状态被清除前保存，防止面板数据丢失）
         const streamState = store.get(agentStreamingStatesAtom).get(data.sessionId)

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -468,6 +468,8 @@ export type AgentEvent =
   // ExitPlanMode 计划审批
   | { type: 'exit_plan_mode_request'; request: ExitPlanModeRequest }
   | { type: 'exit_plan_mode_resolved'; requestId: string }
+  // EnterPlanMode 进入计划模式
+  | { type: 'enter_plan_mode'; sessionId: string }
   // 提示建议
   | { type: 'prompt_suggestion'; suggestion: string }
   // 模型确认（SDK 确认实际使用的模型）
@@ -488,6 +490,7 @@ export type PromaEvent =
   | { type: 'ask_user_resolved'; requestId: string }
   | { type: 'exit_plan_mode_request'; request: ExitPlanModeRequest }
   | { type: 'exit_plan_mode_resolved'; requestId: string }
+  | { type: 'enter_plan_mode'; sessionId: string }
   | { type: 'retry'; status: 'starting' | 'attempt' | 'cleared' | 'failed'; attempt?: number; maxAttempts?: number; delaySeconds?: number; reason?: string; attemptData?: RetryAttempt; error?: TypedError }
   | { type: 'model_resolved'; model: string }
   | { type: 'waiting_resume'; message: string }
@@ -1214,4 +1217,20 @@ export const AGENT_IPC_CHANNELS = {
   PROMOTE_QUEUED_MESSAGE: 'agent:promote-queued-message',
   /** 队列消息状态变更通知（主进程 → 渲染进程推送） */
   QUEUED_MESSAGE_STATUS: 'agent:queued-message-status',
+
+  // 待处理请求恢复（渲染进程重载后查询主进程状态）
+  /** 获取所有待处理的交互请求快照 */
+  GET_PENDING_REQUESTS: 'agent:get-pending-requests',
 } as const
+
+/**
+ * 待处理交互请求快照（用于渲染进程重载后恢复状态）
+ */
+export interface PendingRequestsSnapshot {
+  /** 待处理的权限请求 */
+  permissions: PermissionRequest[]
+  /** 待处理的 AskUser 请求 */
+  askUsers: AskUserRequest[]
+  /** 待处理的 ExitPlanMode 请求 */
+  exitPlans: ExitPlanModeRequest[]
+}


### PR DESCRIPTION
## Summary
- 新增 EnterPlanMode 事件流转和"Agent 正在规划中"指示条，用户可实时感知 Agent 进入 Plan 模式
- 新增 `GET_PENDING_REQUESTS` IPC 通道，渲染进程 HMR/重载后自动恢复待处理的权限、AskUser、ExitPlanMode 请求
- 持久化 `result` 消息并附加 `_durationMs`，优化运行时长统计准确性
- 修复 `isRelativeFilePath` 对 `.context/file.md` 等含子路径的点开头目录的误判
- 优化 Agent prompt：丰富工具使用指南、计划模式写入路径改为 `.context/plan/`、交互规范增加 CLAUDE.md 维护建议

## Test plan
- [ ] 在 Plan 权限模式下发送消息，验证"Agent 正在规划中"指示条出现和消失
- [ ] 在 Agent 运行中触发渲染进程重载（Cmd+R），验证待处理的权限/AskUser 请求能恢复
- [ ] 验证 `.context/plan.md` 等相对路径在消息中正确渲染为可点击 chip
- [ ] 验证 Actions Bar 的运行时长和布局对齐正常