### PR TITLE
fix: AskUserBanner 单选题选完后自动切换到下一个问题

### DIFF
--- a/apps/electron/src/renderer/components/agent/AskUserBanner.tsx
+++ b/apps/electron/src/renderer/components/agent/AskUserBanner.tsx
@@ -269,7 +269,12 @@ export function AskUserBanner({ sessionId }: AskUserBannerProps): React.ReactEle
           answer={getAnswer(activeTab)}
           focusedIndex={focusedOptIdx}
           showBadge={questions.length === 1}
-          onToggleOption={(label) => toggleOptionByState(activeTab, currentQuestion, label)}
+          onToggleOption={(label) => {
+            toggleOptionByState(activeTab, currentQuestion, label)
+            if (!currentQuestion.multiSelect && !isLastTab) {
+              setTimeout(() => setActiveTab((prev) => prev + 1), 150)
+            }
+          }}
           onToggleCustom={() => toggleCustomByState(activeTab)}
           onCustomTextChange={(text) => setAnswers((prev) => {
             const map = new Map(prev)


### PR DESCRIPTION
## 问题

多问题场景下，单选题选完一个选项后不会自动切换到下一个问题，需要手动点击 Tab。

## 修复

在 `onToggleOption` 回调中，单选题选完后 150ms 自动跳转到下一个问题。

- 仅对单选题生效（`!multiSelect`）
- 最后一题不触发跳转
- 多选题行为不变