### PR TITLE
feat: 自动归档 + 全局搜索 Dialog，降低对话列表认知负担

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -95,6 +95,8 @@ import {
   deleteMessage,
   truncateMessagesFrom,
   updateContextDividers,
+  autoArchiveConversations,
+  searchConversationMessages,
 } from './lib/conversation-manager'
 import { sendMessage, stopGeneration, generateTitle } from './lib/chat-service'
 import {
@@ -121,6 +123,8 @@ import {
   migrateChatToAgentSession,
   moveSessionToWorkspace,
   forkAgentSession,
+  autoArchiveAgentSessions,
+  searchAgentSessionMessages,
 } from './lib/agent-session-manager'
 import { runAgent, stopAgent, generateAgentTitle, saveFilesToAgentSession, saveFilesToWorkspaceFiles, isAgentSessionActive, queueAgentMessage } from './lib/agent-service'
 import { permissionService } from './lib/agent-permission-service'
@@ -352,6 +356,25 @@ export function registerIpcHandlers(): void {
       const current = conversations.find((c) => c.id === id)
       if (!current) throw new Error(`对话不存在: ${id}`)
       return updateConversationMeta(id, { pinned: !current.pinned })
+    }
+  )
+
+  // 切换对话归档状态
+  ipcMain.handle(
+    CHAT_IPC_CHANNELS.TOGGLE_ARCHIVE,
+    async (_, id: string): Promise<ConversationMeta> => {
+      const conversations = listConversations()
+      const current = conversations.find((c) => c.id === id)
+      if (!current) throw new Error(`对话不存在: ${id}`)
+      return updateConversationMeta(id, { archived: !current.archived })
+    }
+  )
+
+  // 搜索对话消息内容
+  ipcMain.handle(
+    CHAT_IPC_CHANNELS.SEARCH_MESSAGES,
+    async (_, query: string) => {
+      return searchConversationMessages(query)
     }
   )
 
@@ -684,6 +707,25 @@ export function registerIpcHandlers(): void {
       const current = sessions.find((s) => s.id === id)
       if (!current) throw new Error(`Agent 会话不存在: ${id}`)
       return updateAgentSessionMeta(id, { pinned: !current.pinned })
+    }
+  )
+
+  // 切换 Agent 会话归档状态
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.TOGGLE_ARCHIVE,
+    async (_, id: string): Promise<AgentSessionMeta> => {
+      const sessions = listAgentSessions()
+      const current = sessions.find((s) => s.id === id)
+      if (!current) throw new Error(`Agent 会话不存在: ${id}`)
+      return updateAgentSessionMeta(id, { archived: !current.archived })
+    }
+  )
+
+  // 搜索 Agent 会话消息内容
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.SEARCH_MESSAGES,
+    async (_, query: string) => {
+      return searchAgentSessionMessages(query)
     }
   )
 
@@ -1781,4 +1823,19 @@ export function registerIpcHandlers(): void {
 
   // 注册更新 IPC 处理器
   registerUpdaterIpc()
+
+  // 启动时自动归档
+  try {
+    const settings = getSettings()
+    const days = settings.archiveAfterDays ?? 7
+    if (days > 0) {
+      const archivedChats = autoArchiveConversations(days)
+      const archivedSessions = autoArchiveAgentSessions(days)
+      if (archivedChats + archivedSessions > 0) {
+        console.log(`[自动归档] 已归档 ${archivedChats} 个对话, ${archivedSessions} 个 Agent 会话`)
+      }
+    }
+  } catch (error) {
+    console.error('[自动归档] 启动时自动归档失败:', error)
+  }
 }

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -1824,18 +1824,23 @@ export function registerIpcHandlers(): void {
   // 注册更新 IPC 处理器
   registerUpdaterIpc()
 
-  // 启动时自动归档
-  try {
-    const settings = getSettings()
-    const days = settings.archiveAfterDays ?? 7
-    if (days > 0) {
-      const archivedChats = autoArchiveConversations(days)
-      const archivedSessions = autoArchiveAgentSessions(days)
-      if (archivedChats + archivedSessions > 0) {
-        console.log(`[自动归档] 已归档 ${archivedChats} 个对话, ${archivedSessions} 个 Agent 会话`)
+  // 启动时自动归档 + 每 24 小时定期检查
+  const runAutoArchive = (): void => {
+    try {
+      const settings = getSettings()
+      const days = settings.archiveAfterDays ?? 7
+      if (days > 0) {
+        const archivedChats = autoArchiveConversations(days)
+        const archivedSessions = autoArchiveAgentSessions(days)
+        if (archivedChats + archivedSessions > 0) {
+          console.log(`[自动归档] 已归档 ${archivedChats} 个对话, ${archivedSessions} 个 Agent 会话`)
+        }
       }
+    } catch (error) {
+      console.error('[自动归档] 自动归档失败:', error)
     }
-  } catch (error) {
-    console.error('[自动归档] 启动时自动归档失败:', error)
   }
+
+  runAutoArchive()
+  setInterval(runAutoArchive, 24 * 60 * 60 * 1000)
 }

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -152,6 +152,16 @@ export function appendAgentMessage(id: string, message: AgentMessage): void {
   try {
     const line = JSON.stringify(message) + '\n'
     appendFileSync(filePath, line, 'utf-8')
+
+    // 追加消息时更新 updatedAt，若已归档则自动恢复活跃
+    const index = readIndex()
+    const idx = index.sessions.findIndex((s) => s.id === id)
+    if (idx !== -1) {
+      const session = index.sessions[idx]!
+      session.updatedAt = Date.now()
+      if (session.archived) session.archived = false
+      writeIndex(index)
+    }
   } catch (error) {
     console.error(`[Agent 会话] 追加消息失败 (${id}):`, error)
     throw new Error('追加 Agent 消息失败')
@@ -282,9 +292,12 @@ export function updateAgentSessionMeta(
   }
 
   const existing = index.sessions[idx]!
+  // 非手动归档操作时，若会话已归档则自动恢复为活跃
+  const autoUnarchive = existing.archived && !('archived' in updates)
   const updated: AgentSessionMeta = {
     ...existing,
     ...updates,
+    ...(autoUnarchive ? { archived: false } : {}),
     updatedAt: Date.now(),
   }
 

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -19,7 +19,7 @@ import {
   getAgentWorkspacePath,
 } from './config-paths'
 import { getAgentWorkspace } from './agent-workspace-manager'
-import type { AgentSessionMeta, AgentMessage, SDKMessage, ForkSessionInput } from '@proma/shared'
+import type { AgentSessionMeta, AgentMessage, SDKMessage, ForkSessionInput, AgentMessageSearchResult } from '@proma/shared'
 import { getConversationMessages } from './conversation-manager'
 import { clearNanoBananaAgentHistory } from './chat-tools/nano-banana-mcp'
 
@@ -272,7 +272,7 @@ function convertLegacyMessage(legacy: AgentMessage): SDKMessage {
  */
 export function updateAgentSessionMeta(
   id: string,
-  updates: Partial<Pick<AgentSessionMeta, 'title' | 'channelId' | 'sdkSessionId' | 'workspaceId' | 'pinned' | 'attachedDirectories' | 'forkedFromSdkSessionId' | 'forkAtMessageUuid' | 'forkSourceDir'>>,
+  updates: Partial<Pick<AgentSessionMeta, 'title' | 'channelId' | 'sdkSessionId' | 'workspaceId' | 'pinned' | 'archived' | 'attachedDirectories' | 'forkedFromSdkSessionId' | 'forkAtMessageUuid' | 'forkSourceDir'>>,
 ): AgentSessionMeta {
   const index = readIndex()
   const idx = index.sessions.findIndex((s) => s.id === id)
@@ -521,4 +521,102 @@ export function forkAgentSession(input: ForkSessionInput): AgentSessionMeta {
 
   console.log(`[Agent 会话] 分叉会话已创建（延迟 fork）: ${sourceMeta.title} → ${forkTitle} (${messagesToCopy.length} 条消息)`)
   return newMeta
+}
+
+/**
+ * 自动归档超过指定天数未更新的 Agent 会话
+ *
+ * 置顶会话不会被归档。
+ *
+ * @param daysThreshold 天数阈值
+ * @returns 本次归档的会话数量
+ */
+export function autoArchiveAgentSessions(daysThreshold: number): number {
+  const index = readIndex()
+  const threshold = Date.now() - daysThreshold * 86_400_000
+  let count = 0
+
+  for (const session of index.sessions) {
+    if (!session.pinned && !session.archived && session.updatedAt < threshold) {
+      session.archived = true
+      count++
+    }
+  }
+
+  if (count > 0) {
+    writeIndex(index)
+    console.log(`[Agent 会话] 自动归档 ${count} 个会话（阈值: ${daysThreshold} 天）`)
+  }
+
+  return count
+}
+
+/**
+ * 搜索 Agent 会话消息内容
+ *
+ * 遍历所有会话的 JSONL 文件，逐行搜索 content 字段。
+ * 每个会话最多返回 1 条最佳匹配，总计最多 30 条结果。
+ *
+ * @param query 搜索关键词
+ * @returns 匹配结果列表
+ */
+export function searchAgentSessionMessages(query: string): AgentMessageSearchResult[] {
+  if (!query || query.length < 2) return []
+
+  const index = readIndex()
+  const results: AgentMessageSearchResult[] = []
+  const queryLower = query.toLowerCase()
+  const maxResults = 30
+
+  for (const session of index.sessions) {
+    if (results.length >= maxResults) break
+
+    const filePath = getAgentSessionMessagesPath(session.id)
+    if (!existsSync(filePath)) continue
+
+    try {
+      const raw = readFileSync(filePath, 'utf-8')
+      const lines = raw.split('\n').filter((line) => line.trim())
+
+      for (const line of lines) {
+        const parsed = JSON.parse(line)
+        // 兼容旧 AgentMessage 和新 SDKMessage 格式
+        const content = parsed.content ?? ''
+        const role = parsed.role ?? 'assistant'
+        const messageId = parsed.id ?? parsed.uuid ?? ''
+        if (!content) continue
+
+        const contentLower = (typeof content === 'string' ? content : '').toLowerCase()
+        const matchIndex = contentLower.indexOf(queryLower)
+        if (matchIndex === -1) continue
+
+        // 提取匹配上下文 snippet
+        const textContent = typeof content === 'string' ? content : ''
+        const snippetStart = Math.max(0, matchIndex - 40)
+        const snippetEnd = Math.min(textContent.length, matchIndex + query.length + 40)
+        const snippet = (snippetStart > 0 ? '...' : '') +
+          textContent.slice(snippetStart, snippetEnd) +
+          (snippetEnd < textContent.length ? '...' : '')
+        const matchStart = matchIndex - snippetStart + (snippetStart > 0 ? 3 : 0)
+
+        results.push({
+          sessionId: session.id,
+          sessionTitle: session.title,
+          messageId,
+          role,
+          snippet,
+          matchStart,
+          matchLength: query.length,
+          archived: session.archived,
+        })
+
+        // 每个会话只取 1 条匹配
+        break
+      }
+    } catch {
+      // 跳过读取失败的文件
+    }
+  }
+
+  return results
 }

--- a/apps/electron/src/main/lib/conversation-manager.ts
+++ b/apps/electron/src/main/lib/conversation-manager.ts
@@ -183,6 +183,16 @@ export function appendMessage(id: string, message: ChatMessage): void {
   try {
     const line = JSON.stringify(message) + '\n'
     appendFileSync(filePath, line, 'utf-8')
+
+    // 追加消息时更新 updatedAt，若已归档则自动恢复活跃
+    const index = readIndex()
+    const idx = index.conversations.findIndex((c) => c.id === id)
+    if (idx !== -1) {
+      const conv = index.conversations[idx]!
+      conv.updatedAt = Date.now()
+      if (conv.archived) conv.archived = false
+      writeIndex(index)
+    }
   } catch (error) {
     console.error(`[对话管理] 追加消息失败 (${id}):`, error)
     throw new Error('追加消息失败')
@@ -228,9 +238,12 @@ export function updateConversationMeta(
   }
 
   const existing = index.conversations[idx]!
+  // 非手动归档操作时，若对话已归档则自动恢复为活跃
+  const autoUnarchive = existing.archived && !('archived' in updates)
   const updated: ConversationMeta = {
     ...existing,
     ...updates,
+    ...(autoUnarchive ? { archived: false } : {}),
     updatedAt: Date.now(),
   }
 

--- a/apps/electron/src/main/lib/conversation-manager.ts
+++ b/apps/electron/src/main/lib/conversation-manager.ts
@@ -14,7 +14,7 @@ import {
   getConversationMessagesPath,
 } from './config-paths'
 import { deleteConversationAttachments, deleteAttachment } from './attachment-service'
-import type { ConversationMeta, ChatMessage, RecentMessagesResult } from '@proma/shared'
+import type { ConversationMeta, ChatMessage, RecentMessagesResult, MessageSearchResult } from '@proma/shared'
 
 /**
  * 对话索引文件格式
@@ -218,7 +218,7 @@ export function saveConversationMessages(id: string, messages: ChatMessage[]): v
  */
 export function updateConversationMeta(
   id: string,
-  updates: Partial<Pick<ConversationMeta, 'title' | 'modelId' | 'channelId' | 'contextDividers' | 'contextLength' | 'pinned'>>,
+  updates: Partial<Pick<ConversationMeta, 'title' | 'modelId' | 'channelId' | 'contextDividers' | 'contextLength' | 'pinned' | 'archived'>>,
 ): ConversationMeta {
   const index = readIndex()
   const idx = index.conversations.findIndex((c) => c.id === id)
@@ -358,4 +358,97 @@ export function truncateMessagesFrom(
  */
 export function updateContextDividers(conversationId: string, dividers: string[]): ConversationMeta {
   return updateConversationMeta(conversationId, { contextDividers: dividers })
+}
+
+/**
+ * 自动归档超过指定天数未更新的对话
+ *
+ * 置顶对话不会被归档。
+ *
+ * @param daysThreshold 天数阈值
+ * @returns 本次归档的对话数量
+ */
+export function autoArchiveConversations(daysThreshold: number): number {
+  const index = readIndex()
+  const threshold = Date.now() - daysThreshold * 86_400_000
+  let count = 0
+
+  for (const conv of index.conversations) {
+    if (!conv.pinned && !conv.archived && conv.updatedAt < threshold) {
+      conv.archived = true
+      count++
+    }
+  }
+
+  if (count > 0) {
+    writeIndex(index)
+    console.log(`[对话管理] 自动归档 ${count} 个对话（阈值: ${daysThreshold} 天）`)
+  }
+
+  return count
+}
+
+/**
+ * 搜索对话消息内容
+ *
+ * 遍历所有对话的 JSONL 文件，逐行搜索 content 字段。
+ * 每个对话最多返回 1 条最佳匹配，总计最多 30 条结果。
+ *
+ * @param query 搜索关键词
+ * @returns 匹配结果列表
+ */
+export function searchConversationMessages(query: string): MessageSearchResult[] {
+  if (!query || query.length < 2) return []
+
+  const index = readIndex()
+  const results: MessageSearchResult[] = []
+  const queryLower = query.toLowerCase()
+  const maxResults = 30
+
+  for (const conv of index.conversations) {
+    if (results.length >= maxResults) break
+
+    const filePath = getConversationMessagesPath(conv.id)
+    if (!existsSync(filePath)) continue
+
+    try {
+      const raw = readFileSync(filePath, 'utf-8')
+      const lines = raw.split('\n').filter((line) => line.trim())
+
+      for (const line of lines) {
+        const msg = JSON.parse(line) as ChatMessage
+        if (!msg.content) continue
+
+        const contentLower = msg.content.toLowerCase()
+        const matchIndex = contentLower.indexOf(queryLower)
+        if (matchIndex === -1) continue
+
+        // 提取匹配上下文 snippet（匹配词前后各约 40 字符）
+        const snippetStart = Math.max(0, matchIndex - 40)
+        const snippetEnd = Math.min(msg.content.length, matchIndex + query.length + 40)
+        const snippet = (snippetStart > 0 ? '...' : '') +
+          msg.content.slice(snippetStart, snippetEnd) +
+          (snippetEnd < msg.content.length ? '...' : '')
+        const matchStart = matchIndex - snippetStart + (snippetStart > 0 ? 3 : 0)
+
+        results.push({
+          conversationId: conv.id,
+          conversationTitle: conv.title,
+          messageId: msg.id,
+          role: msg.role,
+          snippet,
+          matchStart,
+          matchLength: query.length,
+          archived: conv.archived,
+        })
+
+        // 每个对话只取 1 条匹配
+        break
+      }
+    } catch {
+      // 跳过读取失败的文件
+    }
+  }
+
+  return results
 }

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -30,6 +30,7 @@ import type {
   AttachmentSaveResult,
   FileDialogResult,
   RecentMessagesResult,
+  MessageSearchResult,
   AgentSessionMeta,
   AgentMessage,
   SDKMessage,
@@ -73,6 +74,7 @@ import type {
   AgentTeamData,
   MoveSessionToWorkspaceInput,
   ForkSessionInput,
+  AgentMessageSearchResult,
   FeishuConfig,
   FeishuConfigInput,
   FeishuBridgeState,
@@ -162,6 +164,12 @@ export interface ElectronAPI {
 
   /** 切换对话置顶状态 */
   togglePinConversation: (id: string) => Promise<ConversationMeta>
+
+  /** 切换对话归档状态 */
+  toggleArchiveConversation: (id: string) => Promise<ConversationMeta>
+
+  /** 搜索对话消息内容 */
+  searchConversationMessages: (query: string) => Promise<MessageSearchResult[]>
 
   // ===== 教程 =====
 
@@ -295,6 +303,12 @@ export interface ElectronAPI {
 
   /** 切换 Agent 会话置顶状态 */
   togglePinAgentSession: (id: string) => Promise<AgentSessionMeta>
+
+  /** 切换 Agent 会话归档状态 */
+  toggleArchiveAgentSession: (id: string) => Promise<AgentSessionMeta>
+
+  /** 搜索 Agent 会话消息内容 */
+  searchAgentSessionMessages: (query: string) => Promise<AgentMessageSearchResult[]>
 
   /** 迁移 Agent 会话到另一个工作区 */
   moveAgentSessionToWorkspace: (input: MoveSessionToWorkspaceInput) => Promise<AgentSessionMeta>
@@ -680,6 +694,14 @@ const electronAPI: ElectronAPI = {
     return ipcRenderer.invoke(CHAT_IPC_CHANNELS.TOGGLE_PIN, id)
   },
 
+  toggleArchiveConversation: (id: string) => {
+    return ipcRenderer.invoke(CHAT_IPC_CHANNELS.TOGGLE_ARCHIVE, id)
+  },
+
+  searchConversationMessages: (query: string) => {
+    return ipcRenderer.invoke(CHAT_IPC_CHANNELS.SEARCH_MESSAGES, query)
+  },
+
   // 教程
   getTutorialContent: () => {
     return ipcRenderer.invoke(CHAT_IPC_CHANNELS.GET_TUTORIAL_CONTENT)
@@ -856,6 +878,14 @@ const electronAPI: ElectronAPI = {
 
   togglePinAgentSession: (id: string) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.TOGGLE_PIN, id)
+  },
+
+  toggleArchiveAgentSession: (id: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.TOGGLE_ARCHIVE, id)
+  },
+
+  searchAgentSessionMessages: (query: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.SEARCH_MESSAGES, query)
   },
 
   moveAgentSessionToWorkspace: (input: MoveSessionToWorkspaceInput) => {

--- a/apps/electron/src/renderer/atoms/search-atoms.ts
+++ b/apps/electron/src/renderer/atoms/search-atoms.ts
@@ -1,0 +1,10 @@
+/**
+ * 搜索 Dialog 状态 Atoms
+ *
+ * 管理全局搜索 Dialog 的开关、查询词和搜索结果。
+ */
+
+import { atom } from 'jotai'
+
+/** 搜索 Dialog 是否打开 */
+export const searchDialogOpenAtom = atom(false)

--- a/apps/electron/src/renderer/atoms/sidebar-atoms.ts
+++ b/apps/electron/src/renderer/atoms/sidebar-atoms.ts
@@ -1,0 +1,13 @@
+/**
+ * 侧边栏状态 Atoms
+ *
+ * 管理侧边栏视图模式（活跃 / 已归档）。
+ */
+
+import { atom } from 'jotai'
+
+/** 侧边栏视图模式 */
+export type SidebarViewMode = 'active' | 'archived'
+
+/** 侧边栏视图模式（active = 显示活跃对话，archived = 显示已归档对话） */
+export const sidebarViewModeAtom = atom<SidebarViewMode>('active')

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -11,10 +11,11 @@
 import * as React from 'react'
 import { useAtom, useSetAtom, useAtomValue } from 'jotai'
 import { toast } from 'sonner'
-import { Pin, PinOff, Settings, Plus, Trash2, Pencil, ChevronDown, ChevronRight, Plug, Zap, PanelLeftClose, PanelLeftOpen, ArrowRightLeft } from 'lucide-react'
+import { Pin, PinOff, Settings, Plus, Trash2, Pencil, ChevronDown, ChevronRight, Plug, Zap, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { ModeSwitcher } from './ModeSwitcher'
+import { SearchDialog } from './SearchDialog'
 import { activeViewAtom } from '@/atoms/active-view'
 import { appModeAtom } from '@/atoms/app-mode'
 import { settingsTabAtom } from '@/atoms/settings-tab'
@@ -48,6 +49,8 @@ import {
   updateTabTitle,
 } from '@/atoms/tab-atoms'
 import { userProfileAtom } from '@/atoms/user-profile'
+import { sidebarViewModeAtom } from '@/atoms/sidebar-atoms'
+import { searchDialogOpenAtom } from '@/atoms/search-atoms'
 import { hasUpdateAtom } from '@/atoms/updater'
 import { hasEnvironmentIssuesAtom } from '@/atoms/environment'
 import { promptConfigAtom, selectedPromptIdAtom, conversationPromptIdAtom } from '@/atoms/system-prompt-atoms'
@@ -182,6 +185,10 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   const activeTabId = useAtomValue(activeTabIdAtom)
   const [sidebarCollapsed, setSidebarCollapsed] = useAtom(sidebarCollapsedAtom)
 
+  // 归档 & 搜索状态
+  const [viewMode, setViewMode] = useAtom(sidebarViewModeAtom)
+  const setSearchDialogOpen = useSetAtom(searchDialogOpenAtom)
+
   // per-conversation/session Map atoms（删除时清理）
   const setConvModels = useSetAtom(conversationModelsAtom)
   const setConvContextLength = useSetAtom(conversationContextLengthAtom)
@@ -222,22 +229,39 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       .catch(console.error)
   }, [currentWorkspaceSlug, mode, activeView, capabilitiesVersion])
 
-  /** 置顶对话列表 */
+  /** 置顶对话列表（仅活跃模式显示） */
   const pinnedConversations = React.useMemo(
-    () => conversations.filter((c) => c.pinned),
-    [conversations]
+    () => viewMode === 'active' ? conversations.filter((c) => c.pinned) : [],
+    [conversations, viewMode]
   )
 
-  /** 置顶 Agent 会话列表（跨工作区） */
+  /** 置顶 Agent 会话列表（仅活跃模式显示，跨工作区） */
   const pinnedAgentSessions = React.useMemo(
-    () => agentSessions.filter((s) => s.pinned),
-    [agentSessions]
+    () => viewMode === 'active' ? agentSessions.filter((s) => s.pinned) : [],
+    [agentSessions, viewMode]
   )
 
-  /** 对话按日期分组 */
+  /** 对话按日期分组（根据 viewMode 过滤归档状态） */
   const conversationGroups = React.useMemo(
-    () => groupByDate(conversations),
+    () => {
+      const filtered = viewMode === 'archived'
+        ? conversations.filter((c) => c.archived)
+        : conversations.filter((c) => !c.archived)
+      return groupByDate(filtered)
+    },
+    [conversations, viewMode]
+  )
+
+  /** 已归档对话数量 */
+  const archivedConversationCount = React.useMemo(
+    () => conversations.filter((c) => c.archived).length,
     [conversations]
+  )
+
+  /** 已归档 Agent 会话数量（当前工作区） */
+  const archivedAgentSessionCount = React.useMemo(
+    () => agentSessions.filter((s) => s.archived && (!currentWorkspaceId || s.workspaceId === currentWorkspaceId)).length,
+    [agentSessions, currentWorkspaceId]
   )
 
   // 初始加载对话列表 + 用户档案 + Agent 会话
@@ -276,6 +300,11 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       setActiveItem('all-chats')
     }
   }, [activeView, activeItem])
+
+  // 切换模式时重置归档视图
+  React.useEffect(() => {
+    setViewMode('active')
+  }, [mode, setViewMode])
 
   /** 创建新对话（继承当前选中的模型/渠道） */
   const handleNewConversation = async (): Promise<void> => {
@@ -341,6 +370,19 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       )
     } catch (error) {
       console.error('[侧边栏] 切换置顶失败:', error)
+    }
+  }
+
+  /** 切换对话归档状态 */
+  const handleToggleArchive = async (id: string): Promise<void> => {
+    try {
+      const updated = await window.electronAPI.toggleArchiveConversation(id)
+      setConversations((prev) =>
+        prev.map((c) => (c.id === updated.id ? updated : c))
+      )
+      toast.success(updated.archived ? '已归档' : '已取消归档')
+    } catch (error) {
+      console.error('[侧边栏] 切换归档失败:', error)
     }
   }
 
@@ -442,6 +484,19 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     }
   }
 
+  /** 切换 Agent 会话归档状态 */
+  const handleToggleArchiveAgent = async (id: string): Promise<void> => {
+    try {
+      const updated = await window.electronAPI.toggleArchiveAgentSession(id)
+      setAgentSessions((prev) =>
+        prev.map((s) => (s.id === updated.id ? updated : s))
+      )
+      toast.success(updated.archived ? '已归档' : '已取消归档')
+    } catch (error) {
+      console.error('[侧边栏] 切换 Agent 会话归档失败:', error)
+    }
+  }
+
   /** 迁移会话到另一个工作区后的回调 */
   const handleSessionMoved = (updatedSession: AgentSessionMeta, targetWorkspaceName: string): void => {
     setAgentSessions((prev) =>
@@ -460,10 +515,15 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     })
   }
 
-  /** Agent 会话按工作区过滤 */
+  /** Agent 会话按工作区过滤 + 归档过滤 */
   const filteredAgentSessions = React.useMemo(
-    () => agentSessions.filter((s) => s.workspaceId === currentWorkspaceId),
-    [agentSessions, currentWorkspaceId]
+    () => {
+      const byWorkspace = agentSessions.filter((s) => s.workspaceId === currentWorkspaceId)
+      return viewMode === 'archived'
+        ? byWorkspace.filter((s) => s.archived)
+        : byWorkspace.filter((s) => !s.archived)
+    },
+    [agentSessions, currentWorkspaceId, viewMode]
   )
 
   /** Agent 会话按日期分组 */
@@ -587,6 +647,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
 
         {deleteDialog}
         {moveDialog}
+        <SearchDialog />
       </div>
     )
   }
@@ -625,16 +686,40 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         </div>
       )}
 
-      {/* 新对话/新会话按钮 */}
-      <div className="px-3 pt-2">
+      {/* 新对话/新会话按钮 + 搜索按钮 */}
+      <div className="px-3 pt-2 flex items-center gap-1.5">
         <button
           onClick={mode === 'agent' ? handleNewAgentSession : handleNewConversation}
-          className="w-full flex items-center gap-2 px-3 py-2 rounded-[10px] text-[13px] font-medium text-foreground/70 bg-foreground/[0.04] hover:bg-foreground/[0.08] transition-colors duration-100 titlebar-no-drag border border-dashed border-foreground/10 hover:border-foreground/20"
+          className="flex-1 flex items-center gap-2 px-3 py-2 rounded-[10px] text-[13px] font-medium text-foreground/70 bg-foreground/[0.04] hover:bg-foreground/[0.08] transition-colors duration-100 titlebar-no-drag border border-dashed border-foreground/10 hover:border-foreground/20"
         >
           <Plus size={14} />
           <span>{mode === 'agent' ? '新会话' : '新对话'}</span>
         </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={() => setSearchDialogOpen(true)}
+              className="flex-shrink-0 size-[36px] flex items-center justify-center rounded-[10px] text-foreground/40 bg-foreground/[0.04] hover:bg-foreground/[0.08] hover:text-foreground/60 transition-colors duration-100 titlebar-no-drag border border-dashed border-foreground/10 hover:border-foreground/20"
+            >
+              <Search size={14} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">搜索 (⌘F)</TooltipContent>
+        </Tooltip>
       </div>
+
+      {/* 归档视图标题栏 */}
+      {viewMode === 'archived' && (
+        <div className="px-3 pt-3">
+          <button
+            onClick={() => setViewMode('active')}
+            className="flex items-center gap-2 px-2 py-1.5 rounded-lg text-[13px] text-foreground/60 hover:text-foreground/80 hover:bg-foreground/[0.04] transition-colors titlebar-no-drag"
+          >
+            <ArrowLeft size={14} />
+            <span>返回活跃{mode === 'agent' ? '会话' : '对话'}</span>
+          </button>
+        </div>
+      )}
 
       {/* Chat 模式：导航菜单（置顶区域） */}
       {mode === 'chat' && (
@@ -670,6 +755,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                 onRequestDelete={() => handleRequestDelete(conv.id)}
                 onRename={handleRename}
                 onTogglePin={handleTogglePin}
+                onToggleArchive={handleToggleArchive}
                 onMouseEnter={() => setHoveredId(conv.id)}
                 onMouseLeave={() => setHoveredId(null)}
               />
@@ -713,6 +799,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                 onRequestMove={() => setMoveTargetId(session.id)}
                 onRename={handleAgentRename}
                 onTogglePin={handleTogglePinAgent}
+                onToggleArchive={handleToggleArchiveAgent}
                 onMouseEnter={() => setHoveredId(session.id)}
                 onMouseLeave={() => setHoveredId(null)}
               />
@@ -743,6 +830,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                     onRequestDelete={() => handleRequestDelete(conv.id)}
                     onRename={handleRename}
                     onTogglePin={handleTogglePin}
+                    onToggleArchive={handleToggleArchive}
                     onMouseEnter={() => setHoveredId(conv.id)}
                     onMouseLeave={() => setHoveredId(null)}
                   />
@@ -771,6 +859,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                     onRequestMove={() => setMoveTargetId(session.id)}
                     onRename={handleAgentRename}
                     onTogglePin={handleTogglePinAgent}
+                    onToggleArchive={handleToggleArchiveAgent}
                     onMouseEnter={() => setHoveredId(session.id)}
                     onMouseLeave={() => setHoveredId(null)}
                   />
@@ -780,6 +869,30 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
           ))
         )}
       </div>
+
+      {/* 已归档入口 */}
+      {viewMode === 'active' && (
+        <div className="px-3 pb-1">
+          {mode === 'chat' && archivedConversationCount > 0 && (
+            <button
+              onClick={() => setViewMode('archived')}
+              className="w-full flex items-center gap-2 px-3 py-2 rounded-[10px] text-[12px] text-foreground/40 hover:bg-foreground/[0.04] hover:text-foreground/60 transition-colors titlebar-no-drag"
+            >
+              <Archive size={13} className="text-foreground/30" />
+              <span>已归档 ({archivedConversationCount})</span>
+            </button>
+          )}
+          {mode === 'agent' && archivedAgentSessionCount > 0 && (
+            <button
+              onClick={() => setViewMode('archived')}
+              className="w-full flex items-center gap-2 px-3 py-2 rounded-[10px] text-[12px] text-foreground/40 hover:bg-foreground/[0.04] hover:text-foreground/60 transition-colors titlebar-no-drag"
+            >
+              <Archive size={13} className="text-foreground/30" />
+              <span>已归档 ({archivedAgentSessionCount})</span>
+            </button>
+          )}
+        </div>
+      )}
 
       {/* Agent 模式：工作区能力指示器 */}
       {mode === 'agent' && capabilities && (
@@ -827,6 +940,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
 
       {deleteDialog}
       {moveDialog}
+      <SearchDialog />
     </div>
   )
 }
@@ -844,6 +958,7 @@ interface ConversationItemProps {
   onRequestDelete: () => void
   onRename: (id: string, newTitle: string) => Promise<void>
   onTogglePin: (id: string) => Promise<void>
+  onToggleArchive: (id: string) => Promise<void>
   onMouseEnter: () => void
   onMouseLeave: () => void
 }
@@ -858,6 +973,7 @@ function ConversationItem({
   onRequestDelete,
   onRename,
   onTogglePin,
+  onToggleArchive,
   onMouseEnter,
   onMouseLeave,
 }: ConversationItemProps): React.ReactElement {
@@ -993,6 +1109,20 @@ function ConversationItem({
             <button
               onClick={(e) => {
                 e.stopPropagation()
+                onToggleArchive(conversation.id)
+              }}
+              className="p-1 rounded-md text-foreground/30 hover:bg-foreground/[0.08] hover:text-foreground/60 transition-colors"
+            >
+              {conversation.archived ? <ArchiveRestore size={13} /> : <Archive size={13} />}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{conversation.archived ? '取消归档' : '归档'}</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
                 onRequestDelete()
               }}
               className="p-1 rounded-md text-foreground/30 hover:bg-destructive/10 hover:text-destructive transition-colors"
@@ -1020,6 +1150,7 @@ interface AgentSessionItemProps {
   onRequestMove: () => void
   onRename: (id: string, newTitle: string) => Promise<void>
   onTogglePin: (id: string) => Promise<void>
+  onToggleArchive: (id: string) => Promise<void>
   onMouseEnter: () => void
   onMouseLeave: () => void
 }
@@ -1035,6 +1166,7 @@ function AgentSessionItem({
   onRequestMove,
   onRename,
   onTogglePin,
+  onToggleArchive,
   onMouseEnter,
   onMouseLeave,
 }: AgentSessionItemProps): React.ReactElement {
@@ -1171,6 +1303,20 @@ function AgentSessionItem({
             </button>
           </TooltipTrigger>
           <TooltipContent side="bottom">重命名</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onToggleArchive(session.id)
+              }}
+              className="p-1 rounded-md text-foreground/30 hover:bg-foreground/[0.08] hover:text-foreground/60 transition-colors"
+            >
+              {session.archived ? <ArchiveRestore size={13} /> : <Archive size={13} />}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{session.archived ? '取消归档' : '归档'}</TooltipContent>
         </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>

--- a/apps/electron/src/renderer/components/app-shell/SearchDialog.tsx
+++ b/apps/electron/src/renderer/components/app-shell/SearchDialog.tsx
@@ -1,0 +1,476 @@
+/**
+ * SearchDialog - 全局搜索 Dialog
+ *
+ * 浮动搜索面板，支持：
+ * - 即时标题匹配（纯前端过滤）
+ * - 渐进式消息内容搜索（debounce 后 IPC 调用）
+ * - 匹配文字高亮
+ * - 键盘导航（上下箭头 + Enter + Esc）
+ * - 同时搜索 Chat 和 Agent 模式
+ */
+
+import * as React from 'react'
+import { useAtom, useAtomValue, useSetAtom } from 'jotai'
+import { Search, X, MessageSquare, Bot, Archive, Loader2 } from 'lucide-react'
+import { Dialog, DialogContent } from '@/components/ui/dialog'
+import { cn } from '@/lib/utils'
+import { searchDialogOpenAtom } from '@/atoms/search-atoms'
+import { conversationsAtom, currentConversationIdAtom } from '@/atoms/chat-atoms'
+import {
+  agentSessionsAtom,
+  currentAgentSessionIdAtom,
+  currentAgentWorkspaceIdAtom,
+} from '@/atoms/agent-atoms'
+import { appModeAtom } from '@/atoms/app-mode'
+import { openTab, tabsAtom, splitLayoutAtom } from '@/atoms/tab-atoms'
+import { activeViewAtom } from '@/atoms/active-view'
+import type { ConversationMeta, AgentSessionMeta, MessageSearchResult, AgentMessageSearchResult } from '@proma/shared'
+
+/** 标题搜索结果项 */
+interface TitleResult {
+  id: string
+  title: string
+  type: 'chat' | 'agent'
+  archived?: boolean
+  updatedAt: number
+}
+
+/** 内容搜索结果项（统一格式） */
+interface ContentResult {
+  id: string
+  title: string
+  type: 'chat' | 'agent'
+  snippet: string
+  matchStart: number
+  matchLength: number
+  archived?: boolean
+}
+
+/**
+ * 高亮文本中的匹配部分
+ */
+function HighlightText({ text, query }: { text: string; query: string }): React.ReactElement {
+  if (!query) return <>{text}</>
+
+  const lowerText = text.toLowerCase()
+  const lowerQuery = query.toLowerCase()
+  const parts: React.ReactNode[] = []
+  let lastIndex = 0
+
+  let idx = lowerText.indexOf(lowerQuery)
+  while (idx !== -1) {
+    if (idx > lastIndex) {
+      parts.push(text.slice(lastIndex, idx))
+    }
+    parts.push(
+      <mark key={idx} className="bg-primary/20 text-foreground rounded-sm px-0.5">
+        {text.slice(idx, idx + query.length)}
+      </mark>
+    )
+    lastIndex = idx + query.length
+    idx = lowerText.indexOf(lowerQuery, lastIndex)
+  }
+
+  if (lastIndex < text.length) {
+    parts.push(text.slice(lastIndex))
+  }
+
+  return <>{parts}</>
+}
+
+/**
+ * 高亮 snippet 中的匹配部分（使用预计算位置）
+ */
+function HighlightSnippet({ snippet, matchStart, matchLength }: {
+  snippet: string
+  matchStart: number
+  matchLength: number
+}): React.ReactElement {
+  if (matchStart < 0 || matchStart >= snippet.length) return <>{snippet}</>
+
+  const before = snippet.slice(0, matchStart)
+  const match = snippet.slice(matchStart, matchStart + matchLength)
+  const after = snippet.slice(matchStart + matchLength)
+
+  return (
+    <>
+      {before}
+      <mark className="bg-primary/20 text-foreground rounded-sm px-0.5">{match}</mark>
+      {after}
+    </>
+  )
+}
+
+export function SearchDialog(): React.ReactElement {
+  const [open, setOpen] = useAtom(searchDialogOpenAtom)
+  const conversations = useAtomValue(conversationsAtom)
+  const agentSessions = useAtomValue(agentSessionsAtom)
+  const setMode = useSetAtom(appModeAtom)
+  const setActiveView = useSetAtom(activeViewAtom)
+  const setCurrentConversationId = useSetAtom(currentConversationIdAtom)
+  const setCurrentAgentSessionId = useSetAtom(currentAgentSessionIdAtom)
+  const currentWorkspaceId = useAtomValue(currentAgentWorkspaceIdAtom)
+  const [tabs, setTabs] = useAtom(tabsAtom)
+  const [layout, setLayout] = useAtom(splitLayoutAtom)
+
+  const [query, setQuery] = React.useState('')
+  const [searchQuery, setSearchQuery] = React.useState('')
+  const [selectedIndex, setSelectedIndex] = React.useState(0)
+  const [contentResults, setContentResults] = React.useState<ContentResult[]>([])
+  const [contentLoading, setContentLoading] = React.useState(false)
+  const inputRef = React.useRef<HTMLInputElement>(null)
+  const listRef = React.useRef<HTMLDivElement>(null)
+  const isComposingRef = React.useRef(false)
+  const commitTimerRef = React.useRef<ReturnType<typeof setTimeout>>()
+
+  /**
+   * 提交搜索词（微 debounce 60ms）
+   *
+   * 为什么需要这一层：中文输入法下 compositionend 和 onChange 的触发顺序
+   * 在 Chrome / Firefox / Safari 之间不一致。微 debounce 保证无论事件顺序如何，
+   * 最终都能拿到用户确认后的完整文本，避免逐字输入时搜索结果跳动。
+   * 60ms 对人眼不可感知，但足以合并同一次 composition 的所有事件。
+   */
+  const commitSearchQuery = React.useCallback((value: string) => {
+    clearTimeout(commitTimerRef.current)
+    commitTimerRef.current = setTimeout(() => setSearchQuery(value), 60)
+  }, [])
+
+  const handleInputChange = React.useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+    setQuery(value)
+    if (!isComposingRef.current) {
+      commitSearchQuery(value)
+    }
+  }, [commitSearchQuery])
+
+  const handleCompositionStart = React.useCallback(() => {
+    isComposingRef.current = true
+  }, [])
+
+  const handleCompositionEnd = React.useCallback((e: React.CompositionEvent<HTMLInputElement>) => {
+    isComposingRef.current = false
+    // 不直接读 e.currentTarget.value（在部分浏览器中可能拿到中间态），
+    // 而是通过 commitSearchQuery 让微 debounce 等 onChange 也触发后再提交
+    commitSearchQuery(e.currentTarget.value)
+  }, [commitSearchQuery])
+
+  const handleClearQuery = React.useCallback(() => {
+    clearTimeout(commitTimerRef.current)
+    setQuery('')
+    setSearchQuery('')
+  }, [])
+
+  // 标题搜索：即时响应，纯内存过滤，基于 searchQuery 避免输入法抖动
+  const titleResults = React.useMemo((): TitleResult[] => {
+    if (!searchQuery) return []
+    const q = searchQuery.toLowerCase()
+
+    const chatMatches: TitleResult[] = conversations
+      .filter((c) => c.title.toLowerCase().includes(q))
+      .map((c) => ({ id: c.id, title: c.title, type: 'chat' as const, archived: c.archived, updatedAt: c.updatedAt }))
+
+    const agentMatches: TitleResult[] = agentSessions
+      .filter((s) => s.title.toLowerCase().includes(q))
+      .map((s) => ({ id: s.id, title: s.title, type: 'agent' as const, archived: s.archived, updatedAt: s.updatedAt }))
+
+    return [...chatMatches, ...agentMatches]
+      .sort((a, b) => b.updatedAt - a.updatedAt)
+      .slice(0, 20)
+  }, [searchQuery, conversations, agentSessions])
+
+  // 内容搜索：debounce 300ms 后 IPC 调用，基于 searchQuery
+  React.useEffect(() => {
+    if (!searchQuery || searchQuery.length < 2) {
+      setContentResults([])
+      setContentLoading(false)
+      return
+    }
+
+    setContentLoading(true)
+    let cancelled = false
+
+    const timer = setTimeout(async () => {
+      try {
+        const [chatResults, agentResults] = await Promise.all([
+          window.electronAPI.searchConversationMessages(searchQuery),
+          window.electronAPI.searchAgentSessionMessages(searchQuery),
+        ])
+        if (cancelled) return
+
+        const titleIds = new Set(titleResults.map((t) => t.id))
+
+        const chatContent: ContentResult[] = (chatResults as MessageSearchResult[])
+          .filter((r) => !titleIds.has(r.conversationId))
+          .map((r) => ({
+            id: r.conversationId,
+            title: r.conversationTitle,
+            type: 'chat' as const,
+            snippet: r.snippet,
+            matchStart: r.matchStart,
+            matchLength: r.matchLength,
+            archived: r.archived,
+          }))
+
+        const agentContent: ContentResult[] = (agentResults as AgentMessageSearchResult[])
+          .filter((r) => !titleIds.has(r.sessionId))
+          .map((r) => ({
+            id: r.sessionId,
+            title: r.sessionTitle,
+            type: 'agent' as const,
+            snippet: r.snippet,
+            matchStart: r.matchStart,
+            matchLength: r.matchLength,
+            archived: r.archived,
+          }))
+
+        setContentResults([...chatContent, ...agentContent])
+      } catch (error) {
+        console.error('[搜索] 内容搜索失败:', error)
+        if (!cancelled) setContentResults([])
+      } finally {
+        if (!cancelled) setContentLoading(false)
+      }
+    }, 300)
+
+    return () => { cancelled = true; clearTimeout(timer) }
+  }, [searchQuery, titleResults])
+
+  // 全部结果列表
+  const allResults = React.useMemo(
+    () => [...titleResults, ...contentResults.map((c) => ({ ...c, updatedAt: 0 }))],
+    [titleResults, contentResults]
+  )
+
+  // 重置选中索引
+  React.useEffect(() => {
+    setSelectedIndex(0)
+  }, [searchQuery])
+
+  // 导航到对话/会话
+  const navigateToResult = React.useCallback((result: TitleResult | ContentResult) => {
+    setOpen(false)
+    setActiveView('conversations')
+
+    if (result.type === 'chat') {
+      setMode('chat')
+      setCurrentConversationId(result.id)
+      // 查找对话标题
+      const conv = conversations.find((c) => c.id === result.id)
+      const title = conv?.title ?? result.title
+      const newState = openTab(tabs, layout, { type: 'chat', sessionId: result.id, title })
+      setTabs(newState.tabs)
+      setLayout(newState.layout)
+    } else {
+      setMode('agent')
+      setCurrentAgentSessionId(result.id)
+      const session = agentSessions.find((s) => s.id === result.id)
+      const title = session?.title ?? result.title
+      const newState = openTab(tabs, layout, { type: 'agent', sessionId: result.id, title })
+      setTabs(newState.tabs)
+      setLayout(newState.layout)
+    }
+  }, [setOpen, setActiveView, setMode, setCurrentConversationId, setCurrentAgentSessionId, conversations, agentSessions, tabs, layout, setTabs, setLayout])
+
+  // 键盘导航
+  const handleKeyDown = React.useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setSelectedIndex((prev) => Math.min(prev + 1, allResults.length - 1))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setSelectedIndex((prev) => Math.max(prev - 1, 0))
+    } else if (e.key === 'Enter' && allResults[selectedIndex]) {
+      e.preventDefault()
+      navigateToResult(allResults[selectedIndex]!)
+    }
+  }, [allResults, selectedIndex, navigateToResult])
+
+  // 自动滚动选中项到可视区域
+  React.useEffect(() => {
+    const list = listRef.current
+    if (!list) return
+    const selected = list.querySelector(`[data-index="${selectedIndex}"]`)
+    if (selected) {
+      selected.scrollIntoView({ block: 'nearest' })
+    }
+  }, [selectedIndex])
+
+  // 全局快捷键 Cmd+F
+  React.useEffect(() => {
+    const handler = (e: KeyboardEvent): void => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'f') {
+        e.preventDefault()
+        setOpen(true)
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [setOpen])
+
+  // 打开时重置状态并聚焦
+  React.useEffect(() => {
+    if (open) {
+      clearTimeout(commitTimerRef.current)
+      setQuery('')
+      setSearchQuery('')
+      setContentResults([])
+      setSelectedIndex(0)
+      setTimeout(() => inputRef.current?.focus(), 50)
+    }
+  }, [open])
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent
+        hideClose
+        className="sm:max-w-[520px] p-0 gap-0 overflow-hidden"
+        onKeyDown={handleKeyDown}
+        aria-label="搜索对话"
+      >
+        {/* 搜索输入框 */}
+        <div className="flex items-center gap-2 px-4 py-3 border-b border-border/50">
+          <Search size={16} className="text-foreground/40 flex-shrink-0" />
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={handleInputChange}
+            onCompositionStart={handleCompositionStart}
+            onCompositionEnd={handleCompositionEnd}
+            placeholder="搜索对话和会话..."
+            className="flex-1 bg-transparent text-[14px] text-foreground placeholder:text-foreground/40 outline-none"
+          />
+          {query && (
+            <button
+              onClick={handleClearQuery}
+              className="p-0.5 rounded text-foreground/30 hover:text-foreground/60 transition-colors"
+            >
+              <X size={14} />
+            </button>
+          )}
+          <kbd className="hidden sm:inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded bg-foreground/[0.06] text-[11px] text-foreground/40 font-mono">
+            ESC
+          </kbd>
+        </div>
+
+        {/* 搜索结果 */}
+        <div ref={listRef} className="max-h-[400px] overflow-y-auto">
+          {!query && (
+            <div className="py-12 text-center text-[13px] text-foreground/40">
+              输入关键词搜索对话标题和消息内容
+            </div>
+          )}
+
+          {searchQuery && titleResults.length === 0 && contentResults.length === 0 && !contentLoading && (
+            <div className="py-12 text-center text-[13px] text-foreground/40">
+              未找到匹配结果
+            </div>
+          )}
+
+          {/* 标题匹配区域 */}
+          {titleResults.length > 0 && (
+            <div className="py-1 animate-in fade-in duration-150">
+              <div className="px-4 pt-2 pb-1 text-[11px] font-medium text-foreground/40 select-none">
+                标题匹配
+              </div>
+              {titleResults.map((result, idx) => (
+                <button
+                  key={`title-${result.id}`}
+                  data-index={idx}
+                  onClick={() => navigateToResult(result)}
+                  onMouseEnter={() => setSelectedIndex(idx)}
+                  className={cn(
+                    'w-full flex items-center gap-2.5 px-4 py-2 text-left transition-colors',
+                    selectedIndex === idx
+                      ? 'bg-primary/10'
+                      : 'hover:bg-foreground/[0.04]',
+                    result.archived && 'opacity-60'
+                  )}
+                >
+                  {result.type === 'chat' ? (
+                    <MessageSquare size={14} className="flex-shrink-0 text-foreground/40" />
+                  ) : (
+                    <Bot size={14} className="flex-shrink-0 text-blue-500/70" />
+                  )}
+                  <span className="flex-1 min-w-0 truncate text-[13px] text-foreground/80">
+                    <HighlightText text={result.title} query={searchQuery} />
+                  </span>
+                  {result.archived && (
+                    <Archive size={12} className="flex-shrink-0 text-foreground/30" />
+                  )}
+                </button>
+              ))}
+            </div>
+          )}
+
+          {/* 内容匹配区域 */}
+          {(contentResults.length > 0 || (contentLoading && searchQuery.length >= 2)) && (
+            <div className="py-1 border-t border-border/30 animate-in fade-in duration-150">
+              <div className="px-4 pt-2 pb-1 flex items-center gap-2 text-[11px] font-medium text-foreground/40 select-none">
+                <span>消息内容匹配</span>
+                {contentLoading && <Loader2 size={12} className="animate-spin text-foreground/30" />}
+              </div>
+              {contentResults.map((result, i) => {
+                const globalIdx = titleResults.length + i
+                return (
+                  <button
+                    key={`content-${result.id}`}
+                    data-index={globalIdx}
+                    onClick={() => navigateToResult(result)}
+                    onMouseEnter={() => setSelectedIndex(globalIdx)}
+                    className={cn(
+                      'w-full flex flex-col gap-0.5 px-4 py-2 text-left transition-colors',
+                      selectedIndex === globalIdx
+                        ? 'bg-primary/10'
+                        : 'hover:bg-foreground/[0.04]',
+                      result.archived && 'opacity-60'
+                    )}
+                  >
+                    <div className="flex items-center gap-2.5">
+                      {result.type === 'chat' ? (
+                        <MessageSquare size={14} className="flex-shrink-0 text-foreground/40" />
+                      ) : (
+                        <Bot size={14} className="flex-shrink-0 text-blue-500/70" />
+                      )}
+                      <span className="flex-1 min-w-0 truncate text-[13px] text-foreground/80">
+                        {result.title}
+                      </span>
+                      {result.archived && (
+                        <Archive size={12} className="flex-shrink-0 text-foreground/30" />
+                      )}
+                    </div>
+                    <div className="pl-[22px] text-[12px] text-foreground/50 truncate">
+                      <HighlightSnippet
+                        snippet={result.snippet}
+                        matchStart={result.matchStart}
+                        matchLength={result.matchLength}
+                      />
+                    </div>
+                  </button>
+                )
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* 底部快捷键提示 */}
+        {allResults.length > 0 && (
+          <div className="flex items-center gap-3 px-4 py-2 border-t border-border/30 text-[11px] text-foreground/30">
+            <span className="flex items-center gap-1">
+              <kbd className="px-1 py-0.5 rounded bg-foreground/[0.06] font-mono">↑↓</kbd>
+              <span>选择</span>
+            </span>
+            <span className="flex items-center gap-1">
+              <kbd className="px-1 py-0.5 rounded bg-foreground/[0.06] font-mono">↵</kbd>
+              <span>打开</span>
+            </span>
+            <span className="flex items-center gap-1">
+              <kbd className="px-1 py-0.5 rounded bg-foreground/[0.06] font-mono">Esc</kbd>
+              <span>关闭</span>
+            </span>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/electron/src/renderer/components/settings/GeneralSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/GeneralSettings.tsx
@@ -17,6 +17,13 @@ import {
   SettingsToggle,
 } from './primitives'
 import { Popover, PopoverTrigger, PopoverContent } from '../ui/popover'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '../ui/select'
 import { UserAvatar } from '../chat/UserAvatar'
 import { userProfileAtom } from '@/atoms/user-profile'
 import {
@@ -41,7 +48,26 @@ export function GeneralSettings(): React.ReactElement {
   const [isEditingName, setIsEditingName] = React.useState(false)
   const [nameInput, setNameInput] = React.useState(userProfile.userName)
   const [showEmojiPicker, setShowEmojiPicker] = React.useState(false)
+  const [archiveAfterDays, setArchiveAfterDays] = React.useState<number>(7)
   const fileInputRef = React.useRef<HTMLInputElement>(null)
+
+  // 加载归档天数设置
+  React.useEffect(() => {
+    window.electronAPI.getSettings().then((settings) => {
+      setArchiveAfterDays(settings.archiveAfterDays ?? 7)
+    }).catch(console.error)
+  }, [])
+
+  /** 更新归档天数 */
+  const handleArchiveDaysChange = async (value: string): Promise<void> => {
+    const days = parseInt(value, 10)
+    setArchiveAfterDays(days)
+    try {
+      await window.electronAPI.updateSettings({ archiveAfterDays: days })
+    } catch (error) {
+      console.error('[通用设置] 更新归档天数失败:', error)
+    }
+  }
 
   /** 更新头像 */
   const handleAvatarChange = async (avatar: string): Promise<void> => {
@@ -211,6 +237,23 @@ export function GeneralSettings(): React.ReactElement {
               updateNotificationsEnabled(checked)
             }}
           />
+          <SettingsRow
+            label="自动归档"
+            description="超过指定天数未更新的对话将自动归档（置顶对话除外）"
+          >
+            <Select value={String(archiveAfterDays)} onValueChange={handleArchiveDaysChange}>
+              <SelectTrigger className="w-[120px] h-8 text-[13px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="0">禁用</SelectItem>
+                <SelectItem value="7">7 天</SelectItem>
+                <SelectItem value="14">14 天</SelectItem>
+                <SelectItem value="30">30 天</SelectItem>
+                <SelectItem value="60">60 天</SelectItem>
+              </SelectContent>
+            </Select>
+          </SettingsRow>
         </SettingsCard>
       </SettingsSection>
     </div>

--- a/apps/electron/src/renderer/components/ui/dialog.tsx
+++ b/apps/electron/src/renderer/components/ui/dialog.tsx
@@ -31,8 +31,8 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & { hideClose?: boolean }
+>(({ className, children, hideClose, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
@@ -44,10 +44,12 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
+      {!hideClose && (
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      )}
     </DialogPrimitive.Content>
   </DialogPortal>
 ))

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -46,6 +46,8 @@ export interface AppSettings {
   agentMaxTurns?: number
   /** 教程推荐横幅是否已关闭 */
   tutorialBannerDismissed?: boolean
+  /** 自动归档天数（0 = 禁用，默认 7） */
+  archiveAfterDays?: number
 }
 
 /** 持久化的标签页状态 */

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/shared",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "license": "Apache-2.0",
   "description": "Shared types, configs and utilities for proma",
   "type": "module",

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -524,6 +524,8 @@ export interface AgentSessionMeta {
   workspaceId?: string
   /** 是否置顶 */
   pinned?: boolean
+  /** 是否已归档 */
+  archived?: boolean
   /** 附加的外部目录路径列表（绝对路径，作为 SDK additionalDirectories 传递） */
   attachedDirectories?: string[]
   /** 分叉来源：源会话的 SDK session ID（首次发消息时用于 resume + forkSession） */
@@ -572,6 +574,30 @@ export interface AgentMessage {
   durationMs?: number
   /** Token 用量明细（assistant 消息完成时记录） */
   usage?: AgentEventUsage
+}
+
+// ===== Agent 消息搜索 =====
+
+/**
+ * Agent 会话消息搜索结果
+ */
+export interface AgentMessageSearchResult {
+  /** 会话 ID */
+  sessionId: string
+  /** 会话标题 */
+  sessionTitle: string
+  /** 消息 ID */
+  messageId: string
+  /** 消息角色 */
+  role: 'user' | 'assistant' | 'tool' | 'status'
+  /** 匹配上下文片段（约 80 字符） */
+  snippet: string
+  /** snippet 内匹配起始位置 */
+  matchStart: number
+  /** 匹配长度 */
+  matchLength: number
+  /** 是否已归档 */
+  archived?: boolean
 }
 
 // ===== Agent 标题生成输入 =====
@@ -1069,6 +1095,10 @@ export const AGENT_IPC_CHANNELS = {
   MIGRATE_CHAT_TO_AGENT: 'agent:migrate-chat-to-agent',
   /** 切换会话置顶状态 */
   TOGGLE_PIN: 'agent:toggle-pin',
+  /** 切换会话归档状态 */
+  TOGGLE_ARCHIVE: 'agent:toggle-archive',
+  /** 搜索会话消息内容 */
+  SEARCH_MESSAGES: 'agent:search-messages',
   /** 迁移会话到另一个工作区 */
   MOVE_SESSION_TO_WORKSPACE: 'agent:move-session-to-workspace',
   /** 分叉会话（从指定消息处创建新会话） */

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -126,10 +126,36 @@ export interface ConversationMeta {
   contextLength?: number | 'infinite'
   /** 是否置顶 */
   pinned?: boolean
+  /** 是否已归档 */
+  archived?: boolean
   /** 创建时间戳 */
   createdAt: number
   /** 更新时间戳 */
   updatedAt: number
+}
+
+// ===== 消息搜索 =====
+
+/**
+ * 消息搜索结果
+ */
+export interface MessageSearchResult {
+  /** 对话 ID */
+  conversationId: string
+  /** 对话标题 */
+  conversationTitle: string
+  /** 消息 ID */
+  messageId: string
+  /** 消息角色 */
+  role: MessageRole
+  /** 匹配上下文片段（约 80 字符） */
+  snippet: string
+  /** snippet 内匹配起始位置 */
+  matchStart: number
+  /** 匹配长度 */
+  matchLength: number
+  /** 是否已归档 */
+  archived?: boolean
 }
 
 // ===== 消息发送 =====
@@ -336,6 +362,10 @@ export const CHAT_IPC_CHANNELS = {
   // 置顶管理
   /** 切换对话置顶状态 */
   TOGGLE_PIN: 'chat:toggle-pin',
+  /** 切换对话归档状态 */
+  TOGGLE_ARCHIVE: 'chat:toggle-archive',
+  /** 搜索对话消息内容 */
+  SEARCH_MESSAGES: 'chat:search-messages',
 
   // 教程
   /** 获取教程内容 */


### PR DESCRIPTION
## Summary

- **自动归档**：超过 7 天（可配置）未更新的对话/Agent 会话自动归档，置顶对话除外。侧边栏底部显示"已归档 (N)"入口，支持手动归档/取消归档
- **全局搜索 Dialog**：Cmd+F 或侧边栏搜索按钮打开浮动搜索面板，即时标题匹配 + debounce 消息内容搜索，同时覆盖 Chat 和 Agent 模式，支持匹配高亮和键盘导航
- **中文输入法优化**：通过 composition 事件感知 + 微 debounce（60ms）合并策略，解决中文 IME 逐字输入导致搜索结果跳动的问题
- **UI 细节**：DialogContent 新增 hideClose prop、搜索结果渐显动画、归档设置集成到通用设置页

## Test plan
- [ ] 创建对话 → 手动将 updatedAt 改为 8 天前 → 重启 → 确认从主列表消失并出现在已归档
- [ ] hover 对话 → 点击归档按钮 → 确认移入已归档 → 取消归档 → 确认恢复
- [ ] Cmd+F 打开搜索 → 输入关键词 → 确认标题即时匹配 + 内容搜索渐进加载
- [ ] 中文输入法逐字输入 → 确认搜索结果不跳动
- [ ] 设置页修改归档天数 → 重启 → 确认新阈值生效
- [ ] `bun run typecheck` 全部通过