### PR TITLE
fix: 工作区文件渲染优化、置顶会话按工作区过滤、Write 工具行数显示

### DIFF
--- a/apps/electron/src/renderer/components/agent/ContentBlock.tsx
+++ b/apps/electron/src/renderer/components/agent/ContentBlock.tsx
@@ -256,9 +256,9 @@ function PromptRow({ prompt, dimmed = false }: { prompt: string; dimmed?: boolea
 
 // ===== 工具短语 diff 着色 =====
 
-/** 将 displayLabel 中的 +N 染绿、-N 染红（仅对 Edit 工具生效，避免 `head -5` 等命令参数被误染） */
+/** 将 displayLabel 中的 +N 染绿、-N 染红（仅对 Edit/Write 工具生效，避免 `head -5` 等命令参数被误染） */
 function renderLabelWithDiffColors(label: string, toolName: string): React.ReactNode {
-  if (toolName !== 'Edit') return label
+  if (toolName !== 'Edit' && toolName !== 'Write') return label
   const parts = label.split(/((?:^|(?<=\s))[+-]\d+)/g)
   if (parts.length === 1) return label
   return parts.map((part, i) => {

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -309,7 +309,12 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                           />
                         )}
                         {/* 会话文件浏览器 */}
-                        <FileBrowser rootPath={sessionPath} hideToolbar embedded />
+                        <>
+                          {attachedDirs.length > 0 && (
+                            <div className="text-[11px] font-medium text-muted-foreground mb-1 px-3 pt-2">工作文件（存储于该工作区目录）</div>
+                          )}
+                          <FileBrowser rootPath={sessionPath} hideToolbar embedded hideEmpty={attachedDirs.length > 0} />
+                        </>
                         {/* 会话文件拖拽上传区域 */}
                         <FileDropZone
                           workspaceSlug={workspaceSlug}
@@ -392,7 +397,12 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                       )}
                       {/* 工作区文件浏览器 */}
                       {workspaceFilesPath && (
-                        <FileBrowser rootPath={workspaceFilesPath} hideToolbar embedded />
+                        <>
+                          {wsAttachedDirs.length > 0 && (
+                            <div className="text-[11px] font-medium text-muted-foreground mb-1 px-3 pt-2">工作文件（存储于该工作区目录）</div>
+                          )}
+                          <FileBrowser rootPath={workspaceFilesPath} hideToolbar embedded hideEmpty={wsAttachedDirs.length > 0} />
+                        </>
                       )}
                       {/* 工作区文件拖拽上传区域 */}
                       <FileDropZone
@@ -468,7 +478,7 @@ function AttachedDirsSection({ attachedDirs, onDetach, refreshVersion }: Attache
 
   return (
     <div className="pt-2.5 pb-1 flex-shrink-0">
-      <div className="text-[11px] font-medium text-muted-foreground mb-1 px-3">附加目录（Agent 可以读取并操作此文件夹）</div>
+      <div className="text-[11px] font-medium text-muted-foreground mb-1 px-3">附加目录（Agent 可以读取并操作此外部文件夹）</div>
       {attachedDirs.map((dir) => (
         <AttachedDirTree
           key={dir}
@@ -527,7 +537,7 @@ function AttachedDirTree({ dirPath, onDetach, selectedPaths, onSelect, refreshVe
   return (
     <div>
       <div
-        className="flex items-center gap-1 py-1 px-2 cursor-pointer hover:bg-accent/50 group"
+        className="flex items-center gap-1 py-1 pl-2 pr-2 text-sm cursor-pointer hover:bg-accent/50 group mx-2 rounded-lg"
         onClick={toggleExpand}
       >
         <ChevronRight
@@ -678,7 +688,7 @@ function AttachedDirItem({ entry, depth, selectedPaths, onSelect, refreshVersion
     <>
       <div
         className={cn(
-          'flex items-center gap-1 py-1 pr-2 text-sm cursor-pointer group',
+          'flex items-center gap-1 py-1 pr-2 text-sm cursor-pointer group mx-2 rounded-lg',
           isSelected ? 'bg-accent' : 'hover:bg-accent/50',
         )}
         style={{ paddingLeft }}

--- a/apps/electron/src/renderer/components/agent/ToolActivityItem.tsx
+++ b/apps/electron/src/renderer/components/agent/ToolActivityItem.tsx
@@ -87,6 +87,27 @@ function StatusIcon({ status, toolName }: { status: ActivityStatus; toolName?: s
   )
 }
 
+// ===== Diff 标记着色 =====
+
+/** 将 Edit/Write label 中末尾的 +N / -N 标记渲染为绿/红色 */
+function renderLabelWithDiff(label: string, toolName: string): React.ReactNode {
+  if (toolName !== 'Edit' && toolName !== 'Write') return label
+  const match = label.match(/^(.+?)(\s+[+-]\d+(?:\s+[+-]\d+)?)$/)
+  if (!match) return label
+  const [, text, diffPart] = match
+  const tokens = diffPart!.trim().split(/\s+/)
+  return (
+    <>
+      {text}{' '}
+      {tokens.map((tok, i) => (
+        <span key={i} className={tok.startsWith('+') ? 'text-green-500' : 'text-red-500'}>
+          {tok}{i < tokens.length - 1 ? ' ' : ''}
+        </span>
+      ))}
+    </>
+  )
+}
+
 // ===== 错误 Badge =====
 
 function ErrorBadge(): React.ReactElement {
@@ -177,7 +198,7 @@ export function ActivityRow({ activity, index = 0, animate = false, onOpenDetail
           onClick={(e) => { e.stopPropagation(); onOpenDetails(activity) }}
         >
           <StatusIcon status={status} toolName={activity.toolName} />
-          <span className="truncate text-foreground/80 group-hover/expand:text-foreground transition-colors duration-150 flex-1">{displayLabel}</span>
+          <span className="truncate text-foreground/80 group-hover/expand:text-foreground transition-colors duration-150 flex-1">{renderLabelWithDiff(displayLabel, activity.toolName)}</span>
           {activity.isError && <ErrorBadge />}
           {activity.elapsedSeconds !== undefined && activity.elapsedSeconds > 0 && (
             <span className="shrink-0 text-[11px] text-muted-foreground/60 tabular-nums">
@@ -189,7 +210,7 @@ export function ActivityRow({ activity, index = 0, animate = false, onOpenDetail
       ) : (
         <>
           <StatusIcon status={status} toolName={activity.toolName} />
-          <span className="truncate text-foreground/80">{displayLabel}</span>
+          <span className="truncate text-foreground/80">{renderLabelWithDiff(displayLabel, activity.toolName)}</span>
           {activity.isError && <ErrorBadge />}
           {activity.elapsedSeconds !== undefined && activity.elapsedSeconds > 0 && (
             <span className="shrink-0 text-[11px] text-muted-foreground/60 tabular-nums">

--- a/apps/electron/src/renderer/components/agent/tool-phrase.ts
+++ b/apps/electron/src/renderer/components/agent/tool-phrase.ts
@@ -65,6 +65,11 @@ export function getToolPhrase(toolName: string, input: Record<string, unknown>):
     case 'Write': {
       const fp = input.file_path ?? input.filePath
       const name = typeof fp === 'string' ? filename(fp) : '文件'
+      const content = input.content
+      if (typeof content === 'string' && content.length > 0) {
+        const lines = content.split('\n').length
+        return phrase(`写入 ${name} +${lines}`)
+      }
       return phrase(`写入 ${name}`)
     }
 

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -248,10 +248,10 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     [conversations, viewMode, draftSessionIds]
   )
 
-  /** 置顶 Agent 会话列表（仅活跃模式显示，跨工作区，排除 draft） */
+  /** 置顶 Agent 会话列表（仅活跃模式显示，按当前工作区过滤，排除 draft） */
   const pinnedAgentSessions = React.useMemo(
-    () => viewMode === 'active' ? agentSessions.filter((s) => s.pinned && !draftSessionIds.has(s.id)) : [],
-    [agentSessions, viewMode, draftSessionIds]
+    () => viewMode === 'active' ? agentSessions.filter((s) => s.pinned && !draftSessionIds.has(s.id) && (!currentWorkspaceId || s.workspaceId === currentWorkspaceId)) : [],
+    [agentSessions, viewMode, draftSessionIds, currentWorkspaceId]
   )
 
   /** 对话按日期分组（根据 viewMode 过滤归档状态，排除 draft） */

--- a/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
@@ -52,9 +52,11 @@ interface FileBrowserProps {
   hideToolbar?: boolean
   /** 嵌入模式：不使用内部 ScrollArea 和 h-full，由外部容器控制布局和滚动 */
   embedded?: boolean
+  /** 隐藏"目录为空"提示（当外部已有附加目录等内容时使用） */
+  hideEmpty?: boolean
 }
 
-export function FileBrowser({ rootPath, hideToolbar, embedded }: FileBrowserProps): React.ReactElement {
+export function FileBrowser({ rootPath, hideToolbar, embedded, hideEmpty }: FileBrowserProps): React.ReactElement {
   const [entries, setEntries] = React.useState<FileEntry[]>([])
   const [loading, setLoading] = React.useState(false)
   const [error, setError] = React.useState<string | null>(null)
@@ -219,7 +221,7 @@ export function FileBrowser({ rootPath, hideToolbar, embedded }: FileBrowserProp
       {error && (
         <div className="px-3 py-2 text-xs text-destructive">{error}</div>
       )}
-      {!error && entries.length === 0 && !loading && (
+      {!error && entries.length === 0 && !loading && !hideEmpty && (
         <div className="px-3 py-4 text-xs text-muted-foreground text-center">
           目录为空
         </div>


### PR DESCRIPTION
## 问题根因

1. **工作区文件区附加目录渲染不一致**：AttachedDirTree/AttachedDirItem 缺少 `mx-2 rounded-lg`，比 FileBrowser 的文件项更靠左；附加目录存在时 FileBrowser 仍显示"目录为空"；附加目录与工作区存储文件缺乏区域标题区分
2. **置顶会话跨工作区显示**：`pinnedAgentSessions` 未按 `currentWorkspaceId` 过滤，切换工作区后仍显示所有置顶会话
3. **Write 工具缺少行数标记**：收起态只显示"写入 filename"，不像 Edit 有 `+XX -XX` 标记；且 diff 着色未覆盖 Write 工具

## 具体修改

- **SidePanel.tsx**：附加目录项增加 `mx-2 rounded-lg` 对齐样式；有附加目录时在 FileBrowser 上方显示"附加目录"和"工作文件"区域标题；传入 `hideEmpty` 隐藏空目录提示；更新附加目录文案
- **FileBrowser.tsx**：新增 `hideEmpty` prop 控制"目录为空"提示显示
- **LeftSidebar.tsx**：`pinnedAgentSessions` 增加 `(!currentWorkspaceId || s.workspaceId === currentWorkspaceId)` 过滤条件
- **tool-phrase.ts**：Write 工具收起态从 `input.content` 计算行数，显示 `写入 filename +XX`
- **ToolActivityItem.tsx**：新增 `renderLabelWithDiff` 函数，对 Edit/Write 的 `+N/-N` 标记着绿/红色
- **ContentBlock.tsx**：已有的 `renderLabelWithDiffColors` 扩展条件覆盖 Write 工具

## 审查情况

- TypeScript 编译零错误
- 代码审查修复了 `currentWorkspaceId` 为 null 时的防御、Bash 命令参数误染等问题
- 两条渲染路径（SDK / ToolActivity）均已覆盖着色逻辑