### PR TITLE
fix: 修复手动停止后立即继续导致双 session 并发运行的竞态 bug

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -67,7 +67,7 @@ export interface SessionCallbacks {
   /** 发送流式错误 */
   onError: (error: string) => void
   /** 发送流式完成（携带已持久化的消息列表） */
-  onComplete: (messages?: AgentMessage[], opts?: { stoppedByUser?: boolean }) => void
+  onComplete: (messages?: AgentMessage[], opts?: { stoppedByUser?: boolean; startedAt?: number }) => void
   /** 发送标题更新 */
   onTitleUpdated: (title: string) => void
 }
@@ -398,7 +398,7 @@ const DEFAULT_MODEL_ID = 'claude-sonnet-4-5-20250929'
 export class AgentOrchestrator {
   private adapter: AgentProviderAdapter
   private eventBus: AgentEventBus
-  private activeSessions = new Set<string>()
+  private activeSessions = new Map<string, number>()
 
   /** 队列消息本地记录（sessionId → UUID 集合，用于防重） */
   private queuedMessageUuids = new Map<string, Set<string>>()
@@ -839,8 +839,9 @@ export class AgentOrchestrator {
     } as unknown as SDKMessage
     appendSDKMessages(sessionId, [userSDKMsg])
 
-    // 6. 注册活跃会话
-    this.activeSessions.add(sessionId)
+    // 6. 注册活跃会话（用时间戳作为 generation 标识，区分同一 session 的不同运行轮次）
+    const runGeneration = Date.now()
+    this.activeSessions.set(sessionId, runGeneration)
 
     // 7. 状态初始化
     const accumulatedMessages: SDKMessage[] = []
@@ -1244,7 +1245,7 @@ export class AgentOrchestrator {
           // 等待期间如果会话被中止，退出
           if (!this.activeSessions.has(sessionId)) {
             this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
-            callbacks.onComplete(getAgentSessionMessages(sessionId))
+            callbacks.onComplete(getAgentSessionMessages(sessionId), { startedAt: runGeneration })
             return
           }
         }
@@ -1394,7 +1395,7 @@ export class AgentOrchestrator {
                 if (!loopAbort.signal.aborted) loopAbort.abort()
                 await watchdogDone
                 try { updateAgentSessionMeta(sessionId, {}) } catch { /* 忽略 */ }
-                callbacks.onComplete(getAgentSessionMessages(sessionId))
+                callbacks.onComplete(getAgentSessionMessages(sessionId), { startedAt: runGeneration })
                 return
               }
             }
@@ -1590,7 +1591,7 @@ export class AgentOrchestrator {
           }
 
           // 发送完成信号
-          callbacks.onComplete(getAgentSessionMessages(sessionId))
+          callbacks.onComplete(getAgentSessionMessages(sessionId), { startedAt: runGeneration })
 
           break  // 成功完成，退出重试循环
 
@@ -1611,7 +1612,7 @@ export class AgentOrchestrator {
             this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
             // 持久化中断状态到会话 meta
             try { updateAgentSessionMeta(sessionId, { stoppedByUser: wasStoppedByUser }) } catch { /* 会话可能已删除 */ }
-            callbacks.onComplete(getAgentSessionMessages(sessionId), { stoppedByUser: wasStoppedByUser })
+            callbacks.onComplete(getAgentSessionMessages(sessionId), { stoppedByUser: wasStoppedByUser, startedAt: runGeneration })
             return
           }
 
@@ -1699,7 +1700,7 @@ export class AgentOrchestrator {
           }
 
           callbacks.onError(userFacingError)
-          callbacks.onComplete(getAgentSessionMessages(sessionId))
+          callbacks.onComplete(getAgentSessionMessages(sessionId), { startedAt: runGeneration })
 
           // 根据错误类型决定是否保留 sdkSessionId
           const shouldClearSession = !apiError || apiError.statusCode >= 500
@@ -1739,13 +1740,16 @@ export class AgentOrchestrator {
         appendSDKMessages(sessionId, [retryErrorSDKMsg])
 
         callbacks.onError(`重试 ${MAX_AUTO_RETRIES} 次后仍然失败: ${lastRetryableError}`)
-        callbacks.onComplete(getAgentSessionMessages(sessionId))
+        callbacks.onComplete(getAgentSessionMessages(sessionId), { startedAt: runGeneration })
       }
 
     } finally {
-      this.activeSessions.delete(sessionId)
-      this.sessionPermissionModes.delete(sessionId)
-      this.queuedMessageUuids.delete(sessionId)
+      // 只在 generation 匹配时才清理，防止旧流的 finally 误删新流的注册
+      if (this.activeSessions.get(sessionId) === runGeneration) {
+        this.activeSessions.delete(sessionId)
+        this.sessionPermissionModes.delete(sessionId)
+        this.queuedMessageUuids.delete(sessionId)
+      }
       permissionService.clearSessionPending(sessionId)
       askUserService.clearSessionPending(sessionId)
       exitPlanService.clearSessionPending(sessionId)

--- a/apps/electron/src/main/lib/agent-prompt-builder.ts
+++ b/apps/electron/src/main/lib/agent-prompt-builder.ts
@@ -112,6 +112,7 @@ export function buildSystemPrompt(ctx: SystemPromptContext): string {
 - 执行 shell 命令用 Bash — 破坏性操作（rm、git push --force 等）前先确认
 - 文本输出直接写在回复中，不要用 echo/printf
 - 当存在内置工具时，优先采用内置工具完成任务，避免滥用 MCP、shell 等过于通用的工具来完成简单任务
+- **路径规则**：你的 cwd 是会话目录，不是项目源码目录。操作附加工作目录中的文件时，Glob/Grep/Read 的 path 参数必须使用**绝对路径**（如 \`/Users/xxx/project/src\`），不要用相对路径
 - 处理多个独立任务时，尽量并行调用工具以提高效率
 - 用户可能也会在工作区文件夹下添加文件或者附加文件作为长期上下文或者长期处理任务，要注意及时感知这些变化并利用起来
 - **先搜后写**：修改代码前先用 Grep/Glob 搜索现有实现，复用已有模式和工具函数，最小化变更范围。避免重复造轮子`)

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -87,6 +87,7 @@ export async function runAgent(
             sessionId: input.sessionId,
             messages,
             stoppedByUser: opts?.stoppedByUser ?? false,
+            startedAt: opts?.startedAt,
           })
         }
       },
@@ -141,13 +142,15 @@ export async function runAgentHeadless(
           })
         }
       },
-      onComplete: (messages) => {
+      onComplete: (messages, opts) => {
         callbacks.onComplete()
         // 同步到渲染进程
         if (wc && !wc.isDestroyed()) {
           wc.send(AGENT_IPC_CHANNELS.STREAM_COMPLETE, {
             sessionId: input.sessionId,
             messages,
+            stoppedByUser: opts?.stoppedByUser ?? false,
+            startedAt: opts?.startedAt,
           })
         }
       },

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -465,9 +465,12 @@ export function useGlobalAgentListeners(): void {
         // STREAM_COMPLETE 表示后端已完全结束 — 立即标记 running: false
         // 同时将所有未完成的工具活动标记为已完成，防止 subagent spinner 继续转动
         // （complete 事件只清除 retrying，保持 running: true 以防竞态）
+        // 竞态保护：通过 startedAt 区分新旧流，防止旧流的 complete 事件重置新流的 running 状态
         store.set(agentStreamingStatesAtom, (prev) => {
           const current = prev.get(data.sessionId)
           if (!current || !current.running) return prev
+          // 如果当前流有 startedAt 且比 complete 事件的更新，说明这是旧流的 complete — 忽略
+          if (current.startedAt != null && (data.startedAt == null || current.startedAt > data.startedAt)) return prev
           const map = new Map(prev)
           map.set(data.sessionId, {
             ...current,

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -787,6 +787,8 @@ export interface AgentStreamCompletePayload {
   messages?: AgentMessage[]
   /** 是否由用户手动中止 */
   stoppedByUser?: boolean
+  /** 本轮流式开始时间戳（用于区分新旧流，防止旧流的 complete 事件重置新流状态） */
+  startedAt?: number
 }
 
 // ===== 文件浏览器 =====


### PR DESCRIPTION
## 问题

手动停止正在运行的任务后，立即发送"继续"消息，会导致两个 session 同时在后端运行，表现为每次发送消息都同时触发两个会话。

## 日志审查发现

通过分析会话 `50c759b0` 的 JSONL 日志，确认了双流并发的实际证据：

- **两组消息交错写入同一个 JSONL 文件**，tool_use_id 完全独立，无重叠，证实是两个独立的 SDK 流在并行运行
- 时间线重建：流B 运行期间（00:08:14 - 00:09:12），流C 也在并行运行（00:08:58 - 00:10:46），两个流各自独立执行工具调用和代码编辑

## 根因

两个竞态条件叠加导致：

1. **前端竞态**：`handleStop` 立即将 `running` 设为 `false`，用户发"继续"触发新流（`running=true`）。旧流 abort 后的 `STREAM_COMPLETE` 延迟到达前端，无条件将 `running` 重置为 `false` —— 把新流的状态打掉了。前端误认为"已完成"，用户再次操作即可触发第三个流。

2. **后端竞态**：旧流的 `finally` 块执行 `activeSessions.delete(sessionId)`，误删了新流刚注册的条目，导致后端并发守卫（`activeSessions.has(sessionId)`）失效。

## 修复

核心思路：给每次 `sendMessage` 调用分配一个 generation 时间戳，前后端都用它区分新旧流。

### 后端（agent-orchestrator.ts）
- `activeSessions` 从 `Set<string>` 改为 `Map<string, number>`，value 为 generation 时间戳
- `finally` 块只在 generation 匹配时才清理，防止旧流误删新流的注册
- 所有 `onComplete` 回调传递 `startedAt: runGeneration`

### IPC 层（agent-service.ts）
- `runAgent` 和 `runAgentHeadless` 的 `onComplete` 都转发 `startedAt` 到前端

### 前端（useGlobalAgentListeners.ts）
- `STREAM_COMPLETE` handler 通过比较 `startedAt` 区分新旧流
- 如果当前流的 `startedAt` 比 complete 事件的更新，说明是旧流的 complete，忽略不处理

### 类型（@proma/shared agent.ts）
- `AgentStreamCompletePayload` 增�� `startedAt?: number` 字段

---

## 附加修复：SubAgent 首次工具调用路径错误

### 问题

Agent/SubAgent 启动后，首次使用 Glob/Grep 等工具搜索附加工作目录中的文件时，经常因使用相对路径而失败（cwd 是会话目录而非项目源码目录），然后 fallback 到 Bash 命令用绝对路径重试，浪费一轮工具调用。

### 修复

在 `agent-prompt-builder.ts` 的工具使用指南中增加一条路径规则提醒，明确告知 Agent：cwd 是会话目录，操作附加工作目时必须使用绝对路径。

---

## 代码审查

- 所有 `activeSessions` 用法与 `Map` 兼容（`has`/`delete`/`size`/`clear` 签名一致）
- 6 处 `callbacks.onComplete` 调用均已传递 `startedAt`
- `startedAt` 防护条件做了兜底：即使 `data.startedAt` 缺失（未来遗漏路径），只要当前流有 `startedAt` 也能防护
- TypeScript 编译通过，无类型错误

## 影响范围

5 个文件，27 行新增 / 14 行删除。竞态保护逻辑不影响正常的发送、停止、流式推送等功能；提示词改动仅影响 Agent 工具调用行为。