### PR TITLE
fix(ui): 微调使得面板按钮 UI 对齐

### DIFF
--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -220,7 +220,7 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
       {/* 面板内容 */}
       <div
         className={cn(
-          'w-[320px] h-full flex flex-col titlebar-no-drag pt-3',
+          'w-[320px] h-full flex flex-col titlebar-no-drag pt-0',
           shouldAnimate && 'transition-opacity duration-300',
           isOpen ? 'opacity-100' : 'opacity-0 pointer-events-none',
         )}
@@ -231,7 +231,7 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                   {/* ===== 会话文件区（仅当 sessionPath 存在时显示） ===== */}
                   {sessionPath && (
                     <>
-                      <div className="flex items-center gap-1 px-3 h-[32px] flex-shrink-0">
+                      <div className="flex items-center gap-1 pl-2 pr-0.5 h-[34px] flex-shrink-0">
                         <FolderOpen className="size-3 text-muted-foreground" />
                         <span className="text-[11px] font-medium text-muted-foreground">会话文件</span>
                         <Tooltip>
@@ -277,17 +277,17 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                             <p>刷新文件列表</p>
                           </TooltipContent>
                         </Tooltip>
-                        {/* 关闭面板按钮 */}
+                        {/* 关闭面板按钮 — 右上圆角与面板外层 rounded-2xl 呼应 */}
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <Button
                               type="button"
                               variant="ghost"
                               size="icon"
-                              className="h-5 w-5 flex-shrink-0"
+                              className="h-7 w-7 flex-shrink-0 rounded-tl-md rounded-tr-[13px] rounded-br-md rounded-bl-md"
                               onClick={() => setIsOpen((prev) => !prev)}
                             >
-                              <X className="size-2.5" />
+                              <X className="size-3" />
                             </Button>
                           </TooltipTrigger>
                           <TooltipContent side="bottom">

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -220,7 +220,7 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
       {/* 面板内容 */}
       <div
         className={cn(
-          'w-[320px] h-full flex flex-col titlebar-no-drag pt-0',
+          'w-[320px] h-full flex flex-col titlebar-no-drag pt-0.5',
           shouldAnimate && 'transition-opacity duration-300',
           isOpen ? 'opacity-100' : 'opacity-0 pointer-events-none',
         )}
@@ -231,7 +231,7 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                   {/* ===== 会话文件区（仅当 sessionPath 存在时显示） ===== */}
                   {sessionPath && (
                     <>
-                      <div className="flex items-center gap-1 pl-2 pr-0.5 h-[34px] flex-shrink-0">
+                      <div className="flex items-center gap-1 pl-3 pr-2 h-[32px] flex-shrink-0">
                         <FolderOpen className="size-3 text-muted-foreground" />
                         <span className="text-[11px] font-medium text-muted-foreground">会话文件</span>
                         <Tooltip>
@@ -277,17 +277,17 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                             <p>刷新文件列表</p>
                           </TooltipContent>
                         </Tooltip>
-                        {/* 关闭面板按钮 — 右上圆角与面板外层 rounded-2xl 呼应 */}
+                        {/* 关闭面板按钮 */}
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <Button
                               type="button"
                               variant="ghost"
                               size="icon"
-                              className="h-7 w-7 flex-shrink-0 rounded-tl-md rounded-tr-[13px] rounded-br-md rounded-bl-md"
+                              className="h-5 w-5 flex-shrink-0"
                               onClick={() => setIsOpen((prev) => !prev)}
                             >
-                              <X className="size-3" />
+                              <X className="size-2.5" />
                             </Button>
                           </TooltipTrigger>
                           <TooltipContent side="bottom">

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -738,7 +738,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       {/* 顶部留空，避开 macOS 红绿灯 */}
       <div className="pt-[50px]">
         {/* 模式切换器 + 折叠按钮 */}
-        <div className="flex items-start gap-1 pr-1">
+        <div className="flex items-start gap-1.5 px-3">
           <div className="flex-1 min-w-0">
             <ModeSwitcher />
           </div>
@@ -746,9 +746,9 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
             <TooltipTrigger asChild>
               <button
                 onClick={() => setSidebarCollapsed(true)}
-                className="mt-2 size-10 flex items-center justify-center rounded-[10px] text-foreground/40 hover:bg-foreground/[0.04] hover:text-foreground/60 transition-colors titlebar-no-drag"
+                className="mt-2 size-[36px] flex-shrink-0 flex items-center justify-center rounded-[10px] text-foreground/40 hover:bg-foreground/[0.04] hover:text-foreground/60 transition-colors titlebar-no-drag"
               >
-                <PanelLeftClose size={18} />
+                <PanelLeftClose size={14} />
               </button>
             </TooltipTrigger>
             <TooltipContent side="right">收起侧边栏</TooltipContent>

--- a/apps/electron/src/renderer/components/app-shell/ModeSwitcher.tsx
+++ b/apps/electron/src/renderer/components/app-shell/ModeSwitcher.tsx
@@ -16,7 +16,7 @@ export function ModeSwitcher(): React.ReactElement {
   const [mode, setMode] = useAtom(appModeAtom)
 
   return (
-    <div className="px-2 pt-2">
+    <div className="pt-2">
       <div className="relative flex rounded-lg bg-muted p-1">
         {/* 滑动背景指示器 */}
         <div


### PR DESCRIPTION
## Summary
- 调整侧面板上方标题，使其和左侧标签栏对齐
<img width="385" height="42" alt="image" src="https://github.com/user-attachments/assets/0c414a51-811f-4784-8bfd-5ec1aa9bdaf8" />

- Chat/Agent模式切换条 & 新建按钮UI和下方对齐
<img width="370" height="251" alt="image" src="https://github.com/user-attachments/assets/d35e4714-cab9-4fa4-9be6-d66f8820bca4" />
