### PR TITLE
fix: prevent duplicate session creation when switching Chat/Agent mode

### DIFF
--- a/apps/electron/src/renderer/components/welcome/WelcomeEmptyState.tsx
+++ b/apps/electron/src/renderer/components/welcome/WelcomeEmptyState.tsx
@@ -15,7 +15,6 @@ import { userProfileAtom } from '@/atoms/user-profile'
 import { appModeAtom, type AppMode } from '@/atoms/app-mode'
 import { themeStyleAtom } from '@/atoms/theme'
 import { getRandomTip, getPlatform, type Tip } from '@/lib/tips'
-import { useCreateSession } from '@/hooks/useCreateSession'
 
 /** 根据小时返回时段问候 */
 function getGreeting(hour: number): string {
@@ -35,7 +34,6 @@ export function WelcomeEmptyState(): React.ReactElement {
   const userProfile = useAtomValue(userProfileAtom)
   const [mode, setMode] = useAtom(appModeAtom)
   const themeStyle = useAtomValue(themeStyleAtom)
-  const { createChat, createAgent } = useCreateSession()
 
   // 稳定的随机 Tip（组件挂载时选一条）
   const [tip] = React.useState<Tip>(() => getRandomTip(getPlatform()))
@@ -47,16 +45,11 @@ export function WelcomeEmptyState(): React.ReactElement {
   // 森息晨光主题下选中按钮使用主色
   const selectedColor = themeStyle === 'forest-light' ? '#3f8361' : undefined
 
-  /** 切换模式：切换模式并创建对应的 draft 会话 */
-  const handleModeSwitch = React.useCallback(async (targetMode: AppMode): Promise<void> => {
+  /** 切换模式：仅切换模式，不创建新会话 */
+  const handleModeSwitch = React.useCallback((targetMode: AppMode): void => {
     if (targetMode === mode) return
     setMode(targetMode)
-    if (targetMode === 'chat') {
-      await createChat({ draft: true })
-    } else {
-      await createAgent({ draft: true })
-    }
-  }, [mode, setMode, createChat, createAgent])
+  }, [mode, setMode])
 
   return (
     <div className="flex h-full flex-col items-center justify-center gap-6 px-4 animate-in fade-in duration-500">

--- a/apps/electron/src/renderer/components/welcome/WelcomeView.tsx
+++ b/apps/electron/src/renderer/components/welcome/WelcomeView.tsx
@@ -29,16 +29,17 @@ export function WelcomeView(): React.ReactElement {
   const [tabs, setTabs] = useAtom(tabsAtom)
   const [layout, setLayout] = useAtom(splitLayoutAtom)
   const { createChat, createAgent } = useCreateSession()
-  const initRef = React.useRef(false)
+  const initRef = React.useRef<string | null>(null)
 
   React.useEffect(() => {
-    if (initRef.current) return
+    // 如果已经为当前模式初始化过，则跳过
+    if (initRef.current === mode) return
     // Agent 模式需等待 settings 就绪（workspaceId 等异步加载完成）
     if (mode === 'agent' && !agentSettingsReady) return
-    initRef.current = true
+    initRef.current = mode
 
     if (mode === 'chat') {
-      // 优先复用现有非归档、非 draft 会话
+      // 1. 优先复用现有非归档、非 draft 会话
       const existing = conversations.find((c) => !c.archived && !draftSessionIds.has(c.id))
       if (existing) {
         const result = openTab(tabs, layout, {
@@ -48,11 +49,25 @@ export function WelcomeView(): React.ReactElement {
         })
         setTabs(result.tabs)
         setLayout(result.layout)
-      } else {
-        createChat({ draft: true })
+        return
       }
+      // 2. 检查是否已有 draft 会话，复用而不是创建新的
+      const draftSession = conversations.find((c) => !c.archived && draftSessionIds.has(c.id))
+      if (draftSession) {
+        const result = openTab(tabs, layout, {
+          type: 'chat',
+          sessionId: draftSession.id,
+          title: draftSession.title,
+        })
+        setTabs(result.tabs)
+        setLayout(result.layout)
+        return
+      }
+      // 3. 没有任何会话时才创建新的 draft 会话
+      createChat({ draft: true })
     } else {
       // Agent 模式：按当前工作区过滤
+      // 1. 优先复用现有非归档、非 draft 会话
       const existing = agentSessions.find(
         (s) => !s.archived && s.workspaceId === currentWorkspaceId && !draftSessionIds.has(s.id),
       )
@@ -64,11 +79,26 @@ export function WelcomeView(): React.ReactElement {
         })
         setTabs(result.tabs)
         setLayout(result.layout)
-      } else {
-        createAgent({ draft: true })
+        return
       }
+      // 2. 检查是否已有 draft 会话（当前工作区），复用而不是创建新的
+      const draftSession = agentSessions.find(
+        (s) => !s.archived && s.workspaceId === currentWorkspaceId && draftSessionIds.has(s.id),
+      )
+      if (draftSession) {
+        const result = openTab(tabs, layout, {
+          type: 'agent',
+          sessionId: draftSession.id,
+          title: draftSession.title,
+        })
+        setTabs(result.tabs)
+        setLayout(result.layout)
+        return
+      }
+      // 3. 没有任何会话时才创建新的 draft 会话
+      createAgent({ draft: true })
     }
-  }, [agentSettingsReady]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [mode, agentSettingsReady]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // 短暂的过渡状态（通常几十毫秒内就会被 SplitContainer 替换）
   return (


### PR DESCRIPTION
## 问题描述

在使用中间的Welcome按钮进行 Chat/Agent 模式切换时，每次点击切换按钮都会创建新的会话，导致：
- 标签栏出现多个重复的标签页
- 这些会话被标记为 draft，不在左侧列表显示
- 需要重新打开应用才能在侧边栏看到这些会话

## 根本原因

1. **WelcomeView 问题**： 使用布尔值，一旦设为 true 就不会重置，导致模式切换时不会重新执行初始化逻辑
2. **WelcomeEmptyState 问题**：空会话内的模式切换按钮会创建新的 draft 会话，这是主要问题

## 修复方案

### WelcomeView.tsx
- 将 `initRef` 从布尔值改为存储当前模式（`'chat' | 'agent' | null`）
- 添加 `mode` 到 useEffect 依赖项
- 添加三级检查逻辑：
  1. 优先复用现有非 draft 会话
  2. 检查并复用已有的 draft 会话
  3. 只有在完全没有会话时才创建新的 draft 会话

### WelcomeEmptyState.tsx
- 移除 `createChat` 和 `createAgent` 调用
- 模式切换时只改变模式状态，不创建新会话
- 移除不必要的 `useCreateSession` hook

## 测试

- [x] 在空会话中点击 Chat/Agent 切换按钮，不会创建新标签页
- [x] 切换模式时会复用已有的 draft 会话
- [x] 没有标签页时，WelcomeView 会自动创建 draft 会话
- [x] 发送第一条消息后，会话正常出现在侧边栏

## 影响范围

- 仅影响模式切换和会话创建逻辑
- 不影响其他功能
- 向后兼容