### PR TITLE
fix: Skill 展开消息被错误渲染为用户消息气泡

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -713,7 +713,15 @@ export class AgentOrchestrator {
     const toPersist = accumulatedMessages.filter(
       (m) => m.type === 'assistant' || m.type === 'user' || m.type === 'result'
         || (m.type === 'system' && (m as import('@proma/shared').SDKSystemMessage).subtype === 'compact_boundary')
-    )
+    ).filter((m) => {
+      // 过滤 SDK 内部生成的 user 文本消息（如 Skill 展开 prompt），与实时流过滤逻辑一致
+      if (m.type === 'user') {
+        const content = (m as { message?: { content?: Array<{ type: string }> } }).message?.content
+        const hasToolResult = Array.isArray(content) && content.some((b) => b.type === 'tool_result')
+        if (!hasToolResult) return false
+      }
+      return true
+    })
 
     if (toPersist.length === 0) return
 

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -143,6 +143,8 @@ function extractUserText(message: SDKUserMessage): string | null {
 
 function isUserInputMessage(message: SDKUserMessage): boolean {
   if (message.parent_tool_use_id) return false
+  // SDK 合成消息（如 Skill 展开 prompt）不是用户输入
+  if (message.isSynthetic) return false
   // 包含 tool_result 块的消息是工具结果，不是用户输入
   const content = message.message?.content
   if (Array.isArray(content) && content.some((b) => b.type === 'tool_result')) return false

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -228,6 +228,8 @@ export interface SDKUserMessage {
   uuid?: string
   tool_use_result?: unknown
   isReplay?: boolean
+  /** SDK 合成的消息（如 Skill 展开 prompt），非人类用户输入 */
+  isSynthetic?: boolean
 }
 
 /** SDK result 消息（查询结束时返回） */


### PR DESCRIPTION
## 问题根因

Agent 调用 Skill 工具后，SDK 将展开的 prompt 作为 `isSynthetic: true` 的 user 消息注入消息流。但前端 `isUserInputMessage()` 未识别该标记，将其误判为真正的用户输入，渲染为用户消息气泡（显示用户头像）。

同时，`persistSDKMessages` 未过滤该消息，导致 Skill 展开内容被写入 jsonl，重新加载会话时问题持续存在。

## 具体修改

- **`packages/shared/src/types/agent.ts`** — `SDKUserMessage` 新增 `isSynthetic?: boolean` 字段声明
- **`apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx`** — `isUserInputMessage()` 增加 `isSynthetic` 检查，兼容已有 jsonl 中的脏数据
- **`apps/electron/src/main/lib/agent-orchestrator.ts`** — `persistSDKMessages` 过滤不含 `tool_result` 的 user 消息，与实时流过滤逻辑对齐

## 审查情况

- 通过日志分析确认 SDK 的 `isSynthetic` 字段是标准标记
- 持久化过滤与已有实时流过滤逻辑（1451-1461行）保持一致
- 用户测试通过