### PR TITLE
Refactor(ui): subtab UI 小重构 + 工作区 UI 小重构 + FileDropZone 双区拆分 + 其他小 UI 重构 【PR 二次审核已完成】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.9.15",
+  "version": "0.9.10",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {
@@ -37,7 +37,13 @@
     "dist:debug": "bun run scripts/dist.ts --current-arch --verbose"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.2.111"
+    "@anthropic-ai/claude-agent-sdk": "0.2.120"
+  },
+  "optionalDependencies": {
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.120",
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.120",
+    "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.120",
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.120"
   },
   "devDependencies": {
     "@emoji-mart/data": "^1.2.1",

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.9.14",
+  "version": "0.9.15",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {
@@ -37,13 +37,13 @@
     "dist:debug": "bun run scripts/dist.ts --current-arch --verbose"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.2.120"
+    "@anthropic-ai/claude-agent-sdk": "0.2.123"
   },
   "optionalDependencies": {
-    "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.120",
-    "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.120",
-    "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.120",
-    "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.120"
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.123",
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.123",
+    "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.123",
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.123"
   },
   "devDependencies": {
     "@emoji-mart/data": "^1.2.1",

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -276,11 +276,11 @@ export const agentPendingPromptAtom = atom<AgentPendingPrompt | null>(null)
 /** Agent 待发送文件列表 */
 export const agentPendingFilesAtom = atom<AgentPendingFile[]>([])
 
-/** 工作区能力版本号 — 每次修改 MCP/Skills 后自增，触发侧边栏重新获取 */
-export const workspaceCapabilitiesVersionAtom = atom(0)
+/** 工作区能力版本号 — 每次修改 MCP/Skills 后自增，触发侧边栏重新获取（按 workspaceId 隔离） */
+export const workspaceCapabilitiesVersionAtom = atom<Map<string, number>>(new Map())
 
-/** 工作区文件版本号 — 文件变化时自增，触发文件浏览器重新加载 */
-export const workspaceFilesVersionAtom = atom(0)
+/** 工作区文件版本号 — 文件变化时自增，触发文件浏览器重新加载（按 workspaceId 隔离） */
+export const workspaceFilesVersionAtom = atom<Map<string, number>>(new Map())
 
 // ===== 侧面板 Atoms =====
 

--- a/apps/electron/src/renderer/atoms/sidebar-atoms.ts
+++ b/apps/electron/src/renderer/atoms/sidebar-atoms.ts
@@ -13,12 +13,6 @@ export type SidebarViewMode = 'active' | 'archived'
 /** 侧边栏视图模式（active = 显示活跃对话，archived = 显示已归档对话） */
 export const sidebarViewModeAtom = atom<SidebarViewMode>('active')
 
-/** 工作区列表高度（px），用户可拖拽调整，持久化到 localStorage */
-export const workspaceListHeightAtom = atomWithStorage<number>(
-  'proma-workspace-list-height',
-  120,
-)
-
 /**
  * Agent 模式侧边栏上区（Working/置顶 Tab）的高度（px）。
  *

--- a/apps/electron/src/renderer/components/agent/AgentHeader.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentHeader.tsx
@@ -7,10 +7,8 @@
 
 import * as React from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
-import { Pencil, Check, X, PanelRight } from 'lucide-react'
-import { Button } from '@/components/ui/button'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { agentSessionsAtom, agentSidePanelOpenMapAtom, workspaceFilesVersionAtom } from '@/atoms/agent-atoms'
+import { Pencil, Check, X } from 'lucide-react'
+import { agentSessionsAtom } from '@/atoms/agent-atoms'
 
 /** AgentHeader 属性接口 */
 interface AgentHeaderProps {
@@ -24,21 +22,6 @@ export function AgentHeader({ sessionId }: AgentHeaderProps): React.ReactElement
   const [editing, setEditing] = React.useState(false)
   const [editTitle, setEditTitle] = React.useState('')
   const inputRef = React.useRef<HTMLInputElement>(null)
-
-  // 文件面板切换状态
-  const sidePanelOpenMap = useAtomValue(agentSidePanelOpenMapAtom)
-  const setSidePanelOpenMap = useSetAtom(agentSidePanelOpenMapAtom)
-  const filesVersion = useAtomValue(workspaceFilesVersionAtom)
-  const isPanelOpen = sidePanelOpenMap.get(sessionId) ?? true
-  const hasFileChanges = filesVersion > 0
-
-  const togglePanel = React.useCallback(() => {
-    setSidePanelOpenMap((prev) => {
-      const map = new Map(prev)
-      map.set(sessionId, !(map.get(sessionId) ?? true))
-      return map
-    })
-  }, [sessionId, setSidePanelOpenMap])
 
   if (!session) return null
 

--- a/apps/electron/src/renderer/components/agent/AgentHeader.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentHeader.tsx
@@ -124,28 +124,6 @@ export function AgentHeader({ sessionId }: AgentHeaderProps): React.ReactElement
               <Pencil className="size-3.5" />
             </button>
           </div>
-          {/* 文件面板打开按钮（仅面板关闭时显示） */}
-          {!isPanelOpen && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="relative titlebar-no-drag h-7 w-7 flex-shrink-0"
-                  onClick={togglePanel}
-                >
-                  <PanelRight className="size-3.5" />
-                  {hasFileChanges && (
-                    <span className="absolute -top-0.5 -right-0.5 size-2 rounded-full bg-primary animate-pulse" />
-                  )}
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">
-                <p>打开文件面板</p>
-              </TooltipContent>
-            </Tooltip>
-          )}
         </>
       )}
     </div>

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -74,7 +74,6 @@ import {
   allPendingAskUserRequestsAtom,
   allPendingExitPlanRequestsAtom,
   finalizeStreamingActivities,
-  currentAgentSessionIdAtom,
   agentSidePanelOpenMapAtom,
   workspaceFilesVersionAtom,
 } from '@/atoms/agent-atoms'
@@ -1326,7 +1325,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   return (
     <>
     <AgentSessionProvider sessionId={sessionId}>
-      {/* 文件面板打开按钮（仅面板关闭时显示，固定右上角） */}
+      {/* 文件面板打开按钮（仅面板关闭时显示，固定右上角）
+          垂直位置：titlebar 底部 + AgentHeader 内垂直居中（(header高 - 按钮高)/2） */}
       {!isPanelOpen && (
         <Tooltip>
           <TooltipTrigger asChild>
@@ -1334,7 +1334,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
               type="button"
               variant="ghost"
               size="icon"
-              className="fixed right-4 top-[63px] z-50 titlebar-no-drag h-7 w-7"
+              className="fixed right-4 top-[calc(var(--titlebar-height)+(var(--agent-header-height)-1.75rem)/2)] z-50 titlebar-no-drag h-7 w-7"
               onClick={() => setPanelOpenMap((prev) => { const m = new Map(prev); m.set(sessionId, true); return m })}
             >
               <PanelRight className="size-3.5" />

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -16,7 +16,7 @@
 import * as React from 'react'
 import { useAtom, useAtomValue, useSetAtom, useStore } from 'jotai'
 import { toast } from 'sonner'
-import { Bot, CornerDownLeft, Square, Settings, Paperclip, FolderPlus, X, Copy, Check, Brain, Map as MapIcon, Sparkles } from 'lucide-react'
+import { Bot, CornerDownLeft, Square, Settings, Paperclip, FolderPlus, X, Copy, Check, Brain, Map as MapIcon, Sparkles, PanelRight } from 'lucide-react'
 import { AgentMessages } from './AgentMessages'
 import { AgentHeader } from './AgentHeader'
 import { ContextUsageBadge } from './ContextUsageBadge'
@@ -74,6 +74,9 @@ import {
   allPendingAskUserRequestsAtom,
   allPendingExitPlanRequestsAtom,
   finalizeStreamingActivities,
+  currentAgentSessionIdAtom,
+  agentSidePanelOpenMapAtom,
+  workspaceFilesVersionAtom,
 } from '@/atoms/agent-atoms'
 import type { AgentContextStatus } from '@/atoms/agent-atoms'
 import { settingsOpenAtom } from '@/atoms/settings-tab'
@@ -185,6 +188,12 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const stoppedByUserSessions = useAtomValue(stoppedByUserSessionsAtom)
   const sendWithCmdEnter = useAtomValue(sendWithCmdEnterAtom)
   const stoppedByUser = stoppedByUserSessions.has(sessionId)
+  // 文件面板
+  const panelOpenMap = useAtomValue(agentSidePanelOpenMapAtom)
+  const isPanelOpen = panelOpenMap.get(sessionId) ?? true
+  const setPanelOpenMap = useSetAtom(agentSidePanelOpenMapAtom)
+  const filesVersion = useAtomValue(workspaceFilesVersionAtom)
+  const hasFileChanges = filesVersion > 0
   const liveMessagesMap = useAtomValue(liveMessagesMapAtom)
   const setLiveMessagesMap = useSetAtom(liveMessagesMapAtom)
   // 稳定化空数组引用，避免 ?? [] 每次创建新引用导致下游 useMemo 链不必要重算
@@ -1313,6 +1322,28 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   return (
     <>
     <AgentSessionProvider sessionId={sessionId}>
+      {/* 文件面板打开按钮（仅面板关闭时显示，固定右上角） */}
+      {!isPanelOpen && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="fixed right-4 top-[63px] z-50 titlebar-no-drag h-7 w-7"
+              onClick={() => setPanelOpenMap((prev) => { const m = new Map(prev); m.set(sessionId, true); return m })}
+            >
+              <PanelRight className="size-3.5" />
+              {hasFileChanges && (
+                <span className="absolute -top-0.5 -right-0.5 size-2 rounded-full bg-primary animate-pulse" />
+              )}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            <p>打开文件面板</p>
+          </TooltipContent>
+        </Tooltip>
+      )}
       {/* 主内容区域 */}
       <div className="flex flex-col h-full flex-1 min-w-0 max-w-[min(72rem,100%)] mx-auto">
         {/* Agent Header */}

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -192,8 +192,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const panelOpenMap = useAtomValue(agentSidePanelOpenMapAtom)
   const isPanelOpen = panelOpenMap.get(sessionId) ?? true
   const setPanelOpenMap = useSetAtom(agentSidePanelOpenMapAtom)
-  const filesVersion = useAtomValue(workspaceFilesVersionAtom)
-  const hasFileChanges = filesVersion > 0
+  const filesVersionMap = useAtomValue(workspaceFilesVersionAtom)
   const liveMessagesMap = useAtomValue(liveMessagesMapAtom)
   const setLiveMessagesMap = useSetAtom(liveMessagesMapAtom)
   // 稳定化空数组引用，避免 ?? [] 每次创建新引用导致下游 useMemo 链不必要重算
@@ -219,6 +218,11 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     if (!meta) return globalWorkspaceId // 数据未加载，回退全局
     return meta.workspaceId ?? null     // 数据已加载，以会话自身为准
   }, [sessions, sessionId, globalWorkspaceId])
+  // 按工作区隔离的文件变更指示：仅当前工作区有文件变更时才显示脉冲点
+  const hasFileChanges = React.useMemo(
+    () => (filesVersionMap.get(currentWorkspaceId ?? '') ?? 0) > 0,
+    [filesVersionMap, currentWorkspaceId],
+  )
   const [pendingPrompt, setPendingPrompt] = useAtom(agentPendingPromptAtom)
   const [pendingFiles, setPendingFiles] = useAtom(agentPendingFilesAtom)
   const workspaces = useAtomValue(agentWorkspacesAtom)

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -16,7 +16,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { cn } from '@/lib/utils'
+import { cn, bumpMapVersion } from '@/lib/utils'
 import { FileBrowser, FileDropZone, FileTypeIcon } from '@/components/file-browser'
 import {
   agentSidePanelOpenMapAtom,
@@ -60,13 +60,16 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
     })
   }, [sessionId, setSidePanelOpenMap])
 
-  const filesVersion = useAtomValue(workspaceFilesVersionAtom)
-  const setFilesVersion = useSetAtom(workspaceFilesVersionAtom)
-  const hasFileChanges = filesVersion > 0
-
-  // 派生当前工作区 slug（用于 FileDropZone IPC 调用）
+  // 派生当前工作区 ID（用于文件版本隔离和 FileDropZone IPC 调用）
   const currentWorkspaceId = useAtomValue(currentAgentWorkspaceIdAtom)
   const workspaces = useAtomValue(agentWorkspacesAtom)
+
+  const filesVersionMap = useAtomValue(workspaceFilesVersionAtom)
+  const setFilesVersionMap = useSetAtom(workspaceFilesVersionAtom)
+  // 按工作区隔离文件变更指示
+  const filesVersion = filesVersionMap.get(currentWorkspaceId ?? '') ?? 0
+  const hasFileChanges = filesVersion > 0
+
   const workspaceSlug = workspaces.find((w) => w.id === currentWorkspaceId)?.slug ?? null
 
   // 附加目录列表（会话级）
@@ -179,13 +182,15 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
 
   // 文件上传完成后递增版本号，触发 FileBrowser 刷新
   const handleFilesUploaded = React.useCallback(() => {
-    setFilesVersion((prev) => prev + 1)
-  }, [setFilesVersion])
+    if (!currentWorkspaceId) return
+    setFilesVersionMap((prev) => bumpMapVersion(prev, currentWorkspaceId))
+  }, [setFilesVersionMap, currentWorkspaceId])
 
   // 手动刷新文件列表
   const handleRefresh = React.useCallback(() => {
-    setFilesVersion((prev) => prev + 1)
-  }, [setFilesVersion])
+    if (!currentWorkspaceId) return
+    setFilesVersionMap((prev) => bumpMapVersion(prev, currentWorkspaceId))
+  }, [setFilesVersionMap, currentWorkspaceId])
 
   // 添加文件到聊天
   const pendingFiles = useAtomValue(agentPendingFilesAtom)
@@ -284,15 +289,7 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                           </TooltipContent>
                         </Tooltip>
                         {/* 操作按钮组 */}
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Info className="size-3 text-muted-foreground/50 cursor-help" />
-                          </TooltipTrigger>
-                          <TooltipContent side="bottom" className="max-w-[200px]">
-                            <p>当前会话的专属文件，仅本次对话的 Agent 可以访问</p>
-                          </TooltipContent>
-                        </Tooltip>
-                        <span className="text-[10px] text-muted-foreground/75 truncate flex-1" title={sessionPath}>
+                        <span className="text-[10px] text-muted-foreground/75 truncate flex-1" title={sessionPath}>>
                           {breadcrumb}
                         </span>
                         <Tooltip>

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -289,7 +289,7 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                           </TooltipContent>
                         </Tooltip>
                         {/* 操作按钮组 */}
-                        <span className="text-[10px] text-muted-foreground/75 truncate flex-1" title={sessionPath}>>
+                        <span className="text-[10px] text-muted-foreground/75 truncate flex-1" title={sessionPath}>
                           {breadcrumb}
                         </span>
                         <Tooltip>

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -7,7 +7,7 @@
 
 import * as React from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
-import { X, FolderOpen, ExternalLink, RefreshCw, ChevronRight, MoreHorizontal, FolderSearch, Pencil, FolderInput, FolderHeart, MessageSquarePlus } from 'lucide-react'
+import { X, FolderOpen, ExternalLink, RefreshCw, ChevronRight, MoreHorizontal, FolderSearch, Pencil, FolderInput, FolderHeart, MessageSquarePlus, Info } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import {
@@ -283,38 +283,50 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                             <p>当前会话的专属文件，仅本次对话的 Agent 可以访问</p>
                           </TooltipContent>
                         </Tooltip>
+                        {/* 操作按钮组 */}
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Info className="size-3 text-muted-foreground/50 cursor-help" />
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom" className="max-w-[200px]">
+                            <p>当前会话的专属文件，仅本次对话的 Agent 可以访问</p>
+                          </TooltipContent>
+                        </Tooltip>
                         <span className="text-[10px] text-muted-foreground/75 truncate flex-1" title={sessionPath}>
                           {breadcrumb}
                         </span>
-                        {/* 更多操作菜单 */}
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
                             <Button
                               type="button"
                               variant="ghost"
                               size="icon"
                               className="h-5 w-5 flex-shrink-0"
+                              onClick={() => window.electronAPI.openFile(sessionPath).catch(console.error)}
                             >
-                              <MoreHorizontal className="size-2.5" />
+                              <ExternalLink className="size-2.5" />
                             </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="end" className="w-36 min-w-0 p-0.5">
-                            <DropdownMenuItem
-                              className="text-xs py-1 [&>svg]:size-3"
-                              onSelect={() => window.electronAPI.openFile(sessionPath).catch(console.error)}
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom">
+                            <p>在 Finder 中打开</p>
+                          </TooltipContent>
+                        </Tooltip>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon"
+                              className="h-5 w-5 flex-shrink-0"
+                              onClick={handleRefresh}
                             >
-                              <ExternalLink />
-                              在 Finder 中打开
-                            </DropdownMenuItem>
-                            <DropdownMenuItem
-                              className="text-xs py-1 [&>svg]:size-3"
-                              onSelect={handleRefresh}
-                            >
-                              <RefreshCw />
-                              刷新文件列表
-                            </DropdownMenuItem>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
+                              <RefreshCw className="size-2.5" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom">
+                            <p>刷新文件列表</p>
+                          </TooltipContent>
+                        </Tooltip>
                         {/* 关闭面板按钮 */}
                         <Tooltip>
                           <TooltipTrigger asChild>
@@ -393,9 +405,10 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                   <div className="flex-1 min-h-0 flex flex-col mx-2 mb-2">
                     <div className="flex items-center gap-1 px-2 h-[32px] flex-shrink-0">
                       <FolderHeart className="size-3 text-muted-foreground" />
+                      <span className="text-[11px] font-medium text-muted-foreground">工作区文件</span>
                       <Tooltip>
                         <TooltipTrigger asChild>
-                          <span className="text-[11px] font-medium text-muted-foreground cursor-help">工作区文件</span>
+                          <Info className="size-3 text-muted-foreground/50 cursor-help" />
                         </TooltipTrigger>
                         <TooltipContent side="bottom" className="max-w-[220px]">
                           <p>工作区内所有会话可访问的文件和文件夹，每个新对话都可以自动读取</p>
@@ -403,27 +416,22 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                       </Tooltip>
                       <div className="flex-1" />
                       {workspaceFilesPath && (
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
                             <Button
                               type="button"
                               variant="ghost"
                               size="icon"
                               className="h-5 w-5 flex-shrink-0"
+                              onClick={() => window.electronAPI.openFile(workspaceFilesPath).catch(console.error)}
                             >
-                              <MoreHorizontal className="size-2.5" />
+                              <ExternalLink className="size-2.5" />
                             </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="end" className="w-36 min-w-0 p-0.5">
-                            <DropdownMenuItem
-                              className="text-xs py-1 [&>svg]:size-3"
-                              onSelect={() => window.electronAPI.openFile(workspaceFilesPath).catch(console.error)}
-                            >
-                              <ExternalLink />
-                              在 Finder 中打开
-                            </DropdownMenuItem>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom">
+                            <p>在 Finder 中打开工作区文件目录</p>
+                          </TooltipContent>
+                        </Tooltip>
                       )}
                     </div>
                     {/* 工作区文件内容区（独立滚动） */}

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -359,6 +359,7 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                           onFilesUploaded={handleFilesUploaded}
                           onAttachFolder={handleAttachFolder}
                           onFoldersDropped={handleSessionFoldersDropped}
+                          tooltip="拖拽文件到此处，供 Agent 读取和处理"
                         />
                       </div>
                       {/* ===== 分隔线 ===== */}
@@ -452,6 +453,7 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                         onFilesUploaded={handleFilesUploaded}
                         onAttachFolder={handleAttachWorkspaceFolder}
                         onFoldersDropped={handleWorkspaceFoldersDropped}
+                        tooltip="拖拽文件到此处，供本工作区内所有 Agent 访问"
                       />
                     </div>
                   </div>

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -68,7 +68,6 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
   const setFilesVersionMap = useSetAtom(workspaceFilesVersionAtom)
   // 按工作区隔离文件变更指示
   const filesVersion = filesVersionMap.get(currentWorkspaceId ?? '') ?? 0
-  const hasFileChanges = filesVersion > 0
 
   const workspaceSlug = workspaces.find((w) => w.id === currentWorkspaceId)?.slug ?? null
 

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -371,7 +371,6 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                           onFilesUploaded={handleFilesUploaded}
                           onAttachFolder={handleAttachFolder}
                           onFoldersDropped={handleSessionFoldersDropped}
-                          tooltip="拖拽文件到此处，供 Agent 读取和处理"
                         />
                       </div>
                       {/* ===== 分隔线 ===== */}
@@ -461,7 +460,6 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                         onFilesUploaded={handleFilesUploaded}
                         onAttachFolder={handleAttachWorkspaceFolder}
                         onFoldersDropped={handleWorkspaceFoldersDropped}
-                        tooltip="拖拽文件到此处，供本工作区内所有 Agent 访问"
                       />
                     </div>
                   </div>

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -7,7 +7,7 @@
 
 import * as React from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
-import { X, FolderOpen, ExternalLink, RefreshCw, ChevronRight, MoreHorizontal, FolderSearch, Pencil, FolderInput, Info, FolderHeart, MessageSquarePlus } from 'lucide-react'
+import { X, FolderOpen, ExternalLink, RefreshCw, ChevronRight, MoreHorizontal, FolderSearch, Pencil, FolderInput, FolderHeart, MessageSquarePlus } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import {
@@ -275,10 +275,9 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                     <>
                       <div className="flex items-center gap-1 pl-3 pr-2 h-[32px] flex-shrink-0">
                         <FolderOpen className="size-3 text-muted-foreground" />
-                        <span className="text-[11px] font-medium text-muted-foreground">会话文件</span>
                         <Tooltip>
                           <TooltipTrigger asChild>
-                            <Info className="size-3 text-muted-foreground/50 cursor-help" />
+                            <span className="text-[11px] font-medium text-muted-foreground cursor-help">会话文件</span>
                           </TooltipTrigger>
                           <TooltipContent side="bottom" className="max-w-[200px]">
                             <p>当前会话的专属文件，仅本次对话的 Agent 可以访问</p>
@@ -287,38 +286,35 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                         <span className="text-[10px] text-muted-foreground/75 truncate flex-1" title={sessionPath}>
                           {breadcrumb}
                         </span>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
+                        {/* 更多操作菜单 */}
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
                             <Button
                               type="button"
                               variant="ghost"
                               size="icon"
                               className="h-5 w-5 flex-shrink-0"
-                              onClick={() => window.electronAPI.openFile(sessionPath).catch(console.error)}
                             >
-                              <ExternalLink className="size-2.5" />
+                              <MoreHorizontal className="size-2.5" />
                             </Button>
-                          </TooltipTrigger>
-                          <TooltipContent side="bottom">
-                            <p>在 Finder 中打开</p>
-                          </TooltipContent>
-                        </Tooltip>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="icon"
-                              className="h-5 w-5 flex-shrink-0"
-                              onClick={handleRefresh}
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end" className="w-36 min-w-0 p-0.5">
+                            <DropdownMenuItem
+                              className="text-xs py-1 [&>svg]:size-3"
+                              onSelect={() => window.electronAPI.openFile(sessionPath).catch(console.error)}
                             >
-                              <RefreshCw className="size-2.5" />
-                            </Button>
-                          </TooltipTrigger>
-                          <TooltipContent side="bottom">
-                            <p>刷新文件列表</p>
-                          </TooltipContent>
-                        </Tooltip>
+                              <ExternalLink />
+                              在 Finder 中打开
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              className="text-xs py-1 [&>svg]:size-3"
+                              onSelect={handleRefresh}
+                            >
+                              <RefreshCw />
+                              刷新文件列表
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
                         {/* 关闭面板按钮 */}
                         <Tooltip>
                           <TooltipTrigger asChild>
@@ -396,10 +392,9 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                   <div className="flex-1 min-h-0 flex flex-col mx-2 mb-2">
                     <div className="flex items-center gap-1 px-2 h-[32px] flex-shrink-0">
                       <FolderHeart className="size-3 text-muted-foreground" />
-                      <span className="text-[11px] font-medium text-muted-foreground">工作区文件</span>
                       <Tooltip>
                         <TooltipTrigger asChild>
-                          <Info className="size-3 text-muted-foreground/50 cursor-help" />
+                          <span className="text-[11px] font-medium text-muted-foreground cursor-help">工作区文件</span>
                         </TooltipTrigger>
                         <TooltipContent side="bottom" className="max-w-[220px]">
                           <p>工作区内所有会话可访问的文件和文件夹，每个新对话都可以自动读取</p>
@@ -407,22 +402,27 @@ export function SidePanel({ sessionId, sessionPath }: SidePanelProps): React.Rea
                       </Tooltip>
                       <div className="flex-1" />
                       {workspaceFilesPath && (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
                             <Button
                               type="button"
                               variant="ghost"
                               size="icon"
                               className="h-5 w-5 flex-shrink-0"
-                              onClick={() => window.electronAPI.openFile(workspaceFilesPath).catch(console.error)}
                             >
-                              <ExternalLink className="size-2.5" />
+                              <MoreHorizontal className="size-2.5" />
                             </Button>
-                          </TooltipTrigger>
-                          <TooltipContent side="bottom">
-                            <p>在 Finder 中打开工作区文件目录</p>
-                          </TooltipContent>
-                        </Tooltip>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end" className="w-36 min-w-0 p-0.5">
+                            <DropdownMenuItem
+                              className="text-xs py-1 [&>svg]:size-3"
+                              onSelect={() => window.electronAPI.openFile(workspaceFilesPath).catch(console.error)}
+                            >
+                              <ExternalLink />
+                              在 Finder 中打开
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
                       )}
                     </div>
                     {/* 工作区文件内容区（独立滚动） */}

--- a/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
@@ -259,7 +259,7 @@ export function WorkspaceSelector(): React.ReactElement {
 
   return (
     <>
-      <div className="rounded-xl">
+      <div className={expanded ? 'border border-border rounded-lg overflow-hidden' : undefined}>
         {/* Toggle Bar — 点击展开/收起工作区列表 */}
         <div
           onClick={() => setExpanded((v) => !v)}
@@ -286,7 +286,7 @@ export function WorkspaceSelector(): React.ReactElement {
 
         {/* 展开后的工作区列表 */}
         {expanded && (
-          <div className="overflow-y-auto scrollbar-thin flex flex-col pb-1" style={{ maxHeight: 176 }}>
+          <div className="overflow-y-auto scrollbar-thin flex flex-col pb-1" style={{ maxHeight: 140 }}>
             {workspaces.map((ws) => (
               <div key={ws.id} className="relative">
                 {/* 上方插入指示线 */}

--- a/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
@@ -31,14 +31,6 @@ export function WorkspaceSelector(): React.ReactElement {
   const [currentWorkspaceId, setCurrentWorkspaceId] = useAtom(currentAgentWorkspaceIdAtom)
   const [expanded, setExpanded] = React.useState(false)
 
-  // 折叠时清理拖拽状态，防止 DOM 卸载导致 dragend 丢失
-  React.useEffect(() => {
-    if (!expanded) {
-      setDragId(null)
-      setDropIndicator(null)
-    }
-  }, [expanded])
-
   // 新建状态
   const [creating, setCreating] = React.useState(false)
   const [newName, setNewName] = React.useState('')
@@ -57,6 +49,14 @@ export function WorkspaceSelector(): React.ReactElement {
   // 拖拽状态
   const [dragId, setDragId] = React.useState<string | null>(null)
   const [dropIndicator, setDropIndicator] = React.useState<{ id: string; position: 'before' | 'after' } | null>(null)
+
+  // 折叠时清理拖拽状态，防止 DOM 卸载导致 dragend 丢失
+  React.useEffect(() => {
+    if (!expanded) {
+      setDragId(null)
+      setDropIndicator(null)
+    }
+  }, [expanded, setDragId, setDropIndicator])
 
   /** 切换工作区 */
   const handleSelect = (workspace: AgentWorkspace): void => {

--- a/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
@@ -7,7 +7,7 @@
 
 import * as React from 'react'
 import { useAtom } from 'jotai'
-import { FolderOpen, Plus, Pencil, Trash2, GripVertical } from 'lucide-react'
+import { FolderOpen, Plus, Pencil, Trash2, GripVertical, ChevronRight, ChevronDown } from 'lucide-react'
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
 import {
@@ -24,55 +24,12 @@ import {
   agentWorkspacesAtom,
   currentAgentWorkspaceIdAtom,
 } from '@/atoms/agent-atoms'
-import { workspaceListHeightAtom } from '@/atoms/sidebar-atoms'
 import type { AgentWorkspace } from '@proma/shared'
 
 export function WorkspaceSelector(): React.ReactElement {
   const [workspaces, setWorkspaces] = useAtom(agentWorkspacesAtom)
   const [currentWorkspaceId, setCurrentWorkspaceId] = useAtom(currentAgentWorkspaceIdAtom)
-  const [listHeight, setListHeight] = useAtom(workspaceListHeightAtom)
-
-  // 高度拖拽调整
-  const listRef = React.useRef<HTMLDivElement>(null)
-  const resizing = React.useRef(false)
-  const startY = React.useRef(0)
-  const startH = React.useRef(0)
-  const cleanupResizeRef = React.useRef<(() => void) | null>(null)
-
-  React.useEffect(() => {
-    return () => { cleanupResizeRef.current?.() }
-  }, [])
-
-  const handleResizeStart = React.useCallback(
-    (e: React.MouseEvent) => {
-      e.preventDefault()
-      resizing.current = true
-      startY.current = e.clientY
-      // 用实际渲染高度作为起点，避免 maxHeight > 实际高度时不跟手
-      startH.current = listRef.current?.getBoundingClientRect().height ?? 120
-
-      const onMove = (ev: MouseEvent): void => {
-        if (!resizing.current) return
-        const delta = ev.clientY - startY.current
-        const next = Math.min(400, Math.max(80, startH.current + delta))
-        setListHeight(next)
-      }
-      const onUp = (): void => {
-        resizing.current = false
-        document.removeEventListener('mousemove', onMove)
-        document.removeEventListener('mouseup', onUp)
-        document.body.style.cursor = ''
-        document.body.style.userSelect = ''
-        cleanupResizeRef.current = null
-      }
-      document.addEventListener('mousemove', onMove)
-      document.addEventListener('mouseup', onUp)
-      document.body.style.cursor = 'row-resize'
-      document.body.style.userSelect = 'none'
-      cleanupResizeRef.current = onUp
-    },
-    [setListHeight],
-  )
+  const [expanded, setExpanded] = React.useState(false)
 
   // 新建状态
   const [creating, setCreating] = React.useState(false)
@@ -295,124 +252,131 @@ export function WorkspaceSelector(): React.ReactElement {
     setDropIndicator(null)
   }
 
+  const currentWorkspace = React.useMemo(
+    () => workspaces.find((w) => w.id === currentWorkspaceId) ?? workspaces[0] ?? null,
+    [workspaces, currentWorkspaceId],
+  )
+
   return (
     <>
-      <div className="rounded-xl px-1 py-1.5">
-        {/* 头部 */}
-        <div className="flex items-center justify-between px-2.5 py-1.5">
-          <span className="text-[11px] font-medium text-foreground/50 uppercase tracking-wide">工作区</span>
+      <div className="rounded-xl">
+        {/* Toggle Bar — 点击展开/收起工作区列表 */}
+        <div
+          onClick={() => setExpanded((v) => !v)}
+          className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-xl hover:bg-foreground/[0.04] cursor-pointer titlebar-no-drag transition-colors"
+        >
+          {expanded
+            ? <ChevronDown size={13} className="text-foreground/40 flex-shrink-0" />
+            : <ChevronRight size={13} className="text-foreground/40 flex-shrink-0" />
+          }
+          <span className="text-[13px] font-medium text-foreground/50 uppercase tracking-wide">工作区</span>
+          {!expanded && (
+            <span className="flex-1 min-w-0 truncate text-[13px] font-medium text-foreground/60 ml-[27px]">
+              {currentWorkspace?.name ?? '默认'}
+            </span>
+          )}
           <button
-            onClick={handleStartCreate}
-            className="p-1 rounded hover:bg-foreground/[0.06] text-foreground/35 hover:text-foreground/60 transition-colors titlebar-no-drag"
+            onClick={(e) => { e.stopPropagation(); handleStartCreate() }}
+            className="p-0.5 rounded hover:bg-foreground/[0.08] text-foreground/35 hover:text-foreground/60 transition-colors flex-shrink-0 ml-auto"
             title="新建工作区"
           >
             <Plus size={13} />
           </button>
         </div>
 
-        {/* 工作区列表 */}
-        <div
-          ref={listRef}
-          className="overflow-y-auto scrollbar-thin flex flex-col p-1"
-          style={{ maxHeight: listHeight }}
-        >
-          {workspaces.map((ws) => (
-            <div key={ws.id} className="relative">
-              {/* 上方插入指示线 */}
-              {dropIndicator?.id === ws.id && dropIndicator.position === 'before' && (
-                <div className="absolute top-0 left-1 right-1 h-0.5 bg-primary rounded-full z-10" />
-              )}
-
-              <div
-                draggable={editingId !== ws.id}
-                onDragStart={(e) => handleDragStart(e, ws.id)}
-                onDragOver={(e) => handleDragOver(e, ws.id)}
-                onDragLeave={handleDragLeave}
-                onDrop={(e) => handleDrop(e, ws.id)}
-                onDragEnd={handleDragEnd}
-                onClick={() => handleSelect(ws)}
-                className={cn(
-                  'group w-full flex items-center gap-1 px-1 py-[5px] rounded-md text-[13px] transition-colors duration-100 cursor-pointer titlebar-no-drag',
-                  ws.id === currentWorkspaceId
-                    ? 'workspace-item-selected text-foreground font-semibold'
-                    : 'text-foreground/60 hover:text-foreground/80',
-                  dragId === ws.id && 'opacity-40',
+        {/* 展开后的工作区列表 */}
+        {expanded && (
+          <div className="overflow-y-auto scrollbar-thin flex flex-col px-1 pb-1" style={{ maxHeight: 176 }}>
+            {workspaces.map((ws) => (
+              <div key={ws.id} className="relative">
+                {/* 上方插入指示线 */}
+                {dropIndicator?.id === ws.id && dropIndicator.position === 'before' && (
+                  <div className="absolute top-0 left-1 right-1 h-0.5 bg-primary rounded-full z-10" />
                 )}
-              >
-              {/* 拖拽手柄 */}
-              <GripVertical size={12} className="flex-shrink-0 text-foreground/20 opacity-0 group-hover:opacity-100 transition-opacity cursor-grab active:cursor-grabbing" />
 
-              <FolderOpen size={13} className="flex-shrink-0 text-foreground/40" />
+                <div
+                  draggable={editingId !== ws.id}
+                  onDragStart={(e) => handleDragStart(e, ws.id)}
+                  onDragOver={(e) => handleDragOver(e, ws.id)}
+                  onDragLeave={handleDragLeave}
+                  onDrop={(e) => handleDrop(e, ws.id)}
+                  onDragEnd={handleDragEnd}
+                  onClick={() => handleSelect(ws)}
+                  className={cn(
+                    'group w-full flex items-center gap-1 px-3 py-[7px] rounded-xl text-[13px] transition-colors duration-100 cursor-pointer titlebar-no-drag',
+                    ws.id === currentWorkspaceId
+                      ? 'workspace-item-selected text-foreground'
+                      : 'text-foreground/60 hover:text-foreground/80',
+                    dragId === ws.id && 'opacity-40',
+                  )}
+                >
+                {/* 拖拽手柄 */}
+                <GripVertical size={12} className="flex-shrink-0 text-foreground/20 opacity-0 group-hover:opacity-100 transition-opacity cursor-grab active:cursor-grabbing" />
 
-              {editingId === ws.id ? (
+                <FolderOpen size={13} className="flex-shrink-0 text-foreground/40" />
+
+                {editingId === ws.id ? (
+                  <input
+                    ref={editInputRef}
+                    value={editName}
+                    onChange={(e) => setEditName(e.target.value)}
+                    onKeyDown={handleRenameKeyDown}
+                    onBlur={handleRename}
+                    onClick={(e) => e.stopPropagation()}
+                    className="flex-1 min-w-0 bg-transparent text-[13px] text-foreground border-b border-primary/50 outline-none px-0.5"
+                    maxLength={50}
+                  />
+                ) : (
+                  <>
+                    <span className="flex-1 min-w-0 truncate">{ws.name}</span>
+
+                    <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0">
+                      <button
+                        onClick={(e) => handleStartRename(e, ws)}
+                        className="p-0.5 rounded hover:bg-foreground/[0.08] text-foreground/30 hover:text-foreground/60 transition-colors"
+                        title="重命名"
+                      >
+                        <Pencil size={12} />
+                      </button>
+                      {canDelete(ws) && (
+                        <button
+                          onClick={(e) => handleStartDelete(e, ws.id)}
+                          className="p-0.5 rounded hover:bg-destructive/10 text-foreground/30 hover:text-destructive transition-colors"
+                          title="删除"
+                        >
+                          <Trash2 size={12} />
+                        </button>
+                      )}
+                    </div>
+                  </>
+                )}
+                </div>
+
+                {/* 下方插入指示线 */}
+                {dropIndicator?.id === ws.id && dropIndicator.position === 'after' && (
+                  <div className="absolute bottom-0 left-1 right-1 h-0.5 bg-primary rounded-full z-10" />
+                )}
+              </div>
+            ))}
+
+            {/* 新建工作区输入框 */}
+            {creating && (
+              <div className="flex items-center gap-2 px-2 py-[5px]">
+                <FolderOpen size={13} className="flex-shrink-0 text-foreground/40" />
                 <input
-                  ref={editInputRef}
-                  value={editName}
-                  onChange={(e) => setEditName(e.target.value)}
-                  onKeyDown={handleRenameKeyDown}
-                  onBlur={handleRename}
-                  onClick={(e) => e.stopPropagation()}
+                  ref={createInputRef}
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  onKeyDown={handleCreateKeyDown}
+                  onBlur={() => setCreating(false)}
+                  placeholder="工作区名称..."
                   className="flex-1 min-w-0 bg-transparent text-[13px] text-foreground border-b border-primary/50 outline-none px-0.5"
                   maxLength={50}
                 />
-              ) : (
-                <>
-                  <span className="flex-1 min-w-0 truncate">{ws.name}</span>
-
-                  <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0">
-                    <button
-                      onClick={(e) => handleStartRename(e, ws)}
-                      className="p-0.5 rounded hover:bg-foreground/[0.08] text-foreground/30 hover:text-foreground/60 transition-colors"
-                      title="重命名"
-                    >
-                      <Pencil size={12} />
-                    </button>
-                    {canDelete(ws) && (
-                      <button
-                        onClick={(e) => handleStartDelete(e, ws.id)}
-                        className="p-0.5 rounded hover:bg-destructive/10 text-foreground/30 hover:text-destructive transition-colors"
-                        title="删除"
-                      >
-                        <Trash2 size={12} />
-                      </button>
-                    )}
-                  </div>
-                </>
-              )}
               </div>
-
-              {/* 下方插入指示线 */}
-              {dropIndicator?.id === ws.id && dropIndicator.position === 'after' && (
-                <div className="absolute bottom-0 left-1 right-1 h-0.5 bg-primary rounded-full z-10" />
-              )}
-            </div>
-          ))}
-
-          {/* 新建工作区输入框 */}
-          {creating && (
-            <div className="flex items-center gap-2 px-2 py-[5px]">
-              <FolderOpen size={13} className="flex-shrink-0 text-foreground/40" />
-              <input
-                ref={createInputRef}
-                value={newName}
-                onChange={(e) => setNewName(e.target.value)}
-                onKeyDown={handleCreateKeyDown}
-                onBlur={() => setCreating(false)}
-                placeholder="工作区名称..."
-                className="flex-1 min-w-0 bg-transparent text-[13px] text-foreground border-b border-primary/50 outline-none px-0.5"
-                maxLength={50}
-              />
-            </div>
-          )}
-        </div>
-
-        {/* 拖拽调整高度的 handle */}
-        <div
-          onMouseDown={handleResizeStart}
-          className="h-1 cursor-row-resize group/resize flex items-center justify-center hover:bg-foreground/[0.06] transition-colors titlebar-no-drag"
-        >
-          <div className="w-8 h-[2px] rounded-full bg-foreground/0 group-hover/resize:bg-foreground/20 transition-colors" />
-        </div>
+            )}
+          </div>
+        )}
       </div>
 
       {/* 删除确认弹窗 */}

--- a/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
@@ -286,7 +286,7 @@ export function WorkspaceSelector(): React.ReactElement {
 
         {/* 展开后的工作区列表 */}
         {expanded && (
-          <div className="overflow-y-auto scrollbar-thin flex flex-col px-1 pb-1" style={{ maxHeight: 176 }}>
+          <div className="overflow-y-auto scrollbar-thin flex flex-col pb-1" style={{ maxHeight: 176 }}>
             {workspaces.map((ws) => (
               <div key={ws.id} className="relative">
                 {/* 上方插入指示线 */}
@@ -303,7 +303,7 @@ export function WorkspaceSelector(): React.ReactElement {
                   onDragEnd={handleDragEnd}
                   onClick={() => handleSelect(ws)}
                   className={cn(
-                    'group w-full flex items-center gap-1 px-3 py-[7px] rounded-xl text-[13px] transition-colors duration-100 cursor-pointer titlebar-no-drag',
+                    'group w-full flex items-center gap-2 px-3 py-[7px] rounded-[10px] text-[13px] transition-colors duration-100 cursor-pointer titlebar-no-drag',
                     ws.id === currentWorkspaceId
                       ? 'workspace-item-selected text-foreground'
                       : 'text-foreground/60 hover:text-foreground/80',

--- a/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
@@ -259,11 +259,11 @@ export function WorkspaceSelector(): React.ReactElement {
 
   return (
     <>
-      <div>
+      <div className="relative -ml-[7px]">
         {/* Toggle Bar — 点击展开/收起工作区列表 */}
         <div
           onClick={() => setExpanded((v) => !v)}
-          className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-xl hover:bg-foreground/[0.04] cursor-pointer titlebar-no-drag transition-colors"
+          className="flex items-center gap-1.5 pl-[4px] pr-2.5 py-1.5 rounded-xl hover:bg-foreground/[0.04] cursor-pointer titlebar-no-drag transition-colors"
         >
           {expanded
             ? <ChevronDown size={13} className="text-foreground/40 flex-shrink-0" />
@@ -286,6 +286,9 @@ export function WorkspaceSelector(): React.ReactElement {
 
         {/* 展开后的工作区列表 */}
         {expanded && (
+          <>
+          {/* 竖线指示器：从 chevron 下方延伸至列表底部 */}
+          <div className="absolute left-[9.5px] top-[24px] bottom-0 w-0.5 bg-primary/60 rounded-full" />
           <div className="overflow-y-auto scrollbar-thin flex flex-col pb-1" style={{ maxHeight: 140 }}>
             {workspaces.map((ws) => (
               <div key={ws.id} className="relative">
@@ -303,7 +306,7 @@ export function WorkspaceSelector(): React.ReactElement {
                   onDragEnd={handleDragEnd}
                   onClick={() => handleSelect(ws)}
                   className={cn(
-                    'group w-full flex items-center gap-2 px-3 py-[7px] rounded-[10px] text-[13px] transition-colors duration-100 cursor-pointer titlebar-no-drag',
+                    'group flex items-center gap-2 ml-[22px] w-[calc(100%-22px)] py-[7px] pr-2 rounded-[10px] text-[13px] transition-colors duration-100 cursor-pointer titlebar-no-drag',
                     ws.id === currentWorkspaceId
                       ? 'workspace-item-selected text-foreground'
                       : 'text-foreground/60 hover:text-foreground/80',
@@ -376,6 +379,7 @@ export function WorkspaceSelector(): React.ReactElement {
               </div>
             )}
           </div>
+          </>
         )}
       </div>
 

--- a/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
@@ -297,9 +297,9 @@ export function WorkspaceSelector(): React.ReactElement {
 
   return (
     <>
-      <div className="rounded-lg border border-border/60 overflow-hidden">
+      <div className="rounded-xl px-1 py-1.5">
         {/* 头部 */}
-        <div className="flex items-center justify-between px-2.5 py-1.5 border-b border-border/40">
+        <div className="flex items-center justify-between px-2.5 py-1.5">
           <span className="text-[11px] font-medium text-foreground/50 uppercase tracking-wide">工作区</span>
           <button
             onClick={handleStartCreate}
@@ -334,8 +334,8 @@ export function WorkspaceSelector(): React.ReactElement {
                 className={cn(
                   'group w-full flex items-center gap-1 px-1 py-[5px] rounded-md text-[13px] transition-colors duration-100 cursor-pointer titlebar-no-drag',
                   ws.id === currentWorkspaceId
-                    ? 'workspace-item-selected bg-foreground/[0.08] text-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
-                    : 'text-foreground/70 hover:bg-foreground/[0.04]',
+                    ? 'workspace-item-selected text-foreground font-semibold'
+                    : 'text-foreground/60 hover:text-foreground/80',
                   dragId === ws.id && 'opacity-40',
                 )}
               >

--- a/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
@@ -31,6 +31,14 @@ export function WorkspaceSelector(): React.ReactElement {
   const [currentWorkspaceId, setCurrentWorkspaceId] = useAtom(currentAgentWorkspaceIdAtom)
   const [expanded, setExpanded] = React.useState(false)
 
+  // 折叠时清理拖拽状态，防止 DOM 卸载导致 dragend 丢失
+  React.useEffect(() => {
+    if (!expanded) {
+      setDragId(null)
+      setDropIndicator(null)
+    }
+  }, [expanded])
+
   // 新建状态
   const [creating, setCreating] = React.useState(false)
   const [newName, setNewName] = React.useState('')
@@ -263,7 +271,7 @@ export function WorkspaceSelector(): React.ReactElement {
         {/* Toggle Bar — 点击展开/收起工作区列表 */}
         <div
           onClick={() => setExpanded((v) => !v)}
-          className="flex items-center gap-1.5 pl-[4px] pr-2.5 py-1.5 rounded-xl hover:bg-foreground/[0.04] cursor-pointer titlebar-no-drag transition-colors"
+          className="flex items-center gap-1.5 pl-[6px] pr-2.5 py-1.5 rounded-xl hover:bg-foreground/[0.04] cursor-pointer titlebar-no-drag transition-colors"
         >
           {expanded
             ? <ChevronDown size={13} className="text-foreground/40 flex-shrink-0" />
@@ -271,7 +279,7 @@ export function WorkspaceSelector(): React.ReactElement {
           }
           <span className="text-[13px] font-medium text-foreground/50 uppercase tracking-wide">工作区</span>
           {!expanded && (
-            <span className="flex-1 min-w-0 truncate text-[13px] font-medium text-foreground/60 ml-[27px]">
+            <span className="flex-1 min-w-0 truncate text-[13px] font-medium text-foreground/50 tracking-wide ml-[27px]">
               {currentWorkspace?.name ?? '默认'}
             </span>
           )}
@@ -288,7 +296,7 @@ export function WorkspaceSelector(): React.ReactElement {
         {expanded && (
           <>
           {/* 竖线指示器：从 chevron 下方延伸至列表底部 */}
-          <div className="absolute left-[9.5px] top-[24px] bottom-0 w-0.5 bg-primary/60 rounded-full" />
+          <div className="absolute left-[11.5px] top-[24px] bottom-0 w-0.5 bg-primary/60 rounded-full indicator-line" />
           <div className="overflow-y-auto scrollbar-thin flex flex-col pb-1" style={{ maxHeight: 140 }}>
             {workspaces.map((ws) => (
               <div key={ws.id} className="relative">

--- a/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
@@ -259,7 +259,7 @@ export function WorkspaceSelector(): React.ReactElement {
 
   return (
     <>
-      <div className={expanded ? 'border border-border rounded-lg overflow-hidden' : undefined}>
+      <div>
         {/* Toggle Bar — 点击展开/收起工作区列表 */}
         <div
           onClick={() => setExpanded((v) => !v)}

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -1013,7 +1013,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                 className="flex flex-col min-h-0 flex-shrink-0 overflow-hidden"
               >
                 {/* Tab 切换按钮 */}
-                <div className="pt-2 px-3 flex-shrink-0">
+                <div className="pt-3 px-3 flex-shrink-0">
                   <div className="flex border-b border-border/30">
                     <button
                       onClick={() => setAgentSubTab('working')}

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -1024,12 +1024,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                           : 'border-transparent text-muted-foreground/70 hover:text-foreground'
                       )}
                     >
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Hammer size={13} fill="currentColor" />
-                        </TooltipTrigger>
-                        <TooltipContent side="bottom">工作中</TooltipContent>
-                      </Tooltip>
+                      工作中
                       {hasWorkingSessions && (
                         <span className={cn(
                           'inline-flex items-center justify-center min-w-[16px] h-4 px-1 rounded-full text-[10px]',
@@ -1050,12 +1045,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                           : 'border-transparent text-muted-foreground/70 hover:text-foreground'
                       )}
                     >
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Pin size={13} fill="currentColor" />
-                        </TooltipTrigger>
-                        <TooltipContent side="bottom">置顶</TooltipContent>
-                      </Tooltip>
+                      置顶
                       {pinnedAgentSessions.length > 0 && (
                         <span className={cn(
                           'inline-flex items-center justify-center min-w-[16px] h-4 px-1 rounded-full text-[10px]',
@@ -1157,7 +1147,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
           )}
 
           {/* 下区标题：最近会话 */}
-          <div className="px-3 pt-2 pb-1 text-[11px] font-medium text-foreground/40 select-none flex-shrink-0">
+          <div className="px-3 pt-[1px] pb-1 text-[11px] font-medium text-muted-foreground select-none flex-shrink-0">
             最近会话
           </div>
 
@@ -1445,7 +1435,7 @@ function ConversationItem({
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       className={cn(
-        'relative w-full flex items-center gap-2 px-3 py-[7px] rounded-xl transition-colors duration-100 titlebar-no-drag text-left',
+        'relative w-full flex items-center gap-2 px-3 py-[7px] rounded-[10px] transition-colors duration-100 titlebar-no-drag text-left',
         active
           ? 'session-item-selected bg-primary/10 shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
           : 'hover:bg-primary/5'
@@ -1647,23 +1637,16 @@ function AgentSessionItem({
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       className={cn(
-        'relative w-full flex items-center gap-2 py-[7px] rounded-xl transition-colors duration-100 titlebar-no-drag text-left',
-        leftAccent ? 'pl-[27px] pr-3' : 'px-3',
+        'relative w-full flex items-center gap-2 px-3 py-[7px] rounded-[10px] transition-colors duration-100 titlebar-no-drag text-left',
         active
-          ? cn(
-              'session-item-selected shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]',
-              !leftAccent && 'bg-primary/10',
-            )
+          ? 'session-item-selected bg-primary/10 shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
           : 'hover:bg-primary/5'
       )}
-      style={active && leftAccent ? {
-        background: 'linear-gradient(to right, transparent 15px, hsl(var(--primary) / 0.1) 15px)',
-      } : undefined}
     >
       {leftAccent && (
         <span
           className={cn(
-            'absolute left-[8px] top-1.5 bottom-1.5 w-[2px] rounded-full pointer-events-none',
+            'absolute left-1 top-1.5 bottom-1.5 w-[2px] rounded-full pointer-events-none',
             SESSION_LEFT_ACCENT_CLASS[leftAccent]
           )}
         />

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -1014,7 +1014,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
               >
                 {/* Tab 切换按钮 */}
                 <div className="pt-3 px-3 flex-shrink-0">
-                  <div className="flex border-b border-border/30">
+                  <div className="flex border-t border-border/30">
                     <button
                       onClick={() => setAgentSubTab('working')}
                       className={cn(

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -1014,7 +1014,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
               >
                 {/* Tab 切换按钮 */}
                 <div className="pt-3 px-3 flex-shrink-0">
-                  <div className="flex border-t border-border/30">
+                  <div className="flex border-b border-border/30">
                     <button
                       onClick={() => setAgentSubTab('working')}
                       className={cn(

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -200,7 +200,8 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
 
   // 工作区能力（MCP + Skill 计数）
   const [capabilities, setCapabilities] = React.useState<WorkspaceCapabilities | null>(null)
-  const capabilitiesVersion = useAtomValue(workspaceCapabilitiesVersionAtom)
+  const capabilitiesVersionMap = useAtomValue(workspaceCapabilitiesVersionAtom)
+  const capabilitiesVersion = capabilitiesVersionMap.get(currentWorkspaceId ?? '') ?? 0
 
   // Tab 状态
   const [tabs, setTabs] = useAtom(tabsAtom)
@@ -927,13 +928,13 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
 
       {/* Agent 模式：工作区选择器 */}
       {mode === 'agent' && (
-        <div className="px-3 pt-2">
+        <div className="px-3 pt-[13px]">
           <WorkspaceSelector />
         </div>
       )}
 
       {/* 新对话/新会话按钮 + 搜索按钮 */}
-      <div className="px-3 pt-2 flex items-center gap-1.5">
+      <div className="px-3 pt-[15px] flex items-center gap-1.5">
         <Tooltip>
           <TooltipTrigger asChild>
             <button
@@ -1013,12 +1014,12 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                 className="flex flex-col min-h-0 flex-shrink-0 overflow-hidden"
               >
                 {/* Tab 切换按钮 */}
-                <div className="pt-3 px-3 flex-shrink-0">
+                <div className="pt-[22px] px-3 flex-shrink-0">
                   <div className="flex border-b border-border/30">
                     <button
                       onClick={() => setAgentSubTab('working')}
                       className={cn(
-                        'relative flex-1 flex items-center justify-center gap-1.5 pb-1.5 text-[12px] font-medium transition-colors titlebar-no-drag',
+                        'relative flex-1 flex items-center justify-center gap-1.5 pb-1.5 pl-[3px] text-[12px] font-medium transition-colors titlebar-no-drag',
                         agentSubTab === 'working'
                           ? 'text-primary subtab-active'
                           : 'text-muted-foreground/70 hover:text-foreground'
@@ -1026,13 +1027,13 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                     >
                       工作中
                       {agentSubTab === 'working' && (
-                        <span className="absolute bottom-[3px] left-1/2 -translate-x-1/2 w-9/10 h-[3px] bg-primary rounded-full" />
+                        <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-4/5 h-0.5 bg-primary/60 indicator-line" />
                       )}
                       {hasWorkingSessions && (
                         <span className={cn(
                           'inline-flex items-center justify-center min-w-[16px] h-4 px-1 rounded-full text-[10px]',
                           agentSubTab === 'working'
-                            ? 'bg-primary/10 text-primary'
+                            ? 'bg-primary/20 text-primary'
                             : 'bg-foreground/10 text-foreground/50'
                         )}>
                           {workingGroups.todo.length + workingGroups.running.length + workingGroups.done.length}
@@ -1042,7 +1043,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                     <button
                       onClick={() => setAgentSubTab('pinned')}
                       className={cn(
-                        'relative flex-1 flex items-center justify-center gap-1.5 pb-1.5 text-[12px] font-medium transition-colors titlebar-no-drag',
+                        'relative flex-1 flex items-center justify-center gap-1.5 pb-1.5 pl-[3px] text-[12px] font-medium transition-colors titlebar-no-drag',
                         agentSubTab === 'pinned'
                           ? 'text-primary subtab-active'
                           : 'text-muted-foreground/70 hover:text-foreground'
@@ -1050,13 +1051,13 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                     >
                       置顶
                       {agentSubTab === 'pinned' && (
-                        <span className="absolute bottom-[3px] left-1/2 -translate-x-1/2 w-9/10 h-[3px] bg-primary rounded-full" />
+                        <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-4/5 h-0.5 bg-primary/60 indicator-line" />
                       )}
                       {pinnedAgentSessions.length > 0 && (
                         <span className={cn(
                           'inline-flex items-center justify-center min-w-[16px] h-4 px-1 rounded-full text-[10px]',
                           agentSubTab === 'pinned'
-                            ? 'bg-primary/10 text-primary'
+                            ? 'bg-primary/20 text-primary'
                             : 'bg-foreground/10 text-foreground/50'
                         )}>
                           {pinnedAgentSessions.length}
@@ -1153,7 +1154,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
           )}
 
           {/* 下区标题：最近会话 */}
-          <div className="px-3 -mt-[3px] pb-1 text-[11px] font-medium text-muted-foreground select-none flex-shrink-0">
+          <div className="px-3 -mt-[5px] pb-1 text-[11px] font-medium text-muted-foreground select-none flex-shrink-0">
             最近会话
           </div>
 

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -934,13 +934,18 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
 
       {/* 新对话/新会话按钮 + 搜索按钮 */}
       <div className="px-3 pt-2 flex items-center gap-1.5">
-        <button
-          onClick={mode === 'agent' ? handleNewAgentSession : handleNewConversation}
-          className="flex-1 flex items-center gap-2 px-3 py-2 rounded-[10px] text-[13px] font-medium text-foreground/70 bg-primary/5 hover:bg-primary/10 transition-colors duration-100 titlebar-no-drag border border-dashed border-[hsl(var(--dashed-border))] hover:border-[hsl(var(--dashed-border-hover))]"
-        >
-          <Plus size={14} />
-          <span>{mode === 'agent' ? '新会话' : '新对话'}</span>
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={mode === 'agent' ? handleNewAgentSession : handleNewConversation}
+              className="flex-1 flex items-center gap-2 px-3 py-2 rounded-[10px] text-[13px] font-medium text-foreground/70 bg-primary/5 hover:bg-primary/10 transition-colors duration-100 titlebar-no-drag border border-dashed border-[hsl(var(--dashed-border))] hover:border-[hsl(var(--dashed-border-hover))]"
+            >
+              <Plus size={14} />
+              <span>{mode === 'agent' ? '新会话' : '新对话'}</span>
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{mode === 'agent' ? '新会话' : '新对话'} (⌘N)</TooltipContent>
+        </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>
             <button
@@ -1009,22 +1014,27 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
               >
                 {/* Tab 切换按钮 */}
                 <div className="pt-2 px-3 flex-shrink-0">
-                  <div className="flex items-center gap-1 mb-0.5">
+                  <div className="flex border-b border-border/30">
                     <button
                       onClick={() => setAgentSubTab('working')}
                       className={cn(
-                        'px-2.5 py-0.5 rounded-md text-[12px] font-medium transition-colors titlebar-no-drag inline-flex items-center',
+                        'flex-1 flex items-center justify-center gap-1.5 pb-1.5 text-[12px] font-medium transition-colors titlebar-no-drag border-b-2',
                         agentSubTab === 'working'
-                          ? 'bg-foreground/[0.08] text-foreground/80'
-                          : 'text-foreground/40 hover:text-foreground/60 hover:bg-foreground/[0.04]'
+                          ? 'border-primary text-primary subtab-active'
+                          : 'border-transparent text-muted-foreground/70 hover:text-foreground'
                       )}
                     >
-                      工作中
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Hammer size={13} fill="currentColor" />
+                        </TooltipTrigger>
+                        <TooltipContent side="bottom">工作中</TooltipContent>
+                      </Tooltip>
                       {hasWorkingSessions && (
                         <span className={cn(
-                          'ml-1.5 inline-flex items-center justify-center min-w-[16px] h-4 px-1 rounded-full text-[10px]',
+                          'inline-flex items-center justify-center min-w-[16px] h-4 px-1 rounded-full text-[10px]',
                           agentSubTab === 'working'
-                            ? 'bg-foreground/10 text-foreground/60'
+                            ? 'bg-primary/10 text-primary'
                             : 'bg-foreground/10 text-foreground/50'
                         )}>
                           {workingGroups.todo.length + workingGroups.running.length + workingGroups.done.length}
@@ -1034,18 +1044,23 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                     <button
                       onClick={() => setAgentSubTab('pinned')}
                       className={cn(
-                        'px-2.5 py-0.5 rounded-md text-[12px] font-medium transition-colors titlebar-no-drag inline-flex items-center',
+                        'flex-1 flex items-center justify-center gap-1.5 pb-1.5 text-[12px] font-medium transition-colors titlebar-no-drag border-b-2',
                         agentSubTab === 'pinned'
-                          ? 'bg-foreground/[0.08] text-foreground/80'
-                          : 'text-foreground/40 hover:text-foreground/60 hover:bg-foreground/[0.04]'
+                          ? 'border-primary text-primary subtab-active'
+                          : 'border-transparent text-muted-foreground/70 hover:text-foreground'
                       )}
                     >
-                      置顶
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Pin size={13} fill="currentColor" />
+                        </TooltipTrigger>
+                        <TooltipContent side="bottom">置顶</TooltipContent>
+                      </Tooltip>
                       {pinnedAgentSessions.length > 0 && (
                         <span className={cn(
-                          'ml-1.5 inline-flex items-center justify-center min-w-[16px] h-4 px-1 rounded-full text-[10px]',
+                          'inline-flex items-center justify-center min-w-[16px] h-4 px-1 rounded-full text-[10px]',
                           agentSubTab === 'pinned'
-                            ? 'bg-foreground/10 text-foreground/60'
+                            ? 'bg-primary/10 text-primary'
                             : 'bg-foreground/10 text-foreground/50'
                         )}>
                           {pinnedAgentSessions.length}
@@ -1058,7 +1073,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                 {/* Tab 内容（自己滚动） */}
                 <div className="flex-1 overflow-y-auto scrollbar-none px-3 pb-1 min-h-0">
                   {agentSubTab === 'working' && (
-                    <div className="pt-0.5 pb-0.5">
+                    <div className="pt-2 pb-0.5">
                       {hasWorkingSessions ? (() => {
                         const workingItems: Array<{ session: AgentSessionMeta; accent: SessionLeftAccent; keyPrefix: string }> = [
                           ...workingGroups.todo.map((s) => ({ session: s, accent: 'orange' as const, keyPrefix: 'working-todo' })),
@@ -1099,7 +1114,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                   )}
 
                   {agentSubTab === 'pinned' && (
-                    <div className="pt-0.5 pb-0.5">
+                    <div className="pt-2 pb-0.5">
                       {pinnedAgentSessions.length > 0 ? (
                         <div className="flex flex-col gap-0.5">
                           {pinnedAgentSessions.map((session) => (

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -916,7 +916,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
             <TooltipTrigger asChild>
               <button
                 onClick={() => setSidebarCollapsed(true)}
-                className="mt-2 size-[36px] flex-shrink-0 flex items-center justify-center rounded-xl bg-muted text-foreground/40 hover:bg-foreground/[0.08] hover:text-foreground/60 transition-colors titlebar-no-drag"
+                className="mt-2 size-[36px] flex-shrink-0 flex items-center justify-center rounded-[10px] bg-muted text-foreground/40 hover:bg-foreground/[0.08] hover:text-foreground/60 transition-colors titlebar-no-drag"
               >
                 <PanelLeftClose size={14} />
               </button>

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -916,7 +916,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
             <TooltipTrigger asChild>
               <button
                 onClick={() => setSidebarCollapsed(true)}
-                className="mt-2 size-[36px] flex-shrink-0 flex items-center justify-center rounded-xl text-foreground/40 hover:bg-foreground/[0.04] hover:text-foreground/60 transition-colors titlebar-no-drag"
+                className="mt-2 size-[36px] flex-shrink-0 flex items-center justify-center rounded-xl bg-muted text-foreground/40 hover:bg-foreground/[0.08] hover:text-foreground/60 transition-colors titlebar-no-drag"
               >
                 <PanelLeftClose size={14} />
               </button>

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -1018,13 +1018,16 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                     <button
                       onClick={() => setAgentSubTab('working')}
                       className={cn(
-                        'flex-1 flex items-center justify-center gap-1.5 pb-1.5 text-[12px] font-medium transition-colors titlebar-no-drag border-b-2',
+                        'relative flex-1 flex items-center justify-center gap-1.5 pb-1.5 text-[12px] font-medium transition-colors titlebar-no-drag',
                         agentSubTab === 'working'
-                          ? 'border-primary text-primary subtab-active'
-                          : 'border-transparent text-muted-foreground/70 hover:text-foreground'
+                          ? 'text-primary subtab-active'
+                          : 'text-muted-foreground/70 hover:text-foreground'
                       )}
                     >
                       工作中
+                      {agentSubTab === 'working' && (
+                        <span className="absolute bottom-[3px] left-1/2 -translate-x-1/2 w-9/10 h-[3px] bg-primary rounded-full" />
+                      )}
                       {hasWorkingSessions && (
                         <span className={cn(
                           'inline-flex items-center justify-center min-w-[16px] h-4 px-1 rounded-full text-[10px]',
@@ -1039,13 +1042,16 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                     <button
                       onClick={() => setAgentSubTab('pinned')}
                       className={cn(
-                        'flex-1 flex items-center justify-center gap-1.5 pb-1.5 text-[12px] font-medium transition-colors titlebar-no-drag border-b-2',
+                        'relative flex-1 flex items-center justify-center gap-1.5 pb-1.5 text-[12px] font-medium transition-colors titlebar-no-drag',
                         agentSubTab === 'pinned'
-                          ? 'border-primary text-primary subtab-active'
-                          : 'border-transparent text-muted-foreground/70 hover:text-foreground'
+                          ? 'text-primary subtab-active'
+                          : 'text-muted-foreground/70 hover:text-foreground'
                       )}
                     >
                       置顶
+                      {agentSubTab === 'pinned' && (
+                        <span className="absolute bottom-[3px] left-1/2 -translate-x-1/2 w-9/10 h-[3px] bg-primary rounded-full" />
+                      )}
                       {pinnedAgentSessions.length > 0 && (
                         <span className={cn(
                           'inline-flex items-center justify-center min-w-[16px] h-4 px-1 rounded-full text-[10px]',
@@ -1147,7 +1153,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
           )}
 
           {/* 下区标题：最近会话 */}
-          <div className="px-3 pt-[1px] pb-1 text-[11px] font-medium text-muted-foreground select-none flex-shrink-0">
+          <div className="px-3 -mt-[3px] pb-1 text-[11px] font-medium text-muted-foreground select-none flex-shrink-0">
             最近会话
           </div>
 

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -92,7 +92,7 @@ function SidebarItem({ icon, label, active, suffix, onClick }: SidebarItemProps)
     <button
       onClick={onClick}
       className={cn(
-        'w-full flex items-center justify-between px-3 py-2 rounded-[10px] text-[13px] transition-colors duration-100 titlebar-no-drag',
+        'w-full flex items-center justify-between px-3 py-2 rounded-xl text-[13px] transition-colors duration-100 titlebar-no-drag',
         active
           ? 'bg-primary/10 text-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
           : 'text-foreground/60 hover:bg-primary/5 hover:text-foreground'
@@ -844,7 +844,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
             <TooltipTrigger asChild>
               <button
                 onClick={() => setSidebarCollapsed(false)}
-                className="p-2 rounded-[10px] text-foreground/60 hover:bg-foreground/[0.04] hover:text-foreground transition-colors titlebar-no-drag"
+                className="p-2 rounded-xl text-foreground/60 hover:bg-foreground/[0.04] hover:text-foreground transition-colors titlebar-no-drag"
               >
                 <PanelLeftOpen size={18} />
               </button>
@@ -859,7 +859,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
             <TooltipTrigger asChild>
               <button
                 onClick={mode === 'agent' ? handleNewAgentSession : handleNewConversation}
-                className="p-2 rounded-[10px] text-foreground/70 bg-primary/5 hover:bg-primary/10 transition-colors titlebar-no-drag border border-dashed border-[hsl(var(--dashed-border))] hover:border-[hsl(var(--dashed-border-hover))]"
+                className="p-2 rounded-xl text-foreground/70 bg-primary/5 hover:bg-primary/10 transition-colors titlebar-no-drag border border-dashed border-[hsl(var(--dashed-border))] hover:border-[hsl(var(--dashed-border-hover))]"
               >
                 <Plus size={16} />
               </button>
@@ -879,7 +879,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
             <TooltipTrigger asChild>
               <button
                 onClick={() => setSettingsOpen(true)}
-                className="relative p-1 rounded-[10px] transition-colors titlebar-no-drag hover:bg-foreground/5"
+                className="relative p-1 rounded-xl transition-colors titlebar-no-drag hover:bg-foreground/5"
               >
                 <UserAvatar avatar={userProfile.avatar} size={28} />
                 {(hasUpdate || hasEnvironmentIssues) && (
@@ -915,7 +915,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
             <TooltipTrigger asChild>
               <button
                 onClick={() => setSidebarCollapsed(true)}
-                className="mt-2 size-[36px] flex-shrink-0 flex items-center justify-center rounded-[10px] text-foreground/40 hover:bg-foreground/[0.04] hover:text-foreground/60 transition-colors titlebar-no-drag"
+                className="mt-2 size-[36px] flex-shrink-0 flex items-center justify-center rounded-xl text-foreground/40 hover:bg-foreground/[0.04] hover:text-foreground/60 transition-colors titlebar-no-drag"
               >
                 <PanelLeftClose size={14} />
               </button>
@@ -938,7 +938,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
           <TooltipTrigger asChild>
             <button
               onClick={mode === 'agent' ? handleNewAgentSession : handleNewConversation}
-              className="flex-1 flex items-center gap-2 px-3 py-2 rounded-[10px] text-[13px] font-medium text-foreground/70 bg-primary/5 hover:bg-primary/10 transition-colors duration-100 titlebar-no-drag border border-dashed border-[hsl(var(--dashed-border))] hover:border-[hsl(var(--dashed-border-hover))]"
+              className="flex-1 flex items-center gap-2 px-3 py-2 rounded-xl text-[13px] font-medium text-foreground/70 bg-primary/5 hover:bg-primary/10 transition-colors duration-100 titlebar-no-drag border border-dashed border-[hsl(var(--dashed-border))] hover:border-[hsl(var(--dashed-border-hover))]"
             >
               <Plus size={14} />
               <span>{mode === 'agent' ? '新会话' : '新对话'}</span>
@@ -950,7 +950,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
           <TooltipTrigger asChild>
             <button
               onClick={() => setSearchDialogOpen(true)}
-              className="flex-shrink-0 size-[36px] flex items-center justify-center rounded-[10px] text-foreground/40 bg-primary/5 hover:bg-primary/10 hover:text-foreground/60 transition-colors duration-100 titlebar-no-drag border border-dashed border-[hsl(var(--dashed-border))] hover:border-[hsl(var(--dashed-border-hover))]"
+              className="flex-shrink-0 size-[36px] flex items-center justify-center rounded-xl text-foreground/40 bg-primary/5 hover:bg-primary/10 hover:text-foreground/60 transition-colors duration-100 titlebar-no-drag border border-dashed border-[hsl(var(--dashed-border))] hover:border-[hsl(var(--dashed-border-hover))]"
             >
               <Search size={14} />
             </button>
@@ -1148,10 +1148,10 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                 </div>
               </div>
 
-              {/* 拖拽分割条：默认 1px 细线，hover 扩为 4px 热区 */}
+              {/* 拖拽分割条：视觉与右侧分隔线统一，py-1.5 扩大拖拽判定区域 */}
               <div
                 onMouseDown={handleAgentTopResizeStart}
-                className="h-px bg-border/60 hover:h-1 hover:bg-foreground/[0.08] cursor-row-resize titlebar-no-drag flex-shrink-0 transition-[height,background-color] duration-75"
+                className="mx-3 my-3 py-1.5 border-t border-muted-foreground/20 cursor-row-resize titlebar-no-drag flex-shrink-0"
               />
             </>
           )}
@@ -1278,7 +1278,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
             {mode === 'chat' && archivedConversationCount > 0 && (
               <button
                 onClick={() => setViewMode('archived')}
-                className="w-full flex items-center gap-2 px-3 py-2 rounded-[10px] text-[12px] text-foreground/40 hover:bg-foreground/[0.04] hover:text-foreground/60 transition-colors titlebar-no-drag"
+                className="w-full flex items-center gap-2 px-3 py-2 rounded-xl text-[12px] text-foreground/40 hover:bg-foreground/[0.04] hover:text-foreground/60 transition-colors titlebar-no-drag"
               >
                 <Archive size={13} className="text-foreground/30" />
                 <span>已归档 ({archivedConversationCount})</span>
@@ -1287,7 +1287,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
             {mode === 'agent' && archivedAgentSessionCount > 0 && (
               <button
                 onClick={() => setViewMode('archived')}
-                className="w-full flex items-center gap-2 px-3 py-2 rounded-[10px] text-[12px] text-foreground/40 hover:bg-foreground/[0.04] hover:text-foreground/60 transition-colors titlebar-no-drag"
+                className="w-full flex items-center gap-2 px-3 py-2 rounded-xl text-[12px] text-foreground/40 hover:bg-foreground/[0.04] hover:text-foreground/60 transition-colors titlebar-no-drag"
               >
                 <Archive size={13} className="text-foreground/30" />
                 <span>已归档 ({archivedAgentSessionCount})</span>
@@ -1297,7 +1297,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         ) : (
           <button
             onClick={() => setViewMode('active')}
-            className="w-full flex items-center gap-2 px-3 py-2 rounded-[10px] text-[12px] text-foreground/60 bg-foreground/[0.04] hover:bg-foreground/[0.07] hover:text-foreground/80 transition-colors titlebar-no-drag"
+            className="w-full flex items-center gap-2 px-3 py-2 rounded-xl text-[12px] text-foreground/60 bg-foreground/[0.04] hover:bg-foreground/[0.07] hover:text-foreground/80 transition-colors titlebar-no-drag"
           >
             <ArrowLeft size={13} className="text-foreground/50" />
             <span>返回活跃{mode === 'agent' ? '会话' : '对话'}</span>
@@ -1312,7 +1312,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
             <TooltipTrigger asChild>
               <button
                 onClick={() => { setSettingsTab('agent'); setSettingsOpen(true) }}
-                className="w-full flex items-center gap-3 px-3 py-2 rounded-[10px] text-[12px] text-foreground/50 hover:bg-foreground/[0.04] hover:text-foreground/70 transition-colors titlebar-no-drag"
+                className="w-full flex items-center gap-3 px-3 py-2 rounded-xl text-[12px] text-foreground/50 hover:bg-foreground/[0.04] hover:text-foreground/70 transition-colors titlebar-no-drag"
               >
                 <div className="flex items-center gap-2.5 flex-1 min-w-0">
                   <span className="flex items-center gap-1">
@@ -1338,7 +1338,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       <div className="px-3 pb-3">
         <button
           onClick={() => setSettingsOpen(true)}
-          className="w-full flex items-center gap-3 px-3 py-2 rounded-[10px] transition-colors titlebar-no-drag text-foreground/70 hover:bg-foreground/[0.04] hover:text-foreground"
+          className="w-full flex items-center gap-3 px-3 py-2 rounded-xl transition-colors titlebar-no-drag text-foreground/70 hover:bg-foreground/[0.04] hover:text-foreground"
         >
           <UserAvatar avatar={userProfile.avatar} size={28} />
           <span className="flex-1 text-sm truncate text-left">{userProfile.userName}</span>
@@ -1445,7 +1445,7 @@ function ConversationItem({
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       className={cn(
-        'relative w-full flex items-center gap-2 px-3 py-[7px] rounded-[10px] transition-colors duration-100 titlebar-no-drag text-left',
+        'relative w-full flex items-center gap-2 px-3 py-[7px] rounded-xl transition-colors duration-100 titlebar-no-drag text-left',
         active
           ? 'session-item-selected bg-primary/10 shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
           : 'hover:bg-primary/5'
@@ -1647,16 +1647,23 @@ function AgentSessionItem({
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       className={cn(
-        'relative w-full flex items-center gap-2 px-3 py-[7px] rounded-[10px] transition-colors duration-100 titlebar-no-drag text-left',
+        'relative w-full flex items-center gap-2 py-[7px] rounded-xl transition-colors duration-100 titlebar-no-drag text-left',
+        leftAccent ? 'pl-[27px] pr-3' : 'px-3',
         active
-          ? 'session-item-selected bg-primary/10 shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
+          ? cn(
+              'session-item-selected shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]',
+              !leftAccent && 'bg-primary/10',
+            )
           : 'hover:bg-primary/5'
       )}
+      style={active && leftAccent ? {
+        background: 'linear-gradient(to right, transparent 15px, hsl(var(--primary) / 0.1) 15px)',
+      } : undefined}
     >
       {leftAccent && (
         <span
           className={cn(
-            'absolute left-1 top-1.5 bottom-1.5 w-[2px] rounded-full pointer-events-none',
+            'absolute left-[8px] top-1.5 bottom-1.5 w-[2px] rounded-full pointer-events-none',
             SESSION_LEFT_ACCENT_CLASS[leftAccent]
           )}
         />

--- a/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
@@ -43,7 +43,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { cn } from '@/lib/utils'
-import { workspaceFilesVersionAtom, fileBrowserAutoRevealAtom, recentlyModifiedPathsAtom, currentAgentSessionIdAtom } from '@/atoms/agent-atoms'
+import { workspaceFilesVersionAtom, fileBrowserAutoRevealAtom, recentlyModifiedPathsAtom, currentAgentSessionIdAtom, currentAgentWorkspaceIdAtom } from '@/atoms/agent-atoms'
 import type { FileEntry } from '@proma/shared'
 import { FileTypeIcon } from './FileTypeIcon'
 
@@ -92,7 +92,9 @@ export function FileBrowser({ rootPath, hideToolbar, embedded, hideEmpty, onAddT
   const [entries, setEntries] = React.useState<FileEntry[]>([])
   const [loading, setLoading] = React.useState(false)
   const [error, setError] = React.useState<string | null>(null)
-  const filesVersion = useAtomValue(workspaceFilesVersionAtom)
+  const filesVersionMap = useAtomValue(workspaceFilesVersionAtom)
+  const currentWorkspaceId = useAtomValue(currentAgentWorkspaceIdAtom)
+  const filesVersion = filesVersionMap.get(currentWorkspaceId ?? '') ?? 0
 
   // ===== Agent 写入文件时的自动定位 =====
   const autoReveal = useAtomValue(fileBrowserAutoRevealAtom)

--- a/apps/electron/src/renderer/components/file-browser/FileDropZone.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileDropZone.tsx
@@ -1,7 +1,7 @@
 /**
  * FileDropZone — 文件拖拽上传区域
  *
- * 两个并排 drop zone：添加文件（回形针）+ 附加文件（文件夹）
+ * 两个并排 drop zone：添加文件（回形针）+ 附加文件夹（文件夹）
  * 两个 zone 都接受文件和文件夹拖放。
  */
 
@@ -18,7 +18,7 @@ interface FileDropZoneProps {
   target?: 'session' | 'workspace'
   onFilesUploaded: () => void
   onAttachFolder?: () => void
-  onFoldersDropped?: (folderPaths: string[]) => void
+  onFoldersDropped: (folderPaths: string[]) => void
 }
 
 export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onFilesUploaded, onAttachFolder, onFoldersDropped }: FileDropZoneProps): React.ReactElement {
@@ -29,6 +29,10 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
 
   const saveFiles = React.useCallback(async (files: globalThis.File[]): Promise<void> => {
     if (files.length === 0) return
+    if (!isWorkspace && !sessionId) {
+      console.error('[FileDropZone] session 模式下 sessionId 不能为空')
+      return
+    }
 
     setIsUploading(true)
     try {
@@ -61,7 +65,7 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
     }
   }, [workspaceSlug, sessionId, isWorkspace, onFilesUploaded])
 
-  const handleDrop = React.useCallback(async (e: React.DragEvent): Promise<void> => {
+  const handleDrop = React.useCallback(async (e: React.DragEvent, side: 'left' | 'right'): Promise<void> => {
     e.preventDefault()
     e.stopPropagation()
     setIsDragOver(null)
@@ -85,20 +89,30 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
       try {
         const { directories, files: filePaths } = await window.electronAPI.checkPathsType(paths)
 
-        if (directories.length > 0 && onFoldersDropped) {
-          onFoldersDropped(directories)
-        }
-
-        const regularFiles = filePaths.map((p) => pathMap.get(p)!).filter(Boolean)
-        if (regularFiles.length > 0) {
-          await saveFiles(regularFiles)
+        // 左侧：只上传文件，忽略目录
+        if (side === 'left') {
+          const regularFiles = filePaths.map((p) => pathMap.get(p)!).filter(Boolean)
+          if (regularFiles.length > 0) {
+            await saveFiles(regularFiles)
+          }
+        } else {
+          // 右侧：只附加文件夹，不上传文件
+          if (directories.length > 0) {
+            onFoldersDropped(directories)
+          }
         }
       } catch (error) {
         console.error('[FileDropZone] 路径检测失败，回退处理:', error)
-        await saveFiles(droppedFiles)
+        // 回退：左侧按常规文件处理
+        if (side === 'left') {
+          await saveFiles(droppedFiles)
+        }
       }
     } else {
-      await saveFiles(droppedFiles)
+      // 无路径信息回退：左侧按常规文件处理
+      if (side === 'left') {
+        await saveFiles(droppedFiles)
+      }
     }
   }, [saveFiles, onFoldersDropped])
 
@@ -115,6 +129,10 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
   }, [])
 
   const handleSelectFiles = React.useCallback(async (): Promise<void> => {
+    if (!isWorkspace && !sessionId) {
+      console.error('[FileDropZone] session 模式下 sessionId 不能为空')
+      return
+    }
     try {
       const result = await window.electronAPI.openFileDialog()
       if (result.files.length === 0) return
@@ -173,7 +191,7 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
                 className={zoneClass('left')}
                 onDragOver={(e) => handleDragOver(e, 'left')}
                 onDragLeave={handleDragLeave}
-                onDrop={handleDrop}
+                onDrop={(e) => handleDrop(e, 'left')}
                 onClick={handleSelectFiles}
               >
                 <span className="text-[11px] text-muted-foreground/75">添加文件</span>
@@ -184,17 +202,17 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
               <p>{isWorkspace ? '添加文件到工作区文件目录' : '将文件放入 Agent 工作文件夹'}</p>
             </TooltipContent>
           </Tooltip>
-          {/* 附加文件 */}
+          {/* 附加文件夹 */}
           <Tooltip>
             <TooltipTrigger asChild>
               <div
                 className={zoneClass('right')}
                 onDragOver={(e) => handleDragOver(e, 'right')}
                 onDragLeave={handleDragLeave}
-                onDrop={handleDrop}
+                onDrop={(e) => handleDrop(e, 'right')}
                 onClick={onAttachFolder}
               >
-                <span className="text-[11px] text-muted-foreground/75">附加文件</span>
+                <span className="text-[11px] text-muted-foreground/75">附加文件夹</span>
                 <FolderPlus className="size-4 text-muted-foreground/60" />
               </div>
             </TooltipTrigger>

--- a/apps/electron/src/renderer/components/file-browser/FileDropZone.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileDropZone.tsx
@@ -1,14 +1,13 @@
 /**
  * FileDropZone — 文件拖拽上传区域
  *
- * 极简 inline 提示，拖拽时高亮。文件上传后直接保存到目标目录。
+ * 两个并排 drop zone：添加文件（回形针）+ 附加文件（文件夹）
+ * 两个 zone 都接受文件和文件夹拖放。
  */
 
 import * as React from 'react'
 import { toast } from 'sonner'
 import { Paperclip, FolderPlus, Loader2 } from 'lucide-react'
-import { Button } from '@/components/ui/button'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { fileToBase64 } from '@/lib/file-utils'
 
@@ -22,9 +21,8 @@ interface FileDropZoneProps {
 }
 
 export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onFilesUploaded, onAttachFolder, onFoldersDropped }: FileDropZoneProps): React.ReactElement {
-  const [isDragOver, setIsDragOver] = React.useState(false)
+  const [isDragOver, setIsDragOver] = React.useState<'left' | 'right' | null>(null)
   const [isUploading, setIsUploading] = React.useState(false)
-  const [activeTooltip, setActiveTooltip] = React.useState<'paperclip' | 'folder' | null>(null)
 
   const isWorkspace = target === 'workspace'
 
@@ -62,22 +60,10 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
     }
   }, [workspaceSlug, sessionId, isWorkspace, onFilesUploaded])
 
-  const handleDragOver = React.useCallback((e: React.DragEvent): void => {
-    e.preventDefault()
-    e.stopPropagation()
-    setIsDragOver(true)
-  }, [])
-
-  const handleDragLeave = React.useCallback((e: React.DragEvent): void => {
-    e.preventDefault()
-    e.stopPropagation()
-    setIsDragOver(false)
-  }, [])
-
   const handleDrop = React.useCallback(async (e: React.DragEvent): Promise<void> => {
     e.preventDefault()
     e.stopPropagation()
-    setIsDragOver(false)
+    setIsDragOver(null)
 
     const droppedFiles = Array.from(e.dataTransfer.files)
     if (droppedFiles.length === 0) return
@@ -98,12 +84,8 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
       try {
         const { directories, files: filePaths } = await window.electronAPI.checkPathsType(paths)
 
-        if (directories.length > 0) {
-          if (onFoldersDropped) {
-            onFoldersDropped(directories)
-          } else {
-            toast.info('不支持拖拽文件夹', { description: '请使用「附加文件夹」按钮' })
-          }
+        if (directories.length > 0 && onFoldersDropped) {
+          onFoldersDropped(directories)
         }
 
         const regularFiles = filePaths.map((p) => pathMap.get(p)!).filter(Boolean)
@@ -118,6 +100,18 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
       await saveFiles(droppedFiles)
     }
   }, [saveFiles, onFoldersDropped])
+
+  const handleDragOver = React.useCallback((e: React.DragEvent, side: 'left' | 'right'): void => {
+    e.preventDefault()
+    e.stopPropagation()
+    setIsDragOver(side)
+  }, [])
+
+  const handleDragLeave = React.useCallback((e: React.DragEvent): void => {
+    e.preventDefault()
+    e.stopPropagation()
+    setIsDragOver(null)
+  }, [])
 
   const handleSelectFiles = React.useCallback(async (): Promise<void> => {
     try {
@@ -153,75 +147,48 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
     }
   }, [workspaceSlug, sessionId, isWorkspace, onFilesUploaded])
 
-  const dropZone = (
-    <div
-      className={cn(
-        'flex items-center gap-1.5 rounded-lg px-2 py-3 transition-colors duration-200',
-        isDragOver
-          ? 'bg-primary/10 ring-1 ring-primary/30'
-          : 'bg-muted/40 hover:bg-muted/70',
-        isUploading && 'pointer-events-none opacity-60',
-      )}
-      onDragOver={handleDragOver}
-      onDragLeave={handleDragLeave}
-      onDrop={handleDrop}
-    >
-      {isUploading ? (
-        <>
-          <Loader2 className="size-3.5 text-muted-foreground animate-spin" />
-          <span className="text-[11px] text-muted-foreground">正在上传...</span>
-        </>
-      ) : (
-        <>
-          <span className="text-[11px] text-muted-foreground/75 flex-1 truncate ml-[7px]">
-            {isDragOver ? '释放以添加文件' : '拖拽文件到此处'}
-          </span>
-          <Tooltip open={activeTooltip === 'paperclip'}>
-            <TooltipTrigger asChild>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                className="h-5 w-5 flex-shrink-0 text-muted-foreground/60 hover:text-foreground"
-                onClick={handleSelectFiles}
-                onMouseEnter={() => setActiveTooltip('paperclip')}
-                onMouseLeave={() => setActiveTooltip(null)}
-              >
-                <Paperclip className="size-3" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom" className="data-[state=closed]:animate-none data-[state=closed]:opacity-0 pointer-events-none">
-              <p>{isWorkspace ? '添加文件到工作区文件目录' : '将文件放入 Agent 工作文件夹'}</p>
-            </TooltipContent>
-          </Tooltip>
-          {onAttachFolder && (
-            <Tooltip open={activeTooltip === 'folder'}>
-              <TooltipTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="h-5 w-5 flex-shrink-0 text-muted-foreground/60 hover:text-foreground"
-                  onClick={onAttachFolder}
-                  onMouseEnter={() => setActiveTooltip('folder')}
-                  onMouseLeave={() => setActiveTooltip(null)}
-                >
-                  <FolderPlus className="size-3" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom" className="data-[state=closed]:animate-none data-[state=closed]:opacity-0 pointer-events-none">
-                <p>{isWorkspace ? '附加文件夹供工作区所有会话访问' : '告知 Agent 你想处理的文件夹'}</p>
-              </TooltipContent>
-            </Tooltip>
-          )}
-        </>
-      )}
-    </div>
-  )
+  const zoneClass = (side: 'left' | 'right'): string =>
+    cn(
+      'flex-1 flex flex-col items-center justify-center gap-1 rounded-lg px-2 py-2.5 transition-colors duration-200 cursor-pointer',
+      isDragOver === side
+        ? 'bg-primary/25 ring-2 ring-primary/50'
+        : 'bg-muted/40 hover:bg-muted/70',
+      isUploading && 'pointer-events-none opacity-60',
+    )
 
   return (
-    <div className="flex-shrink-0 px-3 pt-2 pb-1.5">
-      {dropZone}
+    <div className="flex gap-2 px-3 pt-2 pb-1.5 flex-shrink-0">
+      {isUploading ? (
+        <div className="flex-1 flex items-center justify-center gap-1.5 py-2.5 text-[11px] text-muted-foreground">
+          <Loader2 className="size-3.5 animate-spin" />
+          正在上传...
+        </div>
+      ) : (
+        <>
+          {/* 添加文件 */}
+          <div
+            className={zoneClass('left')}
+            onDragOver={(e) => handleDragOver(e, 'left')}
+            onDragLeave={handleDragLeave}
+            onDrop={handleDrop}
+            onClick={handleSelectFiles}
+          >
+            <span className="text-[11px] text-muted-foreground/75">添加文件</span>
+            <Paperclip className="size-4 text-muted-foreground/60" />
+          </div>
+          {/* 附加文件 */}
+          <div
+            className={zoneClass('right')}
+            onDragOver={(e) => handleDragOver(e, 'right')}
+            onDragLeave={handleDragLeave}
+            onDrop={handleDrop}
+            onClick={onAttachFolder}
+          >
+            <span className="text-[11px] text-muted-foreground/75">附加文件</span>
+            <FolderPlus className="size-4 text-muted-foreground/60" />
+          </div>
+        </>
+      )}
     </div>
   )
 }

--- a/apps/electron/src/renderer/components/file-browser/FileDropZone.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileDropZone.tsx
@@ -19,13 +19,12 @@ interface FileDropZoneProps {
   onFilesUploaded: () => void
   onAttachFolder?: () => void
   onFoldersDropped?: (folderPaths: string[]) => void
-  /** 拖拽区域的 tooltip 提示文字 */
-  tooltip?: string
 }
 
-export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onFilesUploaded, onAttachFolder, onFoldersDropped, tooltip }: FileDropZoneProps): React.ReactElement {
+export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onFilesUploaded, onAttachFolder, onFoldersDropped }: FileDropZoneProps): React.ReactElement {
   const [isDragOver, setIsDragOver] = React.useState(false)
   const [isUploading, setIsUploading] = React.useState(false)
+  const [activeTooltip, setActiveTooltip] = React.useState<'paperclip' | 'folder' | null>(null)
 
   const isWorkspace = target === 'workspace'
 
@@ -174,10 +173,10 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
         </>
       ) : (
         <>
-          <span className="text-[11px] text-muted-foreground/75 flex-1 truncate">
+          <span className="text-[11px] text-muted-foreground/75 flex-1 truncate ml-[7px]">
             {isDragOver ? '释放以添加文件' : '拖拽文件到此处'}
           </span>
-          <Tooltip>
+          <Tooltip open={activeTooltip === 'paperclip'}>
             <TooltipTrigger asChild>
               <Button
                 type="button"
@@ -185,16 +184,18 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
                 size="icon"
                 className="h-5 w-5 flex-shrink-0 text-muted-foreground/60 hover:text-foreground"
                 onClick={handleSelectFiles}
+                onMouseEnter={() => setActiveTooltip('paperclip')}
+                onMouseLeave={() => setActiveTooltip(null)}
               >
                 <Paperclip className="size-3" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent side="bottom">
+            <TooltipContent side="bottom" className="data-[state=closed]:animate-none data-[state=closed]:opacity-0 pointer-events-none">
               <p>{isWorkspace ? '添加文件到工作区文件目录' : '将文件放入 Agent 工作文件夹'}</p>
             </TooltipContent>
           </Tooltip>
           {onAttachFolder && (
-            <Tooltip>
+            <Tooltip open={activeTooltip === 'folder'}>
               <TooltipTrigger asChild>
                 <Button
                   type="button"
@@ -202,11 +203,13 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
                   size="icon"
                   className="h-5 w-5 flex-shrink-0 text-muted-foreground/60 hover:text-foreground"
                   onClick={onAttachFolder}
+                  onMouseEnter={() => setActiveTooltip('folder')}
+                  onMouseLeave={() => setActiveTooltip(null)}
                 >
                   <FolderPlus className="size-3" />
                 </Button>
               </TooltipTrigger>
-              <TooltipContent side="bottom">
+              <TooltipContent side="bottom" className="data-[state=closed]:animate-none data-[state=closed]:opacity-0 pointer-events-none">
                 <p>{isWorkspace ? '附加文件夹供工作区所有会话访问' : '告知 Agent 你想处理的文件夹'}</p>
               </TooltipContent>
             </Tooltip>
@@ -218,18 +221,7 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
 
   return (
     <div className="flex-shrink-0 px-3 pt-2 pb-1.5">
-      {tooltip && !isDragOver && !isUploading ? (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            {dropZone}
-          </TooltipTrigger>
-          <TooltipContent side="bottom">
-            <p className="text-[12px]">{tooltip}</p>
-          </TooltipContent>
-        </Tooltip>
-      ) : (
-        dropZone
-      )}
+      {dropZone}
     </div>
   )
 }

--- a/apps/electron/src/renderer/components/file-browser/FileDropZone.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileDropZone.tsx
@@ -1,30 +1,23 @@
 /**
  * FileDropZone — 文件拖拽上传区域
  *
- * 引导用户通过拖拽或点击将文件添加到 Agent 会话目录或工作区文件目录。
- * 文件上传后直接保存到目标目录，FileBrowser 通过版本号自动刷新。
+ * 极简 inline 提示，拖拽时高亮。文件上传后直接保存到目标目录。
  */
 
 import * as React from 'react'
 import { toast } from 'sonner'
-import { Upload, File, FolderPlus, Loader2 } from 'lucide-react'
+import { Paperclip, FolderPlus, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { fileToBase64 } from '@/lib/file-utils'
 
 interface FileDropZoneProps {
-  /** 当前工作区 slug（用于 IPC 调用） */
   workspaceSlug: string
-  /** 当前会话 ID（session 模式必传） */
   sessionId?: string
-  /** 上传目标：session（会话目录）或 workspace（工作区文件目录） */
   target?: 'session' | 'workspace'
-  /** 上传成功后的回调（触发文件浏览器刷新） */
   onFilesUploaded: () => void
-  /** 附加文件夹回调（点击按钮时打开对话框） */
   onAttachFolder?: () => void
-  /** 拖拽文件夹回调（拖拽放下文件夹时直接附加） */
   onFoldersDropped?: (folderPaths: string[]) => void
 }
 
@@ -34,7 +27,6 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
 
   const isWorkspace = target === 'workspace'
 
-  /** 保存文件到目标目录 */
   const saveFiles = React.useCallback(async (files: globalThis.File[]): Promise<void> => {
     if (files.length === 0) return
 
@@ -69,8 +61,6 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
     }
   }, [workspaceSlug, sessionId, isWorkspace, onFilesUploaded])
 
-  // ===== 拖拽处理 =====
-
   const handleDragOver = React.useCallback((e: React.DragEvent): void => {
     e.preventDefault()
     e.stopPropagation()
@@ -91,7 +81,6 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
     const droppedFiles = Array.from(e.dataTransfer.files)
     if (droppedFiles.length === 0) return
 
-    // 通过 preload 的 webUtils.getPathForFile 获取真实路径
     const pathMap = new Map<string, globalThis.File>()
     const paths: string[] = []
     for (const f of droppedFiles) {
@@ -106,7 +95,6 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
 
     if (paths.length > 0) {
       try {
-        // 通过主进程检测目录 vs 文件
         const { directories, files: filePaths } = await window.electronAPI.checkPathsType(paths)
 
         if (directories.length > 0) {
@@ -126,12 +114,9 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
         await saveFiles(droppedFiles)
       }
     } else {
-      // 无路径信息：回退，所有项按普通文件处理
       await saveFiles(droppedFiles)
     }
   }, [saveFiles, onFoldersDropped])
-
-  // ===== 按钮点击处理 =====
 
   const handleSelectFiles = React.useCallback(async (): Promise<void> => {
     try {
@@ -168,14 +153,13 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
   }, [workspaceSlug, sessionId, isWorkspace, onFilesUploaded])
 
   return (
-    <div className="flex-shrink-0 px-3 pt-3 pb-1">
+    <div className="flex-shrink-0 px-3 pt-2 pb-1.5">
       <div
         className={cn(
-          'relative flex flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed px-3 py-4',
-          'transition-colors duration-200 cursor-default',
+          'flex items-center gap-1.5 rounded-lg px-2 py-3 transition-colors duration-200',
           isDragOver
-            ? 'border-primary bg-primary/5'
-            : 'border-muted-foreground/20 hover:border-muted-foreground/40',
+            ? 'bg-primary/10 ring-1 ring-primary/30'
+            : 'bg-muted/40 hover:bg-muted/70',
           isUploading && 'pointer-events-none opacity-60',
         )}
         onDragOver={handleDragOver}
@@ -184,60 +168,49 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
       >
         {isUploading ? (
           <>
-            <Loader2 className="size-5 text-muted-foreground animate-spin" />
-            <span className="text-xs text-muted-foreground">正在上传...</span>
+            <Loader2 className="size-3.5 text-muted-foreground animate-spin" />
+            <span className="text-[11px] text-muted-foreground">正在上传...</span>
           </>
         ) : (
           <>
-            <Upload className={cn(
-              'size-5 transition-colors',
-              isDragOver ? 'text-primary' : 'text-muted-foreground/75',
-            )} />
-            <p className="text-xs text-muted-foreground text-center leading-relaxed">
-              拖拽文件到此处
-              <br />
-              <span className="text-[10px] text-muted-foreground/75">
-                {isWorkspace ? '工作区内所有会话可访问' : '供 Agent 读取和处理'}
-              </span>
-            </p>
-            <div className="flex items-center gap-1.5">
+            <Paperclip className="size-3.5 text-muted-foreground/60 flex-shrink-0" />
+            <span className="text-[11px] text-muted-foreground/75 flex-1 truncate">
+              {isDragOver ? '释放以添加文件' : '拖拽文件到此处'}
+            </span>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-5 w-5 flex-shrink-0 text-muted-foreground/60 hover:text-foreground"
+                  onClick={handleSelectFiles}
+                >
+                  <Paperclip className="size-3" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                <p>{isWorkspace ? '添加文件到工作区文件目录' : '将文件放入 Agent 工作文件夹'}</p>
+              </TooltipContent>
+            </Tooltip>
+            {onAttachFolder && (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button
                     type="button"
                     variant="ghost"
-                    size="sm"
-                    className="h-6 text-[11px] px-2 gap-1 text-muted-foreground hover:text-foreground"
-                    onClick={handleSelectFiles}
+                    size="icon"
+                    className="h-5 w-5 flex-shrink-0 text-muted-foreground/60 hover:text-foreground"
+                    onClick={onAttachFolder}
                   >
-                    <File className="size-3" />
-                    选择文件
+                    <FolderPlus className="size-3" />
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent side="bottom">
-                  <p>{isWorkspace ? '添加文件到工作区文件目录' : '将文件放入 Agent 工作文件夹'}</p>
+                  <p>{isWorkspace ? '附加文件夹供工作区所有会话访问' : '告知 Agent 你想处理的文件夹'}</p>
                 </TooltipContent>
               </Tooltip>
-              {onAttachFolder && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      className="h-6 text-[11px] px-2 gap-1 text-muted-foreground hover:text-foreground"
-                      onClick={onAttachFolder}
-                    >
-                      <FolderPlus className="size-3" />
-                      附加文件夹
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    <p>{isWorkspace ? '附加文件夹供工作区所有会话访问' : '告知 Agent 你想处理的文件夹'}</p>
-                  </TooltipContent>
-                </Tooltip>
-              )}
-            </div>
+            )}
           </>
         )}
       </div>

--- a/apps/electron/src/renderer/components/file-browser/FileDropZone.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileDropZone.tsx
@@ -8,6 +8,7 @@
 import * as React from 'react'
 import { toast } from 'sonner'
 import { Paperclip, FolderPlus, Loader2 } from 'lucide-react'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { fileToBase64 } from '@/lib/file-utils'
 
@@ -166,27 +167,41 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
       ) : (
         <>
           {/* 添加文件 */}
-          <div
-            className={zoneClass('left')}
-            onDragOver={(e) => handleDragOver(e, 'left')}
-            onDragLeave={handleDragLeave}
-            onDrop={handleDrop}
-            onClick={handleSelectFiles}
-          >
-            <span className="text-[11px] text-muted-foreground/75">添加文件</span>
-            <Paperclip className="size-4 text-muted-foreground/60" />
-          </div>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div
+                className={zoneClass('left')}
+                onDragOver={(e) => handleDragOver(e, 'left')}
+                onDragLeave={handleDragLeave}
+                onDrop={handleDrop}
+                onClick={handleSelectFiles}
+              >
+                <span className="text-[11px] text-muted-foreground/75">添加文件</span>
+                <Paperclip className="size-4 text-muted-foreground/60" />
+              </div>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="data-[state=closed]:animate-none data-[state=closed]:opacity-0 pointer-events-none">
+              <p>{isWorkspace ? '添加文件到工作区文件目录' : '将文件放入 Agent 工作文件夹'}</p>
+            </TooltipContent>
+          </Tooltip>
           {/* 附加文件 */}
-          <div
-            className={zoneClass('right')}
-            onDragOver={(e) => handleDragOver(e, 'right')}
-            onDragLeave={handleDragLeave}
-            onDrop={handleDrop}
-            onClick={onAttachFolder}
-          >
-            <span className="text-[11px] text-muted-foreground/75">附加文件</span>
-            <FolderPlus className="size-4 text-muted-foreground/60" />
-          </div>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div
+                className={zoneClass('right')}
+                onDragOver={(e) => handleDragOver(e, 'right')}
+                onDragLeave={handleDragLeave}
+                onDrop={handleDrop}
+                onClick={onAttachFolder}
+              >
+                <span className="text-[11px] text-muted-foreground/75">附加文件</span>
+                <FolderPlus className="size-4 text-muted-foreground/60" />
+              </div>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="data-[state=closed]:animate-none data-[state=closed]:opacity-0 pointer-events-none">
+              <p>{isWorkspace ? '附加文件夹供工作区所有会话访问' : '告知 Agent 你想处理的文件夹'}</p>
+            </TooltipContent>
+          </Tooltip>
         </>
       )}
     </div>

--- a/apps/electron/src/renderer/components/file-browser/FileDropZone.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileDropZone.tsx
@@ -174,7 +174,6 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
         </>
       ) : (
         <>
-          <Paperclip className="size-3.5 text-muted-foreground/60 flex-shrink-0" />
           <span className="text-[11px] text-muted-foreground/75 flex-1 truncate">
             {isDragOver ? '释放以添加文件' : '拖拽文件到此处'}
           </span>

--- a/apps/electron/src/renderer/components/file-browser/FileDropZone.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileDropZone.tsx
@@ -19,9 +19,11 @@ interface FileDropZoneProps {
   onFilesUploaded: () => void
   onAttachFolder?: () => void
   onFoldersDropped?: (folderPaths: string[]) => void
+  /** 拖拽区域的 tooltip 提示文字 */
+  tooltip?: string
 }
 
-export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onFilesUploaded, onAttachFolder, onFoldersDropped }: FileDropZoneProps): React.ReactElement {
+export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onFilesUploaded, onAttachFolder, onFoldersDropped, tooltip }: FileDropZoneProps): React.ReactElement {
   const [isDragOver, setIsDragOver] = React.useState(false)
   const [isUploading, setIsUploading] = React.useState(false)
 
@@ -152,31 +154,47 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
     }
   }, [workspaceSlug, sessionId, isWorkspace, onFilesUploaded])
 
-  return (
-    <div className="flex-shrink-0 px-3 pt-2 pb-1.5">
-      <div
-        className={cn(
-          'flex items-center gap-1.5 rounded-lg px-2 py-3 transition-colors duration-200',
-          isDragOver
-            ? 'bg-primary/10 ring-1 ring-primary/30'
-            : 'bg-muted/40 hover:bg-muted/70',
-          isUploading && 'pointer-events-none opacity-60',
-        )}
-        onDragOver={handleDragOver}
-        onDragLeave={handleDragLeave}
-        onDrop={handleDrop}
-      >
-        {isUploading ? (
-          <>
-            <Loader2 className="size-3.5 text-muted-foreground animate-spin" />
-            <span className="text-[11px] text-muted-foreground">正在上传...</span>
-          </>
-        ) : (
-          <>
-            <Paperclip className="size-3.5 text-muted-foreground/60 flex-shrink-0" />
-            <span className="text-[11px] text-muted-foreground/75 flex-1 truncate">
-              {isDragOver ? '释放以添加文件' : '拖拽文件到此处'}
-            </span>
+  const dropZone = (
+    <div
+      className={cn(
+        'flex items-center gap-1.5 rounded-lg px-2 py-3 transition-colors duration-200',
+        isDragOver
+          ? 'bg-primary/10 ring-1 ring-primary/30'
+          : 'bg-muted/40 hover:bg-muted/70',
+        isUploading && 'pointer-events-none opacity-60',
+      )}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
+      {isUploading ? (
+        <>
+          <Loader2 className="size-3.5 text-muted-foreground animate-spin" />
+          <span className="text-[11px] text-muted-foreground">正在上传...</span>
+        </>
+      ) : (
+        <>
+          <Paperclip className="size-3.5 text-muted-foreground/60 flex-shrink-0" />
+          <span className="text-[11px] text-muted-foreground/75 flex-1 truncate">
+            {isDragOver ? '释放以添加文件' : '拖拽文件到此处'}
+          </span>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-5 w-5 flex-shrink-0 text-muted-foreground/60 hover:text-foreground"
+                onClick={handleSelectFiles}
+              >
+                <Paperclip className="size-3" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              <p>{isWorkspace ? '添加文件到工作区文件目录' : '将文件放入 Agent 工作文件夹'}</p>
+            </TooltipContent>
+          </Tooltip>
+          {onAttachFolder && (
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button
@@ -184,36 +202,35 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
                   variant="ghost"
                   size="icon"
                   className="h-5 w-5 flex-shrink-0 text-muted-foreground/60 hover:text-foreground"
-                  onClick={handleSelectFiles}
+                  onClick={onAttachFolder}
                 >
-                  <Paperclip className="size-3" />
+                  <FolderPlus className="size-3" />
                 </Button>
               </TooltipTrigger>
               <TooltipContent side="bottom">
-                <p>{isWorkspace ? '添加文件到工作区文件目录' : '将文件放入 Agent 工作文件夹'}</p>
+                <p>{isWorkspace ? '附加文件夹供工作区所有会话访问' : '告知 Agent 你想处理的文件夹'}</p>
               </TooltipContent>
             </Tooltip>
-            {onAttachFolder && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    className="h-5 w-5 flex-shrink-0 text-muted-foreground/60 hover:text-foreground"
-                    onClick={onAttachFolder}
-                  >
-                    <FolderPlus className="size-3" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">
-                  <p>{isWorkspace ? '附加文件夹供工作区所有会话访问' : '告知 Agent 你想处理的文件夹'}</p>
-                </TooltipContent>
-              </Tooltip>
-            )}
-          </>
-        )}
-      </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+
+  return (
+    <div className="flex-shrink-0 px-3 pt-2 pb-1.5">
+      {tooltip && !isDragOver && !isUploading ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            {dropZone}
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            <p className="text-[12px]">{tooltip}</p>
+          </TooltipContent>
+        </Tooltip>
+      ) : (
+        dropZone
+      )}
     </div>
   )
 }

--- a/apps/electron/src/renderer/components/settings/AgentSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AgentSettings.tsx
@@ -17,7 +17,7 @@ import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } f
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
-import { cn } from '@/lib/utils'
+import { cn, bumpMapVersion } from '@/lib/utils'
 import {
   agentWorkspacesAtom,
   currentAgentWorkspaceIdAtom,
@@ -59,6 +59,10 @@ export function AgentSettings(): React.ReactElement {
   const setSettingsOpen = useSetAtom(settingsOpenAtom)
   const setAppMode = useSetAtom(appModeAtom)
   const bumpCapabilitiesVersion = useSetAtom(workspaceCapabilitiesVersionAtom)
+  const bumpCaps = React.useCallback(() => {
+    if (!currentWorkspaceId) return
+    bumpCapabilitiesVersion((prev) => bumpMapVersion(prev, currentWorkspaceId))
+  }, [bumpCapabilitiesVersion, currentWorkspaceId])
 
   // 派生当前工作区 slug
   const currentWorkspace = workspaces.find((w) => w.id === currentWorkspaceId)
@@ -254,7 +258,7 @@ ${skillList}
       const newConfig: WorkspaceMcpConfig = { servers: newServers }
       await window.electronAPI.saveWorkspaceMcpConfig(workspaceSlug, newConfig)
       setMcpConfig(newConfig)
-      bumpCapabilitiesVersion((v) => v + 1)
+      bumpCaps()
     } catch (error) {
       console.error('[Agent 设置] 删除 MCP 服务器失败:', error)
     }
@@ -274,7 +278,7 @@ ${skillList}
       }
       await window.electronAPI.saveWorkspaceMcpConfig(workspaceSlug, newConfig)
       setMcpConfig(newConfig)
-      bumpCapabilitiesVersion((v) => v + 1)
+      bumpCaps()
     } catch (error) {
       console.error('[Agent 设置] 切换 MCP 服务器状态失败:', error)
     }
@@ -287,7 +291,7 @@ ${skillList}
     try {
       await window.electronAPI.deleteWorkspaceSkill(workspaceSlug, skillSlug)
       setSkills((prev) => prev.filter((s) => s.slug !== skillSlug))
-      bumpCapabilitiesVersion((v) => v + 1)
+      bumpCaps()
     } catch (error) {
       console.error('[Agent 设置] 删除 Skill 失败:', error)
     }
@@ -298,7 +302,7 @@ ${skillList}
     try {
       await window.electronAPI.toggleWorkspaceSkill(workspaceSlug, skillSlug, enabled)
       setSkills((prev) => prev.map((s) => s.slug === skillSlug ? { ...s, enabled } : s))
-      bumpCapabilitiesVersion((v) => v + 1)
+      bumpCaps()
     } catch (error) {
       console.error('[Agent 设置] 切换 Skill 状态失败:', error)
     }
@@ -312,7 +316,7 @@ ${skillList}
     try {
       const imported = await window.electronAPI.importSkillFromWorkspace(workspaceSlug, sourceSlug, skillSlug)
       setSkills((prev) => prev.some((skill) => skill.slug === imported.slug) ? prev : [...prev, imported])
-      bumpCapabilitiesVersion((v) => v + 1)
+      bumpCaps()
       setShowImportDialog(false)
       toast.success(`已导入 Skill: ${imported.name}`)
     } catch (error) {
@@ -332,7 +336,7 @@ ${skillList}
     try {
       const updated = await window.electronAPI.updateSkillFromSource(workspaceSlug, skillSlug)
       setSkills((prev) => prev.map((s) => s.slug === skillSlug ? updated : s))
-      bumpCapabilitiesVersion((v) => v + 1)
+      bumpCaps()
       toast.success(`已同步更新 Skill: ${updated.name}`)
     } catch (error) {
       console.error('[Agent 设置] 更新 Skill 失败:', error)
@@ -348,7 +352,7 @@ ${skillList}
     setViewMode('list')
     setEditingServer(null)
     loadData()
-    bumpCapabilitiesVersion((v) => v + 1)
+    bumpCaps()
   }
 
   /** 取消表单 */

--- a/apps/electron/src/renderer/lib/utils.ts
+++ b/apps/electron/src/renderer/lib/utils.ts
@@ -4,3 +4,10 @@ import { twMerge } from 'tailwind-merge'
 export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs))
 }
+
+/** 递增 Map 中指定 key 的数值版本号，返回新 Map（不可变） */
+export function bumpMapVersion(prev: Map<string, number>, key: string): Map<string, number> {
+  const m = new Map(prev)
+  m.set(key, (m.get(key) ?? 0) + 1)
+  return m
+}

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -261,10 +261,24 @@ function AgentSettingsInitializer(): null {
   }, [currentWorkspaceId, workspaces])
 
   // 订阅主进程文件监听推送
+  //
+  // 用 ref 镜像 currentWorkspaceId / workspaces，让回调每次触发时读最新值，
+  // 而订阅生命周期本身只在 mount/unmount 时各跑一次 —— 避免工作区切换导致
+  // unsubscribe → re-subscribe 的时间窗口里丢失主进程推送的事件。
+  const workspaceIdRef = useRef(currentWorkspaceId)
+  const workspacesRef = useRef(workspaces)
+  useEffect(() => {
+    workspaceIdRef.current = currentWorkspaceId
+  }, [currentWorkspaceId])
+  useEffect(() => {
+    workspacesRef.current = workspaces
+  }, [workspaces])
+
   useEffect(() => {
     const unsubCapabilities = window.electronAPI.onCapabilitiesChanged(() => {
+      const id = workspaceIdRef.current
       // 查找当前工作区 slug
-      const ws = workspaces.find((w) => w.id === currentWorkspaceId)
+      const ws = workspacesRef.current.find((w) => w.id === id)
       if (ws) {
         window.electronAPI
           .getWorkspaceCapabilities(ws.slug)
@@ -280,13 +294,14 @@ function AgentSettingsInitializer(): null {
           .catch(console.error)
       }
 
-      if (currentWorkspaceId) {
-        bumpCapabilities((prev) => bumpMapVersion(prev, currentWorkspaceId))
+      if (id) {
+        bumpCapabilities((prev) => bumpMapVersion(prev, id))
       }
     })
     const unsubFiles = window.electronAPI.onWorkspaceFilesChanged(() => {
-      if (currentWorkspaceId) {
-        bumpFiles((prev) => bumpMapVersion(prev, currentWorkspaceId))
+      const id = workspaceIdRef.current
+      if (id) {
+        bumpFiles((prev) => bumpMapVersion(prev, id))
       }
     })
 
@@ -294,7 +309,7 @@ function AgentSettingsInitializer(): null {
       unsubCapabilities()
       unsubFiles()
     }
-  }, [bumpCapabilities, bumpFiles, currentWorkspaceId, workspaces])
+  }, [bumpCapabilities, bumpFiles])
 
   return null
 }

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -7,6 +7,7 @@
 import React, { useEffect, useMemo, useRef } from 'react'
 import ReactDOM from 'react-dom/client'
 import { useSetAtom, useAtomValue, useStore } from 'jotai'
+import { bumpMapVersion } from '@/lib/utils'
 import App from './App'
 import {
   themeModeAtom,
@@ -279,10 +280,14 @@ function AgentSettingsInitializer(): null {
           .catch(console.error)
       }
 
-      bumpCapabilities((v) => v + 1)
+      if (currentWorkspaceId) {
+        bumpCapabilities((prev) => bumpMapVersion(prev, currentWorkspaceId))
+      }
     })
     const unsubFiles = window.electronAPI.onWorkspaceFilesChanged(() => {
-      bumpFiles((v) => v + 1)
+      if (currentWorkspaceId) {
+        bumpFiles((prev) => bumpMapVersion(prev, currentWorkspaceId))
+      }
     })
 
     return () => {

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -401,6 +401,11 @@
   color: inherit !important;
 }
 
+/* 苍穹暮色：subtab 选中态浅化 */
+.theme-ocean-dark .subtab-active {
+  color: hsl(205 70% 65%) !important;
+}
+
 /* ===== 森系主题：会话/工作区选中状态 ===== */
 /* 森息晨光：浅绿背景 + 深绿文字 */
 .theme-forest-light .session-item-selected,
@@ -422,6 +427,11 @@
 .theme-forest-dark .session-item-selected *,
 .theme-forest-dark .workspace-item-selected * {
   color: inherit !important;
+}
+
+/* 森息夜语：subtab 选中态浅化 */
+.theme-forest-dark .subtab-active {
+  color: hsl(150 45% 60%) !important;
 }
 
 /* ===== 莫兰迪主题：模式切换器选中状态 ===== */

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -77,7 +77,7 @@
 
   /* 晴空碧海 (ocean-light) */
   .theme-ocean-light {
-    --background: 205 45% 91%;            /* #deeaf2 背景 */
+    --background: 205 40% 93%;            /* #eaf0f5 背景 */
     --foreground: 210 30% 15%;            /* #1b2632 前景文字 */
     --content-area: 205 40% 97%;          /* #f4f8fa 内容区域 */
     --muted: 205 40% 85%;                 /* #c9dbe8 次要背景 */

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -36,6 +36,10 @@
     /* 虚线边框色（新会话按钮、搜索按钮） */
     --dashed-border: 0 0% 9% / 0.35;
     --dashed-border-hover: 0 0% 9% / 0.50;
+    /* 布局尺寸：顶部可拖动标题栏高度（与 AppShell 中 titlebar-drag-region 的高度一致） */
+    --titlebar-height: 50px;
+    /* AgentHeader 高度（与 AgentHeader 根 div 的 h-[48px] 一致） */
+    --agent-header-height: 48px;
   }
 
   .dark {
@@ -77,7 +81,7 @@
 
   /* 晴空碧海 (ocean-light) */
   .theme-ocean-light {
-    --background: 205 40% 93%;            /* #eaf0f5 背景 */
+    --background: 205 35% 94%;            /* #ecf2f7 背景（侧边栏）- 调浅 */
     --foreground: 210 30% 15%;            /* #1b2632 前景文字 */
     --content-area: 205 40% 97%;          /* #f4f8fa 内容区域 */
     --muted: 205 40% 85%;                 /* #c9dbe8 次要背景 */

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -434,6 +434,14 @@
   color: hsl(150 45% 60%) !important;
 }
 
+/* 苍穹暮色 + 森息夜语：指示条颜色跟随 subtab 选中文字 */
+.theme-ocean-dark .indicator-line {
+  background-color: hsl(205 70% 65% / 0.6) !important;
+}
+.theme-forest-dark .indicator-line {
+  background-color: hsl(150 45% 60% / 0.6) !important;
+}
+
 /* ===== 莫兰迪主题：模式切换器选中状态 ===== */
 /* 莫兰迪夜：淡杏粉滑块 + 深色文字 */
 .theme-slate-dark .mode-slider {


### PR DESCRIPTION
## Overview

左侧栏 UI 细节打磨：subtab 选中指示条从圆角 border-b 重构为绝对定位矩形条，与分割线重合；工作区展开竖线样式对齐；FileDropZone 拆分为"添加文件"+"附加文件夹"两个独立 drop zone。

## Changes

- **LeftSidebar.tsx** — subtab 指示条改用 `absolute bottom-0` 矩形，宽度 `w-4/5`，颜色 `bg-primary/60`，与父级 `border-b` 分割线重合；选中态 badge 背景加亮至 `bg-primary/20`；工作区/新会话/tab 区整体下移 5px
- **WorkspaceSelector.tsx** — 竖线颜色统一为 `bg-primary/60` + `indicator-line` class；toggle chevron 右移 2px；折叠态工作区名称 format 对齐标签
- **FileDropZone.tsx** — 单 drop zone + 内嵌 icon 按钮重构为两个独立并排 zone："添加文件"（回形针）+ "附加文件夹"（FolderPlus），文字在 icon 上方，拖拽高亮加亮，两个 zone 均接受文件与文件夹拖放
- **globals.css** — 新增 `.indicator-line` 暗色主题规则，苍穹暮色/森息夜语下指示条颜色跟随 subtab 选中文字色
- **SidePanel.tsx** — 修复面包屑 JSX 多余闭合符号

## Code Review Fixes

基于代码审查反馈，修复以下质量问题：

- **AgentView 浮动按钮位置**：`top-[63px]` 魔法数字改为 `calc(var(--titlebar-height) + (var(--agent-header-height) - 1.75rem) / 2)`，并在 globals.css 定义两个布局变量
- **IPC 订阅丢事件**：`main.tsx` 的 `onCapabilitiesChanged` / `onWorkspaceFilesChanged` 订阅从"随工作区切换反复重建"改为"mount 时注册一次 + ref 读最新 workspaceId"
- **FileDropZone 静默失败**：`onFoldersDropped` prop 去掉 `?`，改为必传；右侧 zone 标签 "附加文件" → "附加文件夹"（与 icon、tooltip 一致）
- **WorkspaceSelector useEffect**：使用 setter 的副作用从第 34 行挪到第 52 行（state 声明之后），依赖数组补齐 `setDragId` / `setDropIndicator`
- **AgentView 死导入**：删除未使用的 `currentAgentSessionIdAtom`
- **LeftSidebar 圆角落单**：侧栏折叠按钮的 `rounded-[10px]` 统一为 `rounded-xl`

## How to Test

1. 打开 Agent 模式，切换"工作中"/"置顶"tab，确认指示条矩形显示、颜色正确
2. 切换至暗色主题（苍穹暮色/森息夜语），确认指示条颜色跟随选中文字
3. 展开/折叠工作区列表，确认竖线与 subtab 指示条颜色一致
4. 拖拽文件/文件夹到侧面板 drop zone，确认两个 zone 独立高亮，均接受文件和文件夹
5. 点击两个 zone 分别测试文件对话框和文件夹对话框

## Verification

- `bun run typecheck` ✅ 4 个 workspace 全绿
- `bun run build` ✅ 4 个 workspace 全绿（仅历史遗留的 chunk size 警告，与本 PR 无关）

## Notes

- 指示条使用 `indicator-line` class 统一管理暗色主题颜色覆盖
- FileDropZone 移除了 Tooltip 依赖，简化了组件结构
