### PR TITLE
fix: 切换模型后历史消息模型标识被覆盖

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -1482,6 +1482,10 @@ export class AgentOrchestrator {
                     accumulatedMessages.push(msg)
                   }
                 } else {
+                  // 为 assistant 消息注入渠道 modelId，确保持久化后能正确匹配模型显示名
+                  if (msg.type === 'assistant' && modelId) {
+                    (msg as Record<string, unknown>)._channelModelId = modelId
+                  }
                   accumulatedMessages.push(msg)
                 }
               }

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -240,7 +240,7 @@ export function groupIntoTurns(messages: SDKMessage[], sessionModelId?: string):
           type: 'assistant-turn',
           assistantMessages: [aMsg],
           turnMessages: [msg],
-          model: sessionModelId || aMsg.message?.model,
+          model: aMsg._channelModelId || aMsg.message?.model || sessionModelId,
           createdAt: meta.createdAt,
         }
       } else {
@@ -597,7 +597,7 @@ export function SDKMessageRenderer({
     const blocks = aMsg.message?.content
     if (!Array.isArray(blocks) || blocks.length === 0) return null
 
-    const model = sessionModelId || aMsg.message?.model
+    const model = aMsg._channelModelId || aMsg.message?.model || sessionModelId
     const meta = extractMeta(message)
 
     // 检测是否有主要内容（text 块）

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -23,6 +23,8 @@ import {
   agentSidePanelOpenMapAtom,
   applyAgentEvent,
   liveMessagesMapAtom,
+  agentSessionModelMapAtom,
+  agentModelIdAtom,
   agentPermissionModeMapAtom,
   stoppedByUserSessionsAtom,
   agentPlanModeSessionsAtom,
@@ -317,6 +319,13 @@ export function useGlobalAgentListeners(): void {
             // 避免 AssistantTurnRenderer 因缺少时间戳导致 header 时间消失
             if (typeof msgRecord._createdAt !== 'number') {
               msgRecord._createdAt = Date.now()
+            }
+
+            // 为 assistant 消息注入渠道 modelId，确保流式期间就绑定正确模型
+            if (msgRecord.type === 'assistant' && !msgRecord._channelModelId) {
+              const sessionModelMap = store.get(agentSessionModelMapAtom)
+              const defaultModelId = store.get(agentModelIdAtom)
+              msgRecord._channelModelId = sessionModelMap.get(sessionId) ?? defaultModelId ?? undefined
             }
 
             store.set(liveMessagesMapAtom, (prev) => {

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -214,6 +214,8 @@ export interface SDKAssistantMessage {
   uuid?: string
   error?: { message: string; errorType?: string }
   isReplay?: boolean
+  /** 渠道配置的模型 ID，持久化/流式期间注入，用于正确匹配模型显示名 */
+  _channelModelId?: string
 }
 
 /** SDK user 消息 */


### PR DESCRIPTION
## 问题根因

`SDKMessageRenderer.tsx` 中 `sessionModelId || aMsg.message?.model` 的优先级设计，使得当前会话选择的模型（`sessionModelId`）始终覆盖消息自身的 model 字段。切换模型后，所有历史消息的模型标识都变成新选的模型。

## 具体修改

- **`packages/shared/src/types/agent.ts`** — `SDKAssistantMessage` 新增 `_channelModelId?: string` 可选字段
- **`apps/electron/src/main/lib/agent-orchestrator.ts`** — assistant 消息持久化前注入 `_channelModelId`（渠道配置的 model.id）
- **`apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts`** — 实时流 assistant 消息进入 liveMessagesMap 时注入 `_channelModelId`
- **`apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx`** — 模型优先级改为 `_channelModelId > message.model > sessionModelId`

修复后：
- 新消息自带 `_channelModelId`，能正确匹配渠道显示名（如 "Claude Opus 4.6"）
- 旧消息（修复前产生）无 `_channelModelId`，使用 SDK 原始 model ID（如 `claude-opus-4-6`），至少能区分不同模型
- 切换模型不再影响历史消息

## 审查情况

自审查 + 代码审查子代理审查通过。用户手动测试确认历史消息不再被覆盖。