### PR TITLE
fix: improve attachment preview spacing in ChatInput

### DIFF
--- a/apps/electron/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatInput.tsx
@@ -244,7 +244,7 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
         >
           {/* 附件预览区域 — Cherry Studio: padding 5px 15px, flex-wrap, gap 4px */}
           {pendingAttachments.length > 0 && (
-            <div className="flex flex-wrap gap-1 px-[15px] py-[5px]">
+            <div className="flex flex-wrap gap-1 px-[15px] pt-[10px] pb-[15px]">
               {pendingAttachments.map((att) => (
                 <AttachmentPreviewItem
                   key={att.id}


### PR DESCRIPTION
## Summary

- **Fix cramped attachment previews**: When files/images are attached in the chat input, the preview thumbnails were visually pressed against the text editor with insufficient spacing
- Increased top padding from `5px` → `10px` and bottom padding from `5px` → `15px` in the attachment preview container
- Only touches the attachment preview wrapper div — no behavior changes

## Test plan

- [ ] Attach one or more images/files in the chat input
- [ ] Verify there is comfortable spacing between the preview thumbnails and the text editor below
- [ ] Verify spacing above the previews looks balanced within the input card
- [ ] Confirm no layout shifts or overflow issues with multiple attachments

🤖 Generated with [Claude Code](https://claude.com/claude-code)