### PR TITLE
fix: 用户消息气泡宽度自适应文字长度

### DIFF
--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -120,9 +120,9 @@ export function MessageContent({
   return (
     <div
       className={cn(
-        'flex w-full max-w-full min-w-0 flex-col gap-2 overflow-hidden pl-[46px]',
-        'group-[.is-user]:text-foreground',
-        'group-[.is-assistant]:text-foreground',
+        'flex max-w-full min-w-0 flex-col gap-2 overflow-hidden pl-[46px]',
+        'group-[.is-user]:text-foreground group-[.is-user]:items-start',
+        'group-[.is-assistant]:w-full group-[.is-assistant]:text-foreground',
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- 移除 `MessageContent` 的 `w-full`，让用户消息气泡根据文字内容自适应宽度
- 仅 assistant 消息保留占满宽度的行为
- 用户消息使用 `items-start` 让 flex 子元素靠左对齐

## Test plan
- [ ] 发送短消息，确认气泡宽度随文字长度变化
- [ ] 发送长消息，确认换行后气泡正常显示
- [ ] 确认 AI 回复仍然占满宽度