### PR TITLE
fix: Agent 会话切换状态隔离 — per-session 渠道/模型配置

### DIFF
--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -216,10 +216,17 @@ export interface AgentPendingPrompt {
 export const agentSessionsAtom = atom<AgentSessionMeta[]>([])
 export const agentWorkspacesAtom = atom<AgentWorkspace[]>([])
 export const currentAgentWorkspaceIdAtom = atom<string | null>(null)
+/** 全局默认渠道 ID（新会话继承用，从 settings.json 加载） */
 export const agentChannelIdAtom = atom<string | null>(null)
+/** 全局默认模型 ID（新会话继承用，从 settings.json 加载） */
 export const agentModelIdAtom = atom<string | null>(null)
 /** Agent 启用的渠道 ID 列表（多选，设置页 Switch 开关控制） */
 export const agentChannelIdsAtom = atom<string[]>([])
+
+/** Per-session 渠道 ID Map — sessionId → channelId */
+export const agentSessionChannelMapAtom = atom<Map<string, string>>(new Map())
+/** Per-session 模型 ID Map — sessionId → modelId */
+export const agentSessionModelMapAtom = atom<Map<string, string>>(new Map())
 export const currentAgentSessionIdAtom = atom<string | null>(null)
 export const currentAgentMessagesAtom = atom<AgentMessage[]>([])
 export const agentStreamingStatesAtom = atom<Map<string, AgentStreamState>>(new Map())

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -37,6 +37,8 @@ import {
   agentChannelIdAtom,
   agentModelIdAtom,
   agentChannelIdsAtom,
+  agentSessionChannelMapAtom,
+  agentSessionModelMapAtom,
   currentAgentWorkspaceIdAtom,
   agentPendingPromptAtom,
   agentPendingFilesAtom,
@@ -72,8 +74,15 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const liveMessagesMap = useAtomValue(liveMessagesMapAtom)
   const setLiveMessagesMap = useSetAtom(liveMessagesMapAtom)
   const liveMessages = liveMessagesMap.get(sessionId) ?? []
-  const [agentChannelId, setAgentChannelId] = useAtom(agentChannelIdAtom)
-  const [agentModelId, setAgentModelId] = useAtom(agentModelIdAtom)
+  // Per-session 渠道/模型配置（优先读 session map，回退到全局默认值）
+  const sessionChannelMap = useAtomValue(agentSessionChannelMapAtom)
+  const sessionModelMap = useAtomValue(agentSessionModelMapAtom)
+  const setSessionChannelMap = useSetAtom(agentSessionChannelMapAtom)
+  const setSessionModelMap = useSetAtom(agentSessionModelMapAtom)
+  const [defaultChannelId, setDefaultChannelId] = useAtom(agentChannelIdAtom)
+  const [defaultModelId, setDefaultModelId] = useAtom(agentModelIdAtom)
+  const agentChannelId = sessionChannelMap.get(sessionId) ?? defaultChannelId
+  const agentModelId = sessionModelMap.get(sessionId) ?? defaultModelId
   const agentChannelIds = useAtomValue(agentChannelIdsAtom)
   const [agentThinking, setAgentThinking] = useAtom(agentThinkingAtom)
   const setSettingsOpen = useSetAtom(settingsOpenAtom)
@@ -85,6 +94,27 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const stableChannelIdRef = React.useRef(agentChannelId)
   if (agentChannelId) stableChannelIdRef.current = agentChannelId
   const stableChannelId = agentChannelId ?? stableChannelIdRef.current
+
+  // 已有会话首次打开时，从全局默认值初始化 per-session map
+  React.useEffect(() => {
+    if (!sessionId) return
+    if (!sessionChannelMap.has(sessionId) && defaultChannelId) {
+      setSessionChannelMap((prev) => {
+        if (prev.has(sessionId)) return prev
+        const map = new Map(prev)
+        map.set(sessionId, defaultChannelId)
+        return map
+      })
+    }
+    if (!sessionModelMap.has(sessionId) && defaultModelId) {
+      setSessionModelMap((prev) => {
+        if (prev.has(sessionId)) return prev
+        const map = new Map(prev)
+        map.set(sessionId, defaultModelId)
+        return map
+      })
+    }
+  }, [sessionId, sessionChannelMap, sessionModelMap, defaultChannelId, defaultModelId, setSessionChannelMap, setSessionModelMap])
 
   const contextStatus: AgentContextStatus = {
     isCompacting: streamState?.isCompacting ?? false,
@@ -147,12 +177,19 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     const firstModel = channel.models.find((m) => m.enabled)
     if (!firstModel) return
 
-    setAgentModelId(firstModel.id)
+    // 更新 per-session map
+    setSessionModelMap((prev) => {
+      const map = new Map(prev)
+      map.set(sessionId, firstModel.id)
+      return map
+    })
+    // 同步全局默认值
+    setDefaultModelId(firstModel.id)
     window.electronAPI.updateSettings({
       agentChannelId,
       agentModelId: firstModel.id,
     }).catch(console.error)
-  }, [agentChannelId, agentModelId, globalChannels, setAgentModelId])
+  }, [agentChannelId, agentModelId, globalChannels, sessionId, setSessionModelMap, setDefaultModelId])
 
   // 获取当前 session 的工作路径（文件浏览器需要）
   React.useEffect(() => {
@@ -221,6 +258,9 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         })
         setLiveMessagesMap((prev) => {
           if (!prev.has(sessionId)) return prev
+          // 仍在运行中，不清除实时消息（与 streamingStates 保护逻辑一致）
+          const streamingState = store.get(agentStreamingStatesAtom).get(sessionId)
+          if (streamingState?.running) return prev
           const map = new Map(prev)
           map.delete(sessionId)
           return map
@@ -484,15 +524,28 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
 
   /** ModelSelector 选择回调 */
   const handleModelSelect = React.useCallback((option: ModelOption): void => {
-    setAgentChannelId(option.channelId)
-    setAgentModelId(option.modelId)
+    // 更新当前会话的 per-session 配置
+    setSessionChannelMap((prev) => {
+      const map = new Map(prev)
+      map.set(sessionId, option.channelId)
+      return map
+    })
+    setSessionModelMap((prev) => {
+      const map = new Map(prev)
+      map.set(sessionId, option.modelId)
+      return map
+    })
+
+    // 同时更新全局默认值（新会话继承）
+    setDefaultChannelId(option.channelId)
+    setDefaultModelId(option.modelId)
 
     // 持久化到设置
     window.electronAPI.updateSettings({
       agentChannelId: option.channelId,
       agentModelId: option.modelId,
     }).catch(console.error)
-  }, [setAgentChannelId, setAgentModelId])
+  }, [sessionId, setSessionChannelMap, setSessionModelMap, setDefaultChannelId, setDefaultModelId])
 
   /** 构建 externalSelectedModel 给 ModelSelector */
   const externalSelectedModel = React.useMemo(() => {

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -35,6 +35,9 @@ import {
   currentAgentSessionIdAtom,
   agentRunningSessionIdsAtom,
   agentChannelIdAtom,
+  agentModelIdAtom,
+  agentSessionChannelMapAtom,
+  agentSessionModelMapAtom,
   currentAgentWorkspaceIdAtom,
   agentWorkspacesAtom,
   workspaceCapabilitiesVersionAtom,
@@ -173,6 +176,9 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   const [currentAgentSessionId, setCurrentAgentSessionId] = useAtom(currentAgentSessionIdAtom)
   const agentRunningIds = useAtomValue(agentRunningSessionIdsAtom)
   const agentChannelId = useAtomValue(agentChannelIdAtom)
+  const agentModelId = useAtomValue(agentModelIdAtom)
+  const setSessionChannelMap = useSetAtom(agentSessionChannelMapAtom)
+  const setSessionModelMap = useSetAtom(agentSessionModelMapAtom)
   const currentWorkspaceId = useAtomValue(currentAgentWorkspaceIdAtom)
   const workspaces = useAtomValue(agentWorkspacesAtom)
 
@@ -212,7 +218,9 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     setConvParallel(deleteKey)
     setConvPromptId(deleteKey)
     setAgentSidePanelOpen(deleteKey)
-  }, [setConvModels, setConvContextLength, setConvThinking, setConvParallel, setConvPromptId, setAgentSidePanelOpen])
+    setSessionChannelMap(deleteKey)
+    setSessionModelMap(deleteKey)
+  }, [setConvModels, setConvContextLength, setConvThinking, setConvParallel, setConvPromptId, setAgentSidePanelOpen, setSessionChannelMap, setSessionModelMap])
 
   const currentWorkspaceSlug = React.useMemo(() => {
     if (!currentWorkspaceId) return null
@@ -430,6 +438,21 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         currentWorkspaceId || undefined,
       )
       setAgentSessions((prev) => [meta, ...prev])
+      // 从全局默认值初始化 per-session 渠道/模型配置
+      if (agentChannelId) {
+        setSessionChannelMap((prev) => {
+          const map = new Map(prev)
+          map.set(meta.id, agentChannelId)
+          return map
+        })
+      }
+      if (agentModelId) {
+        setSessionModelMap((prev) => {
+          const map = new Map(prev)
+          map.set(meta.id, agentModelId)
+          return map
+        })
+      }
       // 打开新标签页
       const result = openTab(tabs, layout, { type: 'agent', sessionId: meta.id, title: meta.title })
       setTabs(result.tabs)


### PR DESCRIPTION
## Summary

- 将全局 `agentChannelIdAtom` / `agentModelIdAtom` 改为 per-session Map（`agentSessionChannelMapAtom` / `agentSessionModelMapAtom`），切换会话时模型名称不再互相污染
- 修复 `liveMessages` 清理逻辑缺少 `running` 状态检查的 bug，流式期间切回会话不再丢失工具输出数据
- 新建会话从全局默认值初始化，改模型同时更新默认值（跟随用户最近选择）
- 会话删除时同步清理 Map entry，避免内存泄漏

## Test plan
- [ ] 打开 Session A（选 Sonnet），开始流式，切换到 Session B（选 Haiku），确认 UI 显示各自正确的模型
- [ ] 流式期间切回 Session A，确认工具输出完整无丢失
- [ ] 新建 Session C，确认默认模型跟随最近选择
- [ ] 删除会话后无报错