### PR TITLE
feat: Write 工具展开详情改为内容视图

### DIFF
--- a/apps/electron/src/renderer/components/agent/tool-result-renderers/write-result.tsx
+++ b/apps/electron/src/renderer/components/agent/tool-result-renderers/write-result.tsx
@@ -1,8 +1,9 @@
 /**
- * Write 工具结果渲染器 — 简洁成功消息
+ * Write 工具结果渲染器 — 内容视图
  */
 
 import * as React from 'react'
+import { cn } from '@/lib/utils'
 
 interface WriteResultRendererProps {
   result: string
@@ -19,15 +20,32 @@ export function WriteResultRenderer({ result, isError, input }: WriteResultRende
     )
   }
 
-  const filePath = typeof input.file_path === 'string' ? input.file_path : ''
-  const filename = filePath.split('/').pop() ?? filePath
   const content = typeof input.content === 'string' ? input.content : ''
-  const lineCount = content ? content.split('\n').length : 0
+
+  if (!content) {
+    const filePath = typeof input.file_path === 'string' ? input.file_path : ''
+    const filename = filePath.split(/[/\\]/).pop() ?? filePath
+    return (
+      <div className="text-[12px] text-muted-foreground">
+        已写入 <span className="font-mono text-foreground/70">{filename || '文件'}</span>
+      </div>
+    )
+  }
+
+  const lines = content.split('\n')
 
   return (
-    <div className="text-[12px] text-muted-foreground">
-      已写入 <span className="font-mono text-foreground/70">{filename || '文件'}</span>
-      {lineCount > 0 && <span>, {lineCount} 行</span>}
+    <div className="rounded-md font-mono text-[12px] leading-relaxed overflow-x-auto bg-zinc-900 dark:bg-zinc-950">
+      {lines.map((line, i) => (
+        <div key={i} className="flex bg-green-500/10">
+          <span className="shrink-0 w-10 text-right pr-3 select-none text-green-400/60 text-[11px]">
+            +
+          </span>
+          <span className={cn('flex-1 whitespace-pre-wrap break-all text-green-300')}>
+            {line || '\u200B'}
+          </span>
+        </div>
+      ))}
     </div>
   )
 }


### PR DESCRIPTION
## 问题根因

Write 工具调用展开详情时，只显示"已写入 N 行"的文字，无法直观查看实际写入的内容，与 Edit 工具提供 diff 视图的体验不一致。

## 具体修改

- `apps/electron/src/renderer/components/agent/tool-result-renderers/write-result.tsx`
  - 展开详情时将 `input.content` 按行渲染为绿色 `+` 前缀视图（与 Edit 工具 diff 风格一致）
  - 无内容时兜底显示"已写入 {filename}"
  - 路径分隔符改为正则 `/[/\\]/`，兼容 Windows 路径

## 审查情况

代码自审通过，样式与 Edit 工具完全一致，改动范围仅限单一渲染器文件，无副作用。用户测试 OK。