### PR TITLE
fix: prevent .bak self-destruction during recovery

### DIFF
--- a/apps/electron/src/main/lib/safe-file.ts
+++ b/apps/electron/src/main/lib/safe-file.ts
@@ -12,12 +12,12 @@ import { writeFileSync, renameSync, existsSync, copyFileSync, readFileSync, unli
  * 原子写入 JSON 文件：write-to-temp → rename
  * 写入前自动保留 .bak 备份
  */
-export function writeJsonFileAtomic(filePath: string, data: object): void {
+export function writeJsonFileAtomic(filePath: string, data: object, skipBackup = false): void {
   const tmpPath = filePath + '.tmp'
   const bakPath = filePath + '.bak'
 
   // 备份当前文件（如果存在且可读）
-  if (existsSync(filePath)) {
+  if (!skipBackup && existsSync(filePath)) {
     try {
       copyFileSync(filePath, bakPath)
     } catch {
@@ -76,8 +76,8 @@ export function readJsonFileSafe<T>(filePath: string): T | null {
       const raw = readFileSync(bakPath, 'utf-8')
       if (raw.trim().length > 0) {
         const parsed = JSON.parse(raw) as T
-        // 用 .bak 恢复主文件（原子写入）
-        writeJsonFileAtomic(filePath, parsed as object)
+        // 用 .bak 恢复主文件（跳过备份，避免用损坏的主文件覆盖好的 .bak）
+        writeJsonFileAtomic(filePath, parsed as object, true)
         console.log(`[数据恢复] 从 .bak 文件恢复: ${filePath}`)
         return parsed
       }


### PR DESCRIPTION
## Summary

- 修复 PR #271 引入的 `readJsonFileSafe` 从 `.bak` 恢复时，`writeJsonFileAtomic` 会先把损坏的主文件拷贝覆盖好的 `.bak`，导致恢复后备份失效的 Bug
- 为 `writeJsonFileAtomic` 增加 `skipBackup` 参数，在 `.bak` 恢复路径中跳过备份步骤

## Problem

`readJsonFileSafe` 第 3 步从 `.bak` 恢复时调用 `writeJsonFileAtomic(filePath, parsed)` 重建主文件。但 `writeJsonFileAtomic` 内部会先执行 `copyFileSync(filePath, bakPath)` — 此时主文件是损坏的，**好的 `.bak` 被损坏数据覆盖**。

如果此后再次崩溃且主文件未被正常写入过，所有恢复路径全部失效，数据彻底丢失。

## Fix

```typescript
// writeJsonFileAtomic 新增 skipBackup 参数
export function writeJsonFileAtomic(filePath: string, data: object, skipBackup = false): void {
  if (!skipBackup && existsSync(filePath)) {
    copyFileSync(filePath, bakPath)
  }
  // ...
}

// .bak 恢复路径中跳过备份
writeJsonFileAtomic(filePath, parsed as object, true)
```

## Test plan

- [ ] 模拟主文件损坏 + `.bak` 完好 → 恢复后 `.bak` 仍保持完好（修复前会被覆盖为损坏数据）
- [ ] 正常写入路径不受影响，`.bak` 正常创建
- [ ] 连续两次崩溃场景：第一次从 `.bak` 恢复后，第二次崩溃仍可从 `.bak` 恢复

🤖 Generated with [Claude Code](https://claude.com/claude-code)