### PR TITLE
fix(agent): 修复会话文件区附加文件夹首次不显示问题 【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -471,19 +471,16 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       .catch(console.error)
   }, [sessionId, refreshVersion, setStreamingStates, setLiveMessagesMap, store])
 
-  // 从会话元数据初始化附加目录
+  // 从会话元数据初始化附加目录（仅冷启动水合，后续由 handleAttachFolder/handleDetachDirectory 实时写入）
   React.useEffect(() => {
     const meta = sessions.find((s) => s.id === sessionId)
     const dirs = meta?.attachedDirectories ?? []
     setAttachedDirsMap((prev) => {
       const existing = prev.get(sessionId)
-      // 避免不必要的更新
-      if (JSON.stringify(existing) === JSON.stringify(dirs)) return prev
+      if (existing != null) return prev
       const map = new Map(prev)
       if (dirs.length > 0) {
         map.set(sessionId, dirs)
-      } else {
-        map.delete(sessionId)
       }
       return map
     })


### PR DESCRIPTION
## Overview

修复 Agent 模式下会话文件区域点击\"附加文件夹\"后，第一次不显示已附加目录的问题。

## 问题根因

AgentView.tsx 中有一个从 sessions（agentSessionsAtom）同步附加目录到 agentAttachedDirectoriesMapAtom 的 useEffect。该 effect 的依赖项包含 sessions。

当用户在 SidePanel 点击\"附加文件夹\"时：
1. attachDirectory IPC 被调用，写入磁盘并返回更新后的目录数组
2. SidePanel 将新数组写入 agentAttachedDirectoriesMapAtom
3. 但 agentSessionsAtom 没有被刷新，sessions 中仍然是旧的空数组
4. 关闭文件夹对话框触发 AgentView 重渲染，该 effect 用 sessions 中的旧空数组覆盖了 atom 中的新数据

这导致用户感觉\"第一次没附加上去\"，实际上是被竞态条件擦除了。

工作区文件的附加文件夹没有这个问题，因为它没有类似的\"从 sessions 同步到 atom\"的机制。

## Changes

- apps/electron/src/renderer/components/agent/AgentView.tsx — 将附加目录同步 effect 改为仅冷启动水合：只要 atom 中已有该 session 的数据，就不再从 sessions 覆盖，避免旧数据擦除新数据。

## How to Test

1. 进入 Agent 模式，打开侧面板
2. 在\"会话文件\"区域点击\"附加文件夹\"，选择一个文件夹
3. 观察是否第一次就显示已附加的文件夹
4. 同时验证：刷新页面、切换标签页、窗口失焦/聚焦后，附加目录仍然保持显示

## Notes

- 该修复将同步逻辑明确为\"仅冷启动水合\"，后续增删操作由 SidePanel 的 handleAttachFolder/handleDetachDirectory 实时写入 atom
- 不影响工作区文件附加文件夹的行为