### PR TITLE
perf: skip scroll listeners when sticky user message disabled

### DIFF
--- a/apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx
@@ -63,7 +63,7 @@ export function StickyUserMessage({ userMessages }: StickyUserMessageProps): Rea
 
   React.useEffect(() => {
     const el = scrollRef.current
-    if (!el || userMessages.length === 0) {
+    if (!el || userMessages.length === 0 || !stickyEnabled) {
       setStickyMessage(null)
       return
     }
@@ -109,7 +109,7 @@ export function StickyUserMessage({ userMessages }: StickyUserMessageProps): Rea
       resizeObserver.disconnect()
       cancelAnimationFrame(rafId)
     }
-  }, [scrollRef, userMessages, messageMap])
+  }, [scrollRef, userMessages, messageMap, stickyEnabled])
 
   // 点击回滚到原始消息
   const scrollToOriginal = React.useCallback(() => {
@@ -133,8 +133,8 @@ export function StickyUserMessage({ userMessages }: StickyUserMessageProps): Rea
   const isSticky = stickyMessage !== null
   const hasContent = stickyMessage && (stickyMessage.text || stickyMessage.attachments.length > 0)
 
-  if (!hasContent && !isSticky) return <></>
   if (!stickyEnabled) return <></>
+  if (!hasContent && !isSticky) return <></>
 
   return (
     <div


### PR DESCRIPTION
## Summary

Follow-up 补齐 PR #292 @Andreaseszhang 的 code review 发现的性能小瑕疵。

- PR #292 新增了 `stickyUserMessageEnabled` 开关，但 `StickyUserMessage` 组件在开关关闭时，仍然会：
  - 注册 `scroll` / `ResizeObserver` 监听
  - 在每次滚动事件触发 `querySelectorAll('[data-message-role="user"]')` 遍历所有用户消息节点
  - 计算 `getBoundingClientRect`
  - 只在最后的 `return` 处短路

本 PR 把 `!stickyEnabled` 判断分别上移到：
1. `useEffect` 开头——关闭时直接 early return，不订阅任何 DOM 事件（依赖数组加入 `stickyEnabled`，切换时会正确重新订阅）
2. 渲染早返回——挪到 `!hasContent && !isSticky` 之前

## Test plan

- [ ] 打开对话，确认开关打开时悬浮条照常工作
- [ ] 关闭开关后滚动对话，悬浮条不出现，且 DevTools Performance 中不再看到 scroll 监听开销
- [ ] 重新打开开关，滚动时悬浮条恢复显示
- [ ] 切换会话时无 stale state 残留

🤖 Generated with [Claude Code](https://claude.com/claude-code)