### PR TITLE
refactor(feishu): 复用 bridge-attachment-utils，移除重复的附件保存逻辑

### DIFF
--- a/apps/electron/src/main/lib/feishu-bridge.ts
+++ b/apps/electron/src/main/lib/feishu-bridge.ts
@@ -35,9 +35,14 @@ import {
   getAgentWorkspace,
   getWorkspaceCapabilities,
 } from './agent-workspace-manager'
-import { getAgentSessionWorkspacePath, getFeishuBotBindingsPath } from './config-paths'
-import { mkdirSync, writeFileSync, readFileSync, existsSync, readdirSync } from 'node:fs'
-import { join } from 'node:path'
+import { getFeishuBotBindingsPath } from './config-paths'
+import { writeFileSync, readFileSync, existsSync, readdirSync } from 'node:fs'
+import {
+  inferImageMediaType as inferImageMediaTypeShared,
+  saveImageToSession as saveImageToSessionShared,
+  saveFileToSession as saveFileToSessionShared,
+  inferExtension,
+} from './bridge-attachment-utils'
 import { getSettings } from './settings-service'
 import { presenceService } from './feishu-presence'
 import {
@@ -437,70 +442,6 @@ class FeishuBridge {
     return Buffer.concat(chunks)
   }
 
-  /**
-   * 保存文件到 Agent session 工作目录
-   */
-  private saveFileToSession(
-    workspaceSlug: string,
-    sessionId: string,
-    fileName: string,
-    data: Buffer,
-  ): string {
-    const sessionDir = getAgentSessionWorkspacePath(workspaceSlug, sessionId)
-    const targetPath = join(sessionDir, fileName)
-
-    mkdirSync(sessionDir, { recursive: true })
-    writeFileSync(targetPath, data)
-    console.log(`[飞书 Bridge] 文件已保存: ${targetPath} (${data.length} bytes)`)
-
-    return targetPath
-  }
-
-  /**
-   * 通过 magic bytes 推断图片 MIME 类型
-   */
-  private inferImageMediaType(buffer: Buffer): string {
-    if (buffer.length < 4) return 'image/jpeg'
-
-    // JPEG: FF D8 FF
-    if (buffer[0] === 0xFF && buffer[1] === 0xD8 && buffer[2] === 0xFF) return 'image/jpeg'
-    // PNG: 89 50 4E 47
-    if (buffer[0] === 0x89 && buffer[1] === 0x50 && buffer[2] === 0x4E && buffer[3] === 0x47) return 'image/png'
-    // GIF: 47 49 46 38
-    if (buffer[0] === 0x47 && buffer[1] === 0x49 && buffer[2] === 0x46 && buffer[3] === 0x38) return 'image/gif'
-    // WebP: 52 49 46 46 ... 57 45 42 50
-    if (buffer[0] === 0x52 && buffer[1] === 0x49 && buffer[2] === 0x46 && buffer[3] === 0x46 &&
-        buffer.length >= 12 && buffer[8] === 0x57 && buffer[9] === 0x45 && buffer[10] === 0x42 && buffer[11] === 0x50) {
-      return 'image/webp'
-    }
-
-    return 'image/jpeg'
-  }
-
-  /**
-   * 保存图片到 Agent session 工作目录
-   *
-   * @returns 图片文件的绝对路径
-   */
-  private saveImageToSession(
-    workspaceSlug: string,
-    sessionId: string,
-    imageKey: string,
-    mediaType: string,
-    data: Buffer,
-  ): string {
-    const sessionDir = getAgentSessionWorkspacePath(workspaceSlug, sessionId)
-    const ext = mediaType.split('/')[1] || 'jpg'
-    const filename = `feishu-${imageKey}.${ext}`
-    const targetPath = join(sessionDir, filename)
-
-    mkdirSync(sessionDir, { recursive: true })
-    writeFileSync(targetPath, data)
-    console.log(`[飞书 Bridge] 图片已保存: ${targetPath} (${data.length} bytes)`)
-
-    return targetPath
-  }
-
   // ===== 飞书消息处理 =====
 
   private async handleFeishuMessage(data: Record<string, unknown>): Promise<void> {
@@ -598,7 +539,7 @@ class FeishuBridge {
           } else if (node.tag === 'img' && node.image_key) {
             try {
               const imageData = await this.downloadFeishuImage(messageId, node.image_key)
-              const mediaType = this.inferImageMediaType(imageData)
+              const mediaType = inferImageMediaTypeShared(imageData)
               imageAttachments.push({ imageKey: node.image_key, data: imageData, mediaType })
             } catch (error) {
               console.error('[飞书 Bridge] 下载富文本图片失败:', error)
@@ -612,7 +553,7 @@ class FeishuBridge {
       if (content.image_key) {
         try {
           const imageData = await this.downloadFeishuImage(messageId, content.image_key)
-          const mediaType = this.inferImageMediaType(imageData)
+          const mediaType = inferImageMediaTypeShared(imageData)
           if (imageData.length > 10 * 1024 * 1024) {
             console.warn(`[飞书 Bridge] 图片较大: ${(imageData.length / 1024 / 1024).toFixed(1)}MB`)
           }
@@ -1140,14 +1081,13 @@ class FeishuBridge {
     const workspace = binding.workspaceId ? getAgentWorkspace(binding.workspaceId) : undefined
     if (workspace) {
       for (const img of imageAttachments) {
-        const savedPath = this.saveImageToSession(
-          workspace.slug, binding.sessionId, img.imageKey, img.mediaType, img.data,
+        const savedPath = saveImageToSessionShared(
+          workspace.slug, binding.sessionId, `feishu-${img.imageKey}`, img.mediaType, img.data,
         )
-        const imgExt = img.mediaType.split('/')[1] || 'jpg'
-        attachedRefs.push(`- feishu-${img.imageKey}.${imgExt}: ${savedPath}`)
+        attachedRefs.push(`- feishu-${img.imageKey}.${inferExtension(img.mediaType)}: ${savedPath}`)
       }
       for (const file of fileAttachments) {
-        const savedPath = this.saveFileToSession(
+        const savedPath = saveFileToSessionShared(
           workspace.slug, binding.sessionId, file.fileName, file.data,
         )
         attachedRefs.push(`- ${file.fileName}: ${savedPath}`)


### PR DESCRIPTION
## Summary

- #330 修了飞书图片扩展名缺失，但实现时内联了 \`mediaType.split('/')[1]\`，而微信/钉钉已经把等价逻辑抽到 \`bridge-attachment-utils.ts\` 的 \`inferExtension()\`。三个 bridge 出现了职责重复，且飞书的实现对 \`image/svg+xml\`、带 \`;charset\` 的 MIME 不够鲁棒
- 本 PR 把飞书 bridge 的附件保存逻辑统一迁移到共享工具：\`saveImageToSession\` / \`saveFileToSession\` / \`inferImageMediaType\` / \`inferExtension\`，净删 60 行重复代码
- 附带收益：飞书文件附件现在也走共享工具的 \`sanitizeFileName\` 与 \`ensurePathWithin\`（原飞书实现未做文件名清理和路径穿越防御）

## Behavior Differences

| 场景 | 之前 | 现在 | 影响 |
|------|------|------|------|
| JPEG 图片文件扩展名 | \`.jpeg\` | \`.jpg\` | 与微信/钉钉一致；渲染器 \`isImageFile()\` 两者均识别，缩略图展示不受影响 |
| 未知 MIME（如 \`image/svg+xml\`、\`image/jpeg;charset=x\`） | 直接用子类型做扩展名，可能产生非法文件名 | fallback 到 \`jpg\` | 更鲁棒 |
| 飞书文件名含 \`/ \\ : * ? \" < > \|\` | 原样写入磁盘 | 替换为 \`_\` | 安全性提升 |

历史 JSONL 中已存在的 \`feishu-<key>.jpeg\` 引用指向旧文件，不会与新写入的 \`.jpg\` 失配。

## Test plan

- [x] \`pnpm typecheck\` 通过
- [x] \`pnpm build:main\` 通过
- [ ] 飞书发送 JPEG 图片 → Agent 消息显示缩略图（文件名应为 \`.jpg\`）
- [ ] 飞书发送 PNG 图片 → 缩略图正常
- [ ] 飞书发送 GIF/WebP → 缩略图正常
- [ ] 飞书发送普通文件（PDF 等）→ 附件引用正常
- [ ] 飞书发送文件名含特殊字符的文件 → 文件名被 sanitize，保存成功

## 邮箱

erlichliu@gmail.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)