### PR TITLE
feat: 快照回退与 Fork 重构 — 会话时间旅行与原生分叉

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -63,6 +63,8 @@ import type {
   AgentTeamData,
   MoveSessionToWorkspaceInput,
   ForkSessionInput,
+  RewindSessionInput,
+  RewindSessionResult,
   FeishuConfigInput,
   FeishuConfig,
   FeishuBridgeState,
@@ -133,7 +135,7 @@ import {
   autoArchiveAgentSessions,
   searchAgentSessionMessages,
 } from './lib/agent-session-manager'
-import { runAgent, stopAgent, generateAgentTitle, saveFilesToAgentSession, saveFilesToWorkspaceFiles, isAgentSessionActive, queueAgentMessage, updateAgentPermissionMode } from './lib/agent-service'
+import { runAgent, stopAgent, generateAgentTitle, saveFilesToAgentSession, saveFilesToWorkspaceFiles, isAgentSessionActive, queueAgentMessage, updateAgentPermissionMode, rewindAgentSession } from './lib/agent-service'
 import { permissionService } from './lib/agent-permission-service'
 import { askUserService } from './lib/agent-ask-user-service'
 import { exitPlanService } from './lib/agent-exit-plan-service'
@@ -840,6 +842,17 @@ export function registerIpcHandlers(): void {
     AGENT_IPC_CHANNELS.FORK_SESSION,
     async (_, input: ForkSessionInput): Promise<AgentSessionMeta> => {
       return forkAgentSession(input)
+    }
+  )
+
+  // 快照回退（同一会话内回退到指定点）
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.REWIND_SESSION,
+    async (_, input: RewindSessionInput): Promise<RewindSessionResult> => {
+      return rewindAgentSession(
+        input.sessionId,
+        input.assistantMessageUuid,
+      )
     }
   )
 

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -1987,9 +1987,13 @@ export class AgentOrchestrator {
 
     // 0.5 从 SDK session JSONL 解析对应的 user message UUID（rewindFiles 需要）
     let projectDir: string | undefined
+    let workspaceSlug: string | undefined
     if (sessionMeta.workspaceId) {
       const ws = getAgentWorkspace(sessionMeta.workspaceId)
-      if (ws) projectDir = getAgentSessionWorkspacePath(ws.slug, sessionMeta.id)
+      if (ws) {
+        workspaceSlug = ws.slug
+        projectDir = getAgentSessionWorkspacePath(ws.slug, sessionMeta.id)
+      }
     }
     const userMessageUuid = resolveUserUuidFromSDK(sessionMeta.sdkSessionId, assistantMessageUuid, projectDir, sessionMeta.forkSourceSdkSessionId)
     console.log(`[Agent 编排] 回退: 解析 user uuid=${userMessageUuid || '未找到'} (assistant uuid=${assistantMessageUuid}, forkSource=${sessionMeta.forkSourceSdkSessionId ?? 'none'})`)
@@ -2005,8 +2009,14 @@ export class AgentOrchestrator {
         // 确定 cwd（文件的基准路径）
         let cwd = homedir()
         if (projectDir) cwd = projectDir
-        console.log(`[Agent 编排] 回退: 直接从 snapshot 恢复文件 (cwd=${cwd}, forkSource=${sessionMeta.forkSourceSdkSessionId ?? 'none'})`)
-        fileRewindResult = rewindFilesFromSnapshot(sessionMeta.sdkSessionId, userMessageUuid, cwd, projectDir, sessionMeta.forkSourceSdkSessionId, sessionMeta.attachedDirectories)
+        // 收集附加目录（与发消息时相同的来源：工作区附加目录 + 工作区文件目录）
+        const rewindAttachedDirs: string[] = []
+        if (workspaceSlug) {
+          rewindAttachedDirs.push(...getWorkspaceAttachedDirectories(workspaceSlug))
+          rewindAttachedDirs.push(getWorkspaceFilesDir(workspaceSlug))
+        }
+        console.log(`[Agent 编排] 回退: 直接从 snapshot 恢复文件 (cwd=${cwd}, forkSource=${sessionMeta.forkSourceSdkSessionId ?? 'none'}, attachedDirs=${rewindAttachedDirs.length})`)
+        fileRewindResult = rewindFilesFromSnapshot(sessionMeta.sdkSessionId, userMessageUuid, cwd, projectDir, sessionMeta.forkSourceSdkSessionId, rewindAttachedDirs)
       } catch (err) {
         const errMsg = err instanceof Error ? err.message : String(err)
         console.warn('[Agent 编排] 文件恢复失败，继续截断对话:', errMsg)

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -2006,7 +2006,7 @@ export class AgentOrchestrator {
         let cwd = homedir()
         if (projectDir) cwd = projectDir
         console.log(`[Agent 编排] 回退: 直接从 snapshot 恢复文件 (cwd=${cwd}, forkSource=${sessionMeta.forkSourceSdkSessionId ?? 'none'})`)
-        fileRewindResult = rewindFilesFromSnapshot(sessionMeta.sdkSessionId, userMessageUuid, cwd, projectDir, sessionMeta.forkSourceSdkSessionId)
+        fileRewindResult = rewindFilesFromSnapshot(sessionMeta.sdkSessionId, userMessageUuid, cwd, projectDir, sessionMeta.forkSourceSdkSessionId, sessionMeta.attachedDirectories)
       } catch (err) {
         const errMsg = err instanceof Error ? err.message : String(err)
         console.warn('[Agent 编排] 文件恢复失败，继续截断对话:', errMsg)

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -21,7 +21,7 @@ import { existsSync, mkdirSync, symlinkSync, readFileSync, writeFileSync } from 
 import { execFileSync } from 'node:child_process'
 import { createRequire } from 'node:module'
 import { app } from 'electron'
-import type { AgentSendInput, AgentMessage, AgentGenerateTitleInput, AgentProviderAdapter, TypedError, RetryAttempt, SDKMessage, SDKAssistantMessage, AgentStreamPayload } from '@proma/shared'
+import type { AgentSendInput, AgentMessage, AgentGenerateTitleInput, AgentProviderAdapter, TypedError, RetryAttempt, SDKMessage, SDKAssistantMessage, AgentStreamPayload, RewindSessionResult } from '@proma/shared'
 import { SAFE_TOOLS } from '@proma/shared'
 import type { PermissionRequest, PromaPermissionMode, AskUserRequest, ExitPlanModeRequest } from '@proma/shared'
 import type { ClaudeAgentQueryOptions } from './adapters/claude-agent-adapter'
@@ -31,7 +31,7 @@ import { decryptApiKey, getChannelById, listChannels } from './channel-manager'
 import { getAdapter, fetchTitle, normalizeAnthropicBaseUrlForSdk } from '@proma/core'
 import { getFetchFn } from './proxy-fetch'
 import { getEffectiveProxyUrl } from './proxy-settings-service'
-import { appendSDKMessages, updateAgentSessionMeta, getAgentSessionMeta, getAgentSessionMessages, getAgentSessionSDKMessages } from './agent-session-manager'
+import { appendSDKMessages, updateAgentSessionMeta, getAgentSessionMeta, getAgentSessionMessages, getAgentSessionSDKMessages, truncateSDKMessages, resolveUserUuidFromSDK, rewindFilesFromSnapshot } from './agent-session-manager'
 import { getAgentWorkspace, getWorkspaceMcpConfig, ensurePluginManifest, getWorkspacePermissionMode, setWorkspacePermissionMode } from './agent-workspace-manager'
 import { getAgentWorkspacePath, getAgentSessionWorkspacePath, getSdkConfigDir, getWorkspaceFilesDir } from './config-paths'
 import { getWorkspaceAttachedDirectories } from './agent-workspace-manager'
@@ -821,25 +821,16 @@ export class AgentOrchestrator {
     const sessionMeta = getAgentSessionMeta(sessionId)
     let existingSdkSessionId = sessionMeta?.sdkSessionId
 
-    // 4.1 检测延迟 fork 元数据：首次发消息时消费，使用 resume + forkSession 让 SDK 在当前目录创建分叉
-    let isForkResume = false
-    let forkResumeSessionAt: string | undefined
-    let forkSourceDir: string | undefined
-    if (!existingSdkSessionId && sessionMeta?.forkedFromSdkSessionId) {
-      existingSdkSessionId = sessionMeta.forkedFromSdkSessionId
-      forkResumeSessionAt = sessionMeta.forkAtMessageUuid
-      forkSourceDir = sessionMeta.forkSourceDir
-      isForkResume = true
-      console.log(`[Agent 编排] 检测到延迟 fork: 源 SDK session=${existingSdkSessionId}, 截断点=${forkResumeSessionAt || '全部'}, 源目录=${forkSourceDir || '无'}`)
-      // 清除 fork 元数据（只消费一次）
-      updateAgentSessionMeta(sessionId, {
-        forkedFromSdkSessionId: undefined,
-        forkAtMessageUuid: undefined,
-        forkSourceDir: undefined,
-      })
+    // 4.1 检测回退后的 resume 截断点（快照回退功能）
+    let rewindResumeAt: string | undefined
+    if (sessionMeta?.resumeAtMessageUuid) {
+      rewindResumeAt = sessionMeta.resumeAtMessageUuid
+      // 消费一次后清除
+      updateAgentSessionMeta(sessionId, { resumeAtMessageUuid: undefined })
+      console.log(`[Agent 编排] 检测到回退 resume: resumeSessionAt=${rewindResumeAt}`)
     }
 
-    console.log(`[Agent 编排] Resume 状态: sdkSessionId=${existingSdkSessionId || '无'}, proma sessionId=${sessionId}, fork=${isForkResume}`)
+    console.log(`[Agent 编排] Resume 状态: sdkSessionId=${existingSdkSessionId || '无'}, proma sessionId=${sessionId}`)
 
     // 5. 持久化用户消息（SDKMessage 格式）
     const userSDKMsg: SDKMessage = {
@@ -911,11 +902,14 @@ export class AgentOrchestrator {
         }
       }
 
-      // 9.4.1 Fork resume: 使用源会话的 cwd，让 SDK 能找到源 session 文件
-      // fork 后 SDK 会创建新 session，后续 resume 使用新 sdkSessionId 在新 cwd 下工作
-      if (isForkResume && forkSourceDir) {
-        agentCwd = forkSourceDir
-        console.log(`[Agent 编排] Fork resume: 使用源会话 cwd=${forkSourceDir}`)
+      // 9.4.1 Fork 后首次 resume：使用源 cwd 让 SDK 找到 session 文件
+      // SDK forkSession() 在源 cwd 的项目哈希下创建新 session 文件，
+      // 首次 resume 需要从该目录查找，之后 SDK 会在新 cwd 下创建新数据
+      if (sessionMeta?.forkSourceDir) {
+        agentCwd = sessionMeta.forkSourceDir
+        console.log(`[Agent 编排] Fork 首次 resume: 使用源会话 cwd=${sessionMeta.forkSourceDir}`)
+        // 消费一次后清除
+        updateAgentSessionMeta(sessionId, { forkSourceDir: undefined })
       }
 
       // 9.5 确保 SDK 项目设置（plansDirectory → .context）
@@ -1236,9 +1230,8 @@ export class AgentOrchestrator {
           }),
         },
         resumeSessionId: existingSdkSessionId,
-        // 延迟 fork：首次发消息时让 SDK 在当前 cwd 的项目空间创建分叉 session
-        ...(isForkResume && { forkSession: true }),
-        ...(isForkResume && forkResumeSessionAt && { resumeSessionAt: forkResumeSessionAt }),
+        // 回退后 resume：从指定消息处继续（SDK 在同一 JSONL 内创建分支）
+        ...(rewindResumeAt && { resumeSessionAt: rewindResumeAt }),
         ...(Object.keys(mcpServers).length > 0 && { mcpServers }),
         ...(workspaceSlug && { plugins: [{ type: 'local' as const, path: getAgentWorkspacePath(workspaceSlug) }] }),
         // 合并用户附加目录 + 工作区附加目录 + 工作区文件目录
@@ -1258,6 +1251,8 @@ export class AgentOrchestrator {
           }
           return allDirs.length > 0 ? { additionalDirectories: allDirs } : {}
         })(),
+        // 启用文件检查点，支持 rewindFiles 回退
+        enableFileCheckpointing: true,
         // SDK 0.2.52+ 新增选项（从 settings 读取）
         ...(appSettings.agentThinking && { thinking: appSettings.agentThinking }),
         effort: appSettings.agentEffort ?? 'high',
@@ -1962,6 +1957,78 @@ export class AgentOrchestrator {
       await this.adapter.setPermissionMode(sessionId, mode)
     }
     console.log(`[Agent 编排] 运行中权限模式已切换: sessionId=${sessionId}, mode=${mode}`)
+  }
+
+  // ===== 快照回退 =====
+
+  /**
+   * 回退会话到指定消息点
+   *
+   * 1. 直接从 SDK JSONL 的 file-history-snapshot 恢复文件到目标时刻的状态
+   * 2. 截断 Proma JSONL 到 assistantMessageUuid（inclusive）
+   * 3. 记录 resumeAtMessageUuid，下次发消息时 SDK 从该点分支继续
+   *
+   * 文件恢复通过解析 SDK JSONL 中的快照完成，无需运行中的 Query。
+   * 文件恢复失败时仍然截断对话（优雅降级）。
+   */
+  async rewindSession(
+    sessionId: string,
+    assistantMessageUuid: string,
+  ): Promise<RewindSessionResult> {
+    // 0. 阻止运行中会话回退（JSONL 并发写入会损坏文件）
+    if (this.activeSessions.has(sessionId)) {
+      throw new Error('会话正在运行中，请停止后再回退')
+    }
+
+    const sessionMeta = getAgentSessionMeta(sessionId)
+    if (!sessionMeta?.sdkSessionId) {
+      throw new Error('会话没有 SDK session ID，无法回退')
+    }
+
+    // 0.5 从 SDK session JSONL 解析对应的 user message UUID（rewindFiles 需要）
+    let projectDir: string | undefined
+    if (sessionMeta.workspaceId) {
+      const ws = getAgentWorkspace(sessionMeta.workspaceId)
+      if (ws) projectDir = getAgentSessionWorkspacePath(ws.slug, sessionMeta.id)
+    }
+    const userMessageUuid = resolveUserUuidFromSDK(sessionMeta.sdkSessionId, assistantMessageUuid, projectDir, sessionMeta.forkSourceSdkSessionId)
+    console.log(`[Agent 编排] 回退: 解析 user uuid=${userMessageUuid || '未找到'} (assistant uuid=${assistantMessageUuid}, forkSource=${sessionMeta.forkSourceSdkSessionId ?? 'none'})`)
+
+    // 1. 文件恢复：直接从 SDK JSONL 的 file-history-snapshot 恢复，无需临时 Query
+    let fileRewindResult: { canRewind: boolean; error?: string; filesChanged?: string[]; insertions?: number; deletions?: number } | undefined
+    if (userMessageUuid === '__LAST_TURN__') {
+      // 最后一个 turn：当前文件系统已是该 turn 完成后的状态，无需回退文件
+      console.log(`[Agent 编排] 回退: 最后一个 turn，跳过文件恢复`)
+      fileRewindResult = { canRewind: true, filesChanged: [] }
+    } else if (userMessageUuid) {
+      try {
+        // 确定 cwd（文件的基准路径）
+        let cwd = homedir()
+        if (projectDir) cwd = projectDir
+        console.log(`[Agent 编排] 回退: 直接从 snapshot 恢复文件 (cwd=${cwd}, forkSource=${sessionMeta.forkSourceSdkSessionId ?? 'none'})`)
+        fileRewindResult = rewindFilesFromSnapshot(sessionMeta.sdkSessionId, userMessageUuid, cwd, projectDir, sessionMeta.forkSourceSdkSessionId)
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err)
+        console.warn('[Agent 编排] 文件恢复失败，继续截断对话:', errMsg)
+        if (err instanceof Error && err.stack) console.warn('[Agent 编排] 文件恢复错误堆栈:', err.stack)
+        fileRewindResult = { canRewind: false, error: errMsg }
+      }
+    } else {
+      fileRewindResult = { canRewind: false, error: '无法从 SDK session 中解析 user message UUID' }
+    }
+
+    // 2. 截断 Proma JSONL
+    const kept = truncateSDKMessages(sessionId, assistantMessageUuid)
+
+    // 3. 记录 resumeAtMessageUuid，下次发消息时 SDK 从此点继续
+    updateAgentSessionMeta(sessionId, { resumeAtMessageUuid: assistantMessageUuid })
+
+    console.log(`[Agent 编排] 回退完成: sessionId=${sessionId}, 保留 ${kept.length} 条消息, 文件恢复=${fileRewindResult?.canRewind ?? '跳过'}`)
+
+    return {
+      remainingMessages: kept.length,
+      fileRewind: fileRewindResult,
+    }
   }
 
   /** 中止所有活跃的 Agent 会话（应用退出时调用） */

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -193,6 +193,16 @@ export function stopAgent(sessionId: string): void {
 }
 
 /**
+ * 快照回退：回退到指定消息点，恢复文件 + 截断对话
+ */
+export async function rewindAgentSession(
+  sessionId: string,
+  assistantMessageUuid: string,
+): Promise<import('@proma/shared').RewindSessionResult> {
+  return orchestrator.rewindSession(sessionId, assistantMessageUuid)
+}
+
+/**
  * 检查指定会话是否正在运行
  */
 export function isAgentSessionActive(sessionId: string): boolean {

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -808,6 +808,7 @@ function findSdkSessionJsonl(sdkSessionId: string, _projectDir?: string): string
  * @param cwd  会话工作目录（文件的基准路径）
  * @param projectDir  项目目录（可选，用于定位 SDK JSONL）
  * @param forkSourceSdkSessionId  源会话 SDK session ID（可选，fork 会话回退时使用）
+ * @param attachedDirectories  附加的外部目录列表（绝对路径，SDK 会将这些目录下的文件以绝对路径记录在 snapshot 中）
  */
 export function rewindFilesFromSnapshot(
   sdkSessionId: string,
@@ -815,6 +816,7 @@ export function rewindFilesFromSnapshot(
   cwd: string,
   projectDir?: string,
   forkSourceSdkSessionId?: string,
+  attachedDirectories?: string[],
 ): { canRewind: boolean; error?: string; filesChanged?: string[]; insertions?: number; deletions?: number } {
   const sdkConfigDir = getSdkConfigDir()
 
@@ -931,11 +933,17 @@ export function rewindFilesFromSnapshot(
     const filesChanged: string[] = []
 
     const resolvedCwd = resolve(cwd)
-    for (const [filePath, backupFileName] of fileState) {
-      const fullPath = resolve(cwd, filePath)
+    // 预计算允许写入的目录列表（cwd + attachedDirectories）
+    const allowedDirs = [resolvedCwd, ...(attachedDirectories || []).map((d) => resolve(d))]
 
-      // 路径越界检查：防止恶意或损坏的 JSONL 中 filePath 包含 ../../ 导致写入 cwd 之外
-      if (!fullPath.startsWith(resolvedCwd + '/') && fullPath !== resolvedCwd) {
+    for (const [filePath, backupFileName] of fileState) {
+      // SDK 对 cwd 内文件使用相对路径，对 additionalDirectories 内文件使用绝对路径
+      const isAbsolute = filePath.startsWith('/')
+      const fullPath = isAbsolute ? resolve(filePath) : resolve(cwd, filePath)
+
+      // 路径安全检查：文件必须位于 cwd 或 attachedDirectories 之内
+      const isInAllowedDir = allowedDirs.some((dir) => fullPath.startsWith(dir + '/') || fullPath === dir)
+      if (!isInAllowedDir) {
         console.warn(`[Agent 会话] rewindFiles: 拒绝路径越界 ${filePath}`)
         continue
       }

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -8,15 +8,16 @@
  * 照搬 conversation-manager.ts 的模式。
  */
 
-import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync, unlinkSync, rmSync, renameSync, readdirSync } from 'node:fs'
+import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync, unlinkSync, rmSync, renameSync, readdirSync, cpSync } from 'node:fs'
 import { randomUUID } from 'node:crypto'
-import { join } from 'node:path'
+import { join, resolve, dirname } from 'node:path'
 import {
   getAgentSessionsIndexPath,
   getAgentSessionsDir,
   getAgentSessionMessagesPath,
   getAgentSessionWorkspacePath,
   getAgentWorkspacePath,
+  getSdkConfigDir,
 } from './config-paths'
 import { getAgentWorkspace } from './agent-workspace-manager'
 import type { AgentSessionMeta, AgentMessage, SDKMessage, ForkSessionInput, AgentMessageSearchResult } from '@proma/shared'
@@ -307,7 +308,7 @@ function convertLegacyMessage(legacy: AgentMessage): SDKMessage {
  */
 export function updateAgentSessionMeta(
   id: string,
-  updates: Partial<Pick<AgentSessionMeta, 'title' | 'channelId' | 'sdkSessionId' | 'workspaceId' | 'pinned' | 'archived' | 'attachedDirectories' | 'forkedFromSdkSessionId' | 'forkAtMessageUuid' | 'forkSourceDir' | 'stoppedByUser'>>,
+  updates: Partial<Pick<AgentSessionMeta, 'title' | 'channelId' | 'sdkSessionId' | 'workspaceId' | 'pinned' | 'archived' | 'attachedDirectories' | 'forkSourceDir' | 'forkSourceSdkSessionId' | 'resumeAtMessageUuid' | 'stoppedByUser'>>,
 ): AgentSessionMeta {
   const index = readIndex()
   const idx = index.sessions.findIndex((s) => s.id === id)
@@ -492,17 +493,35 @@ export function migrateChatToAgentSession(conversationId: string, agentSessionId
   console.log(`[Agent 会话] 已迁移 ${count} 条消息到 Agent 会话 (${conversationId} → ${agentSessionId})`)
 }
 
+/** fork 操作串行锁，防止并发 forkAgentSession 调用导致 process.env 交叉突变 */
+let forkLock = Promise.resolve()
+
 /**
- * 分叉 Agent 会话（延迟 fork 模式）
+ * 分叉 Agent 会话（SDK 原生 fork）
  *
- * 不直接调用 SDK forkSession()，而是创建一个带有 fork 元数据的新会话。
- * 首次发消息时，orchestrator 检测到 fork 元数据，会使用
- * `resume + forkSession: true + resumeSessionAt` 让 SDK 在正确的项目目录下
- * 创建分叉 session 文件。
+ * 直接调用 SDK 的 forkSession() 独立函数完成 JSONL 复制和 UUID 重映射，
+ * 新会话立即获得 sdkSessionId，无需延迟到首次发消息。
+ *
+ * forkSourceDir 用于首次 resume 时定位 SDK session 文件（因 fork 后的 session
+ * 存储在源 cwd 的项目哈希下），orchestrator 首次 resume 后会清除该字段。
  *
  * @returns 新创建的会话元数据
  */
-export function forkAgentSession(input: ForkSessionInput): AgentSessionMeta {
+export async function forkAgentSession(input: ForkSessionInput): Promise<AgentSessionMeta> {
+  // 串行化：等待前一个 fork 操作完成，防止 process.env.CLAUDE_CONFIG_DIR 并发突变
+  const prev = forkLock
+  let releaseLock: () => void
+  forkLock = new Promise<void>((resolve) => { releaseLock = resolve })
+  await prev
+
+  try {
+    return await forkAgentSessionImpl(input)
+  } finally {
+    releaseLock!()
+  }
+}
+
+async function forkAgentSessionImpl(input: ForkSessionInput): Promise<AgentSessionMeta> {
   const { sessionId, upToMessageUuid } = input
 
   // 1. 获取源会话元数据
@@ -515,7 +534,7 @@ export function forkAgentSession(input: ForkSessionInput): AgentSessionMeta {
     throw new Error('该会话没有 SDK session，无法分叉')
   }
 
-  // 2. 确定源会话的工作目录（fork 时 SDK 需要从此目录的项目空间读取 session 文件）
+  // 2. 确定源会话的工作目录（SDK 需要从此目录的项目空间读取 session 文件）
   let sourceDir: string | undefined
   if (sourceMeta.workspaceId) {
     const ws = getAgentWorkspace(sourceMeta.workspaceId)
@@ -524,7 +543,38 @@ export function forkAgentSession(input: ForkSessionInput): AgentSessionMeta {
     }
   }
 
-  // 3. 创建 Proma 新会话，携带 fork 元数据
+  // 3. 调用 SDK 原生 forkSession
+  // SDK 的独立函数（forkSession）读取 process.env.CLAUDE_CONFIG_DIR 定位 session 文件
+  // Proma 使用隔离配置目录，必须在调用前设置
+  const prevConfigDir = process.env.CLAUDE_CONFIG_DIR
+  process.env.CLAUDE_CONFIG_DIR = getSdkConfigDir()
+  const sdk = await import('@anthropic-ai/claude-agent-sdk')
+  let forkResult: Awaited<ReturnType<typeof sdk.forkSession>>
+  try {
+    forkResult = await sdk.forkSession(sourceMeta.sdkSessionId, {
+      upToMessageId: upToMessageUuid,
+      dir: sourceDir,
+    })
+  } catch (err) {
+    // 指定 dir 失败时，让 SDK 自动搜索所有项目目录
+    if (sourceDir) {
+      console.warn(`[Agent 会话] forkSession 指定 dir 失败，改用全局搜索:`, err)
+      forkResult = await sdk.forkSession(sourceMeta.sdkSessionId, {
+        upToMessageId: upToMessageUuid,
+      })
+    } else {
+      throw err
+    }
+  } finally {
+    // 恢复环境变量
+    if (prevConfigDir !== undefined) {
+      process.env.CLAUDE_CONFIG_DIR = prevConfigDir
+    } else {
+      delete process.env.CLAUDE_CONFIG_DIR
+    }
+  }
+
+  // 4. 创建 Proma 新会话，立即设置 sdkSessionId
   const forkTitle = `${sourceMeta.title} (fork)`
   const newMeta = createAgentSession(
     forkTitle,
@@ -532,17 +582,39 @@ export function forkAgentSession(input: ForkSessionInput): AgentSessionMeta {
     sourceMeta.workspaceId,
   )
 
-  // 4. 写入 fork 元数据（orchestrator 首次发消息时消费）
   updateAgentSessionMeta(newMeta.id, {
-    forkedFromSdkSessionId: sourceMeta.sdkSessionId,
-    forkAtMessageUuid: upToMessageUuid,
+    sdkSessionId: forkResult.sessionId,
     forkSourceDir: sourceDir,
+    forkSourceSdkSessionId: sourceMeta.sdkSessionId,
   })
-  newMeta.forkedFromSdkSessionId = sourceMeta.sdkSessionId
-  newMeta.forkAtMessageUuid = upToMessageUuid
+  // 同步返回值（updateAgentSessionMeta 已写入磁盘，这里让调用方拿到最新值）
+  newMeta.sdkSessionId = forkResult.sessionId
   newMeta.forkSourceDir = sourceDir
+  newMeta.forkSourceSdkSessionId = sourceMeta.sdkSessionId
 
-  // 5. 复制截断后的 SDKMessages 到新会话的 JSONL（用于 UI 展示历史）
+  // 5. 复制源会话工作区文件到新会话目录（排除 .claude/ 和 .context/，它们会自动创建）
+  if (sourceDir && sourceMeta.workspaceId) {
+    const ws = getAgentWorkspace(sourceMeta.workspaceId)
+    if (ws) {
+      const destDir = getAgentSessionWorkspacePath(ws.slug, newMeta.id)
+      if (!existsSync(destDir)) mkdirSync(destDir, { recursive: true })
+      try {
+        const entries = readdirSync(sourceDir)
+        for (const entry of entries) {
+          if (entry === '.claude' || entry === '.context' || entry === '.DS_Store' || entry === '.git') continue
+          const srcPath = join(sourceDir, entry)
+          const destPath = join(destDir, entry)
+          cpSync(srcPath, destPath, { recursive: true })
+        }
+        const copiedCount = entries.filter(e => e !== '.claude' && e !== '.context' && e !== '.DS_Store' && e !== '.git').length
+        console.log(`[Agent 会话] 已复制工作区文件: ${sourceDir} → ${destDir} (${copiedCount} 个条目)`)
+      } catch (err) {
+        console.warn(`[Agent 会话] 复制工作区文件失败:`, err)
+      }
+    }
+  }
+
+  // 6. 复制截断后的 SDKMessages 到新会话的 JSONL（用于 UI 展示历史）
   const sourceMessages = getAgentSessionSDKMessages(sessionId)
   let messagesToCopy: SDKMessage[]
 
@@ -559,8 +631,357 @@ export function forkAgentSession(input: ForkSessionInput): AgentSessionMeta {
     appendSDKMessages(newMeta.id, messagesToCopy)
   }
 
-  console.log(`[Agent 会话] 分叉会话已创建（延迟 fork）: ${sourceMeta.title} → ${forkTitle} (${messagesToCopy.length} 条消息)`)
+  console.log(`[Agent 会话] 分叉会话已创建（SDK 原生 fork）: ${sourceMeta.title} → ${forkTitle} (${messagesToCopy.length} 条消息, sdkSessionId=${forkResult.sessionId})`)
   return newMeta
+}
+
+/**
+ * 截断 Agent 会话的 SDK 消息到指定 UUID（inclusive）
+ *
+ * 保留 uuid 匹配消息及之前的所有消息，删除之后的消息。
+ * 通过 writeFileSync 全量重写 JSONL 文件。
+ *
+ * @returns 截断后保留的消息列表
+ */
+export function truncateSDKMessages(id: string, upToUuidInclusive: string): SDKMessage[] {
+  const messages = getAgentSessionSDKMessages(id)
+  const cutIndex = messages.findIndex(
+    (m) => 'uuid' in m && (m as { uuid?: string }).uuid === upToUuidInclusive,
+  )
+  if (cutIndex < 0) {
+    throw new Error(`[Agent 会话] 截断失败: 未找到 uuid=${upToUuidInclusive}, sessionId=${id}`)
+  }
+  const kept = messages.slice(0, cutIndex + 1)
+
+  const filePath = getAgentSessionMessagesPath(id)
+  const content = kept.map((m) => JSON.stringify(m)).join('\n') + (kept.length > 0 ? '\n' : '')
+  writeFileSync(filePath, content, 'utf-8')
+
+  console.log(`[Agent 会话] 消息已截断: sessionId=${id}, 保留 ${kept.length}/${messages.length} 条`)
+  return kept
+}
+
+/**
+ * 从 SDK session JSONL 中查找指定 assistant message 之后最近的 user message UUID
+ *
+ * SDK session JSONL（~/.proma/sdk-config/projects/...）中的消息都带有 uuid，
+ * 但 Proma 自己构造的 user message 没有 uuid。此函数直接读取 SDK 的 JSONL
+ * 来解析 rewindFiles 所需的 user message UUID。
+ *
+ * 对于 fork 会话：Proma JSONL 中的 UUID 来自**源会话**（fork 时直接复制），
+ * 而 forked SDK JSONL 中的 UUID 已被重映射。因此 fork 会话需要搜索**源**
+ * SDK JSONL 来匹配 assistant UUID。通过 forkSourceSdkSessionId 参数指定。
+ *
+ * @param sdkSessionId SDK session UUID
+ * @param assistantMessageUuid 要回退到的 assistant message UUID
+ * @param projectDir SDK 项目目录路径（session 运行时的 cwd）
+ * @param forkSourceSdkSessionId 源会话 SDK session ID（fork 会话时传入）
+ * @returns user message UUID，找不到时返回 undefined
+ */
+export function resolveUserUuidFromSDK(
+  sdkSessionId: string,
+  assistantMessageUuid: string,
+  projectDir?: string,
+  forkSourceSdkSessionId?: string,
+): string | undefined {
+  // 优先搜索当前 session JSONL
+  let sessionFilePath = findSdkSessionJsonl(sdkSessionId, projectDir)
+
+  // 当前 session JSONL 中未找到 assistant UUID（作为消息 .uuid 字段）时，尝试源会话（fork 场景）
+  let usingSourceSession = false
+  if (sessionFilePath && forkSourceSdkSessionId) {
+    try {
+      const lines = readFileSync(sessionFilePath, 'utf-8').split('\n').filter(Boolean)
+      const hasUuidAsField = lines.some((line) => {
+        try {
+          const m = JSON.parse(line)
+          return m.uuid === assistantMessageUuid
+        } catch { return false }
+      })
+      if (!hasUuidAsField) {
+        // Proma JSONL 中的 UUID 来自源会话，forked JSONL 中已重映射
+        const sourceFilePath = findSdkSessionJsonl(forkSourceSdkSessionId, projectDir)
+        if (sourceFilePath) {
+          console.log(`[Agent 会话] resolveUserUuid: fork 会话 UUID 不匹配（非 .uuid 字段），切换到源会话 ${forkSourceSdkSessionId}`)
+          sessionFilePath = sourceFilePath
+          usingSourceSession = true
+        }
+      }
+    } catch { /* fall through to main logic */ }
+  } else if (!sessionFilePath && forkSourceSdkSessionId) {
+    // 当前 session JSONL 完全找不到，直接尝试源会话
+    sessionFilePath = findSdkSessionJsonl(forkSourceSdkSessionId, projectDir)
+    if (sessionFilePath) {
+      usingSourceSession = true
+      console.log(`[Agent 会话] resolveUserUuid: 当前 JSONL 未找到，使用源会话 ${forkSourceSdkSessionId}`)
+    }
+  }
+
+  if (!sessionFilePath) {
+    console.warn(`[Agent 会话] 未找到 SDK session JSONL: sdkSessionId=${sdkSessionId}`)
+    return undefined
+  }
+
+  // 读取并解析 SDK JSONL
+  try {
+    const lines = readFileSync(sessionFilePath, 'utf-8').split('\n').filter(Boolean)
+    const messages = lines.map((l) => JSON.parse(l) as Record<string, unknown>)
+
+    // 找到 assistant message 的位置
+    const assistantIdx = messages.findIndex((m) => m.uuid === assistantMessageUuid)
+    if (assistantIdx < 0) {
+      console.warn(`[Agent 会话] SDK JSONL 中未找到 assistant uuid=${assistantMessageUuid}${usingSourceSession ? ' (源会话)' : ''}`)
+      return undefined
+    }
+
+    // rewindFiles(userMessageId) 恢复文件到该 user message 发送时的快照状态。
+    // 回退到某个 assistant turn = 恢复到"该 turn 完成后"的文件状态
+    // = 下一轮用户消息发送时的快照（因为快照记录的是 user 消息发出时的文件状态，
+    //   而 assistant turn 完成后到下一条 user 消息之间没有其他文件变化）。
+    //
+    // 策略：向后找第一条非 tool_result 的 user message。
+    // 如果找不到（最后一个 turn），返回 '__LAST_TURN__' 特殊标记 —— 因为当前文件系统
+    // 已经是最后一个 turn 完成后的状态，不需要文件回退。
+
+    const isRealUserMessage = (m: Record<string, unknown>): boolean => {
+      if (m.type !== 'user' || !m.uuid) return false
+      const content = (m.message as { content?: Array<{ type: string }> } | undefined)?.content
+      const hasToolResult = Array.isArray(content) && content.some((b) => b.type === 'tool_result')
+      return !hasToolResult
+    }
+
+    // 向后找下一条真实 user message
+    for (let i = assistantIdx + 1; i < messages.length; i++) {
+      const m = messages[i]!
+      if (isRealUserMessage(m)) {
+        console.log(`[Agent 会话] 解析到下一轮 user uuid=${m.uuid} (assistant uuid=${assistantMessageUuid}${usingSourceSession ? ', 源会话' : ''})`)
+        return m.uuid as string
+      }
+    }
+
+    // 最后一个 turn — 当前文件系统已是该 turn 完成后的状态，无需文件回退
+    console.log(`[Agent 会话] 最后一个 turn，无需文件回退 (assistant uuid=${assistantMessageUuid})`)
+    return '__LAST_TURN__'
+  } catch (err) {
+    console.warn(`[Agent 会话] 读取 SDK session JSONL 失败:`, err)
+    return undefined
+  }
+}
+
+/**
+ * 在 SDK 项目目录中查找指定 session 的 JSONL 文件。
+ *
+ * @param sdkSessionId SDK session ID
+ * @param projectDir 项目目录（可选，优先在此目录的哈希下查找）
+ * @returns JSONL 文件路径，找不到返回 undefined
+ */
+function findSdkSessionJsonl(sdkSessionId: string, _projectDir?: string): string | undefined {
+  const sdkConfigDir = getSdkConfigDir()
+
+  // 遍历所有项目目录查找匹配的 session JSONL
+  // （SDK 的目录命名规则与 Proma 不完全一致，直接遍历最可靠）
+  const projectsDir = join(sdkConfigDir, 'projects')
+  if (existsSync(projectsDir)) {
+    for (const dir of readdirSync(projectsDir)) {
+      const candidate = join(projectsDir, dir, `${sdkSessionId}.jsonl`)
+      if (existsSync(candidate)) return candidate
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * 直接从 SDK JSONL 的 file-history-snapshot 恢复文件到指定 user message 时的状态。
+ *
+ * 绕过 SDK 的 rewindFiles API（避免分支加载问题），直接：
+ * 1. 读取 SDK JSONL 中的所有 file-history-snapshot
+ * 2. 构建目标 user message 时的文件状态表
+ * 3. 从 file-history 备份目录恢复文件
+ *
+ * 对于 fork 出的会话：resolveUserUuidFromSDK 已从源 SDK JSONL 解析出源空间的 user UUID，
+ * 因此 userMessageUuid 可能在源 JSONL 中而非 forked JSONL 中。当在当前 JSONL 中找不到
+ * 目标 UUID 时，自动 fallback 到源会话的 JSONL 和 file-history 备份。
+ *
+ * @param sdkSessionId  SDK session ID
+ * @param userMessageUuid  目标 user message UUID（恢复到此时的文件状态）
+ * @param cwd  会话工作目录（文件的基准路径）
+ * @param projectDir  项目目录（可选，用于定位 SDK JSONL）
+ * @param forkSourceSdkSessionId  源会话 SDK session ID（可选，fork 会话回退时使用）
+ */
+export function rewindFilesFromSnapshot(
+  sdkSessionId: string,
+  userMessageUuid: string,
+  cwd: string,
+  projectDir?: string,
+  forkSourceSdkSessionId?: string,
+): { canRewind: boolean; error?: string; filesChanged?: string[]; insertions?: number; deletions?: number } {
+  const sdkConfigDir = getSdkConfigDir()
+
+  // 1. 查找 SDK session JSONL（优先当前 session，找不到目标 UUID 时 fallback 到源会话）
+  let sessionFilePath = findSdkSessionJsonl(sdkSessionId, projectDir)
+  let effectiveSdkSessionId = sdkSessionId
+  let isForkFallback = false
+
+  // 2. 读取所有消息，构建到目标 user message 为止的文件状态
+  try {
+    let messages: Record<string, unknown>[] = []
+    if (sessionFilePath) {
+      const lines = readFileSync(sessionFilePath, 'utf-8').split('\n').filter(Boolean)
+      messages = lines.map((l) => JSON.parse(l) as Record<string, unknown>)
+    }
+
+    // 找到目标 user message 的位置
+    let targetIdx = messages.findIndex((m) => m.uuid === userMessageUuid)
+
+    // Fork 场景：userMessageUuid 来自源会话（resolveUserUuidFromSDK 已做过 fallback），
+    // 在 forked JSONL 中找不到 → 直接切换到源会话 JSONL
+    if (targetIdx < 0 && forkSourceSdkSessionId) {
+      console.log(`[Agent 会话] rewindFilesFromSnapshot: 目标 UUID 在当前 JSONL 中未找到，切换到源会话 ${forkSourceSdkSessionId}`)
+      const sourceFilePath = findSdkSessionJsonl(forkSourceSdkSessionId, projectDir)
+      if (!sourceFilePath) {
+        return { canRewind: false, error: '未找到源会话 SDK session JSONL（fork 回退需要源会话数据）' }
+      }
+      const sourceLines = readFileSync(sourceFilePath, 'utf-8').split('\n').filter(Boolean)
+      messages = sourceLines.map((l) => JSON.parse(l) as Record<string, unknown>)
+      targetIdx = messages.findIndex((m) => m.uuid === userMessageUuid)
+      effectiveSdkSessionId = forkSourceSdkSessionId
+      isForkFallback = true
+
+      if (targetIdx < 0) {
+        return { canRewind: false, error: `源会话 SDK JSONL 中也未找到 user message uuid=${userMessageUuid}` }
+      }
+      console.log(`[Agent 会话] rewindFilesFromSnapshot: 在源会话中找到目标 UUID (idx=${targetIdx})`)
+    } else if (targetIdx < 0) {
+      return { canRewind: false, error: `SDK JSONL 中未找到 user message uuid=${userMessageUuid}` }
+    }
+
+    // 查找目标 user message 对应的 snapshot（isSnapshotUpdate: false 且 messageId 匹配）
+    // SDK 的 file-history-snapshot 有两种：
+    // - isSnapshotUpdate: false — user message 发出时的完整文件追踪状态
+    // - isSnapshotUpdate: true — assistant 工具修改文件前的增量备份
+    // 只使用 user message snapshot 来构建目标时刻的文件状态。
+    const fileState = new Map<string, string | null>()
+    let targetSnapshotFound = false
+
+    for (const m of messages) {
+      if (m.type !== 'file-history-snapshot') continue
+      if (m.isSnapshotUpdate) continue
+      const snapshot = m.snapshot as {
+        messageId?: string
+        trackedFileBackups?: Record<string, { backupFileName: string | null }>
+      } | undefined
+      if (snapshot?.messageId === userMessageUuid && snapshot.trackedFileBackups) {
+        for (const [filePath, info] of Object.entries(snapshot.trackedFileBackups)) {
+          fileState.set(filePath, info.backupFileName)
+        }
+        targetSnapshotFound = true
+      }
+    }
+
+    // 同时收集 target snapshot 对应的增量更新（isSnapshotUpdate: true 且 snapshot.messageId 匹配）
+    // 这些记录了 target user message 那轮 assistant 操作前的文件备份
+    if (targetSnapshotFound) {
+      for (const m of messages) {
+        if (m.type !== 'file-history-snapshot' || !m.isSnapshotUpdate) continue
+        const snapshot = m.snapshot as {
+          messageId?: string
+          trackedFileBackups?: Record<string, { backupFileName: string | null }>
+        } | undefined
+        if (snapshot?.messageId === userMessageUuid && snapshot.trackedFileBackups) {
+          // 增量更新可能记录了更多被追踪的文件，但不覆盖已有状态
+          for (const [filePath, info] of Object.entries(snapshot.trackedFileBackups)) {
+            if (!fileState.has(filePath)) {
+              fileState.set(filePath, info.backupFileName)
+            }
+          }
+        }
+      }
+    }
+
+    // 处理 target 之后新创建的文件（它们在 target 时不存在，需要删除）
+    for (let i = targetIdx + 1; i < messages.length; i++) {
+      const m = messages[i]!
+      if (m.type !== 'file-history-snapshot') continue
+
+      const snapshot = m.snapshot as {
+        trackedFileBackups?: Record<string, { backupFileName: string | null }>
+      } | undefined
+      if (!snapshot?.trackedFileBackups) continue
+
+      for (const [filePath, info] of Object.entries(snapshot.trackedFileBackups)) {
+        // 如果这个文件在 target 时不存在（没被追踪），且 backupFileName 为 null（新创建的），标记删除
+        if (!fileState.has(filePath) && info.backupFileName === null) {
+          fileState.set(filePath, null) // null = 文件应该不存在
+        }
+      }
+    }
+
+    if (fileState.size === 0) {
+      if (!targetSnapshotFound) {
+        console.log(`[Agent 会话] rewindFilesFromSnapshot: 目标消息无文件快照记录`)
+        return { canRewind: false, error: '目标消息无文件快照记录（会话可能在启用文件检查点前创建）' }
+      }
+      console.log(`[Agent 会话] rewindFilesFromSnapshot: 快照存在但无文件变化`)
+      return { canRewind: true, filesChanged: [] }
+    }
+
+    // 3. 恢复文件（fork 会话使用源会话的 file-history 备份）
+    const fileHistoryDir = join(sdkConfigDir, 'file-history', effectiveSdkSessionId)
+    const filesChanged: string[] = []
+
+    const resolvedCwd = resolve(cwd)
+    for (const [filePath, backupFileName] of fileState) {
+      const fullPath = resolve(cwd, filePath)
+
+      // 路径越界检查：防止恶意或损坏的 JSONL 中 filePath 包含 ../../ 导致写入 cwd 之外
+      if (!fullPath.startsWith(resolvedCwd + '/') && fullPath !== resolvedCwd) {
+        console.warn(`[Agent 会话] rewindFiles: 拒绝路径越界 ${filePath}`)
+        continue
+      }
+
+      if (backupFileName === null) {
+        // 文件在 target 时不存在 → 删除
+        if (existsSync(fullPath)) {
+          try {
+            unlinkSync(fullPath)
+            filesChanged.push(filePath)
+            console.log(`[Agent 会话] rewindFiles: 删除 ${filePath}`)
+          } catch (err) {
+            console.warn(`[Agent 会话] rewindFiles: 删除失败 ${filePath}:`, err)
+          }
+        }
+      } else {
+        // 文件在 target 时存在 → 用备份恢复
+        const backupPath = resolve(fileHistoryDir, backupFileName)
+        // backupPath 越界检查
+        if (!backupPath.startsWith(resolve(fileHistoryDir) + '/') && backupPath !== resolve(fileHistoryDir)) {
+          console.warn(`[Agent 会话] rewindFiles: 拒绝备份路径越界 ${backupFileName}`)
+          continue
+        }
+        if (!existsSync(backupPath)) {
+          console.warn(`[Agent 会话] rewindFiles: 备份文件不存在 ${backupPath}`)
+          continue
+        }
+        try {
+          const backupContent = readFileSync(backupPath)
+          // 确保目录存在
+          const dir = dirname(fullPath)
+          if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+          writeFileSync(fullPath, backupContent)
+          filesChanged.push(filePath)
+          console.log(`[Agent 会话] rewindFiles: 恢复 ${filePath} ← ${backupFileName}${isForkFallback ? ' (from source session)' : ''}`)
+        } catch (err) {
+          console.warn(`[Agent 会话] rewindFiles: 恢复失败 ${filePath}:`, err)
+        }
+      }
+    }
+
+    console.log(`[Agent 会话] rewindFilesFromSnapshot 完成: ${filesChanged.length} 个文件已恢复${isForkFallback ? ' (fork fallback)' : ''}`)
+    return { canRewind: true, filesChanged }
+  } catch (err) {
+    return { canRewind: false, error: err instanceof Error ? err.message : String(err) }
+  }
 }
 
 /**

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -75,6 +75,8 @@ import type {
   AgentTeamData,
   MoveSessionToWorkspaceInput,
   ForkSessionInput,
+  RewindSessionInput,
+  RewindSessionResult,
   AgentMessageSearchResult,
   FeishuConfig,
   FeishuConfigInput,
@@ -326,6 +328,9 @@ export interface ElectronAPI {
 
   /** 分叉 Agent 会话 */
   forkAgentSession: (input: ForkSessionInput) => Promise<AgentSessionMeta>
+
+  /** 快照回退（同一会话内回退到指定点，恢复文件 + 截断对话） */
+  rewindSession: (input: RewindSessionInput) => Promise<RewindSessionResult>
 
   /** 生成 Agent 会话标题 */
   generateAgentTitle: (input: AgentGenerateTitleInput) => Promise<string | null>
@@ -1013,6 +1018,10 @@ const electronAPI: ElectronAPI = {
 
   forkAgentSession: (input: ForkSessionInput) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.FORK_SESSION, input)
+  },
+
+  rewindSession: (input: RewindSessionInput) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.REWIND_SESSION, input)
   },
 
   generateAgentTitle: (input: AgentGenerateTitleInput) => {

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -65,6 +65,7 @@ interface AgentMessagesProps {
   onRetry?: () => void
   onRetryInNewSession?: () => void
   onFork?: (upToMessageUuid: string) => void
+  onRewind?: (assistantMessageUuid: string) => void
   onCompact?: () => void
 }
 
@@ -649,7 +650,7 @@ function AgentRunningIndicator({ startedAt }: { startedAt?: number }): React.Rea
   )
 }
 
-export function AgentMessages({ sessionId, sessionModelId, messages, messagesLoaded, persistedSDKMessages, streaming, streamState, liveMessages, sessionPath, stoppedByUser, onRetry, onRetryInNewSession, onFork, onCompact }: AgentMessagesProps): React.ReactElement {
+export function AgentMessages({ sessionId, sessionModelId, messages, messagesLoaded, persistedSDKMessages, streaming, streamState, liveMessages, sessionPath, stoppedByUser, onRetry, onRetryInNewSession, onFork, onRewind, onCompact }: AgentMessagesProps): React.ReactElement {
   const userProfile = useAtomValue(userProfileAtom)
   const setMinimapCache = useSetAtom(tabMinimapCacheAtom)
   const channels = useAtomValue(channelsAtom)
@@ -839,6 +840,7 @@ export function AgentMessages({ sessionId, sessionModelId, messages, messagesLoa
                     allMessages={allSDKMessages}
                     basePath={sessionPath || undefined}
                     onFork={isLive ? undefined : onFork}
+                    onRewind={isLive ? undefined : onRewind}
                     isStreaming={isLive || undefined}
                     stoppedByUser={isLastAssistantTurn || undefined}
                     sessionModelId={sessionModelId}

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -1128,6 +1128,43 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     }
   }, [sessionId, openSession, setAgentSessions])
 
+  /** 快照回退：同一会话内回退到指定消息点，恢复文件 + 截断对话 */
+  const handleRewind = React.useCallback(async (
+    assistantMessageUuid: string,
+  ): Promise<void> => {
+    try {
+      const result = await window.electronAPI.rewindSession({
+        sessionId,
+        assistantMessageUuid,
+      })
+
+      // 刷新消息列表
+      store.set(agentMessageRefreshAtom, (prev) => {
+        const map = new Map(prev)
+        map.set(sessionId, (prev.get(sessionId) ?? 0) + 1)
+        return map
+      })
+
+      if (result.fileRewind?.canRewind) {
+        const fileCount = result.fileRewind.filesChanged?.length ?? 0
+        toast.success('已回退到此处', {
+          description: fileCount > 0 ? `${fileCount} 个文件已恢复` : '文件无变化',
+        })
+      } else if (result.fileRewind?.error) {
+        toast.warning('已回退对话', {
+          description: `文件恢复不可用：${result.fileRewind.error}`,
+        })
+      } else {
+        toast.success('已回退到此处')
+      }
+    } catch (error) {
+      console.error('[AgentView] 回退失败:', error)
+      toast.error('回退失败', {
+        description: error instanceof Error ? error.message : '未知错误',
+      })
+    }
+  }, [sessionId, store])
+
   // 监听快捷键系统分发的 stop-generation 事件（Cmd+.）
   React.useEffect(() => {
     const handler = (): void => {
@@ -1178,6 +1215,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           onRetry={handleRetry}
           onRetryInNewSession={handleRetryInNewSession}
           onFork={handleFork}
+          onRewind={handleRewind}
           onCompact={handleCompact}
         />
 

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -12,7 +12,7 @@
  */
 
 import * as React from 'react'
-import { Bot, Loader2, AlertTriangle, FileText, FileImage, Download, Split } from 'lucide-react'
+import { Bot, Loader2, AlertTriangle, FileText, FileImage, Download, Split, Undo2 } from 'lucide-react'
 import { useAtomValue } from 'jotai'
 import { cn } from '@/lib/utils'
 import { ImageLightbox } from '@/components/ui/image-lightbox'
@@ -323,6 +323,8 @@ export interface AssistantTurnRendererProps {
   basePath?: string
   /** 分叉回调（传入最后一条 assistant 消息的 uuid） */
   onFork?: (upToMessageUuid: string) => void
+  /** 回退回调（传入 assistant message uuid） */
+  onRewind?: (assistantMessageUuid: string) => void
   /** 是否正在流式输出中（隐藏操作栏） */
   isStreaming?: boolean
   /** 是否被用户中断 */
@@ -331,7 +333,7 @@ export interface AssistantTurnRendererProps {
   sessionModelId?: string
 }
 
-export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, isStreaming, stoppedByUser, sessionModelId }: AssistantTurnRendererProps): React.ReactElement | null {
+export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, onRewind, isStreaming, stoppedByUser, sessionModelId }: AssistantTurnRendererProps): React.ReactElement | null {
   const channels = useAtomValue(channelsAtom)
   // 收集所有 assistant 消息的内容块，保留 parent_tool_use_id 关联
   interface EnrichedBlock {
@@ -546,7 +548,7 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, isS
         const lastUuid = turn.assistantMessages.length > 0
           ? turn.assistantMessages[turn.assistantMessages.length - 1]?.uuid
           : undefined
-        const hasActions = !!(textContent || (onFork && lastUuid))
+        const hasActions = !!(textContent || (onFork && lastUuid) || (onRewind && lastUuid))
         const hasDuration = durationMs != null
         if (!hasDuration && !hasActions && !stoppedByUser) return null
         return (
@@ -556,6 +558,11 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, isS
             {onFork && lastUuid && (
               <MessageAction tooltip="从此处分叉" onClick={() => onFork(lastUuid)}>
                 <Split className="size-3.5" />
+              </MessageAction>
+            )}
+            {onRewind && lastUuid && (
+              <MessageAction tooltip="回退到此处" onClick={() => onRewind(lastUuid)}>
+                <Undo2 className="size-3.5" />
               </MessageAction>
             )}
             {stoppedByUser && (
@@ -855,6 +862,7 @@ export interface MessageGroupRendererProps {
   allMessages: SDKMessage[]
   basePath?: string
   onFork?: (upToMessageUuid: string) => void
+  onRewind?: (assistantMessageUuid: string) => void
   /** 是否正在流式输出中（隐藏操作栏） */
   isStreaming?: boolean
   /** 是否被用户中断 */
@@ -929,7 +937,7 @@ export function getGroupPreview(group: MessageGroup): string {
   return texts.join(' ').slice(0, 200)
 }
 
-export function MessageGroupRenderer({ group, allMessages, basePath, onFork, isStreaming, stoppedByUser, sessionModelId }: MessageGroupRendererProps): React.ReactElement | null {
+export function MessageGroupRenderer({ group, allMessages, basePath, onFork, onRewind, isStreaming, stoppedByUser, sessionModelId }: MessageGroupRendererProps): React.ReactElement | null {
   const groupId = getGroupId(group)
 
   if (group.type === 'user') {
@@ -955,6 +963,7 @@ export function MessageGroupRenderer({ group, allMessages, basePath, onFork, isS
         allMessages={allMessages}
         basePath={basePath}
         onFork={onFork}
+        onRewind={onRewind}
         isStreaming={isStreaming}
         stoppedByUser={stoppedByUser}
         sessionModelId={sessionModelId}

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -530,12 +530,12 @@ export interface AgentSessionMeta {
   archived?: boolean
   /** 附加的外部目录路径列表（绝对路径，作为 SDK additionalDirectories 传递） */
   attachedDirectories?: string[]
-  /** 分叉来源：源会话的 SDK session ID（首次发消息时用于 resume + forkSession） */
-  forkedFromSdkSessionId?: string
-  /** 分叉截断点：源会话中的消息 uuid（inclusive） */
-  forkAtMessageUuid?: string
-  /** 分叉来源：源会话的 Proma 工作目录（SDK session 文件在此目录的项目空间中） */
+  /** 分叉来源：源会话的 Proma 工作目录（SDK session 文件在此目录的项目空间中，首次 resume 后清除） */
   forkSourceDir?: string
+  /** 分叉来源：源会话的 SDK session ID（用于 rewind 时读取源会话的 file-history-snapshot 和备份文件） */
+  forkSourceSdkSessionId?: string
+  /** 回退后的 resume 截断点：下次发消息时传给 SDK resumeSessionAt（消费后清除） */
+  resumeAtMessageUuid?: string
   /** 最后一次流式执行是否被用户主动中断 */
   stoppedByUser?: boolean
   /** 创建时间戳 */
@@ -748,6 +748,28 @@ export interface ForkSessionInput {
   sessionId: string
   /** SDK 消息 uuid（截断点，inclusive）。省略时复制全部历史 */
   upToMessageUuid?: string
+}
+
+/** 快照回退输入（同一会话内回退到指定点） */
+export interface RewindSessionInput {
+  /** Proma 会话 ID */
+  sessionId: string
+  /** 回退到哪条 assistant message（inclusive，截断该消息之后的一切） */
+  assistantMessageUuid: string
+}
+
+/** 快照回退结果 */
+export interface RewindSessionResult {
+  /** 截断后剩余的消息数 */
+  remainingMessages: number
+  /** 文件恢复结果（enableFileCheckpointing 启用时可用） */
+  fileRewind?: {
+    canRewind: boolean
+    error?: string
+    filesChanged?: string[]
+    insertions?: number
+    deletions?: number
+  }
 }
 
 // ===== 后台任务管理 =====
@@ -1129,6 +1151,8 @@ export const AGENT_IPC_CHANNELS = {
   MOVE_SESSION_TO_WORKSPACE: 'agent:move-session-to-workspace',
   /** 分叉会话（从指定消息处创建新会话） */
   FORK_SESSION: 'agent:fork-session',
+  /** 快照回退（同一会话内回退到指定点，恢复文件 + 截断对话） */
+  REWIND_SESSION: 'agent:rewind-session',
 
   // 工作区管理
   /** 获取工作区列表 */


### PR DESCRIPTION
## 核心提交

Agent 会话的两个关键能力：
1. **新增记忆点回退**：支持用户在同一会话内回到之前的对话点并恢复当时的上下文和文件状态（具备越界检测，恢复仅对会话工作区 + 附加文件夹范围内的文件生效）
2. **更新会话分叉机制**：新的 fork 功能基于SDK原生能力完成，设计为 fork 时会复制会话文件到 fork 的新会话

## 具体修改

### Snapshot Rewind（快照回退）
- **`agent-session-manager.ts`**：新增 `resolveUserUuidFromSDK()` 从 SDK JSONL 解析 user message UUID；新增 `rewindFilesFromSnapshot()` 直接解析 `file-history-snapshot` 恢复文件状态；新增 `truncateSDKMessages()` 截断 Proma JSONL
- **`agent-orchestrator.ts`**：新增 `rewindSession()` 编排方法，协调文件恢复 + 对话截断 + `resumeAtMessageUuid` 记录
- **`AgentView.tsx`**：添加回退按钮点击处理和 toast 反馈
- **`SDKMessageRenderer.tsx`**：在 assistant 消息气泡上显示回退按钮
- **`AgentMessages.tsx`**：传递 `onRewind` 回调

### Fork Refactor（分叉重构）
- **`agent-session-manager.ts`**：`forkAgentSession()` 改用 SDK 原生 `forkSession()`，自动复制工作区文件（排除 `.claude/`、`.context/`），新增 `forkSourceSdkSessionId` 追踪源会话
- Fork 会话支持回退：`resolveUserUuidFromSDK` 和 `rewindFilesFromSnapshot` 自动 fallback 到源 SDK JSONL

### 附加目录文件恢复
- SDK 对 `additionalDirectories` 下的文件使用绝对路径记录 snapshot
- `rewindFilesFromSnapshot` 区分绝对/相对路径，绝对路径校验是否属于附加目录
- `rewindSession` 从工作区配置获取附加目录（`getWorkspaceAttachedDirectories` + `getWorkspaceFilesDir`）

### 安全与质量
- 路径遍历防护：`filePath` 和 `backupFileName` 做 `resolve()` + `startsWith()` 越界检查
- Fork 操作 Promise 锁串行化，防止 `process.env.CLAUDE_CONFIG_DIR` 并发突变
- 移除 `findSdkSessionJsonl` 中无效的 projectDir 快速路径猜测

### 类型与 IPC
- **`agent.ts`**：新增 `ForkSessionInput`、`RewindSessionResult` 类型，`AgentSessionMeta` 增加 `forkSourceSdkSessionId`、`resumeAtMessageUuid` 字段
- **`ipc.ts`** / **`preload/index.ts`** / **`agent-service.ts`**：注册 `agent:fork-session`、`agent:rewind-session` IPC 通道

## 审查情况

- Sonnet 级别全量代码审查通过，11 项发现全部修复
- 用户手动测试通过：正常回退、fork 后回退、最后一轮回退、附加目录文件恢复均工作正常