### PR TITLE
feat: 集中式快捷键系统 — 9 个快捷键 + 自定义设置面板

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/menu.ts
+++ b/apps/electron/src/main/menu.ts
@@ -1,7 +1,15 @@
-import { Menu, shell } from 'electron'
+import { Menu, shell, BrowserWindow } from 'electron'
 
 export function createApplicationMenu(): Menu {
   const isMac = process.platform === 'darwin'
+
+  /**
+   * 菜单快捷键说明：
+   *
+   * 大部分快捷键由渲染进程的 shortcut-registry 统一管理。
+   * 但 Cmd+W 需要在菜单中拦截（否则 macOS 默认关闭窗口），
+   * 改为通知渲染进程关闭当前标签页。
+   */
 
   const template: Electron.MenuItemConstructorOptions[] = [
     // 应用菜单 (仅 macOS)
@@ -27,7 +35,20 @@ export function createApplicationMenu(): Menu {
     // 文件菜单
     {
       label: '文件',
-      submenu: [isMac ? { role: 'close' as const, label: '关闭窗口' } : { role: 'quit' as const, label: '退出' }],
+      submenu: [
+        // Cmd+W / Ctrl+W：关闭当前标签页（而非关闭窗口）
+        {
+          label: '关闭标签页',
+          accelerator: 'CmdOrCtrl+W',
+          click: () => {
+            const win = BrowserWindow.getFocusedWindow()
+            if (win) {
+              win.webContents.send('menu:close-tab')
+            }
+          },
+        },
+        ...(isMac ? [] : [{ type: 'separator' as const }, { role: 'quit' as const, label: '退出' }]),
+      ],
     },
 
     // 编辑菜单

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -608,6 +608,8 @@ export interface ElectronAPI {
   onFeishuStatusChanged: (callback: (state: FeishuBridgeState) => void) => () => void
   /** 订阅飞书通知已发送事件 */
   onFeishuNotificationSent: (callback: (payload: FeishuNotificationSentPayload) => void) => () => void
+  /** 订阅菜单关闭标签页事件（Cmd+W 被菜单拦截后转发） */
+  onMenuCloseTab: (callback: () => void) => () => void
 }
 
 /**
@@ -1297,6 +1299,12 @@ const electronAPI: ElectronAPI = {
     const listener = (_event: Electron.IpcRendererEvent, payload: FeishuNotificationSentPayload): void => callback(payload)
     ipcRenderer.on(FEISHU_IPC_CHANNELS.NOTIFICATION_SENT, listener)
     return () => { ipcRenderer.removeListener(FEISHU_IPC_CHANNELS.NOTIFICATION_SENT, listener) }
+  },
+
+  onMenuCloseTab: (callback: () => void) => {
+    const listener = (): void => callback()
+    ipcRenderer.on('menu:close-tab', listener)
+    return () => { ipcRenderer.removeListener('menu:close-tab', listener) }
   },
 }
 

--- a/apps/electron/src/renderer/atoms/settings-tab.ts
+++ b/apps/electron/src/renderer/atoms/settings-tab.ts
@@ -11,7 +11,7 @@
 
 import { atom } from 'jotai'
 
-export type SettingsTab = 'general' | 'channels' | 'proxy' | 'appearance' | 'about' | 'agent' | 'prompts' | 'tools' | 'feishu' | 'tutorial'
+export type SettingsTab = 'general' | 'channels' | 'proxy' | 'appearance' | 'about' | 'agent' | 'prompts' | 'tools' | 'feishu' | 'tutorial' | 'shortcuts'
 
 /** 当前设置标签页（不持久化，每次打开设置默认显示渠道） */
 export const settingsTabAtom = atom<SettingsTab>('channels')

--- a/apps/electron/src/renderer/atoms/shortcut-atoms.ts
+++ b/apps/electron/src/renderer/atoms/shortcut-atoms.ts
@@ -1,0 +1,12 @@
+/**
+ * Shortcut Atoms — 快捷键状态管理
+ *
+ * 管理用户自定义快捷键覆盖配置。
+ * 通过 settings IPC 通道持久化到 settings.json。
+ */
+
+import { atom } from 'jotai'
+import type { ShortcutOverrides } from '@/lib/shortcut-defaults'
+
+/** 用户自定义快捷键覆盖（从 settings.json 加载） */
+export const shortcutOverridesAtom = atom<ShortcutOverrides>({})

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -936,6 +936,25 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     }
   }, [sessionId, tabs, layout, setAgentSessions, setCurrentAgentSessionId, setTabs, setLayout])
 
+  // 监听快捷键系统分发的 stop-generation 事件（Cmd+.）
+  React.useEffect(() => {
+    const handler = (): void => {
+      if (streaming) handleStop()
+    }
+    window.addEventListener('proma:stop-generation', handler)
+    return () => window.removeEventListener('proma:stop-generation', handler)
+  }, [streaming, handleStop])
+
+  // 监听快捷键系统分发的 focus-input 事件（Cmd+L）
+  React.useEffect(() => {
+    const handler = (): void => {
+      const proseMirror = document.querySelector('[data-input-mode="agent"] .ProseMirror') as HTMLElement | null
+      proseMirror?.focus()
+    }
+    window.addEventListener('proma:focus-input', handler)
+    return () => window.removeEventListener('proma:focus-input', handler)
+  }, [])
+
   const canSend = (inputContent.trim().length > 0 || pendingFiles.length > 0) && agentChannelId !== null && !streaming
 
   return (
@@ -995,7 +1014,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         <ExitPlanModeBanner sessionId={sessionId} />
 
         {/* 输入区域 — 复用 Chat 的卡片式输入风格 */}
-        <div className="px-2.5 pb-2.5 md:px-[18px] md:pb-[18px] pt-2">
+        <div className="px-2.5 pb-2.5 md:px-[18px] md:pb-[18px] pt-2" data-input-mode="agent">
           <div
             className={cn(
               'rounded-[17px] border-[0.5px] border-border bg-background/70 backdrop-blur-sm pt-2 transition-all duration-200',

--- a/apps/electron/src/renderer/components/app-shell/SearchDialog.tsx
+++ b/apps/electron/src/renderer/components/app-shell/SearchDialog.tsx
@@ -296,17 +296,7 @@ export function SearchDialog(): React.ReactElement {
     }
   }, [selectedIndex])
 
-  // 全局快捷键 Cmd+F
-  React.useEffect(() => {
-    const handler = (e: KeyboardEvent): void => {
-      if ((e.metaKey || e.ctrlKey) && e.key === 'f') {
-        e.preventDefault()
-        setOpen(true)
-      }
-    }
-    window.addEventListener('keydown', handler)
-    return () => window.removeEventListener('keydown', handler)
-  }, [setOpen])
+  // 全局快捷键 Cmd+F 已迁移到 GlobalShortcuts 组件统一管理
 
   // 打开时重置状态并聚焦
   React.useEffect(() => {

--- a/apps/electron/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatInput.tsx
@@ -8,7 +8,7 @@
  *   左侧：Paperclip 附件按钮、ModelSelector、ThinkingButton、SpeechButton、ContextSettingsPopover、ClearContextButton
  *   右侧：Send/Stop 按钮
  * - 拖放文件支持（onDragOver/onDragLeave/onDrop）
- * - Cmd/Ctrl+K 快捷键绑定清除上下文
+ * - 监听 proma:clear-context 和 proma:focus-input 自定义事件
  * - 卡片式容器样式
  */
 
@@ -209,20 +209,28 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
     }
   }, [addFilesAsAttachments])
 
-  // Cmd/Ctrl+K 快捷键
+  // 监听快捷键系统分发的 clear-context 事件（Cmd+K）
   React.useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent): void => {
-      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
-        e.preventDefault()
-        onClearContext?.()
-      }
+    const handler = (): void => {
+      onClearContext?.()
     }
-    window.addEventListener('keydown', handleKeyDown)
-    return () => window.removeEventListener('keydown', handleKeyDown)
+    window.addEventListener('proma:clear-context', handler)
+    return () => window.removeEventListener('proma:clear-context', handler)
   }, [onClearContext])
 
+  // 监听快捷键系统分发的 focus-input 事件（Cmd+L）
+  React.useEffect(() => {
+    const handler = (): void => {
+      // 聚焦 TipTap 编辑器：查找 Chat 输入框内的 ProseMirror 元素
+      const proseMirror = document.querySelector('[data-input-mode="chat"] .ProseMirror') as HTMLElement | null
+      proseMirror?.focus()
+    }
+    window.addEventListener('proma:focus-input', handler)
+    return () => window.removeEventListener('proma:focus-input', handler)
+  }, [])
+
   return (
-    <div className="px-2.5 pb-2.5 md:px-[18px] md:pb-[18px] pt-2">
+    <div className="px-2.5 pb-2.5 md:px-[18px] md:pb-[18px] pt-2" data-input-mode="chat">
         {/* 卡片式输入容器 — 对标 Cherry Studio: border-radius 17px, 0.5px border */}
         <div
           className={cn(

--- a/apps/electron/src/renderer/components/chat/ChatView.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatView.tsx
@@ -382,6 +382,15 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
     window.electronAPI.stopGeneration(conversationId).catch(console.error)
   }, [conversationId, setStreamingStates])
 
+  // 监听快捷键系统分发的 stop-generation 事件（Cmd+.）
+  React.useEffect(() => {
+    const handler = (): void => {
+      if (isStreaming) handleStop()
+    }
+    window.addEventListener('proma:stop-generation', handler)
+    return () => window.removeEventListener('proma:stop-generation', handler)
+  }, [isStreaming, handleStop])
+
   /** 删除消息 */
   const handleDeleteMessage = React.useCallback(async (messageId: string): Promise<void> => {
     try {

--- a/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
+++ b/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
@@ -8,7 +8,7 @@
 import * as React from 'react'
 import { useAtom, useAtomValue } from 'jotai'
 import { cn } from '@/lib/utils'
-import { Settings, Radio, Palette, Info, Plug, Globe, BookOpen, Wrench, MessageSquare, GraduationCap, X } from 'lucide-react'
+import { Settings, Radio, Palette, Info, Plug, Globe, BookOpen, Wrench, MessageSquare, GraduationCap, X, Keyboard } from 'lucide-react'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { settingsTabAtom } from '@/atoms/settings-tab'
 import type { SettingsTab } from '@/atoms/settings-tab'
@@ -25,6 +25,7 @@ import { PromptSettings } from './PromptSettings'
 import { ToolSettings } from './ToolSettings'
 import { FeishuSettings } from './FeishuSettings'
 import { TutorialViewer } from '../tutorial/TutorialViewer'
+import { ShortcutSettings } from './ShortcutSettings'
 
 /** 设置 Tab 定义 */
 interface TabItem {
@@ -46,6 +47,7 @@ const AGENT_TAB: TabItem = { id: 'agent', label: '配置', icon: <Plug size={16}
 const TOOLS_TAB: TabItem = { id: 'tools', label: '工具', icon: <Wrench size={16} /> }
 const FEISHU_TAB: TabItem = { id: 'feishu', label: '飞书', icon: <MessageSquare size={16} /> }
 const TUTORIAL_TAB: TabItem = { id: 'tutorial', label: '教程', icon: <GraduationCap size={16} /> }
+const SHORTCUTS_TAB: TabItem = { id: 'shortcuts', label: '快捷键', icon: <Keyboard size={16} /> }
 
 /** 尾部 Tabs */
 const TAIL_TABS: TabItem[] = [
@@ -76,6 +78,8 @@ function renderTabContent(tab: SettingsTab): React.ReactElement {
       return <FeishuSettings />
     case 'tutorial':
       return <TutorialViewer />
+    case 'shortcuts':
+      return <ShortcutSettings />
   }
 }
 
@@ -92,9 +96,9 @@ export function SettingsPanel({ onClose }: SettingsPanelProps): React.ReactEleme
   // Agent 模式时在渠道后插入 Agent Tab，工具 tab 两种模式都显示
   const tabs = React.useMemo(() => {
     if (appMode === 'agent') {
-      return [...BASE_TABS, AGENT_TAB, TOOLS_TAB, FEISHU_TAB, TUTORIAL_TAB, ...TAIL_TABS]
+      return [...BASE_TABS, AGENT_TAB, TOOLS_TAB, FEISHU_TAB, TUTORIAL_TAB, SHORTCUTS_TAB, ...TAIL_TABS]
     }
-    return [...BASE_TABS, TOOLS_TAB, FEISHU_TAB, TUTORIAL_TAB, ...TAIL_TABS]
+    return [...BASE_TABS, TOOLS_TAB, FEISHU_TAB, TUTORIAL_TAB, SHORTCUTS_TAB, ...TAIL_TABS]
   }, [appMode])
 
   // 当前 tab 标题

--- a/apps/electron/src/renderer/components/settings/ShortcutSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/ShortcutSettings.tsx
@@ -1,0 +1,324 @@
+/**
+ * ShortcutSettings — 快捷键设置面板
+ *
+ * 分组展示所有快捷键，支持：
+ * - 查看当前快捷键绑定
+ * - 点击录制自定义快捷键
+ * - 冲突检测和提示
+ * - 恢复默认值
+ */
+
+import * as React from 'react'
+import { useAtom } from 'jotai'
+import { RotateCcw } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { shortcutOverridesAtom } from '@/atoms/shortcut-atoms'
+import {
+  DEFAULT_SHORTCUTS,
+  SHORTCUT_CATEGORY_LABELS,
+} from '@/lib/shortcut-defaults'
+import type { ShortcutCategory, ShortcutOverrides } from '@/lib/shortcut-defaults'
+import {
+  getActiveAccelerator,
+  getAcceleratorDisplay,
+  checkConflict,
+  updateShortcutOverrides,
+  isMac,
+} from '@/lib/shortcut-registry'
+
+// ===== 快捷键录制组件 =====
+
+interface ShortcutRecorderProps {
+  /** 快捷键 ID */
+  shortcutId: string
+  /** 当前显示的 accelerator */
+  currentAccelerator: string
+  /** 录制完成回调 */
+  onRecord: (shortcutId: string, accelerator: string) => void
+}
+
+function ShortcutRecorder({
+  shortcutId,
+  currentAccelerator,
+  onRecord,
+}: ShortcutRecorderProps): React.ReactElement {
+  const [recording, setRecording] = React.useState(false)
+  const [pendingKeys, setPendingKeys] = React.useState('')
+  const [conflict, setConflict] = React.useState<string | null>(null)
+
+  const handleStartRecording = React.useCallback(() => {
+    setRecording(true)
+    setPendingKeys('')
+    setConflict(null)
+  }, [])
+
+  const handleCancel = React.useCallback(() => {
+    setRecording(false)
+    setPendingKeys('')
+    setConflict(null)
+  }, [])
+
+  // 录制模式下的按键捕获
+  React.useEffect(() => {
+    if (!recording) return
+
+    const handleKeyDown = (e: KeyboardEvent): void => {
+      e.preventDefault()
+      e.stopPropagation()
+
+      // 忽略单独的修饰键
+      if (['Meta', 'Control', 'Shift', 'Alt'].includes(e.key)) return
+
+      // 构建 accelerator 字符串
+      const parts: string[] = []
+      if (e.metaKey && isMac) parts.push('Cmd')
+      if (e.ctrlKey && !isMac) parts.push('Ctrl')
+      if (e.shiftKey) parts.push('Shift')
+      if (e.altKey) parts.push('Alt')
+
+      // 至少需要一个修饰键
+      if (parts.length === 0) return
+
+      // 标准化按键名称
+      let key = e.key
+      if (key === ' ') key = 'Space'
+      if (key.length === 1) key = key.toUpperCase()
+      // 特殊键映射
+      const keyMap: Record<string, string> = {
+        ArrowUp: 'Up', ArrowDown: 'Down',
+        ArrowLeft: 'Left', ArrowRight: 'Right',
+        Escape: 'Esc', Backspace: 'Backspace',
+        Delete: 'Delete', Enter: 'Enter', Tab: 'Tab',
+      }
+      const mapped = keyMap[key]
+      if (mapped) key = mapped
+
+      parts.push(key)
+      const accelerator = parts.join('+')
+
+      // 冲突检测
+      const conflictId = checkConflict(accelerator, shortcutId)
+      if (conflictId) {
+        const conflictDef = DEFAULT_SHORTCUTS.find((s) => s.id === conflictId)
+        setConflict(conflictDef?.name ?? conflictId)
+        setPendingKeys(accelerator)
+        return
+      }
+
+      // 无冲突，直接应用
+      setPendingKeys('')
+      setConflict(null)
+      setRecording(false)
+      onRecord(shortcutId, accelerator)
+    }
+
+    // Escape 取消录制
+    const handleEsc = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        handleCancel()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown, true)
+    window.addEventListener('keydown', handleEsc, true)
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown, true)
+      window.removeEventListener('keydown', handleEsc, true)
+    }
+  }, [recording, shortcutId, onRecord, handleCancel])
+
+  if (recording) {
+    return (
+      <div className="flex items-center gap-2">
+        {conflict ? (
+          <>
+            <span className="text-xs px-2 py-1 rounded bg-destructive/10 text-destructive border border-destructive/20">
+              {getAcceleratorDisplay(pendingKeys)} 与「{conflict}」冲突
+            </span>
+            <Button variant="ghost" size="sm" className="h-6 text-xs" onClick={handleCancel}>
+              取消
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 text-xs text-destructive"
+              onClick={() => {
+                setRecording(false)
+                setConflict(null)
+                onRecord(shortcutId, pendingKeys)
+              }}
+            >
+              覆盖
+            </Button>
+          </>
+        ) : (
+          <>
+            <span className="text-xs px-2 py-1 rounded bg-primary/10 text-primary border border-primary/20 animate-pulse">
+              请按下快捷键...
+            </span>
+            <Button variant="ghost" size="sm" className="h-6 text-xs" onClick={handleCancel}>
+              取消
+            </Button>
+          </>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      className="text-xs px-2.5 py-1 rounded-md bg-muted hover:bg-muted/80 text-foreground/80 font-mono transition-colors"
+      onClick={handleStartRecording}
+      title="点击自定义快捷键"
+    >
+      {getAcceleratorDisplay(currentAccelerator)}
+    </button>
+  )
+}
+
+// ===== 主组件 =====
+
+export function ShortcutSettings(): React.ReactElement {
+  const [overrides, setOverrides] = useAtom(shortcutOverridesAtom)
+
+  // 按分类分组
+  const grouped = React.useMemo(() => {
+    const groups = new Map<ShortcutCategory, typeof DEFAULT_SHORTCUTS>()
+    for (const def of DEFAULT_SHORTCUTS) {
+      const list = groups.get(def.category) ?? []
+      list.push(def)
+      groups.set(def.category, list)
+    }
+    return groups
+  }, [])
+
+  // 录制回调：更新 overrides 并持久化
+  const handleRecord = React.useCallback(
+    (shortcutId: string, accelerator: string) => {
+      const key = isMac ? 'mac' : 'win'
+      const newOverrides: ShortcutOverrides = {
+        ...overrides,
+        [shortcutId]: {
+          ...overrides[shortcutId],
+          [key]: accelerator,
+        },
+      }
+      setOverrides(newOverrides)
+      updateShortcutOverrides(newOverrides)
+
+      // 持久化到 settings.json
+      window.electronAPI
+        .updateSettings({ shortcutOverrides: newOverrides })
+        .catch(console.error)
+    },
+    [overrides, setOverrides],
+  )
+
+  // 恢复单个快捷键默认值
+  const handleReset = React.useCallback(
+    (shortcutId: string) => {
+      const newOverrides = { ...overrides }
+      delete newOverrides[shortcutId]
+      setOverrides(newOverrides)
+      updateShortcutOverrides(newOverrides)
+
+      window.electronAPI
+        .updateSettings({ shortcutOverrides: newOverrides })
+        .catch(console.error)
+    },
+    [overrides, setOverrides],
+  )
+
+  // 恢复所有默认值
+  const handleResetAll = React.useCallback(() => {
+    setOverrides({})
+    updateShortcutOverrides({})
+
+    window.electronAPI
+      .updateSettings({ shortcutOverrides: {} })
+      .catch(console.error)
+  }, [setOverrides])
+
+  const hasOverrides = Object.keys(overrides).length > 0
+
+  // 分类顺序
+  const categoryOrder: ShortcutCategory[] = ['app', 'navigation', 'edit']
+
+  return (
+    <div className="space-y-6">
+      {/* 描述 + 恢复全部按钮 */}
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          点击快捷键可自定义，按 Esc 取消录制
+        </p>
+        {hasOverrides && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-xs text-muted-foreground"
+            onClick={handleResetAll}
+          >
+            <RotateCcw size={12} className="mr-1" />
+            恢复全部默认
+          </Button>
+        )}
+      </div>
+
+      {/* 按分类分组展示 */}
+      {categoryOrder.map((category) => {
+        const shortcuts = grouped.get(category)
+        if (!shortcuts) return null
+
+        return (
+          <div key={category}>
+            <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
+              {SHORTCUT_CATEGORY_LABELS[category]}
+            </h3>
+            <div className="space-y-1">
+              {shortcuts.map((def) => {
+                const currentAccel = getActiveAccelerator(def.id)
+                const isCustomized = !!overrides[def.id]
+
+                return (
+                  <div
+                    key={def.id}
+                    className="flex items-center justify-between py-2.5 px-3 rounded-lg hover:bg-muted/50 transition-colors group"
+                  >
+                    <div className="flex-1 min-w-0">
+                      <div className="text-sm font-medium text-foreground">
+                        {def.name}
+                      </div>
+                      <div className="text-xs text-muted-foreground mt-0.5">
+                        {def.description}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-2 ml-4">
+                      <ShortcutRecorder
+                        shortcutId={def.id}
+                        currentAccelerator={currentAccel}
+                        onRecord={handleRecord}
+                      />
+                      {isCustomized && (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="size-6 opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground"
+                          onClick={() => handleReset(def.id)}
+                          title="恢复默认"
+                        >
+                          <RotateCcw size={12} />
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx
+++ b/apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx
@@ -1,0 +1,155 @@
+/**
+ * GlobalShortcuts — 全局快捷键注册 + 初始化组件
+ *
+ * 在 main.tsx 顶层挂载（类似 AgentListenersInitializer），永不销毁。
+ * 负责：
+ * 1. 初始化快捷键注册表
+ * 2. 从 settings 加载用户自定义配置
+ * 3. 注册所有应用级快捷键的 handler
+ * 4. 监听菜单 IPC 事件（Cmd+W 关闭标签）
+ */
+
+import { useEffect, useCallback } from 'react'
+import { useAtomValue, useSetAtom, useAtom } from 'jotai'
+import { appModeAtom } from '@/atoms/app-mode'
+import { settingsOpenAtom } from '@/atoms/settings-tab'
+import { searchDialogOpenAtom } from '@/atoms/search-atoms'
+import {
+  tabsAtom,
+  splitLayoutAtom,
+  sidebarCollapsedAtom,
+  activeTabIdAtom,
+  closeTab,
+} from '@/atoms/tab-atoms'
+import { shortcutOverridesAtom } from '@/atoms/shortcut-atoms'
+import { useCreateSession } from '@/hooks/useCreateSession'
+import { useShortcut } from '@/hooks/useShortcut'
+import {
+  initShortcutRegistry,
+  updateShortcutOverrides,
+} from '@/lib/shortcut-registry'
+
+/**
+ * 快捷键初始化 + 全局 Handler 注册
+ *
+ * 挂载后从 settings 加载自定义配置，并注册所有应用级快捷键。
+ */
+export function GlobalShortcuts(): null {
+  const [appMode, setAppMode] = useAtom(appModeAtom)
+  const setSettingsOpen = useSetAtom(settingsOpenAtom)
+  const setSearchOpen = useSetAtom(searchDialogOpenAtom)
+  const [sidebarCollapsed, setSidebarCollapsed] = useAtom(sidebarCollapsedAtom)
+  const setShortcutOverrides = useSetAtom(shortcutOverridesAtom)
+  const shortcutOverrides = useAtomValue(shortcutOverridesAtom)
+  const { createChat, createAgent } = useCreateSession()
+
+  // Tab 管理（用于关闭标签页）
+  const [tabs, setTabs] = useAtom(tabsAtom)
+  const [layout, setLayout] = useAtom(splitLayoutAtom)
+  const activeTabId = useAtomValue(activeTabIdAtom)
+
+  // 初始化：挂载注册表 + 加载用户配置
+  useEffect(() => {
+    initShortcutRegistry()
+
+    window.electronAPI.getSettings().then((settings) => {
+      if (settings.shortcutOverrides) {
+        setShortcutOverrides(settings.shortcutOverrides)
+        updateShortcutOverrides(settings.shortcutOverrides)
+      }
+    }).catch(console.error)
+  }, [setShortcutOverrides])
+
+  // 配置变更时同步到注册表
+  useEffect(() => {
+    updateShortcutOverrides(shortcutOverrides)
+  }, [shortcutOverrides])
+
+  // ===== 关闭标签页逻辑 =====
+
+  const handleCloseTab = useCallback(() => {
+    if (!activeTabId) return
+    const result = closeTab(tabs, layout, activeTabId)
+    setTabs(result.tabs)
+    setLayout(result.layout)
+  }, [activeTabId, tabs, layout, setTabs, setLayout])
+
+  // 监听菜单 IPC 事件（Cmd+W 被 Electron 菜单拦截后通过 IPC 转发）
+  useEffect(() => {
+    const cleanup = window.electronAPI.onMenuCloseTab(handleCloseTab)
+    return cleanup
+  }, [handleCloseTab])
+
+  // 同时注册到快捷键系统（用于设置面板展示和自定义，实际触发走 IPC）
+  useShortcut('close-tab', handleCloseTab)
+
+  // ===== 快捷键 Handler =====
+
+  // Cmd+, → 打开设置
+  useShortcut(
+    'open-settings',
+    useCallback(() => setSettingsOpen(true), [setSettingsOpen]),
+  )
+
+  // Cmd+F → 全局搜索
+  useShortcut(
+    'global-search',
+    useCallback(() => setSearchOpen(true), [setSearchOpen]),
+  )
+
+  // Cmd+N → 新建对话/会话（根据当前模式）
+  useShortcut(
+    'new-session',
+    useCallback(() => {
+      if (appMode === 'agent') {
+        createAgent({ draft: true })
+      } else {
+        createChat({ draft: true })
+      }
+    }, [appMode, createAgent, createChat]),
+  )
+
+  // Cmd+B → 切换侧边栏
+  useShortcut(
+    'toggle-sidebar',
+    useCallback(
+      () => setSidebarCollapsed(!sidebarCollapsed),
+      [sidebarCollapsed, setSidebarCollapsed],
+    ),
+  )
+
+  // Cmd+Shift+M → 切换模式
+  useShortcut(
+    'toggle-mode',
+    useCallback(
+      () => setAppMode(appMode === 'chat' ? 'agent' : 'chat'),
+      [appMode, setAppMode],
+    ),
+  )
+
+  // Cmd+K → 清除上下文（通过 CustomEvent 分发到 ChatInput）
+  useShortcut(
+    'clear-context',
+    useCallback(() => {
+      window.dispatchEvent(new CustomEvent('proma:clear-context'))
+    }, []),
+  )
+
+  // Cmd+L → 聚焦输入框（通过 CustomEvent 分发到 ChatInput/AgentView）
+  useShortcut(
+    'focus-input',
+    useCallback(() => {
+      window.dispatchEvent(new CustomEvent('proma:focus-input'))
+    }, []),
+  )
+
+  // Cmd+. → 停止生成（通过 CustomEvent 分发到 ChatView/AgentView）
+  useShortcut(
+    'stop-generation',
+    useCallback(() => {
+      window.dispatchEvent(new CustomEvent('proma:stop-generation'))
+    }, []),
+  )
+
+  return null
+}

--- a/apps/electron/src/renderer/hooks/useShortcut.ts
+++ b/apps/electron/src/renderer/hooks/useShortcut.ts
@@ -1,0 +1,27 @@
+/**
+ * useShortcut — 快捷键 React Hook
+ *
+ * 将快捷键 handler 绑定到 React 组件生命周期。
+ * 组件卸载时自动注销。
+ */
+
+import { useEffect } from 'react'
+import { registerShortcut } from '@/lib/shortcut-registry'
+
+/**
+ * 注册一个快捷键 handler
+ *
+ * @param id - 快捷键 ID（对应 shortcut-defaults.ts 中的定义）
+ * @param callback - 触发时的回调
+ * @param enabled - 是否启用（默认 true）
+ */
+export function useShortcut(
+  id: string,
+  callback: () => void,
+  enabled = true,
+): void {
+  useEffect(() => {
+    if (!enabled) return
+    return registerShortcut(id, callback)
+  }, [id, callback, enabled])
+}

--- a/apps/electron/src/renderer/lib/shortcut-defaults.ts
+++ b/apps/electron/src/renderer/lib/shortcut-defaults.ts
@@ -1,0 +1,128 @@
+/**
+ * 快捷键默认配置
+ *
+ * 定义所有快捷键的 ID、名称、描述、默认绑定和分类。
+ * 这是快捷键系统的基础数据层，由 shortcut-registry 消费。
+ */
+
+// ===== 类型定义 =====
+
+/** 快捷键分类 */
+export type ShortcutCategory = 'app' | 'edit' | 'navigation'
+
+/** 快捷键定义（不可变，内置于代码） */
+export interface ShortcutDefinition {
+  /** 唯一标识（如 'open-settings'） */
+  id: string
+  /** 中文名称 */
+  name: string
+  /** 中文描述 */
+  description: string
+  /** macOS 默认快捷键（如 'Cmd+,'） */
+  defaultMac: string
+  /** Windows 默认快捷键（如 'Ctrl+,'） */
+  defaultWin: string
+  /** 分类 */
+  category: ShortcutCategory
+}
+
+/** 用户自定义快捷键覆盖（持久化到 settings.json） */
+export interface ShortcutOverrides {
+  [shortcutId: string]: {
+    mac?: string
+    win?: string
+  }
+}
+
+// ===== 分类标签 =====
+
+export const SHORTCUT_CATEGORY_LABELS: Record<ShortcutCategory, string> = {
+  app: '应用',
+  edit: '编辑',
+  navigation: '导航',
+}
+
+// ===== 默认快捷键列表 =====
+
+export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
+  // 应用级
+  {
+    id: 'open-settings',
+    name: '打开设置',
+    description: '打开应用设置面板',
+    defaultMac: 'Cmd+,',
+    defaultWin: 'Ctrl+,',
+    category: 'app',
+  },
+  {
+    id: 'new-session',
+    name: '新建对话',
+    description: '根据当前模式创建 Chat 对话或 Agent 会话',
+    defaultMac: 'Cmd+N',
+    defaultWin: 'Ctrl+N',
+    category: 'app',
+  },
+  {
+    id: 'toggle-sidebar',
+    name: '切换侧边栏',
+    description: '显示或隐藏左侧边栏',
+    defaultMac: 'Cmd+B',
+    defaultWin: 'Ctrl+B',
+    category: 'app',
+  },
+  {
+    id: 'toggle-mode',
+    name: '切换模式',
+    description: '在 Chat 和 Agent 模式之间切换',
+    defaultMac: 'Cmd+Shift+M',
+    defaultWin: 'Ctrl+Shift+M',
+    category: 'app',
+  },
+  {
+    id: 'global-search',
+    name: '全局搜索',
+    description: '搜索对话和会话',
+    defaultMac: 'Cmd+F',
+    defaultWin: 'Ctrl+F',
+    category: 'navigation',
+  },
+  {
+    id: 'focus-input',
+    name: '聚焦输入框',
+    description: '快速跳转到输入框',
+    defaultMac: 'Cmd+L',
+    defaultWin: 'Ctrl+L',
+    category: 'navigation',
+  },
+
+  // 编辑级
+  {
+    id: 'clear-context',
+    name: '清除上下文',
+    description: '清除当前对话的上下文',
+    defaultMac: 'Cmd+K',
+    defaultWin: 'Ctrl+K',
+    category: 'edit',
+  },
+  {
+    id: 'stop-generation',
+    name: '停止生成',
+    description: '中断当前 AI 响应',
+    defaultMac: 'Cmd+.',
+    defaultWin: 'Ctrl+.',
+    category: 'edit',
+  },
+  {
+    id: 'close-tab',
+    name: '关闭当前标签',
+    description: '关闭当前活跃的 Chat 或 Agent 标签页',
+    defaultMac: 'Cmd+W',
+    defaultWin: 'Ctrl+W',
+    category: 'app',
+  },
+]
+
+/** 按 ID 索引的快捷键 Map（用于快速查找） */
+export const SHORTCUT_MAP = new Map(
+  DEFAULT_SHORTCUTS.map((s) => [s.id, s]),
+)

--- a/apps/electron/src/renderer/lib/shortcut-registry.ts
+++ b/apps/electron/src/renderer/lib/shortcut-registry.ts
@@ -1,0 +1,224 @@
+/**
+ * 快捷键中央注册表
+ *
+ * 单一全局 keydown listener + Map 分发模式。
+ * 所有快捷键监听集中在一处，避免多个 addEventListener 分散注册。
+ */
+
+import { DEFAULT_SHORTCUTS, SHORTCUT_MAP } from './shortcut-defaults'
+import type { ShortcutOverrides } from './shortcut-defaults'
+
+// ===== 平台检测 =====
+
+const isMac =
+  typeof navigator !== 'undefined' && navigator.userAgent.includes('Mac')
+
+// ===== 注册表状态 =====
+
+/** shortcutId → handler 集合 */
+const handlers = new Map<string, Set<() => void>>()
+
+/** 当前用户自定义配置 */
+let currentOverrides: ShortcutOverrides = {}
+
+/** 是否已初始化 */
+let initialized = false
+
+// ===== 快捷键匹配 =====
+
+interface ParsedAccelerator {
+  cmd: boolean
+  shift: boolean
+  alt: boolean
+  key: string
+}
+
+/**
+ * 解析快捷键字符串为结构化对象
+ *
+ * 支持格式：'Cmd+Shift+M'、'Ctrl+K'、'Cmd+,'
+ */
+function parseAccelerator(accelerator: string): ParsedAccelerator {
+  const parts = accelerator.split('+').map((p) => p.trim())
+  const key = (parts[parts.length - 1] ?? '').toLowerCase()
+  const modifiers = parts.slice(0, -1).map((m) => m.toLowerCase())
+
+  return {
+    cmd:
+      modifiers.includes('cmd') ||
+      modifiers.includes('ctrl') ||
+      modifiers.includes('cmdorctrl'),
+    shift: modifiers.includes('shift'),
+    alt: modifiers.includes('alt') || modifiers.includes('option'),
+    key,
+  }
+}
+
+/**
+ * 检查键盘事件是否匹配解析后的快捷键
+ *
+ * 严格匹配：确保修饰键精确对应，防止 Cmd+K 被 Cmd+Shift+K 误触
+ */
+function matchesParsed(e: KeyboardEvent, parsed: ParsedAccelerator): boolean {
+  // 修饰键匹配
+  const cmdMatch = isMac ? e.metaKey : e.ctrlKey
+  if (parsed.cmd !== cmdMatch) return false
+  if (parsed.shift !== e.shiftKey) return false
+  if (parsed.alt !== e.altKey) return false
+  // macOS 上不应有 Ctrl 被意外按下（除非快捷键要求）
+  if (isMac && !parsed.cmd && e.ctrlKey) return false
+
+  // 按键匹配
+  const eventKey = e.key.toLowerCase()
+  return eventKey === parsed.key
+}
+
+// ===== 预计算加速器缓存 =====
+
+/** 缓存：shortcutId → ParsedAccelerator */
+let parsedCache = new Map<string, ParsedAccelerator>()
+
+/** 重建缓存（配置变更时调用） */
+function rebuildCache(): void {
+  parsedCache = new Map()
+  for (const def of DEFAULT_SHORTCUTS) {
+    const accel = getActiveAccelerator(def.id)
+    parsedCache.set(def.id, parseAccelerator(accel))
+  }
+}
+
+// ===== 核心事件分发 =====
+
+/**
+ * 全局 keydown 事件处理器
+ *
+ * 遍历所有注册的快捷键，匹配后执行对应 handler
+ */
+function dispatchShortcut(e: KeyboardEvent): void {
+  // 忽略输入法组合过程
+  if (e.isComposing) return
+
+  for (const [id, parsed] of parsedCache) {
+    if (matchesParsed(e, parsed)) {
+      const handlerSet = handlers.get(id)
+      if (handlerSet && handlerSet.size > 0) {
+        e.preventDefault()
+        e.stopPropagation()
+        // 执行所有注册的 handler
+        for (const handler of handlerSet) {
+          handler()
+        }
+      }
+      return // 匹配一个即停止
+    }
+  }
+}
+
+// ===== 公开 API =====
+
+/**
+ * 初始化快捷键注册表
+ *
+ * 挂载全局 keydown listener，仅执行一次
+ */
+export function initShortcutRegistry(): void {
+  if (initialized) return
+  initialized = true
+  rebuildCache()
+  window.addEventListener('keydown', dispatchShortcut, true) // capture 阶段
+}
+
+/**
+ * 注册快捷键 handler
+ *
+ * @returns 注销函数
+ */
+export function registerShortcut(
+  id: string,
+  callback: () => void,
+): () => void {
+  if (!handlers.has(id)) {
+    handlers.set(id, new Set())
+  }
+  handlers.get(id)!.add(callback)
+
+  return () => {
+    const set = handlers.get(id)
+    if (set) {
+      set.delete(callback)
+      if (set.size === 0) handlers.delete(id)
+    }
+  }
+}
+
+/**
+ * 更新用户自定义快捷键配置
+ *
+ * 配置变更后自动重建匹配缓存
+ */
+export function updateShortcutOverrides(overrides: ShortcutOverrides): void {
+  currentOverrides = overrides
+  rebuildCache()
+}
+
+/**
+ * 获取某快捷键当前生效的 accelerator 字符串
+ *
+ * 优先使用用户自定义，否则使用默认值
+ */
+export function getActiveAccelerator(id: string): string {
+  const override = currentOverrides[id]
+  if (override) {
+    const customAccel = isMac ? override.mac : override.win
+    if (customAccel) return customAccel
+  }
+  const def = SHORTCUT_MAP.get(id)
+  if (!def) return ''
+  return isMac ? def.defaultMac : def.defaultWin
+}
+
+/**
+ * 获取快捷键的显示文本（用于 UI 展示）
+ *
+ * 将内部格式转换为用户友好的显示：Cmd → ⌘，Shift → ⇧ 等
+ */
+export function getAcceleratorDisplay(accelerator: string): string {
+  if (!accelerator) return ''
+  if (isMac) {
+    return accelerator
+      .replace(/Cmd\+/gi, '⌘')
+      .replace(/Shift\+/gi, '⇧')
+      .replace(/Alt\+/gi, '⌥')
+      .replace(/Ctrl\+/gi, '⌃')
+  }
+  return accelerator
+}
+
+/**
+ * 检查快捷键冲突
+ *
+ * @returns 冲突的快捷键 ID，无冲突返回 null
+ */
+export function checkConflict(
+  accelerator: string,
+  excludeId?: string,
+): string | null {
+  const parsed = parseAccelerator(accelerator)
+  for (const def of DEFAULT_SHORTCUTS) {
+    if (excludeId && def.id === excludeId) continue
+    const existingAccel = getActiveAccelerator(def.id)
+    const existingParsed = parseAccelerator(existingAccel)
+    if (
+      parsed.cmd === existingParsed.cmd &&
+      parsed.shift === existingParsed.shift &&
+      parsed.alt === existingParsed.alt &&
+      parsed.key === existingParsed.key
+    ) {
+      return def.id
+    }
+  }
+  return null
+}
+
+/** 导出平台信息供其他模块使用 */
+export { isMac }

--- a/apps/electron/src/renderer/lib/tips.ts
+++ b/apps/electron/src/renderer/lib/tips.ts
@@ -24,23 +24,34 @@ export function getPlatform(): Platform {
 
 /** 所有 Tips 数据 */
 export const TIPS: Tip[] = [
-  // macOS 专用
-  { id: 'mac-shortcut-new', text: '按 ⌘+N 快速创建新对话', platform: 'mac' },
-  { id: 'mac-shortcut-search', text: '按 ⌘+K 快速搜索历史对话', platform: 'mac' },
-  { id: 'mac-shortcut-settings', text: '按 ⌘+, 打开设置', platform: 'mac' },
+  // macOS 快捷键
+  { id: 'mac-shortcut-new', text: '按 ⌘N 快速创建新对话', platform: 'mac' },
+  { id: 'mac-shortcut-search', text: '按 ⌘F 搜索历史对话', platform: 'mac' },
+  { id: 'mac-shortcut-settings', text: '按 ⌘, 打开设置', platform: 'mac' },
+  { id: 'mac-shortcut-sidebar', text: '按 ⌘B 切换侧边栏显示', platform: 'mac' },
+  { id: 'mac-shortcut-mode', text: '按 ⌘⇧M 快速切换 Chat / Agent 模式', platform: 'mac' },
+  { id: 'mac-shortcut-focus', text: '按 ⌘L 快速跳转到输入框', platform: 'mac' },
+  { id: 'mac-shortcut-clear', text: '按 ⌘K 清除当前对话上下文', platform: 'mac' },
+  { id: 'mac-shortcut-stop', text: '按 ⌘. 中断 AI 响应', platform: 'mac' },
+  { id: 'mac-shortcut-close', text: '按 ⌘W 关闭当前标签页', platform: 'mac' },
 
-  // Windows 专用
+  // Windows 快捷键
   { id: 'win-shortcut-new', text: '按 Ctrl+N 快速创建新对话', platform: 'windows' },
-  { id: 'win-shortcut-search', text: '按 Ctrl+K 快速搜索历史对话', platform: 'windows' },
+  { id: 'win-shortcut-search', text: '按 Ctrl+F 搜索历史对话', platform: 'windows' },
   { id: 'win-shortcut-settings', text: '按 Ctrl+, 打开设置', platform: 'windows' },
+  { id: 'win-shortcut-sidebar', text: '按 Ctrl+B 切换侧边栏显示', platform: 'windows' },
+  { id: 'win-shortcut-mode', text: '按 Ctrl+Shift+M 快速切换 Chat / Agent 模式', platform: 'windows' },
+  { id: 'win-shortcut-focus', text: '按 Ctrl+L 快速跳转到输入框', platform: 'windows' },
+  { id: 'win-shortcut-clear', text: '按 Ctrl+K 清除当前对话上下文', platform: 'windows' },
+  { id: 'win-shortcut-stop', text: '按 Ctrl+. 中断 AI 响应', platform: 'windows' },
+  { id: 'win-shortcut-close', text: '按 Ctrl+W 关闭当前标签页', platform: 'windows' },
 
   // 通用
-  { id: 'tip-thinking', text: '开启思考模式，让 AI 展示推理过程', platform: 'all' },
   { id: 'tip-agent-file', text: 'Agent 模式下输入 @ 可以引用工作区文件', platform: 'all' },
   { id: 'tip-agent-mcp', text: 'Agent 模式下输入 # 可以调用 MCP 工具', platform: 'all' },
   { id: 'tip-agent-skill', text: 'Agent 模式下输入 / 可以使用 Skill', platform: 'all' },
   { id: 'tip-attachment', text: '支持拖拽文件到输入框直接上传附件', platform: 'all' },
-  { id: 'tip-parallel', text: 'Chat 模式支持并排对比多个模型的回答', platform: 'all' },
+  { id: 'tip-shortcuts-custom', text: '在设置 → 快捷键中可以自定义所有快捷键', platform: 'all' },
 ]
 
 /** 获取适用于当前平台的随机 Tip */

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -49,6 +49,7 @@ import { diffCapabilities, migratePermissionMode } from '@proma/shared'
 import type { WorkspaceCapabilities } from '@proma/shared'
 import { showCapabilityChangeToasts } from './lib/capabilities-toast'
 import { UpdateDialog } from './components/settings/UpdateDialog'
+import { GlobalShortcuts } from './components/shortcuts/GlobalShortcuts'
 import './styles/globals.css'
 import 'katex/dist/katex.min.css'
 
@@ -382,6 +383,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     <ChatToolInitializer />
     <UpdaterInitializer />
     <FeishuInitializer />
+    <GlobalShortcuts />
     <App />
     <UpdateDialog />
     <Toaster position="top-right" />

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -6,6 +6,14 @@
 
 import type { EnvironmentCheckResult, PromaPermissionMode, ThinkingConfig, AgentEffort } from '@proma/shared'
 
+/** 用户自定义快捷键覆盖（持久化到 settings.json） */
+export interface ShortcutOverrides {
+  [shortcutId: string]: {
+    mac?: string
+    win?: string
+  }
+}
+
 /** 主题模式 */
 export type ThemeMode = 'light' | 'dark' | 'system'
 
@@ -48,6 +56,8 @@ export interface AppSettings {
   tutorialBannerDismissed?: boolean
   /** 自动归档天数（0 = 禁用，默认 7） */
   archiveAfterDays?: number
+  /** 用户自定义快捷键覆盖 */
+  shortcutOverrides?: ShortcutOverrides
 }
 
 /** 持久化的标签页状态 */


### PR DESCRIPTION
## Summary

- 实现集中式快捷键系统，替代原有分散的 `addEventListener` 方式，采用单一全局 `keydown` listener + Map 分发模式
- 支持 9 个快捷键（⌘, / ⌘F / ⌘N / ⌘B / ⌘⇧M / ⌘K / ⌘L / ⌘. / ⌘W），涵盖设置、搜索、新建、侧边栏、模式切换、清除上下文、聚焦输入、停止生成、关闭标签
- 新增快捷键设置面板，支持按键录制自定义、冲突检测和恢复默认，配置持久化到 settings.json
- ⌘W 通过 Electron 菜单拦截 + IPC 转发实现关闭当前标签页（而非关闭窗口）
- 迁移现有 ⌘F / ⌘K 到统一系统，修正并完善 tips.ts 快捷键提示内容

## Test plan
- [ ] 逐个测试 9 个快捷键在 Chat 和 Agent 模式下的行为
- [ ] 打开设置 → 快捷键 tab，自定义一个快捷键，验证冲突检测和持久化
- [ ] 验证 ⌘W 关闭标签后自动切换到相邻标签
- [ ] 运行 `bun run typecheck` 确认类型检查通过