### PR TITLE
fix: fork 后第 2-3 轮 Session 已失效重试问题

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -899,15 +899,9 @@ export class AgentOrchestrator {
         }
       }
 
-      // 9.4.1 Fork 后首次 resume：使用源 cwd 让 SDK 找到 session 文件
-      // SDK forkSession() 在源 cwd 的项目哈希下创建新 session 文件，
-      // 首次 resume 需要从该目录查找，之后 SDK 会在新 cwd 下创建新数据
-      if (sessionMeta?.forkSourceDir) {
-        agentCwd = sessionMeta.forkSourceDir
-        console.log(`[Agent 编排] Fork 首次 resume: 使用源会话 cwd=${sessionMeta.forkSourceDir}`)
-        // 消费一次后清除
-        updateAgentSessionMeta(sessionId, { forkSourceDir: undefined })
-      }
+      // 9.4.1 Fork session JSONL 迁移已在 forkAgentSession 中完成，
+      // fork 后的会话直接使用自己的 cwd，无需回退到源目录。
+      // forkSourceDir 仅作为备用参考字段保留，不再影响 agentCwd。
 
       // 9.5 确保 SDK 项目设置（plansDirectory → .context）
       {

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -8,7 +8,7 @@
  * 照搬 conversation-manager.ts 的模式。
  */
 
-import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync, unlinkSync, rmSync, renameSync, readdirSync, cpSync } from 'node:fs'
+import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync, unlinkSync, rmSync, renameSync, readdirSync, cpSync, copyFileSync } from 'node:fs'
 import { randomUUID } from 'node:crypto'
 import { join, resolve, dirname } from 'node:path'
 import {
@@ -505,8 +505,9 @@ export function migrateChatToAgentSession(conversationId: string, agentSessionId
  * 直接调用 SDK 的 forkSession() 独立函数完成 JSONL 复制和 UUID 重映射，
  * 新会话立即获得 sdkSessionId，无需延迟到首次发消息。
  *
- * forkSourceDir 用于首次 resume 时定位 SDK session 文件（因 fork 后的 session
- * 存储在源 cwd 的项目哈希下），orchestrator 首次 resume 后会清除该字段。
+ * forkSourceDir 记录源会话的工作目录，仅作为元数据参考保留。
+ * SDK session JSONL 已在 fork 创建时复制到新会话的 project-hash 目录下，
+ * orchestrator 无需在运行时切换 cwd。
  *
  * process.env.CLAUDE_CONFIG_DIR 已在模块加载时设置，无需在此处临时修改。
  *
@@ -572,6 +573,33 @@ export async function forkAgentSession(input: ForkSessionInput): Promise<AgentSe
   newMeta.sdkSessionId = forkResult.sessionId
   newMeta.forkSourceDir = sourceDir
   newMeta.forkSourceSdkSessionId = sourceMeta.sdkSessionId
+
+  // 4.5 将 SDK session JSONL 复制到 fork 自己的 project-hash 目录
+  // SDK forkSession() 在源 cwd 的 project-hash 下创建 JSONL（如 projects/<hash-of-sourceDir>/<newId>.jsonl），
+  // 但 fork 会话的 cwd 是新的 session 目录（不同 project-hash），resume 时 SDK 会找不到。
+  // 这里直接将 JSONL 复制到 fork 目标 cwd 的 project-hash 下，让后续每轮 resume 都能直接命中。
+  if (sourceDir && sourceMeta.workspaceId) {
+    const ws = getAgentWorkspace(sourceMeta.workspaceId)
+    if (ws) {
+      const destCwd = getAgentSessionWorkspacePath(ws.slug, newMeta.id)
+      const sourceJsonl = findSdkSessionJsonl(forkResult.sessionId)
+      if (sourceJsonl) {
+        // SDK 使用简单的字符替换计算 project-hash：path.replace(/[^a-zA-Z0-9]/g, '-')
+        const destProjectHash = destCwd.replace(/[^a-zA-Z0-9]/g, '-')
+        const sdkProjectsDir = join(getSdkConfigDir(), 'projects', destProjectHash)
+        if (!existsSync(sdkProjectsDir)) mkdirSync(sdkProjectsDir, { recursive: true })
+        const destJsonl = join(sdkProjectsDir, `${forkResult.sessionId}.jsonl`)
+        try {
+          copyFileSync(sourceJsonl, destJsonl)
+          console.log(`[Agent 会话] 已将 SDK session JSONL 复制到 fork 目标目录: ${destJsonl}`)
+        } catch (err) {
+          console.warn(`[Agent 会话] 复制 SDK session JSONL 失败，fork 后首轮可能触发上下文回填:`, err)
+        }
+      } else {
+        console.warn(`[Agent 会话] 未找到 SDK session JSONL (${forkResult.sessionId})，fork 后首轮可能触发上下文回填`)
+      }
+    }
+  }
 
   // 5. 复制源会话工作区文件到新会话目录（排除 .claude/ 和 .context/，它们会自动创建）
   if (sourceDir && sourceMeta.workspaceId) {


### PR DESCRIPTION
## Overview

Fork 一个会话后，第 1 轮对话正常，但第 2-3 轮会触发 "Session 已失效，切换到上下文回填模式" 错误并重试。根因是 SDK `forkSession()` 在**源 cwd 的 project-hash** 下创建 JSONL，而 fork 会话的 cwd 对应不同的 project-hash 目录，SDK 在第 2 轮 resume 时找不到 session 文件。

本 PR 在 fork 创建时立即将 SDK session JSONL 复制到 fork 自己 cwd 的 project-hash 目录下，从根本上消除路径不匹配问题。

## Changes

- `apps/electron/src/main/lib/agent-session-manager.ts`
  - 新增步骤 4.5：`forkAgentSession()` 中，SDK fork 完成后用 `findSdkSessionJsonl()` 定位源 JSONL，通过 `copyFileSync` 复制到 fork 目标 cwd 的 project-hash 目录（使用 SDK 相同的 hash 算法 `path.replace(/[^a-zA-Z0-9]/g, '-')`）
  - 新增 `copyFileSync` import
  - 更新 `forkAgentSession` 注释

- `apps/electron/src/main/lib/agent-orchestrator.ts`
  - 移除 9.4.1 的 `forkSourceDir` cwd 回退逻辑（不再在运行时切换 agentCwd 到源目录）
  - `onSessionId` 回调保持原始行为

## How to Test

1. 在一个有多轮对话的 Agent 会话中，点击 fork
2. 在 fork 出的新会话中发送第 1 条消息 → 应正常响应
3. 继续发送第 2、3 条消息 → 应正常响应，**不再出现 "Session 已失效" 重试提示**
4. 验证 fork 会话能记住完整的对话历史

## Notes

- `forkSourceDir` 字段仍写入 meta 作为元数据参考，但不再影响运行时 cwd 选择
- 源 project-hash 下的 JSONL 副本会保留（SDK 创建的那份），不影响功能，仅占少量磁盘空间
- SDK hash 算法依赖 `path.replace(/[^a-zA-Z0-9]/g, '-')`，路径 ≤200 字符时完全匹配（Proma 的路径远低于此限制）