### PR TITLE
fix: 修复输入框 mention 草稿丢失、工作区 IME 回车误触发、拖拽排序异常

### DIFF
--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -792,6 +792,12 @@ export const currentAgentErrorAtom = atom<string | null>((get) => {
 export const agentSessionDraftsAtom = atom<Map<string, string>>(new Map())
 
 /**
+ * Agent 会话输入框 HTML 草稿 Map — 以 sessionId 为 key
+ * 保存 TipTap 编辑器的原始 HTML，用于切换会话时恢复 mention 等富文本节点
+ */
+export const agentSessionDraftHtmlAtom = atom<Map<string, string>>(new Map())
+
+/**
  * 会话附加目录 Map — 以 sessionId 为 key
  * 存储每个会话通过"附加文件夹"功能关联的外部目录路径列表。
  * 这些路径作为 SDK additionalDirectories 参数传递。

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -47,6 +47,7 @@ import {
   agentWorkspacesAtom,
   agentStreamErrorsAtom,
   agentSessionDraftsAtom,
+  agentSessionDraftHtmlAtom,
   agentPromptSuggestionsAtom,
   agentMessageRefreshAtom,
   agentSessionsAtom,
@@ -248,6 +249,20 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       return map
     })
   }, [sessionId, setDraftsMap])
+  const draftHtmlMap = useAtomValue(agentSessionDraftHtmlAtom)
+  const setDraftHtmlMap = useSetAtom(agentSessionDraftHtmlAtom)
+  const inputHtmlContent = draftHtmlMap.get(sessionId) ?? ''
+  const setInputHtmlContent = React.useCallback((html: string) => {
+    setDraftHtmlMap((prev) => {
+      const map = new Map(prev)
+      if (!html || html === '<p></p>') {
+        map.delete(sessionId)
+      } else {
+        map.set(sessionId, html)
+      }
+      return map
+    })
+  }, [sessionId, setDraftHtmlMap])
   const sessionPathMap = useAtomValue(agentSessionPathMapAtom)
   const setSessionPathMap = useSetAtom(agentSessionPathMapAtom)
   const sessionPath = sessionPathMap.get(sessionId) ?? null
@@ -746,6 +761,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
 
       // 2. 清空输入框
       setInputContent('')
+      setInputHtmlContent('')
       setPromptSuggestions((prev) => {
         if (!prev.has(sessionId)) return prev
         const map = new Map(prev)
@@ -910,6 +926,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     }
 
     setInputContent('')
+    setInputHtmlContent('')
 
     window.electronAPI.sendAgentMessage(input).catch((error) => {
       console.error('[AgentView] 发送消息失败:', error)
@@ -1242,6 +1259,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
               workspacePath={sessionPath}
               workspaceSlug={workspaceSlug}
               attachedDirs={allAttachedDirs}
+              htmlValue={inputHtmlContent}
+              onHtmlChange={setInputHtmlContent}
             />
 
             {/* Footer 工具栏 */}

--- a/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
@@ -196,9 +196,21 @@ export function WorkspaceSelector(): React.ReactElement {
       return
     }
     // 根据鼠标在目标元素的上半/下半部分决定插入位置
+    // 中线附近 30% 区域为死区，避免鼠标抖动导致横线闪烁
     const rect = e.currentTarget.getBoundingClientRect()
-    const midY = rect.top + rect.height / 2
-    const position = e.clientY < midY ? 'before' : 'after'
+    const ratio = (e.clientY - rect.top) / rect.height
+    let position: 'before' | 'after'
+    if (ratio < 0.35) {
+      position = 'before'
+    } else if (ratio > 0.65) {
+      position = 'after'
+    } else {
+      // 死区内保持当前方向不变
+      if (dropIndicator?.id === wsId) return
+      position = ratio < 0.5 ? 'before' : 'after'
+    }
+    // 仅在状态变化时更新，减少不必要的重渲染
+    if (dropIndicator?.id === wsId && dropIndicator.position === position) return
     setDropIndicator({ id: wsId, position })
   }
 

--- a/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
@@ -47,7 +47,7 @@ export function WorkspaceSelector(): React.ReactElement {
 
   // 拖拽状态
   const [dragId, setDragId] = React.useState<string | null>(null)
-  const [dropTargetId, setDropTargetId] = React.useState<string | null>(null)
+  const [dropIndicator, setDropIndicator] = React.useState<{ id: string; position: 'before' | 'after' } | null>(null)
 
   /** 切换工作区 */
   const handleSelect = (workspace: AgentWorkspace): void => {
@@ -98,6 +98,7 @@ export function WorkspaceSelector(): React.ReactElement {
 
   const handleCreateKeyDown = (e: React.KeyboardEvent): void => {
     if (e.key === 'Enter') {
+      if (e.nativeEvent.isComposing) return
       e.preventDefault()
       handleCreate()
     } else if (e.key === 'Escape') {
@@ -139,6 +140,7 @@ export function WorkspaceSelector(): React.ReactElement {
 
   const handleRenameKeyDown = (e: React.KeyboardEvent): void => {
     if (e.key === 'Enter') {
+      if (e.nativeEvent.isComposing) return
       e.preventDefault()
       handleRename()
     } else if (e.key === 'Escape') {
@@ -189,22 +191,28 @@ export function WorkspaceSelector(): React.ReactElement {
   const handleDragOver = (e: React.DragEvent, wsId: string): void => {
     e.preventDefault()
     e.dataTransfer.dropEffect = 'move'
-    if (dragId && wsId !== dragId) {
-      setDropTargetId(wsId)
+    if (!dragId || wsId === dragId) {
+      setDropIndicator(null)
+      return
     }
+    // 根据鼠标在目标元素的上半/下半部分决定插入位置
+    const rect = e.currentTarget.getBoundingClientRect()
+    const midY = rect.top + rect.height / 2
+    const position = e.clientY < midY ? 'before' : 'after'
+    setDropIndicator({ id: wsId, position })
   }
 
   const handleDragLeave = (e: React.DragEvent): void => {
     if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-      setDropTargetId(null)
+      setDropIndicator(null)
     }
   }
 
   const handleDrop = (e: React.DragEvent, targetId: string): void => {
     e.preventDefault()
-    if (!dragId || dragId === targetId) {
+    if (!dragId || dragId === targetId || !dropIndicator || dropIndicator.id !== targetId) {
       setDragId(null)
-      setDropTargetId(null)
+      setDropIndicator(null)
       return
     }
 
@@ -214,19 +222,21 @@ export function WorkspaceSelector(): React.ReactElement {
 
     const reordered = [...workspaces]
     const [moved] = reordered.splice(fromIdx, 1)
-    const insertIdx = fromIdx < toIdx ? toIdx - 1 : toIdx
+    // 从原数组中移除后，目标索引需要调整
+    const adjustedToIdx = fromIdx < toIdx ? toIdx - 1 : toIdx
+    const insertIdx = dropIndicator.position === 'after' ? adjustedToIdx + 1 : adjustedToIdx
     reordered.splice(insertIdx, 0, moved!)
 
     setWorkspaces(reordered)
     setDragId(null)
-    setDropTargetId(null)
+    setDropIndicator(null)
 
     window.electronAPI.reorderAgentWorkspaces(reordered.map((w) => w.id)).catch(console.error)
   }
 
   const handleDragEnd = (): void => {
     setDragId(null)
-    setDropTargetId(null)
+    setDropIndicator(null)
   }
 
   return (
@@ -245,26 +255,30 @@ export function WorkspaceSelector(): React.ReactElement {
         </div>
 
         {/* 工作区列表 */}
-        <div className="max-h-[120px] overflow-y-auto scrollbar-thin flex flex-col gap-0.5 p-1">
+        <div className="max-h-[120px] overflow-y-auto scrollbar-thin flex flex-col p-1">
           {workspaces.map((ws) => (
-            <div
-              key={ws.id}
-              draggable={editingId !== ws.id}
-              onDragStart={(e) => handleDragStart(e, ws.id)}
-              onDragOver={(e) => handleDragOver(e, ws.id)}
-              onDragLeave={handleDragLeave}
-              onDrop={(e) => handleDrop(e, ws.id)}
-              onDragEnd={handleDragEnd}
-              onClick={() => handleSelect(ws)}
-              className={cn(
-                'group w-full flex items-center gap-1 px-1 py-[5px] rounded-md text-[13px] transition-colors duration-100 cursor-pointer titlebar-no-drag',
-                ws.id === currentWorkspaceId
-                  ? 'workspace-item-selected bg-foreground/[0.08] text-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
-                  : 'text-foreground/70 hover:bg-foreground/[0.04]',
-                dragId === ws.id && 'opacity-40',
-                dropTargetId === ws.id && 'ring-1 ring-primary/40',
+            <div key={ws.id} className="relative">
+              {/* 上方插入指示线 */}
+              {dropIndicator?.id === ws.id && dropIndicator.position === 'before' && (
+                <div className="absolute top-0 left-1 right-1 h-0.5 bg-primary rounded-full z-10" />
               )}
-            >
+
+              <div
+                draggable={editingId !== ws.id}
+                onDragStart={(e) => handleDragStart(e, ws.id)}
+                onDragOver={(e) => handleDragOver(e, ws.id)}
+                onDragLeave={handleDragLeave}
+                onDrop={(e) => handleDrop(e, ws.id)}
+                onDragEnd={handleDragEnd}
+                onClick={() => handleSelect(ws)}
+                className={cn(
+                  'group w-full flex items-center gap-1 px-1 py-[5px] rounded-md text-[13px] transition-colors duration-100 cursor-pointer titlebar-no-drag',
+                  ws.id === currentWorkspaceId
+                    ? 'workspace-item-selected bg-foreground/[0.08] text-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
+                    : 'text-foreground/70 hover:bg-foreground/[0.04]',
+                  dragId === ws.id && 'opacity-40',
+                )}
+              >
               {/* 拖拽手柄 */}
               <GripVertical size={12} className="flex-shrink-0 text-foreground/20 opacity-0 group-hover:opacity-100 transition-opacity cursor-grab active:cursor-grabbing" />
 
@@ -304,6 +318,12 @@ export function WorkspaceSelector(): React.ReactElement {
                     )}
                   </div>
                 </>
+              )}
+              </div>
+
+              {/* 下方插入指示线 */}
+              {dropIndicator?.id === ws.id && dropIndicator.position === 'after' && (
+                <div className="absolute bottom-0 left-1 right-1 h-0.5 bg-primary rounded-full z-10" />
               )}
             </div>
           ))}

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -190,6 +190,10 @@ interface RichTextInputProps {
   workspaceSlug?: string | null
   /** 附加目录路径列表（@ 引用时一并搜索） */
   attachedDirs?: string[]
+  /** HTML 草稿值（切换会话恢复时使用，保留 mention 等富文本结构） */
+  htmlValue?: string
+  /** HTML 值变更回调（用于保存富文本草稿） */
+  onHtmlChange?: (html: string) => void
   className?: string
 }
 
@@ -213,6 +217,8 @@ export function RichTextInput({
   workspacePath,
   workspaceSlug,
   attachedDirs = [],
+  htmlValue,
+  onHtmlChange,
 }: RichTextInputProps): React.ReactElement {
   const [isExpanded, setIsExpanded] = useState(false)
   // 手动折叠状态：用户主动折叠输入框
@@ -227,6 +233,9 @@ export function RichTextInput({
   // 保持 onPasteFiles 引用最新
   const onPasteFilesRef = useRef(onPasteFiles)
   onPasteFilesRef.current = onPasteFiles
+  // 保持 onHtmlChange 引用最新
+  const onHtmlChangeRef = useRef(onHtmlChange)
+  onHtmlChangeRef.current = onHtmlChange
   // Mention 活跃状态（阻止 Enter 发送消息）
   const mentionActiveRef = useRef(false)
   // Mention 弹窗中的可选项数量（0 时 Enter 不阻塞发送）
@@ -416,12 +425,14 @@ export function RichTextInput({
       if (html === '<p></p>') {
         lastEditorValueRef.current = ''
         onChange('')
+        onHtmlChangeRef.current?.('')
         setIsExpanded(false)
         setIsManuallyCollapsed(false)
       } else {
         const markdown = htmlToMarkdown(html)
         lastEditorValueRef.current = markdown
         onChange(markdown)
+        onHtmlChangeRef.current?.(html)
 
         // 检查行数，超过5行时展开输入框
         const lineCount = countEditorLines(ed)
@@ -444,6 +455,10 @@ export function RichTextInput({
         lastEditorValueRef.current = ''
         setIsExpanded(false)
         setIsManuallyCollapsed(false)
+      } else if (htmlValue) {
+        // 优先使用 HTML 草稿恢复（保留 mention 等富文本节点）
+        editor.commands.setContent(htmlValue)
+        lastEditorValueRef.current = controllerValue
       } else {
         const html = controllerValue
           .split(/\n\n+/)


### PR DESCRIPTION
## 问题根因

1. **输入框 mention 草稿丢失**：切换对话时草稿仅保存 Markdown 纯文本，TipTap 编辑器的 mention 富文本节点（`@`/`/`/`#`）在恢复时通过段落拆分重建 HTML，丢失了 mention 结构
2. **工作区 IME 回车误触发**：创建/重命名工作区输入框的 `onKeyDown` 未检查 `isComposing` 状态，中文输入法选字时的 Enter 被当作确认操作
3. **拖拽排序无法到最后且视觉不直观**：向下拖时 `insertIdx = toIdx - 1` 导致永远无法排到末尾；drop indicator 使用整行 `ring` 高亮而非条目间横线

## 具体修改

- `agent-atoms.ts`：新增 `agentSessionDraftHtmlAtom`，以 sessionId 为 key 存储 HTML 草稿
- `AgentView.tsx`：引入 HTML 草稿 atom 的读写逻辑，发送消息时同步清空 HTML 草稿，将 `htmlValue`/`onHtmlChange` 传入 RichTextInput
- `rich-text-input.tsx`：新增 `htmlValue`/`onHtmlChange` 可选 props；`onUpdate` 时同步输出 HTML；恢复逻辑优先使用 HTML 草稿
- `WorkspaceSelector.tsx`：`handleCreateKeyDown`/`handleRenameKeyDown` 添加 `e.nativeEvent.isComposing` 检查；`dropTargetId` 重构为 `dropIndicator`（含 before/after 方向），基于鼠标在元素上下半区判断插入位置，ring 高亮替换为条目间蓝色横线指示器

## 审查情况

- TypeScript 编译通过，无类型错误
- 代码审查已完成，修复了审查中发现的 `handleDrop` 中 `dropIndicator.id !== targetId` 竞态校验问题
- Chat 模式不受影响（不传 `htmlValue`/`onHtmlChange`，走原有纯文本恢复路径）