### PR TITLE
fix: 终止会话时调用 query.close() 确保 CLI 子进程被 kill

### DIFF
--- a/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
@@ -259,6 +259,13 @@ const QUERY_READY_TIMEOUT_MS = 60_000
 export class ClaudeAgentAdapter implements AgentProviderAdapter {
 
   abort(sessionId: string): void {
+    // 先调用 query.close() 强制终止 CLI 子进程及其所有子进程（包括正在运行的 bash 命令）
+    const query = activeQueries.get(sessionId)
+    if (query) {
+      query.close()
+      activeQueries.delete(sessionId)
+    }
+
     const controller = activeControllers.get(sessionId)
     if (controller) {
       controller.abort()


### PR DESCRIPTION
## Summary
- 修复 Agent 模式下终止会话时，正在运行的 bash 命令（如编译、测试）可能成为孤儿进程继续运行的问题
- 在 `ClaudeAgentAdapter.abort()` 中新增 `query.close()` 调用，利用 SDK 提供的 API 强制终止 CLI 子进程及其所有资源
- 改动仅涉及 `abort()` 方法内 7 行新增代码，不影响现有状态更新、错误处理、重试等逻辑

## Root Cause
之前 `abort()` 仅调用 `AbortController.abort()` 设置信号标志，让 `for await` 循环在下次迭代时 break。但正在运行的 CLI 子进程（及其 bash 子进程）不会被主动终止，可能导致长时间运行的命令（`npm test`、`cargo build` 等）成为孤儿进程继续在后台执行。

## Fix
在 `abort()` 中先调用 SDK 的 `query.close()`（文档：*"forcefully ends the query, cleaning up all resources including pending requests, MCP transports, and the CLI subprocess"*），再调用 `controller.abort()`。

## Test plan
- [ ] 启动一个长时间运行的 bash 命令（如 `sleep 60`），点击停止按钮，确认进程被终止（`ps aux | grep sleep` 无残留）
- [ ] 停止后前端 UI 正确显示"已停止"状态
- [ ] 正常会话完成流程不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)