### PR TITLE
feat: Agent 交互横幅增加关闭按钮

### DIFF
--- a/apps/electron/src/renderer/components/agent/AskUserBanner.tsx
+++ b/apps/electron/src/renderer/components/agent/AskUserBanner.tsx
@@ -6,10 +6,10 @@
  */
 
 import * as React from 'react'
-import { useAtom } from 'jotai'
-import { Send } from 'lucide-react'
+import { useAtom, useSetAtom } from 'jotai'
+import { Send, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { allPendingAskUserRequestsAtom } from '@/atoms/agent-atoms'
+import { allPendingAskUserRequestsAtom, agentStreamingStatesAtom, finalizeStreamingActivities } from '@/atoms/agent-atoms'
 import type { AskUserQuestion } from '@proma/shared'
 
 interface QuestionAnswer {
@@ -27,6 +27,7 @@ interface AskUserBannerProps {
 
 export function AskUserBanner({ sessionId }: AskUserBannerProps): React.ReactElement | null {
   const [allRequests, setAllRequests] = useAtom(allPendingAskUserRequestsAtom)
+  const setStreamingStates = useSetAtom(agentStreamingStatesAtom)
   const requests = allRequests.get(sessionId) ?? []
   const [answers, setAnswers] = React.useState<Map<number, QuestionAnswer>>(new Map())
   const [submitting, setSubmitting] = React.useState(false)
@@ -115,6 +116,30 @@ export function AskUserBanner({ sessionId }: AskUserBannerProps): React.ReactEle
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [request?.requestId])
 
+  /** 关闭问题 & 终止 Agent */
+  const handleDismiss = (): void => {
+    // 立即标记 streaming 停止，避免 UI 残留
+    setStreamingStates((prev) => {
+      const current = prev.get(sessionId)
+      if (!current || !current.running) return prev
+      const map = new Map(prev)
+      map.set(sessionId, {
+        ...current,
+        running: false,
+        ...finalizeStreamingActivities(current.toolActivities, current.teammates),
+      })
+      return map
+    })
+    // 清除当前 session 所有待处理的 AskUser 请求
+    setAllRequests((prev) => {
+      const map = new Map(prev)
+      map.delete(sessionId)
+      return map
+    })
+    // 终止 Agent
+    window.electronAPI.stopAgent(sessionId).catch(console.error)
+  }
+
   if (!request) return null
 
   const getAnswer = (idx: number): QuestionAnswer => answers.get(idx) ?? EMPTY_ANSWER
@@ -189,9 +214,19 @@ export function AskUserBanner({ sessionId }: AskUserBannerProps): React.ReactEle
       <div className="px-4 pt-3 pb-2">
         <div className="flex items-center justify-between mb-2">
           <span className="text-sm font-medium text-foreground">Proma Agent 需要你的输入</span>
-          {requests.length > 1 && (
-            <span className="text-xs text-muted-foreground">(+{requests.length - 1})</span>
-          )}
+          <div className="flex items-center gap-1.5">
+            {requests.length > 1 && (
+              <span className="text-xs text-muted-foreground">(+{requests.length - 1})</span>
+            )}
+            <button
+              type="button"
+              className="size-5 flex items-center justify-center rounded-md text-muted-foreground/50 hover:text-foreground hover:bg-muted/60 transition-colors"
+              onClick={handleDismiss}
+              title="关闭并终止 Agent"
+            >
+              <X className="size-3.5" />
+            </button>
+          </div>
         </div>
 
         {/* Tab 栏（多问题时显示） */}

--- a/apps/electron/src/renderer/components/agent/ExitPlanModeBanner.tsx
+++ b/apps/electron/src/renderer/components/agent/ExitPlanModeBanner.tsx
@@ -11,7 +11,7 @@
  */
 
 import * as React from 'react'
-import { useAtom } from 'jotai'
+import { useAtom, useSetAtom } from 'jotai'
 import {
   Check,
   ShieldCheck,
@@ -21,7 +21,7 @@ import {
   FileText,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { allPendingExitPlanRequestsAtom } from '@/atoms/agent-atoms'
+import { allPendingExitPlanRequestsAtom, agentStreamingStatesAtom, finalizeStreamingActivities } from '@/atoms/agent-atoms'
 import type { ExitPlanModeAction, ExitPlanAllowedPrompt } from '@proma/shared'
 
 /** 选项定义 */
@@ -70,6 +70,7 @@ interface ExitPlanModeBannerProps {
 
 export function ExitPlanModeBanner({ sessionId }: ExitPlanModeBannerProps): React.ReactElement | null {
   const [allRequests, setAllRequests] = useAtom(allPendingExitPlanRequestsAtom)
+  const setStreamingStates = useSetAtom(agentStreamingStatesAtom)
   const requests = allRequests.get(sessionId) ?? []
   const [focusedIdx, setFocusedIdx] = React.useState(0)
   const [showFeedback, setShowFeedback] = React.useState(false)
@@ -118,6 +119,27 @@ export function ExitPlanModeBanner({ sessionId }: ExitPlanModeBannerProps): Reac
   }
 
   handleActionRef.current = handleAction
+
+  /** 关闭计划审批 & 终止 Agent */
+  const handleDismiss = (): void => {
+    setStreamingStates((prev) => {
+      const current = prev.get(sessionId)
+      if (!current || !current.running) return prev
+      const map = new Map(prev)
+      map.set(sessionId, {
+        ...current,
+        running: false,
+        ...finalizeStreamingActivities(current.toolActivities, current.teammates),
+      })
+      return map
+    })
+    setAllRequests((prev) => {
+      const map = new Map(prev)
+      map.delete(sessionId)
+      return map
+    })
+    window.electronAPI.stopAgent(sessionId).catch(console.error)
+  }
 
   // 键盘导航：只在 requestId 变化时重建 handler，内部通过 ref 读取最新值
   React.useEffect(() => {
@@ -185,7 +207,15 @@ export function ExitPlanModeBanner({ sessionId }: ExitPlanModeBannerProps): Reac
       <div className="px-4 pt-3 pb-2">
         <div className="flex items-center gap-2 mb-1">
           <FileText className="size-4 text-primary" />
-          <span className="text-sm font-medium text-foreground">Agent 计划待审批</span>
+          <span className="text-sm font-medium text-foreground flex-1">Agent 计划待审批</span>
+          <button
+            type="button"
+            className="size-5 flex items-center justify-center rounded-md text-muted-foreground/50 hover:text-foreground hover:bg-muted/60 transition-colors"
+            onClick={handleDismiss}
+            title="关闭并终止 Agent"
+          >
+            <X className="size-3.5" />
+          </button>
         </div>
         <p className="text-xs text-muted-foreground">
           Agent 已完成计划，请选择如何继续

--- a/apps/electron/src/renderer/components/agent/PermissionBanner.tsx
+++ b/apps/electron/src/renderer/components/agent/PermissionBanner.tsx
@@ -9,10 +9,10 @@
  */
 
 import * as React from 'react'
-import { useAtom } from 'jotai'
+import { useAtom, useSetAtom } from 'jotai'
 import { Shield, ShieldAlert, Check, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { allPendingPermissionRequestsAtom } from '@/atoms/agent-atoms'
+import { allPendingPermissionRequestsAtom, agentStreamingStatesAtom, finalizeStreamingActivities } from '@/atoms/agent-atoms'
 import type { DangerLevel } from '@proma/shared'
 
 /** 危险等级对应的图标颜色 */
@@ -38,6 +38,7 @@ interface PermissionBannerProps {
 
 export function PermissionBanner({ sessionId }: PermissionBannerProps): React.ReactElement | null {
   const [allRequests, setAllRequests] = useAtom(allPendingPermissionRequestsAtom)
+  const setStreamingStates = useSetAtom(agentStreamingStatesAtom)
   const requests = allRequests.get(sessionId) ?? []
   const [responding, setResponding] = React.useState(false)
   const respondRef = React.useRef<(behavior: 'allow' | 'deny', alwaysAllow?: boolean) => void>()
@@ -61,6 +62,27 @@ export function PermissionBanner({ sessionId }: PermissionBannerProps): React.Re
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [request?.requestId])
+
+  /** 关闭权限请求 & 终止 Agent */
+  const handleDismiss = (): void => {
+    setStreamingStates((prev) => {
+      const current = prev.get(sessionId)
+      if (!current || !current.running) return prev
+      const map = new Map(prev)
+      map.set(sessionId, {
+        ...current,
+        running: false,
+        ...finalizeStreamingActivities(current.toolActivities, current.teammates),
+      })
+      return map
+    })
+    setAllRequests((prev) => {
+      const map = new Map(prev)
+      map.delete(sessionId)
+      return map
+    })
+    window.electronAPI.stopAgent(sessionId).catch(console.error)
+  }
 
   if (!request) return null
 
@@ -114,9 +136,19 @@ export function PermissionBanner({ sessionId }: PermissionBannerProps): React.Re
             </span>
           )}
         </div>
-        <span className="text-xs text-muted-foreground font-mono">
-          {formatToolName(request.toolName)}
-        </span>
+        <div className="flex items-center gap-1.5">
+          <span className="text-xs text-muted-foreground font-mono">
+            {formatToolName(request.toolName)}
+          </span>
+          <button
+            type="button"
+            className="size-5 flex items-center justify-center rounded-md text-muted-foreground/50 hover:text-foreground hover:bg-muted/60 transition-colors"
+            onClick={handleDismiss}
+            title="关闭并终止 Agent"
+          >
+            <X className="size-3.5" />
+          </button>
+        </div>
       </div>
 
       {/* 命令/操作内容 */}


### PR DESCRIPTION
## 概述

为 Agent 模式下的三个交互横幅（AskUserBanner、PermissionBanner、ExitPlanModeBanner）的右上角添加了 X 关闭按钮。之前用户在面对 Agent 提问/权限确认/计划审批时，必须选择一个答案才能继续操作；现在可以直接点 X 关闭提示并终止 Agent。

## 改动内容

- `apps/electron/src/renderer/components/agent/AskUserBanner.tsx` — 头部右上角添加 X 关闭按钮；新增 `handleDismiss()` 方法：立即更新 `streamingStates`（设 `running: false`、finalize tool activities）→ 清除 Jotai atom 中该 session 的所有待处理请求 → 调用 `stopAgent` 终止 Agent。新增 `useSetAtom`、`agentStreamingStatesAtom`、`finalizeStreamingActivities` 导入。

- `apps/electron/src/renderer/components/agent/PermissionBanner.tsx` — 同上，X 按钮位于工具名称右侧。

- `apps/electron/src/renderer/components/agent/ExitPlanModeBanner.tsx` — 同上，X 按钮位于标题栏最右侧。

## 测试方法

1. 启动 Agent 会话，触发 AskUserQuestion（例如让 Agent 使用提问工具）
2. 确认横幅右上角出现 X 按钮
3. 点击 X — 横幅应立即消失，Agent 应停止运行，停止按钮和 tool spinner 不应残留
4. 对权限请求（触发需要审批的工具）和计划模式（触发 ExitPlanMode）重复以上测试
5. 确认关闭后输入区域恢复正常，可以正常发送新消息

## 补充说明

- 关闭行为与 AgentView.tsx 中的 `handleStop` 一致 — 先立即更新 `streamingStates` 再调用 `stopAgent`，不会出现 UI 短暂不一致
- 后端清理通过 AbortSignal + orchestrator finally 块双重保障，不会有 Promise 泄露
- 组件卸载时 `useEffect` 注册的键盘监听器会正常清理