### PR TITLE
fix: 恢复 Agent 流式中打断发送与 prompt_suggestion 显示

### DIFF
--- a/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
@@ -361,6 +361,26 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
     }
   }
 
+  /**
+   * 软中断当前 turn（用户流式追加并要求立即打断时使用）。
+   *
+   * 调用 SDK 的 query.interrupt()：停止当前 turn 但保留子进程与消息通道。
+   * 调用后 SDK 会 yield 一条 result（subtype: 'interrupt'），随后从 channel
+   * 继续读取下一条用户输入——此方法通常紧跟 sendQueuedMessage() 使用。
+   *
+   * 若查询已不存在（如已经 abort 过），静默返回。
+   */
+  async interruptQuery(sessionId: string): Promise<void> {
+    const query = activeQueries.get(sessionId)
+    if (!query) return
+    try {
+      await query.interrupt()
+      console.log(`[Claude 适配器] 已软中断当前 turn: sessionId=${sessionId}`)
+    } catch (error) {
+      console.warn(`[Claude 适配器] 软中断失败: sessionId=${sessionId}`, error)
+    }
+  }
+
   dispose(): void {
     for (const [, query] of activeQueries) {
       try {
@@ -504,17 +524,27 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
 
         // 捕获 result 中的 contextWindow
         if (msg.type === 'result') {
-          const resultMsg = msg as { modelUsage?: Record<string, { contextWindow?: number }> }
+          const resultMsg = msg as {
+            modelUsage?: Record<string, { contextWindow?: number }>
+            terminal_reason?: string
+          }
           if (resultMsg.modelUsage) {
             const firstEntry = Object.values(resultMsg.modelUsage)[0]
             if (firstEntry?.contextWindow) {
               options.onContextWindow?.(firstEntry.contextWindow)
             }
           }
-          // result 表示当前轮次完成，关闭消息通道让 SDK 自然调用 endInput() 关闭 stdin。
-          // 子进程检测到 stdin EOF 后会退出，readMessages() 结束，iterator 返回 done:true。
-          // 注意：prompt_suggestion 等尾部消息仍会通过 stdout 正常传递，不受影响。
-          channel.close()
+          // 被软中断（query.interrupt()）产生的 result：不关闭通道，
+          // 让 SDK 继续读取通道中已排队的下一条用户消息并开启新一轮 turn。
+          const wasAborted =
+            resultMsg.terminal_reason === 'aborted_streaming' ||
+            resultMsg.terminal_reason === 'aborted_tools'
+          if (!wasAborted) {
+            // result 表示当前轮次完成，关闭消息通道让 SDK 自然调用 endInput() 关闭 stdin。
+            // 子进程检测到 stdin EOF 后会退出，readMessages() 结束，iterator 返回 done:true。
+            // 注意：prompt_suggestion 等尾部消息仍会通过 stdout 正常传递，不受影响。
+            channel.close()
+          }
         }
 
         yield sdkMessage as SDKMessage

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -1565,9 +1565,15 @@ export class AgentOrchestrator {
               capturedResultSubtype = (msg as { subtype?: string }).subtype
               this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
               accumulatedMessages.length = 0
-              // 启动 drain 超时安全网：adapter 层 channel.close() 应让 iterator 自然关闭，
-              // 此处仅在极端情况下（如 SDK 版本不兼容）保护事件循环不无限挂起
-              if (!drainTimeoutPromise) {
+              // 软中断（aborted_streaming / aborted_tools）场景下，adapter 保留 channel
+              // 等待队列中的后续用户消息继续 drive Query，此处跳过 drain 超时以免误关闭事件循环
+              const resultTerminalReason = (msg as { terminal_reason?: string }).terminal_reason
+              const isAbortedByInterrupt =
+                resultTerminalReason === 'aborted_streaming' ||
+                resultTerminalReason === 'aborted_tools'
+              if (!isAbortedByInterrupt && !drainTimeoutPromise) {
+                // 启动 drain 超时安全网：adapter 层 channel.close() 应让 iterator 自然关闭，
+                // 此处仅在极端情况下（如 SDK 版本不兼容）保护事件循环不无限挂起
                 drainTimeoutPromise = new Promise((resolve) =>
                   setTimeout(() => resolve('drain_timeout'), RESULT_DRAIN_TIMEOUT_MS),
                 )
@@ -2042,6 +2048,7 @@ export class AgentOrchestrator {
     text: string,
     _priority?: string,
     presetUuid?: string,
+    opts?: { interrupt?: boolean },
   ): Promise<string> {
     if (!this.activeSessions.has(sessionId)) {
       throw new Error(`[Agent 编排] 会话未运行，无法追加消息: ${sessionId}`)
@@ -2069,8 +2076,19 @@ export class AgentOrchestrator {
     }
 
     try {
+      // 用户希望"立即打断当前输出并续跑新消息"：先软中断，再把消息压入通道
+      // - interrupt() 让 SDK 结束当前 turn 并 yield 一个 aborted result
+      // - 随后通道里的 'now' 消息会作为下一轮 turn 的用户输入被消费
+      if (opts?.interrupt && this.adapter.interruptQuery) {
+        try {
+          await this.adapter.interruptQuery(sessionId)
+        } catch (error) {
+          console.warn(`[Agent 编排] 软中断失败（将继续追加消息）:`, error)
+        }
+      }
+
       await this.adapter.sendQueuedMessage(sessionId, sdkMessage)
-      console.log(`[Agent 编排] 追加消息已注入: sessionId=${sessionId}, uuid=${uuid}`)
+      console.log(`[Agent 编排] 追加消息已注入: sessionId=${sessionId}, uuid=${uuid}, interrupt=${!!opts?.interrupt}`)
 
       // 立即持久化到 JSONL
       const persistMsg: SDKMessage = {

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -239,6 +239,7 @@ export async function queueAgentMessage(
     input.userMessage,
     undefined,
     input.uuid,
+    { interrupt: input.interrupt },
   )
 }
 

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -815,11 +815,12 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         return map
       })
 
-      // 3. 异步发送到后端（'now' 优先级立即注入 SDK + 持久化 JSONL）
+      // 3. 异步发送到后端（立即软中断当前 turn，再注入消息作为新一轮输入）
       window.electronAPI.queueAgentMessage({
         sessionId,
         userMessage: effectiveText,
         uuid: localUuid,
+        interrupt: true,
       }).catch((error) => {
         console.error('[AgentView] 追加消息失败:', error)
         toast.error('追加消息失败', { description: String(error) })

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -260,6 +260,10 @@ export function groupIntoTurns(messages: SDKMessage[], sessionModelId?: string):
       }
     } else {
       // result, tool_progress 等 → 归入当前 turn
+      // prompt_suggestion 不属于对话转录，不入 turn，避免被当作文本附加到助手消息末尾
+      if ((msg as { type: string }).type === 'prompt_suggestion') {
+        continue
+      }
       if (currentTurn) {
         currentTurn.turnMessages.push(msg)
       }
@@ -369,6 +373,15 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, onR
 
   // 从 turnMessages 中提取 result 消息的耗时和用量
   const { durationMs, usage } = extractTurnUsage(turn.turnMessages)
+
+  // 该 turn 是否被软中断（aborted_streaming / aborted_tools）
+  // 用于在消息底部显示“已被用户中断”徽章，独立于会话级 stoppedByUser 标记
+  const isInterruptedTurn = turn.turnMessages.some((m) => {
+    if (m.type !== 'result') return false
+    const reason = (m as { terminal_reason?: string }).terminal_reason
+    return reason === 'aborted_streaming' || reason === 'aborted_tools'
+  })
+  const showStoppedBadge = stoppedByUser || isInterruptedTurn
 
   // 构建 Agent/Task tool_use → 子代理内容块映射
   const agentToolIds = new Set<string>()
@@ -550,7 +563,7 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, onR
           : undefined
         const hasActions = !!(textContent || (onFork && lastUuid) || (onRewind && lastUuid))
         const hasDuration = durationMs != null
-        if (!hasDuration && !hasActions && !stoppedByUser) return null
+        if (!hasDuration && !hasActions && !showStoppedBadge) return null
         return (
           <MessageActions className="pl-[46px] mt-0.5 min-h-[28px] justify-start">
             {hasDuration && <DurationBadge durationMs={durationMs!} usage={usage} />}
@@ -565,7 +578,7 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, onR
                 <Undo2 className="size-3.5" />
               </MessageAction>
             )}
-            {stoppedByUser && (
+            {showStoppedBadge && (
               <Badge variant="outline" className="text-xs text-muted-foreground/70 border-muted-foreground/30 shrink-0">
                 已被用户中断
               </Badge>

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -334,7 +334,11 @@ export function useGlobalAgentListeners(): void {
         // Phase 2: 直接累积 SDKMessage 到 liveMessagesMapAtom（跳过 replay 消息，避免与持久化消息重复）
         if (payload.kind === 'sdk_message') {
           const msgRecord = payload.message as Record<string, unknown>
-          if (!msgRecord.isReplay) {
+          // prompt_suggestion 不是对话转录消息，不能进入 liveMessages（会被错误渲染到最后一条助手消息中）
+          // 它通过下方 legacyEvents 分支写入 agentPromptSuggestionsAtom，显示在输入框上方
+          if (msgRecord.type === 'prompt_suggestion') {
+            // 跳过写入 liveMessages
+          } else if (!msgRecord.isReplay) {
             // 为实时消息补充 _createdAt 时间戳（与持久化时的逻辑一致），
             // 避免 AssistantTurnRenderer 因缺少时间戳导致 header 时间消失
             if (typeof msgRecord._createdAt !== 'number') {

--- a/packages/shared/src/types/agent-provider.ts
+++ b/packages/shared/src/types/agent-provider.ts
@@ -48,6 +48,11 @@ export interface AgentProviderAdapter {
   query(input: AgentQueryInput): AsyncIterable<SDKMessage>
   /** 中止指定会话的执行 */
   abort(sessionId: string): void
+  /**
+   * 软中断当前 turn，但保留活跃 Query/Channel 以便继续注入下一条用户消息。
+   * 与 abort() 的区别：不杀子进程，允许立即续跑新消息。
+   */
+  interruptQuery?(sessionId: string): Promise<void>
   /** 释放资源 */
   dispose(): void
   /** 向活跃查询注入队列消息（可选，仅支持队列的 Provider 实现） */

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -732,6 +732,12 @@ export interface AgentQueueMessageInput {
   userMessage: string
   /** 前端预生成的 UUID（用于乐观更新去重） */
   uuid?: string
+  /**
+   * 软中断当前 Agent turn 后再追加消息。
+   * true：先调用 SDK query.interrupt() 立即打断正在输出的 turn，再注入消息。
+   * false / undefined：排队追加（默认行为，turn 结束后才会被消费）。
+   */
+  interrupt?: boolean
 }
 
 // ===== 会话迁移输入 =====


### PR DESCRIPTION
## Summary

修复两个 Agent 模式的回归问题：

### Regression 1 — Agent 输出过程中无法打断并追加新消息
之前实现仅通过 `priority: 'now'` 元数据排队，但底层 channel 仍是 FIFO，用户在 Agent 流式输出中发送的消息只会排队等当前 turn 结束，无法立刻打断。

改用 SDK 0.2.111 的 `query.interrupt()` 实现软中断：
- `AgentProviderAdapter` 新增可选 `interruptQuery(sessionId)`；`ClaudeAgentAdapter` 调用 SDK 的 `query.interrupt()`，并在收到 `terminal_reason = aborted_streaming / aborted_tools` 的 result 时**不关闭** channel，保留活跃 Query 让 SDK 继续消费队列中已注入的下一条用户消息
- `AgentOrchestrator.queueMessage` 新增 `opts.interrupt`；aborted 的 result 跳过 `drainTimeoutPromise`，避免事件循环被误关闭
- `AgentQueueMessageInput` 新增 `interrupt?: boolean` 字段并在 IPC/preload/agent-service 中透传
- 前端 `AgentView` 流式期间 send 时带 `interrupt: true`
- `AssistantTurnRenderer` 自检 turn 内 aborted result，强制显示 "已被用户中断" 徽章，适配中断后继续对话的场景（不再依赖会话级 `stoppedByUser`）

### Regression 2 — prompt_suggestion 被追加到最后一条助手消息
`prompt_suggestion` 是非转录消息，应渲染到输入框上方，而不是进入 assistant turn 的内容块。修复：
- `useGlobalAgentListeners`：跳过 `prompt_suggestion` 写入 `liveMessagesMapAtom`
- `SDKMessageRenderer.groupMessages`：显式排除 `prompt_suggestion` 加入当前 turn

## Test plan

- [x] Agent 流式输出中，在输入框输入文本并点击发送：当前输出立即停止，新消息作为新一轮用户输入被 Agent 继续响应
- [ ] 被中断的 assistant 消息底部显示"已被用户中断"徽章
- [ ] 中断后继续对话，旧的徽章依然保留在对应 turn 上
- [x] 触发 `prompt_suggestion`（如 Plan 模式完成规划）时，建议文本正确显示在输入框上方，不会出现在助手消息内
- [ ] 点击 Stop（硬中止）路径不受影响
- [ ] `pnpm typecheck` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)