### PR TITLE
chore: remove redundant node_modules and bundled Bun from package

### DIFF
--- a/apps/electron/electron-builder.yml
+++ b/apps/electron/electron-builder.yml
@@ -68,11 +68,6 @@ mac:
         - x64
   # macOS 额外资源
   extraResources:
-    # Bun 二进制（download-bun.ts 使用 darwin-${arch} 命名）
-    - from: "vendor/bun/darwin-${arch}"
-      to: "vendor/bun"
-      filter:
-        - "**/*"
     # 根据架构选择正确的 ripgrep（实际位于 packages/core 的 node_modules 中）
     - from: "../../packages/core/node_modules/@anthropic-ai/claude-agent-sdk/vendor/ripgrep/${arch}-darwin"
       to: "vendor/ripgrep"
@@ -103,11 +98,6 @@ win:
         - x64
   # Windows 额外资源
   extraResources:
-    # Bun 二进制
-    - from: "vendor/bun/win32-${arch}"
-      to: "vendor/bun"
-      filter:
-        - "**/*"
     - from: "../../packages/core/node_modules/@anthropic-ai/claude-agent-sdk/vendor/ripgrep/x64-win32"
       to: "vendor/ripgrep"
       filter:

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -21,10 +21,7 @@
     "watch:preload": "esbuild src/preload/index.ts --bundle --platform=node --format=cjs --outfile=dist/preload.cjs --external:electron --watch=forever",
     "build:renderer": "vite build",
     "build:resources": "cp -r resources dist/ 2>/dev/null || true",
-    "build:vendor": "bun run scripts/download-bun.ts",
-    "build:vendor:current": "bun run scripts/download-bun.ts --platform $(node -p \"process.platform + '-' + process.arch\")",
     "build": "bun run build:main && bun run build:preload && bun run build:renderer && bun run build:resources",
-    "build:full": "bun run build:vendor && bun run build",
     "start": "bun run build && bunx electron .",
     "typecheck": "tsc --noEmit",
     "generate:icons": "cd resources && ./generate-icons.sh",
@@ -38,7 +35,9 @@
     "dist:debug": "bun run scripts/dist.ts --current-arch --verbose"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.2.89",
+    "@anthropic-ai/claude-agent-sdk": "0.2.89"
+  },
+  "devDependencies": {
     "@emoji-mart/data": "^1.2.1",
     "@emoji-mart/react": "^1.1.1",
     "@larksuiteoapi/node-sdk": "^1.59.0",
@@ -62,6 +61,7 @@
     "@radix-ui/react-toast": "^1.2.15",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@react-symbols/icons": "^1.3.1",
+    "@tailwindcss/typography": "^0.5.19",
     "@tiptap/extension-code-block-lowlight": "^3.19.0",
     "@tiptap/extension-link": "^3.19.0",
     "@tiptap/extension-mention": "^3.19.0",
@@ -70,52 +70,49 @@
     "@tiptap/react": "^3.19.0",
     "@tiptap/starter-kit": "^3.19.0",
     "@tiptap/suggestion": "^3.19.0",
-    "@types/qrcode": "^1.5.6",
-    "chokidar": "^5.0.0",
-    "class-variance-authority": "0.7.1",
-    "clsx": "^2.1.1",
-    "cmdk": "^1.1.1",
-    "dingtalk-stream-sdk-nodejs": "^2.0.4",
-    "electron-updater": "^6.7.3",
-    "katex": "^0.16",
-    "lowlight": "^3.3.0",
-    "lucide-react": "^0.460.0",
-    "officeparser": "4.2.0",
-    "pdf-parse": "1.1.1",
-    "qrcode": "^1.5.4",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "react-markdown": "^10.1.0",
-    "rehype-katex": "^7",
-    "remark-gfm": "^4.0.1",
-    "remark-math": "^6",
-    "sonner": "^2.0.7",
-    "tailwind-merge": "^2.5.5",
-    "undici": "^7.21.0",
-    "use-stick-to-bottom": "^1.1.2",
-    "word-extractor": "1.0.4",
-    "zod": "^4.0.0"
-  },
-  "devDependencies": {
-    "@tailwindcss/typography": "^0.5.19",
     "@types/node": "^20.0.0",
     "@types/pdf-parse": "^1.1.5",
+    "@types/qrcode": "^1.5.6",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
     "@types/word-extractor": "1.0.6",
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.4.20",
+    "chokidar": "^5.0.0",
+    "class-variance-authority": "0.7.1",
+    "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "concurrently": "^9.2.1",
+    "dingtalk-stream-sdk-nodejs": "^2.0.4",
     "electron": "^39.5.1",
     "electron-builder": "^25.1.8",
+    "electron-updater": "^6.7.3",
     "electronmon": "^2.0.4",
     "esbuild": "^0.24.0",
+    "katex": "^0.16",
+    "lowlight": "^3.3.0",
+    "lucide-react": "^0.460.0",
+    "officeparser": "4.2.0",
+    "pdf-parse": "1.1.1",
     "postcss": "^8.4.49",
+    "qrcode": "^1.5.4",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-markdown": "^10.1.0",
+    "rehype-katex": "^7",
     "rehype-raw": "^7.0.0",
+    "remark-gfm": "^4.0.1",
+    "remark-math": "^6",
+    "sonner": "^2.0.7",
+    "tailwind-merge": "^2.5.5",
     "tailwindcss": "^3.4.17",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.0.0",
-    "vite": "^6.0.3"
+    "undici": "^7.21.0",
+    "use-stick-to-bottom": "^1.1.2",
+    "vite": "^6.0.3",
+    "word-extractor": "1.0.4",
+    "zod": "^4.0.0"
   },
   "electronmon": {
     "patterns": [
@@ -127,9 +124,5 @@
   "build": {
     "extends": "electron-builder.yml"
   },
-  "proma": {
-    "bun": {
-      "version": "1.2.5"
-    }
-  }
+  "proma": {}
 }

--- a/apps/electron/scripts/dist.ts
+++ b/apps/electron/scripts/dist.ts
@@ -18,7 +18,6 @@
  */
 
 import { spawnSync } from 'child_process'
-import { existsSync } from 'fs'
 import { join } from 'path'
 
 // ============================================
@@ -168,7 +167,7 @@ function main(): void {
   console.log(`  ${color.bold}详细日志${color.reset}: ${opts.verbose ? '开启' : '关闭'}`)
   printSeparator()
 
-  const totalSteps = 6
+  const totalSteps = 5
   let step = 0
 
   // ── 步骤 1: 构建主进程 ──
@@ -206,23 +205,7 @@ function main(): void {
   )
   printStepResult(results[results.length - 1])
 
-  // ── 步骤 5: 检查 Vendor 文件 ──
-  step++
-  printStepStart(step, totalSteps, '检查 Vendor 依赖')
-  const vendorPath = join(import.meta.dir, '..', 'vendor', 'bun')
-  const vendorExists = existsSync(vendorPath)
-  if (!vendorExists) {
-    console.log(`${color.yellow}  vendor/bun 目录不存在，正在下载...${color.reset}`)
-    results.push(
-      runStep('下载 Vendor 依赖', 'bun', ['run', 'build:vendor:current'], { verbose: opts.verbose })
-    )
-  } else {
-    console.log(`${color.green}  vendor/bun 已存在，跳过下载${color.reset}`)
-    results.push({ name: '检查 Vendor 依赖', duration: 0, success: true, skipped: true })
-  }
-  printStepResult(results[results.length - 1])
-
-  // ── 步骤 6: electron-builder 打包 ──
+  // ── 步骤 5: electron-builder 打包 ──
   step++
   printStepStart(step, totalSteps, 'Electron Builder 打包')
 

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -243,21 +243,17 @@ function resolveSDKCliPath(): string {
 /**
  * 获取 Agent SDK 运行时可执行文件
  *
- * 优先级：Node.js → Bun → which node 同步查找 → 字符串 'node'
+ * 优先级：Node.js（缓存）→ which node 同步查找
  *
  * 当 runtimeStatusCache 尚未初始化时（应用启动竞态），
- * 降级到 'node' 字符串可能因 Electron 进程 PATH 不含 node 而触发 ENOENT。
- * 此时用 which/where 同步查找作为兜底，避免 SDK spawn 失败。
+ * 用 which/where 同步查找作为兜底，避免 SDK spawn 失败。
+ * 如果 Node.js 完全不可用，抛出明确错误。
  */
-function getAgentExecutable(): { type: 'node' | 'bun'; path: string } {
+function getAgentExecutable(): { type: 'node'; path: string } {
   const status = getRuntimeStatus()
 
   if (status?.node?.available && status.node.path) {
     return { type: 'node', path: status.node.path }
-  }
-
-  if (status?.bun?.available && status.bun.path) {
-    return { type: 'bun', path: status.bun.path }
   }
 
   // runtimeStatusCache 未就绪时，同步查找 node 路径
@@ -271,10 +267,13 @@ function getAgentExecutable(): { type: 'node' | 'bun'; path: string } {
       return { type: 'node', path: nodePath }
     }
   } catch {
-    // 忽略查找失败，继续降级
+    // 忽略查找失败
   }
 
-  return { type: 'node', path: 'node' }
+  throw new Error(
+    'Node.js 运行时未找到。Agent 功能需要系统安装 Node.js (v18+)。' +
+      '请访问 https://nodejs.org 下载安装后重启 Proma。',
+  )
 }
 
 /**
@@ -853,7 +852,7 @@ export class AgentOrchestrator {
     const accumulatedMessages: SDKMessage[] = []
     let resolvedModel = modelId || DEFAULT_MODEL_ID
     let titleGenerationStarted = false
-    let agentExec: { type: 'node' | 'bun'; path: string } | undefined
+    let agentExec: { type: 'node'; path: string } | undefined
     let agentCwd: string | undefined
     let workspaceSlug: string | undefined
     let workspace: import('@proma/shared').AgentWorkspace | undefined
@@ -879,8 +878,7 @@ export class AgentOrchestrator {
         `[Agent 编排] 启动 SDK — CLI: ${cliPath}, 运行时: ${agentExec.type} (${agentExec.path}), 模型: ${modelId || DEFAULT_MODEL_ID}, resume: ${existingSdkSessionId ?? '无'}`,
       )
 
-      const nullDevice = process.platform === 'win32' ? 'NUL' : '/dev/null'
-      const executableArgs = agentExec.type === 'bun' ? [`--env-file=${nullDevice}`] : []
+      const executableArgs: string[] = []
 
       // 确定 Agent 工作目录
       agentCwd = homedir()


### PR DESCRIPTION
## Summary

- Move 45 packages from `dependencies` to `devDependencies` — they are already bundled by esbuild/Vite into `dist/`, so their `node_modules` copies were unnecessarily packaged by electron-builder
- Remove the 55MB Bun binary from `extraResources` (mac & win) — Node.js is the required runtime for Agent functionality
- Add clear error message when Node.js is unavailable instead of silently falling back to Bun
- Clean up `build:vendor` / `build:full` scripts and vendor download step from `dist.ts`

Only `@anthropic-ai/claude-agent-sdk` remains in `dependencies` (esbuild `--external`).

## Test plan

- [ ] Run `bun run build` to verify esbuild/Vite still resolve all dependencies correctly
- [ ] Run `bun run dist:fast` and verify the packaged app launches and Agent functionality works
- [ ] Verify the packaged app size is significantly smaller (no redundant node_modules or Bun binary)
- [ ] Test Agent on a machine with Node.js installed — should work as before
- [ ] Test Agent on a machine without Node.js — should show clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)