### PR TITLE
feat: 跨会话 Input 弹窗通知

### DIFF
--- a/apps/electron/src/renderer/atoms/notifications.ts
+++ b/apps/electron/src/renderer/atoms/notifications.ts
@@ -9,6 +9,25 @@
 import { atom } from 'jotai'
 import type { NotificationSoundId, NotificationSoundType, NotificationSoundSettings } from '@/types/settings'
 
+// ===== 跨会话 Input 弹窗通知类型 =====
+
+/** 弹窗通知的触发类型 */
+export type InputNotificationType = 'permission' | 'ask_user' | 'plan'
+
+/** 跨会话 Input 弹窗通知条目 */
+export interface InputNotification {
+  /** 唯一 ID */
+  id: string
+  /** 目标会话 ID */
+  sessionId: string
+  /** 目标会话标题 */
+  sessionTitle: string
+  /** 通知类型 */
+  type: InputNotificationType
+  /** 描述文本，如"请求使用工具: Bash" */
+  message: string
+}
+
 // ===== 音频资源导入 =====
 import soundDing from '@/assets/sound/ding.mp3'
 import soundDingDong from '@/assets/sound/ding-dong.mp3'
@@ -63,6 +82,12 @@ export const notificationSoundEnabledAtom = atom<boolean>(true)
 /** 各场景通知音配置 */
 export const notificationSoundsAtom = atom<NotificationSoundSettings>({})
 
+/** 跨会话 Input 弹窗通知是否启用（默认 true） */
+export const inputNotificationPopupEnabledAtom = atom<boolean>(true)
+
+/** 跨会话 Input 弹窗通知队列 */
+export const inputNotificationsAtom = atom<InputNotification[]>([])
+
 // ===== 初始化 =====
 
 /**
@@ -71,13 +96,15 @@ export const notificationSoundsAtom = atom<NotificationSoundSettings>({})
 export async function initializeNotifications(
   setEnabled: (enabled: boolean) => void,
   setSoundEnabled: (enabled: boolean) => void,
-  setSounds: (sounds: NotificationSoundSettings) => void
+  setSounds: (sounds: NotificationSoundSettings) => void,
+  setInputPopupEnabled: (enabled: boolean) => void
 ): Promise<void> {
   try {
     const settings = await window.electronAPI.getSettings()
     setEnabled(settings.notificationsEnabled ?? true)
     setSoundEnabled(settings.notificationSoundEnabled ?? true)
     setSounds(settings.notificationSounds ?? {})
+    setInputPopupEnabled(settings.inputNotificationPopupEnabled ?? true)
   } catch (error) {
     console.error('[通知] 初始化失败:', error)
   }
@@ -104,6 +131,17 @@ export async function updateNotificationSoundEnabled(enabled: boolean): Promise<
     await window.electronAPI.updateSettings({ notificationSoundEnabled: enabled })
   } catch (error) {
     console.error('[通知] 更新提示音设置失败:', error)
+  }
+}
+
+/**
+ * 更新跨会话弹窗通知开关并持久化
+ */
+export async function updateInputNotificationPopupEnabled(enabled: boolean): Promise<void> {
+  try {
+    await window.electronAPI.updateSettings({ inputNotificationPopupEnabled: enabled })
+  } catch (error) {
+    console.error('[通知] 更新弹窗通知设置失败:', error)
   }
 }
 

--- a/apps/electron/src/renderer/components/agent/InputNotificationPopup.tsx
+++ b/apps/electron/src/renderer/components/agent/InputNotificationPopup.tsx
@@ -1,0 +1,132 @@
+/**
+ * InputNotificationPopup — 跨会话 Input 弹窗通知
+ *
+ * 当后台 Agent 会话需要用户输入（权限确认 / AskUser / Plan 审批）时，
+ * 在右下角弹出小卡片通知。用户可以点击跳转到对应会话或关闭通知。
+ * 当目标会话的挂起请求被清空后，对应弹窗自动消失。
+ */
+
+import * as React from 'react'
+import { useAtom, useAtomValue } from 'jotai'
+import { useStore } from 'jotai'
+import { Shield, MessageSquareMore, GitBranch, ArrowRight } from 'lucide-react'
+import {
+  inputNotificationsAtom,
+  inputNotificationPopupEnabledAtom,
+} from '@/atoms/notifications'
+import type { InputNotificationType } from '@/atoms/notifications'
+import {
+  allPendingPermissionRequestsAtom,
+  allPendingAskUserRequestsAtom,
+  allPendingExitPlanRequestsAtom,
+} from '@/atoms/agent-atoms'
+import { tabsAtom, splitLayoutAtom, openTab } from '@/atoms/tab-atoms'
+import { cn } from '@/lib/utils'
+
+/** 最多同时显示的弹窗数量 */
+const MAX_VISIBLE = 3
+
+/** 通知类型对应的图标和标签 */
+const TYPE_CONFIG: Record<InputNotificationType, {
+  icon: React.ElementType
+  label: string
+}> = {
+  permission: { icon: Shield, label: '权限确认' },
+  ask_user: { icon: MessageSquareMore, label: '等待回答' },
+  plan: { icon: GitBranch, label: '计划审批' },
+}
+
+export function InputNotificationPopup(): React.ReactElement | null {
+  const store = useStore()
+  const enabled = useAtomValue(inputNotificationPopupEnabledAtom)
+  const [notifications, setNotifications] = useAtom(inputNotificationsAtom)
+
+  // 监听三个 pending Map atoms，自动清理已解决的通知
+  const pendingPermissions = useAtomValue(allPendingPermissionRequestsAtom)
+  const pendingAskUser = useAtomValue(allPendingAskUserRequestsAtom)
+  const pendingExitPlan = useAtomValue(allPendingExitPlanRequestsAtom)
+
+  React.useEffect(() => {
+    setNotifications((prev) => {
+      if (prev.length === 0) return prev
+      const filtered = prev.filter((n) => {
+        if (n.type === 'permission') return (pendingPermissions.get(n.sessionId)?.length ?? 0) > 0
+        if (n.type === 'ask_user') return (pendingAskUser.get(n.sessionId)?.length ?? 0) > 0
+        if (n.type === 'plan') return (pendingExitPlan.get(n.sessionId)?.length ?? 0) > 0
+        return false
+      })
+      // 仅在实际变化时更新，避免无限循环
+      return filtered.length === prev.length ? prev : filtered
+    })
+  }, [pendingPermissions, pendingAskUser, pendingExitPlan, setNotifications])
+
+  if (!enabled || notifications.length === 0) return null
+
+  const visible = notifications.slice(-MAX_VISIBLE)
+
+  /** 关闭单条通知 */
+  const handleDismiss = (id: string): void => {
+    setNotifications((prev) => prev.filter((n) => n.id !== id))
+  }
+
+  /** 跳转到对应会话并关闭通知 */
+  const handleNavigate = (id: string, sessionId: string, sessionTitle: string): void => {
+    const tabs = store.get(tabsAtom)
+    const layout = store.get(splitLayoutAtom)
+    const result = openTab(tabs, layout, { type: 'agent', sessionId, title: sessionTitle })
+    store.set(tabsAtom, result.tabs)
+    store.set(splitLayoutAtom, result.layout)
+    handleDismiss(id)
+  }
+
+  return (
+    <div className="fixed top-14 right-4 z-[100] flex flex-col gap-2 pointer-events-none">
+      {visible.map((notification) => {
+        const config = TYPE_CONFIG[notification.type]
+        const Icon = config.icon
+        return (
+          <div
+            key={notification.id}
+            className={cn(
+              'pointer-events-auto w-[320px] rounded-lg border bg-background overflow-hidden',
+              'shadow-[0_2px_12px_rgba(0,0,0,0.12)] dark:shadow-[0_2px_12px_rgba(255,255,255,0.08)]',
+              'animate-in slide-in-from-right-5 fade-in duration-200',
+              'flex flex-col'
+            )}
+          >
+            {/* 头部：带背景色的 title 栏 */}
+            <div className="flex items-center gap-2 px-3 py-2 bg-foreground/[0.04] dark:bg-foreground/[0.06]">
+              <Icon size={16} className="shrink-0 text-foreground/60" />
+              <span className="text-[13px] font-medium truncate flex-1 text-foreground">
+                {notification.sessionTitle}
+              </span>
+              <span className="text-[11px] shrink-0 text-foreground/50">
+                {config.label}
+              </span>
+            </div>
+            {/* 描述文本 */}
+            <p className="text-[12px] text-foreground/60 line-clamp-2 px-3 pt-2 pl-9">
+              {notification.message}
+            </p>
+            {/* 操作按钮行：三等分布局，按钮分别在 2/3 和 3/3 位置 */}
+            <div className="grid grid-cols-3 px-3 pb-3 pt-3 -ml-[105px]">
+              <button
+                onClick={() => handleNavigate(notification.id, notification.sessionId, notification.sessionTitle)}
+                className="flex items-center justify-center gap-1 text-[12px] font-medium text-foreground/70 hover:underline col-start-2"
+              >
+                跳转到会话
+                <ArrowRight size={12} />
+              </button>
+              <button
+                onClick={() => handleDismiss(notification.id)}
+                className="text-[12px] font-medium text-red-500/70 hover:underline col-start-3"
+              >
+                关闭
+              </button>
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/settings/GeneralSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/GeneralSettings.tsx
@@ -30,8 +30,10 @@ import {
   notificationsEnabledAtom,
   notificationSoundEnabledAtom,
   notificationSoundsAtom,
+  inputNotificationPopupEnabledAtom,
   updateNotificationsEnabled,
   updateNotificationSoundEnabled,
+  updateInputNotificationPopupEnabled,
   updateNotificationSound,
   playNotificationSound,
   NOTIFICATION_SOUNDS,
@@ -56,6 +58,7 @@ export function GeneralSettings(): React.ReactElement {
   const [notificationsEnabled, setNotificationsEnabled] = useAtom(notificationsEnabledAtom)
   const [notificationSoundEnabled, setNotificationSoundEnabled] = useAtom(notificationSoundEnabledAtom)
   const [notificationSounds, setNotificationSounds] = useAtom(notificationSoundsAtom)
+  const [inputPopupEnabled, setInputPopupEnabled] = useAtom(inputNotificationPopupEnabledAtom)
   const [isEditingName, setIsEditingName] = React.useState(false)
   const [nameInput, setNameInput] = React.useState(userProfile.userName)
   const [showEmojiPicker, setShowEmojiPicker] = React.useState(false)
@@ -256,6 +259,15 @@ export function GeneralSettings(): React.ReactElement {
             onCheckedChange={(checked) => {
               setNotificationSoundEnabled(checked)
               updateNotificationSoundEnabled(checked)
+            }}
+          />
+          <SettingsToggle
+            label="跨会话 Input 弹窗"
+            description="当其他 Agent 会话需要你的操作时，在右下角弹出提醒"
+            checked={inputPopupEnabled}
+            onCheckedChange={(checked) => {
+              setInputPopupEnabled(checked)
+              updateInputNotificationPopupEnabled(checked)
             }}
           />
           <SoundPicker

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -31,11 +31,14 @@ import {
   notificationsEnabledAtom,
   notificationSoundEnabledAtom,
   notificationSoundsAtom,
+  inputNotificationPopupEnabledAtom,
+  inputNotificationsAtom,
   sendDesktopNotification,
 } from '@/atoms/notifications'
 import { tabsAtom, splitLayoutAtom, openTab, updateTabTitle } from '@/atoms/tab-atoms'
 import type { AgentStreamState } from '@/atoms/agent-atoms'
 import type { NotificationSoundType } from '@/types/settings'
+import type { InputNotificationType } from '@/atoms/notifications'
 import type { AgentStreamEvent, AgentStreamCompletePayload, AgentEvent, AgentStreamPayload, SDKAssistantMessage, SDKUserMessage, SDKSystemMessage, SDKContentBlock, SDKUserContentBlock } from '@proma/shared'
 
 // ============================================================================
@@ -261,8 +264,22 @@ export function useGlobalAgentListeners(): void {
       return sessions.find((s) => s.id === sessionId)?.title ?? '未命名会话'
     }
 
-    /** 发送阻塞通知（带提示音 + 会话导航） */
-    const sendBlockingNotification = (sessionId: string, title: string, body: string, soundType: NotificationSoundType) => {
+    /** 判断 sessionId 是否已在某个面板的活跃 tab 中可见 */
+    const isSessionVisible = (sessionId: string): boolean => {
+      const tabs = store.get(tabsAtom)
+      const layout = store.get(splitLayoutAtom)
+      const activeTabIds = new Set(layout.panels.map((p) => p.activeTabId).filter(Boolean))
+      return tabs.some((tab) => tab.sessionId === sessionId && activeTabIds.has(tab.id))
+    }
+
+    /** 发送阻塞通知（带提示音 + 会话导航），并在后台会话时入队弹窗 */
+    const sendBlockingNotification = (
+      sessionId: string,
+      title: string,
+      body: string,
+      soundType: NotificationSoundType,
+      popupType?: InputNotificationType
+    ) => {
       const enabled = store.get(notificationsEnabledAtom)
       const soundEnabled = store.get(notificationSoundEnabledAtom)
       const sounds = store.get(notificationSoundsAtom)
@@ -279,6 +296,24 @@ export function useGlobalAgentListeners(): void {
           onNavigate: makeNavigateToSession(sessionId, sessionTitle),
         }
       )
+      // 若目标 session 不在任何活跃面板中，且弹窗通知已启用，则入队弹窗
+      if (popupType && !isSessionVisible(sessionId) && store.get(inputNotificationPopupEnabledAtom)) {
+        store.set(inputNotificationsAtom, (prev) => {
+          // 同 session + 同类型：更新已有条目（防止堆积）
+          const exists = prev.find((n) => n.sessionId === sessionId && n.type === popupType)
+          const newItem = {
+            id: exists?.id ?? `${sessionId}-${popupType}-${Date.now()}`,
+            sessionId,
+            sessionTitle,
+            type: popupType,
+            message: body,
+          }
+          if (exists) {
+            return prev.map((n) => (n.id === exists.id ? newItem : n))
+          }
+          return [...prev, newItem]
+        })
+      }
     }
     // ===== 0. 初始化：从持久化 meta 恢复 stoppedByUser 状态 =====
     window.electronAPI.listAgentSessions().then((sessions) => {
@@ -420,7 +455,8 @@ export function useGlobalAgentListeners(): void {
               event.request.toolName
                 ? `Agent 请求使用工具: ${event.request.toolName}`
                 : 'Agent 需要你的权限确认',
-              'permissionRequest'
+              'permissionRequest',
+              'permission'
             )
           } else if (event.type === 'ask_user_request') {
             // AskUser 请求入队（统一通道，不区分当前/后台会话）
@@ -435,7 +471,8 @@ export function useGlobalAgentListeners(): void {
               sessionId,
               'Agent 需要你的输入',
               event.request.questions[0]?.question ?? 'Agent 有问题需要你回答',
-              'permissionRequest'
+              'permissionRequest',
+              'ask_user'
             )
           } else if (event.type === 'exit_plan_mode_request') {
             // ExitPlanMode 请求入队
@@ -457,7 +494,8 @@ export function useGlobalAgentListeners(): void {
               sessionId,
               'Agent 计划待审批',
               'Agent 已完成计划，等待你的审批',
-              'exitPlanMode'
+              'exitPlanMode',
+              'plan'
             )
           } else if (event.type === 'enter_plan_mode') {
             // 进入 Plan 模式

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -37,6 +37,7 @@ import {
   notificationsEnabledAtom,
   notificationSoundEnabledAtom,
   notificationSoundsAtom,
+  inputNotificationPopupEnabledAtom,
   initializeNotifications,
 } from './atoms/notifications'
 import { useGlobalAgentListeners } from './hooks/useGlobalAgentListeners'
@@ -49,6 +50,7 @@ import { dingtalkBotStatesAtom } from './atoms/dingtalk-atoms'
 import { currentConversationIdAtom, channelsAtom, channelsLoadedAtom, selectedModelAtom } from './atoms/chat-atoms'
 import type { FeishuBotBridgeState, FeishuBridgeState, FeishuNotificationSentPayload, DingTalkBotBridgeState, DingTalkBridgeState } from '@proma/shared'
 import { Toaster } from './components/ui/sonner'
+import { InputNotificationPopup } from './components/agent/InputNotificationPopup'
 import { toast } from 'sonner'
 import { diffCapabilities, migratePermissionMode } from '@proma/shared'
 import type { WorkspaceCapabilities } from '@proma/shared'
@@ -299,10 +301,11 @@ function NotificationsInitializer(): null {
   const setEnabled = useSetAtom(notificationsEnabledAtom)
   const setSoundEnabled = useSetAtom(notificationSoundEnabledAtom)
   const setSounds = useSetAtom(notificationSoundsAtom)
+  const setInputPopupEnabled = useSetAtom(inputNotificationPopupEnabledAtom)
 
   useEffect(() => {
-    initializeNotifications(setEnabled, setSoundEnabled, setSounds)
-  }, [setEnabled, setSoundEnabled, setSounds])
+    initializeNotifications(setEnabled, setSoundEnabled, setSounds, setInputPopupEnabled)
+  }, [setEnabled, setSoundEnabled, setSounds, setInputPopupEnabled])
 
   return null
 }
@@ -506,6 +509,7 @@ if (isQuickTaskWindow) {
       <App />
       <UpdateDialog />
       <Toaster position="top-right" />
+      <InputNotificationPopup />
     </React.StrictMode>
   )
 }

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -88,6 +88,8 @@ export interface AppSettings {
   sendWithCmdEnter?: boolean
   /** 用户自定义快捷键覆盖 */
   shortcutOverrides?: ShortcutOverrides
+  /** 跨会话 Input 弹窗通知是否启用（默认 true） */
+  inputNotificationPopupEnabled?: boolean
 }
 
 /** 持久化的标签页状态 */


### PR DESCRIPTION
## Overview

当用户并行使用多个 Agent 会话时，若非当前活跃会话需要用户操作（权限确认 / AskUser 问题 / Plan 审批），除了音效以外缺乏可视化提醒。**对于不想开音效但又希望被提醒的用户来说尤其不友好。**

本 PR 新增右上角弹窗通知卡片，在后台 Agent 会话需要 input 时弹出提醒，用户可以一键跳转到对应会话或关闭通知。当用户处理完请求后，弹窗自动消失。功能可在通用设置中手动开关。

## Changes

- `apps/electron/src/types/settings.ts` — 新增 `inputNotificationPopupEnabled?: boolean` 设置字段
- `apps/electron/src/renderer/atoms/notifications.ts` — 新增 `InputNotification` 类型、`inputNotificationsAtom`（弹窗队列）、`inputNotificationPopupEnabledAtom`（开关）、`updateInputNotificationPopupEnabled()` 持久化函数；扩展 `initializeNotifications()` 加载新设置
- `apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts` — 扩展 `sendBlockingNotification()` 新增可选 `popupType` 参数 + `isSessionVisible()` 辅助函数，在目标会话不在任何活跃面板中时入队弹窗（同 session + 同类型去重）
- `apps/electron/src/renderer/components/agent/InputNotificationPopup.tsx` — **新建** 弹窗组件：`fixed top-14 right-4`，卡片式 UI，title 栏带浅色背景与内容区分，支持跳转（openTab）和关闭操作，自动监听 pending Map atoms 在请求清空时移除对应通知
- `apps/electron/src/renderer/main.tsx` — 挂载 `InputNotificationPopup`，`NotificationsInitializer` 传入新 atom setter
- `apps/electron/src/renderer/components/settings/GeneralSettings.tsx` — 通知区块新增「跨会话 Input 弹窗」SettingsToggle 开关

## How to Test

1. `bun run dev` 启动应用
2. 开启至少 2 个 Agent 会话（Session A 和 Session B）
3. 停留在 Session A 的 tab 上
4. 让 Session B 触发权限请求（如执行 Bash 命令）或 AskUser 问题
5. 确认右上角弹出通知卡片，显示 Session B 标题、类型标签和描述
6. 点击「跳转到会话」→ 验证切换到 Session B，弹窗消失
7. 重复步骤 3-5，点击「关闭」→ 弹窗消失，不跳转
8. 在 Session B 处理完请求后，验证弹窗自动消失
9. 进入设置 → 通用 → 关闭「跨会话 Input 弹窗」→ 重复测试，确认不再出现弹窗
10. 分别在浅色和深色主题（含森息夜语、苍穹暮色）下验证弹窗可见性

## Notes

- 新增 atom 均为惰性，无组件订阅时零开销
- `sendBlockingNotification` 的 `popupType` 为可选参数，不影响现有调用
- `settings.json` 向后兼容：缺少字段时 fallback 到默认值 `true`
- 弹窗最多同时显示 3 条，同 session + 同类型去重防止堆积
- 此功能的一个重要场景：**为不想开音效但又需要被提醒的用户提供可视化通知方式**