### PR TITLE
fix(bridge): 多 Bot 平台状态灯改为任一连接即显示绿色 【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/settings/BotHubSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/BotHubSettings.tsx
@@ -9,8 +9,8 @@ import * as React from 'react'
 import { useAtomValue } from 'jotai'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { cn } from '@/lib/utils'
-import { feishuBridgeStateAtom } from '@/atoms/feishu-atoms'
-import { dingtalkBridgeStateAtom } from '@/atoms/dingtalk-atoms'
+import { feishuBotStatesAtom } from '@/atoms/feishu-atoms'
+import { dingtalkBotStatesAtom } from '@/atoms/dingtalk-atoms'
 import { wechatBridgeStateAtom } from '@/atoms/wechat-atoms'
 import { FeishuSettings } from './FeishuSettings'
 import { DingTalkSettings } from './DingTalkSettings'
@@ -85,21 +85,31 @@ const BRIDGE_STATUS_COLORS = {
 
 /** 平台连接状态指示点 */
 function PlatformStatusDot({ platformId }: { platformId: BotPlatformId }): React.ReactElement | null {
-  const feishuState = useAtomValue(feishuBridgeStateAtom)
-  const dingtalkState = useAtomValue(dingtalkBridgeStateAtom)
+  const feishuBotStates = useAtomValue(feishuBotStatesAtom)
+  const dingtalkBotStates = useAtomValue(dingtalkBotStatesAtom)
   const wechatState = useAtomValue(wechatBridgeStateAtom)
 
   if (platformId === 'defaults' || platformId === 'logos') return null
 
   const statusMap: Record<string, string> = {
-    feishu: feishuState.status,
-    dingtalk: dingtalkState.status,
+    feishu: getPlatformStatus(feishuBotStates),
+    dingtalk: getPlatformStatus(dingtalkBotStates),
     wechat: wechatState.status,
   }
   const status = statusMap[platformId] ?? 'disconnected'
   const colorClass = BRIDGE_STATUS_COLORS[status as keyof typeof BRIDGE_STATUS_COLORS] ?? 'bg-gray-400'
 
   return <span className={cn('w-1.5 h-1.5 rounded-full flex-shrink-0', colorClass)} />
+}
+
+/** 从多 Bot 状态推导平台级状态：任一 connected → connected，否则按 error > connecting > disconnected 优先级 */
+function getPlatformStatus(states: Record<string, { status: string }>): string {
+  const values = Object.values(states)
+  if (values.length === 0) return 'disconnected'
+  if (values.some((s) => s.status === 'connected')) return 'connected'
+  if (values.some((s) => s.status === 'error')) return 'error'
+  if (values.some((s) => s.status === 'connecting')) return 'connecting'
+  return 'disconnected'
 }
 
 /** 左侧平台选择项 */


### PR DESCRIPTION
## Overview

修复「设置 → 远程连接」页中飞书/钉钉的**平台级状态灯**在多 Bot 场景下的显示问题。

此前 `PlatformStatusDot` 使用了只取**第一个 Bot** 状态的 atom（`feishuBridgeStateAtom` / `dingtalkBridgeStateAtom`），导致只要第一个 Bot 未启动，即使其他 Bot 正常运行，平台级指示灯也变灰。

修复后：读取所有 Bot 的状态（`feishuBotStatesAtom` / `dingtalkBotStatesAtom`），按优先级推导平台级状态——**只要任一 Bot 已连接，就显示绿色**。

## Changes

- `apps/electron/src/renderer/components/settings/BotHubSettings.tsx` — 核心改动
  - 导入从 `feishuBridgeStateAtom` / `dingtalkBridgeStateAtom` 改为 `feishuBotStatesAtom` / `dingtalkBotStatesAtom`
  - `PlatformStatusDot` 组件改为读取多 Bot 状态映射，而非取第一个
  - 新增 `getPlatformStatus()` 辅助函数，按优先级推导平台级状态

## Status 优先级

```
任一 connected  → 绿色 (connected)
否则 任一 error     → 红色 (error)
否则 任一 connecting → 黄色 (connecting)
否则 None/全部 disconnected → 灰色 (disconnected)
```

## Notes

- 飞书和钉钉均有此问题，一并修复
- WeChat 只有单 Bot 支持，不涉及此问题，无需修改
- `feishuBridgeStateAtom` / `dingtalkBridgeStateAtom` 本身未改动，不影响其他向后兼容的使用方

🤖 Generated with [Claude Code](https://claude.com/claude-code)