### PR TITLE
fix: StickyUserMessage 不再遮挡迷你地图悬停区域

### DIFF
--- a/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
@@ -275,7 +275,7 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
   const thumbTopPct = scrollRange > 0 ? (scrollTop / scrollRange) * (100 - thumbHeightPct) : 0
 
   return (
-    <div className="absolute right-1 top-0 bottom-0 z-10 flex pointer-events-none">
+    <div className="absolute right-1 top-0 bottom-0 z-30 flex pointer-events-none">
       {/* ── 迷你地图悬停区域（面板 + 横杠） ── */}
       <div className="flex items-start h-full">
         {/* 展开面板 */}

--- a/apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx
@@ -126,14 +126,14 @@ export function StickyUserMessage({ userMessages }: StickyUserMessageProps): Rea
   return (
     <div
       className={cn(
-        'absolute left-0 right-0 top-0 z-20 transition-all duration-150 ease-out',
+        'absolute left-0 right-9 top-0 z-20 transition-all duration-150 ease-out',
         isSticky
           ? 'opacity-100 translate-y-0 pointer-events-auto'
           : 'opacity-0 -translate-y-2 pointer-events-none'
       )}
     >
       <div
-        className="mx-8 mt-2 rounded-xl bg-background/95 backdrop-blur-sm border border-border/40 shadow-sm cursor-pointer hover:bg-accent/50 transition-colors"
+        className="ml-6 mr-[9px] mt-2 rounded-xl bg-background/95 backdrop-blur-sm border border-border/40 shadow-sm cursor-pointer hover:bg-accent/50 transition-colors"
         onClick={scrollToOriginal}
       >
         <div className="px-3.5 py-2.5">


### PR DESCRIPTION
## 概述

`StickyUserMessage` 组件（聊天顶部的用户消息置顶浮条）使用了 `left-0 right-0` 全宽定位且 `z-20`，导致其容器覆盖在 `ScrollMinimap`（`z-10`）之上，阻断了迷你地图的鼠标悬停事件，使部分区域无法触发预览面板。

## 变更内容

- `apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx` — 将迷你地图 z-index 从 `z-10` 提升到 `z-30`，确保始终位于覆盖层之上
- `apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx` — 外层容器右侧从 `right-0` 收窄为 `right-9`（36px 内缩），避免覆盖迷你地图区域；内层 margin 从对称的 `mx-8` 调整为 `ml-6 mr-[9px]`，保持内容右边缘距窗口右侧 45px，视觉效果接近原版

## 测试方法

1. 打开一个有多条消息的 Agent 会话（足以激活迷你地图）
2. 向下滚动，使某条用户消息滑出视口顶部 — 顶部应出现 StickyUserMessage 浮条
3. 将鼠标悬停在右侧迷你地图上 — 预览面板应正常弹出
4. 验证迷你地图在**所有**垂直位置（包括与浮条重叠的顶部区域）均可响应悬停
5. 验证浮条视觉效果仍然平衡、可点击

## 备注

- 双重保障：外层容器不再延伸到迷你地图区域（`right-9`），同时迷你地图 z-index 更高（`z-30` > `z-20`），即使有局部重叠也不会阻断悬停事件