### PR TITLE
fix(electron): dev 使用独立 userData 目录，避免与正式版冲突

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -1,6 +1,19 @@
 import { app, BrowserWindow, Menu, screen, shell } from 'electron'
 import { join } from 'path'
 import { existsSync } from 'fs'
+
+// Dev 与正式版使用独立的 userData 目录，避免共享 Chromium SingletonLock 导致 dev 启动被静默退出
+// 必须在任何会读取 userData 路径的模块加载之前执行
+if (!app.isPackaged) {
+  app.setPath('userData', join(app.getPath('appData'), '@proma/electron-dev'))
+}
+
+// 单实例锁：防止重复启动同一个版本（dev/prod 因 userData 已隔离，互不影响）
+if (!app.requestSingleInstanceLock()) {
+  app.quit()
+  process.exit(0)
+}
+
 import { getSettings } from './lib/settings-service'
 
 // 处理 EPIPE 错误：当 stdout/stderr 管道被关闭时（如 electronmon 重启），忽略写入错误


### PR DESCRIPTION
## Summary

- 本地安装的正式版 Proma 和 dev 版共享同一个 Electron userData 路径 (`@proma/electron`)，Chromium 的 `SingletonLock` 文件锁会被先启动的一方占用，后启动的进程（通常是 dev）直接静默退出，没有任何错误输出
- 在 `apps/electron/src/main/index.ts` 最顶端（任何会读取 userData 的模块 import 之前）做两件事：
  - 非 packaged 环境下把 userData 重定向到 `@proma/electron-dev`
  - 显式加上 `requestSingleInstanceLock`，防止同一个版本被重复启动
- Proma 业务配置在 `~/.proma-dev/`，和 userData 无关，这次变更不影响业务数据；dev 会失去此前在 userData 里的 cookies / 窗口状态（需要重新登录渠道）

## Test plan

- [x] `tsc --noEmit` 通过
- [x] `esbuild` 打包 `dist/main.cjs` 成功
- [x] 正式版 Proma 运行中时，`bun run dev` 能正常启动，不再静默退出
- [x] 确认 `~/Library/Application Support/@proma/electron-dev/` 目录被创建，`--user-data-dir` 参数指向该新路径
- [ ] CI 绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)