### PR TITLE
fix: idle timeout 在等待用户交互时误触发重试

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -1072,6 +1072,9 @@ export class AgentOrchestrator {
       /** Plan 模式是否已被 Agent 进入（初始 plan 模式时天然为 true，其他模式需 EnterPlanMode 触发） */
       let planModeEntered = initialPermissionMode === 'plan'
 
+      /** 正在等待用户交互（AskUser / ExitPlanMode 审批 / 权限确认），idle watcher 应暂停计时 */
+      let waitingForUserInput = false
+
       // 动态 canUseTool：每次调用读取当前权限模式，支持运行中切换
       const canUseTool = async (toolName: string, input: Record<string, unknown>, options: CanUseToolOptions): Promise<PermissionResult> => {
         const currentMode = getPermissionMode()
@@ -1112,19 +1115,24 @@ export class AgentOrchestrator {
           if (!planModeEntered) {
             return { behavior: 'allow' as const, updatedInput: input }
           }
-          const result = await handleExitPlanMode(input, options.signal)
-          if (result.behavior === 'allow' && 'targetMode' in result && result.targetMode) {
-            // 更新 Map，后续 canUseTool 调用使用新模式
-            this.sessionPermissionModes.set(sessionId, result.targetMode)
-            planModeEntered = false
-            // 同步通知 SDK 侧切换权限模式
-            if (this.adapter.setPermissionMode) {
-              this.adapter.setPermissionMode(sessionId, result.targetMode).catch((err: unknown) => {
-                console.warn(`[Agent 编排] SDK 权限模式切换失败:`, err)
-              })
+          waitingForUserInput = true
+          try {
+            const result = await handleExitPlanMode(input, options.signal)
+            if (result.behavior === 'allow' && 'targetMode' in result && result.targetMode) {
+              // 更新 Map，后续 canUseTool 调用使用新模式
+              this.sessionPermissionModes.set(sessionId, result.targetMode)
+              planModeEntered = false
+              // 同步通知 SDK 侧切换权限模式
+              if (this.adapter.setPermissionMode) {
+                this.adapter.setPermissionMode(sessionId, result.targetMode).catch((err: unknown) => {
+                  console.warn(`[Agent 编排] SDK 权限模式切换失败:`, err)
+                })
+              }
             }
+            return result
+          } finally {
+            waitingForUserInput = false
           }
-          return result
         }
 
         // EnterPlanMode：标记进入状态，通知渲染进程
@@ -1136,12 +1144,17 @@ export class AgentOrchestrator {
 
         // AskUserQuestion：始终走交互式问答流程，不受权限模式影响
         if (toolName === 'AskUserQuestion') {
-          return askUserService.handleAskUserQuestion(
-            sessionId, input, options.signal,
-            (request: AskUserRequest) => {
-              this.eventBus.emit(sessionId, { kind: 'proma_event', event: { type: 'ask_user_request', request } })
-            },
-          )
+          waitingForUserInput = true
+          try {
+            return await askUserService.handleAskUserQuestion(
+              sessionId, input, options.signal,
+              (request: AskUserRequest) => {
+                this.eventBus.emit(sessionId, { kind: 'proma_event', event: { type: 'ask_user_request', request } })
+              },
+            )
+          } finally {
+            waitingForUserInput = false
+          }
         }
 
         // ── 普通工具的权限分派 ──
@@ -1187,8 +1200,14 @@ export class AgentOrchestrator {
             return { behavior: 'deny' as const, message: '计划模式下不允许执行写操作，请在计划审批通过后再执行' }
           }
 
-          case 'acceptEdits':
-            return acceptEditsCanUseTool(toolName, input, options)
+          case 'acceptEdits': {
+            waitingForUserInput = true
+            try {
+              return await acceptEditsCanUseTool(toolName, input, options)
+            } finally {
+              waitingForUserInput = false
+            }
+          }
 
           default:
             return { behavior: 'allow' as const, updatedInput: input }
@@ -1400,6 +1419,11 @@ export class AgentOrchestrator {
             while (!loopAbort.signal.aborted) {
               await timerWithAbort(CHECK_INTERVAL_MS, loopAbort.signal)
               if (loopAbort.signal.aborted) break
+              // 等待用户交互时（AskUser / 权限确认 / ExitPlanMode 审批）暂停 idle 计时
+              if (waitingForUserInput) {
+                lastActivityAt = Date.now()
+                continue
+              }
               if (Date.now() - lastActivityAt >= IDLE_TIMEOUT_MS) {
                 console.log(
                   `[Agent 编排] Idle timeout: 超过 ${IDLE_TIMEOUT_MS / 1000}s 无 SDK 事件，触发重试`,


### PR DESCRIPTION
## Overview

修复 idle timeout 在用户交互等待期间误触发自动重试的问题。当 Agent 发出 AskUserQuestion、ExitPlanMode 审批请求或 acceptEdits 权限确认时，`canUseTool` 回调会阻塞等待用户操作，期间 SDK 不产出新事件。idle watcher（120s 超时）无法区分"API 挂了"和"正在等用户回答"，导致会话被错误中断重试，用户回答后还需重复回答来自重试的相同问题。

## Changes

- `apps/electron/src/main/lib/agent-orchestrator.ts` — 添加 `waitingForUserInput` 标志：
  - 在 `canUseTool` 中 AskUserQuestion、ExitPlanMode、acceptEdits 三个阻塞等待分支设置/清除标志（try/finally 保证异常路径也能清除）
  - idle watcher 协程每 30s 检查时，若标志为 true 则重置 `lastActivityAt` 并跳过本轮超时判断

## How to Test

1. 启动 Proma，进入任意 Agent 会话（acceptEdits 或 plan 模式）
2. 触发 Agent 调用 AskUserQuestion（例如让 Agent 分析一个需要确认的任务）
3. 出现问题选项后**等待超过 120 秒**再回答
4. 验证：不应出现"Agent 响应超时，正在自动重试"的黄色提示
5. 同样测试 ExitPlanMode 审批和 acceptEdits 权限确认场景

## Notes

- acceptEdits 模式下即使工具命中白名单立即返回，`waitingForUserInput` 也会短暂闪烁 true→false，但 idle watcher 30s 检查间隔远大于此窗口，不会产生误判
- 修改仅涉及 1 个文件，TypeScript 类型检查和构建均通过