### PR TITLE
feat: 空状态引导重设计 — 个性化问候 + Tips + 模式切换

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -8,6 +8,7 @@
 import * as React from 'react'
 import { useAtomValue } from 'jotai'
 import { Bot, FileText, FileImage, RotateCw, AlertTriangle, ChevronDown, ChevronRight, Plus, Minimize2, Download, Square } from 'lucide-react'
+import { WelcomeEmptyState } from '@/components/welcome/WelcomeEmptyState'
 import {
   Message,
   MessageHeader,
@@ -59,17 +60,9 @@ interface AgentMessagesProps {
   onCompact?: () => void
 }
 
+/** 空状态引导 — 使用 WelcomeEmptyState */
 function EmptyState(): React.ReactElement {
-  return (
-    <div className="flex h-full items-center justify-center">
-      <div className="flex flex-col items-center gap-3 text-muted-foreground">
-        <div className="w-12 h-12 rounded-full bg-muted flex items-center justify-center">
-          <Bot size={24} className="text-muted-foreground/60" />
-        </div>
-        <p className="text-sm">在下方输入框开始使用 Agent</p>
-      </div>
-    </div>
-  )
+  return <WelcomeEmptyState />
 }
 
 function AssistantLogo({ model }: { model?: string }): React.ReactElement {

--- a/apps/electron/src/renderer/components/chat/ChatMessages.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessages.tsx
@@ -14,7 +14,8 @@
 
 import * as React from 'react'
 import { useAtomValue } from 'jotai'
-import { MessageSquare, Loader2 } from 'lucide-react'
+import { Loader2 } from 'lucide-react'
+import { WelcomeEmptyState } from '@/components/welcome/WelcomeEmptyState'
 import { ChatMessageItem, formatMessageTime } from './ChatMessageItem'
 import type { InlineEditSubmitPayload } from './ChatMessageItem'
 import { ChatToolActivityIndicator } from './ChatToolActivityIndicator'
@@ -152,18 +153,9 @@ interface ChatMessagesProps {
   onLoadMore?: () => Promise<void>
 }
 
-/** 空状态引导 */
+/** 空状态引导 — 使用 WelcomeEmptyState */
 function EmptyState(): React.ReactElement {
-  return (
-    <div className="flex h-full items-center justify-center">
-      <div className="flex flex-col items-center gap-3 text-muted-foreground">
-        <div className="w-12 h-12 rounded-full bg-muted flex items-center justify-center">
-          <MessageSquare size={24} className="text-muted-foreground/60" />
-        </div>
-        <p className="text-sm">在下方输入框开始对话</p>
-      </div>
-    </div>
-  )
+  return <WelcomeEmptyState />
 }
 
 export function ChatMessages({

--- a/apps/electron/src/renderer/components/tabs/MainArea.tsx
+++ b/apps/electron/src/renderer/components/tabs/MainArea.tsx
@@ -9,9 +9,9 @@ import { useAtomValue } from 'jotai'
 import { tabsAtom } from '@/atoms/tab-atoms'
 import { Panel } from '@/components/app-shell/Panel'
 import { SettingsDialog } from '@/components/settings'
+import { WelcomeView } from '@/components/welcome/WelcomeView'
 import { TabBar } from './TabBar'
 import { SplitContainer } from './SplitContainer'
-import { MessageSquare } from 'lucide-react'
 
 export function MainArea(): React.ReactElement {
   const tabs = useAtomValue(tabsAtom)
@@ -24,17 +24,7 @@ export function MainArea(): React.ReactElement {
       >
         <TabBar />
         {tabs.length === 0 ? (
-          <div className="flex flex-col items-center justify-center flex-1 gap-4 text-muted-foreground titlebar-no-drag" style={{ zoom: 1.1 }}>
-            <div className="w-16 h-16 rounded-full bg-muted flex items-center justify-center">
-              <MessageSquare size={32} className="text-muted-foreground/60" />
-            </div>
-            <div className="text-center space-y-2">
-              <h2 className="text-lg font-medium text-foreground">开始使用</h2>
-              <p className="text-sm max-w-[300px]">
-                从左侧选择或创建一个对话，它将以标签页的形式打开
-              </p>
-            </div>
-          </div>
+          <WelcomeView />
         ) : (
           <SplitContainer />
         )}

--- a/apps/electron/src/renderer/components/welcome/WelcomeEmptyState.tsx
+++ b/apps/electron/src/renderer/components/welcome/WelcomeEmptyState.tsx
@@ -1,0 +1,104 @@
+/**
+ * WelcomeEmptyState — 对话/会话空状态引导
+ *
+ * 在 ChatMessages / AgentMessages 没有消息时展示：
+ * 1. 个性化时段问候
+ * 2. 平台感知的小 Tips
+ * 3. Chat/Agent 模式切换 Tab（切换时创建新会话）
+ */
+
+import * as React from 'react'
+import { useAtomValue, useAtom } from 'jotai'
+import { Lightbulb, MessageSquare, Bot } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { userProfileAtom } from '@/atoms/user-profile'
+import { appModeAtom, type AppMode } from '@/atoms/app-mode'
+import { getRandomTip, getPlatform, type Tip } from '@/lib/tips'
+import { useCreateSession } from '@/hooks/useCreateSession'
+
+/** 根据小时返回时段问候 */
+function getGreeting(hour: number): string {
+  if (hour < 6) return '夜深了'
+  if (hour < 12) return '早上好'
+  if (hour < 18) return '下午好'
+  return '晚上好'
+}
+
+/** 模式配置 */
+const MODE_CONFIG: Record<AppMode, { icon: React.ReactNode; label: string }> = {
+  chat: { icon: <MessageSquare size={15} />, label: 'Chat' },
+  agent: { icon: <Bot size={15} />, label: 'Agent' },
+}
+
+export function WelcomeEmptyState(): React.ReactElement {
+  const userProfile = useAtomValue(userProfileAtom)
+  const [mode, setMode] = useAtom(appModeAtom)
+  const { createChat, createAgent } = useCreateSession()
+
+  // 稳定的随机 Tip（组件挂载时选一条）
+  const [tip] = React.useState<Tip>(() => getRandomTip(getPlatform()))
+
+  const hour = new Date().getHours()
+  const greeting = getGreeting(hour)
+  const displayName = userProfile.userName || '用户'
+
+  /** 切换模式：创建新会话并切换 */
+  const handleModeSwitch = React.useCallback(async (targetMode: AppMode): Promise<void> => {
+    if (targetMode === mode) return
+    setMode(targetMode)
+    if (targetMode === 'chat') {
+      await createChat()
+    } else {
+      await createAgent()
+    }
+  }, [mode, setMode, createChat, createAgent])
+
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-6 px-4 animate-in fade-in duration-500">
+      {/* 问候语 */}
+      <h1 className="text-[26px] font-semibold tracking-tight text-foreground">
+        {displayName}，{greeting}
+      </h1>
+
+      {/* Tips */}
+      <div className="flex items-center gap-2.5 rounded-full bg-muted/50 px-4 py-2 text-[13px] text-muted-foreground">
+        <Lightbulb size={14} className="flex-shrink-0 text-amber-500/80" />
+        <span>{tip.text}</span>
+      </div>
+
+      {/* 模式切换 Tab */}
+      <div className="relative flex rounded-xl bg-muted/60 p-1">
+        {/* 滑动背景指示器 */}
+        <div
+          className={cn(
+            'absolute top-1 bottom-1 w-[calc(50%-4px)] rounded-lg bg-background shadow-sm transition-transform duration-300 ease-in-out',
+            mode === 'chat' ? 'translate-x-0' : 'translate-x-full',
+          )}
+        />
+        {(['chat', 'agent'] as const).map((m) => {
+          const config = MODE_CONFIG[m]
+          return (
+            <button
+              key={m}
+              onClick={() => handleModeSwitch(m)}
+              className={cn(
+                'relative z-[1] flex items-center gap-1.5 rounded-lg px-5 py-1.5 text-[13px] font-medium transition-colors duration-200',
+                mode === m
+                  ? 'text-foreground'
+                  : 'text-muted-foreground hover:text-foreground',
+              )}
+            >
+              {config.icon}
+              {config.label}
+            </button>
+          )
+        })}
+      </div>
+
+      {/* 底部提示 */}
+      <p className="text-xs text-muted-foreground/60">
+        {mode === 'chat' ? '在下方输入框开始对话' : '在下方输入框开始使用 Agent'}
+      </p>
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/welcome/WelcomeView.tsx
+++ b/apps/electron/src/renderer/components/welcome/WelcomeView.tsx
@@ -1,0 +1,37 @@
+/**
+ * WelcomeView — 主区域空状态启动器
+ *
+ * 当没有打开任何标签页时，自动为当前模式创建一个新会话并打开标签页。
+ * 这样用户直接看到完整的 ChatView/AgentView（含全功能输入框），
+ * 问候语和 Tips 在对话空状态中展示。
+ */
+
+import * as React from 'react'
+import { useAtomValue } from 'jotai'
+import { Loader2 } from 'lucide-react'
+import { appModeAtom } from '@/atoms/app-mode'
+import { useCreateSession } from '@/hooks/useCreateSession'
+
+export function WelcomeView(): React.ReactElement {
+  const mode = useAtomValue(appModeAtom)
+  const { createChat, createAgent } = useCreateSession()
+  const createdRef = React.useRef(false)
+
+  React.useEffect(() => {
+    if (createdRef.current) return
+    createdRef.current = true
+
+    if (mode === 'agent') {
+      createAgent()
+    } else {
+      createChat()
+    }
+  }, [mode, createChat, createAgent])
+
+  // 短暂的过渡状态（通常几十毫秒内就会被 SplitContainer 替换）
+  return (
+    <div className="flex h-full items-center justify-center">
+      <Loader2 className="size-5 animate-spin text-muted-foreground/40" />
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/hooks/useCreateSession.ts
+++ b/apps/electron/src/renderer/hooks/useCreateSession.ts
@@ -1,0 +1,92 @@
+/**
+ * useCreateSession — 共享的创建 Chat 对话 / Agent 会话逻辑
+ *
+ * 从 LeftSidebar 提取，供 WelcomeView 模式切换和侧边栏共同使用。
+ */
+
+import { useAtom, useAtomValue, useSetAtom } from 'jotai'
+import {
+  conversationsAtom,
+  currentConversationIdAtom,
+  selectedModelAtom,
+} from '@/atoms/chat-atoms'
+import {
+  agentSessionsAtom,
+  currentAgentSessionIdAtom,
+  agentChannelIdAtom,
+  currentAgentWorkspaceIdAtom,
+} from '@/atoms/agent-atoms'
+import {
+  tabsAtom,
+  splitLayoutAtom,
+  openTab,
+} from '@/atoms/tab-atoms'
+import { activeViewAtom } from '@/atoms/active-view'
+import { promptConfigAtom, selectedPromptIdAtom } from '@/atoms/system-prompt-atoms'
+
+interface CreateSessionActions {
+  /** 创建新 Chat 对话并打开标签页 */
+  createChat: () => Promise<void>
+  /** 创建新 Agent 会话并打开标签页 */
+  createAgent: () => Promise<void>
+}
+
+export function useCreateSession(): CreateSessionActions {
+  const [tabs, setTabs] = useAtom(tabsAtom)
+  const [layout, setLayout] = useAtom(splitLayoutAtom)
+  const setActiveView = useSetAtom(activeViewAtom)
+
+  // Chat
+  const setConversations = useSetAtom(conversationsAtom)
+  const setCurrentConversationId = useSetAtom(currentConversationIdAtom)
+  const selectedModel = useAtomValue(selectedModelAtom)
+  const promptConfig = useAtomValue(promptConfigAtom)
+  const setSelectedPromptId = useSetAtom(selectedPromptIdAtom)
+
+  // Agent
+  const setAgentSessions = useSetAtom(agentSessionsAtom)
+  const setCurrentAgentSessionId = useSetAtom(currentAgentSessionIdAtom)
+  const agentChannelId = useAtomValue(agentChannelIdAtom)
+  const currentWorkspaceId = useAtomValue(currentAgentWorkspaceIdAtom)
+
+  const createChat = async (): Promise<void> => {
+    try {
+      const meta = await window.electronAPI.createConversation(
+        undefined,
+        selectedModel?.modelId,
+        selectedModel?.channelId,
+      )
+      setConversations((prev) => [meta, ...prev])
+      const result = openTab(tabs, layout, { type: 'chat', sessionId: meta.id, title: meta.title })
+      setTabs(result.tabs)
+      setLayout(result.layout)
+      setCurrentConversationId(meta.id)
+      setActiveView('conversations')
+      if (promptConfig.defaultPromptId) {
+        setSelectedPromptId(promptConfig.defaultPromptId)
+      }
+    } catch (error) {
+      console.error('[创建会话] 创建 Chat 对话失败:', error)
+    }
+  }
+
+  const createAgent = async (): Promise<void> => {
+    try {
+      const meta = await window.electronAPI.createAgentSession(
+        undefined,
+        agentChannelId || undefined,
+        currentWorkspaceId || undefined,
+      )
+      setAgentSessions((prev) => [meta, ...prev])
+      const result = openTab(tabs, layout, { type: 'agent', sessionId: meta.id, title: meta.title })
+      setTabs(result.tabs)
+      setLayout(result.layout)
+      setCurrentAgentSessionId(meta.id)
+      setActiveView('conversations')
+    } catch (error) {
+      console.error('[创建会话] 创建 Agent 会话失败:', error)
+    }
+  }
+
+  return { createChat, createAgent }
+}

--- a/apps/electron/src/renderer/lib/tips.ts
+++ b/apps/electron/src/renderer/lib/tips.ts
@@ -1,0 +1,51 @@
+/**
+ * Tips 管理模块 — 平台感知的使用技巧
+ *
+ * 区分 macOS / Windows 平台，提供随机轮换的小贴士。
+ * Tips 内容可后续手动扩充。
+ */
+
+export type Platform = 'mac' | 'windows'
+
+export interface Tip {
+  id: string
+  text: string
+  /** 适用平台，'all' 表示通用 */
+  platform: Platform | 'all'
+}
+
+/** 检测当前平台 */
+export function getPlatform(): Platform {
+  if (typeof navigator !== 'undefined' && navigator.userAgent.includes('Mac')) {
+    return 'mac'
+  }
+  return 'windows'
+}
+
+/** 所有 Tips 数据 */
+export const TIPS: Tip[] = [
+  // macOS 专用
+  { id: 'mac-shortcut-new', text: '按 ⌘+N 快速创建新对话', platform: 'mac' },
+  { id: 'mac-shortcut-search', text: '按 ⌘+K 快速搜索历史对话', platform: 'mac' },
+  { id: 'mac-shortcut-settings', text: '按 ⌘+, 打开设置', platform: 'mac' },
+
+  // Windows 专用
+  { id: 'win-shortcut-new', text: '按 Ctrl+N 快速创建新对话', platform: 'windows' },
+  { id: 'win-shortcut-search', text: '按 Ctrl+K 快速搜索历史对话', platform: 'windows' },
+  { id: 'win-shortcut-settings', text: '按 Ctrl+, 打开设置', platform: 'windows' },
+
+  // 通用
+  { id: 'tip-thinking', text: '开启思考模式，让 AI 展示推理过程', platform: 'all' },
+  { id: 'tip-agent-file', text: 'Agent 模式下输入 @ 可以引用工作区文件', platform: 'all' },
+  { id: 'tip-agent-mcp', text: 'Agent 模式下输入 # 可以调用 MCP 工具', platform: 'all' },
+  { id: 'tip-agent-skill', text: 'Agent 模式下输入 / 可以使用 Skill', platform: 'all' },
+  { id: 'tip-attachment', text: '支持拖拽文件到输入框直接上传附件', platform: 'all' },
+  { id: 'tip-parallel', text: 'Chat 模式支持并排对比多个模型的回答', platform: 'all' },
+]
+
+/** 获取适用于当前平台的随机 Tip */
+export function getRandomTip(platform: Platform): Tip {
+  const filtered = TIPS.filter((t) => t.platform === 'all' || t.platform === platform)
+  const index = Math.floor(Math.random() * filtered.length)
+  return filtered[index] ?? filtered[0]!
+}


### PR DESCRIPTION
## Summary

重设计 Chat/Agent 模式的空状态页面，提升新用户引导体验：

- **WelcomeView 启动器**：无标签页时自动为当前模式创建会话，用户直接进入完整的 ChatView/AgentView（含全功能输入框、模型选择等）
- **WelcomeEmptyState**：对话无消息时展示个性化时段问候（早上好/下午好/晚上好 + 用户名）、平台感知的随机 Tips（macOS ⌘ / Windows Ctrl）、Chat/Agent 模式切换 Tab
- **Tips 管理模块**（`renderer/lib/tips.ts`）：独立模块管理平台感知提示，支持后续手动扩充
- **useCreateSession hook**：从 LeftSidebar 提取共享的创建 Chat/Agent 会话逻辑，供 WelcomeView 和 WelcomeEmptyState 复用

## Test plan

- [ ] 启动应用，无标签页时应自动创建会话进入完整视图
- [ ] 新建对话/会话后，空状态显示问候语 + Tip + 模式切换 Tab
- [ ] 点击模式切换 Tab 应创建对应类型新会话并切换
- [ ] macOS 显示 ⌘ 快捷键提示，Windows 显示 Ctrl 快捷键提示
- [ ] `bun run typecheck` 无类型错误