### PR TITLE
fix: 置顶会话不再重复显示在日期分组列表中

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -258,7 +258,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     () => {
       const filtered = viewMode === 'archived'
         ? conversations.filter((c) => c.archived && !draftSessionIds.has(c.id))
-        : conversations.filter((c) => !c.archived && !draftSessionIds.has(c.id))
+        : conversations.filter((c) => !c.archived && !c.pinned && !draftSessionIds.has(c.id))
       return groupByDate(filtered)
     },
     [conversations, viewMode, draftSessionIds]
@@ -593,7 +593,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       const byWorkspace = agentSessions.filter((s) => s.workspaceId === currentWorkspaceId && !draftSessionIds.has(s.id))
       return viewMode === 'archived'
         ? byWorkspace.filter((s) => s.archived)
-        : byWorkspace.filter((s) => !s.archived)
+        : byWorkspace.filter((s) => !s.archived && !s.pinned)
     },
     [agentSessions, currentWorkspaceId, viewMode, draftSessionIds]
   )


### PR DESCRIPTION
## Summary

- 修复置顶（pinned）会话同时出现在「置顶会话」区域和下方日期分组列表中的重复显示问题
- Chat 对话和 Agent 会话的日期分组列表现在会过滤掉已置顶的条目
- 取消置顶后，会话自动回到日期分组列表中正常显示

## Changes

**`apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx`**

- `conversationGroups`（Chat 模式）：active 视图下增加 `!c.pinned` 过滤条件
- `filteredAgentSessions`（Agent 模式）：active 视图下增加 `!s.pinned` 过滤条件

## Test plan

- [ ] 置顶一个 Chat 对话，确认它只出现在「置顶会话」区域，不在下方日期分组中重复
- [ ] 置顶一个 Agent 会话，同样验证不重复显示
- [ ] 取消置顶后，确认会话回到日期分组列表中
- [ ] 切换到已归档视图，确认归档列表不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)