### PR TITLE
fix(file-preview): 附加目录文件双击改走 Proma 内置预览

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -1730,12 +1730,13 @@ export function registerIpcHandlers(): void {
     }
   )
 
-  // 用系统默认应用打开附加目录文件（无工作区路径限制）
+  // 在 Proma 内置预览窗口打开附加目录文件（无工作区路径限制；
+  // 不支持的格式由 openFilePreview 内部 fallback 到系统默认应用）
   ipcMain.handle(
     AGENT_IPC_CHANNELS.OPEN_ATTACHED_FILE,
     async (_, filePath: string): Promise<void> => {
-      const { resolve } = await import('node:path')
-      await shell.openPath(resolve(filePath))
+      const { openFilePreview } = await import('./lib/file-preview-service')
+      openFilePreview(filePath)
     }
   )
 


### PR DESCRIPTION
## Summary
- `OPEN_ATTACHED_FILE` IPC handler 此前直接 `shell.openPath`，导致 SidePanel "附加目录" 区域里双击文件总是被系统默认应用打开
- 改为调用 `openFilePreview`，与 FileBrowser 主 cwd 双击行为一致
- 不支持的格式（如 zip、二进制等）仍会在 `openFilePreview` 内部 fallback 到系统默认应用

## Test plan
- [ ] SidePanel 附加目录里双击 `.ts` / `.py` / `.md` / `.json` → Proma 内置预览
- [ ] 双击 `.png` / `.pdf` / `.docx` → Proma 内置预览
- [ ] 双击 `.zip` / 未知格式 → 系统默认应用（fallback）

🤖 Generated with [Claude Code](https://claude.com/claude-code)