### PR TITLE
fix: 限制 diff 着色仅对 Edit 工具生效，避免命令参数被误染

### DIFF
--- a/apps/electron/src/renderer/components/agent/ContentBlock.tsx
+++ b/apps/electron/src/renderer/components/agent/ContentBlock.tsx
@@ -256,8 +256,9 @@ function PromptRow({ prompt, dimmed = false }: { prompt: string; dimmed?: boolea
 
 // ===== 工具短语 diff 着色 =====
 
-/** 将 displayLabel 中的 +N 染绿、-N 染红（仅匹配前面是空格或字符串开头的，避免误染行范围如 505-600） */
-function renderLabelWithDiffColors(label: string): React.ReactNode {
+/** 将 displayLabel 中的 +N 染绿、-N 染红（仅对 Edit 工具生效，避免 `head -5` 等命令参数被误染） */
+function renderLabelWithDiffColors(label: string, toolName: string): React.ReactNode {
+  if (toolName !== 'Edit') return label
   const parts = label.split(/((?:^|(?<=\s))[+-]\d+)/g)
   if (parts.length === 1) return label
   return parts.map((part, i) => {
@@ -415,7 +416,7 @@ function ToolUseBlock({ block, allMessages, animate = false, index = 0, dimmed =
         <span className={cn(
           'truncate text-[14px]',
           dimmed ? 'text-muted-foreground/70' : 'text-muted-foreground',
-        )}>{renderLabelWithDiffColors(displayLabel)}</span>
+        )}>{renderLabelWithDiffColors(displayLabel, block.name)}</span>
 
         <ChevronRight
           className={cn(


### PR DESCRIPTION
## Summary

- `renderLabelWithDiffColors` 之前对**所有工具**的 displayLabel 做 `+N/-N` 绿红着色，导致 `head -5`、`tail -20` 等 Bash 命令参数被错误识别为 diff 删除行（红色）
- 修复：增加 `toolName` 参数，仅当工具为 `Edit` 时才应用 diff 着色，其他工具直接返回原文本

## 当前匹配规则

| 条件 | 行为 |
|------|------|
| 工具为 `Edit` | 对 displayLabel 应用 diff 着色 |
| 其他工具 | 直接返回原文本，不做任何着色 |

着色正则：`/((?:^|(?<=\s))[+-]\d+)/g`
- 匹配字符串开头或空格后的 `+N` / `-N`
- `+N` → `text-green-500`（绿色）
- `-N` → `text-red-500`（红色）

## 修复前后对比

- **修复前**: `执行 head -5 file.txt` → `-5` 被染红 ❌
- **修复后**: `执行 head -5 file.txt` → 原样显示 ✅
- **Edit 工具**: `编辑 file.tsx +3 -2` → `+3` 绿色、`-2` 红色（不受影响）✅

## Test plan

- [ ] 执行含 `-N` 参数的 Bash 命令（如 `head -5`、`tail -20`），确认不再被误染色
- [ ] 执行 Edit 操作，确认 `+N/-N` 仍正确染绿/染红
- [ ] 执行 Write、Read 等其他工具，确认无异常着色

🤖 Generated with [Claude Code](https://claude.com/claude-code)