### PR TITLE
fix: 苍穹暮色侧边栏背景色调亮以增强与内容区对比度

### DIFF
--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -112,7 +112,7 @@
 
   /* 苍穹暮色 (ocean-dark) */
   .theme-ocean-dark {
-    --background: 210 35% 11%;            /* #121c26 背景（侧边栏） */
+    --background: 210 35% 13%;            /* #182434 背景（侧边栏） */
     --foreground: 210 20% 92%;            /* #e7ebef 前景文字 */
     --content-area: 210 40% 8%;           /* #0c141d 内容区域 */
     --muted: 210 30% 14%;                 /* #19242e 次要背景 */


### PR DESCRIPTION
## Overview

苍穹暮色（ocean-dark）主题中，左侧侧边栏（chat bar）与右侧主内容区的背景色明度差过小（仅 3%），视觉分层不够清晰。本 PR 将侧边栏背景色的亮度适度提高，使两侧对比更明显。

## Changes

- `apps/electron/src/renderer/styles/globals.css` — 将 `.theme-ocean-dark` 中的 `--background`（侧边栏背景）从 `210 35% 11%` 调整为 `210 35% 13%`，与主内容区 `--content-area`（`210 40% 8%`）的明度差从 3% 扩大至 5%。`--card` 保持 `210 35% 11%` 不变。

## How to Test

1. 打开 Proma，切换主题至「苍穹暮色」
2. 对比左侧 chat bar 与右侧对话主区域的背景色
3. 确认侧边栏比主内容区明显更亮，层次感清晰

## Notes

- 仅修改 `--background` 一个 CSS 变量，影响范围最小
- `--card` 刻意保持原值（11%），使设置面板中的卡片元素与侧边栏保持微妙的深度差