### PR TITLE
refactor: Bridge Registry 统一管理 + Session Recovery 去重

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -34,6 +34,7 @@ import { initAutoUpdater, cleanupUpdater } from './lib/updater/auto-updater'
 import { startWorkspaceWatcher, stopWorkspaceWatcher } from './lib/workspace-watcher'
 import { startChatToolsWatcher, stopChatToolsWatcher } from './lib/chat-tools-watcher'
 import { getIsQuitting, setQuitting } from './lib/app-lifecycle'
+import { registerBridge, startAllBridges, stopAllBridges } from './lib/bridge-registry'
 import { feishuBridgeManager } from './lib/feishu-bridge-manager'
 import { getFeishuMultiBotConfig } from './lib/feishu-config'
 import { dingtalkBridge } from './lib/dingtalk-bridge'
@@ -42,6 +43,38 @@ import { wechatBridge } from './lib/wechat-bridge'
 import { getWeChatConfig } from './lib/wechat-config'
 import { createQuickTaskWindow, toggleQuickTaskWindow, destroyQuickTaskWindow } from './lib/quick-task-window'
 import { registerGlobalShortcut, unregisterAllGlobalShortcuts } from './lib/global-shortcut-service'
+
+// ===== Bridge 注册（新增 Bridge 只需在此添加一个 registerBridge 调用） =====
+
+registerBridge({
+  name: '飞书 BridgeManager',
+  shouldAutoStart: () => {
+    const config = getFeishuMultiBotConfig()
+    return config.bots.some((b) => b.enabled && b.appId && b.appSecret)
+  },
+  start: () => feishuBridgeManager.startAll(),
+  stop: () => feishuBridgeManager.stopAll(),
+})
+
+registerBridge({
+  name: '钉钉 Bridge',
+  shouldAutoStart: () => {
+    const config = getDingTalkConfig()
+    return !!(config.enabled && config.clientId && config.clientSecret)
+  },
+  start: () => dingtalkBridge.start(),
+  stop: () => dingtalkBridge.stop(),
+})
+
+registerBridge({
+  name: '微信 Bridge',
+  shouldAutoStart: () => {
+    const config = getWeChatConfig()
+    return !!(config.enabled && config.credentials)
+  },
+  start: () => wechatBridge.start(),
+  stop: () => wechatBridge.stop(),
+})
 
 let mainWindow: BrowserWindow | null = null
 
@@ -236,29 +269,8 @@ app.whenReady().then(async () => {
   registerGlobalShortcut('quick-task', toggleQuickTaskWindow)
   registerGlobalShortcut('show-main-window', showAndFocusMainWindow)
 
-  // 飞书 Bridge 自动启动（所有已启用的 Bot）
-  const feishuMultiConfig = getFeishuMultiBotConfig()
-  if (feishuMultiConfig.bots.some((b) => b.enabled && b.appId && b.appSecret)) {
-    feishuBridgeManager.startAll().catch((err) => {
-      console.error('[飞书 BridgeManager] 自动启动失败:', err)
-    })
-  }
-
-  // 钉钉 Bridge 自动启动（配置启用时）
-  const dingtalkConfig = getDingTalkConfig()
-  if (dingtalkConfig.enabled && dingtalkConfig.clientId && dingtalkConfig.clientSecret) {
-    dingtalkBridge.start().catch((err) => {
-      console.error('[钉钉 Bridge] 自动启动失败:', err)
-    })
-  }
-
-  // 微信 Bridge 自动启动（有已保存凭证时）
-  const wechatConfig = getWeChatConfig()
-  if (wechatConfig.enabled && wechatConfig.credentials) {
-    wechatBridge.start().catch((err) => {
-      console.error('[微信 Bridge] 自动启动失败:', err)
-    })
-  }
+  // 启动所有已注册的 Bridge（飞书/钉钉/微信等）
+  await startAllBridges()
 
   app.on('activate', () => {
     // 直接检查 mainWindow 引用，避免 getAllWindows() 包含 DevTools 等其他窗口导致误判
@@ -292,12 +304,8 @@ app.on('before-quit', () => {
   stopWorkspaceWatcher()
   // 停止 Chat 工具配置文件监听
   stopChatToolsWatcher()
-  // 停止飞书 Bridge
-  feishuBridgeManager.stopAll()
-  // 停止钉钉 Bridge
-  dingtalkBridge.stop()
-  // 停止微信 Bridge
-  wechatBridge.stop()
+  // 停止所有 Bridge
+  stopAllBridges()
   // 注销全局快捷键
   unregisterAllGlobalShortcuts()
   // 销毁快速任务窗口

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -671,6 +671,31 @@ export class AgentOrchestrator {
   }
 
   /**
+   * Session-not-found 恢复：清除失效的 sdkSessionId，切换到上下文回填模式
+   *
+   * 当 resume 的目标 session 已过期/被清理时，SDK 会抛出 "No conversation found" 错误。
+   * 此方法执行恢复的公共逻辑，调用方负责设置 existingSdkSessionId = undefined 和流程控制（break/continue）。
+   *
+   * @returns lastRetryableError 描述字符串
+   */
+  private prepareSessionNotFoundRecovery(
+    sessionId: string,
+    queryOptions: ClaudeAgentQueryOptions,
+    contextualMessage: string,
+    agentCwd: string,
+    accumulatedMessages: SDKMessage[],
+    queryStartedAt: number,
+  ): string {
+    console.log(`[Agent 编排] 检测到 session-not-found 错误，清除 sdkSessionId 并切换到上下文回填模式`)
+    try { updateAgentSessionMeta(sessionId, { sdkSessionId: undefined }) } catch { /* 忽略 */ }
+    queryOptions.resumeSessionId = undefined
+    queryOptions.prompt = buildContextPrompt(sessionId, contextualMessage, { agentCwd })
+    this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
+    accumulatedMessages.length = 0
+    return 'Session 已失效，切换到上下文回填模式'
+  }
+
+  /**
    * 持久化累积的 SDKMessage（Phase 4: 直接存储原始 SDKMessage）
    *
    * 只持久化 assistant、user、result 和 compact_boundary system 消息
@@ -1311,14 +1336,8 @@ export class AgentOrchestrator {
 
                 // Session 不存在错误：清除 sdkSessionId，切换到上下文回填模式重试
                 if (isSessionNotFoundError(detailedMessage, originalError) && existingSdkSessionId && attempt <= MAX_AUTO_RETRIES) {
-                  console.log(`[Agent 编排] 检测到 session-not-found 错误 (assistant error)，切换到上下文回填模式`)
                   existingSdkSessionId = undefined
-                  try { updateAgentSessionMeta(sessionId, { sdkSessionId: undefined }) } catch { /* 忽略 */ }
-                  queryOptions.resumeSessionId = undefined
-                  queryOptions.prompt = buildContextPrompt(sessionId, contextualMessage, { agentCwd })
-                  lastRetryableError = 'Session 已失效，切换到上下文回填模式'
-                  this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
-                  accumulatedMessages.length = 0
+                  lastRetryableError = this.prepareSessionNotFoundRecovery(sessionId, queryOptions, contextualMessage, agentCwd, accumulatedMessages, queryStartedAt)
                   shouldRetryFromError = true
                   break
                 }
@@ -1596,17 +1615,8 @@ export class AgentOrchestrator {
 
           // Session 不存在错误：清除 sdkSessionId，切换到上下文回填模式重试
           if (isSessionNotFoundError(rawErrorMessage, stderrOutput) && existingSdkSessionId && attempt <= MAX_AUTO_RETRIES) {
-            console.log(`[Agent 编排] 检测到 session-not-found 错误，清除 sdkSessionId 并切换到上下文回填模式`)
-            // 清除失效的 sdkSessionId
             existingSdkSessionId = undefined
-            try { updateAgentSessionMeta(sessionId, { sdkSessionId: undefined }) } catch { /* 忽略 */ }
-            // 重建 prompt：从 resume 模式切换到上下文回填，并注入 session 元信息
-            queryOptions.resumeSessionId = undefined
-            queryOptions.prompt = buildContextPrompt(sessionId, contextualMessage, { agentCwd })
-            lastRetryableError = 'Session 已失效，切换到上下文回填模式'
-            // 保存部分内容
-            this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
-            accumulatedMessages.length = 0
+            lastRetryableError = this.prepareSessionNotFoundRecovery(sessionId, queryOptions, contextualMessage, agentCwd, accumulatedMessages, queryStartedAt)
             stderrChunks.length = 0
             continue  // 进入下一次 retry 循环
           }

--- a/apps/electron/src/main/lib/bridge-registry.ts
+++ b/apps/electron/src/main/lib/bridge-registry.ts
@@ -1,0 +1,60 @@
+/**
+ * Bridge Registry — 统一管理 IM Bridge 生命周期
+ *
+ * 解决的问题：每新增一个 Bridge（飞书、钉钉、微信…），都需要在 index.ts 的
+ * `app.whenReady()` 和 `before-quit` 两个位置分别添加启动/清理代码。
+ * 遗漏任一处会导致 Bridge 不启动或进程无法正常退出。
+ *
+ * 使用方式：
+ * 1. 在各 Bridge 模块中调用 `registerBridge()` 注册
+ * 2. 在 `app.whenReady()` 中调用 `startAllBridges()`
+ * 3. 在 `before-quit` 中调用 `stopAllBridges()`
+ *
+ * 新增 Bridge 只需一个 `registerBridge()` 调用，无需修改两个位置。
+ */
+
+/** Bridge 注册信息 */
+export interface BridgeRegistration {
+  /** 显示名称，用于日志 */
+  name: string
+  /** 判断是否应在启动时自动连接（检查配置是否完整/启用） */
+  shouldAutoStart: () => boolean
+  /** 启动连接 */
+  start: () => Promise<void>
+  /** 停止连接并释放资源 */
+  stop: () => void
+}
+
+const bridges: BridgeRegistration[] = []
+
+/** 注册一个 Bridge（通常在模块顶层调用） */
+export function registerBridge(bridge: BridgeRegistration): void {
+  bridges.push(bridge)
+}
+
+/**
+ * 启动所有满足条件的 Bridge
+ *
+ * 每个 Bridge 独立启动，单个失败不影响其他 Bridge。
+ * 启动是 fire-and-forget，不阻塞主流程。
+ */
+export async function startAllBridges(): Promise<void> {
+  for (const bridge of bridges) {
+    if (bridge.shouldAutoStart()) {
+      bridge.start().catch((err) => {
+        console.error(`[Bridge Registry] ${bridge.name} 自动启动失败:`, err)
+      })
+    }
+  }
+}
+
+/** 停止所有已注册的 Bridge（进程退出时调用） */
+export function stopAllBridges(): void {
+  for (const bridge of bridges) {
+    try {
+      bridge.stop()
+    } catch (err) {
+      console.error(`[Bridge Registry] ${bridge.name} 停止失败:`, err)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- **新增 `bridge-registry.ts`**：统一的 Bridge 生命周期管理器，提供 `registerBridge()` / `startAllBridges()` / `stopAllBridges()` 三个 API
- **简化 `index.ts`**：3 个 Bridge 的重复启动/清理代码替换为声明式注册，新增 Bridge 只需添加一个 `registerBridge()` 调用
- **提取 `prepareSessionNotFoundRecovery()`**：消除 `agent-orchestrator.ts` 中 session-not-found 恢复逻辑的重复代码

## Motivation

当前每新增一个 IM Bridge（飞书→钉钉→微信），都需要在 `index.ts` 的 `app.whenReady()` 和 `before-quit` 两处分别添加启动和清理代码。这违反了开闭原则，且容易在新增 Bridge 时遗漏清理逻辑。

同样，`agent-orchestrator.ts` 中 session-not-found 的恢复逻辑在 assistant-error 和 outer-catch 两处几乎完全相同，未来修改时容易遗漏同步更新。

## Changes

### 1. Bridge Registry (`bridge-registry.ts`)

```typescript
// 新增 Bridge 只需一个调用
registerBridge({
  name: '钉钉 Bridge',
  shouldAutoStart: () => { ... },
  start: () => dingtalkBridge.start(),
  stop: () => dingtalkBridge.stop(),
})

// index.ts 中只需两行
await startAllBridges()  // app.whenReady()
stopAllBridges()         // before-quit
```

### 2. Session Recovery 去重

提取 `prepareSessionNotFoundRecovery()` 私有方法，统一处理：
- 清除失效的 sdkSessionId
- 切换到上下文回填模式
- 持久化已累积的消息

两个调用点只保留各自的流程控制（`break` / `continue`）。

## Test plan

- [ ] TypeScript 类型检查通过 ✅
- [ ] esbuild 构建通过 ✅
- [ ] App 正常启动，飞书/钉钉/微信 Bridge 按配置自动连接
- [ ] 退出时所有 Bridge 正常停止
- [ ] Session-not-found 场景自动恢复到上下文回填模式

🤖 Generated with [Claude Code](https://claude.com/claude-code)