### PR TITLE
fix: 统一 Agent/Chat 模式切换器样式与顺序

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -747,7 +747,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
 
       {/* Agent 模式：工作区选择器 */}
       {mode === 'agent' && (
-        <div className="px-3 pt-3">
+        <div className="px-3 pt-2">
           <WorkspaceSelector />
         </div>
       )}

--- a/apps/electron/src/renderer/components/app-shell/ModeSwitcher.tsx
+++ b/apps/electron/src/renderer/components/app-shell/ModeSwitcher.tsx
@@ -15,11 +15,12 @@ import { conversationsAtom, currentConversationIdAtom } from '@/atoms/chat-atoms
 import { agentSessionsAtom, currentAgentSessionIdAtom } from '@/atoms/agent-atoms'
 import { tabsAtom } from '@/atoms/tab-atoms'
 import { useOpenSession } from '@/hooks/useOpenSession'
+import { Bot, MessageSquare } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
-const modes: { value: AppMode; label: string }[] = [
-  { value: 'agent', label: 'Agent' },
-  { value: 'chat', label: 'Chat' },
+const modes: { value: AppMode; label: string; icon: React.ReactNode }[] = [
+  { value: 'agent', label: 'Agent', icon: <Bot size={15} /> },
+  { value: 'chat', label: 'Chat', icon: <MessageSquare size={15} /> },
 ]
 
 export function ModeSwitcher(): React.ReactElement {
@@ -68,25 +69,26 @@ export function ModeSwitcher(): React.ReactElement {
 
   return (
     <div className="pt-2">
-      <div className="relative flex rounded-lg bg-muted p-1">
+      <div className="relative flex rounded-xl bg-muted p-1">
         {/* 滑动背景指示器 */}
         <div
           className={cn(
-            'mode-slider absolute top-1 bottom-1 w-[calc(50%-4px)] rounded bg-background shadow-sm transition-transform duration-300 ease-in-out',
+            'mode-slider absolute top-1 bottom-1 w-[calc(50%-4px)] rounded-lg bg-background shadow-sm transition-transform duration-300 ease-in-out',
             mode === 'agent' ? 'translate-x-0' : 'translate-x-full'
           )}
         />
-        {modes.map(({ value, label }) => (
+        {modes.map(({ value, label, icon }) => (
           <button
             key={value}
             onClick={() => handleModeSwitch(value)}
             className={cn(
-              'mode-btn relative z-[1] flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors duration-200',
+              'mode-btn relative z-[1] flex-1 flex items-center justify-center gap-1.5 rounded-lg px-3 py-1 text-sm font-medium transition-colors duration-200',
               mode === value
                 ? 'mode-btn-selected text-foreground'
                 : 'text-muted-foreground hover:text-foreground'
             )}
           >
+            {icon}
             {label}
           </button>
         ))}

--- a/apps/electron/src/renderer/components/welcome/WelcomeEmptyState.tsx
+++ b/apps/electron/src/renderer/components/welcome/WelcomeEmptyState.tsx
@@ -70,10 +70,10 @@ export function WelcomeEmptyState(): React.ReactElement {
         <div
           className={cn(
             'absolute top-1 bottom-1 w-[calc(50%-4px)] rounded-lg bg-background shadow-sm transition-transform duration-300 ease-in-out',
-            mode === 'chat' ? 'translate-x-0' : 'translate-x-full',
+            mode === 'agent' ? 'translate-x-0' : 'translate-x-full',
           )}
         />
-        {(['chat', 'agent'] as const).map((m) => {
+        {(['agent', 'chat'] as const).map((m) => {
           const config = MODE_CONFIG[m]
           const isSelected = mode === m
           return (


### PR DESCRIPTION
## 问题根因

左侧边栏 ModeSwitcher 与 Welcome 页面的模式切换器在按钮顺序、圆角、图标三方面存在不一致：
- 顺序不同（侧边栏 Agent→Chat，Welcome Chat→Agent）
- ModeSwitcher 无图标、圆角较小
- 工作区选择器上下间距不对称

## 具体修改

- **ModeSwitcher.tsx**：添加 Bot/MessageSquare 图标，圆角统一为 xl/lg，按钮内边距 py-1.5→py-1 与收起按钮高度对齐
- **WelcomeEmptyState.tsx**：按钮顺序改为 Agent→Chat，滑块动画方向同步调整
- **LeftSidebar.tsx**：工作区选择器上方间距 pt-3→pt-2，与下方新会话按钮间距对称

## 审查情况

自审查通过，所有改动最小且必要，未影响功能逻辑。用户已测试确认。