### PR TITLE
feat(shortcuts): 停止 Agent 快捷键 + Tooltip 【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -43,6 +43,7 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import { cn } from '@/lib/utils'
+import { getActiveAccelerator, getAcceleratorDisplay } from '@/lib/shortcut-registry'
 import { FeishuNotifyToggle } from '@/components/chat/FeishuNotifyToggle'
 import {
   agentStreamingStatesAtom,
@@ -1237,7 +1238,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     }
   }, [rewindTargetUuid, sessionId, store])
 
-  // 监听快捷键系统分发的 stop-generation 事件（Cmd+.）
+  // 监听快捷键系统分发的 stop-generation 事件
   React.useEffect(() => {
     const handler = (): void => {
       if (streaming) handleStop()
@@ -1473,15 +1474,22 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
 
               <div className="flex items-center gap-1.5">
                 {streaming && !hasTextInput ? (
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    className="size-[36px] rounded-full text-destructive hover:!text-[hsl(0,75%,55%)] hover:!bg-[var(--stop-hover-bg)]"
-                    onClick={handleStop}
-                  >
-                    <Square className="size-[16px]" fill="currentColor" strokeWidth={0} />
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="size-[36px] rounded-full text-destructive hover:!text-[hsl(0,75%,55%)] hover:!bg-[var(--stop-hover-bg)]"
+                        onClick={handleStop}
+                      >
+                        <Square className="size-[16px]" fill="currentColor" strokeWidth={0} />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="top">
+                      <p>停止 Agent ({getAcceleratorDisplay(getActiveAccelerator('stop-generation'))})</p>
+                    </TooltipContent>
+                  </Tooltip>
                 ) : (
                   <Button
                     type="button"

--- a/apps/electron/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatInput.tsx
@@ -28,6 +28,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
+import { getActiveAccelerator, getAcceleratorDisplay } from '@/lib/shortcut-registry'
 import {
   conversationDraftsAtom,
 } from '@/atoms/chat-atoms'
@@ -329,15 +330,22 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
             {/* 右侧：发送 / 停止按钮 */}
             <div className="flex items-center gap-1.5">
               {streaming ? (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="size-[36px] rounded-full text-destructive hover:!text-[hsl(0,75%,55%)] hover:!bg-[var(--stop-hover-bg)]"
-                  onClick={onStop}
-                >
-                  <Square className="size-[16px]" fill="currentColor" strokeWidth={0} />
-                </Button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="size-[36px] rounded-full text-destructive hover:!text-[hsl(0,75%,55%)] hover:!bg-[var(--stop-hover-bg)]"
+                      onClick={onStop}
+                    >
+                      <Square className="size-[16px]" fill="currentColor" strokeWidth={0} />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="top">
+                    <p>停止 Agent ({getAcceleratorDisplay(getActiveAccelerator('stop-generation'))})</p>
+                  </TooltipContent>
+                </Tooltip>
               ) : (
                 <Button
                   type="button"

--- a/apps/electron/src/renderer/components/chat/ChatView.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatView.tsx
@@ -419,7 +419,7 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
     window.electronAPI.stopGeneration(conversationId).catch(console.error)
   }, [conversationId, setStreamingStates])
 
-  // 监听快捷键系统分发的 stop-generation 事件（Cmd+.）
+  // 监听快捷键系统分发的 stop-generation 事件
   React.useEffect(() => {
     const handler = (): void => {
       if (isStreaming) handleStop()

--- a/apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx
+++ b/apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx
@@ -190,7 +190,7 @@ export function GlobalShortcuts(): null {
     }, []),
   )
 
-  // Cmd+. → 停止生成（通过 CustomEvent 分发到 ChatView/AgentView）
+  // Cmd+Shift+Backspace → 停止 Agent（通过 CustomEvent 分发到 ChatView/AgentView）
   useShortcut(
     'stop-generation',
     useCallback(() => {

--- a/apps/electron/src/renderer/lib/shortcut-defaults.ts
+++ b/apps/electron/src/renderer/lib/shortcut-defaults.ts
@@ -131,10 +131,10 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
   },
   {
     id: 'stop-generation',
-    name: '停止生成',
+    name: '停止 Agent',
     description: '中断当前 AI 响应',
-    defaultMac: 'Cmd+.',
-    defaultWin: 'Ctrl+.',
+    defaultMac: 'Cmd+Shift+Backspace',
+    defaultWin: 'Ctrl+Shift+Backspace',
     category: 'edit',
   },
   {

--- a/apps/electron/src/renderer/lib/shortcut-registry.ts
+++ b/apps/electron/src/renderer/lib/shortcut-registry.ts
@@ -192,6 +192,7 @@ export function getAcceleratorDisplay(accelerator: string): string {
       .replace(/Shift\+/gi, '⇧')
       .replace(/Alt\+/gi, '⌥')
       .replace(/Ctrl\+/gi, '⌃')
+      .replace(/Backspace/gi, '⌫')
   }
   return accelerator
 }

--- a/apps/electron/src/renderer/lib/tips.ts
+++ b/apps/electron/src/renderer/lib/tips.ts
@@ -45,7 +45,7 @@ export const TIPS: Tip[] = [
   { id: 'win-shortcut-mode', text: '按 Ctrl+Shift+M 快速切换 Chat / Agent 模式', platform: 'windows' },
   { id: 'win-shortcut-focus', text: '按 Ctrl+L 快速跳转到输入框', platform: 'windows' },
   { id: 'win-shortcut-clear', text: '按 Ctrl+K 清除当前对话上下文', platform: 'windows' },
-  { id: 'win-shortcut-stop', text: '按 Ctrl+. 中断 AI 响应', platform: 'windows' },
+  { id: 'win-shortcut-stop', text: '按 Ctrl+Shift+Backspace 中断 AI 响应', platform: 'windows' },
   { id: 'win-shortcut-close', text: '按 Ctrl+W 关闭当前标签页', platform: 'windows' },
   { id: 'win-shortcut-zoom', text: '按 Ctrl++ / Ctrl+- 可以放大或缩小界面，Ctrl+0 重置', platform: 'windows' },
   { id: 'win-shortcut-tab-switch', text: '按 Ctrl+Tab 快速切换标签，长按 Ctrl 反复按 Tab 可在标签间循环选择', platform: 'windows' },


### PR DESCRIPTION
## Overview

为 Agent/Chat 模式的停止按钮添加键盘快捷键（`Cmd+Shift+Backspace` / `Ctrl+Shift+Backspace`），并在 hover 时显示 Tooltip 提示快捷键。同时在设置页的快捷键面板中可查看和自定义该键位。

## Changes

- `apps/electron/src/renderer/lib/shortcut-defaults.ts` — 将 `stop-generation` 默认快捷键从 `Cmd+.` 改为 `Cmd+Shift+Backspace`，名称改为「停止 Agent」
- `apps/electron/src/renderer/lib/shortcut-registry.ts` — `getAcceleratorDisplay` 增加 `Backspace` → `⌫` 映射，macOS 上显示为 `⌘⇧⌫`
- `apps/electron/src/renderer/components/agent/AgentView.tsx` — Agent 模式停止按钮包裹 Tooltip，hover 显示「停止 Agent (⌘⇧⌫)」，引入 `getActiveAccelerator` / `getAcceleratorDisplay`
- `apps/electron/src/renderer/components/chat/ChatInput.tsx` — Chat 模式停止按钮同样添加 Tooltip
- `apps/electron/src/renderer/components/chat/ChatView.tsx` — 微调相关引用
- `apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx` — 微调相关引用
- `apps/electron/src/renderer/lib/tips.ts` — 微调相关引用

## How to Test

1. `bun run dev` 启动开发模式
2. 进入 Agent 模式，发起一次对话
3. 在 Agent 运行中，hover 停止按钮 → 应看到 Tooltip「停止 Agent (⌘⇧⌫)」
4. 按 `Cmd+Shift+Backspace` → Agent 应停止运行
5. 进入 Chat 模式，发起流式响应 → hover 停止按钮同样有 Tooltip
6. 打开设置 → 快捷键 → 确认「停止 Agent」显示为 `⌘⇧⌫`，点击可自定义

## Notes

- Tooltip 使用 `getActiveAccelerator` 动态读取，用户自定义快捷键后 Tooltip 自动更新
- 遵循 ClearContextButton 的既有 Tooltip 模式