### PR TITLE
fix: agent stability — 0-token 检测重试、idle timeout、SDK init 清理、Opus thinking budget

### DIFF
--- a/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
@@ -450,7 +450,13 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
       const timeoutPromise = new Promise<never>((_, reject) =>
         setTimeout(() => reject(new Error('[Claude 适配器] 等待 SDK 初始化超时，请稍后重试')), QUERY_READY_TIMEOUT_MS)
       )
-      await Promise.race([readyPromise, timeoutPromise])
+      try {
+        await Promise.race([readyPromise, timeoutPromise])
+      } catch (err) {
+        // 超时：强制中止可能已启动的 SDK 子进程，防止僵尸进程残留
+        this.abort(sessionId)
+        throw err
+      }
     }
 
     const query = activeQueries.get(sessionId)

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -171,7 +171,7 @@ function isSessionNotFoundError(errorMessage: string, stderr?: string): boolean 
 const MAX_AUTO_RETRIES = 3
 
 /** 单次 API 调用最长无响应时间（毫秒），超时后触发自动重试 */
-const IDLE_TIMEOUT_MS = 500_000
+const IDLE_TIMEOUT_MS = 120_000
 
 /** 计算重试延迟（指数退避：1s, 2s, 4s） */
 function getRetryDelayMs(attempt: number): number {
@@ -1542,9 +1542,29 @@ export class AgentOrchestrator {
               }
             }
 
-            // Turn 结束时：持久化累积消息
+            // Turn 结束时：持久化累积消息，并检测 0-token 空响应
             if (msg.type === 'result') {
-              capturedResultSubtype = (msg as { subtype?: string }).subtype
+              const resultMsg = msg as import('@proma/shared').SDKResultMessage
+              capturedResultSubtype = resultMsg.subtype
+
+              // 检测"成功但 0 输出"：API 返回 HTTP 200 但模型未产出任何 token
+              // 根因：tool_result 后无文本触发的已知 Anthropic bug（见 sdk-python#958）
+              // 此时 SDK 正常结束 turn，不会自行报错，需要在此层拦截并重试
+              if (
+                resultMsg.subtype === 'success' &&
+                resultMsg.usage.output_tokens === 0 &&
+                attempt <= MAX_AUTO_RETRIES
+              ) {
+                console.log(
+                  `[Agent 编排] 检测到 0-token 空响应 (output_tokens=0, subtype=success)，触发自动重试 (attempt=${attempt})`,
+                )
+                lastRetryableError = 'Agent 返回空响应（0 输出 tokens），正在自动重试'
+                this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
+                accumulatedMessages.length = 0
+                shouldRetryFromError = true
+                break
+              }
+
               this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
               accumulatedMessages.length = 0
             }

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -170,6 +170,9 @@ function isSessionNotFoundError(errorMessage: string, stderr?: string): boolean 
 /** 最大自动重试次数 */
 const MAX_AUTO_RETRIES = 3
 
+/** 单次 API 调用最长无响应时间（毫秒），超时后触发自动重试 */
+const IDLE_TIMEOUT_MS = 500_000
+
 /** 计算重试延迟（指数退避：1s, 2s, 4s） */
 function getRetryDelayMs(attempt: number): number {
   return Math.min(1000 * Math.pow(2, attempt - 1), 8000)
@@ -1353,6 +1356,25 @@ export class AgentOrchestrator {
             }
           })()
 
+          // Idle timeout 守卫：普通单轮对话无响应时触发重试
+          // （Watchdog 仅覆盖 startedTaskIds.size > 0 的 Teams 场景）
+          const idleAbort = new AbortController()
+          let lastActivityAt = Date.now()
+          const idleWatcherDone = (async () => {
+            const CHECK_INTERVAL_MS = 30_000
+            while (!loopAbort.signal.aborted) {
+              await timerWithAbort(CHECK_INTERVAL_MS, loopAbort.signal)
+              if (loopAbort.signal.aborted) break
+              if (Date.now() - lastActivityAt >= IDLE_TIMEOUT_MS) {
+                console.log(
+                  `[Agent 编排] Idle timeout: 超过 ${IDLE_TIMEOUT_MS / 1000}s 无 SDK 事件，触发重试`,
+                )
+                idleAbort.abort()
+                break
+              }
+            }
+          })()
+
           // 手动事件循环：Promise.race（SDKMessage vs Watchdog 中断）
           let pendingNext: Promise<IteratorResult<SDKMessage>> | null = null
           // Teams 活跃时延迟 result 消息，避免前端提前标记 teammates 为 stopped
@@ -1370,9 +1392,15 @@ export class AgentOrchestrator {
               loopAbort.signal.addEventListener('abort', () => resolve(null), { once: true })
             })
 
+            const idleAbortPromise = new Promise<null>((resolve) => {
+              if (idleAbort.signal.aborted) { resolve(null); return }
+              idleAbort.signal.addEventListener('abort', () => resolve(null), { once: true })
+            })
+
             const raceResult = await Promise.race([
               pendingNext.then((r) => ({ kind: 'event' as const, result: r })),
               abortPromise.then(() => ({ kind: 'abort' as const, result: null })),
+              idleAbortPromise.then(() => ({ kind: 'idle_timeout' as const, result: null })),
             ])
 
             if (raceResult.kind === 'abort') {
@@ -1388,11 +1416,27 @@ export class AgentOrchestrator {
               break
             }
 
+            if (raceResult.kind === 'idle_timeout') {
+              // Idle timeout：强制中止 SDK 子进程，触发外层重试
+              console.log(`[Agent 编排] Idle timeout 处理：强制中止 SDK 子进程，准备重试`)
+              this.adapter.abort(sessionId)
+              pendingNext?.catch(() => {})
+              pendingNext = null
+              lastRetryableError = `Agent 响应超时（${IDLE_TIMEOUT_MS / 1000}s 无输出），正在自动重试`
+              this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
+              accumulatedMessages.length = 0
+              shouldRetryFromError = true
+              break
+            }
+
             const iterResult = raceResult.result
             if (!iterResult || iterResult.done) break
 
             pendingNext = null
             const msg = iterResult.value
+
+            // 收到 SDK 事件：重置 idle 计时器
+            lastActivityAt = Date.now()
 
             // 检测 assistant 消息中的 SDK 错误
             if (msg.type === 'assistant') {
@@ -1544,9 +1588,9 @@ export class AgentOrchestrator {
             }
           }
 
-          // 清理 Watchdog（事件循环正常结束或被 Watchdog 中断）
+          // 清理 Watchdog 和 idle watcher（事件循环正常结束或被中断）
           if (!loopAbort.signal.aborted) loopAbort.abort()
-          await watchdogDone
+          await Promise.all([watchdogDone, idleWatcherDone])
 
           if (abortedByWatchdog) {
             console.log(`[Agent 编排] Watchdog 中断了事件循环，将触发 auto-resume`)

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -1422,6 +1422,12 @@ export class AgentOrchestrator {
               this.adapter.abort(sessionId)
               pendingNext?.catch(() => {})
               pendingNext = null
+              // 等待 generator finally 块执行完毕（最多 1s），防止旧 finally 与新 query 注册产生竞态
+              const returnPromise = queryIterator.return?.(undefined as never).catch(() => {})
+              await Promise.race([
+                returnPromise,
+                new Promise<void>((r) => setTimeout(r, 1000)),
+              ])
               lastRetryableError = `Agent 响应超时（${IDLE_TIMEOUT_MS / 1000}s 无输出），正在自动重试`
               this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
               accumulatedMessages.length = 0

--- a/packages/core/src/providers/anthropic-adapter.ts
+++ b/packages/core/src/providers/anthropic-adapter.ts
@@ -196,6 +196,27 @@ function appendContinuationMessages(
 
 // ===== 适配器实现 =====
 
+/**
+ * 根据模型差异化 thinking budget 配置
+ *
+ * 验证后的模型上限（budget_tokens 必须 < max_tokens）：
+ * - Opus 4.6: max_tokens 最高 128k，推荐 budget ≤ 32k
+ * - Opus 4.5: max_tokens 最高 64k，推荐 budget ≤ 24k
+ * - Sonnet 4.x: max_tokens 最高 64k，推荐 budget 10k–24k
+ */
+function getThinkingConfig(modelId: string): { budget: number; maxTokens: number } {
+  if (modelId.includes('claude-opus-4')) {
+    // Opus 4.x：预算充足以支撑复杂长会话推理，防止 thinking block 截断
+    return { budget: 32000, maxTokens: 40192 }
+  }
+  if (modelId.includes('claude-sonnet-4')) {
+    // Sonnet 4.x：适度提升，兼顾质量与响应速度
+    return { budget: 20000, maxTokens: 28192 }
+  }
+  // 其他模型兜底（原有值，对所有模型均合法）
+  return { budget: 16384, maxTokens: 32768 }
+}
+
 export class AnthropicAdapter implements ProviderAdapter {
   readonly providerType = 'anthropic' as const
 
@@ -204,8 +225,9 @@ export class AnthropicAdapter implements ProviderAdapter {
     const messages = toAnthropicMessages(input)
 
     // 启用思考时需要更大的 max_tokens（budget_tokens 必须 < max_tokens）
-    const thinkingBudget = 16384
-    const maxTokens = input.thinkingEnabled ? thinkingBudget + 16384 : 8192
+    // Opus 4.x 支持更大的 thinking budget，按模型差异化配置防止 thinking block 截断
+    const { budget: thinkingBudget, maxTokens: thinkingMaxTokens } = getThinkingConfig(input.modelId)
+    const maxTokens = input.thinkingEnabled ? thinkingMaxTokens : 8192
 
     const body: Record<string, unknown> = {
       model: input.modelId,

--- a/packages/core/src/providers/anthropic-adapter.ts
+++ b/packages/core/src/providers/anthropic-adapter.ts
@@ -203,17 +203,21 @@ function appendContinuationMessages(
  * - Opus 4.6: max_tokens 最高 128k，推荐 budget ≤ 32k
  * - Opus 4.5: max_tokens 最高 64k，推荐 budget ≤ 24k
  * - Sonnet 4.x: max_tokens 最高 64k，推荐 budget 10k–24k
+ *
+ * maxTokens = budget + THINKING_OUTPUT_HEADROOM（为非 thinking 输出内容预留空间）
  */
+const THINKING_OUTPUT_HEADROOM = 8192
+
 function getThinkingConfig(modelId: string): { budget: number; maxTokens: number } {
-  if (modelId.includes('claude-opus-4')) {
+  if (/^claude-opus-4[-.]/.test(modelId) || modelId === 'claude-opus-4') {
     // Opus 4.x：预算充足以支撑复杂长会话推理，防止 thinking block 截断
-    return { budget: 32000, maxTokens: 40192 }
+    return { budget: 32000, maxTokens: 32000 + THINKING_OUTPUT_HEADROOM }
   }
-  if (modelId.includes('claude-sonnet-4')) {
+  if (/^claude-sonnet-4[-.]/.test(modelId) || modelId === 'claude-sonnet-4') {
     // Sonnet 4.x：适度提升，兼顾质量与响应速度
-    return { budget: 20000, maxTokens: 28192 }
+    return { budget: 20000, maxTokens: 20000 + THINKING_OUTPUT_HEADROOM }
   }
-  // 其他模型兜底（原有值，对所有模型均合法）
+  // 其他模型兜底（保持原有值 budget=16384/maxTokens=32768，对所有已知模型均合法）
   return { budget: 16384, maxTokens: 32768 }
 }
 


### PR DESCRIPTION
## 背景

Sonnet 4.6 / Opus 4.6 在 Agent 模式下频繁出现 **0 输出卡住** 问题，经调研（[sdk-python#958](https://github.com/anthropics/anthropic-sdk-python/issues/958)）确认是 Anthropic 已知 bug：tool_result 后无文本内容时模型偶发空输出，SDK 将其视为正常 turn 结束，orchestrator 层无感知、无重试。

本 PR 基于 #235（cjvayhxy-dev 原始提案）追加了核心检测逻辑。

---

## 修复内容

### P0 — 0-token 空响应检测与自动重试（新增）

**问题：** SDK 返回 `result { subtype: 'success', usage: { output_tokens: 0 } }` 时，orchestrator 直接透传给前端显示空白，不触发任何重试。

**修复：** 在 `result` 消息处理中检测 `output_tokens === 0`，若成立则设置 `shouldRetryFromError = true`，复用现有指数退避重试（1s/2s/4s，最多 3 次）。

```typescript
if (resultMsg.subtype === 'success' && resultMsg.usage.output_tokens === 0 && attempt <= MAX_AUTO_RETRIES) {
  // 触发自动重试
}
```

### P1 — 缩短 idle timeout（修改原 #235）

`IDLE_TIMEOUT_MS`: 500s → **120s**

Opus 正常响应首 token < 30s，500s 对用户体验代价太高。2 分钟已足够宽裕。

> ⚠️ 注意：idle timeout 无法捕获 0-token 场景（SDK 仍在持续发事件，idle timer 不断被重置）。两个机制互补，不重叠。

### P2 — SDK init 超时后子进程未关闭（原 #235）

`sendQueuedMessage` 等待 `readyPromise` 超时后，在 catch 块调用 `this.abort(sessionId)` 确保子进程被强制关闭，防止僵尸进程残留。

### P3 — Thinking budget 对 Opus 偏小（原 #235）

提取 `getThinkingConfig(modelId)` 按模型系列差异化配置：
- **Opus 4.x**: `budget=32000, max_tokens=40192`
- **Sonnet 4.x**: `budget=20000, max_tokens=28192`
- **其他**: 保持原有值（向后兼容）

---

## 影响范围

| 文件 | 改动 |
|------|------|
| `apps/electron/src/main/lib/agent-orchestrator.ts` | 0-token 检测 +20 行、idle timeout 改 1 行 |
| `apps/electron/src/main/lib/adapters/claude-agent-adapter.ts` | SDK init cleanup +6 行 |
| `packages/core/src/providers/anthropic-adapter.ts` | thinking config +22 行 |

无破坏性变更，向后兼容。

感谢 @cjvayhxy-dev 的原始提案（#235）。

🤖 Generated with [Claude Code](https://claude.ai/claude-code)