### PR TITLE
feat(agent): 置顶会话时自动切到置顶子标签并闪烁高亮【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -177,6 +177,8 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   const [pinnedExpanded, setPinnedExpanded] = React.useState(true)
   /** Agent 上区子 Tab：'working' | 'pinned'，默认 working 在前 */
   const [agentSubTab, setAgentSubTab] = React.useState<'working' | 'pinned'>('working')
+  /** 刚置顶的会话 ID（用于闪烁高亮），为 null 时不闪烁 */
+  const [flashSessionId, setFlashSessionId] = React.useState<string | null>(null)
   const [userProfile, setUserProfile] = useAtom(userProfileAtom)
   const selectedModel = useAtomValue(selectedModelAtom)
   const streamingIds = useAtomValue(streamingConversationIdsAtom)
@@ -664,6 +666,11 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       if (original?.archived && updated.pinned && !updated.archived) {
         toast.success('已取消归档并置顶')
       }
+      // 置顶非工作中的会话时，自动切换到置顶子标签页并闪烁
+      if (updated.pinned && !original?.pinned && !workingSessionIds.has(id)) {
+        setAgentSubTab('pinned')
+        setFlashSessionId(id)
+      }
     } catch (error) {
       console.error('[侧边栏] 切换 Agent 会话置顶失败:', error)
     }
@@ -1111,6 +1118,8 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                               indicatorStatus={agentIndicatorMap.get(session.id) ?? 'idle'}
                               isInWorkingSection={workingSessionIds.has(session.id)}
                               showPinIcon={false}
+                              flash={session.id === flashSessionId}
+                              onFlashEnd={() => setFlashSessionId(null)}
                               onSelect={() => handleSelectAgentSession(session.id, session.title)}
                               onRequestDelete={() => handleRequestDelete(session.id)}
                               onRequestMove={() => setMoveTargetId(session.id)}
@@ -1555,6 +1564,10 @@ interface AgentSessionItemProps {
   isInWorkingSection?: boolean
   /** 行左侧状态色块；未传则不显示 */
   leftAccent?: SessionLeftAccent
+  /** 是否播放置顶闪烁动画 */
+  flash?: boolean
+  /** 闪烁动画结束时回调 */
+  onFlashEnd?: () => void
   onSelect: () => void
   onRequestDelete: () => void
   onRequestMove: () => void
@@ -1574,6 +1587,8 @@ function AgentSessionItem({
   showPinIcon,
   isInWorkingSection,
   leftAccent,
+  flash,
+  onFlashEnd,
   onSelect,
   onRequestDelete,
   onRequestMove,
@@ -1631,8 +1646,10 @@ function AgentSessionItem({
       }}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
+      onAnimationEnd={onFlashEnd}
       className={cn(
         'relative w-full flex items-center gap-2 px-3 py-[7px] rounded-[10px] transition-colors duration-100 titlebar-no-drag text-left',
+        flash && 'session-pin-flash',
         active
           ? 'session-item-selected bg-primary/10 shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
           : 'hover:bg-primary/5'

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -790,3 +790,12 @@
 .file-browser-row-flash {
   animation: file-browser-flash 1.2s ease-out;
 }
+
+/* ===== 侧边栏置顶闪烁 ===== */
+@keyframes session-pin-flash {
+  0%   { background-color: hsl(var(--primary) / 0.15); }
+  100% { background-color: transparent; }
+}
+.session-pin-flash {
+  animation: session-pin-flash 1.7s ease-out;
+}


### PR DESCRIPTION
## Overview

修复 Agent 模式下从"工作中"子标签页置顶非工作中会话后，会话消失找不到的问题。现在置顶时会自动切换到"置顶"子标签页，并通过背景闪烁动画引导用户注意到刚置顶的会话。

## Changes

- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — `handleTogglePinAgent` 中新增：置顶非工作中会话时自动 `setAgentSubTab('pinned')`；新增 `flashSessionId` 状态，在置顶列表的 `AgentSessionItem` 中传入 `flash` / `onFlashEnd` props，动画结束时清除闪烁状态
- `apps/electron/src/renderer/styles/globals.css` — 新增 `@keyframes session-pin-flash` 动画（1.7s ease-out，背景从 primary/0.15 渐隐到透明）

## How to Test

1. 启动 Proma 进入 Agent 模式
2. 在"最近会话"区域找一个非工作中的会话
3. Hover 该会话，点击置顶按钮
4. 确认：自动切换到"置顶"子标签页，且该会话背景闪烁高亮约 1.7 秒
5. 在"工作中"区域置顶一个工作中的会话，确认不切换子标签（工作中会话仍在原处）

## Notes

- 工作在中的会话置顶后仍留在"工作中"区域，不做切换，因为 working 区域独立于 pinned 状态
- Chat 模式不受影响（Chat 没有子标签切换机制）

🤖 Generated with [Claude Code](https://claude.com/claude-code)