### PR TITLE
feat: 通用设置新增「消息悬浮置顶条」开关

### DIFF
--- a/apps/electron/src/renderer/atoms/ui-preferences.ts
+++ b/apps/electron/src/renderer/atoms/ui-preferences.ts
@@ -1,0 +1,41 @@
+/**
+ * UI 偏好设置状态管理
+ *
+ * 管理用户界面相关的显示偏好，如悬浮置顶条等。
+ */
+
+import { atom } from 'jotai'
+
+// ===== Jotai Atoms =====
+
+/** 是否显示用户消息悬浮置顶条 */
+export const stickyUserMessageEnabledAtom = atom<boolean>(true)
+
+// ===== 初始化 =====
+
+/**
+ * 从主进程加载 UI 偏好设置
+ */
+export async function initializeUiPreferences(
+  setStickyUserMessageEnabled: (enabled: boolean) => void
+): Promise<void> {
+  try {
+    const settings = await window.electronAPI.getSettings()
+    setStickyUserMessageEnabled(settings.stickyUserMessageEnabled ?? true)
+  } catch (error) {
+    console.error('[UI偏好] 初始化失败:', error)
+  }
+}
+
+// ===== 持久化更新 =====
+
+/**
+ * 更新悬浮置顶条开关并持久化
+ */
+export async function updateStickyUserMessageEnabled(enabled: boolean): Promise<void> {
+  try {
+    await window.electronAPI.updateSettings({ stickyUserMessageEnabled: enabled })
+  } catch (error) {
+    console.error('[UI偏好] 更新悬浮置顶条设置失败:', error)
+  }
+}

--- a/apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx
@@ -16,6 +16,7 @@ import { useStickToBottomContext } from 'use-stick-to-bottom'
 import { useAtomValue } from 'jotai'
 import { UserAvatar } from '@/components/chat/UserAvatar'
 import { userProfileAtom } from '@/atoms/user-profile'
+import { stickyUserMessageEnabledAtom } from '@/atoms/ui-preferences'
 import { MessageResponse, remarkMentions } from './message'
 import type { RemarkPluginFn } from './message'
 import { cn } from '@/lib/utils'
@@ -46,6 +47,7 @@ interface StickyUserMessageProps {
 export function StickyUserMessage({ userMessages }: StickyUserMessageProps): React.ReactElement {
   const { scrollRef, stopScroll, state: stickyState } = useStickToBottomContext()
   const userProfile = useAtomValue(userProfileAtom)
+  const stickyEnabled = useAtomValue(stickyUserMessageEnabledAtom)
 
   // 当前悬浮展示的消息
   const [stickyMessage, setStickyMessage] = React.useState<UserMessageData | null>(null)
@@ -132,6 +134,7 @@ export function StickyUserMessage({ userMessages }: StickyUserMessageProps): Rea
   const hasContent = stickyMessage && (stickyMessage.text || stickyMessage.attachments.length > 0)
 
   if (!hasContent && !isSticky) return <></>
+  if (!stickyEnabled) return <></>
 
   return (
     <div

--- a/apps/electron/src/renderer/components/settings/GeneralSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/GeneralSettings.tsx
@@ -37,6 +37,10 @@ import {
   NOTIFICATION_SOUNDS,
   DEFAULT_NOTIFICATION_SOUNDS,
 } from '@/atoms/notifications'
+import {
+  stickyUserMessageEnabledAtom,
+  updateStickyUserMessageEnabled,
+} from '@/atoms/ui-preferences'
 import { cn } from '@/lib/utils'
 import { Button } from '../ui/button'
 import type { NotificationSoundId, NotificationSoundType, NotificationSoundSettings } from '@/types/settings'
@@ -56,6 +60,7 @@ export function GeneralSettings(): React.ReactElement {
   const [notificationsEnabled, setNotificationsEnabled] = useAtom(notificationsEnabledAtom)
   const [notificationSoundEnabled, setNotificationSoundEnabled] = useAtom(notificationSoundEnabledAtom)
   const [notificationSounds, setNotificationSounds] = useAtom(notificationSoundsAtom)
+  const [stickyUserMessageEnabled, setStickyUserMessageEnabled] = useAtom(stickyUserMessageEnabledAtom)
   const [isEditingName, setIsEditingName] = React.useState(false)
   const [nameInput, setNameInput] = React.useState(userProfile.userName)
   const [showEmojiPicker, setShowEmojiPicker] = React.useState(false)
@@ -305,6 +310,15 @@ export function GeneralSettings(): React.ReactElement {
               </SelectContent>
             </Select>
           </SettingsRow>
+          <SettingsToggle
+            label="消息悬浮置顶条"
+            description="滚动浏览对话时，在顶部显示最近的用户消息摘要"
+            checked={stickyUserMessageEnabled}
+            onCheckedChange={(checked) => {
+              setStickyUserMessageEnabled(checked)
+              updateStickyUserMessageEnabled(checked)
+            }}
+          />
         </SettingsCard>
       </SettingsSection>
     </div>

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -39,6 +39,10 @@ import {
   notificationSoundsAtom,
   initializeNotifications,
 } from './atoms/notifications'
+import {
+  stickyUserMessageEnabledAtom,
+  initializeUiPreferences,
+} from './atoms/ui-preferences'
 import { useGlobalAgentListeners } from './hooks/useGlobalAgentListeners'
 import { useGlobalChatListeners } from './hooks/useGlobalChatListeners'
 import { tabsAtom, activeTabIdAtom } from './atoms/tab-atoms'
@@ -304,6 +308,21 @@ function NotificationsInitializer(): null {
   useEffect(() => {
     initializeNotifications(setEnabled, setSoundEnabled, setSounds)
   }, [setEnabled, setSoundEnabled, setSounds])
+
+  return null
+}
+
+/**
+ * UI 偏好初始化组件
+ *
+ * 从主进程加载 UI 偏好设置（悬浮置顶条等）。
+ */
+function UiPreferencesInitializer(): null {
+  const setStickyUserMessageEnabled = useSetAtom(stickyUserMessageEnabledAtom)
+
+  useEffect(() => {
+    initializeUiPreferences(setStickyUserMessageEnabled)
+  }, [setStickyUserMessageEnabled])
 
   return null
 }
@@ -649,6 +668,7 @@ if (isQuickTaskWindow) {
       <ThemeInitializer />
       <AgentSettingsInitializer />
       <NotificationsInitializer />
+      <UiPreferencesInitializer />
       <ChatListenersInitializer />
       <AgentListenersInitializer />
       <ChatToolInitializer />

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -88,6 +88,8 @@ export interface AppSettings {
   sendWithCmdEnter?: boolean
   /** 用户自定义快捷键覆盖 */
   shortcutOverrides?: ShortcutOverrides
+  /** 是否显示用户消息悬浮置顶条（默认 true） */
+  stickyUserMessageEnabled?: boolean
   /** 应用图标变体 ID（dock + window icon），'default' 或 logo 变体 id */
   appIconVariant?: string
 }


### PR DESCRIPTION
## Overview

在通用设置中添加一个开关，让用户可以自由控制 Agent 对话区域顶部「用户消息悬浮置顶条（StickyUserMessage）」的显示与隐藏。默认开启，关闭后滚动浏览对话时不再显示置顶摘要栏。

## Changes

- `apps/electron/src/types/settings.ts` — `AppSettings` 接口新增 `stickyUserMessageEnabled?: boolean` 字段
- `apps/electron/src/renderer/atoms/ui-preferences.ts` — **新建**，jotai atom + 初始化函数 + 持久化更新函数
- `apps/electron/src/renderer/main.tsx` — 新增 `UiPreferencesInitializer` 组件，应用启动时从 `settings.json` 加载 UI 偏好
- `apps/electron/src/renderer/components/settings/GeneralSettings.tsx` — 通用设置区末尾新增「消息悬浮置顶条」SettingsToggle
- `apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx` — 读取 atom 值，关闭时跳过渲染

## How to Test

1. 打开 Proma → 设置 → 通用设置
2. 在最底部找到「消息悬浮置顶条」开关
3. 打开一个 Agent 对话，向上滚动使用户消息超出视口 → 应出现悬浮置顶条
4. 关闭开关 → 悬浮置顶条应立即消失
5. 重启应用 → 设置应保持（持久化到 settings.json）

## Notes

- 遵循现有 `notificationsEnabled` 模式：type → atom → initializer → settings toggle → consumer
- 新建 `atoms/ui-preferences.ts` 作为 UI 偏好的统一管理点，后续类似的 UI 开关可复用此模块