### PR TITLE
fix(file-preview): 附加目录中相对路径文件支持 Proma 内置预览

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -1648,12 +1648,12 @@ export function registerIpcHandlers(): void {
     }
   )
 
-  // 在新窗口中预览文件（允许任意绝对路径）
+  // 在新窗口中预览文件（允许任意绝对路径；相对路径按 basePaths 依次解析）
   ipcMain.handle(
     AGENT_IPC_CHANNELS.PREVIEW_FILE,
-    async (_, filePath: string): Promise<void> => {
+    async (_, filePath: string, basePaths?: string[]): Promise<void> => {
       const { openFilePreview } = await import('./lib/file-preview-service')
-      openFilePreview(filePath)
+      openFilePreview(filePath, basePaths)
     }
   )
 

--- a/apps/electron/src/main/lib/file-preview-service.ts
+++ b/apps/electron/src/main/lib/file-preview-service.ts
@@ -1410,11 +1410,35 @@ function watchExternalChange(previewWindow: BrowserWindow, state: PreviewWindowS
 }
 
 /**
+ * 解析待预览的文件路径
+ * - 绝对路径：直接 resolve
+ * - 相对路径：依次尝试 basePaths，返回第一个存在的；都不存在则返回基于第一个 base 的拼接结果
+ *   （让后续 statSync 抛出更明确的错误，而不是被相对 process.cwd 误导）
+ */
+function resolveTargetPath(filePath: string, basePaths?: string[]): string {
+  if (filePath.startsWith('/') || /^[A-Za-z]:[\\/]/.test(filePath)) {
+    return resolve(filePath)
+  }
+  if (basePaths && basePaths.length > 0) {
+    for (const base of basePaths) {
+      if (!base) continue
+      const candidate = resolve(base, filePath)
+      if (existsSync(candidate)) return candidate
+    }
+    return resolve(basePaths[0]!, filePath)
+  }
+  return resolve(filePath)
+}
+
+/**
  * 在新窗口中预览文件
  * 不支持的文件类型会调用系统默认应用打开
+ *
+ * @param filePath 绝对路径或相对路径
+ * @param basePaths 当 filePath 为相对路径时，依次尝试这些基础目录解析（主 cwd + 附加目录）
  */
-export function openFilePreview(filePath: string): void {
-  const safePath = resolve(filePath)
+export function openFilePreview(filePath: string, basePaths?: string[]): void {
+  const safePath = resolveTargetPath(filePath, basePaths)
   const filename = basename(safePath)
   const ext = extname(safePath).toLowerCase()
   const previewType = getPreviewType(safePath, ext)

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -542,8 +542,8 @@ export interface ElectronAPI {
   /** 在系统文件管理器中显示文件 */
   showInFolder: (filePath: string) => Promise<void>
 
-  /** 在新窗口中预览文件 */
-  previewFile: (filePath: string) => Promise<void>
+  /** 在新窗口中预览文件（相对路径会按 basePaths 依次解析） */
+  previewFile: (filePath: string, basePaths?: string[]) => Promise<void>
 
   /** 重命名文件/目录 */
   renameFile: (filePath: string, newName: string) => Promise<void>
@@ -1331,8 +1331,8 @@ const electronAPI: ElectronAPI = {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.SHOW_IN_FOLDER, filePath)
   },
 
-  previewFile: (filePath: string) => {
-    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.PREVIEW_FILE, filePath)
+  previewFile: (filePath: string, basePaths?: string[]) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.PREVIEW_FILE, filePath, basePaths)
   },
 
   renameFile: (filePath: string, newName: string) => {

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -17,6 +17,7 @@ import {
   MessageActions,
   MessageResponse,
   UserMessageContent,
+  BasePathsProvider,
 } from '@/components/ai-elements/message'
 import {
   Conversation,
@@ -60,6 +61,8 @@ interface AgentMessagesProps {
   liveMessages?: SDKMessage[]
   /** 当前会话工作目录，用于解析相对文件路径 */
   sessionPath?: string | null
+  /** 附加目录列表（与 sessionPath 一并用作相对路径解析候选） */
+  attachedDirs?: string[]
   /** 最后一轮是否被用户中断 */
   stoppedByUser?: boolean
   onRetry?: () => void
@@ -456,12 +459,13 @@ function RetryAttemptItem({
 interface AgentMessageItemProps {
   message: AgentMessage
   sessionPath?: string | null
+  attachedDirs?: string[]
   onRetry?: () => void
   onRetryInNewSession?: () => void
   onCompact?: () => void
 }
 
-function AgentMessageItem({ message, sessionPath, onRetry, onRetryInNewSession, onCompact }: AgentMessageItemProps): React.ReactElement | null {
+function AgentMessageItem({ message, sessionPath, attachedDirs, onRetry, onRetryInNewSession, onCompact }: AgentMessageItemProps): React.ReactElement | null {
   const userProfile = useAtomValue(userProfileAtom)
   const channels = useAtomValue(channelsAtom)
 
@@ -517,7 +521,7 @@ function AgentMessageItem({ message, sessionPath, onRetry, onRetryInNewSession, 
           )}
           <ToolResultInlineImages activities={toolActivities} />
           {message.content && (
-            <MessageResponse basePath={sessionPath || undefined}>{message.content}</MessageResponse>
+            <MessageResponse basePath={sessionPath || undefined} basePaths={attachedDirs}>{message.content}</MessageResponse>
           )}
         </MessageContent>
         {/* 操作栏：左侧靠左排列 */}
@@ -650,7 +654,7 @@ function AgentRunningIndicator({ startedAt }: { startedAt?: number }): React.Rea
   )
 }
 
-export function AgentMessages({ sessionId, sessionModelId, messages, messagesLoaded, persistedSDKMessages, streaming, streamState, liveMessages, sessionPath, stoppedByUser, onRetry, onRetryInNewSession, onFork, onRewind, onCompact }: AgentMessagesProps): React.ReactElement {
+export function AgentMessages({ sessionId, sessionModelId, messages, messagesLoaded, persistedSDKMessages, streaming, streamState, liveMessages, sessionPath, attachedDirs, stoppedByUser, onRetry, onRetryInNewSession, onFork, onRewind, onCompact }: AgentMessagesProps): React.ReactElement {
   const userProfile = useAtomValue(userProfileAtom)
   const setMinimapCache = useSetAtom(tabMinimapCacheAtom)
   const channels = useAtomValue(channelsAtom)
@@ -829,6 +833,7 @@ export function AgentMessages({ sessionId, sessionModelId, messages, messagesLoa
   const hasLiveAssistantContent = allGroups.some((g) => g.type === 'assistant-turn' && liveGroupSet.has(g))
 
   return (
+    <BasePathsProvider basePaths={attachedDirs}>
     <Conversation resize={ready && !transitioning ? 'smooth' : 'instant'} className={ready ? 'opacity-100 transition-opacity duration-200' : 'opacity-0'}>
       <ScrollPositionManager id={sessionId} ready={ready} />
       <ConversationContent>
@@ -865,6 +870,7 @@ export function AgentMessages({ sessionId, sessionModelId, messages, messagesLoa
                   <AgentMessageItem
                     message={msg}
                     sessionPath={sessionPath}
+                    attachedDirs={attachedDirs}
                     onRetry={onRetry}
                     onRetryInNewSession={onRetryInNewSession}
                     onCompact={onCompact}
@@ -894,7 +900,7 @@ export function AgentMessages({ sessionId, sessionModelId, messages, messagesLoa
                   {retrying && <RetryingNotice retrying={retrying} />}
                   {smoothContent ? (
                     <>
-                      <MessageResponse basePath={sessionPath || undefined}>{smoothContent}</MessageResponse>
+                      <MessageResponse basePath={sessionPath || undefined} basePaths={attachedDirs}>{smoothContent}</MessageResponse>
                       {streaming && <AgentRunningIndicator startedAt={startedAt} />}
                     </>
                   ) : (
@@ -917,5 +923,6 @@ export function AgentMessages({ sessionId, sessionModelId, messages, messagesLoa
         <StickyUserMessage userMessages={allUserMessagesData} />
       )}
     </Conversation>
+    </BasePathsProvider>
   )
 }

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -1284,6 +1284,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           streamState={streamState}
           liveMessages={liveMessages}
           sessionPath={sessionPath}
+          attachedDirs={attachedDirs}
           stoppedByUser={stoppedByUser}
           onRetry={handleRetry}
           onRetryInNewSession={handleRetryInNewSession}

--- a/apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx
@@ -64,40 +64,52 @@ function getFileIcon(ext: string): React.ReactElement {
 interface FilePathChipProps {
   /** 文件路径（绝对或相对） */
   filePath: string
-  /** 基础目录路径，用于解析相对路径 */
+  /** 基础目录路径（向后兼容，单值） */
   basePath?: string
+  /** 多个候选基础目录（如主 cwd + 附加目录），点击时由主进程依次解析 */
+  basePaths?: string[]
   className?: string
 }
 
 /** 文件路径芯片 — 可点击，触发文件预览 */
-export function FilePathChip({ filePath, basePath, className }: FilePathChipProps): React.ReactElement {
+export function FilePathChip({ filePath, basePath, basePaths, className }: FilePathChipProps): React.ReactElement {
   const filename = getFileName(filePath)
   const ext = getExtension(filename)
 
-  // 解析完整路径：绝对路径直接使用，相对路径拼接 basePath
-  const fullPath = React.useMemo(() => {
-    const trimmed = filePath.trim()
-    if (trimmed.startsWith('/') || /^[A-Z]:\\/.test(trimmed)) {
-      return trimmed
+  const trimmedPath = filePath.trim()
+  const isAbsolute = trimmedPath.startsWith('/') || /^[A-Z]:\\/.test(trimmedPath)
+
+  // 候选基础目录列表：优先使用 basePaths；否则退化到 basePath 单值
+  const candidateBases = React.useMemo<string[]>(() => {
+    if (basePaths && basePaths.length > 0) return basePaths.filter(Boolean)
+    if (basePath) return [basePath]
+    return []
+  }, [basePath, basePaths])
+
+  // 用于 title 提示：绝对路径直接展示；相对路径展示首个候选拼接（仅作提示）
+  const displayPath = React.useMemo(() => {
+    if (isAbsolute) return trimmedPath
+    if (candidateBases.length > 0) {
+      const base = candidateBases[0]!
+      return base.endsWith('/') ? `${base}${trimmedPath}` : `${base}/${trimmedPath}`
     }
-    if (basePath) {
-      // 拼接时确保分隔符正确
-      return basePath.endsWith('/') ? `${basePath}${trimmed}` : `${basePath}/${trimmed}`
-    }
-    return trimmed
-  }, [filePath, basePath])
+    return trimmedPath
+  }, [trimmedPath, isAbsolute, candidateBases])
 
   const handleClick = React.useCallback(() => {
-    window.electronAPI.previewFile(fullPath).catch((error: unknown) => {
+    // 绝对路径直接预览；相对路径把候选 basePaths 交给主进程依次尝试
+    const target = isAbsolute ? trimmedPath : trimmedPath
+    const bases = isAbsolute ? undefined : (candidateBases.length > 0 ? candidateBases : undefined)
+    window.electronAPI.previewFile(target, bases).catch((error: unknown) => {
       console.error('[FilePathChip] 预览文件失败:', error)
     })
-  }, [fullPath])
+  }, [trimmedPath, isAbsolute, candidateBases])
 
   return (
     <button
       type="button"
       onClick={handleClick}
-      title={fullPath}
+      title={displayPath}
       className={cn(
         'inline-flex items-center gap-1 rounded px-1.5 py-[2px] text-[12px] font-medium leading-[1.6]',
         'bg-primary/10 text-primary hover:bg-primary/20',

--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -341,12 +341,25 @@ export function remarkPreserveBreaks() {
 /** remark 插件函数签名 */
 export type RemarkPluginFn = () => (tree: MdastParent) => void
 
+/**
+ * 附加 basePaths 上下文 — 用于把"附加目录候选"穿透到 MarkdownInlineCode 而不必逐层透传 props。
+ * AgentMessages 在顶层用 BasePathsProvider 包裹，FilePathChip 渲染时会自动取到。
+ */
+const BasePathsContext = React.createContext<string[] | undefined>(undefined)
+
+/** 提供附加目录候选给所有内嵌的 MessageResponse */
+export function BasePathsProvider({ basePaths, children }: { basePaths?: string[]; children: React.ReactNode }): React.ReactElement {
+  return <BasePathsContext.Provider value={basePaths}>{children}</BasePathsContext.Provider>
+}
+
 interface MessageResponseProps {
   /** Markdown 内容 */
   children: string
   className?: string
   /** 基础目录路径，用于解析相对文件路径（如 Agent 会话工作目录） */
   basePath?: string
+  /** 额外的基础目录候选（如附加目录），点击 chip 时由主进程依次解析 */
+  basePaths?: string[]
   /** 额外的 remark 插件（追加到内置 remarkGfm + remarkMath 之后） */
   remarkPlugins?: RemarkPluginFn[]
 }
@@ -434,8 +447,11 @@ const MarkdownInlineCode = React.memo(function MarkdownInlineCode({
   children: codeChildren,
   className: codeClassName,
   basePath,
+  basePaths,
   ...codeProps
-}: React.HTMLAttributes<HTMLElement> & { basePath?: string }): React.ReactElement {
+}: React.HTMLAttributes<HTMLElement> & { basePath?: string; basePaths?: string[] }): React.ReactElement {
+  // 兜底：从 context 读附加 basePaths（避免穿透 SDKMessageRenderer / ContentBlock 等中间层）
+  const ctxBasePaths = React.useContext(BasePathsContext)
   if (codeClassName) {
     return <code className={codeClassName} {...codeProps}>{codeChildren}</code>
   }
@@ -446,8 +462,17 @@ const MarkdownInlineCode = React.memo(function MarkdownInlineCode({
     if (isAbsoluteFilePath(text)) {
       return <FilePathChip filePath={text.trim()} />
     }
-    if (basePath && isRelativeFilePath(text)) {
-      return <FilePathChip filePath={text.trim()} basePath={basePath} />
+    // 相对路径：合并 basePath（主 cwd）+ basePaths（props 或 context 提供的附加目录）作为候选
+    const merged: string[] = []
+    if (basePath) merged.push(basePath)
+    const allExtra = basePaths || ctxBasePaths
+    if (allExtra) {
+      for (const p of allExtra) {
+        if (p && !merged.includes(p)) merged.push(p)
+      }
+    }
+    if (merged.length > 0 && isRelativeFilePath(text)) {
+      return <FilePathChip filePath={text.trim()} basePaths={merged} />
     }
   }
 
@@ -463,7 +488,7 @@ const MarkdownInlineCode = React.memo(function MarkdownInlineCode({
 
 /** 使用 react-markdown 渲染 assistant 消息内容，代码块使用 Shiki 语法高亮 */
 export const MessageResponse = React.memo(
-  function MessageResponse({ children, className, basePath, remarkPlugins }: MessageResponseProps): React.ReactElement {
+  function MessageResponse({ children, className, basePath, basePaths, remarkPlugins }: MessageResponseProps): React.ReactElement {
     // 合并内置 + 外部 remark 插件（保持引用稳定）
     const mergedRemarkPlugins = React.useMemo(
       () => remarkPlugins ? [...REMARK_PLUGINS, ...remarkPlugins] : REMARK_PLUGINS,
@@ -475,9 +500,9 @@ export const MessageResponse = React.memo(
       a: MarkdownLink,
       pre: MarkdownPre,
       code: (props: React.HTMLAttributes<HTMLElement>) => (
-        <MarkdownInlineCode {...props} basePath={basePath} />
+        <MarkdownInlineCode {...props} basePath={basePath} basePaths={basePaths} />
       ),
-    }), [basePath])
+    }), [basePath, basePaths])
 
     return (
       <div
@@ -503,6 +528,7 @@ export const MessageResponse = React.memo(
   (prevProps, nextProps) =>
     prevProps.children === nextProps.children &&
     prevProps.basePath === nextProps.basePath &&
+    prevProps.basePaths === nextProps.basePaths &&
     prevProps.remarkPlugins === nextProps.remarkPlugins
 )
 


### PR DESCRIPTION
## Summary
- 主进程 `openFilePreview(filePath, basePaths?)` 新增 `basePaths` 参数：相对路径会依次尝试候选目录，返回首个存在的文件再预览
- 前端通过新增 `BasePathsContext` + `BasePathsProvider` 把附加目录候选注入到 `MarkdownInlineCode`，避免逐层穿透 SDKMessageRenderer / ContentBlock 等中间组件
- AgentView → AgentMessages 顶层挂载 Provider；FilePathChip 点击时把候选 basePaths 一并发给主进程
- 绝对路径行为不变；附加目录里的代码/配置文件现在能在 Proma 内打开

## Test plan
- [ ] 附加一个目录到 Agent 会话，让 Agent 输出该目录下的相对路径（如 `src/foo.ts`），点击应在 Proma 内置预览窗口打开
- [ ] 主 cwd 内相对路径预览仍正常
- [ ] 绝对路径 chip 点击仍正常
- [ ] 同名相对路径在主 cwd 与附加目录都存在时优先匹配主 cwd

🤖 Generated with [Claude Code](https://claude.com/claude-code)