### PR TITLE
fix: Agent 搜索兼容新 SDK 消息格式，修复内容搜索失效

### DIFF
--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -613,17 +613,25 @@ export function searchAgentSessionMessages(query: string): AgentMessageSearchRes
       for (const line of lines) {
         const parsed = JSON.parse(line)
         // 兼容旧 AgentMessage 和新 SDKMessage 格式
-        const content = parsed.content ?? ''
-        const role = parsed.role ?? 'assistant'
-        const messageId = parsed.id ?? parsed.uuid ?? ''
-        if (!content) continue
+        const role = parsed.role ?? parsed.message?.role ?? 'assistant'
+        const messageId = parsed.id ?? parsed.uuid ?? parsed.message?.id ?? ''
 
-        const contentLower = (typeof content === 'string' ? content : '').toLowerCase()
+        let textContent = ''
+        if (typeof parsed.content === 'string') {
+          // 旧 AgentMessage 格式: {role, content: "..."}
+          textContent = parsed.content
+        } else if (Array.isArray(parsed.message?.content)) {
+          // 新 SDKMessage 格式: {type, message: {content: [{type:"text", text:"..."}]}}
+          textContent = parsed.message.content
+            .filter((b: { type: string; text?: string }) => b.type === 'text' && b.text)
+            .map((b: { text: string }) => b.text)
+            .join('\n')
+        }
+        if (!textContent) continue
+
+        const contentLower = textContent.toLowerCase()
         const matchIndex = contentLower.indexOf(queryLower)
         if (matchIndex === -1) continue
-
-        // 提取匹配上下文 snippet
-        const textContent = typeof content === 'string' ? content : ''
         const snippetStart = Math.max(0, matchIndex - 40)
         const snippetEnd = Math.min(textContent.length, matchIndex + query.length + 40)
         const snippet = (snippetStart > 0 ? '...' : '') +

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "proma",


### PR DESCRIPTION
## Overview

全局搜索（Cmd+F）中 Agent 会话的消息内容搜索对新 SDK 格式消息完全失效。原因是 `searchAgentSessionMessages` 函数从 `parsed.content` 取值，但新 SDKMessage 格式的文本数据在 `parsed.message.content`（content blocks 数组），导致所有新格式消息的 content 都是 `undefined`，被当作空字符串跳过。

只有旧格式（`{role, content: "字符串"}`）的历史 Agent 会话能被搜到，升级到 SDK 格式后的会话搜索完全失效。

## Changes

- `apps/electron/src/main/lib/agent-session-manager.ts` — 重写 `searchAgentSessionMessages` 函数中提取消息文本的逻辑，同时兼容旧格式（`parsed.content` 字符串）和新 SDK 格式（从 `parsed.message.content` 数组中提取 `type === "text"` 的 block 的 `text` 字段并拼接）。同时修正 `role` 和 `messageId` 的取值路径以兼容新格式。
- `bun.lock` — 依赖安装时的 lock 文件更新

## How to Test

1. 启动 Proma（`bun run dev`）
2. 打开搜索对话框（Cmd+F）
3. 搜索一个确认存在于近期 Agent 会话中 AI 回复的关键词
4. 验证搜索结果能正确返回新 SDK 格式的 Agent 消息，且显示正确的上下文片段
5. 同时验证旧格式的 Chat 对话和旧格式 Agent 会话搜索不受影响

## Notes

- 提取逻辑与 `agent-orchestrator.ts` 中已有的 content block 解析模式保持一致
- 仅搜索 `type === "text"` 的 block，不搜索 thinking、tool_use 等其他 block 类型