### PR TITLE
fix: correct dev mode default-skills path resolution

### DIFF
--- a/apps/electron/src/main/lib/config-paths.ts
+++ b/apps/electron/src/main/lib/config-paths.ts
@@ -424,7 +424,7 @@ export function seedDefaultSkills(): void {
   const { app } = require('electron')
   const bundledDir = app.isPackaged
     ? join(process.resourcesPath, 'default-skills')
-    : join(__dirname, '../../default-skills')
+    : join(__dirname, '../default-skills')
 
   if (!existsSync(bundledDir)) {
     console.log('[配置] 未找到内置 default-skills 目录，跳过')


### PR DESCRIPTION
## Summary
- Fix `seedDefaultSkills()` using wrong `__dirname` relative path in dev mode
- `../../default-skills` resolved to non-existent `apps/default-skills/` instead of correct `apps/electron/default-skills/`
- This caused all `~/.proma-dev/` workspaces to have no skills copied after the dev/prod config isolation change (#278)

## Root Cause
`__dirname` at runtime is `apps/electron/dist`. The path `join(__dirname, '../../default-skills')` goes up two levels to `apps/`, but `default-skills/` lives at `apps/electron/default-skills/` — only one level up is needed.

## Fix
Change `../../default-skills` → `../default-skills` (one line in `config-paths.ts:427`)

## Test plan
- [ ] Run in dev mode, verify `~/.proma-dev/default-skills/` is populated on startup
- [ ] Create a new workspace, verify skills are copied into it
- [ ] Verify production build is unaffected (uses `process.resourcesPath` path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)