### PR TITLE
feat: macOS 输入框支持 Ctrl+B 加粗和 Ctrl+S 删除线

### DIFF
--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -367,6 +367,22 @@ export function RichTextInput({
         return false
       },
       handleKeyDown: (view, event) => {
+        // macOS 上 Cmd+B/S 被全局快捷键占用，用 Ctrl+B/S 作为格式化替代键
+        const isMacOS = navigator.platform.startsWith('Mac')
+        if (isMacOS && event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey) {
+          const key = event.key.toLowerCase()
+          if (key === 'b') {
+            event.preventDefault()
+            editor?.chain().focus().toggleBold().run()
+            return true
+          }
+          if (key === 's') {
+            event.preventDefault()
+            editor?.chain().focus().toggleStrike().run()
+            return true
+          }
+        }
+
         // Enter 提交，Shift+Enter 换行
         if (event.key === 'Enter' && !event.shiftKey) {
           // 如果在代码块中，允许正常换行

--- a/apps/electron/src/renderer/components/settings/ShortcutSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/ShortcutSettings.tsx
@@ -300,7 +300,7 @@ export function ShortcutSettings(): React.ReactElement {
               </p>
             )}
             <div className="space-y-1">
-              {shortcuts.map((def) => {
+              {shortcuts.filter((def) => !def.readonly || (isMac ? def.defaultMac : def.defaultWin)).map((def) => {
                 const currentAccel = getActiveAccelerator(def.id)
                 const isCustomized = !!overrides[def.id]
 
@@ -318,21 +318,29 @@ export function ShortcutSettings(): React.ReactElement {
                       </div>
                     </div>
                     <div className="flex items-center gap-2 ml-4">
-                      <ShortcutRecorder
-                        shortcutId={def.id}
-                        currentAccelerator={currentAccel}
-                        onRecord={handleRecord}
-                      />
-                      {isCustomized && (
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="size-6 opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground"
-                          onClick={() => handleReset(def.id)}
-                          title="恢复默认"
-                        >
-                          <RotateCcw size={12} />
-                        </Button>
+                      {def.readonly ? (
+                        <span className="text-xs px-2.5 py-1 rounded-md bg-muted text-foreground/60 font-mono">
+                          {getAcceleratorDisplay(isMac ? def.defaultMac : def.defaultWin)}
+                        </span>
+                      ) : (
+                        <>
+                          <ShortcutRecorder
+                            shortcutId={def.id}
+                            currentAccelerator={currentAccel}
+                            onRecord={handleRecord}
+                          />
+                          {isCustomized && (
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="size-6 opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground"
+                              onClick={() => handleReset(def.id)}
+                              title="恢复默认"
+                            >
+                              <RotateCcw size={12} />
+                            </Button>
+                          )}
+                        </>
                       )}
                     </div>
                   </div>

--- a/apps/electron/src/renderer/lib/shortcut-defaults.ts
+++ b/apps/electron/src/renderer/lib/shortcut-defaults.ts
@@ -26,6 +26,8 @@ export interface ShortcutDefinition {
   category: ShortcutCategory
   /** 是否为全局快捷键（由主进程 globalShortcut 注册） */
   global?: boolean
+  /** 是否为只读（仅展示，不可自定义） */
+  readonly?: boolean
 }
 
 /** 用户自定义快捷键覆盖（持久化到 settings.json） */
@@ -96,6 +98,26 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
     defaultMac: 'Cmd+L',
     defaultWin: 'Ctrl+L',
     category: 'navigation',
+  },
+
+  // 编辑级（输入框格式化，仅 macOS — Cmd+B/S 被全局快捷键占用）
+  {
+    id: 'editor-bold',
+    name: '加粗 / 取消加粗',
+    description: '输入框中切换文字加粗（因 Cmd+B 已用于切换侧边栏）',
+    defaultMac: 'Ctrl+B',
+    defaultWin: '',
+    category: 'edit',
+    readonly: true,
+  },
+  {
+    id: 'editor-strikethrough',
+    name: '删除线 / 取消删除线',
+    description: '输入框中切换文字删除线',
+    defaultMac: 'Ctrl+S',
+    defaultWin: '',
+    category: 'edit',
+    readonly: true,
   },
 
   // 编辑级


### PR DESCRIPTION
## Summary

- macOS 上 `Cmd+B` 被全局快捷键（切换侧边栏）占用，导致 TipTap 输入框无法用键盘切换加粗
- 新增 `Ctrl+B`（加粗）和 `Ctrl+S`（删除线）作为 macOS 专属替代快捷键
- 在快捷键设置页「编辑」分类下以只读方式展示这两个键位，Windows 上自动隐藏

## 改动文件

- `rich-text-input.tsx` — 在 `handleKeyDown` 中新增 macOS Ctrl+B/S 格式化处理
- `shortcut-defaults.ts` — 新增 `readonly` 字段和两个编辑器快捷键定义
- `ShortcutSettings.tsx` — 支持 `readonly` 条目只读展示，按平台过滤

## Test plan

- [ ] macOS：输入框中按 Ctrl+B 切换加粗，Ctrl+S 切换删除线
- [ ] macOS：快捷键设置页「编辑」分类下显示 ⌃B 和 ⌃S（不可点击修改）
- [ ] Windows：输入框中 Ctrl+B 仍为切换侧边栏，不受影响
- [ ] Windows：快捷键设置页不显示这两个编辑器快捷键
- [ ] 其他快捷键功能正常不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)