### PR TITLE
fix: 修复飞书 Bot 停止不生效、UI 状态不刷新及 button 嵌套警告

### DIFF
--- a/apps/electron/src/main/lib/feishu-bridge.ts
+++ b/apps/electron/src/main/lib/feishu-bridge.ts
@@ -225,9 +225,13 @@ class FeishuBridge {
     this.eventBusUnsubscribe?.()
     this.eventBusUnsubscribe = null
 
-    // 清理 WebSocket
+    // 关闭 WebSocket 连接
     if (this.wsClient) {
-      // SDK WSClient 没有显式的 stop 方法，清空引用让 GC 回收
+      try {
+        this.wsClient.close({ force: true })
+      } catch {
+        // 忽略关闭时的错误
+      }
       this.wsClient = null
     }
     this.client = null

--- a/apps/electron/src/renderer/components/settings/FeishuSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/FeishuSettings.tsx
@@ -401,6 +401,7 @@ interface BotConfigCardProps {
 }
 
 function BotConfigCard({ bot, state, onSaved, onRemoved }: BotConfigCardProps): React.ReactElement {
+  const setBotStates = useSetAtom(feishuBotStatesAtom)
   const [name, setName] = React.useState(bot.name)
   const [appId, setAppId] = React.useState(bot.appId)
   const [appSecret, setAppSecret] = React.useState('')
@@ -456,19 +457,53 @@ function BotConfigCard({ bot, state, onSaved, onRemoved }: BotConfigCardProps): 
     }
   }, [appId, appSecret])
 
+  /** 操作完成后主动拉取最新状态，确保 UI 同步 */
+  const refreshBotStates = React.useCallback(async () => {
+    try {
+      const multiState = await window.electronAPI.getFeishuMultiStatus?.()
+      if (multiState?.bots) {
+        setBotStates(multiState.bots)
+      }
+    } catch { /* 忽略 */ }
+  }, [setBotStates])
+
   const handleToggle = React.useCallback(async () => {
     if (isConnected) {
       await window.electronAPI.stopFeishuBot(bot.id)
       toast.success(`Bot "${bot.name}" 已停止`)
+      await refreshBotStates()
     } else {
-      try {
-        await window.electronAPI.startFeishuBot(bot.id)
-        toast.success(`Bot "${bot.name}" 启动中...`)
-      } catch (err) {
+      // 启动是异步的（10-15秒），不阻塞等待完成
+      // 先发起启动请求，然后轮询状态直到连接成功或失败
+      window.electronAPI.startFeishuBot(bot.id).catch((err: unknown) => {
         toast.error(err instanceof Error ? err.message : '启动失败')
-      }
+        refreshBotStates()
+      })
+      // 短暂等待让主进程设置 connecting 状态
+      await new Promise((r) => setTimeout(r, 300))
+      await refreshBotStates()
+      // 轮询直到状态不再是 connecting
+      const poll = setInterval(async () => {
+        try {
+          const multiState = await window.electronAPI.getFeishuMultiStatus?.()
+          if (multiState?.bots) {
+            setBotStates(multiState.bots)
+            const botState = multiState.bots[bot.id]
+            if (!botState || botState.status !== 'connecting') {
+              clearInterval(poll)
+              if (botState?.status === 'connected') {
+                toast.success(`Bot "${bot.name}" 已连接`)
+              }
+            }
+          }
+        } catch {
+          clearInterval(poll)
+        }
+      }, 1000)
+      // 安全超时：60秒后停止轮询
+      setTimeout(() => clearInterval(poll), 60_000)
     }
-  }, [bot.id, bot.name, isConnected])
+  }, [bot.id, bot.name, isConnected, refreshBotStates, setBotStates])
 
   const handleRemove = React.useCallback(async () => {
     try {
@@ -483,10 +518,12 @@ function BotConfigCard({ bot, state, onSaved, onRemoved }: BotConfigCardProps): 
   return (
     <SettingsCard>
       {/* 头部：名称 + 状态 + 展开/折叠 */}
-      <button
-        type="button"
-        className="w-full px-4 py-3 flex items-center justify-between hover:bg-muted/30 transition-colors"
+      <div
+        role="button"
+        tabIndex={0}
+        className="w-full px-4 py-3 flex items-center justify-between hover:bg-muted/30 transition-colors cursor-pointer"
         onClick={() => setExpanded(!expanded)}
+        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setExpanded(!expanded) } }}
       >
         <div className="flex items-center gap-3">
           <span className={`w-2 h-2 rounded-full flex-shrink-0 ${statusConfig.color}`} />
@@ -508,7 +545,7 @@ function BotConfigCard({ bot, state, onSaved, onRemoved }: BotConfigCardProps): 
           ) : null}
           <span className="text-xs text-muted-foreground">{expanded ? '▾' : '▸'}</span>
         </div>
-      </button>
+      </div>
 
       {/* 展开的配置表单 */}
       {expanded && (


### PR DESCRIPTION
## Summary

- **修复停止 Bot 不生效**：`feishu-bridge.ts` 的 `stop()` 方法原来仅将 `wsClient` 置为 `null`（误以为 SDK 无关闭方法），实际上 `WSClient` 提供了 `close()` API。现在调用 `wsClient.close({ force: true })` 强制关闭 WebSocket 连接及内部定时器（ping/reconnect），确保 Bot 真正停止。

- **修复 button 嵌套 DOM 警告**：`BotConfigCard` 头部使用 `<button>` 作为展开/折叠区域，内部又嵌套了启动/停止的 `<Button>` 组件，违反 HTML 规范。将外层改为 `<div role="button">`，保留键盘可访问性。

- **修复启动/停止后 UI 状态不刷新**：原来 UI 状态更新完全依赖主进程 `webContents.send()` 推送，但推送事件因 IPC 调度时序问题未及时到达渲染进程。现在操作完成后主动调用 `getFeishuMultiStatus` 拉取最新状态；启动时采用 fire-and-forget + 轮询机制，实时反映 `connecting` → `connected` / `error` 状态变化。

## Test plan

- [ ] 打开设置 → 机器人 → 飞书，确认 Console 不再报 `validateDOMNesting` 警告
- [ ] 点击"停止"按钮，确认 Bot 真正断开（飞书侧不再收到消息）且 UI 立刻更新为"未连接"
- [ ] 点击"启动"按钮，确认 UI 显示连接状态变化，连接成功后 toast 提示"已连接"
- [ ] 验证启动/停止多次切换后状态一致，无残留连接

🤖 Generated with [Claude Code](https://claude.com/claude-code)