### PR TITLE
fix: 微信/钉钉 Bridge 添加 Agent 并发保护（和 PR#291 飞书一样问题的微信/钉钉版本）

### DIFF
--- a/apps/electron/src/main/lib/bridge-command-handler.ts
+++ b/apps/electron/src/main/lib/bridge-command-handler.ts
@@ -16,7 +16,7 @@ import {
   getAgentWorkspace,
   getWorkspaceCapabilities,
 } from './agent-workspace-manager'
-import { runAgentHeadless, agentEventBus, stopAgent } from './agent-service'
+import { runAgentHeadless, agentEventBus, stopAgent, isAgentSessionActive } from './agent-service'
 import { getSettings } from './settings-service'
 import { getAgentWorkspacePath } from './config-paths'
 import { readdirSync } from 'node:fs'
@@ -522,6 +522,12 @@ export class BridgeCommandHandler {
 
     if (binding.mode !== 'agent') {
       await this.send(chatId, 'Chat 模式暂未实现，请使用 /agent 切换到 Agent 模式。', contextData)
+      return
+    }
+
+    // 并发保护：如果该会话的 Agent 仍在运行，直接拒绝，不要触碰 buffer
+    if (isAgentSessionActive(binding.sessionId)) {
+      await this.send(chatId, '❌ 上一条消息仍在处理中，请稍候再试', contextData)
       return
     }
 


### PR DESCRIPTION
## Overview

微信和钉钉 Bot Bridge（`BridgeCommandHandler`）存在与飞书 Bridge 完全相同的并发消息 bug：当 Agent 正在执行长时间任务时，用户发送的第二条消息会覆盖 `sessionBuffers`，然后 orchestrator 拒绝请求触发 `onError` 删除 buffer，导致第一条消息的 Agent 结果永远无法返回给用户。

本 PR 在 `handleUserMessage` 入口处添加 `isAgentSessionActive` 检查，当检测到会话正在运行时直接返回错误提示，不触碰正在运行任务的 buffer。

关联 PR: #291（飞书 Bridge 的相同修复）

## Changes

- `apps/electron/src/main/lib/bridge-command-handler.ts`
  - 添加 `isAgentSessionActive` 到 `agent-service` import
  - 在 `handleUserMessage` 中 binding 模式检查之后、buffer 初始化之前，添加并发保护 guard：检测到 Agent 活跃时返回 `❌ 上一条消息仍在处理中，请稍候再试` 并 early return

## How to Test

1. 在微信或钉钉 Bot 中发送一条需要 Agent 长时间处理的消息
2. 在 Agent 处理期间发送第二条消息
3. 验证第二条消息收到 `❌ 上一条消息仍在处理中，请稍候再试` 的回复
4. 验证第一条消息的 Agent 任务正常完成并返回结果

## Notes

- 与 #291 的修复逻辑完全一致，只是应用在不同的 Bridge 模块
- `BridgeCommandHandler` 是微信和钉钉共享的通用处理器，一处修复同时覆盖两个平台