### PR TITLE
fix: 归档会话时自动关闭对应的标签页

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -385,6 +385,16 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       setConversations((prev) =>
         prev.map((c) => (c.id === updated.id ? updated : c))
       )
+      // 归档时自动关闭该对话的标签页
+      if (updated.archived) {
+        const tabResult = closeTab(tabs, layout, id)
+        setTabs(tabResult.tabs)
+        setLayout(tabResult.layout)
+        // 如果归档的是当前选中的对话，取消选中
+        if (currentConversationId === id) {
+          setCurrentConversationId(null)
+        }
+      }
       toast.success(updated.archived ? '已归档' : '已取消归档')
     } catch (error) {
       console.error('[侧边栏] 切换归档失败:', error)
@@ -519,6 +529,16 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       setAgentSessions((prev) =>
         prev.map((s) => (s.id === updated.id ? updated : s))
       )
+      // 归档时自动关闭该会话的标签页
+      if (updated.archived) {
+        const tabResult = closeTab(tabs, layout, id)
+        setTabs(tabResult.tabs)
+        setLayout(tabResult.layout)
+        // 如果归档的是当前选中的会话，取消选中
+        if (currentAgentSessionId === id) {
+          setCurrentAgentSessionId(null)
+        }
+      }
       toast.success(updated.archived ? '已归档' : '已取消归档')
     } catch (error) {
       console.error('[侧边栏] 切换 Agent 会话归档失败:', error)


### PR DESCRIPTION
## Summary
- 归档会话/对话时，如果其标签页已打开，自动关闭该标签页
- 同时取消选中状态，避免用户需要手动关闭的冗余操作
- 同时修复了 Chat 模式和 Agent 模式的归档逻辑

## Test plan
- [ ] 打开一个 Agent 会话的标签页，归档该会话，验证标签页自动关闭
- [ ] 打开一个 Chat 对话的标签页，归档该对话，验证标签页自动关闭
- [ ] 取消归档后重新打开，验证功能正常