### PR TITLE
fix: 添加 @/types/* 路径别名，修复 tsc 类型解析

### DIFF
--- a/apps/electron/tsconfig.json
+++ b/apps/electron/tsconfig.json
@@ -5,7 +5,8 @@
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/renderer/*"]
+      "@/*": ["./src/renderer/*"],
+      "@/types/*": ["./src/types/*"]
     }
   },
   "include": ["src/**/*"]

--- a/apps/electron/vite.config.ts
+++ b/apps/electron/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      '@/types': resolve(__dirname, 'src/types'),
       '@': resolve(__dirname, 'src/renderer'),
     },
   },


### PR DESCRIPTION
## Summary

- #209 引入了 `import type { ... } from '@/types/settings'`，但 `@` 别名仅映射到 `src/renderer/`，而 `src/types/` 在其外层
- TypeScript 和 Vite 均无法正确解析 `@/types/settings` → `src/types/settings.ts`
- 在 `tsconfig.json` 和 `vite.config.ts` 中添加 `@/types/*` → `src/types/*` 显式映射

## Changes

- `tsconfig.json`: 添加 `"@/types/*": ["./src/types/*"]` paths 映射
- `vite.config.ts`: 添加 `'@/types': resolve(__dirname, 'src/types')` alias（置于 `@` 之前确保优先匹配）

## Test plan

- [x] `npx tsc --noEmit` 零错误
- [ ] `bun run build` 构建通过
- [ ] 通知音设置面板正常渲染和交互

🤖 Generated with [Claude Code](https://claude.com/claude-code)