### PR TITLE
fix: Agent 会话切换时 workspaceId 不同步导致回填模式

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -178,7 +178,14 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const [agentThinking, setAgentThinking] = useAtom(agentThinkingAtom)
   const setSettingsOpen = useSetAtom(settingsOpenAtom)
   const setDraftSessionIds = useSetAtom(draftSessionIdsAtom)
-  const currentWorkspaceId = useAtomValue(currentAgentWorkspaceIdAtom)
+  const globalWorkspaceId = useAtomValue(currentAgentWorkspaceIdAtom)
+  const sessions = useAtomValue(agentSessionsAtom)
+  // 从会话元数据派生 workspaceId：会话数据已加载时以自身为准，未加载时回退全局 atom
+  const currentWorkspaceId = React.useMemo(() => {
+    const meta = sessions.find((s) => s.id === sessionId)
+    if (!meta) return globalWorkspaceId // 数据未加载，回退全局
+    return meta.workspaceId ?? null     // 数据已加载，以会话自身为准
+  }, [sessions, sessionId, globalWorkspaceId])
   const [pendingPrompt, setPendingPrompt] = useAtom(agentPendingPromptAtom)
   const [pendingFiles, setPendingFiles] = useAtom(agentPendingFilesAtom)
   const workspaces = useAtomValue(agentWorkspacesAtom)
@@ -408,7 +415,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   }, [sessionId, refreshVersion, setStreamingStates, setLiveMessagesMap, store])
 
   // 从会话元数据初始化附加目录
-  const sessions = useAtomValue(agentSessionsAtom)
   React.useEffect(() => {
     const meta = sessions.find((s) => s.id === sessionId)
     const dirs = meta?.attachedDirectories ?? []

--- a/apps/electron/src/renderer/hooks/useOpenSession.ts
+++ b/apps/electron/src/renderer/hooks/useOpenSession.ts
@@ -6,11 +6,11 @@
  */
 
 import * as React from 'react'
-import { useAtom, useSetAtom } from 'jotai'
+import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { tabsAtom, splitLayoutAtom, openTab, type TabType } from '@/atoms/tab-atoms'
 import { appModeAtom } from '@/atoms/app-mode'
 import { currentConversationIdAtom } from '@/atoms/chat-atoms'
-import { currentAgentSessionIdAtom } from '@/atoms/agent-atoms'
+import { currentAgentSessionIdAtom, agentSessionsAtom, currentAgentWorkspaceIdAtom } from '@/atoms/agent-atoms'
 
 type OpenSessionFn = (type: TabType, sessionId: string, title: string) => void
 
@@ -20,6 +20,8 @@ export function useOpenSession(): OpenSessionFn {
   const setAppMode = useSetAtom(appModeAtom)
   const setCurrentConversationId = useSetAtom(currentConversationIdAtom)
   const setCurrentAgentSessionId = useSetAtom(currentAgentSessionIdAtom)
+  const agentSessions = useAtomValue(agentSessionsAtom)
+  const setCurrentAgentWorkspaceId = useSetAtom(currentAgentWorkspaceIdAtom)
 
   return React.useCallback(
     (type: TabType, sessionId: string, title: string): void => {
@@ -32,8 +34,17 @@ export function useOpenSession(): OpenSessionFn {
         setCurrentConversationId(sessionId)
       } else {
         setCurrentAgentSessionId(sessionId)
+
+        // 同步 workspaceId，确保与 TabBar 切换行为一致
+        const session = agentSessions.find((s) => s.id === sessionId)
+        if (session?.workspaceId) {
+          setCurrentAgentWorkspaceId(session.workspaceId)
+          window.electronAPI.updateSettings({
+            agentWorkspaceId: session.workspaceId,
+          }).catch(console.error)
+        }
       }
     },
-    [tabs, layout, setTabs, setLayout, setAppMode, setCurrentConversationId, setCurrentAgentSessionId],
+    [tabs, layout, setTabs, setLayout, setAppMode, setCurrentConversationId, setCurrentAgentSessionId, agentSessions, setCurrentAgentWorkspaceId],
   )
 }


### PR DESCRIPTION
## Summary
- **Bug**: 左侧会话列表切换 Agent 会话时，`currentAgentWorkspaceIdAtom` 未跟随更新，导致 `AgentView` 发消息时传递错误的 `workspaceId`，后端用错误 cwd 初始化 SDK → session not found → 触发回填模式
- **Fix (防御层)**: `useOpenSession` 切换 agent 会话时同步 `currentAgentWorkspaceIdAtom`，与 `TabBar` 行为对齐
- **Fix (治本层)**: `AgentView` 从 `agentSessionsAtom` 派生 `workspaceId`，不完全依赖全局 atom；仅在 session 数据未加载时回退全局值

## Test plan
- [ ] 创建两个不同工作区的 Agent 会话 A、B
- [ ] 激活会话 B 后，通过左侧列表切换到会话 A
- [ ] 在会话 A 中发送消息，确认不会走回填模式
- [ ] 通过 TabBar 切换会话，确认行为不变
- [ ] 新建会话（session 数据未加载时），确认回退逻辑正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)