### PR TITLE
fix: 无可用模型时锁住 Agent 输入框 bug

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -286,6 +286,18 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
 
   // 渠道已选但模型未选时，自动选择第一个可用模型
   const globalChannels = useAtomValue(channelsAtom)
+
+  // 检查 Agent 渠道列表中是否存在可用的模型（渠道 enabled + 模型 enabled）
+  const hasAvailableModel = React.useMemo(() => {
+    // Proma 官方渠道（商业版）：只要 enabled 且有可用模型，直接视为可用
+    const promaOfficial = globalChannels.find((c) => c.id === 'proma-official')
+    if (promaOfficial?.enabled && promaOfficial.models.some((m) => m.enabled)) return true
+    // 其他渠道：需在 agentChannelIds 白名单中
+    if (!agentChannelIds || agentChannelIds.length === 0) return false
+    return globalChannels.some(
+      (c) => c.enabled && agentChannelIds.includes(c.id) && c.models.some((m) => m.enabled),
+    )
+  }, [globalChannels, agentChannelIds])
   React.useEffect(() => {
     if (!agentChannelId || agentModelId) return
 
@@ -734,7 +746,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     const text = inputContent.trim()
     // 如果输入为空但有建议，使用建议内容
     const effectiveText = text || suggestion || ''
-    if ((!effectiveText && pendingFiles.length === 0) || !agentChannelId) return
+    if ((!effectiveText && pendingFiles.length === 0) || !agentChannelId || !hasAvailableModel) return
 
     // 上一条消息仍在处理中，直接追加发送
     if (streaming) {
@@ -944,7 +956,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         return map
       })
     })
-  }, [inputContent, pendingFiles, attachedDirs, sessionId, agentChannelId, agentModelId, currentWorkspaceId, workspaces, streaming, suggestion, store, setStreamingStates, setPendingFiles, setAgentStreamErrors, setPromptSuggestions, setInputContent, setLiveMessagesMap])
+  }, [inputContent, pendingFiles, attachedDirs, sessionId, agentChannelId, agentModelId, currentWorkspaceId, workspaces, streaming, suggestion, hasAvailableModel, store, setStreamingStates, setPendingFiles, setAgentStreamErrors, setPromptSuggestions, setInputContent, setLiveMessagesMap])
 
   /** 停止生成 */
   const handleStop = React.useCallback((): void => {
@@ -1134,7 +1146,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     (allExitPlanRequests.get(sessionId)?.length ?? 0) > 0
 
   const hasTextInput = inputContent.trim().length > 0
-  const canSend = (hasTextInput || pendingFiles.length > 0 || !!suggestion) && agentChannelId !== null && (!streaming || hasTextInput)
+  const canSend = (hasTextInput || pendingFiles.length > 0 || !!suggestion) && agentChannelId !== null && hasAvailableModel && (!streaming || hasTextInput)
 
   return (
     <AgentSessionProvider sessionId={sessionId}>
@@ -1193,11 +1205,11 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
             onDrop={handleDrop}
           >
             {(isPlanMode || isPermissionPlanMode) && !isDragOver && <PlanModeDashedBorder />}
-            {/* 无 Agent 渠道提示 */}
-            {!agentChannelId && (
+            {/* 无 Agent 渠道或无可用模型提示 */}
+            {(!agentChannelId || !hasAvailableModel) && (
               <div className="flex items-center gap-2 px-4 py-2 text-sm text-amber-600 dark:text-amber-400">
                 <Settings size={14} />
-                <span>请在设置中选择 Agent 供应商</span>
+                <span>{!agentChannelId ? '请在设置中选择 Agent 供应商' : '暂无可用模型，请在设置中启用 Agent 渠道并配置模型'}</span>
                 <button
                   type="button"
                   className="text-xs underline underline-offset-2 hover:text-foreground transition-colors"
@@ -1255,13 +1267,15 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
               onSubmit={handleSend}
               onPasteFiles={handlePasteFiles}
               placeholder={
-                agentChannelId
+                agentChannelId && hasAvailableModel
                   ? sendWithCmdEnter
                     ? '输入消息... (⌘/Ctrl+Enter 发送，Enter 换行，@ 引用文件，/ 调用 Skill，# 调用 MCP)'
                     : '输入消息... (Enter 发送，Shift+Enter 换行，@ 引用文件，/ 调用 Skill，# 调用 MCP)'
-                  : '请先在设置中选择 Agent 供应商'
+                  : !agentChannelId
+                    ? '请先在设置中选择 Agent 供应商'
+                    : '暂无可用模型，请先在设置中启用渠道'
               }
-              disabled={!agentChannelId}
+              disabled={!agentChannelId || !hasAvailableModel}
               autoFocusTrigger={sessionId}
               collapsible
               workspacePath={sessionPath}

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "proma",


### PR DESCRIPTION
## Overview

修复 Agent 模式下两个相关的 bug：一是当所有渠道/模型均被禁用时，输入框未被正确锁住；二是 Proma 官方渠道（商业版）在模型配置中开启后，Agent 输入框仍然被锁住。

## Changes

- `apps/electron/src/renderer/components/agent/AgentView.tsx` — 新增 `hasAvailableModel` 派生值，综合检查渠道启用状态和模型可用性；同时对 `id === 'proma-official'` 的商业版渠道做特判，只要该渠道 enabled 且有可用模型，直接视为可用，无需加入 `agentChannelIds` 白名单

## Root Cause

原代码中，`canSend`、`handleSend` 守卫、`RichTextInput` 的 `disabled` 属性均只检查 `agentChannelId !== null`。而 `agentChannelId` 来自 `settings.json` 持久化配置——即使用户关闭了所有渠道开关，之前保存的渠道 ID 仍然存在，导致输入框不会被锁住，用户可以继续发送消息。

对于 Proma 官方渠道，由于其 `provider` 为商业版专属的 `'proma'` 类型（不是 `'anthropic'`），它不会出现在 Agent 供应商列表中，也无法被加入 `agentChannelIds` 白名单，导致即使开启后也被新加的检查拦截。

## How to Test

1. 在设置 → 模型中关闭所有渠道 → Agent 输入框应显示"暂无可用模型"提示并被禁用
2. 开启 Proma 官方渠道（商业版）→ 输入框应立即解锁，可正常输入和发送
3. 关闭 Proma 官方，开启一个 Anthropic 格式渠道并在 Agent 供应商中启用 → 输入框应解锁（原有逻辑不受影响）
4. 关闭所有渠道和 Proma 官方 → 输入框重新被锁

## Notes

- `hasAvailableModel` 对 Proma 官方渠道的特判通过 `channel.id === 'proma-official'` 识别，这是商业版渠道的固定 ID
- 输入框的提示文案区分了两种状态："未选渠道"和"渠道存在但无可用模型"