### PR TITLE
feat: 微信收到消息后立即发送确认回复

### DIFF
--- a/apps/electron/src/main/lib/bridge-command-handler.ts
+++ b/apps/electron/src/main/lib/bridge-command-handler.ts
@@ -525,6 +525,13 @@ export class BridgeCommandHandler {
       return
     }
 
+    // 即时确认：[workspace_name]->[session_title]: ⏳ Agent 处理中...
+    const workspace = binding.workspaceId ? getAgentWorkspace(binding.workspaceId) : undefined
+    const session = getAgentSessionMeta(binding.sessionId)
+    const wsName = workspace?.name ?? '默认'
+    const chatName = session?.title ?? '新会话'
+    await this.send(chatId, `${wsName} → ${chatName}: ⏳ Agent 处理中...`, contextData)
+
     // 初始化回复缓冲
     this.sessionBuffers.set(binding.sessionId, {
       text: '',


### PR DESCRIPTION
## Overview

微信用户通过 iLink Bot 发消息给 Proma 时，需要等待 Agent 完整处理完毕才能收到回复，期间没有任何反馈，用户体验较差。本 PR 在 Agent 启动处理之前，立即发送一条格式化确认消息，让用户知道消息已被接收。

## Changes

- `apps/electron/src/main/lib/bridge-command-handler.ts` — 在 `handleUserMessage()` 方法中，Agent 启动前新增即时确认逻辑：读取当前工作区名称和会话标题，发送 `{工作区} → {会话标题}: ⏳ Agent 处理中...` 格式的确认消息给微信用户。

## How to Test

1. 启动 Proma 桌面端，确保微信 Bridge 已连接
2. 通过微信向 Proma Bot 发送一条消息
3. 验证立即收到确认消息，格式为 `DEV PMA → 微信会话: ⏳ Agent 处理中...`
4. 等待 Agent 完成后，验证正式回复正常返回

## Notes

- 仅影响微信/钉钉等使用 BridgeCommandHandler 的平台，飞书 Bridge 使用独立的卡片消息格式不受影响
- 确认消息通过现有的 ILinkClient.sendText() 发送，无需新增 API 调用