### PR TITLE
feat(sidebar): 统一会话状态指示为左侧/底部线条

### DIFF
--- a/apps/electron/src/renderer/atoms/tab-atoms.ts
+++ b/apps/electron/src/renderer/atoms/tab-atoms.ts
@@ -14,6 +14,7 @@ import {
 import {
   agentRunningSessionIdsAtom,
   agentSessionIndicatorMapAtom,
+  workingDoneSessionIdsAtom,
 } from './agent-atoms'
 import type { SessionIndicatorStatus } from './agent-atoms'
 
@@ -97,12 +98,15 @@ export const tabIndicatorMapAtom = atom<Map<string, SessionIndicatorStatus>>((ge
   const tabs = get(tabsAtom)
   const chatStreaming = get(streamingConversationIdsAtom)
   const agentIndicator = get(agentSessionIndicatorMapAtom)
+  const workingDoneIds = get(workingDoneSessionIdsAtom)
   const map = new Map<string, SessionIndicatorStatus>()
   for (const tab of tabs) {
     if (tab.type === 'chat') {
       map.set(tab.id, chatStreaming.has(tab.sessionId) ? 'running' : 'idle')
     } else if (tab.type === 'agent') {
-      map.set(tab.id, agentIndicator.get(tab.sessionId) ?? 'idle')
+      const status = agentIndicator.get(tab.sessionId)
+        ?? (workingDoneIds.has(tab.sessionId) ? 'completed' : 'idle')
+      map.set(tab.id, status)
     }
   }
   return map

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -77,17 +77,6 @@ import {
 import type { ActiveView } from '@/atoms/active-view'
 import type { ConversationMeta, AgentSessionMeta, WorkspaceCapabilities } from '@proma/shared'
 
-/** Working 区域子分组的横线分割器 ── Label ── */
-function SectionDivider({ label }: { label: string }): React.ReactElement {
-  return (
-    <div className="flex items-center gap-2 px-2 py-1.5 select-none">
-      <div className="flex-1 h-px bg-foreground/10" />
-      <span className="text-[10px] font-medium text-foreground/30 tracking-wider">{label}</span>
-      <div className="flex-1 h-px bg-foreground/10" />
-    </div>
-  )
-}
-
 interface SidebarItemProps {
   icon: React.ReactNode
   label: string
@@ -177,7 +166,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   const [moveTargetId, setMoveTargetId] = React.useState<string | null>(null)
   /** 置顶区域展开/收起 */
   const [pinnedExpanded, setPinnedExpanded] = React.useState(true)
-  /** Agent Working/Pinned 子 Tab：'working' | 'pinned' */
+  /** Agent 上区子 Tab：'working' | 'pinned'，默认 working 在前 */
   const [agentSubTab, setAgentSubTab] = React.useState<'working' | 'pinned'>('working')
   const [userProfile, setUserProfile] = useAtom(userProfileAtom)
   const selectedModel = useAtomValue(selectedModelAtom)
@@ -925,189 +914,145 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         </div>
       )}
 
-      {/* Agent 模式 active 视图：可拖拽双区（上 Working/置顶 + 下 最近会话） */}
+      {/* Agent 模式 active 视图：可拖拽双区（上 置顶+Working + 下 最近会话） */}
       {mode === 'agent' && viewMode === 'active' ? (
         <div ref={agentSplitContainerRef} className="flex-1 flex flex-col min-h-0">
-          {/* 上区：Working / 置顶 Tab（高度可拖拽） */}
-          <div
-            style={{ height: agentTopHeight > 0 ? agentTopHeight : undefined }}
-            className="flex flex-col min-h-0 flex-shrink-0 overflow-hidden"
-          >
-            {/* Tab 切换按钮 */}
-            <div className="pt-2 px-3 flex-shrink-0">
-              <div className="flex items-center gap-1 mb-0.5">
-                <button
-                  onClick={() => setAgentSubTab('working')}
-                  className={cn(
-                    'px-2.5 py-0.5 rounded-md text-[12px] font-medium transition-colors titlebar-no-drag',
-                    agentSubTab === 'working'
-                      ? 'bg-foreground/[0.08] text-foreground/80'
-                      : 'text-foreground/40 hover:text-foreground/60 hover:bg-foreground/[0.04]'
+          {(pinnedAgentSessions.length > 0 || hasWorkingSessions) && (
+            <>
+              {/* 上区：工作中 / 置顶 Tab 切换（高度可拖拽） */}
+              <div
+                style={{ height: agentTopHeight > 0 ? agentTopHeight : undefined }}
+                className="flex flex-col min-h-0 flex-shrink-0 overflow-hidden"
+              >
+                {/* Tab 切换按钮 */}
+                <div className="pt-2 px-3 flex-shrink-0">
+                  <div className="flex items-center gap-1 mb-0.5">
+                    <button
+                      onClick={() => setAgentSubTab('working')}
+                      className={cn(
+                        'px-2.5 py-0.5 rounded-md text-[12px] font-medium transition-colors titlebar-no-drag inline-flex items-center',
+                        agentSubTab === 'working'
+                          ? 'bg-foreground/[0.08] text-foreground/80'
+                          : 'text-foreground/40 hover:text-foreground/60 hover:bg-foreground/[0.04]'
+                      )}
+                    >
+                      工作中
+                      {hasWorkingSessions && (
+                        <span className={cn(
+                          'ml-1.5 inline-flex items-center justify-center min-w-[16px] h-4 px-1 rounded-full text-[10px]',
+                          agentSubTab === 'working'
+                            ? 'bg-foreground/10 text-foreground/60'
+                            : 'bg-foreground/10 text-foreground/50'
+                        )}>
+                          {workingGroups.todo.length + workingGroups.running.length + workingGroups.done.length}
+                        </span>
+                      )}
+                    </button>
+                    <button
+                      onClick={() => setAgentSubTab('pinned')}
+                      className={cn(
+                        'px-2.5 py-0.5 rounded-md text-[12px] font-medium transition-colors titlebar-no-drag inline-flex items-center',
+                        agentSubTab === 'pinned'
+                          ? 'bg-foreground/[0.08] text-foreground/80'
+                          : 'text-foreground/40 hover:text-foreground/60 hover:bg-foreground/[0.04]'
+                      )}
+                    >
+                      置顶
+                      {pinnedAgentSessions.length > 0 && (
+                        <span className={cn(
+                          'ml-1.5 inline-flex items-center justify-center min-w-[16px] h-4 px-1 rounded-full text-[10px]',
+                          agentSubTab === 'pinned'
+                            ? 'bg-foreground/10 text-foreground/60'
+                            : 'bg-foreground/10 text-foreground/50'
+                        )}>
+                          {pinnedAgentSessions.length}
+                        </span>
+                      )}
+                    </button>
+                  </div>
+                </div>
+
+                {/* Tab 内容（自己滚动） */}
+                <div className="flex-1 overflow-y-auto scrollbar-none px-3 pb-1 min-h-0">
+                  {agentSubTab === 'working' && (
+                    <div className="pt-0.5 pb-0.5">
+                      {hasWorkingSessions ? (() => {
+                        const workingItems: Array<{ session: AgentSessionMeta; accent: SessionLeftAccent; keyPrefix: string }> = [
+                          ...workingGroups.todo.map((s) => ({ session: s, accent: 'orange' as const, keyPrefix: 'working-todo' })),
+                          ...workingGroups.running.map((s) => ({ session: s, accent: 'blue' as const, keyPrefix: 'working-running' })),
+                          ...workingGroups.done.map((s) => ({ session: s, accent: 'green' as const, keyPrefix: 'working-done' })),
+                        ]
+                        return (
+                          <div className="flex flex-col gap-0.5">
+                            {workingItems.map(({ session, accent, keyPrefix }) => (
+                              <AgentSessionItem
+                                key={`${keyPrefix}-${session.id}`}
+                                session={session}
+                                active={session.id === activeTabId}
+                                hovered={session.id === hoveredId}
+                                indicatorStatus={agentIndicatorMap.get(session.id) ?? 'idle'}
+                                showPinIcon={false}
+                                leftAccent={accent}
+                                onSelect={() => handleSelectAgentSession(session.id, session.title)}
+                                onRequestDelete={() => handleRequestDelete(session.id)}
+                                onRequestMove={() => setMoveTargetId(session.id)}
+                                onRename={handleAgentRename}
+                                onTogglePin={handleTogglePinAgent}
+                                onToggleArchive={handleToggleArchiveAgent}
+                                onMouseEnter={() => setHoveredId(session.id)}
+                                onMouseLeave={() => setHoveredId(null)}
+                              />
+                            ))}
+                          </div>
+                        )
+                      })() : (
+                        <div className="px-2 py-3 text-[11px] text-foreground/30 text-center select-none">
+                          暂无进行中的会话
+                        </div>
+                      )}
+                    </div>
                   )}
-                >
-                  Working
-                  {hasWorkingSessions && agentSubTab !== 'working' && (
-                    <span className="ml-1.5 inline-flex items-center justify-center min-w-[16px] h-4 px-1 rounded-full text-[10px] bg-foreground/10 text-foreground/50">
-                      {workingGroups.todo.length + workingGroups.running.length + workingGroups.done.length}
-                    </span>
+
+                  {agentSubTab === 'pinned' && (
+                    <div className="pt-0.5 pb-0.5">
+                      {pinnedAgentSessions.length > 0 ? (
+                        <div className="flex flex-col gap-0.5">
+                          {pinnedAgentSessions.map((session) => (
+                            <AgentSessionItem
+                              key={`pinned-${session.id}`}
+                              session={session}
+                              active={session.id === activeTabId}
+                              hovered={session.id === hoveredId}
+                              indicatorStatus={agentIndicatorMap.get(session.id) ?? 'idle'}
+                              showPinIcon={false}
+                              onSelect={() => handleSelectAgentSession(session.id, session.title)}
+                              onRequestDelete={() => handleRequestDelete(session.id)}
+                              onRequestMove={() => setMoveTargetId(session.id)}
+                              onRename={handleAgentRename}
+                              onTogglePin={handleTogglePinAgent}
+                              onToggleArchive={handleToggleArchiveAgent}
+                              onMouseEnter={() => setHoveredId(session.id)}
+                              onMouseLeave={() => setHoveredId(null)}
+                            />
+                          ))}
+                        </div>
+                      ) : (
+                        <div className="px-2 py-3 text-[11px] text-foreground/30 text-center select-none">
+                          暂无置顶会话
+                        </div>
+                      )}
+                    </div>
                   )}
-                </button>
-                <button
-                  onClick={() => setAgentSubTab('pinned')}
-                  className={cn(
-                    'px-2.5 py-0.5 rounded-md text-[12px] font-medium transition-colors titlebar-no-drag',
-                    agentSubTab === 'pinned'
-                      ? 'bg-foreground/[0.08] text-foreground/80'
-                      : 'text-foreground/40 hover:text-foreground/60 hover:bg-foreground/[0.04]'
-                  )}
-                >
-                  置顶
-                  {pinnedAgentSessions.length > 0 && agentSubTab !== 'pinned' && (
-                    <span className="ml-1.5 inline-flex items-center justify-center min-w-[16px] h-4 px-1 rounded-full text-[10px] bg-foreground/10 text-foreground/50">
-                      {pinnedAgentSessions.length}
-                    </span>
-                  )}
-                </button>
+                </div>
               </div>
-            </div>
 
-            {/* Tab 内容（自己滚动） */}
-            <div className="flex-1 overflow-y-auto scrollbar-none px-3 pb-1 min-h-0">
-              {/* Working Tab 内容 */}
-              {agentSubTab === 'working' && (
-                <div className="pt-0.5 pb-0.5">
-                  {hasWorkingSessions ? (() => {
-                    const nonEmptyCount =
-                      (workingGroups.todo.length > 0 ? 1 : 0) +
-                      (workingGroups.running.length > 0 ? 1 : 0) +
-                      (workingGroups.done.length > 0 ? 1 : 0)
-                    const showDivider = nonEmptyCount > 1
-                    return (
-                      <>
-                        {workingGroups.todo.length > 0 && (
-                          <>
-                            {showDivider && <SectionDivider label="待处理" />}
-                            <div className="flex flex-col gap-0.5">
-                              {workingGroups.todo.map((session) => (
-                                <AgentSessionItem
-                                  key={`working-todo-${session.id}`}
-                                  session={session}
-                                  active={session.id === activeTabId}
-                                  hovered={session.id === hoveredId}
-                                  indicatorStatus={agentIndicatorMap.get(session.id) ?? 'idle'}
-                                  showPinIcon={false}
-                                  onSelect={() => handleSelectAgentSession(session.id, session.title)}
-                                  onRequestDelete={() => handleRequestDelete(session.id)}
-                                  onRequestMove={() => setMoveTargetId(session.id)}
-                                  onRename={handleAgentRename}
-                                  onTogglePin={handleTogglePinAgent}
-                                  onToggleArchive={handleToggleArchiveAgent}
-                                  onMouseEnter={() => setHoveredId(session.id)}
-                                  onMouseLeave={() => setHoveredId(null)}
-                                />
-                              ))}
-                            </div>
-                          </>
-                        )}
-                        {workingGroups.running.length > 0 && (
-                          <>
-                            {showDivider && <SectionDivider label="运行中" />}
-                            <div className="flex flex-col gap-0.5">
-                              {workingGroups.running.map((session) => (
-                                <AgentSessionItem
-                                  key={`working-running-${session.id}`}
-                                  session={session}
-                                  active={session.id === activeTabId}
-                                  hovered={session.id === hoveredId}
-                                  indicatorStatus={agentIndicatorMap.get(session.id) ?? 'idle'}
-                                  showPinIcon={false}
-                                  onSelect={() => handleSelectAgentSession(session.id, session.title)}
-                                  onRequestDelete={() => handleRequestDelete(session.id)}
-                                  onRequestMove={() => setMoveTargetId(session.id)}
-                                  onRename={handleAgentRename}
-                                  onTogglePin={handleTogglePinAgent}
-                                  onToggleArchive={handleToggleArchiveAgent}
-                                  onMouseEnter={() => setHoveredId(session.id)}
-                                  onMouseLeave={() => setHoveredId(null)}
-                                />
-                              ))}
-                            </div>
-                          </>
-                        )}
-                        {workingGroups.done.length > 0 && (
-                          <>
-                            {showDivider && <SectionDivider label="已完成" />}
-                            <div className="flex flex-col gap-0.5">
-                              {workingGroups.done.map((session) => (
-                                <AgentSessionItem
-                                  key={`working-done-${session.id}`}
-                                  session={session}
-                                  active={session.id === activeTabId}
-                                  hovered={session.id === hoveredId}
-                                  indicatorStatus={agentIndicatorMap.get(session.id) ?? 'idle'}
-                                  showPinIcon={false}
-                                  onSelect={() => handleSelectAgentSession(session.id, session.title)}
-                                  onRequestDelete={() => handleRequestDelete(session.id)}
-                                  onRequestMove={() => setMoveTargetId(session.id)}
-                                  onRename={handleAgentRename}
-                                  onTogglePin={handleTogglePinAgent}
-                                  onToggleArchive={handleToggleArchiveAgent}
-                                  onMouseEnter={() => setHoveredId(session.id)}
-                                  onMouseLeave={() => setHoveredId(null)}
-                                />
-                              ))}
-                            </div>
-                          </>
-                        )}
-                      </>
-                    )
-                  })() : (
-                    <div className="px-2 py-3 text-[11px] text-foreground/30 text-center select-none">
-                      暂无进行中的会话
-                    </div>
-                  )}
-                </div>
-              )}
-
-              {/* 置顶 Tab 内容 */}
-              {agentSubTab === 'pinned' && (
-                <div className="pt-0.5 pb-0.5">
-                  {pinnedAgentSessions.length > 0 ? (
-                    <div className="flex flex-col gap-0.5">
-                      {pinnedAgentSessions.map((session) => (
-                        <AgentSessionItem
-                          key={`pinned-${session.id}`}
-                          session={session}
-                          active={session.id === activeTabId}
-                          hovered={session.id === hoveredId}
-                          indicatorStatus={agentIndicatorMap.get(session.id) ?? 'idle'}
-                          showPinIcon={false}
-                          onSelect={() => handleSelectAgentSession(session.id, session.title)}
-                          onRequestDelete={() => handleRequestDelete(session.id)}
-                          onRequestMove={() => setMoveTargetId(session.id)}
-                          onRename={handleAgentRename}
-                          onTogglePin={handleTogglePinAgent}
-                          onToggleArchive={handleToggleArchiveAgent}
-                          onMouseEnter={() => setHoveredId(session.id)}
-                          onMouseLeave={() => setHoveredId(null)}
-                        />
-                      ))}
-                    </div>
-                  ) : (
-                    <div className="px-2 py-3 text-[11px] text-foreground/30 text-center select-none">
-                      暂无置顶会话
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
-          </div>
-
-          {/* 拖拽分割条：默认 1px 细线，hover 扩为 4px 热区 */}
-          <div
-            onMouseDown={handleAgentTopResizeStart}
-            className="h-px bg-border/60 hover:h-1 hover:bg-foreground/[0.08] cursor-row-resize titlebar-no-drag flex-shrink-0 transition-[height,background-color] duration-75"
-          />
+              {/* 拖拽分割条：默认 1px 细线，hover 扩为 4px 热区 */}
+              <div
+                onMouseDown={handleAgentTopResizeStart}
+                className="h-px bg-border/60 hover:h-1 hover:bg-foreground/[0.08] cursor-row-resize titlebar-no-drag flex-shrink-0 transition-[height,background-color] duration-75"
+              />
+            </>
+          )}
 
           {/* 下区标题：最近会话 */}
           <div className="px-3 pt-2 pb-1 text-[11px] font-medium text-foreground/40 select-none flex-shrink-0">
@@ -1394,12 +1339,19 @@ function ConversationItem({
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       className={cn(
-        'w-full flex items-center gap-2 px-3 py-[7px] rounded-[10px] transition-colors duration-100 titlebar-no-drag text-left',
+        'relative w-full flex items-center gap-2 px-3 py-[7px] rounded-[10px] transition-colors duration-100 titlebar-no-drag text-left',
         active
           ? 'session-item-selected bg-primary/10 shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
           : 'hover:bg-primary/5'
       )}
     >
+      {/* 流式状态左侧竖线条（与 Agent 保持一致） */}
+      {streaming && (
+        <span
+          className="absolute left-1 top-1.5 bottom-1.5 w-[2px] rounded-full bg-emerald-500 animate-pulse pointer-events-none"
+          aria-hidden="true"
+        />
+      )}
       <div className="flex-1 min-w-0">
         {editing ? (
           <input
@@ -1417,13 +1369,6 @@ function ConversationItem({
             'truncate text-[13px] leading-5 flex items-center gap-1.5',
             active ? 'text-foreground' : 'text-foreground/80'
           )}>
-            {/* 流式输出绿色呼吸点指示器 */}
-            {streaming && (
-              <span className="relative flex-shrink-0 size-2">
-                <span className="absolute inset-0 rounded-full bg-green-500/60 animate-ping" />
-                <span className="relative block size-2 rounded-full bg-green-500" />
-              </span>
-            )}
             {/* 置顶标记 */}
             {showPinIcon && (
               <Pin size={11} className="flex-shrink-0 text-primary/60" />
@@ -1501,12 +1446,22 @@ function ConversationItem({
 
 // ===== Agent 会话列表项 =====
 
+/** 会话行左侧状态色块的颜色 — 与 SessionIndicatorStatus 呼应 */
+type SessionLeftAccent = 'orange' | 'blue' | 'green'
+const SESSION_LEFT_ACCENT_CLASS: Record<SessionLeftAccent, string> = {
+  orange: 'bg-orange-500',
+  blue: 'bg-blue-500',
+  green: 'bg-green-500',
+}
+
 interface AgentSessionItemProps {
   session: AgentSessionMeta
   active: boolean
   hovered: boolean
   indicatorStatus: SessionIndicatorStatus
   showPinIcon?: boolean
+  /** 行左侧状态色块；未传则不显示 */
+  leftAccent?: SessionLeftAccent
   onSelect: () => void
   onRequestDelete: () => void
   onRequestMove: () => void
@@ -1523,6 +1478,7 @@ function AgentSessionItem({
   hovered,
   indicatorStatus,
   showPinIcon,
+  leftAccent,
   onSelect,
   onRequestDelete,
   onRequestMove,
@@ -1580,12 +1536,20 @@ function AgentSessionItem({
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       className={cn(
-        'w-full flex items-center gap-2 px-3 py-[7px] rounded-[10px] transition-colors duration-100 titlebar-no-drag text-left',
+        'relative w-full flex items-center gap-2 px-3 py-[7px] rounded-[10px] transition-colors duration-100 titlebar-no-drag text-left',
         active
           ? 'session-item-selected bg-primary/10 shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
           : 'hover:bg-primary/5'
       )}
     >
+      {leftAccent && (
+        <span
+          className={cn(
+            'absolute left-1 top-1.5 bottom-1.5 w-[2px] rounded-full pointer-events-none',
+            SESSION_LEFT_ACCENT_CLASS[leftAccent]
+          )}
+        />
+      )}
       <div className="flex-1 min-w-0">
         {editing ? (
           <input
@@ -1603,24 +1567,6 @@ function AgentSessionItem({
             'truncate text-[13px] leading-5 flex items-center gap-1.5',
             active ? 'text-foreground' : 'text-foreground/80'
           )}>
-            {indicatorStatus !== 'idle' && (
-              <span className="relative flex-shrink-0 size-4 flex items-center justify-center">
-                {indicatorStatus === 'completed' ? (
-                  <span className="relative block size-2 rounded-full bg-green-500" />
-                ) : (
-                  <>
-                    <span className={cn(
-                      'absolute size-2 rounded-full animate-ping',
-                      indicatorStatus === 'blocked' ? 'bg-orange-500/60' : 'bg-blue-500/60'
-                    )} />
-                    <span className={cn(
-                      'relative block size-2 rounded-full',
-                      indicatorStatus === 'blocked' ? 'bg-orange-500' : 'bg-blue-500'
-                    )} />
-                  </>
-                )}
-              </span>
-            )}
             {showPinIcon && (
               <Pin size={11} className="flex-shrink-0 text-primary/60" />
             )}

--- a/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
@@ -89,11 +89,12 @@ export function TabBarItem({
     ? isStreaming === 'completed'
       ? 'bg-green-500'
       : isStreaming === 'blocked'
-        ? 'bg-orange-500 animate-pulse'
+        ? 'bg-orange-500'
         : type === 'chat'
-          ? 'bg-emerald-500 animate-pulse'
-          : 'bg-blue-500 animate-pulse'
+          ? 'bg-emerald-500'
+          : 'bg-blue-500'
     : undefined
+  const indicatorPulse = isStreaming === 'running' || isStreaming === 'blocked'
   const previewItems = minimapCache.get(id) ?? []
   // 当前 active Tab 不显示预览面板
   const showPreview = isHovered && !isActive
@@ -119,31 +120,14 @@ export function TabBarItem({
         onMouseDown={handleMouseDown}
         onPointerDown={onDragStart}
       >
-        {/* 类型图标 + 窄状态下的状态角标 */}
-        <span className="relative shrink-0">
-          <Icon className={cn(isNarrow ? 'size-3.5' : 'size-3')} />
-          {indicatorColor && isNarrow && (
-            <span
-              className={cn(
-                'absolute -top-0.5 -right-1.5 size-1.5 rounded-full',
-                indicatorColor
-              )}
-            />
-          )}
-        </span>
+        {/* 类型图标 */}
+        <Icon className={cn('shrink-0', isNarrow ? 'size-3.5' : 'size-3')} />
 
         {/* 标题（窄状态下隐藏，用 spacer 撑开让关闭按钮靠右） */}
         {isNarrow ? (
           <span className="flex-1" />
         ) : (
           <span className="flex-1 min-w-0 truncate text-left">{title}</span>
-        )}
-
-        {/* 流式/状态指示器（宽状态下内联显示） */}
-        {indicatorColor && !isNarrow && (
-          <span
-            className={cn('size-1.5 rounded-full shrink-0', indicatorColor)}
-          />
         )}
 
         {/* 关闭按钮 */}
@@ -162,6 +146,18 @@ export function TabBarItem({
         >
           <X className="size-2.5" />
         </span>
+
+        {/* 底部状态横线条 */}
+        {indicatorColor && (
+          <span
+            className={cn(
+              'absolute left-2 right-2 bottom-0 h-[2px] rounded-full pointer-events-none',
+              indicatorColor,
+              indicatorPulse && 'animate-pulse',
+            )}
+            aria-hidden="true"
+          />
+        )}
       </button>
 
       {/* 悬浮预览面板（Portal 渲染到 body） */}

--- a/apps/electron/src/renderer/components/tabs/TabSwitcher.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabSwitcher.tsx
@@ -223,24 +223,27 @@ export function TabSwitcher(): React.ReactElement | null {
         {/* 标签列表 */}
         <div className="py-1.5">
           {displayTabs.map((tab, index) => {
-            const indicatorColor = getIndicatorColor(
-              indicatorMap.get(tab.id) ?? 'idle',
-              tab.type,
-            )
+            const status = indicatorMap.get(tab.id) ?? 'idle'
+            const indicatorColor = getIndicatorColor(status, tab.type)
+            const indicatorPulse = status === 'running' || status === 'blocked'
             return (
               <div
                 key={tab.id}
                 className={cn(
-                  'flex items-center gap-3 px-5 py-2.5 text-[15px] cursor-default transition-colors',
+                  'relative flex items-center gap-3 pl-5 pr-5 py-2.5 text-[15px] cursor-default transition-colors',
                   index === safeIndex
                     ? 'bg-primary/15 text-foreground font-medium'
                     : 'text-muted-foreground',
                 )}
               >
-                {/* 状态指示点（不占固定空间，存在时向后挤压 title） */}
+                {/* 左侧状态竖线条 */}
                 {indicatorColor && (
                   <span
-                    className={cn('size-1.5 rounded-full shrink-0', indicatorColor)}
+                    className={cn(
+                      'absolute left-1.5 top-2 bottom-2 w-[2px] rounded-full',
+                      indicatorColor,
+                      indicatorPulse && 'animate-pulse',
+                    )}
                     aria-hidden="true"
                   />
                 )}
@@ -296,6 +299,6 @@ function getIndicatorColor(
 ): string | undefined {
   if (status === 'idle') return undefined
   if (status === 'completed') return 'bg-green-500'
-  if (status === 'blocked') return 'bg-orange-500 animate-pulse'
-  return type === 'chat' ? 'bg-emerald-500 animate-pulse' : 'bg-blue-500 animate-pulse'
+  if (status === 'blocked') return 'bg-orange-500'
+  return type === 'chat' ? 'bg-emerald-500' : 'bg-blue-500'
 }


### PR DESCRIPTION
## Summary
- 将 Chat/Agent 侧边栏、顶部 TabBar、Ctrl+Tab 切换器 四处的会话状态指示从"圆点"统一改为"线条"（侧栏/切换器为左侧竖线，TabBar 为底部横线）。
- Agent 侧栏采用 Tab 切换：工作中 / 置顶；Working 列表内部用 orange/blue/green 左竖线表示 待处理/运行中/已完成。
- `tabIndicatorMapAtom` 接入 `workingDoneSessionIdsAtom` 作为 completed 状态兜底，让 TabBar 底部和 Ctrl+Tab 的绿色"已完成"指示与侧栏同源——会话跑完后持续显示直到用户主动从 Working 清除。

## 改动范围
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx`
  - 移除会话列表项状态圆点
  - Agent Tab（工作中/置顶）+ 每行 `leftAccent` 彩色竖线
  - Chat 会话流式指示从 `animate-ping` 绿点 → `animate-pulse` emerald 左竖线
- `apps/electron/src/renderer/components/tabs/TabBarItem.tsx`
  - 圆点 → 底部横线条，窄/宽状态统一
- `apps/electron/src/renderer/components/tabs/TabSwitcher.tsx`
  - 圆点 → 左侧竖线，与侧栏视觉一致
- `apps/electron/src/renderer/atoms/tab-atoms.ts`
  - `tabIndicatorMapAtom` 增加 `workingDoneSessionIdsAtom` 兜底，修复 TabBar/切换器看不到绿色"已完成"的问题

## Test plan
- [ ] Agent：新建并跑完一个会话，验证侧边栏 Working"已完成"绿竖线、TabBar 底部绿横线、Ctrl+Tab 切换器左侧绿竖线三处同步出现
- [ ] Agent：会话进入 blocked（权限/AskUser）时三处显示橙色
- [ ] Agent：会话 running 时三处显示蓝色脉动
- [ ] Chat：流式输出时左侧出现 emerald 脉动竖线；结束后消失
- [ ] 置顶切换：Tab 在"工作中 / 置顶"之间切换正常，计数徽章正确
- [ ] 窄 TabBar（多 Tab 时宽度 < 72px）底部横线仍可见
- [ ] 明/暗主题切换视觉无异常

🤖 Generated with [Claude Code](https://claude.com/claude-code)