### PR TITLE
fix: 导入 Skill 弹窗无法滚动及卡片高度不齐

### DIFF
--- a/apps/electron/src/renderer/components/settings/AgentSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AgentSettings.tsx
@@ -14,7 +14,6 @@ import { Plus, Plug, Pencil, Trash2, Sparkles, FolderOpen, MessageSquare, Shield
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
-import { ScrollArea } from '@/components/ui/scroll-area'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
@@ -873,7 +872,7 @@ function ImportSkillFromWorkspaceDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4 px-6 pb-6">
+        <div className="space-y-4 overflow-y-auto px-6 pb-6 max-h-[60vh]">
           {availableWorkspaces.length === 0 ? (
             <SettingsCard divided={false}>
               <div className="py-10 text-center text-sm text-muted-foreground">
@@ -906,7 +905,7 @@ function ImportSkillFromWorkspaceDialog({
                       {workspace.skills.length} 个
                     </span>
                   </div>
-                  <ScrollArea className="max-h-[420px] pr-4">
+                  <div className="pr-1">
                     <div className="grid gap-3 sm:grid-cols-2">
                     {workspace.skills.map((skill) => (
                       <SettingsCard key={skill.slug} divided={false} className="overflow-hidden">
@@ -928,7 +927,7 @@ function ImportSkillFromWorkspaceDialog({
                             </div>
                           </div>
 
-                          <div className="min-h-[40px] text-sm leading-6 text-muted-foreground">
+                          <div className="line-clamp-3 min-h-[40px] text-sm leading-6 text-muted-foreground">
                             {skill.description ?? '暂无描述'}
                           </div>
 
@@ -944,7 +943,7 @@ function ImportSkillFromWorkspaceDialog({
                       </SettingsCard>
                     ))}
                     </div>
-                  </ScrollArea>
+                  </div>
                 </div>
               ))}
             </div>


### PR DESCRIPTION
## 修复内容

修复 Agent 设置页中"从其他工作区导入 Skill"弹窗的两个 UI 问题：

1. **内容区无法滚动**：当来源工作区的 Skill 较多时，弹窗底部内容被截断，无法查看。通过给内容区添加 `overflow-y-auto max-h-[60vh]` 解决。
2. **卡片高度不齐**：不同 Skill 的描述文本长度差异大，导致卡片高度不一致。通过 `line-clamp-3` 限制描述最多显示 3 行，保持视觉对齐。

同时移除了多余的 `ScrollArea` 组件。

🤖 Generated with [Claude Code](https://claude.ai/code)