### PR TITLE
fix: 消除启动与系统主题切换时的全屏闪烁

### DIFF
--- a/apps/electron/src/renderer/atoms/theme.ts
+++ b/apps/electron/src/renderer/atoms/theme.ts
@@ -92,31 +92,66 @@ export const resolvedThemeAtom = atom<'light' | 'dark'>((get) => {
   return mode
 })
 
+/** 所有特殊风格 class（用于清理旧值） */
+const ALL_THEME_STYLE_CLASSES = [
+  'theme-ocean-light',
+  'theme-ocean-dark',
+  'theme-forest-light',
+  'theme-forest-dark',
+  'theme-slate-light',
+  'theme-slate-dark',
+] as const
+
 /**
  * 应用主题到 DOM
  *
  * 在 <html> 元素上切换 dark 类名和特殊风格类名。
+ *
+ * 幂等实现：先计算目标 class 状态，与当前 DOM 对比，一致时直接 return，
+ * 不触发任何 classList mutation。避免与 vibrancy + backdrop-blur 合成层叠加
+ * 导致 Chromium 重建合成层造成的全屏闪烁。
  */
 export function applyThemeToDOM(themeMode: ThemeMode, themeStyle: ThemeStyle = 'default', systemIsDark: boolean = true): void {
-  // [FLASH-DEBUG] 主题 DOM 操作会影响整个页面
-  console.log(`[FLASH-DEBUG] applyThemeToDOM called: mode=${themeMode}, style=${themeStyle}, systemIsDark=${systemIsDark}`)
   const html = document.documentElement
 
-  // 移除所有特殊风格类
-  html.classList.remove('theme-ocean-light', 'theme-ocean-dark', 'theme-forest-light', 'theme-forest-dark', 'theme-slate-light', 'theme-slate-dark')
+  // 计算目标状态
+  let targetStyleClass: string | null = null
+  let targetIsDark: boolean
 
   if (themeMode === 'special' && themeStyle !== 'default') {
-    // 特殊风格模式：根据风格决定 dark 类
-    const isDark = themeStyle.endsWith('-dark')
-    html.classList.toggle('dark', isDark)
-    html.classList.add(`theme-${themeStyle}`)
+    targetStyleClass = `theme-${themeStyle}`
+    targetIsDark = themeStyle.endsWith('-dark')
+  } else if (themeMode === 'system') {
+    targetIsDark = systemIsDark
   } else {
-    // 普通模式
-    let isDark = themeMode === 'dark'
-    if (themeMode === 'system') {
-      isDark = systemIsDark
+    targetIsDark = themeMode === 'dark'
+  }
+
+  // 读取当前状态
+  const currentIsDark = html.classList.contains('dark')
+  const currentStyleClass = ALL_THEME_STYLE_CLASSES.find((c) => html.classList.contains(c)) ?? null
+
+  // 与目标一致 → 直接跳过，避免触发 CSS 重新级联
+  if (currentIsDark === targetIsDark && currentStyleClass === targetStyleClass) {
+    return
+  }
+
+  // [FLASH-DEBUG] 仅在真正发生 DOM 变更时打印
+  console.log(
+    `[FLASH-DEBUG] applyThemeToDOM apply: mode=${themeMode}, style=${themeStyle}, systemIsDark=${systemIsDark}, diff={dark: ${currentIsDark}→${targetIsDark}, style: ${currentStyleClass}→${targetStyleClass}}`
+  )
+
+  // 只修改确实需要变的 class
+  if (currentStyleClass !== targetStyleClass) {
+    if (currentStyleClass) {
+      html.classList.remove(currentStyleClass)
     }
-    html.classList.toggle('dark', isDark)
+    if (targetStyleClass) {
+      html.classList.add(targetStyleClass)
+    }
+  }
+  if (currentIsDark !== targetIsDark) {
+    html.classList.toggle('dark', targetIsDark)
   }
 }
 

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -4,7 +4,7 @@
  * 挂载 React 应用，初始化主题系统。
  */
 
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useMemo, useRef } from 'react'
 import ReactDOM from 'react-dom/client'
 import { useSetAtom, useAtomValue, useStore } from 'jotai'
 import App from './App'
@@ -97,9 +97,23 @@ function ThemeInitializer(): null {
   }, [setThemeMode, setSystemIsDark, setThemeStyle])
 
   // 响应式应用主题到 DOM
+  // 用 useMemo 计算"实际会影响 DOM 的状态签名"作为唯一依赖：
+  // special 模式下 systemIsDark 不影响最终 class，避免系统主题变化时触发无意义的
+  // applyThemeToDOM 调用（配合 applyThemeToDOM 内部的幂等检查双重兜底）。
+  const themeSignature = useMemo(() => {
+    if (themeMode === 'special') {
+      return `special:${themeStyle}`
+    }
+    if (themeMode === 'system') {
+      return `system:${systemIsDark ? 'dark' : 'light'}`
+    }
+    return themeMode
+  }, [themeMode, themeStyle, systemIsDark])
+
   useEffect(() => {
     applyThemeToDOM(themeMode, themeStyle, systemIsDark)
-  }, [themeMode, themeStyle, systemIsDark])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [themeSignature])
 
   return null
 }


### PR DESCRIPTION
## Summary
- **根因**：`applyThemeToDOM` 非幂等（每次无条件 `remove` 6 个 theme-* 类再 `add`）+ `ThemeInitializer` useEffect 在 `special` 模式下依然会被 `systemIsDark` 变化触发，叠加主窗口的 `vibrancy: 'under-window'` + CSS `backdrop-blur-xl` 导致 Chromium 被迫重建合成层 → 全屏闪烁
- **证据来源**：PR #286 加入的 FLASH-DEBUG 日志，在用户合盖/开盖后采集到 `applyThemeToDOM` 连续触发两次（`systemIsDark` 从 `true` 翻转为 `false`），而无任何 React 渲染风暴或事件洪流

## Changes
### `apps/electron/src/renderer/atoms/theme.ts`
- `applyThemeToDOM` 改为幂等实现：
  - 先根据入参计算 `targetStyleClass` + `targetIsDark`
  - 读取当前 `<html>` 对应状态，**一致则直接 return**，不触发任何 `classList` mutation
  - 需要变更时只做 diff 操作（替换 style class、切换 dark），不再无条件 remove 所有 `theme-*` 类
- 保留 `[FLASH-DEBUG]` 日志，但仅在真正 mutate 时打印并附带 diff 详情

### `apps/electron/src/renderer/main.tsx`
- `ThemeInitializer` 用 `useMemo` 计算 `themeSignature`（`special:${style}` / `system:${dark|light}` / `dark` / `light`）
- effect 依赖从 `[themeMode, themeStyle, systemIsDark]` 收敛为 `[themeSignature]`
- `special` 模式下系统明暗变化不再触发 effect 重跑；即便触发，`applyThemeToDOM` 的幂等检查兜底

## Test plan
- [ ] 启动应用，观察控制台应**不再**在初始化阶段出现 `[FLASH-DEBUG] applyThemeToDOM apply` 日志
- [ ] 合盖 → 开盖场景：反复测试，观察无全屏闪烁，控制台无 apply 日志
- [ ] 系统深浅模式切换（控制中心）：special 模式下应无 apply 日志；system 模式下仅正常主题切换一次 apply 日志
- [ ] 设置面板手动切换主题：正常生效，apply 日志出现一次且带正确 diff
- [ ] Agent 模式下长时间运行任务，观察 STREAM_COMPLETE 前后无闪烁

## Follow-up
- 确认修复生效后，另起一个 PR 清理所有 FLASH-DEBUG 日志（来自 #286 与本 PR）

🤖 Generated with [Claude Code](https://claude.com/claude-code)