### PR TITLE
feat: 内联聚合式任务进度卡片

### DIFF
--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -16,6 +16,7 @@ import { Bot, Loader2, AlertTriangle, FileText, FileImage, Download, Split } fro
 import { useAtomValue } from 'jotai'
 import { cn } from '@/lib/utils'
 import { ContentBlock } from './ContentBlock'
+import { TaskProgressCard, TASK_TOOL_NAMES } from './TaskProgressCard'
 import { DurationBadge } from './AgentMessages'
 import {
   Message,
@@ -41,7 +42,10 @@ import type {
   SDKContentBlock,
   SDKResultMessage,
   AgentEventUsage,
+  SDKToolUseBlock,
+  SDKToolResultBlock,
 } from '@proma/shared'
+import type { ToolActivity } from '@/atoms/agent-atoms'
 
 // ===== SDKMessageRenderer Props =====
 
@@ -390,6 +394,51 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, isS
     (b) => b.type === 'text' && 'text' in b && !!(b as { text: string }).text
   )
 
+  // Task 聚合数据（useMemo 防止每次渲染重算）
+  const { taskActivities, firstTaskIndex } = React.useMemo(() => {
+    const taskBlocks: SDKToolUseBlock[] = []
+    let _firstTaskIndex = -1
+
+    for (let i = 0; i < topLevelBlocks.length; i++) {
+      const block = topLevelBlocks[i]!
+      if (block.type === 'tool_use' && TASK_TOOL_NAMES.has((block as SDKToolUseBlock).name)) {
+        if (_firstTaskIndex === -1) _firstTaskIndex = i
+        taskBlocks.push(block as SDKToolUseBlock)
+      }
+    }
+
+    // 从 turnMessages 中提取 tool_result 文本，用于 TaskProgressCard 匹配真实 taskId
+    const toolResultMap = new Map<string, string>()
+    for (const msg of turn.turnMessages) {
+      if (msg.type !== 'user') continue
+      const userMsg = msg as SDKUserMessage
+      const blocks = userMsg.message?.content
+      if (!Array.isArray(blocks)) continue
+      for (const b of blocks) {
+        if (b.type === 'tool_result') {
+          const rb = b as SDKToolResultBlock
+          const text = typeof rb.content === 'string'
+            ? rb.content
+            : Array.isArray(rb.content)
+              ? (rb.content as Array<{ text?: string }>).map((c) => c.text ?? '').join('')
+              : ''
+          if (text) toolResultMap.set(rb.tool_use_id, text)
+        }
+      }
+    }
+
+    // 将 SDKToolUseBlock 转换为 ToolActivity 格式（含 result）
+    const _taskActivities: ToolActivity[] = taskBlocks.map((tb) => ({
+      toolUseId: tb.id,
+      toolName: tb.name,
+      input: tb.input as Record<string, unknown>,
+      result: toolResultMap.get(tb.id),
+      done: true,
+    }))
+
+    return { taskActivities: _taskActivities, firstTaskIndex: _firstTaskIndex }
+  }, [topLevelBlocks, turn.turnMessages])
+
   return (
     <Message from="assistant">
       <MessageHeader
@@ -400,26 +449,34 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, isS
       <MessageContent>
         <div className={cn('space-y-2')}>
           {topLevelBlocks.map((block, i) => {
-            const isAgentTool = block.type === 'tool_use'
-              && ((block as { name: string }).name === 'Agent' || (block as { name: string }).name === 'Task')
-            const childBlocks = isAgentTool
-              ? childBlocksMap.get((block as { id: string }).id)
-              : undefined
+              // Task 工具块：聚合为卡片（同 ToolActivityList 路径的逻辑，此处用索引定位）
+              if (block.type === 'tool_use' && TASK_TOOL_NAMES.has((block as SDKToolUseBlock).name)) {
+                if (i === firstTaskIndex) {
+                  return <TaskProgressCard key="task-progress-card" activities={taskActivities} streamEnded={!isStreaming} />
+                }
+                return null
+              }
 
-            return (
-              <ContentBlock
-                key={i}
-                block={block}
-                allMessages={allMessages}
-                basePath={basePath}
-                animate={!!isStreaming}
-                index={i}
-                dimmed={hasTextContent && block.type !== 'text'}
-                childBlocks={childBlocks}
-                isStreaming={isStreaming}
-              />
-            )
-          })}
+              const isAgentTool = block.type === 'tool_use'
+                && ((block as { name: string }).name === 'Agent' || (block as { name: string }).name === 'Task')
+              const childBlocks = isAgentTool
+                ? childBlocksMap.get((block as { id: string }).id)
+                : undefined
+
+              return (
+                <ContentBlock
+                  key={i}
+                  block={block}
+                  allMessages={allMessages}
+                  basePath={basePath}
+                  animate={!!isStreaming}
+                  index={i}
+                  dimmed={hasTextContent && block.type !== 'text'}
+                  childBlocks={childBlocks}
+                  isStreaming={isStreaming}
+                />
+              )
+            })}
         </div>
         {/* 如果有错误但也有内容块，在末尾显示错误 */}
         {hasError && errorContent && topLevelBlocks.length > 0 && (

--- a/apps/electron/src/renderer/components/agent/TaskProgressCard.tsx
+++ b/apps/electron/src/renderer/components/agent/TaskProgressCard.tsx
@@ -1,0 +1,276 @@
+/**
+ * TaskProgressCard — 内联聚合式任务进度卡片
+ *
+ * 将消息流中散落的 TaskCreate / TaskUpdate / TodoWrite 工具调用
+ * 聚合为一个实时更新的进度卡片。
+ *
+ * 数据来源：直接从 ToolActivity[] 中提取 task 相关活动并聚合状态。
+ */
+
+import * as React from 'react'
+import {
+  CheckCircle2,
+  Loader2,
+  Circle,
+  ListTodo,
+  ChevronDown,
+  ChevronUp,
+} from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type { ToolActivity } from '@/atoms/agent-atoms'
+
+// ===== 数据类型 =====
+
+/** Task 工具名集合（用于聚合判断，与 ToolActivityItem / SDKMessageRenderer 共享语义）
+ * 注意：TaskGet/TaskList 是只读查询工具，不纳入聚合，保留为普通工具活动行 */
+export const TASK_TOOL_NAMES = new Set(['TaskCreate', 'TaskUpdate', 'TodoWrite'])
+
+interface TaskItem {
+  id: string
+  subject: string
+  status: 'pending' | 'in_progress' | 'completed' | 'deleted'
+  activeForm?: string
+}
+
+// ===== 聚合逻辑 =====
+
+/**
+ * 从 ToolActivity[] 中提取并聚合所有任务项的最新状态
+ *
+ * 策略：
+ * 1. 先扫描所有 TaskCreate，从 result 中提取 SDK 分配的真实 taskId
+ * 2. 对于 result 尚未到达的 TaskCreate，用 toolUseId 作为临时 key
+ * 3. TaskUpdate 通过真实 taskId 匹配已有条目
+ */
+function aggregateTaskItems(activities: ToolActivity[], streamEnded: boolean): TaskItem[] {
+  const taskMap = new Map<string, TaskItem>()
+  let todoAutoId = 0
+
+  // 第一遍：为每个 TaskCreate 确定其真实 ID
+  // result 格式: "Task #7 created successfully: xxx"
+  const taskCreateIdMap = new Map<string, string>() // toolUseId → realTaskId | toolUseId(fallback)
+  for (const activity of activities) {
+    if (activity.toolName !== 'TaskCreate') continue
+    let realId: string | undefined
+    if (activity.result) {
+      const match = activity.result.match(/Task\s*#(\d+)/i)
+      if (match) realId = match[1]
+    }
+    taskCreateIdMap.set(activity.toolUseId, realId ?? activity.toolUseId)
+  }
+
+  // 第二遍：聚合
+  for (const activity of activities) {
+    if (activity.toolName === 'TodoWrite') {
+      const todos = activity.input.todos
+      if (Array.isArray(todos)) {
+        taskMap.clear()
+        for (const t of todos as Array<Record<string, unknown>>) {
+          const id = `todo-${todoAutoId++}`
+          taskMap.set(id, {
+            id,
+            subject: String(t.subject ?? t.content ?? ''),
+            status: (t.status as TaskItem['status']) ?? 'pending',
+            activeForm: typeof t.activeForm === 'string' ? t.activeForm : undefined,
+          })
+        }
+      }
+    } else if (activity.toolName === 'TaskCreate') {
+      const id = taskCreateIdMap.get(activity.toolUseId) ?? activity.toolUseId
+
+      const subject = typeof activity.input.subject === 'string'
+        ? activity.input.subject
+        : typeof activity.input.description === 'string'
+          ? activity.input.description
+          : '未命名任务'
+      const activeForm = typeof activity.input.activeForm === 'string'
+        ? activity.input.activeForm
+        : undefined
+
+      taskMap.set(id, {
+        id,
+        subject,
+        status: 'pending',
+        activeForm,
+      })
+    } else if (activity.toolName === 'TaskUpdate') {
+      const rawId = activity.input.taskId
+      const taskId = typeof rawId === 'string' ? rawId : typeof rawId === 'number' ? String(rawId) : undefined
+      if (!taskId) continue
+
+      const existing = taskMap.get(taskId)
+      if (existing) {
+        taskMap.set(taskId, {
+          ...existing,
+          ...(typeof activity.input.status === 'string' && { status: activity.input.status as TaskItem['status'] }),
+          ...(typeof activity.input.subject === 'string' && { subject: activity.input.subject }),
+          ...(typeof activity.input.activeForm === 'string' && { activeForm: activity.input.activeForm }),
+        })
+      } else {
+        // TaskCreate 的 result 尚未到达，通过遍历 taskCreateIdMap 找临时 key
+        // 查找是否有 TaskCreate 的临时 key（toolUseId）尚未被替换为真实 ID
+        // 此时无法确定对应关系，走兜底
+        taskMap.set(taskId, {
+          id: taskId,
+          subject: typeof activity.input.subject === 'string' ? activity.input.subject : `任务 #${taskId}`,
+          status: (typeof activity.input.status === 'string' ? activity.input.status : 'pending') as TaskItem['status'],
+          activeForm: typeof activity.input.activeForm === 'string' ? activity.input.activeForm : undefined,
+        })
+      }
+    }
+  }
+
+  // 流式结束后，将仍处于 in_progress 的任务降级为 pending（停止 spinner）
+  let items = Array.from(taskMap.values()).filter((t) => t.status !== 'deleted')
+  if (streamEnded) {
+    items = items.map((t) =>
+      t.status === 'in_progress' ? { ...t, status: 'pending' as const } : t
+    )
+  }
+  return items
+}
+
+// ===== 任务行 =====
+
+interface TaskRowProps {
+  item: TaskItem
+}
+
+function TaskRow({ item }: TaskRowProps): React.ReactElement {
+  const isCompleted = item.status === 'completed'
+  const isInProgress = item.status === 'in_progress'
+
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-1.5 text-[13px] py-[3px]',
+        'transition-colors duration-200',
+        isCompleted && 'opacity-50',
+      )}
+    >
+      {/* 状态图标 */}
+      <span className="flex items-center justify-center size-2.5 shrink-0">
+        {item.status === 'pending' && (
+          <Circle className="size-2.5 text-muted-foreground/40" />
+        )}
+        {isInProgress && (
+          <Loader2 className="size-2 animate-spin text-blue-500" />
+        )}
+        {isCompleted && (
+          <CheckCircle2 className="size-2.5 text-green-500" />
+        )}
+      </span>
+
+      {/* 任务文字 */}
+      <span
+        className={cn(
+          'truncate flex-1',
+          isCompleted && 'text-muted-foreground line-through',
+          isInProgress && 'text-foreground/90',
+          !isCompleted && !isInProgress && 'text-muted-foreground',
+        )}
+      >
+        {isInProgress && item.activeForm ? item.activeForm : item.subject}
+      </span>
+    </div>
+  )
+}
+
+// ===== 进度条 =====
+
+function ProgressBar({ completed, total }: { completed: number; total: number }): React.ReactElement | null {
+  if (total <= 1) return null
+  const percent = Math.round((completed / total) * 100)
+
+  return (
+    <div className="h-0.5 bg-muted rounded-full mb-2 overflow-hidden">
+      <div
+        className="h-full bg-primary rounded-full transition-[width] duration-500 ease-out"
+        style={{ width: `${percent}%` }}
+      />
+    </div>
+  )
+}
+
+// ===== 主组件 =====
+
+const MAX_VISIBLE = 8
+
+/** 虚线边框 SVG（与 Thinking 块相同风格） */
+const dashedBorderStyle = {
+  border: 'none',
+  backgroundImage: `url("data:image/svg+xml,%3csvg width='100%25' height='100%25' xmlns='http://www.w3.org/2000/svg'%3e%3crect width='100%25' height='100%25' fill='none' rx='8' ry='8' stroke='rgba(128,128,128,0.4)' stroke-width='1.5' stroke-dasharray='8%2c 6' stroke-dashoffset='0' stroke-linecap='round'/%3e%3c/svg%3e")`,
+} as const
+
+interface TaskProgressCardProps {
+  /** 包含 TaskCreate/TaskUpdate/TodoWrite 的活动列表 */
+  activities: ToolActivity[]
+  /** 是否处于流式状态 */
+  animate?: boolean
+  /** 流式是否已结束（用于停止 in_progress 任务的 spinner） */
+  streamEnded?: boolean
+}
+
+export function TaskProgressCard({ activities, animate = false, streamEnded = false }: TaskProgressCardProps): React.ReactElement | null {
+  const items = React.useMemo(() => aggregateTaskItems(activities, streamEnded), [activities, streamEnded])
+  const [expanded, setExpanded] = React.useState(false)
+
+  if (items.length === 0) return null
+
+  const completedCount = items.filter((t) => t.status === 'completed').length
+  const totalCount = items.length
+  const needsCollapse = items.length > MAX_VISIBLE
+  const visibleItems = needsCollapse && !expanded ? items.slice(0, MAX_VISIBLE) : items
+
+  return (
+    <div className={cn('my-1 max-w-[630px]', animate && 'animate-in fade-in duration-200')}>
+      {/* 虚线边框容器 */}
+      <div
+        className="rounded-lg bg-muted/40 px-3.5 py-3"
+        style={dashedBorderStyle}
+      >
+        {/* 标题行 */}
+        <div className="flex items-center gap-1.5 mb-1.5">
+          <ListTodo className="size-3.5 text-muted-foreground" />
+          <span className="text-[13px] font-medium text-muted-foreground">
+            任务进度
+          </span>
+          <span className="text-[11px] text-muted-foreground/50 tabular-nums">
+            {completedCount}/{totalCount}
+          </span>
+        </div>
+
+        {/* 进度条 */}
+        <ProgressBar completed={completedCount} total={totalCount} />
+
+        {/* 任务列表 */}
+        <div className="space-y-0">
+          {visibleItems.map((item) => (
+            <TaskRow key={item.id} item={item} />
+          ))}
+        </div>
+
+        {/* 展开/收起按钮 */}
+        {needsCollapse && (
+          <button
+            type="button"
+            onClick={() => setExpanded(!expanded)}
+            className="mt-1 flex items-center gap-1 text-[11px] text-muted-foreground/50 hover:text-foreground/70 transition-colors"
+          >
+            {expanded ? (
+              <>
+                <ChevronUp className="size-3" />
+                <span>收起</span>
+              </>
+            ) : (
+              <>
+                <ChevronDown className="size-3" />
+                <span>展开全部 {totalCount} 项</span>
+              </>
+            )}
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/agent/ToolActivityItem.tsx
+++ b/apps/electron/src/renderer/components/agent/ToolActivityItem.tsx
@@ -31,6 +31,7 @@ import {
   groupActivities,
   isActivityGroup,
 } from '@/atoms/agent-atoms'
+import { TaskProgressCard, TASK_TOOL_NAMES } from './TaskProgressCard'
 
 // ===== 尺寸配置 =====
 
@@ -460,16 +461,34 @@ export function ToolActivityList({ activities, animate = false }: ToolActivityLi
 
   const grouped = React.useMemo(() => groupActivities(activities), [activities])
 
+  // 提取所有 task 相关的活动用于聚合卡片
+  const taskActivities = React.useMemo(
+    () => activities.filter((a) => TASK_TOOL_NAMES.has(a.toolName)),
+    [activities]
+  )
+  const hasTaskCard = taskActivities.length > 0
+  // 从原始 activities 查找第一个 task 工具的 toolUseId，定位卡片插入点
+  const firstTaskToolUseId = React.useMemo(
+    () => activities.find((a) => TASK_TOOL_NAMES.has(a.toolName))?.toolUseId ?? null,
+    [activities]
+  )
+
   const visibleRows = React.useMemo(() => {
     let count = 0
     for (const item of grouped) {
+      if (!isActivityGroup(item) && TASK_TOOL_NAMES.has((item as ToolActivity).toolName)) {
+        // task 工具聚合为一张卡片，不计入独立行数
+        continue
+      }
       count += 1
       if (isActivityGroup(item)) {
         count += item.children.length
       }
     }
+    // 卡片��� 1 行
+    if (hasTaskCard) count += 1
     return count
-  }, [grouped])
+  }, [grouped, hasTaskCard])
 
   const needsCollapse = visibleRows > SIZE.autoScrollThreshold
 
@@ -527,23 +546,20 @@ export function ToolActivityList({ activities, animate = false }: ToolActivityLi
 
         const activity = item as ToolActivity
 
-        // TodoWrite / TaskCreate 特殊渲染
-        if (activity.toolName === 'TodoWrite' || activity.toolName === 'TaskCreate') {
-          const todos = parseTodoItems(activity.input)
-          if (todos && todos.length > 0) {
+        // Task 相关工具：聚合为一个 TaskProgressCard
+        if (TASK_TOOL_NAMES.has(activity.toolName)) {
+          // 在第一个 task 工具位置插入卡片，后续的跳过
+          if (activity.toolUseId === firstTaskToolUseId) {
             return (
-              <React.Fragment key={activity.toolUseId}>
-                <ActivityRow
-                  activity={activity}
-                  index={i}
-                  animate={animate}
-                  // 不传递 onOpenDetails，TodoWrite/TaskCreate 不支持点击展开详情
-                  // 因为它们已经有专属的 TodoList 展示
-                />
-                <TodoList items={todos} />
-              </React.Fragment>
+              <TaskProgressCard
+                key="task-progress-card"
+                activities={taskActivities}
+                animate={animate}
+                streamEnded={!animate}
+              />
             )
           }
+          return null
         }
 
         return (


### PR DESCRIPTION
## 问题根因

Agent 执行任务时，TaskCreate/TaskUpdate/TodoWrite 等工具调用以散落的工具活动日志逐行显示，信息密度低、缺乏整体进度感知，用户难以一目了然地掌握任务状态。

## 具体修改

### 新增文件
- **TaskProgressCard.tsx** — 核心卡片组件
  - 聚合 TaskCreate/TaskUpdate/TodoWrite 为统一任务状态面板
  - 两遍扫描策略：从 tool_result 提取真实 SDK taskId，解决跨 turn 全局递增 ID 匹配问题
  - Thinking 块风格虚线 SVG 边框，进度条，状态图标
  - streamEnded 支持：用户中断会话时自动停止 spinner
  - TaskGet/TaskList 不纳入聚合，保留为普通工具活动行

### 修改文件
- **ToolActivityItem.tsx** — 流式渲染路径集成
  - ToolActivityList 中过滤 task 活动，在首个 task 工具位置插入 TaskProgressCard
  - 后续 task 工具活动返回 null 不再单独渲染

- **SDKMessageRenderer.tsx** — SDK 持久化渲染路径集成
  - 从 turn.turnMessages 提取 tool_result 文本，填入 taskActivities 的 result 字段
  - 聚合逻辑提取到 useMemo 避免不必要的重算
  - 新增 SDKToolResultBlock 类型导入

## 审查情况

- 代码审查已完成，修复了审查中发现的 3 个问题：TaskGet/TaskList 静默丢弃、taskId 类型兼容、SDK 路径缺少 useMemo
- 用户手动测试通过：多轮对话跨 turn taskId 匹配正确，中断会话 spinner 正常停止