### PR TITLE
feat: 用户消息气泡支持 Markdown 渲染

### DIFF
--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -400,6 +400,11 @@ function renderTextWithMentions(text: string): React.ReactNode {
   return parts.length > 0 ? parts : text
 }
 
+/** 预处理用户消息：保留单换行符（Markdown 默认忽略单换行） */
+function preserveLineBreaks(text: string): string {
+  return text.replace(/\n/g, '  \n')
+}
+
 interface UserMessageContentProps extends HTMLAttributes<HTMLDivElement> {
   children: string
 }
@@ -436,12 +441,12 @@ export const UserMessageContent = React.memo(
         <div
           ref={contentRef}
           className={cn(
-            'whitespace-pre-wrap overflow-hidden transition-[max-height] duration-200 text-[15px] leading-[1.6]',
+            'overflow-hidden transition-[max-height] duration-200',
             '[&>*:first-child]:mt-0 [&>*:last-child]:mb-0',
             shouldCollapse && !isExpanded && 'max-h-[6.5em]'
           )}
         >
-          {renderTextWithMentions(children)}
+          <MessageResponse className="prose-p:my-0.5 prose-headings:my-1.5">{preserveLineBreaks(children)}</MessageResponse>
         </div>
         {shouldCollapse && (
           <button

--- a/apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx
@@ -16,6 +16,7 @@ import { useStickToBottomContext } from 'use-stick-to-bottom'
 import { useAtomValue } from 'jotai'
 import { UserAvatar } from '@/components/chat/UserAvatar'
 import { userProfileAtom } from '@/atoms/user-profile'
+import { MessageResponse } from './message'
 import { cn } from '@/lib/utils'
 
 interface StickyAttachment {
@@ -146,9 +147,11 @@ export function StickyUserMessage({ userMessages }: StickyUserMessageProps): Rea
               <ChevronUp className="size-3 text-muted-foreground ml-auto" />
             </div>
 
-            {/* 文本内容：最多两行 */}
+            {/* 文本内容：最多两行，支持 Markdown 渲染 */}
             {stickyMessage?.text && (
-              <p className="text-sm text-foreground/80 line-clamp-2 leading-relaxed">{stickyMessage.text}</p>
+              <div className="text-sm text-foreground/80 line-clamp-2 leading-relaxed [&>div]:inline">
+                <MessageResponse className="prose-p:my-0 prose-p:inline prose-headings:my-0 prose-headings:text-sm prose-pre:hidden prose-ul:my-0 prose-ol:my-0">{stickyMessage.text}</MessageResponse>
+              </div>
             )}
 
             {/* 附件 badges */}


### PR DESCRIPTION
## 概述

为用户发送的消息气泡启用 Markdown 渲染，复用现有的 `MessageResponse` 组件（react-markdown + remark-gfm + rehype-katex + Shiki），使用户消息支持与 AI 回复相同的富文本格式。

## 改动文件

- `apps/electron/src/renderer/components/ai-elements/message.tsx`
  - 新增 `preserveLineBreaks()` 函数，将 `\n` 转为 Markdown 换行（行尾双空格），确保用户输入的换行不被 Markdown 吞掉
  - `UserMessageContent` 组件中，将原先的 `whitespace-pre-wrap` 纯文本渲染替换为 `<MessageResponse>` Markdown 渲染
  - 通过 `prose-p:my-0.5 prose-headings:my-1.5` 覆盖默认间距，使用户气泡内的排版更紧凑

- `apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx`
  - 导入 `MessageResponse` 组件
  - 悬浮置顶条中的用户文本由纯 `<p>` 改为 `<MessageResponse>` 渲染，保留 `line-clamp-2` 两行裁剪
  - 通过 prose 覆盖类（`prose-p:my-0 prose-p:inline prose-pre:hidden` 等）压平间距并隐藏代码块，避免悬浮条被撑开

## 效果

用户消息气泡现在支持：**粗体**、*斜体*、`行内代码`、代码块（Shiki 语法高亮）、GFM 表格、有序/无序列表、链接、KaTeX 数学公式、Mermaid 图表等完整 Markdown 语法。

## 测试方法

1. 在 Chat 模式下发送包含 Markdown 语法的消息（如 `**加粗** *斜体* \`代码\``），确认渲染正确
2. 在 Agent 模式下发送同样的消息，确认渲染一致
3. 发送超过 4 行的消息，确认折叠/展开功能正常
4. 滚动使用户消息离开视口，确认悬浮置顶条中也正确渲染 Markdown
5. 发送纯文本消息，确认换行行为与改动前一致

## 备注

- `@file:`、`/skill:`、`#mcp:` 的 mention chip 样式暂未适配 Markdown 渲染管线，后续可通过自定义 remark 插件恢复
- 未引入新依赖，所有渲染能力均复用现有基础设施


![Uploading Screenshot 2026-04-15 at 21.20.13.png…]()
