### PR TITLE
feat: add dismiss button to Agent interaction banners

### DIFF
--- a/apps/electron/src/renderer/components/agent/AskUserBanner.tsx
+++ b/apps/electron/src/renderer/components/agent/AskUserBanner.tsx
@@ -6,10 +6,10 @@
  */
 
 import * as React from 'react'
-import { useAtom } from 'jotai'
-import { Send } from 'lucide-react'
+import { useAtom, useSetAtom } from 'jotai'
+import { Send, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { allPendingAskUserRequestsAtom } from '@/atoms/agent-atoms'
+import { allPendingAskUserRequestsAtom, agentStreamingStatesAtom, finalizeStreamingActivities } from '@/atoms/agent-atoms'
 import type { AskUserQuestion } from '@proma/shared'
 
 interface QuestionAnswer {
@@ -27,6 +27,7 @@ interface AskUserBannerProps {
 
 export function AskUserBanner({ sessionId }: AskUserBannerProps): React.ReactElement | null {
   const [allRequests, setAllRequests] = useAtom(allPendingAskUserRequestsAtom)
+  const setStreamingStates = useSetAtom(agentStreamingStatesAtom)
   const requests = allRequests.get(sessionId) ?? []
   const [answers, setAnswers] = React.useState<Map<number, QuestionAnswer>>(new Map())
   const [submitting, setSubmitting] = React.useState(false)
@@ -115,6 +116,30 @@ export function AskUserBanner({ sessionId }: AskUserBannerProps): React.ReactEle
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [request?.requestId])
 
+  /** 关闭问题 & 终止 Agent */
+  const handleDismiss = (): void => {
+    // 立即标记 streaming 停止，避免 UI 残留
+    setStreamingStates((prev) => {
+      const current = prev.get(sessionId)
+      if (!current || !current.running) return prev
+      const map = new Map(prev)
+      map.set(sessionId, {
+        ...current,
+        running: false,
+        ...finalizeStreamingActivities(current.toolActivities, current.teammates),
+      })
+      return map
+    })
+    // 清除当前 session 所有待处理的 AskUser 请求
+    setAllRequests((prev) => {
+      const map = new Map(prev)
+      map.delete(sessionId)
+      return map
+    })
+    // 终止 Agent
+    window.electronAPI.stopAgent(sessionId).catch(console.error)
+  }
+
   if (!request) return null
 
   const getAnswer = (idx: number): QuestionAnswer => answers.get(idx) ?? EMPTY_ANSWER
@@ -189,9 +214,19 @@ export function AskUserBanner({ sessionId }: AskUserBannerProps): React.ReactEle
       <div className="px-4 pt-3 pb-2">
         <div className="flex items-center justify-between mb-2">
           <span className="text-sm font-medium text-foreground">Proma Agent 需要你的输入</span>
-          {requests.length > 1 && (
-            <span className="text-xs text-muted-foreground">(+{requests.length - 1})</span>
-          )}
+          <div className="flex items-center gap-1.5">
+            {requests.length > 1 && (
+              <span className="text-xs text-muted-foreground">(+{requests.length - 1})</span>
+            )}
+            <button
+              type="button"
+              className="size-5 flex items-center justify-center rounded-md text-muted-foreground/50 hover:text-foreground hover:bg-muted/60 transition-colors"
+              onClick={handleDismiss}
+              title="关闭并终止 Agent"
+            >
+              <X className="size-3.5" />
+            </button>
+          </div>
         </div>
 
         {/* Tab 栏（多问题时显示） */}

--- a/apps/electron/src/renderer/components/agent/ExitPlanModeBanner.tsx
+++ b/apps/electron/src/renderer/components/agent/ExitPlanModeBanner.tsx
@@ -11,7 +11,7 @@
  */
 
 import * as React from 'react'
-import { useAtom } from 'jotai'
+import { useAtom, useSetAtom } from 'jotai'
 import {
   Check,
   ShieldCheck,
@@ -21,7 +21,7 @@ import {
   FileText,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { allPendingExitPlanRequestsAtom } from '@/atoms/agent-atoms'
+import { allPendingExitPlanRequestsAtom, agentStreamingStatesAtom, finalizeStreamingActivities } from '@/atoms/agent-atoms'
 import type { ExitPlanModeAction, ExitPlanAllowedPrompt } from '@proma/shared'
 
 /** 选项定义 */
@@ -70,6 +70,7 @@ interface ExitPlanModeBannerProps {
 
 export function ExitPlanModeBanner({ sessionId }: ExitPlanModeBannerProps): React.ReactElement | null {
   const [allRequests, setAllRequests] = useAtom(allPendingExitPlanRequestsAtom)
+  const setStreamingStates = useSetAtom(agentStreamingStatesAtom)
   const requests = allRequests.get(sessionId) ?? []
   const [focusedIdx, setFocusedIdx] = React.useState(0)
   const [showFeedback, setShowFeedback] = React.useState(false)
@@ -118,6 +119,27 @@ export function ExitPlanModeBanner({ sessionId }: ExitPlanModeBannerProps): Reac
   }
 
   handleActionRef.current = handleAction
+
+  /** 关闭计划审批 & 终止 Agent */
+  const handleDismiss = (): void => {
+    setStreamingStates((prev) => {
+      const current = prev.get(sessionId)
+      if (!current || !current.running) return prev
+      const map = new Map(prev)
+      map.set(sessionId, {
+        ...current,
+        running: false,
+        ...finalizeStreamingActivities(current.toolActivities, current.teammates),
+      })
+      return map
+    })
+    setAllRequests((prev) => {
+      const map = new Map(prev)
+      map.delete(sessionId)
+      return map
+    })
+    window.electronAPI.stopAgent(sessionId).catch(console.error)
+  }
 
   // 键盘导航：只在 requestId 变化时重建 handler，内部通过 ref 读取最新值
   React.useEffect(() => {
@@ -185,7 +207,15 @@ export function ExitPlanModeBanner({ sessionId }: ExitPlanModeBannerProps): Reac
       <div className="px-4 pt-3 pb-2">
         <div className="flex items-center gap-2 mb-1">
           <FileText className="size-4 text-primary" />
-          <span className="text-sm font-medium text-foreground">Agent 计划待审批</span>
+          <span className="text-sm font-medium text-foreground flex-1">Agent 计划待审批</span>
+          <button
+            type="button"
+            className="size-5 flex items-center justify-center rounded-md text-muted-foreground/50 hover:text-foreground hover:bg-muted/60 transition-colors"
+            onClick={handleDismiss}
+            title="关闭并终止 Agent"
+          >
+            <X className="size-3.5" />
+          </button>
         </div>
         <p className="text-xs text-muted-foreground">
           Agent 已完成计划，请选择如何继续

--- a/apps/electron/src/renderer/components/agent/PermissionBanner.tsx
+++ b/apps/electron/src/renderer/components/agent/PermissionBanner.tsx
@@ -9,10 +9,10 @@
  */
 
 import * as React from 'react'
-import { useAtom } from 'jotai'
+import { useAtom, useSetAtom } from 'jotai'
 import { Shield, ShieldAlert, Check, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { allPendingPermissionRequestsAtom } from '@/atoms/agent-atoms'
+import { allPendingPermissionRequestsAtom, agentStreamingStatesAtom, finalizeStreamingActivities } from '@/atoms/agent-atoms'
 import type { DangerLevel } from '@proma/shared'
 
 /** 危险等级对应的图标颜色 */
@@ -38,6 +38,7 @@ interface PermissionBannerProps {
 
 export function PermissionBanner({ sessionId }: PermissionBannerProps): React.ReactElement | null {
   const [allRequests, setAllRequests] = useAtom(allPendingPermissionRequestsAtom)
+  const setStreamingStates = useSetAtom(agentStreamingStatesAtom)
   const requests = allRequests.get(sessionId) ?? []
   const [responding, setResponding] = React.useState(false)
   const respondRef = React.useRef<(behavior: 'allow' | 'deny', alwaysAllow?: boolean) => void>()
@@ -61,6 +62,27 @@ export function PermissionBanner({ sessionId }: PermissionBannerProps): React.Re
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [request?.requestId])
+
+  /** 关闭权限请求 & 终止 Agent */
+  const handleDismiss = (): void => {
+    setStreamingStates((prev) => {
+      const current = prev.get(sessionId)
+      if (!current || !current.running) return prev
+      const map = new Map(prev)
+      map.set(sessionId, {
+        ...current,
+        running: false,
+        ...finalizeStreamingActivities(current.toolActivities, current.teammates),
+      })
+      return map
+    })
+    setAllRequests((prev) => {
+      const map = new Map(prev)
+      map.delete(sessionId)
+      return map
+    })
+    window.electronAPI.stopAgent(sessionId).catch(console.error)
+  }
 
   if (!request) return null
 
@@ -114,9 +136,19 @@ export function PermissionBanner({ sessionId }: PermissionBannerProps): React.Re
             </span>
           )}
         </div>
-        <span className="text-xs text-muted-foreground font-mono">
-          {formatToolName(request.toolName)}
-        </span>
+        <div className="flex items-center gap-1.5">
+          <span className="text-xs text-muted-foreground font-mono">
+            {formatToolName(request.toolName)}
+          </span>
+          <button
+            type="button"
+            className="size-5 flex items-center justify-center rounded-md text-muted-foreground/50 hover:text-foreground hover:bg-muted/60 transition-colors"
+            onClick={handleDismiss}
+            title="关闭并终止 Agent"
+          >
+            <X className="size-3.5" />
+          </button>
+        </div>
       </div>
 
       {/* 命令/操作内容 */}


### PR DESCRIPTION
## Overview

Adds a close/dismiss button (X icon) to the top-right corner of all three Agent interaction banners: AskUserBanner, PermissionBanner, and ExitPlanModeBanner. Previously, users were forced to select an answer before they could stop the Agent — now they can simply click X to close the prompt and terminate the Agent in one action.

## Changes

- `apps/electron/src/renderer/components/agent/AskUserBanner.tsx` — Added X dismiss button in the header; added `handleDismiss()` that updates `streamingStates` (sets `running: false`, finalizes tool activities), clears pending AskUser requests from the Jotai atom, and calls `stopAgent`. Imported `useSetAtom`, `agentStreamingStatesAtom`, and `finalizeStreamingActivities`.

- `apps/electron/src/renderer/components/agent/PermissionBanner.tsx` — Same dismiss button and `handleDismiss()` logic for permission requests. The X button sits next to the tool name label in the header.

- `apps/electron/src/renderer/components/agent/ExitPlanModeBanner.tsx` — Same dismiss button and `handleDismiss()` logic for plan approval requests. The X button sits at the far right of the header row.

## How to Test

1. Start an Agent session and trigger a question (e.g., use AskUserQuestion tool)
2. Verify the X button appears in the top-right corner of the banner
3. Click X — the banner should disappear immediately, the Agent should stop, and the stop button / tool spinners should not linger
4. Repeat for permission requests (trigger a tool that needs approval) and plan mode (trigger ExitPlanMode)
5. Verify that after dismissing, the input area returns to normal state and you can send new messages

## Notes

- The dismiss behavior mirrors `handleStop` in AgentView.tsx — it updates `streamingStates` immediately before calling `stopAgent`, so there is no brief UI inconsistency (stop button / spinner lingering)
- Backend cleanup is handled via AbortSignal + finally block in the orchestrator, so dangling Promises are not an issue
- Keyboard event listeners registered via `useEffect` are properly cleaned up on component unmount