### PR TITLE
fix: 钉钉 Bot 无法用 /stop 停止的问题

### DIFF
--- a/apps/electron/src/main/lib/dingtalk-bridge-manager.ts
+++ b/apps/electron/src/main/lib/dingtalk-bridge-manager.ts
@@ -54,19 +54,21 @@ class DingTalkBridgeManager {
 
   /** 启动单个 Bot */
   async startBot(botId: string): Promise<void> {
-    // 如果已有实例，先停止
-    const existing = this.bridges.get(botId)
-    if (existing) {
-      existing.stop()
-      this.bridges.delete(botId)
-    }
-
     const botConfig = getDingTalkBotById(botId)
     if (!botConfig) {
       throw new Error(`Bot ${botId} 不存在`)
     }
     if (!botConfig.enabled) {
       throw new Error(`Bot "${botConfig.name}" 未启用`)
+    }
+
+    // 复用已有实例（保留 commandHandler 中的 chatBindings），仅重建连接
+    const existing = this.bridges.get(botId)
+    if (existing) {
+      existing.stop()
+      existing.updateConfig(botConfig)
+      await existing.start()
+      return
     }
 
     const bridge = new DingTalkBridge(botConfig)
@@ -83,9 +85,8 @@ class DingTalkBridgeManager {
     }
   }
 
-  /** 重启单个 Bot（配置变更后调用） */
+  /** 重启单个 Bot（配置变更后调用，复用实例保留绑定） */
   async restartBot(botId: string): Promise<void> {
-    this.stopBot(botId)
     await this.startBot(botId)
   }
 

--- a/apps/electron/src/main/lib/dingtalk-bridge.ts
+++ b/apps/electron/src/main/lib/dingtalk-bridge.ts
@@ -130,6 +130,11 @@ class DingTalkBridge {
     })
   }
 
+  /** 更新 Bot 配置（重连时复用实例，避免丢失 chatBindings） */
+  updateConfig(botConfig: DingTalkBotConfig): void {
+    this.botConfig = botConfig
+  }
+
   /** 获取当前状态 */
   getStatus(): DingTalkBridgeState {
     return { ...this.state }


### PR DESCRIPTION
## 问题

钉钉 Bot 在 WebSocket 断连重建时，`startBot()` 会销毁旧的 `DingTalkBridge` 实例并创建新实例，导致 `BridgeCommandHandler` 中的 `chatBindings`（chatId → sessionId 映射）全部丢失。

表现：Agent 正在运行时，`/stop` 返回"当前没有绑定的会话"。

根本原因：微信 Bridge 是模块级单例，断连后在同一实例内重试；钉钉 Bridge 每次重连都 `new DingTalkBridge()`，带来全新的空 `chatBindings`。

## 修复

复用已有 `DingTalkBridge` 实例，重连时只重建 WebSocket 连接，不重建 `commandHandler`：

- `DingTalkBridge.updateConfig()` — 新增方法，允许热更新 botConfig 而不重建实例
- `DingTalkBridgeManager.startBot()` — 已有实例时调用 `stop()` + `updateConfig()` + `start()`，不再 delete + new
- `DingTalkBridgeManager.restartBot()` — 直接委托给 `startBot()`，不再先 `stopBot()`（会从 map 删除实例）

## 测试

- WebSocket 断连重建后，`/stop` 可正常停止 Agent
- Bot 配置变更后重启，新配置（clientId/clientSecret/workspace）正确生效
- 类型检查通过（`tsc --noEmit`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)