### PR TITLE
fix: fork 时使用消息实际所属的 SDK session ID

### DIFF
--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -535,12 +535,32 @@ export async function forkAgentSession(input: ForkSessionInput): Promise<AgentSe
     }
   }
 
+  // 2.5 确定目标消息所属的 SDK session ID
+  // 当会话经历过 "session not found" 恢复后，sdkSessionId 会被替换为新的，
+  // 但旧消息仍保留在 Proma JSONL 中，其 session_id 指向旧的 SDK session。
+  // 这里从 JSONL 中查找目标消息的实际 session_id，确保 fork 调用使用正确的 SDK session。
+  let forkSourceSdkSessionId = sourceMeta.sdkSessionId
+  if (upToMessageUuid) {
+    const allMessages = getAgentSessionSDKMessages(sessionId)
+    for (let i = allMessages.length - 1; i >= 0; i--) {
+      const m = allMessages[i]
+      if ('uuid' in m && (m as { uuid?: string }).uuid === upToMessageUuid) {
+        const msgSessionId = (m as { session_id?: string }).session_id
+        if (msgSessionId && msgSessionId !== sourceMeta.sdkSessionId) {
+          console.log(`[Agent 会话] fork 目标消息属于旧 SDK session ${msgSessionId}（当前为 ${sourceMeta.sdkSessionId}），使用消息所属 session 进行 fork`)
+          forkSourceSdkSessionId = msgSessionId
+        }
+        break
+      }
+    }
+  }
+
   // 3. 调用 SDK 原生 forkSession
   // process.env.CLAUDE_CONFIG_DIR 已在模块加载时设置，SDK 会自动读取
   const sdk = await import('@anthropic-ai/claude-agent-sdk')
   let forkResult: Awaited<ReturnType<typeof sdk.forkSession>>
   try {
-    forkResult = await sdk.forkSession(sourceMeta.sdkSessionId, {
+    forkResult = await sdk.forkSession(forkSourceSdkSessionId, {
       upToMessageId: upToMessageUuid,
       dir: sourceDir,
     })
@@ -548,7 +568,7 @@ export async function forkAgentSession(input: ForkSessionInput): Promise<AgentSe
     // 指定 dir 失败时，让 SDK 自动搜索所有项目目录
     if (sourceDir) {
       console.warn(`[Agent 会话] forkSession 指定 dir 失败，改用全局搜索:`, err)
-      forkResult = await sdk.forkSession(sourceMeta.sdkSessionId, {
+      forkResult = await sdk.forkSession(forkSourceSdkSessionId, {
         upToMessageId: upToMessageUuid,
       })
     } else {
@@ -567,12 +587,12 @@ export async function forkAgentSession(input: ForkSessionInput): Promise<AgentSe
   updateAgentSessionMeta(newMeta.id, {
     sdkSessionId: forkResult.sessionId,
     forkSourceDir: sourceDir,
-    forkSourceSdkSessionId: sourceMeta.sdkSessionId,
+    forkSourceSdkSessionId: forkSourceSdkSessionId,
   })
   // 同步返回值（updateAgentSessionMeta 已写入磁盘，这里让调用方拿到最新值）
   newMeta.sdkSessionId = forkResult.sessionId
   newMeta.forkSourceDir = sourceDir
-  newMeta.forkSourceSdkSessionId = sourceMeta.sdkSessionId
+  newMeta.forkSourceSdkSessionId = forkSourceSdkSessionId
 
   // 4.5 将 SDK session JSONL 复制到 fork 自己的 project-hash 目录
   // SDK forkSession() 在源 cwd 的 project-hash 下创建 JSONL（如 projects/<hash-of-sourceDir>/<newId>.jsonl），


### PR DESCRIPTION
## Overview

修复 fork 会话时报 `Message {id} not found in session {sessionId}` 错误的问题。

当一个会话经历过 "session not found" 恢复后，`sdkSessionId` 会被替换为新的 SDK session，但旧消息的 UUID 仍绑定在旧 SDK session 的 JSONL 中。此时 fork 旧消息时，`forkAgentSession` 固定使用 `sourceMeta.sdkSessionId`（新的），导致 SDK 在新 session 的 JSONL 中找不到旧 UUID。

## Changes

- `apps/electron/src/main/lib/agent-session-manager.ts` — 在 `forkAgentSession()` 中新增步骤 2.5：当指定 `upToMessageUuid` 时，从 Proma JSONL 中查找目标消息的 `session_id` 字段，如果与当前 `sdkSessionId` 不同，则使用消息实际所属的 SDK session ID 调用 `sdk.forkSession`。同时更新 fork meta 中的 `forkSourceSdkSessionId` 为实际使用的 session ID。

## How to Test

1. 找到一个经历过 session-not-found 恢复的会话（sdkSessionId 被替换过）
2. 尝试 fork 该会话中恢复前的旧消息（非最新轮次）
3. 修复前会报 `Message not found in session`，修复后应正常 fork

## Notes

- 纯增量逻辑，不影响正常会话（未经历 session 恢复的会话行为完全不变）
- 当消息没有 `session_id` 字段或与当前 `sdkSessionId` 一致时，回退到原有行为