### PR TITLE
fix: 移除 Skills 列表在 Agent 上下文中的重复注入

### DIFF
--- a/apps/electron/src/main/lib/agent-prompt-builder.ts
+++ b/apps/electron/src/main/lib/agent-prompt-builder.ts
@@ -373,32 +373,21 @@ export function buildDynamicContext(ctx: DynamicContext): string {
       }
     }
 
-    // Skills 列表（SDK plugin 机制下 skill 名称带 plugin 前缀）
+    // Skills 列表已通过 SDK plugin 机制自动发现并注册，无需手动注入
+    // 仅检查 skill-creator 是否启用，注入持续改进提示
     const skills = getWorkspaceSkills(ctx.workspaceSlug)
-    if (skills.length > 0) {
-      const pluginPrefix = `proma-workspace-${ctx.workspaceSlug}`
-      wsLines.push(`Skills（调用 Skill 工具时必须使用含前缀的完整名称，如 ${pluginPrefix}:skill-name，不可省略前缀）:`)
-      for (const skill of skills) {
-        const qualifiedName = `${pluginPrefix}:${skill.slug}`
-        const desc = skill.description ? `: ${skill.description}` : ''
-        wsLines.push(`- ${qualifiedName}${desc}`)
-      }
-
-      // 当 skill-creator 处于启用状态时，注入 Skill 持续改进提示
-      const hasSkillCreator = skills.some((s) => s.slug === 'skill-creator')
-      if (hasSkillCreator) {
-        wsLines.push('')
-        wsLines.push([
-          '<skill_improvement_hint>',
-          'skill-creator 已启用。在调用其他 Skill 前后，留意以下信号：',
-          '- 用户主动修正了某个 Skill 产出的内容（格式、流程、术语等）→ 该 Skill 可能需要更新',
-          '- 用户反复描述一类任务但没有匹配的 Skill → 可能值得创建新 Skill',
-          '- 某个 Skill 的输出持续需要大量后续调整 → 可能需要重构',
-          '发现上述信号时，先简要告知用户观察到的改进点，征得同意后再通过 skill-creator 执行创建、更新或重构。',
-          '不要在每次调用 Skill 后都提出建议——仅在确实观察到可复用的改进模式时才提出。',
-          '</skill_improvement_hint>',
-        ].join('\n'))
-      }
+    const hasSkillCreator = skills.some((s) => s.slug === 'skill-creator')
+    if (hasSkillCreator) {
+      wsLines.push([
+        '<skill_improvement_hint>',
+        'skill-creator 已启用。在调用其他 Skill 前后，留意以下信号：',
+        '- 用户主动修正了某个 Skill 产出的内容（格式、流程、术语等）→ 该 Skill 可能需要更新',
+        '- 用户反复描述一类任务但没有匹配的 Skill → 可能值得创建新 Skill',
+        '- 某个 Skill 的输出持续需要大量后续调整 → 可能需要重构',
+        '发现上述信号时，先简要告知用户观察到的改进点，征得同意后再通过 skill-creator 执行创建、更新或重构。',
+        '不要在每次调用 Skill 后都提出建议——仅在确实观察到可复用的改进模式时才提出。',
+        '</skill_improvement_hint>',
+      ].join('\n'))
     }
 
     if (wsLines.length > 0) {


### PR DESCRIPTION
## 问题

Skills 通过两条路径被注入到 Agent 上下文中，导致重复加载：

1. **SDK 插件自动发现**（`agent-orchestrator.ts:1027`）：工作区目录作为 plugin 传给 SDK，SDK 自动发现 `skills/` 下的所有 skill 并注册为可调用工具
2. **手动注入到动态上下文**（`agent-prompt-builder.ts:377-385`）：`buildDynamicContext()` 手动读取同一个 `skills/` 目录，将 skill 列表作为文本注入到 `<workspace_state>` 中

两条路径读取的是同一个目录，导致 Agent 在上下文中看到 skills 被列出两次。

## 修改方案

- **移除** `agent-prompt-builder.ts` 中 `buildDynamicContext()` 对 skill 列表的手动注入，由 SDK 插件机制统一处理 skill 的发现和注册
- **保留** `skill_improvement_hint` 逻辑（当 skill-creator 启用时注入持续改进提示），该逻辑是自定义行为引导，SDK 不提供

## 测试计划

- [ ] 验证 Agent 模式下 Skills 仍然可以正常调用
- [ ] 验证 Skills 在上下文中只出现一次
- [ ] 验证 skill-creator 启用时改进提示仍然正常注入