### PR TITLE
feat: 全局快捷键系统 + Option+Space 快速任务窗口

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -24,8 +24,15 @@ import { startChatToolsWatcher, stopChatToolsWatcher } from './lib/chat-tools-wa
 import { getIsQuitting, setQuitting } from './lib/app-lifecycle'
 import { feishuBridge } from './lib/feishu-bridge'
 import { getFeishuConfig } from './lib/feishu-config'
+import { createQuickTaskWindow, toggleQuickTaskWindow, destroyQuickTaskWindow } from './lib/quick-task-window'
+import { registerGlobalShortcut, unregisterAllGlobalShortcuts } from './lib/global-shortcut-service'
 
 let mainWindow: BrowserWindow | null = null
+
+/** 获取主窗口实例（供其他模块使用） */
+export function getMainWindow(): BrowserWindow | null {
+  return mainWindow
+}
 
 /**
  * 检查窗口是否在可用显示器范围内
@@ -203,6 +210,13 @@ app.whenReady().then(async () => {
     initAutoUpdater(mainWindow)
   }
 
+  // 预创建快速任务窗口（隐藏状态，首次唤起秒开）
+  createQuickTaskWindow()
+
+  // 注册全局快捷键
+  registerGlobalShortcut('quick-task', toggleQuickTaskWindow)
+  registerGlobalShortcut('show-main-window', showAndFocusMainWindow)
+
   // 飞书 Bridge 自动启动（配置启用时）
   const feishuConfig = getFeishuConfig()
   if (feishuConfig.enabled && feishuConfig.appId && feishuConfig.appSecret) {
@@ -245,6 +259,10 @@ app.on('before-quit', () => {
   stopChatToolsWatcher()
   // 停止飞书 Bridge
   feishuBridge.stop()
+  // 注销全局快捷键
+  unregisterAllGlobalShortcuts()
+  // 销毁快速任务窗口
+  destroyQuickTaskWindow()
   // Clean up system tray before quitting
   destroyTray()
 })

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -6,7 +6,8 @@
 
 import { ipcMain, nativeTheme, shell, dialog, BrowserWindow } from 'electron'
 import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, MEMORY_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS } from '@proma/shared'
-import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS } from '../types'
+import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS, QUICK_TASK_IPC_CHANNELS } from '../types'
+import type { QuickTaskSubmitInput } from '../types'
 import type {
   RuntimeStatus,
   GitRepoStatus,
@@ -1843,4 +1844,46 @@ export function registerIpcHandlers(): void {
 
   runAutoArchive()
   setInterval(runAutoArchive, 24 * 60 * 60 * 1000)
+
+  // ===== 快速任务窗口 =====
+
+  // 提交快速任务 → 隐藏窗口 + 转发到主窗口（由渲染进程创建会话并发送消息）
+  ipcMain.handle(
+    QUICK_TASK_IPC_CHANNELS.SUBMIT,
+    async (_, input: QuickTaskSubmitInput): Promise<void> => {
+      const { hideQuickTaskWindow } = await import('./lib/quick-task-window')
+      const { getMainWindow } = await import('./index')
+      hideQuickTaskWindow()
+
+      const mainWin = getMainWindow()
+      if (mainWin && !mainWin.isDestroyed()) {
+        // 转发到主窗口渲染进程，由 GlobalShortcuts 创建会话并触发发送
+        mainWin.webContents.send('quick-task:open-session', {
+          mode: input.mode,
+          text: input.text,
+          files: input.files,
+        })
+        mainWin.show()
+        mainWin.focus()
+      }
+    }
+  )
+
+  // 隐藏快速任务窗口
+  ipcMain.handle(
+    QUICK_TASK_IPC_CHANNELS.HIDE,
+    async (): Promise<void> => {
+      const { hideQuickTaskWindow } = await import('./lib/quick-task-window')
+      hideQuickTaskWindow()
+    }
+  )
+
+  // 重新注册全局快捷键（设置中修改快捷键后调用）
+  ipcMain.handle(
+    QUICK_TASK_IPC_CHANNELS.REREGISTER_GLOBAL_SHORTCUTS,
+    async (): Promise<Record<string, boolean>> => {
+      const { reregisterAllGlobalShortcuts } = await import('./lib/global-shortcut-service')
+      return reregisterAllGlobalShortcuts()
+    }
+  )
 }

--- a/apps/electron/src/main/lib/global-shortcut-service.ts
+++ b/apps/electron/src/main/lib/global-shortcut-service.ts
@@ -1,0 +1,131 @@
+/**
+ * 全局快捷键服务（主进程）
+ *
+ * 使用 Electron globalShortcut API 注册系统级快捷键。
+ * 全局快捷键在应用不在前台时也能触发。
+ *
+ * 与渲染进程的 shortcut-registry 完全独立：
+ * - 渲染进程：keydown listener，仅应用内生效
+ * - 主进程：globalShortcut.register，系统级生效
+ */
+
+import { globalShortcut } from 'electron'
+import { getSettings } from './settings-service'
+
+/** 全局快捷键 ID → 回调映射 */
+const globalCallbacks = new Map<string, () => void>()
+
+/** 当前注册的 accelerator → 快捷键 ID 映射（用于注销） */
+const registeredAccelerators = new Map<string, string>()
+
+/** 默认全局快捷键配置 */
+const GLOBAL_SHORTCUT_DEFAULTS: Record<string, { mac: string; win: string }> = {
+  'quick-task': { mac: 'Alt+Space', win: 'Alt+Space' },
+  'show-main-window': { mac: 'CommandOrControl+Shift+P', win: 'CommandOrControl+Shift+P' },
+}
+
+const isMac = process.platform === 'darwin'
+
+/**
+ * 获取某全局快捷键当前生效的 Electron accelerator 字符串
+ *
+ * 优先使用用户自定义，否则使用默认值。
+ * 将 Cmd/Ctrl 统一转为 Electron 的 CommandOrControl。
+ */
+function getGlobalAccelerator(id: string): string {
+  const settings = getSettings()
+  const override = settings.shortcutOverrides?.[id]
+
+  let accelerator: string
+  if (override) {
+    const customAccel = isMac ? override.mac : override.win
+    if (customAccel) {
+      accelerator = customAccel
+    } else {
+      const def = GLOBAL_SHORTCUT_DEFAULTS[id]
+      accelerator = def ? (isMac ? def.mac : def.win) : ''
+    }
+  } else {
+    const def = GLOBAL_SHORTCUT_DEFAULTS[id]
+    accelerator = def ? (isMac ? def.mac : def.win) : ''
+  }
+
+  // 转换为 Electron 标准格式
+  return accelerator
+    .replace(/Cmd\+/gi, 'CommandOrControl+')
+    .replace(/Ctrl\+/gi, 'CommandOrControl+')
+}
+
+/**
+ * 注册单个全局快捷键
+ *
+ * @returns 是否注册成功（可能被系统占用）
+ */
+function registerOne(id: string): boolean {
+  const callback = globalCallbacks.get(id)
+  if (!callback) return false
+
+  const accelerator = getGlobalAccelerator(id)
+  if (!accelerator) return false
+
+  try {
+    const success = globalShortcut.register(accelerator, callback)
+    if (success) {
+      registeredAccelerators.set(accelerator, id)
+      console.log(`[全局快捷键] 注册成功: ${id} → ${accelerator}`)
+    } else {
+      console.warn(`[全局快捷键] 注册失败（可能被占用）: ${id} → ${accelerator}`)
+    }
+    return success
+  } catch (err) {
+    console.error(`[全局快捷键] 注册异常: ${id} → ${accelerator}`, err)
+    return false
+  }
+}
+
+/**
+ * 注册全局快捷键回调
+ *
+ * 在 app.whenReady() 后调用。设置回调函数并尝试注册。
+ */
+export function registerGlobalShortcut(id: string, callback: () => void): boolean {
+  globalCallbacks.set(id, callback)
+  return registerOne(id)
+}
+
+/**
+ * 重新注册所有全局快捷键
+ *
+ * 用户在设置中修改全局快捷键后调用。
+ * 先注销所有已注册的，再重新注册。
+ */
+export function reregisterAllGlobalShortcuts(): Record<string, boolean> {
+  // 注销所有已注册的
+  for (const accelerator of registeredAccelerators.keys()) {
+    try {
+      globalShortcut.unregister(accelerator)
+    } catch {
+      // 忽略注销错误
+    }
+  }
+  registeredAccelerators.clear()
+
+  // 重新注册所有有回调的快捷键
+  const results: Record<string, boolean> = {}
+  for (const id of globalCallbacks.keys()) {
+    results[id] = registerOne(id)
+  }
+  return results
+}
+
+/**
+ * 注销所有全局快捷键
+ *
+ * 在 app.will-quit / before-quit 时调用。
+ */
+export function unregisterAllGlobalShortcuts(): void {
+  globalShortcut.unregisterAll()
+  registeredAccelerators.clear()
+  globalCallbacks.clear()
+  console.log('[全局快捷键] 已注销所有')
+}

--- a/apps/electron/src/main/lib/quick-task-window.ts
+++ b/apps/electron/src/main/lib/quick-task-window.ts
@@ -1,0 +1,145 @@
+/**
+ * 快速任务窗口管理
+ *
+ * 预创建隐藏窗口，通过全局快捷键唤起。
+ * 无边框 + 透明 + 置顶，失焦自动隐藏。
+ */
+
+import { BrowserWindow, screen } from 'electron'
+import { join } from 'path'
+import { app } from 'electron'
+
+/** 快速任务窗口单例 */
+let quickTaskWindow: BrowserWindow | null = null
+
+/** 窗口宽高 */
+const WINDOW_WIDTH = 680
+const WINDOW_HEIGHT = 320
+
+/**
+ * 预创建快速任务窗口（隐藏状态）
+ *
+ * 在 app.whenReady() 中调用，避免首次唤起时的创建延迟。
+ */
+export function createQuickTaskWindow(): void {
+  if (quickTaskWindow && !quickTaskWindow.isDestroyed()) return
+
+  quickTaskWindow = new BrowserWindow({
+    width: WINDOW_WIDTH,
+    height: WINDOW_HEIGHT,
+    frame: false,
+    transparent: true,
+    alwaysOnTop: true,
+    skipTaskbar: true,
+    resizable: false,
+    movable: false,
+    minimizable: false,
+    maximizable: false,
+    fullscreenable: false,
+    show: false,
+    hasShadow: true,
+    webPreferences: {
+      preload: join(__dirname, 'preload.cjs'),
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  })
+
+  // 加载渲染进程（附带 query 参数区分窗口类型）
+  const isDev = !app.isPackaged
+  if (isDev) {
+    quickTaskWindow.loadURL('http://localhost:5173?window=quick-task')
+  } else {
+    quickTaskWindow.loadFile(join(__dirname, 'renderer', 'index.html'), {
+      query: { window: 'quick-task' },
+    })
+  }
+
+  // 失焦自动隐藏
+  quickTaskWindow.on('blur', () => {
+    if (quickTaskWindow && !quickTaskWindow.isDestroyed()) {
+      quickTaskWindow.hide()
+    }
+  })
+
+  quickTaskWindow.on('closed', () => {
+    quickTaskWindow = null
+  })
+
+  console.log('[快速任务窗口] 预创建完成')
+}
+
+/**
+ * 切换快速任务窗口显示/隐藏
+ *
+ * 窗口居中于鼠标所在显示器的上方 25% 位置。
+ */
+export function toggleQuickTaskWindow(): void {
+  if (!quickTaskWindow || quickTaskWindow.isDestroyed()) {
+    createQuickTaskWindow()
+    // 窗口 ready 后再显示
+    quickTaskWindow?.once('ready-to-show', () => {
+      positionAndShow()
+    })
+    return
+  }
+
+  if (quickTaskWindow.isVisible()) {
+    quickTaskWindow.hide()
+  } else {
+    positionAndShow()
+  }
+}
+
+/** 定位到鼠标所在显示器并显示 */
+function positionAndShow(): void {
+  if (!quickTaskWindow || quickTaskWindow.isDestroyed()) return
+
+  // 获取鼠标所在的显示器
+  const cursorPoint = screen.getCursorScreenPoint()
+  const display = screen.getDisplayNearestPoint(cursorPoint)
+  const { x, y, width, height } = display.workArea
+
+  // 居中水平，垂直方向位于屏幕上方 25%
+  const posX = Math.round(x + (width - WINDOW_WIDTH) / 2)
+  const posY = Math.round(y + height * 0.25)
+
+  quickTaskWindow.setBounds({
+    x: posX,
+    y: posY,
+    width: WINDOW_WIDTH,
+    height: WINDOW_HEIGHT,
+  })
+
+  quickTaskWindow.show()
+  quickTaskWindow.focus()
+
+  // 通知渲染进程聚焦输入框
+  quickTaskWindow.webContents.send('quick-task:focus')
+}
+
+/**
+ * 隐藏快速任务窗口
+ */
+export function hideQuickTaskWindow(): void {
+  if (quickTaskWindow && !quickTaskWindow.isDestroyed() && quickTaskWindow.isVisible()) {
+    quickTaskWindow.hide()
+  }
+}
+
+/**
+ * 获取快速任务窗口实例（用于 IPC 注册）
+ */
+export function getQuickTaskWindow(): BrowserWindow | null {
+  return quickTaskWindow
+}
+
+/**
+ * 销毁快速任务窗口（应用退出时调用）
+ */
+export function destroyQuickTaskWindow(): void {
+  if (quickTaskWindow && !quickTaskWindow.isDestroyed()) {
+    quickTaskWindow.destroy()
+    quickTaskWindow = null
+  }
+}

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -87,7 +87,8 @@ import type {
   AgentQueueMessageInput,
   PendingRequestsSnapshot,
 } from '@proma/shared'
-import type { UserProfile, AppSettings } from '../types'
+import type { UserProfile, AppSettings, QuickTaskSubmitInput, QuickTaskOpenSessionData } from '../types'
+import { QUICK_TASK_IPC_CHANNELS } from '../types'
 
 /**
  * 暴露给渲染进程的 API 接口定义
@@ -610,6 +611,19 @@ export interface ElectronAPI {
   onFeishuNotificationSent: (callback: (payload: FeishuNotificationSentPayload) => void) => () => void
   /** 订阅菜单关闭标签页事件（Cmd+W 被菜单拦截后转发） */
   onMenuCloseTab: (callback: () => void) => () => void
+
+  // ===== 快速任务窗口 =====
+
+  /** 提交快速任务 */
+  submitQuickTask: (input: QuickTaskSubmitInput) => Promise<void>
+  /** 隐藏快速任务窗口 */
+  hideQuickTask: () => Promise<void>
+  /** 重新注册全局快捷键（设置变更后） */
+  reregisterGlobalShortcuts: () => Promise<Record<string, boolean>>
+  /** 订阅快速任务窗口聚焦事件 */
+  onQuickTaskFocus: (callback: () => void) => () => void
+  /** 订阅快速任务打开会话事件（主窗口接收，由渲染进程负责创建会话） */
+  onQuickTaskOpenSession: (callback: (data: QuickTaskOpenSessionData) => void) => () => void
 }
 
 /**
@@ -1305,6 +1319,32 @@ const electronAPI: ElectronAPI = {
     const listener = (): void => callback()
     ipcRenderer.on('menu:close-tab', listener)
     return () => { ipcRenderer.removeListener('menu:close-tab', listener) }
+  },
+
+  // ===== 快速任务窗口 =====
+
+  submitQuickTask: (input: QuickTaskSubmitInput) => {
+    return ipcRenderer.invoke(QUICK_TASK_IPC_CHANNELS.SUBMIT, input)
+  },
+
+  hideQuickTask: () => {
+    return ipcRenderer.invoke(QUICK_TASK_IPC_CHANNELS.HIDE)
+  },
+
+  reregisterGlobalShortcuts: () => {
+    return ipcRenderer.invoke(QUICK_TASK_IPC_CHANNELS.REREGISTER_GLOBAL_SHORTCUTS)
+  },
+
+  onQuickTaskFocus: (callback: () => void) => {
+    const listener = (): void => callback()
+    ipcRenderer.on(QUICK_TASK_IPC_CHANNELS.FOCUS, listener)
+    return () => { ipcRenderer.removeListener(QUICK_TASK_IPC_CHANNELS.FOCUS, listener) }
+  },
+
+  onQuickTaskOpenSession: (callback: (data: QuickTaskOpenSessionData) => void) => {
+    const listener = (_: unknown, data: QuickTaskOpenSessionData): void => callback(data)
+    ipcRenderer.on('quick-task:open-session', listener)
+    return () => { ipcRenderer.removeListener('quick-task:open-session', listener) }
   },
 }
 

--- a/apps/electron/src/renderer/atoms/chat-atoms.ts
+++ b/apps/electron/src/renderer/atoms/chat-atoms.ts
@@ -212,6 +212,19 @@ export const currentConversationDraftAtom = atom(
   }
 )
 
+// ===== 快速任务待发送消息 =====
+
+/** Chat 模式待发送消息（从快速任务窗口注入） */
+export interface ChatPendingMessage {
+  conversationId: string
+  message: string
+  /** 已保存的附件（从快速任务窗口传入时已通过 IPC 保存到磁盘） */
+  attachments?: FileAttachment[]
+}
+
+/** 快速任务窗口提交后写入，ChatView 检测到后自动发送并清除 */
+export const chatPendingMessageAtom = atom<ChatPendingMessage | null>(null)
+
 /**
  * Chat 消息刷新版本 Map — 以 conversationId 为 key
  * 全局监听器在流式完成/错误时递增版本号，

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -237,8 +237,12 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const refreshMap = useAtomValue(agentMessageRefreshAtom)
   const refreshVersion = refreshMap.get(sessionId) ?? 0
 
+  // 消息是否已完成首次加载（用于 auto-send 等待）
+  const [messagesLoaded, setMessagesLoaded] = React.useState(false)
+
   // 加载当前会话消息
   React.useEffect(() => {
+    setMessagesLoaded(false)
     // 并行加载旧格式（用于 Team 数据重建）和新格式（用于 UI 渲染）
     const loadOldMessages = window.electronAPI.getAgentSessionMessages(sessionId)
     const loadSDKMessages = window.electronAPI.getAgentSessionSDKMessages(sessionId)
@@ -247,6 +251,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       .then(([msgs, sdkMsgs]) => {
         setMessages(msgs)
         setPersistedSDKMessages(sdkMsgs)
+        setMessagesLoaded(true)
 
         // 消息加载完成后，同步清除流式状态和实时消息，
         // 确保 React 在一次渲染中同时显示持久化消息并移除流式气泡/实时消息，
@@ -290,18 +295,25 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     })
   }, [sessionId, sessions, setAttachedDirsMap])
 
-  // 自动发送 pending prompt（从设置页"对话完成配置"触发）
+  // 自动发送 pending prompt（从快速任务窗口或设置页触发）
+  // 等待 messagesLoaded 确保消息加载完成后再插入乐观消息，避免被加载结果覆盖。
+  // 使用 queueMicrotask 延迟发送：避免 setState → 重渲染 → cleanup 取消 timer 的竞态。
   React.useEffect(() => {
+    if (!messagesLoaded) return
     if (!pendingPrompt) return
     if (pendingPrompt.sessionId !== sessionId) return
     if (!agentChannelId || streaming) return
 
-    // 立即清除，防止重复执行
-    const prompt = pendingPrompt
+    // 快照当前上下文
+    const snapshot = {
+      message: pendingPrompt.message,
+      channelId: agentChannelId,
+      modelId: agentModelId || undefined,
+      workspaceId: currentWorkspaceId || undefined,
+    }
     setPendingPrompt(null)
 
-    // 短延时确保 IPC 订阅已就绪
-    const timer = setTimeout(() => {
+    queueMicrotask(() => {
       // 初始化流式状态
       setStreamingStates((prev) => {
         const map = new Map(prev)
@@ -310,7 +322,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           content: '',
           toolActivities: [],
           teammates: [],
-          model: agentModelId || undefined,
+          model: snapshot.modelId,
           startedAt: Date.now(),
         })
         return map
@@ -320,7 +332,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       const tempUserMsg: AgentMessage = {
         id: `temp-${Date.now()}`,
         role: 'user',
-        content: prompt.message,
+        content: snapshot.message,
         createdAt: Date.now(),
       }
       setMessages((prev) => [...prev, tempUserMsg])
@@ -329,7 +341,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       const tempUserSDKMsg: SDKMessage = {
         type: 'user',
         message: {
-          content: [{ type: 'text', text: prompt.message }],
+          content: [{ type: 'text', text: snapshot.message }],
         },
         parent_tool_use_id: null,
         _createdAt: Date.now(),
@@ -339,10 +351,10 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       // 发送消息
       const input: AgentSendInput = {
         sessionId,
-        userMessage: prompt.message,
-        channelId: agentChannelId,
-        modelId: agentModelId || undefined,
-        workspaceId: currentWorkspaceId || undefined,
+        userMessage: snapshot.message,
+        channelId: snapshot.channelId,
+        modelId: snapshot.modelId,
+        workspaceId: snapshot.workspaceId,
       }
       window.electronAPI.sendAgentMessage(input).catch((error) => {
         console.error('[AgentView] 自动发送配置消息失败:', error)
@@ -352,10 +364,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           return map
         })
       })
-    }, 150)
-
-    return () => clearTimeout(timer)
-  }, [pendingPrompt, sessionId, agentChannelId, agentModelId, currentWorkspaceId, streaming, setPendingPrompt, setStreamingStates])
+    })
+  }, [messagesLoaded, pendingPrompt, sessionId, agentChannelId, agentModelId, currentWorkspaceId, streaming, setPendingPrompt, setStreamingStates])
 
   // ===== 附件处理 =====
 

--- a/apps/electron/src/renderer/components/chat/ChatView.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatView.tsx
@@ -29,9 +29,10 @@ import {
   chatMessageRefreshAtom,
   pendingAgentRecommendationAtom,
   conversationModelsAtom,
+  chatPendingMessageAtom,
   INITIAL_MESSAGE_LIMIT,
 } from '@/atoms/chat-atoms'
-import type { PendingAttachment } from '@/atoms/chat-atoms'
+import type { PendingAttachment, ChatPendingMessage } from '@/atoms/chat-atoms'
 import { promptConfigAtom, promptSidebarOpenAtom, conversationPromptIdAtom, resolveSystemMessage, selectedPromptIdAtom } from '@/atoms/system-prompt-atoms'
 import { activeToolIdsAtom } from '@/atoms/chat-tool-atoms'
 import { userProfileAtom } from '@/atoms/user-profile'
@@ -92,6 +93,19 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
   const promptSidebarOpen = useAtomValue(promptSidebarOpenAtom)
   const activeToolIds = useAtomValue(activeToolIdsAtom)
   const setPendingRecommendation = useSetAtom(pendingAgentRecommendationAtom)
+  const [chatPendingMessage, setChatPendingMessage] = React.useState<ChatPendingMessage | null>(null)
+
+  // 从全局 atom 读取快速任务待发送消息
+  const globalChatPending = useAtomValue(chatPendingMessageAtom)
+  const setGlobalChatPending = useSetAtom(chatPendingMessageAtom)
+
+  // 检测到当前对话的待发送消息时，捕获到本地状态
+  React.useEffect(() => {
+    if (!globalChatPending) return
+    if (globalChatPending.conversationId !== conversationId) return
+    setChatPendingMessage(globalChatPending)
+    setGlobalChatPending(null)
+  }, [globalChatPending, conversationId, setGlobalChatPending])
 
   // ===== 从 Map 派生当前对话状态 =====
   const conversation = conversations.find((c) => c.id === conversationId) ?? null
@@ -328,6 +342,26 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
     setChatStreamErrors,
     setStreamingStates,
   ])
+
+  // ===== 自动发送快速任务消息 =====
+  // 使用 queueMicrotask 延迟发送：microtask 在当前任务结束后、React 下一次渲染前执行，
+  // 避免 setState → 重渲染 → cleanup 取消 timer 的竞态。
+  React.useEffect(() => {
+    if (!chatPendingMessage) return
+    if (chatPendingMessage.conversationId !== conversationId) return
+    if (!selectedModel || isStreaming) return
+
+    const pending = chatPendingMessage
+    setChatPendingMessage(null)
+
+    queueMicrotask(() => {
+      handleSend(pending.message, {
+        consumePendingAttachments: false,
+        messageCountBeforeSend: 0,
+        attachments: pending.attachments,
+      })
+    })
+  }, [chatPendingMessage, conversationId, selectedModel, isStreaming, handleSend])
 
   /** 从某条消息起截断（包含该条） */
   const truncateFromMessage = React.useCallback(async (

--- a/apps/electron/src/renderer/components/quick-task/QuickTaskApp.tsx
+++ b/apps/electron/src/renderer/components/quick-task/QuickTaskApp.tsx
@@ -1,0 +1,434 @@
+/**
+ * QuickTaskApp — 快速任务窗口根组件
+ *
+ * 当 URL 含 ?window=quick-task 时渲染此组件（替代主 App）。
+ * 轻量级独立窗口：多行输入 + 附件粘贴 + 模式切换 + 默认模型展示。
+ */
+
+import React, { useState, useRef, useEffect, useCallback } from 'react'
+import { fileToBase64 } from '@/lib/file-utils'
+
+/** 任务模式 */
+type TaskMode = 'chat' | 'agent'
+
+/** 待上传附件（仅在快速任务窗口内使用） */
+interface QuickAttachment {
+  id: string
+  filename: string
+  mediaType: string
+  base64: string
+  size: number
+  previewUrl?: string
+}
+
+/** 模型展示信息 */
+interface ModelInfo {
+  channelName: string
+  modelId: string
+}
+
+export function QuickTaskApp(): React.ReactElement {
+  const [mode, setMode] = useState<TaskMode>('agent')
+  const [text, setText] = useState('')
+  const [attachments, setAttachments] = useState<QuickAttachment[]>([])
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [modelInfo, setModelInfo] = useState<ModelInfo | null>(null)
+  const [isDragOver, setIsDragOver] = useState(false)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  // 设置透明背景
+  useEffect(() => {
+    document.body.style.background = 'transparent'
+    document.documentElement.style.background = 'transparent'
+  }, [])
+
+  // 加载默认模型信息
+  useEffect(() => {
+    loadModelInfo()
+  }, [mode])
+
+  async function loadModelInfo(): Promise<void> {
+    try {
+      const [settings, channels] = await Promise.all([
+        window.electronAPI.getSettings(),
+        window.electronAPI.listChannels(),
+      ])
+
+      if (mode === 'agent') {
+        const channelId = settings.agentChannelId
+        const modelId = settings.agentModelId
+        if (channelId && modelId) {
+          const channel = channels.find((c) => c.id === channelId)
+          if (channel) {
+            setModelInfo({ channelName: channel.name, modelId })
+            return
+          }
+        }
+      } else {
+        // Chat 模式读取 localStorage 中的 selectedModel
+        const raw = localStorage.getItem('proma-selected-model')
+        if (raw) {
+          try {
+            const selected = JSON.parse(raw) as { channelId: string; modelId: string }
+            const channel = channels.find((c) => c.id === selected.channelId)
+            if (channel) {
+              setModelInfo({ channelName: channel.name, modelId: selected.modelId })
+              return
+            }
+          } catch { /* 忽略解析错误 */ }
+        }
+      }
+      setModelInfo(null)
+    } catch {
+      setModelInfo(null)
+    }
+  }
+
+  // 聚焦输入框
+  const focusInput = useCallback(() => {
+    requestAnimationFrame(() => {
+      textareaRef.current?.focus()
+    })
+  }, [])
+
+  // 监听主进程的聚焦通知（窗口每次显示时）
+  useEffect(() => {
+    const cleanup = window.electronAPI.onQuickTaskFocus(() => {
+      setText('')
+      setAttachments([])
+      focusInput()
+      loadModelInfo()
+    })
+    return cleanup
+  }, [focusInput])
+
+  // 初始聚焦
+  useEffect(() => {
+    focusInput()
+  }, [focusInput])
+
+  // 自动调整 textarea 高度
+  useEffect(() => {
+    const el = textareaRef.current
+    if (!el) return
+    el.style.height = 'auto'
+    el.style.height = `${Math.min(el.scrollHeight, 160)}px`
+  }, [text])
+
+  // 全局键盘事件
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        window.electronAPI.hideQuickTask()
+        return
+      }
+
+      const isMac = navigator.userAgent.includes('Mac')
+      const mod = isMac ? e.metaKey : e.ctrlKey
+
+      if (mod && e.key === '1') {
+        e.preventDefault()
+        setMode('chat')
+        return
+      }
+      if (mod && e.key === '2') {
+        e.preventDefault()
+        setMode('agent')
+        return
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [])
+
+  // 添加文件为附件
+  const addFiles = useCallback(async (files: File[]) => {
+    const newAttachments: QuickAttachment[] = []
+    for (const file of files) {
+      try {
+        const base64 = await fileToBase64(file)
+        const previewUrl = file.type.startsWith('image/')
+          ? URL.createObjectURL(file)
+          : undefined
+        newAttachments.push({
+          id: crypto.randomUUID(),
+          filename: file.name,
+          mediaType: file.type || 'application/octet-stream',
+          base64,
+          size: file.size,
+          previewUrl,
+        })
+      } catch (err) {
+        console.error('[快速任务] 读取文件失败:', err)
+      }
+    }
+    if (newAttachments.length > 0) {
+      setAttachments((prev) => [...prev, ...newAttachments])
+    }
+  }, [])
+
+  // 移除附件
+  const removeAttachment = useCallback((id: string) => {
+    setAttachments((prev) => {
+      const item = prev.find((a) => a.id === id)
+      if (item?.previewUrl) URL.revokeObjectURL(item.previewUrl)
+      return prev.filter((a) => a.id !== id)
+    })
+  }, [])
+
+  // 粘贴事件
+  const handlePaste = useCallback((e: React.ClipboardEvent) => {
+    const files = Array.from(e.clipboardData.files)
+    if (files.length > 0) {
+      e.preventDefault()
+      addFiles(files)
+    }
+  }, [addFiles])
+
+  // 拖拽事件
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    setIsDragOver(true)
+  }, [])
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    setIsDragOver(false)
+  }, [])
+
+  const handleDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    setIsDragOver(false)
+    const files = Array.from(e.dataTransfer.files)
+    if (files.length > 0) addFiles(files)
+  }, [addFiles])
+
+  // 文件选择
+  const handleFileSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files ?? [])
+    if (files.length > 0) addFiles(files)
+    e.target.value = '' // 允许重复选择同一文件
+  }, [addFiles])
+
+  // 提交任务
+  const handleSubmit = useCallback(async () => {
+    const trimmed = text.trim()
+    if ((!trimmed && attachments.length === 0) || isSubmitting) return
+
+    setIsSubmitting(true)
+    try {
+      await window.electronAPI.submitQuickTask({
+        text: trimmed,
+        mode,
+        files: attachments.map(({ filename, mediaType, base64, size }) => ({
+          filename, mediaType, base64, size,
+        })),
+      })
+      setText('')
+      setAttachments([])
+    } catch (err) {
+      console.error('[快速任务] 提交失败:', err)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }, [text, mode, attachments, isSubmitting])
+
+  // Enter 提交，Shift+Enter 换行
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+      e.preventDefault()
+      handleSubmit()
+    }
+  }, [handleSubmit])
+
+  const hasContent = text.trim().length > 0 || attachments.length > 0
+
+  return (
+    <div
+      className="flex h-screen w-screen items-start justify-center p-3 bg-transparent"
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
+      <div className={`quick-task-container flex w-full flex-col rounded-2xl bg-background shadow-2xl transition-colors ${isDragOver ? 'ring-2 ring-primary/50' : ''}`}>
+        {/* 顶栏：模式切换 + 模型信息 */}
+        <div className="flex items-center justify-between px-4 pt-3 pb-1">
+          <div className="flex items-center gap-2">
+            {/* 模式切换器 */}
+            <div className="flex gap-0.5 rounded-lg bg-muted/60 p-0.5">
+              <button
+                type="button"
+                className={`rounded-md px-2.5 py-1 text-xs font-medium transition-all ${
+                  mode === 'chat'
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+                onClick={() => setMode('chat')}
+              >
+                Chat
+              </button>
+              <button
+                type="button"
+                className={`rounded-md px-2.5 py-1 text-xs font-medium transition-all ${
+                  mode === 'agent'
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+                onClick={() => setMode('agent')}
+              >
+                Agent
+              </button>
+            </div>
+
+            {/* 模型信息 */}
+            {modelInfo && (
+              <span className="text-[11px] text-muted-foreground/70 truncate max-w-[280px]">
+                {modelInfo.channelName} / {modelInfo.modelId}
+              </span>
+            )}
+          </div>
+
+          {/* 快捷键提示 */}
+          <div className="flex items-center gap-2 text-[10px] text-muted-foreground/40">
+            <span>⌘1 Chat</span>
+            <span>⌘2 Agent</span>
+            <span>Esc 关闭</span>
+          </div>
+        </div>
+
+        {/* 输入区域 */}
+        <div className="flex-1 px-4 py-2">
+          <textarea
+            ref={textareaRef}
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            onKeyDown={handleKeyDown}
+            onPaste={handlePaste}
+            placeholder={mode === 'agent' ? '向 Proma 描述你的任务，Enter 发送...' : '向 Proma 发送消息，Enter 发送...'}
+            className="w-full resize-none bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/50 leading-relaxed"
+            style={{ minHeight: '60px', maxHeight: '160px' }}
+            disabled={isSubmitting}
+            rows={3}
+          />
+        </div>
+
+        {/* 附件预览区 */}
+        {attachments.length > 0 && (
+          <div className="flex flex-wrap gap-2 px-4 pb-2">
+            {attachments.map((att) => (
+              <AttachmentChip
+                key={att.id}
+                filename={att.filename}
+                mediaType={att.mediaType}
+                previewUrl={att.previewUrl}
+                onRemove={() => removeAttachment(att.id)}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* 底栏：附件按钮 + 发送 */}
+        <div className="flex items-center justify-between px-4 pb-3 pt-1">
+          <div className="flex items-center gap-1">
+            {/* 附件按钮 */}
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="flex items-center gap-1.5 rounded-lg px-2 py-1 text-xs text-muted-foreground hover:bg-muted/60 hover:text-foreground transition-colors"
+              title="添加附件"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48" />
+              </svg>
+              附件
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              onChange={handleFileSelect}
+              className="hidden"
+            />
+
+            {/* 拖拽/粘贴提示 */}
+            <span className="text-[10px] text-muted-foreground/30 ml-1">
+              支持粘贴或拖拽文件
+            </span>
+          </div>
+
+          {/* 发送按钮 */}
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!hasContent || isSubmitting}
+            className="flex items-center gap-1.5 rounded-lg bg-primary px-3.5 py-1.5 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-30 disabled:cursor-not-allowed"
+          >
+            {isSubmitting ? (
+              <span className="inline-block size-3 animate-spin rounded-full border-2 border-primary-foreground/30 border-t-primary-foreground" />
+            ) : (
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M5 12h14" />
+                <path d="m12 5 7 7-7 7" />
+              </svg>
+            )}
+            发送
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ===== 附件小标签 =====
+
+interface AttachmentChipProps {
+  filename: string
+  mediaType: string
+  previewUrl?: string
+  onRemove: () => void
+}
+
+function AttachmentChip({ filename, mediaType, previewUrl, onRemove }: AttachmentChipProps): React.ReactElement {
+  const isImage = mediaType.startsWith('image/')
+  const displayName = filename.length > 20 ? filename.slice(0, 17) + '...' : filename
+
+  if (isImage && previewUrl) {
+    return (
+      <div className="group/chip relative size-14 shrink-0 rounded-lg overflow-hidden">
+        <img src={previewUrl} alt={filename} className="size-full object-cover" />
+        <button
+          type="button"
+          onClick={onRemove}
+          className="absolute top-0.5 right-0.5 size-4 rounded-full bg-black/50 text-white flex items-center justify-center opacity-0 group-hover/chip:opacity-100 transition-opacity"
+        >
+          <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round">
+            <path d="M18 6 6 18" />
+            <path d="m6 6 12 12" />
+          </svg>
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="group/chip relative flex items-center gap-1.5 shrink-0 rounded-lg bg-muted/60 px-2.5 py-1.5 text-xs text-muted-foreground">
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48" />
+      </svg>
+      <span className="max-w-[120px] truncate">{displayName}</span>
+      <button
+        type="button"
+        onClick={onRemove}
+        className="ml-0.5 size-3.5 rounded-full flex items-center justify-center text-muted-foreground/50 hover:text-foreground hover:bg-muted opacity-0 group-hover/chip:opacity-100 transition-all"
+      >
+        <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round">
+          <path d="M18 6 6 18" />
+          <path d="m6 6 12 12" />
+        </svg>
+      </button>
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/settings/ShortcutSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/ShortcutSettings.tsx
@@ -211,6 +211,13 @@ export function ShortcutSettings(): React.ReactElement {
       // 持久化到 settings.json
       window.electronAPI
         .updateSettings({ shortcutOverrides: newOverrides })
+        .then(() => {
+          // 如果修改的是全局快捷键，通知主进程重新注册
+          const def = DEFAULT_SHORTCUTS.find((s) => s.id === shortcutId)
+          if (def?.global) {
+            window.electronAPI.reregisterGlobalShortcuts().catch(console.error)
+          }
+        })
         .catch(console.error)
     },
     [overrides, setOverrides],
@@ -226,6 +233,13 @@ export function ShortcutSettings(): React.ReactElement {
 
       window.electronAPI
         .updateSettings({ shortcutOverrides: newOverrides })
+        .then(() => {
+          // 如果重置的是全局快捷键，通知主进程重新注册
+          const def = DEFAULT_SHORTCUTS.find((s) => s.id === shortcutId)
+          if (def?.global) {
+            window.electronAPI.reregisterGlobalShortcuts().catch(console.error)
+          }
+        })
         .catch(console.error)
     },
     [overrides, setOverrides],
@@ -238,13 +252,17 @@ export function ShortcutSettings(): React.ReactElement {
 
     window.electronAPI
       .updateSettings({ shortcutOverrides: {} })
+      .then(() => {
+        // 重新注册全局快捷键（恢复默认绑定）
+        window.electronAPI.reregisterGlobalShortcuts().catch(console.error)
+      })
       .catch(console.error)
   }, [setOverrides])
 
   const hasOverrides = Object.keys(overrides).length > 0
 
   // 分类顺序
-  const categoryOrder: ShortcutCategory[] = ['app', 'navigation', 'edit']
+  const categoryOrder: ShortcutCategory[] = ['app', 'navigation', 'edit', 'global']
 
   return (
     <div className="space-y-6">
@@ -276,6 +294,11 @@ export function ShortcutSettings(): React.ReactElement {
             <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
               {SHORTCUT_CATEGORY_LABELS[category]}
             </h3>
+            {category === 'global' && (
+              <p className="text-xs text-muted-foreground/70 mb-2">
+                全局快捷键在应用未聚焦时也能触发，可能与系统或其他应用冲突
+              </p>
+            )}
             <div className="space-y-1">
               {shortcuts.map((def) => {
                 const currentAccel = getActiveAccelerator(def.id)

--- a/apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx
+++ b/apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx
@@ -10,7 +10,7 @@
  */
 
 import { useEffect, useCallback } from 'react'
-import { useAtomValue, useSetAtom, useAtom } from 'jotai'
+import { useAtomValue, useSetAtom, useAtom, useStore } from 'jotai'
 import { appModeAtom } from '@/atoms/app-mode'
 import { settingsOpenAtom } from '@/atoms/settings-tab'
 import { searchDialogOpenAtom } from '@/atoms/search-atoms'
@@ -20,8 +20,24 @@ import {
   sidebarCollapsedAtom,
   activeTabIdAtom,
   closeTab,
+  openTab,
 } from '@/atoms/tab-atoms'
 import { shortcutOverridesAtom } from '@/atoms/shortcut-atoms'
+import {
+  agentPendingPromptAtom,
+  agentSessionsAtom,
+  currentAgentSessionIdAtom,
+  agentChannelIdAtom,
+  currentAgentWorkspaceIdAtom,
+  agentWorkspacesAtom,
+} from '@/atoms/agent-atoms'
+import {
+  chatPendingMessageAtom,
+  conversationsAtom,
+  currentConversationIdAtom,
+  selectedModelAtom,
+} from '@/atoms/chat-atoms'
+import { activeViewAtom } from '@/atoms/active-view'
 import { useCreateSession } from '@/hooks/useCreateSession'
 import { useShortcut } from '@/hooks/useShortcut'
 import {
@@ -150,6 +166,125 @@ export function GlobalShortcuts(): null {
       window.dispatchEvent(new CustomEvent('proma:stop-generation'))
     }, []),
   )
+
+  // ===== 快速任务窗口 → 创建会话并自动发送 =====
+
+  const store = useStore()
+
+  useEffect(() => {
+    const cleanup = window.electronAPI.onQuickTaskOpenSession(async (data) => {
+      try {
+        // 切换到对应模式
+        store.set(appModeAtom, data.mode)
+        store.set(activeViewAtom, 'conversations')
+
+        if (data.mode === 'agent') {
+          // Agent 模式：创建会话 + 保存附件到 session 目录
+          const channelId = store.get(agentChannelIdAtom) || undefined
+          const workspaceId = store.get(currentAgentWorkspaceIdAtom) || undefined
+          const meta = await window.electronAPI.createAgentSession(
+            undefined,
+            channelId,
+            workspaceId,
+          )
+          // 更新 atom 状态
+          store.set(agentSessionsAtom, (prev) => [meta, ...prev])
+          store.set(currentAgentSessionIdAtom, meta.id)
+
+          // 处理附件：保存到 session 目录，构建 file references
+          let fileReferences = ''
+          if (data.files && data.files.length > 0 && workspaceId) {
+            const workspaces = store.get(agentWorkspacesAtom)
+            const workspace = workspaces.find((w) => w.id === workspaceId)
+            if (workspace) {
+              try {
+                const filesToSave = data.files.map((f) => ({
+                  filename: f.filename,
+                  data: f.base64,
+                }))
+                const saved = await window.electronAPI.saveFilesToAgentSession({
+                  workspaceSlug: workspace.slug,
+                  sessionId: meta.id,
+                  files: filesToSave,
+                })
+                const refs = saved.map((f) => `- ${f.filename}: ${f.targetPath}`).join('\n')
+                fileReferences = `<attached_files>\n${refs}\n</attached_files>\n\n`
+              } catch (error) {
+                console.error('[快速任务] 保存 Agent 附件失败:', error)
+              }
+            }
+          }
+
+          // 打开新标签页
+          const currentTabs = store.get(tabsAtom)
+          const currentLayout = store.get(splitLayoutAtom)
+          const result = openTab(currentTabs, currentLayout, {
+            type: 'agent',
+            sessionId: meta.id,
+            title: data.text.slice(0, 30),
+          })
+          store.set(tabsAtom, result.tabs)
+          store.set(splitLayoutAtom, result.layout)
+
+          // 设置待发送消息（附件引用已内联到消息文本中）
+          store.set(agentPendingPromptAtom, {
+            sessionId: meta.id,
+            message: fileReferences + data.text,
+          })
+        } else {
+          // Chat 模式：创建对话 + 保存附件到磁盘
+          const chatModel = store.get(selectedModelAtom)
+          const meta = await window.electronAPI.createConversation(
+            undefined,
+            chatModel?.modelId,
+            chatModel?.channelId,
+          )
+          // 更新 atom 状态
+          store.set(conversationsAtom, (prev) => [meta, ...prev])
+          store.set(currentConversationIdAtom, meta.id)
+
+          // 处理附件：保存到磁盘，收集 FileAttachment[]
+          const savedAttachments: import('@proma/shared').FileAttachment[] = []
+          if (data.files && data.files.length > 0) {
+            for (const file of data.files) {
+              try {
+                const result = await window.electronAPI.saveAttachment({
+                  conversationId: meta.id,
+                  filename: file.filename,
+                  mediaType: file.mediaType,
+                  data: file.base64,
+                })
+                savedAttachments.push(result.attachment)
+              } catch (error) {
+                console.error('[快速任务] 保存 Chat 附件失败:', error)
+              }
+            }
+          }
+
+          // 打开新标签页
+          const currentTabs = store.get(tabsAtom)
+          const currentLayout = store.get(splitLayoutAtom)
+          const tabResult = openTab(currentTabs, currentLayout, {
+            type: 'chat',
+            sessionId: meta.id,
+            title: data.text.slice(0, 30),
+          })
+          store.set(tabsAtom, tabResult.tabs)
+          store.set(splitLayoutAtom, tabResult.layout)
+
+          // 设置待发送消息（含已保存的附件）
+          store.set(chatPendingMessageAtom, {
+            conversationId: meta.id,
+            message: data.text,
+            attachments: savedAttachments.length > 0 ? savedAttachments : undefined,
+          })
+        }
+      } catch (error) {
+        console.error('[快速任务] 创建会话失败:', error)
+      }
+    })
+    return cleanup
+  }, [store])
 
   return null
 }

--- a/apps/electron/src/renderer/lib/shortcut-defaults.ts
+++ b/apps/electron/src/renderer/lib/shortcut-defaults.ts
@@ -8,7 +8,7 @@
 // ===== 类型定义 =====
 
 /** 快捷键分类 */
-export type ShortcutCategory = 'app' | 'edit' | 'navigation'
+export type ShortcutCategory = 'app' | 'edit' | 'navigation' | 'global'
 
 /** 快捷键定义（不可变，内置于代码） */
 export interface ShortcutDefinition {
@@ -24,6 +24,8 @@ export interface ShortcutDefinition {
   defaultWin: string
   /** 分类 */
   category: ShortcutCategory
+  /** 是否为全局快捷键（由主进程 globalShortcut 注册） */
+  global?: boolean
 }
 
 /** 用户自定义快捷键覆盖（持久化到 settings.json） */
@@ -40,6 +42,7 @@ export const SHORTCUT_CATEGORY_LABELS: Record<ShortcutCategory, string> = {
   app: '应用',
   edit: '编辑',
   navigation: '导航',
+  global: '全局',
 }
 
 // ===== 默认快捷键列表 =====
@@ -119,6 +122,26 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
     defaultMac: 'Cmd+W',
     defaultWin: 'Ctrl+W',
     category: 'app',
+  },
+
+  // 全局快捷键（由主进程 globalShortcut 注册，应用外也生效）
+  {
+    id: 'quick-task',
+    name: '快速任务',
+    description: '唤起浮动快速任务输入窗口',
+    defaultMac: 'Alt+Space',
+    defaultWin: 'Alt+Space',
+    category: 'global',
+    global: true,
+  },
+  {
+    id: 'show-main-window',
+    name: '显示主窗口',
+    description: '显示并聚焦 Proma 主窗口',
+    defaultMac: 'Cmd+Shift+P',
+    defaultWin: 'Ctrl+Shift+P',
+    category: 'global',
+    global: true,
   },
 ]
 

--- a/apps/electron/src/renderer/lib/shortcut-registry.ts
+++ b/apps/electron/src/renderer/lib/shortcut-registry.ts
@@ -82,6 +82,8 @@ let parsedCache = new Map<string, ParsedAccelerator>()
 function rebuildCache(): void {
   parsedCache = new Map()
   for (const def of DEFAULT_SHORTCUTS) {
+    // 全局快捷键由主进程 globalShortcut 处理，不在渲染进程注册
+    if (def.global) continue
     const accel = getActiveAccelerator(def.id)
     parsedCache.set(def.id, parseAccelerator(accel))
   }

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -41,7 +41,7 @@ import { tabsAtom, splitLayoutAtom } from './atoms/tab-atoms'
 import type { TabItem, SplitLayoutState } from './atoms/tab-atoms'
 import { chatToolsAtom } from './atoms/chat-tool-atoms'
 import { feishuBridgeStateAtom } from './atoms/feishu-atoms'
-import { currentConversationIdAtom, channelsAtom, channelsLoadedAtom } from './atoms/chat-atoms'
+import { currentConversationIdAtom, channelsAtom, channelsLoadedAtom, selectedModelAtom } from './atoms/chat-atoms'
 import type { FeishuBridgeState, FeishuNotificationSentPayload } from '@proma/shared'
 import { Toaster } from './components/ui/sonner'
 import { toast } from 'sonner'
@@ -52,6 +52,9 @@ import { UpdateDialog } from './components/settings/UpdateDialog'
 import { GlobalShortcuts } from './components/shortcuts/GlobalShortcuts'
 import './styles/globals.css'
 import 'katex/dist/katex.min.css'
+
+// ===== 窗口类型检测 =====
+const isQuickTaskWindow = new URLSearchParams(window.location.search).get('window') === 'quick-task'
 
 /**
  * 主题初始化组件
@@ -113,6 +116,7 @@ function AgentSettingsInitializer(): null {
 
   const setChannels = useSetAtom(channelsAtom)
   const setChannelsLoaded = useSetAtom(channelsLoadedAtom)
+  const store = useStore()
 
   // 读取当前工作区信息（用于能力变化 diff）
   const currentWorkspaceId = useAtomValue(currentAgentWorkspaceIdAtom)
@@ -124,28 +128,52 @@ function AgentSettingsInitializer(): null {
   const suppressToastRef = useRef(true)
 
   useEffect(() => {
-    // 预加载渠道列表到全局缓存（ModelSelector 直接读 atom，无需各自 fetch）
-    window.electronAPI.listChannels()
-      .then((list) => { setChannels(list); setChannelsLoaded(true) })
-      .catch(console.error)
+    // 并行加载渠道列表和设置，确保两者都就绪后再验证渠道有效性
+    Promise.all([
+      window.electronAPI.listChannels(),
+      window.electronAPI.getSettings(),
+    ]).then(([channels, settings]) => {
+      // 缓存渠道列表
+      setChannels(channels)
+      setChannelsLoaded(true)
 
-    // 加载设置
-    window.electronAPI.getSettings().then((settings) => {
-      if (settings.agentChannelId) {
-        setAgentChannelId(settings.agentChannelId)
+      const channelIds = new Set(channels.map((c) => c.id))
+
+      // 验证 Chat 模式的全局默认模型（localStorage 持久化的可能指向已删除渠道）
+      const chatModel = store.get(selectedModelAtom)
+      if (chatModel && !channelIds.has(chatModel.channelId)) {
+        console.warn('[AgentSettings] Chat selectedModel 指向已删除的渠道，清除')
+        store.set(selectedModelAtom, null)
       }
-      if (settings.agentModelId) {
+
+      // 验证并加载 Agent 渠道/模型
+      if (settings.agentChannelId && channelIds.has(settings.agentChannelId)) {
+        setAgentChannelId(settings.agentChannelId)
+      } else if (settings.agentChannelId && !channelIds.has(settings.agentChannelId)) {
+        // 渠道已删除，清除无效设置
+        console.warn('[AgentSettings] agentChannelId 指向已删除的渠道，清除')
+        window.electronAPI.updateSettings({ agentChannelId: undefined, agentModelId: undefined }).catch(console.error)
+      }
+      if (settings.agentModelId && (!settings.agentChannelId || channelIds.has(settings.agentChannelId))) {
         setAgentModelId(settings.agentModelId)
       }
-      // 加载 Agent 启用渠道列表，兼容旧版本从 agentChannelId 迁移
+
+      // 加载 Agent 启用渠道列表，过滤已删除的渠道
       if (settings.agentChannelIds && settings.agentChannelIds.length > 0) {
-        setAgentChannelIds(settings.agentChannelIds)
-      } else if (settings.agentChannelId) {
+        const validIds = settings.agentChannelIds.filter((id) => channelIds.has(id))
+        setAgentChannelIds(validIds)
+        // 如果有渠道被清理，持久化更新后的列表
+        if (validIds.length !== settings.agentChannelIds.length) {
+          console.warn('[AgentSettings] 清理了已删除的 agentChannelIds')
+          window.electronAPI.updateSettings({ agentChannelIds: validIds }).catch(console.error)
+        }
+      } else if (settings.agentChannelId && channelIds.has(settings.agentChannelId)) {
         // 迁移：旧版本只有 agentChannelId，自动转为数组
         const migrated = [settings.agentChannelId]
         setAgentChannelIds(migrated)
         window.electronAPI.updateSettings({ agentChannelIds: migrated }).catch(console.error)
       }
+
       if (settings.agentPermissionMode) {
         // 迁移旧权限模式值（auto/smart/supervised → acceptEdits/bypassPermissions/plan）
         setPermissionMode(migratePermissionMode(settings.agentPermissionMode))
@@ -373,19 +401,32 @@ function FeishuInitializer(): null {
   return null
 }
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <ThemeInitializer />
-    <AgentSettingsInitializer />
-    <NotificationsInitializer />
-    <ChatListenersInitializer />
-    <AgentListenersInitializer />
-    <ChatToolInitializer />
-    <UpdaterInitializer />
-    <FeishuInitializer />
-    <GlobalShortcuts />
-    <App />
-    <UpdateDialog />
-    <Toaster position="top-right" />
-  </React.StrictMode>
-)
+// ===== 快速任务窗口：轻量渲染 =====
+if (isQuickTaskWindow) {
+  import('./components/quick-task/QuickTaskApp').then(({ QuickTaskApp }) => {
+    ReactDOM.createRoot(document.getElementById('root')!).render(
+      <React.StrictMode>
+        <ThemeInitializer />
+        <QuickTaskApp />
+      </React.StrictMode>
+    )
+  })
+} else {
+  // ===== 主窗口：完整渲染 =====
+  ReactDOM.createRoot(document.getElementById('root')!).render(
+    <React.StrictMode>
+      <ThemeInitializer />
+      <AgentSettingsInitializer />
+      <NotificationsInitializer />
+      <ChatListenersInitializer />
+      <AgentListenersInitializer />
+      <ChatToolInitializer />
+      <UpdaterInitializer />
+      <FeishuInitializer />
+      <GlobalShortcuts />
+      <App />
+      <UpdateDialog />
+      <Toaster position="top-right" />
+    </React.StrictMode>
+  )
+}

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -63,6 +63,12 @@
   app-region: drag;
 }
 
+/* 快速任务窗口：透明背景 + 无拖拽 */
+.quick-task-container {
+  -webkit-app-region: no-drag;
+  app-region: no-drag;
+}
+
 .titlebar-no-drag {
   -webkit-app-region: no-drag;
   app-region: no-drag;

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -85,3 +85,40 @@ export const SETTINGS_IPC_CHANNELS = {
   GET_SYSTEM_THEME: 'settings:get-system-theme',
   ON_SYSTEM_THEME_CHANGED: 'settings:system-theme-changed',
 } as const
+
+/** 快速任务窗口 IPC 通道 */
+export const QUICK_TASK_IPC_CHANNELS = {
+  /** 提交快速任务（渲染进程 → 主进程） */
+  SUBMIT: 'quick-task:submit',
+  /** 隐藏快速任务窗口 */
+  HIDE: 'quick-task:hide',
+  /** 通知渲染进程聚焦输入框 */
+  FOCUS: 'quick-task:focus',
+  /** 重新注册全局快捷键（设置变更后） */
+  REREGISTER_GLOBAL_SHORTCUTS: 'quick-task:reregister-global-shortcuts',
+} as const
+
+/** 快速任务提交输入 */
+export interface QuickTaskSubmitInput {
+  /** 任务文本内容 */
+  text: string
+  /** 目标模式 */
+  mode: 'chat' | 'agent'
+  /** 附件列表（base64 编码） */
+  files?: QuickTaskFile[]
+}
+
+/** 快速任务附件 */
+export interface QuickTaskFile {
+  filename: string
+  mediaType: string
+  base64: string
+  size: number
+}
+
+/** 主窗口接收的快速任务打开会话数据 */
+export interface QuickTaskOpenSessionData {
+  mode: 'chat' | 'agent'
+  text: string
+  files?: QuickTaskFile[]
+}


### PR DESCRIPTION
## Summary
- 新增全局快捷键服务（2 个系统级快捷键）和应用级快捷键注册表（9 个快捷键），支持用户自定义按键绑定
- 新增 Option+Space 快速任务浮窗：无边框透明置顶窗口，支持 Chat/Agent 模式切换、文件附件（粘贴/拖拽）、模型信息展示
- 快速任务提交后自动创建会话、打开标签页、发送消息（含附件），Chat 通过 saveAttachment、Agent 通过 saveFilesToAgentSession 传递文件
- 修复 auto-send 竞态问题：用 queueMicrotask 替代 setTimeout+cleanup 避免重渲染取消 timer，新增 messagesLoaded 守卫防止消息加载覆盖乐观更新

## Test plan
- [ ] Option+Space 唤起快速任务窗口，Escape 关闭，失焦自动隐藏
- [ ] Chat 模式：输入文本 + 附件 → 提交 → 主窗口创建对话、显示用户消息（含附件）、收到 AI 回复
- [ ] Agent 模式：输入文本 + 附件 → 提交 → 主窗口创建会话、显示用户消息、Agent 正常响应
- [ ] 设置面板 → 快捷键设置：录制自定义按键、冲突检测、重置默认值
- [ ] Cmd+N / Cmd+B / Cmd+Shift+M 等应用级快捷键正常工作