### PR TITLE
fix(shortcuts): Cmd+W 优先关闭浮窗而非标签页

### DIFF
--- a/apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx
+++ b/apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx
@@ -53,8 +53,8 @@ import {
  */
 export function GlobalShortcuts(): null {
   const [appMode, setAppMode] = useAtom(appModeAtom)
-  const setSettingsOpen = useSetAtom(settingsOpenAtom)
-  const setSearchOpen = useSetAtom(searchDialogOpenAtom)
+  const [settingsOpen, setSettingsOpen] = useAtom(settingsOpenAtom)
+  const [searchOpen, setSearchOpen] = useAtom(searchDialogOpenAtom)
   const [sidebarCollapsed, setSidebarCollapsed] = useAtom(sidebarCollapsedAtom)
   const setShortcutOverrides = useSetAtom(shortcutOverridesAtom)
   const shortcutOverrides = useAtomValue(shortcutOverridesAtom)
@@ -90,6 +90,16 @@ export function GlobalShortcuts(): null {
   // ===== 关闭标签页逻辑 =====
 
   const handleCloseTab = useCallback(() => {
+    // 浮窗优先：有浮窗打开时 Cmd+W 先关闭浮窗而非 tab
+    if (settingsOpen) {
+      setSettingsOpen(false)
+      return
+    }
+    if (searchOpen) {
+      setSearchOpen(false)
+      return
+    }
+
     if (!activeTabId) return
     const closedTabId = activeTabId
     const result = closeTab(tabs, activeTabId, activeTabId)
@@ -109,7 +119,7 @@ export function GlobalShortcuts(): null {
       next.delete(closedTabId)
       return next
     })
-  }, [activeTabId, tabs, setTabs, setActiveTabId, setWorkingDone, syncActiveTabSideEffects])
+  }, [settingsOpen, setSettingsOpen, searchOpen, setSearchOpen, activeTabId, tabs, setTabs, setActiveTabId, setWorkingDone, syncActiveTabSideEffects])
 
   // 监听菜单 IPC 事件（Cmd+W 被 Electron 菜单拦截后通过 IPC 转发）
   useEffect(() => {


### PR DESCRIPTION
## Summary
- 修复设置浮窗/搜索浮窗打开时，Cmd+W 仍然关闭底层标签页的问题
- 在 `GlobalShortcuts.handleCloseTab` 开头判断 `settingsOpenAtom` / `searchDialogOpenAtom`，若有浮窗打开则优先关闭浮窗并提前返回

## 背景
Cmd+W 在 macOS 默认会关闭窗口，项目通过 Electron 菜单拦截后经 IPC (`menu:close-tab`) 转发到渲染进程执行 `handleCloseTab`。但之前的实现没有考虑上层是否存在浮窗（Radix Dialog 的默认 Esc 关闭不响应 Cmd+W），所以按下 Cmd+W 时用户会看到浮窗仍在、底层 tab 被关掉。

## Test plan
- [x] 打开设置浮窗 → 按 Cmd+W → 浮窗关闭，底层 tab 保留
- [x] 打开全局搜索浮窗（Cmd+F） → 按 Cmd+W → 浮窗关闭，底层 tab 保留
- [x] 浮窗都未打开时按 Cmd+W → 关闭当前活跃 tab（行为不变）
- [ ] 自定义 close-tab 快捷键（非 Cmd+W） → 同样遵循浮窗优先规则

🤖 Generated with [Claude Code](https://claude.com/claude-code)