### PR TITLE
fix: 改进输入框列表交互体验及换行行为

### DIFF
--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -55,7 +55,7 @@ function htmlToMarkdown(html: string): string {
 
     switch (tagName) {
       case 'p':
-        return children + '\n\n'
+        return children + '\n'
       case 'br':
         return '\n'
       case 'strong':
@@ -83,7 +83,7 @@ function htmlToMarkdown(html: string): string {
         const langMatch = langClass.match(/language-(\w+)/)
         const lang = langMatch ? langMatch[1] : ''
         const codeContent = codeEl ? processNode(codeEl) : children
-        return `\`\`\`${lang}\n${codeContent}\n\`\`\`\n\n`
+        return `\`\`\`${lang}\n${codeContent}\n\`\`\`\n`
       }
       case 'a': {
         const href = el.getAttribute('href') || ''
@@ -92,25 +92,25 @@ function htmlToMarkdown(html: string): string {
       case 'ul':
         return Array.from(el.children)
           .map((li) => `- ${processNode(li).trim()}`)
-          .join('\n') + '\n\n'
+          .join('\n') + '\n'
       case 'ol':
         return Array.from(el.children)
           .map((li, i) => `${i + 1}. ${processNode(li).trim()}`)
-          .join('\n') + '\n\n'
+          .join('\n') + '\n'
       case 'li':
         return children
       case 'blockquote':
         return children
           .split('\n')
           .map((line) => `> ${line}`)
-          .join('\n') + '\n\n'
-      case 'h1': return `# ${children}\n\n`
-      case 'h2': return `## ${children}\n\n`
-      case 'h3': return `### ${children}\n\n`
-      case 'h4': return `#### ${children}\n\n`
-      case 'h5': return `##### ${children}\n\n`
-      case 'h6': return `###### ${children}\n\n`
-      case 'hr': return '---\n\n'
+          .join('\n') + '\n'
+      case 'h1': return `# ${children}\n`
+      case 'h2': return `## ${children}\n`
+      case 'h3': return `### ${children}\n`
+      case 'h4': return `#### ${children}\n`
+      case 'h5': return `##### ${children}\n`
+      case 'h6': return `###### ${children}\n`
+      case 'hr': return '---\n'
       case 'span': {
         // Mention 节点：根据 data-mention-suggestion-char 区分类型
         const dataType = el.getAttribute('data-type')
@@ -370,6 +370,20 @@ export function RichTextInput({
           isComposingRef.current = false
           return false
         },
+        copy: (_view, event) => {
+          // 复制时只写纯文本，避免粘贴到外部应用时出现多余空行
+          const selection = window.getSelection()
+          if (!selection || selection.isCollapsed || !event.clipboardData) return false
+          const range = selection.getRangeAt(0)
+          const fragment = range.cloneContents()
+          const tempDiv = document.createElement('div')
+          tempDiv.appendChild(fragment)
+          const text = htmlToMarkdown(tempDiv.innerHTML) || selection.toString()
+          event.preventDefault()
+          event.clipboardData.setData('text/plain', text)
+          event.clipboardData.setData('text/html', '')
+          return true
+        },
       },
       handlePaste: (view, event) => {
         // 拦截粘贴的文件（图片等）
@@ -435,15 +449,45 @@ export function RichTextInput({
           event.preventDefault()
           // 检查是否在列表项内（遍历祖先节点）
           let isInList = false
+          let listItemNode = null
           for (let d = $from.depth; d > 0; d--) {
-            if ($from.node(d).type.name === 'listItem') { isInList = true; break }
+            if ($from.node(d).type.name === 'listItem') {
+              isInList = true
+              listItemNode = $from.node(d)
+              break
+            }
           }
           if (isInList && editor) {
-            editor.chain().focus().splitListItem('listItem').run()
+            // 空列表项再次按 Enter：退出列表，回到普通输入
+            if (listItemNode && listItemNode.textContent === '') {
+              editor.chain().focus().liftListItem('listItem').run()
+            } else {
+              editor.chain().focus().splitListItem('listItem').run()
+            }
           } else if (editor) {
-            editor.chain().focus().setHardBreak().run()
+            editor.chain().focus().splitBlock().run()
           }
           return true
+        }
+
+        // Backspace：空列表项时退出列表
+        if (event.key === 'Backspace') {
+          const { state } = view
+          const { $from } = state.selection
+          let isInList = false
+          let listItemNode = null
+          for (let d = $from.depth; d > 0; d--) {
+            if ($from.node(d).type.name === 'listItem') {
+              isInList = true
+              listItemNode = $from.node(d)
+              break
+            }
+          }
+          if (isInList && listItemNode && listItemNode.textContent === '' && editor) {
+            event.preventDefault()
+            editor.chain().focus().liftListItem('listItem').run()
+            return true
+          }
         }
 
         return false
@@ -573,6 +617,15 @@ export function RichTextInput({
         }
         .ProseMirror p {
           font-style: normal;
+          margin: 0;
+        }
+        .ProseMirror ul,
+        .ProseMirror ol {
+          margin: 0;
+          padding-left: 1.5em;
+        }
+        .ProseMirror li {
+          margin: 0;
         }
         .ProseMirror p.is-editor-empty:first-child::before {
           content: attr(data-placeholder);

--- a/apps/electron/src/renderer/components/settings/AgentSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AgentSettings.tsx
@@ -10,7 +10,7 @@
 
 import * as React from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
-import { Plus, Plug, Pencil, Trash2, Sparkles, FolderOpen, MessageSquare, ShieldCheck, ChevronDown, ChevronRight, Brain, ImagePlus, Settings, RefreshCw } from 'lucide-react'
+import { Plus, Plug, Pencil, Trash2, Sparkles, FolderOpen, MessageSquare, ShieldCheck, ChevronDown, ChevronRight, Brain, ImagePlus, Settings, RefreshCw, Search } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
@@ -1004,6 +1004,7 @@ function BuiltinAgentTools(): React.ReactElement {
 
   const memoryTool = tools.find((t) => t.meta.id === 'memory')
   const nanoBananaTool = tools.find((t) => t.meta.id === 'nano-banana')
+  const webSearchTool = tools.find((t) => t.meta.id === 'web-search')
 
   /** 跳转到工具设置页 */
   const goToToolSettings = (): void => {
@@ -1035,6 +1036,14 @@ function BuiltinAgentTools(): React.ReactElement {
       icon: <ImagePlus className="size-4" />,
       enabled: nanoBananaTool?.enabled ?? false,
       available: nanoBananaTool?.available ?? false,
+    },
+    {
+      id: 'web-search',
+      name: '联网搜索',
+      description: '实时搜索互联网获取最新信息',
+      icon: <Search className="size-4" />,
+      enabled: webSearchTool?.enabled ?? false,
+      available: webSearchTool?.available ?? false,
     },
   ]
 
@@ -1140,11 +1149,11 @@ function AgentAdvancedSettings(): React.ReactElement {
           onClick={() => setCollapsed(!collapsed)}
           className="flex items-center gap-2 hover:text-foreground/80 transition-colors"
         >
+          <span>Agent 高级设置</span>
           {collapsed
             ? <ChevronRight size={16} className="text-muted-foreground" />
             : <ChevronDown size={16} className="text-muted-foreground" />
           }
-          <span>Agent 高级设置</span>
         </button>
       }
       description={collapsed ? undefined : '控制 Agent 的思考模式、推理深度和资源限制'}

--- a/apps/electron/src/renderer/components/settings/AppearanceSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AppearanceSettings.tsx
@@ -160,7 +160,7 @@ export function AppearanceSettings(): React.ReactElement {
   }, [setThemeMode, setThemeStyle, systemIsDark])
 
   return (
-    <>
+    <div className="space-y-6">
       <SettingsSection
         title="外观设置"
         description="自定义应用的视觉风格"
@@ -198,7 +198,7 @@ export function AppearanceSettings(): React.ReactElement {
       </SettingsSection>
 
       <AppIconPicker />
-    </>
+    </div>
   )
 }
 

--- a/apps/electron/src/renderer/components/settings/FeishuSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/FeishuSettings.tsx
@@ -712,6 +712,7 @@ function BotConfigCard({ bot, state, onSaved, onRemoved }: BotConfigCardProps): 
 
 function FeishuConfigTab(): React.ReactElement {
   const botStates = useAtomValue(feishuBotStatesAtom)
+  const setBotStates = useSetAtom(feishuBotStatesAtom)
   const [bots, setBots] = React.useState<FeishuBotConfig[]>([])
   const [loading, setLoading] = React.useState(true)
 
@@ -738,7 +739,20 @@ function FeishuConfigTab(): React.ReactElement {
     }
   }, [])
 
-  React.useEffect(() => { loadBots() }, [loadBots])
+  // 进入 Tab 时同步最新状态，避免因启动时序问题导致颜色显示错误
+  const refreshStates = React.useCallback(async () => {
+    try {
+      const multiState = await window.electronAPI.getFeishuMultiStatus?.()
+      if (multiState?.bots) {
+        setBotStates(multiState.bots)
+      }
+    } catch { /* 忽略 */ }
+  }, [setBotStates])
+
+  React.useEffect(() => {
+    loadBots()
+    refreshStates()
+  }, [loadBots, refreshStates])
 
   const handleAddBot = React.useCallback(async () => {
     try {

--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -227,7 +227,7 @@ function TabBarInner({
         setHoveredTabId(null)
         setIsLeaving(false)
       }, 80)
-    }, 40)
+    }, 200)
   }, [])
 
   // 面板的 hover 进入（阻止关闭）

--- a/apps/electron/src/renderer/lib/model-logo.ts
+++ b/apps/electron/src/renderer/lib/model-logo.ts
@@ -178,6 +178,7 @@ const MODEL_LOGO_MAP: Record<string, string> = {
   // === Doubao / 豆包 ===
   doubao: DoubaoLogo,
   'ep-202': DoubaoLogo,
+  seed: DoubaoLogo,
 
   // === Zhipu / 智谱 ===
   zhipu: ZhipuLogo,


### PR DESCRIPTION
## 问题根因

1. **列表退出**：输入框在空列表项上按 Enter/Backspace 时，没有退出列表的逻辑，只会继续延续或无反应
2. **换行后列表失效**：原来用 `setHardBreak` 插入 `<br>` 换行，TipTap 的 inputRules 只在段落节点行首生效，`<br>` 后无法触发 `1. ` / `- ` 自动转列表
3. **发送内容多余空行**：`htmlToMarkdown` 各块级元素末尾使用 `\n\n`，导致发送内容每行之间多一个空行
4. **复制到外部应用空行过多**：复制时剪贴板包含 HTML 富文本，粘贴到微信等应用时 `<p>`/`<ol>` 的默认样式产生大量空行
5. **设置页面若干 UI/逻辑问题**：外观间距、飞书状态颜色、Agent 配置展开标识位置、内置工具列表缺项
6. **模型 icon 匹配缺失**：seed 系列模型（字节跳动/豆包）无法匹配到正确图标
7. **Tab 预览面板意外消失**：鼠标从 Tab 移向预览面板时，40ms 关闭延迟过短，导致面板在鼠标到达前就消失（之前鼠标要很快才能赶上，体现为消失以及弹窗异常闪烁）

## 具体修改

**输入框交互（rich-text-input.tsx）**
- Enter 键：空列表项时调用 `liftListItem` 退出列表，而非继续 `splitListItem`
- Backspace 键：新增处理，空列表项时调用 `liftListItem` 退出列表
- 换行从 `setHardBreak`（插入 `<br>`）改为 `splitBlock`（创建新段落），使 inputRules 能正常识别行首
- `htmlToMarkdown` 所有块级元素末尾统一从 `\n\n` 改为 `\n`
- copy 事件：拦截复制，将选中内容通过 `htmlToMarkdown` 转为纯文本写入剪贴板，清空 `text/html`
- CSS 新增 `.ProseMirror p/ul/ol/li { margin: 0 }`，抵消 `prose` 类的默认段落间距

**外观设置（AppearanceSettings.tsx）**
- 将 `<>` fragment 替换为 `<div className="space-y-6">`，使「应用图标」区块与上方「外观设置」区块保持合理间距

**飞书机器人（FeishuSettings.tsx）**
- `FeishuConfigTab` mount 时新增 `refreshStates()` 调用，主动从主进程拉取最新 Bot 连接状态
- 根因：`startAllBridges()` 是 fire-and-forget，Bot 连接完成时渲染进程可能尚未就绪，导致状态广播丢失，设置页一直显示黄色

**Agent 配置（AgentSettings.tsx）**
- 展开/折叠箭头从标题左侧移至右侧，使「Agent 高级设置」标题能够左对齐
- 内置工具列表补充第三项「联网搜索」（tool id: `web-search`），与工具设置页保持一致

**模型 icon 匹配（model-logo.ts）**
- 新增 `seed` 规则映射到 DoubaoLogo（seed 系列模型属于字节跳动/豆包）
- `seedgemini` 的具体规则排在前面，优先匹配，不受影响

**Tab 预览面板（TabBar.tsx）**
- `handleTabHoverLeave` 关闭延迟从 40ms 调整为 200ms，给鼠标从 Tab 移动到预览面板足够缓冲时间

## 审查情况

- 改动均为最小修改，无副作用
- `.ProseMirror` 全局样式经确认只影响 `RichTextInput` 组件
- 飞书状态修复仅在设置页打开时触发一次额外 IPC 调用，开销可忽略
- 用户测试：列表退出、换行后再触发列表、发送内容格式、复制到外部应用均测试通过