### PR TITLE
fix: idle timeout 在工具执行期间误触发重试

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -1414,6 +1414,9 @@ export class AgentOrchestrator {
           // （Watchdog 仅覆盖 startedTaskIds.size > 0 的 Teams 场景）
           const idleAbort = new AbortController()
           let lastActivityAt = Date.now()
+          // 追踪是否有工具调用正在执行中（tool_use 已发出但 tool_result 尚未收到）
+          // 执行 bun run dev 等长时间 Bash 命令时此标志为 true，应暂停 idle 计时
+          let hasActiveTool = false
           const idleWatcherDone = (async () => {
             const CHECK_INTERVAL_MS = 30_000
             while (!loopAbort.signal.aborted) {
@@ -1421,6 +1424,11 @@ export class AgentOrchestrator {
               if (loopAbort.signal.aborted) break
               // 等待用户交互时（AskUser / 权限确认 / ExitPlanMode 审批）暂停 idle 计时
               if (waitingForUserInput) {
+                lastActivityAt = Date.now()
+                continue
+              }
+              // 有工具正在执行中（如长时间 Bash 命令）：暂停 idle 计时，避免误杀
+              if (hasActiveTool) {
                 lastActivityAt = Date.now()
                 continue
               }
@@ -1502,6 +1510,23 @@ export class AgentOrchestrator {
 
             // 收到 SDK 事件：重置 idle 计时器
             lastActivityAt = Date.now()
+
+            // 追踪工具执行状态：assistant 含 tool_use 时标记为活跃，收到 tool_result 时清除
+            // 用于 idle watcher 区分"API SSE stall"和"工具正在执行中"
+            if (msg.type === 'assistant') {
+              const assistantContent = (msg as SDKAssistantMessage).message?.content
+              if (Array.isArray(assistantContent) && assistantContent.some((b: { type: string }) => b.type === 'tool_use')) {
+                hasActiveTool = true
+              }
+            } else if (msg.type === 'user') {
+              const userContent = (msg as { message?: { content?: Array<{ type: string }> } }).message?.content
+              if (Array.isArray(userContent) && userContent.some((b) => b.type === 'tool_result')) {
+                hasActiveTool = false
+              }
+            } else if (msg.type === 'result') {
+              // Turn 正常结束，清除工具活跃标志
+              hasActiveTool = false
+            }
 
             // 检测 assistant 消息中的 SDK 错误
             if (msg.type === 'assistant') {


### PR DESCRIPTION
## Overview

长时间运行的 Bash 命令（如 `bun run dev`、`sleep N`、`npm run watch`）执行期间，SDK 不产出新事件，导致 idle watcher 在 120s 后误判为 API 无响应并触发自动重试，强制中断正在执行的工具调用。用户会看到会话被意外重启，之前启动的后台进程也随之被杀掉。

本 PR 通过追踪工具执行状态来区分「API SSE stall（真正的挂起）」和「工具正在执行中（预期的沉默）」，避免误触发。

## Changes

- `apps/electron/src/main/lib/agent-orchestrator.ts` — 添加 `hasActiveTool` 标志：
  - assistant 消息含 `tool_use` block 时设为 `true`
  - 收到对应 `tool_result`（user 消息）或 turn 结束（result 消息）时清除为 `false`
  - idle watcher 检查时若 `hasActiveTool === true` 则重置 `lastActivityAt` 并跳过本轮超时检查

## How to Test

1. 将 `IDLE_TIMEOUT_MS` 临时改为 `10_000`（10 秒）
2. 启动 Proma dev 版本
3. 在 Agent 模式下发送：「帮我在终端里跑一下 sleep 30」
4. 观察结果：
   - **修复前**：约 10s 后会话被自动重试中断
   - **修复后**：等待约 30s 后 agent 正常返回结果，不中断

## Notes

- 与已有的 `waitingForUserInput` 机制对称，两者共同覆盖所有「预期沉默」场景：
  - `waitingForUserInput`：AskUserQuestion / 权限确认 / ExitPlanMode 审批等待用户操作
  - `hasActiveTool`：工具调用已发出，等待执行结果返回
- idle timeout 仍然有效覆盖真正的 API SSE stall 场景（模型尚未发出 tool_use 就挂起）
- 已在本地验证：IDLE_TIMEOUT_MS=10s 时，sleep 30 正常执行完成不中断