### PR TITLE
debug: add flash-screen diagnostics for Agent mode

### DIFF
--- a/apps/electron/src/renderer/App.tsx
+++ b/apps/electron/src/renderer/App.tsx
@@ -11,6 +11,13 @@ import { tabsAtom, splitLayoutAtom, openTab } from './atoms/tab-atoms'
 import type { AppShellContextType } from './contexts/AppShellContext'
 
 export default function App(): React.ReactElement {
+  // [FLASH-DEBUG] 监控 App 组件重渲染（如果看到频繁日志，说明根组件被频繁重渲染）
+  const appRenderCountRef = React.useRef(0)
+  appRenderCountRef.current++
+  if (appRenderCountRef.current > 1) {
+    console.warn(`[FLASH-DEBUG] App re-render #${appRenderCountRef.current}, isLoading/showOnboarding may have changed`)
+  }
+
   const setEnvironmentResult = useSetAtom(environmentCheckResultAtom)
   const store = useStore()
   const [isLoading, setIsLoading] = React.useState(true)

--- a/apps/electron/src/renderer/atoms/theme.ts
+++ b/apps/electron/src/renderer/atoms/theme.ts
@@ -98,6 +98,8 @@ export const resolvedThemeAtom = atom<'light' | 'dark'>((get) => {
  * 在 <html> 元素上切换 dark 类名和特殊风格类名。
  */
 export function applyThemeToDOM(themeMode: ThemeMode, themeStyle: ThemeStyle = 'default', systemIsDark: boolean = true): void {
+  // [FLASH-DEBUG] 主题 DOM 操作会影响整个页面
+  console.log(`[FLASH-DEBUG] applyThemeToDOM called: mode=${themeMode}, style=${themeStyle}, systemIsDark=${systemIsDark}`)
   const html = document.documentElement
 
   // 移除所有特殊风格类

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -168,6 +168,13 @@ function AgentThinkingPopover({ agentThinking, onToggle }: AgentThinkingPopoverP
 }
 
 export function AgentView({ sessionId }: { sessionId: string }): React.ReactElement {
+  // [FLASH-DEBUG] 渲染计数器
+  const renderCountRef = React.useRef(0)
+  renderCountRef.current++
+  if (renderCountRef.current % 50 === 0) {
+    console.log(`[FLASH-DEBUG] AgentView(${sessionId.slice(0, 8)}) render #${renderCountRef.current}`)
+  }
+
   const [messages, setMessages] = React.useState<AgentMessage[]>([])
   const [persistedSDKMessages, setPersistedSDKMessages] = React.useState<SDKMessage[]>([])
   const setStreamingStates = useSetAtom(agentStreamingStatesAtom)

--- a/apps/electron/src/renderer/components/tabs/MainArea.tsx
+++ b/apps/electron/src/renderer/components/tabs/MainArea.tsx
@@ -16,6 +16,13 @@ import { SplitContainer } from './SplitContainer'
 export function MainArea(): React.ReactElement {
   const tabs = useAtomValue(tabsAtom)
 
+  // [FLASH-DEBUG] 监控 tabs 变化，如果 tabs.length 变为 0 说明所有标签被卸载
+  React.useEffect(() => {
+    if (tabs.length === 0) {
+      console.warn('[FLASH-DEBUG] MainArea: tabs.length === 0, showing WelcomeView!', new Error().stack)
+    }
+  }, [tabs.length])
+
   return (
     <>
       <Panel

--- a/apps/electron/src/renderer/components/tabs/SplitContainer.tsx
+++ b/apps/electron/src/renderer/components/tabs/SplitContainer.tsx
@@ -30,6 +30,24 @@ const GRID_AREAS = ['a', 'b', 'c', 'd']
 export function SplitContainer(): React.ReactElement {
   const layout = useAtomValue(splitLayoutAtom)
 
+  // [FLASH-DEBUG] 监控 layout 变化
+  const prevLayoutRef = React.useRef(layout)
+  React.useEffect(() => {
+    const prev = prevLayoutRef.current
+    const panelsChanged = prev.panels.length !== layout.panels.length
+    const activeIdsChanged = prev.panels.some((p, i) => p.activeTabId !== layout.panels[i]?.activeTabId)
+    const focusChanged = prev.focusedPanelIndex !== layout.focusedPanelIndex
+    if (panelsChanged || activeIdsChanged || focusChanged) {
+      console.log('[FLASH-DEBUG] SplitContainer layout changed:', {
+        prevActiveIds: prev.panels.map(p => p.activeTabId),
+        newActiveIds: layout.panels.map(p => p.activeTabId),
+        focusChanged,
+        panelsChanged,
+      })
+    }
+    prevLayoutRef.current = layout
+  })
+
   const isSplit = layout.mode !== 'single'
 
   return (

--- a/apps/electron/src/renderer/components/tabs/SplitPanel.tsx
+++ b/apps/electron/src/renderer/components/tabs/SplitPanel.tsx
@@ -35,6 +35,13 @@ export function SplitPanel({
     }))
   }, [panelIndex, setLayout])
 
+  // [FLASH-DEBUG] 监控 activeTabId 变化
+  React.useEffect(() => {
+    if (!panel.activeTabId) {
+      console.warn(`[FLASH-DEBUG] SplitPanel[${panelIndex}]: activeTabId is null/empty!`, new Error().stack)
+    }
+  }, [panel.activeTabId, panelIndex])
+
   return (
     <div
       className={cn(

--- a/apps/electron/src/renderer/components/tabs/TabContent.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabContent.tsx
@@ -19,6 +19,13 @@ export function TabContent({ tabId }: TabContentProps): React.ReactElement {
   const tabs = useAtomValue(tabsAtom)
   const tab = tabs.find((t) => t.id === tabId)
 
+  // [FLASH-DEBUG] 监控 tab 查找失败（说明 tabId 指向了不存在的标签）
+  React.useEffect(() => {
+    if (!tab) {
+      console.warn(`[FLASH-DEBUG] TabContent: tab not found for tabId="${tabId}"`, { tabIds: tabs.map(t => t.id) })
+    }
+  }, [tab, tabId, tabs])
+
   if (!tab) {
     return (
       <div className="flex items-center justify-center h-full text-muted-foreground text-sm">

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -307,8 +307,20 @@ export function useGlobalAgentListeners(): void {
     }).catch(console.error)
 
     // ===== 1. 流式事件 =====
+    // [FLASH-DEBUG] 事件频率计数器
+    let eventCount = 0
+    let lastLogTime = Date.now()
     const cleanupEvent = window.electronAPI.onAgentStreamEvent(
       (streamEvent: AgentStreamEvent) => {
+        // [FLASH-DEBUG] 每 2 秒输出一次事件频率
+        eventCount++
+        const now = Date.now()
+        if (now - lastLogTime >= 2000) {
+          console.log(`[FLASH-DEBUG] GlobalListener: ${eventCount} events in ${((now - lastLogTime) / 1000).toFixed(1)}s (${(eventCount / ((now - lastLogTime) / 1000)).toFixed(1)} evt/s)`)
+          eventCount = 0
+          lastLogTime = now
+        }
+
         unstable_batchedUpdates(() => {
         const { sessionId, payload } = streamEvent
 
@@ -539,6 +551,7 @@ export function useGlobalAgentListeners(): void {
     // ===== 2. 流式完成 =====
     const cleanupComplete = window.electronAPI.onAgentStreamComplete(
       (data: AgentStreamCompletePayload) => {
+        console.log(`[FLASH-DEBUG] STREAM_COMPLETE for session=${data.sessionId.slice(0, 8)}, stoppedByUser=${data.stoppedByUser}, resultSubtype=${data.resultSubtype}`)
         unstable_batchedUpdates(() => {
         // 发送桌面通知（任务完成，始终播放提示音）
         const enabled = store.get(notificationsEnabledAtom)


### PR DESCRIPTION
## Summary
- Add `[FLASH-DEBUG]` console logs across the full render chain (App → MainArea → SplitContainer → SplitPanel → TabContent → AgentView) to identify the root cause of occasional full-screen flicker in Agent mode
- Monitor event frequency in global agent listeners and stream completion flow
- Track theme DOM manipulation calls that could trigger full-page repaint

## How to use
1. Open DevTools Console, filter by `FLASH-DEBUG`
2. Use Agent mode normally until flash occurs
3. Check logs around the flash timestamp for: `activeTabId is null`, `tabs.length === 0`, `applyThemeToDOM`, render count spikes, or `STREAM_COMPLETE`

## Test plan
- [ ] Verify diagnostic logs appear in DevTools Console during Agent streaming
- [ ] Reproduce flash and capture surrounding log context
- [ ] Remove diagnostics after root cause is identified

🤖 Generated with [Claude Code](https://claude.com/claude-code)