### PR TITLE
fix: 统一 openTab + setAppMode 封装，修复文件面板跟随问题

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -50,7 +50,6 @@ import {
   agentPromptSuggestionsAtom,
   agentMessageRefreshAtom,
   agentSessionsAtom,
-  currentAgentSessionIdAtom,
   agentAttachedDirectoriesMapAtom,
   workspaceAttachedDirectoriesMapAtom,
   liveMessagesMapAtom,
@@ -68,7 +67,7 @@ import {
 import type { AgentContextStatus } from '@/atoms/agent-atoms'
 import { settingsOpenAtom } from '@/atoms/settings-tab'
 import { channelsAtom, thinkingExpandedAtom } from '@/atoms/chat-atoms'
-import { tabsAtom, splitLayoutAtom, openTab } from '@/atoms/tab-atoms'
+import { useOpenSession } from '@/hooks/useOpenSession'
 import { AgentSessionProvider } from '@/contexts/session-context'
 import { draftSessionIdsAtom } from '@/atoms/draft-session-atoms'
 import type { AgentSendInput, AgentMessage, AgentPendingFile, ModelOption, SDKMessage } from '@proma/shared'
@@ -228,9 +227,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const suggestion = suggestionsMap.get(sessionId) ?? null
   const setPromptSuggestions = useSetAtom(agentPromptSuggestionsAtom)
   const setAgentSessions = useSetAtom(agentSessionsAtom)
-  const setCurrentAgentSessionId = useSetAtom(currentAgentSessionIdAtom)
-  const [tabs, setTabs] = useAtom(tabsAtom)
-  const [layout, setLayout] = useAtom(splitLayoutAtom)
+  const openSession = useOpenSession()
   const setAttachedDirsMap = useSetAtom(agentAttachedDirectoriesMapAtom)
   const attachedDirsMap = useAtomValue(agentAttachedDirectoriesMapAtom)
   const attachedDirs = attachedDirsMap.get(sessionId) ?? []
@@ -1033,10 +1030,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       setAgentSessions((prev) => [meta, ...prev])
 
       // 切换到新会话 tab
-      const result = openTab(tabs, layout, { type: 'agent', sessionId: meta.id, title: meta.title })
-      setTabs(result.tabs)
-      setLayout(result.layout)
-      setCurrentAgentSessionId(meta.id)
+      openSession('agent', meta.id, meta.title)
 
       // 发送引用旧会话的默认提示词
       const prompt = `上个会话的 id 是 ${sessionId}，可以参考同工作区下的会话继续完成工作`
@@ -1065,7 +1059,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     } catch (error) {
       console.error('[AgentView] 在新会话中重试失败:', error)
     }
-  }, [sessionId, agentChannelId, agentModelId, currentWorkspaceId, tabs, layout, setAgentSessions, setCurrentAgentSessionId, setTabs, setLayout, setStreamingStates])
+  }, [sessionId, agentChannelId, agentModelId, currentWorkspaceId, openSession, setAgentSessions, setStreamingStates])
 
   /** 分叉会话：从指定消息处创建新会话并自动切换 */
   const handleFork = React.useCallback(async (upToMessageUuid: string): Promise<void> => {
@@ -1077,10 +1071,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       setAgentSessions((prev) => [meta, ...prev])
 
       // 切换到新会话 tab
-      const result = openTab(tabs, layout, { type: 'agent', sessionId: meta.id, title: meta.title })
-      setTabs(result.tabs)
-      setLayout(result.layout)
-      setCurrentAgentSessionId(meta.id)
+      openSession('agent', meta.id, meta.title)
 
       toast.success('已创建分叉会话', {
         description: meta.title,
@@ -1091,7 +1082,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         description: error instanceof Error ? error.message : '未知错误',
       })
     }
-  }, [sessionId, tabs, layout, setAgentSessions, setCurrentAgentSessionId, setTabs, setLayout])
+  }, [sessionId, openSession, setAgentSessions])
 
   // 监听快捷键系统分发的 stop-generation 事件（Cmd+.）
   React.useEffect(() => {

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -48,7 +48,6 @@ import {
   splitLayoutAtom,
   activeTabIdAtom,
   sidebarCollapsedAtom,
-  openTab,
   closeTab,
   updateTabTitle,
 } from '@/atoms/tab-atoms'
@@ -59,6 +58,7 @@ import { hasUpdateAtom } from '@/atoms/updater'
 import { draftSessionIdsAtom } from '@/atoms/draft-session-atoms'
 import { hasEnvironmentIssuesAtom } from '@/atoms/environment'
 import { promptConfigAtom, selectedPromptIdAtom, conversationPromptIdAtom } from '@/atoms/system-prompt-atoms'
+import { useOpenSession } from '@/hooks/useOpenSession'
 import { WorkspaceSelector } from '@/components/agent/WorkspaceSelector'
 import { MoveSessionDialog } from '@/components/agent/MoveSessionDialog'
 import {
@@ -194,6 +194,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   const [layout, setLayout] = useAtom(splitLayoutAtom)
   const activeTabId = useAtomValue(activeTabIdAtom)
   const [sidebarCollapsed, setSidebarCollapsed] = useAtom(sidebarCollapsedAtom)
+  const openSession = useOpenSession()
 
   // 归档 & 搜索状态
   const [viewMode, setViewMode] = useAtom(sidebarViewModeAtom)
@@ -331,10 +332,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       )
       setConversations((prev) => [meta, ...prev])
       // 打开新标签页
-      const result = openTab(tabs, layout, { type: 'chat', sessionId: meta.id, title: meta.title })
-      setTabs(result.tabs)
-      setLayout(result.layout)
-      setCurrentConversationId(meta.id)
+      openSession('chat', meta.id, meta.title)
       // 确保在对话视图
       setActiveView('conversations')
       setActiveItem('all-chats')
@@ -349,10 +347,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
 
   /** 选择对话（打开或聚焦标签页） */
   const handleSelectConversation = (id: string, title: string): void => {
-    const result = openTab(tabs, layout, { type: 'chat', sessionId: id, title })
-    setTabs(result.tabs)
-    setLayout(result.layout)
-    setCurrentConversationId(id)
+    openSession('chat', id, title)
     setActiveView('conversations')
     setActiveItem('all-chats')
   }
@@ -504,10 +499,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         })
       }
       // 打开新标签页
-      const result = openTab(tabs, layout, { type: 'agent', sessionId: meta.id, title: meta.title })
-      setTabs(result.tabs)
-      setLayout(result.layout)
-      setCurrentAgentSessionId(meta.id)
+      openSession('agent', meta.id, meta.title)
       setActiveView('conversations')
       setActiveItem('all-chats')
     } catch (error) {
@@ -517,10 +509,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
 
   /** 选择 Agent 会话（打开或聚焦标签页） */
   const handleSelectAgentSession = (id: string, title: string): void => {
-    const result = openTab(tabs, layout, { type: 'agent', sessionId: id, title })
-    setTabs(result.tabs)
-    setLayout(result.layout)
-    setCurrentAgentSessionId(id)
+    openSession('agent', id, title)
     setActiveView('conversations')
     setActiveItem('all-chats')
   }

--- a/apps/electron/src/renderer/components/app-shell/SearchDialog.tsx
+++ b/apps/electron/src/renderer/components/app-shell/SearchDialog.tsx
@@ -15,15 +15,13 @@ import { Search, X, MessageSquare, Bot, Archive, Loader2 } from 'lucide-react'
 import { Dialog, DialogContent, DialogTitle, DialogDescription } from '@/components/ui/dialog'
 import { cn } from '@/lib/utils'
 import { searchDialogOpenAtom } from '@/atoms/search-atoms'
-import { conversationsAtom, currentConversationIdAtom } from '@/atoms/chat-atoms'
+import { conversationsAtom } from '@/atoms/chat-atoms'
 import {
   agentSessionsAtom,
-  currentAgentSessionIdAtom,
   currentAgentWorkspaceIdAtom,
 } from '@/atoms/agent-atoms'
-import { appModeAtom } from '@/atoms/app-mode'
-import { openTab, tabsAtom, splitLayoutAtom } from '@/atoms/tab-atoms'
 import { activeViewAtom } from '@/atoms/active-view'
+import { useOpenSession } from '@/hooks/useOpenSession'
 import type { ConversationMeta, AgentSessionMeta, MessageSearchResult, AgentMessageSearchResult } from '@proma/shared'
 
 /** 标题搜索结果项 */
@@ -105,13 +103,9 @@ export function SearchDialog(): React.ReactElement {
   const [open, setOpen] = useAtom(searchDialogOpenAtom)
   const conversations = useAtomValue(conversationsAtom)
   const agentSessions = useAtomValue(agentSessionsAtom)
-  const setMode = useSetAtom(appModeAtom)
   const setActiveView = useSetAtom(activeViewAtom)
-  const setCurrentConversationId = useSetAtom(currentConversationIdAtom)
-  const setCurrentAgentSessionId = useSetAtom(currentAgentSessionIdAtom)
   const currentWorkspaceId = useAtomValue(currentAgentWorkspaceIdAtom)
-  const [tabs, setTabs] = useAtom(tabsAtom)
-  const [layout, setLayout] = useAtom(splitLayoutAtom)
+  const openSession = useOpenSession()
 
   const [query, setQuery] = React.useState('')
   const [searchQuery, setSearchQuery] = React.useState('')
@@ -253,24 +247,15 @@ export function SearchDialog(): React.ReactElement {
     setActiveView('conversations')
 
     if (result.type === 'chat') {
-      setMode('chat')
-      setCurrentConversationId(result.id)
-      // 查找对话标题
       const conv = conversations.find((c) => c.id === result.id)
       const title = conv?.title ?? result.title
-      const newState = openTab(tabs, layout, { type: 'chat', sessionId: result.id, title })
-      setTabs(newState.tabs)
-      setLayout(newState.layout)
+      openSession('chat', result.id, title)
     } else {
-      setMode('agent')
-      setCurrentAgentSessionId(result.id)
       const session = agentSessions.find((s) => s.id === result.id)
       const title = session?.title ?? result.title
-      const newState = openTab(tabs, layout, { type: 'agent', sessionId: result.id, title })
-      setTabs(newState.tabs)
-      setLayout(newState.layout)
+      openSession('agent', result.id, title)
     }
-  }, [setOpen, setActiveView, setMode, setCurrentConversationId, setCurrentAgentSessionId, conversations, agentSessions, tabs, layout, setTabs, setLayout])
+  }, [setOpen, setActiveView, openSession, conversations, agentSessions])
 
   // 键盘导航
   const handleKeyDown = React.useCallback((e: React.KeyboardEvent) => {

--- a/apps/electron/src/renderer/hooks/useCreateSession.ts
+++ b/apps/electron/src/renderer/hooks/useCreateSession.ts
@@ -4,26 +4,20 @@
  * 从 LeftSidebar 提取，供 WelcomeView 模式切换和侧边栏共同使用。
  */
 
-import { useAtom, useAtomValue, useSetAtom } from 'jotai'
+import { useAtomValue, useSetAtom } from 'jotai'
 import {
   conversationsAtom,
-  currentConversationIdAtom,
   selectedModelAtom,
 } from '@/atoms/chat-atoms'
 import {
   agentSessionsAtom,
-  currentAgentSessionIdAtom,
   agentChannelIdAtom,
   currentAgentWorkspaceIdAtom,
 } from '@/atoms/agent-atoms'
-import {
-  tabsAtom,
-  splitLayoutAtom,
-  openTab,
-} from '@/atoms/tab-atoms'
 import { activeViewAtom } from '@/atoms/active-view'
 import { promptConfigAtom, selectedPromptIdAtom } from '@/atoms/system-prompt-atoms'
 import { draftSessionIdsAtom } from '@/atoms/draft-session-atoms'
+import { useOpenSession } from './useOpenSession'
 
 interface CreateSessionOptions {
   /** 标记为草稿会话（不在侧边栏显示，发送首条消息后自动取消） */
@@ -38,21 +32,18 @@ interface CreateSessionActions {
 }
 
 export function useCreateSession(): CreateSessionActions {
-  const [tabs, setTabs] = useAtom(tabsAtom)
-  const [layout, setLayout] = useAtom(splitLayoutAtom)
+  const openSession = useOpenSession()
   const setActiveView = useSetAtom(activeViewAtom)
   const setDraftSessionIds = useSetAtom(draftSessionIdsAtom)
 
   // Chat
   const setConversations = useSetAtom(conversationsAtom)
-  const setCurrentConversationId = useSetAtom(currentConversationIdAtom)
   const selectedModel = useAtomValue(selectedModelAtom)
   const promptConfig = useAtomValue(promptConfigAtom)
   const setSelectedPromptId = useSetAtom(selectedPromptIdAtom)
 
   // Agent
   const setAgentSessions = useSetAtom(agentSessionsAtom)
-  const setCurrentAgentSessionId = useSetAtom(currentAgentSessionIdAtom)
   const agentChannelId = useAtomValue(agentChannelIdAtom)
   const currentWorkspaceId = useAtomValue(currentAgentWorkspaceIdAtom)
 
@@ -64,10 +55,7 @@ export function useCreateSession(): CreateSessionActions {
         selectedModel?.channelId,
       )
       setConversations((prev) => [meta, ...prev])
-      const result = openTab(tabs, layout, { type: 'chat', sessionId: meta.id, title: meta.title })
-      setTabs(result.tabs)
-      setLayout(result.layout)
-      setCurrentConversationId(meta.id)
+      openSession('chat', meta.id, meta.title)
       setActiveView('conversations')
       if (promptConfig.defaultPromptId) {
         setSelectedPromptId(promptConfig.defaultPromptId)
@@ -90,10 +78,7 @@ export function useCreateSession(): CreateSessionActions {
         currentWorkspaceId || undefined,
       )
       setAgentSessions((prev) => [meta, ...prev])
-      const result = openTab(tabs, layout, { type: 'agent', sessionId: meta.id, title: meta.title })
-      setTabs(result.tabs)
-      setLayout(result.layout)
-      setCurrentAgentSessionId(meta.id)
+      openSession('agent', meta.id, meta.title)
       setActiveView('conversations')
       if (options?.draft) {
         setDraftSessionIds((prev: Set<string>) => { const next = new Set(prev); next.add(meta.id); return next })

--- a/apps/electron/src/renderer/hooks/useOpenSession.ts
+++ b/apps/electron/src/renderer/hooks/useOpenSession.ts
@@ -1,0 +1,39 @@
+/**
+ * useOpenSession — 统一的"打开/聚焦会话 Tab"操作
+ *
+ * 封装 openTab + setTabs + setLayout + setAppMode + setCurrentXxxId，
+ * 确保所有打开会话的入口都能正确同步 appMode 和 currentSessionId。
+ */
+
+import * as React from 'react'
+import { useAtom, useSetAtom } from 'jotai'
+import { tabsAtom, splitLayoutAtom, openTab, type TabType } from '@/atoms/tab-atoms'
+import { appModeAtom } from '@/atoms/app-mode'
+import { currentConversationIdAtom } from '@/atoms/chat-atoms'
+import { currentAgentSessionIdAtom } from '@/atoms/agent-atoms'
+
+type OpenSessionFn = (type: TabType, sessionId: string, title: string) => void
+
+export function useOpenSession(): OpenSessionFn {
+  const [tabs, setTabs] = useAtom(tabsAtom)
+  const [layout, setLayout] = useAtom(splitLayoutAtom)
+  const setAppMode = useSetAtom(appModeAtom)
+  const setCurrentConversationId = useSetAtom(currentConversationIdAtom)
+  const setCurrentAgentSessionId = useSetAtom(currentAgentSessionIdAtom)
+
+  return React.useCallback(
+    (type: TabType, sessionId: string, title: string): void => {
+      const result = openTab(tabs, layout, { type, sessionId, title })
+      setTabs(result.tabs)
+      setLayout(result.layout)
+      setAppMode(type)
+
+      if (type === 'chat') {
+        setCurrentConversationId(sessionId)
+      } else {
+        setCurrentAgentSessionId(sessionId)
+      }
+    },
+    [tabs, layout, setTabs, setLayout, setAppMode, setCurrentConversationId, setCurrentAgentSessionId],
+  )
+}


### PR DESCRIPTION
## Summary
- **问题**：右侧文件面板的显隐跟随左上角 ModeSwitcher 而非当前活跃会话类型，切换会话时文件面板状态不正确
- **根因**：从侧边栏、搜索框等入口打开/切换会话时，未同步更新全局 `appModeAtom`
- **方案**：新增 `useOpenSession` hook 统一封装 `openTab + setTabs + setLayout + setAppMode + setCurrentXxxId`，重构 9 个调用点（LeftSidebar 4处、useCreateSession 2处、SearchDialog 2处、AgentView 2处），净减少 11 行代码

## Test plan
- [ ] 在侧边栏点击 Chat 会话 → 文件面板消失，ModeSwitcher 切到 Chat
- [ ] 在侧边栏点击 Agent 会话 → 文件面板显示对应目录，ModeSwitcher 切到 Agent
- [ ] 通过 TabBar 切换不同类型 tab → 行为不变
- [ ] 搜索对话框打开会话 → appMode 正确同步
- [ ] Agent 中重试/分叉 → 文件面板保持显示
- [ ] 新建 Chat/Agent 会话 → 模式正确切换

🤖 Generated with [Claude Code](https://claude.com/claude-code)