### PR TITLE
fix: AskUserBanner 第一个选项不再显示多余的 focus ring

### DIFF
--- a/apps/electron/src/renderer/components/agent/AskUserBanner.tsx
+++ b/apps/electron/src/renderer/components/agent/AskUserBanner.tsx
@@ -32,7 +32,7 @@ export function AskUserBanner({ sessionId }: AskUserBannerProps): React.ReactEle
   const [answers, setAnswers] = React.useState<Map<number, QuestionAnswer>>(new Map())
   const [submitting, setSubmitting] = React.useState(false)
   const [activeTab, setActiveTab] = React.useState(0)
-  const [focusedOptIdx, setFocusedOptIdx] = React.useState(0)
+  const [focusedOptIdx, setFocusedOptIdx] = React.useState(-1)
 
   const request = requests[0] ?? null
   const questions = request?.questions ?? []
@@ -49,7 +49,7 @@ export function AskUserBanner({ sessionId }: AskUserBannerProps): React.ReactEle
 
   React.useEffect(() => {
     setActiveTab(0)
-    setFocusedOptIdx(0)
+    setFocusedOptIdx(-1)
     const firstOpt = questions[0]?.options[0]
     setAnswers(firstOpt
       ? new Map([[0, { ...EMPTY_ANSWER, selected: [firstOpt.label] }]])
@@ -58,7 +58,7 @@ export function AskUserBanner({ sessionId }: AskUserBannerProps): React.ReactEle
 
   // 切换 Tab 时重置焦点并默认选中第一个选项
   React.useEffect(() => {
-    setFocusedOptIdx(0)
+    setFocusedOptIdx(-1)
     setAnswers((prev) => {
       if (prev.has(activeTab)) return prev
       const firstOpt = questions[activeTab]?.options[0]
@@ -94,9 +94,11 @@ export function AskUserBanner({ sessionId }: AskUserBannerProps): React.ReactEle
 
       if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
         e.preventDefault()
-        const nextIdx = e.key === 'ArrowDown'
-          ? (curFocusIdx + 1) % itemCount
-          : (curFocusIdx - 1 + itemCount) % itemCount
+        const nextIdx = curFocusIdx === -1
+          ? (e.key === 'ArrowDown' ? 0 : itemCount - 1)
+          : e.key === 'ArrowDown'
+            ? (curFocusIdx + 1) % itemCount
+            : (curFocusIdx - 1 + itemCount) % itemCount
         setFocusedOptIdx(nextIdx)
         // 移动焦点同时选中
         if (nextIdx < q.options.length) {


### PR DESCRIPTION
## 概述

AskUserQuestion 弹窗中，第一个选项在初始状态下会显示一圈多余的 focus ring（`ring-2 ring-primary/50`），即使用户从未使用键盘导航。这会让用户以为第一个选项处于激活/聚焦状态，造成视觉混淆。

根本原因：`focusedOptIdx` 状态初始化为 `0`，导致第一个选项始终被当作键盘焦点项渲染。

## 改动

- `apps/electron/src/renderer/components/agent/AskUserBanner.tsx`
  - `focusedOptIdx` 初始值从 `0` 改为 `-1`（无焦点）
  - 新请求到达（`requestId` 变化）时重置为 `-1`
  - 切换 Tab 时重置为 `-1`
  - 键盘导航兼容 `-1` 起点：`ArrowDown` → 第 0 项，`ArrowUp` → 最后一项

## 测试方式

1. 打开 Agent 模式，触发一个 AskUserQuestion 弹窗
2. 确认弹窗刚出现时，第一个选项**没有** focus ring 边框（只有默认选中的背景色）
3. 按 `↑↓` 键，确认 focus ring 能正常跟随键盘移动
4. 点击任意选项，确认不会出现 focus ring

## 备注

- 第一个选项仍默认选中（`bg-primary` 背景），行为不变，只去掉了多余的 ring 描边
- 键盘导航逻辑不受影响