### PR TITLE
fix(file-preview): 恢复 AI 消息中代码/配置文件的可点击预览

### DIFF
--- a/apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx
@@ -14,8 +14,25 @@ import { cn } from '@/lib/utils'
 const IMAGE_EXTS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp'])
 /** 视频扩展名 */
 const VIDEO_EXTS = new Set(['mp4', 'webm', 'mov'])
-/** 代码/结构化文本扩展名 */
-const CODE_EXTS = new Set(['json', 'xml', 'html', 'htm', 'md', 'markdown'])
+/**
+ * 代码/结构化文本扩展名
+ * 需与主进程 file-preview-service.ts 的 CODE_EXTENSIONS + MARKDOWN_EXTENSIONS 保持一致，
+ * 否则消息中的相对路径无法被识别为可点击 chip。
+ */
+const CODE_EXTS = new Set([
+  'md', 'markdown',
+  'json', 'jsonc', 'json5',
+  'xml', 'html', 'htm',
+  'txt', 'log', 'csv',
+  'yaml', 'yml', 'toml', 'ini', 'env', 'lock',
+  'ts', 'tsx', 'js', 'jsx', 'mjs', 'cjs',
+  'py', 'go', 'rs', 'java', 'kt', 'swift',
+  'c', 'h', 'cpp', 'hpp', 'cs',
+  'sh', 'bash', 'zsh', 'fish',
+  'css', 'scss', 'less',
+  'sql', 'rb', 'php',
+  'diff', 'patch',
+])
 /** 文档扩展名 */
 const DOC_EXTS = new Set(['pdf', 'docx'])
 


### PR DESCRIPTION
## Summary
- 修复 AI 消息中相对路径的 `.ts` / `.py` / `.yaml` / `.toml` 等代码和配置文件无法被渲染为可点击 chip 的问题
- 渲染层 `file-path-chip.tsx` 的 `CODE_EXTS` 白名单只有 6 个扩展名，与主进程 `file-preview-service.ts` 的 `CODE_EXTENSIONS`（40+ 扩展名）脱节
- 统一到一致的扩展名集合，恢复 Proma 内部预览体验（走 IPC → `openFilePreview`，不会被系统默认应用抢占）

## Test plan
- [ ] AI 消息中出现相对路径 `src/main.ts`、`config.yaml`、`script.py` 时渲染为可点击 chip
- [ ] 点击 chip 打开 Proma 内置预览窗口，不跳转到外部应用
- [ ] 绝对路径、FileBrowser 双击预览继续正常工作
- [ ] Markdown 消息里点击 `.md` 路径仍正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)