### PR TITLE
feat: 文件列表支持 VS Code 风格文件类型图标 + 修复选中行高跳动

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -60,6 +60,7 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-toast": "^1.2.15",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@react-symbols/icons": "^1.3.1",
     "@tiptap/extension-code-block-lowlight": "^3.19.0",
     "@tiptap/extension-link": "^3.19.0",
     "@tiptap/extension-mention": "^3.19.0",

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -7,7 +7,7 @@
 
 import * as React from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
-import { PanelRight, X, FolderOpen, ExternalLink, RefreshCw, ChevronRight, Folder, FileText, MoreHorizontal, FolderSearch, Pencil, FolderInput, Info, FolderHeart } from 'lucide-react'
+import { PanelRight, X, FolderOpen, ExternalLink, RefreshCw, ChevronRight, MoreHorizontal, FolderSearch, Pencil, FolderInput, Info, FolderHeart } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import {
@@ -17,7 +17,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { cn } from '@/lib/utils'
-import { FileBrowser, FileDropZone } from '@/components/file-browser'
+import { FileBrowser, FileDropZone, FileTypeIcon } from '@/components/file-browser'
 import {
   agentSidePanelOpenMapAtom,
   workspaceFilesVersionAtom,
@@ -510,11 +510,7 @@ function AttachedDirTree({ dirPath, onDetach, selectedPaths, onSelect, refreshVe
             expanded && 'rotate-90',
           )}
         />
-        {expanded ? (
-          <FolderOpen className="size-4 text-amber-500 flex-shrink-0" />
-        ) : (
-          <Folder className="size-4 text-amber-500 flex-shrink-0" />
-        )}
+        <FileTypeIcon name={dirName} isDirectory isOpen={expanded} />
         <span className="text-xs truncate flex-1" title={dirPath}>
           {dirName}
         </span>
@@ -673,15 +669,7 @@ function AttachedDirItem({ entry, depth, selectedPaths, onSelect, refreshVersion
         ) : (
           <span className="w-3.5 flex-shrink-0" />
         )}
-        {entry.isDirectory ? (
-          expanded ? (
-            <FolderOpen className="size-4 text-amber-500 flex-shrink-0" />
-          ) : (
-            <Folder className="size-4 text-amber-500 flex-shrink-0" />
-          )
-        ) : (
-          <FileText className="size-4 text-muted-foreground flex-shrink-0" />
-        )}
+        <FileTypeIcon name={currentName} isDirectory={entry.isDirectory} isOpen={expanded} />
 
         {/* 名称：正常显示 / 重命名输入框 */}
         {isRenaming ? (
@@ -702,21 +690,22 @@ function AttachedDirItem({ entry, depth, selectedPaths, onSelect, refreshVersion
           <span className="truncate text-xs flex-1">{currentName}</span>
         )}
 
-        {/* 三点菜单按钮 */}
-        {isSelected && !isRenaming && (
-          <div
-            onClick={(e) => e.stopPropagation()}
-            onMouseDown={(e) => e.stopPropagation()}
-          >
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button
-                  type="button"
-                  className="h-6 w-6 rounded flex items-center justify-center hover:bg-accent/70"
-                >
-                  <MoreHorizontal className="size-3.5" />
-                </button>
-              </DropdownMenuTrigger>
+        {/* 三点菜单按钮（始终占位，避免选中时行高跳动） */}
+        <div
+          className={cn('flex-shrink-0', !(isSelected && !isRenaming) && 'invisible')}
+          onClick={(e) => e.stopPropagation()}
+          onMouseDown={(e) => e.stopPropagation()}
+        >
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                className="h-6 w-6 rounded flex items-center justify-center hover:bg-accent/70"
+              >
+                <MoreHorizontal className="size-3.5" />
+              </button>
+            </DropdownMenuTrigger>
+            {isSelected && !isRenaming && (
               <DropdownMenuContent align="start" className="w-40 z-[9999] min-w-0 p-0.5">
                 <DropdownMenuItem
                   className="text-xs py-1 [&>svg]:size-3.5"
@@ -749,9 +738,9 @@ function AttachedDirItem({ entry, depth, selectedPaths, onSelect, refreshVersion
                   移动到...
                 </DropdownMenuItem>
               </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-        )}
+            )}
+          </DropdownMenu>
+        </div>
       </div>
       {expanded && children.length === 0 && loaded && (
         <div

--- a/apps/electron/src/renderer/components/agent/tool-result-renderers/glob-result.tsx
+++ b/apps/electron/src/renderer/components/agent/tool-result-renderers/glob-result.tsx
@@ -3,8 +3,8 @@
  */
 
 import * as React from 'react'
-import { FileText } from 'lucide-react'
 import { CollapsibleResult } from './collapsible-result'
+import { FileTypeIcon } from '@/components/file-browser'
 
 interface GlobResultRendererProps {
   result: string
@@ -32,7 +32,7 @@ export function GlobResultRenderer({ result, isError }: GlobResultRendererProps)
         <div className="rounded-md bg-muted/20 p-2 space-y-0.5">
           {visibleFiles.map((file, i) => (
             <div key={i} className="flex items-center gap-1.5 text-[12px] font-mono text-foreground/70 py-0.5">
-              <FileText className="size-3 shrink-0 text-muted-foreground/50" />
+              <FileTypeIcon name={file.split('/').pop() || file} isDirectory={false} size={12} />
               <span className="truncate">{file}</span>
             </div>
           ))}

--- a/apps/electron/src/renderer/components/agent/tool-result-renderers/grep-result.tsx
+++ b/apps/electron/src/renderer/components/agent/tool-result-renderers/grep-result.tsx
@@ -6,8 +6,8 @@
  */
 
 import * as React from 'react'
-import { FileText } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { FileTypeIcon } from '@/components/file-browser'
 import { CollapsibleResult } from './collapsible-result'
 
 interface GrepResultRendererProps {
@@ -117,7 +117,7 @@ export function GrepResultRenderer({ result, isError, input }: GrepResultRendere
           <div key={group.file} className="rounded-md overflow-hidden bg-zinc-900 dark:bg-zinc-950">
             {/* 文件头 */}
             <div className="flex items-center gap-1.5 px-3 py-1.5 bg-zinc-800/50 text-[11px]">
-              <FileText className="size-3 text-zinc-400" />
+              <FileTypeIcon name={group.file.split('/').pop() || group.file} isDirectory={false} size={12} />
               <span className="font-mono text-zinc-300">{group.file}</span>
               <span className="text-zinc-500">({group.matches.length})</span>
             </div>

--- a/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
@@ -13,9 +13,6 @@
 import * as React from 'react'
 import { useAtomValue } from 'jotai'
 import {
-  Folder,
-  FolderOpen,
-  FileText,
   ChevronRight,
   Trash2,
   RefreshCw,
@@ -47,6 +44,7 @@ import {
 import { cn } from '@/lib/utils'
 import { workspaceFilesVersionAtom } from '@/atoms/agent-atoms'
 import type { FileEntry } from '@proma/shared'
+import { FileTypeIcon } from './FileTypeIcon'
 
 interface FileBrowserProps {
   rootPath: string
@@ -518,15 +516,7 @@ function FileTreeItem({
         )}
 
         {/* 文件/文件夹图标 */}
-        {entry.isDirectory ? (
-          expanded ? (
-            <FolderOpen className="size-4 text-amber-500 flex-shrink-0" />
-          ) : (
-            <Folder className="size-4 text-amber-500 flex-shrink-0" />
-          )
-        ) : (
-          <FileText className="size-4 text-muted-foreground flex-shrink-0" />
-        )}
+        <FileTypeIcon name={entry.name} isDirectory={entry.isDirectory} isOpen={expanded} />
 
         {/* 文件名 / 重命名输入框 */}
         {isRenaming ? (
@@ -552,21 +542,22 @@ function FileTreeItem({
           <span className="truncate text-xs flex-1">{entry.name}</span>
         )}
 
-        {/* 三点菜单按钮 */}
-        {showMenu && (
-          <div
-            onClick={(e) => e.stopPropagation()}
-            onMouseDown={(e) => e.stopPropagation()}
-          >
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button
-                  type="button"
-                  className="h-6 w-6 rounded flex items-center justify-center hover:bg-accent/70"
-                >
-                  <MoreHorizontal className="size-3.5" />
-                </button>
-              </DropdownMenuTrigger>
+        {/* 三点菜单按钮（始终占位，避免选中时行高跳动） */}
+        <div
+          className={cn('flex-shrink-0', !showMenu && 'invisible')}
+          onClick={(e) => e.stopPropagation()}
+          onMouseDown={(e) => e.stopPropagation()}
+        >
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                className="h-6 w-6 rounded flex items-center justify-center hover:bg-accent/70"
+              >
+                <MoreHorizontal className="size-3.5" />
+              </button>
+            </DropdownMenuTrigger>
+            {showMenu && (
               <DropdownMenuContent align="start" className="w-40 z-[9999] min-w-0 p-0.5">
                 {selectedCount === 1 && (
                   <DropdownMenuItem
@@ -603,9 +594,9 @@ function FileTreeItem({
                   {selectedCount > 1 ? `删除选中 (${selectedCount})` : '删除'}
                 </DropdownMenuItem>
               </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-        )}
+            )}
+          </DropdownMenu>
+        </div>
       </div>
 
       {/* 子项 */}

--- a/apps/electron/src/renderer/components/file-browser/FileMentionList.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileMentionList.tsx
@@ -6,9 +6,9 @@
  */
 
 import * as React from 'react'
-import { Folder, FileText } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import type { FileIndexEntry } from '@proma/shared'
+import { FileTypeIcon } from './FileTypeIcon'
 
 export interface FileMentionListProps {
   items: FileIndexEntry[]
@@ -85,11 +85,7 @@ export const FileMentionList = React.forwardRef<FileMentionRef, FileMentionListP
             )}
             onClick={() => onSelect(item)}
           >
-            {item.type === 'dir' ? (
-              <Folder className="size-3 text-amber-500 flex-shrink-0" />
-            ) : (
-              <FileText className="size-3 text-muted-foreground flex-shrink-0" />
-            )}
+            <FileTypeIcon name={item.name} isDirectory={item.type === 'dir'} size={12} />
             <span className="truncate flex-1">{item.name}</span>
             {/* 显示相对路径（当路径不等于文件名时） */}
             {item.path !== item.name && (

--- a/apps/electron/src/renderer/components/file-browser/FileTypeIcon.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileTypeIcon.tsx
@@ -1,0 +1,42 @@
+/**
+ * FileTypeIcon — 根据文件名/文件夹名渲染对应的 VS Code 风格图标
+ *
+ * 封装 @react-symbols/icons，统一尺寸和样式。
+ */
+
+import * as React from 'react'
+import { FileIcon, FolderIcon } from '@react-symbols/icons/utils'
+
+interface FileTypeIconProps {
+  /** 文件名或文件夹名（如 "index.ts"、"node_modules"） */
+  name: string
+  /** 是否为目录 */
+  isDirectory: boolean
+  /** 目录是否展开（仅目录有效） */
+  isOpen?: boolean
+  /** 图标尺寸（像素），默认 16 */
+  size?: number
+  /** 额外 className */
+  className?: string
+}
+
+export const FileTypeIcon = React.memo(function FileTypeIcon({
+  name,
+  isDirectory,
+  size = 16,
+  className,
+}: FileTypeIconProps): React.ReactElement {
+  if (isDirectory) {
+    return (
+      <span className={className} style={{ width: size, height: size, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+        <FolderIcon folderName={name} width={size} height={size} />
+      </span>
+    )
+  }
+
+  return (
+    <span className={className} style={{ width: size, height: size, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+      <FileIcon fileName={name} autoAssign width={size} height={size} />
+    </span>
+  )
+})

--- a/apps/electron/src/renderer/components/file-browser/index.ts
+++ b/apps/electron/src/renderer/components/file-browser/index.ts
@@ -4,3 +4,4 @@
 
 export * from './FileBrowser'
 export * from './FileDropZone'
+export * from './FileTypeIcon'

--- a/bun.lock
+++ b/bun.lock
@@ -44,6 +44,7 @@
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-toast": "^1.2.15",
         "@radix-ui/react-tooltip": "^1.2.8",
+        "@react-symbols/icons": "^1.3.1",
         "@tiptap/extension-code-block-lowlight": "^3.19.0",
         "@tiptap/extension-link": "^3.19.0",
         "@tiptap/extension-mention": "^3.19.0",
@@ -455,6 +456,8 @@
     "@radix-ui/react-visually-hidden": ["@radix-ui/react-visually-hidden@1.2.3", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug=="],
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
+
+    "@react-symbols/icons": ["@react-symbols/icons@1.3.1", "", { "peerDependencies": { "react": ">= 16.8", "react-dom": ">= 16.8" } }, "sha512-8F1q0duC1x8ykHyhKyDRwclK+0lvMQcslkprpMnhrROYAjhDz5bZpbQUtBr8WaQxJfXuUrRXrr9KUa4OI+NUHg=="],
 
     "@remirror/core-constants": ["@remirror/core-constants@3.0.0", "", {}, "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg=="],
 


### PR DESCRIPTION
## Summary
- 引入 `@react-symbols/icons` 库，为文件浏览器、附加目录、@ 文件引用、工具结果（Glob/Grep）等 6 处替换为根据文件名/扩展名/文件夹名自动匹配的 VS Code 风格图标
- 新增 `FileTypeIcon` 封装组件，统一图标渲染逻辑
- 修复文件选中时三点菜单按钮条件渲染导致行高从 24px 跳到 32px 的问题，改为始终占位 + `invisible` 控制可见性

## Test plan
- [ ] Agent 模式下会话文件区各类型文件（.ts/.json/.md 等）显示对应图标
- [ ] 特殊文件夹（node_modules、.github、src 等）显示专用图标
- [ ] 附加目录树文件/文件夹图标正确
- [ ] @ 文件引用下拉列表图标正确
- [ ] Glob/Grep 工具结果文件图标正确
- [ ] 点击文件选中时行高不再跳动