### PR TITLE
feat: Agent Profile 全局配置体系（Phase 1-2）

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -24,6 +24,7 @@ for (const key of Object.keys(process.env)) {
 
 import { createApplicationMenu } from './menu'
 import { registerIpcHandlers } from './ipc'
+import { initAgentProfiles } from './lib/agent-profile-service'
 import { createTray, destroyTray } from './tray'
 import { initializeRuntime } from './lib/runtime-init'
 import { seedDefaultSkills } from './lib/config-paths'
@@ -231,6 +232,9 @@ app.whenReady().then(async () => {
   // Create application menu
   const menu = createApplicationMenu()
   Menu.setApplicationMenu(menu)
+
+  // 初始化 Agent Profile（确保预置通用助手存在）
+  initAgentProfiles()
 
   // Register IPC handlers
   registerIpcHandlers()

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -80,6 +80,7 @@ import type {
   WeChatConfig,
   WeChatBridgeState,
   SDKMessage,
+  WorkspaceCapabilitiesSummary,
 } from '@proma/shared'
 import type { UserProfile, AppSettings } from '../types'
 import { getRuntimeStatus, getGitRepoStatus } from './lib/runtime-init'
@@ -164,6 +165,14 @@ import {
   attachWorkspaceDirectory,
   detachWorkspaceDirectory,
 } from './lib/agent-workspace-manager'
+import {
+  listAgentProfiles,
+  getAgentProfile,
+  createAgentProfile,
+  updateAgentProfile,
+  deleteAgentProfile,
+} from './lib/agent-profile-service'
+import type { AgentProfile, AgentProfileCreateInput, AgentProfileUpdateInput } from '@proma/shared'
 import { getMemoryConfig, setMemoryConfig } from './lib/memory-service'
 import { getAllToolInfos } from './lib/chat-tool-registry'
 import { updateToolState, updateToolCredentials, getToolCredentials, addCustomTool, deleteCustomTool } from './lib/chat-tool-config'
@@ -993,6 +1002,58 @@ export function registerIpcHandlers(): void {
     AGENT_IPC_CHANNELS.UPDATE_SKILL_FROM_SOURCE,
     async (_, targetSlug: string, skillSlug: string): Promise<SkillMeta> => {
       return updateSkillFromSource(targetSlug, skillSlug)
+    }
+  )
+
+  // ===== Agent Profile 管理 =====
+
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.LIST_PROFILES,
+    async (): Promise<AgentProfile[]> => {
+      return listAgentProfiles()
+    }
+  )
+
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.GET_PROFILE,
+    async (_, id: string): Promise<AgentProfile | null> => {
+      return getAgentProfile(id)
+    }
+  )
+
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.CREATE_PROFILE,
+    async (_, input: AgentProfileCreateInput): Promise<AgentProfile> => {
+      return createAgentProfile(input)
+    }
+  )
+
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.UPDATE_PROFILE,
+    async (_, id: string, input: AgentProfileUpdateInput): Promise<AgentProfile | null> => {
+      return updateAgentProfile(id, input)
+    }
+  )
+
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.DELETE_PROFILE,
+    async (_, id: string): Promise<boolean> => {
+      return deleteAgentProfile(id)
+    }
+  )
+
+  // ===== 获取所有工作区的能力汇总 =====
+
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.LIST_ALL_CAPABILITIES,
+    async (): Promise<WorkspaceCapabilitiesSummary[]> => {
+      const workspaces = listAgentWorkspaces()
+      return workspaces.map((ws) => ({
+        workspaceId: ws.id,
+        workspaceName: ws.name,
+        workspaceSlug: ws.slug,
+        capabilities: getWorkspaceCapabilities(ws.slug),
+      }))
     }
   )
 
@@ -2325,6 +2386,7 @@ export function registerIpcHandlers(): void {
           mode: input.mode,
           text: input.text,
           files: input.files,
+          agentProfileId: input.agentProfileId,
         })
         mainWin.show()
         mainWin.focus()

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -16,12 +16,12 @@
 
 import { randomUUID } from 'node:crypto'
 import { homedir } from 'node:os'
-import { join, dirname } from 'node:path'
-import { existsSync, mkdirSync, symlinkSync, readFileSync, writeFileSync } from 'node:fs'
+import { join, dirname, resolve, sep } from 'node:path'
+import { existsSync, mkdirSync, symlinkSync, readFileSync, writeFileSync, rmSync, readdirSync } from 'node:fs'
 import { execFileSync } from 'node:child_process'
 import { createRequire } from 'node:module'
 import { app } from 'electron'
-import type { AgentSendInput, AgentMessage, AgentGenerateTitleInput, AgentProviderAdapter, TypedError, RetryAttempt, SDKMessage, SDKAssistantMessage, AgentStreamPayload, RewindSessionResult } from '@proma/shared'
+import type { AgentSendInput, AgentMessage, AgentGenerateTitleInput, AgentProviderAdapter, TypedError, RetryAttempt, SDKMessage, SDKAssistantMessage, AgentStreamPayload, RewindSessionResult, AgentProfileMcpRef, AgentProfileSkillRef, ThinkingConfig, AgentEffort } from '@proma/shared'
 import { SAFE_TOOLS } from '@proma/shared'
 import type { PermissionRequest, PromaPermissionMode, AskUserRequest, ExitPlanModeRequest } from '@proma/shared'
 import type { ClaudeAgentQueryOptions } from './adapters/claude-agent-adapter'
@@ -33,7 +33,7 @@ import { getFetchFn } from './proxy-fetch'
 import { getEffectiveProxyUrl } from './proxy-settings-service'
 import { appendSDKMessages, updateAgentSessionMeta, getAgentSessionMeta, getAgentSessionMessages, getAgentSessionSDKMessages, truncateSDKMessages, resolveUserUuidFromSDK, rewindFilesFromSnapshot } from './agent-session-manager'
 import { getAgentWorkspace, getWorkspaceMcpConfig, ensurePluginManifest, getWorkspacePermissionMode, setWorkspacePermissionMode } from './agent-workspace-manager'
-import { getAgentWorkspacePath, getAgentSessionWorkspacePath, getSdkConfigDir, getWorkspaceFilesDir } from './config-paths'
+import { getAgentWorkspacePath, getAgentSessionWorkspacePath, getSdkConfigDir, getWorkspaceFilesDir, getAgentProfilePluginDir } from './config-paths'
 import { getWorkspaceAttachedDirectories } from './agent-workspace-manager'
 import { getRuntimeStatus } from './runtime-init'
 import { getSettings } from './settings-service'
@@ -42,6 +42,7 @@ import { permissionService } from './agent-permission-service'
 import type { PermissionResult, CanUseToolOptions } from './agent-permission-service'
 import { askUserService } from './agent-ask-user-service'
 import { exitPlanService, type ExitPlanPermissionResult } from './agent-exit-plan-service'
+import { getAgentProfile } from './agent-profile-service'
 import { getMemoryConfig } from './memory-service'
 import { searchMemory, addMemory, formatSearchResult } from './memos-client'
 import {
@@ -532,6 +533,137 @@ export class AgentOrchestrator {
   }
 
   /**
+   * 根据 Agent Profile 的 enabledMcpServers 精确构建 MCP 服务器配置
+   * 只加载 Profile 指定的服务器（可能来自不同工作区），不加载工作区全量。
+   */
+  private buildProfileMcpServers(refs: AgentProfileMcpRef[]): Record<string, Record<string, unknown>> {
+    const mcpServers: Record<string, Record<string, unknown>> = {}
+    for (const ref of refs) {
+      const sourceWs = getAgentWorkspace(ref.workspaceId)
+      if (!sourceWs) continue
+      const sourceMcpCfg = getWorkspaceMcpConfig(sourceWs.slug)
+      const entry = sourceMcpCfg.servers?.[ref.serverName]
+      if (!entry || !entry.enabled) continue
+      if (mcpServers[ref.serverName]) continue // 避免同名冲突
+      if (entry.type === 'stdio' && entry.command) {
+        const mergedEnv: Record<string, string> = {
+          ...(process.env.PATH && { PATH: process.env.PATH }),
+          ...entry.env,
+        }
+        mcpServers[ref.serverName] = {
+          type: 'stdio',
+          command: entry.command,
+          ...(entry.args?.length && { args: entry.args }),
+          ...(Object.keys(mergedEnv).length > 0 && { env: mergedEnv }),
+          required: false,
+          startup_timeout_sec: entry.timeout ?? 30,
+        }
+      } else if ((entry.type === 'http' || entry.type === 'sse') && entry.url) {
+        mcpServers[ref.serverName] = {
+          type: entry.type,
+          url: entry.url,
+          ...(entry.headers && Object.keys(entry.headers).length > 0 && { headers: entry.headers }),
+          required: false,
+        }
+      }
+    }
+    if (Object.keys(mcpServers).length > 0) {
+      console.log(`[Agent 编排] 已加载 Agent Profile 指定的 ${Object.keys(mcpServers).length} 个 MCP 服务器`)
+    }
+    return mcpServers
+  }
+
+  /** 正在构建 plugin 目录的 profileId 集合，防止并发重建 */
+  private pluginBuildLocks = new Set<string>()
+
+  /**
+   * 为 Agent Profile 构建临时 plugin 目录，只 symlink Profile 选中的 Skills。
+   * 目录结构：
+   *   ~/.proma/.cache/agent-plugins/<profileId>/
+   *     .claude-plugin/plugin.json
+   *     skills/
+   *       <skillName> -> <source workspace>/skills/<skillName>
+   *
+   * @returns 临时 plugin 目录的绝对路径，可直接作为 SDK plugin path
+   */
+  private buildProfilePluginDir(
+    profileId: string,
+    skillRefs: AgentProfileSkillRef[],
+  ): string {
+    const pluginDir = getAgentProfilePluginDir(profileId)
+    const skillsDir = join(pluginDir, 'skills')
+    const manifestDir = join(pluginDir, '.claude-plugin')
+
+    // 快速一致性检查：已有目录且 skill 列表未变 → 直接复用
+    if (existsSync(skillsDir)) {
+      const expected = new Set(skillRefs.map(r => r.skillName).sort())
+      try {
+        const existing = new Set(readdirSync(skillsDir).filter(n => !n.startsWith('.')).sort())
+        if (expected.size === existing.size && [...expected].every(s => existing.has(s))) {
+          return pluginDir
+        }
+      } catch { /* 读取失败则重建 */ }
+    }
+
+    // 并发守卫：同一 profileId 不允许并发重建
+    if (this.pluginBuildLocks.has(profileId)) {
+      // 另一个 session 正在构建，直接返回目录路径（即使目录可能不完整，
+      // SDK 在加载时会容错处理缺失的 skill）
+      console.warn(`[Agent 编排] Profile ${profileId} 的 plugin 目录正在被另一个会话构建，跳过重建`)
+      return pluginDir
+    }
+
+    this.pluginBuildLocks.add(profileId)
+    try {
+      // 需要重建：清除旧目录
+      if (existsSync(pluginDir)) {
+        rmSync(pluginDir, { recursive: true, force: true })
+      }
+
+      // 创建目录结构
+      mkdirSync(skillsDir, { recursive: true })
+      mkdirSync(manifestDir, { recursive: true })
+
+      // 写入 plugin.json
+      writeFileSync(
+        join(manifestDir, 'plugin.json'),
+        JSON.stringify({ name: `proma-agent-${profileId}`, version: '1.0.0' }),
+      )
+
+      // 为每个 skillRef 创建 symlink（校验路径防穿越）
+      for (const ref of skillRefs) {
+        const sourceWs = getAgentWorkspace(ref.workspaceId)
+        if (!sourceWs) continue
+        const sourceSkillDir = join(getAgentWorkspacePath(sourceWs.slug), 'skills', ref.skillName)
+        if (!existsSync(sourceSkillDir)) continue
+        const targetLink = resolve(skillsDir, ref.skillName)
+        // 防止路径穿越：确保 targetLink 在 skillsDir 内
+        if (!targetLink.startsWith(skillsDir + sep)) continue
+        try {
+          symlinkSync(sourceSkillDir, targetLink, 'dir')
+        } catch (err) {
+          console.warn(`[Agent 编排] 创建 Skill symlink 失败: ${ref.skillName}`, err)
+        }
+      }
+
+      console.log(`[Agent 编排] 已构建 Profile plugin 目录: ${pluginDir} (${skillRefs.length} skills)`)
+    } finally {
+      this.pluginBuildLocks.delete(profileId)
+    }
+    return pluginDir
+  }
+
+  /**
+   * 清理 Agent Profile 的临时 plugin 目录
+   */
+  static cleanupProfilePluginDir(profileId: string): void {
+    const pluginDir = getAgentProfilePluginDir(profileId)
+    if (existsSync(pluginDir)) {
+      rmSync(pluginDir, { recursive: true, force: true })
+    }
+  }
+
+  /**
    * 注入 SDK 内置记忆工具（全局，不依赖工作区）
    */
   private async injectMemoryTools(
@@ -752,7 +884,47 @@ export class AgentOrchestrator {
    * 通过 EventBus 分发 AgentEvent，通过 callbacks 发送控制信号。
    */
   async sendMessage(input: AgentSendInput, callbacks: SessionCallbacks): Promise<void> {
-    const { sessionId, userMessage, channelId, modelId, workspaceId, additionalDirectories, customMcpServers, permissionModeOverride, mentionedSkills, mentionedMcpServers } = input
+    const { sessionId, userMessage, channelId: inputChannelId, modelId: inputModelId, workspaceId: inputWorkspaceId, additionalDirectories, customMcpServers, permissionModeOverride, mentionedSkills, mentionedMcpServers, agentProfileId } = input
+
+    // 读取 Agent Profile 配置（如果指定了）
+    let profileChannelId: string | undefined
+    let profileModelId: string | undefined
+    let profileWorkspaceId: string | undefined
+    let profileAdditionalPrompt: string | undefined
+    let profileMcpServerRefs: AgentProfileMcpRef[] | undefined
+    let profileSkillRefs: AgentProfileSkillRef[] | undefined
+    let profileThinking: ThinkingConfig | undefined
+    let profileEffort: AgentEffort | undefined
+    let profileMaxBudgetUsd: number | undefined
+    let profileMaxTurns: number | undefined
+
+    if (agentProfileId) {
+      const profile = getAgentProfile(agentProfileId)
+      if (profile) {
+        console.log(`[Agent 编排] 使用 Agent Profile: ${profile.name} (${profile.id})`)
+        profileChannelId = profile.defaultChannelId
+        profileModelId = profile.defaultModelId
+        profileWorkspaceId = profile.defaultWorkspaceId
+        profileAdditionalPrompt = profile.additionalPrompt
+        profileMcpServerRefs = profile.enabledMcpServers
+        profileSkillRefs = profile.enabledSkills
+        profileThinking = profile.thinking
+        profileEffort = profile.effort
+        profileMaxBudgetUsd = profile.maxBudgetUsd
+        profileMaxTurns = profile.maxTurns
+      }
+    }
+
+    // 配置优先级：
+    // - channelId/modelId: 会话输入（renderer per-session map）> Agent Profile > 全局默认
+    //   renderer 在选择 Agent 时已将 profile 的 channel/model 写入 session map，
+    //   用户手动切换模型时会覆盖 session map，因此 inputChannelId/inputModelId 始终是最终决策。
+    // - workspaceId: 会话输入 > Agent Profile（会话已有工作区上下文时不应被 profile 覆盖）
+    // - additionalPrompt/MCP/Skills: Agent Profile > 会话输入
+    const channelId = inputChannelId || profileChannelId || ''
+    const modelId = inputModelId || profileModelId
+    const workspaceId = inputWorkspaceId || profileWorkspaceId
+
     const stderrChunks: string[] = []
 
     // 0. 并发保护
@@ -948,7 +1120,11 @@ export class AgentOrchestrator {
       }
 
       // 10. 构建 MCP 服务器配置 + 记忆工具 + 生图工具 + 自定义工具
-      const mcpServers = this.buildMcpServers(workspaceSlug)
+      // 当 Agent Profile 指定了 enabledMcpServers（含空数组，表示"不使用 MCP"），
+      // 只加载 Profile 指定的 MCP 服务器（精确过滤），否则加载工作区全部 MCP 服务器（默认行为）。
+      const mcpServers = agentProfileId && profileMcpServerRefs !== undefined
+        ? this.buildProfileMcpServers(profileMcpServerRefs)
+        : this.buildMcpServers(workspaceSlug)
       await this.injectMemoryTools(sdk, mcpServers)
       await this.injectNanoBananaTools(sdk, mcpServers, sessionId, agentCwd)
 
@@ -1198,9 +1374,8 @@ export class AgentOrchestrator {
       // 13. 构建 Adapter 查询选项
       // 检测用户选用的模型是否为 Claude 系列，决定 SubAgent 是否使用独立模型分层
       const claudeAvailable = (modelId || DEFAULT_MODEL_ID).toLowerCase().includes('claude')
-      const maxTurns = appSettings.agentMaxTurns && appSettings.agentMaxTurns > 0
-        ? appSettings.agentMaxTurns
-        : undefined
+      const rawMaxTurns = profileMaxTurns ?? appSettings.agentMaxTurns
+      const maxTurns = rawMaxTurns && rawMaxTurns > 0 ? rawMaxTurns : undefined
       const queryOptions: ClaudeAgentQueryOptions = {
         sessionId,
         prompt: finalPrompt,
@@ -1232,13 +1407,29 @@ export class AgentOrchestrator {
             permissionMode: initialPermissionMode,
             memoryEnabled: (() => { const mc = getMemoryConfig(); return mc.enabled && !!mc.apiKey })(),
             claudeAvailable,
-          }),
+          }) + (profileAdditionalPrompt
+            ? `\n\n## Agent 角色附加指令\n\n${profileAdditionalPrompt}`
+            : ''),
         },
         resumeSessionId: existingSdkSessionId,
         // 回退后 resume：从指定消息处继续（SDK 在同一 JSONL 内创建分支）
         ...(rewindResumeAt && { resumeSessionAt: rewindResumeAt }),
         ...(Object.keys(mcpServers).length > 0 && { mcpServers }),
-        ...(workspaceSlug && { plugins: [{ type: 'local' as const, path: getAgentWorkspacePath(workspaceSlug) }] }),
+        // plugins: Agent Profile 指定 enabledSkills（含空数组表示"不使用 Skills"）时精确过滤，否则加载当前工作区全量
+        ...(() => {
+          const plugins: Array<{ type: 'local'; path: string }> = []
+          if (agentProfileId && profileSkillRefs !== undefined) {
+            // Profile 精确模式：构建临时 plugin 目录，只 symlink 选中的 Skills（空数组 = 不加载任何 Skill）
+            if (profileSkillRefs.length > 0) {
+              const profilePluginDir = this.buildProfilePluginDir(agentProfileId, profileSkillRefs)
+              plugins.push({ type: 'local' as const, path: profilePluginDir })
+            }
+          } else if (workspaceSlug) {
+            // 默认模式：加载当前工作区全部 Skills
+            plugins.push({ type: 'local' as const, path: getAgentWorkspacePath(workspaceSlug) })
+          }
+          return plugins.length > 0 ? { plugins } : {}
+        })(),
         // 合并用户附加目录 + 工作区附加目录 + 工作区文件目录
         ...(() => {
           const allDirs = [...(additionalDirectories || [])]
@@ -1258,12 +1449,15 @@ export class AgentOrchestrator {
         })(),
         // 启用文件检查点，支持 rewindFiles 回退
         enableFileCheckpointing: true,
-        // SDK 0.2.52+ 新增选项（从 settings 读取）
-        ...(appSettings.agentThinking && { thinking: appSettings.agentThinking }),
-        effort: appSettings.agentEffort ?? 'high',
-        ...(appSettings.agentMaxBudgetUsd != null && appSettings.agentMaxBudgetUsd > 0 && {
-          maxBudgetUsd: appSettings.agentMaxBudgetUsd,
+        // SDK 0.2.52+ 新增选项（Agent Profile > settings 全局默认）
+        ...((profileThinking ?? appSettings.agentThinking) && {
+          thinking: profileThinking ?? appSettings.agentThinking,
         }),
+        effort: profileEffort ?? appSettings.agentEffort ?? 'high',
+        ...(() => {
+          const budget = profileMaxBudgetUsd ?? appSettings.agentMaxBudgetUsd
+          return budget != null && budget > 0 ? { maxBudgetUsd: budget } : {}
+        })(),
         // 内置 SubAgent 定义（code-reviewer / explorer / researcher）
         // claudeAvailable=false 时 SubAgent 省略 model 字段，自动继承主 Agent 模型
         agents: buildBuiltinAgents(claudeAvailable),

--- a/apps/electron/src/main/lib/agent-profile-service.ts
+++ b/apps/electron/src/main/lib/agent-profile-service.ts
@@ -1,0 +1,154 @@
+/**
+ * Agent Profile 服务
+ *
+ * 管理全局 Agent Profile 的 CRUD 操作。
+ * 存储在 ~/.proma/agents.json
+ */
+
+import { readFileSync, writeFileSync, existsSync, rmSync } from 'node:fs'
+import { getAgentProfilesPath, getAgentProfilePluginDir } from './config-paths.ts'
+import type {
+  AgentProfile,
+  AgentProfileCreateInput,
+  AgentProfileUpdateInput,
+} from '@proma/shared'
+
+/** 预置通用助手 Agent 的固定 ID */
+const BUILTIN_AGENT_ID = 'builtin-general-assistant'
+
+/** 创建预置通用助手 Agent */
+function createBuiltinAgent(): AgentProfile {
+  const now = Date.now()
+  return {
+    id: BUILTIN_AGENT_ID,
+    name: '通用助手',
+    description: '通用 AI 助手，适用于各类任务',
+    icon: '🤖',
+    isBuiltin: true,
+    enabledMcpServers: [],
+    enabledSkills: [],
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+/** 读取所有 Agent Profile */
+function readProfiles(): AgentProfile[] {
+  const filePath = getAgentProfilesPath()
+  if (!existsSync(filePath)) return []
+  try {
+    return JSON.parse(readFileSync(filePath, 'utf-8')) as AgentProfile[]
+  } catch {
+    console.error('[Agent Profile] 读取 agents.json 失败')
+    return []
+  }
+}
+
+/** 写入所有 Agent Profile */
+function writeProfiles(profiles: AgentProfile[]): void {
+  const filePath = getAgentProfilesPath()
+  writeFileSync(filePath, JSON.stringify(profiles, null, 2), 'utf-8')
+}
+
+/**
+ * 初始化 Agent Profile 存储
+ * 确保预置通用助手 Agent 存在
+ */
+export function initAgentProfiles(): void {
+  const profiles = readProfiles()
+  const hasBuiltin = profiles.some((p) => p.isBuiltin)
+  if (!hasBuiltin) {
+    profiles.unshift(createBuiltinAgent())
+    writeProfiles(profiles)
+    console.log('[Agent Profile] 已创建预置通用助手 Agent')
+  }
+}
+
+/** 获取所有 Agent Profile */
+export function listAgentProfiles(): AgentProfile[] {
+  const profiles = readProfiles()
+  // 确保预置 Agent 始终排在最前
+  return profiles.sort((a, b) => {
+    if (a.isBuiltin && !b.isBuiltin) return -1
+    if (!a.isBuiltin && b.isBuiltin) return 1
+    return 0
+  })
+}
+
+/** 获取单个 Agent Profile */
+export function getAgentProfile(id: string): AgentProfile | null {
+  const profiles = readProfiles()
+  return profiles.find((p) => p.id === id) ?? null
+}
+
+/** 创建 Agent Profile */
+export function createAgentProfile(input: AgentProfileCreateInput): AgentProfile {
+  const profiles = readProfiles()
+  const now = Date.now()
+  const profile: AgentProfile = {
+    id: crypto.randomUUID(),
+    name: input.name,
+    description: input.description,
+    icon: input.icon,
+    defaultChannelId: input.defaultChannelId,
+    defaultModelId: input.defaultModelId,
+    thinking: input.thinking,
+    effort: input.effort,
+    maxBudgetUsd: input.maxBudgetUsd,
+    maxTurns: input.maxTurns,
+    enabledMcpServers: input.enabledMcpServers ?? [],
+    enabledSkills: input.enabledSkills ?? [],
+    additionalPrompt: input.additionalPrompt,
+    defaultWorkspaceId: input.defaultWorkspaceId,
+    createdAt: now,
+    updatedAt: now,
+  }
+  profiles.push(profile)
+  writeProfiles(profiles)
+  console.log(`[Agent Profile] 已创建: ${profile.name} (${profile.id})`)
+  return profile
+}
+
+/** 更新 Agent Profile */
+export function updateAgentProfile(id: string, input: AgentProfileUpdateInput): AgentProfile | null {
+  const profiles = readProfiles()
+  const index = profiles.findIndex((p) => p.id === id)
+  if (index === -1) return null
+
+  const existing = profiles[index]!
+  const updated: AgentProfile = {
+    ...existing,
+    ...input,
+    id: existing.id,
+    name: input.name ?? existing.name,
+    isBuiltin: existing.isBuiltin,
+    createdAt: existing.createdAt,
+    enabledMcpServers: input.enabledMcpServers ?? existing.enabledMcpServers,
+    enabledSkills: input.enabledSkills ?? existing.enabledSkills,
+    updatedAt: Date.now(),
+  }
+  profiles[index] = updated
+  writeProfiles(profiles)
+  console.log(`[Agent Profile] 已更新: ${updated.name} (${updated.id})`)
+  return updated
+}
+
+/** 删除 Agent Profile（预置 Agent 不可删除） */
+export function deleteAgentProfile(id: string): boolean {
+  const profiles = readProfiles()
+  const target = profiles.find((p) => p.id === id)
+  if (!target) return false
+  if (target.isBuiltin) {
+    console.warn('[Agent Profile] 预置 Agent 不可删除')
+    return false
+  }
+  const filtered = profiles.filter((p) => p.id !== id)
+  writeProfiles(filtered)
+  // 清理临时 plugin 目录
+  const pluginDir = getAgentProfilePluginDir(id)
+  if (existsSync(pluginDir)) {
+    rmSync(pluginDir, { recursive: true, force: true })
+  }
+  console.log(`[Agent Profile] 已删除: ${target.name} (${id})`)
+  return true
+}

--- a/apps/electron/src/main/lib/config-paths.ts
+++ b/apps/electron/src/main/lib/config-paths.ts
@@ -212,6 +212,28 @@ export function getAgentSessionMessagesPath(id: string): string {
 }
 
 /**
+ * 获取 Agent Profile 索引文件路径
+ *
+ * @returns ~/.proma/agents.json
+ */
+export function getAgentProfilesPath(): string {
+  return join(getConfigDir(), 'agents.json')
+}
+
+/**
+ * 获取 Agent Profile 临时 plugin 目录路径（用于 Skill 精确过滤）
+ *
+ * @returns ~/.proma/.cache/agent-plugins/<profileId>/
+ */
+export function getAgentProfilePluginDir(profileId: string): string {
+  // 校验 profileId 为 UUID 格式，防止路径穿越
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(profileId)) {
+    throw new Error(`无效的 profileId: ${profileId}`)
+  }
+  return join(getConfigDir(), '.cache', 'agent-plugins', profileId)
+}
+
+/**
  * 获取 Agent 工作区索引文件路径
  *
  * @returns ~/.proma/agent-workspaces.json

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -51,6 +51,7 @@ import type {
   SkillMeta,
   OtherWorkspaceSkillsGroup,
   WorkspaceCapabilities,
+  WorkspaceCapabilitiesSummary,
   FileEntry,
   FileSearchResult,
   EnvironmentCheckResult,
@@ -95,6 +96,9 @@ import type {
   WeChatBridgeState,
   AgentQueueMessageInput,
   PendingRequestsSnapshot,
+  AgentProfile,
+  AgentProfileCreateInput,
+  AgentProfileUpdateInput,
 } from '@proma/shared'
 import type { UserProfile, AppSettings, QuickTaskSubmitInput, QuickTaskOpenSessionData } from '../types'
 import { QUICK_TASK_IPC_CHANNELS } from '../types'
@@ -353,6 +357,26 @@ export interface ElectronAPI {
 
   /** 停止任务 */
   stopTask: (input: StopTaskInput) => Promise<void>
+
+  // ===== Agent Profile 管理 =====
+
+  /** 获取 Agent Profile 列表 */
+  listAgentProfiles: () => Promise<AgentProfile[]>
+
+  /** 获取单个 Agent Profile */
+  getAgentProfile: (id: string) => Promise<AgentProfile | null>
+
+  /** 创建 Agent Profile */
+  createAgentProfile: (input: AgentProfileCreateInput) => Promise<AgentProfile>
+
+  /** 更新 Agent Profile */
+  updateAgentProfile: (id: string, input: AgentProfileUpdateInput) => Promise<AgentProfile | null>
+
+  /** 删除 Agent Profile */
+  deleteAgentProfile: (id: string) => Promise<boolean>
+
+  /** 获取所有工作区的能力汇总（供 Agent Profile 编辑页） */
+  listAllCapabilities: () => Promise<WorkspaceCapabilitiesSummary[]>
 
   // ===== Agent 工作区管理相关 =====
 
@@ -1048,6 +1072,26 @@ const electronAPI: ElectronAPI = {
 
   stopTask: (input: StopTaskInput) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.STOP_TASK, input)
+  },
+
+  // Agent Profile 管理
+  listAgentProfiles: () => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.LIST_PROFILES)
+  },
+  getAgentProfile: (id: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.GET_PROFILE, id)
+  },
+  createAgentProfile: (input: AgentProfileCreateInput) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.CREATE_PROFILE, input)
+  },
+  updateAgentProfile: (id: string, input: AgentProfileUpdateInput) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.UPDATE_PROFILE, id, input)
+  },
+  deleteAgentProfile: (id: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.DELETE_PROFILE, id)
+  },
+  listAllCapabilities: () => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.LIST_ALL_CAPABILITIES)
   },
 
   // Agent 工作区管理

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -7,7 +7,7 @@
 
 import { atom } from 'jotai'
 import { atomFamily } from 'jotai/utils'
-import type { AgentSessionMeta, AgentMessage, AgentEvent, AgentWorkspace, AgentPendingFile, RetryAttempt, PromaPermissionMode, PermissionRequest, AskUserRequest, ExitPlanModeRequest, ThinkingConfig, AgentEffort, TaskUsage, SDKMessage } from '@proma/shared'
+import type { AgentSessionMeta, AgentMessage, AgentEvent, AgentWorkspace, AgentProfile, AgentPendingFile, RetryAttempt, PromaPermissionMode, PermissionRequest, AskUserRequest, ExitPlanModeRequest, ThinkingConfig, AgentEffort, TaskUsage, SDKMessage } from '@proma/shared'
 
 /** 活动状态 */
 export type ActivityStatus = 'pending' | 'running' | 'completed' | 'error' | 'backgrounded'
@@ -235,12 +235,19 @@ export function isActivityGroup(item: ActivityGroup | ToolActivity): item is Act
 export interface AgentPendingPrompt {
   sessionId: string
   message: string
+  /** 指定的 Agent Profile ID */
+  agentProfileId?: string
+  /** Profile 指定的渠道（用于 UI 显示和发送） */
+  profileChannelId?: string
+  /** Profile 指定的模型（用于 UI 显示和发送） */
+  profileModelId?: string
 }
 
 // ===== Atoms =====
 
 export const agentSessionsAtom = atom<AgentSessionMeta[]>([])
 export const agentWorkspacesAtom = atom<AgentWorkspace[]>([])
+export const agentProfilesAtom = atom<AgentProfile[]>([])
 export const currentAgentWorkspaceIdAtom = atom<string | null>(null)
 /** 全局默认渠道 ID（新会话继承用，从 settings.json 加载） */
 export const agentChannelIdAtom = atom<string | null>(null)
@@ -253,6 +260,8 @@ export const agentChannelIdsAtom = atom<string[]>([])
 export const agentSessionChannelMapAtom = atom<Map<string, string>>(new Map())
 /** Per-session 模型 ID Map — sessionId → modelId */
 export const agentSessionModelMapAtom = atom<Map<string, string>>(new Map())
+/** Per-session Agent Profile ID Map — sessionId → profileId（键不存在 = 未选择 Profile，使用全局默认） */
+export const agentSessionProfileMapAtom = atom<Map<string, string>>(new Map())
 export const currentAgentSessionIdAtom = atom<string | null>(null)
 export const currentAgentMessagesAtom = atom<AgentMessage[]>([])
 export const agentStreamingStatesAtom = atom<Map<string, AgentStreamState>>(new Map())

--- a/apps/electron/src/renderer/atoms/settings-tab.ts
+++ b/apps/electron/src/renderer/atoms/settings-tab.ts
@@ -11,7 +11,7 @@
 
 import { atom } from 'jotai'
 
-export type SettingsTab = 'general' | 'channels' | 'proxy' | 'appearance' | 'about' | 'agent' | 'prompts' | 'tools' | 'bots' | 'tutorial' | 'shortcuts'
+export type SettingsTab = 'general' | 'channels' | 'proxy' | 'appearance' | 'about' | 'agent' | 'agents' | 'prompts' | 'tools' | 'bots' | 'tutorial' | 'shortcuts'
 
 /** 当前设置标签页（不持久化，每次打开设置默认显示渠道） */
 export const settingsTabAtom = atom<SettingsTab>('channels')

--- a/apps/electron/src/renderer/components/agent/AgentSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentSelector.tsx
@@ -1,0 +1,84 @@
+/**
+ * AgentSelector — Agent Profile 选择器
+ *
+ * 集成在 AgentView 输入框底部工具栏，下拉选择当前会话的 Agent Profile。
+ * 默认显示"默认"（工作区隐式配置），可选择自定义 Agent Profile。
+ */
+
+import * as React from 'react'
+import { useAtomValue } from 'jotai'
+import { ChevronDown, Check } from 'lucide-react'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { agentProfilesAtom } from '@/atoms/agent-atoms'
+import type { AgentProfile } from '@proma/shared'
+
+interface AgentSelectorProps {
+  /** 当前选中的 Profile ID（null = 工作区隐式默认） */
+  selectedProfileId: string | null
+  /** 选择回调（null = 切回隐式默认） */
+  onSelect: (profile: AgentProfile | null) => void
+}
+
+export function AgentSelector({ selectedProfileId, onSelect }: AgentSelectorProps): React.ReactElement {
+  const [open, setOpen] = React.useState(false)
+  const profiles = useAtomValue(agentProfilesAtom)
+  const selectedProfile = selectedProfileId ? profiles.find((p) => p.id === selectedProfileId) : null
+
+  const handleSelect = (profile: AgentProfile | null): void => {
+    onSelect(profile)
+    setOpen(false)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+        >
+          <span className="text-sm leading-none">{selectedProfile?.icon || '🤖'}</span>
+          <span className="max-w-[100px] truncate">
+            {selectedProfile?.name || '默认'}
+          </span>
+          <ChevronDown className="size-3" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        side="top"
+        align="start"
+        className="w-52 p-1"
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
+        {/* 默认选项 */}
+        <button
+          type="button"
+          onClick={() => handleSelect(null)}
+          className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-xs hover:bg-accent transition-colors"
+        >
+          <span className="text-sm leading-none">⚙️</span>
+          <span className="flex-1 text-left truncate">默认（工作区配置）</span>
+          {!selectedProfileId && <Check className="size-3 text-primary" />}
+        </button>
+
+        {/* Profile 列表 */}
+        {profiles.map((profile) => (
+          <button
+            key={profile.id}
+            type="button"
+            onClick={() => handleSelect(profile)}
+            className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-xs hover:bg-accent transition-colors"
+          >
+            <span className="text-sm leading-none">{profile.icon || '🤖'}</span>
+            <div className="flex-1 min-w-0 text-left">
+              <div className="truncate">{profile.name}</div>
+              {profile.description && (
+                <div className="text-[10px] text-muted-foreground truncate">{profile.description}</div>
+              )}
+            </div>
+            {selectedProfileId === profile.id && <Check className="size-3 text-primary shrink-0" />}
+          </button>
+        ))}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -22,6 +22,7 @@ import { AgentHeader } from './AgentHeader'
 import { ContextUsageBadge } from './ContextUsageBadge'
 import { PermissionBanner } from './PermissionBanner'
 import { PermissionModeSelector } from './PermissionModeSelector'
+import { AgentSelector } from './AgentSelector'
 import { AskUserBanner } from './AskUserBanner'
 import { ExitPlanModeBanner } from './ExitPlanModeBanner'
 import { PlanModeDashedBorder } from './PlanModeDashedBorder'
@@ -70,6 +71,8 @@ import {
   agentPermissionModeMapAtom,
   agentDefaultPermissionModeAtom,
   agentSessionPathMapAtom,
+  agentSessionProfileMapAtom,
+  agentProfilesAtom,
   allPendingAskUserRequestsAtom,
   allPendingExitPlanRequestsAtom,
   finalizeStreamingActivities,
@@ -81,7 +84,7 @@ import { useOpenSession } from '@/hooks/useOpenSession'
 import { AgentSessionProvider } from '@/contexts/session-context'
 import { draftSessionIdsAtom } from '@/atoms/draft-session-atoms'
 import { sendWithCmdEnterAtom } from '@/atoms/shortcut-atoms'
-import type { AgentSendInput, AgentMessage, AgentPendingFile, ModelOption, SDKMessage } from '@proma/shared'
+import type { AgentSendInput, AgentMessage, AgentPendingFile, ModelOption, SDKMessage, AgentProfile } from '@proma/shared'
 import { fileToBase64 } from '@/lib/file-utils'
 
 /** 稳定的空 SDKMessage 数组引用，避免 ?? [] 每次创建新引用 */
@@ -191,6 +194,12 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const agentChannelId = sessionChannelMap.get(sessionId) ?? defaultChannelId
   const agentModelId = sessionModelMap.get(sessionId) ?? defaultModelId
   const agentChannelIds = useAtomValue(agentChannelIdsAtom)
+  // Per-session Agent Profile 选择
+  const sessionProfileMap = useAtomValue(agentSessionProfileMapAtom)
+  const setSessionProfileMap = useSetAtom(agentSessionProfileMapAtom)
+  const profiles = useAtomValue(agentProfilesAtom)
+  const currentProfileId = sessionProfileMap.get(sessionId) ?? null
+  const currentProfile = currentProfileId ? profiles.find(p => p.id === currentProfileId) ?? null : null
   const [agentThinking, setAgentThinking] = useAtom(agentThinkingAtom)
   const setSettingsOpen = useSetAtom(settingsOpenAtom)
   const setDraftSessionIds = useSetAtom(draftSessionIdsAtom)
@@ -473,12 +482,36 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     if (pendingPrompt.sessionId !== sessionId) return
     if (!agentChannelId || streaming) return
 
-    // 快照当前上下文
+    // 同步 pendingPrompt 的 agentProfileId + channel/model 到 per-session maps
+    if (pendingPrompt.agentProfileId) {
+      setSessionProfileMap(prev => {
+        const map = new Map(prev)
+        map.set(sessionId, pendingPrompt.agentProfileId!)
+        return map
+      })
+    }
+    if (pendingPrompt.profileChannelId) {
+      setSessionChannelMap(prev => {
+        const map = new Map(prev)
+        map.set(sessionId, pendingPrompt.profileChannelId!)
+        return map
+      })
+    }
+    if (pendingPrompt.profileModelId) {
+      setSessionModelMap(prev => {
+        const map = new Map(prev)
+        map.set(sessionId, pendingPrompt.profileModelId!)
+        return map
+      })
+    }
+
+    // 快照当前上下文（Profile 配置优先于全局默认）
     const snapshot = {
       message: pendingPrompt.message,
-      channelId: agentChannelId,
-      modelId: agentModelId || undefined,
+      channelId: pendingPrompt.profileChannelId || agentChannelId,
+      modelId: pendingPrompt.profileModelId || agentModelId || undefined,
       workspaceId: currentWorkspaceId || undefined,
+      agentProfileId: pendingPrompt.agentProfileId,
     }
     setPendingPrompt(null)
 
@@ -524,6 +557,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         channelId: snapshot.channelId,
         modelId: snapshot.modelId,
         workspaceId: snapshot.workspaceId,
+        agentProfileId: snapshot.agentProfileId,
       }
       window.electronAPI.sendAgentMessage(input).catch((error) => {
         console.error('[AgentView] 自动发送配置消息失败:', error)
@@ -534,7 +568,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         })
       })
     })
-  }, [messagesLoaded, pendingPrompt, sessionId, agentChannelId, agentModelId, currentWorkspaceId, streaming, setPendingPrompt, setStreamingStates])
+  }, [messagesLoaded, pendingPrompt, sessionId, agentChannelId, agentModelId, currentWorkspaceId, streaming, setPendingPrompt, setStreamingStates, setSessionProfileMap, setSessionChannelMap, setSessionModelMap])
 
   // ===== 附件处理 =====
 
@@ -753,6 +787,31 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     }).catch(console.error)
   }, [sessionId, setSessionChannelMap, setSessionModelMap, setDefaultChannelId, setDefaultModelId])
 
+  /** Agent 选择回调 */
+  const handleAgentSelect = React.useCallback((profile: AgentProfile | null): void => {
+    // 更新 per-session profile map
+    setSessionProfileMap(prev => {
+      const map = new Map(prev)
+      if (profile) map.set(sessionId, profile.id)
+      else map.delete(sessionId)
+      return map
+    })
+
+    // 如果 Profile 有默认渠道/模型，同步更新 per-session channel/model map
+    if (profile?.defaultChannelId) {
+      setSessionChannelMap(prev => { const m = new Map(prev); m.set(sessionId, profile.defaultChannelId!); return m })
+    }
+    if (profile?.defaultModelId) {
+      setSessionModelMap(prev => { const m = new Map(prev); m.set(sessionId, profile.defaultModelId!); return m })
+    }
+    // 更新思考 atom：有配置则应用，取消选择则重置
+    if (profile?.thinking) {
+      setAgentThinking(profile.thinking)
+    } else if (!profile) {
+      setAgentThinking(undefined)
+    }
+  }, [sessionId, setSessionProfileMap, setSessionChannelMap, setSessionModelMap, setAgentThinking])
+
   /** 构建 externalSelectedModel 给 ModelSelector */
   const externalSelectedModel = React.useMemo(() => {
     if (!agentChannelId || !agentModelId) return null
@@ -950,6 +1009,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       channelId: agentChannelId,
       modelId: agentModelId || undefined,
       workspaceId: currentWorkspaceId || undefined,
+      agentProfileId: currentProfileId || undefined,
       ...(attachedDirs.length > 0 && { additionalDirectories: attachedDirs }),
       // 解析用户消息中的 Skill/MCP 引用，传递结构化元数据给后端
       ...(() => {
@@ -974,7 +1034,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         return map
       })
     })
-  }, [inputContent, pendingFiles, attachedDirs, sessionId, agentChannelId, agentModelId, currentWorkspaceId, workspaces, streaming, suggestion, hasAvailableModel, store, setStreamingStates, setPendingFiles, setAgentStreamErrors, setPromptSuggestions, setInputContent, setLiveMessagesMap])
+  }, [inputContent, pendingFiles, attachedDirs, sessionId, agentChannelId, agentModelId, currentWorkspaceId, currentProfileId, workspaces, streaming, suggestion, hasAvailableModel, store, setStreamingStates, setPendingFiles, setAgentStreamErrors, setPromptSuggestions, setInputContent, setLiveMessagesMap])
 
   /** 停止生成 */
   const handleStop = React.useCallback((): void => {
@@ -1354,6 +1414,10 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
             {/* Footer 工具栏 */}
             <div className="flex items-center justify-between px-2 py-1 h-[48px] gap-4">
               <div className="flex items-center gap-1.5 flex-1 min-w-0">
+                <AgentSelector
+                  selectedProfileId={currentProfileId}
+                  onSelect={handleAgentSelect}
+                />
                 <ModelSelector
                   filterChannelIds={agentChannelIds}
                   externalSelectedModel={externalSelectedModel}

--- a/apps/electron/src/renderer/components/quick-task/QuickTaskApp.tsx
+++ b/apps/electron/src/renderer/components/quick-task/QuickTaskApp.tsx
@@ -7,6 +7,7 @@
 
 import React, { useState, useRef, useEffect, useCallback } from 'react'
 import { fileToBase64 } from '@/lib/file-utils'
+import type { AgentProfile } from '@proma/shared'
 
 /** 任务模式 */
 type TaskMode = 'chat' | 'agent'
@@ -34,8 +35,16 @@ export function QuickTaskApp(): React.ReactElement {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [modelInfo, setModelInfo] = useState<ModelInfo | null>(null)
   const [isDragOver, setIsDragOver] = useState(false)
+  const [agentProfiles, setAgentProfiles] = useState<AgentProfile[]>([])
+  const [selectedAgent, setSelectedAgent] = useState<AgentProfile | null>(null)
+  const [showAgentPicker, setShowAgentPicker] = useState(false)
+  const [agentFilterText, setAgentFilterText] = useState('')
+  const [pickerPos, setPickerPos] = useState({ left: 0, top: 0 })
+  const [pickerIndex, setPickerIndex] = useState(0)
+  const mirrorRef = useRef<HTMLDivElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const pickerRef = useRef<HTMLDivElement>(null)
 
   // 设置透明背景
   useEffect(() => {
@@ -44,11 +53,7 @@ export function QuickTaskApp(): React.ReactElement {
   }, [])
 
   // 加载默认模型信息
-  useEffect(() => {
-    loadModelInfo()
-  }, [mode])
-
-  async function loadModelInfo(): Promise<void> {
+  const loadModelInfo = useCallback(async (): Promise<void> => {
     try {
       const [settings, channels] = await Promise.all([
         window.electronAPI.getSettings(),
@@ -83,7 +88,18 @@ export function QuickTaskApp(): React.ReactElement {
     } catch {
       setModelInfo(null)
     }
-  }
+  }, [mode])
+
+  useEffect(() => {
+    loadModelInfo()
+  }, [loadModelInfo])
+
+  // Agent 模式下加载 Profile 列表
+  useEffect(() => {
+    if (mode === 'agent') {
+      window.electronAPI.listAgentProfiles().then(setAgentProfiles).catch(console.error)
+    }
+  }, [mode])
 
   // 聚焦输入框
   const focusInput = useCallback(() => {
@@ -97,11 +113,17 @@ export function QuickTaskApp(): React.ReactElement {
     const cleanup = window.electronAPI.onQuickTaskFocus(() => {
       setText('')
       setAttachments([])
+      setSelectedAgent(null)
+      setShowAgentPicker(false)
+      setAgentFilterText('')
+      setPickerIndex(0)
       focusInput()
       loadModelInfo()
+      // 每次聚焦时重新加载 Agent Profile 列表（设置页可能已新增/修改）
+      window.electronAPI.listAgentProfiles().then(setAgentProfiles).catch(console.error)
     })
     return cleanup
-  }, [focusInput])
+  }, [focusInput, loadModelInfo])
 
   // 初始聚焦
   useEffect(() => {
@@ -116,10 +138,57 @@ export function QuickTaskApp(): React.ReactElement {
     el.style.height = `${Math.min(el.scrollHeight, 160)}px`
   }, [text])
 
+  // 计算 @ 字符在 textarea 中的像素坐标（用 mirror div 技术）
+  const measureCaretPosition = useCallback((textUpToCaret: string) => {
+    const textarea = textareaRef.current
+    const mirror = mirrorRef.current
+    if (!textarea || !mirror) return { left: 0, top: 0 }
+
+    const style = getComputedStyle(textarea)
+    // 同步 mirror 样式
+    mirror.style.font = style.font
+    mirror.style.fontSize = style.fontSize
+    mirror.style.letterSpacing = style.letterSpacing
+    mirror.style.lineHeight = style.lineHeight
+    mirror.style.padding = style.padding
+    mirror.style.width = `${textarea.clientWidth}px`
+    mirror.style.wordWrap = style.wordWrap
+    mirror.style.whiteSpace = 'pre-wrap'
+    mirror.style.overflowWrap = style.overflowWrap
+
+    // 在 mirror 中放入 @ 前的文本 + 一个 marker span
+    mirror.textContent = ''
+    const textNode = document.createTextNode(textUpToCaret)
+    const marker = document.createElement('span')
+    marker.textContent = '@'
+    mirror.appendChild(textNode)
+    mirror.appendChild(marker)
+
+    const markerRect = marker.getBoundingClientRect()
+    const mirrorRect = mirror.getBoundingClientRect()
+
+    return {
+      left: markerRect.left - mirrorRect.left,
+      top: markerRect.top - mirrorRect.top + markerRect.height + 4,
+    }
+  }, [])
+
+  // 过滤后的 agent 列表
+  const filteredAgents = agentProfiles.filter((a) =>
+    !agentFilterText ||
+    a.name.toLowerCase().includes(agentFilterText.toLowerCase()) ||
+    a.description?.toLowerCase().includes(agentFilterText.toLowerCase())
+  )
+
   // 全局键盘事件
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent): void => {
       if (e.key === 'Escape') {
+        if (showAgentPicker) {
+          e.preventDefault()
+          setShowAgentPicker(false)
+          return
+        }
         e.preventDefault()
         window.electronAPI.hideQuickTask()
         return
@@ -142,7 +211,7 @@ export function QuickTaskApp(): React.ReactElement {
 
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [])
+  }, [showAgentPicker])
 
   // 添加文件为附件
   const addFiles = useCallback(async (files: File[]) => {
@@ -213,6 +282,17 @@ export function QuickTaskApp(): React.ReactElement {
     e.target.value = '' // 允许重复选择同一文件
   }, [addFiles])
 
+  // 选择 Agent
+  const selectAgent = useCallback((agent: AgentProfile) => {
+    setSelectedAgent(agent)
+    setShowAgentPicker(false)
+    setPickerIndex(0)
+    // 清除 @xxx 文本
+    const atIndex = text.lastIndexOf('@')
+    setText(atIndex !== -1 ? text.slice(0, atIndex) : '')
+    textareaRef.current?.focus()
+  }, [text])
+
   // 提交任务
   const handleSubmit = useCallback(async () => {
     const trimmed = text.trim()
@@ -226,6 +306,7 @@ export function QuickTaskApp(): React.ReactElement {
         files: attachments.map(({ filename, mediaType, base64, size }) => ({
           filename, mediaType, base64, size,
         })),
+        agentProfileId: selectedAgent?.id,
       })
       setText('')
       setAttachments([])
@@ -234,15 +315,49 @@ export function QuickTaskApp(): React.ReactElement {
     } finally {
       setIsSubmitting(false)
     }
-  }, [text, mode, attachments, isSubmitting])
+  }, [text, mode, attachments, isSubmitting, selectedAgent])
 
-  // Enter 提交，Shift+Enter 换行
+  // 键盘事件：Enter 提交 / Shift+Enter 换行 / 弹窗导航
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (showAgentPicker) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setPickerIndex((i) => Math.min(i + 1, filteredAgents.length - 1))
+        return
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setPickerIndex((i) => Math.max(i - 1, 0))
+        return
+      }
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault()
+        if (filteredAgents[pickerIndex]) {
+          selectAgent(filteredAgents[pickerIndex])
+        }
+        return
+      }
+      if (e.key === 'Tab') {
+        e.preventDefault()
+        if (filteredAgents[pickerIndex]) {
+          selectAgent(filteredAgents[pickerIndex])
+        }
+        return
+      }
+    }
+
     if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault()
       handleSubmit()
     }
-  }, [handleSubmit])
+  }, [handleSubmit, showAgentPicker, filteredAgents, pickerIndex, selectAgent])
+
+  // 滚动 picker 使高亮项可见
+  useEffect(() => {
+    if (!showAgentPicker || !pickerRef.current) return
+    const items = pickerRef.current.querySelectorAll('[data-picker-item]')
+    items[pickerIndex]?.scrollIntoView({ block: 'nearest' })
+  }, [pickerIndex, showAgentPicker])
 
   const hasContent = text.trim().length > 0 || attachments.length > 0
 
@@ -299,20 +414,145 @@ export function QuickTaskApp(): React.ReactElement {
           </div>
         </div>
 
-        {/* 输入区域 */}
-        <div className="flex-1 px-4 py-2">
-          <textarea
-            ref={textareaRef}
-            value={text}
-            onChange={(e) => setText(e.target.value)}
-            onKeyDown={handleKeyDown}
-            onPaste={handlePaste}
-            placeholder={mode === 'agent' ? '向 Proma 描述你的任务，Enter 发送...' : '向 Proma 发送消息，Enter 发送...'}
-            className="w-full resize-none bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/50 leading-relaxed"
-            style={{ minHeight: '60px', maxHeight: '160px' }}
-            disabled={isSubmitting}
-            rows={3}
+        {/* 输入区域 — 内联 mention + textarea */}
+        <div className="relative flex-1 px-4 py-2">
+          <div className="flex items-start gap-0 flex-wrap">
+            {/* 内联 Agent mention 标签 */}
+            {selectedAgent && mode === 'agent' && (
+              <span
+                className="inline-flex items-center gap-1 rounded-full bg-primary/10 pl-1.5 pr-1 py-0.5 text-xs text-primary mr-1.5 mt-[3px] shrink-0 group/mention cursor-default"
+              >
+                <span className="text-sm leading-none">{selectedAgent.icon || '🤖'}</span>
+                <span className="font-medium">{selectedAgent.name}</span>
+                <button
+                  type="button"
+                  onClick={() => setSelectedAgent(null)}
+                  className="ml-0.5 size-3.5 rounded-full flex items-center justify-center text-primary/40 hover:text-primary hover:bg-primary/10 transition-colors"
+                >
+                  <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round">
+                    <path d="M18 6 6 18" />
+                    <path d="m6 6 12 12" />
+                  </svg>
+                </button>
+              </span>
+            )}
+            <textarea
+              ref={textareaRef}
+              value={text}
+              onChange={(e) => {
+                const newText = e.target.value
+                setText(newText)
+                // Agent 模式下检测 @ 触发
+                if (mode === 'agent' && !selectedAgent) {
+                  const lastChar = newText.slice(-1)
+                  if (lastChar === '@') {
+                    setShowAgentPicker(true)
+                    setAgentFilterText('')
+                    setPickerIndex(0)
+                    // 用 mirror div 测量 @ 字符的位置
+                    requestAnimationFrame(() => {
+                      const atIdx = newText.lastIndexOf('@')
+                      const pos = measureCaretPosition(newText.slice(0, atIdx))
+                      setPickerPos(pos)
+                    })
+                  } else if (showAgentPicker) {
+                    const atIndex = newText.lastIndexOf('@')
+                    if (atIndex !== -1) {
+                      setAgentFilterText(newText.slice(atIndex + 1))
+                      setPickerIndex(0)
+                    } else {
+                      setShowAgentPicker(false)
+                    }
+                  }
+                }
+              }}
+              onKeyDown={handleKeyDown}
+              onPaste={handlePaste}
+              placeholder={
+                mode === 'agent'
+                  ? (selectedAgent
+                      ? `向 ${selectedAgent.name} 描述任务，Enter 发送...`
+                      : '输入 @ 选择 Agent，或直接描述任务...')
+                  : '向 Proma 发送消息，Enter 发送...'
+              }
+              className="flex-1 min-w-0 resize-none bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/50 leading-relaxed"
+              style={{ minHeight: '60px', maxHeight: '160px' }}
+              disabled={isSubmitting}
+              rows={3}
+            />
+          </div>
+
+          {/* Mirror div（不可见），用于精确计算 @ 字符位置 */}
+          <div
+            ref={mirrorRef}
+            aria-hidden="true"
+            className="invisible absolute overflow-hidden whitespace-pre-wrap break-words"
+            style={{ top: 0, left: 0, pointerEvents: 'none' }}
           />
+
+          {/* Agent 选择弹窗 — 紧跟 @ 字符 */}
+          {showAgentPicker && mode === 'agent' && (
+            <div
+              ref={pickerRef}
+              className="absolute w-52 max-h-44 overflow-hidden rounded-xl border border-border/60 bg-popover/95 backdrop-blur-xl shadow-xl shadow-black/10 z-50"
+              style={{
+                left: `${Math.min(Math.max(pickerPos.left, 0), (textareaRef.current?.clientWidth ?? 500) - 208)}px`,
+                top: `${pickerPos.top + 8}px`,
+              }}
+            >
+              {/* 搜索提示 */}
+              {agentFilterText && (
+                <div className="px-3 pt-2 pb-1">
+                  <span className="text-[10px] text-muted-foreground/50">搜索: {agentFilterText}</span>
+                </div>
+              )}
+              <div className="max-h-32 overflow-y-auto">
+                {filteredAgents.map((agent, idx) => (
+                  <button
+                    key={agent.id}
+                    type="button"
+                    data-picker-item
+                    className={`flex w-full items-center gap-2.5 px-3 py-2 text-left transition-colors ${
+                      idx === pickerIndex
+                        ? 'bg-accent text-accent-foreground'
+                        : 'text-foreground hover:bg-accent/50'
+                    }`}
+                    onClick={() => selectAgent(agent)}
+                    onMouseEnter={() => setPickerIndex(idx)}
+                  >
+                    <span className="flex size-7 items-center justify-center rounded-lg bg-muted text-sm shrink-0">
+                      {agent.icon || '🤖'}
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <div className="text-xs font-medium truncate">{agent.name}</div>
+                      {agent.description && (
+                        <div className="text-[11px] text-muted-foreground truncate leading-tight mt-0.5">{agent.description}</div>
+                      )}
+                    </div>
+                    {agent.isBuiltin && (
+                      <span className="text-[9px] text-muted-foreground/50 bg-muted rounded px-1 py-0.5 shrink-0">内置</span>
+                    )}
+                  </button>
+                ))}
+                {filteredAgents.length === 0 && (
+                  <div className="px-3 py-4 text-center text-xs text-muted-foreground/60">
+                    {agentProfiles.length === 0
+                      ? '暂无 Agent，在设置中创建'
+                      : '无匹配结果'
+                    }
+                  </div>
+                )}
+              </div>
+              {/* 底部操作提示 */}
+              {filteredAgents.length > 0 && (
+                <div className="border-t border-border/40 px-3 py-1.5 flex items-center gap-2 text-[10px] text-muted-foreground/40">
+                  <span>↑↓ 选择</span>
+                  <span>↵ 确认</span>
+                  <span>esc 取消</span>
+                </div>
+              )}
+            </div>
+          )}
         </div>
 
         {/* 附件预览区 */}

--- a/apps/electron/src/renderer/components/settings/AgentProfileForm.tsx
+++ b/apps/electron/src/renderer/components/settings/AgentProfileForm.tsx
@@ -1,0 +1,649 @@
+/**
+ * AgentProfileForm - Agent Profile 创建/编辑表单
+ *
+ * 包含 4 个区块：基础信息、模型配置、能力配置（MCP/Skills）、附加配置。
+ * 复用设置原语组件 + emoji-mart picker + chip 选择器。
+ */
+
+import * as React from 'react'
+import { ArrowLeft, ChevronDown, ChevronRight, Check, Plug, Sparkles } from 'lucide-react'
+import { toast } from 'sonner'
+import Picker from '@emoji-mart/react'
+import data from '@emoji-mart/data'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { cn } from '@/lib/utils'
+import type {
+  AgentProfile,
+  AgentProfileCreateInput,
+  AgentProfileMcpRef,
+  AgentProfileSkillRef,
+  Channel,
+  WorkspaceCapabilitiesSummary,
+  AgentWorkspace,
+  ThinkingConfig,
+  AgentEffort,
+} from '@proma/shared'
+import {
+  SettingsSection,
+  SettingsCard,
+  SettingsInput,
+  SettingsSelect,
+  SettingsSegmentedControl,
+  LABEL_CLASS,
+  DESCRIPTION_CLASS,
+} from './primitives'
+
+// ===== Types =====
+
+/** emoji-mart 选择回调的 emoji 对象类型 */
+interface EmojiMartEmoji {
+  id: string
+  name: string
+  native: string
+  unified: string
+  keywords: string[]
+  shortcodes: string
+}
+
+// ===== 辅助函数 =====
+
+function thinkingToValue(config: ThinkingConfig | undefined): string {
+  if (!config) return 'default'
+  if (config.type === 'adaptive') return 'adaptive'
+  if (config.type === 'disabled') return 'disabled'
+  if (config.type === 'enabled') return 'enabled'
+  return 'default'
+}
+
+function valueToThinking(value: string, existing?: ThinkingConfig): ThinkingConfig | undefined {
+  if (value === 'adaptive') return { type: 'adaptive' }
+  if (value === 'disabled') return { type: 'disabled' }
+  // 保留已有 enabled 配置中的 budgetTokens，否则使用默认值
+  if (value === 'enabled') {
+    const budget = existing?.type === 'enabled' ? existing.budgetTokens : 10000
+    return { type: 'enabled', budgetTokens: budget }
+  }
+  return undefined
+}
+
+const THINKING_OPTIONS = [
+  { value: 'default', label: '默认' },
+  { value: 'enabled', label: '开启' },
+  { value: 'adaptive', label: '自适应' },
+  { value: 'disabled', label: '关闭' },
+]
+
+const EFFORT_OPTIONS = [
+  { value: 'default', label: '默认' },
+  { value: 'low', label: '低' },
+  { value: 'medium', label: '中' },
+  { value: 'high', label: '高' },
+  { value: 'max', label: '最大' },
+]
+
+/** 占位值：Radix Select 不允许 value="" */
+const NONE = '__none__'
+
+// ===== 主组件 =====
+
+interface AgentProfileFormProps {
+  /** 编辑模式传入已有 Profile，创建模式传 null */
+  profile: AgentProfile | null
+  onSaved: () => void
+  onCancel: () => void
+}
+
+export function AgentProfileForm({ profile, onSaved, onCancel }: AgentProfileFormProps): React.ReactElement {
+  const isEdit = profile !== null
+
+  // 基础信息
+  const [name, setName] = React.useState(profile?.name ?? '')
+  const [description, setDescription] = React.useState(profile?.description ?? '')
+  const [icon, setIcon] = React.useState(profile?.icon ?? '')
+  const [showEmojiPicker, setShowEmojiPicker] = React.useState(false)
+
+  // 模型配置
+  const [channelId, setChannelId] = React.useState(profile?.defaultChannelId || NONE)
+  const [modelId, setModelId] = React.useState(profile?.defaultModelId || NONE)
+  const [thinking, setThinking] = React.useState<ThinkingConfig | undefined>(profile?.thinking)
+  const [effort, setEffort] = React.useState<AgentEffort | undefined>(profile?.effort)
+  const [budgetStr, setBudgetStr] = React.useState(profile?.maxBudgetUsd != null ? String(profile.maxBudgetUsd) : '')
+  const [turnsStr, setTurnsStr] = React.useState(profile?.maxTurns != null ? String(profile.maxTurns) : '')
+  const [advancedOpen, setAdvancedOpen] = React.useState(
+    profile?.maxBudgetUsd != null || profile?.maxTurns != null
+  )
+
+  // 能力配置
+  const [enabledMcpServers, setEnabledMcpServers] = React.useState<AgentProfileMcpRef[]>(profile?.enabledMcpServers ?? [])
+  const [enabledSkills, setEnabledSkills] = React.useState<AgentProfileSkillRef[]>(profile?.enabledSkills ?? [])
+
+  // 附加配置
+  const [defaultWorkspaceId, setDefaultWorkspaceId] = React.useState(profile?.defaultWorkspaceId || NONE)
+  const [additionalPrompt, setAdditionalPrompt] = React.useState(profile?.additionalPrompt ?? '')
+
+  // 外部数据
+  const [channels, setChannels] = React.useState<Channel[]>([])
+  const [workspaces, setWorkspaces] = React.useState<AgentWorkspace[]>([])
+  const [allCapabilities, setAllCapabilities] = React.useState<WorkspaceCapabilitiesSummary[]>([])
+  const [saving, setSaving] = React.useState(false)
+
+  // 加载外部数据
+  React.useEffect(() => {
+    Promise.all([
+      window.electronAPI.listChannels(),
+      window.electronAPI.listAgentWorkspaces(),
+      window.electronAPI.listAllCapabilities(),
+    ]).then(([ch, ws, caps]) => {
+      setChannels(ch.filter((c) => c.enabled))
+      setWorkspaces(ws)
+      setAllCapabilities(caps)
+    }).catch((err) => {
+      console.error('[Agent Profile] 加载数据失败:', err)
+      toast.error('加载配置数据失败')
+    })
+  }, [])
+
+  // 渠道下的模型列表
+  const selectedChannel = channelId !== NONE ? channels.find((c) => c.id === channelId) : undefined
+  const modelOptions = selectedChannel?.models
+    ?.filter((m) => m.enabled !== false)
+    ?.map((m) => ({ value: m.id, label: m.name || m.id })) ?? []
+
+  // 切换渠道时重置模型
+  const handleChannelChange = (newChannelId: string): void => {
+    setChannelId(newChannelId)
+    setModelId(NONE)
+  }
+
+  // MCP checkbox 切换
+  const toggleMcpServer = (workspaceId: string, serverName: string): void => {
+    setEnabledMcpServers((prev) => {
+      const exists = prev.some((r) => r.workspaceId === workspaceId && r.serverName === serverName)
+      if (exists) {
+        return prev.filter((r) => !(r.workspaceId === workspaceId && r.serverName === serverName))
+      }
+      return [...prev, { workspaceId, serverName }]
+    })
+  }
+
+  // Skill checkbox 切换
+  const toggleSkill = (workspaceId: string, skillName: string): void => {
+    setEnabledSkills((prev) => {
+      const exists = prev.some((r) => r.workspaceId === workspaceId && r.skillName === skillName)
+      if (exists) {
+        return prev.filter((r) => !(r.workspaceId === workspaceId && r.skillName === skillName))
+      }
+      return [...prev, { workspaceId, skillName }]
+    })
+  }
+
+  // 检查是否选中
+  const isMcpSelected = (workspaceId: string, serverName: string): boolean =>
+    enabledMcpServers.some((r) => r.workspaceId === workspaceId && r.serverName === serverName)
+
+  const isSkillSelected = (workspaceId: string, skillName: string): boolean =>
+    enabledSkills.some((r) => r.workspaceId === workspaceId && r.skillName === skillName)
+
+  // 保存
+  const handleSave = async (): Promise<void> => {
+    if (!name.trim()) {
+      toast.error('请输入 Agent 名称')
+      return
+    }
+
+    const budget = parseFloat(budgetStr)
+    const turns = parseInt(turnsStr, 10)
+
+    const input: AgentProfileCreateInput = {
+      name: name.trim(),
+      description: description.trim() || undefined,
+      icon: icon.trim() || undefined,
+      defaultChannelId: channelId !== NONE ? channelId : undefined,
+      defaultModelId: modelId !== NONE ? modelId : undefined,
+      thinking,
+      effort,
+      maxBudgetUsd: !isNaN(budget) && budget > 0 ? budget : undefined,
+      maxTurns: !isNaN(turns) && turns > 0 ? turns : undefined,
+      enabledMcpServers,
+      enabledSkills,
+      additionalPrompt: additionalPrompt.trim() || undefined,
+      defaultWorkspaceId: defaultWorkspaceId !== NONE ? defaultWorkspaceId : undefined,
+    }
+
+    setSaving(true)
+    try {
+      if (isEdit) {
+        await window.electronAPI.updateAgentProfile(profile.id, input)
+        toast.success(`已更新 Agent「${name}」`)
+      } else {
+        await window.electronAPI.createAgentProfile(input)
+        toast.success(`已创建 Agent「${name}」`)
+      }
+      // 先重置 saving 再触发 onSaved（onSaved 可能导致组件卸载）
+      setSaving(false)
+      onSaved()
+    } catch (error) {
+      console.error('[Agent Profile] 保存失败:', error)
+      toast.error('保存失败')
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6 p-1">
+      {/* 顶部导航 + 实时预览 header */}
+      <div className="flex items-center gap-3 pb-2">
+        <button
+          onClick={onCancel}
+          className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors shrink-0"
+        >
+          <ArrowLeft size={18} />
+        </button>
+        <div className="flex items-center gap-2.5 min-w-0">
+          <div className="flex size-9 items-center justify-center rounded-xl bg-muted text-xl leading-none shrink-0">
+            {icon || '🤖'}
+          </div>
+          <div className="min-w-0">
+            <h3 className="text-base font-semibold leading-tight truncate">
+              {name || (isEdit ? profile.name : '新建 Agent')}
+            </h3>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              {isEdit ? '编辑 Agent 配置' : '新 Agent 配置'}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Section 1: 基础信息 — emoji picker + 水平布局 */}
+      <SettingsSection title="基础信息">
+        <SettingsCard divided={false}>
+          <div className="px-4 py-4">
+            <div className="flex items-start gap-4">
+              {/* Emoji 选择器 */}
+              <Popover open={showEmojiPicker} onOpenChange={setShowEmojiPicker}>
+                <PopoverTrigger asChild>
+                  <button
+                    type="button"
+                    className={cn(
+                      'flex size-16 items-center justify-center rounded-2xl bg-muted text-3xl leading-none shrink-0',
+                      'ring-offset-background transition-all',
+                      'hover:ring-2 hover:ring-ring hover:ring-offset-2',
+                      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+                    )}
+                    title="选择图标"
+                  >
+                    {icon || '🤖'}
+                  </button>
+                </PopoverTrigger>
+                <PopoverContent
+                  side="right"
+                  align="start"
+                  sideOffset={12}
+                  className="w-auto p-0 border-none shadow-xl"
+                >
+                  <Picker
+                    data={data}
+                    onEmojiSelect={(emoji: EmojiMartEmoji) => {
+                      setIcon(emoji.native)
+                      setShowEmojiPicker(false)
+                    }}
+                    locale="zh"
+                    theme="auto"
+                    previewPosition="none"
+                    skinTonePosition="search"
+                    perLine={8}
+                  />
+                </PopoverContent>
+              </Popover>
+
+              {/* Name + Description */}
+              <div className="flex-1 min-w-0 space-y-3">
+                <div className="space-y-1.5">
+                  <label className={LABEL_CLASS}>
+                    名称 <span className="text-destructive">*</span>
+                  </label>
+                  <Input
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder="如：PPT Agent"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <label className={LABEL_CLASS}>描述</label>
+                  <Input
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    placeholder="如：专注制作演示文稿"
+                  />
+                </div>
+              </div>
+            </div>
+            <p className={cn(DESCRIPTION_CLASS, 'mt-2 pl-0.5')}>
+              点击图标更换 emoji
+            </p>
+          </div>
+        </SettingsCard>
+      </SettingsSection>
+
+      {/* Section 2: 模型配置 */}
+      <SettingsSection title="模型配置" description="不设置则使用全局默认配置">
+        <SettingsCard>
+          <SettingsSelect
+            label="默认渠道"
+            value={channelId}
+            onValueChange={handleChannelChange}
+            options={[
+              { value: NONE, label: '不指定' },
+              ...channels.map((c) => ({ value: c.id, label: c.name })),
+            ]}
+            placeholder="选择渠道"
+          />
+          {channelId !== NONE && (
+            <SettingsSelect
+              label="默认模型"
+              value={modelId}
+              onValueChange={setModelId}
+              options={[
+                { value: NONE, label: '不指定' },
+                ...modelOptions,
+              ]}
+              placeholder="选择模型"
+            />
+          )}
+          <SettingsSegmentedControl
+            label="思考模式"
+            description="自适应模式下 Agent 会根据任务复杂度自动决定是否启用深度思考"
+            value={thinkingToValue(thinking)}
+            onValueChange={(v) => setThinking(valueToThinking(v, thinking))}
+            options={THINKING_OPTIONS}
+          />
+          <SettingsSegmentedControl
+            label="推理深度"
+            description="控制 Agent 在每次回复中投入的推理计算量"
+            value={effort ?? 'default'}
+            onValueChange={(v) => setEffort(v === 'default' ? undefined : v as AgentEffort)}
+            options={EFFORT_OPTIONS}
+          />
+          {/* 高级限制（折叠） */}
+          <div
+            className="flex items-center gap-2 px-4 py-2.5 cursor-pointer select-none hover:bg-muted/30 transition-colors"
+            onClick={() => setAdvancedOpen(!advancedOpen)}
+          >
+            {advancedOpen
+              ? <ChevronDown size={13} className="text-muted-foreground" />
+              : <ChevronRight size={13} className="text-muted-foreground" />
+            }
+            <span className="text-xs font-medium text-muted-foreground">高级限制</span>
+            {!advancedOpen && (budgetStr || turnsStr) && (
+              <span className="text-xs text-muted-foreground/60 ml-auto">
+                {[budgetStr && `$${budgetStr}`, turnsStr && `${turnsStr} 轮`].filter(Boolean).join(' · ')}
+              </span>
+            )}
+          </div>
+          {advancedOpen && (
+            <>
+              <SettingsInput
+                label="预算限制（美元/次）"
+                description="单次会话的最大花费，留空则不限制"
+                value={budgetStr}
+                onChange={setBudgetStr}
+                placeholder="例如: 1.0"
+                type="number"
+              />
+              <SettingsInput
+                label="最大轮次"
+                description="单次会话的最大交互轮次，留空则使用默认值"
+                value={turnsStr}
+                onChange={setTurnsStr}
+                placeholder="例如: 50"
+                type="number"
+              />
+            </>
+          )}
+        </SettingsCard>
+      </SettingsSection>
+
+      {/* Section 3: 能力配置 */}
+      <CapabilitiesSection
+        allCapabilities={allCapabilities}
+        enabledMcpServers={enabledMcpServers}
+        enabledSkills={enabledSkills}
+        isMcpSelected={isMcpSelected}
+        isSkillSelected={isSkillSelected}
+        toggleMcpServer={toggleMcpServer}
+        toggleSkill={toggleSkill}
+      />
+
+      {/* Section 4: 附加配置 */}
+      <SettingsSection title="附加配置">
+        <SettingsCard>
+          <SettingsSelect
+            label="默认工作区"
+            description="使用此 Agent 时默认在哪个工作区创建会话"
+            value={defaultWorkspaceId}
+            onValueChange={setDefaultWorkspaceId}
+            options={[
+              { value: NONE, label: '不指定' },
+              ...workspaces.map((w) => ({ value: w.id, label: w.name })),
+            ]}
+            placeholder="选择工作区"
+          />
+          {/* 附加提示词 */}
+          <div className="px-4 py-3 space-y-2">
+            <div>
+              <div className={LABEL_CLASS}>附加提示词</div>
+              <div className={cn(DESCRIPTION_CLASS, 'mt-0.5')}>
+                追加在默认 system prompt 之后，用于微调 Agent 的角色和行为
+              </div>
+            </div>
+            <Textarea
+              value={additionalPrompt}
+              onChange={(e) => setAdditionalPrompt(e.target.value)}
+              placeholder="如：你是一个专业的 PPT 制作助手，擅长使用 Marp 和 reveal.js..."
+              rows={5}
+              className="resize-y min-h-[100px]"
+            />
+          </div>
+        </SettingsCard>
+      </SettingsSection>
+
+      {/* 保存/取消按钮 */}
+      <div className="flex items-center justify-end gap-3 pt-4 border-t border-border/50 mt-2">
+        <Button variant="outline" onClick={onCancel} disabled={saving}>
+          取消
+        </Button>
+        <Button onClick={handleSave} disabled={saving} className="min-w-[100px]">
+          {saving ? (
+            <span className="flex items-center gap-2">
+              <span className="size-3.5 rounded-full border-2 border-current border-t-transparent animate-spin" />
+              保存中...
+            </span>
+          ) : isEdit ? '保存修改' : '创建 Agent'}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// ===== 能力配置子组件 =====
+
+interface CapabilitiesSectionProps {
+  allCapabilities: WorkspaceCapabilitiesSummary[]
+  enabledMcpServers: AgentProfileMcpRef[]
+  enabledSkills: AgentProfileSkillRef[]
+  isMcpSelected: (workspaceId: string, serverName: string) => boolean
+  isSkillSelected: (workspaceId: string, skillName: string) => boolean
+  toggleMcpServer: (workspaceId: string, serverName: string) => void
+  toggleSkill: (workspaceId: string, skillName: string) => void
+}
+
+function CapabilitiesSection({
+  allCapabilities,
+  enabledMcpServers,
+  enabledSkills,
+  isMcpSelected,
+  isSkillSelected,
+  toggleMcpServer,
+  toggleSkill,
+}: CapabilitiesSectionProps): React.ReactElement {
+  const workspacesWithMcp = allCapabilities.filter((ws) => ws.capabilities.mcpServers.length > 0)
+  const workspacesWithSkills = allCapabilities.filter((ws) => ws.capabilities.skills.length > 0)
+
+  const mcpCount = enabledMcpServers.length
+  const skillCount = enabledSkills.length
+
+  return (
+    <SettingsSection
+      title="能力配置"
+      description="为此 Agent 挑选工具和技能"
+    >
+      <div className="space-y-4">
+        {/* 已选摘要 */}
+        {(mcpCount > 0 || skillCount > 0) && (
+          <div className="flex items-center gap-2 flex-wrap">
+            {mcpCount > 0 && (
+              <span className="inline-flex items-center gap-1 rounded-full bg-blue-500/10 px-2.5 py-1 text-xs font-medium text-blue-600 dark:text-blue-400">
+                <Plug size={11} />
+                {mcpCount} MCP
+              </span>
+            )}
+            {skillCount > 0 && (
+              <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2.5 py-1 text-xs font-medium text-amber-600 dark:text-amber-400">
+                <Sparkles size={11} />
+                {skillCount} Skills
+              </span>
+            )}
+          </div>
+        )}
+
+        {/* MCP 服务器 */}
+        {workspacesWithMcp.length > 0 && (
+          <CapabilityGroup label="MCP 服务器" icon={<Plug size={13} />}>
+            {workspacesWithMcp.map((ws) => (
+              <WorkspaceChipGroup key={ws.workspaceId} workspaceName={ws.workspaceName}>
+                {ws.capabilities.mcpServers.map((server) => (
+                  <CapabilityChip
+                    key={server.name}
+                    label={server.name}
+                    badge={server.type}
+                    selected={isMcpSelected(ws.workspaceId, server.name)}
+                    disabled={!server.enabled}
+                    onClick={() => toggleMcpServer(ws.workspaceId, server.name)}
+                    variant="mcp"
+                  />
+                ))}
+              </WorkspaceChipGroup>
+            ))}
+          </CapabilityGroup>
+        )}
+
+        {/* Skills */}
+        {workspacesWithSkills.length > 0 && (
+          <CapabilityGroup label="Skills" icon={<Sparkles size={13} />}>
+            {workspacesWithSkills.map((ws) => (
+              <WorkspaceChipGroup key={ws.workspaceId} workspaceName={ws.workspaceName}>
+                {ws.capabilities.skills.map((skill) => (
+                  <CapabilityChip
+                    key={skill.slug}
+                    label={skill.name}
+                    icon={skill.icon || '⚡'}
+                    selected={isSkillSelected(ws.workspaceId, skill.slug)}
+                    onClick={() => toggleSkill(ws.workspaceId, skill.slug)}
+                    variant="skill"
+                  />
+                ))}
+              </WorkspaceChipGroup>
+            ))}
+          </CapabilityGroup>
+        )}
+
+        {/* 空状态 */}
+        {workspacesWithMcp.length === 0 && workspacesWithSkills.length === 0 && (
+          <SettingsCard divided={false}>
+            <div className="py-10 text-center text-sm text-muted-foreground">
+              暂无可用的 MCP 或 Skills，请先在工作区中配置
+            </div>
+          </SettingsCard>
+        )}
+      </div>
+    </SettingsSection>
+  )
+}
+
+// ===== Chip 子组件 =====
+
+function CapabilityGroup({ label, icon, children }: {
+  label: string
+  icon: React.ReactNode
+  children: React.ReactNode
+}): React.ReactElement {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-1.5 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+        {icon}
+        {label}
+      </div>
+      <div className="space-y-3">{children}</div>
+    </div>
+  )
+}
+
+function WorkspaceChipGroup({ workspaceName, children }: {
+  workspaceName: string
+  children: React.ReactNode
+}): React.ReactElement {
+  return (
+    <div className="space-y-1.5">
+      <div className="text-[11px] text-muted-foreground/70 font-medium pl-0.5">
+        {workspaceName}
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        {children}
+      </div>
+    </div>
+  )
+}
+
+interface CapabilityChipProps {
+  label: string
+  icon?: string
+  badge?: string
+  selected: boolean
+  disabled?: boolean
+  onClick: () => void
+  variant: 'mcp' | 'skill'
+}
+
+function CapabilityChip({ label, icon, badge, selected, disabled, onClick, variant }: CapabilityChipProps): React.ReactElement {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium',
+        'transition-all duration-150',
+        'disabled:cursor-not-allowed disabled:opacity-40',
+        selected && variant === 'mcp' && 'border-blue-500/40 bg-blue-500/10 text-blue-600 dark:text-blue-400 hover:bg-blue-500/15',
+        selected && variant === 'skill' && 'border-amber-500/40 bg-amber-500/10 text-amber-600 dark:text-amber-400 hover:bg-amber-500/15',
+        !selected && 'border-border bg-transparent text-muted-foreground hover:border-foreground/20 hover:text-foreground hover:bg-muted/50',
+      )}
+      title={disabled ? '已禁用' : undefined}
+    >
+      {selected && <Check size={11} className="shrink-0" />}
+      {icon && !selected && <span className="text-[11px] leading-none">{icon}</span>}
+      <span>{label}</span>
+      {badge && (
+        <span className={cn(
+          'rounded px-1 py-px text-[10px] font-normal',
+          selected ? 'opacity-60' : 'bg-muted text-muted-foreground/70',
+        )}>
+          {badge}
+        </span>
+      )}
+    </button>
+  )
+}

--- a/apps/electron/src/renderer/components/settings/AgentProfileSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AgentProfileSettings.tsx
@@ -1,0 +1,187 @@
+/**
+ * AgentProfileSettings - Agent Profile 管理页
+ *
+ * 设置页 Agents Tab，管理全局 Agent Profile 的 CRUD。
+ * 视图模式：list / create / edit
+ */
+
+import * as React from 'react'
+import { useSetAtom } from 'jotai'
+import { Plus, Pencil, Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import type { AgentProfile } from '@proma/shared'
+import { agentProfilesAtom } from '@/atoms/agent-atoms'
+import { SettingsSection, SettingsCard, SettingsRow } from './primitives'
+import { AgentProfileForm } from './AgentProfileForm'
+
+type ViewMode = 'list' | 'create' | 'edit'
+
+export function AgentProfileSettings(): React.ReactElement {
+  const setGlobalProfiles = useSetAtom(agentProfilesAtom)
+
+  const [viewMode, setViewMode] = React.useState<ViewMode>('list')
+  const [profiles, setProfiles] = React.useState<AgentProfile[]>([])
+  const [editingProfile, setEditingProfile] = React.useState<AgentProfile | null>(null)
+  const [loading, setLoading] = React.useState(true)
+
+  const loadProfiles = React.useCallback(async () => {
+    try {
+      const list = await window.electronAPI.listAgentProfiles()
+      setProfiles(list)
+      setGlobalProfiles(list)
+    } catch (error) {
+      console.error('[Agent Profile] 加载失败:', error)
+    } finally {
+      setLoading(false)
+    }
+  }, [setGlobalProfiles])
+
+  React.useEffect(() => {
+    loadProfiles()
+  }, [loadProfiles])
+
+  const handleDelete = React.useCallback(async (profile: AgentProfile) => {
+    if (profile.isBuiltin) return
+    if (!confirm(`确定要删除 Agent「${profile.name}」吗？`)) return
+    try {
+      const ok = await window.electronAPI.deleteAgentProfile(profile.id)
+      if (ok) {
+        toast.success(`已删除 Agent「${profile.name}」`)
+        await loadProfiles()
+      } else {
+        toast.error('删除失败')
+      }
+    } catch (error) {
+      console.error('[Agent Profile] 删除失败:', error)
+      toast.error('删除失败')
+    }
+  }, [loadProfiles])
+
+  const handleFormSaved = React.useCallback(async () => {
+    setViewMode('list')
+    setEditingProfile(null)
+    await loadProfiles()
+  }, [loadProfiles])
+
+  const handleFormCancel = React.useCallback(() => {
+    setViewMode('list')
+    setEditingProfile(null)
+  }, [])
+
+  // 创建/编辑视图
+  if (viewMode === 'create' || viewMode === 'edit') {
+    return (
+      <AgentProfileForm
+        profile={editingProfile}
+        onSaved={handleFormSaved}
+        onCancel={handleFormCancel}
+      />
+    )
+  }
+
+  // 列表视图
+  return (
+    <div className="space-y-6 p-1">
+      <SettingsSection
+        title="Agents"
+        description="管理你的 Agent 角色配置，每个 Agent 可以拥有独立的模型、MCP、Skills 和提示词配置"
+        action={
+          <Button size="sm" onClick={() => setViewMode('create')}>
+            <Plus size={16} />
+            <span>新建 Agent</span>
+          </Button>
+        }
+      >
+        {loading ? (
+          /* 骨架屏 */
+          <SettingsCard divided={false}>
+            {[0, 1, 2].map((i) => (
+              <div key={i} className="flex items-center gap-3 px-4 py-3">
+                <div className="size-8 rounded-xl bg-muted animate-pulse" />
+                <div className="flex-1 space-y-1.5">
+                  <div className="h-3.5 w-28 rounded bg-muted animate-pulse" />
+                  <div className="h-3 w-44 rounded bg-muted animate-pulse" />
+                </div>
+              </div>
+            ))}
+          </SettingsCard>
+        ) : profiles.length === 0 ? (
+          /* 空状态 */
+          <SettingsCard divided={false}>
+            <div className="flex flex-col items-center gap-3 py-14 text-center">
+              <div className="flex size-12 items-center justify-center rounded-2xl bg-muted text-2xl">
+                🤖
+              </div>
+              <div className="space-y-1">
+                <p className="text-sm font-medium text-foreground">还没有任何 Agent</p>
+                <p className="text-sm text-muted-foreground">点击「新建 Agent」开始配置</p>
+              </div>
+            </div>
+          </SettingsCard>
+        ) : (
+          <SettingsCard>
+            {profiles.map((profile) => (
+              <div key={profile.id} className="relative">
+                {/* 预置 Agent 左侧主题色竖线 */}
+                {profile.isBuiltin && (
+                  <div className="absolute left-0 top-2 bottom-2 w-0.5 rounded-full bg-primary/30" />
+                )}
+                <SettingsRow
+                  label={profile.name}
+                  icon={
+                    <span className="flex size-8 items-center justify-center rounded-xl bg-muted text-lg leading-none shrink-0">
+                      {profile.icon || '🤖'}
+                    </span>
+                  }
+                  description={profile.description || '未设置描述'}
+                  className="group"
+                >
+                  <div className="flex items-center gap-2">
+                    {profile.isBuiltin && (
+                      <span className="flex items-center gap-1 text-[11px] px-1.5 py-0.5 rounded-md bg-blue-500/10 text-blue-600 dark:text-blue-400 font-medium">
+                        预置
+                      </span>
+                    )}
+                    {profile.defaultModelId && (
+                      <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-muted text-muted-foreground font-medium max-w-[120px] truncate">
+                        {profile.defaultModelId}
+                      </span>
+                    )}
+                    {(profile.enabledMcpServers.length > 0 || profile.enabledSkills.length > 0) && (
+                      <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-muted/60 text-muted-foreground font-medium tabular-nums">
+                        {[
+                          profile.enabledMcpServers.length > 0 && `${profile.enabledMcpServers.length} MCP`,
+                          profile.enabledSkills.length > 0 && `${profile.enabledSkills.length} Skills`,
+                        ].filter(Boolean).join(' · ')}
+                      </span>
+                    )}
+                    <button
+                      onClick={() => {
+                        setEditingProfile(profile)
+                        setViewMode('edit')
+                      }}
+                      className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors opacity-0 group-hover:opacity-100"
+                      title="编辑"
+                    >
+                      <Pencil size={14} />
+                    </button>
+                    {!profile.isBuiltin && (
+                      <button
+                        onClick={() => handleDelete(profile)}
+                        className="p-1.5 rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors opacity-0 group-hover:opacity-100"
+                        title="删除"
+                      >
+                        <Trash2 size={14} />
+                      </button>
+                    )}
+                  </div>
+                </SettingsRow>
+              </div>
+            ))}
+          </SettingsCard>
+        )}
+      </SettingsSection>
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
+++ b/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
@@ -8,7 +8,7 @@
 import * as React from 'react'
 import { useAtom, useAtomValue } from 'jotai'
 import { cn } from '@/lib/utils'
-import { Settings, Radio, Palette, Info, Plug, Globe, BookOpen, Wrench, Bot, GraduationCap, X, Keyboard } from 'lucide-react'
+import { Settings, Radio, Palette, Info, Plug, Globe, BookOpen, Wrench, Bot, GraduationCap, X, Keyboard, Users } from 'lucide-react'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { settingsTabAtom } from '@/atoms/settings-tab'
 import type { SettingsTab } from '@/atoms/settings-tab'
@@ -26,6 +26,7 @@ import { ToolSettings } from './ToolSettings'
 import { BotHubSettings } from './BotHubSettings'
 import { TutorialViewer } from '../tutorial/TutorialViewer'
 import { ShortcutSettings } from './ShortcutSettings'
+import { AgentProfileSettings } from './AgentProfileSettings'
 
 /** 设置 Tab 定义 */
 interface TabItem {
@@ -44,6 +45,7 @@ const BASE_TABS: TabItem[] = [
 
 /** Agent 模式专属 Tab */
 const AGENT_TAB: TabItem = { id: 'agent', label: '配置', icon: <Plug size={16} /> }
+const AGENTS_TAB: TabItem = { id: 'agents', label: 'Agents', icon: <Users size={16} /> }
 const TOOLS_TAB: TabItem = { id: 'tools', label: '工具', icon: <Wrench size={16} /> }
 const BOTS_TAB: TabItem = { id: 'bots', label: '机器人', icon: <Bot size={16} /> }
 const TUTORIAL_TAB: TabItem = { id: 'tutorial', label: '教程', icon: <GraduationCap size={16} /> }
@@ -68,6 +70,8 @@ function renderTabContent(tab: SettingsTab): React.ReactElement {
       return <ProxySettings />
     case 'agent':
       return <AgentSettings />
+    case 'agents':
+      return <AgentProfileSettings />
     case 'tools':
       return <ToolSettings />
     case 'appearance':
@@ -96,7 +100,7 @@ export function SettingsPanel({ onClose }: SettingsPanelProps): React.ReactEleme
   // Agent 模式时在渠道后插入 Agent Tab，工具 tab 两种模式都显示
   const tabs = React.useMemo(() => {
     if (appMode === 'agent') {
-      return [...BASE_TABS, AGENT_TAB, TOOLS_TAB, BOTS_TAB, TUTORIAL_TAB, SHORTCUTS_TAB, ...TAIL_TABS]
+      return [...BASE_TABS, AGENT_TAB, AGENTS_TAB, TOOLS_TAB, BOTS_TAB, TUTORIAL_TAB, SHORTCUTS_TAB, ...TAIL_TABS]
     }
     return [...BASE_TABS, TOOLS_TAB, BOTS_TAB, TUTORIAL_TAB, SHORTCUTS_TAB, ...TAIL_TABS]
   }, [appMode])

--- a/apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx
+++ b/apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx
@@ -182,8 +182,32 @@ export function GlobalShortcuts(): null {
 
         if (data.mode === 'agent') {
           // Agent 模式：创建会话 + 保存附件到 session 目录
-          const channelId = store.get(agentChannelIdAtom) || undefined
-          const workspaceId = store.get(currentAgentWorkspaceIdAtom) || undefined
+          let channelId = store.get(agentChannelIdAtom) || undefined
+          let workspaceId = store.get(currentAgentWorkspaceIdAtom) || undefined
+
+          // 如果指定了 Agent Profile，使用其默认配置
+          let profileChannelId: string | undefined
+          let profileModelId: string | undefined
+          if (data.agentProfileId) {
+            try {
+              const profile = await window.electronAPI.getAgentProfile(data.agentProfileId)
+              if (profile) {
+                if (profile.defaultChannelId) {
+                  channelId = profile.defaultChannelId
+                  profileChannelId = profile.defaultChannelId
+                }
+                if (profile.defaultModelId) {
+                  profileModelId = profile.defaultModelId
+                }
+                if (profile.defaultWorkspaceId) {
+                  workspaceId = profile.defaultWorkspaceId
+                }
+              }
+            } catch (err) {
+              console.error('[快速任务] 获取 Agent Profile 失败:', err)
+            }
+          }
+
           const meta = await window.electronAPI.createAgentSession(
             undefined,
             channelId,
@@ -232,6 +256,9 @@ export function GlobalShortcuts(): null {
           store.set(agentPendingPromptAtom, {
             sessionId: meta.id,
             message: fileReferences + data.text,
+            agentProfileId: data.agentProfileId,
+            profileChannelId,
+            profileModelId,
           })
         } else {
           // Chat 模式：创建对话 + 保存附件到磁盘

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -21,6 +21,7 @@ import {
   agentModelIdAtom,
   agentChannelIdsAtom,
   agentWorkspacesAtom,
+  agentProfilesAtom,
   currentAgentWorkspaceIdAtom,
   currentAgentSessionIdAtom,
   workspaceCapabilitiesVersionAtom,
@@ -113,6 +114,7 @@ function AgentSettingsInitializer(): null {
   const setAgentModelId = useSetAtom(agentModelIdAtom)
   const setAgentChannelIds = useSetAtom(agentChannelIdsAtom)
   const setAgentWorkspaces = useSetAtom(agentWorkspacesAtom)
+  const setAgentProfiles = useSetAtom(agentProfilesAtom)
   const setCurrentWorkspaceId = useSetAtom(currentAgentWorkspaceIdAtom)
   const bumpCapabilities = useSetAtom(workspaceCapabilitiesVersionAtom)
   const bumpFiles = useSetAtom(workspaceFilesVersionAtom)
@@ -199,6 +201,11 @@ function AgentSettingsInitializer(): null {
       if (settings.agentMaxTurns != null) {
         setMaxTurns(settings.agentMaxTurns)
       }
+
+      // 加载 Agent Profile 列表
+      window.electronAPI.listAgentProfiles().then((profiles) => {
+        setAgentProfiles(profiles)
+      }).catch((err) => console.error('[AgentSettings] 加载 Agent Profile 失败:', err))
 
       // 加载工作区列表并恢复上次选中的工作区
       window.electronAPI.listAgentWorkspaces().then((workspaces) => {

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -136,6 +136,8 @@ export interface QuickTaskSubmitInput {
   mode: 'chat' | 'agent'
   /** 附件列表（base64 编码） */
   files?: QuickTaskFile[]
+  /** 指定的 Agent Profile ID（Agent 模式下，不指定则使用预置通用助手） */
+  agentProfileId?: string
 }
 
 /** 快速任务附件 */
@@ -151,4 +153,6 @@ export interface QuickTaskOpenSessionData {
   mode: 'chat' | 'agent'
   text: string
   files?: QuickTaskFile[]
+  /** 指定的 Agent Profile ID */
+  agentProfileId?: string
 }

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -540,11 +540,99 @@ export interface AgentSessionMeta {
   resumeAtMessageUuid?: string
   /** 最后一次流式执行是否被用户主动中断 */
   stoppedByUser?: boolean
+  /** 使用的 Agent Profile ID（隐式默认 Agent 时为空） */
+  agentProfileId?: string
+  // TODO: 以下 override 字段为 Phase 3（会话输入框 Agent 配置切换）预留，暂未实现消费端
+  /** 会话级临时覆盖：渠道 */
+  overrideChannelId?: string
+  /** 会话级临时覆盖：模型 */
+  overrideModelId?: string
+  /** 会话级临时覆盖：思考模式 */
+  overrideThinking?: ThinkingConfig
+  /** 会话级临时覆盖：推理深度 */
+  overrideEffort?: AgentEffort
   /** 创建时间戳 */
   createdAt: number
   /** 更新时间戳 */
   updatedAt: number
 }
+
+// ===== Agent Profile（全局 Agent 配置模板） =====
+
+/** Agent Profile 中挑选的 MCP 服务器引用 */
+export interface AgentProfileMcpRef {
+  /** 来源工作区 ID */
+  workspaceId: string
+  /** MCP server 名称（对应 mcp.json 中的 key） */
+  serverName: string
+}
+
+/** Agent Profile 中挑选的 Skill 引用 */
+export interface AgentProfileSkillRef {
+  /** 来源工作区 ID */
+  workspaceId: string
+  /** Skill 目录名 */
+  skillName: string
+}
+
+/**
+ * Agent Profile — 全局 Agent 配置模板
+ *
+ * 独立于工作区的 Agent 角色定义，包含模型配置、能力挑选、附加提示词等。
+ * 存储在 ~/.proma/agents.json
+ */
+export interface AgentProfile {
+  id: string
+  /** 显示名，如 "PPT Agent" */
+  name: string
+  /** 描述，如 "专注制作演示文稿" */
+  description?: string
+  /** emoji 图标标识 */
+  icon?: string
+  /** 预置 Agent 标记（不可删除） */
+  isBuiltin?: boolean
+
+  // 模型配置
+  defaultChannelId?: string
+  defaultModelId?: string
+  thinking?: ThinkingConfig
+  effort?: AgentEffort
+  maxBudgetUsd?: number
+  maxTurns?: number
+
+  // 能力配置 — 从全局所有工作区的 MCP/Skills 池中挑选
+  enabledMcpServers: AgentProfileMcpRef[]
+  enabledSkills: AgentProfileSkillRef[]
+
+  /** 附加提示词（追加在默认 system prompt 之后，用于微调角色/行为） */
+  additionalPrompt?: string
+
+  /** 默认工作区 ID（未指定时在此创建会话） */
+  defaultWorkspaceId?: string
+
+  createdAt: number
+  updatedAt: number
+}
+
+/** 创建 Agent Profile 的输入 */
+export interface AgentProfileCreateInput {
+  name: string
+  description?: string
+  icon?: string
+  defaultChannelId?: string
+  defaultModelId?: string
+  thinking?: ThinkingConfig
+  effort?: AgentEffort
+  maxBudgetUsd?: number
+  maxTurns?: number
+  enabledMcpServers?: AgentProfileMcpRef[]
+  enabledSkills?: AgentProfileSkillRef[]
+  additionalPrompt?: string
+  defaultWorkspaceId?: string
+}
+
+/** 更新 Agent Profile 的输入（部分更新） */
+export type AgentProfileUpdateInput = Partial<AgentProfileCreateInput>
 
 /**
  * Agent 持久化消息
@@ -692,6 +780,14 @@ export interface WorkspaceCapabilities {
   skills: SkillMeta[]
 }
 
+/** 所有工作区的能力汇总（供 Agent Profile 编辑页勾选） */
+export interface WorkspaceCapabilitiesSummary {
+  workspaceId: string
+  workspaceName: string
+  workspaceSlug: string
+  capabilities: WorkspaceCapabilities
+}
+
 // ===== Agent 发送输入 =====
 
 /**
@@ -718,6 +814,8 @@ export interface AgentSendInput {
   mentionedSkills?: string[]
   /** 用户通过 #mcp:xxx 引用的 MCP 服务器名称列表 */
   mentionedMcpServers?: string[]
+  /** 指定的 Agent Profile ID */
+  agentProfileId?: string
 }
 
 // ===== Agent 队列消息 =====
@@ -1313,6 +1411,20 @@ export const AGENT_IPC_CHANNELS = {
   // 待处理请求恢复（渲染进程重载后查询主进程状态）
   /** 获取所有待处理的交互请求快照 */
   GET_PENDING_REQUESTS: 'agent:get-pending-requests',
+
+  // Agent Profile 管理
+  /** 获取 Agent Profile 列表 */
+  LIST_PROFILES: 'agent:list-profiles',
+  /** 获取单个 Agent Profile */
+  GET_PROFILE: 'agent:get-profile',
+  /** 创建 Agent Profile */
+  CREATE_PROFILE: 'agent:create-profile',
+  /** 更新 Agent Profile */
+  UPDATE_PROFILE: 'agent:update-profile',
+  /** 删除 Agent Profile */
+  DELETE_PROFILE: 'agent:delete-profile',
+  /** 获取所有工作区的 MCP/Skills 汇总（供 Profile 编辑页勾选） */
+  LIST_ALL_CAPABILITIES: 'agent:list-all-capabilities',
 } as const
 
 /**


### PR DESCRIPTION
## Agent 角色

Agent 模式独立的角色配置体系，实现按角色精确分配能力和任务：
- 由角色决定 MCP/Skills/Model 等详细配置，工作区只管理 Seesion/File
- 设置页新增「Agents」进行角色配置

## 具体修改

### 数据层（4 文件）
- `packages/shared/src/types/agent.ts` — 新增 AgentProfile 类型定义、IPC 通道常量、CRUD 输入类型
- `apps/electron/src/main/lib/agent-profile-service.ts` — **新文件**，AgentProfile CRUD + 预置通用助手初始化
- `apps/electron/src/main/lib/config-paths.ts` — 新增 `getAgentProfilePluginDir`（含 UUID 格式校验）
- `apps/electron/src/main/ipc.ts` — 注册 Agent Profile 的 5 个 IPC handler + LIST_ALL_CAPABILITIES

### 编排层（1 文件）
- `apps/electron/src/main/lib/agent-orchestrator.ts`
  - `buildProfileMcpServers()` — 按 Profile 精确加载 MCP 服务器
  - `buildProfilePluginDir()` — 基于 symlink 的 Skill 精确过滤 + 缓存复用 + 并发锁
  - 配置优先级调整：会话输入 > Agent Profile > 全局默认
  - 动态 import 改为静态 import，inline import type 提升至顶层

### 渲染层（10 文件）
- `AgentSelector.tsx` — **新文件**，会话输入框的 Agent 选择器组件
- `AgentView.tsx` — 集成 per-session profile/channel/model map，pendingPrompt 同步
- `QuickTaskApp.tsx` — @ mention 触发弹窗（mirror div 精确定位、键盘导航、内联 mention 标签）
- `AgentProfileSettings.tsx` — **新文件**，设置页 Agents 列表（骨架屏、能力 badge、builtin 标识）
- `AgentProfileForm.tsx` — **新文件**，Agent 编辑表单（emoji picker、chip 能力选择、折叠高级选项）
- `SettingsPanel.tsx` — Agent 模式下注册 Agents Tab
- `GlobalShortcuts.tsx` — QuickTask 提交时注入 Agent Profile 配置
- `agent-atoms.ts` — 新增 `agentSessionProfileMapAtom`
- `settings-tab.ts` — 新增 `'agents'` tab ID
- `main.tsx` / `index.ts` / `preload/index.ts` / `types/settings.ts` — 启动初始化 + IPC bridge

### 审查情况
3 个 SubAgent 并行审查（主进程/渲染层/设置页 UI），共发现 4 Critical + 12 Warning + 6 Nit
- QuickTask @agent 发起的会话，ModelSelector 未显示 agent 配置的模型
- 会话内手动切换模型后，下次发消息被 agent 配置覆盖
- `profileId` UUID 正则校验防路径穿越
- symlink 目标 `resolve()` + `startsWith()` 防目录逃逸
- `pluginBuildLocks` Set 防同 profile 并发重建竞态

## 测试结果
- 全部 Critical 和 Warning 已修复，`bun run typecheck` 通过
- 用户测试确认功能正常