### PR TITLE
feat: 支持拖拽文件夹直接附加到会话/工作区

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -1661,6 +1661,29 @@ export function registerIpcHandlers(): void {
     }
   )
 
+  // 检查路径类型（文件 or 目录），用于拖拽检测
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.CHECK_PATHS_TYPE,
+    async (_, paths: string[]): Promise<{ directories: string[]; files: string[] }> => {
+      const { statSync } = await import('node:fs')
+      const directories: string[] = []
+      const files: string[] = []
+      for (const p of paths) {
+        try {
+          const stat = statSync(p)
+          if (stat.isDirectory()) {
+            directories.push(p)
+          } else {
+            files.push(p)
+          }
+        } catch {
+          // 无法访问的路径忽略
+        }
+      }
+      return { directories, files }
+    }
+  )
+
   // 搜索工作区文件（用于 @ 引用，递归扫描，支持附加目录）
   ipcMain.handle(
     AGENT_IPC_CHANNELS.SEARCH_WORKSPACE_FILES,

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -5,7 +5,7 @@
  * 使用上下文隔离确保安全性
  */
 
-import { contextBridge, ipcRenderer } from 'electron'
+import { contextBridge, ipcRenderer, webUtils } from 'electron'
 import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, MEMORY_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS, DINGTALK_IPC_CHANNELS, WECHAT_IPC_CHANNELS } from '@proma/shared'
 import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS } from '../types'
 import type {
@@ -539,6 +539,12 @@ export interface ElectronAPI {
 
   /** 移动附加目录文件/目录（无工作区路径限制） */
   moveAttachedFile: (filePath: string, targetDir: string) => Promise<void>
+
+  /** 检查路径类型（文件 or 目录），用于拖拽检测 */
+  checkPathsType: (paths: string[]) => Promise<{ directories: string[]; files: string[] }>
+
+  /** 获取拖拽文件的本地路径（替代已废弃的 File.path） */
+  getPathForFile: (file: File) => string
 
   /** 搜索工作区文件（用于 @ 引用，支持附加目录） */
   searchWorkspaceFiles: (rootPath: string, query: string, limit?: number, additionalPaths?: string[]) => Promise<FileSearchResult>
@@ -1289,6 +1295,14 @@ const electronAPI: ElectronAPI = {
 
   moveAttachedFile: (filePath: string, targetDir: string) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.MOVE_ATTACHED_FILE, filePath, targetDir)
+  },
+
+  checkPathsType: (paths: string[]) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.CHECK_PATHS_TYPE, paths)
+  },
+
+  getPathForFile: (file: File) => {
+    return webUtils.getPathForFile(file)
   },
 
   searchWorkspaceFiles: (rootPath: string, query: string, limit = 20, additionalPaths?: string[]) => {

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -255,7 +255,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const sessionPath = sessionPathMap.get(sessionId) ?? null
   const [workspaceFilesPath, setWorkspaceFilesPath] = React.useState<string | null>(null)
   const [isDragOver, setIsDragOver] = React.useState(false)
-  const [dragFolderWarning, setDragFolderWarning] = React.useState(false)
   const [errorCopied, setErrorCopied] = React.useState(false)
 
   // pendingFiles ref（供 addFilesAsAttachments 读取最新列表，避免闭包旧值）
@@ -624,35 +623,60 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     e.stopPropagation()
     setIsDragOver(false)
 
-    const items = Array.from(e.dataTransfer.items)
-    const regularFiles: File[] = []
-    let hasFolders = false
+    const droppedFiles = Array.from(e.dataTransfer.files)
+    if (droppedFiles.length === 0) return
 
-    // 使用 webkitGetAsEntry 区分文件和文件夹
-    for (const item of items) {
-      if (item.kind !== 'file') continue
-      const entry = item.webkitGetAsEntry?.()
-      if (entry?.isDirectory) {
-        // 检测到文件夹，显示警告
-        hasFolders = true
-        console.warn('[AgentView] 拖拽文件夹已禁用，请使用"添加文件夹"按钮')
-      } else {
-        const file = item.getAsFile()
-        if (file) regularFiles.push(file)
+    // 通过 preload 的 webUtils.getPathForFile 获取真实路径
+    const pathMap = new Map<string, File>()
+    const paths: string[] = []
+    for (const f of droppedFiles) {
+      try {
+        const p = window.electronAPI.getPathForFile(f)
+        if (p) {
+          paths.push(p)
+          pathMap.set(p, f)
+        }
+      } catch { /* 无法获取路径时忽略 */ }
+    }
+
+    if (paths.length > 0) {
+      try {
+        // 通过主进程检测目录 vs 文件
+        const { directories, files: filePaths } = await window.electronAPI.checkPathsType(paths)
+
+        // 拖拽的文件夹直接附加
+        for (const dirPath of directories) {
+          try {
+            const updated = await window.electronAPI.attachDirectory({
+              sessionId,
+              directoryPath: dirPath,
+            })
+            setAttachedDirsMap((prev) => {
+              const map = new Map(prev)
+              map.set(sessionId, updated)
+              return map
+            })
+            const dirName = dirPath.split('/').pop() || dirPath
+            toast.success(`已附加目录: ${dirName}`)
+          } catch (error) {
+            console.error('[AgentView] 拖拽附加文件夹失败:', error)
+          }
+        }
+
+        // 普通文件作为附件
+        const regularFiles = filePaths.map((p) => pathMap.get(p)!).filter(Boolean)
+        if (regularFiles.length > 0) {
+          addFilesAsAttachments(regularFiles)
+        }
+      } catch (error) {
+        console.error('[AgentView] 路径检测失败，回退处理:', error)
+        addFilesAsAttachments(droppedFiles)
       }
+    } else {
+      // 无路径信息：回退，所有项按普通文件处理
+      addFilesAsAttachments(droppedFiles)
     }
-
-    // 如果检测到文件夹，显示提示
-    if (hasFolders) {
-      setDragFolderWarning(true)
-      setTimeout(() => setDragFolderWarning(false), 3000)
-    }
-
-    // 只处理普通文件
-    if (regularFiles.length > 0) {
-      addFilesAsAttachments(regularFiles)
-    }
-  }, [addFilesAsAttachments])
+  }, [sessionId, addFilesAsAttachments, setAttachedDirsMap])
 
   /** ModelSelector 选择回调 */
   const handleModelSelect = React.useCallback((option: ModelOption): void => {
@@ -1116,21 +1140,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           onFork={handleFork}
           onCompact={handleCompact}
         />
-
-        {/* 拖拽文件夹警告 */}
-        {dragFolderWarning && (
-          <div className="mx-4 mb-2 px-4 py-2.5 rounded-lg bg-amber-500/10 text-amber-600 dark:text-amber-400 text-sm flex items-center gap-2">
-            <FolderPlus className="size-4 shrink-0" />
-            <span className="flex-1">不支持拖拽文件夹，请使用"附加文件夹"按钮</span>
-            <button
-              type="button"
-              className="shrink-0 p-0.5 rounded hover:bg-amber-500/10 transition-colors"
-              onClick={() => setDragFolderWarning(false)}
-            >
-              <X className="size-3.5" />
-            </button>
-          </div>
-        )}
 
         {/* 权限请求横幅 */}
         <PermissionBanner sessionId={sessionId} />

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -92,38 +92,40 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
       .catch(console.error)
   }, [workspaceSlug, currentWorkspaceId, setWsAttachedDirsMap])
 
+  // === 会话级：附加/移除目录 ===
+
+  const attachSessionDir = React.useCallback(async (dirPath: string) => {
+    const updated = await window.electronAPI.attachDirectory({ sessionId, directoryPath: dirPath })
+    setAttachedDirsMap((prev) => {
+      const map = new Map(prev)
+      map.set(sessionId, updated)
+      return map
+    })
+  }, [sessionId, setAttachedDirsMap])
+
   const handleAttachFolder = React.useCallback(async () => {
     try {
       const result = await window.electronAPI.openFolderDialog()
-      if (!result) return
-
-      const updated = await window.electronAPI.attachDirectory({
-        sessionId,
-        directoryPath: result.path,
-      })
-      setAttachedDirsMap((prev) => {
-        const map = new Map(prev)
-        map.set(sessionId, updated)
-        return map
-      })
+      if (result) await attachSessionDir(result.path)
     } catch (error) {
       console.error('[SidePanel] 附加文件夹失败:', error)
     }
-  }, [sessionId, setAttachedDirsMap])
+  }, [attachSessionDir])
+
+  const handleSessionFoldersDropped = React.useCallback(async (folderPaths: string[]) => {
+    for (const dirPath of folderPaths) {
+      try { await attachSessionDir(dirPath) } catch (error) {
+        console.error('[SidePanel] 拖拽附加文件夹失败:', error)
+      }
+    }
+  }, [attachSessionDir])
 
   const handleDetachDirectory = React.useCallback(async (dirPath: string) => {
     try {
-      const updated = await window.electronAPI.detachDirectory({
-        sessionId,
-        directoryPath: dirPath,
-      })
+      const updated = await window.electronAPI.detachDirectory({ sessionId, directoryPath: dirPath })
       setAttachedDirsMap((prev) => {
         const map = new Map(prev)
-        if (updated.length > 0) {
-          map.set(sessionId, updated)
-        } else {
-          map.delete(sessionId)
-        }
+        if (updated.length > 0) { map.set(sessionId, updated) } else { map.delete(sessionId) }
         return map
       })
     } catch (error) {
@@ -131,41 +133,42 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
     }
   }, [sessionId, setAttachedDirsMap])
 
-  // 工作区级附加文件夹
-  const handleAttachWorkspaceFolder = React.useCallback(async () => {
+  // === 工作区级：附加/移除目录 ===
+
+  const attachWorkspaceDir = React.useCallback(async (dirPath: string) => {
     if (!workspaceSlug || !currentWorkspaceId) return
+    const updated = await window.electronAPI.attachWorkspaceDirectory({ workspaceSlug, directoryPath: dirPath })
+    setWsAttachedDirsMap((prev) => {
+      const map = new Map(prev)
+      map.set(currentWorkspaceId, updated)
+      return map
+    })
+  }, [workspaceSlug, currentWorkspaceId, setWsAttachedDirsMap])
+
+  const handleAttachWorkspaceFolder = React.useCallback(async () => {
     try {
       const result = await window.electronAPI.openFolderDialog()
-      if (!result) return
-
-      const updated = await window.electronAPI.attachWorkspaceDirectory({
-        workspaceSlug,
-        directoryPath: result.path,
-      })
-      setWsAttachedDirsMap((prev) => {
-        const map = new Map(prev)
-        map.set(currentWorkspaceId, updated)
-        return map
-      })
+      if (result) await attachWorkspaceDir(result.path)
     } catch (error) {
       console.error('[SidePanel] 附加工作区文件夹失败:', error)
     }
-  }, [workspaceSlug, currentWorkspaceId, setWsAttachedDirsMap])
+  }, [attachWorkspaceDir])
+
+  const handleWorkspaceFoldersDropped = React.useCallback(async (folderPaths: string[]) => {
+    for (const dirPath of folderPaths) {
+      try { await attachWorkspaceDir(dirPath) } catch (error) {
+        console.error('[SidePanel] 拖拽附加工作区文件夹失败:', error)
+      }
+    }
+  }, [attachWorkspaceDir])
 
   const handleDetachWorkspaceDirectory = React.useCallback(async (dirPath: string) => {
     if (!workspaceSlug || !currentWorkspaceId) return
     try {
-      const updated = await window.electronAPI.detachWorkspaceDirectory({
-        workspaceSlug,
-        directoryPath: dirPath,
-      })
+      const updated = await window.electronAPI.detachWorkspaceDirectory({ workspaceSlug, directoryPath: dirPath })
       setWsAttachedDirsMap((prev) => {
         const map = new Map(prev)
-        if (updated.length > 0) {
-          map.set(currentWorkspaceId, updated)
-        } else {
-          map.delete(currentWorkspaceId)
-        }
+        if (updated.length > 0) { map.set(currentWorkspaceId, updated) } else { map.delete(currentWorkspaceId) }
         return map
       })
     } catch (error) {
@@ -314,6 +317,7 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                           target="session"
                           onFilesUploaded={handleFilesUploaded}
                           onAttachFolder={handleAttachFolder}
+                          onFoldersDropped={handleSessionFoldersDropped}
                         />
                       </div>
                       {/* ===== 分隔线 ===== */}
@@ -396,6 +400,7 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                         target="workspace"
                         onFilesUploaded={handleFilesUploaded}
                         onAttachFolder={handleAttachWorkspaceFolder}
+                        onFoldersDropped={handleWorkspaceFoldersDropped}
                       />
                     </div>
                   </div>

--- a/apps/electron/src/renderer/components/file-browser/FileDropZone.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileDropZone.tsx
@@ -22,11 +22,13 @@ interface FileDropZoneProps {
   target?: 'session' | 'workspace'
   /** 上传成功后的回调（触发文件浏览器刷新） */
   onFilesUploaded: () => void
-  /** 附加文件夹回调 */
+  /** 附加文件夹回调（点击按钮时打开对话框） */
   onAttachFolder?: () => void
+  /** 拖拽文件夹回调（拖拽放下文件夹时直接附加） */
+  onFoldersDropped?: (folderPaths: string[]) => void
 }
 
-export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onFilesUploaded, onAttachFolder }: FileDropZoneProps): React.ReactElement {
+export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onFilesUploaded, onAttachFolder, onFoldersDropped }: FileDropZoneProps): React.ReactElement {
   const [isDragOver, setIsDragOver] = React.useState(false)
   const [isUploading, setIsUploading] = React.useState(false)
 
@@ -86,29 +88,48 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
     e.stopPropagation()
     setIsDragOver(false)
 
-    const items = Array.from(e.dataTransfer.items)
-    const regularFiles: globalThis.File[] = []
-    let hasFolders = false
+    const droppedFiles = Array.from(e.dataTransfer.files)
+    if (droppedFiles.length === 0) return
 
-    for (const item of items) {
-      if (item.kind !== 'file') continue
-      const entry = item.webkitGetAsEntry?.()
-      if (entry?.isDirectory) {
-        hasFolders = true
-      } else {
-        const file = item.getAsFile()
-        if (file) regularFiles.push(file)
+    // 通过 preload 的 webUtils.getPathForFile 获取真实路径
+    const pathMap = new Map<string, globalThis.File>()
+    const paths: string[] = []
+    for (const f of droppedFiles) {
+      try {
+        const p = window.electronAPI.getPathForFile(f)
+        if (p) {
+          paths.push(p)
+          pathMap.set(p, f)
+        }
+      } catch { /* 无法获取路径时忽略 */ }
+    }
+
+    if (paths.length > 0) {
+      try {
+        // 通过主进程检测目录 vs 文件
+        const { directories, files: filePaths } = await window.electronAPI.checkPathsType(paths)
+
+        if (directories.length > 0) {
+          if (onFoldersDropped) {
+            onFoldersDropped(directories)
+          } else {
+            toast.info('不支持拖拽文件夹', { description: '请使用「附加文件夹」按钮' })
+          }
+        }
+
+        const regularFiles = filePaths.map((p) => pathMap.get(p)!).filter(Boolean)
+        if (regularFiles.length > 0) {
+          await saveFiles(regularFiles)
+        }
+      } catch (error) {
+        console.error('[FileDropZone] 路径检测失败，回退处理:', error)
+        await saveFiles(droppedFiles)
       }
+    } else {
+      // 无路径信息：回退，所有项按普通文件处理
+      await saveFiles(droppedFiles)
     }
-
-    if (hasFolders) {
-      toast.info('不支持拖拽文件夹', { description: '请使用「附加文件夹」按钮' })
-    }
-
-    if (regularFiles.length > 0) {
-      await saveFiles(regularFiles)
-    }
-  }, [saveFiles])
+  }, [saveFiles, onFoldersDropped])
 
   // ===== 按钮点击处理 =====
 

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1206,6 +1206,8 @@ export const AGENT_IPC_CHANNELS = {
   RENAME_ATTACHED_FILE: 'agent:rename-attached-file',
   /** 移动附加目录文件/目录（无工作区路径限制） */
   MOVE_ATTACHED_FILE: 'agent:move-attached-file',
+  /** 检查路径类型（文件 or 目录），用于拖拽检测 */
+  CHECK_PATHS_TYPE: 'agent:check-paths-type',
   /** 搜索工作区文件（用于 @ 引用） */
   SEARCH_WORKSPACE_FILES: 'agent:search-workspace-files',
 


### PR DESCRIPTION
## Summary

拖拽文件夹到 Agent 会话区或侧面板时，直接作为附加目录附加，无需再通过「附加文件夹」按钮。

## 改动说明

**核心方案：`webUtils.getPathForFile` + 主进程 `fs.statSync` 两步检测**

原有的 `webkitGetAsEntry()` 和 `File.path` 在 Electron sandbox 模式下均不可用，改为：
1. Preload 层通过 `electron.webUtils.getPathForFile(file)` 获取拖拽文件的真实本地路径
2. 主进程通过 `fs.statSync` 可靠区分文件与目录

**涉及文件：**

| 文件 | 改动 |
|------|------|
| `packages/shared/src/types/agent.ts` | 新增 `CHECK_PATHS_TYPE` IPC 通道常量 |
| `apps/electron/src/main/ipc.ts` | 新增 `checkPathsType` handler，遍历路径用 `statSync` 判断类型 |
| `apps/electron/src/preload/index.ts` | 导入 `webUtils`，暴露 `getPathForFile` 和 `checkPathsType` API |
| `FileDropZone.tsx` | 新增 `onFoldersDropped` 可选回调；`handleDrop` 改用新检测方案，失败时回退为普通文件处理 |
| `SidePanel.tsx` | 提取 `attachSessionDir` / `attachWorkspaceDir` 共用函数，对话框和拖拽复用同一逻辑 |
| `AgentView.tsx` | 主区域拖拽文件夹直接附加 + toast 提示；移除已失效的 `dragFolderWarning` 状态和警告 UI |

## 代码审查

- `FileDropZone` 仅在 SidePanel 中使用（2 处），`onFoldersDropped` 为可选参数，向后兼容
- `FolderPlus` 图标在 AgentView 中仍有使用（附加文件夹按钮），非死引用
- `dragFolderWarning` 状态及警告 UI 已完整移除，无残留引用
- `webkitGetAsEntry` / `File.path` 等旧代码已完整清理
- `checkPathsType` IPC 调用已包裹 try/catch，失败时回退为普通文件处理，不会静默吞错
- `statSync` 在 async handler 中使用，拖拽场景文件数量极少（个位数），不阻塞主进程
- `webUtils` 为 Electron 内置模块，不引入新外部依赖
- SidePanel 提取共用函数后依赖链正确，对话框/拖拽两条路径复用同一核心逻辑

## Test plan

- [x] 拖拽文件夹到主聊天区域 → 附加为会话目录 + toast 提示
- [x] 拖拽文件夹到侧面板会话文件区 → 附加为会话目录
- [x] 拖拽文件夹到侧面板工作区文件区 → 附加为工作区目录
- [x] 拖拽普通文件 → 正常上传/附加（不受影响）
- [x] 点击「附加文件夹」按钮 → 原有功能正常
- [x] 点击「选择文件」按钮 → 原有功能正常