### PR TITLE
fix: rewind 并发安全与确认对话框

### DIFF
--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -20,6 +20,12 @@ import {
   getSdkConfigDir,
 } from './config-paths'
 import { getAgentWorkspace } from './agent-workspace-manager'
+
+// 在模块加载时一次性设置 SDK 配置目录，避免在 forkSession 等异步调用中临时修改/恢复
+// process.env 导致的并发安全问题（异步操作的 await 间隙其他代码可能读到错误值）
+if (!process.env.CLAUDE_CONFIG_DIR) {
+  process.env.CLAUDE_CONFIG_DIR = getSdkConfigDir()
+}
 import type { AgentSessionMeta, AgentMessage, SDKMessage, ForkSessionInput, AgentMessageSearchResult } from '@proma/shared'
 import { getConversationMessages } from './conversation-manager'
 import { clearNanoBananaAgentHistory } from './chat-tools/nano-banana-mcp'
@@ -493,9 +499,6 @@ export function migrateChatToAgentSession(conversationId: string, agentSessionId
   console.log(`[Agent 会话] 已迁移 ${count} 条消息到 Agent 会话 (${conversationId} → ${agentSessionId})`)
 }
 
-/** fork 操作串行锁，防止并发 forkAgentSession 调用导致 process.env 交叉突变 */
-let forkLock = Promise.resolve()
-
 /**
  * 分叉 Agent 会话（SDK 原生 fork）
  *
@@ -505,23 +508,11 @@ let forkLock = Promise.resolve()
  * forkSourceDir 用于首次 resume 时定位 SDK session 文件（因 fork 后的 session
  * 存储在源 cwd 的项目哈希下），orchestrator 首次 resume 后会清除该字段。
  *
+ * process.env.CLAUDE_CONFIG_DIR 已在模块加载时设置，无需在此处临时修改。
+ *
  * @returns 新创建的会话元数据
  */
 export async function forkAgentSession(input: ForkSessionInput): Promise<AgentSessionMeta> {
-  // 串行化：等待前一个 fork 操作完成，防止 process.env.CLAUDE_CONFIG_DIR 并发突变
-  const prev = forkLock
-  let releaseLock: () => void
-  forkLock = new Promise<void>((resolve) => { releaseLock = resolve })
-  await prev
-
-  try {
-    return await forkAgentSessionImpl(input)
-  } finally {
-    releaseLock!()
-  }
-}
-
-async function forkAgentSessionImpl(input: ForkSessionInput): Promise<AgentSessionMeta> {
   const { sessionId, upToMessageUuid } = input
 
   // 1. 获取源会话元数据
@@ -544,10 +535,7 @@ async function forkAgentSessionImpl(input: ForkSessionInput): Promise<AgentSessi
   }
 
   // 3. 调用 SDK 原生 forkSession
-  // SDK 的独立函数（forkSession）读取 process.env.CLAUDE_CONFIG_DIR 定位 session 文件
-  // Proma 使用隔离配置目录，必须在调用前设置
-  const prevConfigDir = process.env.CLAUDE_CONFIG_DIR
-  process.env.CLAUDE_CONFIG_DIR = getSdkConfigDir()
+  // process.env.CLAUDE_CONFIG_DIR 已在模块加载时设置，SDK 会自动读取
   const sdk = await import('@anthropic-ai/claude-agent-sdk')
   let forkResult: Awaited<ReturnType<typeof sdk.forkSession>>
   try {
@@ -564,13 +552,6 @@ async function forkAgentSessionImpl(input: ForkSessionInput): Promise<AgentSessi
       })
     } else {
       throw err
-    }
-  } finally {
-    // 恢复环境变量
-    if (prevConfigDir !== undefined) {
-      process.env.CLAUDE_CONFIG_DIR = prevConfigDir
-    } else {
-      delete process.env.CLAUDE_CONFIG_DIR
     }
   }
 

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -32,6 +32,16 @@ import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Switch } from '@/components/ui/switch'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import { cn } from '@/lib/utils'
 import { FeishuNotifyToggle } from '@/components/chat/FeishuNotifyToggle'
 import {
@@ -1129,13 +1139,21 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   }, [sessionId, openSession, setAgentSessions])
 
   /** 快照回退：同一会话内回退到指定消息点，恢复文件 + 截断对话 */
-  const handleRewind = React.useCallback(async (
-    assistantMessageUuid: string,
-  ): Promise<void> => {
+  const [rewindTargetUuid, setRewindTargetUuid] = React.useState<string | null>(null)
+
+  const handleRewindRequest = React.useCallback((assistantMessageUuid: string): void => {
+    setRewindTargetUuid(assistantMessageUuid)
+  }, [])
+
+  const handleRewindConfirm = React.useCallback(async (): Promise<void> => {
+    if (!rewindTargetUuid) return
+    const targetUuid = rewindTargetUuid
+    setRewindTargetUuid(null)
+
     try {
       const result = await window.electronAPI.rewindSession({
         sessionId,
-        assistantMessageUuid,
+        assistantMessageUuid: targetUuid,
       })
 
       // 刷新消息列表
@@ -1163,7 +1181,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         description: error instanceof Error ? error.message : '未知错误',
       })
     }
-  }, [sessionId, store])
+  }, [rewindTargetUuid, sessionId, store])
 
   // 监听快捷键系统分发的 stop-generation 事件（Cmd+.）
   React.useEffect(() => {
@@ -1194,6 +1212,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const canSend = (hasTextInput || pendingFiles.length > 0 || !!suggestion) && agentChannelId !== null && hasAvailableModel && (!streaming || hasTextInput)
 
   return (
+    <>
     <AgentSessionProvider sessionId={sessionId}>
       {/* 主内容区域 */}
       <div className="flex flex-col h-full flex-1 min-w-0 max-w-[min(72rem,100%)] mx-auto">
@@ -1215,7 +1234,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           onRetry={handleRetry}
           onRetryInNewSession={handleRetryInNewSession}
           onFork={handleFork}
-          onRewind={handleRewind}
+          onRewind={handleRewindRequest}
           onCompact={handleCompact}
         />
 
@@ -1432,5 +1451,30 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         )}
       </div>
     </AgentSessionProvider>
+
+    {/* 回退确认弹窗 */}
+    <AlertDialog
+      open={rewindTargetUuid !== null}
+      onOpenChange={(v) => { if (!v) setRewindTargetUuid(null) }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>确认回退</AlertDialogTitle>
+          <AlertDialogDescription>
+            回退将截断该消息之后的所有对话，并恢复文件到该时刻的状态。此操作不可撤销，确定要回退吗？
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>取消</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleRewindConfirm}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            回退
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- 模块加载时一次性设置 `CLAUDE_CONFIG_DIR`，移除 `forkAgentSession` 中的临时修改/恢复模式和 Promise 锁，消除 `await` 间隙的并发读取风险
- 回退操作添加 `AlertDialog` 确认弹窗，防止误触不可逆的对话截断和文件恢复

## Test plan
- [ ] Fork 会话功能正常工作（SDK 正确读取 `CLAUDE_CONFIG_DIR`）
- [ ] 点击回退按钮弹出确认对话框，取消后不执行回退
- [ ] 确认后回退正常执行，toast 反馈正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> Follow-up fix for PR #238