### PR TITLE
fix: 在系统提示词中说明 Skill 安装路径规则

### DIFF
--- a/apps/electron/src/main/lib/agent-prompt-builder.ts
+++ b/apps/electron/src/main/lib/agent-prompt-builder.ts
@@ -253,7 +253,7 @@ Agent 工具支持 \`model\` 参数（可选值：\`sonnet\` / \`opus\` / \`haik
 - 工作区根目录: ~/${configDirName}/agent-workspaces/${ctx.workspaceSlug}/
 - 当前会话目录（cwd）: ~/${configDirName}/agent-workspaces/${ctx.workspaceSlug}/${ctx.sessionId}/
 - MCP 配置: ~/${configDirName}/agent-workspaces/${ctx.workspaceSlug}/mcp.json（顶层 key 是 \`servers\`）
-- Skills 目录: ~/${configDirName}/agent-workspaces/${ctx.workspaceSlug}/skills/
+- Skills 目录: ~/${configDirName}/agent-workspaces/${ctx.workspaceSlug}/skills/（Proma 只从此目录加载 skill；npx skills add 等外部命令安装到 .agents/skills/ 不会被加载，需手动 mv 到此目录）
 
 ### .context 目录层级
 


### PR DESCRIPTION
## 问题根因

Proma Agent 只从工作区 `skills/` 目录加载 skill，但 `npx skills add` 等外部命令默认安装到当前 cwd 下的 `.agents/skills/`，两者路径不同，导致 Agent 安装 skill 后始终找不到。
原系统提示词中 Skills 目录一行只写了路径，没有说明Proma的skill加载方式。

## 具体修改

- `apps/electron/src/main/lib/agent-prompt-builder.ts`：在 Skills 目录说明后追加一句注释，明确 Proma 只从此目录加载，外部命令安装后需手动 `mv` 到正确路径。

## 审查情况

变更仅一行，不影响任何逻辑，只修改注入给 Agent 的提示词文字。
已在开发环境通过功能测试，确认 Agent 能正确识别安装路径实现一句话安装全流程。