### PR TITLE
feat(sidebar): 支持手动标记会话为工作中【已审核 PR】

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -855,11 +855,27 @@ export function registerIpcHandlers(): void {
     async (_, id: string): Promise<AgentSessionMeta> => {
       const sessions = listAgentSessions()
       const current = sessions.find((s) => s.id === id)
-      if (!current) throw new Error(`Agent 会话不存在: ${id}`)
+      if (!current) throw new Error(`Agent session not found: ${id}`)
       const newPinned = !current.pinned
       // 置顶时自动取消归档
       const updates: Partial<AgentSessionMeta> = { pinned: newPinned }
       if (newPinned && current.archived) {
+        updates.archived = false
+      }
+      return updateAgentSessionMeta(id, updates)
+    }
+  )
+
+  // 切换 Agent 会话手动工作中状态
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.TOGGLE_MANUAL_WORKING,
+    async (_, id: string): Promise<AgentSessionMeta> => {
+      const sessions = listAgentSessions()
+      const current = sessions.find((s) => s.id === id)
+      if (!current) throw new Error(`Agent session not found: ${id}`)
+      const newManualWorking = !current.manualWorking
+      const updates: Partial<AgentSessionMeta> = { manualWorking: newManualWorking }
+      if (newManualWorking && current.archived) {
         updates.archived = false
       }
       return updateAgentSessionMeta(id, updates)
@@ -872,7 +888,7 @@ export function registerIpcHandlers(): void {
     async (_, id: string): Promise<AgentSessionMeta> => {
       const sessions = listAgentSessions()
       const current = sessions.find((s) => s.id === id)
-      if (!current) throw new Error(`Agent 会话不存在: ${id}`)
+      if (!current) throw new Error(`Agent session not found: ${id}`)
       const newArchived = !current.archived
       // 归档时自动取消置顶
       const updates: Partial<AgentSessionMeta> = { archived: newArchived }

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -328,6 +328,9 @@ export interface ElectronAPI {
   /** 切换 Agent 会话置顶状态 */
   togglePinAgentSession: (id: string) => Promise<AgentSessionMeta>
 
+  /** 切换 Agent 会话手动工作中状态 */
+  toggleManualWorkingAgentSession: (id: string) => Promise<AgentSessionMeta>
+
   /** 切换 Agent 会话归档状态 */
   toggleArchiveAgentSession: (id: string) => Promise<AgentSessionMeta>
 
@@ -1028,6 +1031,10 @@ const electronAPI: ElectronAPI = {
 
   togglePinAgentSession: (id: string) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.TOGGLE_PIN, id)
+  },
+
+  toggleManualWorkingAgentSession: (id: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.TOGGLE_MANUAL_WORKING, id)
   },
 
   toggleArchiveAgentSession: (id: string) => {

--- a/apps/electron/src/renderer/atoms/working-atoms.ts
+++ b/apps/electron/src/renderer/atoms/working-atoms.ts
@@ -26,7 +26,9 @@ export interface WorkingSessionGroups {
  * 派生 atom：计算 Working 区域的三组会话（跨工作区，不按当前工作区过滤）
  * - todo: blocked（orange，等待用户决策）
  * - running: running（blue，Agent 执行中）
- * - done: 完成且 Tab 仍打开（green / idle）
+ * - done: 完成且 Tab 仍打开（green / idle），包含手动标记为工作中的会话
+ *
+ * manualWorking 会话始终纳入工作中，按当前 indicator 分配到对应子组
  */
 export const workingSessionGroupsAtom = atom<WorkingSessionGroups>((get) => {
   const sessions = get(agentSessionsAtom)
@@ -43,23 +45,33 @@ export const workingSessionGroupsAtom = atom<WorkingSessionGroups>((get) => {
   const todo: AgentSessionMeta[] = []
   const running: AgentSessionMeta[] = []
   const done: AgentSessionMeta[] = []
+  const includedIds = new Set<string>()
 
   // 从 indicatorMap 提取 blocked + running
   for (const [id, status] of indicatorMap) {
     const session = sessionMap.get(id)
     if (!session || draftIds.has(id)) continue
-    if (status === 'blocked') todo.push(session)
-    else if (status === 'running') running.push(session)
+    if (status === 'blocked') { todo.push(session); includedIds.add(id) }
+    else if (status === 'running') { running.push(session); includedIds.add(id) }
   }
 
   // 从 workingDoneSessionIdsAtom 提取 done
   for (const id of doneIds) {
-    const indicatorStatus = indicatorMap.get(id)
-    if (indicatorStatus === 'running' || indicatorStatus === 'blocked') continue // 已在 running/blocked 中
-    if (!openAgentTabIds.has(id)) continue // Tab 已关闭
+    if (includedIds.has(id)) continue
+    if (!openAgentTabIds.has(id)) continue
     const session = sessionMap.get(id)
     if (!session || draftIds.has(id)) continue
     done.push(session)
+    includedIds.add(id)
+  }
+
+  // manualWorking 会话：按当前 indicator 分配到对应子组
+  for (const session of sessions) {
+    if (!session.manualWorking || draftIds.has(session.id) || includedIds.has(session.id)) continue
+    const status = indicatorMap.get(session.id)
+    if (status === 'blocked') { todo.push(session); includedIds.add(session.id) }
+    else if (status === 'running') { running.push(session); includedIds.add(session.id) }
+    else { done.push(session); includedIds.add(session.id) }
   }
 
   const byDate = (a: AgentSessionMeta, b: AgentSessionMeta): number =>

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -11,7 +11,7 @@
 import * as React from 'react'
 import { useAtom, useSetAtom, useAtomValue } from 'jotai'
 import { toast } from 'sonner'
-import { Pin, PinOff, Settings, Plus, Trash2, Pencil, ChevronDown, ChevronRight, Plug, Zap, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft } from 'lucide-react'
+import { Pin, PinOff, Settings, Plus, Trash2, Pencil, ChevronDown, ChevronRight, Plug, Zap, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Hammer } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { ModeSwitcher } from './ModeSwitcher'
@@ -160,6 +160,14 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   const draftSessionIds = useAtomValue(draftSessionIdsAtom)
   const setDraftSessionIds = useSetAtom(draftSessionIdsAtom)
   const [hoveredId, setHoveredId] = React.useState<string | null>(null)
+
+  // 窗口失焦时清除 hover 状态，防止 Tooltip 残留
+  React.useEffect(() => {
+    const handleBlur = (): void => setHoveredId(null)
+    window.addEventListener('blur', handleBlur)
+    return () => window.removeEventListener('blur', handleBlur)
+  }, [])
+
   /** 待删除对话 ID，非空时显示确认弹窗 */
   const [pendingDeleteId, setPendingDeleteId] = React.useState<string | null>(null)
   /** 待迁移会话 ID，非空时显示迁移对话框 */
@@ -628,6 +636,42 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     }
   }
 
+  /** 切换 Agent 会话手动工作中状态 */
+  const handleToggleManualWorkingAgent = async (id: string): Promise<void> => {
+    try {
+      const isCurrentlyInWorking = workingSessionIds.has(id)
+      if (isCurrentlyInWorking) {
+        // 从工作中移出：清除 manualWorking + 清除 workingDone
+        const session = agentSessions.find((s) => s.id === id)
+        if (session?.manualWorking) {
+          const updated = await window.electronAPI.toggleManualWorkingAgentSession(id)
+          setAgentSessions((prev) =>
+            prev.map((s) => (s.id === updated.id ? updated : s))
+          )
+        }
+        setWorkingDone((prev) => {
+          if (!prev.has(id)) return prev
+          const next = new Set(prev)
+          next.delete(id)
+          return next
+        })
+      } else {
+        // 加入工作中
+        const original = agentSessions.find((s) => s.id === id)
+        const updated = await window.electronAPI.toggleManualWorkingAgentSession(id)
+        setAgentSessions((prev) =>
+          prev.map((s) => (s.id === updated.id ? updated : s))
+        )
+        if (original?.archived && updated.manualWorking && !updated.archived) {
+          toast.success('已取消归档并标记为工作中')
+        }
+      }
+    } catch (error) {
+      console.error('[Sidebar] Failed to toggle manual working:', error)
+      toast.error('操作失败')
+    }
+  }
+
   /** 切换 Agent 会话归档状态 */
   const handleToggleArchiveAgent = async (id: string): Promise<void> => {
     try {
@@ -991,6 +1035,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                                 active={session.id === activeTabId}
                                 hovered={session.id === hoveredId}
                                 indicatorStatus={agentIndicatorMap.get(session.id) ?? 'idle'}
+                                isInWorkingSection={workingSessionIds.has(session.id)}
                                 showPinIcon={false}
                                 leftAccent={accent}
                                 onSelect={() => handleSelectAgentSession(session.id, session.title)}
@@ -998,6 +1043,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                                 onRequestMove={() => setMoveTargetId(session.id)}
                                 onRename={handleAgentRename}
                                 onTogglePin={handleTogglePinAgent}
+                                onToggleManualWorking={handleToggleManualWorkingAgent}
                                 onToggleArchive={handleToggleArchiveAgent}
                                 onMouseEnter={() => setHoveredId(session.id)}
                                 onMouseLeave={() => setHoveredId(null)}
@@ -1024,12 +1070,14 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                               active={session.id === activeTabId}
                               hovered={session.id === hoveredId}
                               indicatorStatus={agentIndicatorMap.get(session.id) ?? 'idle'}
+                              isInWorkingSection={workingSessionIds.has(session.id)}
                               showPinIcon={false}
                               onSelect={() => handleSelectAgentSession(session.id, session.title)}
                               onRequestDelete={() => handleRequestDelete(session.id)}
                               onRequestMove={() => setMoveTargetId(session.id)}
                               onRename={handleAgentRename}
                               onTogglePin={handleTogglePinAgent}
+                              onToggleManualWorking={handleToggleManualWorkingAgent}
                               onToggleArchive={handleToggleArchiveAgent}
                               onMouseEnter={() => setHoveredId(session.id)}
                               onMouseLeave={() => setHoveredId(null)}
@@ -1074,12 +1122,14 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                       active={session.id === activeTabId}
                       hovered={session.id === hoveredId}
                       indicatorStatus={agentIndicatorMap.get(session.id) ?? 'idle'}
+                      isInWorkingSection={workingSessionIds.has(session.id)}
                       showPinIcon={!!session.pinned}
                       onSelect={() => handleSelectAgentSession(session.id, session.title)}
                       onRequestDelete={() => handleRequestDelete(session.id)}
                       onRequestMove={() => setMoveTargetId(session.id)}
                       onRename={handleAgentRename}
                       onTogglePin={handleTogglePinAgent}
+                      onToggleManualWorking={handleToggleManualWorkingAgent}
                       onToggleArchive={handleToggleArchiveAgent}
                       onMouseEnter={() => setHoveredId(session.id)}
                       onMouseLeave={() => setHoveredId(null)}
@@ -1146,12 +1196,14 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                         active={session.id === activeTabId}
                         hovered={session.id === hoveredId}
                         indicatorStatus={agentIndicatorMap.get(session.id) ?? 'idle'}
+                        isInWorkingSection={workingSessionIds.has(session.id)}
                         showPinIcon={!!session.pinned}
                         onSelect={() => handleSelectAgentSession(session.id, session.title)}
                         onRequestDelete={() => handleRequestDelete(session.id)}
                         onRequestMove={() => setMoveTargetId(session.id)}
                         onRename={handleAgentRename}
                         onTogglePin={handleTogglePinAgent}
+                        onToggleManualWorking={handleToggleManualWorkingAgent}
                         onToggleArchive={handleToggleArchiveAgent}
                         onMouseEnter={() => setHoveredId(session.id)}
                         onMouseLeave={() => setHoveredId(null)}
@@ -1460,6 +1512,8 @@ interface AgentSessionItemProps {
   hovered: boolean
   indicatorStatus: SessionIndicatorStatus
   showPinIcon?: boolean
+  /** 是否在工作中分区（auto 或 manual） */
+  isInWorkingSection?: boolean
   /** 行左侧状态色块；未传则不显示 */
   leftAccent?: SessionLeftAccent
   onSelect: () => void
@@ -1467,6 +1521,7 @@ interface AgentSessionItemProps {
   onRequestMove: () => void
   onRename: (id: string, newTitle: string) => Promise<void>
   onTogglePin: (id: string) => Promise<void>
+  onToggleManualWorking: (id: string) => Promise<void>
   onToggleArchive: (id: string) => Promise<void>
   onMouseEnter: () => void
   onMouseLeave: () => void
@@ -1478,12 +1533,14 @@ function AgentSessionItem({
   hovered,
   indicatorStatus,
   showPinIcon,
+  isInWorkingSection,
   leftAccent,
   onSelect,
   onRequestDelete,
   onRequestMove,
   onRename,
   onTogglePin,
+  onToggleManualWorking,
   onToggleArchive,
   onMouseEnter,
   onMouseLeave,
@@ -1593,6 +1650,34 @@ function AgentSessionItem({
             </button>
           </TooltipTrigger>
           <TooltipContent side="top">{session.pinned ? '取消置顶' : '置顶会话'}</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                if (indicatorStatus !== 'running') {
+                  onToggleManualWorking(session.id)
+                }
+              }}
+              disabled={indicatorStatus === 'running'}
+              className={cn(
+                'p-1 rounded-md transition-colors',
+                indicatorStatus === 'running'
+                  ? 'text-primary/40 cursor-not-allowed'
+                  : (isInWorkingSection || session.manualWorking)
+                    ? 'text-primary hover:bg-foreground/[0.08]'
+                    : 'text-foreground/30 hover:bg-foreground/[0.08] hover:text-foreground/60'
+              )}
+            >
+              <Hammer size={13} className={(isInWorkingSection || session.manualWorking) ? 'fill-current' : ''} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="top">
+            {indicatorStatus === 'running'
+              ? '运行中无法移出'
+              : (isInWorkingSection || session.manualWorking) ? '取消工作中' : '标记为工作中'}
+          </TooltipContent>
         </Tooltip>
         {(indicatorStatus === 'idle' || indicatorStatus === 'completed') && (
           <Tooltip>

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -538,6 +538,8 @@ export interface AgentSessionMeta {
   forkSourceSdkSessionId?: string
   /** 回退后的 resume 截断点：下次发消息时传给 SDK resumeSessionAt（消费后清除） */
   resumeAtMessageUuid?: string
+  /** 手动标记为工作中 */
+  manualWorking?: boolean
   /** 最后一次流式执行是否被用户主动中断 */
   stoppedByUser?: boolean
   /** 创建时间戳 */
@@ -1153,6 +1155,8 @@ export const AGENT_IPC_CHANNELS = {
   MIGRATE_CHAT_TO_AGENT: 'agent:migrate-chat-to-agent',
   /** 切换会话置顶状态 */
   TOGGLE_PIN: 'agent:toggle-pin',
+  /** 切换会话手动工作中状态 */
+  TOGGLE_MANUAL_WORKING: 'agent:toggle-manual-working',
   /** 切换会话归档状态 */
   TOGGLE_ARCHIVE: 'agent:toggle-archive',
   /** 搜索会话消息内容 */


### PR DESCRIPTION
## Overview

添加「手动工作中」功能，允许用户通过侧边栏的锤子图标将任意 Agent 会话手动固定到 Working 区域。即使 Agent 已完成执行，会话仍可保持在工作中可见，方便追踪多会话工作流。

## Changes

- `packages/shared/src/types/agent.ts` — 新增 `manualWorking` 字段到 `AgentSessionMeta`，新增 `TOGGLE_MANUAL_WORKING` IPC 通道常量
- `apps/electron/src/main/ipc.ts` — 新增 `TOGGLE_MANUAL_WORKING` handler，切换 manualWorking 标志（标记时自动取消归档）
- `apps/electron/src/preload/index.ts` — 新增 `toggleManualWorkingAgentSession` API 暴露给渲染进程
- `apps/electron/src/renderer/atoms/working-atoms.ts` — 扩展 `workingSessionGroupsAtom`，将 manualWorking 会话按当前 indicator 状态分配到对应子组（todo/running/done）
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 每个会话项增加锤子按钮（运行中禁用）；窗口失焦时清除 hover 状态修复 Tooltip 残留

## How to Test

1. 打开侧边栏，hover 任意已完成的 Agent 会话
2. 点击锤子图标 → 会话出现在 Working 区域
3. 再次点击锤子图标 → 会话从 Working 区域移除
4. 对归档会话点击锤子 → 自动取消归档并进入 Working
5. 运行中的会话锤子按钮应为禁用状态

## Notes

- 与现有 pin/archive 模式保持一致的交互范式
- 类型检查全部通过（4 个包 0 错误）