### PR TITLE
fix: 修复微信/飞书/钉钉 workspace 切换后消息路由到旧工作区的问题

### DIFF
--- a/apps/electron/src/main/lib/dingtalk-bridge.ts
+++ b/apps/electron/src/main/lib/dingtalk-bridge.ts
@@ -79,8 +79,8 @@ class DingTalkBridge {
   private webhookCache = new Map<string, string>()
   private readonly MAX_WEBHOOK_CACHE = 200
 
-  /** Bot 配置（构造时传入） */
-  readonly botConfig: DingTalkBotConfig
+  /** Bot 配置（构造时传入，workspace 切换时同步更新） */
+  botConfig: DingTalkBotConfig
 
   /** 通用命令处理器 */
   private commandHandler: BridgeCommandHandler
@@ -115,6 +115,18 @@ class DingTalkBridge {
         },
       },
       getDefaultWorkspaceId: () => this.botConfig.defaultWorkspaceId,
+      onWorkspaceSwitched: async (workspaceId) => {
+        const { saveDingTalkBotConfig } = await import('./dingtalk-config')
+        saveDingTalkBotConfig({
+          id: this.botConfig.id,
+          name: this.botConfig.name,
+          enabled: this.botConfig.enabled,
+          clientId: this.botConfig.clientId,
+          clientSecret: '',
+          defaultWorkspaceId: workspaceId,
+        })
+        this.botConfig = { ...this.botConfig, defaultWorkspaceId: workspaceId }
+      },
     })
   }
 

--- a/apps/electron/src/main/lib/feishu-bridge.ts
+++ b/apps/electron/src/main/lib/feishu-bridge.ts
@@ -85,8 +85,8 @@ interface SessionBuffer {
 // ===== Bridge =====
 
 class FeishuBridge {
-  /** Bot 配置（构造时注入） */
-  private readonly botConfig: FeishuBotConfig
+  /** Bot 配置（构造时注入，workspace 切换时同步更新） */
+  private botConfig: FeishuBotConfig
 
   /** SDK Client（发消息用） */
   private client: InstanceType<typeof import('@larksuiteoapi/node-sdk').Client> | null = null
@@ -1005,6 +1005,8 @@ class FeishuBridge {
       defaultChannelId: this.botConfig.defaultChannelId,
       defaultModelId: this.botConfig.defaultModelId,
     })
+    // 同步更新内存中的 botConfig，避免后续读到旧快照
+    this.botConfig = { ...this.botConfig, defaultWorkspaceId: match.id }
 
     // 列出该工作区下最近 10 条会话（序号为全局排序位置）
     const sessions = listAgentSessions()

--- a/apps/electron/src/main/lib/wechat-bridge.ts
+++ b/apps/electron/src/main/lib/wechat-bridge.ts
@@ -17,7 +17,7 @@ import type {
   WeChatMessageItem,
 } from '@proma/shared'
 import { WECHAT_IPC_CHANNELS, WECHAT_ITEM_TYPE, WECHAT_MESSAGE_TYPE, WECHAT_MESSAGE_STATE } from '@proma/shared'
-import { getDecryptedCredentials, saveWeChatCredentials, clearWeChatCredentials } from './wechat-config'
+import { getDecryptedCredentials, saveWeChatCredentials, clearWeChatCredentials, getWeChatConfig, updateWeChatDefaultWorkspace } from './wechat-config'
 import { getWeChatSyncPath } from './config-paths'
 import { BridgeCommandHandler } from './bridge-command-handler'
 import { readFileSync, writeFileSync, existsSync } from 'node:fs'
@@ -222,6 +222,8 @@ class WeChatBridge {
         }
       },
     },
+    getDefaultWorkspaceId: () => getWeChatConfig().defaultWorkspaceId,
+    onWorkspaceSwitched: (workspaceId) => updateWeChatDefaultWorkspace(workspaceId),
   })
 
   /** 获取当前状态 */

--- a/apps/electron/src/main/lib/wechat-config.ts
+++ b/apps/electron/src/main/lib/wechat-config.ts
@@ -82,6 +82,13 @@ export function getDecryptedCredentials(): WeChatCredentials | null {
   }
 }
 
+/** 仅更新默认工作区 ID（不修改凭证） */
+export function updateWeChatDefaultWorkspace(workspaceId: string): void {
+  const configPath = getWeChatConfigPath()
+  const config = getWeChatConfig()
+  writeFileSync(configPath, JSON.stringify({ ...config, defaultWorkspaceId: workspaceId }, null, 2), 'utf-8')
+}
+
 /** 清除微信凭证（登出） */
 export function clearWeChatCredentials(): void {
   const configPath = getWeChatConfigPath()


### PR DESCRIPTION
## Overview

在微信、飞书、钉钉平台上，用户通过 `/workspace` 命令切换工作区后，确认消息能正确显示（如「已切换到工作区: defaults」），但后续消息仍然被路由到切换前的旧工作区。这是一个跨平台的后端执行逻辑 bug，三个平台各有不同的 root cause。

## Changes

- `apps/electron/src/main/lib/wechat-config.ts` — 新增 `updateWeChatDefaultWorkspace()` 函数，直接 patch `wechat.json` 中的 `defaultWorkspaceId` 字段，不涉及 token 加解密逻辑

- `apps/electron/src/main/lib/wechat-bridge.ts` — 补齐 `BridgeCommandHandler` 的两个缺失回调：`getDefaultWorkspaceId`（创建新会话时读取已持久化的 workspace）和 `onWorkspaceSwitched`（切换时写入磁盘）

- `apps/electron/src/main/lib/feishu-bridge.ts` — 移除 `botConfig` 的 `readonly` 修饰符；在 `handleWorkspaceCommand` 调用 `saveFeishuBotConfig()` 之后，同步更新内存中的 `this.botConfig`，避免后续读到构造时的旧快照

- `apps/electron/src/main/lib/dingtalk-bridge.ts` — 移除 `botConfig` 的 `readonly` 修饰符；补齐 `onWorkspaceSwitched` 回调，在切换时调用 `saveDingTalkBotConfig()` 持久化并同步更新内存快照

## Root Cause

| 平台 | 问题 |
|------|------|
| 微信 | `BridgeCommandHandler` 构造时未传 `onWorkspaceSwitched` 和 `getDefaultWorkspaceId`，切换从未持久化，回退到全局 `settings.agentWorkspaceId` |
| 飞书 | `botConfig` 是 `readonly` 冻结快照，`saveFeishuBotConfig()` 写文件成功但内存未更新，重启前一直读旧值 |
| 钉钉 | 同时存在上述两个问题：`onWorkspaceSwitched` 未传 + `botConfig` 快照未更新 |

## How to Test

1. 在微信/飞书/钉钉任一平台发送 `/workspace <N>` 切换到非默认工作区
2. 确认收到「已切换到工作区: xxx」的确认消息
3. 发送任意消息，确认 Agent 响应前缀显示的是新工作区名称（不再是旧 workspace）
4. 发送 `/new` 创建新会话，确认新会话归属在新工作区下
5. 重启应用后重复步骤 3-4，确认 workspace 选择持久生效

## Notes

- `bun.lock` 未包含在本次提交中（仅依赖安装产生的变化，无实质改动）
- 飞书的 `getBotConfig()` 公开方法在外部无调用者，移除 `readonly` 不影响外部行为
- 钉钉的 `onWorkspaceSwitched` 回调使用 `clientSecret: ''` 调用 `saveDingTalkBotConfig()`，与飞书的惯例一致（空字符串表示不修改 secret 字段）