### PR TITLE
fix: tab persistence race condition and reliability

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -667,6 +667,19 @@ export function registerIpcHandlers(): void {
     }
   )
 
+  // 同步更新应用设置（用于 beforeunload 场景）
+  ipcMain.on(
+    SETTINGS_IPC_CHANNELS.UPDATE_SYNC,
+    (event, updates: Partial<AppSettings>) => {
+      try {
+        updateSettings(updates)
+        event.returnValue = true
+      } catch {
+        event.returnValue = false
+      }
+    }
+  )
+
   // 获取系统主题（是否深色模式）
   ipcMain.handle(
     SETTINGS_IPC_CHANNELS.GET_SYSTEM_THEME,

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -252,6 +252,9 @@ export interface ElectronAPI {
   /** 更新应用设置 */
   updateSettings: (updates: Partial<AppSettings>) => Promise<AppSettings>
 
+  /** 同步更新应用设置（用于 beforeunload 场景） */
+  updateSettingsSync: (updates: Partial<AppSettings>) => boolean
+
   /** 获取系统主题（是否深色模式） */
   getSystemTheme: () => Promise<boolean>
 
@@ -918,6 +921,10 @@ const electronAPI: ElectronAPI = {
 
   updateSettings: (updates: Partial<AppSettings>) => {
     return ipcRenderer.invoke(SETTINGS_IPC_CHANNELS.UPDATE, updates)
+  },
+
+  updateSettingsSync: (updates: Partial<AppSettings>) => {
+    return ipcRenderer.sendSync(SETTINGS_IPC_CHANNELS.UPDATE_SYNC, updates)
   },
 
   getSystemTheme: () => {

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -550,13 +550,11 @@ function TabStatePersistenceInitializer(): null {
         return
       }
 
+      const finalPanels = validPanels.length === fixedPanels.length ? fixedPanels : validPanels
       const restoredLayout: SplitLayoutState = {
         ...layout,
-        panels: validPanels.length === fixedPanels.length ? fixedPanels : validPanels,
-        focusedPanelIndex: Math.min(
-          layout.focusedPanelIndex,
-          Math.max((validPanels.length === fixedPanels.length ? fixedPanels : validPanels).length - 1, 0),
-        ),
+        panels: finalPanels,
+        focusedPanelIndex: Math.min(layout.focusedPanelIndex, Math.max(finalPanels.length - 1, 0)),
       }
 
       store.set(tabsAtom, validTabs)
@@ -607,7 +605,11 @@ function TabStatePersistenceInitializer(): null {
       const tabs = store.get(tabsAtom)
       const splitLayout = store.get(splitLayoutAtom)
       if (tabs.length > 0 && window.electronAPI.updateSettingsSync) {
-        window.electronAPI.updateSettingsSync({ tabState: { tabs, splitLayout } })
+        const ok = window.electronAPI.updateSettingsSync({ tabState: { tabs, splitLayout } })
+        if (!ok) {
+          console.warn('[TabPersist] sync IPC failed, falling back to async save')
+          save()
+        }
       } else {
         save()
       }

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -488,6 +488,7 @@ function DingTalkInitializer(): null {
  */
 function TabStatePersistenceInitializer(): null {
   const store = useStore()
+  const restoredRef = useRef(false)
 
   // 启动恢复：读取 settings.tabState + 校验会话有效性
   useEffect(() => {
@@ -497,7 +498,10 @@ function TabStatePersistenceInitializer(): null {
       window.electronAPI.listAgentSessions(),
     ]).then(([settings, conversations, agentSessions]) => {
       const tabState = settings.tabState
-      if (!tabState?.tabs?.length) return
+      if (!tabState?.tabs?.length) {
+        restoredRef.current = true
+        return
+      }
 
       // 构建有效 sessionId 集合
       const validSessionIds = new Set([
@@ -505,9 +509,21 @@ function TabStatePersistenceInitializer(): null {
         ...agentSessions.map((s) => s.id),
       ])
 
-      // 过滤掉已被删除的会话
-      const validTabs = tabState.tabs.filter((t) => validSessionIds.has(t.sessionId))
-      if (validTabs.length === 0) return
+      // 过滤掉已被删除的会话，同时校验数据结构
+      const validTabs = tabState.tabs.filter(
+        (t): t is TabItem =>
+          typeof t === 'object' &&
+          t !== null &&
+          'id' in t &&
+          'sessionId' in t &&
+          'type' in t &&
+          'title' in t &&
+          validSessionIds.has(t.sessionId),
+      )
+      if (validTabs.length === 0) {
+        restoredRef.current = true
+        return
+      }
 
       const validTabIds = new Set(validTabs.map((t) => t.id))
       const layout = tabState.splitLayout
@@ -520,22 +536,34 @@ function TabStatePersistenceInitializer(): null {
           usedTabIds.add(p.activeTabId)
           return p
         }
-        const fallback = validTabs.find((t) => !usedTabIds.has(t.id))?.id ?? validTabs[0]?.id ?? null
-        if (fallback) usedTabIds.add(fallback)
-        return { ...p, activeTabId: fallback }
+        const fallback = validTabs.find((t) => !usedTabIds.has(t.id))?.id ?? validTabs[0]?.id
+        if (fallback) {
+          usedTabIds.add(fallback)
+          return { ...p, activeTabId: fallback }
+        }
+        return p
       })
 
-      const restoredLayout = {
-        ...layout,
-        panels: fixedPanels,
-        focusedPanelIndex: Math.min(layout.focusedPanelIndex, fixedPanels.length - 1),
+      const validPanels = fixedPanels.filter((p) => p.activeTabId && validTabIds.has(p.activeTabId))
+      if (validPanels.length === 0) {
+        restoredRef.current = true
+        return
       }
 
-      store.set(tabsAtom, validTabs as TabItem[])
-      store.set(splitLayoutAtom, restoredLayout as SplitLayoutState)
+      const restoredLayout: SplitLayoutState = {
+        ...layout,
+        panels: validPanels.length === fixedPanels.length ? fixedPanels : validPanels,
+        focusedPanelIndex: Math.min(
+          layout.focusedPanelIndex,
+          Math.max((validPanels.length === fixedPanels.length ? fixedPanels : validPanels).length - 1, 0),
+        ),
+      }
+
+      store.set(tabsAtom, validTabs)
+      store.set(splitLayoutAtom, restoredLayout)
 
       // 同步 appMode 和 currentSessionId
-      const activePanel = fixedPanels[restoredLayout.focusedPanelIndex]
+      const activePanel = restoredLayout.panels[restoredLayout.focusedPanelIndex]
       const activeTab = validTabs.find((t) => t.id === activePanel?.activeTabId)
       if (activeTab) {
         store.set(appModeAtom, activeTab.type)
@@ -548,6 +576,7 @@ function TabStatePersistenceInitializer(): null {
 
       console.log(`[TabRestore] 已恢复 ${validTabs.length} 个标签页`)
     }).catch((err) => console.error('[TabRestore] 恢复标签页失败:', err))
+      .finally(() => { restoredRef.current = true })
   }, [store])
 
   // 自动保存：监听 tabsAtom / splitLayoutAtom 变化，防抖写入 settings.json
@@ -563,6 +592,7 @@ function TabStatePersistenceInitializer(): null {
     }
 
     const debouncedSave = (): void => {
+      if (!restoredRef.current) return
       if (timer) clearTimeout(timer)
       timer = setTimeout(save, 500)
     }
@@ -573,7 +603,14 @@ function TabStatePersistenceInitializer(): null {
     // 窗口关闭前立即刷新，避免最后 500ms 内的变更丢失
     const handleBeforeUnload = (): void => {
       if (timer) clearTimeout(timer)
-      save()
+      // 使用同步 IPC 确保关闭前数据写入磁盘
+      const tabs = store.get(tabsAtom)
+      const splitLayout = store.get(splitLayoutAtom)
+      if (tabs.length > 0 && window.electronAPI.updateSettingsSync) {
+        window.electronAPI.updateSettingsSync({ tabState: { tabs, splitLayout } })
+      } else {
+        save()
+      }
     }
     window.addEventListener('beforeunload', handleBeforeUnload)
 

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -114,6 +114,7 @@ export interface PersistedTabSettings {
 export const SETTINGS_IPC_CHANNELS = {
   GET: 'settings:get',
   UPDATE: 'settings:update',
+  UPDATE_SYNC: 'settings:update-sync',
   GET_SYSTEM_THEME: 'settings:get-system-theme',
   ON_SYSTEM_THEME_CHANGED: 'settings:system-theme-changed',
   /** 用户手动切换主题时广播给所有窗口 */


### PR DESCRIPTION
## Summary

修复 PR #273（标签页状态持久化）引入的几个缺陷：

- **竞态条件修复**：添加 `restoredRef` 标志，恢复完成前跳过自动保存，防止空状态覆盖持久化数据
- **beforeunload 可靠性**：新增 `settings:update-sync` 同步 IPC 通道，确保窗口关闭前数据写入磁盘
- **类型安全**：用运行时类型守卫替代 `as` 断言，防止 settings.json 数据异常导致运行时错误
- **面板边界处理**：正确处理 fallback 为 null 和 focusedPanelIndex 越界的情况

## Changed Files

| File | Purpose |
|------|---------|
| `apps/electron/src/renderer/main.tsx` | 竞态条件守卫、类型安全、面板边界处理 |
| `apps/electron/src/main/ipc.ts` | 新增 `settings:update-sync` 同步 IPC handler |
| `apps/electron/src/preload/index.ts` | 暴露 `updateSettingsSync` 方法 |
| `apps/electron/src/types/settings.ts` | 添加 `UPDATE_SYNC` IPC 通道常量 |

## Test plan

- [ ] 启动应用，打开多个标签页 + 分屏，退出重启 → 标签页和布局完整恢复
- [ ] 快速切换标签页后立即关闭窗口 → 重启后最后状态被保留（验证同步 IPC）
- [ ] 删除一个被多面板引用的会话，重启 → 面板显示不同的有效标签页
- [ ] 手动破坏 settings.json 中的 tabState 数据结构 → 应用正常启动不崩溃

🤖 Generated with [Claude Code](https://claude.com/claude-code)