### PR TITLE
fix: 侧面板始终显示折叠按钮，移除 hasContent 条件限制

### DIFF
--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -208,19 +208,16 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
     prevFilesVersionRef.current = filesVersion
   }, [filesVersion, sessionPath, setIsOpen])
 
-  // 面板是否可显示内容（需要有 sessionPath 或附加目录）
-  const hasContent = sessionPath || attachedDirs.length > 0
-
   return (
     <div
       className={cn(
         'relative h-full flex-shrink-0 overflow-hidden titlebar-drag-region bg-content-area/95 backdrop-blur-xl rounded-2xl shadow-xl',
         animateRef.current && 'transition-[width] duration-300 ease-in-out',
-        isOpen ? 'w-[320px]' : hasContent ? 'w-10' : 'w-0',
+        isOpen ? 'w-[320px]' : 'w-10',
       )}
     >
       {/* 面板关闭时的打开按钮 */}
-      {hasContent && !isOpen && (
+      {!isOpen && (
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
@@ -243,106 +240,129 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
       )}
 
       {/* 面板内容 */}
-      {hasContent && (
-        <div
-          className={cn(
-            'w-[320px] h-full flex flex-col titlebar-no-drag pt-3',
-            animateRef.current && 'transition-opacity duration-300',
-            isOpen ? 'opacity-100' : 'opacity-0 pointer-events-none',
-          )}
+      <div
+        className={cn(
+          'w-[320px] h-full flex flex-col titlebar-no-drag pt-3',
+          animateRef.current && 'transition-opacity duration-300',
+          isOpen ? 'opacity-100' : 'opacity-0 pointer-events-none',
+        )}
         >
           {/* 文件浏览内容 */}
-          {sessionPath && workspaceSlug ? (
+          {workspaceSlug ? (
             <div className="flex-1 min-h-0 flex flex-col">
-                  {/* ===== 会话文件区 ===== */}
-                  <div className="flex items-center gap-1 px-3 h-[32px] flex-shrink-0">
-                    <FolderOpen className="size-3 text-muted-foreground" />
-                    <span className="text-[11px] font-medium text-muted-foreground">会话文件</span>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Info className="size-3 text-muted-foreground/50 cursor-help" />
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom" className="max-w-[200px]">
-                        <p>当前会话的专属文件，仅本次对话的 Agent 可以访问</p>
-                      </TooltipContent>
-                    </Tooltip>
-                    <span className="text-[10px] text-muted-foreground/50 truncate flex-1" title={sessionPath}>
-                      {breadcrumb}
-                    </span>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon"
-                          className="h-5 w-5 flex-shrink-0"
-                          onClick={() => window.electronAPI.openFile(sessionPath).catch(console.error)}
-                        >
-                          <ExternalLink className="size-2.5" />
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom">
-                        <p>在 Finder 中打开</p>
-                      </TooltipContent>
-                    </Tooltip>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon"
-                          className="h-5 w-5 flex-shrink-0"
-                          onClick={handleRefresh}
-                        >
-                          <RefreshCw className="size-2.5" />
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom">
-                        <p>刷新文件列表</p>
-                      </TooltipContent>
-                    </Tooltip>
-                    {/* 关闭/打开面板按钮 */}
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon"
-                          className="h-5 w-5 flex-shrink-0"
-                          onClick={() => setIsOpen((prev) => !prev)}
-                        >
-                          <X className="size-2.5" />
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom">
-                        <p>关闭侧面板</p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </div>
-                  {/* 会话文件内容区（独立滚动） */}
-                  <div className="flex-1 min-h-0 overflow-y-auto">
-                    {/* 附加目录列表（可展开目录树） */}
-                    {attachedDirs.length > 0 && (
-                      <AttachedDirsSection
-                        attachedDirs={attachedDirs}
-                        onDetach={handleDetachDirectory}
-                        refreshVersion={filesVersion}
-                      />
-                    )}
-                    {/* 会话文件浏览器 */}
-                    <FileBrowser rootPath={sessionPath} hideToolbar embedded />
-                    {/* 会话文件拖拽上传区域 */}
-                    <FileDropZone
-                      workspaceSlug={workspaceSlug}
-                      sessionId={sessionId}
-                      target="session"
-                      onFilesUploaded={handleFilesUploaded}
-                      onAttachFolder={handleAttachFolder}
-                    />
-                  </div>
+                  {/* ===== 会话文件区（仅当 sessionPath 存在时显示） ===== */}
+                  {sessionPath && (
+                    <>
+                      <div className="flex items-center gap-1 px-3 h-[32px] flex-shrink-0">
+                        <FolderOpen className="size-3 text-muted-foreground" />
+                        <span className="text-[11px] font-medium text-muted-foreground">会话文件</span>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Info className="size-3 text-muted-foreground/50 cursor-help" />
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom" className="max-w-[200px]">
+                            <p>当前会话的专属文件，仅本次对话的 Agent 可以访问</p>
+                          </TooltipContent>
+                        </Tooltip>
+                        <span className="text-[10px] text-muted-foreground/50 truncate flex-1" title={sessionPath}>
+                          {breadcrumb}
+                        </span>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon"
+                              className="h-5 w-5 flex-shrink-0"
+                              onClick={() => window.electronAPI.openFile(sessionPath).catch(console.error)}
+                            >
+                              <ExternalLink className="size-2.5" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom">
+                            <p>在 Finder 中打开</p>
+                          </TooltipContent>
+                        </Tooltip>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon"
+                              className="h-5 w-5 flex-shrink-0"
+                              onClick={handleRefresh}
+                            >
+                              <RefreshCw className="size-2.5" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom">
+                            <p>刷新文件列表</p>
+                          </TooltipContent>
+                        </Tooltip>
+                        {/* 关闭面板按钮 */}
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon"
+                              className="h-5 w-5 flex-shrink-0"
+                              onClick={() => setIsOpen((prev) => !prev)}
+                            >
+                              <X className="size-2.5" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom">
+                            <p>关闭侧面板</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </div>
+                      <div className="flex-1 min-h-0 overflow-y-auto">
+                        {/* 附加目录列表（可展开目录树） */}
+                        {attachedDirs.length > 0 && (
+                          <AttachedDirsSection
+                            attachedDirs={attachedDirs}
+                            onDetach={handleDetachDirectory}
+                            refreshVersion={filesVersion}
+                          />
+                        )}
+                        {/* 会话文件浏览器 */}
+                        <FileBrowser rootPath={sessionPath} hideToolbar embedded />
+                        {/* 会话文件拖拽上传区域 */}
+                        <FileDropZone
+                          workspaceSlug={workspaceSlug}
+                          sessionId={sessionId}
+                          target="session"
+                          onFilesUploaded={handleFilesUploaded}
+                          onAttachFolder={handleAttachFolder}
+                        />
+                      </div>
+                      {/* ===== 分隔线 ===== */}
+                      <div className="mx-3 my-3 border-t border-muted-foreground/20" />
+                    </>
+                  )}
 
-                  {/* ===== 分隔线 ===== */}
-                  <div className="mx-3 my-3 border-t border-muted-foreground/20" />
+                  {/* ===== 顶部关闭按钮（仅在无 sessionPath 时显示，有 sessionPath 时关闭按钮在会话文件区标题栏） ===== */}
+                  {!sessionPath && (
+                    <div className="flex items-center justify-end px-3 h-[32px] flex-shrink-0">
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="h-5 w-5 flex-shrink-0"
+                            onClick={() => setIsOpen((prev) => !prev)}
+                          >
+                            <X className="size-2.5" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent side="bottom">
+                          <p>关闭侧面板</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </div>
+                  )}
 
                   {/* ===== 工作区文件区 ===== */}
                   <div className="flex-1 min-h-0 flex flex-col mx-2 mb-2">
@@ -428,7 +448,6 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                 </div>
               )}
         </div>
-      )}
     </div>
   )
 }

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
       "name": "@proma/electron",
       "version": "0.8.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.2.87",
+        "@anthropic-ai/claude-agent-sdk": "0.2.89",
         "@emoji-mart/data": "^1.2.1",
         "@emoji-mart/react": "^1.1.1",
         "@larksuiteoapi/node-sdk": "^1.59.0",
@@ -147,7 +147,7 @@
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.87", "", { "dependencies": { "@anthropic-ai/sdk": "^0.74.0", "@modelcontextprotocol/sdk": "^1.27.1" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-WWmgBPxPhBOvNT0ujI8vPTI2lK+w5YEkEZ/y1mH0EDkK/0kBnxVJNhCtG5vnueiAViwLoUOFn66pbkDiivijdA=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.89", "", { "dependencies": { "@anthropic-ai/sdk": "^0.74.0", "@modelcontextprotocol/sdk": "^1.27.1" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-/9W0lyBGuGHw1uu7pQafsp6BLpxfqCv1QYE0Z/eZTX6lGHht4j4Q+O3UImzjsiyEE9cGkOAwZBGAEHDEqt+QUA=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.74.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-srbJV7JKsc5cQ6eVuFzjZO7UR3xEPJqPamHFIe29bs38Ij2IripoAhC0S5NslNbaFUYqBKypmmpzMTpqfHEUDw=="],
 


### PR DESCRIPTION
## Summary

- 移除 SidePanel 组件中的 `hasContent` 条件判断，使侧面板在无 `sessionPath` 时也能正常显示折叠/展开按钮（`w-10`），而非完全隐藏（`w-0`）
- 重构了会话文件区和关闭按钮的条件渲染逻辑，确保在不同状态下 UI 行为一致
- 当没有 `sessionPath` 时，面板内容区仍可展开查看工作区文件；有 `sessionPath` 时，关闭按钮在会话文件区标题栏显示

## 改动详情

**`SidePanel.tsx`**：
- 移除 `hasContent` 变量及其所有引用
- 面板宽度逻辑简化：打开时 `w-[320px]`，关闭时始终 `w-10`
- 将会话文件区（文件浏览器、附加目录、拖拽上传）包裹在 `sessionPath` 条件内
- 新增无 `sessionPath` 时的独立关闭按钮

## Test plan

- [ ] 验证有 sessionPath 时，侧面板正常显示会话文件区 + 工作区文件区
- [ ] 验证无 sessionPath 时（新会话），侧面板显示折叠按钮且可展开查看工作区文件
- [ ] 验证面板折叠/展开动画正常
- [ ] 验证关闭按钮在两种状态下都能正常工作