### PR TITLE
fix: idle timeout 忽略 Hook 阻塞时间 & Banner 增加终止按钮

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -1072,6 +1072,9 @@ export class AgentOrchestrator {
       /** Plan 模式是否已被 Agent 进入（初始 plan 模式时天然为 true，其他模式需 EnterPlanMode 触发） */
       let planModeEntered = initialPermissionMode === 'plan'
 
+      /** Hook 正在等待用户响应时为 true，抑制 idle timeout（权限审批、AskUserQuestion、ExitPlanMode） */
+      let hookPending = false
+
       // 动态 canUseTool：每次调用读取当前权限模式，支持运行中切换
       const canUseTool = async (toolName: string, input: Record<string, unknown>, options: CanUseToolOptions): Promise<PermissionResult> => {
         const currentMode = getPermissionMode()
@@ -1112,19 +1115,24 @@ export class AgentOrchestrator {
           if (!planModeEntered) {
             return { behavior: 'allow' as const, updatedInput: input }
           }
-          const result = await handleExitPlanMode(input, options.signal)
-          if (result.behavior === 'allow' && 'targetMode' in result && result.targetMode) {
-            // 更新 Map，后续 canUseTool 调用使用新模式
-            this.sessionPermissionModes.set(sessionId, result.targetMode)
-            planModeEntered = false
-            // 同步通知 SDK 侧切换权限模式
-            if (this.adapter.setPermissionMode) {
-              this.adapter.setPermissionMode(sessionId, result.targetMode).catch((err: unknown) => {
-                console.warn(`[Agent 编排] SDK 权限模式切换失败:`, err)
-              })
+          hookPending = true
+          try {
+            const result = await handleExitPlanMode(input, options.signal)
+            if (result.behavior === 'allow' && 'targetMode' in result && result.targetMode) {
+              // 更新 Map，后续 canUseTool 调用使用新模式
+              this.sessionPermissionModes.set(sessionId, result.targetMode)
+              planModeEntered = false
+              // 同步通知 SDK 侧切换权限模式
+              if (this.adapter.setPermissionMode) {
+                this.adapter.setPermissionMode(sessionId, result.targetMode).catch((err: unknown) => {
+                  console.warn(`[Agent 编排] SDK 权限模式切换失败:`, err)
+                })
+              }
             }
+            return result
+          } finally {
+            hookPending = false
           }
-          return result
         }
 
         // EnterPlanMode：标记进入状态，通知渲染进程
@@ -1136,12 +1144,17 @@ export class AgentOrchestrator {
 
         // AskUserQuestion：始终走交互式问答流程，不受权限模式影响
         if (toolName === 'AskUserQuestion') {
-          return askUserService.handleAskUserQuestion(
-            sessionId, input, options.signal,
-            (request: AskUserRequest) => {
-              this.eventBus.emit(sessionId, { kind: 'proma_event', event: { type: 'ask_user_request', request } })
-            },
-          )
+          hookPending = true
+          try {
+            return await askUserService.handleAskUserQuestion(
+              sessionId, input, options.signal,
+              (request: AskUserRequest) => {
+                this.eventBus.emit(sessionId, { kind: 'proma_event', event: { type: 'ask_user_request', request } })
+              },
+            )
+          } finally {
+            hookPending = false
+          }
         }
 
         // ── 普通工具的权限分派 ──
@@ -1188,7 +1201,12 @@ export class AgentOrchestrator {
           }
 
           case 'acceptEdits':
-            return acceptEditsCanUseTool(toolName, input, options)
+            hookPending = true
+            try {
+              return await acceptEditsCanUseTool(toolName, input, options)
+            } finally {
+              hookPending = false
+            }
 
           default:
             return { behavior: 'allow' as const, updatedInput: input }
@@ -1401,6 +1419,11 @@ export class AgentOrchestrator {
               await timerWithAbort(CHECK_INTERVAL_MS, loopAbort.signal)
               if (loopAbort.signal.aborted) break
               if (Date.now() - lastActivityAt >= IDLE_TIMEOUT_MS) {
+                // Hook 正在等待用户响应（权限审批、AskUserQuestion 等），不视为 idle
+                if (hookPending) {
+                  lastActivityAt = Date.now()
+                  continue
+                }
                 console.log(
                   `[Agent 编排] Idle timeout: 超过 ${IDLE_TIMEOUT_MS / 1000}s 无 SDK 事件，触发重试`,
                 )

--- a/apps/electron/src/renderer/components/agent/AskUserBanner.tsx
+++ b/apps/electron/src/renderer/components/agent/AskUserBanner.tsx
@@ -7,7 +7,7 @@
 
 import * as React from 'react'
 import { useAtom } from 'jotai'
-import { Send } from 'lucide-react'
+import { Send, Square } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { allPendingAskUserRequestsAtom } from '@/atoms/agent-atoms'
 import type { AskUserQuestion } from '@proma/shared'
@@ -171,6 +171,15 @@ export function AskUserBanner({ sessionId }: AskUserBannerProps): React.ReactEle
 
   submitRef.current = handleSubmit
 
+  const handleStop = (): void => {
+    setAllRequests((prev) => {
+      const map = new Map(prev)
+      map.delete(sessionId)
+      return map
+    })
+    window.electronAPI.stopAgent(sessionId).catch(console.error)
+  }
+
   const hasValidAnswers = questions.some((_, idx) => {
     const a = getAnswer(idx)
     return a.selected.length > 0 || (a.showCustom && a.customText.trim().length > 0)
@@ -249,6 +258,15 @@ export function AskUserBanner({ sessionId }: AskUserBannerProps): React.ReactEle
         <span className="text-[10px] text-muted-foreground/40 mr-auto">
           ↑↓ 选择 · Enter {isLastTab ? '确认' : '下一个'}
         </span>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={handleStop}
+          className="h-7 px-2 text-xs text-destructive hover:text-destructive hover:bg-destructive/10"
+        >
+          <Square className="size-3 mr-1" fill="currentColor" strokeWidth={0} />
+          终止
+        </Button>
         {isLastTab && (
           <Button
             variant="default"

--- a/apps/electron/src/renderer/components/agent/ExitPlanModeBanner.tsx
+++ b/apps/electron/src/renderer/components/agent/ExitPlanModeBanner.tsx
@@ -19,6 +19,7 @@ import {
   MessageSquare,
   Send,
   FileText,
+  Square,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { allPendingExitPlanRequestsAtom } from '@/atoms/agent-atoms'
@@ -118,6 +119,15 @@ export function ExitPlanModeBanner({ sessionId }: ExitPlanModeBannerProps): Reac
   }
 
   handleActionRef.current = handleAction
+
+  const handleStop = (): void => {
+    setAllRequests((prev) => {
+      const map = new Map(prev)
+      map.delete(sessionId)
+      return map
+    })
+    window.electronAPI.stopAgent(sessionId).catch(console.error)
+  }
 
   // 键盘导航：只在 requestId 变化时重建 handler，内部通过 ref 读取最新值
   React.useEffect(() => {
@@ -278,6 +288,15 @@ export function ExitPlanModeBanner({ sessionId }: ExitPlanModeBannerProps): Reac
         <span className="text-[10px] text-muted-foreground/40">
           点击选择 · ↑↓ Enter 确认 · 1-4 快速选择
         </span>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={handleStop}
+          className="ml-auto h-7 px-2 text-xs text-destructive hover:text-destructive hover:bg-destructive/10"
+        >
+          <Square className="size-3 mr-1" fill="currentColor" strokeWidth={0} />
+          终止
+        </Button>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

- **idle timeout Hook 感知**：120s idle timeout 在权限审批、AskUserQuestion、ExitPlanMode 等 Hook 等待用户响应期间暂停计时，避免误判为连接挂起触发重试
- **Banner 终止按钮**：AskUserBanner 和 ExitPlanModeBanner 底部增加"终止"按钮，解决这两个 Banner 替换输入区域后用户无法中止会话的问题

## 背景

PR #237 引入的 120s idle timeout 没有考虑 Hook 阻塞时间。`lastActivityAt` 只在 SDK 事件到达时更新，而 Hook 阻塞期间 SDK generator 被挂起无法产生事件，导致用户在弹窗上停留超过 120s 后会话被强制重试。

## 实现

### 后端（agent-orchestrator.ts）
- 在 `sendMessage()` 闭包内新增 `hookPending` 布尔变量
- 三个阻塞 Hook（ExitPlanMode、AskUserQuestion、acceptEdits）用 `try/finally` 包裹设置状态
- idle watcher 检测到 `hookPending === true` 时重置计时器并跳过超时判定

### 前端（AskUserBanner.tsx、ExitPlanModeBanner.tsx）
- 两个 Banner 底部 footer 各增加红色"终止"按钮（Square 图标）
- 点击后清理 Jotai atom pending request + 调用 `stopAgent(sessionId)`
- PermissionBanner 无需改动（不替换输入区域，停止按钮仍可用）

## Test plan

- [ ] acceptEdits 模式下触发工具调用，等待 >120s 后点击允许，验证不会触发重试
- [ ] AskUserQuestion 弹窗等待 >120s 后回答，验证不会触发重试
- [ ] 正常 SDK 挂起场景（无 Hook 阻塞），验证 120s 后仍能正确触发重试
- [ ] AskUserBanner 显示时点击"终止"按钮，验证会话正常终止
- [ ] ExitPlanModeBanner 显示时点击"终止"按钮，验证会话正常终止

🤖 Generated with [Claude Code](https://claude.com/claude-code)