### PR TITLE
fix: Quick Task 面板主题颜色跨窗口实时同步

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -649,8 +649,21 @@ export function registerIpcHandlers(): void {
   // 更新应用设置
   ipcMain.handle(
     SETTINGS_IPC_CHANNELS.UPDATE,
-    async (_, updates: Partial<AppSettings>): Promise<AppSettings> => {
-      return updateSettings(updates)
+    async (event, updates: Partial<AppSettings>): Promise<AppSettings> => {
+      const result = await updateSettings(updates)
+
+      // 主题相关设置变化时，广播给所有窗口（跨窗口同步，如 Quick Task 面板）
+      if (updates.themeMode !== undefined || updates.themeStyle !== undefined) {
+        const payload = { themeMode: result.themeMode, themeStyle: result.themeStyle }
+        BrowserWindow.getAllWindows().forEach((win) => {
+          // 跳过发起者窗口，避免重复应用
+          if (win.webContents.id !== event.sender.id) {
+            win.webContents.send(SETTINGS_IPC_CHANNELS.ON_THEME_SETTINGS_CHANGED, payload)
+          }
+        })
+      }
+
+      return result
     }
   )
 

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -258,6 +258,9 @@ export interface ElectronAPI {
   /** 订阅系统主题变化事件（返回清理函数） */
   onSystemThemeChanged: (callback: (isDark: boolean) => void) => () => void
 
+  /** 订阅用户手动切换主题事件（跨窗口同步，返回清理函数） */
+  onThemeSettingsChanged: (callback: (payload: { themeMode: string; themeStyle: string }) => void) => () => void
+
   // ===== 应用图标切换 =====
 
   /** 设置应用图标变体（传入 variant ID，如 'blue'、'cyberpunk'，'default' 恢复默认） */
@@ -925,6 +928,12 @@ const electronAPI: ElectronAPI = {
     const listener = (_: unknown, isDark: boolean): void => callback(isDark)
     ipcRenderer.on(SETTINGS_IPC_CHANNELS.ON_SYSTEM_THEME_CHANGED, listener)
     return () => { ipcRenderer.removeListener(SETTINGS_IPC_CHANNELS.ON_SYSTEM_THEME_CHANGED, listener) }
+  },
+
+  onThemeSettingsChanged: (callback: (payload: { themeMode: string; themeStyle: string }) => void) => {
+    const listener = (_: unknown, payload: { themeMode: string; themeStyle: string }): void => callback(payload)
+    ipcRenderer.on(SETTINGS_IPC_CHANNELS.ON_THEME_SETTINGS_CHANGED, listener)
+    return () => { ipcRenderer.removeListener(SETTINGS_IPC_CHANNELS.ON_THEME_SETTINGS_CHANGED, listener) }
   },
 
   // 应用图标切换

--- a/apps/electron/src/renderer/atoms/theme.ts
+++ b/apps/electron/src/renderer/atoms/theme.ts
@@ -145,11 +145,26 @@ export async function initializeTheme(
   setSystemIsDark(isDark)
 
   // 监听系统主题变化
-  const cleanup = window.electronAPI.onSystemThemeChanged((newIsDark) => {
+  const cleanupSystem = window.electronAPI.onSystemThemeChanged((newIsDark) => {
     setSystemIsDark(newIsDark)
   })
 
-  return cleanup
+  // 监听用户手动切换主题（跨窗口同步，如 Quick Task 面板）
+  const cleanupThemeSettings = window.electronAPI.onThemeSettingsChanged((payload) => {
+    const mode = payload.themeMode as ThemeMode
+    const style = (payload.themeStyle || 'default') as ThemeStyle
+    setThemeMode(mode)
+    cacheThemeMode(mode)
+    if (setThemeStyle) {
+      setThemeStyle(style)
+      cacheThemeStyle(style)
+    }
+  })
+
+  return () => {
+    cleanupSystem()
+    cleanupThemeSettings()
+  }
 }
 
 /**

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -116,6 +116,8 @@ export const SETTINGS_IPC_CHANNELS = {
   UPDATE: 'settings:update',
   GET_SYSTEM_THEME: 'settings:get-system-theme',
   ON_SYSTEM_THEME_CHANGED: 'settings:system-theme-changed',
+  /** 用户手动切换主题时广播给所有窗口 */
+  ON_THEME_SETTINGS_CHANGED: 'settings:theme-settings-changed',
 } as const
 
 /** 应用图标 IPC 通道 */


### PR DESCRIPTION
## Overview

Quick Task 面板（Option+Space 唤起）的主题颜色在用户手动切换主题后不会实时更新，需要重启应用才能生效。原因是 `settings:update` IPC 处理器仅将设置保存到磁盘，没有广播给其他 BrowserWindow。

本 PR 新增了主题设置变更的跨窗口广播机制，复用已有的 `onSystemThemeChanged` 模式，使 Quick Task 窗口能实时响应主题切换。

## Changes

- `apps/electron/src/types/settings.ts` — 新增 `ON_THEME_SETTINGS_CHANGED` IPC 通道常量
- `apps/electron/src/main/ipc.ts` — 在 `settings:update` 处理器中，检测到 `themeMode` 或 `themeStyle` 变化时，广播给除发起者外的所有窗口
- `apps/electron/src/preload/index.ts` — 暴露 `onThemeSettingsChanged` 监听 API（类型声明 + 实现）
- `apps/electron/src/renderer/atoms/theme.ts` — `initializeTheme()` 中订阅新事件，接收到广播后更新 Jotai atoms 和 localStorage 缓存

## How to Test

1. 启动应用，打开设置 → 外观，记住当前主题
2. 按 Option+Space 唤起 Quick Task 面板，确认颜色与主窗口一致
3. 回到主窗口，切换到不同的主题（如从深色切到浅色，或切换特殊风格）
4. 再次按 Option+Space 唤起 Quick Task 面板
5. **预期结果：** Quick Task 面板立即显示新主题颜色，无需重启

## Notes

- 仅在 `themeMode` 或 `themeStyle` 变化时触发广播，其他设置更新不受影响
- 广播跳过发起者窗口（`event.sender.id`），避免主窗口重复应用
- 性能影响可忽略：主题切换为极低频操作，payload 仅两个字符串字段