### PR TITLE
style: 左侧边栏圆角卡片 + 移除面板边框

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/electron/src/renderer/components/app-shell/AppShell.tsx
@@ -23,8 +23,10 @@ export function AppShell({ contextValue }: AppShellProps): React.ReactElement {
       <div className="titlebar-drag-region fixed top-0 left-0 right-0 h-[50px] z-50" />
 
       <div className="h-screen w-screen flex overflow-hidden bg-gradient-to-br from-zinc-50 to-zinc-100 dark:from-zinc-950 dark:to-zinc-900">
-        {/* 左侧边栏：可折叠 */}
-        <LeftSidebar />
+        {/* 左侧边栏：可折叠，带圆角和内边距 */}
+        <div className="p-2 pr-0 relative z-[60]">
+          <LeftSidebar />
+        </div>
 
         {/* 右侧容器：relative z-[60] 使其在 z-50 拖动区域之上 */}
         <div className="flex-1 min-w-0 p-2 relative z-[60]">

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -575,7 +575,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   if (sidebarCollapsed) {
     return (
       <div
-        className="h-full flex flex-col items-center bg-background transition-[width] duration-300"
+        className="h-full flex flex-col items-center bg-white/95 dark:bg-zinc-900/95 backdrop-blur-xl rounded-2xl shadow-xl transition-[width] duration-300"
         style={{ width: 48, flexShrink: 0 }}
       >
         {/* 顶部留空，避开 macOS 红绿灯 */}
@@ -644,7 +644,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   // ===== 展开状态：完整侧边栏 =====
   return (
     <div
-      className="h-full flex flex-col bg-background transition-[width] duration-300"
+      className="h-full flex flex-col bg-white/95 dark:bg-zinc-900/95 backdrop-blur-xl rounded-2xl shadow-xl transition-[width] duration-300"
       style={{ width: width ?? 280, minWidth: 180, flexShrink: 1 }}
     >
       {/* 顶部留空，避开 macOS 红绿灯 */}

--- a/apps/electron/src/renderer/components/app-shell/MainContentPanel.tsx
+++ b/apps/electron/src/renderer/components/app-shell/MainContentPanel.tsx
@@ -38,7 +38,7 @@ export function MainContentPanel(): React.ReactElement {
   return (
     <Panel
       variant="grow"
-      className="bg-white/95 dark:bg-zinc-900/95 backdrop-blur-xl rounded-2xl shadow-xl border border-border/50"
+      className="bg-white/95 dark:bg-zinc-900/95 backdrop-blur-xl rounded-2xl shadow-xl"
     >
       {renderConversations()}
     </Panel>

--- a/apps/electron/src/renderer/components/tabs/MainArea.tsx
+++ b/apps/electron/src/renderer/components/tabs/MainArea.tsx
@@ -20,7 +20,7 @@ export function MainArea(): React.ReactElement {
     <>
       <Panel
         variant="grow"
-        className="bg-white/95 dark:bg-zinc-900/95 backdrop-blur-xl rounded-2xl shadow-xl border border-border/50"
+        className="bg-white/95 dark:bg-zinc-900/95 backdrop-blur-xl rounded-2xl shadow-xl"
       >
         <TabBar />
         {tabs.length === 0 ? (


### PR DESCRIPTION
## Summary
- 左侧边栏（LeftSidebar）增加 `rounded-2xl` 圆角、`shadow-xl` 阴影和毛玻璃背景，与右侧 MainArea 风格统一
- AppShell 为 LeftSidebar 包裹 padding 容器，确保圆角可见且与右侧对称
- 移除左右面板的 `border border-border/50`，仅靠阴影区分层次，视觉更干净利落

## Test plan
- [ ] 验证左侧边栏展开/折叠态均有圆角和阴影
- [ ] 验证左右面板无边框，阴影层次清晰
- [ ] 验证 dark mode 下显示正常