### PR TITLE
fix: 文件预览弹窗滚动条始终可见 【已审核 PR】

### DIFF
--- a/apps/electron/src/main/lib/file-preview-service.ts
+++ b/apps/electron/src/main/lib/file-preview-service.ts
@@ -388,16 +388,15 @@ function baseStyles(): string {
       justify-content: center;
       background: var(--content-bg);
     }
-    /* 自定义细滚动条：默认透明，hover 容器才显示 */
+    /* 自定义细滚动条 */
     ::-webkit-scrollbar { width: 10px; height: 10px; }
     ::-webkit-scrollbar-track { background: transparent; }
     ::-webkit-scrollbar-thumb {
-      background: transparent;
+      background: var(--scrollbar);
       border-radius: 10px;
       border: 2px solid transparent;
       background-clip: content-box;
     }
-    *:hover::-webkit-scrollbar-thumb { background: var(--scrollbar); background-clip: content-box; }
     ::-webkit-scrollbar-thumb:hover { background-color: var(--scrollbar) !important; }
   `
 }


### PR DESCRIPTION
## Overview
文件预览弹窗（双击工作区文件后弹出的独立窗口）的滚动条 thumb 默认透明，只有鼠标 hover 到内容区域才显示，导致用户无法看到滚动进度条。

## Changes
- `apps/electron/src/main/lib/file-preview-service.ts` — 将 `::-webkit-scrollbar-thumb` 的 `background` 从 `transparent` 改为 `var(--scrollbar)`，移除 `*:hover::-webkit-scrollbar-thumb` 规则，滚动条始终可见

## How to Test
1. 打开 Proma Agent 模式
2. 在右侧工作区文件列表中双击任意文本/代码文件
3. 确认预览弹窗中滚动条始终可见（不再需要 hover 才显示）
4. 切换浅色/深色主题，确认滚动条颜色跟随主题变化

## Notes
- `--scrollbar` CSS 变量已在 `baseStyles()` 中按主题定义，无需额外处理