### PR TITLE
fix(agent): AskUserQuestions 答案无法被 Agent 读取的问题 【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/agent/AskUserBanner.tsx
+++ b/apps/electron/src/renderer/components/agent/AskUserBanner.tsx
@@ -185,11 +185,14 @@ export function AskUserBanner({ sessionId }: AskUserBannerProps): React.ReactEle
     try {
       const answersRecord: Record<string, string> = {}
       for (let i = 0; i < questions.length; i++) {
+        const q = questions[i]
+        if (!q) continue
         const answer = getAnswer(i)
+        const key = q.question || String(i)
         if (answer.showCustom && answer.customText.trim()) {
-          answersRecord[String(i)] = answer.customText.trim()
+          answersRecord[key] = answer.customText.trim()
         } else if (answer.selected.length > 0) {
-          answersRecord[String(i)] = answer.selected.join(', ')
+          answersRecord[key] = answer.selected.join(', ')
         }
       }
       await window.electronAPI.respondAskUser({ requestId: request.requestId, answers: answersRecord })

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "proma",

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -965,7 +965,7 @@ export interface AskUserRequest {
 export interface AskUserResponse {
   /** 请求 ID */
   requestId: string
-  /** 用户答案（问题索引字符串 → 答案文本） */
+  /** 用户答案（问题文本 → 答案文本，与 SDK 约定一致） */
   answers: Record<string, string>
 }
 


### PR DESCRIPTION
## Overview

SDK 的 `AskUserQuestionOutput` 类型明确约定 `answers` 的 key 为**问题文本**（`question text → answer string`），但 Proma 渲染进程在构建答案记录时错误地使用了数字索引（`String(i)`）。这导致 Claude 模型收到的工具结果中 key 为 `"0"`, `"1"` 等无意义字符串，无法将答案与问题对应。

## Changes

- `apps/electron/src/renderer/components/agent/AskUserBanner.tsx` — `handleSubmit` 中构建 `answersRecord` 时，key 从 `String(i)` 改为 `q.question`（fallback `String(i)` 用于问题文本为空的极端情况）；同时新增 `if (!q) continue` 的 null guard，防止稀疏数组导致运行时崩溃
- `packages/shared/src/types/agent.ts` — 更新 `AskUserResponse.answers` 的注释，明确说明 key 为问题文本，与 SDK 约定一致

## How to Test

1. 触发 Agent 调用 `AskUserQuestion` 工具，发起一个或多个问题
2. 在 AskUserBanner 中选择选项并提交
3. 观察 Agent 后续回复中是否能正确引用用户的答案内容（旧版本会显示 `"0": "Yes"` 这样的无上下文结果）
4. 验证多问题（多 tab）场景下每个问题的答案均被正确收集

## Notes

- 数据流追踪：渲染进程 → preload IPC → main 主进程 → `agent-ask-user-service` → SDK `canUseTool` 返回 `updatedInput`，整个链路均透传 `answers`，无额外转换，因此 key 格式完全由渲染进程决定
- SDK 类型参考：`@anthropic-ai/claude-agent-sdk/sdk-tools.d.ts` 中 `AskUserQuestionOutput.answers` 的 JSDoc 注释
- 类型检查：`bun run typecheck` 全部通过（shared / core / ui / electron）