### PR TITLE
feat: 设置浮窗化 + 侧边栏用户头像 + 模型配置改造

### DIFF
--- a/apps/electron/electron-builder.yml
+++ b/apps/electron/electron-builder.yml
@@ -39,8 +39,8 @@ extraResources:
     filter:
       - "**/*"
   # 教程文件（教程查看器 + 欢迎对话使用）
-  - from: ../../tutorial/tutorial-1.md
-    to: tutorial-1.md
+  - from: ../../tutorial/tutorial.md
+    to: tutorial.md
 
 # ============================================
 # macOS 配置

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -107,6 +107,7 @@
     "electronmon": "^2.0.4",
     "esbuild": "^0.24.0",
     "postcss": "^8.4.49",
+    "rehype-raw": "^7.0.0",
     "tailwindcss": "^3.4.17",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.0.0",

--- a/apps/electron/src/main/lib/tutorial-service.ts
+++ b/apps/electron/src/main/lib/tutorial-service.ts
@@ -20,10 +20,10 @@ import type { ConversationMeta, FileAttachment, ChatMessage } from '@proma/share
  */
 function getTutorialFilePath(): string {
   if (app.isPackaged) {
-    return join(process.resourcesPath, 'tutorial-1.md')
+    return join(process.resourcesPath, 'tutorial.md')
   }
   // 开发模式：app.getAppPath() → apps/electron/
-  return join(app.getAppPath(), '../../tutorial/tutorial-1.md')
+  return join(app.getAppPath(), '../../tutorial/tutorial.md')
 }
 
 /**

--- a/apps/electron/src/renderer/atoms/active-view.ts
+++ b/apps/electron/src/renderer/atoms/active-view.ts
@@ -3,12 +3,11 @@
  *
  * 控制 MainContentPanel 显示的内容：
  * - conversations: 对话视图（Chat/Agent 模式内容）
- * - settings: 设置面板
  */
 
 import { atom } from 'jotai'
 
-export type ActiveView = 'conversations' | 'settings'
+export type ActiveView = 'conversations'
 
 /** 当前活跃视图（不持久化，每次启动默认显示对话） */
 export const activeViewAtom = atom<ActiveView>('conversations')

--- a/apps/electron/src/renderer/atoms/settings-tab.ts
+++ b/apps/electron/src/renderer/atoms/settings-tab.ts
@@ -15,3 +15,6 @@ export type SettingsTab = 'general' | 'channels' | 'proxy' | 'appearance' | 'abo
 
 /** 当前设置标签页（不持久化，每次打开设置默认显示渠道） */
 export const settingsTabAtom = atom<SettingsTab>('channels')
+
+/** 设置浮窗是否打开 */
+export const settingsOpenAtom = atom(false)

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -55,7 +55,7 @@ import {
   agentPlanModeSessionsAtom,
 } from '@/atoms/agent-atoms'
 import type { AgentContextStatus } from '@/atoms/agent-atoms'
-import { activeViewAtom } from '@/atoms/active-view'
+import { settingsOpenAtom } from '@/atoms/settings-tab'
 import { channelsAtom } from '@/atoms/chat-atoms'
 import { tabsAtom, splitLayoutAtom, openTab } from '@/atoms/tab-atoms'
 import { AgentSessionProvider } from '@/contexts/session-context'
@@ -76,7 +76,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const [agentModelId, setAgentModelId] = useAtom(agentModelIdAtom)
   const agentChannelIds = useAtomValue(agentChannelIdsAtom)
   const [agentThinking, setAgentThinking] = useAtom(agentThinkingAtom)
-  const setActiveView = useSetAtom(activeViewAtom)
+  const setSettingsOpen = useSetAtom(settingsOpenAtom)
   const currentWorkspaceId = useAtomValue(currentAgentWorkspaceIdAtom)
   const [pendingPrompt, setPendingPrompt] = useAtom(agentPendingPromptAtom)
   const [pendingFiles, setPendingFiles] = useAtom(agentPendingFilesAtom)
@@ -950,7 +950,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
                 <button
                   type="button"
                   className="text-xs underline underline-offset-2 hover:text-foreground transition-colors"
-                  onClick={() => setActiveView('settings')}
+                  onClick={() => setSettingsOpen(true)}
                 >
                   前往设置
                 </button>

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -15,9 +15,10 @@ import { Pin, PinOff, Settings, Plus, Trash2, Pencil, ChevronDown, ChevronRight,
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { ModeSwitcher } from './ModeSwitcher'
+import { UserAvatar } from '@/components/chat/UserAvatar'
 import { activeViewAtom } from '@/atoms/active-view'
 import { appModeAtom } from '@/atoms/app-mode'
-import { settingsTabAtom } from '@/atoms/settings-tab'
+import { settingsTabAtom, settingsOpenAtom } from '@/atoms/settings-tab'
 import {
   conversationsAtom,
   currentConversationIdAtom,
@@ -101,13 +102,12 @@ export interface LeftSidebarProps {
 }
 
 /** 侧边栏导航项标识 */
-type SidebarItemId = 'pinned' | 'all-chats' | 'settings'
+type SidebarItemId = 'pinned' | 'all-chats'
 
 /** 导航项到视图的映射 */
 const ITEM_TO_VIEW: Record<SidebarItemId, ActiveView> = {
   pinned: 'conversations',
   'all-chats': 'conversations',
-  settings: 'settings',
 }
 
 /** 日期分组标签 */
@@ -143,6 +143,7 @@ function groupByDate<T extends { updatedAt: number }>(items: T[]): Array<{ label
 export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   const [activeView, setActiveView] = useAtom(activeViewAtom)
   const setSettingsTab = useSetAtom(settingsTabAtom)
+  const setSettingsOpen = useSetAtom(settingsOpenAtom)
   const [activeItem, setActiveItem] = React.useState<SidebarItemId>('all-chats')
   const [conversations, setConversations] = useAtom(conversationsAtom)
   const [currentConversationId, setCurrentConversationId] = useAtom(currentConversationIdAtom)
@@ -155,7 +156,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   const [pinnedExpanded, setPinnedExpanded] = React.useState(true)
   /** Agent 置顶区域展开/收起 */
   const [pinnedAgentExpanded, setPinnedAgentExpanded] = React.useState(true)
-  const setUserProfile = useSetAtom(userProfileAtom)
+  const [userProfile, setUserProfile] = useAtom(userProfileAtom)
   const selectedModel = useAtomValue(selectedModelAtom)
   const streamingIds = useAtomValue(streamingConversationIdsAtom)
   const mode = useAtomValue(appModeAtom)
@@ -269,13 +270,6 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     setActiveItem(item)
     setActiveView(ITEM_TO_VIEW[item])
   }
-
-  // 当 activeView 从外部改变时，同步 activeItem
-  React.useEffect(() => {
-    if (activeView === 'conversations' && activeItem === 'settings') {
-      setActiveItem('all-chats')
-    }
-  }, [activeView, activeItem])
 
   /** 创建新对话（继承当前选中的模型/渠道） */
   const handleNewConversation = async (): Promise<void> => {
@@ -562,22 +556,17 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         {/* 弹性空间 */}
         <div className="flex-1" />
 
-        {/* 设置按钮 */}
+        {/* 用户头像（点击打开设置） */}
         <div className="pb-3">
           <Tooltip>
             <TooltipTrigger asChild>
               <button
-                onClick={() => handleItemClick('settings')}
-                className={cn(
-                  'relative p-2 rounded-[10px] transition-colors titlebar-no-drag',
-                  activeItem === 'settings'
-                    ? 'bg-foreground/[0.08] text-foreground'
-                    : 'text-foreground/60 hover:bg-foreground/[0.04] hover:text-foreground'
-                )}
+                onClick={() => setSettingsOpen(true)}
+                className="relative p-1 rounded-[10px] transition-colors titlebar-no-drag hover:bg-foreground/[0.04]"
               >
-                <Settings size={18} />
+                <UserAvatar avatar={userProfile.avatar} size={28} />
                 {(hasUpdate || hasEnvironmentIssues) && (
-                  <span className="absolute top-1.5 right-1.5 w-2 h-2 rounded-full bg-red-500" />
+                  <span className="absolute top-0 right-0 w-2 h-2 rounded-full bg-red-500" />
                 )}
               </button>
             </TooltipTrigger>
@@ -787,7 +776,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
           <Tooltip>
             <TooltipTrigger asChild>
               <button
-                onClick={() => { setSettingsTab('agent'); handleItemClick('settings') }}
+                onClick={() => { setSettingsTab('agent'); setSettingsOpen(true) }}
                 className="w-full flex items-center gap-3 px-3 py-2 rounded-[10px] text-[12px] text-foreground/50 hover:bg-foreground/[0.04] hover:text-foreground/70 transition-colors titlebar-no-drag"
               >
                 <div className="flex items-center gap-2.5 flex-1 min-w-0">
@@ -810,19 +799,21 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         </div>
       )}
 
-      {/* 底部设置 */}
+      {/* 底部：用户资料 + 设置入口 */}
       <div className="px-3 pb-3">
-        <SidebarItem
-          icon={<Settings size={18} />}
-          label="设置"
-          active={activeItem === 'settings'}
-          onClick={() => handleItemClick('settings')}
-          suffix={
-            (hasUpdate || hasEnvironmentIssues) ? (
-              <span className="w-2 h-2 rounded-full bg-red-500" />
-            ) : undefined
-          }
-        />
+        <button
+          onClick={() => setSettingsOpen(true)}
+          className="w-full flex items-center gap-3 px-3 py-2 rounded-[10px] transition-colors titlebar-no-drag text-foreground/70 hover:bg-foreground/[0.04] hover:text-foreground"
+        >
+          <UserAvatar avatar={userProfile.avatar} size={28} />
+          <span className="flex-1 text-sm truncate text-left">{userProfile.userName}</span>
+          <div className="relative flex-shrink-0 text-foreground/40">
+            <Settings size={16} />
+            {(hasUpdate || hasEnvironmentIssues) && (
+              <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-red-500" />
+            )}
+          </div>
+        </button>
       </div>
 
       {deleteDialog}

--- a/apps/electron/src/renderer/components/app-shell/MainContentPanel.tsx
+++ b/apps/electron/src/renderer/components/app-shell/MainContentPanel.tsx
@@ -9,11 +9,9 @@
 import * as React from 'react'
 import { useAtomValue } from 'jotai'
 import { appModeAtom } from '@/atoms/app-mode'
-import { activeViewAtom } from '@/atoms/active-view'
 import { Panel } from './Panel'
 import { ChatView } from '@/components/chat'
 import { AgentView } from '@/components/agent'
-import { SettingsPanel } from '@/components/settings'
 import { currentConversationIdAtom } from '@/atoms/chat-atoms'
 import { currentAgentSessionIdAtom } from '@/atoms/agent-atoms'
 
@@ -23,7 +21,6 @@ import { currentAgentSessionIdAtom } from '@/atoms/agent-atoms'
  */
 export function MainContentPanel(): React.ReactElement {
   const mode = useAtomValue(appModeAtom)
-  const activeView = useAtomValue(activeViewAtom)
   const conversationId = useAtomValue(currentConversationIdAtom)
   const sessionId = useAtomValue(currentAgentSessionIdAtom)
 
@@ -43,7 +40,7 @@ export function MainContentPanel(): React.ReactElement {
       variant="grow"
       className="bg-white/95 dark:bg-zinc-900/95 backdrop-blur-xl rounded-2xl shadow-xl border border-border/50"
     >
-      {activeView === 'settings' ? <SettingsPanel /> : renderConversations()}
+      {renderConversations()}
     </Panel>
   )
 }

--- a/apps/electron/src/renderer/components/chat/ToolSelectorPopover.tsx
+++ b/apps/electron/src/renderer/components/chat/ToolSelectorPopover.tsx
@@ -23,8 +23,7 @@ import {
 import { cn } from '@/lib/utils'
 import { Wrench, Brain, Globe, Settings, ImagePlus } from 'lucide-react'
 import { chatToolsAtom, hasActiveToolsAtom } from '@/atoms/chat-tool-atoms'
-import { settingsTabAtom } from '@/atoms/settings-tab'
-import { activeViewAtom } from '@/atoms/active-view'
+import { settingsTabAtom, settingsOpenAtom } from '@/atoms/settings-tab'
 
 /** 工具 ID 到图标的映射 */
 function getToolIcon(iconName?: string): React.ReactElement {
@@ -45,7 +44,7 @@ export function ToolSelectorPopover(): React.ReactElement {
   const tools = useAtomValue(chatToolsAtom)
   const setChatTools = useSetAtom(chatToolsAtom)
   const hasActiveTools = useAtomValue(hasActiveToolsAtom)
-  const setActiveView = useSetAtom(activeViewAtom)
+  const setSettingsOpen = useSetAtom(settingsOpenAtom)
   const setSettingsTab = useSetAtom(settingsTabAtom)
 
   /** 切换工具开关（通过 IPC 更新后端配置，再刷新 atom） */
@@ -62,7 +61,7 @@ export function ToolSelectorPopover(): React.ReactElement {
   /** 跳转到设置页工具 tab */
   const goToToolSettings = (): void => {
     setOpen(false)
-    setActiveView('settings')
+    setSettingsOpen(true)
     setSettingsTab('tools')
   }
 

--- a/apps/electron/src/renderer/components/settings/AgentSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AgentSettings.tsx
@@ -29,10 +29,9 @@ import {
   agentMaxBudgetUsdAtom,
   agentMaxTurnsAtom,
 } from '@/atoms/agent-atoms'
-import { activeViewAtom } from '@/atoms/active-view'
+import { settingsTabAtom, settingsOpenAtom } from '@/atoms/settings-tab'
 import { appModeAtom } from '@/atoms/app-mode'
 import { chatToolsAtom } from '@/atoms/chat-tool-atoms'
-import { settingsTabAtom } from '@/atoms/settings-tab'
 import type { McpServerEntry, SkillMeta, WorkspaceMcpConfig, ThinkingConfig, AgentEffort } from '@proma/shared'
 import { SettingsSection, SettingsCard, SettingsRow, SettingsSegmentedControl, SettingsInput } from './primitives'
 import { McpServerForm } from './McpServerForm'
@@ -54,7 +53,7 @@ export function AgentSettings(): React.ReactElement {
   const setAgentSessions = useSetAtom(agentSessionsAtom)
   const setCurrentSessionId = useSetAtom(currentAgentSessionIdAtom)
   const setPendingPrompt = useSetAtom(agentPendingPromptAtom)
-  const setActiveView = useSetAtom(activeViewAtom)
+  const setSettingsOpen = useSetAtom(settingsOpenAtom)
   const setAppMode = useSetAtom(appModeAtom)
   const bumpCapabilitiesVersion = useSetAtom(workspaceCapabilitiesVersionAtom)
 
@@ -208,7 +207,7 @@ ${skillList}
 
       // 跳转到 Agent 对话视图
       setAppMode('agent')
-      setActiveView('conversations')
+      setSettingsOpen(false)
     } catch (error) {
       console.error('[Agent 设置] 创建配置会话失败:', error)
     }
@@ -749,7 +748,6 @@ function valueToEffort(value: string): AgentEffort | undefined {
 /** 内置 Agent 工具状态展示 */
 function BuiltinAgentTools(): React.ReactElement {
   const tools = useAtomValue(chatToolsAtom)
-  const setActiveView = useSetAtom(activeViewAtom)
   const setSettingsTab = useSetAtom(settingsTabAtom)
 
   const memoryTool = tools.find((t) => t.meta.id === 'memory')
@@ -757,7 +755,6 @@ function BuiltinAgentTools(): React.ReactElement {
 
   /** 跳转到工具设置页 */
   const goToToolSettings = (): void => {
-    setActiveView('settings')
     setSettingsTab('tools')
   }
 

--- a/apps/electron/src/renderer/components/settings/ChannelForm.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelForm.tsx
@@ -1,12 +1,12 @@
 /**
- * ChannelForm - 渠道编辑表单
+ * ChannelForm - 模型配置编辑表单
  *
- * 支持创建和编辑渠道，包含：
+ * 支持创建和编辑模型配置，包含：
  * - 基本信息（名称、供应商、Base URL、API Key）
- * - 模型列表编辑
+ * - 模型列表：已启用模型置顶 + 可用模型搜索
  * - 连接测试
  *
- * 使用设置原语组件实现卡片化布局。
+ * 编辑模式下修改即时保存（auto-save），创建模式仍需手动提交。
  */
 
 import * as React from 'react'
@@ -22,6 +22,7 @@ import {
   Zap,
   Download,
   Search,
+  Check,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
@@ -97,6 +98,9 @@ function buildPreviewUrl(baseUrl: string, provider: ProviderType): string {
   return `${trimmed}${PROVIDER_CHAT_PATHS[provider]}`
 }
 
+/** auto-save 防抖延迟 */
+const AUTO_SAVE_DELAY = 600
+
 export function ChannelForm({ channel, onSaved, onCancel }: ChannelFormProps): React.ReactElement {
   const isEdit = channel !== null
 
@@ -123,6 +127,8 @@ export function ChannelForm({ channel, onSaved, onCancel }: ChannelFormProps): R
   const [fetchingModels, setFetchingModels] = React.useState(false)
   const [fetchResult, setFetchResult] = React.useState<FetchModelsResult | null>(null)
   const [apiKeyLoaded, setApiKeyLoaded] = React.useState(false)
+  /** auto-save 状态指示 */
+  const [autoSaveStatus, setAutoSaveStatus] = React.useState<'idle' | 'saving' | 'saved'>('idle')
 
   // 编辑模式下加载明文 API Key
   React.useEffect(() => {
@@ -131,11 +137,78 @@ export function ChannelForm({ channel, onSaved, onCancel }: ChannelFormProps): R
         setApiKey(key)
         setApiKeyLoaded(true)
       }).catch((error) => {
-        console.error('[渠道表单] 解密 API Key 失败:', error)
+        console.error('[模型配置表单] 解密 API Key 失败:', error)
         setApiKeyLoaded(true)
       })
     }
   }, [isEdit, channel, apiKeyLoaded])
+
+  // ===== Auto-save（仅编辑模式） =====
+  const autoSaveTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+  /** 初始化完成标志，避免加载时触发 auto-save */
+  const initializedRef = React.useRef(false)
+
+  /** 执行 auto-save */
+  const doAutoSave = React.useCallback(async (
+    currentModels: ChannelModel[],
+    currentName: string,
+    currentProvider: ProviderType,
+    currentBaseUrl: string,
+    currentApiKey: string,
+    currentEnabled: boolean,
+  ) => {
+    if (!isEdit || !channel) return
+    setAutoSaveStatus('saving')
+    try {
+      await window.electronAPI.updateChannel(channel.id, {
+        name: currentName,
+        provider: currentProvider,
+        baseUrl: currentBaseUrl,
+        apiKey: currentApiKey || undefined,
+        models: currentModels,
+        enabled: currentEnabled,
+      })
+      setAutoSaveStatus('saved')
+      setTimeout(() => setAutoSaveStatus('idle'), 1500)
+    } catch (error) {
+      console.error('[模型配置表单] auto-save 失败:', error)
+      setAutoSaveStatus('idle')
+    }
+  }, [isEdit, channel])
+
+  /** 触发防抖 auto-save */
+  const scheduleAutoSave = React.useCallback((
+    nextModels: ChannelModel[],
+    nextName: string,
+    nextProvider: ProviderType,
+    nextBaseUrl: string,
+    nextApiKey: string,
+    nextEnabled: boolean,
+  ) => {
+    if (!isEdit || !initializedRef.current) return
+    if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current)
+    autoSaveTimerRef.current = setTimeout(() => {
+      doAutoSave(nextModels, nextName, nextProvider, nextBaseUrl, nextApiKey, nextEnabled)
+    }, AUTO_SAVE_DELAY)
+  }, [isEdit, doAutoSave])
+
+  // API Key 加载完成后标记初始化
+  React.useEffect(() => {
+    if (isEdit && apiKeyLoaded) {
+      // 延迟标记，避免加载时触发
+      const t = setTimeout(() => { initializedRef.current = true }, 100)
+      return () => clearTimeout(t)
+    }
+    if (!isEdit) {
+      initializedRef.current = true
+    }
+  }, [isEdit, apiKeyLoaded])
+
+  // 监听字段变化触发 auto-save
+  React.useEffect(() => {
+    scheduleAutoSave(models, name, provider, baseUrl, apiKey, enabled)
+    return () => { if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current) }
+  }, [models, name, provider, baseUrl, apiKey, enabled, scheduleAutoSave])
 
   // 切换供应商时自动更新 Base URL
   const handleProviderChange = (newProvider: string): void => {
@@ -165,7 +238,7 @@ export function ChannelForm({ channel, onSaved, onCancel }: ChannelFormProps): R
     setModels((prev) => prev.filter((m) => m.id !== modelId))
   }
 
-  /** 切换模型启用状态 */
+  /** 切换模型启用状态（点击可用模型 → 启用，点击已启用模型 → 禁用） */
   const handleToggleModel = (modelId: string): void => {
     setModels((prev) =>
       prev.map((m) => (m.id === modelId ? { ...m, enabled: !m.enabled } : m))
@@ -226,18 +299,12 @@ export function ChannelForm({ channel, onSaved, onCancel }: ChannelFormProps): R
     }
   }
 
-  /** 保存渠道 */
-  const saveChannel = async (): Promise<void> => {
-    if (isEdit && channel) {
-      await window.electronAPI.updateChannel(channel.id, {
-        name,
-        provider,
-        baseUrl,
-        apiKey: apiKey || undefined,
-        models,
-        enabled,
-      })
-    } else {
+  /** 创建渠道（仅新建模式） */
+  const handleCreate = async (): Promise<void> => {
+    if (!name.trim() || !apiKey.trim()) return
+
+    setSaving(true)
+    try {
       const input: ChannelCreateInput = {
         name,
         provider,
@@ -247,74 +314,66 @@ export function ChannelForm({ channel, onSaved, onCancel }: ChannelFormProps): R
         enabled,
       }
       await window.electronAPI.createChannel(input)
-    }
-  }
-
-  /** 提交表单 */
-  const handleSubmit = async (e: React.FormEvent): Promise<void> => {
-    e.preventDefault()
-
-    if (!name.trim() || !apiKey.trim()) return
-
-    setSaving(true)
-    try {
-      await saveChannel()
       onSaved()
     } catch (error) {
-      console.error('[渠道表单] 保存失败:', error)
+      console.error('[模型配置表单] 创建失败:', error)
     } finally {
       setSaving(false)
     }
   }
 
-  // 过滤并排序模型列表：已启用的排前面，再按搜索词过滤
-  const filteredModels = React.useMemo(() => {
-    const sorted = [...models].sort((a, b) => {
-      if (a.enabled !== b.enabled) return a.enabled ? -1 : 1
-      return 0
-    })
-    if (!modelFilter.trim()) return sorted
+  // ===== 模型分区 =====
+  const enabledModels = models.filter((m) => m.enabled)
+  const availableModels = React.useMemo(() => {
+    const disabled = models.filter((m) => !m.enabled)
+    if (!modelFilter.trim()) return disabled
     const keyword = modelFilter.trim().toLowerCase()
-    return sorted.filter(
+    return disabled.filter(
       (m) => m.id.toLowerCase().includes(keyword) || m.name.toLowerCase().includes(keyword)
     )
   }, [models, modelFilter])
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-6">
-      {/* 标题栏 + 操作按钮 */}
+    <div className="space-y-6">
+      {/* 标题栏 */}
       <div className="flex items-center gap-3">
-        <Button variant="ghost" size="icon" className="h-8 w-8" type="button" onClick={onCancel}>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          onClick={() => { isEdit ? onSaved() : onCancel() }}
+        >
           <ArrowLeft size={18} />
         </Button>
         <h3 className="text-lg font-medium text-foreground flex-1">
-          {isEdit ? '编辑渠道' : '添加渠道'}
+          {isEdit ? '编辑模型配置' : '添加模型配置'}
         </h3>
-        <div className="flex items-center gap-2">
+        {/* 编辑模式：auto-save 状态 */}
+        {isEdit && autoSaveStatus !== 'idle' && (
+          <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            {autoSaveStatus === 'saving' && <Loader2 size={12} className="animate-spin" />}
+            {autoSaveStatus === 'saved' && <Check size={12} className="text-emerald-500" />}
+            <span>{autoSaveStatus === 'saving' ? '保存中...' : '已保存'}</span>
+          </span>
+        )}
+        {/* 新建模式：创建按钮 */}
+        {!isEdit && (
           <Button
-            variant="ghost"
             size="sm"
-            type="button"
-            onClick={onCancel}
-          >
-            取消
-          </Button>
-          <Button
-            size="sm"
-            type="submit"
-            disabled={saving || !name.trim() || (!isEdit && !apiKey.trim())}
+            onClick={handleCreate}
+            disabled={saving || !name.trim() || !apiKey.trim()}
           >
             {saving && <Loader2 size={14} className="animate-spin" />}
-            <span>{isEdit ? '保存修改' : '创建渠道'}</span>
+            <span>创建</span>
           </Button>
-        </div>
+        )}
       </div>
 
       {/* 基本信息卡片 */}
       <SettingsSection title="基本信息">
         <SettingsCard>
           <SettingsInput
-            label="渠道名称"
+            label="配置名称"
             value={name}
             onChange={setName}
             placeholder="例如: My Anthropic"
@@ -383,17 +442,56 @@ export function ChannelForm({ channel, onSaved, onCancel }: ChannelFormProps): R
             )}
           </div>
           <SettingsToggle
-            label="启用此渠道"
-            description="关闭后该渠道不会在模型选择中出现"
+            label="启用此配置"
+            description="关闭后该配置的模型不会在选择列表中出现"
             checked={enabled}
             onCheckedChange={setEnabled}
           />
         </SettingsCard>
       </SettingsSection>
 
-      {/* 模型列表卡片 */}
+      {/* 已启用模型 */}
       <SettingsSection
-        title="模型列表"
+        title="已启用模型"
+        description={enabledModels.length > 0 ? `${enabledModels.length} 个模型` : undefined}
+      >
+        <SettingsCard divided={false}>
+          {enabledModels.length === 0 ? (
+            <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+              还没有启用任何模型，从下方可用模型中选择
+            </div>
+          ) : (
+            <div className="divide-y divide-border/50">
+              {enabledModels.map((model) => (
+                <div
+                  key={model.id}
+                  className="flex items-center gap-2 px-4 py-2.5 group"
+                >
+                  <CheckCircle2 size={14} className="text-emerald-500 flex-shrink-0" />
+                  <span className="text-sm text-foreground flex-1">
+                    {model.name}
+                    {model.name !== model.id && (
+                      <span className="text-muted-foreground ml-1">({model.id})</span>
+                    )}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => handleToggleModel(model.id)}
+                    className="p-0.5 text-muted-foreground hover:text-destructive transition-colors opacity-0 group-hover:opacity-100"
+                    title="取消启用"
+                  >
+                    <X size={14} />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </SettingsCard>
+      </SettingsSection>
+
+      {/* 可用模型 */}
+      <SettingsSection
+        title="可用模型"
         action={
           <Button
             variant="outline"
@@ -425,43 +523,38 @@ export function ChannelForm({ channel, onSaved, onCancel }: ChannelFormProps): R
 
         <SettingsCard divided={false}>
           {/* 模型搜索过滤 */}
-          {models.length > 5 && (
+          {models.filter((m) => !m.enabled).length > 5 && (
             <div className="px-4 pt-3 pb-1">
               <div className="relative">
                 <Search size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground" />
                 <Input
                   value={modelFilter}
                   onChange={(e) => setModelFilter(e.target.value)}
-                  placeholder="搜索模型..."
+                  placeholder="搜索可用模型..."
                   className="h-8 text-sm pl-8"
                 />
               </div>
             </div>
           )}
 
-          {/* 模型计数 */}
-          {models.length > 0 && (
+          {/* 可用模型计数 */}
+          {models.filter((m) => !m.enabled).length > 0 && (
             <div className="px-4 pt-2 pb-1 text-xs text-muted-foreground">
               {modelFilter.trim()
-                ? `${filteredModels.length} / ${models.length} 个模型`
-                : `${models.filter((m) => m.enabled).length} 个已启用，共 ${models.length} 个模型`}
+                ? `${availableModels.length} / ${models.filter((m) => !m.enabled).length} 个可用模型`
+                : `${models.filter((m) => !m.enabled).length} 个可用模型`}
             </div>
           )}
 
-          <ScrollArea className={models.length > 8 ? 'h-[320px]' : undefined}>
+          <ScrollArea className={availableModels.length > 8 ? 'h-[280px]' : undefined}>
             <div className="divide-y divide-border/50">
-              {/* 已有模型列表（过滤 + 排序后） */}
-              {filteredModels.map((model) => (
+              {availableModels.map((model) => (
                 <div
                   key={model.id}
-                  className="flex items-center gap-2 px-4 py-2.5"
+                  className="flex items-center gap-2 px-4 py-2.5 group cursor-pointer hover:bg-muted/30 transition-colors"
+                  onClick={() => handleToggleModel(model.id)}
                 >
-                  <input
-                    type="checkbox"
-                    checked={model.enabled}
-                    onChange={() => handleToggleModel(model.id)}
-                    className="w-3.5 h-3.5 rounded border-input accent-foreground"
-                  />
+                  <Plus size={14} className="text-muted-foreground flex-shrink-0" />
                   <span className="text-sm text-foreground flex-1">
                     {model.name}
                     {model.name !== model.id && (
@@ -470,8 +563,9 @@ export function ChannelForm({ channel, onSaved, onCancel }: ChannelFormProps): R
                   </span>
                   <button
                     type="button"
-                    onClick={() => handleRemoveModel(model.id)}
-                    className="p-0.5 text-muted-foreground hover:text-destructive transition-colors"
+                    onClick={(e) => { e.stopPropagation(); handleRemoveModel(model.id) }}
+                    className="p-0.5 text-muted-foreground hover:text-destructive transition-colors opacity-0 group-hover:opacity-100"
+                    title="删除"
                   >
                     <X size={14} />
                   </button>
@@ -479,15 +573,22 @@ export function ChannelForm({ channel, onSaved, onCancel }: ChannelFormProps): R
               ))}
 
               {/* 搜索无结果提示 */}
-              {modelFilter.trim() && filteredModels.length === 0 && (
+              {modelFilter.trim() && availableModels.length === 0 && (
                 <div className="px-4 py-6 text-center text-sm text-muted-foreground">
                   未找到匹配的模型
+                </div>
+              )}
+
+              {/* 无可用模型提示 */}
+              {!modelFilter.trim() && models.filter((m) => !m.enabled).length === 0 && models.length > 0 && (
+                <div className="px-4 py-6 text-center text-sm text-muted-foreground">
+                  所有模型已启用
                 </div>
               )}
             </div>
           </ScrollArea>
 
-          {/* 添加新模型 */}
+          {/* 手动添加模型 */}
           <div className="flex items-center gap-2 px-4 py-2.5 border-t border-border/50">
             <Input
               value={newModelId}
@@ -526,6 +627,6 @@ export function ChannelForm({ channel, onSaved, onCancel }: ChannelFormProps): R
           </div>
         </SettingsCard>
       </SettingsSection>
-    </form>
+    </div>
   )
 }

--- a/apps/electron/src/renderer/components/settings/ChannelSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelSettings.tsx
@@ -159,14 +159,14 @@ export function ChannelSettings(): React.ReactElement {
   // 列表视图
   return (
     <div className="space-y-8">
-      {/* 区块一：渠道管理 */}
+      {/* 区块一：模型配置 */}
       <SettingsSection
-        title="渠道管理"
+        title="模型配置"
         description="管理 AI 供应商连接，配置 API Key 和可用模型。Anthropic 渠道同时可用于 Agent 模式"
         action={
           <Button size="sm" onClick={() => setViewMode('create')}>
             <Plus size={16} />
-            <span>添加渠道</span>
+            <span>添加配置</span>
           </Button>
         }
       >
@@ -178,7 +178,7 @@ export function ChannelSettings(): React.ReactElement {
         ) : channels.length === 0 ? (
           <SettingsCard divided={false}>
             <div className="text-sm text-muted-foreground py-12 text-center">
-              还没有配置任何渠道，点击上方"添加渠道"开始
+              还没有配置任何模型，点击上方"添加配置"开始
             </div>
           </SettingsCard>
         ) : (

--- a/apps/electron/src/renderer/components/settings/SettingsDialog.tsx
+++ b/apps/electron/src/renderer/components/settings/SettingsDialog.tsx
@@ -1,0 +1,33 @@
+/**
+ * SettingsDialog - 设置浮窗
+ *
+ * 以 Dialog 浮窗形式展示设置面板，不覆盖主内容区。
+ * 使用低级 Dialog 原语实现轻遮罩 + 无默认关闭按钮（关闭按钮由 SettingsPanel 内部提供）。
+ */
+
+import * as React from 'react'
+import { useAtom } from 'jotai'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { settingsOpenAtom } from '@/atoms/settings-tab'
+import { SettingsPanel } from './SettingsPanel'
+
+export function SettingsDialog(): React.ReactElement {
+  const [open, setOpen] = useAtom(settingsOpenAtom)
+
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={setOpen}>
+      <DialogPrimitive.Portal>
+        {/* 轻遮罩 */}
+        <DialogPrimitive.Overlay
+          className="fixed inset-0 z-[100] bg-black/20 titlebar-no-drag transition-opacity duration-100 data-[state=open]:opacity-100 data-[state=closed]:opacity-0"
+        />
+        <DialogPrimitive.Content
+          className="fixed left-[50%] top-[50%] z-[100] translate-x-[-50%] translate-y-[-50%] w-[920px] h-[680px] bg-background shadow-2xl rounded-xl overflow-hidden titlebar-no-drag transition-all duration-100 data-[state=open]:opacity-100 data-[state=open]:scale-100 data-[state=closed]:opacity-0 data-[state=closed]:scale-[0.98]"
+        >
+          <DialogPrimitive.Title className="sr-only">设置</DialogPrimitive.Title>
+          <SettingsPanel onClose={() => setOpen(false)} />
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  )
+}

--- a/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
+++ b/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
@@ -1,15 +1,14 @@
 /**
  * SettingsPanel - 设置面板
  *
- * 左侧导航 + 右侧 ScrollArea 内容区域。
- * 四个标签页：通用 / 渠道配置 / 外观 / 关于
+ * 顶部 Header（标题 + 关闭按钮）+ 下方（左侧导航 + 右侧 ScrollArea 内容区域）。
  * 使用 Jotai atom 管理当前标签页状态。
  */
 
 import * as React from 'react'
 import { useAtom, useAtomValue } from 'jotai'
 import { cn } from '@/lib/utils'
-import { Settings, Radio, Palette, Info, Plug, Globe, BookOpen, Wrench, MessageSquare, GraduationCap } from 'lucide-react'
+import { Settings, Radio, Palette, Info, Plug, Globe, BookOpen, Wrench, MessageSquare, GraduationCap, X } from 'lucide-react'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { settingsTabAtom } from '@/atoms/settings-tab'
 import type { SettingsTab } from '@/atoms/settings-tab'
@@ -37,7 +36,7 @@ interface TabItem {
 /** 基础 Tabs（所有模式都有） */
 const BASE_TABS: TabItem[] = [
   { id: 'general', label: '通用', icon: <Settings size={16} /> },
-  { id: 'channels', label: '渠道', icon: <Radio size={16} /> },
+  { id: 'channels', label: '模型', icon: <Radio size={16} /> },
   { id: 'prompts', label: '提示词', icon: <BookOpen size={16} /> },
   { id: 'proxy', label: '代理', icon: <Globe size={16} /> },
 ]
@@ -80,7 +79,11 @@ function renderTabContent(tab: SettingsTab): React.ReactElement {
   }
 }
 
-export function SettingsPanel(): React.ReactElement {
+interface SettingsPanelProps {
+  onClose?: () => void
+}
+
+export function SettingsPanel({ onClose }: SettingsPanelProps): React.ReactElement {
   const [activeTab, setActiveTab] = useAtom(settingsTabAtom)
   const appMode = useAtomValue(appModeAtom)
   const hasUpdate = useAtomValue(hasUpdateAtom)
@@ -94,41 +97,57 @@ export function SettingsPanel(): React.ReactElement {
     return [...BASE_TABS, TOOLS_TAB, FEISHU_TAB, TUTORIAL_TAB, ...TAIL_TABS]
   }, [appMode])
 
+  // 当前 tab 标题
+  const activeTabLabel = tabs.find((t) => t.id === activeTab)?.label ?? '设置'
+
   return (
-    <div className="flex h-full">
-      {/* 左侧 Tab 导航 */}
-      <div className="w-[180px] border-r border-border/50 pt-14 px-2">
-        <h2 className="text-xs font-medium text-muted-foreground px-3 mb-2 uppercase tracking-wider">
-          设置
-        </h2>
-        <nav className="flex flex-col gap-1">
-          {tabs.map((tab) => (
-            <button
-              key={tab.id}
-              onClick={() => setActiveTab(tab.id)}
-              className={cn(
-                'flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors',
-                activeTab === tab.id
-                  ? 'bg-muted text-foreground font-medium'
-                  : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground'
-              )}
-            >
-              {tab.icon}
-              <span>{tab.label}</span>
-              {tab.id === 'about' && (hasUpdate || hasEnvironmentIssues) && (
-                <span className="w-2 h-2 rounded-full bg-red-500" />
-              )}
-            </button>
-          ))}
-        </nav>
+    <div className="flex flex-col h-full">
+      {/* 顶部 Header 栏 */}
+      <div className="h-12 flex items-center justify-between px-5 border-b border-border/50 flex-shrink-0">
+        <h2 className="text-sm font-medium text-foreground">{activeTabLabel}</h2>
+        {onClose && (
+          <button
+            onClick={onClose}
+            className="rounded-md p-1.5 text-muted-foreground/60 hover:text-foreground hover:bg-muted transition-colors"
+          >
+            <X size={16} />
+          </button>
+        )}
       </div>
 
-      {/* 右侧内容区域 */}
-      <ScrollArea className="flex-1 pt-14">
-        <div className="px-6 pb-6">
-          {renderTabContent(activeTab)}
+      {/* 下方主体：左导航 + 右内容 */}
+      <div className="flex flex-1 min-h-0">
+        {/* 左侧 Tab 导航 */}
+        <div className="w-[160px] border-r border-border/50 pt-3 px-2 flex-shrink-0">
+          <nav className="flex flex-col gap-0.5">
+            {tabs.map((tab) => (
+              <button
+                key={tab.id}
+                onClick={() => setActiveTab(tab.id)}
+                className={cn(
+                  'flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors',
+                  activeTab === tab.id
+                    ? 'bg-muted text-foreground font-medium'
+                    : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground'
+                )}
+              >
+                {tab.icon}
+                <span>{tab.label}</span>
+                {tab.id === 'about' && (hasUpdate || hasEnvironmentIssues) && (
+                  <span className="w-2 h-2 rounded-full bg-red-500" />
+                )}
+              </button>
+            ))}
+          </nav>
         </div>
-      </ScrollArea>
+
+        {/* 右侧内容区域 */}
+        <ScrollArea className="flex-1">
+          <div className="px-6 py-4">
+            {renderTabContent(activeTab)}
+          </div>
+        </ScrollArea>
+      </div>
     </div>
   )
 }

--- a/apps/electron/src/renderer/components/settings/index.ts
+++ b/apps/electron/src/renderer/components/settings/index.ts
@@ -3,6 +3,7 @@
  */
 
 export * from './SettingsPanel'
+export * from './SettingsDialog'
 export * from './ChannelSettings'
 export * from './ChannelForm'
 export * from './GeneralSettings'

--- a/apps/electron/src/renderer/components/tabs/MainArea.tsx
+++ b/apps/electron/src/renderer/components/tabs/MainArea.tsx
@@ -1,58 +1,45 @@
 /**
  * MainArea — 主内容区域
  *
- * 替代原 MainContentPanel，组合 TabBar + SplitContainer。
- * Settings 视图仍为独立全屏覆盖。
+ * 组合 TabBar + SplitContainer。设置以浮窗形式叠加显示。
  */
 
 import * as React from 'react'
 import { useAtomValue } from 'jotai'
-import { activeViewAtom } from '@/atoms/active-view'
 import { tabsAtom } from '@/atoms/tab-atoms'
 import { Panel } from '@/components/app-shell/Panel'
-import { SettingsPanel } from '@/components/settings'
+import { SettingsDialog } from '@/components/settings'
 import { TabBar } from './TabBar'
 import { SplitContainer } from './SplitContainer'
 import { MessageSquare } from 'lucide-react'
 
 export function MainArea(): React.ReactElement {
-  const activeView = useAtomValue(activeViewAtom)
   const tabs = useAtomValue(tabsAtom)
 
-  // Settings 视图覆盖整个右侧
-  if (activeView === 'settings') {
-    return (
+  return (
+    <>
       <Panel
         variant="grow"
-        className="bg-white/95 dark:bg-zinc-900/95 backdrop-blur-xl rounded-2xl shadow-xl border border-border/50 titlebar-no-drag"
+        className="bg-white/95 dark:bg-zinc-900/95 backdrop-blur-xl rounded-2xl shadow-xl border border-border/50"
       >
-        <SettingsPanel />
+        <TabBar />
+        {tabs.length === 0 ? (
+          <div className="flex flex-col items-center justify-center flex-1 gap-4 text-muted-foreground titlebar-no-drag" style={{ zoom: 1.1 }}>
+            <div className="w-16 h-16 rounded-full bg-muted flex items-center justify-center">
+              <MessageSquare size={32} className="text-muted-foreground/60" />
+            </div>
+            <div className="text-center space-y-2">
+              <h2 className="text-lg font-medium text-foreground">开始使用</h2>
+              <p className="text-sm max-w-[300px]">
+                从左侧选择或创建一个对话，它将以标签页的形式打开
+              </p>
+            </div>
+          </div>
+        ) : (
+          <SplitContainer />
+        )}
       </Panel>
-    )
-  }
-
-  // 标签视图
-  return (
-    <Panel
-      variant="grow"
-      className="bg-white/95 dark:bg-zinc-900/95 backdrop-blur-xl rounded-2xl shadow-xl border border-border/50"
-    >
-      <TabBar />
-      {tabs.length === 0 ? (
-        <div className="flex flex-col items-center justify-center flex-1 gap-4 text-muted-foreground titlebar-no-drag" style={{ zoom: 1.1 }}>
-          <div className="w-16 h-16 rounded-full bg-muted flex items-center justify-center">
-            <MessageSquare size={32} className="text-muted-foreground/60" />
-          </div>
-          <div className="text-center space-y-2">
-            <h2 className="text-lg font-medium text-foreground">开始使用</h2>
-            <p className="text-sm max-w-[300px]">
-              从左侧选择或创建一个对话，它将以标签页的形式打开
-            </p>
-          </div>
-        </div>
-      ) : (
-        <SplitContainer />
-      )}
-    </Panel>
+      <SettingsDialog />
+    </>
   )
 }

--- a/apps/electron/src/renderer/components/tutorial/TutorialBanner.tsx
+++ b/apps/electron/src/renderer/components/tutorial/TutorialBanner.tsx
@@ -11,13 +11,12 @@ import * as React from 'react'
 import { useSetAtom } from 'jotai'
 import { GraduationCap, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { activeViewAtom } from '@/atoms/active-view'
-import { settingsTabAtom } from '@/atoms/settings-tab'
+import { settingsTabAtom, settingsOpenAtom } from '@/atoms/settings-tab'
 
 export function TutorialBanner(): React.ReactElement | null {
   const [visible, setVisible] = React.useState(false)
   const [dismissed, setDismissed] = React.useState(true)
-  const setActiveView = useSetAtom(activeViewAtom)
+  const setSettingsOpen = useSetAtom(settingsOpenAtom)
   const setSettingsTab = useSetAtom(settingsTabAtom)
 
   // 初始化：从主进程读取 settings 判断是否需要显示
@@ -43,7 +42,7 @@ export function TutorialBanner(): React.ReactElement | null {
   // 立即学习：跳转到设置教程页并关闭横幅
   const handleLearnNow = async () => {
     setSettingsTab('tutorial')
-    setActiveView('settings')
+    setSettingsOpen(true)
     await handleDismiss()
   }
 

--- a/apps/electron/src/renderer/components/tutorial/TutorialViewer.tsx
+++ b/apps/electron/src/renderer/components/tutorial/TutorialViewer.tsx
@@ -3,14 +3,42 @@
  *
  * 通过 IPC 从主进程获取教程 markdown 内容并渲染。
  * 复用 react-markdown + remarkGfm 渲染栈。
- * 支持外部图片、代码块高亮、链接跳转。
+ * 支持外部图片、代码块高亮、链接跳转、内嵌视频。
  */
 
 import * as React from 'react'
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import rehypeRaw from 'rehype-raw'
 import { Loader2 } from 'lucide-react'
 import { CodeBlock } from '@proma/ui'
+
+/** 视频块信息 */
+interface VideoBlock {
+  id: string
+  src: string
+}
+
+/** 占位符前缀 */
+const VIDEO_PLACEHOLDER_PREFIX = '$$VIDEO_BLOCK_'
+
+/**
+ * 提取 markdown 中的 <video> 标签，替换为占位符。
+ * react-markdown + rehype-raw 对多行 HTML 标签支持不稳定，
+ * 改为手动提取后通过自定义组件渲染。
+ */
+function extractVideoBlocks(markdown: string): { processed: string; videos: VideoBlock[] } {
+  const videos: VideoBlock[] = []
+  const processed = markdown.replace(
+    /<video[^>]*\bsrc=["']([^"']+)["'][^>]*>[\s\S]*?<\/video>/gi,
+    (_match, src: string) => {
+      const id = `${VIDEO_PLACEHOLDER_PREFIX}${videos.length}`
+      videos.push({ id, src })
+      return `\n\n${id}\n\n`
+    },
+  )
+  return { processed, videos }
+}
 
 export function TutorialViewer(): React.ReactElement {
   const [content, setContent] = React.useState<string | null>(null)
@@ -45,6 +73,8 @@ export function TutorialViewer(): React.ReactElement {
     )
   }
 
+  const { processed, videos } = extractVideoBlocks(content)
+
   return (
     <div
       className="prose dark:prose-invert max-w-none text-[14px]
@@ -56,6 +86,7 @@ export function TutorialViewer(): React.ReactElement {
     >
       <Markdown
         remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeRaw]}
         components={{
           a: ({ href, children: linkChildren, ...linkProps }) => (
             <a
@@ -84,9 +115,40 @@ export function TutorialViewer(): React.ReactElement {
               loading="lazy"
             />
           ),
+          p: ({ children, ...pProps }) => {
+            // 检查段落内容是否为视频占位符
+            if (typeof children === 'string' && children.startsWith(VIDEO_PLACEHOLDER_PREFIX)) {
+              const video = videos.find((v) => v.id === children)
+              if (video) {
+                return (
+                  <video
+                    src={video.src}
+                    controls
+                    playsInline
+                    className="rounded-xl shadow-md max-w-full h-auto my-2"
+                  />
+                )
+              }
+            }
+            // children 可能是数组，检查单个子元素
+            if (Array.isArray(children) && children.length === 1 && typeof children[0] === 'string' && (children[0] as string).startsWith(VIDEO_PLACEHOLDER_PREFIX)) {
+              const video = videos.find((v) => v.id === children[0])
+              if (video) {
+                return (
+                  <video
+                    src={video.src}
+                    controls
+                    playsInline
+                    className="rounded-xl shadow-md max-w-full h-auto my-2"
+                  />
+                )
+              }
+            }
+            return <p {...pProps}>{children}</p>
+          },
         }}
       >
-        {content}
+        {processed}
       </Markdown>
     </div>
   )

--- a/bun.lock
+++ b/bun.lock
@@ -91,6 +91,7 @@
         "electronmon": "^2.0.4",
         "esbuild": "^0.24.0",
         "postcss": "^8.4.49",
+        "rehype-raw": "^7.0.0",
         "tailwindcss": "^3.4.17",
         "tailwindcss-animate": "^1.0.7",
         "typescript": "^5.0.0",
@@ -975,7 +976,7 @@
 
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
-    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
@@ -1125,9 +1126,13 @@
 
     "hast-util-parse-selector": ["hast-util-parse-selector@4.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A=="],
 
+    "hast-util-raw": ["hast-util-raw@9.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "hast-util-from-parse5": "^8.0.0", "hast-util-to-parse5": "^8.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "parse5": "^7.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw=="],
+
     "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
 
     "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
+
+    "hast-util-to-parse5": ["hast-util-to-parse5@8.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA=="],
 
     "hast-util-to-text": ["hast-util-to-text@4.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "hast-util-is-element": "^3.0.0", "unist-util-find-after": "^5.0.0" } }, "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A=="],
 
@@ -1673,6 +1678,8 @@
 
     "rehype-katex": ["rehype-katex@7.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/katex": "^0.16.0", "hast-util-from-html-isomorphic": "^2.0.0", "hast-util-to-text": "^4.0.0", "katex": "^0.16.0", "unist-util-visit-parents": "^6.0.0", "vfile": "^6.0.0" } }, "sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA=="],
 
+    "rehype-raw": ["rehype-raw@7.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-raw": "^9.0.0", "vfile": "^6.0.0" } }, "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww=="],
+
     "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
 
     "remark-math": ["remark-math@6.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-math": "^3.0.0", "micromark-extension-math": "^3.0.0", "unified": "^11.0.0" } }, "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA=="],
@@ -2199,6 +2206,8 @@
 
     "make-fetch-happen/negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
 
+    "markdown-it/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "micromark/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
@@ -2222,8 +2231,6 @@
     "node-gyp/rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
-
-    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 


### PR DESCRIPTION
## Summary
- 设置面板从全屏覆盖改为居中 Dialog 浮窗（920×680），轻遮罩 + 微缩放动画
- 浮窗顶部增加 Header 栏（当前 tab 名称 + 关闭按钮），避免与内容操作按钮冲突
- 侧边栏底部展示用户头像 + 名称 + 设置齿轮图标，折叠时仅显示头像，点击打开设置
- 渠道配置改名为「模型配置」，编辑模式改为 auto-save 即时生效（600ms 防抖）
- 模型列表拆分为「已启用模型」（始终置顶可见）和「可用模型」（受搜索过滤），解决搜索隐藏已启用模型的问题
- 教程文件路径更新 tutorial-1.md → tutorial.md
- 教程 Markdown 渲染支持 `<video>` HTML 标签（rehype-raw + 手动提取方案）

## Test plan
- [ ] 点击侧边栏底部用户资料区域，设置浮窗正常弹出
- [ ] 折叠侧边栏后点击头像图标，设置浮窗正常弹出
- [ ] 设置浮窗 Header 栏关闭按钮、遮罩点击、Escape 均可关闭
- [ ] 模型配置页：已启用模型始终可见，搜索只过滤可用模型
- [ ] 编辑模式下修改字段后自动保存，显示「保存中/已保存」状态
- [ ] 教程页面中 `<video>` 标签正确渲染为视频播放器