### PR TITLE
fix(scroll): 发送消息后自动滚动到对话底部 【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -37,6 +37,7 @@ import { ToolActivityList } from './ToolActivityItem'
 import { userProfileAtom } from '@/atoms/user-profile'
 import { tabMinimapCacheAtom } from '@/atoms/tab-atoms'
 import { channelsAtom } from '@/atoms/chat-atoms'
+import { useStickToBottomContext } from 'use-stick-to-bottom'
 import { ScrollPositionManager } from '@/hooks/useScrollPositionMemory'
 import { cn } from '@/lib/utils'
 import { Spinner } from '@/components/ui/spinner'
@@ -44,6 +45,26 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { groupIntoTurns, MessageGroupRenderer, getGroupId, getGroupPreview, extractUserText, parseAttachedFiles as sdkParseAttachedFiles, isImageFile as sdkIsImageFile, CompactingIndicator, type MessageGroup } from './SDKMessageRenderer'
 import type { AgentMessage, AgentEventUsage, RetryAttempt, SDKMessage } from '@proma/shared'
 import type { ToolActivity, AgentStreamState } from '@/atoms/agent-atoms'
+
+// ===== 发送消息后自动滚动到底部 =====
+
+function AutoScrollOnUserSend({ messages }: { messages: AgentMessage[] }): null {
+  const { scrollToBottom } = useStickToBottomContext()
+  const prevLenRef = React.useRef(messages.length)
+
+  React.useEffect(() => {
+    const prevLen = prevLenRef.current
+    prevLenRef.current = messages.length
+    if (messages.length > prevLen) {
+      const last = messages[messages.length - 1]
+      if (last?.role === 'user') {
+        scrollToBottom()
+      }
+    }
+  }, [messages.length, messages, scrollToBottom])
+
+  return null
+}
 
 /** AgentMessages 属性接口 */
 interface AgentMessagesProps {
@@ -836,6 +857,7 @@ export function AgentMessages({ sessionId, sessionModelId, messages, messagesLoa
     <BasePathsProvider basePaths={attachedDirs}>
     <Conversation resize={ready && !transitioning ? 'smooth' : 'instant'} className={ready ? 'opacity-100 transition-opacity duration-200' : 'opacity-0'}>
       <ScrollPositionManager id={sessionId} ready={ready} />
+      <AutoScrollOnUserSend messages={messages} />
       <ConversationContent>
         {!hasContent && !streaming ? (
           <EmptyState />

--- a/apps/electron/src/renderer/components/chat/ChatMessages.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessages.tsx
@@ -113,6 +113,26 @@ function ScrollTopLoader({ hasMore, loading, onLoadMore }: ScrollTopLoaderProps)
   return null
 }
 
+// ===== 发送消息后自动滚动到底部 =====
+
+function AutoScrollOnUserSend({ messages }: { messages: ChatMessage[] }): null {
+  const { scrollToBottom } = useStickToBottomContext()
+  const prevLenRef = React.useRef(messages.length)
+
+  React.useEffect(() => {
+    const prevLen = prevLenRef.current
+    prevLenRef.current = messages.length
+    if (messages.length > prevLen) {
+      const last = messages[messages.length - 1]
+      if (last?.role === 'user') {
+        scrollToBottom()
+      }
+    }
+  }, [messages.length, messages, scrollToBottom])
+
+  return null
+}
+
 // ===== 主组件 =====
 
 interface ChatMessagesProps {
@@ -330,6 +350,7 @@ export function ChatMessages({
   return (
     <Conversation resize={ready && !transitioning ? 'smooth' : 'instant'} className={ready ? 'opacity-100 transition-opacity duration-200' : 'opacity-0'}>
       <ScrollPositionManager id={conversationId} ready={ready} />
+      <AutoScrollOnUserSend messages={messages} />
       {/* 滚动到顶部时自动加载更多历史 */}
       <ScrollTopLoader
         hasMore={hasMore}


### PR DESCRIPTION
## Overview

在长对话的中间位置发送消息时，Chat 和 Agent 模式都不会自动滚动到底部，用户需要手动滚动才能看到新的 AI 输出。这是因为 `use-stick-to-bottom` 库只在用户已经处于底部时才自动跟随，而 `handleSend` 中没有主动调用 `scrollToBottom()`。

## Changes

- `apps/electron/src/renderer/components/chat/ChatMessages.tsx` — 添加 `AutoScrollOnUserSend` 组件，监听 messages 数组变化，检测到新增用户消息时调用 `scrollToBottom()`
- `apps/electron/src/renderer/components/agent/AgentMessages.tsx` — 同上，为 Agent 模式添加相同的自动滚动逻辑

## How to Test

1. 打开一个有较多历史消息的 Chat 或 Agent 对话
2. 滚动到对话中间位置
3. 在输入框输入消息并发送
4. 验证视图自动滚动到底部，能立即看到 AI 的新输出
5. 验证正常在底部发送消息时行为不受影响

## Notes

- `AutoScrollOnUserSend` 只在最后一条新增消息是 `role === 'user'` 时触发滚动，避免与 assistant 回复的自动跟随冲突
- 组件放在 `<Conversation>` 内部，通过 `useStickToBottomContext()` 获取 `scrollToBottom`，无需修改父组件的 props 传递