### PR TITLE
fix(sidebar): 优化归档会话的交互逻辑

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -378,7 +378,13 @@ export function registerIpcHandlers(): void {
       const conversations = listConversations()
       const current = conversations.find((c) => c.id === id)
       if (!current) throw new Error(`对话不存在: ${id}`)
-      return updateConversationMeta(id, { pinned: !current.pinned })
+      const newPinned = !current.pinned
+      // 置顶时自动取消归档
+      const updates: Partial<ConversationMeta> = { pinned: newPinned }
+      if (newPinned && current.archived) {
+        updates.archived = false
+      }
+      return updateConversationMeta(id, updates)
     }
   )
 
@@ -775,7 +781,13 @@ export function registerIpcHandlers(): void {
       const sessions = listAgentSessions()
       const current = sessions.find((s) => s.id === id)
       if (!current) throw new Error(`Agent 会话不存在: ${id}`)
-      return updateAgentSessionMeta(id, { pinned: !current.pinned })
+      const newPinned = !current.pinned
+      // 置顶时自动取消归档
+      const updates: Partial<AgentSessionMeta> = { pinned: newPinned }
+      if (newPinned && current.archived) {
+        updates.archived = false
+      }
+      return updateAgentSessionMeta(id, updates)
     }
   )
 

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -389,7 +389,13 @@ export function registerIpcHandlers(): void {
       const conversations = listConversations()
       const current = conversations.find((c) => c.id === id)
       if (!current) throw new Error(`对话不存在: ${id}`)
-      return updateConversationMeta(id, { archived: !current.archived })
+      const newArchived = !current.archived
+      // 归档时自动取消置顶
+      const updates: Partial<ConversationMeta> = { archived: newArchived }
+      if (newArchived && current.pinned) {
+        updates.pinned = false
+      }
+      return updateConversationMeta(id, updates)
     }
   )
 
@@ -780,7 +786,13 @@ export function registerIpcHandlers(): void {
       const sessions = listAgentSessions()
       const current = sessions.find((s) => s.id === id)
       if (!current) throw new Error(`Agent 会话不存在: ${id}`)
-      return updateAgentSessionMeta(id, { archived: !current.archived })
+      const newArchived = !current.archived
+      // 归档时自动取消置顶
+      const updates: Partial<AgentSessionMeta> = { archived: newArchived }
+      if (newArchived && current.pinned) {
+        updates.pinned = false
+      }
+      return updateAgentSessionMeta(id, updates)
     }
   )
 

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -379,10 +379,15 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   /** 切换对话置顶状态 */
   const handleTogglePin = async (id: string): Promise<void> => {
     try {
+      const original = conversations.find((c) => c.id === id)
       const updated = await window.electronAPI.togglePinConversation(id)
       setConversations((prev) =>
         prev.map((c) => (c.id === updated.id ? updated : c))
       )
+      // 归档会话被置顶时会自动取消归档
+      if (original?.archived && updated.pinned && !updated.archived) {
+        toast.success('已取消归档并置顶')
+      }
     } catch (error) {
       console.error('[侧边栏] 切换置顶失败:', error)
     }
@@ -537,10 +542,15 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   /** 切换 Agent 会话置顶状态 */
   const handleTogglePinAgent = async (id: string): Promise<void> => {
     try {
+      const original = agentSessions.find((s) => s.id === id)
       const updated = await window.electronAPI.togglePinAgentSession(id)
       setAgentSessions((prev) =>
         prev.map((s) => (s.id === updated.id ? updated : s))
       )
+      // 归档会话被置顶时会自动取消归档
+      if (original?.archived && updated.pinned && !updated.archived) {
+        toast.success('已取消归档并置顶')
+      }
     } catch (error) {
       console.error('[侧边栏] 切换 Agent 会话置顶失败:', error)
     }
@@ -775,19 +785,6 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         </Tooltip>
       </div>
 
-      {/* 归档视图标题栏 */}
-      {viewMode === 'archived' && (
-        <div className="px-3 pt-3">
-          <button
-            onClick={() => setViewMode('active')}
-            className="flex items-center gap-2 px-2 py-1.5 rounded-lg text-[13px] text-foreground/60 hover:text-foreground/80 hover:bg-foreground/[0.04] transition-colors titlebar-no-drag"
-          >
-            <ArrowLeft size={14} />
-            <span>返回活跃{mode === 'agent' ? '会话' : '对话'}</span>
-          </button>
-        </div>
-      )}
-
       {/* Chat 模式：导航菜单（置顶区域） */}
       {mode === 'chat' && (
         <div className="flex flex-col gap-1 pt-3 px-3">
@@ -875,6 +872,15 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         </div>
       )}
 
+      {/* 归档视图标题栏（置顶区域下方） */}
+      {viewMode === 'archived' && (
+        <div className="px-6 pt-3 pb-1">
+          <div className="text-[12px] font-medium text-foreground/40">
+            已归档{mode === 'agent' ? '会话' : '对话'}
+          </div>
+        </div>
+      )}
+
       {/* 列表区域：根据模式切换 */}
       <div className="flex-1 overflow-y-auto px-3 pt-2 pb-3 scrollbar-none">
         {mode === 'chat' ? (
@@ -937,29 +943,39 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         )}
       </div>
 
-      {/* 已归档入口 */}
-      {viewMode === 'active' && (
-        <div className="px-3 pb-1">
-          {mode === 'chat' && archivedConversationCount > 0 && (
-            <button
-              onClick={() => setViewMode('archived')}
-              className="w-full flex items-center gap-2 px-3 py-2 rounded-[10px] text-[12px] text-foreground/40 hover:bg-foreground/[0.04] hover:text-foreground/60 transition-colors titlebar-no-drag"
-            >
-              <Archive size={13} className="text-foreground/30" />
-              <span>已归档 ({archivedConversationCount})</span>
-            </button>
-          )}
-          {mode === 'agent' && archivedAgentSessionCount > 0 && (
-            <button
-              onClick={() => setViewMode('archived')}
-              className="w-full flex items-center gap-2 px-3 py-2 rounded-[10px] text-[12px] text-foreground/40 hover:bg-foreground/[0.04] hover:text-foreground/60 transition-colors titlebar-no-drag"
-            >
-              <Archive size={13} className="text-foreground/30" />
-              <span>已归档 ({archivedAgentSessionCount})</span>
-            </button>
-          )}
-        </div>
-      )}
+      {/* 已归档入口 / 返回活跃对话 */}
+      <div className="px-3 pb-1">
+        {viewMode === 'active' ? (
+          <>
+            {mode === 'chat' && archivedConversationCount > 0 && (
+              <button
+                onClick={() => setViewMode('archived')}
+                className="w-full flex items-center gap-2 px-3 py-2 rounded-[10px] text-[12px] text-foreground/40 hover:bg-foreground/[0.04] hover:text-foreground/60 transition-colors titlebar-no-drag"
+              >
+                <Archive size={13} className="text-foreground/30" />
+                <span>已归档 ({archivedConversationCount})</span>
+              </button>
+            )}
+            {mode === 'agent' && archivedAgentSessionCount > 0 && (
+              <button
+                onClick={() => setViewMode('archived')}
+                className="w-full flex items-center gap-2 px-3 py-2 rounded-[10px] text-[12px] text-foreground/40 hover:bg-foreground/[0.04] hover:text-foreground/60 transition-colors titlebar-no-drag"
+              >
+                <Archive size={13} className="text-foreground/30" />
+                <span>已归档 ({archivedAgentSessionCount})</span>
+              </button>
+            )}
+          </>
+        ) : (
+          <button
+            onClick={() => setViewMode('active')}
+            className="w-full flex items-center gap-2 px-3 py-2 rounded-[10px] text-[12px] text-foreground/60 bg-foreground/[0.04] hover:bg-foreground/[0.07] hover:text-foreground/80 transition-colors titlebar-no-drag"
+          >
+            <ArrowLeft size={13} className="text-foreground/50" />
+            <span>返回活跃{mode === 'agent' ? '会话' : '对话'}</span>
+          </button>
+        )}
+      </div>
 
       {/* Agent 模式：工作区能力指示器 */}
       {mode === 'agent' && capabilities && (


### PR DESCRIPTION
## 问题

侧边栏的归档功能存在几个交互体验问题：

### 1. 置顶会话归档后没有被正确处理
对一个**置顶会话**点击归档后：
- 它从置顶区消失了 ✓
- 但打开归档列表，它混在普通对话里，且仍带着 `pinned` 状态 ✗
- 回到活跃视图，它既不在置顶区也不在普通列表——"消失了" ✗

**原因**：归档只设置 `archived: true`，没有清除 `pinned: true`，导致状态矛盾。

### 2. "返回活跃对话"按钮位置跳变
- 点击底部的「已归档 (X)」进入归档视图
- 「返回活跃对话」按钮出现在**顶部**
- UI产生大幅度变化，且用户需要先找到返回活跃对话的方式，再大幅移动鼠标点击操作

### 3. 对已归档会话被置顶时缺少提示
- 在归档列表中对会话点置顶，会话静默消失（实际已经被 autoUnarchive 移回活跃列表）
- 用户不知道发生什么，只看到会话消失

## 修复

### 归档时自动取消置顶（后端）
归档一个置顶会话时，同时设置 `archived: true` + `pinned: false`，消除矛盾状态。Chat 和 Agent 两侧均已处理。

### 底部按钮原地切换（前端）
「已归档 (N)」和「返回活跃对话」共享底部同一位置：
- 活跃视图 → 底部显示「已归档 (3)」
- 点击后进入归档视图 → 同一位置变为「返回活跃对话」（带轻微背景色强调）
- 顶部改为轻量标题文字「已归档对话」，放在置顶区域下方

### 置顶归档会话时 toast 提示（前端）
在归档列表中置顶会话时，弹出 toast「已取消归档并置顶」，明确告知用户会话已转移到活跃列表。

## 影响范围
- `ipc.ts`：Chat/Agent 归档 handler
- `LeftSidebar.tsx`：置顶/归档操作函数、视图切换按钮布局

## Test plan
- [ ] 置顶一个会话 → 归档它 → 确认从置顶区消失且归档列表中正常显示
- [ ] 在归档列表中置顶一个会话 → 确认 toast 提示且会话出现在活跃列表的置顶区
- [ ] 点击「已归档」进入归档视图 → 确认「返回活跃对话」出现在底部同一位置
- [ ] Agent 模式下重复以上测试