### PR TITLE
feat: atomic writes + backup rotation for JSON index files 对话索引原子写入 + 防丢失/备份功能

### DIFF
--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -9,6 +9,7 @@
  */
 
 import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync, unlinkSync, rmSync, renameSync, readdirSync, cpSync, copyFileSync } from 'node:fs'
+import { writeJsonFileAtomic, readJsonFileSafe } from './safe-file'
 import { randomUUID } from 'node:crypto'
 import { join, resolve, dirname } from 'node:path'
 import {
@@ -48,18 +49,9 @@ const INDEX_VERSION = 1
  */
 function readIndex(): AgentSessionsIndex {
   const indexPath = getAgentSessionsIndexPath()
-
-  if (!existsSync(indexPath)) {
-    return { version: INDEX_VERSION, sessions: [] }
-  }
-
-  try {
-    const raw = readFileSync(indexPath, 'utf-8')
-    return JSON.parse(raw) as AgentSessionsIndex
-  } catch (error) {
-    console.error('[Agent 会话] 读取索引文件失败:', error)
-    return { version: INDEX_VERSION, sessions: [] }
-  }
+  const data = readJsonFileSafe<AgentSessionsIndex>(indexPath)
+  if (data) return data
+  return { version: INDEX_VERSION, sessions: [] }
 }
 
 /**
@@ -69,7 +61,7 @@ function writeIndex(index: AgentSessionsIndex): void {
   const indexPath = getAgentSessionsIndexPath()
 
   try {
-    writeFileSync(indexPath, JSON.stringify(index, null, 2), 'utf-8')
+    writeJsonFileAtomic(indexPath, index)
   } catch (error) {
     console.error('[Agent 会话] 写入索引文件失败:', error)
     throw new Error('写入 Agent 会话索引失败')

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -7,6 +7,7 @@
  */
 
 import { readFileSync, writeFileSync, existsSync, readdirSync, cpSync, rmSync, mkdirSync, statSync, renameSync } from 'node:fs'
+import { writeJsonFileAtomic, readJsonFileSafe } from './safe-file'
 import { randomUUID } from 'node:crypto'
 import { join } from 'node:path'
 import {
@@ -31,25 +32,17 @@ const INDEX_VERSION = 2
 /** 读取工作区索引文件，自动执行版本迁移 */
 function readIndex(): AgentWorkspacesIndex {
   const indexPath = getAgentWorkspacesIndexPath()
+  const data = readJsonFileSafe<AgentWorkspacesIndex>(indexPath)
 
-  if (!existsSync(indexPath)) {
-    return { version: INDEX_VERSION, workspaces: [] }
-  }
-
-  try {
-    const raw = readFileSync(indexPath, 'utf-8')
-    const index = JSON.parse(raw) as AgentWorkspacesIndex
-
+  if (data) {
     // 版本迁移
-    if ((index.version ?? 1) < INDEX_VERSION) {
-      migrateIndex(index)
+    if ((data.version ?? 1) < INDEX_VERSION) {
+      migrateIndex(data)
     }
-
-    return index
-  } catch (error) {
-    console.error('[Agent 工作区] 读取索引文件失败:', error)
-    return { version: INDEX_VERSION, workspaces: [] }
+    return data
   }
+
+  return { version: INDEX_VERSION, workspaces: [] }
 }
 
 function migrateIndex(index: AgentWorkspacesIndex): void {
@@ -92,7 +85,7 @@ function writeIndex(index: AgentWorkspacesIndex): void {
   const indexPath = getAgentWorkspacesIndexPath()
 
   try {
-    writeFileSync(indexPath, JSON.stringify(index, null, 2), 'utf-8')
+    writeJsonFileAtomic(indexPath, index)
   } catch (error) {
     console.error('[Agent 工作区] 写入索引文件失败:', error)
     throw new Error('写入 Agent 工作区索引失败')

--- a/apps/electron/src/main/lib/conversation-manager.ts
+++ b/apps/electron/src/main/lib/conversation-manager.ts
@@ -7,6 +7,7 @@
  */
 
 import { readFileSync, writeFileSync, appendFileSync, existsSync, unlinkSync } from 'node:fs'
+import { writeJsonFileAtomic, readJsonFileSafe } from './safe-file'
 import { randomUUID } from 'node:crypto'
 import {
   getConversationsIndexPath,
@@ -34,18 +35,9 @@ const INDEX_VERSION = 1
  */
 function readIndex(): ConversationsIndex {
   const indexPath = getConversationsIndexPath()
-
-  if (!existsSync(indexPath)) {
-    return { version: INDEX_VERSION, conversations: [] }
-  }
-
-  try {
-    const raw = readFileSync(indexPath, 'utf-8')
-    return JSON.parse(raw) as ConversationsIndex
-  } catch (error) {
-    console.error('[对话管理] 读取索引文件失败:', error)
-    return { version: INDEX_VERSION, conversations: [] }
-  }
+  const data = readJsonFileSafe<ConversationsIndex>(indexPath)
+  if (data) return data
+  return { version: INDEX_VERSION, conversations: [] }
 }
 
 /**
@@ -55,7 +47,7 @@ function writeIndex(index: ConversationsIndex): void {
   const indexPath = getConversationsIndexPath()
 
   try {
-    writeFileSync(indexPath, JSON.stringify(index, null, 2), 'utf-8')
+    writeJsonFileAtomic(indexPath, index)
   } catch (error) {
     console.error('[对话管理] 写入索引文件失败:', error)
     throw new Error('写入对话索引失败')

--- a/apps/electron/src/main/lib/safe-file.ts
+++ b/apps/electron/src/main/lib/safe-file.ts
@@ -1,0 +1,90 @@
+/**
+ * 崩溃安全的 JSON 文件读写工具
+ *
+ * 解决系统强制关机/崩溃时 JSON 索引文件被截断导致数据丢失的问题。
+ * - 写入：write-to-temp → rename（POSIX 原子操作）+ .bak 备份
+ * - 读取：主文件 → .tmp 残留 → .bak 回退，多层容错
+ */
+
+import { writeFileSync, renameSync, existsSync, copyFileSync, readFileSync, unlinkSync } from 'node:fs'
+
+/**
+ * 原子写入 JSON 文件：write-to-temp → rename
+ * 写入前自动保留 .bak 备份
+ */
+export function writeJsonFileAtomic(filePath: string, data: object): void {
+  const tmpPath = filePath + '.tmp'
+  const bakPath = filePath + '.bak'
+
+  // 备份当前文件（如果存在且可读）
+  if (existsSync(filePath)) {
+    try {
+      copyFileSync(filePath, bakPath)
+    } catch {
+      // 备份失败不阻塞写入
+    }
+  }
+
+  // 写入临时文件
+  writeFileSync(tmpPath, JSON.stringify(data, null, 2), 'utf-8')
+
+  // 原子重命名（POSIX rename 是原子操作）
+  renameSync(tmpPath, filePath)
+}
+
+/**
+ * 安全读取 JSON 索引文件
+ * 优先读主文件，损坏则尝试 .tmp / .bak，都失败返回 null
+ */
+export function readJsonFileSafe<T>(filePath: string): T | null {
+  const tmpPath = filePath + '.tmp'
+  const bakPath = filePath + '.bak'
+
+  // 1. 尝试读取主文件
+  if (existsSync(filePath)) {
+    try {
+      const raw = readFileSync(filePath, 'utf-8')
+      if (raw.trim().length > 0) {
+        return JSON.parse(raw) as T
+      }
+    } catch {
+      console.warn(`[数据恢复] 主索引文件损坏: ${filePath}`)
+    }
+  }
+
+  // 2. 检查是否有未完成的 .tmp 文件（上次 rename 前崩溃）
+  if (existsSync(tmpPath)) {
+    try {
+      const raw = readFileSync(tmpPath, 'utf-8')
+      if (raw.trim().length > 0) {
+        const parsed = JSON.parse(raw) as T
+        // .tmp 有效 → 提升为主文件
+        renameSync(tmpPath, filePath)
+        console.log(`[数据恢复] 从 .tmp 文件恢复: ${filePath}`)
+        return parsed
+      }
+    } catch {
+      // .tmp 也损坏，继续 fallback
+    }
+    // 清理无效的 .tmp
+    try { unlinkSync(tmpPath) } catch { /* ignore */ }
+  }
+
+  // 3. Fallback 到 .bak
+  if (existsSync(bakPath)) {
+    try {
+      const raw = readFileSync(bakPath, 'utf-8')
+      if (raw.trim().length > 0) {
+        const parsed = JSON.parse(raw) as T
+        // 用 .bak 恢复主文件（原子写入）
+        writeJsonFileAtomic(filePath, parsed as object)
+        console.log(`[数据恢复] 从 .bak 文件恢复: ${filePath}`)
+        return parsed
+      }
+    } catch {
+      console.error(`[数据恢复] .bak 文件也损坏: ${bakPath}`)
+    }
+  }
+
+  return null // 全部失败，需要上层从 JSONL 重建
+}


### PR DESCRIPTION
## Overview

系统强制关机/崩溃时，JSON 索引文件（`agent-sessions.json`、`conversations.json`、`agent-workspaces.json`）可能因 `writeFileSync` 写入中断而被截断，导致下次启动时所有会话/工作区"消失"（`JSON.parse` 失败后静默返回空列表）。

本 PR 引入**原子写入 + .bak 备份轮转**机制，从写入层面根治此问题。

## Changes

- `apps/electron/src/main/lib/safe-file.ts` — **新建**，提供两个工具函数：
  - `writeJsonFileAtomic`：write-to-temp → `renameSync`（POSIX 原子操作），写入前自动 `copyFileSync` 到 `.bak`
  - `readJsonFileSafe<T>`：三级回退读取（主文件 → `.tmp` 残留 → `.bak`），全部失败返回 `null`

- `apps/electron/src/main/lib/agent-session-manager.ts` — `readIndex`/`writeIndex` 替换为使用 `readJsonFileSafe`/`writeJsonFileAtomic`
- `apps/electron/src/main/lib/conversation-manager.ts` — 同上
- `apps/electron/src/main/lib/agent-workspace-manager.ts` — 同上（保留版本迁移逻辑）

## How to Test

1. **正常功能验证**：启动 Proma，正常创建会话/工作区，检查 `~/.proma/` 下是否出现 `.bak` 文件
2. **模拟索引损坏**：关闭 Proma → `echo '{' > ~/.proma/agent-sessions.json` → 重新启动 → 应从 `.bak` 自动恢复，会话不丢
3. **模拟主文件 + .bak 都丢失**：删除 `agent-sessions.json` 和 `.bak` → 启动 → 显示空列表（预期行为，后续 JSONL 重建 PR 解决）

## Notes

- 不影响现有功能和数据格式，纯增量改动
- `.bak` 永远只保留最近一个版本，不会累积
- 后续 PR 将添加启动时从 JSONL 文件重建损坏索引的兜底机制（P1）