### PR TITLE
fix(feishu): 飞书图片附件缺少扩展名导致无法显示缩略图 【已审核 PR】

### DIFF
--- a/apps/electron/src/main/lib/feishu-bridge.ts
+++ b/apps/electron/src/main/lib/feishu-bridge.ts
@@ -1143,7 +1143,8 @@ class FeishuBridge {
         const savedPath = this.saveImageToSession(
           workspace.slug, binding.sessionId, img.imageKey, img.mediaType, img.data,
         )
-        attachedRefs.push(`- feishu-${img.imageKey}: ${savedPath}`)
+        const imgExt = img.mediaType.split('/')[1] || 'jpg'
+        attachedRefs.push(`- feishu-${img.imageKey}.${imgExt}: ${savedPath}`)
       }
       for (const file of fileAttachments) {
         const savedPath = this.saveFileToSession(


### PR DESCRIPTION
## Overview

飞书发送图片到 Proma 后，图片在 Agent 消息中只显示为普通附件图标，无法显示缩略图预览。原因是 `feishu-bridge.ts` 构建 `<attached_files>` 引用时，标签名缺少文件扩展名，导致渲染器的 `isImageFile()` 判断失败。

## Changes

- `apps/electron/src/main/lib/feishu-bridge.ts` — 在构建 `attachedRefs` 时，从 `img.mediaType`（如 `image/jpeg`）提取扩展名，追加到标签名末尾（如 `feishu-img_xxx.jpeg`），使渲染器能正确识别图片类型并展示缩略图

## How to Test

1. 在飞书上给绑定了 Proma 的机器人发送一张图片
2. 在 Proma Agent 会话中查看该消息
3. 确认图片显示为缩略图预览，而非普通附件图标
4. 测试不同格式的图片（PNG、JPEG、GIF 等），确认扩展名正确

## Notes

- 已有的历史飞书消息中图片仍会显示为附件（存量 JSONL 数据未修改）
- 该逻辑与 `saveImageToSession()` 中提取扩展名的方式完全一致，保证标签名和文件名的扩展名一致