### PR TITLE
fix: 修复中止任务后继续执行时看板任务名丢失的问题

### DIFF
--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -398,7 +398,7 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, isS
   )
 
   // Task 聚合数据（useMemo 防止每次渲染重算）
-  const { taskActivities, firstTaskIndex } = React.useMemo(() => {
+  const { taskActivities, firstTaskIndex, historicalTaskSubjects } = React.useMemo(() => {
     const taskBlocks: SDKToolUseBlock[] = []
     let _firstTaskIndex = -1
 
@@ -439,8 +439,57 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, isS
       done: true,
     }))
 
-    return { taskActivities: _taskActivities, firstTaskIndex: _firstTaskIndex }
-  }, [topLevelBlocks, turn.turnMessages])
+    // 从 allMessages 中回溯历史 TaskCreate 的 taskId → subject 映射
+    // 用于"继续"后当前 turn 缺少 TaskCreate 时恢复任务名
+    const _historicalTaskSubjects = new Map<string, string>()
+    const globalResultMap = new Map<string, string>()
+    const pendingTaskCreates: SDKToolUseBlock[] = []
+    // 单次遍历：同时收集 tool_result 映射和 TaskCreate 块
+    for (const msg of allMessages) {
+      if (msg.type === 'user') {
+        const userMsg = msg as SDKUserMessage
+        const blocks = userMsg.message?.content
+        if (!Array.isArray(blocks)) continue
+        for (const b of blocks) {
+          if (b.type === 'tool_result') {
+            const rb = b as SDKToolResultBlock
+            const text = typeof rb.content === 'string'
+              ? rb.content
+              : Array.isArray(rb.content)
+                ? (rb.content as Array<{ text?: string }>).map((c) => c.text ?? '').join('')
+                : ''
+            if (text) globalResultMap.set(rb.tool_use_id, text)
+          }
+        }
+      } else if (msg.type === 'assistant') {
+        const aMsg = msg as SDKAssistantMessage
+        const blocks = aMsg.message?.content
+        if (!Array.isArray(blocks)) continue
+        for (const b of blocks) {
+          if (b.type === 'tool_use' && (b as SDKToolUseBlock).name === 'TaskCreate') {
+            pendingTaskCreates.push(b as SDKToolUseBlock)
+          }
+        }
+      }
+    }
+    // 解析 TaskCreate 的真实 taskId 和 subject
+    for (const tb of pendingTaskCreates) {
+      const input = tb.input as Record<string, unknown>
+      const subject = typeof input.subject === 'string'
+        ? input.subject
+        : typeof input.description === 'string'
+          ? input.description
+          : undefined
+      if (!subject) continue
+      const resultText = globalResultMap.get(tb.id)
+      if (resultText) {
+        const match = resultText.match(/Task\s*#(\d+)/i)
+        if (match) _historicalTaskSubjects.set(match[1], subject)
+      }
+    }
+
+    return { taskActivities: _taskActivities, firstTaskIndex: _firstTaskIndex, historicalTaskSubjects: _historicalTaskSubjects }
+  }, [topLevelBlocks, turn.turnMessages, allMessages])
 
   return (
     <Message from="assistant">
@@ -455,7 +504,7 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, isS
               // Task 工具块：聚合为卡片（同 ToolActivityList 路径的逻辑，此处用索引定位）
               if (block.type === 'tool_use' && TASK_TOOL_NAMES.has((block as SDKToolUseBlock).name)) {
                 if (i === firstTaskIndex) {
-                  return <TaskProgressCard key="task-progress-card" activities={taskActivities} streamEnded={!isStreaming} />
+                  return <TaskProgressCard key="task-progress-card" activities={taskActivities} streamEnded={!isStreaming} historicalTaskSubjects={historicalTaskSubjects} />
                 }
                 return null
               }

--- a/apps/electron/src/renderer/components/agent/TaskProgressCard.tsx
+++ b/apps/electron/src/renderer/components/agent/TaskProgressCard.tsx
@@ -42,7 +42,7 @@ interface TaskItem {
  * 2. 对于 result 尚未到达的 TaskCreate，用 toolUseId 作为临时 key
  * 3. TaskUpdate 通过真实 taskId 匹配已有条目
  */
-function aggregateTaskItems(activities: ToolActivity[], streamEnded: boolean): TaskItem[] {
+function aggregateTaskItems(activities: ToolActivity[], streamEnded: boolean, historicalTaskSubjects?: Map<string, string>): TaskItem[] {
   const taskMap = new Map<string, TaskItem>()
   let todoAutoId = 0
 
@@ -115,7 +115,9 @@ function aggregateTaskItems(activities: ToolActivity[], streamEnded: boolean): T
         // 此时无法确定对应关系，走兜底
         taskMap.set(taskId, {
           id: taskId,
-          subject: typeof activity.input.subject === 'string' ? activity.input.subject : `任务 #${taskId}`,
+          subject: typeof activity.input.subject === 'string'
+            ? activity.input.subject
+            : historicalTaskSubjects?.get(taskId) ?? `任务 #${taskId}`,
           status: (typeof activity.input.status === 'string' ? activity.input.status : 'pending') as TaskItem['status'],
           activeForm: typeof activity.input.activeForm === 'string' ? activity.input.activeForm : undefined,
         })
@@ -212,10 +214,12 @@ interface TaskProgressCardProps {
   animate?: boolean
   /** 流式是否已结束（用于停止 in_progress 任务的 spinner） */
   streamEnded?: boolean
+  /** 历史 TaskCreate 的 taskId → subject 映射（跨 turn 回溯，用于恢复任务名） */
+  historicalTaskSubjects?: Map<string, string>
 }
 
-export function TaskProgressCard({ activities, animate = false, streamEnded = false }: TaskProgressCardProps): React.ReactElement | null {
-  const items = React.useMemo(() => aggregateTaskItems(activities, streamEnded), [activities, streamEnded])
+export function TaskProgressCard({ activities, animate = false, streamEnded = false, historicalTaskSubjects }: TaskProgressCardProps): React.ReactElement | null {
+  const items = React.useMemo(() => aggregateTaskItems(activities, streamEnded, historicalTaskSubjects), [activities, streamEnded, historicalTaskSubjects])
   const [expanded, setExpanded] = React.useState(false)
 
   if (items.length === 0) return null


### PR DESCRIPTION
## 问题根因

`TaskProgressCard` 的 `aggregateTaskItems` 只从当前 turn 的 `ToolActivity[]` 中聚合任务状态。当用户手动中止任务后输入"继续"，新 turn 中只有 `TaskUpdate` 调用而没有对应的 `TaskCreate`，导致走入兜底分支，任务名显示为 `任务 #X` 而非原始名称。

## 具体修改

- **TaskProgressCard.tsx**：新增可选 `historicalTaskSubjects` prop（`Map<string, string>`），在兜底分支优先从历史映射中查找原始任务名
- **SDKMessageRenderer.tsx**：在构建 `taskActivities` 的 `useMemo` 中，从 `allMessages`（包含所有历史消息）中单次遍历提取历史 `TaskCreate` 的 `taskId → subject` 映射，传给 `TaskProgressCard`

## 审查情况

- 自审查 + 代码审查通过：改动最小化，仅在兜底分支生效，不影响正常流程
- 用户手动测试通过