### PR TITLE
fix: show status indicator badge on narrow tabs

### DIFF
--- a/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
@@ -85,6 +85,15 @@ export function TabBarItem({
   }
 
   const Icon = type === 'chat' ? MessageSquare : Bot
+  const indicatorColor = isStreaming !== 'idle'
+    ? isStreaming === 'completed'
+      ? 'bg-green-500'
+      : isStreaming === 'blocked'
+        ? 'bg-orange-500 animate-pulse'
+        : type === 'chat'
+          ? 'bg-emerald-500 animate-pulse'
+          : 'bg-blue-500 animate-pulse'
+    : undefined
   const previewItems = minimapCache.get(id) ?? []
   // 当前 active Tab 不显示预览面板
   const showPreview = isHovered && !isActive
@@ -110,8 +119,18 @@ export function TabBarItem({
         onMouseDown={handleMouseDown}
         onPointerDown={onDragStart}
       >
-        {/* 类型图标（窄状态下放大） */}
-        <Icon className={cn('shrink-0', isNarrow ? 'size-3.5' : 'size-3')} />
+        {/* 类型图标 + 窄状态下的状态角标 */}
+        <span className="relative shrink-0">
+          <Icon className={cn(isNarrow ? 'size-3.5' : 'size-3')} />
+          {indicatorColor && isNarrow && (
+            <span
+              className={cn(
+                'absolute -top-0.5 -right-1.5 size-1.5 rounded-full',
+                indicatorColor
+              )}
+            />
+          )}
+        </span>
 
         {/* 标题（窄状态下隐藏，用 spacer 撑开让关闭按钮靠右） */}
         {isNarrow ? (
@@ -120,19 +139,10 @@ export function TabBarItem({
           <span className="flex-1 min-w-0 truncate text-left">{title}</span>
         )}
 
-        {/* 流式/状态指示器（窄状态下隐藏） */}
-        {isStreaming !== 'idle' && !isNarrow && (
+        {/* 流式/状态指示器（宽状态下内联显示） */}
+        {indicatorColor && !isNarrow && (
           <span
-            className={cn(
-              'size-1.5 rounded-full shrink-0',
-              isStreaming === 'completed'
-                ? 'bg-green-500'
-                : isStreaming === 'blocked'
-                  ? 'bg-orange-500 animate-pulse'
-                  : type === 'chat'
-                    ? 'bg-emerald-500 animate-pulse'
-                    : 'bg-blue-500 animate-pulse'
-            )}
+            className={cn('size-1.5 rounded-full shrink-0', indicatorColor)}
           />
         )}
 


### PR DESCRIPTION
## Summary
- 当 Tab 数量较多、宽度收窄到 icon-only 模式时，运行状态指示器（蓝色/绿色/橙色圆点）之前被完全隐藏
- 现在改为以角标（badge）形式显示在图标右上角，不占用水平布局空间
- 提取 `indicatorColor` 变量消除颜色逻辑重复

## Test plan
- [ ] 打开 5+ 个 Tab 使其进入窄模式（宽度 < 72px）
- [ ] 触发 Agent 运行，确认窄模式下图标右上角出现蓝色脉冲圆点
- [ ] 等待 Agent 完成，确认圆点变为绿色（静态）
- [ ] 触发需要确认的操作，确认圆点变为橙色脉冲
- [ ] 减少 Tab 数量回到宽模式，确认指示器恢复为内联显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)