### PR TITLE
feat: 工作区列表支持拖拽调整高度

### DIFF
--- a/apps/electron/src/renderer/atoms/sidebar-atoms.ts
+++ b/apps/electron/src/renderer/atoms/sidebar-atoms.ts
@@ -5,9 +5,16 @@
  */
 
 import { atom } from 'jotai'
+import { atomWithStorage } from 'jotai/utils'
 
 /** 侧边栏视图模式 */
 export type SidebarViewMode = 'active' | 'archived'
 
 /** 侧边栏视图模式（active = 显示活跃对话，archived = 显示已归档对话） */
 export const sidebarViewModeAtom = atom<SidebarViewMode>('active')
+
+/** 工作区列表高度（px），用户可拖拽调整，持久化到 localStorage */
+export const workspaceListHeightAtom = atomWithStorage<number>(
+  'proma-workspace-list-height',
+  120,
+)

--- a/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
@@ -24,11 +24,55 @@ import {
   agentWorkspacesAtom,
   currentAgentWorkspaceIdAtom,
 } from '@/atoms/agent-atoms'
+import { workspaceListHeightAtom } from '@/atoms/sidebar-atoms'
 import type { AgentWorkspace } from '@proma/shared'
 
 export function WorkspaceSelector(): React.ReactElement {
   const [workspaces, setWorkspaces] = useAtom(agentWorkspacesAtom)
   const [currentWorkspaceId, setCurrentWorkspaceId] = useAtom(currentAgentWorkspaceIdAtom)
+  const [listHeight, setListHeight] = useAtom(workspaceListHeightAtom)
+
+  // 高度拖拽调整
+  const listRef = React.useRef<HTMLDivElement>(null)
+  const resizing = React.useRef(false)
+  const startY = React.useRef(0)
+  const startH = React.useRef(0)
+  const cleanupResizeRef = React.useRef<(() => void) | null>(null)
+
+  React.useEffect(() => {
+    return () => { cleanupResizeRef.current?.() }
+  }, [])
+
+  const handleResizeStart = React.useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault()
+      resizing.current = true
+      startY.current = e.clientY
+      // 用实际渲染高度作为起点，避免 maxHeight > 实际高度时不跟手
+      startH.current = listRef.current?.getBoundingClientRect().height ?? 120
+
+      const onMove = (ev: MouseEvent): void => {
+        if (!resizing.current) return
+        const delta = ev.clientY - startY.current
+        const next = Math.min(400, Math.max(80, startH.current + delta))
+        setListHeight(next)
+      }
+      const onUp = (): void => {
+        resizing.current = false
+        document.removeEventListener('mousemove', onMove)
+        document.removeEventListener('mouseup', onUp)
+        document.body.style.cursor = ''
+        document.body.style.userSelect = ''
+        cleanupResizeRef.current = null
+      }
+      document.addEventListener('mousemove', onMove)
+      document.addEventListener('mouseup', onUp)
+      document.body.style.cursor = 'row-resize'
+      document.body.style.userSelect = 'none'
+      cleanupResizeRef.current = onUp
+    },
+    [setListHeight],
+  )
 
   // 新建状态
   const [creating, setCreating] = React.useState(false)
@@ -267,7 +311,11 @@ export function WorkspaceSelector(): React.ReactElement {
         </div>
 
         {/* 工作区列表 */}
-        <div className="max-h-[120px] overflow-y-auto scrollbar-thin flex flex-col p-1">
+        <div
+          ref={listRef}
+          className="overflow-y-auto scrollbar-thin flex flex-col p-1"
+          style={{ maxHeight: listHeight }}
+        >
           {workspaces.map((ws) => (
             <div key={ws.id} className="relative">
               {/* 上方插入指示线 */}
@@ -356,6 +404,14 @@ export function WorkspaceSelector(): React.ReactElement {
               />
             </div>
           )}
+        </div>
+
+        {/* 拖拽调整高度的 handle */}
+        <div
+          onMouseDown={handleResizeStart}
+          className="h-1 cursor-row-resize group/resize flex items-center justify-center hover:bg-foreground/[0.06] transition-colors titlebar-no-drag"
+        >
+          <div className="w-8 h-[2px] rounded-full bg-foreground/0 group-hover/resize:bg-foreground/20 transition-colors" />
         </div>
       </div>
 

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -735,7 +735,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       style={{ width: width ?? 280, minWidth: 180, flexShrink: 1 }}
     >
       {/* 顶部留空，避开 macOS 红绿灯 */}
-      <div className="pt-[50px]">
+      <div className="pt-[30px]">
         {/* 模式切换器 + 折叠按钮 */}
         <div className="flex items-start gap-1.5 px-3">
           <div className="flex-1 min-w-0">


### PR DESCRIPTION
## 问题根因

工作区列表固定 `max-h-[120px]`，工作区较多时只能看到约 4 个，需要滚动才能浏览全部，用户体验不佳。(#224)

## 具体修改

- **`sidebar-atoms.ts`** — 新增 `workspaceListHeightAtom`（atomWithStorage，默认 120px），持久化工作区列表高度
- **`WorkspaceSelector.tsx`** — 将硬编码 `max-h-[120px]` 替换为动态 `maxHeight`，底部添加拖拽 resize handle（范围 80-400px），使用 `getBoundingClientRect` 取实际渲染高度保证拖拽跟手，组件卸载时自动清理事件监听
- **`LeftSidebar.tsx`** — 侧边栏顶部留空从 50px 缩减至 30px，释放更多垂直空间

## 审查情况

- 自审查通过：事件监听正确清理、useCallback deps 优化、无副作用冲突
- 用户测试 OK