### PR TITLE
fix(agent): 上下文用量圆环切换 tab 后保持显示【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -430,14 +430,31 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         setPersistedSDKMessages(sdkMsgs)
         setMessagesLoaded(true)
 
-        // 消息加载完成后，同步清除流式状态和实时消息，
+        // 消息加载完成后，同步清除流式展示状态和实时消息，
         // 确保 React 在一次渲染中同时显示持久化消息并移除流式气泡/实时消息，
         // 避免「实时消息已清 → 持久化消息未到」的空档闪烁
+        // 注意：保留 inputTokens/contextWindow 以维持上下文用量圆环显示
         setStreamingStates((prev) => {
           const state = prev.get(sessionId)
           if (!state || state.running) return prev  // 仍在运行中，不清除
           const map = new Map(prev)
-          map.delete(sessionId)
+          if (state.inputTokens !== undefined) {
+            // 保留 usage 数据，仅清除流式展示字段
+            map.set(sessionId, {
+              running: false,
+              content: '',
+              toolActivities: [],
+              teammates: [],
+              inputTokens: state.inputTokens,
+              outputTokens: state.outputTokens,
+              cacheReadTokens: state.cacheReadTokens,
+              cacheCreationTokens: state.cacheCreationTokens,
+              contextWindow: state.contextWindow,
+              model: state.model,
+            })
+          } else {
+            map.delete(sessionId)
+          }
           return map
         })
         setLiveMessagesMap((prev) => {
@@ -494,6 +511,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       const streamStartedAt = Date.now()
       setStreamingStates((prev) => {
         const map = new Map(prev)
+        const existing = prev.get(sessionId)
         map.set(sessionId, {
           running: true,
           content: '',
@@ -501,6 +519,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           teammates: [],
           model: snapshot.modelId,
           startedAt: streamStartedAt,
+          inputTokens: existing?.inputTokens,
+          contextWindow: existing?.contextWindow,
         })
         return map
       })
@@ -537,8 +557,10 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       window.electronAPI.sendAgentMessage(input).catch((error) => {
         console.error('[AgentView] 自动发送配置消息失败:', error)
         setStreamingStates((prev) => {
+          const current = prev.get(sessionId)
+          if (!current) return prev
           const map = new Map(prev)
-          map.delete(sessionId)
+          map.set(sessionId, { ...current, running: false })
           return map
         })
       })
@@ -924,6 +946,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     const streamStartedAt = Date.now()
     setStreamingStates((prev) => {
       const map = new Map(prev)
+      const existing = prev.get(sessionId)
       map.set(sessionId, {
         running: true,
         content: '',
@@ -931,6 +954,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         teammates: [],
         model: agentModelId || undefined,
         startedAt: streamStartedAt,
+        inputTokens: existing?.inputTokens,
+        contextWindow: existing?.contextWindow,
       })
       return map
     })
@@ -980,9 +1005,10 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     window.electronAPI.sendAgentMessage(input).catch((error) => {
       console.error('[AgentView] 发送消息失败:', error)
       setStreamingStates((prev) => {
-        if (!prev.has(sessionId)) return prev
+        const current = prev.get(sessionId)
+        if (!current) return prev
         const map = new Map(prev)
-        map.delete(sessionId)
+        map.set(sessionId, { ...current, running: false })
         return map
       })
     })
@@ -1106,6 +1132,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     const streamStartedAt = Date.now()
     setStreamingStates((prev) => {
       const map = new Map(prev)
+      const existing = prev.get(sessionId)
       map.set(sessionId, {
         running: true,
         content: '',
@@ -1113,6 +1140,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         teammates: [],
         model: agentModelId || undefined,
         startedAt: streamStartedAt,
+        inputTokens: existing?.inputTokens,
+        contextWindow: existing?.contextWindow,
       })
       return map
     })


### PR DESCRIPTION
## Overview

修复 Agent 输入框右下角的上下文用量圆环（ContextUsageBadge）经常无故消失的问题。

原本的行为：圆环只在「本次 app 启动后、该会话发送消息并刚收到 AI 回复」的极短时间内显示，**切换 tab 后立刻消失**，再次发送、发送失败、重试后也会消失。

修复后：会话只要在本次 app 启动后收到过至少一次 AI 回复，圆环就会一直显示，无论是否切换 tab、是否重新发送、是否报错。唯一会丢失的情况是重启 app（因为 token 数据只在内存中，不持久化到磁盘）。

## Root Cause

`agentStreamingStatesAtom` 中保存了每个 session 的 `inputTokens` / `contextWindow` 等用量数据。但有几处代码会**意外丢弃**这些字段：

1. **消息加载 effect**：每次 `AgentView` 因切 tab 而重新挂载（`key={tab.sessionId}`）时，会触发加载历史消息的 effect。在加载完成的回调里，原本无条件 `map.delete(sessionId)`，把整个 entry（包括 token 数据）删掉。这是切 tab 后圆环消失的根本原因。
2. **发送/重试/auto-send**：每次发送都用一个不含 `inputTokens`/`contextWindow` 的全新对象覆盖整个 stream state，从点击发送到 SDK 回传第一个带 usage 的 assistant 消息之间圆环会消失。
3. **发送失败的 catch**：原本 `map.delete(sessionId)`，失败后所有 token 数据丢失。

## Changes

- `apps/electron/src/renderer/components/agent/AgentView.tsx`
  - **消息加载完成回调（~L433-460）**：从 `map.delete(sessionId)` 改为：若存在 `inputTokens` 则保留所有 usage 字段（inputTokens / outputTokens / cacheRead/CreationTokens / contextWindow / model），仅清除流式展示字段（content / toolActivities / teammates / running）；只有完全没有 usage 数据时才删除 entry。
  - **handleSend 主路径（~L932）**：重置流式状态时，从上一次的 entry 读取 `inputTokens` 和 `contextWindow` 并继承到新对象。
  - **handleRetry（~L1130）**：同上。
  - **auto-send pendingPrompt（~L499）**：同上。
  - **sendAgentMessage 失败 catch（~L1005、~L559）**：从 `map.delete(sessionId)` 改为只把 `running` 设为 `false`，保留其他所有字段。

注意：仅 `AgentView.tsx` 一处文件修改，`bun.lock` 是本地 `bun install` 副作用，未纳入提交。

## How to Test

1. 启动 Proma，进入 Agent 模式，打开任意会话发送一条消息并等待 AI 回复
2. 验证输入框右下角的圆环正常显示
3. 切换到其他 tab，再切回来 → **圆环应一直保持显示**（修复前会消失）
4. 在该会话再发一条消息 → 点击发送瞬间到收到回复期间，圆环应保持显示上次的占用数（修复前会暂时消失）
5. 关闭 tab 再打开同一会话 → 圆环仍保持显示（atom entry 仍在内存中）
6. 重启 app 后打开旧会话 → 圆环不显示（这是预期行为，token 数据不持久化）

## Notes

- 该修复仅是内存层面的状态保留，不涉及任何持久化变更
- 没有修改 `ContextUsageBadge.tsx` 组件本身的渲染逻辑
- 类型检查与完整 build 均通过