### PR TITLE
fix: Agent 流式打断发送与 /compact 体验优化

### DIFF
--- a/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
@@ -361,6 +361,26 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
     }
   }
 
+  /**
+   * 软中断当前 turn（用户流式追加并要求立即打断时使用）。
+   *
+   * 调用 SDK 的 query.interrupt()：停止当前 turn 但保留子进程与消息通道。
+   * 调用后 SDK 会 yield 一条 result（subtype: 'interrupt'），随后从 channel
+   * 继续读取下一条用户输入——此方法通常紧跟 sendQueuedMessage() 使用。
+   *
+   * 若查询已不存在（如已经 abort 过），静默返回。
+   */
+  async interruptQuery(sessionId: string): Promise<void> {
+    const query = activeQueries.get(sessionId)
+    if (!query) return
+    try {
+      await query.interrupt()
+      console.log(`[Claude 适配器] 已软中断当前 turn: sessionId=${sessionId}`)
+    } catch (error) {
+      console.warn(`[Claude 适配器] 软中断失败: sessionId=${sessionId}`, error)
+    }
+  }
+
   dispose(): void {
     for (const [, query] of activeQueries) {
       try {
@@ -504,17 +524,27 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
 
         // 捕获 result 中的 contextWindow
         if (msg.type === 'result') {
-          const resultMsg = msg as { modelUsage?: Record<string, { contextWindow?: number }> }
+          const resultMsg = msg as {
+            modelUsage?: Record<string, { contextWindow?: number }>
+            terminal_reason?: string
+          }
           if (resultMsg.modelUsage) {
             const firstEntry = Object.values(resultMsg.modelUsage)[0]
             if (firstEntry?.contextWindow) {
               options.onContextWindow?.(firstEntry.contextWindow)
             }
           }
-          // result 表示当前轮次完成，关闭消息通道让 SDK 自然调用 endInput() 关闭 stdin。
-          // 子进程检测到 stdin EOF 后会退出，readMessages() 结束，iterator 返回 done:true。
-          // 注意：prompt_suggestion 等尾部消息仍会通过 stdout 正常传递，不受影响。
-          channel.close()
+          // 被软中断（query.interrupt()）产生的 result：不关闭通道，
+          // 让 SDK 继续读取通道中已排队的下一条用户消息并开启新一轮 turn。
+          const wasAborted =
+            resultMsg.terminal_reason === 'aborted_streaming' ||
+            resultMsg.terminal_reason === 'aborted_tools'
+          if (!wasAborted) {
+            // result 表示当前轮次完成，关闭消息通道让 SDK 自然调用 endInput() 关闭 stdin。
+            // 子进程检测到 stdin EOF 后会退出，readMessages() 结束，iterator 返回 done:true。
+            // 注意：prompt_suggestion 等尾部消息仍会通过 stdout 正常传递，不受影响。
+            channel.close()
+          }
         }
 
         yield sdkMessage as SDKMessage

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -1565,9 +1565,15 @@ export class AgentOrchestrator {
               capturedResultSubtype = (msg as { subtype?: string }).subtype
               this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
               accumulatedMessages.length = 0
-              // 启动 drain 超时安全网：adapter 层 channel.close() 应让 iterator 自然关闭，
-              // 此处仅在极端情况下（如 SDK 版本不兼容）保护事件循环不无限挂起
-              if (!drainTimeoutPromise) {
+              // 软中断（aborted_streaming / aborted_tools）场景下，adapter 保留 channel
+              // 等待队列中的后续用户消息继续 drive Query，此处跳过 drain 超时以免误关闭事件循环
+              const resultTerminalReason = (msg as { terminal_reason?: string }).terminal_reason
+              const isAbortedByInterrupt =
+                resultTerminalReason === 'aborted_streaming' ||
+                resultTerminalReason === 'aborted_tools'
+              if (!isAbortedByInterrupt && !drainTimeoutPromise) {
+                // 启动 drain 超时安全网：adapter 层 channel.close() 应让 iterator 自然关闭，
+                // 此处仅在极端情况下（如 SDK 版本不兼容）保护事件循环不无限挂起
                 drainTimeoutPromise = new Promise((resolve) =>
                   setTimeout(() => resolve('drain_timeout'), RESULT_DRAIN_TIMEOUT_MS),
                 )
@@ -2042,6 +2048,7 @@ export class AgentOrchestrator {
     text: string,
     _priority?: string,
     presetUuid?: string,
+    opts?: { interrupt?: boolean },
   ): Promise<string> {
     if (!this.activeSessions.has(sessionId)) {
       throw new Error(`[Agent 编排] 会话未运行，无法追加消息: ${sessionId}`)
@@ -2069,8 +2076,19 @@ export class AgentOrchestrator {
     }
 
     try {
+      // 用户希望"立即打断当前输出并续跑新消息"：先软中断，再把消息压入通道
+      // - interrupt() 让 SDK 结束当前 turn 并 yield 一个 aborted result
+      // - 随后通道里的 'now' 消息会作为下一轮 turn 的用户输入被消费
+      if (opts?.interrupt && this.adapter.interruptQuery) {
+        try {
+          await this.adapter.interruptQuery(sessionId)
+        } catch (error) {
+          console.warn(`[Agent 编排] 软中断失败（将继续追加消息）:`, error)
+        }
+      }
+
       await this.adapter.sendQueuedMessage(sessionId, sdkMessage)
-      console.log(`[Agent 编排] 追加消息已注入: sessionId=${sessionId}, uuid=${uuid}`)
+      console.log(`[Agent 编排] 追加消息已注入: sessionId=${sessionId}, uuid=${uuid}, interrupt=${!!opts?.interrupt}`)
 
       // 立即持久化到 JSONL
       const persistMsg: SDKMessage = {

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -239,6 +239,7 @@ export async function queueAgentMessage(
     input.userMessage,
     undefined,
     input.uuid,
+    { interrupt: input.interrupt },
   )
 }
 

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -125,6 +125,12 @@ export interface AgentStreamState {
   contextWindow?: number
   /** 是否正在压缩上下文 */
   isCompacting?: boolean
+  /**
+   * 压缩流程是否进行中（含收尾窗口）。
+   * 从用户点击压缩 / SDK compacting 事件开始 → 到整个 stream 结束（state 被删除）前一直为 true。
+   * 用于抑制压缩分隔符切换期间 AgentRunningIndicator 的短暂闪烁。
+   */
+  compactInFlight?: boolean
   /** 流式开始时间戳（用于思考计时持久化） */
   startedAt?: number
   /** 重试状态（扩展版） */
@@ -704,7 +710,7 @@ export function applyAgentEvent(
       }
 
     case 'compacting':
-      return { ...prev, isCompacting: true }
+      return { ...prev, isCompacting: true, compactInFlight: true }
 
     case 'compact_complete':
       return { ...prev, isCompacting: false }

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -40,7 +40,7 @@ import { ScrollPositionManager } from '@/hooks/useScrollPositionMemory'
 import { cn } from '@/lib/utils'
 import { Spinner } from '@/components/ui/spinner'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { groupIntoTurns, MessageGroupRenderer, getGroupId, getGroupPreview, extractUserText, parseAttachedFiles as sdkParseAttachedFiles, isImageFile as sdkIsImageFile, type MessageGroup } from './SDKMessageRenderer'
+import { groupIntoTurns, MessageGroupRenderer, getGroupId, getGroupPreview, extractUserText, parseAttachedFiles as sdkParseAttachedFiles, isImageFile as sdkIsImageFile, CompactingIndicator, type MessageGroup } from './SDKMessageRenderer'
 import type { AgentMessage, AgentEventUsage, RetryAttempt, SDKMessage } from '@proma/shared'
 import type { ToolActivity, AgentStreamState } from '@/atoms/agent-atoms'
 
@@ -729,6 +729,12 @@ export function AgentMessages({ sessionId, sessionModelId, messages, messagesLoa
     return [...persisted.filter(m => !liveSet.has(m)), ...live]
   }, [persistedSDKMessages, liveMessages])
 
+  // 压缩流程进行中（含收尾窗口：compact_boundary 已到但 result 未到）
+  // → 一律抑制 AgentRunningIndicator，避免压缩分隔符切换期间闪烁。
+  // compactInFlight 从点击压缩 / SDK compacting 事件开始为 true，
+  // 直到整个 stream 结束（stream state 被删除）才消失。
+  const suppressAgentRunning = streamState?.isCompacting || streamState?.compactInFlight
+
   // 统一分组：将持久化 + 实时消息合并后再分组，确保 system 消息（如压缩分割线）出现在正确位置
   const allGroups = React.useMemo(() => {
     if (!useSDKRenderer) return []
@@ -868,7 +874,7 @@ export function AgentMessages({ sessionId, sessionModelId, messages, messagesLoa
             )}
 
             {/* 有实时助手内容时：显示运行指示器或占位（防止 streaming 结束到 Actions Bar 出现之间的高度跳动） */}
-            {hasLiveAssistantContent && (
+            {hasLiveAssistantContent && !suppressAgentRunning && (
               <div className="pl-[56px] mt-0.5 min-h-[28px]">
                 {retrying && <RetryingNotice retrying={retrying} />}
                 {streaming && <AgentRunningIndicator startedAt={startedAt} />}
@@ -877,7 +883,7 @@ export function AgentMessages({ sessionId, sessionModelId, messages, messagesLoa
 
             {/* 无实时助手内容时：显示完整气泡（含头像/名称/时间） */}
             {/* 注意：工具活动已通过 SDK 渲染路径（liveGroups）展示，此处不再使用 ToolActivityList */}
-            {!hasLiveAssistantContent && (streaming || smoothContent || retrying) && (
+            {!hasLiveAssistantContent && !suppressAgentRunning && (streaming || smoothContent || retrying) && (
               <Message from="assistant">
                 <MessageHeader
                   model={agentStreamingModel}
@@ -897,6 +903,10 @@ export function AgentMessages({ sessionId, sessionModelId, messages, messagesLoa
                 </MessageContent>
               </Message>
             )}
+
+            {/* 压缩中指示器：由 isCompacting flag 驱动的尾部元素，compact_boundary 到达时 flag 翻 false 自然消失，
+                视觉上被流中新出现的"上下文已压缩"分隔符无缝替换 */}
+            {streamState?.isCompacting && <CompactingIndicator />}
 
           </>
         )}

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -815,11 +815,12 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         return map
       })
 
-      // 3. 异步发送到后端（'now' 优先级立即注入 SDK + 持久化 JSONL）
+      // 3. 异步发送到后端（立即软中断当前 turn，再注入消息作为新一轮输入）
       window.electronAPI.queueAgentMessage({
         sessionId,
         userMessage: effectiveText,
         uuid: localUuid,
+        interrupt: true,
       }).catch((error) => {
         console.error('[AgentView] 追加消息失败:', error)
         toast.error('追加消息失败', { description: String(error) })

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -1009,8 +1009,28 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const handleCompact = React.useCallback((): void => {
     if (!agentChannelId || streaming) return
 
-    // 初始化流式状态（startedAt 由渲染进程生成，传递给主进程原样回传）
     const streamStartedAt = Date.now()
+    const localUuid = crypto.randomUUID()
+
+    // 1. 立即注入合成用户消息（/compact 气泡立刻可见，与普通发送路径一致）
+    const syntheticMsg: import('@proma/shared').SDKMessage = {
+      type: 'user',
+      uuid: localUuid,
+      message: {
+        content: [{ type: 'text', text: '/compact' }],
+      },
+      parent_tool_use_id: null,
+      _createdAt: streamStartedAt,
+    } as unknown as import('@proma/shared').SDKMessage
+
+    store.set(liveMessagesMapAtom, (prev) => {
+      const map = new Map(prev)
+      const current = map.get(sessionId) ?? []
+      map.set(sessionId, [...current, syntheticMsg])
+      return map
+    })
+
+    // 2. 初始化流式状态 + 乐观设 isCompacting=true（SDK compacting 事件之前就显示"正在压缩..."分隔符）
     setStreamingStates((prev) => {
       const map = new Map(prev)
       const current = prev.get(sessionId) ?? {
@@ -1021,7 +1041,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         model: agentModelId || undefined,
         startedAt: streamStartedAt,
       }
-      map.set(sessionId, { ...current, running: true, startedAt: streamStartedAt })
+      map.set(sessionId, { ...current, running: true, startedAt: streamStartedAt, isCompacting: true, compactInFlight: true })
       return map
     })
 
@@ -1032,8 +1052,26 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       modelId: agentModelId || undefined,
       workspaceId: currentWorkspaceId || undefined,
       startedAt: streamStartedAt,
-    }).catch(console.error)
-  }, [sessionId, agentChannelId, agentModelId, currentWorkspaceId, streaming, setStreamingStates])
+    }).catch((error) => {
+      console.error('[AgentView] /compact 发送失败:', error)
+      // 回滚：移除合成用户消息 + 清除 isCompacting flag
+      store.set(liveMessagesMapAtom, (prev) => {
+        const map = new Map(prev)
+        const current = (map.get(sessionId) ?? []).filter(
+          (m) => (m as unknown as { uuid?: string }).uuid !== localUuid,
+        )
+        map.set(sessionId, current)
+        return map
+      })
+      setStreamingStates((prev) => {
+        const map = new Map(prev)
+        const current = prev.get(sessionId)
+        if (!current) return prev
+        map.set(sessionId, { ...current, isCompacting: false, compactInFlight: false })
+        return map
+      })
+    })
+  }, [sessionId, agentChannelId, agentModelId, currentWorkspaceId, streaming, setStreamingStates, store])
 
   /** 复制错误信息到剪贴板 */
   const handleCopyError = React.useCallback(async (): Promise<void> => {

--- a/apps/electron/src/renderer/components/agent/ContextUsageBadge.tsx
+++ b/apps/electron/src/renderer/components/agent/ContextUsageBadge.tsx
@@ -1,23 +1,26 @@
 /**
- * ContextUsageBadge — 上下文使用量徽章
+ * ContextUsageBadge — 上下文使用量指示器
  *
- * 常驻显示在输入框工具栏，展示当前 Agent 会话的上下文占用情况：
- * - 有数据时显示 "Xk / Yk"（已用 / 总窗口大小）
- * - 无数据时不显示（首次请求前无 usage 数据）
- * - 压缩中时显示 Loader2 旋转图标
- * - 使用量接近压缩阈值（窗口 × 0.775 × 80%）时显示琥珀色警告
- * - hover tooltip 显示 token 用量明细
+ * 输入框工具栏上的一个 36×36 圆形按钮：
+ * - 内部为 16px 圆环，按 displayTokens / displayWindow 比例渲染
+ * - hover / click 弹出 Popover，内含 token 明细 + 手动压缩按钮
+ * - 压缩中时按钮位置显示 Loader2 旋转图标
+ * - 占用接近压缩阈值（窗口 × 0.775 × 80%）时圆环变琥珀色
+ * - 无数据时不显示
  */
 
 import * as React from 'react'
 import { Loader2, Minimize2 } from 'lucide-react'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { Button } from '@/components/ui/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { cn } from '@/lib/utils'
 
 /** 压缩阈值比例（SDK 在 ~77.5% 窗口大小时自动压缩） */
 const COMPACT_THRESHOLD_RATIO = 0.775
 /** 显示警告的阈值（压缩阈值的 80%） */
 const WARNING_RATIO = 0.80
+/** Popover hover 关闭延迟（ms），与 AgentThinkingPopover 一致 */
+const HOVER_CLOSE_DELAY = 150
 
 interface ContextUsageBadgeProps {
   inputTokens?: number
@@ -42,34 +45,69 @@ function formatTokens(tokens: number): string {
   return `${tokens}`
 }
 
-/** 构建多行 tooltip 文本 */
-function buildTooltipLines(props: {
-  inputTokens: number
-  outputTokens?: number
-  cacheReadTokens?: number
-  cacheCreationTokens?: number
-  contextWindow?: number
+/** 圆环进度指示器 — 16×16 SVG，描边 2px */
+interface UsageRingProps {
+  ratio: number
   isWarning: boolean
-}): string {
-  const lines: string[] = []
+}
+function UsageRing({ ratio, isWarning }: UsageRingProps): React.ReactElement {
+  const radius = 8
+  const circumference = 2 * Math.PI * radius
+  const clamped = Math.max(0, Math.min(1, ratio))
+  const dashOffset = circumference * (1 - clamped)
 
-  // 纯输入 = 总上下文 - 缓存读取 - 缓存写入
-  const pureInput = props.inputTokens - (props.cacheReadTokens ?? 0) - (props.cacheCreationTokens ?? 0)
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 20 20"
+      className={cn(
+        'shrink-0 transition-colors',
+        isWarning ? 'text-amber-500 dark:text-amber-400' : 'text-foreground/70',
+      )}
+      aria-hidden="true"
+    >
+      <circle
+        cx="10"
+        cy="10"
+        r={radius}
+        fill="none"
+        stroke="currentColor"
+        strokeOpacity="0.2"
+        strokeWidth="2"
+      />
+      <circle
+        cx="10"
+        cy="10"
+        r={radius}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeDasharray={circumference}
+        strokeDashoffset={dashOffset}
+        transform="rotate(-90 10 10)"
+        style={{ transition: 'stroke-dashoffset 300ms ease-out' }}
+      />
+    </svg>
+  )
+}
 
-  if (pureInput > 0) lines.push(`输入: ${pureInput.toLocaleString()}`)
-  if (props.outputTokens) lines.push(`输出: ${props.outputTokens.toLocaleString()}`)
-  if (props.cacheCreationTokens) lines.push(`缓存写入: ${props.cacheCreationTokens.toLocaleString()}`)
-  if (props.cacheReadTokens) lines.push(`缓存读取: ${props.cacheReadTokens.toLocaleString()}`)
-
-  if (props.contextWindow) {
-    lines.push(`上下文窗口: ${props.contextWindow.toLocaleString()}`)
-  }
-
-  if (props.isWarning) {
-    lines.push('点击手动压缩')
-  }
-
-  return lines.join('\n')
+/** Popover 里的一行 key/value */
+interface DetailRowProps {
+  label: string
+  value: string
+  emphasized?: boolean
+}
+function DetailRow({ label, value, emphasized }: DetailRowProps): React.ReactElement {
+  return (
+    <div className="flex items-center justify-between gap-4 text-xs">
+      <span className="text-foreground/70">{label}</span>
+      <span className={cn('tabular-nums', emphasized ? 'font-medium text-foreground' : 'text-foreground/90')}>
+        {value}
+      </span>
+    </div>
+  )
 }
 
 export function ContextUsageBadge({
@@ -94,13 +132,35 @@ export function ContextUsageBadge({
     stableRef.current = { inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, contextWindow }
   }
 
-  // 压缩中 → 始终显示 spinner
+  const [open, setOpen] = React.useState(false)
+  const closeTimerRef = React.useRef<number | null>(null)
+
+  const cancelClose = React.useCallback(() => {
+    if (closeTimerRef.current != null) {
+      window.clearTimeout(closeTimerRef.current)
+      closeTimerRef.current = null
+    }
+  }, [])
+
+  const scheduleClose = React.useCallback(() => {
+    cancelClose()
+    closeTimerRef.current = window.setTimeout(() => setOpen(false), HOVER_CLOSE_DELAY)
+  }, [cancelClose])
+
+  React.useEffect(() => cancelClose, [cancelClose])
+
+  // 压缩中 → 按钮位置显示 spinner
   if (isCompacting) {
     return (
-      <div className="flex items-center gap-1.5 px-2 py-0.5 text-xs text-muted-foreground">
-        <Loader2 className="size-3.5 animate-spin" />
-        <span>压缩中...</span>
-      </div>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="size-[36px] rounded-full text-muted-foreground cursor-default"
+        disabled
+      >
+        <Loader2 className="size-4 animate-spin" />
+      </Button>
     )
   }
 
@@ -124,77 +184,91 @@ export function ContextUsageBadge({
     ? displayTokens / compactThreshold >= WARNING_RATIO
     : false
 
-  // 显示文本：已用 / 总窗口
-  const displayText = displayWindow
-    ? `${formatTokens(displayTokens)} / ${formatTokens(displayWindow)}`
-    : formatTokens(displayTokens)
+  const ratio = displayWindow ? displayTokens / displayWindow : 0
 
-  const tooltipText = buildTooltipLines({
-    inputTokens: displayTokens,
-    outputTokens: displayOutput,
-    cacheReadTokens: displayCacheRead,
-    cacheCreationTokens: displayCacheCreation,
-    contextWindow: displayWindow,
-    isWarning,
-  })
+  // 纯输入 = 总上下文 - 缓存读取 - 缓存写入
+  const pureInput = displayTokens - (displayCacheRead ?? 0) - (displayCacheCreation ?? 0)
 
-  // 占用百分比（相对完整窗口）
-  const percentText = displayWindow
-    ? `${Math.round((displayTokens / displayWindow) * 100)}%`
+  const percent = displayWindow
+    ? Math.round((displayTokens / displayWindow) * 100)
     : undefined
 
-  // 压缩按钮的 tooltip 文案
-  const compactTooltip = isProcessing
-    ? '对话进行中，无法压缩'
-    : '手动压缩上下文'
+  const handleCompactClick = (): void => {
+    if (isProcessing) return
+    onCompact()
+    setOpen(false)
+  }
 
   return (
-    <div className="flex items-center gap-0.5">
-      {/* 上下文用量显示 */}
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span
-            className={cn(
-              'flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs transition-colors',
-              isWarning
-                ? 'text-amber-600 dark:text-amber-400'
-                : 'text-muted-foreground',
-            )}
-          >
-            <span>{displayText}</span>
-            {percentText && (
-              <span className={cn('tabular-nums', isWarning && 'font-medium')}>{percentText}</span>
-            )}
-          </span>
-        </TooltipTrigger>
-        <TooltipContent side="top">
-          <p className="whitespace-pre-line text-left">{tooltipText}</p>
-        </TooltipContent>
-      </Tooltip>
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className={cn(
+            'size-[36px] rounded-full',
+            isWarning ? 'text-amber-600 dark:text-amber-400' : 'text-foreground/60 hover:text-foreground',
+          )}
+          onMouseEnter={() => {
+            cancelClose()
+            setOpen(true)
+          }}
+          onMouseLeave={scheduleClose}
+        >
+          <UsageRing ratio={ratio} isWarning={isWarning} />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        side="top"
+        align="center"
+        sideOffset={8}
+        className="w-auto min-w-[220px] p-2.5"
+        onMouseEnter={cancelClose}
+        onMouseLeave={scheduleClose}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
+        <div className="flex flex-col gap-1.5">
+          {pureInput > 0 && <DetailRow label="输入" value={pureInput.toLocaleString()} />}
+          {displayOutput ? <DetailRow label="输出" value={displayOutput.toLocaleString()} /> : null}
+          {displayCacheCreation ? <DetailRow label="缓存写入" value={displayCacheCreation.toLocaleString()} /> : null}
+          {displayCacheRead ? <DetailRow label="缓存读取" value={displayCacheRead.toLocaleString()} /> : null}
 
-      {/* 压缩按钮 — 始终可见 */}
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
+          {displayWindow ? (
+            <>
+              <div className="h-px bg-border my-0.5" />
+              <DetailRow
+                label="上下文"
+                value={`${formatTokens(displayTokens)} / ${formatTokens(displayWindow)}`}
+                emphasized
+              />
+              {percent != null && (
+                <DetailRow
+                  label="占用"
+                  value={`${percent}%`}
+                  emphasized={isWarning}
+                />
+              )}
+            </>
+          ) : null}
+
+          <div className="h-px bg-border my-0.5" />
+          <Button
             type="button"
+            variant={isWarning ? 'default' : 'outline'}
+            size="sm"
             className={cn(
-              'flex items-center justify-center size-[22px] rounded transition-colors',
-              isProcessing
-                ? 'text-muted-foreground/40 cursor-not-allowed'
-                : isWarning
-                  ? 'text-amber-600 dark:text-amber-400 hover:bg-amber-500/10 cursor-pointer'
-                  : 'text-muted-foreground hover:bg-muted cursor-pointer',
+              'h-7 text-xs gap-1.5',
+              isWarning && 'bg-amber-500 hover:bg-amber-600 text-white',
             )}
-            onClick={!isProcessing ? onCompact : undefined}
+            onClick={handleCompactClick}
             disabled={isProcessing}
           >
             <Minimize2 className="size-3.5" />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent side="top">
-          <p>{compactTooltip}</p>
-        </TooltipContent>
-      </Tooltip>
-    </div>
+            {isProcessing ? '对话进行中' : '手动压缩'}
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
   )
 }

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -260,6 +260,10 @@ export function groupIntoTurns(messages: SDKMessage[], sessionModelId?: string):
       }
     } else {
       // result, tool_progress 等 → 归入当前 turn
+      // prompt_suggestion 不属于对话转录，不入 turn，避免被当作文本附加到助手消息末尾
+      if ((msg as { type: string }).type === 'prompt_suggestion') {
+        continue
+      }
       if (currentTurn) {
         currentTurn.turnMessages.push(msg)
       }
@@ -369,6 +373,15 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, onR
 
   // 从 turnMessages 中提取 result 消息的耗时和用量
   const { durationMs, usage } = extractTurnUsage(turn.turnMessages)
+
+  // 该 turn 是否被软中断（aborted_streaming / aborted_tools）
+  // 用于在消息底部显示“已被用户中断”徽章，独立于会话级 stoppedByUser 标记
+  const isInterruptedTurn = turn.turnMessages.some((m) => {
+    if (m.type !== 'result') return false
+    const reason = (m as { terminal_reason?: string }).terminal_reason
+    return reason === 'aborted_streaming' || reason === 'aborted_tools'
+  })
+  const showStoppedBadge = stoppedByUser || isInterruptedTurn
 
   // 构建 Agent/Task tool_use → 子代理内容块映射
   const agentToolIds = new Set<string>()
@@ -550,7 +563,7 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, onR
           : undefined
         const hasActions = !!(textContent || (onFork && lastUuid) || (onRewind && lastUuid))
         const hasDuration = durationMs != null
-        if (!hasDuration && !hasActions && !stoppedByUser) return null
+        if (!hasDuration && !hasActions && !showStoppedBadge) return null
         return (
           <MessageActions className="pl-[46px] mt-0.5 min-h-[28px] justify-start">
             {hasDuration && <DurationBadge durationMs={durationMs!} usage={usage} />}
@@ -565,7 +578,7 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, onR
                 <Undo2 className="size-3.5" />
               </MessageAction>
             )}
-            {stoppedByUser && (
+            {showStoppedBadge && (
               <Badge variant="outline" className="text-xs text-muted-foreground/70 border-muted-foreground/30 shrink-0">
                 已被用户中断
               </Badge>

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -77,13 +77,17 @@ function CompactBoundaryDivider(): React.ReactElement {
   )
 }
 
-// ===== system 消息：正在压缩指示器 =====
+// ===== system 消息：正在压缩指示器（与 CompactBoundaryDivider 同款横线样式，pill 内带 spinner） =====
 
-function CompactingIndicator(): React.ReactElement {
+export function CompactingIndicator(): React.ReactElement {
   return (
-    <div className="flex items-center gap-2 my-2 px-1 text-[12px] text-muted-foreground/70">
-      <Loader2 className="size-3 animate-spin" />
-      <span>正在压缩上下文...</span>
+    <div className="flex items-center gap-3 my-4 px-1">
+      <div className="flex-1 h-px bg-border/40" />
+      <span className="shrink-0 inline-flex items-center gap-1.5 text-[11px] text-muted-foreground/70 px-2 py-0.5 rounded-full border border-border/30 bg-muted/20">
+        <Loader2 className="size-3 animate-spin" />
+        正在压缩...
+      </span>
+      <div className="flex-1 h-px bg-border/40" />
     </div>
   )
 }
@@ -297,6 +301,7 @@ function mergeAdjacentSameModelTurns(groups: MessageGroup[]): MessageGroup[] {
     for (let i = result.length - 1; i >= 0; i--) {
       const prev = result[i]!
       if (prev.type === 'user') break // 真正的用户输入阻断合并
+      if (prev.type === 'system' && (prev.message as SDKSystemMessage).subtype === 'compact_boundary') break // 压缩边界阻断合并
       if (prev.type === 'assistant-turn') {
         if (prev.model === group.model) {
           mergeTargetIdx = i
@@ -670,9 +675,7 @@ export function SDKMessageRenderer({
       return <CompactBoundaryDivider />
     }
 
-    if (subtype === 'compacting') {
-      return <CompactingIndicator />
-    }
+    // compacting 事件已由 isCompacting flag 驱动的尾部指示器接管（见 AgentMessages），此处不再渲染持久条目
 
     return null
   }

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -334,7 +334,11 @@ export function useGlobalAgentListeners(): void {
         // Phase 2: 直接累积 SDKMessage 到 liveMessagesMapAtom（跳过 replay 消息，避免与持久化消息重复）
         if (payload.kind === 'sdk_message') {
           const msgRecord = payload.message as Record<string, unknown>
-          if (!msgRecord.isReplay) {
+          // prompt_suggestion 不是对话转录消息，不能进入 liveMessages（会被错误渲染到最后一条助手消息中）
+          // 它通过下方 legacyEvents 分支写入 agentPromptSuggestionsAtom，显示在输入框上方
+          if (msgRecord.type === 'prompt_suggestion') {
+            // 跳过写入 liveMessages
+          } else if (!msgRecord.isReplay) {
             // 为实时消息补充 _createdAt 时间戳（与持久化时的逻辑一致），
             // 避免 AssistantTurnRenderer 因缺少时间戳导致 header 时间消失
             if (typeof msgRecord._createdAt !== 'number') {

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -52,6 +52,21 @@ import type { AgentStreamEvent, AgentStreamCompletePayload, AgentEvent, AgentStr
 // Phase 2 将移除此转换，直接使用 SDKMessage 渲染
 // ============================================================================
 
+/**
+ * 按模型名推断 contextWindow。SDK 流式过程中不返回此字段，
+ * 只有 result 消息的 modelUsage 才带（且部分渠道不返回）。
+ * 这里提供一个按模型家族的 fallback，保证进度环永远有分母可用。
+ */
+function inferContextWindow(model?: string): number | undefined {
+  if (!model) return undefined
+  const m = model.toLowerCase()
+  // Claude Haiku 为 200k
+  if (m.includes('claude-haiku')) return 200_000
+  // Claude Sonnet 4.6、Opus 4.6 以及 Opus 4.7 均为 1M 上下文
+  if (m.includes('claude-sonnet-4-6') || m.includes('claude-opus-4-6') || m.includes('claude-opus-4-7')) return 1_000_000
+  return 200_000
+}
+
 function payloadToLegacyEvents(payload: AgentStreamPayload): AgentEvent[] {
   if (payload.kind === 'proma_event') {
     const evt = payload.event
@@ -133,6 +148,9 @@ function payloadToLegacyEvents(payload: AgentStreamPayload): AgentEvent[] {
       if (!aMsg.parent_tool_use_id && aMsg.message.usage) {
         const u = aMsg.message.usage
         const inputTokens = u.input_tokens + (u.cache_read_input_tokens ?? 0) + (u.cache_creation_input_tokens ?? 0)
+        // 流式过程中 SDK 不返回 contextWindow，按模型名推断一个默认值作为 fallback
+        const modelName = aMsg.message.model ?? aMsg._channelModelId
+        const fallbackWindow = inferContextWindow(modelName)
         events.push({
           type: 'usage_update',
           usage: {
@@ -140,6 +158,7 @@ function payloadToLegacyEvents(payload: AgentStreamPayload): AgentEvent[] {
             outputTokens: u.output_tokens,
             cacheReadTokens: u.cache_read_input_tokens,
             cacheCreationTokens: u.cache_creation_input_tokens,
+            ...(fallbackWindow ? { contextWindow: fallbackWindow } : {}),
           },
         })
       }

--- a/packages/shared/src/types/agent-provider.ts
+++ b/packages/shared/src/types/agent-provider.ts
@@ -48,6 +48,11 @@ export interface AgentProviderAdapter {
   query(input: AgentQueryInput): AsyncIterable<SDKMessage>
   /** 中止指定会话的执行 */
   abort(sessionId: string): void
+  /**
+   * 软中断当前 turn，但保留活跃 Query/Channel 以便继续注入下一条用户消息。
+   * 与 abort() 的区别：不杀子进程，允许立即续跑新消息。
+   */
+  interruptQuery?(sessionId: string): Promise<void>
   /** 释放资源 */
   dispose(): void
   /** 向活跃查询注入队列消息（可选，仅支持队列的 Provider 实现） */

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -732,6 +732,12 @@ export interface AgentQueueMessageInput {
   userMessage: string
   /** 前端预生成的 UUID（用于乐观更新去重） */
   uuid?: string
+  /**
+   * 软中断当前 Agent turn 后再追加消息。
+   * true：先调用 SDK query.interrupt() 立即打断正在输出的 turn，再注入消息。
+   * false / undefined：排队追加（默认行为，turn 结束后才会被消费）。
+   */
+  interrupt?: boolean
 }
 
 // ===== 会话迁移输入 =====


### PR DESCRIPTION
## Summary
- 恢复 Agent 流式过程中的打断发送与 `prompt_suggestion` 显示（dc64b1a）
- `/compact` 体验优化：点击后立即注入合成用户气泡 + 乐观置 `isCompacting`，并新增 `compactInFlight` 抑制 `compact_boundary` 切换瞬间 `AgentRunningIndicator` 的闪烁；`CompactingIndicator` 改为与分隔线同款样式实现无缝过渡（b6c89f4）
- `ContextUsageBadge` 重构为 36×36 圆环按钮 + Popover，圆环按占用比例渲染，hover 弹出 token 明细与手动压缩按钮；新增按模型家族推断 `contextWindow` 的流式 fallback，避免进度环无分母

## Test plan
- [ ] 流式过程中点击发送按钮，消息正常排队/发送
- [ ] 流式中 `prompt_suggestion` 正常展示
- [ ] 点击 `ContextUsageBadge` 手动压缩按钮，`/compact` 气泡立即出现；压缩过程无 `AgentRunningIndicator` 闪烁
- [ ] 压缩完成后 `compact_boundary` 分隔线正常渲染，前后气泡正确分段
- [ ] 压缩请求失败时合成气泡与状态正确回滚
- [ ] `ContextUsageBadge` 圆环在无 `contextWindow` 的流式阶段仍能按推断值渲染进度
- [ ] Popover hover 打开/关闭延迟正常，Token 明细与百分比显示准确

🤖 Generated with [Claude Code](https://claude.com/claude-code)