### PR TITLE
fix: idle timeout 在长耗时工具执行期间误触发重试

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -178,6 +178,14 @@ function getRetryDelayMs(attempt: number): number {
   return Math.min(1000 * Math.pow(2, attempt - 1), 8000)
 }
 
+/** 判定是否为可能长时间执行的工具（抑制 idle timeout） */
+function isLongRunningTool(toolName: string): boolean {
+  return toolName === 'Bash'
+    || toolName === 'Agent'
+    || toolName === 'TaskOutput'
+    || toolName.startsWith('mcp__')
+}
+
 /**
  * 可中断的定时器
  *
@@ -1073,8 +1081,17 @@ export class AgentOrchestrator {
       /** 正在等待用户交互（AskUser / ExitPlanMode 审批 / 权限确认），idle watcher 应暂停计时 */
       let waitingForUserInput = false
 
+      /** 长耗时工具正在执行时为 true，抑制 idle timeout（Bash、MCP、Agent 等） */
+      let longRunningToolActive = false
+
       // 动态 canUseTool：每次调用读取当前权限模式，支持运行中切换
       const canUseTool = async (toolName: string, input: Record<string, unknown>, options: CanUseToolOptions): Promise<PermissionResult> => {
+        // 长耗时工具：标记执行状态，抑制 idle timeout
+        // （工具完成后由事件循环中的 tool_result 清除）
+        if (isLongRunningTool(toolName)) {
+          longRunningToolActive = true
+        }
+
         const currentMode = getPermissionMode()
 
         // ── 参数校验守卫（所有模式、所有工具，优先于权限检查） ──
@@ -1417,8 +1434,8 @@ export class AgentOrchestrator {
             while (!loopAbort.signal.aborted) {
               await timerWithAbort(CHECK_INTERVAL_MS, loopAbort.signal)
               if (loopAbort.signal.aborted) break
-              // 等待用户交互时（AskUser / 权限确认 / ExitPlanMode 审批）暂停 idle 计时
-              if (waitingForUserInput) {
+              // 等待用户交互 或 长耗时工具执行中 时暂停 idle 计时
+              if (waitingForUserInput || longRunningToolActive) {
                 lastActivityAt = Date.now()
                 continue
               }
@@ -1587,6 +1604,7 @@ export class AgentOrchestrator {
                   const hasToolResult = Array.isArray(content) && content.some((b) => b.type === 'tool_result')
                   if (hasToolResult) {
                     accumulatedMessages.push(msg)
+                    longRunningToolActive = false // 工具执行完毕，恢复 idle timeout
                   }
                 } else {
                   // 为 assistant 消息注入渠道 modelId，确保持久化后能正确匹配模型显示名
@@ -1605,6 +1623,7 @@ export class AgentOrchestrator {
 
             // Turn 结束时：持久化累积消息，并检测 0-token 空响应
             if (msg.type === 'result') {
+              longRunningToolActive = false // turn 结束，兜底清除
               const resultMsg = msg as import('@proma/shared').SDKResultMessage
               capturedResultSubtype = resultMsg.subtype
 


### PR DESCRIPTION
## Summary

- 长时间运行的 Bash/Agent/TaskOutput/MCP 工具执行期间，SDK 不产出新事件，idle watcher 120s 后误判为 API 无响应并触发自动重试，中断正在执行的工具
- 通过 `canUseTool` 回调层检测长耗时工具（`isLongRunningTool`），执行期间设置 `longRunningToolActive` 标志抑制 idle timeout，收到 `tool_result` 或 turn 结束时清除
- 与 `waitingForUserInput` 机制对称，共同覆盖所有「预期沉默」场景

## Design

在 `canUseTool` 回调层（而非消息内容解析层）检测工具类型，仅对确实可能长时间执行的工具抑制 idle timeout：

```typescript
function isLongRunningTool(toolName: string): boolean {
  return toolName === 'Bash'
    || toolName === 'Agent'
    || toolName === 'TaskOutput'
    || toolName.startsWith('mcp__')
}
```

清除时机：
- `tool_result` user 消息 → 工具执行完毕
- `result` 消息 → turn 结束兜底清除

## Test plan

- [ ] 将 `IDLE_TIMEOUT_MS` 改为 `10_000`，执行 `sleep 30`，验证不被中断
- [ ] 调用 MCP 工具（如长耗时查询），验证不被中断
- [ ] 工具执行完成后 API 挂起，验证 idle timeout 仍能正常触发
- [ ] Read/Write 等快速工具不影响 idle timeout 检测

🤖 Generated with [Claude Code](https://claude.com/claude-code)