### PR TITLE
feat: 开发/生产配置目录隔离

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -33,7 +33,7 @@ import { getFetchFn } from './proxy-fetch'
 import { getEffectiveProxyUrl } from './proxy-settings-service'
 import { appendSDKMessages, updateAgentSessionMeta, getAgentSessionMeta, getAgentSessionMessages, getAgentSessionSDKMessages, truncateSDKMessages, resolveUserUuidFromSDK, rewindFilesFromSnapshot } from './agent-session-manager'
 import { getAgentWorkspace, getWorkspaceMcpConfig, ensurePluginManifest, getWorkspacePermissionMode, setWorkspacePermissionMode } from './agent-workspace-manager'
-import { getAgentWorkspacePath, getAgentSessionWorkspacePath, getSdkConfigDir, getWorkspaceFilesDir } from './config-paths'
+import { getAgentWorkspacePath, getAgentSessionWorkspacePath, getSdkConfigDir, getWorkspaceFilesDir, getConfigDirName } from './config-paths'
 import { getWorkspaceAttachedDirectories } from './agent-workspace-manager'
 import { getRuntimeStatus } from './runtime-init'
 import { getSettings } from './settings-service'
@@ -375,7 +375,7 @@ function buildContextPrompt(sessionId: string, currentUserMessage: string, sessi
 
   // 注入 session 元信息，便于 Agent 在需要时读取完整历史
   const sessionInfoBlock = sessionHint
-    ? `\n<session_info>\nSession ID: ${sessionId}\nSession CWD: ${sessionHint.agentCwd}\nNote: 上方为近期对话摘要。如需更多上下文，可读取 ~/.proma/agent-sessions/${sessionId}.jsonl 获取完整历史。\n</session_info>\n`
+    ? `\n<session_info>\nSession ID: ${sessionId}\nSession CWD: ${sessionHint.agentCwd}\nNote: 上方为近期对话摘要。如需更多上下文，可读取 ~/${getConfigDirName()}/agent-sessions/${sessionId}.jsonl 获取完整历史。\n</session_info>\n`
     : ''
 
   console.log(`[Agent 编排] buildContextPrompt: 读取 ${allMessages.length} 条消息，注入 ${lines.length} 条历史${sessionHint ? '（含 session 元信息）' : ''}`)

--- a/apps/electron/src/main/lib/agent-prompt-builder.ts
+++ b/apps/electron/src/main/lib/agent-prompt-builder.ts
@@ -12,6 +12,7 @@
 import type { PromaPermissionMode, AgentDefinition } from '@proma/shared'
 import { getUserProfile } from './user-profile-service'
 import { getWorkspaceMcpConfig, getWorkspaceSkills } from './agent-workspace-manager'
+import { getConfigDirName } from './config-paths'
 
 // ===== 内置 SubAgent 定义 =====
 
@@ -245,19 +246,20 @@ Agent 工具支持 \`model\` 参数（可选值：\`sonnet\` / \`opus\` / \`haik
 
   // 工作区信息
   if (ctx.workspaceName && ctx.workspaceSlug) {
+    const configDirName = getConfigDirName()
     sections.push(`## 工作区
 
 - 工作区名称: ${ctx.workspaceName}
-- 工作区根目录: ~/.proma/agent-workspaces/${ctx.workspaceSlug}/
-- 当前会话目录（cwd）: ~/.proma/agent-workspaces/${ctx.workspaceSlug}/${ctx.sessionId}/
-- MCP 配置: ~/.proma/agent-workspaces/${ctx.workspaceSlug}/mcp.json（顶层 key 是 \`servers\`）
-- Skills 目录: ~/.proma/agent-workspaces/${ctx.workspaceSlug}/skills/
+- 工作区根目录: ~/${configDirName}/agent-workspaces/${ctx.workspaceSlug}/
+- 当前会话目录（cwd）: ~/${configDirName}/agent-workspaces/${ctx.workspaceSlug}/${ctx.sessionId}/
+- MCP 配置: ~/${configDirName}/agent-workspaces/${ctx.workspaceSlug}/mcp.json（顶层 key 是 \`servers\`）
+- Skills 目录: ~/${configDirName}/agent-workspaces/${ctx.workspaceSlug}/skills/
 
 ### .context 目录层级
 
 存在两个 \`.context/\` 目录，用途不同：
 - **会话级** \`.context/\`（当前 cwd 下）：当前会话的临时工作台，存放本次任务的 todo.md、plan/、临时笔记等
-- **工作区级** \`~/.proma/agent-workspaces/${ctx.workspaceSlug}/workspace-files/.context/\`：跨会话共享的持久文档，存放长期 note.md、项目级知识等
+- **工作区级** \`~/${configDirName}/agent-workspaces/${ctx.workspaceSlug}/workspace-files/.context/\`：跨会话共享的持久文档，存放长期 note.md、项目级知识等
 
 选择写入哪个目录时：
 - 只与当前任务相关的内容 → 会话级 \`.context/\`

--- a/apps/electron/src/main/lib/config-paths.ts
+++ b/apps/electron/src/main/lib/config-paths.ts
@@ -9,16 +9,44 @@ import { join } from 'node:path'
 import { mkdirSync, existsSync, cpSync, readdirSync, readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 
-/** 配置目录名称 */
-const CONFIG_DIR_NAME = '.proma'
+/**
+ * 获取配置目录名称
+ *
+ * 开发模式下返回 '.proma-dev'，正式版本返回 '.proma'。
+ *
+ * 检测优先级：
+ * 1. PROMA_DEV=1 环境变量（显式覆盖）
+ * 2. Electron app.isPackaged（未打包 = 开发模式）
+ * 3. 兜底 '.proma'
+ */
+let _configDirName: string | undefined
+
+export function getConfigDirName(): string {
+  if (_configDirName === undefined) {
+    if (process.env.PROMA_DEV === '1') {
+      _configDirName = '.proma-dev'
+    } else {
+      try {
+        const { app } = require('electron')
+        _configDirName = app.isPackaged ? '.proma' : '.proma-dev'
+      } catch {
+        _configDirName = '.proma'
+      }
+    }
+    const mode = _configDirName === '.proma-dev' ? '开发模式' : '正式版本'
+    console.log(`[配置] 配置目录: ~/${_configDirName}/（${mode}）`)
+  }
+  return _configDirName
+}
 
 /**
  * 获取配置目录路径
  *
- * 返回 ~/.proma/，如果目录不存在则自动创建。
+ * 开发模式返回 ~/.proma-dev/，正式版本返回 ~/.proma/。
+ * 如果目录不存在则自动创建。
  */
 export function getConfigDir(): string {
-  const configDir = join(homedir(), CONFIG_DIR_NAME)
+  const configDir = join(homedir(), getConfigDirName())
 
   if (!existsSync(configDir)) {
     mkdirSync(configDir, { recursive: true })

--- a/apps/electron/src/renderer/components/settings/AgentSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AgentSettings.tsx
@@ -135,9 +135,12 @@ export function AgentSettings(): React.ReactElement {
     )
   }
 
+  /** 配置目录名称：开发模式用 .proma-dev，正式版用 .proma */
+  const configDirName = import.meta.env.DEV ? '.proma-dev' : '.proma'
+
   /** 构建 MCP 配置提示词 */
   const buildMcpPrompt = (): string => {
-    const configPath = `~/.proma/agent-workspaces/${workspaceSlug}/mcp.json`
+    const configPath = `~/${configDirName}/agent-workspaces/${workspaceSlug}/mcp.json`
     const currentConfig = JSON.stringify(mcpConfig, null, 2)
 
     return `请帮我配置当前工作区的 MCP 服务器，你要主动来帮我实现，你可以采用联网搜索深度研究来尝试，当前环境已经有 Claude Agent SDK 了，除非不确定的时候才来问我，否则默认将帮我完成安装，而不是指导我。
@@ -175,7 +178,7 @@ mcp.json 格式如下：
 
   /** 构建 Skill 配置提示词 */
   const buildSkillPrompt = (): string => {
-    const skillsDir = `~/.proma/agent-workspaces/${workspaceSlug}/skills/`
+    const skillsDir = `~/${configDirName}/agent-workspaces/${workspaceSlug}/skills/`
     const skillList = skills.length > 0
       ? skills.map((s) => `- ${s.name}: ${s.description ?? '无描述'}`).join('\n')
       : '暂无 Skill'


### PR DESCRIPTION
## Summary

- 开发模式 (`bun run dev`) 自动使用 `~/.proma-dev/` 目录，打包发布版使用 `~/.proma/`，彻底隔离开发与正式版本的配置文件
- 检测机制：`PROMA_DEV` 环境变量 > `app.isPackaged` > 兜底 `.proma`
- `config-paths.ts` 新增 `getConfigDirName()` 导出函数，所有下游路径（prompt builder、orchestrator、渲染端设置页）同步适配

## 改动文件

| 文件 | 改动 |
|------|------|
| `config-paths.ts` | `CONFIG_DIR_NAME` 常量 → `getConfigDirName()` 懒加载函数 + 启动日志 |
| `agent-prompt-builder.ts` | 系统 prompt 中硬编码 `~/.proma/` → 动态 `~/${configDirName}/` |
| `agent-orchestrator.ts` | session info 路径同上 |
| `AgentSettings.tsx` | 用 `import.meta.env.DEV` 控制渲染端路径 |

## Test plan

- [x] `bun run dev` 启动后确认控制台输出 `[配置] 配置目录: ~/.proma-dev/（开发模式）`
- [x] 确认 `~/.proma-dev/` 目录被自动创建且配置写入其中
- [x] 确认 `~/.proma/` 目录不被开发模式修改
- [ ] `bun run dist` 打包后运行确认使用 `~/.proma/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)