### PR TITLE
feat(wechat): 微信 Bridge 支持用户发送图片/文件给 Agent【已审核 PR】

### DIFF
--- a/apps/electron/src/main/lib/bridge-attachment-utils.ts
+++ b/apps/electron/src/main/lib/bridge-attachment-utils.ts
@@ -1,0 +1,99 @@
+/**
+ * Bridge 附件处理工具函数
+ *
+ * 为微信、钉钉、飞书等 Bridge 提供图片/文件的保存、类型推断、
+ * 以及 <attached_files> XML 构建能力。
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { getAgentSessionWorkspacePath } from './config-paths'
+
+/** 图片大小警告阈值 */
+export const MAX_IMAGE_SIZE = 10 * 1024 * 1024
+
+/**
+ * 通过 magic bytes 推断图片 MIME 类型
+ */
+export function inferImageMediaType(buffer: Buffer): string {
+  if (buffer.length < 4) return 'image/jpeg'
+
+  // JPEG: FF D8 FF
+  if (buffer[0] === 0xFF && buffer[1] === 0xD8 && buffer[2] === 0xFF) return 'image/jpeg'
+  // PNG: 89 50 4E 47
+  if (buffer[0] === 0x89 && buffer[1] === 0x50 && buffer[2] === 0x4E && buffer[3] === 0x47) return 'image/png'
+  // GIF: 47 49 46 38
+  if (buffer[0] === 0x47 && buffer[1] === 0x49 && buffer[2] === 0x46 && buffer[3] === 0x38) return 'image/gif'
+  // WebP: 52 49 46 46 ... 57 45 42 50
+  if (buffer[0] === 0x52 && buffer[1] === 0x49 && buffer[2] === 0x46 && buffer[3] === 0x46 &&
+      buffer.length >= 12 && buffer[8] === 0x57 && buffer[9] === 0x45 && buffer[10] === 0x42 && buffer[11] === 0x50) {
+    return 'image/webp'
+  }
+
+  return 'image/jpeg'
+}
+
+/**
+ * MIME 类型 → 文件扩展名
+ */
+export function inferExtension(mediaType: string): string {
+  const sub = mediaType.split('/')[1]
+  if (sub === 'jpeg') return 'jpg'
+  return sub || 'jpg'
+}
+
+/**
+ * 保存图片到 Agent session 工作目录
+ *
+ * @returns 图片文件的绝对路径
+ */
+export function saveImageToSession(
+  workspaceSlug: string,
+  sessionId: string,
+  fileNameHint: string,
+  mediaType: string,
+  data: Buffer,
+): string {
+  const sessionDir = getAgentSessionWorkspacePath(workspaceSlug, sessionId)
+  const ext = inferExtension(mediaType)
+  const filename = `${fileNameHint}.${ext}`
+  const targetPath = join(sessionDir, filename)
+
+  mkdirSync(sessionDir, { recursive: true })
+  writeFileSync(targetPath, data)
+  console.log(`[Bridge 附件] 图片已保存: ${targetPath} (${data.length} bytes)`)
+
+  return targetPath
+}
+
+/**
+ * 保存文件到 Agent session 工作目录
+ *
+ * @returns 文件的绝对路径
+ */
+export function saveFileToSession(
+  workspaceSlug: string,
+  sessionId: string,
+  fileName: string,
+  data: Buffer,
+): string {
+  const sessionDir = getAgentSessionWorkspacePath(workspaceSlug, sessionId)
+  const targetPath = join(sessionDir, fileName)
+
+  mkdirSync(sessionDir, { recursive: true })
+  writeFileSync(targetPath, data)
+  console.log(`[Bridge 附件] 文件已保存: ${targetPath} (${data.length} bytes)`)
+
+  return targetPath
+}
+
+/**
+ * 构建 <attached_files> XML 块
+ *
+ * 返回空字符串表示无附件。
+ */
+export function buildAttachedFilesBlock(refs: Array<{ label: string; path: string }>): string {
+  if (refs.length === 0) return ''
+  const lines = refs.map(r => `- ${r.label}: ${r.path}`)
+  return `<attached_files>\n${lines.join('\n')}\n</attached_files>\n\n`
+}

--- a/apps/electron/src/main/lib/bridge-attachment-utils.ts
+++ b/apps/electron/src/main/lib/bridge-attachment-utils.ts
@@ -6,11 +6,22 @@
  */
 
 import { mkdirSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { join, resolve, basename } from 'node:path'
 import { getAgentSessionWorkspacePath } from './config-paths'
 
 /** 图片大小警告阈值 */
 export const MAX_IMAGE_SIZE = 10 * 1024 * 1024
+
+/** 允许的图片扩展名白名单 */
+const SAFE_IMAGE_EXTENSIONS: Record<string, string> = {
+  jpeg: 'jpg',
+  jpg: 'jpg',
+  png: 'png',
+  gif: 'gif',
+  webp: 'webp',
+  bmp: 'bmp',
+  svg: 'svg',
+}
 
 /**
  * 通过 magic bytes 推断图片 MIME 类型
@@ -34,12 +45,29 @@ export function inferImageMediaType(buffer: Buffer): string {
 }
 
 /**
- * MIME 类型 → 文件扩展名
+ * MIME 类型 → 文件扩展名（白名单，不识别的一律回退 jpg）
  */
 export function inferExtension(mediaType: string): string {
-  const sub = mediaType.split('/')[1]
-  if (sub === 'jpeg') return 'jpg'
-  return sub || 'jpg'
+  const sub = mediaType.split('/')[1]?.toLowerCase() ?? ''
+  return SAFE_IMAGE_EXTENSIONS[sub] ?? 'jpg'
+}
+
+/**
+ * 校验路径是否在目标目录内（防路径穿越）
+ */
+function ensurePathWithin(targetPath: string, parentDir: string): void {
+  const resolved = resolve(targetPath)
+  const resolvedParent = resolve(parentDir)
+  if (!resolved.startsWith(resolvedParent + '/') && resolved !== resolvedParent) {
+    throw new Error(`路径穿越: ${resolved} 超出 ${resolvedParent}`)
+  }
+}
+
+/**
+ * 清理文件名，移除路径分隔符和危险字符
+ */
+function sanitizeFileName(name: string): string {
+  return basename(name).replace(/[/\\:*?"<>|]/g, '_')
 }
 
 /**
@@ -56,8 +84,9 @@ export function saveImageToSession(
 ): string {
   const sessionDir = getAgentSessionWorkspacePath(workspaceSlug, sessionId)
   const ext = inferExtension(mediaType)
-  const filename = `${fileNameHint}.${ext}`
+  const filename = `${sanitizeFileName(fileNameHint)}.${ext}`
   const targetPath = join(sessionDir, filename)
+  ensurePathWithin(targetPath, sessionDir)
 
   mkdirSync(sessionDir, { recursive: true })
   writeFileSync(targetPath, data)
@@ -78,7 +107,8 @@ export function saveFileToSession(
   data: Buffer,
 ): string {
   const sessionDir = getAgentSessionWorkspacePath(workspaceSlug, sessionId)
-  const targetPath = join(sessionDir, fileName)
+  const targetPath = join(sessionDir, sanitizeFileName(fileName))
+  ensurePathWithin(targetPath, sessionDir)
 
   mkdirSync(sessionDir, { recursive: true })
   writeFileSync(targetPath, data)

--- a/apps/electron/src/main/lib/bridge-attachment-utils.ts
+++ b/apps/electron/src/main/lib/bridge-attachment-utils.ts
@@ -6,7 +6,7 @@
  */
 
 import { mkdirSync, writeFileSync } from 'node:fs'
-import { join, resolve, basename } from 'node:path'
+import { join, resolve, basename, relative } from 'node:path'
 import { getAgentSessionWorkspacePath } from './config-paths'
 
 /** 图片大小警告阈值 */
@@ -58,7 +58,8 @@ export function inferExtension(mediaType: string): string {
 function ensurePathWithin(targetPath: string, parentDir: string): void {
   const resolved = resolve(targetPath)
   const resolvedParent = resolve(parentDir)
-  if (!resolved.startsWith(resolvedParent + '/') && resolved !== resolvedParent) {
+  const rel = relative(resolvedParent, resolved)
+  if (rel.startsWith('..') || resolve(resolvedParent, rel) !== resolved) {
     throw new Error(`路径穿越: ${resolved} 超出 ${resolvedParent}`)
   }
 }

--- a/apps/electron/src/main/lib/bridge-command-handler.ts
+++ b/apps/electron/src/main/lib/bridge-command-handler.ts
@@ -19,6 +19,7 @@ import {
 import { runAgentHeadless, agentEventBus, stopAgent, isAgentSessionActive } from './agent-service'
 import { getSettings } from './settings-service'
 import { getAgentWorkspacePath } from './config-paths'
+import { buildAttachedFilesBlock } from './bridge-attachment-utils'
 import { readdirSync } from 'node:fs'
 
 // ===== 接口定义 =====
@@ -27,6 +28,16 @@ import { readdirSync } from 'node:fs'
 export interface BridgePlatformAdapter {
   /** 发送纯文本回复。meta 是平台专属的上下文数据（如微信的 contextToken） */
   sendText(chatId: string, text: string, meta?: unknown): Promise<void>
+}
+
+/** 已保存到磁盘的附件引用，由各 Bridge 预处理后传入 handler */
+export interface BridgeAttachment {
+  /** 附件绝对路径 */
+  absolutePath: string
+  /** 在 <attached_files> 中显示的标签 */
+  label: string
+  /** 附件类型，用于未来扩展路由（当前仅信息） */
+  kind: 'image' | 'file'
 }
 
 /** 命令处理器配置 */
@@ -95,12 +106,61 @@ export class BridgeCommandHandler {
   // ===== 公开 API =====
 
   /** 处理收到的消息（自动区分命令 vs 普通消息） */
-  async handleIncomingMessage(chatId: string, text: string, contextData?: unknown): Promise<void> {
+  async handleIncomingMessage(
+    chatId: string,
+    text: string,
+    contextData?: unknown,
+    attachments?: BridgeAttachment[],
+  ): Promise<void> {
     if (text.startsWith('/')) {
+      // 命令消息不携带附件（附件由 Bridge 缓冲，等普通消息触发）
       await this.handleCommand(chatId, text, contextData)
     } else {
-      await this.handleUserMessage(chatId, text, contextData)
+      await this.handleUserMessage(chatId, text, contextData, attachments)
     }
+  }
+
+  /**
+   * 获取或自动创建 chatId 对应的 binding
+   * 用于 Bridge 在保存图片/文件前预先拿到 sessionId 和 workspaceId
+   * 如果未配置 Agent 渠道，返回 null
+   */
+  ensureBinding(chatId: string): BridgeChatBinding | null {
+    const existing = this.chatBindings.get(chatId)
+    if (existing) return existing
+
+    const settings = getSettings()
+    const channelId = settings.agentChannelId
+    if (!channelId) return null
+
+    const workspaceId = this.config.getDefaultWorkspaceId?.() ?? settings.agentWorkspaceId ?? ''
+
+    const session = createAgentSession(
+      `${this.config.platformName}会话`,
+      channelId,
+      workspaceId || undefined,
+    )
+
+    const binding: BridgeChatBinding = {
+      chatId,
+      sessionId: session.id,
+      workspaceId,
+      channelId,
+      modelId: settings.agentModelId ?? undefined,
+      mode: 'agent',
+    }
+    this.chatBindings.set(chatId, binding)
+    this.sessionToChat.set(session.id, chatId)
+    this.log(`为 ${chatId.slice(0, 8)}... 创建会话: ${session.id.slice(0, 8)}`)
+    this.notifySessionCreated(session.id, session.title)
+    return binding
+  }
+
+  /** 检查指定 chatId 的 session 是否正在运行 */
+  isSessionActive(chatId: string): boolean {
+    const binding = this.chatBindings.get(chatId)
+    if (!binding) return false
+    return isAgentSessionActive(binding.sessionId)
   }
 
   /** 订阅 Agent EventBus（Bridge 连接建立后调用） */
@@ -485,7 +545,12 @@ export class BridgeCommandHandler {
 
   // ===== Agent 消息路由 =====
 
-  private async handleUserMessage(chatId: string, text: string, contextData?: unknown): Promise<void> {
+  private async handleUserMessage(
+    chatId: string,
+    text: string,
+    contextData?: unknown,
+    attachments?: BridgeAttachment[],
+  ): Promise<void> {
     const settings = getSettings()
     const channelId = settings.agentChannelId
     if (!channelId) {
@@ -495,29 +560,14 @@ export class BridgeCommandHandler {
 
     let binding = this.chatBindings.get(chatId)
 
-    // 自动创建会话
+    // 自动创建会话（复用 ensureBinding）
     if (!binding) {
-      const workspaceId = this.config.getDefaultWorkspaceId?.() ?? settings.agentWorkspaceId ?? ''
-
-      const session = createAgentSession(
-        `${this.config.platformName}会话`,
-        channelId,
-        workspaceId || undefined,
-      )
-
-      binding = {
-        chatId,
-        sessionId: session.id,
-        workspaceId,
-        channelId,
-        modelId: settings.agentModelId ?? undefined,
-        mode: 'agent',
+      const result = this.ensureBinding(chatId)
+      if (!result) {
+        await this.send(chatId, '请先在 Proma 设置中选择 Agent 渠道。', contextData)
+        return
       }
-      this.chatBindings.set(chatId, binding)
-      this.sessionToChat.set(session.id, chatId)
-      this.log(`为 ${chatId.slice(0, 8)}... 创建会话: ${session.id.slice(0, 8)}`)
-
-      this.notifySessionCreated(session.id, session.title)
+      binding = result
     }
 
     if (binding.mode !== 'agent') {
@@ -551,9 +601,16 @@ export class BridgeCommandHandler {
     const latestChannelId = latestSettings.agentChannelId || binding.channelId
     const modelId = latestSettings.agentModelId || binding.modelId
 
+    // 如果有附件，拼接 <attached_files> 块到用户消息前
+    const fileReferences = attachments?.length
+      ? buildAttachedFilesBlock(attachments.map(a => ({ label: a.label, path: a.absolutePath })))
+      : ''
+    const effectiveText = text.trim() || (attachments?.length ? '请查看上面附加的文件。' : '')
+    const userMessage = fileReferences + effectiveText
+
     const input = {
       sessionId: binding.sessionId,
-      userMessage: text,
+      userMessage,
       channelId: latestChannelId,
       modelId,
       workspaceId: binding.workspaceId,

--- a/apps/electron/src/main/lib/bridge-command-handler.ts
+++ b/apps/electron/src/main/lib/bridge-command-handler.ts
@@ -112,7 +112,7 @@ export class BridgeCommandHandler {
     contextData?: unknown,
     attachments?: BridgeAttachment[],
   ): Promise<void> {
-    if (text.startsWith('/')) {
+    if (text.trimStart().startsWith('/')) {
       // 命令消息不携带附件（附件由 Bridge 缓冲，等普通消息触发）
       await this.handleCommand(chatId, text, contextData)
     } else {

--- a/apps/electron/src/main/lib/wechat-bridge.ts
+++ b/apps/electron/src/main/lib/wechat-bridge.ts
@@ -20,7 +20,7 @@ import { WECHAT_IPC_CHANNELS, WECHAT_ITEM_TYPE, WECHAT_MESSAGE_TYPE, WECHAT_MESS
 import { getDecryptedCredentials, saveWeChatCredentials, clearWeChatCredentials, getWeChatConfig, updateWeChatDefaultWorkspace } from './wechat-config'
 import { getWeChatSyncPath } from './config-paths'
 import { BridgeCommandHandler, type BridgeAttachment } from './bridge-command-handler'
-import { inferImageMediaType, saveImageToSession, inferExtension, MAX_IMAGE_SIZE } from './bridge-attachment-utils'
+import { inferImageMediaType, saveImageToSession, saveFileToSession, inferExtension, MAX_IMAGE_SIZE } from './bridge-attachment-utils'
 import { getAgentWorkspace } from './agent-workspace-manager'
 import { readFileSync, writeFileSync, existsSync } from 'node:fs'
 import * as crypto from 'node:crypto'
@@ -37,9 +37,46 @@ const MAX_CONSECUTIVE_FAILURES = 5
 const INITIAL_BACKOFF_MS = 3_000
 const MAX_BACKOFF_MS = 60_000
 const SESSION_EXPIRED_CODE = -14
-const DOWNLOAD_IMAGE_TIMEOUT_MS = 30_000
+const DOWNLOAD_MEDIA_TIMEOUT_MS = 30_000
+const MAX_MEDIA_DOWNLOAD_SIZE = 20 * 1024 * 1024
+const MAX_FILE_SIZE = 20 * 1024 * 1024
 const HANDLE_MESSAGE_TIMEOUT_MS = 90_000
 const PENDING_IMAGES_CLEANUP_INTERVAL = 7 * 60 * 1000
+
+const ALLOWED_CDN_HOSTS = [
+  '.weixin.qq.com',
+  '.wechat.com',
+  '.qpic.cn',
+  '.qlogo.cn',
+]
+
+function isAllowedCdnUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url)
+    if (parsed.protocol !== 'https:') return false
+    return ALLOWED_CDN_HOSTS.some(suffix => parsed.hostname.endsWith(suffix))
+  } catch {
+    return false
+  }
+}
+
+async function fetchMediaWithSizeGuard(url: string, ac: AbortController, label: string): Promise<Buffer> {
+  const resp = await fetch(url, { signal: ac.signal })
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => '')
+    throw new Error(`${label} 失败: HTTP ${resp.status} ${body.slice(0, 200)}`)
+  }
+  const cl = resp.headers.get('content-length')
+  if (cl && parseInt(cl, 10) > MAX_MEDIA_DOWNLOAD_SIZE) {
+    ac.abort()
+    throw new Error(`${label} 中止: Content-Length ${cl} 超过 ${MAX_MEDIA_DOWNLOAD_SIZE} 限制`)
+  }
+  const buf = Buffer.from(await resp.arrayBuffer())
+  if (buf.length > MAX_MEDIA_DOWNLOAD_SIZE) {
+    throw new Error(`${label} 中止: 实际大小 ${buf.length} 超过 ${MAX_MEDIA_DOWNLOAD_SIZE} 限制`)
+  }
+  return buf
+}
 
 // ===== iLink API 响应类型 =====
 
@@ -93,7 +130,9 @@ function sleep(ms: number): Promise<void> {
  * 参考官方 SDK @tencent-weixin/openclaw-weixin：
  * - 图片场景：base64(raw 16 bytes)
  * - 文件/语音/视频：base64(32-char hex string)
- * 先 base64 解码，若长度为 16 则直接用；若为 32 字符 hex 则再解一层。
+ * - 备选：直接 32-char hex string（无 base64 外层）
+ *
+ * 依次尝试：base64→16B / base64→hex→16B / hex→16B
  */
 function parseAesKey(aesKeyBase64: string): Buffer {
   const decoded = Buffer.from(aesKeyBase64, 'base64')
@@ -101,7 +140,11 @@ function parseAesKey(aesKeyBase64: string): Buffer {
   if (decoded.length === 32 && /^[0-9a-fA-F]{32}$/.test(decoded.toString('ascii'))) {
     return Buffer.from(decoded.toString('ascii'), 'hex')
   }
-  throw new Error(`aes_key 解析失败：期望 16 字节或 32 字符 hex，实际 ${decoded.length} 字节`)
+  // 备选：输入本身就是 32-char hex（未经 base64 编码）
+  if (aesKeyBase64.length === 32 && /^[0-9a-fA-F]{32}$/.test(aesKeyBase64)) {
+    return Buffer.from(aesKeyBase64, 'hex')
+  }
+  throw new Error(`aes_key 解析失败：期望 16 字节或 32 字符 hex，实际 base64 解码后 ${decoded.length} 字节`)
 }
 
 function decryptAesEcbWithKey(ciphertext: Buffer, key: Buffer): Buffer {
@@ -190,20 +233,19 @@ class ILinkClient {
    * 1. 如果 image_item.url 存在，直接 fetch（部分图片服务端已解密）
    * 2. 否则通过 media.encrypt_query_param 构建 CDN URL，fetch 加密字节后用 AES-128-ECB 解密
    *
-   * aes_key 格式不确定，按 base64→16B / base64→hex→16B / hex→16B 依次尝试。
+   * aes_key 格式不确定，依次尝试 base64→16B / base64→hex→16B / hex→16B。
    */
   async downloadImage(item: WeChatMessageItem): Promise<Buffer> {
     const img = item.image_item
     if (!img) throw new Error('缺少 image_item')
 
-    // 路径 1: 直接使用 url
+    // 路径 1: 直接使用 url（须校验域名白名单）
     if (img.url) {
+      if (!isAllowedCdnUrl(img.url)) throw new Error(`图片 URL 域名不在白名单: ${img.url}`)
       const ac = new AbortController()
-      const t = setTimeout(() => ac.abort(), DOWNLOAD_IMAGE_TIMEOUT_MS)
+      const t = setTimeout(() => ac.abort(), DOWNLOAD_MEDIA_TIMEOUT_MS)
       try {
-        const resp = await fetch(img.url, { signal: ac.signal })
-        if (!resp.ok) throw new Error(`直连 url 失败: HTTP ${resp.status}`)
-        return Buffer.from(await resp.arrayBuffer())
+        return await fetchMediaWithSizeGuard(img.url, ac, '图片直连下载')
       } finally {
         clearTimeout(t)
       }
@@ -225,17 +267,48 @@ class ILinkClient {
 
     const cdnBaseUrl = 'https://novac2c.cdn.weixin.qq.com/c2c'
     const url = fullUrl ?? `${cdnBaseUrl}/download?encrypted_query_param=${encodeURIComponent(encryptQueryParam!)}`
+    if (!isAllowedCdnUrl(url)) throw new Error(`图片 CDN URL 域名不在白名单: ${url}`)
 
     const ac = new AbortController()
-    const t = setTimeout(() => ac.abort(), DOWNLOAD_IMAGE_TIMEOUT_MS)
+    const t = setTimeout(() => ac.abort(), DOWNLOAD_MEDIA_TIMEOUT_MS)
     let encrypted: Buffer
     try {
-      const resp = await fetch(url, { signal: ac.signal })
-      if (!resp.ok) {
-        const body = await resp.text().catch(() => '')
-        throw new Error(`CDN 下载失败: HTTP ${resp.status} ${body.slice(0, 200)}`)
-      }
-      encrypted = Buffer.from(await resp.arrayBuffer())
+      encrypted = await fetchMediaWithSizeGuard(url, ac, 'CDN 图片下载')
+    } finally {
+      clearTimeout(t)
+    }
+
+    if (!aesKeyBase64) return encrypted
+
+    const key = parseAesKey(aesKeyBase64)
+    return decryptAesEcbWithKey(encrypted, key)
+  }
+
+  /**
+   * 下载文件
+   *
+   * 通过 file_item.media 的 CDN 参数下载并 AES-128-ECB 解密。
+   */
+  async downloadFile(item: WeChatMessageItem): Promise<Buffer> {
+    const file = item.file_item
+    if (!file) throw new Error('缺少 file_item')
+    if (!file.media) throw new Error('file_item 缺少 media')
+
+    const encryptQueryParam = file.media.encrypt_query_param
+    const fullUrl = file.media.full_url
+    const aesKeyBase64 = file.media.aes_key
+
+    if (!encryptQueryParam && !fullUrl) throw new Error('缺少 encrypt_query_param 和 full_url')
+
+    const cdnBaseUrl = 'https://novac2c.cdn.weixin.qq.com/c2c'
+    const url = fullUrl ?? `${cdnBaseUrl}/download?encrypted_query_param=${encodeURIComponent(encryptQueryParam!)}`
+    if (!isAllowedCdnUrl(url)) throw new Error(`文件 CDN URL 域名不在白名单: ${url}`)
+
+    const ac = new AbortController()
+    const t = setTimeout(() => ac.abort(), DOWNLOAD_MEDIA_TIMEOUT_MS)
+    let encrypted: Buffer
+    try {
+      encrypted = await fetchMediaWithSizeGuard(url, ac, 'CDN 文件下载')
     } finally {
       clearTimeout(t)
     }
@@ -296,6 +369,12 @@ interface WeChatImageAttachment {
   mediaType: string
 }
 
+interface WeChatFileAttachment {
+  id: string
+  data: Buffer
+  fileName: string
+}
+
 class WeChatBridge {
   private client: ILinkClient | null = null
   private state: WeChatBridgeState = { status: 'disconnected' }
@@ -304,8 +383,10 @@ class WeChatBridge {
   private getUpdatesBuf = ''
   private polling = false
   private pendingImages = new Map<string, { images: WeChatImageAttachment[]; createdAt: number }>()
+  private pendingFiles = new Map<string, { files: WeChatFileAttachment[]; createdAt: number }>()
   private static readonly PENDING_IMAGES_TTL = 10 * 60 * 1000 // 10 minutes
   private static readonly PENDING_IMAGES_MAX = 15
+  private static readonly PENDING_FILES_MAX = 15
   private pendingImagesCleanupTimer: ReturnType<typeof setInterval> | null = null
 
   /** 通用命令处理器（命令路由 + Agent 消息路由 + EventBus 监听） */
@@ -400,6 +481,7 @@ class WeChatBridge {
       this.pendingImagesCleanupTimer = null
     }
     this.pendingImages.clear()
+    this.pendingFiles.clear()
     this.updateStatus({ status: 'disconnected', qrCodeData: undefined })
     console.log('[微信 Bridge] 已停止')
   }
@@ -585,6 +667,12 @@ class WeChatBridge {
         this.pendingImages.delete(chatId)
       }
     }
+    for (const [chatId, entry] of this.pendingFiles) {
+      if (now - entry.createdAt > WeChatBridge.PENDING_IMAGES_TTL) {
+        console.log(`[微信 Bridge] 清理过期文件缓冲: ${chatId.slice(0, 8)}... (${entry.files.length} 个)`)
+        this.pendingFiles.delete(chatId)
+      }
+    }
   }
 
   /** 处理收到的消息，委托给通用命令处理器 */
@@ -603,83 +691,149 @@ class WeChatBridge {
       (item) => item.type === WECHAT_ITEM_TYPE.IMAGE && item.image_item,
     )
 
+    const fileItems = msg.item_list.filter(
+      (item) => item.type === WECHAT_ITEM_TYPE.FILE && item.file_item,
+    )
+
     const chatId = msg.from_user_id
     const contextToken = msg.context_token
 
     // 纯粹的空消息
-    if (!text.trim() && imageItems.length === 0) return
+    if (!text.trim() && imageItems.length === 0 && fileItems.length === 0) return
 
     console.log('[微信 Bridge] 收到消息:', {
       from: chatId,
       messageId: msg.message_id,
       text: text.length > 100 ? text.slice(0, 100) + '...' : text,
       imageCount: imageItems.length,
+      fileCount: fileItems.length,
     })
 
     // 下载图片
-    const downloads: WeChatImageAttachment[] = []
+    const imageDownloads: WeChatImageAttachment[] = []
     const msgId = msg.message_id ?? `msg-${Date.now()}`
     for (let idx = 0; idx < imageItems.length; idx++) {
       try {
         const buf = await this.client.downloadImage(imageItems[idx]!)
         const mediaType = inferImageMediaType(buf)
         if (buf.length > MAX_IMAGE_SIZE) {
-          console.warn(`[微信 Bridge] 图片较大: ${(buf.length / 1024 / 1024).toFixed(1)}MB`)
+          console.warn(`[微信 Bridge] 图片超过大小限制: ${(buf.length / 1024 / 1024).toFixed(1)}MB`)
+          await this.client.sendText(chatId, `⚠️ 一张图片超过 ${MAX_IMAGE_SIZE / 1024 / 1024}MB 限制，已跳过`, contextToken)
+          continue
         }
-        downloads.push({ id: `${msgId}-${idx}`, data: buf, mediaType })
+        imageDownloads.push({ id: `${msgId}-img-${idx}`, data: buf, mediaType })
       } catch (error) {
         console.error('[微信 Bridge] 图片下载失败:', error)
         await this.client.sendText(chatId, '⚠️ 一张图片下载失败，已跳过', contextToken)
       }
     }
 
+    // 下载文件
+    const fileDownloads: WeChatFileAttachment[] = []
+    for (let idx = 0; idx < fileItems.length; idx++) {
+      const fileItem = fileItems[idx]!
+      const fileName = fileItem.file_item!.file_name || `file_${msgId}_${idx}`
+      // 预检文件大小（len 字段为字符串形式的字节数）
+      const declaredSize = fileItem.file_item!.len ? parseInt(fileItem.file_item!.len, 10) : 0
+      if (declaredSize > MAX_FILE_SIZE) {
+        console.warn(`[微信 Bridge] 文件超过大小限制: ${(declaredSize / 1024 / 1024).toFixed(1)}MB, 文件名: ${fileName}`)
+        await this.client.sendText(chatId, `⚠️ 文件「${fileName}」超过 20MB 限制，已跳过`, contextToken)
+        continue
+      }
+      try {
+        const buf = await this.client.downloadFile(fileItem)
+        if (buf.length > MAX_FILE_SIZE) {
+          console.warn(`[微信 Bridge] 文件实际大小超限: ${(buf.length / 1024 / 1024).toFixed(1)}MB, 文件名: ${fileName}`)
+          await this.client.sendText(chatId, `⚠️ 文件「${fileName}」超过 20MB 限制，已跳过`, contextToken)
+          continue
+        }
+        fileDownloads.push({ id: `${msgId}-file-${idx}`, data: buf, fileName })
+      } catch (error) {
+        console.error(`[微信 Bridge] 文件下载失败 (${fileName}):`, error)
+        await this.client.sendText(chatId, `⚠️ 文件「${fileName}」下载失败，已跳过`, contextToken)
+      }
+    }
+
+    const hasMedia = imageDownloads.length > 0 || fileDownloads.length > 0
+
     // 清理过期缓冲
     this.cleanExpiredPendingImages()
 
-    // 纯图片消息 → 缓冲，等待文字触发
-    if (!text.trim() && downloads.length > 0) {
-      const entry = this.pendingImages.get(chatId)
-      const existing = entry ? entry.images : []
-      const merged = [...existing, ...downloads].slice(-WeChatBridge.PENDING_IMAGES_MAX)
-      this.pendingImages.set(chatId, { images: merged, createdAt: entry?.createdAt ?? Date.now() })
+    // 纯媒体消息（无文字）→ 缓冲，等待文字触发
+    if (!text.trim() && hasMedia) {
+      // 缓冲图片
+      if (imageDownloads.length > 0) {
+        const entry = this.pendingImages.get(chatId)
+        const existing = entry ? entry.images : []
+        const merged = [...existing, ...imageDownloads].slice(-WeChatBridge.PENDING_IMAGES_MAX)
+        this.pendingImages.set(chatId, { images: merged, createdAt: entry?.createdAt ?? Date.now() })
+      }
+      // 缓冲文件
+      if (fileDownloads.length > 0) {
+        const entry = this.pendingFiles.get(chatId)
+        const existing = entry ? entry.files : []
+        const merged = [...existing, ...fileDownloads].slice(-WeChatBridge.PENDING_FILES_MAX)
+        this.pendingFiles.set(chatId, { files: merged, createdAt: entry?.createdAt ?? Date.now() })
+      }
+      const imgCount = (this.pendingImages.get(chatId)?.images.length ?? 0)
+      const fileCount = (this.pendingFiles.get(chatId)?.files.length ?? 0)
+      const parts: string[] = []
+      if (imgCount > 0) parts.push(`${imgCount} 张图片`)
+      if (fileCount > 0) parts.push(`${fileCount} 个文件`)
       await this.client.sendText(
         chatId,
-        `📎 已收到 ${merged.length} 张图片，请继续发送文字消息以触发处理。`,
+        `📎 已收到 ${parts.join('和 ')}，请继续发送文字消息以触发处理。`,
         contextToken,
       )
       return
     }
 
-    // 文字消息（可能携带或触发缓冲的图片）
+    // 文字消息（可能携带或触发缓冲的媒体）
     if (!text.trim()) return
 
     // 合并缓冲图片
-    const pendingEntry = this.pendingImages.get(chatId)
-    const pending = pendingEntry ? pendingEntry.images : []
-    const allImages = [...pending, ...downloads]
+    const pendingImgEntry = this.pendingImages.get(chatId)
+    const pendingImgs = pendingImgEntry ? pendingImgEntry.images : []
+    const allImages = [...pendingImgs, ...imageDownloads]
     this.pendingImages.delete(chatId)
 
-    // 无图片 → 原有纯文本路径
-    if (allImages.length === 0) {
+    // 合并缓冲文件
+    const pendingFileEntry = this.pendingFiles.get(chatId)
+    const pendingFls = pendingFileEntry ? pendingFileEntry.files : []
+    const allFiles = [...pendingFls, ...fileDownloads]
+    this.pendingFiles.delete(chatId)
+
+    // 无媒体 → 原有纯文本路径
+    if (allImages.length === 0 && allFiles.length === 0) {
       await this.commandHandler.handleIncomingMessage(chatId, text, { contextToken })
       return
     }
 
-    // 命令消息携带图片（极少见）：把图片放回缓冲，仅处理命令
-    if (text.startsWith('/')) {
-      this.pendingImages.set(chatId, { images: allImages, createdAt: Date.now() })
+    // 命令消息携带媒体（极少见）：把媒体放回缓冲，仅处理命令
+    if (text.trimStart().startsWith('/')) {
+      if (allImages.length > 0) {
+        this.pendingImages.set(chatId, { images: allImages, createdAt: Date.now() })
+      }
+      if (allFiles.length > 0) {
+        this.pendingFiles.set(chatId, { files: allFiles, createdAt: Date.now() })
+      }
       await this.commandHandler.handleIncomingMessage(chatId, text, { contextToken })
       return
     }
 
-    // 有图片：先检查 session 是否正在运行，避免保存图片后消息被拦截
+    // 有媒体：先检查 session 是否正在运行
     if (this.commandHandler.isSessionActive(chatId)) {
-      this.pendingImages.set(chatId, { images: allImages, createdAt: Date.now() })
-      await this.client.sendText(chatId, '❌ 上一条消息仍在处理中，图片已暂存，请稍候再试', contextToken)
+      if (allImages.length > 0) {
+        this.pendingImages.set(chatId, { images: allImages, createdAt: Date.now() })
+      }
+      if (allFiles.length > 0) {
+        this.pendingFiles.set(chatId, { files: allFiles, createdAt: Date.now() })
+      }
+      await this.client.sendText(chatId, '❌ 上一条消息仍在处理中，附件已暂存，请稍候再试', contextToken)
       return
     }
 
-    // 确保 binding 存在，保存图片到会话目录
+    // 确保 binding 存在，保存媒体到会话目录
     const binding = this.commandHandler.ensureBinding(chatId)
     if (!binding) {
       await this.client.sendText(chatId, '请先在 Proma 设置中选择 Agent 渠道。', contextToken)
@@ -687,11 +841,14 @@ class WeChatBridge {
     }
     const workspace = binding.workspaceId ? getAgentWorkspace(binding.workspaceId) : undefined
     if (!workspace) {
-      await this.client.sendText(chatId, '⚠️ 当前未设置工作区，无法保存图片', contextToken)
+      await this.client.sendText(chatId, '⚠️ 当前未设置工作区，无法保存附件', contextToken)
       return
     }
 
-    const attachments: BridgeAttachment[] = allImages.map((img) => {
+    const attachments: BridgeAttachment[] = []
+
+    // 保存图片
+    for (const img of allImages) {
       const hint = `wechat-${img.id}`
       const absolutePath = saveImageToSession(
         workspace.slug,
@@ -700,10 +857,20 @@ class WeChatBridge {
         img.mediaType,
         img.data,
       )
-      // label 必须带扩展名，Proma 渲染器据此识别图片类型以显示预览
       const label = `${hint}.${inferExtension(img.mediaType)}`
-      return { absolutePath, label, kind: 'image' as const }
-    })
+      attachments.push({ absolutePath, label, kind: 'image' as const })
+    }
+
+    // 保存文件
+    for (const file of allFiles) {
+      const absolutePath = saveFileToSession(
+        workspace.slug,
+        binding.sessionId,
+        file.fileName,
+        file.data,
+      )
+      attachments.push({ absolutePath, label: file.fileName, kind: 'file' as const })
+    }
 
     await this.commandHandler.handleIncomingMessage(chatId, text, { contextToken }, attachments)
   }

--- a/apps/electron/src/main/lib/wechat-bridge.ts
+++ b/apps/electron/src/main/lib/wechat-bridge.ts
@@ -19,7 +19,9 @@ import type {
 import { WECHAT_IPC_CHANNELS, WECHAT_ITEM_TYPE, WECHAT_MESSAGE_TYPE, WECHAT_MESSAGE_STATE } from '@proma/shared'
 import { getDecryptedCredentials, saveWeChatCredentials, clearWeChatCredentials, getWeChatConfig, updateWeChatDefaultWorkspace } from './wechat-config'
 import { getWeChatSyncPath } from './config-paths'
-import { BridgeCommandHandler } from './bridge-command-handler'
+import { BridgeCommandHandler, type BridgeAttachment } from './bridge-command-handler'
+import { inferImageMediaType, saveImageToSession, inferExtension, MAX_IMAGE_SIZE } from './bridge-attachment-utils'
+import { getAgentWorkspace } from './agent-workspace-manager'
 import { readFileSync, writeFileSync, existsSync } from 'node:fs'
 import * as crypto from 'node:crypto'
 import QRCode from 'qrcode'
@@ -35,6 +37,9 @@ const MAX_CONSECUTIVE_FAILURES = 5
 const INITIAL_BACKOFF_MS = 3_000
 const MAX_BACKOFF_MS = 60_000
 const SESSION_EXPIRED_CODE = -14
+const DOWNLOAD_IMAGE_TIMEOUT_MS = 30_000
+const HANDLE_MESSAGE_TIMEOUT_MS = 90_000
+const PENDING_IMAGES_CLEANUP_INTERVAL = 7 * 60 * 1000
 
 // ===== iLink API 响应类型 =====
 
@@ -80,6 +85,32 @@ function generateWechatUIN(): string {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * 解析 iLink aes_key 为 16 字节原始 AES key
+ *
+ * 参考官方 SDK @tencent-weixin/openclaw-weixin：
+ * - 图片场景：base64(raw 16 bytes)
+ * - 文件/语音/视频：base64(32-char hex string)
+ * 先 base64 解码，若长度为 16 则直接用；若为 32 字符 hex 则再解一层。
+ */
+function parseAesKey(aesKeyBase64: string): Buffer {
+  const decoded = Buffer.from(aesKeyBase64, 'base64')
+  if (decoded.length === 16) return decoded
+  if (decoded.length === 32 && /^[0-9a-fA-F]{32}$/.test(decoded.toString('ascii'))) {
+    return Buffer.from(decoded.toString('ascii'), 'hex')
+  }
+  throw new Error(`aes_key 解析失败：期望 16 字节或 32 字符 hex，实际 ${decoded.length} 字节`)
+}
+
+function decryptAesEcbWithKey(ciphertext: Buffer, key: Buffer): Buffer {
+  if (ciphertext.length === 0 || ciphertext.length % 16 !== 0) {
+    throw new Error(`AES-ECB 密文长度非法: ${ciphertext.length}`)
+  }
+  const decipher = crypto.createDecipheriv('aes-128-ecb', key, null)
+  decipher.setAutoPadding(true)
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()])
 }
 
 // ===== iLink HTTP 客户端 =====
@@ -152,6 +183,69 @@ class ILinkClient {
     }, 10_000)
   }
 
+  /**
+   * 下载图片
+   *
+   * 策略：
+   * 1. 如果 image_item.url 存在，直接 fetch（部分图片服务端已解密）
+   * 2. 否则通过 media.encrypt_query_param 构建 CDN URL，fetch 加密字节后用 AES-128-ECB 解密
+   *
+   * aes_key 格式不确定，按 base64→16B / base64→hex→16B / hex→16B 依次尝试。
+   */
+  async downloadImage(item: WeChatMessageItem): Promise<Buffer> {
+    const img = item.image_item
+    if (!img) throw new Error('缺少 image_item')
+
+    // 路径 1: 直接使用 url
+    if (img.url) {
+      const ac = new AbortController()
+      const t = setTimeout(() => ac.abort(), DOWNLOAD_IMAGE_TIMEOUT_MS)
+      try {
+        const resp = await fetch(img.url, { signal: ac.signal })
+        if (!resp.ok) throw new Error(`直连 url 失败: HTTP ${resp.status}`)
+        return Buffer.from(await resp.arrayBuffer())
+      } finally {
+        clearTimeout(t)
+      }
+    }
+
+    if (!img.media) throw new Error('image_item 既无 url 也无 media')
+    const encryptQueryParam = img.media.encrypt_query_param
+    const fullUrl = img.media.full_url
+
+    // aeskey: image_item.aeskey (hex) 或 media.aes_key (base64)
+    let aesKeyBase64: string | undefined
+    if (img.aeskey) {
+      aesKeyBase64 = Buffer.from(img.aeskey, 'hex').toString('base64')
+    } else if (img.media.aes_key) {
+      aesKeyBase64 = img.media.aes_key
+    }
+
+    if (!encryptQueryParam && !fullUrl) throw new Error('缺少 encrypt_query_param 和 full_url')
+
+    const cdnBaseUrl = 'https://novac2c.cdn.weixin.qq.com/c2c'
+    const url = fullUrl ?? `${cdnBaseUrl}/download?encrypted_query_param=${encodeURIComponent(encryptQueryParam!)}`
+
+    const ac = new AbortController()
+    const t = setTimeout(() => ac.abort(), DOWNLOAD_IMAGE_TIMEOUT_MS)
+    let encrypted: Buffer
+    try {
+      const resp = await fetch(url, { signal: ac.signal })
+      if (!resp.ok) {
+        const body = await resp.text().catch(() => '')
+        throw new Error(`CDN 下载失败: HTTP ${resp.status} ${body.slice(0, 200)}`)
+      }
+      encrypted = Buffer.from(await resp.arrayBuffer())
+    } finally {
+      clearTimeout(t)
+    }
+
+    if (!aesKeyBase64) return encrypted
+
+    const key = parseAesKey(aesKeyBase64)
+    return decryptAesEcbWithKey(encrypted, key)
+  }
+
   private async post<T>(path: string, body: unknown, timeoutMs: number, signal?: AbortSignal): Promise<T> {
     const controller = new AbortController()
     const timeout = setTimeout(() => controller.abort(), timeoutMs)
@@ -196,6 +290,12 @@ class ILinkClient {
 
 // ===== 单例 Bridge =====
 
+interface WeChatImageAttachment {
+  id: string
+  data: Buffer
+  mediaType: string
+}
+
 class WeChatBridge {
   private client: ILinkClient | null = null
   private state: WeChatBridgeState = { status: 'disconnected' }
@@ -203,6 +303,10 @@ class WeChatBridge {
   private loginAbortController: AbortController | null = null
   private getUpdatesBuf = ''
   private polling = false
+  private pendingImages = new Map<string, { images: WeChatImageAttachment[]; createdAt: number }>()
+  private static readonly PENDING_IMAGES_TTL = 10 * 60 * 1000 // 10 minutes
+  private static readonly PENDING_IMAGES_MAX = 15
+  private pendingImagesCleanupTimer: ReturnType<typeof setInterval> | null = null
 
   /** 通用命令处理器（命令路由 + Agent 消息路由 + EventBus 监听） */
   private commandHandler = new BridgeCommandHandler({
@@ -291,6 +395,11 @@ class WeChatBridge {
     this.client = null
     this.polling = false
     this.commandHandler.unsubscribe()
+    if (this.pendingImagesCleanupTimer) {
+      clearInterval(this.pendingImagesCleanupTimer)
+      this.pendingImagesCleanupTimer = null
+    }
+    this.pendingImages.clear()
     this.updateStatus({ status: 'disconnected', qrCodeData: undefined })
     console.log('[微信 Bridge] 已停止')
   }
@@ -384,6 +493,9 @@ class WeChatBridge {
     // 订阅 Agent EventBus 接收 Agent 回复
     this.commandHandler.subscribe()
 
+    // 定期清理过期的图片缓冲
+    this.pendingImagesCleanupTimer = setInterval(() => this.cleanExpiredPendingImages(), PENDING_IMAGES_CLEANUP_INTERVAL)
+
     this.updateStatus({ status: 'connected', connectedAt: Date.now(), qrCodeData: undefined })
     console.log('[微信 Bridge] 长轮询已启动')
 
@@ -433,9 +545,21 @@ class WeChatBridge {
           this.saveSyncBuf()
         }
 
-        // 处理消息
+        // 处理消息（串行避免同一 chatId 并发创建 session，单条超时保护）
         for (const msg of resp.msgs) {
-          this.handleMessage(msg)
+          let timeoutId: ReturnType<typeof setTimeout> | undefined
+          try {
+            await Promise.race([
+              this.handleMessage(msg),
+              new Promise<never>((_, reject) => {
+                timeoutId = setTimeout(() => reject(new Error('handleMessage 超时')), HANDLE_MESSAGE_TIMEOUT_MS)
+              }),
+            ])
+          } catch (error) {
+            console.error('[微信 Bridge] 处理消息失败:', error)
+          } finally {
+            if (timeoutId) clearTimeout(timeoutId)
+          }
         }
       } catch (error) {
         if (signal.aborted) return
@@ -453,33 +577,135 @@ class WeChatBridge {
     }
   }
 
+  private cleanExpiredPendingImages(): void {
+    const now = Date.now()
+    for (const [chatId, entry] of this.pendingImages) {
+      if (now - entry.createdAt > WeChatBridge.PENDING_IMAGES_TTL) {
+        console.log(`[微信 Bridge] 清理过期图片缓冲: ${chatId.slice(0, 8)}... (${entry.images.length} 张)`)
+        this.pendingImages.delete(chatId)
+      }
+    }
+  }
+
   /** 处理收到的消息，委托给通用命令处理器 */
-  private handleMessage(msg: WeChatIncomingMessage): void {
+  private async handleMessage(msg: WeChatIncomingMessage): Promise<void> {
     // 只处理已完成的用户消息
     if (msg.message_type !== WECHAT_MESSAGE_TYPE.USER) return
     if (msg.message_state !== WECHAT_MESSAGE_STATE.FINISH) return
+    if (!this.client) return
 
     const text = msg.item_list
       .filter((item) => item.type === WECHAT_ITEM_TYPE.TEXT && item.text_item)
       .map((item) => item.text_item!.text)
       .join('')
 
-    if (!text.trim()) return
+    const imageItems = msg.item_list.filter(
+      (item) => item.type === WECHAT_ITEM_TYPE.IMAGE && item.image_item,
+    )
+
+    const chatId = msg.from_user_id
+    const contextToken = msg.context_token
+
+    // 纯粹的空消息
+    if (!text.trim() && imageItems.length === 0) return
 
     console.log('[微信 Bridge] 收到消息:', {
-      from: msg.from_user_id,
+      from: chatId,
       messageId: msg.message_id,
       text: text.length > 100 ? text.slice(0, 100) + '...' : text,
+      imageCount: imageItems.length,
     })
 
-    // 委托给通用命令处理器（自动区分 / 命令 vs 普通消息）
-    this.commandHandler.handleIncomingMessage(
-      msg.from_user_id,
-      text,
-      { contextToken: msg.context_token },
-    ).catch((error) => {
-      console.error('[微信 Bridge] 处理消息失败:', error)
+    // 下载图片
+    const downloads: WeChatImageAttachment[] = []
+    const msgId = msg.message_id ?? `msg-${Date.now()}`
+    for (let idx = 0; idx < imageItems.length; idx++) {
+      try {
+        const buf = await this.client.downloadImage(imageItems[idx]!)
+        const mediaType = inferImageMediaType(buf)
+        if (buf.length > MAX_IMAGE_SIZE) {
+          console.warn(`[微信 Bridge] 图片较大: ${(buf.length / 1024 / 1024).toFixed(1)}MB`)
+        }
+        downloads.push({ id: `${msgId}-${idx}`, data: buf, mediaType })
+      } catch (error) {
+        console.error('[微信 Bridge] 图片下载失败:', error)
+        await this.client.sendText(chatId, '⚠️ 一张图片下载失败，已跳过', contextToken)
+      }
+    }
+
+    // 清理过期缓冲
+    this.cleanExpiredPendingImages()
+
+    // 纯图片消息 → 缓冲，等待文字触发
+    if (!text.trim() && downloads.length > 0) {
+      const entry = this.pendingImages.get(chatId)
+      const existing = entry ? entry.images : []
+      const merged = [...existing, ...downloads].slice(-WeChatBridge.PENDING_IMAGES_MAX)
+      this.pendingImages.set(chatId, { images: merged, createdAt: entry?.createdAt ?? Date.now() })
+      await this.client.sendText(
+        chatId,
+        `📎 已收到 ${merged.length} 张图片，请继续发送文字消息以触发处理。`,
+        contextToken,
+      )
+      return
+    }
+
+    // 文字消息（可能携带或触发缓冲的图片）
+    if (!text.trim()) return
+
+    // 合并缓冲图片
+    const pendingEntry = this.pendingImages.get(chatId)
+    const pending = pendingEntry ? pendingEntry.images : []
+    const allImages = [...pending, ...downloads]
+    this.pendingImages.delete(chatId)
+
+    // 无图片 → 原有纯文本路径
+    if (allImages.length === 0) {
+      await this.commandHandler.handleIncomingMessage(chatId, text, { contextToken })
+      return
+    }
+
+    // 命令消息携带图片（极少见）：把图片放回缓冲，仅处理命令
+    if (text.startsWith('/')) {
+      this.pendingImages.set(chatId, { images: allImages, createdAt: Date.now() })
+      await this.commandHandler.handleIncomingMessage(chatId, text, { contextToken })
+      return
+    }
+
+    // 有图片：先检查 session 是否正在运行，避免保存图片后消息被拦截
+    if (this.commandHandler.isSessionActive(chatId)) {
+      this.pendingImages.set(chatId, { images: allImages, createdAt: Date.now() })
+      await this.client.sendText(chatId, '❌ 上一条消息仍在处理中，图片已暂存，请稍候再试', contextToken)
+      return
+    }
+
+    // 确保 binding 存在，保存图片到会话目录
+    const binding = this.commandHandler.ensureBinding(chatId)
+    if (!binding) {
+      await this.client.sendText(chatId, '请先在 Proma 设置中选择 Agent 渠道。', contextToken)
+      return
+    }
+    const workspace = binding.workspaceId ? getAgentWorkspace(binding.workspaceId) : undefined
+    if (!workspace) {
+      await this.client.sendText(chatId, '⚠️ 当前未设置工作区，无法保存图片', contextToken)
+      return
+    }
+
+    const attachments: BridgeAttachment[] = allImages.map((img) => {
+      const hint = `wechat-${img.id}`
+      const absolutePath = saveImageToSession(
+        workspace.slug,
+        binding.sessionId,
+        hint,
+        img.mediaType,
+        img.data,
+      )
+      // label 必须带扩展名，Proma 渲染器据此识别图片类型以显示预览
+      const label = `${hint}.${inferExtension(img.mediaType)}`
+      return { absolutePath, label, kind: 'image' as const }
     })
+
+    await this.commandHandler.handleIncomingMessage(chatId, text, { contextToken }, attachments)
   }
 
   // ===== 同步游标持久化 =====

--- a/packages/shared/src/types/wechat.ts
+++ b/packages/shared/src/types/wechat.ts
@@ -81,7 +81,7 @@ export const WECHAT_MESSAGE_STATE = {
 export interface WeChatMessageItem {
   type: number
   text_item?: { text: string }
-  image_item?: { url?: string; media?: WeChatMediaInfo }
+  image_item?: { url?: string; aeskey?: string; media?: WeChatMediaInfo }
   voice_item?: { media?: WeChatMediaInfo; text?: string; playtime?: number }
   file_item?: { media?: WeChatMediaInfo; file_name?: string; len?: string }
   video_item?: { media?: WeChatMediaInfo; video_size?: number }
@@ -92,6 +92,7 @@ export interface WeChatMediaInfo {
   encrypt_query_param: string
   aes_key: string
   encrypt_type: number
+  full_url?: string
 }
 
 /** iLink 收到的微信消息 */


### PR DESCRIPTION
## Overview

让微信 Bridge 支持接收**图片和文件消息**。媒体从 iLink CDN 下载并用 AES-128-ECB 解密后保存到 Agent session 工作目录，以 `<attached_files>` 格式拼接到用户消息前传递给 Agent，使 Agent 能够"看到"用户发送的图片和文件。

采用「缓冲媒体 → 等待文字触发」的模式，贴合微信用户先发图/文件再打字的使用习惯。

## Changes

- **`apps/electron/src/main/lib/bridge-attachment-utils.ts`** (新文件) — 图片 magic bytes 推断 MIME 类型、保存图片/文件到 session 目录、构建 `<attached_files>` XML 块、路径穿越防护
- **`apps/electron/src/main/lib/bridge-command-handler.ts`** — 新增 `BridgeAttachment` 接口（`kind: 'image' | 'file'`）；提取 `ensureBinding()` / `isSessionActive()` 为公开方法；`handleIncomingMessage` 和 `handleUserMessage` 支持 `attachments` 参数；附件自动拼接到 `userMessage`
- **`apps/electron/src/main/lib/wechat-bridge.ts`** — 核心改动：
  - `ILinkClient.downloadImage()` — 图片下载 + AES-128-ECB 解密（支持直连 URL 和 CDN 加密两条路径）
  - `ILinkClient.downloadFile()` — 文件下载 + AES-128-ECB 解密，复用与图片相同的 CDN 管道
  - CDN 域名白名单校验（`isAllowedCdnUrl()`），防止 SSRF
  - `fetchMediaWithSizeGuard()` — 统一下载函数，Content-Length 预检 + 实际大小兜底，20MB 硬限制
  - 图片缓冲机制 + 文件缓冲机制（纯媒体消息暂存，文字消息触发合并处理）
  - 文件大小预检：下载前通过 `file_item.len` 字段校验，超限直接拒绝
  - fetch 30s 超时保护；`handleMessage` 90s 总超时防阻塞；7 分钟定时清理过期缓冲
  - `handleMessage` 串行 await 避免并发创建 session
- **`packages/shared/src/types/wechat.ts`** — `WeChatMessageItem.image_item` 补充 `aeskey?: string`；`WeChatMediaInfo` 补充 `full_url?: string`

## 安全加固

- **CDN 域名白名单**：所有下载 URL 必须匹配 `.weixin.qq.com` / `.wechat.com` / `.qpic.cn` / `.qlogo.cn`，且强制 HTTPS
- **下载大小限制**：Content-Length 预检 + 实际 Buffer 大小双重校验，上限 20MB
- **文件名清理**：`sanitizeFileName()` 移除路径分隔符和危险字符
- **路径穿越防护**：`ensurePathWithin()` 校验保存路径不超出 session 目录
- **AES key 解析**：兼容 base64(raw 16B) / base64(hex 32B) / hex 32B 三种格式

## How to Test

1. 启动微信 Bridge，扫码登录
2. 从微信发送一张图片（不带文字）→ 应收到「📎 已收到 1 张图片，请继续发送文字消息以触发处理」
3. 发送文字消息 → Agent 应收到带 `<attached_files>` 的消息，图片文件保存在 session 目录
4. 同时发送图片 + 文字 → 图片和文字应一并处理
5. 从微信发送一个文件（如 PDF、Word）→ 应收到「📎 已收到 1 个文件，请继续发送文字消息以触发处理」
6. 发送文字消息 → Agent 应收到带 `<attached_files>` 的消息，文件保存在 session 目录
7. 发送超过 20MB 的文件 → 应收到「⚠️ 文件「xxx」超过 20MB 限制，已跳过」
8. 混合发送图片 + 文件 + 文字 → 所有附件应一并处理
9. 发送 `/status` 命令 → 命令正常执行，媒体不丢失（放回缓冲）
10. 验证超时：模拟慢网络下不会永久阻塞后续消息

## Notes

- `bun.lock` 变更为 bun 版本升级产物（`configVersion: 0`），无功能影响
- AES key 解析兼容官方 SDK 的三种格式：base64(raw 16B)、base64(hex 32B)、hex 32B
- 图片缓冲上限 15 张 / 文件缓冲上限 15 个 / TTL 10 分钟，超限静默丢弃最早的条目
- 文件类型不做限制，任何微信可发的文件类型都接受（Agent 处理能力取决于 Agent 自身）