### PR TITLE
feat: Agent 工具调用结果可读性优化与渠道切换改进

### DIFF
--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -549,6 +549,8 @@ export const agentWorkspacesAtom = atom<AgentWorkspace[]>([])
 export const currentAgentWorkspaceIdAtom = atom<string | null>(null)
 export const agentChannelIdAtom = atom<string | null>(null)
 export const agentModelIdAtom = atom<string | null>(null)
+/** Agent 启用的渠道 ID 列表（多选，设置页 Switch 开关控制） */
+export const agentChannelIdsAtom = atom<string[]>([])
 export const currentAgentSessionIdAtom = atom<string | null>(null)
 export const currentAgentMessagesAtom = atom<AgentMessage[]>([])
 export const agentStreamingStatesAtom = atom<Map<string, AgentStreamState>>(new Map())

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -28,11 +28,12 @@ import { UserAvatar } from '@/components/chat/UserAvatar'
 import { CopyButton } from '@/components/chat/CopyButton'
 import { formatMessageTime } from '@/components/chat/ChatMessageItem'
 import { Button } from '@/components/ui/button'
-import { getModelLogo } from '@/lib/model-logo'
+import { getModelLogo, resolveModelDisplayName } from '@/lib/model-logo'
 import { ToolActivityList } from './ToolActivityItem'
 import { BackgroundTasksPanel } from './BackgroundTasksPanel'
 import { useBackgroundTasks } from '@/hooks/useBackgroundTasks'
 import { userProfileAtom } from '@/atoms/user-profile'
+import { channelsAtom } from '@/atoms/chat-atoms'
 import { stoppedByUserSessionsAtom } from '@/atoms/agent-atoms'
 import { ScrollPositionManager } from '@/hooks/useScrollPositionMemory'
 import { cn } from '@/lib/utils'
@@ -453,6 +454,7 @@ interface AgentMessageItemProps {
 
 function AgentMessageItem({ message, sessionPath, onRetry, onRetryInNewSession, onCompact }: AgentMessageItemProps): React.ReactElement | null {
   const userProfile = useAtomValue(userProfileAtom)
+  const channels = useAtomValue(channelsAtom)
 
   if (message.role === 'user') {
     const { files: attachedFiles, text: messageText } = parseAttachedFiles(message.content)
@@ -494,7 +496,7 @@ function AgentMessageItem({ message, sessionPath, onRetry, onRetryInNewSession, 
     return (
       <Message from="assistant">
         <MessageHeader
-          model={message.model}
+          model={message.model ? resolveModelDisplayName(message.model, channels) : undefined}
           time={formatMessageTime(message.createdAt)}
           logo={<AssistantLogo model={message.model} />}
         />
@@ -641,6 +643,7 @@ function AgentRunningIndicator({ startedAt }: { startedAt?: number }): React.Rea
 
 export function AgentMessages({ sessionId, messages, persistedSDKMessages, streaming, streamState, liveMessages, sessionPath, onRetry, onRetryInNewSession, onFork, onCompact }: AgentMessagesProps): React.ReactElement {
   const userProfile = useAtomValue(userProfileAtom)
+  const channels = useAtomValue(channelsAtom)
   const stoppedByUserSessions = useAtomValue(stoppedByUserSessionsAtom)
   const stoppedByUser = stoppedByUserSessions.has(sessionId)
 
@@ -691,7 +694,7 @@ export function AgentMessages({ sessionId, messages, persistedSDKMessages, strea
   // 从 streamState 属性中计算派生值
   const streamingContent = streamState?.content ?? ''
   const toolActivities = streamState?.toolActivities ?? []
-  const agentStreamingModel = streamState?.model
+  const agentStreamingModel = streamState?.model ? resolveModelDisplayName(streamState.model, channels) : undefined
   const retrying = streamState?.retrying
   const startedAt = streamState?.startedAt
 

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -36,6 +36,7 @@ import {
   agentStreamingStatesAtom,
   agentChannelIdAtom,
   agentModelIdAtom,
+  agentChannelIdsAtom,
   currentAgentWorkspaceIdAtom,
   agentPendingPromptAtom,
   agentPendingFilesAtom,
@@ -79,6 +80,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const liveMessages = liveMessagesMap.get(sessionId) ?? []
   const [agentChannelId, setAgentChannelId] = useAtom(agentChannelIdAtom)
   const [agentModelId, setAgentModelId] = useAtom(agentModelIdAtom)
+  const agentChannelIds = useAtomValue(agentChannelIdsAtom)
   const [agentThinking, setAgentThinking] = useAtom(agentThinkingAtom)
   const setActiveView = useSetAtom(activeViewAtom)
   const currentWorkspaceId = useAtomValue(currentAgentWorkspaceIdAtom)
@@ -1058,13 +1060,11 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
             {/* Footer 工具栏 */}
             <div className="flex items-center justify-between px-2 py-1 h-[48px] gap-4">
               <div className="flex items-center gap-1.5 flex-1 min-w-0">
-                {stableChannelId && (
-                  <ModelSelector
-                    filterChannelId={stableChannelId}
-                    externalSelectedModel={externalSelectedModel}
-                    onModelSelect={handleModelSelect}
-                  />
-                )}
+                <ModelSelector
+                  filterChannelIds={agentChannelIds}
+                  externalSelectedModel={externalSelectedModel}
+                  onModelSelect={handleModelSelect}
+                />
                 <PermissionModeSelector />
                 {/* 思考模式切换 */}
                 <Tooltip>

--- a/apps/electron/src/renderer/components/agent/ContentBlock.tsx
+++ b/apps/electron/src/renderer/components/agent/ContentBlock.tsx
@@ -3,7 +3,7 @@
  *
  * 支持三种内容块类型：
  * - text: 通过 MessageResponse 渲染 Markdown
- * - tool_use: 简洁单行（图标 + 工具名 + 摘要），可展开详情
+ * - tool_use: 语义化短语行（如 "读取 foo.ts 第 10-60 行"），展开显示结构化结果
  * - thinking: 默认展开，左上角 "Thinking" 标签 + 虚线边框内容区
  */
 
@@ -17,7 +17,9 @@ import {
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { MessageResponse } from '@/components/ai-elements/message'
-import { getToolIcon, getToolDisplayName, getInputSummary } from './tool-utils'
+import { getToolIcon } from './tool-utils'
+import { getToolPhrase } from './tool-phrase'
+import { ToolResultRenderer } from './tool-result-renderers'
 import type {
   SDKContentBlock,
   SDKMessage,
@@ -85,8 +87,6 @@ export interface ContentBlockProps {
   childBlocks?: SDKContentBlock[]
 }
 
-// ===== 工具调用块（简洁单行风格） =====
-
 // ===== 提示词折叠行 =====
 
 function PromptRow({ prompt, dimmed = false }: { prompt: string; dimmed?: boolean }): React.ReactElement {
@@ -133,13 +133,14 @@ function PromptRow({ prompt, dimmed = false }: { prompt: string; dimmed?: boolea
   )
 }
 
+// ===== 工具调用块 =====
+
 interface ToolUseBlockProps {
   block: SDKToolUseBlock
   allMessages: SDKMessage[]
   animate?: boolean
   index?: number
   dimmed?: boolean
-  /** 子代理的内容块（Agent/Task 嵌套） */
   childBlocks?: SDKContentBlock[]
   basePath?: string
 }
@@ -153,14 +154,14 @@ function ToolUseBlock({ block, allMessages, animate = false, index = 0, dimmed =
   // Agent/Task 子代理内容默认折叠
   const [childrenExpanded, setChildrenExpanded] = React.useState(false)
 
-  const inputSummary = getInputSummary(block.name, block.input)
-  // 自描述工具：摘要已包含完整语义，直接作为显示名，不再额外显示工具名
-  const isSelfDescribing = block.name === 'TaskUpdate' && !!inputSummary
-  const displayName = isSelfDescribing ? inputSummary : getToolDisplayName(block.name)
-  const ToolIcon = getToolIcon(isSelfDescribing ? 'TaskUpdate' : block.name)
+  const phrase = getToolPhrase(block.name, block.input)
+  const ToolIcon = getToolIcon(block.name)
 
   const isCompleted = toolResult !== null
   const isError = toolResult?.isError === true
+
+  // 运行中显示进行时短语，完成后显示完成态短语
+  const displayLabel = isCompleted ? phrase.label : phrase.loadingLabel
 
   const delay = animate && index < 10 ? `${index * 30}ms` : '0ms'
 
@@ -181,7 +182,7 @@ function ToolUseBlock({ block, allMessages, animate = false, index = 0, dimmed =
         )}
         style={animate ? { animationDelay: delay } : undefined}
       >
-        {/* 头部行：折叠箭头 + Spinner + 工具名 + 描述 */}
+        {/* 头部行：折叠箭头 + 状态 + 语义短语 */}
         <button
           type="button"
           className="w-full flex items-center gap-2 py-0.5 text-left hover:opacity-70 transition-opacity group"
@@ -194,7 +195,7 @@ function ToolUseBlock({ block, allMessages, animate = false, index = 0, dimmed =
             )}
           />
 
-          {/* Spinner / 完成状态 */}
+          {/* 状态指示 */}
           {!isCompleted ? (
             <Loader2 className="size-3.5 animate-spin text-primary/50 shrink-0" />
           ) : isError ? (
@@ -204,18 +205,9 @@ function ToolUseBlock({ block, allMessages, animate = false, index = 0, dimmed =
           <ToolIcon className={cn('size-3.5 shrink-0', dimmed ? 'text-muted-foreground/70' : 'text-muted-foreground')} />
 
           <span className={cn(
-            'shrink-0 text-[14px]',
+            'truncate text-[14px]',
             dimmed ? 'text-muted-foreground/70' : 'text-muted-foreground',
-          )}>{displayName}</span>
-
-          {inputSummary && (
-            <span className={cn(
-              'truncate text-[14px]',
-              dimmed ? 'text-muted-foreground/50' : 'text-muted-foreground/60',
-            )}>
-              {inputSummary}
-            </span>
-          )}
+          )}>{displayLabel}</span>
 
           {/* 子工具计数（折叠时显示） */}
           {childToolCount > 0 && !childrenExpanded && (
@@ -228,7 +220,7 @@ function ToolUseBlock({ block, allMessages, animate = false, index = 0, dimmed =
         {/* 展开内容 */}
         {childrenExpanded && (
           <div className="pl-5 mt-1.5 space-y-2 border-l-2 border-primary/20 ml-[5px] animate-in fade-in slide-in-from-top-1 duration-150">
-            {/* 提示词：可折叠行，与普通工具一致 */}
+            {/* 提示词：可折叠行 */}
             {agentPrompt && <PromptRow prompt={agentPrompt} dimmed={dimmed} />}
 
             {/* 子代理工具调用 */}
@@ -249,7 +241,7 @@ function ToolUseBlock({ block, allMessages, animate = false, index = 0, dimmed =
     )
   }
 
-  // ===== 普通工具：原有渲染 =====
+  // ===== 普通工具：语义化短语 + 结构化结果 =====
   return (
     <div
       className={cn(
@@ -271,18 +263,9 @@ function ToolUseBlock({ block, allMessages, animate = false, index = 0, dimmed =
         <ToolIcon className={cn('size-3.5 shrink-0', dimmed ? 'text-muted-foreground/70' : 'text-muted-foreground')} />
 
         <span className={cn(
-          'shrink-0 text-[14px]',
+          'truncate text-[14px]',
           dimmed ? 'text-muted-foreground/70' : 'text-muted-foreground',
-        )}>{displayName}</span>
-
-        {!isSelfDescribing && inputSummary && (
-          <span className={cn(
-            'truncate text-[14px] font-mono',
-            dimmed ? 'text-muted-foreground/70' : 'text-muted-foreground',
-          )}>
-            {inputSummary}
-          </span>
-        )}
+        )}>{displayLabel}</span>
 
         <ChevronRight
           className={cn(
@@ -292,33 +275,14 @@ function ToolUseBlock({ block, allMessages, animate = false, index = 0, dimmed =
         />
       </button>
 
-      {expanded && (
-        <div className="ml-5.5 mt-1 mb-2 space-y-2 pl-3 border-l-2 border-border/30 animate-in fade-in slide-in-from-top-1 duration-150">
-          {Object.keys(block.input).length > 0 && (
-            <div>
-              <div className="text-[11px] font-medium text-muted-foreground/50 mb-1">输入</div>
-              <pre className="text-[11px] text-muted-foreground bg-muted/30 rounded p-2 overflow-x-auto max-h-[150px] overflow-y-auto whitespace-pre-wrap break-all">
-                {JSON.stringify(block.input, null, 2)}
-              </pre>
-            </div>
-          )}
-          {toolResult?.result && (
-            <div>
-              <div className="text-[11px] font-medium text-muted-foreground/50 mb-1">结果</div>
-              <pre
-                className={cn(
-                  'text-[11px] rounded p-2 overflow-x-auto max-h-[150px] overflow-y-auto whitespace-pre-wrap break-all',
-                  isError
-                    ? 'text-destructive/80 bg-destructive/5'
-                    : 'text-muted-foreground bg-muted/30',
-                )}
-              >
-                {toolResult.result.length > 2000
-                  ? toolResult.result.slice(0, 2000) + '\n… [截断]'
-                  : toolResult.result}
-              </pre>
-            </div>
-          )}
+      {expanded && toolResult?.result && (
+        <div className="ml-5.5 mt-1 mb-2 pl-3 border-l-2 border-border/30 animate-in fade-in slide-in-from-top-1 duration-150">
+          <ToolResultRenderer
+            toolName={block.name}
+            input={block.input}
+            result={toolResult.result}
+            isError={isError}
+          />
         </div>
       )}
     </div>

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -29,8 +29,9 @@ import {
 import { UserAvatar } from '@/components/chat/UserAvatar'
 import { CopyButton } from '@/components/chat/CopyButton'
 import { formatMessageTime } from '@/components/chat/ChatMessageItem'
-import { getModelLogo } from '@/lib/model-logo'
+import { getModelLogo, resolveModelDisplayName } from '@/lib/model-logo'
 import { userProfileAtom } from '@/atoms/user-profile'
+import { channelsAtom } from '@/atoms/chat-atoms'
 import type {
   SDKMessage,
   SDKAssistantMessage,
@@ -317,6 +318,7 @@ export interface AssistantTurnRendererProps {
 }
 
 export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, isStreaming }: AssistantTurnRendererProps): React.ReactElement | null {
+  const channels = useAtomValue(channelsAtom)
   // 收集所有 assistant 消息的内容块，保留 parent_tool_use_id 关联
   interface EnrichedBlock {
     block: SDKContentBlock
@@ -384,7 +386,7 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, isS
   return (
     <Message from="assistant">
       <MessageHeader
-        model={turn.model}
+        model={turn.model ? resolveModelDisplayName(turn.model, channels) : undefined}
         time={turn.createdAt ? formatMessageTime(turn.createdAt) : undefined}
         logo={<AssistantLogo model={turn.model} />}
       />
@@ -454,6 +456,7 @@ export function SDKMessageRenderer({
   basePath,
   showHeader = true,
 }: SDKMessageRendererProps): React.ReactElement | null {
+  const channels = useAtomValue(channelsAtom)
   const msgType = message.type
 
   // assistant 消息：遍历内容块渲染
@@ -483,7 +486,7 @@ export function SDKMessageRenderer({
       <Message from="assistant">
         {showHeader && (
           <MessageHeader
-            model={model}
+            model={model ? resolveModelDisplayName(model, channels) : undefined}
             time={meta.createdAt ? formatMessageTime(meta.createdAt) : undefined}
             logo={<AssistantLogo model={model} />}
           />

--- a/apps/electron/src/renderer/components/agent/ToolActivityItem.tsx
+++ b/apps/electron/src/renderer/components/agent/ToolActivityItem.tsx
@@ -1,11 +1,11 @@
 /**
  * ToolActivityItem — 紧凑列表式工具活动展示
  *
- * 对标 craft-agents-oss TurnCard 的 ActivityRow 设计：
- * - 单行紧凑布局（24px 行高）
- * - 工具类型图标 + 语义状态切换
- * - Badge 系统（文件名 / diff 统计 / 错误）
- * - Task 子代理折叠分组 + 左边框层级
+ * 核心设计：
+ * - 收起行：语义化短语（如 "读取 foo.ts 第 10-60 行"），替代工具名 + Badge + 摘要
+ * - 展开面板：按工具类型结构化渲染结果，无输入区
+ * - Loading 态：语义化进行时（如 "正在读取 foo.ts..."）
+ * - Task/Agent 子代理折叠分组 + 左边框层级
  * - CSS 动画（交错入场 / 状态切换）
  */
 
@@ -21,7 +21,9 @@ import {
   Download,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import { getToolIcon } from './tool-utils'
+import { getToolIcon, formatElapsed } from './tool-utils'
+import { getToolPhrase } from './tool-phrase'
+import { ToolResultRenderer } from './tool-result-renderers'
 import {
   type ToolActivity,
   type ActivityGroup,
@@ -86,52 +88,7 @@ function StatusIcon({ status, toolName }: { status: ActivityStatus; toolName?: s
   )
 }
 
-// ===== Diff 统计 =====
-
-interface DiffStats {
-  additions: number
-  deletions: number
-}
-
-function computeDiffStats(toolName: string, input: Record<string, unknown>): DiffStats | null {
-  if (toolName === 'Edit') {
-    const oldStr = typeof input.old_string === 'string' ? input.old_string : ''
-    const newStr = typeof input.new_string === 'string' ? input.new_string : ''
-    if (!oldStr && !newStr) return null
-    const oldLines = oldStr.split('\n').length
-    const newLines = newStr.split('\n').length
-    return { additions: Math.max(0, newLines - oldLines + 1), deletions: Math.max(0, oldLines - newLines + 1) }
-  }
-  return null
-}
-
-// ===== Badge 组件 =====
-
-function FileBadge({ path }: { path: string }): React.ReactElement {
-  const filename = path.split('/').pop() ?? path
-  return (
-    <span className="shrink-0 px-1.5 py-0.5 rounded text-[10px] bg-background shadow-sm text-foreground/70 leading-none">
-      {filename}
-    </span>
-  )
-}
-
-function DiffBadges({ stats }: { stats: DiffStats }): React.ReactElement {
-  return (
-    <span className="shrink-0 flex items-center gap-1">
-      {stats.deletions > 0 && (
-        <span className="px-1.5 py-0.5 rounded text-[10px] bg-destructive/5 text-destructive leading-none shadow-sm">
-          -{stats.deletions}
-        </span>
-      )}
-      {stats.additions > 0 && (
-        <span className="px-1.5 py-0.5 rounded text-[10px] bg-green-500/5 text-green-600 dark:text-green-400 leading-none shadow-sm">
-          +{stats.additions}
-        </span>
-      )}
-    </span>
-  )
-}
+// ===== 错误 Badge =====
 
 function ErrorBadge(): React.ReactElement {
   return (
@@ -139,146 +96,6 @@ function ErrorBadge(): React.ReactElement {
       Error
     </span>
   )
-}
-
-// ===== 格式化耗时 =====
-
-export function formatElapsed(seconds: number): string {
-  if (seconds < 60) return `${seconds.toFixed(1)}s`
-  const m = Math.floor(seconds / 60)
-  const s = Math.round(seconds % 60)
-  return `${m}m${s}s`
-}
-
-// ===== 提取文件路径 =====
-
-function extractFilePath(input: Record<string, unknown>): string | null {
-  const fp = input.file_path ?? input.filePath ?? input.path ?? input.notebook_path
-  return typeof fp === 'string' ? fp : null
-}
-
-// ===== 格式化输入摘要（单行） =====
-
-function getInputSummary(toolName: string, input: Record<string, unknown>): string | null {
-  if (toolName === 'Bash') {
-    const cmd = input.command
-    if (typeof cmd === 'string') return cmd.length > 80 ? cmd.slice(0, 80) + '…' : cmd
-  }
-  if (toolName === 'Grep') {
-    const pattern = input.pattern
-    if (typeof pattern === 'string') return `/${pattern}/`
-  }
-  if (toolName === 'Glob') {
-    const pattern = input.pattern
-    if (typeof pattern === 'string') return pattern
-  }
-  if (toolName === 'WebFetch' || toolName === 'WebSearch') {
-    const url = input.url ?? input.query
-    if (typeof url === 'string') return url.length > 60 ? url.slice(0, 60) + '…' : url
-  }
-  if (toolName === 'Skill') {
-    const skill = input.skill
-    if (typeof skill === 'string') return skill
-  }
-  // Task 子代理：显示 description
-  if (toolName === 'Task') {
-    const desc = input.description ?? input.prompt
-    if (typeof desc === 'string') return desc.length > 80 ? desc.slice(0, 80) + '…' : desc
-  }
-  // TaskCreate：显示 subject
-  if (toolName === 'TaskCreate') {
-    const subject = input.subject
-    if (typeof subject === 'string') return subject.length > 80 ? subject.slice(0, 80) + '…' : subject
-  }
-  // TaskUpdate：显示状态变更（中文化）
-  if (toolName === 'TaskUpdate') {
-    const statusMap: Record<string, string> = {
-      pending: '待处理',
-      in_progress: '正在进行中',
-      completed: '已结束',
-      cancelled: '已取消',
-      blocked: '已阻塞',
-      error: '出错',
-    }
-    const parts: string[] = []
-    if (typeof input.taskId === 'string') parts.push(`任务 #${input.taskId}`)
-    if (typeof input.status === 'string') parts.push(statusMap[input.status] ?? input.status)
-    if (typeof input.subject === 'string') parts.push(input.subject.length > 60 ? input.subject.slice(0, 60) + '…' : input.subject)
-    return parts.length > 0 ? parts.join(' ') : null
-  }
-  // TaskGet / TaskList：显示 taskId 或 reason
-  if (toolName === 'TaskGet') {
-    const taskId = input.taskId
-    if (typeof taskId === 'string') return `#${taskId}`
-  }
-  if (toolName === 'TaskList') {
-    const reason = input.reason
-    if (typeof reason === 'string') return reason.length > 80 ? reason.slice(0, 80) + '…' : reason
-  }
-  // Read：显示文件路径
-  if (toolName === 'Read') {
-    const fp = input.file_path ?? input.filePath
-    if (typeof fp === 'string') {
-      const filename = fp.split('/').pop() ?? fp
-      return filename
-    }
-  }
-  // Edit / Write：显示文件路径
-  if (toolName === 'Edit' || toolName === 'Write') {
-    const fp = input.file_path ?? input.filePath
-    if (typeof fp === 'string') {
-      const filename = fp.split('/').pop() ?? fp
-      return filename
-    }
-  }
-  // NotebookEdit：显示 notebook 路径
-  if (toolName === 'NotebookEdit') {
-    const fp = input.notebook_path
-    if (typeof fp === 'string') {
-      const filename = fp.split('/').pop() ?? fp
-      return filename
-    }
-  }
-  // TodoWrite：显示任务数量
-  if (toolName === 'TodoWrite') {
-    const todos = input.todos
-    if (Array.isArray(todos)) return `${todos.length} 项任务`
-  }
-  // TeamCreate：显示 team_name + description
-  if (toolName === 'TeamCreate') {
-    const name = input.team_name
-    const desc = input.description
-    if (typeof name === 'string') {
-      if (typeof desc === 'string') return `${name} · ${desc.length > 60 ? desc.slice(0, 60) + '…' : desc}`
-      return name
-    }
-  }
-  // Agent：显示 name + description
-  if (toolName === 'Agent') {
-    const agentName = input.name
-    const desc = input.description ?? input.prompt
-    if (typeof agentName === 'string' && typeof desc === 'string') {
-      return `${agentName} · ${desc.length > 60 ? desc.slice(0, 60) + '…' : desc}`
-    }
-    if (typeof desc === 'string') return desc.length > 80 ? desc.slice(0, 80) + '…' : desc
-    if (typeof agentName === 'string') return agentName
-  }
-  // generate_image (Nano Banana MCP)：显示 prompt
-  if (toolName === 'generate_image') {
-    const prompt = input.prompt
-    if (typeof prompt === 'string') return prompt.length > 80 ? prompt.slice(0, 80) + '…' : prompt
-  }
-  return null
-}
-
-// ===== 格式化 Input JSON =====
-
-function formatInput(input: Record<string, unknown>): string {
-  const filtered: Record<string, unknown> = {}
-  for (const [key, value] of Object.entries(input)) {
-    if (!key.startsWith('_')) filtered[key] = value
-  }
-  try { return JSON.stringify(filtered, null, 2) } catch { return '[不可序列化]' }
 }
 
 // ===== TodoWrite 可视化 =====
@@ -333,18 +150,13 @@ export interface ActivityRowProps {
   onOpenDetails?: (activity: ToolActivity) => void
 }
 
-/** 自描述工具：inputSummary 已包含完整语义，不再额外显示工具名 */
-const SELF_DESCRIBING_TOOLS = new Set(['TaskUpdate'])
-
 export function ActivityRow({ activity, index = 0, animate = false, onOpenDetails }: ActivityRowProps): React.ReactElement {
   const status = getActivityStatus(activity)
-  const filePath = extractFilePath(activity.input)
-  const diffStats = computeDiffStats(activity.toolName, activity.input)
-  const inputSummary = getInputSummary(activity.toolName, activity.input)
-  const intent = activity.intent ?? activity.displayName
+  const phrase = getToolPhrase(activity.toolName, activity.input)
+  const isRunning = status === 'running' || status === 'backgrounded'
 
-  // 自描述工具：摘要已包含完整信息，直接作为主标签，隐藏工具名
-  const isSelfDescribing = SELF_DESCRIBING_TOOLS.has(activity.toolName) && !!inputSummary
+  // 运行中显示进行时短语，完成后显示完成态短语
+  const displayLabel = isRunning ? phrase.loadingLabel : phrase.label
 
   const delay = animate && index < SIZE.staggerLimit ? `${index * 30}ms` : '0ms'
 
@@ -362,45 +174,25 @@ export function ActivityRow({ activity, index = 0, animate = false, onOpenDetail
       {canExpand ? (
         <button
           type="button"
-          className="group/expand shrink-0 flex items-center gap-2 cursor-pointer"
+          className="group/expand shrink-0 flex items-center gap-2 cursor-pointer min-w-0"
           onClick={(e) => { e.stopPropagation(); onOpenDetails(activity) }}
         >
-          <span className={cn(SIZE.icon, 'relative flex items-center justify-center')}>
+          <span className={cn(SIZE.icon, 'relative flex items-center justify-center shrink-0')}>
             <span className="transition-opacity duration-150 group-hover/expand:opacity-0">
               <StatusIcon status={status} toolName={activity.toolName} />
             </span>
             <Plus className={cn(SIZE.icon, 'absolute text-foreground/60 opacity-0 transition-opacity duration-150 group-hover/expand:opacity-100')} />
           </span>
-          {isSelfDescribing ? (
-            <span className="shrink-0 text-foreground/80 group-hover/expand:text-foreground transition-colors duration-150">{inputSummary}</span>
-          ) : (
-            <span className="shrink-0 text-foreground/80 group-hover/expand:text-foreground transition-colors duration-150">{activity.toolName}</span>
-          )}
+          <span className="truncate text-foreground/80 group-hover/expand:text-foreground transition-colors duration-150">{displayLabel}</span>
         </button>
       ) : (
         <>
           <StatusIcon status={status} toolName={activity.toolName} />
-          {isSelfDescribing ? (
-            <span className="shrink-0 text-foreground/80">{inputSummary}</span>
-          ) : (
-            <span className="shrink-0 text-foreground/80">{activity.toolName}</span>
-          )}
+          <span className="truncate text-foreground/80">{displayLabel}</span>
         </>
       )}
 
-      {diffStats && <DiffBadges stats={diffStats} />}
-
-      {filePath && <FileBadge path={filePath} />}
-
       {activity.isError && <ErrorBadge />}
-
-      {!isSelfDescribing && (
-        <span className="truncate flex-1 min-w-0 text-foreground/50">
-          {intent && <>{intent}</>}
-          {!intent && inputSummary && <>{inputSummary}</>}
-          {intent && inputSummary && <> · <span className="opacity-70">{inputSummary}</span></>}
-        </span>
-      )}
 
       {activity.elapsedSeconds !== undefined && activity.elapsedSeconds > 0 && (
         <span className="shrink-0 text-[11px] text-muted-foreground/60 tabular-nums">
@@ -437,16 +229,13 @@ function ActivityGroupRow({ group, index = 0, animate = false, onOpenDetails, de
     return selfStatus
   }, [parent, children])
 
+  const phrase = getToolPhrase(parent.toolName, parent.input)
+  const isRunning = derivedStatus === 'running' || derivedStatus === 'backgrounded'
+  const displayLabel = isRunning ? phrase.loadingLabel : phrase.label
+
   const subagentType = typeof parent.input.subagent_type === 'string'
     ? parent.input.subagent_type
     : undefined
-
-  // 优先使用 description，回退到 prompt
-  const description = typeof parent.input.description === 'string'
-    ? parent.input.description
-    : typeof parent.input.prompt === 'string'
-      ? parent.input.prompt
-      : parent.intent ?? parent.displayName ?? parent.toolName
 
   const delay = animate && index < SIZE.staggerLimit ? `${index * 30}ms` : '0ms'
 
@@ -475,15 +264,13 @@ function ActivityGroupRow({ group, index = 0, animate = false, onOpenDetails, de
 
         <StatusIcon status={derivedStatus} toolName={parent.toolName} />
 
-        <span className="shrink-0 text-foreground/80">{parent.toolName}</span>
-
         {subagentType && (
           <span className="shrink-0 px-1.5 py-0.5 rounded bg-primary/10 text-primary text-[9px] font-medium leading-none">
             {subagentType}
           </span>
         )}
 
-        <span className="truncate flex-1 min-w-0 text-foreground/50">{description}</span>
+        <span className="truncate flex-1 min-w-0 text-foreground/80">{displayLabel}</span>
 
         {parent.elapsedSeconds !== undefined && parent.elapsedSeconds > 0 && (
           <span className="shrink-0 text-[11px] text-muted-foreground/60 tabular-nums">
@@ -567,18 +354,15 @@ function ToolResultImage({ attachment }: { attachment: { localPath: string; file
   )
 }
 
-// ===== 详情面板 =====
+// ===== 详情面板（仅显示结果，使用 ToolResultRenderer） =====
 
 function ActivityDetails({ activity, onClose }: { activity: ToolActivity; onClose: () => void }): React.ReactElement {
   const [copied, setCopied] = React.useState(false)
 
   const handleCopy = (): void => {
     const parts: string[] = [`[${activity.toolName}]`]
-    if (Object.keys(activity.input).length > 0) {
-      parts.push('输入:\n' + formatInput(activity.input))
-    }
     if (activity.result) {
-      parts.push('结果:\n' + (activity.result.length > 2000 ? activity.result.slice(0, 2000) + '\n… [截断]' : activity.result))
+      parts.push(activity.result)
     }
     navigator.clipboard.writeText(parts.join('\n\n')).then(() => {
       setCopied(true)
@@ -589,7 +373,7 @@ function ActivityDetails({ activity, onClose }: { activity: ToolActivity; onClos
   return (
     <div className="mt-1 rounded-md border border-border/40 bg-muted/20 overflow-hidden animate-in fade-in slide-in-from-top-2 duration-300 ease-out">
       <div className="flex items-center justify-between px-3 py-1.5 border-b border-border/30">
-        <span className="text-[11px] font-medium text-foreground/50">{activity.toolName}</span>
+        <span className="text-[11px] font-medium text-foreground/50">{getToolPhrase(activity.toolName, activity.input).label}</span>
         <button
           type="button"
           onClick={handleCopy}
@@ -599,27 +383,14 @@ function ActivityDetails({ activity, onClose }: { activity: ToolActivity; onClos
         </button>
       </div>
 
-      <div className="px-3 py-2 space-y-2 max-h-[300px] overflow-y-auto">
-        {Object.keys(activity.input).length > 0 && (
-          <div>
-            <div className="text-[10px] font-medium text-foreground/40 mb-1">输入</div>
-            <pre className="text-[11px] text-foreground/60 bg-background/50 rounded p-2 overflow-x-auto max-h-[150px] overflow-y-auto whitespace-pre-wrap break-all">
-              {formatInput(activity.input)}
-            </pre>
-          </div>
-        )}
+      <div className="px-3 py-2 space-y-2 max-h-[400px] overflow-y-auto">
         {activity.result && (
-          <div>
-            <div className="text-[10px] font-medium text-foreground/40 mb-1">结果</div>
-            <pre
-              className={cn(
-                'text-[11px] rounded p-2 overflow-x-auto max-h-[150px] overflow-y-auto whitespace-pre-wrap break-all',
-                activity.isError ? 'text-destructive/80 bg-destructive/5' : 'text-foreground/60 bg-background/50',
-              )}
-            >
-              {activity.result.length > 2000 ? activity.result.slice(0, 2000) + '\n… [截断]' : activity.result}
-            </pre>
-          </div>
+          <ToolResultRenderer
+            toolName={activity.toolName}
+            input={activity.input}
+            result={activity.result}
+            isError={activity.isError ?? false}
+          />
         )}
         {activity.imageAttachments && activity.imageAttachments.length > 0 && (
           <div>
@@ -789,3 +560,6 @@ export function ToolActivityList({ activities, animate = false }: ToolActivityLi
 export function ToolActivityItem({ activity }: { activity: ToolActivity }): React.ReactElement {
   return <ToolActivityList activities={[activity]} />
 }
+
+// 导出格式化耗时（向后兼容 TeamActivityPanel 等外部引用）
+export { formatElapsed }

--- a/apps/electron/src/renderer/components/agent/tool-phrase.ts
+++ b/apps/electron/src/renderer/components/agent/tool-phrase.ts
@@ -1,0 +1,274 @@
+/**
+ * 工具语义化短语生成器
+ *
+ * 将工具名 + 输入参数合成为一句连贯、可读的中文短语，
+ * 用于工具活动行的收起态展示和 Loading 态展示。
+ */
+
+import { computeDiffStats } from './tool-utils'
+
+/** 工具短语 */
+export interface ToolPhrase {
+  /** 完成态/收起态短语，如 "读取 foo.ts 第 10-60 行" */
+  label: string
+  /** Loading 态短语，如 "正在读取 foo.ts..." */
+  loadingLabel: string
+}
+
+/** 从路径中提取文件名 */
+function filename(path: string): string {
+  return path.split('/').pop() ?? path
+}
+
+/** 截断文本 */
+function truncate(text: string, max: number): string {
+  return text.length > max ? text.slice(0, max) + '…' : text
+}
+
+/**
+ * 根据工具名和输入参数生成语义化短语
+ *
+ * 返回的 label 应读起来像一个完整动宾短语，无冗余信息。
+ */
+export function getToolPhrase(toolName: string, input: Record<string, unknown>): ToolPhrase {
+  switch (toolName) {
+    case 'Read': {
+      const fp = input.file_path ?? input.filePath
+      if (typeof fp === 'string') {
+        const name = filename(fp)
+        const offset = typeof input.offset === 'number' ? input.offset : undefined
+        const limit = typeof input.limit === 'number' ? input.limit : undefined
+        if (offset !== undefined && limit !== undefined) {
+          return phrase(`读取 ${name} 第 ${offset}-${offset + limit} 行`)
+        }
+        if (offset !== undefined) {
+          return phrase(`读取 ${name} 从第 ${offset} 行`)
+        }
+        return phrase(`读取 ${name}`)
+      }
+      return phrase('读取文件')
+    }
+
+    case 'Edit': {
+      const fp = input.file_path ?? input.filePath
+      const name = typeof fp === 'string' ? filename(fp) : '文件'
+      const diff = computeDiffStats('Edit', input)
+      if (diff) {
+        const parts = [name]
+        if (diff.additions > 0) parts.push(`+${diff.additions}`)
+        if (diff.deletions > 0) parts.push(`-${diff.deletions}`)
+        return phrase(`编辑 ${parts.join(' ')}`)
+      }
+      return phrase(`编辑 ${name}`)
+    }
+
+    case 'Write': {
+      const fp = input.file_path ?? input.filePath
+      const name = typeof fp === 'string' ? filename(fp) : '文件'
+      return phrase(`写入 ${name}`)
+    }
+
+    case 'Bash': {
+      const cmd = input.command
+      if (typeof cmd === 'string') {
+        return phrase(`执行 ${truncate(cmd, 80)}`)
+      }
+      return phrase('执行命令')
+    }
+
+    case 'Grep': {
+      const pattern = input.pattern
+      if (typeof pattern === 'string') {
+        const parts = [`搜索内容 /${pattern}/`]
+        const path = input.path
+        const glob = input.glob
+        if (typeof glob === 'string') {
+          parts.push(`in ${glob}`)
+        } else if (typeof path === 'string') {
+          parts.push(`in ${path}`)
+        }
+        return phrase(parts.join(' '))
+      }
+      return phrase('搜索内容')
+    }
+
+    case 'Glob': {
+      const pattern = input.pattern
+      if (typeof pattern === 'string') {
+        const parts = [`搜索文件 ${pattern}`]
+        const path = input.path
+        if (typeof path === 'string') {
+          parts.push(`in ${path}`)
+        }
+        return phrase(parts.join(' '))
+      }
+      return phrase('搜索文件')
+    }
+
+    case 'WebFetch': {
+      const url = input.url
+      if (typeof url === 'string') {
+        return phrase(`抓取 ${truncate(url, 60)}`)
+      }
+      return phrase('抓取网页')
+    }
+
+    case 'WebSearch': {
+      const query = input.query
+      if (typeof query === 'string') {
+        return phrase(`搜索 "${truncate(query, 60)}"`)
+      }
+      return phrase('搜索网页')
+    }
+
+    case 'Skill': {
+      const skill = input.skill
+      if (typeof skill === 'string') {
+        return phrase(`使用技能 ${skill}`)
+      }
+      return phrase('使用技能')
+    }
+
+    case 'NotebookEdit': {
+      const fp = input.notebook_path
+      if (typeof fp === 'string') {
+        return phrase(`编辑笔记本 ${filename(fp)}`)
+      }
+      return phrase('编辑笔记本')
+    }
+
+    case 'Task': {
+      const desc = input.description ?? input.prompt
+      if (typeof desc === 'string') {
+        return phrase(`子任务 ${truncate(desc, 80)}`)
+      }
+      return phrase('子任务')
+    }
+
+    case 'Agent': {
+      const name = input.name
+      const desc = input.description ?? input.prompt
+      if (typeof name === 'string' && typeof desc === 'string') {
+        return phrase(`Agent ${name} · ${truncate(desc, 60)}`)
+      }
+      if (typeof desc === 'string') return phrase(`Agent ${truncate(desc, 80)}`)
+      if (typeof name === 'string') return phrase(`Agent ${name}`)
+      return phrase('Agent')
+    }
+
+    case 'TaskCreate': {
+      const subject = input.subject
+      if (typeof subject === 'string') {
+        return phrase(`创建任务 ${truncate(subject, 80)}`)
+      }
+      return phrase('创建任务')
+    }
+
+    case 'TaskUpdate': {
+      // TaskUpdate 是自描述工具，label 即完整语义
+      const statusMap: Record<string, string> = {
+        pending: '待处理',
+        in_progress: '进行中',
+        completed: '已完成',
+        cancelled: '已取消',
+        blocked: '已阻塞',
+        error: '出错',
+        deleted: '已删除',
+      }
+      const parts: string[] = []
+      if (typeof input.taskId === 'string') parts.push(`任务 #${input.taskId}`)
+      if (typeof input.status === 'string') parts.push(statusMap[input.status] ?? input.status)
+      if (typeof input.subject === 'string') parts.push(truncate(input.subject, 60))
+      if (parts.length > 0) return phrase(parts.join(' '))
+      return phrase('更新任务')
+    }
+
+    case 'TaskGet': {
+      const taskId = input.taskId
+      if (typeof taskId === 'string') return phrase(`加载任务 #${taskId}`)
+      return phrase('加载任务')
+    }
+
+    case 'TaskList': {
+      return phrase('查看任务列表')
+    }
+
+    case 'TodoWrite': {
+      const todos = input.todos
+      if (Array.isArray(todos)) {
+        return phrase(`更新待办 ${todos.length} 项`)
+      }
+      return phrase('更新待办')
+    }
+
+    case 'TodoRead': {
+      return phrase('读取待办')
+    }
+
+    case 'TeamCreate': {
+      const name = input.team_name
+      if (typeof name === 'string') return phrase(`创建团队 ${name}`)
+      return phrase('创建团队')
+    }
+
+    case 'EnterPlanMode': {
+      return phrase('进入计划模式')
+    }
+
+    case 'ExitPlanMode': {
+      return phrase('退出计划模式')
+    }
+
+    case 'generate_image': {
+      const prompt = input.prompt
+      if (typeof prompt === 'string') return phrase(`生成图片 ${truncate(prompt, 60)}`)
+      return phrase('生成图片')
+    }
+
+    default: {
+      // MCP 工具：mcp__serverName__toolName
+      const mcpParts = toolName.split('__')
+      if (mcpParts[0] === 'mcp' && mcpParts.length >= 3 && mcpParts[1]) {
+        const server = mcpParts[1].toUpperCase()
+        const tool = mcpParts.slice(2).join('_')
+        // 尝试从 input 中提取第一个有意义的参数作为摘要
+        const summary = extractFirstMeaningfulValue(input)
+        if (summary) {
+          return phrase(`${server} / ${tool} ${truncate(summary, 60)}`)
+        }
+        return phrase(`${server} / ${tool}`)
+      }
+      // 未知工具
+      const summary = extractFirstMeaningfulValue(input)
+      if (summary) {
+        return phrase(`${toolName} ${truncate(summary, 60)}`)
+      }
+      return phrase(toolName)
+    }
+  }
+}
+
+/** 构造短语对 */
+function phrase(label: string): ToolPhrase {
+  return {
+    label,
+    loadingLabel: `正在${label}...`,
+  }
+}
+
+/** 从 input 中提取第一个有意义的字符串值作为摘要 */
+function extractFirstMeaningfulValue(input: Record<string, unknown>): string | null {
+  // 优先检查常见的描述性字段
+  const priorityKeys = ['description', 'prompt', 'query', 'command', 'name', 'subject', 'path', 'file_path', 'url']
+  for (const key of priorityKeys) {
+    const value = input[key]
+    if (typeof value === 'string' && value.length > 0) return value
+  }
+  // 回退到第一个非下划线开头的字符串值
+  for (const [key, value] of Object.entries(input)) {
+    if (!key.startsWith('_') && typeof value === 'string' && value.length > 0 && value.length < 200) {
+      return value
+    }
+  }
+  return null
+}

--- a/apps/electron/src/renderer/components/agent/tool-result-renderers/bash-result.tsx
+++ b/apps/electron/src/renderer/components/agent/tool-result-renderers/bash-result.tsx
@@ -1,0 +1,76 @@
+/**
+ * Bash 工具结果渲染器 — 终端风格
+ *
+ * 深色背景、等宽字体、stderr 红色高亮
+ */
+
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+import { CollapsibleResult } from './collapsible-result'
+
+interface BashResultRendererProps {
+  result: string
+  isError: boolean
+  input: Record<string, unknown>
+}
+
+/** 简单检测 stderr 行（常见模式） */
+function classifyLine(line: string): 'stderr' | 'normal' {
+  const lower = line.toLowerCase()
+  if (
+    lower.startsWith('error:') ||
+    lower.startsWith('error ') ||
+    lower.startsWith('fatal:') ||
+    lower.startsWith('warning:') ||
+    lower.includes('traceback') ||
+    lower.includes('exception') ||
+    lower.startsWith('stderr:')
+  ) {
+    return 'stderr'
+  }
+  return 'normal'
+}
+
+export function BashResultRenderer({ result, isError, input }: BashResultRendererProps): React.ReactElement {
+  const command = typeof input.command === 'string' ? input.command : undefined
+
+  const renderTerminal = React.useCallback((text: string): React.ReactNode => {
+    const lines = text.split('\n')
+    return (
+      <div className={cn(
+        'rounded-md font-mono text-[12px] leading-relaxed overflow-x-auto',
+        'bg-zinc-900 text-zinc-100 dark:bg-zinc-950',
+        'p-3',
+      )}>
+        {/* 命令回显 */}
+        {command && (
+          <div className="text-zinc-500 mb-2 select-none">
+            <span className="text-green-400">$</span> {command}
+          </div>
+        )}
+        {/* 输出行 */}
+        {lines.map((line, i) => {
+          const type = isError ? 'stderr' : classifyLine(line)
+          return (
+            <div
+              key={i}
+              className={cn(
+                'whitespace-pre-wrap break-all min-h-[1.25em]',
+                type === 'stderr' && 'text-red-400',
+              )}
+            >
+              {line || '\u200B'}
+            </div>
+          )
+        })}
+      </div>
+    )
+  }, [command, isError])
+
+  return (
+    <CollapsibleResult
+      content={result}
+      renderContent={renderTerminal}
+    />
+  )
+}

--- a/apps/electron/src/renderer/components/agent/tool-result-renderers/collapsible-result.tsx
+++ b/apps/electron/src/renderer/components/agent/tool-result-renderers/collapsible-result.tsx
@@ -1,0 +1,69 @@
+/**
+ * 可折叠长内容包装器
+ *
+ * 替代硬截断 2000 字符的方案：
+ * - 短内容直接展示
+ * - 长内容默认折叠，显示前 N 行 + 长度指示器
+ * - 点击展开/收起全部内容
+ */
+
+import * as React from 'react'
+import { ChevronDown, ChevronUp } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface CollapsibleResultProps {
+  /** 内容文本 */
+  content: string
+  /** 折叠阈值（字符数），超过此值时启用折叠，默认 3000 */
+  threshold?: number
+  /** 折叠时显示的行数，默认 15 */
+  previewLines?: number
+  /** 自定义渲染函数，接收内容文本返回 JSX */
+  renderContent: (text: string) => React.ReactNode
+  /** 外层 className */
+  className?: string
+}
+
+export function CollapsibleResult({
+  content,
+  threshold = 3000,
+  previewLines = 15,
+  renderContent,
+  className,
+}: CollapsibleResultProps): React.ReactElement {
+  const [expanded, setExpanded] = React.useState(false)
+  const needsCollapse = content.length > threshold
+
+  const displayContent = React.useMemo(() => {
+    if (!needsCollapse || expanded) return content
+    const lines = content.split('\n')
+    if (lines.length <= previewLines) return content
+    return lines.slice(0, previewLines).join('\n')
+  }, [content, needsCollapse, expanded, previewLines])
+
+  return (
+    <div className={cn('relative', className)}>
+      {renderContent(displayContent)}
+
+      {needsCollapse && (
+        <button
+          type="button"
+          onClick={() => setExpanded(!expanded)}
+          className="flex items-center gap-1 mt-1.5 text-[11px] text-muted-foreground/60 hover:text-foreground/80 transition-colors"
+        >
+          {expanded ? (
+            <>
+              <ChevronUp className="size-3" />
+              收起
+            </>
+          ) : (
+            <>
+              <ChevronDown className="size-3" />
+              显示全部 ({content.length.toLocaleString()} 字符, {content.split('\n').length} 行)
+            </>
+          )}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/agent/tool-result-renderers/default-result.tsx
+++ b/apps/electron/src/renderer/components/agent/tool-result-renderers/default-result.tsx
@@ -1,0 +1,76 @@
+/**
+ * 默认工具结果渲染器 — Key-Value 表格 / 纯文本
+ *
+ * 用于未匹配到专属渲染器的工具（包括 MCP 工具）
+ */
+
+import * as React from 'react'
+import { CollapsibleResult } from './collapsible-result'
+
+interface DefaultResultRendererProps {
+  result: string
+  isError: boolean
+}
+
+/** 尝试将结果解析为 key-value 对 */
+function tryParseKeyValue(text: string): Array<{ key: string; value: string }> | null {
+  // 尝试 JSON 解析
+  try {
+    const parsed = JSON.parse(text)
+    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+      return Object.entries(parsed as Record<string, unknown>).map(([key, value]) => ({
+        key,
+        value: typeof value === 'string' ? value : JSON.stringify(value, null, 2),
+      }))
+    }
+  } catch {
+    // 非 JSON
+  }
+  return null
+}
+
+export function DefaultResultRenderer({ result, isError }: DefaultResultRendererProps): React.ReactElement {
+  if (isError) {
+    return (
+      <pre className="rounded-md p-3 text-[12px] font-mono text-destructive/80 bg-destructive/5 whitespace-pre-wrap break-all overflow-x-auto">
+        {result}
+      </pre>
+    )
+  }
+
+  const keyValues = React.useMemo(() => tryParseKeyValue(result), [result])
+
+  // Key-Value 表格
+  if (keyValues && keyValues.length > 0) {
+    return (
+      <div className="rounded-md bg-muted/20 overflow-hidden">
+        <table className="w-full text-[12px]">
+          <tbody>
+            {keyValues.map(({ key, value }, i) => (
+              <tr key={i} className="border-b border-border/20 last:border-b-0">
+                <td className="px-3 py-1.5 text-muted-foreground/60 font-mono whitespace-nowrap align-top">
+                  {key}
+                </td>
+                <td className="px-3 py-1.5 text-foreground/70 font-mono whitespace-pre-wrap break-all">
+                  {value}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    )
+  }
+
+  // 纯文本 fallback
+  return (
+    <CollapsibleResult
+      content={result}
+      renderContent={(text) => (
+        <pre className="rounded-md p-3 text-[12px] font-mono text-foreground/60 bg-muted/30 whitespace-pre-wrap break-all overflow-x-auto max-h-[400px] overflow-y-auto">
+          {text}
+        </pre>
+      )}
+    />
+  )
+}

--- a/apps/electron/src/renderer/components/agent/tool-result-renderers/edit-result.tsx
+++ b/apps/electron/src/renderer/components/agent/tool-result-renderers/edit-result.tsx
@@ -1,0 +1,81 @@
+/**
+ * Edit 工具结果渲染器 — Diff 视图
+ *
+ * 显示 old_string → new_string 的差异，
+ * 删除行红色背景，新增行绿色背景
+ */
+
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+interface EditResultRendererProps {
+  result: string
+  isError: boolean
+  input: Record<string, unknown>
+}
+
+export function EditResultRenderer({ result, isError, input }: EditResultRendererProps): React.ReactElement {
+  const oldStr = typeof input.old_string === 'string' ? input.old_string : ''
+  const newStr = typeof input.new_string === 'string' ? input.new_string : ''
+
+  if (isError) {
+    return (
+      <pre className="rounded-md p-3 text-[12px] font-mono text-destructive/80 bg-destructive/5 whitespace-pre-wrap break-all overflow-x-auto">
+        {result}
+      </pre>
+    )
+  }
+
+  // 无 diff 数据时显示成功消息
+  if (!oldStr && !newStr) {
+    return (
+      <div className="text-[12px] text-muted-foreground">
+        {result || '编辑成功'}
+      </div>
+    )
+  }
+
+  const oldLines = oldStr.split('\n')
+  const newLines = newStr.split('\n')
+
+  return (
+    <div className="rounded-md font-mono text-[12px] leading-relaxed overflow-x-auto bg-zinc-900 dark:bg-zinc-950">
+      {/* 删除行 */}
+      {oldLines.length > 0 && oldStr && (
+        <div>
+          {oldLines.map((line, i) => (
+            <div
+              key={`del-${i}`}
+              className="flex bg-red-500/10"
+            >
+              <span className="shrink-0 w-10 text-right pr-3 select-none text-red-400/60 text-[11px]">
+                -
+              </span>
+              <span className={cn('flex-1 whitespace-pre-wrap break-all text-red-300')}>
+                {line || '\u200B'}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+      {/* 新增行 */}
+      {newLines.length > 0 && newStr && (
+        <div>
+          {newLines.map((line, i) => (
+            <div
+              key={`add-${i}`}
+              className="flex bg-green-500/10"
+            >
+              <span className="shrink-0 w-10 text-right pr-3 select-none text-green-400/60 text-[11px]">
+                +
+              </span>
+              <span className={cn('flex-1 whitespace-pre-wrap break-all text-green-300')}>
+                {line || '\u200B'}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/agent/tool-result-renderers/glob-result.tsx
+++ b/apps/electron/src/renderer/components/agent/tool-result-renderers/glob-result.tsx
@@ -1,0 +1,51 @@
+/**
+ * Glob 工具结果渲染器 — 紧凑文件列表
+ */
+
+import * as React from 'react'
+import { FileText } from 'lucide-react'
+import { CollapsibleResult } from './collapsible-result'
+
+interface GlobResultRendererProps {
+  result: string
+  isError: boolean
+}
+
+export function GlobResultRenderer({ result, isError }: GlobResultRendererProps): React.ReactElement {
+  if (isError) {
+    return (
+      <pre className="rounded-md p-3 text-[12px] font-mono text-destructive/80 bg-destructive/5 whitespace-pre-wrap break-all overflow-x-auto">
+        {result}
+      </pre>
+    )
+  }
+
+  const files = React.useMemo(() => result.split('\n').filter(Boolean), [result])
+
+  const renderList = React.useCallback((text: string): React.ReactNode => {
+    const visibleFiles = text.split('\n').filter(Boolean)
+    return (
+      <div className="space-y-1">
+        <div className="text-[11px] text-muted-foreground/60">
+          {files.length} 个文件
+        </div>
+        <div className="rounded-md bg-muted/20 p-2 space-y-0.5">
+          {visibleFiles.map((file, i) => (
+            <div key={i} className="flex items-center gap-1.5 text-[12px] font-mono text-foreground/70 py-0.5">
+              <FileText className="size-3 shrink-0 text-muted-foreground/50" />
+              <span className="truncate">{file}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    )
+  }, [files.length])
+
+  return (
+    <CollapsibleResult
+      content={result}
+      previewLines={20}
+      renderContent={renderList}
+    />
+  )
+}

--- a/apps/electron/src/renderer/components/agent/tool-result-renderers/grep-result.tsx
+++ b/apps/electron/src/renderer/components/agent/tool-result-renderers/grep-result.tsx
@@ -1,0 +1,149 @@
+/**
+ * Grep 工具结果渲染器 — 搜索结果列表
+ *
+ * 解析 grep 输出格式（文件路径:行号:内容），
+ * 按文件分组显示，匹配词高亮
+ */
+
+import * as React from 'react'
+import { FileText } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { CollapsibleResult } from './collapsible-result'
+
+interface GrepResultRendererProps {
+  result: string
+  isError: boolean
+  input: Record<string, unknown>
+}
+
+interface GrepMatch {
+  file: string
+  line: number
+  content: string
+}
+
+interface GrepFileGroup {
+  file: string
+  matches: GrepMatch[]
+}
+
+/** 解析 grep 输出为结构化数据 */
+function parseGrepOutput(text: string): GrepFileGroup[] | null {
+  const lines = text.split('\n').filter(Boolean)
+  if (lines.length === 0) return null
+
+  const matches: GrepMatch[] = []
+  for (const line of lines) {
+    // 格式: filepath:lineNo:content 或 filepath:lineNo-content
+    const match = line.match(/^(.+?):(\d+)[:-](.*)$/)
+    if (match && match[1] && match[2] && match[3] !== undefined) {
+      matches.push({ file: match[1], line: parseInt(match[2], 10), content: match[3] })
+    }
+  }
+
+  if (matches.length === 0) return null
+
+  // 按文件分组
+  const groups = new Map<string, GrepMatch[]>()
+  for (const m of matches) {
+    const existing = groups.get(m.file)
+    if (existing) {
+      existing.push(m)
+    } else {
+      groups.set(m.file, [m])
+    }
+  }
+
+  return Array.from(groups.entries()).map(([file, fileMatches]) => ({ file, matches: fileMatches }))
+}
+
+/** 高亮搜索词 */
+function highlightPattern(text: string, pattern: string): React.ReactNode {
+  if (!pattern) return text
+  try {
+    const regex = new RegExp(`(${pattern})`, 'gi')
+    const parts = text.split(regex)
+    return parts.map((part, i) =>
+      regex.test(part)
+        ? <mark key={i} className="bg-yellow-300/30 text-yellow-200 rounded-sm px-0.5">{part}</mark>
+        : part,
+    )
+  } catch {
+    return text
+  }
+}
+
+export function GrepResultRenderer({ result, isError, input }: GrepResultRendererProps): React.ReactElement {
+  const pattern = typeof input.pattern === 'string' ? input.pattern : ''
+
+  if (isError) {
+    return (
+      <pre className="rounded-md p-3 text-[12px] font-mono text-destructive/80 bg-destructive/5 whitespace-pre-wrap break-all overflow-x-auto">
+        {result}
+      </pre>
+    )
+  }
+
+  const groups = React.useMemo(() => parseGrepOutput(result), [result])
+
+  // 无法解析时 fallback 到纯文本
+  if (!groups) {
+    return (
+      <CollapsibleResult
+        content={result}
+        renderContent={(text) => (
+          <pre className="rounded-md p-3 text-[12px] font-mono text-foreground/60 bg-muted/30 whitespace-pre-wrap break-all overflow-x-auto">
+            {text}
+          </pre>
+        )}
+      />
+    )
+  }
+
+  const totalMatches = groups.reduce((sum, g) => sum + g.matches.length, 0)
+
+  const renderGroups = React.useCallback((text: string): React.ReactNode => {
+    // 根据 text 长度决定显示多少（CollapsibleResult 会截断）
+    const visibleLines = text.split('\n').length
+
+    return (
+      <div className="space-y-2">
+        {/* 统计 */}
+        <div className="text-[11px] text-muted-foreground/60">
+          {totalMatches} 个匹配，{groups.length} 个文件
+        </div>
+
+        {groups.map((group) => (
+          <div key={group.file} className="rounded-md overflow-hidden bg-zinc-900 dark:bg-zinc-950">
+            {/* 文件头 */}
+            <div className="flex items-center gap-1.5 px-3 py-1.5 bg-zinc-800/50 text-[11px]">
+              <FileText className="size-3 text-zinc-400" />
+              <span className="font-mono text-zinc-300">{group.file}</span>
+              <span className="text-zinc-500">({group.matches.length})</span>
+            </div>
+            {/* 匹配行 */}
+            <div className="font-mono text-[12px]">
+              {group.matches.map((m, i) => (
+                <div key={i} className="flex px-3 py-0.5 hover:bg-zinc-800/30">
+                  <span className="shrink-0 w-10 text-right pr-3 select-none text-zinc-500 text-[11px]">
+                    {m.line}
+                  </span>
+                  <span className={cn('flex-1 whitespace-pre-wrap break-all text-zinc-200')}>
+                    {highlightPattern(m.content, pattern)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    )
+  }, [groups, pattern, totalMatches])
+
+  return (
+    <CollapsibleResult
+      content={result}
+      renderContent={renderGroups}
+    />
+  )
+}

--- a/apps/electron/src/renderer/components/agent/tool-result-renderers/index.tsx
+++ b/apps/electron/src/renderer/components/agent/tool-result-renderers/index.tsx
@@ -1,0 +1,49 @@
+/**
+ * ToolResultRenderer — 工具结果分发渲染器
+ *
+ * 根据工具名称分发到对应的专属渲染器，
+ * 未匹配时使用 DefaultResultRenderer。
+ */
+
+import * as React from 'react'
+import { BashResultRenderer } from './bash-result'
+import { ReadResultRenderer } from './read-result'
+import { EditResultRenderer } from './edit-result'
+import { WriteResultRenderer } from './write-result'
+import { GrepResultRenderer } from './grep-result'
+import { GlobResultRenderer } from './glob-result'
+import { WebSearchResultRenderer } from './web-search-result'
+import { WebFetchResultRenderer } from './web-fetch-result'
+import { DefaultResultRenderer } from './default-result'
+
+export interface ToolResultRendererProps {
+  toolName: string
+  input: Record<string, unknown>
+  result: string
+  isError: boolean
+}
+
+export function ToolResultRenderer({ toolName, input, result, isError }: ToolResultRendererProps): React.ReactElement {
+  switch (toolName) {
+    case 'Bash':
+      return <BashResultRenderer result={result} isError={isError} input={input} />
+    case 'Read':
+      return <ReadResultRenderer result={result} isError={isError} input={input} />
+    case 'Edit':
+      return <EditResultRenderer result={result} isError={isError} input={input} />
+    case 'Write':
+      return <WriteResultRenderer result={result} isError={isError} input={input} />
+    case 'Grep':
+      return <GrepResultRenderer result={result} isError={isError} input={input} />
+    case 'Glob':
+      return <GlobResultRenderer result={result} isError={isError} />
+    case 'WebSearch':
+      return <WebSearchResultRenderer result={result} isError={isError} />
+    case 'WebFetch':
+      return <WebFetchResultRenderer result={result} isError={isError} />
+    default:
+      return <DefaultResultRenderer result={result} isError={isError} />
+  }
+}
+
+export { CollapsibleResult } from './collapsible-result'

--- a/apps/electron/src/renderer/components/agent/tool-result-renderers/read-result.tsx
+++ b/apps/electron/src/renderer/components/agent/tool-result-renderers/read-result.tsx
@@ -1,0 +1,119 @@
+/**
+ * Read 工具结果渲染器 — 语法高亮代码块
+ *
+ * 使用 Shiki 进行语法高亮，带行号显示
+ */
+
+import * as React from 'react'
+import { highlightToTokens } from '@proma/core'
+import type { HighlightToken } from '@proma/core'
+import { cn } from '@/lib/utils'
+import { inferLanguageFromPath } from '../tool-utils'
+import { CollapsibleResult } from './collapsible-result'
+
+interface ReadResultRendererProps {
+  result: string
+  isError: boolean
+  input: Record<string, unknown>
+}
+
+/** 单行渲染（memoized） */
+const TokenLine = React.memo(function TokenLine({
+  tokens,
+  lineNumber,
+  fgColor,
+}: {
+  tokens: HighlightToken[]
+  lineNumber: number
+  fgColor: string
+}): React.ReactElement {
+  return (
+    <div className="flex">
+      <span className="shrink-0 w-10 text-right pr-3 select-none text-zinc-500 text-[11px]">
+        {lineNumber}
+      </span>
+      <span className="flex-1 whitespace-pre-wrap break-all">
+        {tokens.map((token, i) => (
+          <span key={i} style={{ color: token.color ?? fgColor }}>
+            {token.content}
+          </span>
+        ))}
+      </span>
+    </div>
+  )
+})
+
+export function ReadResultRenderer({ result, isError, input }: ReadResultRendererProps): React.ReactElement {
+  const filePath = typeof input.file_path === 'string'
+    ? input.file_path
+    : typeof input.filePath === 'string'
+      ? (input.filePath as string)
+      : ''
+
+  const language = inferLanguageFromPath(filePath)
+  const startLine = typeof input.offset === 'number' ? input.offset : 1
+
+  // 高亮处理
+  const highlighted = React.useMemo(() => {
+    if (isError) return null
+    return highlightToTokens({ code: result, language })
+  }, [result, language, isError])
+
+  const renderCode = React.useCallback((text: string): React.ReactNode => {
+    if (isError) {
+      return (
+        <pre className="rounded-md p-3 text-[12px] font-mono text-destructive/80 bg-destructive/5 whitespace-pre-wrap break-all overflow-x-auto">
+          {text}
+        </pre>
+      )
+    }
+
+    if (!highlighted) {
+      // Fallback：无高亮
+      const lines = text.split('\n')
+      return (
+        <div className={cn(
+          'rounded-md font-mono text-[12px] leading-relaxed overflow-x-auto p-2',
+          'bg-zinc-900 text-zinc-100 dark:bg-zinc-950',
+        )}>
+          {lines.map((line, i) => (
+            <div key={i} className="flex">
+              <span className="shrink-0 w-10 text-right pr-3 select-none text-zinc-500 text-[11px]">
+                {startLine + i}
+              </span>
+              <span className="flex-1 whitespace-pre-wrap break-all">{line || '\u200B'}</span>
+            </div>
+          ))}
+        </div>
+      )
+    }
+
+    // 如果内容被截断（CollapsibleResult 传入的 text 可能少于 result），
+    // 则只渲染对应行数的 token
+    const textLineCount = text.split('\n').length
+    const linesToRender = highlighted.lines.slice(0, textLineCount)
+
+    return (
+      <div
+        className="rounded-md font-mono text-[12px] leading-relaxed overflow-x-auto p-2"
+        style={{ backgroundColor: highlighted.bgColor }}
+      >
+        {linesToRender.map((tokens, i) => (
+          <TokenLine
+            key={startLine + i}
+            tokens={tokens}
+            lineNumber={startLine + i}
+            fgColor={highlighted.fgColor}
+          />
+        ))}
+      </div>
+    )
+  }, [highlighted, isError, startLine])
+
+  return (
+    <CollapsibleResult
+      content={result}
+      renderContent={renderCode}
+    />
+  )
+}

--- a/apps/electron/src/renderer/components/agent/tool-result-renderers/web-fetch-result.tsx
+++ b/apps/electron/src/renderer/components/agent/tool-result-renderers/web-fetch-result.tsx
@@ -1,0 +1,37 @@
+/**
+ * WebFetch 工具结果渲染器 — Markdown 渲染
+ *
+ * 复用 MessageResponse 组件渲染抓取到的网页内容
+ */
+
+import * as React from 'react'
+import { MessageResponse } from '@/components/ai-elements/message'
+import { CollapsibleResult } from './collapsible-result'
+
+interface WebFetchResultRendererProps {
+  result: string
+  isError: boolean
+}
+
+export function WebFetchResultRenderer({ result, isError }: WebFetchResultRendererProps): React.ReactElement {
+  if (isError) {
+    return (
+      <pre className="rounded-md p-3 text-[12px] font-mono text-destructive/80 bg-destructive/5 whitespace-pre-wrap break-all overflow-x-auto">
+        {result}
+      </pre>
+    )
+  }
+
+  return (
+    <CollapsibleResult
+      content={result}
+      threshold={5000}
+      previewLines={30}
+      renderContent={(text) => (
+        <div className="rounded-md bg-muted/20 p-3 overflow-x-auto text-[13px]">
+          <MessageResponse>{text}</MessageResponse>
+        </div>
+      )}
+    />
+  )
+}

--- a/apps/electron/src/renderer/components/agent/tool-result-renderers/web-search-result.tsx
+++ b/apps/electron/src/renderer/components/agent/tool-result-renderers/web-search-result.tsx
@@ -1,0 +1,114 @@
+/**
+ * WebSearch 工具结果渲染器 — 搜索结果卡片
+ */
+
+import * as React from 'react'
+import { Globe } from 'lucide-react'
+import { CollapsibleResult } from './collapsible-result'
+
+interface WebSearchResultRendererProps {
+  result: string
+  isError: boolean
+}
+
+interface SearchResult {
+  title: string
+  url: string
+  snippet: string
+}
+
+/** 尝试解析搜索结果（支持多种常见格式） */
+function parseSearchResults(text: string): SearchResult[] | null {
+  // 尝试 JSON 解析
+  try {
+    const parsed = JSON.parse(text)
+    if (Array.isArray(parsed)) {
+      return parsed
+        .filter((item: Record<string, unknown>) => item.title || item.url)
+        .map((item: Record<string, unknown>) => ({
+          title: String(item.title ?? ''),
+          url: String(item.url ?? item.link ?? ''),
+          snippet: String(item.snippet ?? item.description ?? item.content ?? ''),
+        }))
+    }
+  } catch {
+    // 非 JSON，尝试文本解析
+  }
+
+  // 尝试解析常见的文本格式（标题 + URL + 摘要，按段落分隔）
+  const blocks = text.split(/\n{2,}/).filter(Boolean)
+  if (blocks.length < 2) return null
+
+  const results: SearchResult[] = []
+  for (const block of blocks) {
+    const lines = block.split('\n').filter(Boolean)
+    if (lines.length >= 2) {
+      const urlLine = lines.find((l) => l.match(/https?:\/\//))
+      const titleLine = lines.find((l) => !l.match(/https?:\/\//) && l.length > 0)
+      if (urlLine && titleLine) {
+        const urlMatch = urlLine.match(/(https?:\/\/\S+)/)
+        results.push({
+          title: titleLine.replace(/^\d+\.\s*/, '').replace(/\*\*/g, ''),
+          url: urlMatch?.[1] ?? urlLine,
+          snippet: lines.filter((l) => l !== urlLine && l !== titleLine).join(' ').slice(0, 200),
+        })
+      }
+    }
+  }
+
+  return results.length > 0 ? results : null
+}
+
+export function WebSearchResultRenderer({ result, isError }: WebSearchResultRendererProps): React.ReactElement {
+  if (isError) {
+    return (
+      <pre className="rounded-md p-3 text-[12px] font-mono text-destructive/80 bg-destructive/5 whitespace-pre-wrap break-all overflow-x-auto">
+        {result}
+      </pre>
+    )
+  }
+
+  const searchResults = React.useMemo(() => parseSearchResults(result), [result])
+
+  // 无法解析为搜索结果时 fallback
+  if (!searchResults) {
+    return (
+      <CollapsibleResult
+        content={result}
+        renderContent={(text) => (
+          <pre className="rounded-md p-3 text-[12px] font-mono text-foreground/60 bg-muted/30 whitespace-pre-wrap break-all overflow-x-auto">
+            {text}
+          </pre>
+        )}
+      />
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="text-[11px] text-muted-foreground/60">
+        {searchResults.length} 条结果
+      </div>
+      {searchResults.map((item, i) => (
+        <div key={i} className="rounded-md bg-muted/20 p-2.5 space-y-1">
+          <div className="flex items-center gap-1.5">
+            <Globe className="size-3 shrink-0 text-muted-foreground/50" />
+            <span className="text-[12px] font-medium text-foreground/80 truncate">
+              {item.title}
+            </span>
+          </div>
+          {item.url && (
+            <div className="text-[11px] text-primary/60 font-mono truncate">
+              {item.url}
+            </div>
+          )}
+          {item.snippet && (
+            <div className="text-[11px] text-muted-foreground/70 leading-relaxed line-clamp-2">
+              {item.snippet}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/agent/tool-result-renderers/write-result.tsx
+++ b/apps/electron/src/renderer/components/agent/tool-result-renderers/write-result.tsx
@@ -1,0 +1,33 @@
+/**
+ * Write 工具结果渲染器 — 简洁成功消息
+ */
+
+import * as React from 'react'
+
+interface WriteResultRendererProps {
+  result: string
+  isError: boolean
+  input: Record<string, unknown>
+}
+
+export function WriteResultRenderer({ result, isError, input }: WriteResultRendererProps): React.ReactElement {
+  if (isError) {
+    return (
+      <pre className="rounded-md p-3 text-[12px] font-mono text-destructive/80 bg-destructive/5 whitespace-pre-wrap break-all overflow-x-auto">
+        {result}
+      </pre>
+    )
+  }
+
+  const filePath = typeof input.file_path === 'string' ? input.file_path : ''
+  const filename = filePath.split('/').pop() ?? filePath
+  const content = typeof input.content === 'string' ? input.content : ''
+  const lineCount = content ? content.split('\n').length : 0
+
+  return (
+    <div className="text-[12px] text-muted-foreground">
+      已写入 <span className="font-mono text-foreground/70">{filename || '文件'}</span>
+      {lineCount > 0 && <span>, {lineCount} 行</span>}
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/agent/tool-utils.ts
+++ b/apps/electron/src/renderer/components/agent/tool-utils.ts
@@ -340,3 +340,76 @@ export function formatElapsed(seconds: number): string {
   const remainingSeconds = Math.floor(seconds % 60)
   return `${minutes}m ${remainingSeconds}s`
 }
+
+/** 文件扩展名到语言标识的映射 */
+const EXT_LANGUAGE_MAP: Record<string, string> = {
+  ts: 'typescript',
+  tsx: 'tsx',
+  js: 'javascript',
+  jsx: 'jsx',
+  py: 'python',
+  rb: 'ruby',
+  go: 'go',
+  rs: 'rust',
+  java: 'java',
+  kt: 'kotlin',
+  swift: 'swift',
+  c: 'c',
+  cpp: 'cpp',
+  h: 'c',
+  hpp: 'cpp',
+  cs: 'csharp',
+  php: 'php',
+  json: 'json',
+  jsonl: 'json',
+  yaml: 'yaml',
+  yml: 'yaml',
+  toml: 'toml',
+  xml: 'xml',
+  html: 'html',
+  htm: 'html',
+  css: 'css',
+  scss: 'scss',
+  less: 'less',
+  md: 'markdown',
+  mdx: 'mdx',
+  sql: 'sql',
+  sh: 'shellscript',
+  bash: 'shellscript',
+  zsh: 'shellscript',
+  fish: 'shellscript',
+  ps1: 'powershell',
+  dockerfile: 'dockerfile',
+  makefile: 'makefile',
+  lua: 'lua',
+  r: 'r',
+  scala: 'scala',
+  dart: 'dart',
+  vue: 'vue',
+  svelte: 'svelte',
+  graphql: 'graphql',
+  gql: 'graphql',
+  proto: 'protobuf',
+  env: 'shellscript',
+  ini: 'ini',
+  conf: 'ini',
+  cfg: 'ini',
+}
+
+/**
+ * 根据文件路径推断语法高亮语言标识
+ * 返回 Shiki 可识别的语言 ID，未知扩展名返回 'text'
+ */
+export function inferLanguageFromPath(filePath: string): string {
+  const basename = filePath.split('/').pop() ?? filePath
+  // 处理无扩展名的特殊文件
+  const lowerBasename = basename.toLowerCase()
+  if (lowerBasename === 'dockerfile') return 'dockerfile'
+  if (lowerBasename === 'makefile' || lowerBasename === 'gnumakefile') return 'makefile'
+  if (lowerBasename.startsWith('.env')) return 'shellscript'
+
+  const dotIndex = basename.lastIndexOf('.')
+  if (dotIndex === -1) return 'text'
+  const ext = basename.slice(dotIndex + 1).toLowerCase()
+  return EXT_LANGUAGE_MAP[ext] ?? 'text'
+}

--- a/apps/electron/src/renderer/components/chat/ChatMessageItem.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessageItem.tsx
@@ -34,8 +34,9 @@ import { MigrateToAgentButton } from './MigrateToAgentButton'
 import { DeleteMessageDialog } from './DeleteMessageDialog'
 import { InlineEditForm } from './InlineEditForm'
 import { UserAvatar } from './UserAvatar'
-import { getModelLogo } from '@/lib/model-logo'
+import { getModelLogo, resolveModelDisplayName } from '@/lib/model-logo'
 import { userProfileAtom } from '@/atoms/user-profile'
+import { channelsAtom } from '@/atoms/chat-atoms'
 import type { ChatMessage } from '@proma/shared'
 import type { InlineEditSubmitPayload } from './InlineEditForm'
 import { ChatToolActivityIndicator } from './ChatToolActivityIndicator'
@@ -110,6 +111,7 @@ export const ChatMessageItem = React.memo(function ChatMessageItem({
   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false)
   const [isDeleting, setIsDeleting] = React.useState(false)
   const userProfile = useAtomValue(userProfileAtom)
+  const channels = useAtomValue(channelsAtom)
 
   /** 确认删除消息 */
   const handleDeleteConfirm = async (): Promise<void> => {
@@ -138,7 +140,7 @@ export const ChatMessageItem = React.memo(function ChatMessageItem({
         {/* assistant 头像 + 模型名 + 时间 */}
         {message.role === 'assistant' && (
           <MessageHeader
-            model={message.model}
+            model={message.model ? resolveModelDisplayName(message.model, channels) : undefined}
             time={formatMessageTime(message.createdAt)}
             logo={
               <img

--- a/apps/electron/src/renderer/components/chat/ModelSelector.tsx
+++ b/apps/electron/src/renderer/components/chat/ModelSelector.tsx
@@ -30,12 +30,13 @@ import { cn } from '@/lib/utils'
 import type { Channel, ModelOption } from '@proma/shared'
 
 /** 从渠道列表构建扁平化的模型选项 */
-function buildModelOptions(channels: Channel[], filterChannelId?: string): ModelOption[] {
+function buildModelOptions(channels: Channel[], filterChannelId?: string, filterChannelIds?: string[]): ModelOption[] {
   const options: ModelOption[] = []
 
   for (const channel of channels) {
     if (!channel.enabled) continue
     if (filterChannelId && channel.id !== filterChannelId) continue
+    if (filterChannelIds && filterChannelIds.length > 0 && !filterChannelIds.includes(channel.id)) continue
 
     for (const model of channel.models) {
       if (!model.enabled) continue
@@ -71,6 +72,8 @@ function groupByChannel(options: ModelOption[]): Map<string, ModelOption[]> {
 interface ModelSelectorProps {
   /** 仅显示此渠道的模型 */
   filterChannelId?: string
+  /** 仅显示这些渠道的模型（多渠道过滤） */
+  filterChannelIds?: string[]
   /** 外部选中模型（不传则用内部 selectedModelAtom） */
   externalSelectedModel?: { channelId: string; modelId: string } | null
   /** 外部选择回调 */
@@ -79,6 +82,7 @@ interface ModelSelectorProps {
 
 export function ModelSelector({
   filterChannelId,
+  filterChannelIds,
   externalSelectedModel,
   onModelSelect,
 }: ModelSelectorProps = {}): React.ReactElement {
@@ -103,7 +107,7 @@ export function ModelSelector({
     }
   }, [open, setChannels])
 
-  const modelOptions = React.useMemo(() => buildModelOptions(channels, filterChannelId), [channels, filterChannelId])
+  const modelOptions = React.useMemo(() => buildModelOptions(channels, filterChannelId, filterChannelIds), [channels, filterChannelId, filterChannelIds])
   const grouped = React.useMemo(() => groupByChannel(modelOptions), [modelOptions])
 
   // 搜索过滤

--- a/apps/electron/src/renderer/components/settings/ChannelSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelSettings.tsx
@@ -3,7 +3,7 @@
  *
  * 分为两个区块：
  * 1. 渠道管理 — 所有渠道列表 + 添加/编辑/删除（渠道同时用于 Chat 和 Agent）
- * 2. Agent 供应商 — 从已启用的 Anthropic 渠道中选择默认 Agent 供应商
+ * 2. Agent 供应商 — 从已启用的 Anthropic 渠道中通过 Switch 开关启用多个 Agent 供应商
  */
 
 import * as React from 'react'
@@ -14,7 +14,7 @@ import { Switch } from '@/components/ui/switch'
 import { PROVIDER_LABELS } from '@proma/shared'
 import type { Channel } from '@proma/shared'
 import { getChannelLogo, PromaLogo } from '@/lib/model-logo'
-import { agentChannelIdAtom, agentModelIdAtom } from '@/atoms/agent-atoms'
+import { agentChannelIdAtom, agentModelIdAtom, agentChannelIdsAtom } from '@/atoms/agent-atoms'
 import { channelsAtom } from '@/atoms/chat-atoms'
 import { SettingsSection, SettingsCard, SettingsRow } from './primitives'
 import { ChannelForm } from './ChannelForm'
@@ -29,6 +29,7 @@ export function ChannelSettings(): React.ReactElement {
   const [loading, setLoading] = React.useState(true)
   const [agentChannelId, setAgentChannelId] = useAtom(agentChannelIdAtom)
   const [, setAgentModelId] = useAtom(agentModelIdAtom)
+  const [agentChannelIds, setAgentChannelIds] = useAtom(agentChannelIdsAtom)
   const setGlobalChannels = useSetAtom(channelsAtom)
 
   /** 加载渠道列表 */
@@ -57,12 +58,20 @@ export function ChannelSettings(): React.ReactElement {
     try {
       await window.electronAPI.deleteChannel(channel.id)
 
-      // 如果删除的是当前 Agent 渠道，清空选择
+      // 从 Agent 渠道列表中移除
+      const newIds = agentChannelIds.filter((id) => id !== channel.id)
+      setAgentChannelIds(newIds)
+
+      // 如果删除的是当前选中的 Agent 渠道，清空选择
       if (agentChannelId === channel.id) {
         setAgentChannelId(null)
         setAgentModelId(null)
-        await window.electronAPI.updateSettings({ agentChannelId: undefined, agentModelId: undefined })
       }
+
+      await window.electronAPI.updateSettings({
+        agentChannelIds: newIds,
+        ...(agentChannelId === channel.id && { agentChannelId: undefined, agentModelId: undefined }),
+      })
 
       await loadChannels()
     } catch (error) {
@@ -75,62 +84,54 @@ export function ChannelSettings(): React.ReactElement {
     try {
       await window.electronAPI.updateChannel(channel.id, { enabled: !channel.enabled })
 
-      // 如果禁用的是当前 Agent 渠道，清空选择
-      if (channel.enabled && agentChannelId === channel.id) {
-        setAgentChannelId(null)
-        setAgentModelId(null)
-        await window.electronAPI.updateSettings({ agentChannelId: undefined, agentModelId: undefined })
+      // 如果禁用渠道，同时从 Agent 列表中移除
+      if (channel.enabled) {
+        const newIds = agentChannelIds.filter((id) => id !== channel.id)
+        setAgentChannelIds(newIds)
+        await window.electronAPI.updateSettings({ agentChannelIds: newIds })
+
+        // 如果禁用的是当前选中的 Agent 渠道，清空选择
+        if (agentChannelId === channel.id) {
+          setAgentChannelId(null)
+          setAgentModelId(null)
+          await window.electronAPI.updateSettings({ agentChannelId: undefined, agentModelId: undefined })
+        }
       }
 
-      // 加载最新渠道列表并检查是否需要自动选择
-      const updatedChannels = await loadChannels()
-      await checkAndAutoSelectAgentChannel(updatedChannels)
+      await loadChannels()
     } catch (error) {
       console.error('[渠道设置] 切换渠道状态失败:', error)
     }
   }
 
-  /** 选择 Agent 供应商 */
-  const handleSelectAgentProvider = async (channelId: string): Promise<void> => {
-    setAgentChannelId(channelId)
-    setAgentModelId(null)
-    try {
-      await window.electronAPI.updateSettings({ agentChannelId: channelId, agentModelId: undefined })
-    } catch (error) {
-      console.error('[渠道设置] 保存 Agent 供应商失败:', error)
+  /** 切换 Agent 供应商开关 */
+  const handleToggleAgentProvider = async (channelId: string, enabled: boolean): Promise<void> => {
+    const newIds = enabled
+      ? [...agentChannelIds, channelId]
+      : agentChannelIds.filter((id) => id !== channelId)
+
+    setAgentChannelIds(newIds)
+
+    // 如果关闭的是当前选中的渠道，清空选择
+    if (!enabled && agentChannelId === channelId) {
+      setAgentChannelId(null)
+      setAgentModelId(null)
+      await window.electronAPI.updateSettings({
+        agentChannelIds: newIds,
+        agentChannelId: undefined,
+        agentModelId: undefined,
+      }).catch(console.error)
+      return
     }
-  }
 
-  /** 检查并自动选择 Agent 渠道 */
-  const checkAndAutoSelectAgentChannel = async (channels: Channel[]): Promise<void> => {
-    // 获取可用的 Anthropic 渠道
-    const availableAnthropicChannels = channels.filter(
-      (c) => c.provider === 'anthropic' && c.enabled
-    )
-
-    // 如果当前没有选择 Agent 渠道，或当前选择的渠道不可用，自动选择第一个可用渠道
-    const currentAgentChannel = agentChannelId
-      ? channels.find((c) => c.id === agentChannelId)
-      : null
-    const shouldAutoSelect =
-      !agentChannelId || // 没有选择
-      !currentAgentChannel || // 选择的渠道不存在
-      !currentAgentChannel.enabled || // 选择的渠道已禁用
-      currentAgentChannel.provider !== 'anthropic' // 选择的不是 Anthropic 渠道
-
-    if (shouldAutoSelect && availableAnthropicChannels.length > 0) {
-      await handleSelectAgentProvider(availableAnthropicChannels[0]!.id)
-    }
+    await window.electronAPI.updateSettings({ agentChannelIds: newIds }).catch(console.error)
   }
 
   /** 表单保存回调 */
   const handleFormSaved = async (): Promise<void> => {
     setViewMode('list')
     setEditingChannel(null)
-
-    // 加载最新渠道列表并检查是否需要自动选择
-    const updatedChannels = await loadChannels()
-    await checkAndAutoSelectAgentChannel(updatedChannels)
+    await loadChannels()
   }
 
   /** 取消表单 */
@@ -201,7 +202,7 @@ export function ChannelSettings(): React.ReactElement {
       {/* 区块二：Agent 供应商 */}
       <SettingsSection
         title="Agent 供应商"
-        description="选择 Agent 模式的默认供应商，上方已启用的 Anthropic 兼容渠道会自动出现在此列表"
+        description="启用 Agent 模式可用的供应商，支持同时开启多个渠道，在 Agent 模式下可直接切换"
       >
         <SettingsCard>
           <PromaProviderCard />
@@ -220,8 +221,8 @@ export function ChannelSettings(): React.ReactElement {
               <AgentProviderRow
                 key={channel.id}
                 channel={channel}
-                selected={agentChannelId === channel.id}
-                onSelect={() => handleSelectAgentProvider(channel.id)}
+                enabled={agentChannelIds.includes(channel.id)}
+                onToggle={(enabled) => handleToggleAgentProvider(channel.id, enabled)}
               />
             ))}
           </SettingsCard>
@@ -288,11 +289,11 @@ function ChannelRow({ channel, onEdit, onDelete, onToggle }: ChannelRowProps): R
 
 interface AgentProviderRowProps {
   channel: Channel
-  selected: boolean
-  onSelect: () => void
+  enabled: boolean
+  onToggle: (enabled: boolean) => void
 }
 
-function AgentProviderRow({ channel, selected, onSelect }: AgentProviderRowProps): React.ReactElement {
+function AgentProviderRow({ channel, enabled, onToggle }: AgentProviderRowProps): React.ReactElement {
   const enabledCount = channel.models.filter((m) => m.enabled).length
   const description = [
     PROVIDER_LABELS[channel.provider],
@@ -307,21 +308,10 @@ function AgentProviderRow({ channel, selected, onSelect }: AgentProviderRowProps
       icon={<img src={getChannelLogo(channel.baseUrl)} alt="" className="w-8 h-8 rounded" />}
       description={description}
     >
-      <button
-        type="button"
-        onClick={onSelect}
-        className="flex items-center justify-center w-5 h-5 rounded-full border-2 transition-colors"
-        style={{
-          borderColor: selected ? 'hsl(var(--primary))' : 'hsl(var(--border))',
-        }}
-      >
-        {selected && (
-          <span
-            className="w-2.5 h-2.5 rounded-full"
-            style={{ backgroundColor: 'hsl(var(--primary))' }}
-          />
-        )}
-      </button>
+      <Switch
+        checked={enabled}
+        onCheckedChange={onToggle}
+      />
     </SettingsRow>
   )
 }

--- a/apps/electron/src/renderer/lib/model-logo.ts
+++ b/apps/electron/src/renderer/lib/model-logo.ts
@@ -182,7 +182,7 @@ const MODEL_LOGO_MAP: Record<string, string> = {
   // === Zhipu / 智谱 ===
   zhipu: ZhipuLogo,
   cogview: ZhipuLogo,
-  glm: ChatGLMLogo,
+  glm: ZhipuLogo,
 
   // === Meta / Llama ===
   llama: LlamaLogo,
@@ -331,6 +331,23 @@ export function getChannelLogo(baseUrl: string): string {
     }
   }
   return DefaultLogo
+}
+
+/**
+ * 根据模型 ID 在渠道列表中查找显示名称
+ *
+ * 优先返回别名（name !== id），未找到则返回原始 modelId。
+ * 用于将 SDK 返回的 model ID 转为用户友好的显示名称。
+ */
+export function resolveModelDisplayName(modelId: string, channels: import('@proma/shared').Channel[]): string {
+  for (const channel of channels) {
+    for (const model of channel.models) {
+      if (model.id === modelId && model.name && model.name !== model.id) {
+        return model.name
+      }
+    }
+  }
+  return modelId
 }
 
 /** 默认模型图标 */

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -18,6 +18,7 @@ import {
 import {
   agentChannelIdAtom,
   agentModelIdAtom,
+  agentChannelIdsAtom,
   agentWorkspacesAtom,
   currentAgentWorkspaceIdAtom,
   currentAgentSessionIdAtom,
@@ -98,6 +99,7 @@ function ThemeInitializer(): null {
 function AgentSettingsInitializer(): null {
   const setAgentChannelId = useSetAtom(agentChannelIdAtom)
   const setAgentModelId = useSetAtom(agentModelIdAtom)
+  const setAgentChannelIds = useSetAtom(agentChannelIdsAtom)
   const setAgentWorkspaces = useSetAtom(agentWorkspacesAtom)
   const setCurrentWorkspaceId = useSetAtom(currentAgentWorkspaceIdAtom)
   const bumpCapabilities = useSetAtom(workspaceCapabilitiesVersionAtom)
@@ -134,6 +136,15 @@ function AgentSettingsInitializer(): null {
       if (settings.agentModelId) {
         setAgentModelId(settings.agentModelId)
       }
+      // 加载 Agent 启用渠道列表，兼容旧版本从 agentChannelId 迁移
+      if (settings.agentChannelIds && settings.agentChannelIds.length > 0) {
+        setAgentChannelIds(settings.agentChannelIds)
+      } else if (settings.agentChannelId) {
+        // 迁移：旧版本只有 agentChannelId，自动转为数组
+        const migrated = [settings.agentChannelId]
+        setAgentChannelIds(migrated)
+        window.electronAPI.updateSettings({ agentChannelIds: migrated }).catch(console.error)
+      }
       if (settings.agentPermissionMode) {
         // 迁移旧权限模式值（auto/smart/supervised → acceptEdits/bypassPermissions/plan）
         setPermissionMode(migratePermissionMode(settings.agentPermissionMode))
@@ -163,7 +174,7 @@ function AgentSettingsInitializer(): null {
         }
       }).catch(console.error)
     }).catch(console.error)
-  }, [setAgentChannelId, setAgentModelId, setAgentWorkspaces, setCurrentWorkspaceId, setPermissionMode, setThinking, setEffort, setMaxBudget, setMaxTurns, setChannels, setChannelsLoaded])
+  }, [setAgentChannelId, setAgentModelId, setAgentChannelIds, setAgentWorkspaces, setCurrentWorkspaceId, setPermissionMode, setThinking, setEffort, setMaxBudget, setMaxTurns, setChannels, setChannelsLoaded])
 
   // 工作区切换时重置能力缓存，预加载基线
   useEffect(() => {

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -16,10 +16,12 @@ export const DEFAULT_THEME_MODE: ThemeMode = 'dark'
 export interface AppSettings {
   /** 主题模式 */
   themeMode: ThemeMode
-  /** Agent 默认渠道 ID（仅限 Anthropic 渠道） */
+  /** Agent 默认渠道 ID（仅限 Anthropic 渠道） — 当前选中的渠道 */
   agentChannelId?: string
   /** Agent 默认模型 ID */
   agentModelId?: string
+  /** Agent 启用的渠道 ID 列表（多选，Switch 开关） */
+  agentChannelIds?: string[]
   /** Agent 当前工作区 ID */
   agentWorkspaceId?: string
   /** 是否已完成 Onboarding 流程 */


### PR DESCRIPTION
## Summary

- **工具活动语义化**：新增 `tool-phrase.ts`，将收起行从冗余的「工具名 + Badge + 摘要」改为连贯的中文短语（如「读取 foo.ts 第 10-60 行」「执行 bun test」），Loading 态显示进行时（「正在读取 foo.ts...」）
- **结果结构化渲染**：新增 `tool-result-renderers/` 目录，按工具类型分发渲染 — Bash 终端风格、Read 语法高亮 + 行号、Edit diff 视图、Grep 按文件分组高亮、Glob 文件列表、WebSearch 卡片等，替代原有的 raw JSON dump 和 2000 字符硬截断
- **ToolActivityItem / ContentBlock 重构**：接入新的短语和渲染体系，移除本地重复函数，展开面板不再显示输入区（已融入收起行）
- **Agent 渠道多选开关**：设置页支持多渠道 Switch 启用，模型显示名称优化

## Test plan
- [ ] 在 Agent 模式中触发 Read/Edit/Bash/Grep/Glob/WebSearch 等工具，验证收起行短语连贯无冗余
- [ ] 展开工具详情，验证按工具类型正确渲染结果（语法高亮、终端风格、diff 视图等）
- [ ] 验证长内容可折叠展开，无硬截断
- [ ] 验证历史消息（JSONL 加载）的工具活动显示正常
- [ ] 运行 `bun run typecheck` 确认无类型错误