### PR TITLE
feat: add markdown export for agent messages

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -594,6 +594,26 @@ export function registerIpcHandlers(): void {
     }
   )
 
+  // 导出选中消息为 Markdown 文件
+  ipcMain.handle(
+    CHAT_IPC_CHANNELS.EXPORT_MESSAGES_MD,
+    async (event, markdown: string, defaultFilename: string): Promise<boolean> => {
+      const { dialog, BrowserWindow } = await import('electron')
+      const { writeFileSync } = await import('node:fs')
+      const win = BrowserWindow.fromWebContents(event.sender)
+      const result = await dialog.showSaveDialog(win ?? BrowserWindow.getFocusedWindow()!, {
+        defaultPath: defaultFilename,
+        filters: [
+          { name: 'Markdown 文件', extensions: ['md'] },
+          { name: '所有文件', extensions: ['*'] },
+        ],
+      })
+      if (result.canceled || !result.filePath) return false
+      writeFileSync(result.filePath, markdown, 'utf-8')
+      return true
+    }
+  )
+
   // 删除附件
   ipcMain.handle(
     CHAT_IPC_CHANNELS.DELETE_ATTACHMENT,

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -227,6 +227,9 @@ export interface ElectronAPI {
   /** 保存应用内置资源文件到用户选择的位置（原生 Save As 对话框） */
   saveResourceFileAs: (resourceRelativePath: string, defaultFilename: string) => Promise<boolean>
 
+  /** 导出选中消息为 Markdown 文件 */
+  exportMessagesMd: (markdown: string, defaultFilename: string) => Promise<boolean>
+
   /** 删除附件 */
   deleteAttachment: (localPath: string) => Promise<void>
 
@@ -891,6 +894,10 @@ const electronAPI: ElectronAPI = {
 
   saveResourceFileAs: (resourceRelativePath: string, defaultFilename: string) => {
     return ipcRenderer.invoke(CHAT_IPC_CHANNELS.SAVE_RESOURCE_FILE_AS, resourceRelativePath, defaultFilename)
+  },
+
+  exportMessagesMd: (markdown: string, defaultFilename: string) => {
+    return ipcRenderer.invoke(CHAT_IPC_CHANNELS.EXPORT_MESSAGES_MD, markdown, defaultFilename)
   },
 
   deleteAttachment: (localPath: string) => {

--- a/apps/electron/src/renderer/components/agent/SDKExportPanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKExportPanel.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { Check, ChevronDown } from 'lucide-react'
+import { useState, useRef, useEffect } from 'react'
+import { Check, ChevronDown, ChevronUp } from 'lucide-react'
 import { useAtomValue } from 'jotai'
 import type { SDKMessage, SDKUserMessage, SDKAssistantMessage } from '@proma/shared'
 import {
@@ -132,6 +132,28 @@ export function SDKExportPanel({ messages, sessionTitle, sessionModelId, trigger
   const selectAll = () => setSelectedIds(new Set(items.map((it) => it.id)))
   const clearAll = () => setSelectedIds(new Set())
 
+  const panelRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    const el = panelRef.current
+    if (!el) return
+    const handleWheel = (e: WheelEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+      // 找到弹窗内可滚动的容器并手动滚动
+      const scrollable = el.querySelector('.overflow-y-auto') as HTMLElement | null
+      if (scrollable) scrollable.scrollTop += e.deltaY
+    }
+    el.addEventListener('wheel', handleWheel, { passive: false })
+    const handleMouseDown = (e: MouseEvent) => {
+      if (!el.contains(e.target as Node)) onClose()
+    }
+    document.addEventListener('mousedown', handleMouseDown)
+    return () => {
+      el.removeEventListener('wheel', handleWheel)
+      document.removeEventListener('mousedown', handleMouseDown)
+    }
+  }, [onClose])
+
   // 获取选中项对应的 SDKMessage（去重，保持原始顺序）
   const getSelectedMessages = (): SDKMessage[] => {
     const seen = new Set<SDKMessage>()
@@ -161,9 +183,8 @@ export function SDKExportPanel({ messages, sessionTitle, sessionModelId, trigger
 
   return (
     <>
-      {/* 点击面板外关闭 */}
-      <div className="fixed inset-0 z-40" onClick={onClose} />
       <div
+        ref={panelRef}
         className="absolute z-50 w-[280px] rounded-lg border bg-popover shadow-xl flex flex-col overflow-hidden animate-in fade-in-0 zoom-in-95 duration-150 origin-top-left"
         style={{ maxHeight: 'min(520px, 75vh)', left: '100%', bottom: 0, marginLeft: 8 }}
       >
@@ -174,7 +195,7 @@ export function SDKExportPanel({ messages, sessionTitle, sessionModelId, trigger
         </div>
 
         {/* 对话项列表（User / Assistant 独立选中，带头像） */}
-        <div className="overflow-y-auto flex-1 p-1.5 space-y-0.5 scrollbar-thin">
+        <div className="overflow-y-auto p-1.5 space-y-0.5 scrollbar-thin" style={{ maxHeight: '264px' }}>
           {items.length === 0 && (
             <p className="text-xs text-muted-foreground text-center py-4">暂无可导出内容</p>
           )}
@@ -220,15 +241,15 @@ export function SDKExportPanel({ messages, sessionTitle, sessionModelId, trigger
           })}
         </div>
 
-        {/* 合并导出按钮 */}
-        <div className="px-3 pt-2 pb-2.5 border-t flex flex-col gap-2">
-          <div className="flex items-center gap-2">
-            <button onClick={selectAll} className="text-xs text-muted-foreground hover:text-foreground transition-colors">全选</button>
-            <span className="text-muted-foreground text-xs">·</span>
-            <button onClick={clearAll} className="text-xs text-muted-foreground hover:text-foreground transition-colors">取消全选</button>
-          </div>
-          <ExportMenu disabled={selectedIds.size === 0} onExport={handleExport} />
+        {/* 全选/取消全选 */}
+        <div className="px-3 py-1.5 flex items-center gap-2">
+          <button onClick={selectAll} className="text-xs text-muted-foreground hover:text-foreground transition-colors">全选</button>
+          <span className="text-muted-foreground text-xs">·</span>
+          <button onClick={clearAll} className="text-xs text-muted-foreground hover:text-foreground transition-colors">取消全选</button>
         </div>
+
+        {/* 导出 */}
+        <ExportMenu disabled={selectedIds.size === 0} onExport={handleExport} />
       </div>
     </>
   )
@@ -244,24 +265,16 @@ function ExportMenu({
   const [open, setOpen] = useState(false)
 
   const items: { icon: string; label: string; mode: ExportMode }[] = [
-    { icon: '📝', label: 'Markdown · 只含回复', mode: 'final-only' },
-    { icon: '📝', label: 'Markdown · 含工具流程', mode: 'with-flow' },
+    { icon: '📝', label: 'Markdown · 不包含工具调用', mode: 'final-only' },
+    { icon: '📝', label: 'Markdown · 完整', mode: 'with-flow' },
   ]
 
   return (
-    <div className="relative">
-      <button
-        onClick={() => !disabled && setOpen((v) => !v)}
-        disabled={disabled}
-        className="flex items-center justify-center gap-1.5 w-full rounded-md border px-3 py-1.5 text-xs font-medium transition-colors hover:bg-accent disabled:opacity-40 disabled:cursor-not-allowed"
-      >
-        导出
-        <ChevronDown className="size-3 opacity-60" />
-      </button>
+    <div className="relative border-t">
       {open && (
         <>
           <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} />
-          <div className="absolute bottom-full mb-1 left-0 right-0 rounded-md border bg-popover shadow-lg z-20 overflow-hidden">
+          <div className="absolute bottom-full left-0 right-0 z-20 border-x border-t border-b bg-popover overflow-hidden">
             {items.map((item) => (
               <button
                 key={item.mode}
@@ -275,6 +288,14 @@ function ExportMenu({
           </div>
         </>
       )}
+      <button
+        onClick={() => (open || !disabled) && setOpen((v) => !v)}
+        disabled={!open && disabled}
+        className={`flex items-center justify-center gap-1.5 w-full px-3 py-2 text-xs font-medium transition-colors hover:bg-accent disabled:opacity-40 disabled:cursor-not-allowed ${open ? 'bg-accent/50' : ''}`}
+      >
+        导出
+        {open ? <ChevronDown className="size-3 opacity-60" /> : <ChevronUp className="size-3 opacity-60" />}
+      </button>
     </div>
   )
 }

--- a/apps/electron/src/renderer/components/agent/SDKExportPanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKExportPanel.tsx
@@ -1,0 +1,280 @@
+import { useState } from 'react'
+import { Check, ChevronDown } from 'lucide-react'
+import { useAtomValue } from 'jotai'
+import type { SDKMessage, SDKUserMessage, SDKAssistantMessage } from '@proma/shared'
+import {
+  groupIntoTurns,
+  type MessageGroup,
+  type AssistantTurn,
+} from './SDKMessageRenderer'
+import {
+  sdkMessagesToMarkdown,
+  generateExportFilename,
+  type ExportMode,
+} from './export-utils'
+import { UserAvatar } from '@/components/chat/UserAvatar'
+import { userProfileAtom } from '@/atoms/user-profile'
+import { channelsAtom } from '@/atoms/chat-atoms'
+import { getModelLogo, resolveModelDisplayName } from '@/lib/model-logo'
+
+interface SDKExportPanelProps {
+  messages: SDKMessage[]
+  /** 当前会话标题，用于拼接到导出文件名 */
+  sessionTitle?: string
+  /** 当前会话使用的模型 ID（用于显示模型名称和 Logo） */
+  sessionModelId?: string
+  /** 触发导出的 turn 的消息（用于默认选中当前回复+对应用户消息） */
+  triggerTurnMessages?: SDKMessage[]
+  onClose: () => void
+}
+
+interface SelectItem {
+  /** 唯一 key */
+  id: string
+  /** 'user' | 'assistant' */
+  role: 'user' | 'assistant'
+  /** 展示文字 */
+  text: string
+  /** 该项对应的 SDKMessage 集合（导出用） */
+  messages: SDKMessage[]
+}
+
+function buildSelectItems(groups: MessageGroup[]): SelectItem[] {
+  const items: SelectItem[] = []
+  for (let i = 0; i < groups.length; i++) {
+    const g = groups[i]!
+    if (g.type === 'user') {
+      // 用户消息 → 独立一项
+      const userMsg = g.message as SDKUserMessage
+      const textBlocks = userMsg.message?.content?.filter((b) => b.type === 'text') ?? []
+      const text = textBlocks
+        .map((b) => ('text' in b ? (b as { text: string }).text : ''))
+        .join('\n')
+        .trim() || '[消息]'
+      items.push({
+        id: `user-${i}`,
+        role: 'user',
+        text,
+        messages: [g.message],
+      })
+    } else if (g.type === 'assistant-turn') {
+      // Assistant turn → 独立一项（包含整个 turn 的所有消息，含工具调用）
+      const turn = g as AssistantTurn
+      let previewText = ''
+      for (const aMsg of turn.assistantMessages) {
+        const blocks = (aMsg as SDKAssistantMessage).message?.content ?? []
+        const t = blocks
+          .filter((b) => b.type === 'text' && 'text' in b)
+          .map((b) => (b as { text: string }).text)
+          .join('\n')
+          .trim()
+        if (t) { previewText = t; break }
+      }
+      if (!previewText) previewText = '[处理中...]'
+      items.push({
+        id: `assistant-${i}`,
+        role: 'assistant',
+        text: previewText,
+        messages: turn.turnMessages,
+      })
+    }
+  }
+  // 只保留最近 30 项
+  return items.slice(-30)
+}
+
+export function SDKExportPanel({ messages, sessionTitle, sessionModelId, triggerTurnMessages, onClose }: SDKExportPanelProps) {
+  const userProfile = useAtomValue(userProfileAtom)
+  const channels = useAtomValue(channelsAtom)
+  const groups = groupIntoTurns(messages)
+  const items = buildSelectItems(groups)
+
+  // 从第一个 assistant turn 推断模型（multi-model turn 暂用首个），兜底用 sessionModelId
+  const inferredModelId = (() => {
+    for (const g of groups) {
+      if (g.type === 'assistant-turn' && g.model) return g.model
+    }
+    return sessionModelId
+  })()
+  const assistantName = inferredModelId ? resolveModelDisplayName(inferredModelId, channels) : 'Assistant'
+  const userName = userProfile.userName || '用户'
+
+  // 默认选中：触发导出的 assistant turn + 紧前的 user 消息；无触发信息时全选
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => {
+    if (!triggerTurnMessages || triggerTurnMessages.length === 0) {
+      return new Set(items.map((it) => it.id))
+    }
+    const triggerSet = new Set(triggerTurnMessages)
+    const defaultIds = new Set<string>()
+    for (let i = 0; i < items.length; i++) {
+      const it = items[i]!
+      if (it.role === 'assistant' && it.messages.some((m) => triggerSet.has(m))) {
+        defaultIds.add(it.id)
+        // 找紧前的 user item
+        for (let j = i - 1; j >= 0; j--) {
+          if (items[j]!.role === 'user') { defaultIds.add(items[j]!.id); break }
+        }
+        break
+      }
+    }
+    return defaultIds.size > 0 ? defaultIds : new Set(items.map((it) => it.id))
+  })
+
+  const toggleId = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const selectAll = () => setSelectedIds(new Set(items.map((it) => it.id)))
+  const clearAll = () => setSelectedIds(new Set())
+
+  // 获取选中项对应的 SDKMessage（去重，保持原始顺序）
+  const getSelectedMessages = (): SDKMessage[] => {
+    const seen = new Set<SDKMessage>()
+    const result: SDKMessage[] = []
+    for (const it of items) {
+      if (!selectedIds.has(it.id)) continue
+      for (const m of it.messages) {
+        if (!seen.has(m)) { seen.add(m); result.push(m) }
+      }
+    }
+    return result
+  }
+
+  const handleExport = async (mode: ExportMode) => {
+    try {
+      const selected = getSelectedMessages()
+      const cleanTitle = (sessionTitle ?? '').replace(/[\\/:*?"<>|\n\r\t]/g, '').replace(/\s+/g, '-').trim().slice(0, 50)
+      const prefix = cleanTitle ? `proma-${cleanTitle}` : 'proma-chat'
+      const markdown = sdkMessagesToMarkdown(selected, mode, { assistantName, userName })
+      await window.electronAPI.exportMessagesMd(markdown, generateExportFilename(prefix) + '.md')
+    } catch (err) {
+      alert(`导出失败：${err instanceof Error ? err.message : String(err)}`)
+    } finally {
+      onClose()
+    }
+  }
+
+  return (
+    <>
+      {/* 点击面板外关闭 */}
+      <div className="fixed inset-0 z-40" onClick={onClose} />
+      <div
+        className="absolute z-50 w-[280px] rounded-lg border bg-popover shadow-xl flex flex-col overflow-hidden animate-in fade-in-0 zoom-in-95 duration-150 origin-top-left"
+        style={{ maxHeight: 'min(520px, 75vh)', left: '100%', bottom: 0, marginLeft: 8 }}
+      >
+        {/* 标题栏 */}
+        <div className="flex items-center justify-between px-3 py-2 border-b shrink-0">
+          <span className="text-xs font-medium text-popover-foreground/70">导出对话</span>
+          <span className="text-[11px] text-muted-foreground tabular-nums">{selectedIds.size}/{items.length}</span>
+        </div>
+
+        {/* 对话项列表（User / Assistant 独立选中，带头像） */}
+        <div className="overflow-y-auto flex-1 p-1.5 space-y-0.5 scrollbar-thin">
+          {items.length === 0 && (
+            <p className="text-xs text-muted-foreground text-center py-4">暂无可导出内容</p>
+          )}
+          {items.map((it) => {
+            const isSelected = selectedIds.has(it.id)
+            return (
+              <button
+                key={it.id}
+                onClick={() => toggleId(it.id)}
+                className={`flex items-start gap-2 w-full rounded-md px-2 py-1.5 text-left text-xs transition-colors hover:bg-accent ${
+                  isSelected ? 'bg-accent/50' : ''
+                }`}
+              >
+                {/* 复选框 */}
+                <div
+                  className={`size-3.5 rounded border flex items-center justify-center flex-shrink-0 mt-1 ${
+                    isSelected ? 'bg-primary border-primary' : 'border-border'
+                  }`}
+                >
+                  {isSelected && <Check className="size-2.5 text-primary-foreground" />}
+                </div>
+                {/* 头像 */}
+                <div className="flex-shrink-0 mt-0.5">
+                  {it.role === 'user' ? (
+                    <UserAvatar avatar={userProfile.avatar} size={22} />
+                  ) : (
+                    <div className="size-[22px] rounded-[20%] overflow-hidden border-[0.5px] border-foreground/10 bg-foreground/[0.04] flex items-center justify-center">
+                      <img src={inferredModelId ? getModelLogo(inferredModelId) : undefined} alt="Proma" className="size-full object-cover" />
+                    </div>
+                  )}
+                </div>
+                {/* 消息内容，最多 2 行 */}
+                <div className="flex-1 min-w-0">
+                  <div
+                    className="leading-[1.35] text-foreground/85 whitespace-pre-wrap"
+                    style={{ display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}
+                  >
+                    {it.text}
+                  </div>
+                </div>
+              </button>
+            )
+          })}
+        </div>
+
+        {/* 合并导出按钮 */}
+        <div className="px-3 pt-2 pb-2.5 border-t flex flex-col gap-2">
+          <div className="flex items-center gap-2">
+            <button onClick={selectAll} className="text-xs text-muted-foreground hover:text-foreground transition-colors">全选</button>
+            <span className="text-muted-foreground text-xs">·</span>
+            <button onClick={clearAll} className="text-xs text-muted-foreground hover:text-foreground transition-colors">取消全选</button>
+          </div>
+          <ExportMenu disabled={selectedIds.size === 0} onExport={handleExport} />
+        </div>
+      </div>
+    </>
+  )
+}
+
+function ExportMenu({
+  disabled,
+  onExport,
+}: {
+  disabled: boolean
+  onExport: (mode: ExportMode) => void
+}) {
+  const [open, setOpen] = useState(false)
+
+  const items: { icon: string; label: string; mode: ExportMode }[] = [
+    { icon: '📝', label: 'Markdown · 只含回复', mode: 'final-only' },
+    { icon: '📝', label: 'Markdown · 含工具流程', mode: 'with-flow' },
+  ]
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => !disabled && setOpen((v) => !v)}
+        disabled={disabled}
+        className="flex items-center justify-center gap-1.5 w-full rounded-md border px-3 py-1.5 text-xs font-medium transition-colors hover:bg-accent disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        导出
+        <ChevronDown className="size-3 opacity-60" />
+      </button>
+      {open && (
+        <>
+          <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} />
+          <div className="absolute bottom-full mb-1 left-0 right-0 rounded-md border bg-popover shadow-lg z-20 overflow-hidden">
+            {items.map((item) => (
+              <button
+                key={item.mode}
+                onClick={() => { onExport(item.mode); setOpen(false) }}
+                className="flex items-center gap-2 w-full text-left px-3 py-2 text-xs hover:bg-accent transition-colors"
+              >
+                <span className="text-sm leading-none">{item.icon}</span>
+                <span>{item.label}</span>
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -18,6 +18,7 @@ import { cn } from '@/lib/utils'
 import { ImageLightbox } from '@/components/ui/image-lightbox'
 import { ContentBlock } from './ContentBlock'
 import { TaskProgressCard, TASK_TOOL_NAMES } from './TaskProgressCard'
+import { SDKExportPanel } from './SDKExportPanel'
 import { DurationBadge } from './AgentMessages'
 import {
   Message,
@@ -35,6 +36,7 @@ import { formatMessageTime } from '@/components/chat/ChatMessageItem'
 import { getModelLogo, resolveModelDisplayName } from '@/lib/model-logo'
 import { userProfileAtom } from '@/atoms/user-profile'
 import { channelsAtom } from '@/atoms/chat-atoms'
+import { currentAgentSessionAtom } from '@/atoms/agent-atoms'
 import type {
   SDKMessage,
   SDKAssistantMessage,
@@ -335,6 +337,8 @@ export interface AssistantTurnRendererProps {
 
 export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, onRewind, isStreaming, stoppedByUser, sessionModelId }: AssistantTurnRendererProps): React.ReactElement | null {
   const channels = useAtomValue(channelsAtom)
+  const currentSession = useAtomValue(currentAgentSessionAtom)
+  const [exportPanelOpen, setExportPanelOpen] = React.useState(false)
   // 收集所有 assistant 消息的内容块，保留 parent_tool_use_id 关联
   interface EnrichedBlock {
     block: SDKContentBlock
@@ -555,6 +559,22 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, onR
           <MessageActions className="pl-[46px] mt-0.5 min-h-[28px] justify-start">
             {hasDuration && <DurationBadge durationMs={durationMs!} usage={usage} />}
             {textContent && <CopyButton content={textContent} />}
+            {textContent && (
+              <div className="relative">
+                <MessageAction tooltip="导出" onClick={() => setExportPanelOpen((v) => !v)}>
+                  <Download className="size-3.5" />
+                </MessageAction>
+                {exportPanelOpen && (
+                  <SDKExportPanel
+                    messages={allMessages}
+                    sessionTitle={currentSession?.title}
+                    sessionModelId={sessionModelId ?? turn.model}
+                    triggerTurnMessages={turn.turnMessages}
+                    onClose={() => setExportPanelOpen(false)}
+                  />
+                )}
+              </div>
+            )}
             {onFork && lastUuid && (
               <MessageAction tooltip="从此处分叉" onClick={() => onFork(lastUuid)}>
                 <Split className="size-3.5" />

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -559,7 +559,7 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, onR
           <MessageActions className="pl-[46px] mt-0.5 min-h-[28px] justify-start">
             {hasDuration && <DurationBadge durationMs={durationMs!} usage={usage} />}
             {textContent && <CopyButton content={textContent} />}
-            {textContent && (
+            {turn.turnMessages.length > 0 && (
               <div className="relative">
                 <MessageAction tooltip="导出" onClick={() => setExportPanelOpen((v) => !v)}>
                   <Download className="size-3.5" />

--- a/apps/electron/src/renderer/components/agent/export-utils.ts
+++ b/apps/electron/src/renderer/components/agent/export-utils.ts
@@ -1,0 +1,153 @@
+import type { SDKMessage } from '@proma/shared'
+import { getToolDisplayName, getInputSummary, computeDiffStats } from './tool-utils'
+import { groupIntoTurns, type AssistantTurn } from './SDKMessageRenderer'
+
+export type ExportMode = 'final-only' | 'with-flow'
+
+export function generateExportFilename(prefix = 'proma-export'): string {
+  const d = new Date()
+  const date = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+  return `${prefix}-${date}`
+}
+
+/** 工具名 → emoji 前缀（与当前会话风格一致） */
+const TOOL_EMOJI: Record<string, string> = {
+  Write: '📝',
+  Edit: '✏️',
+  Read: '📖',
+  NotebookEdit: '✏️',
+  Bash: '💻',
+  Grep: '🔍',
+  Glob: '🔎',
+  WebFetch: '🌐',
+  WebSearch: '🌐',
+  Task: '🤖',
+  Agent: '🤖',
+  TaskCreate: '✅',
+  TaskUpdate: '✅',
+  TaskList: '📋',
+  TaskGet: '📋',
+  TodoWrite: '📋',
+  TodoRead: '📋',
+  AskUserQuestion: '💬',
+  Skill: '⚡',
+  generate_image: '🖼️',
+  EnterPlanMode: '🗺️',
+  ExitPlanMode: '🗺️',
+}
+
+function getToolEmoji(name: string): string {
+  if (TOOL_EMOJI[name]) return TOOL_EMOJI[name]
+  if (name.startsWith('mcp__')) return '🔌'
+  return '🔧'
+}
+
+/** 计算工具调用的 diff 统计（additions 绿、deletions 红） */
+function getToolDiffStats(
+  name: string,
+  input: Record<string, unknown>,
+): { additions: number; deletions: number } | null {
+  if (name === 'Edit') return computeDiffStats('Edit', input)
+  if (name === 'Write') {
+    const content = input.content
+    if (typeof content === 'string' && content.length > 0) {
+      return { additions: content.split('\n').length, deletions: 0 }
+    }
+    return null
+  }
+  if (name === 'Read') {
+    const limit = input.limit
+    if (typeof limit === 'number' && limit > 0) {
+      return { additions: limit, deletions: 0 }
+    }
+    return null
+  }
+  return null
+}
+
+/** 格式化工具调用为一行 Markdown 引用（含 emoji、中文标题、参数摘要、+/- 统计） */
+function formatToolUseLine(name: string, input: unknown): string {
+  const emoji = getToolEmoji(name)
+  const label = getToolDisplayName(name)
+  const inputObj = input && typeof input === 'object' ? (input as Record<string, unknown>) : {}
+  const summary = getInputSummary(name, inputObj)
+  const diff = getToolDiffStats(name, inputObj)
+
+  let line = `> ${emoji} **${label}**`
+  if (summary) line += ` — ${summary}`
+  if (diff) {
+    const parts: string[] = []
+    if (diff.additions > 0) parts.push(`+${diff.additions}`)
+    if (diff.deletions > 0) parts.push(`-${diff.deletions}`)
+    if (parts.length > 0) line += ` \`${parts.join(' ')}\``
+  }
+  return line
+}
+
+
+/** 从 SDKMessage 列表中提取 Markdown 文本（按 turn 分组：每个 assistant turn 合并为一段） */
+export function sdkMessagesToMarkdown(
+  messages: SDKMessage[],
+  mode: ExportMode,
+  opts?: { assistantName?: string; userName?: string },
+): string {
+  const parts: string[] = []
+  const userLabel = opts?.userName ?? 'User'
+  const assistantLabel = opts?.assistantName ?? 'Assistant'
+
+  const fmtTime = (ts: number | undefined): string => {
+    if (!ts) return ''
+    const d = new Date(ts)
+    const pad = (n: number) => String(n).padStart(2, '0')
+    return ` · ${pad(d.getMonth() + 1)}/${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`
+  }
+
+  const groups = groupIntoTurns(messages)
+
+  for (const g of groups) {
+    if (g.type === 'user') {
+      const userMsg = g.message
+      const content = userMsg.message?.content
+      if (!Array.isArray(content)) continue
+      const textBlocks = content.filter((b) => b.type === 'text')
+      const text = textBlocks.map((b) => ('text' in b ? (b as { text: string }).text : '')).join('\n')
+      if (!text.trim()) continue
+      const userTs = (userMsg as { _createdAt?: number })._createdAt
+      parts.push(`**${userLabel}${fmtTime(userTs)}:**\n\n${text}`)
+    } else if (g.type === 'assistant-turn') {
+      const turn = g as AssistantTurn
+      // 合并整个 turn 的所有 content blocks（thinking → tool_use → text）为一段
+      const segments: string[] = []
+      let hasAssistantText = false
+      for (const aMsg of turn.assistantMessages) {
+        const blocks = aMsg.message?.content ?? []
+        if (!Array.isArray(blocks) || blocks.length === 0) continue
+        for (const block of blocks) {
+          const b = block as { type: string; text?: string; thinking?: string; name?: string; input?: unknown }
+          if (b.type === 'thinking') {
+            if (mode === 'with-flow' && b.thinking) {
+              segments.push(`> 💭 **思考**\n>\n> ${b.thinking.replace(/\n/g, '\n> ')}`)
+            }
+          } else if (b.type === 'tool_use') {
+            if (mode === 'with-flow' && typeof b.name === 'string') {
+              segments.push(formatToolUseLine(b.name, b.input))
+            }
+          } else if (b.type === 'text' && typeof b.text === 'string') {
+            if (!hasAssistantText) {
+              segments.push(`**${assistantLabel}${fmtTime(turn.createdAt)}:**\n\n${b.text}`)
+              hasAssistantText = true
+            } else {
+              segments.push(b.text)
+            }
+          }
+        }
+      }
+      if (segments.length > 0) {
+        parts.push(segments.join('\n\n'))
+      }
+    }
+    // system group 忽略
+  }
+
+  return parts.join('\n\n---\n\n')
+}

--- a/apps/electron/src/renderer/components/agent/tool-utils.ts
+++ b/apps/electron/src/renderer/components/agent/tool-utils.ts
@@ -174,8 +174,10 @@ export function getInputSummary(
 
     case 'Glob': {
       const pattern = input.pattern
+      const path = input.path
       if (typeof pattern === 'string') {
-        return pattern
+        const suffix = typeof path === 'string' ? ` in ${path.split('/').slice(-2).join('/')}` : ''
+        return `${pattern}${suffix}`
       }
       return null
     }

--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -248,7 +248,7 @@ function TabBarInner({
 
   return (
     <div className="flex items-end h-[34px] tabbar-bg relative">
-      <div className="absolute inset-0 titlebar-drag-region" />
+      <div className="absolute inset-0 titlebar-drag-region pointer-events-none" />
 
       <div className="relative flex items-end flex-1 min-w-0 overflow-x-clip titlebar-no-drag">
         {tabs.map((tab) => (

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -358,6 +358,8 @@ export const CHAT_IPC_CHANNELS = {
   SAVE_IMAGE_AS: 'chat:save-image-as',
   /** 保存应用内置资源文件到用户选择的位置（原生 Save As 对话框） */
   SAVE_RESOURCE_FILE_AS: 'chat:save-resource-file-as',
+  /** 导出选中消息为 Markdown 文件 */
+  EXPORT_MESSAGES_MD: 'chat:export-messages-md',
   /** 删除附件 */
   DELETE_ATTACHMENT: 'chat:delete-attachment',
   /** 打开文件选择对话框 */


### PR DESCRIPTION
## 功能说明

为 Agent 会话新增 **Markdown 导出**功能，允许用户将选定的对话轮次导出为 Markdown 文件。

- 点击导出按钮，弹出选择面板
- 默认选中当前轮次 + 对应用户消息，支持全选
- 支持两种导出模式：
  - **仅回复**：只包含最终文字回复
  - **完整**：包含思考块（💭）、中间流程的工具调用标题
- 保存到指定位置

## 代码改动（最小化 & 解耦）

| 文件 | 改动性质 | 说明 |
|------|---------|------|
| `packages/shared/src/types/chat.ts` | 新增常量 | `EXPORT_MESSAGES_MD` IPC channel |
| `apps/electron/src/main/ipc.ts` | 新增 handler | 保存对话框 + 写文件，遵循已有模式 |
| `apps/electron/src/preload/index.ts` | 新增桥接 | `exportMessagesMd`，遵循已有模式 |
| `SDKExportPanel.tsx` | 新增组件 | 导出弹窗，完全独立，和消息导航统一UI |
| `export-utils.ts` | 新增工具函数 | `sdkMessagesToMarkdown` |
| `SDKMessageRenderer.tsx` | 最小改动 | 在 action bar 加入导出按钮（+20 行） |
| `tool-utils.ts` | 单行修改 | Glob summary 显示目录上下文 |

## 代码审查 & 测试

- 通过 subagent 完整审查 diff，确认无死代码、无多余依赖
- 修复滚动穿透（原生 `wheel` 事件 `preventDefault`）
- 修复手动终止任务时导出按钮不显示的问题（条件从 `textContent` 改为 `turn.turnMessages.length > 0`）
- 验证导出内容正确、文件名格式规范、IPC 通信正常