### PR TITLE
fix(sidebar): 顶部 TabBar 切换 tab 时自动同步左侧子标签【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -319,6 +319,19 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     [agentSessions, viewMode, draftSessionIds, currentWorkspaceId, workingSessionIds]
   )
 
+  /** 顶部 TabBar 切换 tab 时，自动同步上区子 Tab 到对应分类 */
+  const prevActiveTabIdForSubTab = React.useRef<string | null>(activeTabId)
+  React.useEffect(() => {
+    if (activeTabId === prevActiveTabIdForSubTab.current) return
+    prevActiveTabIdForSubTab.current = activeTabId
+    if (mode !== 'agent' || viewMode !== 'active' || !activeTabId) return
+    if (pinnedAgentSessions.some((s) => s.id === activeTabId)) {
+      setAgentSubTab('pinned')
+    } else if (workingSessionIds.has(activeTabId)) {
+      setAgentSubTab('working')
+    }
+  }, [activeTabId, mode, viewMode, pinnedAgentSessions, workingSessionIds])
+
   /** 对话按日期分组（根据 viewMode 过滤归档状态，排除 draft） */
   const conversationGroups = React.useMemo(
     () => {


### PR DESCRIPTION
## Overview

点击顶部 TabBar 切换到一个置顶会话时，左侧侧边栏的"工作中 / 置顶"子标签不会自动跟随切换，导致被选中的会话在侧边栏中不可见（反之亦然）。

根因是 `agentSubTab` 是 `LeftSidebar` 组件的本地 React state，顶部 TabBar 的 `handleActivate` 只更新了 `activeTabIdAtom`，无法触达 `agentSubTab`。

## Changes

- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 添加 `useEffect` 监听 `activeTabId` 变化，当新选中的 session 属于置顶分类时自动切换到"置顶"子标签，属于工作中分类时切换到"工作中"子标签。通过 ref 追踪上一次 `activeTabId`，确保只在 tab 实际切换时触发，不干扰用户手动点击子标签按钮。

## How to Test

1. 在 Agent 模式下，确保有至少一个"置顶"会话和一个"工作中"会话
2. 左侧侧边栏选择显示"工作中"子标签
3. 从顶部 TabBar 点击一个置顶会话的标签页
4. 验证左侧侧边栏自动切换到"置顶"子标签，选中的会话高亮可见
5. 反向测试：左侧显示"置顶"，从顶部点击一个工作中会话，验证自动切换到"工作中"
6. 验证手动点击"工作中"/"置顶"按钮仍然正常工作，不会被 effect 覆盖

## Notes

- 当选中的 session 在"最近会话"区域（底部，始终可见）时，不改变子标签状态