### PR TITLE
feat: Ctrl+Tab 标签快速切换器

### DIFF
--- a/apps/electron/src/renderer/atoms/tab-atoms.ts
+++ b/apps/electron/src/renderer/atoms/tab-atoms.ts
@@ -74,6 +74,9 @@ const DEFAULT_SPLIT_LAYOUT: SplitLayoutState = {
 /** 所有打开的标签页列表（有序，控制 TabBar 显示顺序） */
 export const tabsAtom = atom<TabItem[]>([])
 
+/** 标签页 MRU（最近使用）顺序，最近使用的 ID 排在前面 */
+export const tabMruAtom = atom<string[]>([])
+
 /** 分屏布局状态 */
 export const splitLayoutAtom = atom<SplitLayoutState>(DEFAULT_SPLIT_LAYOUT)
 

--- a/apps/electron/src/renderer/components/tabs/TabSwitcher.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabSwitcher.tsx
@@ -1,0 +1,232 @@
+/**
+ * TabSwitcher — Ctrl+Tab 标签快速切换器
+ *
+ * Chrome 风格的 Ctrl+Tab 行为：
+ * 1. 快速按放 Ctrl+Tab → 切换到上一个标签（MRU 顺序）
+ * 2. 长按 Ctrl + 反复按 Tab → 弹出选择器，循环选中，松开 Ctrl 确认
+ * 3. Ctrl+Shift+Tab → 反向循环
+ */
+
+import { useEffect, useRef, useState, useCallback } from 'react'
+import { useAtom, useAtomValue, useSetAtom } from 'jotai'
+import { MessageSquare, Bot } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import {
+  tabsAtom,
+  splitLayoutAtom,
+  activeTabIdAtom,
+  tabMruAtom,
+  focusTab,
+} from '@/atoms/tab-atoms'
+import type { TabItem } from '@/atoms/tab-atoms'
+import { appModeAtom } from '@/atoms/app-mode'
+import { currentConversationIdAtom } from '@/atoms/chat-atoms'
+import {
+  currentAgentSessionIdAtom,
+  agentSessionsAtom,
+  currentAgentWorkspaceIdAtom,
+  unviewedCompletedSessionIdsAtom,
+} from '@/atoms/agent-atoms'
+
+export function TabSwitcher(): React.ReactElement | null {
+  const tabs = useAtomValue(tabsAtom)
+  const setLayout = useSetAtom(splitLayoutAtom)
+  const activeTabId = useAtomValue(activeTabIdAtom)
+  const [mruOrder, setMruOrder] = useAtom(tabMruAtom)
+
+  const setAppMode = useSetAtom(appModeAtom)
+  const setCurrentConversationId = useSetAtom(currentConversationIdAtom)
+  const setCurrentAgentSessionId = useSetAtom(currentAgentSessionIdAtom)
+  const agentSessions = useAtomValue(agentSessionsAtom)
+  const setCurrentAgentWorkspaceId = useSetAtom(currentAgentWorkspaceIdAtom)
+  const setUnviewedCompleted = useSetAtom(unviewedCompletedSessionIdsAtom)
+
+  const [isOpen, setIsOpen] = useState(false)
+  const [selectedIndex, setSelectedIndex] = useState(0)
+
+  // Refs 用于事件回调中读取最新值（避免闭包过期）
+  const isOpenRef = useRef(false)
+  const selectedIndexRef = useRef(0)
+  const mruOrderRef = useRef<string[]>([])
+  const tabsRef = useRef(tabs)
+  const agentSessionsRef = useRef(agentSessions)
+
+  isOpenRef.current = isOpen
+  selectedIndexRef.current = selectedIndex
+  mruOrderRef.current = mruOrder
+  tabsRef.current = tabs
+  agentSessionsRef.current = agentSessions
+
+  // ===== MRU 维护 =====
+
+  // 活跃标签变化时更新 MRU（切换器打开期间 activeTab 不会变）
+  useEffect(() => {
+    if (!activeTabId) return
+    setMruOrder((prev) => {
+      if (prev[0] === activeTabId) return prev
+      const filtered = prev.filter((id) => id !== activeTabId)
+      return [activeTabId, ...filtered]
+    })
+  }, [activeTabId, setMruOrder])
+
+  // 标签列表变化时清理 MRU（移除已关闭的，追加新增的）
+  useEffect(() => {
+    const tabIds = new Set(tabs.map((t) => t.id))
+    setMruOrder((prev) => {
+      const filtered = prev.filter((id) => tabIds.has(id))
+      const prevSet = new Set(prev)
+      const missing = tabs
+        .filter((t) => !prevSet.has(t.id))
+        .map((t) => t.id)
+      if (filtered.length === prev.length && missing.length === 0) return prev
+      return [...filtered, ...missing]
+    })
+  }, [tabs, setMruOrder])
+
+  // ===== 激活标签（复用 TabBar 的同步逻辑） =====
+
+  const activateTab = useCallback(
+    (tabId: string) => {
+      setLayout((prev) => focusTab(prev, tabId))
+
+      const tab = tabsRef.current.find((t) => t.id === tabId)
+      if (!tab) return
+
+      if (tab.type === 'chat') {
+        setAppMode('chat')
+        setCurrentConversationId(tab.sessionId)
+      } else if (tab.type === 'agent') {
+        setAppMode('agent')
+        setCurrentAgentSessionId(tab.sessionId)
+
+        // 清除"已完成未查看"标记
+        setUnviewedCompleted((prev) => {
+          if (!prev.has(tab.sessionId)) return prev
+          const next = new Set(prev)
+          next.delete(tab.sessionId)
+          return next
+        })
+
+        const session = agentSessionsRef.current.find((s) => s.id === tab.sessionId)
+        if (session?.workspaceId) {
+          setCurrentAgentWorkspaceId(session.workspaceId)
+          window.electronAPI
+            .updateSettings({ agentWorkspaceId: session.workspaceId })
+            .catch(console.error)
+        }
+      }
+    },
+    [
+      setLayout,
+      setAppMode,
+      setCurrentConversationId,
+      setCurrentAgentSessionId,
+      setCurrentAgentWorkspaceId,
+      setUnviewedCompleted,
+    ],
+  )
+
+  // ===== 键盘事件处理 =====
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent): void => {
+      // Ctrl+Tab 或 Ctrl+Shift+Tab（macOS 上 Ctrl 是物理 Control 键）
+      if (e.key === 'Tab' && e.ctrlKey && !e.metaKey && !e.altKey) {
+        e.preventDefault()
+        e.stopPropagation()
+
+        const mru = mruOrderRef.current
+        if (mru.length < 2) return
+
+        if (!isOpenRef.current) {
+          // 打开切换器，选中 MRU 第 2 项（上一个标签）
+          setIsOpen(true)
+          isOpenRef.current = true
+          const idx = e.shiftKey ? mru.length - 1 : 1
+          setSelectedIndex(idx)
+          selectedIndexRef.current = idx
+        } else {
+          // 循环选择
+          const len = mru.length
+          const newIdx = e.shiftKey
+            ? (selectedIndexRef.current - 1 + len) % len
+            : (selectedIndexRef.current + 1) % len
+          setSelectedIndex(newIdx)
+          selectedIndexRef.current = newIdx
+        }
+      }
+    }
+
+    const handleKeyUp = (e: KeyboardEvent): void => {
+      if (e.key === 'Control' && isOpenRef.current) {
+        // 确认选择
+        const selectedTabId = mruOrderRef.current[selectedIndexRef.current]
+        if (selectedTabId) {
+          activateTab(selectedTabId)
+        }
+        setIsOpen(false)
+        isOpenRef.current = false
+      }
+    }
+
+    // 窗口失焦时确认当前选择（与松开 Ctrl 行为一致）
+    const handleBlur = (): void => {
+      if (!isOpenRef.current) return
+      const selectedTabId = mruOrderRef.current[selectedIndexRef.current]
+      if (selectedTabId) activateTab(selectedTabId)
+      setIsOpen(false)
+      isOpenRef.current = false
+    }
+
+    window.addEventListener('keydown', handleKeyDown, true)
+    window.addEventListener('keyup', handleKeyUp, true)
+    window.addEventListener('blur', handleBlur)
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown, true)
+      window.removeEventListener('keyup', handleKeyUp, true)
+      window.removeEventListener('blur', handleBlur)
+    }
+  }, [activateTab])
+
+  // ===== 渲染 =====
+
+  if (!isOpen || mruOrder.length < 2) return null
+
+  // 按 MRU 顺序构建显示列表
+  const displayTabs = mruOrder
+    .map((id) => tabs.find((t) => t.id === id))
+    .filter(Boolean) as TabItem[]
+
+  // 防止标签在切换器打开期间被关闭导致越界
+  const safeIndex = Math.min(selectedIndex, displayTabs.length - 1)
+
+  return (
+    <div className="fixed inset-0 z-[9999] flex items-center justify-center">
+      {/* 半透明遮罩 */}
+      <div className="absolute inset-0 bg-black/20" />
+
+      {/* 切换器面板 */}
+      <div className="relative bg-popover/95 backdrop-blur-md border border-border/50 rounded-xl shadow-2xl min-w-[360px] max-w-[480px] py-2.5 overflow-hidden">
+        {displayTabs.map((tab, index) => (
+          <div
+            key={tab.id}
+            className={cn(
+              'flex items-center gap-3 px-5 py-2.5 text-[15px] cursor-default transition-colors',
+              index === safeIndex
+                ? 'bg-primary/15 text-foreground font-medium'
+                : 'text-muted-foreground',
+            )}
+          >
+            {tab.type === 'agent' ? (
+              <Bot className="w-4 h-4 shrink-0 opacity-60" />
+            ) : (
+              <MessageSquare className="w-4 h-4 shrink-0 opacity-60" />
+            )}
+            <span className="truncate">{tab.title || '新对话'}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -56,6 +56,7 @@ import type { WorkspaceCapabilities } from '@proma/shared'
 import { showCapabilityChangeToasts } from './lib/capabilities-toast'
 import { UpdateDialog } from './components/settings/UpdateDialog'
 import { GlobalShortcuts } from './components/shortcuts/GlobalShortcuts'
+import { TabSwitcher } from './components/tabs/TabSwitcher'
 import './styles/globals.css'
 import 'katex/dist/katex.min.css'
 
@@ -652,6 +653,7 @@ if (isQuickTaskWindow) {
       <DingTalkInitializer />
       <TabStatePersistenceInitializer />
       <GlobalShortcuts />
+      <TabSwitcher />
       <App />
       <UpdateDialog />
       <Toaster position="top-right" />


### PR DESCRIPTION
## Overview

添加 Chrome 风格的 Ctrl+Tab 标签快速切换功能。支持两种交互模式：
1. **快速切换**：快速按放 Ctrl+Tab，在当前标签和上一个标签之间来回切换
2. **选择模式**：长按 Ctrl + 反复按 Tab，弹出竖排选择器循环选中，松开 Ctrl 确认切换

标签按 MRU（最近使用）顺序排列，独立于现有快捷键系统实现（因需要 keyup 监听）。

## Changes

- `apps/electron/src/renderer/components/tabs/TabSwitcher.tsx` — **新文件**，核心组件：capture-phase 键盘监听（keydown/keyup/blur）、MRU 自动维护（监听 activeTabIdAtom 变化）、竖排选择器 UI
- `apps/electron/src/renderer/atoms/tab-atoms.ts` — 新增 `tabMruAtom`，跟踪标签的最近使用顺序
- `apps/electron/src/renderer/main.tsx` — 在顶层挂载 `TabSwitcher`（与 `GlobalShortcuts` 并列）

## How to Test

1. 打开至少 2 个标签页（Chat 或 Agent 均可）
2. **快速切换**：快速按 Ctrl+Tab 然后松开，应切到上一个标签；再按一次应切回来
3. **选择模式**：按住 Ctrl 不放，连续按 Tab，应看到居中的竖排选择器，高亮随 Tab 按键移动；松开 Ctrl 后切到选中的标签
4. **反向循环**：按住 Ctrl + Shift+Tab，选择应反向移动
5. **边界情况**：只有 1 个标签时按 Ctrl+Tab 不应有反应

## Notes

- 独立于 `shortcut-registry.ts`，因为 Ctrl+Tab 需要同时监听 keydown（Tab）和 keyup（Control），现有注册表仅处理 keydown
- 使用 Ref 模式避免 capture-phase 事件回调的闭包过期问题
- MRU 追踪通过监听 `activeTabIdAtom` 实现，任何来源的 tab 切换（TabBar 点击、侧边栏、快速任务等）都会自动更新 MRU，无需修改其他文件
- 窗口失焦时自动确认当前选择（与松开 Ctrl 行为一致），防止 Ctrl keyup 事件丢失