### PR TITLE
fix(welcome): 修复 HMR 热重载导致重复创建 Chat/Agent 会话

### DIFF
--- a/apps/electron/src/renderer/components/welcome/WelcomeView.tsx
+++ b/apps/electron/src/renderer/components/welcome/WelcomeView.tsx
@@ -13,16 +13,13 @@ import * as React from 'react'
 import { useAtom, useAtomValue } from 'jotai'
 import { Loader2 } from 'lucide-react'
 import { appModeAtom } from '@/atoms/app-mode'
-import { conversationsAtom } from '@/atoms/chat-atoms'
-import { agentSessionsAtom, currentAgentWorkspaceIdAtom, agentSettingsReadyAtom } from '@/atoms/agent-atoms'
+import { currentAgentWorkspaceIdAtom, agentSettingsReadyAtom } from '@/atoms/agent-atoms'
 import { tabsAtom, splitLayoutAtom, openTab } from '@/atoms/tab-atoms'
 import { draftSessionIdsAtom } from '@/atoms/draft-session-atoms'
 import { useCreateSession } from '@/hooks/useCreateSession'
 
 export function WelcomeView(): React.ReactElement {
   const mode = useAtomValue(appModeAtom)
-  const conversations = useAtomValue(conversationsAtom)
-  const agentSessions = useAtomValue(agentSessionsAtom)
   const currentWorkspaceId = useAtomValue(currentAgentWorkspaceIdAtom)
   const agentSettingsReady = useAtomValue(agentSettingsReadyAtom)
   const draftSessionIds = useAtomValue(draftSessionIdsAtom)
@@ -36,67 +33,83 @@ export function WelcomeView(): React.ReactElement {
     if (initRef.current === mode) return
     // Agent 模式需等待 settings 就绪（workspaceId 等异步加载完成）
     if (mode === 'agent' && !agentSettingsReady) return
+
+    // 标记当前 mode 的请求，用于取消过期的异步回调
+    const currentMode = mode
     initRef.current = mode
 
-    if (mode === 'chat') {
-      // 1. 优先复用现有非归档、非 draft 会话
-      const existing = conversations.find((c) => !c.archived && !draftSessionIds.has(c.id))
-      if (existing) {
-        const result = openTab(tabs, layout, {
-          type: 'chat',
-          sessionId: existing.id,
-          title: existing.title,
-        })
-        setTabs(result.tabs)
-        setLayout(result.layout)
-        return
-      }
-      // 2. 检查是否已有 draft 会话，复用而不是创建新的
-      const draftSession = conversations.find((c) => !c.archived && draftSessionIds.has(c.id))
-      if (draftSession) {
-        const result = openTab(tabs, layout, {
-          type: 'chat',
-          sessionId: draftSession.id,
-          title: draftSession.title,
-        })
-        setTabs(result.tabs)
-        setLayout(result.layout)
-        return
-      }
-      // 3. 没有任何会话时才创建新的 draft 会话
-      createChat({ draft: true })
+    // 从后端 IPC 拿最新数据，避免 HMR 导致 atoms 重置为空时重复创建会话
+    if (currentMode === 'chat') {
+      window.electronAPI.listConversations().then((freshConversations) => {
+        // 如果 mode 已切换，丢弃过期回调
+        if (initRef.current !== currentMode) return
+        // 1. 优先复用现有非归档、非 draft 会话
+        const existing = freshConversations.find(
+          (c) => !c.archived && !draftSessionIds.has(c.id),
+        )
+        if (existing) {
+          const result = openTab(tabs, layout, {
+            type: 'chat',
+            sessionId: existing.id,
+            title: existing.title,
+          })
+          setTabs(result.tabs)
+          setLayout(result.layout)
+          return
+        }
+        // 2. 检查是否已有 draft 会话，复用而不是创建新的
+        const draftSession = freshConversations.find(
+          (c) => !c.archived && draftSessionIds.has(c.id),
+        )
+        if (draftSession) {
+          const result = openTab(tabs, layout, {
+            type: 'chat',
+            sessionId: draftSession.id,
+            title: draftSession.title,
+          })
+          setTabs(result.tabs)
+          setLayout(result.layout)
+          return
+        }
+        // 3. 没有任何会话时才创建新的 draft 会话
+        createChat({ draft: true })
+      }).catch(console.error)
     } else {
-      // Agent 模式：按当前工作区过滤
-      // 1. 优先复用现有非归档、非 draft 会话
-      const existing = agentSessions.find(
-        (s) => !s.archived && s.workspaceId === currentWorkspaceId && !draftSessionIds.has(s.id),
-      )
-      if (existing) {
-        const result = openTab(tabs, layout, {
-          type: 'agent',
-          sessionId: existing.id,
-          title: existing.title,
-        })
-        setTabs(result.tabs)
-        setLayout(result.layout)
-        return
-      }
-      // 2. 检查是否已有 draft 会话（当前工作区），复用而不是创建新的
-      const draftSession = agentSessions.find(
-        (s) => !s.archived && s.workspaceId === currentWorkspaceId && draftSessionIds.has(s.id),
-      )
-      if (draftSession) {
-        const result = openTab(tabs, layout, {
-          type: 'agent',
-          sessionId: draftSession.id,
-          title: draftSession.title,
-        })
-        setTabs(result.tabs)
-        setLayout(result.layout)
-        return
-      }
-      // 3. 没有任何会话时才创建新的 draft 会话
-      createAgent({ draft: true })
+      window.electronAPI.listAgentSessions().then((freshSessions) => {
+        // 如果 mode 已切换，丢弃过期回调
+        if (initRef.current !== currentMode) return
+        // Agent 模式：按当前工作区过滤
+        // 1. 优先复用现有非归档、非 draft 会话
+        const existing = freshSessions.find(
+          (s) => !s.archived && s.workspaceId === currentWorkspaceId && !draftSessionIds.has(s.id),
+        )
+        if (existing) {
+          const result = openTab(tabs, layout, {
+            type: 'agent',
+            sessionId: existing.id,
+            title: existing.title,
+          })
+          setTabs(result.tabs)
+          setLayout(result.layout)
+          return
+        }
+        // 2. 检查是否已有 draft 会话（当前工作区），复用而不是创建新的
+        const draftSession = freshSessions.find(
+          (s) => !s.archived && s.workspaceId === currentWorkspaceId && draftSessionIds.has(s.id),
+        )
+        if (draftSession) {
+          const result = openTab(tabs, layout, {
+            type: 'agent',
+            sessionId: draftSession.id,
+            title: draftSession.title,
+          })
+          setTabs(result.tabs)
+          setLayout(result.layout)
+          return
+        }
+        // 3. 没有任何会话时才创建新的 draft 会话
+        createAgent({ draft: true })
+      }).catch(console.error)
     }
   }, [mode, agentSettingsReady]) // eslint-disable-line react-hooks/exhaustive-deps
 


### PR DESCRIPTION
## 问题

`bun run dev` 开发时保存代码触发 HMR，会反复创建多余的 Chat 和 Agent 会话。

**根因：** `WelcomeView` 的 `useEffect` 通过读取内存中的 Jotai atoms（`conversationsAtom`、`agentSessionsAtom`）判断是否需要创建新会话。HMR 重新挂载组件时这些 atoms 被重置为空数组，导致每次都误判为"无现有会话"并调用 `createConversation` / `createAgentSession` IPC。

## 修复

1. **数据源从 atoms 改为 IPC 查询** — 创建前先调用 `listConversations()` / `listAgentSessions()` 从后端获取最新数据，不依赖可能被 HMR 重置的内存状态
2. **保留 draft 过滤逻辑** — 仍使用 `draftSessionIdsAtom` 区分 draft/非 draft 会话，避免 draft 会话被错误地当作正常会话打开
3. **异步回调取消机制** — mode 切换后，通过 `initRef` 比对丢弃已过期的 IPC 回调，防止跨 mode 的回调污染

## 审查要点

已审查以下潜在风险并确认安全：

| 风险项 | 结论 |
|--------|------|
| stale closure（tabs/layout 在 IPC 回调中过时） | 低风险 — WelcomeView 仅在 tabs 为空时渲染，且与 `useCreateSession` 预有的模式一致 |
| LeftSidebar 同时调用 list IPC 的竞态 | 无影响 — `openTab` 内置去重（已有 tab 只聚焦不重建），LeftSidebar 的 list 只写 atom 不创建会话 |
| React.StrictMode 双重挂载 | `initRef` 守卫有效阻止同一 mode 的重复执行 |

## 测试

- [ ] `bun run dev` 反复保存文件触发 HMR，确认不再产生多余会话
- [ ] 冷启动无现有会话时，正常创建一个 draft 会话
- [ ] Chat ↔ Agent 模式切换正常复用现有会话
- [ ] draft 会话发送消息后正常出现在侧边栏