### PR TITLE
fix: 非 Claude 模型渠道下 SubAgent 自动继承主 Agent 模型

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -1163,6 +1163,8 @@ export class AgentOrchestrator {
       }
 
       // 13. 构建 Adapter 查询选项
+      // 检测用户选用的模型是否为 Claude 系列，决定 SubAgent 是否使用独立模型分层
+      const claudeAvailable = (modelId || DEFAULT_MODEL_ID).toLowerCase().includes('claude')
       const maxTurns = appSettings.agentMaxTurns && appSettings.agentMaxTurns > 0
         ? appSettings.agentMaxTurns
         : undefined
@@ -1196,6 +1198,7 @@ export class AgentOrchestrator {
             sessionId,
             permissionMode: initialPermissionMode,
             memoryEnabled: (() => { const mc = getMemoryConfig(); return mc.enabled && !!mc.apiKey })(),
+            claudeAvailable,
           }),
         },
         resumeSessionId: existingSdkSessionId,
@@ -1228,7 +1231,8 @@ export class AgentOrchestrator {
           maxBudgetUsd: appSettings.agentMaxBudgetUsd,
         }),
         // 内置 SubAgent 定义（code-reviewer / explorer / researcher）
-        agents: buildBuiltinAgents(),
+        // claudeAvailable=false 时 SubAgent 省略 model 字段，自动继承主 Agent 模型
+        agents: buildBuiltinAgents(claudeAvailable),
         onStderr: (data: string) => {
           stderrChunks.push(data)
           console.error(`[Agent SDK stderr] ${data}`)

--- a/apps/electron/src/main/lib/agent-prompt-builder.ts
+++ b/apps/electron/src/main/lib/agent-prompt-builder.ts
@@ -21,7 +21,9 @@ import { getWorkspaceMcpConfig, getWorkspaceSkills } from './agent-workspace-man
  * 预定义一组常用子代理，通过 SDK agents 选项注册，
  * 让主 Agent 可以直接通过 Agent 工具按名称调用。
  */
-export function buildBuiltinAgents(): Record<string, AgentDefinition> {
+export function buildBuiltinAgents(claudeAvailable = true): Record<string, AgentDefinition> {
+  // 非 Claude 渠道时省略 model，让 SubAgent 继承主 Agent 的模型
+  const light = claudeAvailable ? 'haiku' : undefined
   return {
     'code-reviewer': {
       description: '代码审查子代理。在完成代码修改后调用，审查代码质量、发现潜在问题、提出改进建议。适合在任务完成后做最终质量检查。',
@@ -43,7 +45,7 @@ export function buildBuiltinAgents(): Record<string, AgentDefinition> {
 
 保持客观、具体，不要泛泛而谈。如果代码质量很好，直接说"审查通过，无需修改"。`,
       tools: ['Read', 'Glob', 'Grep', 'Bash'],
-      model: 'haiku',
+      ...(light && { model: light }),
     },
     'explorer': {
       description: '代码库探索子代理。用于快速搜索文件、理解项目结构、查找相关代码。适合在动手修改前收集上下文。',
@@ -57,7 +59,7 @@ export function buildBuiltinAgents(): Record<string, AgentDefinition> {
 
 保持简洁，只返回与任务相关的信息。`,
       tools: ['Read', 'Glob', 'Grep', 'Bash'],
-      model: 'haiku',
+      ...(light && { model: light }),
     },
     'researcher': {
       description: '技术调研子代理。用于对比技术方案、评估依赖库、分析架构选型。适合在做技术决策前收集充分信息。',
@@ -72,7 +74,7 @@ export function buildBuiltinAgents(): Record<string, AgentDefinition> {
 
 保持客观，给出有依据的建议。`,
       tools: ['Read', 'Glob', 'Grep', 'Bash', 'WebSearch', 'WebFetch'],
-      model: 'haiku',
+      ...(light && { model: light }),
     },
   }
 }
@@ -85,6 +87,8 @@ interface SystemPromptContext {
   permissionMode: PromaPermissionMode
   /** 记忆服务是否已启用且配置了 API Key */
   memoryEnabled: boolean
+  /** 用户选用的模型是否为 Claude 系列（影响 SubAgent 模型策略描述，缺省视为 true） */
+  claudeAvailable?: boolean
 }
 
 /**
@@ -121,8 +125,10 @@ export function buildSystemPrompt(ctx: SystemPromptContext): string {
 - **先搜后写**：修改代码前先用 Grep/Glob 搜索现有实现，复用已有模式和工具函数，最小化变更范围。避免重复造轮子
 - **大文件写入**：使用 Write 写入超过约 10,000 字（特别是中文/日文/韩文等 CJK 字符）时，主动拆分为多次写入——先 Write 首段，再用 Edit 追加后续段落，避免 token 截断导致文件内容不完整`)
 
-  // SubAgent 委派策略
-  sections.push(`## SubAgent 委派策略
+  // SubAgent 委派策略（根据用户选用的模型是否为 Claude 动态调整）
+  const claudeAvailable = ctx.claudeAvailable !== false
+  if (claudeAvailable) {
+    sections.push(`## SubAgent 委派策略
 
 **核心原则：先探索再行动，用 SubAgent 保持主上下文干净。根据任务复杂度选择合适的模型。**
 
@@ -186,6 +192,51 @@ Agent 工具支持 \`model\` 参数（可选值：\`sonnet\` / \`opus\` / \`haik
 5. 对于重大架构变更或不确定的决策点，通过 AskUserQuestion 与用户确认；其他步骤直接执行，不要逐步等待确认
 6. 执行实施，将进度更新到 \`.context/todo.md\`
 7. 完成后委派 \`code-reviewer\` 做最终质量检查（核心逻辑变更用 sonnet 审查）`)
+  } else {
+    sections.push(`## SubAgent 委派策略
+
+**核心原则：先探索再行动，用 SubAgent 保持主上下文干净。**
+
+当前使用的模型不是 Claude 系列，SubAgent 将自动继承主 Agent 的模型。不要通过 \`model\` 参数指定模型别名（如 haiku/sonnet/opus），否则会导致 SubAgent 调用失败。
+
+### 内置 SubAgent
+
+系统已预定义以下子代理，可直接通过 Agent 工具按名称调用：
+
+- **explorer**：代码库探索。快速搜索文件、理解项目结构、收集相关上下文。动手修改前优先调用
+- **researcher**：技术调研。方案对比、依赖评估、架构分析，输出结构化调研报告
+- **code-reviewer**：代码审查。任务完成后调用，检查代码质量和规范一致性
+
+### 何时委派 SubAgent
+
+- 需要探索代码库、搜索多个文件、理解项目结构时 → 委派 \`explorer\`
+- 需要调研技术方案、对比多个选项时 → 委派 \`researcher\`
+- 代码修改完成后做质量检查 → 委派 \`code-reviewer\`
+- 需要并行处理多个独立子任务时 → 同时委派多个 SubAgent
+- 以上内置 SubAgent 不满足需求时，也可以自行定义临时 SubAgent
+
+### 不需要委派的场景
+
+- 简单的单文件读取或编辑
+- 用户明确指定了操作目标
+- 任务本身就很简单直接
+
+### 委派时的要求
+
+- 给 SubAgent 清晰的任务描述，说明要收集什么信息、返回什么格式
+- 可以同时启动多个 SubAgent 并行工作
+- SubAgent 返回结果后，在主上下文中整合并做决策
+
+### 典型工作流（复杂任务）
+
+1. 委派 \`explorer\` 探索代码库、收集上下文
+2. 根据探索结果，委派 \`researcher\` 分析方案
+3. 整合所有信息，将调研结果输出到 \`.context/note.md\`
+4. 不确定的部分调用头脑风暴 Skill 与用户确认
+5. 对于重大架构变更或不确定的决策点，通过 AskUserQuestion 与用户确认；其他步骤直接执行，不要逐步等待确认
+6. 执行实施，将进度更新到 \`.context/todo.md\`
+7. 完成后委派 \`code-reviewer\` 做最终质量检查`)
+  }
 
   // 用户信息
   sections.push(`## 用户信息


### PR DESCRIPTION
## 问题根因

SubAgent 的 `model` 字段硬编码为 `'haiku'`，SDK 内部将其解析为 Claude 模型 ID。当用户通过非 Claude 渠道（如 OpenRouter 转发非 Claude 模型、MiniMax 等）使用 Agent 模式时，SubAgent 请求的模型 ID 无法被代理识别，导致调用失败。

## 具体修改

**`agent-orchestrator.ts`**（+4 行）
- 在构建 queryOptions 前，通过 `(modelId || DEFAULT_MODEL_ID).toLowerCase().includes('claude')` 检测用户实际选用的模型是否为 Claude 系列
- 将检测结果传入 `buildBuiltinAgents()` 和 `buildSystemPrompt()`

**`agent-prompt-builder.ts`**（+58 行）
- `buildBuiltinAgents(claudeAvailable)` 新增参数：`true` 时保持原有 `model: 'haiku'`；`false` 时省略 `model` 字段，让 SDK 自动继承主 Agent 模型
- `buildSystemPrompt()` 新增 `claudeAvailable` 上下文：Claude 路径提示词完全不变；非 Claude 路径增加一段说明，告知 Agent 不要使用模型别名参数

## 审查情况

- TypeScript 编译通过
- Claude 渠道行为完全不变（`claudeAvailable=true` 走原有路径）
- 实测 MiniMax-M2.7 渠道，SubAgent 成功继承主模型运行
- 每次 sendMessage 自动适应，用户切换渠道后下一条消息立即生效