### PR TITLE
fix(ui): 统一所有弹窗遮罩层暗度为 bg-black/20 【无需审核】

### DIFF
--- a/apps/electron/src/renderer/components/ui/alert-dialog.tsx
+++ b/apps/electron/src/renderer/components/ui/alert-dialog.tsx
@@ -18,7 +18,7 @@ const AlertDialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-[100] bg-black/80 titlebar-no-drag data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-[100] bg-black/20 titlebar-no-drag data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}

--- a/apps/electron/src/renderer/components/ui/dialog.tsx
+++ b/apps/electron/src/renderer/components/ui/dialog.tsx
@@ -21,7 +21,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-[100] bg-black/80 titlebar-no-drag data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-[100] bg-black/20 titlebar-no-drag data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}

--- a/apps/electron/src/renderer/components/ui/image-lightbox.tsx
+++ b/apps/electron/src/renderer/components/ui/image-lightbox.tsx
@@ -40,7 +40,7 @@ export function ImageLightbox({
         {/* 遮罩层 — 点击关闭 */}
         <DialogPrimitive.Overlay
           className={cn(
-            'fixed inset-0 z-[200] bg-black/80 titlebar-no-drag',
+            'fixed inset-0 z-[200] bg-black/20 titlebar-no-drag',
             'data-[state=open]:animate-in data-[state=closed]:animate-out',
             'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0'
           )}

--- a/apps/electron/src/renderer/components/ui/sheet.tsx
+++ b/apps/electron/src/renderer/components/ui/sheet.tsx
@@ -19,7 +19,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/20 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}


### PR DESCRIPTION
## Overview

当前 Settings 弹窗使用 `bg-black/20` 的遮罩层暗度，视觉体验舒适；但其他所有弹窗（Dialog、AlertDialog、Sheet、ImageLightbox）的基础 UI 组件均使用 `bg-black/80`，导致背景过暗，影响使用体验。

本 PR 将所有弹窗遮罩层暗度统一为 `bg-black/20`，与 Settings 弹窗保持一致。

## Changes

- `apps/electron/src/renderer/components/ui/dialog.tsx` — Dialog 遮罩层 `bg-black/80` → `bg-black/20`
- `apps/electron/src/renderer/components/ui/alert-dialog.tsx` — AlertDialog 遮罩层 `bg-black/80` → `bg-black/20`
- `apps/electron/src/renderer/components/ui/sheet.tsx` — Sheet 遮罩层 `bg-black/80` → `bg-black/20`
- `apps/electron/src/renderer/components/ui/image-lightbox.tsx` — ImageLightbox 遮罩层 `bg-black/80` → `bg-black/20`

## 影响范围

以下弹窗/抽屉的遮罩层暗度将全部统一变亮：
- 全局搜索、命令面板、模型选择器、移动会话、Agent 设置弹窗
- 更新提示、删除消息确认、删除/归档会话确认、新手引导、文件浏览器删除确认、钉钉/飞书设置解绑确认、工作区删除确认、Agent 错误重试确认
- 新手引导详情面板（Sheet）
- 聊天/Agent 消息中的图片预览（ImageLightbox）

## How to Test

1. 打开任意弹窗（如全局搜索 Cmd+K、删除消息、模型选择器等）
2. 观察背景遮罩层暗度，应与 Settings 弹窗一致
3. 点击图片预览，确认遮罩层同样为 `bg-black/20`

## Notes

- Settings 弹窗 (`SettingsDialog.tsx`) 原本就是自定义的 `bg-black/20`，无需改动
- 仅修改基础 UI 组件，所有消费这些组件的弹窗自动生效