### PR TITLE
feat(agent): 切换工作区时自动切换到置顶区【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -351,6 +351,15 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     }
   }, [activeTabId, mode, viewMode, pinnedAgentSessions, workingSessionIds])
 
+  /** 切换工作区时默认显示置顶区，避免遗漏各工作区置顶的会话 */
+  const prevWorkspaceIdForSubTab = React.useRef<string | null>(currentWorkspaceId)
+  React.useEffect(() => {
+    if (currentWorkspaceId === prevWorkspaceIdForSubTab.current) return
+    prevWorkspaceIdForSubTab.current = currentWorkspaceId
+    if (mode !== 'agent' || viewMode !== 'active') return
+    setAgentSubTab('pinned')
+  }, [currentWorkspaceId, mode, viewMode])
+
   /** 对话按日期分组（根据 viewMode 过滤归档状态，排除 draft） */
   const conversationGroups = React.useMemo(
     () => {


### PR DESCRIPTION
## Overview

手动切换工作区时，左侧栏的上区子 Tab 会自动切换到「置顶」区域，避免用户遗漏各工作区中置顶的重要会话。如果用户当前已经在置顶区，则不受影响。

## Changes

- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 新增 `useEffect`，监听 `currentWorkspaceId` 变化，当用户切换工作区时自动将 `agentSubTab` 设为 `'pinned'`。使用 `useRef` 记录上一个工作区 ID，跳过首次渲染避免副作用。仅在 Agent 模式 + 活跃视图下生效。

## How to Test

1. 在 Agent 模式下创建多个工作区，每个工作区中有若干置顶会话和工作中会话
2. 将上区子 Tab 切换到「工作中」
3. 通过工作区选择器切换到另一个工作区
4. 预期：上区子 Tab 自动切换到「置顶」，展示该工作区的置顶会话
5. 保持在置顶区状态下再次切换工作区 — 应保持在置顶区不变
6. 在 Chat 模式或归档视图下切换工作区 — 无影响

## Notes

- 修改量极小（+9 行），逻辑简单直接，使用与上方 `activeTabId` 监听相同的模式