### PR TITLE
fix: 快速任务窗口阴影 + Agent 滚动跳动 + Chat 流式闪屏修复

### DIFF
--- a/apps/electron/src/main/lib/quick-task-window.ts
+++ b/apps/electron/src/main/lib/quick-task-window.ts
@@ -37,7 +37,7 @@ export function createQuickTaskWindow(): void {
     maximizable: false,
     fullscreenable: false,
     show: false,
-    hasShadow: true,
+    hasShadow: false,
     webPreferences: {
       preload: join(__dirname, 'preload.cjs'),
       contextIsolation: true,

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -646,19 +646,23 @@ export function AgentMessages({ sessionId, messages, persistedSDKMessages, strea
   const prevSessionIdRef = React.useRef<string | null>(null)
 
   /**
-   * content-visibility 延迟启用：与 ready 状态同步，
-   * 避免流式→持久化消息切换瞬间 content-visibility:auto 导致浏览器 reflow 跳动。
+   * content-visibility 延迟启用：ready 后延迟开启，之后保持不变。
+   * 不随 streaming 状态反复切换，避免 content-visibility:auto 反复开关导致浏览器 reflow 跳动。
+   * 仅在切换会话（ready 重置为 false）时才重新走延迟启用流程。
    */
   const [cvReady, setCvReady] = React.useState(false)
   React.useEffect(() => {
-    if (!ready || streaming) {
+    if (!ready) {
       setCvReady(false)
       return
     }
-    // ready 后延迟启用 content-visibility，等布局稳定后再优化
+    // 已启用则保持，不因 streaming 反复切换
+    if (cvReady) return
+    // 流式期间暂不启用，等首次流式完成后再启用
+    if (streaming) return
     const timer = setTimeout(() => setCvReady(true), 100)
     return () => clearTimeout(timer)
-  }, [ready, streaming])
+  }, [ready, streaming, cvReady])
 
   React.useEffect(() => {
     if (sessionId !== prevSessionIdRef.current) {

--- a/apps/electron/src/renderer/components/chat/ChatMessages.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessages.tsx
@@ -181,14 +181,21 @@ export function ChatMessages({
   const userProfile = useAtomValue(userProfileAtom)
 
   // 平滑流式输出：将高频更新转为逐字渲染
-  const { displayedContent: smoothContent } = useSmoothStream({
+  const { displayedContent: rawSmoothContent } = useSmoothStream({
     content: streamingContent,
     isStreaming: streaming,
   })
-  const { displayedContent: smoothReasoning } = useSmoothStream({
+  const { displayedContent: rawSmoothReasoning } = useSmoothStream({
     content: streamingReasoning,
     isStreaming: streaming,
   })
+
+  // 防闪屏守卫：useSmoothStream 的内部状态通过 useEffect 更新，比 props 晚一帧。
+  // 当流式状态被清除（streamingContent 变为 ''）但 smoothContent 仍持有旧值时，
+  // 会导致持久化消息和流式气泡同时渲染一帧（重复内容闪烁）。
+  // 这里用原始 streamingContent 作为守卫：如果原始内容已清空且不在流式中，立即归零。
+  const smoothContent = (streaming || streamingContent) ? rawSmoothContent : ''
+  const smoothReasoning = (streaming || streamingReasoning) ? rawSmoothReasoning : ''
   const [parallelMode] = useConversationParallelMode()
 
   /** 是否正在加载更多历史 */

--- a/apps/electron/src/renderer/components/quick-task/QuickTaskApp.tsx
+++ b/apps/electron/src/renderer/components/quick-task/QuickTaskApp.tsx
@@ -253,7 +253,7 @@ export function QuickTaskApp(): React.ReactElement {
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
     >
-      <div className={`quick-task-container flex w-full flex-col rounded-2xl bg-background shadow-2xl transition-colors ${isDragOver ? 'ring-2 ring-primary/50' : ''}`}>
+      <div className={`quick-task-container flex w-full flex-col rounded-2xl bg-background transition-colors ${isDragOver ? 'ring-2 ring-primary/50' : ''}`}>
         {/* 顶栏：模式切换 + 模型信息 */}
         <div className="flex items-center justify-between px-4 pt-3 pb-1">
           <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- 移除快速任务窗口的原生 `hasShadow` 和 CSS `shadow-2xl`，消除双重阴影问题
- 修复 Agent 模式下 2+ 轮对话后，助手消息完成输出时页面向上跳动的问题。根因是 `cvReady` 状态随 streaming 反复切换，导致 `content-visibility: auto` 频繁开关触发浏览器 reflow
- 修复 Chat 模式下流式→持久化消息切换瞬间，`useSmoothStream` 滞后一帧导致的内容重复闪烁

## Test plan
- [ ] 在 Agent 模式下进行 3+ 轮对话，确认输出完成后不再发生向上跳动
- [ ] 在 Chat 模式下快速多轮对话，确认流式结束时无内容闪烁
- [ ] 验证快速任务窗口（Option+Space）无双重阴影