### PR TITLE
fix: make split mode toggle button clickable in TabBar

### DIFF
--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -248,7 +248,7 @@ function TabBarInner({
 
   return (
     <div className="flex items-end h-[34px] tabbar-bg relative">
-      <div className="absolute inset-0 titlebar-drag-region" />
+      <div className="absolute inset-0 titlebar-drag-region pointer-events-none" />
 
       <div className="relative flex items-end flex-1 min-w-0 overflow-x-clip titlebar-no-drag">
         {tabs.map((tab) => (


### PR DESCRIPTION
## 问题根因

TabBar 中存在一个绝对定位的拖拽层 `<div className="absolute inset-0 titlebar-drag-region" />`，用于支持 Electron 窗口拖拽。该层覆盖了整个 TabBar 区域，导致 `SplitModeToggle`（右上角分屏按钮）的鼠标事件被拦截，按钮完全无法点击。

## 具体修改

**`apps/electron/src/renderer/components/tabs/TabBar.tsx`**

给该绝对定位覆盖层添加 `pointer-events-none`：

```tsx
// before
<div className="absolute inset-0 titlebar-drag-region" />

// after
<div className="absolute inset-0 titlebar-drag-region pointer-events-none" />
```

`-webkit-app-region: drag` 由 Chromium 在系统层处理，与 CSS `pointer-events` 相互独立，窗口拖拽功能不受影响。

## 审查情况

- 仅改动 1 行，精准修复，无副作用
- 不影响标签页交互、窗口拖拽及其他任何功能
- 用户测试确认分屏按钮可正常点击，其他区域交互正常