### PR TITLE
fix: prose inline code 样式修复

### DIFF
--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -290,7 +290,14 @@ const MarkdownInlineCode = React.memo(function MarkdownInlineCode({
     }
   }
 
-  return <code {...codeProps}>{codeChildren}</code>
+  return (
+    <code
+      className="rounded bg-foreground/10 px-[0.35em] py-[0.15em] text-[0.875em] font-medium"
+      {...codeProps}
+    >
+      {codeChildren}
+    </code>
+  )
 })
 
 /** 使用 react-markdown 渲染 assistant 消息内容，代码块使用 Shiki 语法高亮 */

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -774,3 +774,9 @@
 .theme-forest-dark .plan-mode-border .plan-mode-stroke {
   stroke: hsl(151 40% 45% / 0.7);
 }
+
+/* ===== prose inline code：移除 Tailwind Typography 默认的前后反引号伪元素 ===== */
+.prose code::before,
+.prose code::after {
+  content: none;
+}

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "proma",


### PR DESCRIPTION
## Overview

修复 AI 消息中 inline code（backtick 包裹的内容）没有被正确渲染的问题。之前 Tailwind Typography 的 `prose` 类会给 `<code>` 标签添加 `::before` / `::after` 伪元素（内容为反引号字符），导致 inline code 看起来像没被渲染的纯文本。

## Changes

- `apps/electron/src/renderer/components/ai-elements/message.tsx` — `MarkdownInlineCode` 组件的默认 `<code>` 标签添加显式样式：`bg-foreground/10` 背景色、圆角、内边距、字号和字重，确保 inline code 有明显的视觉区分
- `apps/electron/src/renderer/styles/globals.css` — 添加 `.prose code::before, .prose code::after { content: none; }` 规则，移除 Tailwind Typography 默认的反引号伪元素

## How to Test

1. 启动应用，打开 Agent 或 Chat 对话
2. 让 AI 生成包含 inline code 的回复（如 `commit hash`、`文件名.tsx` 等）
3. 验证 inline code 显示为带背景色的小标签样式，而不是带反引号的纯文本
4. 在浅色和深色主题下分别验证，确保对比度足够

## Notes

- `bg-foreground/10` 在浅色模式下产生浅灰背景，深色模式下产生半透明亮色背景，自动适配主题
- 不影响代码块（code block）的渲染，只影响行内代码（inline code）