### PR TITLE
fix(AskUserBanner): 清理自动跳转定时器，修复 #299 遗留边界问题

### DIFF
--- a/apps/electron/src/renderer/components/agent/AskUserBanner.tsx
+++ b/apps/electron/src/renderer/components/agent/AskUserBanner.tsx
@@ -46,8 +46,20 @@ export function AskUserBanner({ sessionId }: AskUserBannerProps): React.ReactEle
   const focusedOptIdxRef = React.useRef(focusedOptIdx)
   focusedOptIdxRef.current = focusedOptIdx
   const submitRef = React.useRef<(() => void) | null>(null)
+  const autoAdvanceTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const clearAutoAdvanceTimer = React.useCallback((): void => {
+    if (autoAdvanceTimerRef.current != null) {
+      clearTimeout(autoAdvanceTimerRef.current)
+      autoAdvanceTimerRef.current = null
+    }
+  }, [])
+
+  // 组件卸载时清理未触发的跳转定时器
+  React.useEffect(() => clearAutoAdvanceTimer, [clearAutoAdvanceTimer])
 
   React.useEffect(() => {
+    clearAutoAdvanceTimer()
     setActiveTab(0)
     setFocusedOptIdx(-1)
     const firstOpt = questions[0]?.options[0]
@@ -272,7 +284,11 @@ export function AskUserBanner({ sessionId }: AskUserBannerProps): React.ReactEle
           onToggleOption={(label) => {
             toggleOptionByState(activeTab, currentQuestion, label)
             if (!currentQuestion.multiSelect && !isLastTab) {
-              setTimeout(() => setActiveTab((prev) => prev + 1), 150)
+              clearAutoAdvanceTimer()
+              autoAdvanceTimerRef.current = setTimeout(() => {
+                autoAdvanceTimerRef.current = null
+                setActiveTab((prev) => prev + 1)
+              }, 150)
             }
           }}
           onToggleCustom={() => toggleCustomByState(activeTab)}


### PR DESCRIPTION
## 背景

#299 为 `AskUserBanner` 单选题新增了"选完后 150ms 自动跳转下一问题"的 UX 改进。代码审查中发现两处未处理的边界问题，本 PR 做补充修复。

## 修复内容

### 1. 组件卸载 / 请求切换时未清理定时器
PR #299 使用裸 `setTimeout`，若组件在 150ms 内卸载，或 `useEffect` 因 `requestId` 变化重置状态，仍会有未触发的定时器回调在已卸载或已重置的组件上调用 `setActiveTab`。

### 2. 150ms 内连续点击多个选项 → 越过 tab
每次点击都会独立排一个 `setTimeout`，若用户快速改主意点击选项 A → B，两个 timer 都会执行 `setActiveTab((prev) => prev + 1)`，最终跳过本应停留的下一题。

## 方案

- 新增 `autoAdvanceTimerRef: useRef<ReturnType<typeof setTimeout> | null>`
- 新增 `clearAutoAdvanceTimer` 辅助函数
- 点击前先 clear 上一次 timer
- 组件卸载（useEffect cleanup）和请求切换（`requestId` useEffect 开头）时也 clear

## 兼容性

- 不改变 #299 的外部行为：单选题选完后仍在 150ms 后跳转
- 多选题和最后一题行为不变
- 键盘导航逻辑未触发 `onToggleOption`，不受影响

## 测试
- [x] 类型检查通过 (`pnpm run typecheck`)
- [x] 手动验证：快速切换选项不会跳过 tab
- [x] 手动验证：切换请求或关闭 Banner 无 React 控制台告警