### PR TITLE
fix: AskUserBanner 输入法组合状态下回车选词误触发提交

### DIFF
--- a/apps/electron/src/renderer/components/agent/AskUserBanner.tsx
+++ b/apps/electron/src/renderer/components/agent/AskUserBanner.tsx
@@ -81,9 +81,9 @@ export function AskUserBanner({ sessionId }: AskUserBannerProps): React.ReactEle
       const itemCount = q.options.length + 1
       const lastTab = curTab >= qs.length - 1
 
-      // 自由文本输入框内：仅 Enter 生效
+      // 自由文本输入框内：仅 Enter 生效（输入法组合中跳过）
       if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
-        if (e.key === 'Enter' && !e.shiftKey) {
+        if (e.key === 'Enter' && !e.shiftKey && !e.isComposing) {
           e.preventDefault()
           if (lastTab) submitRef.current?.()
           else setActiveTab((prev) => prev + 1)
@@ -104,7 +104,7 @@ export function AskUserBanner({ sessionId }: AskUserBannerProps): React.ReactEle
         } else {
           toggleCustomByState(curTab)
         }
-      } else if (e.key === 'Enter') {
+      } else if (e.key === 'Enter' && !e.isComposing) {
         e.preventDefault()
         if (lastTab) submitRef.current?.()
         else setActiveTab((prev) => prev + 1)
@@ -363,7 +363,7 @@ function QuestionCard({
           value={answer.customText}
           onChange={(e) => onCustomTextChange(e.target.value)}
           onKeyDown={(e) => {
-            if (e.key === 'Enter' && !e.shiftKey) {
+            if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
               e.preventDefault()
               e.stopPropagation() // 阻止冒泡到 document handler，避免重复触发 setActiveTab
               onSubmit()


### PR DESCRIPTION
## 问题根因

AskUserBanner 组件的自由文本输入框在处理 Enter 键时，没有检查 `KeyboardEvent.isComposing` 状态。当用户使用中文输入法输入时，按回车确认候选词会被误判为提交操作，导致未完成的拼音被直接发送。

## 具体修改

**文件**：`apps/electron/src/renderer/components/agent/AskUserBanner.tsx`

在三处 Enter 键判断中加入 `isComposing` 检查：
- document 级 keydown handler 中输入框内的 Enter 判断（第 86 行）
- document 级 keydown handler 中非输入框的 Enter 判断（第 107 行）
- input 元素 onKeyDown 中的 Enter 判断（第 366 行，使用 `nativeEvent.isComposing`）

## 审查情况

- 自审查通过：改动最小化，仅在必要位置加入 isComposing 守卫
- 用户手动测试通过：中文输入法回车选词不再误触发提交