### PR TITLE
fix(商业版 bug): proma-official 渠道 Agent 模式自动激活与模型选择器即时刷新

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -190,7 +190,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const [defaultModelId, setDefaultModelId] = useAtom(agentModelIdAtom)
   const agentChannelId = sessionChannelMap.get(sessionId) ?? defaultChannelId
   const agentModelId = sessionModelMap.get(sessionId) ?? defaultModelId
-  const agentChannelIds = useAtomValue(agentChannelIdsAtom)
+  const [agentChannelIds, setAgentChannelIds] = useAtom(agentChannelIdsAtom)
   const [agentThinking, setAgentThinking] = useAtom(agentThinkingAtom)
   const setSettingsOpen = useSetAtom(settingsOpenAtom)
   const setDraftSessionIds = useSetAtom(draftSessionIdsAtom)
@@ -312,6 +312,48 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       (c) => c.enabled && agentChannelIds.includes(c.id) && c.models.some((m) => m.enabled),
     )
   }, [globalChannels, agentChannelIds])
+
+  // Proma 官方渠道自动激活：用户在模型配置中开启 proma-official 后，
+  // Agent 模式自动将其设为默认渠道并选中第一个可用模型，无需手动去 Agent 供应商区再开一次
+  React.useEffect(() => {
+    if (agentChannelId) return // 已有选中渠道，不干预
+    const promaOfficial = globalChannels.find((c) => c.id === 'proma-official' && c.enabled)
+    if (!promaOfficial) return
+    const firstModel = promaOfficial.models.find((m) => m.enabled)
+    if (!firstModel) return
+
+    // 构建一次性 settings 更新，避免多次 updateSettings IPC 竞争写入
+    const settingsUpdate: Record<string, unknown> = {
+      agentChannelId: promaOfficial.id,
+      agentModelId: firstModel.id,
+    }
+
+    // 将 proma-official 加入 Agent 渠道白名单（ModelSelector 依赖此列表过滤可显示的渠道）
+    if (!agentChannelIds.includes(promaOfficial.id)) {
+      const newIds = [...agentChannelIds, promaOfficial.id]
+      setAgentChannelIds(newIds)
+      settingsUpdate.agentChannelIds = newIds
+    }
+
+    // 设置 per-session 和全局默认值
+    setSessionChannelMap((prev) => {
+      const map = new Map(prev)
+      map.set(sessionId, promaOfficial.id)
+      return map
+    })
+    setSessionModelMap((prev) => {
+      const map = new Map(prev)
+      map.set(sessionId, firstModel.id)
+      return map
+    })
+    setDefaultChannelId(promaOfficial.id)
+    setDefaultModelId(firstModel.id)
+
+    // 单次 IPC 调用持久化所有设置
+    window.electronAPI.updateSettings(settingsUpdate).catch(console.error)
+    // eslint-disable-next-line react-hooks/exhaustive-deps — agentChannelIds 在 effect 内被写入，放入依赖会导致自触发
+  }, [agentChannelId, globalChannels, sessionId, setAgentChannelIds, setSessionChannelMap, setSessionModelMap, setDefaultChannelId, setDefaultModelId])
+
   React.useEffect(() => {
     if (!agentChannelId || agentModelId) return
 

--- a/apps/electron/src/renderer/components/chat/ModelSelector.tsx
+++ b/apps/electron/src/renderer/components/chat/ModelSelector.tsx
@@ -36,7 +36,8 @@ function buildModelOptions(channels: Channel[], filterChannelId?: string, filter
   for (const channel of channels) {
     if (!channel.enabled) continue
     if (filterChannelId && channel.id !== filterChannelId) continue
-    if (filterChannelIds && filterChannelIds.length > 0 && !filterChannelIds.includes(channel.id)) continue
+    // proma-official 始终可见（与 AgentView.hasAvailableModel 的特殊处理保持一致）
+    if (filterChannelIds && filterChannelIds.length > 0 && !filterChannelIds.includes(channel.id) && channel.id !== 'proma-official') continue
 
     for (const model of channel.models) {
       if (!model.enabled) continue
@@ -99,7 +100,12 @@ export function ModelSelector({
   // 外部模型优先 → per-conversation 模型
   const selectedModel = externalSelectedModel !== undefined ? externalSelectedModel : conversationModel
 
-  // 每次打开 Dialog 时刷新渠道列表，确保最新
+  // 组件挂载时刷新渠道列表，确保从设置页返回后立即反映最新状态
+  React.useEffect(() => {
+    window.electronAPI.listChannels().then(setChannels).catch(console.error)
+  }, [setChannels])
+
+  // 每次打开 Dialog 时再次刷新渠道列表
   React.useEffect(() => {
     if (open) {
       window.electronAPI.listChannels().then(setChannels).catch(console.error)

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -217,6 +217,7 @@ function AgentSettingsInitializer(): null {
       })
     }).catch((err) => {
       console.error(err)
+      setChannelsLoaded(true) // 即使出错也标记已加载，避免 ModelSelector 卡在未加载状态
       setAgentSettingsReady(true) // 即使出错也标记就绪，避免永远阻塞
     })
   }, [setAgentChannelId, setAgentModelId, setAgentChannelIds, setAgentWorkspaces, setCurrentWorkspaceId, setPermissionMode, setThinking, setEffort, setMaxBudget, setMaxTurns, setChannels, setChannelsLoaded, setAgentSettingsReady])


### PR DESCRIPTION
## Overview

**商业版本专用 bug fix。** 用户在模型配置中启用 Proma 官方（`proma-official`）渠道后，Agent 模式仍显示「请在设置中选择 Agent 供应商」或「暂无可用模型」，必须手动去 Agent 供应商区再次开启，或刷新页面才能正常使用。此 PR 修复了该问题，使 proma-official 渠道在模型配置中开启后 Agent 模式自动可用，无需额外操作。

### 修改前的问题

1. **Agent 模式无法自动识别 proma-official**：Agent 模式依赖 `agentChannelId`（当前选中渠道）和 `agentChannelIds`（渠道白名单）两个独立状态，但在模型配置中开启 proma-official 只设置了 `channel.enabled`，不会自动设置这两个状态，导致 Agent 输入框显示「请在设置中选择 Agent 供应商」
2. **ModelSelector 白名单过滤**：`buildModelOptions` 用 `filterChannelIds` 过滤渠道，proma-official 不在白名单中时模型列表为空，显示「暂无可用模型」
3. **ModelSelector 刷新时机滞后**：只在 Dialog 打开时刷新渠道列表，组件挂载时不刷新，从设置页切回后仍显示旧状态
4. **启动异常静默卡死**：`AgentSettingsInitializer` 的 catch 路径遗漏 `setChannelsLoaded(true)`，启动 IPC 失败时 ModelSelector 进入永久未加载状态

### 修改后的改善

- proma-official 在模型配置中开启后，Agent 模式**自动激活**——无需手动去 Agent 供应商区再开一次
- 开→关→开 proma-official 后，模型列表**即时刷新**，无需刷新页面或切换会话
- 启动异常时 ModelSelector 能正确显示错误状态而非卡死

## Changes

- `apps/electron/src/renderer/components/agent/AgentView.tsx`
  - `agentChannelIds` 从 `useAtomValue` 改为 `useAtom`（需要 setter）
  - 新增 `useEffect`：当 `agentChannelId` 为空且 proma-official 已启用时，自动设置 `agentChannelId`、`agentModelId`，并将其加入 `agentChannelIds` 白名单
  - 单次 `updateSettings` IPC 调用持久化所有设置，避免竞争写入
  - 从依赖数组中排除 `agentChannelIds`（effect 内写入该值，放入依赖会导致自触发）

- `apps/electron/src/renderer/components/chat/ModelSelector.tsx`
  - `buildModelOptions`：对 `proma-official` 跳过 `filterChannelIds` 白名单过滤，与 `AgentView.hasAvailableModel` 的特殊处理保持一致
  - 新增 mount-time `useEffect`，组件挂载时即刷新渠道列表

- `apps/electron/src/renderer/main.tsx`
  - `AgentSettingsInitializer` 的 `.catch` 路径补加 `setChannelsLoaded(true)`

## How to Test

1. 启动 Proma dev 模式
2. 进入设置 → 模型配置，确保 Proma 官方（proma-official）处于**关闭**状态
3. 开启 Proma 官方 → 关闭设置 → 检查 Agent 模式输入框，应显示可用模型（不再显示「暂无可用模型」或「请在设置中选择 Agent 供应商」）
4. 重新进入设置，**关闭再开启** Proma 官方 → 关闭设置 → Agent 模式应即时显示模型列表，无需刷新页面
5. 切换到其他会话再切回，模型选择应保持正常

## Notes

- 此修复仅影响商业版本中 `proma-official` 渠道的 Agent 模式体验，不影响其他渠道或 Chat 模式
- 对已有用户（已在 Agent 供应商区手动开启渠道）完全无感知——auto-activation 的第一行 `if (agentChannelId) return` 会立即退出
- `typecheck` 通过，无新增类型错误