### PR TITLE
fix: 用户消息「展开全部」点击后立刻折叠回去

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -74,6 +74,9 @@ import { sendWithCmdEnterAtom } from '@/atoms/shortcut-atoms'
 import type { AgentSendInput, AgentMessage, AgentPendingFile, ModelOption, SDKMessage } from '@proma/shared'
 import { fileToBase64 } from '@/lib/file-utils'
 
+/** 稳定的空 SDKMessage 数组引用，避免 ?? [] 每次创建新引用 */
+const EMPTY_SDK_MESSAGES: SDKMessage[] = []
+
 // ===== 思考模式 Hover Popover =====
 
 interface AgentThinkingPopoverProps {
@@ -166,7 +169,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const stoppedByUser = stoppedByUserSessions.has(sessionId)
   const liveMessagesMap = useAtomValue(liveMessagesMapAtom)
   const setLiveMessagesMap = useSetAtom(liveMessagesMapAtom)
-  const liveMessages = liveMessagesMap.get(sessionId) ?? []
+  // 稳定化空数组引用，避免 ?? [] 每次创建新引用导致下游 useMemo 链不必要重算
+  const liveMessages = liveMessagesMap.get(sessionId) ?? EMPTY_SDK_MESSAGES
   // Per-session 渠道/模型配置（优先读 session map，回退到全局默认值）
   const sessionChannelMap = useAtomValue(agentSessionChannelMapAtom)
   const sessionModelMap = useAtomValue(agentSessionModelMapAtom)

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -864,9 +864,11 @@ export interface MessageGroupRendererProps {
 }
 
 /**
- * WeakMap 缓存：为没有 uuid 的 group 生成稳定的 fallback ID
+ * WeakMap 缓存：为没有 uuid 的消息生成稳定的 fallback ID
+ * 使用 message 对象（而非 group 对象）作为 key，因为 group 在 useMemo 重算时会
+ * 被重建为新对象，而 group.message 引用的底层 SDK message 对象是稳定的。
  */
-const groupIdCache = new WeakMap<MessageGroup, string>()
+const messageIdCache = new WeakMap<object, string>()
 let fallbackIdCounter = 0
 
 /**
@@ -875,26 +877,30 @@ let fallbackIdCounter = 0
 export function getGroupId(group: MessageGroup): string {
   if (group.type === 'user') {
     if (group.message.uuid) return group.message.uuid
-    // 没有 uuid：使用缓存的稳定 ID
-    if (!groupIdCache.has(group)) {
-      groupIdCache.set(group, `user-${++fallbackIdCounter}`)
+    // 没有 uuid：使用基于 message 对象引用的缓存 ID（message 引用在重渲染间稳定）
+    if (!messageIdCache.has(group.message)) {
+      messageIdCache.set(group.message, `user-${++fallbackIdCounter}`)
     }
-    return groupIdCache.get(group)!
+    return messageIdCache.get(group.message)!
   }
   if (group.type === 'system') {
-    if (!groupIdCache.has(group)) {
-      groupIdCache.set(group, `system-${group.message.subtype ?? 'unknown'}-${++fallbackIdCounter}`)
+    if (!messageIdCache.has(group.message)) {
+      messageIdCache.set(group.message, `system-${group.message.subtype ?? 'unknown'}-${++fallbackIdCounter}`)
     }
-    return groupIdCache.get(group)!
+    return messageIdCache.get(group.message)!
   }
   // assistant-turn：取首条 assistant 消息的 uuid
   const first = group.assistantMessages[0]
   if (first?.uuid) return first.uuid
-  // 没有 uuid：使用缓存的稳定 ID
-  if (!groupIdCache.has(group)) {
-    groupIdCache.set(group, `turn-${++fallbackIdCounter}`)
+  // 没有 uuid：使用基于首条 assistant message 对象引用的缓存 ID
+  if (first) {
+    if (!messageIdCache.has(first)) {
+      messageIdCache.set(first, `turn-${++fallbackIdCounter}`)
+    }
+    return messageIdCache.get(first)!
   }
-  return groupIdCache.get(group)!
+  // 极端情况：空 turn
+  return `turn-empty-${++fallbackIdCounter}`
 }
 
 /**


### PR DESCRIPTION
## Overview

Agent 模式下，用户发送的长消息被折叠后，点击「展开全部」按钮内容会闪一下展开然后立刻折叠回去。根因是不稳定的数组引用导致 useMemo 链不必要重算，进而触发组件卸载重挂载、丢失展开状态。

## Changes

- `apps/electron/src/renderer/components/agent/AgentView.tsx` — 将 `liveMessages ?? []` 替换为模块级常量 `EMPTY_SDK_MESSAGES`，避免每次渲染创建新的空数组引用，切断 `allSDKMessages → allGroups` useMemo 不必要重算链
- `apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx` — `getGroupId` 的 WeakMap key 从 `group` 对象改为 `group.message`（底层 SDK message 对象），确保 group 重建后缓存仍然命中，无 uuid 消息的 React key 保持稳定

## How to Test

1. 打开 Agent 模式，发送一条超过 4 行的长消息
2. 等消息发出后，点击消息底部的「展开全部」按钮
3. 验证内容正常展开且保持展开状态（不会闪烁回去）
4. 同时打开多个 Agent 会话，在一个会话中运行 Agent，切换到另一个会话点击「展开全部」，验证不受其他会话流式更新影响
5. 验证文本选中操作在消息上不会因为外部重渲染而丢失选区

## Notes

- 此修复同时带来性能提升：其他会话的 streaming 活动不再导致当前会话的消息列表重新分组渲染
- 对有 uuid 的消息影响较小（key 本身稳定），主要修复无 uuid 消息（如每个会话的第一条消息、compact 后的首条消息）的组件重挂载问题