### PR TITLE
fix(sidebar): 选中标签页时自动滚动侧边栏使其可见【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -259,6 +259,15 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     [agentTopHeight, setAgentTopHeight],
   )
 
+  // 当 activeTabId 变化时，自动滚动侧边栏使选中项可见
+  React.useEffect(() => {
+    if (!activeTabId) return
+    requestAnimationFrame(() => {
+      const el = document.querySelector('.session-item-selected')
+      el?.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+    })
+  }, [activeTabId])
+
   // per-conversation/session Map atoms（删除时清理）
   const setConvModels = useSetAtom(conversationModelsAtom)
   const setConvContextLength = useSetAtom(conversationContextLengthAtom)


### PR DESCRIPTION
## Overview

修复侧边栏在主区域切换标签页时不会自动滚动到对应会话项的问题。当最近会话列表较长时，用户在主区域选中一个位于列表下方的标签页，侧边栏不会自动滚动，导致看不到选中状态。

## Changes

- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 新增 `useEffect` 监听 `activeTabId` 变化，通过 `requestAnimationFrame` 等待 DOM 更新后，查找 `.session-item-selected` 元素并调用 `scrollIntoView({ block: 'nearest', behavior: 'smooth' })` 平滑滚动到可见区域

## How to Test

1. 在 Agent 或 Chat 模式下创建足够多的会话，使侧边栏最近会话列表可滚动
2. 将侧边栏滚动到列表顶部
3. 在主区域的标签栏点击一个排在列表下方的会话标签
4. 观察侧边栏是否自动平滑滚动到选中的会话项位置

## Notes

- 使用 `block: 'nearest'` 确保只在元素不在可视区域时才滚动，避免不必要的滚动跳动
- 覆盖 Agent 模式（最近会话列表）和 Chat 模式（对话列表）两种场景
- 复用已有的 `.session-item-selected` CSS 类作为选择器，无需修改子组件