### PR TITLE
feat(file-browser): 侧面板文件支持一键添加到聊天附件【已审核 PR】

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -1756,6 +1756,61 @@ export function registerIpcHandlers(): void {
     }
   )
 
+  // 读取附加目录文件内容为 base64（限制在已附加目录范围内，用于侧面板添加到聊天）
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.READ_ATTACHED_FILE,
+    async (_, filePath: string, sessionId?: string, workspaceSlug?: string): Promise<string> => {
+      if (!filePath || typeof filePath !== 'string') {
+        throw new Error('无效的文件路径')
+      }
+
+      const { resolve, sep } = await import('node:path')
+      const { readFile, stat, realpath } = await import('node:fs/promises')
+
+      // 使用 realpath 解析符号链接，防止 symlink 绕过路径检查
+      const safePath = await realpath(resolve(filePath)).catch(() => {
+        throw new Error(`文件不存在: ${filePath}`)
+      })
+
+      // 收集所有允许的目录：会话附加目录 + 工作区附加目录 + 工作区文件目录
+      const allowedDirs: string[] = []
+
+      if (sessionId) {
+        const meta = getAgentSessionMeta(sessionId)
+        if (meta?.attachedDirectories) {
+          allowedDirs.push(...meta.attachedDirectories)
+        }
+      }
+      if (workspaceSlug) {
+        allowedDirs.push(...getWorkspaceAttachedDirectories(workspaceSlug))
+        allowedDirs.push(getWorkspaceFilesDir(workspaceSlug))
+      }
+
+      // 还允许访问 agent-workspaces 根目录下的文件（session 文件等）
+      allowedDirs.push(getAgentWorkspacesDir())
+
+      const resolvedAllowedDirs = await Promise.all(
+        allowedDirs.map((dir) => realpath(resolve(dir)).catch(() => resolve(dir)))
+      )
+      const isAllowed = resolvedAllowedDirs.some((dir) => safePath.startsWith(dir + sep) || safePath === dir)
+      if (!isAllowed) {
+        throw new Error('访问路径不在允许范围内')
+      }
+
+      const MAX_FILE_SIZE = 20 * 1024 * 1024 // 20 MB
+      const fileStat = await stat(safePath).catch(() => null)
+      if (!fileStat) {
+        throw new Error(`文件不存在: ${filePath}`)
+      }
+      if (fileStat.size > MAX_FILE_SIZE) {
+        throw new Error(`文件过大（${Math.round(fileStat.size / 1024 / 1024)}MB），最大支持 20MB`)
+      }
+
+      const buffer = await readFile(safePath)
+      return buffer.toString('base64')
+    }
+  )
+
   // 在文件管理器中显示附加目录文件（无工作区路径限制）
   ipcMain.handle(
     AGENT_IPC_CHANNELS.SHOW_ATTACHED_IN_FOLDER,

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -560,6 +560,9 @@ export interface ElectronAPI {
   /** 用系统默认应用打开附加目录文件（无工作区路径限制） */
   openAttachedFile: (filePath: string) => Promise<void>
 
+  /** 读取附加目录文件内容为 base64（限制在已附加目录范围内） */
+  readAttachedFile: (filePath: string, sessionId?: string, workspaceSlug?: string) => Promise<string>
+
   /** 在文件管理器中显示附加目录文件（无工作区路径限制） */
   showAttachedInFolder: (filePath: string) => Promise<void>
 
@@ -1356,6 +1359,10 @@ const electronAPI: ElectronAPI = {
 
   openAttachedFile: (filePath: string) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.OPEN_ATTACHED_FILE, filePath)
+  },
+
+  readAttachedFile: (filePath: string, sessionId?: string, workspaceSlug?: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.READ_ATTACHED_FILE, filePath, sessionId, workspaceSlug)
   },
 
   showAttachedInFolder: (filePath: string) => {

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -881,20 +881,38 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     if (pendingFiles.length > 0) {
       const workspace = workspaces.find((w) => w.id === currentWorkspaceId)
       if (workspace) {
-        const filesToSave = pendingFiles.map((f) => ({
-          filename: f.filename,
-          data: window.__pendingAgentFileData?.get(f.id) || '',
-        }))
-        try {
-          const saved = await window.electronAPI.saveFilesToAgentSession({
-            workspaceSlug: workspace.slug,
-            sessionId,
-            files: filesToSave,
-          })
-          const refs = saved.map((f) => `- ${f.filename}: ${f.targetPath}`).join('\n')
+        // 区分：已有 sourcePath 的文件（从侧面板添加）直接引用，其余需要保存
+        const existingFiles = pendingFiles.filter((f) => f.sourcePath)
+        const newFiles = pendingFiles.filter((f) => !f.sourcePath)
+
+        const allRefs: Array<{ filename: string; targetPath: string }> = []
+
+        // 已有路径的文件直接引用
+        for (const f of existingFiles) {
+          allRefs.push({ filename: f.filename, targetPath: f.sourcePath! })
+        }
+
+        // 新上传的文件保存到 session 目录
+        if (newFiles.length > 0) {
+          const filesToSave = newFiles.map((f) => ({
+            filename: f.filename,
+            data: window.__pendingAgentFileData?.get(f.id) || '',
+          }))
+          try {
+            const saved = await window.electronAPI.saveFilesToAgentSession({
+              workspaceSlug: workspace.slug,
+              sessionId,
+              files: filesToSave,
+            })
+            allRefs.push(...saved)
+          } catch (error) {
+            console.error('[AgentView] 保存附件到 session 失败:', error)
+          }
+        }
+
+        if (allRefs.length > 0) {
+          const refs = allRefs.map((f) => `- ${f.filename}: ${f.targetPath}`).join('\n')
           fileReferences += `<attached_files>\n${refs}\n</attached_files>\n\n`
-        } catch (error) {
-          console.error('[AgentView] 保存附件到 session 失败:', error)
         }
       }
 

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -7,7 +7,7 @@
 
 import * as React from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
-import { X, FolderOpen, ExternalLink, RefreshCw, ChevronRight, MoreHorizontal, FolderSearch, Pencil, FolderInput, Info, FolderHeart } from 'lucide-react'
+import { X, FolderOpen, ExternalLink, RefreshCw, ChevronRight, MoreHorizontal, FolderSearch, Pencil, FolderInput, Info, FolderHeart, MessageSquarePlus } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import {
@@ -25,8 +25,9 @@ import {
   agentWorkspacesAtom,
   agentAttachedDirectoriesMapAtom,
   workspaceAttachedDirectoriesMapAtom,
+  agentPendingFilesAtom,
 } from '@/atoms/agent-atoms'
-import type { FileEntry } from '@proma/shared'
+import type { FileEntry, AgentPendingFile } from '@proma/shared'
 
 interface SidePanelProps {
   sessionId: string
@@ -186,6 +187,44 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
     setFilesVersion((prev) => prev + 1)
   }, [setFilesVersion])
 
+  // 添加文件到聊天
+  const pendingFiles = useAtomValue(agentPendingFilesAtom)
+  const setPendingFiles = useSetAtom(agentPendingFilesAtom)
+  const handleAddToChat = React.useCallback(async (entry: FileEntry) => {
+    // 先在 setter 外部检查去重，避免在 updater 函数内执行不可逆副作用
+    if (pendingFiles.some((f) => f.sourcePath === entry.path)) return
+
+    let previewUrl: string | undefined
+    try {
+      const base64 = await window.electronAPI.readAttachedFile(entry.path, sessionId, workspaceSlug ?? undefined)
+      const ext = entry.name.split('.').pop()?.toLowerCase() ?? ''
+      const imageExts = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp', 'ico'])
+      const mimeExt = ext === 'jpg' ? 'jpeg' : ext === 'svg' ? 'svg+xml' : ext
+      const mediaType = imageExts.has(ext) ? `image/${mimeExt}` : 'application/octet-stream'
+
+      if (imageExts.has(ext)) {
+        const binary = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0))
+        const blob = new Blob([binary], { type: mediaType })
+        previewUrl = URL.createObjectURL(blob)
+      }
+
+      const pending: AgentPendingFile = {
+        id: `pending-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+        filename: entry.name,
+        mediaType,
+        size: Math.round(base64.length * 0.75),
+        previewUrl,
+        sourcePath: entry.path,
+      }
+
+      // 有 sourcePath 的文件发送时直接引用原路径，不需要存 base64
+      setPendingFiles((prev) => [...prev, pending])
+    } catch (error) {
+      if (previewUrl) URL.revokeObjectURL(previewUrl)
+      console.error('[SidePanel] 添加文件到聊天失败:', error)
+    }
+  }, [pendingFiles, setPendingFiles, sessionId, workspaceSlug])
+
   // 面包屑：显示根路径最后两段
   const breadcrumb = React.useMemo(() => {
     if (!sessionPath) return ''
@@ -306,6 +345,7 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                             attachedDirs={attachedDirs}
                             onDetach={handleDetachDirectory}
                             refreshVersion={filesVersion}
+                            onAddToChat={handleAddToChat}
                           />
                         )}
                         {/* 会话文件浏览器 */}
@@ -313,7 +353,7 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                           {attachedDirs.length > 0 && (
                             <div className="text-[11px] font-medium text-muted-foreground mb-1 px-3 pt-2">工作文件（存储于该工作区目录）</div>
                           )}
-                          <FileBrowser rootPath={sessionPath} hideToolbar embedded hideEmpty={attachedDirs.length > 0} />
+                          <FileBrowser rootPath={sessionPath} hideToolbar embedded hideEmpty={attachedDirs.length > 0} onAddToChat={handleAddToChat} />
                         </>
                         {/* 会话文件拖拽上传区域 */}
                         <FileDropZone
@@ -393,6 +433,7 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                           attachedDirs={wsAttachedDirs}
                           onDetach={handleDetachWorkspaceDirectory}
                           refreshVersion={filesVersion}
+                          onAddToChat={handleAddToChat}
                         />
                       )}
                       {/* 工作区文件浏览器 */}
@@ -401,7 +442,7 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                           {wsAttachedDirs.length > 0 && (
                             <div className="text-[11px] font-medium text-muted-foreground mb-1 px-3 pt-2">工作文件（存储于该工作区目录）</div>
                           )}
-                          <FileBrowser rootPath={workspaceFilesPath} hideToolbar embedded hideEmpty={wsAttachedDirs.length > 0} />
+                          <FileBrowser rootPath={workspaceFilesPath} hideToolbar embedded hideEmpty={wsAttachedDirs.length > 0} onAddToChat={handleAddToChat} />
                         </>
                       )}
                       {/* 工作区文件拖拽上传区域 */}
@@ -453,10 +494,11 @@ interface AttachedDirsSectionProps {
   onDetach: (dirPath: string) => void
   /** 文件版本号，用于自动刷新已展开的目录 */
   refreshVersion: number
+  onAddToChat?: (entry: FileEntry) => void
 }
 
 /** 附加目录区域：统一管理所有子项的选中状态 */
-function AttachedDirsSection({ attachedDirs, onDetach, refreshVersion }: AttachedDirsSectionProps): React.ReactElement {
+function AttachedDirsSection({ attachedDirs, onDetach, refreshVersion, onAddToChat }: AttachedDirsSectionProps): React.ReactElement {
   const [selectedPaths, setSelectedPaths] = React.useState<Set<string>>(new Set())
 
   const handleSelect = React.useCallback((path: string, ctrlKey: boolean) => {
@@ -487,6 +529,7 @@ function AttachedDirsSection({ attachedDirs, onDetach, refreshVersion }: Attache
           selectedPaths={selectedPaths}
           onSelect={handleSelect}
           refreshVersion={refreshVersion}
+          onAddToChat={onAddToChat}
         />
       ))}
     </div>
@@ -502,10 +545,11 @@ interface AttachedDirTreeProps {
   onSelect: (path: string, ctrlKey: boolean) => void
   /** 文件版本号，变化时已展开的目录自动重新加载 */
   refreshVersion: number
+  onAddToChat?: (entry: FileEntry) => void
 }
 
 /** 附加目录根节点：可展开/收起，带移除按钮 */
-function AttachedDirTree({ dirPath, onDetach, selectedPaths, onSelect, refreshVersion }: AttachedDirTreeProps): React.ReactElement {
+function AttachedDirTree({ dirPath, onDetach, selectedPaths, onSelect, refreshVersion, onAddToChat }: AttachedDirTreeProps): React.ReactElement {
   const [expanded, setExpanded] = React.useState(false)
   const [children, setChildren] = React.useState<FileEntry[]>([])
   const [loaded, setLoaded] = React.useState(false)
@@ -566,7 +610,7 @@ function AttachedDirTree({ dirPath, onDetach, selectedPaths, onSelect, refreshVe
         </div>
       )}
       {expanded && children.map((child) => (
-        <AttachedDirItem key={child.path} entry={child} depth={1} selectedPaths={selectedPaths} onSelect={onSelect} refreshVersion={refreshVersion} />
+        <AttachedDirItem key={child.path} entry={child} depth={1} selectedPaths={selectedPaths} onSelect={onSelect} refreshVersion={refreshVersion} onAddToChat={onAddToChat} />
       ))}
     </div>
   )
@@ -579,10 +623,11 @@ interface AttachedDirItemProps {
   onSelect: (path: string, ctrlKey: boolean) => void
   /** 文件版本号，变化时已展开的目录自动重新加载 */
   refreshVersion: number
+  onAddToChat?: (entry: FileEntry) => void
 }
 
 /** 附加目录子项：递归可展开，支持选中 + 三点菜单（含重命名、移动） */
-function AttachedDirItem({ entry, depth, selectedPaths, onSelect, refreshVersion }: AttachedDirItemProps): React.ReactElement {
+function AttachedDirItem({ entry, depth, selectedPaths, onSelect, refreshVersion, onAddToChat }: AttachedDirItemProps): React.ReactElement {
   const [expanded, setExpanded] = React.useState(false)
   const [children, setChildren] = React.useState<FileEntry[]>([])
   const [loaded, setLoaded] = React.useState(false)
@@ -726,12 +771,28 @@ function AttachedDirItem({ entry, depth, selectedPaths, onSelect, refreshVersion
           <span className="truncate text-xs flex-1">{currentName}</span>
         )}
 
-        {/* 三点菜单按钮（始终占位，避免选中时行高跳动） */}
+        {/* 右侧操作按钮占位 */}
         <div
-          className={cn('flex-shrink-0', !(isSelected && !isRenaming) && 'invisible')}
+          className={cn(
+            'flex-shrink-0',
+            !(isSelected && !isRenaming) && !(onAddToChat && !entry.isDirectory && !isRenaming) && 'invisible',
+          )}
           onClick={(e) => e.stopPropagation()}
           onMouseDown={(e) => e.stopPropagation()}
         >
+          {/* 非文件夹未选中：添加到聊天按钮（悬浮时显示） */}
+          {onAddToChat && !entry.isDirectory && !isRenaming && !(isSelected && !isRenaming) && (
+            <button
+              type="button"
+              className="h-6 w-6 rounded flex items-center justify-center hover:bg-accent/70 text-muted-foreground hover:text-foreground invisible group-hover:visible"
+              title="添加到聊天"
+              onClick={() => onAddToChat({ ...entry, path: currentPath, name: currentName })}
+            >
+              <MessageSquarePlus className="size-3.5" />
+            </button>
+          )}
+          {/* 选中状态：三点菜单 */}
+          {isSelected && !isRenaming && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <button
@@ -741,8 +802,16 @@ function AttachedDirItem({ entry, depth, selectedPaths, onSelect, refreshVersion
                 <MoreHorizontal className="size-3.5" />
               </button>
             </DropdownMenuTrigger>
-            {isSelected && !isRenaming && (
               <DropdownMenuContent align="start" className="w-40 z-[9999] min-w-0 p-0.5">
+                {onAddToChat && !entry.isDirectory && (
+                  <DropdownMenuItem
+                    className="text-xs py-1 [&>svg]:size-3.5"
+                    onSelect={() => onAddToChat({ ...entry, path: currentPath, name: currentName })}
+                  >
+                    <MessageSquarePlus />
+                    添加到聊天
+                  </DropdownMenuItem>
+                )}
                 <DropdownMenuItem
                   className="text-xs py-1 [&>svg]:size-3.5"
                   onSelect={() => window.electronAPI.showAttachedInFolder(currentPath).catch(console.error)}
@@ -774,8 +843,8 @@ function AttachedDirItem({ entry, depth, selectedPaths, onSelect, refreshVersion
                   移动到...
                 </DropdownMenuItem>
               </DropdownMenuContent>
-            )}
           </DropdownMenu>
+          )}
         </div>
       </div>
       {expanded && children.length === 0 && loaded && (
@@ -787,7 +856,7 @@ function AttachedDirItem({ entry, depth, selectedPaths, onSelect, refreshVersion
         </div>
       )}
       {expanded && children.map((child) => (
-        <AttachedDirItem key={child.path} entry={child} depth={depth + 1} selectedPaths={selectedPaths} onSelect={onSelect} refreshVersion={refreshVersion} />
+        <AttachedDirItem key={child.path} entry={child} depth={depth + 1} selectedPaths={selectedPaths} onSelect={onSelect} refreshVersion={refreshVersion} onAddToChat={onAddToChat} />
       ))}
     </>
   )

--- a/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
@@ -21,6 +21,7 @@ import {
   MoreHorizontal,
   FolderInput,
   Pencil,
+  MessageSquarePlus,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
@@ -83,9 +84,11 @@ interface FileBrowserProps {
   embedded?: boolean
   /** 隐藏"目录为空"提示（当外部已有附加目录等内容时使用） */
   hideEmpty?: boolean
+  /** 点击添加到聊天（非文件夹文件悬浮时显示按钮） */
+  onAddToChat?: (entry: FileEntry) => void
 }
 
-export function FileBrowser({ rootPath, hideToolbar, embedded, hideEmpty }: FileBrowserProps): React.ReactElement {
+export function FileBrowser({ rootPath, hideToolbar, embedded, hideEmpty, onAddToChat }: FileBrowserProps): React.ReactElement {
   const [entries, setEntries] = React.useState<FileEntry[]>([])
   const [loading, setLoading] = React.useState(false)
   const [error, setError] = React.useState<string | null>(null)
@@ -307,6 +310,7 @@ export function FileBrowser({ rootPath, hideToolbar, embedded, hideEmpty }: File
           onDelete={handleRequestDelete}
           onMove={handleMove}
           onRefresh={loadRoot}
+          onAddToChat={onAddToChat}
         />
       ))}
     </div>
@@ -406,6 +410,7 @@ interface FileTreeItemProps {
   onDelete: (entry: FileEntry) => void
   onMove: (entry: FileEntry) => void
   onRefresh: () => Promise<void>
+  onAddToChat?: (entry: FileEntry) => void
 }
 
 function FileTreeItem({
@@ -428,6 +433,7 @@ function FileTreeItem({
   onDelete,
   onMove,
   onRefresh,
+  onAddToChat,
 }: FileTreeItemProps): React.ReactElement {
   const [expanded, setExpanded] = React.useState(false)
   const [children, setChildren] = React.useState<FileEntry[]>([])
@@ -666,12 +672,29 @@ function FileTreeItem({
           <span className="truncate text-xs flex-1">{entry.name}</span>
         )}
 
-        {/* 三点菜单按钮（始终占位，避免选中时行高跳动） */}
+        {/* 右侧操作按钮占位（始终占位，避免行高跳动） */}
         <div
-          className={cn('flex-shrink-0', !showMenu && 'invisible')}
+          className={cn(
+            'flex-shrink-0',
+            !(showMenu || (onAddToChat && !entry.isDirectory && !isRenaming)) && 'invisible',
+          )}
           onClick={(e) => e.stopPropagation()}
           onMouseDown={(e) => e.stopPropagation()}
         >
+          {/* 非文件夹：添加到聊天按钮（悬浮时显示） */}
+          {onAddToChat && !entry.isDirectory && !isRenaming && !showMenu && (
+            <button
+              type="button"
+              className="h-6 w-6 rounded flex items-center justify-center hover:bg-accent/70 text-muted-foreground hover:text-foreground invisible group-hover:visible focus-visible:visible"
+              title="添加到聊天"
+              aria-label="添加到聊天"
+              onClick={() => onAddToChat(entry)}
+            >
+              <MessageSquarePlus className="size-3.5" />
+            </button>
+          )}
+          {/* 文件夹/选中状态：三点菜单 */}
+          {showMenu && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <button
@@ -681,8 +704,16 @@ function FileTreeItem({
                 <MoreHorizontal className="size-3.5" />
               </button>
             </DropdownMenuTrigger>
-            {showMenu && (
               <DropdownMenuContent align="start" className="w-40 z-[9999] min-w-0 p-0.5">
+                {onAddToChat && !entry.isDirectory && selectedCount === 1 && (
+                  <DropdownMenuItem
+                    className="text-xs py-1 [&>svg]:size-3.5"
+                    onSelect={() => onAddToChat(entry)}
+                  >
+                    <MessageSquarePlus />
+                    添加到聊天
+                  </DropdownMenuItem>
+                )}
                 {selectedCount === 1 && (
                   <DropdownMenuItem
                     className="text-xs py-1 [&>svg]:size-3.5"
@@ -718,8 +749,8 @@ function FileTreeItem({
                   {selectedCount > 1 ? `删除选中 (${selectedCount})` : '删除'}
                 </DropdownMenuItem>
               </DropdownMenuContent>
-            )}
           </DropdownMenu>
+          )}
         </div>
       </div>
 
@@ -754,6 +785,7 @@ function FileTreeItem({
           onDelete={onDelete}
           onMove={onMove}
           onRefresh={handleRefreshAfterDelete}
+          onAddToChat={onAddToChat}
         />
       ))}
     </>

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -888,6 +888,8 @@ export interface AgentPendingFile {
   mediaType: string
   /** 图片预览 URL（blob/data URL） */
   previewUrl?: string
+  /** 文件原始路径（从侧面板添加时设置，发送时跳过复制直接引用） */
+  sourcePath?: string
 }
 
 /** Agent 文件保存到 session 的输入 */
@@ -1277,6 +1279,8 @@ export const AGENT_IPC_CHANNELS = {
   MOVE_ATTACHED_FILE: 'agent:move-attached-file',
   /** 检查路径类型（文件 or 目录），用于拖拽检测 */
   CHECK_PATHS_TYPE: 'agent:check-paths-type',
+  /** 读取附加目录文件内容为 base64（限制在已附加目录范围内，用于侧面板添加到聊天） */
+  READ_ATTACHED_FILE: 'agent:read-attached-file',
   /** 搜索工作区文件（用于 @ 引用） */
   SEARCH_WORKSPACE_FILES: 'agent:search-workspace-files',
 


### PR DESCRIPTION
## Overview

在右侧文件面板中，为非文件夹文件新增 hover 显示的「添加到聊天」图标按钮。点击后文件直接作为附件添加到 Agent 输入框，无需通过文件对话框或拖拽操作。已在会话/工作区目录中的文件发送时直接引用原路径，避免重复复制。

## Changes

- `packages/shared/src/types/agent.ts` — `AgentPendingFile` 接口新增 `sourcePath?: string` 字段，标记从侧面板添加的文件原路径
- `apps/electron/src/main/ipc.ts` — 新增 `READ_ATTACHED_FILE` IPC handler，带路径白名单安全检查（realpath 解析防 symlink 绕过、20MB 大小限制）
- `apps/electron/src/preload/index.ts` — 新增 `readAttachedFile` API 暴露到渲染进程
- `apps/electron/src/renderer/components/file-browser/FileBrowser.tsx` — `FileBrowserProps` 和 `FileTreeItemProps` 新增 `onAddToChat` 回调；非文件夹文件 hover 显示 `MessageSquarePlus` 图标按钮，与三点菜单共用占位 div
- `apps/electron/src/renderer/components/agent/SidePanel.tsx` — 新增 `handleAddToChat` 回调（读取文件 → 创建预览 → 推入 atom）；`AttachedDirsSection → AttachedDirTree → AttachedDirItem` 全链路传递 `onAddToChat`；`AttachedDirItem` 也新增相同的 hover 图标
- `apps/electron/src/renderer/components/agent/AgentView.tsx` — 发送逻辑按 `sourcePath` 分流：有 sourcePath 的文件直接引用原路径，无 sourcePath 的走原有 `saveFilesToAgentSession` 保存流程

## How to Test

1. 打开 Agent 模式，选择一个有文件的会话
2. 在右侧文件面板中，将鼠标悬浮在任意非文件夹文件上，应看到聊天图标出现在行右侧
3. 点击图标，文件应出现在输入框上方的附件预览区
4. 发送消息，确认 `<attached_files>` 中的路径指向原文件而非副本
5. 验证通过拖拽/粘贴/Paperclip 按钮添加的附件仍正常工作（走 saveFilesToAgentSession 路径）
6. 验证附加目录中的文件也支持同样的操作

## Notes

- 图片文件会生成 blob URL 预览，非图片文件显示文件名 pill
- sourcePath 文件不写入 `window.__pendingAgentFileData`，避免无意义的内存占用
- 同一文件不可重复添加（sourcePath 去重检查）