### PR TITLE
fix: 修复 remarkMentions 共享正则并发问题 + settings 日志脱敏

### DIFF
--- a/apps/electron/src/main/lib/settings-service.ts
+++ b/apps/electron/src/main/lib/settings-service.ts
@@ -64,7 +64,7 @@ export function updateSettings(updates: Partial<AppSettings>): AppSettings {
 
   try {
     writeFileSync(filePath, JSON.stringify(updated, null, 2), 'utf-8')
-    console.log('[设置] 已更新:', JSON.stringify(updated))
+    console.log('[设置] 已更新 keys:', Object.keys(updates).join(', '))
   } catch (error) {
     console.error('[设置] 写入失败:', error)
     throw new Error('写入应用设置失败')

--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -279,21 +279,20 @@ function MentionChip({ type, value }: { type: MentionType; value: string }): Rea
 
 // ----- remarkMentions：将 @file: /skill: #mcp: 转为 mention:// link 节点 -----
 
-const MENTION_PATTERN = /@file:(\S+)|\/skill:(\S+)|#mcp:(\S+)/g
-
 export function remarkMentions() {
   return (tree: MdastParent) => {
     walkMdastText(tree, (node, index, parent) => {
       const text = node.value
-      MENTION_PATTERN.lastIndex = 0
-      if (!MENTION_PATTERN.test(text)) return
-      MENTION_PATTERN.lastIndex = 0
+      // 每次调用创建独立正则实例，避免 /g 状态在并发 remark pipeline 间互相干扰
+      const mentionPattern = /@file:(\S+)|\/skill:(\S+)|#mcp:(\S+)/g
+      if (!mentionPattern.test(text)) return
+      mentionPattern.lastIndex = 0
 
       const parts: MdastNode[] = []
       let lastIdx = 0
       let m: RegExpExecArray | null
 
-      while ((m = MENTION_PATTERN.exec(text)) !== null) {
+      while ((m = mentionPattern.exec(text)) !== null) {
         if (m.index > lastIdx) {
           parts.push({ type: 'text', value: text.slice(lastIdx, m.index) })
         }


### PR DESCRIPTION
## Overview

修复两个独立的代码质量问题：一个会导致生产环境 mention chip 间歇性丢失的并发 bug，以及一个高频泄漏敏感数据到控制台日志的安全隐患。

## Changes

- `apps/electron/src/renderer/components/ai-elements/message.tsx` — `MENTION_PATTERN` 从模块级共享的 `/g` 正则改为 `remarkMentions()` 函数内的局部变量。JavaScript 的 `/g` 正则是有状态的（`lastIndex` 每次 `.exec()` 后前移），当多条消息并发流式渲染时，共享的 `lastIndex` 会在不同 remark pipeline 间互相干扰，导致 mention chip 间歇性被跳过。改为局部变量后每次调用独享实例，彻底消除并发问题。

- `apps/electron/src/main/lib/settings-service.ts` — `updateSettings` 的日志从 `JSON.stringify(updated)`（全量序列化整个 AppSettings 对象）改为 `Object.keys(updates).join(', ')`（只记录本次变更的 key 名）。Tab 持久化功能使 `updateSettings` 调用频率大幅提升（每 500ms 防抖触发），原日志会高频地将 API key、飞书配置、session ID 等敏感数据打印到 Electron DevTools 控制台和日志文件中。

## How to Test

1. **mention 并发修复**：打开两个 Agent 会话同时发送包含 `@file:xxx` mention 的消息，观察 mention chip 是否稳定渲染（修复前在高并发流式场景下会间歇性丢失）
2. **日志脱敏**：打开 DevTools → Console，修改任意设置或切换 tab，确认日志只输出 `[设置] 已更新 keys: tabState` 而非完整 JSON

## Notes

- 两个修复互相独立，合并为一个 PR 是因为都属于代码审核中发现的质量问题
- `bun.lock` 变动未包含在此 PR 中