### PR TITLE
fix(sidebar): 删除/归档当前激活会话后右侧文件面板消失【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.9.7",
+  "version": "0.9.6",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -62,6 +62,7 @@ import { workingSessionGroupsAtom, workingSessionIdsSetAtom } from '@/atoms/work
 import { hasEnvironmentIssuesAtom } from '@/atoms/environment'
 import { promptConfigAtom, selectedPromptIdAtom, conversationPromptIdAtom } from '@/atoms/system-prompt-atoms'
 import { useOpenSession } from '@/hooks/useOpenSession'
+import { useSyncActiveTabSideEffects } from '@/hooks/useSyncActiveTabSideEffects'
 import { WorkspaceSelector } from '@/components/agent/WorkspaceSelector'
 import { MoveSessionDialog } from '@/components/agent/MoveSessionDialog'
 import {
@@ -198,6 +199,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   const [activeTabId, setActiveTabId] = useAtom(activeTabIdAtom)
   const [sidebarCollapsed, setSidebarCollapsed] = useAtom(sidebarCollapsedAtom)
   const openSession = useOpenSession()
+  const syncActiveTabSideEffects = useSyncActiveTabSideEffects()
 
   // 归档 & 搜索状态
   const [viewMode, setViewMode] = useAtom(sidebarViewModeAtom)
@@ -460,14 +462,20 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       setConversations((prev) =>
         prev.map((c) => (c.id === updated.id ? updated : c))
       )
-      // 归档时自动关闭该对话的标签页
+      // 归档时自动关闭该对话的标签页，并同步新激活标签的副作用
+      // （appMode、currentXxxId 等），避免文件面板/工具栏等 per-tab
+      // 状态被遗留为旧值或被错误地置 null。
       if (updated.archived) {
+        const wasActive = activeTabId === id
         const tabResult = closeTab(tabs, activeTabId, id)
         setTabs(tabResult.tabs)
         setActiveTabId(tabResult.activeTabId)
-        // 如果归档的是当前选中的对话，取消选中
-        if (currentConversationId === id) {
-          setCurrentConversationId(null)
+        cleanupMapAtoms(id)
+        if (wasActive) {
+          const newActiveTab = tabResult.activeTabId
+            ? tabResult.tabs.find((t) => t.id === tabResult.activeTabId) ?? null
+            : null
+          syncActiveTabSideEffects(newActiveTab)
         }
       }
       toast.success(updated.archived ? '已归档' : '已取消归档')
@@ -484,9 +492,20 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     // 也避免将来在两者之间意外插入 await 导致跨渲染状态不一致。
     // （React 18 在同一事件回调中会自动批处理多次 setState，所以单次渲染
     // 的一致性由 React 保证，这里只是保持代码组织清晰。）
+    const wasActive = activeTabId === pendingDeleteId
     const tabResult = closeTab(tabs, activeTabId, pendingDeleteId)
     setTabs(tabResult.tabs)
     setActiveTabId(tabResult.activeTabId)
+
+    // 若关闭的是当前活跃标签，同步新激活标签的副作用（appMode、
+    // currentXxxId、以及右侧文件面板等 per-tab 状态），保持与 TabBar
+    // 关闭逻辑一致，避免删除/归档当前会话后新标签状态缺失。
+    if (wasActive) {
+      const newActiveTab = tabResult.activeTabId
+        ? tabResult.tabs.find((t) => t.id === tabResult.activeTabId) ?? null
+        : null
+      syncActiveTabSideEffects(newActiveTab)
+    }
 
     // 清理 draft 标记（如有）
     setDraftSessionIds((prev: Set<string>) => {
@@ -509,21 +528,19 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
 
     if (mode === 'agent') {
       // Agent 模式：删除 Agent 会话
+      // 注意：当前会话指针（currentAgentSessionId）已由上面的
+      // syncActiveTabSideEffects 在 wasActive 分支同步到新激活标签，
+      // 这里不要再按旧闭包值强制置 null，否则会覆盖新 sessionId，
+      // 导致 RightSidePanel 消失（依赖 currentAgentSessionIdAtom）。
       try {
         await window.electronAPI.deleteAgentSession(pendingDeleteId)
         // 全量刷新确保与后端同步
         const sessions = await window.electronAPI.listAgentSessions()
         setAgentSessions(sessions)
-        if (currentAgentSessionId === pendingDeleteId) {
-          setCurrentAgentSessionId(null)
-        }
       } catch (error) {
         console.error('[侧边栏] 删除 Agent 会话失败:', error)
         // 即使后端报错，也从本地列表移除（可能是会话已不存在）
         setAgentSessions((prev) => prev.filter((s) => s.id !== pendingDeleteId))
-        if (currentAgentSessionId === pendingDeleteId) {
-          setCurrentAgentSessionId(null)
-        }
       } finally {
         setPendingDeleteId(null)
       }
@@ -535,16 +552,10 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       // 全量刷新确保与后端同步
       const conversations = await window.electronAPI.listConversations()
       setConversations(conversations)
-      if (currentConversationId === pendingDeleteId) {
-        setCurrentConversationId(null)
-      }
     } catch (error) {
       console.error('[侧边栏] 删除对话失败:', error)
       // 即使后端报错，也从本地列表移除（可能是对话已不存在）
       setConversations((prev) => prev.filter((c) => c.id !== pendingDeleteId))
-      if (currentConversationId === pendingDeleteId) {
-        setCurrentConversationId(null)
-      }
     } finally {
       setPendingDeleteId(null)
     }
@@ -635,11 +646,15 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       setAgentSessions((prev) =>
         prev.map((s) => (s.id === updated.id ? updated : s))
       )
-      // 归档时自动关闭该会话的标签页
+      // 归档时自动关闭该会话的标签页，并同步新激活标签的副作用，
+      // 否则 RightSidePanel（依赖 currentAgentSessionIdAtom）会因为
+      // 指针被错误置 null 而消失。
       if (updated.archived) {
+        const wasActive = activeTabId === id
         const tabResult = closeTab(tabs, activeTabId, id)
         setTabs(tabResult.tabs)
         setActiveTabId(tabResult.activeTabId)
+        cleanupMapAtoms(id)
         // 从 Working Done 集合移除
         setWorkingDone((prev) => {
           if (!prev.has(id)) return prev
@@ -647,9 +662,11 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
           next.delete(id)
           return next
         })
-        // 如果归档的是当前选中的会话，取消选中
-        if (currentAgentSessionId === id) {
-          setCurrentAgentSessionId(null)
+        if (wasActive) {
+          const newActiveTab = tabResult.activeTabId
+            ? tabResult.tabs.find((t) => t.id === tabResult.activeTabId) ?? null
+            : null
+          syncActiveTabSideEffects(newActiveTab)
         }
       }
       toast.success(updated.archived ? '已归档' : '已取消归档')


### PR DESCRIPTION
## Overview

在 Agent 模式下，当用户在侧边栏删除或归档**当前激活的会话**时，系统自动切换到下一个标签页，但切换后右侧工作区文件面板（`RightSidePanel`）会消失，右上角的"打开文件面板"按钮也一并消失。唯一的恢复方式是切到别的标签再切回来。

**根本原因：** `LeftSidebar` 的三个 handler（`handleConfirmDelete`、`handleToggleArchive`、`handleToggleArchiveAgent`）在 `closeTab` 后：
1. 缺少 `syncActiveTabSideEffects(newActiveTab)` 调用，导致新激活标签的全局状态（`appMode`、`currentAgentSessionId` 等）未同步
2. 使用闭包捕获的旧值 `currentAgentSessionId === pendingDeleteId` 判断（恒为 true），将 `syncActiveTabSideEffects` 刚写入的新 sessionId 强制覆盖为 `null`
3. `RightSidePanel` 依赖 `currentAgentSessionIdAtom` 非空才渲染，一旦为 `null` 整个面板组件不挂载

对比 `TabBar.handleClose`（通过点 Tab 上的 X 关闭）的实现，它正确调用了 `syncActiveTabSideEffects`，所以不受影响。

## Changes

- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx`
  - 引入 `useSyncActiveTabSideEffects` hook
  - `handleConfirmDelete`：添加 `wasActive` 判断 + `syncActiveTabSideEffects` 调用；移除 Agent 和 Chat 分支中 4 处冗余且有害的 `setCurrentXxxId(null)`
  - `handleToggleArchive`（Chat 归档）：同上模式修复
  - `handleToggleArchiveAgent`（Agent 归档）：同上模式修复
- `apps/electron/package.json` — 版本 0.9.6 → 0.9.7

## How to Test

1. 打开 Proma，进入 Agent 模式
2. 同时打开 3 个以上 Agent 会话标签页，确保右侧文件面板可见
3. 在当前激活的标签页对应会话上右键 → 删除
4. ✅ 验证：自动切到下一个标签后，右侧文件面板**保持可见**
5. 再对当前激活的会话点归档
6. ✅ 验证：切换后文件面板**保持可见**
7. 切到 Chat 模式，删除/归档当前激活对话
8. ✅ 验证：切换后新对话正常加载，无状态残留

## Notes

- 修复逻辑与 `TabBar.handleClose` 和 `GlobalShortcuts.handleCloseTab` 保持一致，统一使用 `useSyncActiveTabSideEffects` 管理标签切换的全局状态同步
- `useSyncActiveTabSideEffects` 已经处理了 `newActiveTab === null`（所有标签关闭）的场景，会正确置空 `currentAgentSessionId`，因此移除手动置 null 不会引入空指针问题