### PR TITLE
fix(feishu-bridge): 防止用户消息打断正在运行的 Agent 任务

### DIFF
--- a/apps/electron/src/main/lib/feishu-bridge.ts
+++ b/apps/electron/src/main/lib/feishu-bridge.ts
@@ -28,7 +28,7 @@ import type {
 } from '@proma/shared'
 import { FEISHU_IPC_CHANNELS, AGENT_IPC_CHANNELS } from '@proma/shared'
 import { getDecryptedBotAppSecret } from './feishu-config'
-import { agentEventBus, runAgentHeadless, stopAgent } from './agent-service'
+import { agentEventBus, runAgentHeadless, stopAgent, isAgentSessionActive } from './agent-service'
 import { createAgentSession, listAgentSessions, getAgentSessionMeta } from './agent-session-manager'
 import {
   listAgentWorkspacesByUpdatedAt,
@@ -1122,6 +1122,17 @@ class FeishuBridge {
       await this.createNewSession(msgCtx, 'agent')
       binding = this.chatBindings.get(chatId)
       if (!binding) return
+    }
+
+    // 并发保护：如果该会话的 Agent 仍在运行，直接拒绝，不要触碰 buffer
+    if (isAgentSessionActive(binding.sessionId)) {
+      try {
+        const prefix = this.resolveContextPrefix(chatId)
+        await this.sendCardMessage(chatId, buildErrorCard(`${prefix}上一条消息仍在处理中，请稍候再试`))
+      } catch (error) {
+        console.error(`[飞书 Bridge] 发送忙碌错误卡片失败:`, error)
+      }
+      return
     }
 
     // 保存飞书图片和文件到 session 工作目录，构建文件引用


### PR DESCRIPTION
## Overview

修复飞书/微信/钉钉 Bot 中用户在长任务执行期间发送第二条消息时，会导致原任务被静默打断、永远不返回结果的问题。

**根因**：`handleUserMessage` 在调用 orchestrator 之前无条件重置 `sessionBuffers`，当 orchestrator 拒绝第二条消息后，`onError` 回调又删除了 buffer。正在运行的第一个任务完成时找不到 buffer，走进 `handleDesktopSessionComplete` 路径而非 `handleFeishuSessionComplete`，导致结果永远不会发到飞书。同时 orchestrator 发出的虚假 `STREAM_COMPLETE` 还会让桌面端 UI 误以为任务已结束。

## Changes

- `apps/electron/src/main/lib/feishu-bridge.ts`
  - 新增 `isAgentSessionActive` 导入
  - 在 `handleUserMessage` 入口处增加并发保护：检查 orchestrator 的 `activeSessions`，如果当前会话的 Agent 仍在运行，直接发送错误卡片并 return，不触碰 buffer、不调用 `runAgentHeadless`

## How to Test

1. 在飞书 Bot 中发送一条需要较长时间处理的消息（如复杂调研任务）
2. 在 Agent 处理完成之前，再发送一条新消息
3. 验证：
   - 第二条消息应收到错误卡片："上一条消息仍在处理中，请稍候再试"
   - 第一条消息的任务应继续正常运行并最终返回结果
   - Proma 桌面端不应出现异常的 STREAM_COMPLETE/STREAM_ERROR

## Notes

- 此修复仅影响 Bot 消息路径（飞书/微信/钉钉），不影响桌面端的 Agent 交互
- 错误卡片通过 `sendCardMessage` 发送，群聊中会以 thread reply 形式回复