### PR TITLE
fix(agent): 增强 Agent 模式对瞬时网络错误的自动重试

### DIFF
--- a/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
@@ -261,6 +261,29 @@ export function mapSDKErrorToTypedError(
     },
   }
 
+  // 瞬时网络错误（terminated / ECONNRESET / socket hang up 等）：
+  // assistant.error 路径下，SDK 常常把这类错误标记为 errorType='unknown'，
+  // 这里从 detailedMessage / originalError 兜底匹配，归类为可重试的 network_error。
+  const NETWORK_PATTERN =
+    /terminated|socket hang up|ECONNRESET|ETIMEDOUT|EPIPE|ENOTFOUND|EAI_AGAIN|ECONNREFUSED|fetch failed|network error|stream (?:closed|ended|disconnected) prematurely|premature close/i
+  const looksLikeNetwork =
+    (!errorMap[errorCode]) &&
+    (NETWORK_PATTERN.test(detailedMessage ?? '') || NETWORK_PATTERN.test(originalError ?? ''))
+  if (looksLikeNetwork) {
+    return {
+      code: 'network_error',
+      title: '网络异常',
+      message: detailedMessage || '上游 API 连接中断',
+      actions: [
+        { key: 's', label: '设置', action: 'settings' },
+        { key: 'r', label: '重试', action: 'retry' },
+      ],
+      canRetry: true,
+      retryDelayMs: 1000,
+      originalError,
+    }
+  }
+
   const mapped = errorMap[errorCode] || {
     code: 'unknown_error' as ErrorCode,
     title: '',

--- a/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
@@ -19,6 +19,7 @@ import type {
   SDKMessage,
 } from '@proma/shared'
 import type { CanUseToolOptions, PermissionResult } from '../agent-permission-service'
+import { TRANSIENT_NETWORK_PATTERN } from '../error-patterns'
 
 /** SDK Query 对象类型（从动态导入中推断） */
 type SDKQuery = ReturnType<typeof import('@anthropic-ai/claude-agent-sdk').query>
@@ -264,11 +265,9 @@ export function mapSDKErrorToTypedError(
   // 瞬时网络错误（terminated / ECONNRESET / socket hang up 等）：
   // assistant.error 路径下，SDK 常常把这类错误标记为 errorType='unknown'，
   // 这里从 detailedMessage / originalError 兜底匹配，归类为可重试的 network_error。
-  const NETWORK_PATTERN =
-    /terminated|socket hang up|ECONNRESET|ETIMEDOUT|EPIPE|ENOTFOUND|EAI_AGAIN|ECONNREFUSED|fetch failed|network error|stream (?:closed|ended|disconnected) prematurely|premature close/i
   const looksLikeNetwork =
     (!errorMap[errorCode]) &&
-    (NETWORK_PATTERN.test(detailedMessage ?? '') || NETWORK_PATTERN.test(originalError ?? ''))
+    (TRANSIENT_NETWORK_PATTERN.test(detailedMessage ?? '') || TRANSIENT_NETWORK_PATTERN.test(originalError ?? ''))
   if (looksLikeNetwork) {
     return {
       code: 'network_error',

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -141,10 +141,30 @@ function isAutoRetryableTypedError(error: TypedError): boolean {
   return AUTO_RETRYABLE_ERROR_CODES.has(error.code)
 }
 
-/** 判断 catch 块中的 API 错误是否可自动重试（HTTP 429 / 5xx / 已知可恢复错误模式） */
+/**
+ * 瞬时网络错误模式
+ *
+ * 覆盖上游 API 偶发断流/抖动：API SSE 流中途 terminated、TCP 连接被重置、
+ * DNS 抖动、fetch 层超时等。这些错误无 HTTP 状态码，SDK HTTP 客户端层
+ * 内置的 2 次重试无法完全消化时，会穿透到 Orchestrator 应用层兜底。
+ */
+const TRANSIENT_NETWORK_PATTERN =
+  /terminated|socket hang up|ECONNRESET|ETIMEDOUT|EPIPE|ENOTFOUND|EAI_AGAIN|ECONNREFUSED|fetch failed|network error|stream (?:closed|ended|disconnected) prematurely|premature close/i
+
+/** 判断错误消息/stderr 是否为瞬时网络错误 */
+function isTransientNetworkError(message?: string, stderr?: string): boolean {
+  if (!message && !stderr) return false
+  return (
+    (!!message && TRANSIENT_NETWORK_PATTERN.test(message)) ||
+    (!!stderr && TRANSIENT_NETWORK_PATTERN.test(stderr))
+  )
+}
+
+/** 判断 catch 块中的 API 错误是否可自动重试（HTTP 429 / 5xx / 已知可恢复错误模式 / 瞬时网络错误） */
 function isAutoRetryableCatchError(
   apiError: { statusCode: number; message: string } | null,
   rawErrorMessage?: string,
+  stderr?: string,
 ): boolean {
   if (apiError) {
     if (apiError.statusCode === 429 || apiError.statusCode >= 500) return true
@@ -153,6 +173,8 @@ function isAutoRetryableCatchError(
   if (rawErrorMessage) {
     if (rawErrorMessage.includes('context_management')) return true
   }
+  // 瞬时网络错误（terminated / ECONNRESET / socket hang up 等）
+  if (isTransientNetworkError(rawErrorMessage, stderr)) return true
   return false
 }
 
@@ -168,11 +190,22 @@ function isSessionNotFoundError(errorMessage: string, stderr?: string): boolean 
 }
 
 /** 最大自动重试次数 */
-const MAX_AUTO_RETRIES = 3
+const MAX_AUTO_RETRIES = 8
 
-/** 计算重试延迟（指数退避：1s, 2s, 4s） */
+/** 重试单次延迟上限（毫秒） */
+const RETRY_MAX_DELAY_MS = 10_000
+
+/**
+ * 计算重试延迟（指数退避 + ±20% jitter）
+ *
+ * 基础序列：1s, 2s, 4s, 8s, 10s, 10s, 10s, 10s（cap = 10s）
+ * 叠加 ±20% 随机抖动，避免大量 session 同时重试造成惊群。
+ * 最坏情况累计等待 ≈ 55s。
+ */
 function getRetryDelayMs(attempt: number): number {
-  return Math.min(1000 * Math.pow(2, attempt - 1), 8000)
+  const base = Math.min(1000 * Math.pow(2, attempt - 1), RETRY_MAX_DELAY_MS)
+  const jitter = base * (Math.random() * 0.4 - 0.2)
+  return Math.max(0, Math.round(base + jitter))
 }
 
 /**
@@ -1799,11 +1832,11 @@ export class AgentOrchestrator {
           }
 
           // 判断是否可重试
-          if (isAutoRetryableCatchError(apiError, rawErrorMessage) && attempt <= MAX_AUTO_RETRIES) {
+          if (isAutoRetryableCatchError(apiError, rawErrorMessage, stderrOutput) && attempt <= MAX_AUTO_RETRIES) {
             lastRetryableError = apiError
               ? `API Error ${apiError.statusCode}: ${apiError.message}`
               : (error instanceof Error ? error.message : '未知错误')
-            console.log(`[Agent 编排] 可重试错误 (catch): ${lastRetryableError}`)
+            console.log(`[Agent 编排] 可重试错误 (catch, attempt ${attempt}/${MAX_AUTO_RETRIES}): ${lastRetryableError}`)
             // 保存部分内容
             this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
             accumulatedMessages.length = 0

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -26,6 +26,7 @@ import { SAFE_TOOLS } from '@proma/shared'
 import type { PermissionRequest, PromaPermissionMode, AskUserRequest, ExitPlanModeRequest } from '@proma/shared'
 import type { ClaudeAgentQueryOptions } from './adapters/claude-agent-adapter'
 import { isPromptTooLongError, friendlyErrorMessage, mapSDKErrorToTypedError, extractErrorDetails } from './adapters/claude-agent-adapter'
+import { isTransientNetworkError } from './error-patterns'
 import { AgentEventBus } from './agent-event-bus'
 import { decryptApiKey, getChannelById, listChannels } from './channel-manager'
 import { getAdapter, fetchTitle, normalizeAnthropicBaseUrlForSdk } from '@proma/core'
@@ -139,25 +140,6 @@ const AUTO_RETRYABLE_ERROR_CODES: ReadonlySet<string> = new Set([
 /** 判断 typed_error 事件是否可自动重试 */
 function isAutoRetryableTypedError(error: TypedError): boolean {
   return AUTO_RETRYABLE_ERROR_CODES.has(error.code)
-}
-
-/**
- * 瞬时网络错误模式
- *
- * 覆盖上游 API 偶发断流/抖动：API SSE 流中途 terminated、TCP 连接被重置、
- * DNS 抖动、fetch 层超时等。这些错误无 HTTP 状态码，SDK HTTP 客户端层
- * 内置的 2 次重试无法完全消化时，会穿透到 Orchestrator 应用层兜底。
- */
-const TRANSIENT_NETWORK_PATTERN =
-  /terminated|socket hang up|ECONNRESET|ETIMEDOUT|EPIPE|ENOTFOUND|EAI_AGAIN|ECONNREFUSED|fetch failed|network error|stream (?:closed|ended|disconnected) prematurely|premature close/i
-
-/** 判断错误消息/stderr 是否为瞬时网络错误 */
-function isTransientNetworkError(message?: string, stderr?: string): boolean {
-  if (!message && !stderr) return false
-  return (
-    (!!message && TRANSIENT_NETWORK_PATTERN.test(message)) ||
-    (!!stderr && TRANSIENT_NETWORK_PATTERN.test(stderr))
-  )
 }
 
 /** 判断 catch 块中的 API 错误是否可自动重试（HTTP 429 / 5xx / 已知可恢复错误模式 / 瞬时网络错误） */

--- a/apps/electron/src/main/lib/error-patterns.ts
+++ b/apps/electron/src/main/lib/error-patterns.ts
@@ -1,0 +1,18 @@
+/**
+ * 瞬时网络错误模式
+ *
+ * 覆盖上游 API 偶发断流/抖动：API SSE 流中途 terminated、TCP 连接被重置、
+ * DNS 抖动、fetch 层超时等。这些错误无 HTTP 状态码，SDK HTTP 客户端层
+ * 内置的 2 次重试无法完全消化时，会穿透到 Orchestrator 应用层兜底。
+ */
+export const TRANSIENT_NETWORK_PATTERN =
+  /terminated|socket hang up|ECONNRESET|ETIMEDOUT|EPIPE|ENOTFOUND|EAI_AGAIN|ECONNREFUSED|fetch failed|network error|stream (?:closed|ended|disconnected) prematurely|premature close/i
+
+/** 判断错误消息/stderr 是否为瞬时网络错误 */
+export function isTransientNetworkError(message?: string, stderr?: string): boolean {
+  if (!message && !stderr) return false
+  return (
+    (!!message && TRANSIENT_NETWORK_PATTERN.test(message)) ||
+    (!!stderr && TRANSIENT_NETWORK_PATTERN.test(stderr))
+  )
+}


### PR DESCRIPTION
## 背景

Agent 模式偶发上游 API 流式中断错误（如 \`API Error: terminated\`、\`ECONNRESET\`、\`socket hang up\`、\`fetch failed\` 等）会被归类为 \`unknown_error\` 直接报错给用户：

- Claude Agent SDK HTTP 客户端层内置 \`maxRetries=2\`，但 SDK 0.2.111 未暴露透传入口，无法提高
- 这类错误**没有 HTTP 状态码**，原 \`isAutoRetryableCatchError\` 仅识别 429/5xx，全部漏过
- 已定义的 \`network_error\` 错误码在 \`AUTO_RETRYABLE_ERROR_CODES\` 中，但 \`mapSDKErrorToTypedError\` 从未映射到它（死代码）
- 重试上限 3 次、cap 8s，对偶发抖动覆盖不足

## 改动

### \`agent-orchestrator.ts\`
- 新增 \`TRANSIENT_NETWORK_PATTERN\`，覆盖 \`terminated\` / \`ECONNRESET\` / \`socket hang up\` / \`EPIPE\` / \`ETIMEDOUT\` / \`ENOTFOUND\` / \`EAI_AGAIN\` / \`ECONNREFUSED\` / \`fetch failed\` / \`premature close\`
- \`isAutoRetryableCatchError\` 新增 \`stderr\` 参数，接入瞬时网络错误识别
- \`MAX_AUTO_RETRIES\`: 3 → **8**
- \`getRetryDelayMs\`: cap 8s → **10s**，叠加 **±20% jitter**（防惊群）
- 退避序列：1s, 2s, 4s, 8s, 10s, 10s, 10s, 10s（最坏累计 ≈ 55s）

### \`claude-agent-adapter.ts\`
- \`mapSDKErrorToTypedError\`: 对 SDK 标记 \`unknown\` 但消息匹配网络错误模式的情形，兜底映射为 \`network_error\` → 自动落入可重试集合

## 设计原则

- **前置优先**：HTTP 层重试（SDK 内置 2 次）零上下文成本，应用层只兜底已穿透的瞬时网络错误
- **复用 sdkSessionId**：重试时同一 session 续跑，prompt cache 大概率命中，上下文不污染
- **可观测**：日志输出 \`(attempt n/8)\` 便于诊断网络持续异常 vs 偶发抖动

## Test plan

- [ ] 模拟 \`terminated\`（断网 2-3 秒）→ Agent 自动恢复，前端无错误提示
- [ ] 模拟 429 → SDK HTTP 层自己消化（日志确认 Orchestrator 无感知）
- [ ] 模拟连续 8 次失败 → 报 \"重试 8 次后仍然失败\"
- [ ] 正常对话 → 无回归（cache 命中、session 续跑、MCP 连接保持）
- [ ] tsc --noEmit 通过 ✓

## 不在本 PR 范围

- P1: 流式心跳看门狗（adapter 层 idle timeout abort，治本但需更多测试）
- P1: 用户可配置重试参数（settings UI）
- P1: UI 显示重试进度提示

🤖 Generated with [Claude Code](https://claude.com/claude-code)