### PR TITLE
feat: @ 文件引用弹窗增强 — 分层分组、树形层级、路径 tooltip 【PR 二次审核已完成】

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -2007,8 +2007,9 @@ export function registerIpcHandlers(): void {
         for (const addPath of additionalPaths) {
           const addRoot = resolve(addPath)
           // 添加附加目录本身作为顶层条目
+          const rootName = basename(addRoot)
           workspaceEntries.push({
-            name: basename(addRoot),
+            name: rootName === 'workspace-files' ? '工作文件' : rootName,
             path: addRoot,
             type: 'dir',
             source: 'workspace',

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -1938,24 +1938,26 @@ export function registerIpcHandlers(): void {
   // 搜索工作区文件（用于 @ 引用，递归扫描，支持附加目录）
   ipcMain.handle(
     AGENT_IPC_CHANNELS.SEARCH_WORKSPACE_FILES,
-    async (_, rootPath: string, query: string, limit = 20, additionalPaths?: string[]): Promise<FileSearchResult> => {
+    async (_, rootPath: string, query: string, limit = 20, additionalPaths?: string[], sessionPaths?: string[]): Promise<FileSearchResult> => {
       const { readdirSync } = await import('node:fs')
-      const { resolve, relative } = await import('node:path')
+      const { resolve, relative, basename } = await import('node:path')
 
       const safeRoot = resolve(rootPath)
       const ignoreDirs = new Set(['node_modules', '.git', 'dist', '.next', '__pycache__', '.venv', 'build', '.cache'])
       const ignoreFiles = new Set(['.DS_Store', '.Spotlight-V100', '.Trashes', 'Thumbs.db', 'desktop.ini'])
 
-      // 按来源分组收集文件，用于空 query 时均衡分配结果
-      const rootEntries: Array<{ name: string; path: string; type: 'file' | 'dir' }> = []
-      const additionalEntryGroups: Array<Array<{ name: string; path: string; type: 'file' | 'dir' }>> = []
+      // 按来源分组收集文件
+      type Entry = { name: string; path: string; type: 'file' | 'dir'; source: 'session' | 'workspace' }
+      const rootEntries: Entry[] = []
+      const workspaceEntries: Entry[] = []
 
       function scan(
         dir: string,
         depth: number,
         baseRoot: string,
-        target: Array<{ name: string; path: string; type: 'file' | 'dir' }>,
+        target: Entry[],
         useAbsPath: boolean,
+        source: 'session' | 'workspace',
       ): void {
         if (depth > 10) return
         try {
@@ -1970,10 +1972,11 @@ export function registerIpcHandlers(): void {
               name: item.name,
               path: entryPath,
               type: item.isDirectory() ? 'dir' : 'file',
+              source,
             })
 
             if (item.isDirectory()) {
-              scan(fullPath, depth + 1, baseRoot, target, useAbsPath)
+              scan(fullPath, depth + 1, baseRoot, target, useAbsPath, source)
             }
           }
         } catch {
@@ -1982,70 +1985,96 @@ export function registerIpcHandlers(): void {
       }
 
       // session 目录：相对路径
-      scan(safeRoot, 0, safeRoot, rootEntries, false)
+      scan(safeRoot, 0, safeRoot, rootEntries, false, 'session')
 
-      // 附加目录：绝对路径（消除歧义，agent 可直接使用）
+      // 会话级附加目录：绝对路径，标记为 session（归入会话文件分组）
+      if (sessionPaths && sessionPaths.length > 0) {
+        for (const sp of sessionPaths) {
+          const sRoot = resolve(sp)
+          // 添加附加目录本身作为顶层条目
+          rootEntries.push({
+            name: basename(sRoot),
+            path: sRoot,
+            type: 'dir',
+            source: 'session',
+          })
+          scan(sRoot, 0, sRoot, rootEntries, true, 'session')
+        }
+      }
+
+      // 工作区文件 + 工作区级附加目录：绝对路径，标记为 workspace
       if (additionalPaths && additionalPaths.length > 0) {
         for (const addPath of additionalPaths) {
           const addRoot = resolve(addPath)
-          const group: Array<{ name: string; path: string; type: 'file' | 'dir' }> = []
-          scan(addRoot, 0, addRoot, group, true)
-          additionalEntryGroups.push(group)
+          // 添加附加目录本身作为顶层条目
+          workspaceEntries.push({
+            name: basename(addRoot),
+            path: addRoot,
+            type: 'dir',
+            source: 'workspace',
+          })
+          scan(addRoot, 0, addRoot, workspaceEntries, true, 'workspace')
         }
       }
 
-      // 搜索匹配
+      // 组内排序：目录优先，前缀匹配优先，路径短优先
+      function sortGroup(entries: Entry[], q: string): void {
+        entries.sort((a, b) => {
+          const aStartsWith = a.name.toLowerCase().startsWith(q) ? 0 : 1
+          const bStartsWith = b.name.toLowerCase().startsWith(q) ? 0 : 1
+          if (aStartsWith !== bStartsWith) return aStartsWith - bStartsWith
+          if (a.type === 'dir' && b.type !== 'dir') return -1
+          if (a.type !== 'dir' && b.type === 'dir') return 1
+          return a.path.length - b.path.length
+        })
+      }
+
+      function matchEntries(entries: Entry[], q: string): Entry[] {
+        return entries.filter((entry) => {
+          const nameLower = entry.name.toLowerCase()
+          const pathLower = entry.path.toLowerCase()
+          if (nameLower.startsWith(q)) return true
+          if (nameLower.includes(q) || pathLower.includes(q)) return true
+          let qi = 0
+          for (let i = 0; i < nameLower.length && qi < q.length; i++) {
+            if (nameLower[i] === q) qi++
+          }
+          return qi === q.length
+        })
+      }
+
       const q = query.toLowerCase()
 
       if (!q) {
-        // 空 query：从各来源交替取结果，确保均衡展示
-        const allGroups = [rootEntries, ...additionalEntryGroups].filter((g) => g.length > 0)
-        const result: Array<{ name: string; path: string; type: 'file' | 'dir' }> = []
-        const groupCount = allGroups.length
-        if (groupCount > 0) {
-          // 每组至少分配 perGroup 条，剩余名额按需补充
-          const perGroup = Math.max(1, Math.floor(limit / groupCount))
-          for (const group of allGroups) {
-            result.push(...group.slice(0, perGroup))
-          }
-          // 如果还有剩余名额，按组顺序补充
-          if (result.length < limit) {
-            for (const group of allGroups) {
-              for (let i = perGroup; i < group.length && result.length < limit; i++) {
-                result.push(group[i]!)
-              }
-            }
-          }
+        // 空 query：每个分组返回较多条目，避免截断
+        const perGroup = Math.max(limit, 100)
+        const sessionSlice = rootEntries.slice(0, perGroup)
+        const workspaceSlice = workspaceEntries.slice(0, perGroup)
+        const combined = [...sessionSlice, ...workspaceSlice].slice(0, perGroup * 2)
+        return {
+          entries: combined,
+          total: rootEntries.length + workspaceEntries.length,
+          sessionEntries: sessionSlice,
+          workspaceEntries: workspaceSlice,
         }
-        const allEntries = [rootEntries, ...additionalEntryGroups].flat()
-        return { entries: result.slice(0, limit), total: allEntries.length }
       }
 
-      const allEntries = [rootEntries, ...additionalEntryGroups].flat()
-      const matched = allEntries.filter((entry) => {
-        const nameLower = entry.name.toLowerCase()
-        const pathLower = entry.path.toLowerCase()
-        if (nameLower.startsWith(q)) return true
-        if (nameLower.includes(q) || pathLower.includes(q)) return true
-        // 模糊匹配
-        let qi = 0
-        for (let i = 0; i < nameLower.length && qi < q.length; i++) {
-          if (nameLower[i] === q[qi]) qi++
-        }
-        return qi === q.length
-      })
+      const sessionMatched = matchEntries(rootEntries, q)
+      const workspaceMatched = matchEntries(workspaceEntries, q)
+      sortGroup(sessionMatched, q)
+      sortGroup(workspaceMatched, q)
 
-      // 排序：精确前缀优先，目录优先，路径短优先
-      matched.sort((a, b) => {
-        const aStartsWith = a.name.toLowerCase().startsWith(q) ? 0 : 1
-        const bStartsWith = b.name.toLowerCase().startsWith(q) ? 0 : 1
-        if (aStartsWith !== bStartsWith) return aStartsWith - bStartsWith
-        if (a.type === 'dir' && b.type !== 'dir') return -1
-        if (a.type !== 'dir' && b.type === 'dir') return 1
-        return a.path.length - b.path.length
-      })
+      const halfLimit = Math.max(1, Math.floor(limit / 2))
+      const sessionSlice = sessionMatched.slice(0, halfLimit)
+      const workspaceSlice = workspaceMatched.slice(0, halfLimit)
+      const combined = [...sessionSlice, ...workspaceSlice].slice(0, limit)
 
-      return { entries: matched.slice(0, limit), total: matched.length }
+      return {
+        entries: combined,
+        total: sessionMatched.length + workspaceMatched.length,
+        sessionEntries: sessionSlice,
+        workspaceEntries: workspaceSlice,
+      }
     }
   )
 

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -2038,7 +2038,7 @@ export function registerIpcHandlers(): void {
           if (nameLower.includes(q) || pathLower.includes(q)) return true
           let qi = 0
           for (let i = 0; i < nameLower.length && qi < q.length; i++) {
-            if (nameLower[i] === q) qi++
+            if (nameLower[i] === q[qi]) qi++
           }
           return qi === q.length
         })

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -608,7 +608,7 @@ export interface ElectronAPI {
   getPathForFile: (file: File) => string
 
   /** 搜索工作区文件（用于 @ 引用，支持附加目录） */
-  searchWorkspaceFiles: (rootPath: string, query: string, limit?: number, additionalPaths?: string[]) => Promise<FileSearchResult>
+  searchWorkspaceFiles: (rootPath: string, query: string, limit?: number, additionalPaths?: string[], sessionPaths?: string[]) => Promise<FileSearchResult>
 
   // ===== 系统提示词管理 =====
 
@@ -1437,8 +1437,8 @@ const electronAPI: ElectronAPI = {
     return webUtils.getPathForFile(file)
   },
 
-  searchWorkspaceFiles: (rootPath: string, query: string, limit = 20, additionalPaths?: string[]) => {
-    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.SEARCH_WORKSPACE_FILES, rootPath, query, limit, additionalPaths)
+  searchWorkspaceFiles: (rootPath: string, query: string, limit = 20, additionalPaths?: string[], sessionPaths?: string[]) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.SEARCH_WORKSPACE_FILES, rootPath, query, limit, additionalPaths, sessionPaths)
   },
 
   // 系统提示词管理

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -393,19 +393,15 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       .catch(() => setWorkspaceFilesPath(null))
   }, [workspaceSlug])
 
-  // 合并工作区文件目录、工作区级附加目录和会话级附加目录，供 @ 引用搜索
-  const allAttachedDirs = React.useMemo(() => {
-    const dirs = [...attachedDirs]
-    // 添加工作区级附加目录
+  // 工作区级目录（workspace shared files + 工作区级附加目录），@ 引用标记为工作区文件
+  const workspaceDirs = React.useMemo(() => {
+    const dirs: string[] = []
+    if (workspaceFilesPath) dirs.push(workspaceFilesPath)
     for (const d of wsAttachedDirs) {
       if (!dirs.includes(d)) dirs.push(d)
     }
-    // 添加工作区共享文件目录
-    if (workspaceFilesPath && !dirs.includes(workspaceFilesPath)) {
-      dirs.unshift(workspaceFilesPath)
-    }
     return dirs
-  }, [attachedDirs, wsAttachedDirs, workspaceFilesPath])
+  }, [workspaceFilesPath, wsAttachedDirs])
 
   // 监听消息刷新版本号
   const refreshMap = useAtomValue(agentMessageRefreshAtom)
@@ -1445,7 +1441,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
               collapsible
               workspacePath={sessionPath}
               workspaceSlug={workspaceSlug}
-              attachedDirs={allAttachedDirs}
+              attachedDirs={workspaceDirs}
+              sessionAttachedDirs={attachedDirs}
               htmlValue={inputHtmlContent}
               onHtmlChange={setInputHtmlContent}
               sendWithCmdEnter={sendWithCmdEnter}

--- a/apps/electron/src/renderer/components/agent/mention-popup-utils.ts
+++ b/apps/electron/src/renderer/components/agent/mention-popup-utils.ts
@@ -5,6 +5,7 @@
  * - 初始隐藏（防闪烁）
  * - rAF 定位后显示
  * - 右侧/顶部边界限制
+ * - 可选底部锚定（弹窗向上生长）
  */
 
 const POPUP_GAP = 4
@@ -21,10 +22,16 @@ export function createMentionPopup(content: HTMLElement): HTMLDivElement {
   return popup
 }
 
-/** 定位弹窗到光标位置上方，含边界限制 */
+export interface PositionOptions {
+  /** 底部锚定：弹窗底部固定对齐光标上方，高度变化时向上生长 */
+  anchorBottom?: boolean
+}
+
+/** 定位弹窗到光标位置 */
 export function positionPopup(
   popup: HTMLDivElement | null,
   rect: DOMRect | null | undefined,
+  options?: PositionOptions,
 ): void {
   if (!rect || !popup) return
 
@@ -38,12 +45,22 @@ export function positionPopup(
     const left = Math.min(rect.left, window.innerWidth - popupWidth - VIEWPORT_PADDING)
     popup.style.left = `${Math.max(VIEWPORT_PADDING, left)}px`
 
-    // 垂直定位：优先向上弹出，空间不足时向下
-    const spaceAbove = rect.top
-    if (spaceAbove >= popupHeight + POPUP_GAP) {
-      popup.style.top = `${rect.top - popupHeight - POPUP_GAP}px`
+    if (options?.anchorBottom) {
+      // 底部锚定：弹窗底部固定在光标上方，向上生长
+      const bottom = rect.top - POPUP_GAP
+      let top = bottom - popupHeight
+      if (top < VIEWPORT_PADDING) {
+        top = VIEWPORT_PADDING
+      }
+      popup.style.top = `${top}px`
     } else {
-      popup.style.top = `${rect.bottom + POPUP_GAP}px`
+      // 垂直定位：优先向上弹出，空间不足时向下
+      const spaceAbove = rect.top
+      if (spaceAbove >= popupHeight + POPUP_GAP) {
+        popup.style.top = `${rect.top - popupHeight - POPUP_GAP}px`
+      } else {
+        popup.style.top = `${rect.bottom + POPUP_GAP}px`
+      }
     }
 
     popup.style.visibility = 'visible'

--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -306,7 +306,7 @@ export function remarkMentions() {
           parts.push({ type: 'text', value: text.slice(lastIdx, m.index) })
         }
         const mType: MentionType = m[1] ? 'file' : m[2] ? 'skill' : 'mcp'
-        const mValue = m[1] || m[2] || m[3]
+        const mValue = m[1] ?? m[2] ?? m[3] ?? ''
         // 新版 htmlToMarkdown 已 encodeURIComponent，旧消息是原始路径
         const alreadyEncoded = /%[0-9A-Fa-f]{2}/.test(mValue)
         const safeValue = alreadyEncoded ? mValue : encodeURIComponent(mValue)

--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -259,17 +259,26 @@ const MENTION_STYLES: Record<MentionType, { icon: typeof FileText; className: st
   mcp: { icon: Server, className: 'bg-[hsl(160_60%_45%/0.15)] text-[hsl(160_60%_35%)]' },
 }
 
+function safeDecode(raw: string): string {
+  try {
+    return decodeURIComponent(raw)
+  } catch {
+    return raw
+  }
+}
+
 function MentionChip({ type, value }: { type: MentionType; value: string }): React.ReactElement {
   const style = MENTION_STYLES[type]
   const Icon = style.icon
-  const display = type === 'file' ? (value.split('/').pop() || value) : value
+  const decoded = safeDecode(value)
+  const display = type === 'file' ? (decoded.split('/').pop() || decoded) : decoded
   return (
     <span
       className={cn(
         'inline-flex items-center gap-0.5 rounded px-1 py-[1px] text-[13px] font-medium whitespace-nowrap align-baseline',
         style.className
       )}
-      title={type === 'file' ? value : undefined}
+      title={type === 'file' ? decoded : undefined}
     >
       <Icon className="size-3 inline shrink-0" />
       {display}
@@ -298,9 +307,12 @@ export function remarkMentions() {
         }
         const mType: MentionType = m[1] ? 'file' : m[2] ? 'skill' : 'mcp'
         const mValue = m[1] || m[2] || m[3]
+        // 新版 htmlToMarkdown 已 encodeURIComponent，旧消息是原始路径
+        const alreadyEncoded = /%[0-9A-Fa-f]{2}/.test(mValue)
+        const safeValue = alreadyEncoded ? mValue : encodeURIComponent(mValue)
         parts.push({
           type: 'link',
-          url: `mention://${mType}/${mValue}`,
+          url: `mention://${mType}/${safeValue}`,
           children: [{ type: 'text', value: m[0] }],
         })
         lastIdx = m.index + m[0].length

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -188,8 +188,10 @@ interface RichTextInputProps {
   workspacePath?: string | null
   /** 工作区 slug（启用 / Skill 和 # MCP 功能时需要） */
   workspaceSlug?: string | null
-  /** 附加目录路径列表（@ 引用时一并搜索） */
+  /** 附加目录路径列表（工作区级，@ 引用时标记为工作区文件） */
   attachedDirs?: string[]
+  /** 会话级附加目录路径列表（@ 引用时标记为会话文件） */
+  sessionAttachedDirs?: string[]
   /** HTML 草稿值（切换会话恢复时使用，保留 mention 等富文本结构） */
   htmlValue?: string
   /** HTML 值变更回调（用于保存富文本草稿） */
@@ -219,6 +221,7 @@ export function RichTextInput({
   workspacePath,
   workspaceSlug,
   attachedDirs = [],
+  sessionAttachedDirs = [],
   htmlValue,
   onHtmlChange,
   sendWithCmdEnter = false,
@@ -249,9 +252,12 @@ export function RichTextInput({
   // 工作区路径引用（给 Suggestion 使用）
   const workspacePathRef = useRef<string | null>(workspacePath ?? null)
   workspacePathRef.current = workspacePath ?? null
-  // 附加目录路径引用（给 Suggestion 使用）
+  // 工作区级附加目录路径引用（给 Suggestion 使用，标记为 workspace）
   const attachedDirsRef = useRef<string[]>(attachedDirs)
   attachedDirsRef.current = attachedDirs
+  // 会话级附加目录路径引用（给 Suggestion 使用，标记为 session）
+  const sessionAttachedDirsRef = useRef<string[]>(sessionAttachedDirs)
+  sessionAttachedDirsRef.current = sessionAttachedDirs
   // 工作区 slug 引用（给 Skill/MCP Suggestion 使用）
   const workspaceSlugRef = useRef<string | null>(workspaceSlug ?? null)
   workspaceSlugRef.current = workspaceSlug ?? null
@@ -261,7 +267,7 @@ export function RichTextInput({
 
   // Mention Suggestion 配置（稳定引用，不随 workspacePath 变化重建）
   const mentionSuggestion = useMemo(
-    () => createFileMentionSuggestion(workspacePathRef, mentionActiveRef, attachedDirsRef, mentionItemCountRef),
+    () => createFileMentionSuggestion(workspacePathRef, mentionActiveRef, attachedDirsRef, mentionItemCountRef, sessionAttachedDirsRef),
     [],
   )
 

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -119,7 +119,7 @@ function htmlToMarkdown(html: string): string {
         if (dataType === 'mention') {
           if (suggestionChar === '/') return `/skill:${dataId}`
           if (suggestionChar === '#') return `#mcp:${dataId}`
-          return `@file:${dataId}`
+          return `@file:${encodeURIComponent(dataId)}`
         }
         return children
       }

--- a/apps/electron/src/renderer/components/file-browser/FileMentionList.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileMentionList.tsx
@@ -11,6 +11,7 @@
  * 交互：
  * - 文件夹初始折叠，Tab 键展开/折叠，→/← 方向键辅助
  * - 任何时候按 Enter 完成 @ 引用（文件或目录均可）
+ * - 鼠标单击文件夹：展开/折叠；双击文件夹：选中并插入 @ 引用
  */
 
 import * as React from 'react'
@@ -299,13 +300,9 @@ export const FileMentionList = React.forwardRef<FileMentionRef, FileMentionListP
     // 无匹配结果
     if (!hasResults) {
       return (
-        <TooltipProvider>
-          <MentionErrorBoundary>
-            <div className="rounded-lg border bg-popover p-2 shadow-lg text-[11px] text-muted-foreground">
-              无匹配文件
-            </div>
-          </MentionErrorBoundary>
-        </TooltipProvider>
+        <div className="rounded-lg border bg-popover p-2 shadow-lg text-[11px] text-muted-foreground">
+          无匹配文件
+        </div>
       )
     }
 
@@ -318,7 +315,8 @@ export const FileMentionList = React.forwardRef<FileMentionRef, FileMentionListP
       >
         {/* 会话文件 */}
         {hasSession && (
-          <SessionSection
+          <FileSection
+            label="会话文件"
             tree={sessionTreeWithState}
             selectedIndex={selectedIndex}
             baseIndex={0}
@@ -330,7 +328,8 @@ export const FileMentionList = React.forwardRef<FileMentionRef, FileMentionListP
 
         {/* 工作区文件 */}
         {hasWorkspace && (
-          <WorkspaceSection
+          <FileSection
+            label="工作区文件"
             tree={workspaceTreeWithState}
             selectedIndex={selectedIndex}
             baseIndex={sessionVisible.length}
@@ -348,8 +347,9 @@ export const FileMentionList = React.forwardRef<FileMentionRef, FileMentionListP
 
 // ===== 子组件 =====
 
-/** 会话文件区域 */
-function SessionSection({
+/** 分组区域（会话文件 / 工作区文件） */
+function FileSection({
+  label,
   tree,
   selectedIndex,
   baseIndex,
@@ -357,6 +357,7 @@ function SessionSection({
   onToggle,
   setSelectedIndex,
 }: {
+  label: string
   tree: FileTreeNode[]
   selectedIndex: number
   baseIndex: number
@@ -368,41 +369,7 @@ function SessionSection({
     <div>
       <div className="flex items-center gap-1.5 px-2.5 py-1.5 text-[11px] font-medium bg-primary/10 text-primary border-b border-border/50">
         <Folder className="size-3" />
-        <span>会话文件</span>
-      </div>
-      <TreeNodeList
-        nodes={tree}
-        selectedIndex={selectedIndex}
-        baseIndex={baseIndex}
-        onSelect={onSelect}
-        onToggle={onToggle}
-        setSelectedIndex={setSelectedIndex}
-      />
-    </div>
-  )
-}
-
-/** 工作区文件区域 */
-function WorkspaceSection({
-  tree,
-  selectedIndex,
-  baseIndex,
-  onSelect,
-  onToggle,
-  setSelectedIndex,
-}: {
-  tree: FileTreeNode[]
-  selectedIndex: number
-  baseIndex: number
-  onSelect: (node: FileTreeNode) => void
-  onToggle: (path: string) => void
-  setSelectedIndex: (index: number) => void
-}) {
-  return (
-    <div>
-      <div className="flex items-center gap-1.5 px-2.5 py-1.5 text-[11px] font-medium bg-primary/10 text-primary border-b border-border/50">
-        <Folder className="size-3" />
-        <span>工作区文件</span>
+        <span>{label}</span>
       </div>
       <TreeNodeList
         nodes={tree}
@@ -434,6 +401,33 @@ function TreeNodeList({
 }) {
   let offset = 0
 
+  // 双击检测：单击目录时延迟触发 toggle，等待可能的双击
+  const clickTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+  React.useEffect(() => {
+    return () => {
+      if (clickTimerRef.current) clearTimeout(clickTimerRef.current)
+    }
+  }, [])
+
+  function handleDirClick(node: FileTreeNode) {
+    if (clickTimerRef.current) {
+      clearTimeout(clickTimerRef.current)
+      clickTimerRef.current = null
+    }
+    clickTimerRef.current = setTimeout(() => {
+      onToggle(node.path)
+      clickTimerRef.current = null
+    }, 180)
+  }
+
+  function handleDirDoubleClick(node: FileTreeNode) {
+    if (clickTimerRef.current) {
+      clearTimeout(clickTimerRef.current)
+      clickTimerRef.current = null
+    }
+    onSelect(node)
+  }
+
   function renderNode(node: FileTreeNode): React.ReactElement {
     const idx = baseIndex + offset
     const isSelected = idx === selectedIndex
@@ -457,9 +451,14 @@ function TreeNodeList({
           onClick={() => {
             setSelectedIndex(idx)
             if (node.type === 'dir') {
-              onToggle(node.path)
+              handleDirClick(node)
             } else {
               onSelect(node)
+            }
+          }}
+          onDoubleClick={() => {
+            if (node.type === 'dir') {
+              handleDirDoubleClick(node)
             }
           }}
         >

--- a/apps/electron/src/renderer/components/file-browser/FileMentionList.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileMentionList.tsx
@@ -9,7 +9,7 @@
  * - 工作区文件（workspace files + 附加目录下的文件）
  *
  * 交互：
- * - 文件夹初始折叠，选中后按 ` 键展开/折叠
+ * - 文件夹初始折叠，Tab 键展开/折叠，→/← 方向键辅助
  * - 任何时候按 Enter 完成 @ 引用（文件或目录均可）
  */
 
@@ -253,7 +253,15 @@ export const FileMentionList = React.forwardRef<FileMentionRef, FileMentionListP
           setSelectedIndex((prev) => (prev >= totalItems - 1 ? 0 : prev + 1))
           return true
         }
-        if (event.key === '`' || event.key === 'ArrowRight') {
+        if (event.key === 'Tab') {
+          event.preventDefault()
+          const node = getNodeAt(selectedIndex)
+          if (node && node.type === 'dir' && node.children.length > 0) {
+            toggleExpand(node.path)
+          }
+          return true
+        }
+        if (event.key === 'ArrowRight') {
           event.preventDefault()
           const node = getNodeAt(selectedIndex)
           if (node && node.type === 'dir' && node.children.length > 0 && !node.expanded) {
@@ -483,12 +491,12 @@ function TreeNodeList({
           {/* 选中文件夹时的快捷键提示 */}
           {isSelected && node.type === 'dir' && node.children.length > 0 && !node.expanded && (
             <span className="text-[10px] text-muted-foreground/60 shrink-0 bg-muted/50 rounded px-1 py-px">
-              → 展开
+              Tab 展开
             </span>
           )}
           {isSelected && node.type === 'dir' && node.children.length > 0 && node.expanded && (
             <span className="text-[10px] text-muted-foreground/60 shrink-0 bg-muted/50 rounded px-1 py-px">
-              ← 折叠
+              Tab 折叠
             </span>
           )}
         </button>

--- a/apps/electron/src/renderer/components/file-browser/FileMentionList.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileMentionList.tsx
@@ -1,58 +1,279 @@
 /**
  * FileMentionList — @ 引用文件下拉列表
  *
- * 显示文件搜索结果，支持键盘导航（上/下/Enter/Escape）。
+ * 显示按来源分组的文件树，支持键盘导航（上/下/Enter/Escape/`）。
  * 通过 React.useImperativeHandle 暴露 onKeyDown 给 TipTap Suggestion。
+ *
+ * 分组：
+ * - 会话文件（session 工作目录下的文件）
+ * - 工作区文件（workspace files + 附加目录下的文件）
+ *
+ * 交互：
+ * - 文件夹初始折叠，选中后按 ` 键展开/折叠
+ * - 任何时候按 Enter 完成 @ 引用（文件或目录均可）
  */
 
 import * as React from 'react'
 import { cn } from '@/lib/utils'
 import type { FileIndexEntry } from '@proma/shared'
 import { FileTypeIcon } from './FileTypeIcon'
+import { ChevronRight, Folder } from 'lucide-react'
+
+// ===== Error Boundary =====
+
+class MentionErrorBoundary extends React.Component<
+  { children: React.ReactNode },
+  { error: Error | null }
+> {
+  constructor(props: { children: React.ReactNode }) {
+    super(props)
+    this.state = { error: null }
+  }
+  static getDerivedStateFromError(error: Error) {
+    return { error }
+  }
+  override render() {
+    if (this.state.error) {
+      console.error('[FileMentionList] render error:', this.state.error)
+      return (
+        <div className="rounded-lg border bg-popover p-2 shadow-lg text-[11px] text-muted-foreground">
+          无匹配文件
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}
+
+// ===== 树形结构类型 =====
+
+interface FileTreeNode {
+  name: string
+  path: string
+  type: 'file' | 'dir'
+  source: 'session' | 'workspace'
+  depth: number
+  children: FileTreeNode[]
+  expanded: boolean
+}
+
+// ===== Props & Ref =====
 
 export interface FileMentionListProps {
-  items: FileIndexEntry[]
-  selectedIndex: number
-  onSelect: (item: FileIndexEntry) => void
+  sessionEntries: FileIndexEntry[]
+  workspaceEntries: FileIndexEntry[]
+  onSelect: (item: { name: string; path: string; type: 'file' | 'dir' }) => void
 }
 
 export interface FileMentionRef {
   onKeyDown: (props: { event: KeyboardEvent }) => boolean
 }
 
+// ===== 工具函数 =====
+
+/** 从扁平条目列表构建树 */
+function buildTree(entries: FileIndexEntry[]): FileTreeNode[] {
+  const pathMap = new Map<string, FileTreeNode>()
+  const roots: FileTreeNode[] = []
+
+  for (const entry of entries) {
+    pathMap.set(entry.path, {
+      name: entry.name,
+      path: entry.path,
+      type: entry.type,
+      source: entry.source,
+      depth: 0,
+      children: [],
+      expanded: false,
+    })
+  }
+
+  for (const entry of entries) {
+    const node = pathMap.get(entry.path)!
+    const lastSlash = entry.path.lastIndexOf('/')
+    const parentPath = lastSlash === -1 ? '' : entry.path.slice(0, lastSlash)
+
+    if (parentPath && pathMap.has(parentPath)) {
+      pathMap.get(parentPath)!.children.push(node)
+    } else {
+      roots.push(node)
+    }
+  }
+
+  // 递归排序：目录在前、文件在后，按名称字母序
+  function sortNodes(nodes: FileTreeNode[]) {
+    nodes.sort((a, b) => {
+      if (a.type === 'dir' && b.type !== 'dir') return -1
+      if (a.type !== 'dir' && b.type === 'dir') return 1
+      return a.name.localeCompare(b.name)
+    })
+  }
+  for (const [, node] of pathMap) sortNodes(node.children)
+  sortNodes(roots)
+
+  // 设置深度
+  function setDepth(nodes: FileTreeNode[], depth: number) {
+    for (const node of nodes) {
+      node.depth = depth
+      setDepth(node.children, depth + 1)
+    }
+  }
+  setDepth(roots, 0)
+
+  return roots
+}
+
+/** 将树扁平化为可见项列表（仅展开的目录显示子节点） */
+function flattenVisible(nodes: FileTreeNode[]): FileTreeNode[] {
+  const result: FileTreeNode[] = []
+  function walk(nodes: FileTreeNode[]) {
+    for (const node of nodes) {
+      result.push(node)
+      if (node.type === 'dir' && node.expanded) {
+        walk(node.children)
+      }
+    }
+  }
+  walk(nodes)
+  return result
+}
+
+// ===== 组件 =====
+
 export const FileMentionList = React.forwardRef<FileMentionRef, FileMentionListProps>(
-  function FileMentionList({ items, selectedIndex, onSelect }, ref) {
-    const [localIndex, setLocalIndex] = React.useState(selectedIndex)
+  function FileMentionList({ sessionEntries, workspaceEntries, onSelect }, ref) {
+    // 构建树（仅在条目变化时重建）
+    const sessionTree = React.useMemo(
+      () => buildTree(sessionEntries),
+      [sessionEntries],
+    )
+    const workspaceTree = React.useMemo(
+      () => buildTree(workspaceEntries),
+      [workspaceEntries],
+    )
+
+    // 折叠/展开状态（用 expandedPaths Set 管理）
+    const [expandedPaths, setExpandedPaths] = React.useState<Set<string>>(new Set())
+
+    // 将 expanded 状态注入树节点
+    const sessionTreeWithState = React.useMemo(() => {
+      function inject(nodes: FileTreeNode[]): FileTreeNode[] {
+        return nodes.map((n) => ({
+          ...n,
+          expanded: expandedPaths.has(n.path),
+          children: inject(n.children),
+        }))
+      }
+      return inject(sessionTree)
+    }, [sessionTree, expandedPaths])
+
+    const workspaceTreeWithState = React.useMemo(() => {
+      function inject(nodes: FileTreeNode[]): FileTreeNode[] {
+        return nodes.map((n) => ({
+          ...n,
+          expanded: expandedPaths.has(n.path),
+          children: inject(n.children),
+        }))
+      }
+      return inject(workspaceTree)
+    }, [workspaceTree, expandedPaths])
+
+    // 可见项（用于键盘导航和渲染）
+    const sessionVisible = React.useMemo(
+      () => flattenVisible(sessionTreeWithState),
+      [sessionTreeWithState],
+    )
+    const workspaceVisible = React.useMemo(
+      () => flattenVisible(workspaceTreeWithState),
+      [workspaceTreeWithState],
+    )
+
+    // 选中索引
+    const totalItems = sessionVisible.length + workspaceVisible.length
+    const [selectedIndex, setSelectedIndex] = React.useState(0)
     const containerRef = React.useRef<HTMLDivElement>(null)
 
-    // items 变化时重置选中索引
+    // 条目变化或展开状态变化时重置/修正索引
     React.useEffect(() => {
-      setLocalIndex(0)
-    }, [items])
+      setSelectedIndex((prev) => (totalItems > 0 ? Math.min(prev, totalItems - 1) : 0))
+    }, [sessionEntries, workspaceEntries, totalItems])
 
     // 滚动选中项到可见区域
     React.useEffect(() => {
       const container = containerRef.current
       if (!container) return
-      const item = container.children[localIndex] as HTMLElement | undefined
-      item?.scrollIntoView({ block: 'nearest' })
-    }, [localIndex])
+      const items = container.querySelectorAll('[data-mention-item]')
+      const target = items[selectedIndex] as HTMLElement | undefined
+      target?.scrollIntoView({ block: 'nearest' })
+    }, [selectedIndex, totalItems])
+
+    // 获取指定索引对应的实际节点（跨 session 和 workspace 列表）
+    function getNodeAt(index: number): FileTreeNode | null {
+      if (index < sessionVisible.length) return sessionVisible[index] ?? null
+      const wsIdx = index - sessionVisible.length
+      return workspaceVisible[wsIdx] ?? null
+    }
+
+    function toggleExpand(path: string) {
+      setExpandedPaths((prev) => {
+        const next = new Set(prev)
+        if (next.has(path)) {
+          next.delete(path)
+        } else {
+          next.add(path)
+        }
+        return next
+      })
+    }
+
+    const handleSelect = React.useCallback(
+      (node: FileTreeNode) => {
+        onSelect({ name: node.name, path: node.path, type: node.type })
+      },
+      [onSelect],
+    )
+
+    const handleSetIndex = React.useCallback(
+      (index: number) => {
+        setSelectedIndex(index)
+      },
+      [],
+    )
 
     // 暴露键盘处理给 TipTap
     React.useImperativeHandle(ref, () => ({
       onKeyDown: ({ event }) => {
         if (event.key === 'ArrowUp') {
-          setLocalIndex((prev) => (prev <= 0 ? items.length - 1 : prev - 1))
+          event.preventDefault()
+          setSelectedIndex((prev) => (prev <= 0 ? totalItems - 1 : prev - 1))
           return true
         }
         if (event.key === 'ArrowDown') {
-          setLocalIndex((prev) => (prev >= items.length - 1 ? 0 : prev + 1))
+          event.preventDefault()
+          setSelectedIndex((prev) => (prev >= totalItems - 1 ? 0 : prev + 1))
+          return true
+        }
+        if (event.key === '`' || event.key === 'ArrowRight') {
+          event.preventDefault()
+          const node = getNodeAt(selectedIndex)
+          if (node && node.type === 'dir' && node.children.length > 0 && !node.expanded) {
+            toggleExpand(node.path)
+          }
+          return true
+        }
+        if (event.key === 'ArrowLeft') {
+          event.preventDefault()
+          const node = getNodeAt(selectedIndex)
+          if (node && node.type === 'dir' && node.expanded) {
+            toggleExpand(node.path)
+          }
           return true
         }
         if (event.key === 'Enter') {
-          if (items.length === 0) return false
-          const item = items[localIndex]
-          if (item) onSelect(item)
+          if (totalItems === 0) return false
+          event.preventDefault()
+          const node = getNodeAt(selectedIndex)
+          if (node) handleSelect(node)
           return true
         }
         if (event.key === 'Escape') {
@@ -62,41 +283,222 @@ export const FileMentionList = React.forwardRef<FileMentionRef, FileMentionListP
       },
     }))
 
+    const hasSession = sessionEntries.length > 0
+    const hasWorkspace = workspaceEntries.length > 0
+    const hasResults = hasSession || hasWorkspace
+
     // 无匹配结果
-    if (items.length === 0) {
+    if (!hasResults) {
       return (
-        <div className="rounded-lg border bg-popover p-2 shadow-lg text-[11px] text-muted-foreground">
-          无匹配文件
-        </div>
+        <MentionErrorBoundary>
+          <div className="rounded-lg border bg-popover p-2 shadow-lg text-[11px] text-muted-foreground">
+            无匹配文件
+          </div>
+        </MentionErrorBoundary>
       )
     }
 
     return (
+      <MentionErrorBoundary>
       <div
         ref={containerRef}
-        className="rounded-lg border bg-popover shadow-lg overflow-y-auto max-h-[280px] min-w-[200px]"
+        className="rounded-lg border bg-popover shadow-lg overflow-y-auto max-h-[360px] min-w-[260px]"
       >
-        {items.map((item, index) => (
-          <button
-            key={item.path}
-            type="button"
-            className={cn(
-              'w-full flex items-center gap-1.5 px-2.5 py-1 text-left text-xs hover:bg-accent transition-colors',
-              index === localIndex && 'bg-accent text-accent-foreground',
-            )}
-            onClick={() => onSelect(item)}
-          >
-            <FileTypeIcon name={item.name} isDirectory={item.type === 'dir'} size={12} />
-            <span className="truncate flex-1">{item.name}</span>
-            {/* 显示相对路径（当路径不等于文件名时） */}
-            {item.path !== item.name && (
-              <span className="text-[10px] text-muted-foreground/60 truncate max-w-[120px]">
-                {item.path}
-              </span>
-            )}
-          </button>
-        ))}
+        {/* 会话文件 */}
+        {hasSession && (
+          <SessionSection
+            tree={sessionTreeWithState}
+            selectedIndex={selectedIndex}
+            baseIndex={0}
+            onSelect={handleSelect}
+            onToggle={toggleExpand}
+            setSelectedIndex={handleSetIndex}
+          />
+        )}
+
+        {/* 工作区文件 */}
+        {hasWorkspace && (
+          <WorkspaceSection
+            tree={workspaceTreeWithState}
+            selectedIndex={selectedIndex}
+            baseIndex={sessionVisible.length}
+            onSelect={handleSelect}
+            onToggle={toggleExpand}
+            setSelectedIndex={handleSetIndex}
+          />
+        )}
       </div>
+      </MentionErrorBoundary>
     )
   },
 )
+
+// ===== 子组件 =====
+
+/** 会话文件区域 */
+function SessionSection({
+  tree,
+  selectedIndex,
+  baseIndex,
+  onSelect,
+  onToggle,
+  setSelectedIndex,
+}: {
+  tree: FileTreeNode[]
+  selectedIndex: number
+  baseIndex: number
+  onSelect: (node: FileTreeNode) => void
+  onToggle: (path: string) => void
+  setSelectedIndex: (index: number) => void
+}) {
+  return (
+    <div>
+      <div className="flex items-center gap-1.5 px-2.5 py-1.5 text-[11px] font-medium bg-primary/10 text-primary border-b border-border/50">
+        <Folder className="size-3" />
+        <span>会话文件</span>
+      </div>
+      <TreeNodeList
+        nodes={tree}
+        selectedIndex={selectedIndex}
+        baseIndex={baseIndex}
+        onSelect={onSelect}
+        onToggle={onToggle}
+        setSelectedIndex={setSelectedIndex}
+      />
+    </div>
+  )
+}
+
+/** 工作区文件区域 */
+function WorkspaceSection({
+  tree,
+  selectedIndex,
+  baseIndex,
+  onSelect,
+  onToggle,
+  setSelectedIndex,
+}: {
+  tree: FileTreeNode[]
+  selectedIndex: number
+  baseIndex: number
+  onSelect: (node: FileTreeNode) => void
+  onToggle: (path: string) => void
+  setSelectedIndex: (index: number) => void
+}) {
+  return (
+    <div>
+      <div className="flex items-center gap-1.5 px-2.5 py-1.5 text-[11px] font-medium bg-primary/10 text-primary border-b border-border/50">
+        <Folder className="size-3" />
+        <span>工作区文件</span>
+      </div>
+      <TreeNodeList
+        nodes={tree}
+        selectedIndex={selectedIndex}
+        baseIndex={baseIndex}
+        onSelect={onSelect}
+        onToggle={onToggle}
+        setSelectedIndex={setSelectedIndex}
+      />
+    </div>
+  )
+}
+
+/** 树节点递归列表 — 展开的目录会递归渲染子节点 */
+function TreeNodeList({
+  nodes,
+  selectedIndex,
+  baseIndex,
+  onSelect,
+  onToggle,
+  setSelectedIndex,
+}: {
+  nodes: FileTreeNode[]
+  selectedIndex: number
+  baseIndex: number
+  onSelect: (node: FileTreeNode) => void
+  onToggle: (path: string) => void
+  setSelectedIndex: (index: number) => void
+}) {
+  let offset = 0
+
+  function renderNode(node: FileTreeNode): React.ReactElement {
+    const idx = baseIndex + offset
+    const isSelected = idx === selectedIndex
+    const paddingLeft = 8 + node.depth * 16
+    offset++
+
+    return (
+      <React.Fragment key={node.path}>
+        <button
+          type="button"
+          data-mention-item=""
+          className={cn(
+            'w-full flex items-center gap-1.5 px-2.5 py-1 text-left text-xs transition-colors',
+            isSelected
+              ? 'bg-accent text-accent-foreground'
+              : 'hover:bg-accent/50',
+          )}
+          style={{ paddingLeft }}
+          onClick={() => {
+            setSelectedIndex(idx)
+            if (node.type === 'dir') {
+              onToggle(node.path)
+            } else {
+              onSelect(node)
+            }
+          }}
+        >
+          {/* 目录展开/折叠箭头 */}
+          {node.type === 'dir' && node.children.length > 0 ? (
+            <ChevronRight
+              className={cn(
+                'size-3 shrink-0 text-muted-foreground transition-transform duration-150',
+                node.expanded && 'rotate-90',
+              )}
+            />
+          ) : node.type === 'dir' ? (
+            <span className="w-3 shrink-0" />
+          ) : (
+            <span className="w-3 shrink-0" />
+          )}
+
+          {/* 文件/目录图标 */}
+          <FileTypeIcon
+            name={node.name}
+            isDirectory={node.type === 'dir'}
+            isOpen={node.type === 'dir' && node.expanded}
+            size={12}
+          />
+
+          {/* 名称 */}
+          <span className="truncate flex-1">{node.name}</span>
+
+          {/* 路径（当路径不等于文件名时显示） */}
+          {node.path !== node.name && (
+            <span className="text-[10px] text-muted-foreground/60 truncate max-w-[140px] shrink-[2]">
+              {node.path}
+            </span>
+          )}
+
+          {/* 选中文件夹时的快捷键提示 */}
+          {isSelected && node.type === 'dir' && node.children.length > 0 && !node.expanded && (
+            <span className="text-[10px] text-muted-foreground/60 shrink-0 bg-muted/50 rounded px-1 py-px">
+              → 展开
+            </span>
+          )}
+          {isSelected && node.type === 'dir' && node.children.length > 0 && node.expanded && (
+            <span className="text-[10px] text-muted-foreground/60 shrink-0 bg-muted/50 rounded px-1 py-px">
+              ← 折叠
+            </span>
+          )}
+        </button>
+        {/* 展开状态下递归渲染子节点 */}
+        {node.type === 'dir' && node.expanded && node.children.length > 0 &&
+          node.children.map((child) => renderNode(child))
+        }
+      </React.Fragment>
+    )
+  }
+
+  return <>{nodes.map((node) => renderNode(node))}</>
+}

--- a/apps/electron/src/renderer/components/file-browser/FileMentionList.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileMentionList.tsx
@@ -18,6 +18,7 @@ import { cn } from '@/lib/utils'
 import type { FileIndexEntry } from '@proma/shared'
 import { FileTypeIcon } from './FileTypeIcon'
 import { ChevronRight, Folder } from 'lucide-react'
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/components/ui/tooltip'
 
 // ===== Error Boundary =====
 
@@ -298,16 +299,19 @@ export const FileMentionList = React.forwardRef<FileMentionRef, FileMentionListP
     // 无匹配结果
     if (!hasResults) {
       return (
-        <MentionErrorBoundary>
-          <div className="rounded-lg border bg-popover p-2 shadow-lg text-[11px] text-muted-foreground">
-            无匹配文件
-          </div>
-        </MentionErrorBoundary>
+        <TooltipProvider>
+          <MentionErrorBoundary>
+            <div className="rounded-lg border bg-popover p-2 shadow-lg text-[11px] text-muted-foreground">
+              无匹配文件
+            </div>
+          </MentionErrorBoundary>
+        </TooltipProvider>
       )
     }
 
     return (
-      <MentionErrorBoundary>
+      <TooltipProvider>
+        <MentionErrorBoundary>
       <div
         ref={containerRef}
         className="rounded-lg border bg-popover shadow-lg overflow-y-auto max-h-[360px] min-w-[260px]"
@@ -337,6 +341,7 @@ export const FileMentionList = React.forwardRef<FileMentionRef, FileMentionListP
         )}
       </div>
       </MentionErrorBoundary>
+      </TooltipProvider>
     )
   },
 )
@@ -437,7 +442,9 @@ function TreeNodeList({
 
     return (
       <React.Fragment key={node.path}>
-        <button
+        <Tooltip delayDuration={300}>
+          <TooltipTrigger asChild>
+            <button
           type="button"
           data-mention-item=""
           className={cn(
@@ -500,6 +507,11 @@ function TreeNodeList({
             </span>
           )}
         </button>
+          </TooltipTrigger>
+          <TooltipContent side="right" className="z-[10000] max-w-xs break-all">
+            <p>{node.path}</p>
+          </TooltipContent>
+        </Tooltip>
         {/* 展开状态下递归渲染子节点 */}
         {node.type === 'dir' && node.expanded && node.children.length > 0 &&
           node.children.map((child) => renderNode(child))

--- a/apps/electron/src/renderer/components/file-browser/file-mention-suggestion.tsx
+++ b/apps/electron/src/renderer/components/file-browser/file-mention-suggestion.tsx
@@ -10,7 +10,7 @@ import { ReactRenderer } from '@tiptap/react'
 import type { SuggestionOptions } from '@tiptap/suggestion'
 import { FileMentionList } from './FileMentionList'
 import type { FileMentionRef } from './FileMentionList'
-import type { FileIndexEntry } from '@proma/shared'
+import type { FileIndexEntry, FileSearchResult } from '@proma/shared'
 import { createMentionPopup, positionPopup } from '@/components/agent/mention-popup-utils'
 
 /**
@@ -18,38 +18,52 @@ import { createMentionPopup, positionPopup } from '@/components/agent/mention-po
  *
  * @param workspacePathRef 当前工作区根路径引用
  * @param mentionActiveRef 是否正在 mention 模式（用于阻止 Enter 发送消息）
- * @param attachedDirsRef 附加目录路径列表引用（搜索时一并扫描）
+ * @param attachedDirsRef 工作区级附加目录路径列表引用（标记为 workspace）
+ * @param mentionItemCountRef mention 条目计数
+ * @param sessionAttachedDirsRef 会话级附加目录路径列表引用（标记为 session）
  */
 export function createFileMentionSuggestion(
   workspacePathRef: React.RefObject<string | null>,
   mentionActiveRef: React.MutableRefObject<boolean>,
   attachedDirsRef?: React.RefObject<string[]>,
   mentionItemCountRef?: React.MutableRefObject<number>,
+  sessionAttachedDirsRef?: React.RefObject<string[]>,
 ): Omit<SuggestionOptions<FileIndexEntry>, 'editor'> {
+  let lastResult: FileSearchResult | null = null
+
   return {
     char: '@',
     allowSpaces: false,
 
-    // 异步搜索文件
     items: async ({ query }): Promise<FileIndexEntry[]> => {
       const wsPath = workspacePathRef.current
-      if (!wsPath) return []
+      if (!wsPath) {
+        console.warn('[FileMention] workspacePath is null, mention disabled')
+        return []
+      }
 
       try {
         const additionalPaths = attachedDirsRef?.current ?? []
+        const sessionPaths = sessionAttachedDirsRef?.current ?? []
+
+        console.log('[FileMention] searching files, query:', JSON.stringify(query), 'ws:', wsPath, 'additionalPaths:', additionalPaths, 'sessionPaths:', sessionPaths)
         const result = await window.electronAPI.searchWorkspaceFiles(
           wsPath,
           query ?? '',
           20,
           additionalPaths.length > 0 ? additionalPaths : undefined,
+          sessionPaths.length > 0 ? sessionPaths : undefined,
         )
+        console.log('[FileMention] search result:', { total: result.total, sessionCount: result.sessionEntries.length, workspaceCount: result.workspaceEntries.length })
+        lastResult = result
         return result.entries
-      } catch {
+      } catch(e) {
+        console.error('[FileMention] search failed:', e)
+        lastResult = null
         return []
       }
     },
 
-    // 渲染下拉列表
     render: () => {
       let renderer: ReactRenderer<FileMentionRef> | null = null
       let popup: HTMLDivElement | null = null
@@ -58,26 +72,54 @@ export function createFileMentionSuggestion(
         onStart(props) {
           mentionActiveRef.current = true
           if (mentionItemCountRef) mentionItemCountRef.current = props.items.length
-          renderer = new ReactRenderer(FileMentionList, {
-            props: {
-              items: props.items,
-              selectedIndex: 0,
-              onSelect: (item: FileIndexEntry) => {
-                props.command({ id: item.path, label: item.name })
-              },
-            },
-            editor: props.editor,
-          })
 
-          popup = createMentionPopup(renderer.element)
-          positionPopup(popup, props.clientRect?.())
+          try {
+            const result = lastResult
+            // 兼容旧版 IPC（未返回 sessionEntries/workspaceEntries）：从 entries 按 source 拆分
+            let sessionEntries = result?.sessionEntries ?? []
+            let workspaceEntries = result?.workspaceEntries ?? []
+            if (sessionEntries.length === 0 && workspaceEntries.length === 0 && (result?.entries.length ?? 0) > 0) {
+              const hasSource = result!.entries.some((e) => 'source' in e && e.source)
+              if (hasSource) {
+                sessionEntries = result!.entries.filter((e) => e.source === 'session')
+                workspaceEntries = result!.entries.filter((e) => e.source === 'workspace')
+              } else {
+                // 旧版完全不返回 source，全部归入会话文件
+                sessionEntries = result!.entries
+              }
+            }
+            renderer = new ReactRenderer(FileMentionList, {
+              props: {
+                sessionEntries,
+                workspaceEntries,
+                onSelect: (item: { name: string; path: string; type: 'file' | 'dir' }) => {
+                  props.command({ id: item.path, label: item.name })
+                },
+              },
+              editor: props.editor,
+            })
+
+            popup = createMentionPopup(renderer.element)
+            positionPopup(popup, props.clientRect?.())
+          } catch (e) {
+            console.error('[FileMention] render popup failed:', e)
+          }
         },
 
         onUpdate(props) {
           if (mentionItemCountRef) mentionItemCountRef.current = props.items.length
+
+          const result = lastResult
+          let sessionEntries = result?.sessionEntries ?? []
+          let workspaceEntries = result?.workspaceEntries ?? []
+          if (sessionEntries.length === 0 && workspaceEntries.length === 0 && (result?.entries.length ?? 0) > 0) {
+            sessionEntries = result!.entries.filter((e) => e.source === 'session')
+            workspaceEntries = result!.entries.filter((e) => e.source === 'workspace')
+          }
           renderer?.updateProps({
-            items: props.items,
-            onSelect: (item: FileIndexEntry) => {
+            sessionEntries,
+            workspaceEntries,
+            onSelect: (item: { name: string; path: string; type: 'file' | 'dir' }) => {
               props.command({ id: item.path, label: item.name })
             },
           })
@@ -85,12 +127,16 @@ export function createFileMentionSuggestion(
         },
 
         onKeyDown(props) {
-          return renderer?.ref?.onKeyDown({ event: props.event }) ?? false
+          if (renderer?.ref) {
+            return renderer.ref.onKeyDown({ event: props.event })
+          }
+          return false
         },
 
         onExit() {
           mentionActiveRef.current = false
           if (mentionItemCountRef) mentionItemCountRef.current = 0
+          lastResult = null
           popup?.remove()
           popup = null
           renderer?.destroy()

--- a/apps/electron/src/renderer/components/file-browser/file-mention-suggestion.tsx
+++ b/apps/electron/src/renderer/components/file-browser/file-mention-suggestion.tsx
@@ -8,7 +8,7 @@
 
 import type React from 'react'
 import { ReactRenderer } from '@tiptap/react'
-import type { SuggestionOptions } from '@tiptap/suggestion'
+import type { SuggestionOptions, SuggestionProps } from '@tiptap/suggestion'
 import { FileMentionList } from './FileMentionList'
 import type { FileMentionRef } from './FileMentionList'
 import type { FileIndexEntry, FileSearchResult } from '@proma/shared'
@@ -38,7 +38,6 @@ export function createFileMentionSuggestion(
         const additionalPaths = attachedDirsRef?.current ?? []
         const sessionPaths = sessionAttachedDirsRef?.current ?? []
 
-        console.log('[FileMention] searching files, query:', JSON.stringify(query), 'ws:', wsPath, 'additionalPaths:', additionalPaths, 'sessionPaths:', sessionPaths)
         const result = await window.electronAPI.searchWorkspaceFiles(
           wsPath,
           query ?? '',
@@ -46,7 +45,6 @@ export function createFileMentionSuggestion(
           additionalPaths.length > 0 ? additionalPaths : undefined,
           sessionPaths.length > 0 ? sessionPaths : undefined,
         )
-        console.log('[FileMention] search result:', { total: result.total, sessionCount: result.sessionEntries.length, workspaceCount: result.workspaceEntries.length })
         lastResult = result
         return result.entries
       } catch(e) {
@@ -62,21 +60,13 @@ export function createFileMentionSuggestion(
       let resizeObserver: ResizeObserver | null = null
 
       function splitEntries(result: FileSearchResult | null) {
-        let sessionEntries = result?.sessionEntries ?? []
-        let workspaceEntries = result?.workspaceEntries ?? []
-        if (sessionEntries.length === 0 && workspaceEntries.length === 0 && (result?.entries.length ?? 0) > 0) {
-          const hasSource = result!.entries.some((e) => 'source' in e && e.source)
-          if (hasSource) {
-            sessionEntries = result!.entries.filter((e) => e.source === 'session')
-            workspaceEntries = result!.entries.filter((e) => e.source === 'workspace')
-          } else {
-            sessionEntries = result!.entries
-          }
+        return {
+          sessionEntries: result?.sessionEntries ?? [],
+          workspaceEntries: result?.workspaceEntries ?? [],
         }
-        return { sessionEntries, workspaceEntries }
       }
 
-      function createRenderer(props: any) {
+      function createRenderer(props: SuggestionProps<FileIndexEntry>) {
         const { sessionEntries, workspaceEntries } = splitEntries(lastResult)
         renderer = new ReactRenderer(FileMentionList, {
           props: {

--- a/apps/electron/src/renderer/components/file-browser/file-mention-suggestion.tsx
+++ b/apps/electron/src/renderer/components/file-browser/file-mention-suggestion.tsx
@@ -3,6 +3,7 @@
  *
  * 工厂函数，创建用于 @ 引用文件的 TipTap Suggestion 配置。
  * 输入 @ 后异步搜索工作区文件，弹出 FileMentionList 浮动列表。
+ * 弹窗底部锚定在光标上方，展开文件夹时向上生长。
  */
 
 import type React from 'react'
@@ -13,15 +14,6 @@ import type { FileMentionRef } from './FileMentionList'
 import type { FileIndexEntry, FileSearchResult } from '@proma/shared'
 import { createMentionPopup, positionPopup } from '@/components/agent/mention-popup-utils'
 
-/**
- * 创建文件 @ 引用的 Suggestion 配置
- *
- * @param workspacePathRef 当前工作区根路径引用
- * @param mentionActiveRef 是否正在 mention 模式（用于阻止 Enter 发送消息）
- * @param attachedDirsRef 工作区级附加目录路径列表引用（标记为 workspace）
- * @param mentionItemCountRef mention 条目计数
- * @param sessionAttachedDirsRef 会话级附加目录路径列表引用（标记为 session）
- */
 export function createFileMentionSuggestion(
   workspacePathRef: React.RefObject<string | null>,
   mentionActiveRef: React.MutableRefObject<boolean>,
@@ -67,6 +59,41 @@ export function createFileMentionSuggestion(
     render: () => {
       let renderer: ReactRenderer<FileMentionRef> | null = null
       let popup: HTMLDivElement | null = null
+      let resizeObserver: ResizeObserver | null = null
+
+      function splitEntries(result: FileSearchResult | null) {
+        let sessionEntries = result?.sessionEntries ?? []
+        let workspaceEntries = result?.workspaceEntries ?? []
+        if (sessionEntries.length === 0 && workspaceEntries.length === 0 && (result?.entries.length ?? 0) > 0) {
+          const hasSource = result!.entries.some((e) => 'source' in e && e.source)
+          if (hasSource) {
+            sessionEntries = result!.entries.filter((e) => e.source === 'session')
+            workspaceEntries = result!.entries.filter((e) => e.source === 'workspace')
+          } else {
+            sessionEntries = result!.entries
+          }
+        }
+        return { sessionEntries, workspaceEntries }
+      }
+
+      function createRenderer(props: any) {
+        const { sessionEntries, workspaceEntries } = splitEntries(lastResult)
+        renderer = new ReactRenderer(FileMentionList, {
+          props: {
+            sessionEntries,
+            workspaceEntries,
+            onSelect: (item: { name: string; path: string; type: 'file' | 'dir' }) => {
+              props.command({ id: item.path, label: item.name })
+            },
+          },
+          editor: props.editor,
+        })
+      }
+
+      function anchorPopup(rect?: (() => DOMRect | null) | null) {
+        if (!popup) return
+        positionPopup(popup, rect?.(), { anchorBottom: true })
+      }
 
       return {
         onStart(props) {
@@ -74,33 +101,15 @@ export function createFileMentionSuggestion(
           if (mentionItemCountRef) mentionItemCountRef.current = props.items.length
 
           try {
-            const result = lastResult
-            // 兼容旧版 IPC（未返回 sessionEntries/workspaceEntries）：从 entries 按 source 拆分
-            let sessionEntries = result?.sessionEntries ?? []
-            let workspaceEntries = result?.workspaceEntries ?? []
-            if (sessionEntries.length === 0 && workspaceEntries.length === 0 && (result?.entries.length ?? 0) > 0) {
-              const hasSource = result!.entries.some((e) => 'source' in e && e.source)
-              if (hasSource) {
-                sessionEntries = result!.entries.filter((e) => e.source === 'session')
-                workspaceEntries = result!.entries.filter((e) => e.source === 'workspace')
-              } else {
-                // 旧版完全不返回 source，全部归入会话文件
-                sessionEntries = result!.entries
-              }
-            }
-            renderer = new ReactRenderer(FileMentionList, {
-              props: {
-                sessionEntries,
-                workspaceEntries,
-                onSelect: (item: { name: string; path: string; type: 'file' | 'dir' }) => {
-                  props.command({ id: item.path, label: item.name })
-                },
-              },
-              editor: props.editor,
-            })
+            createRenderer(props)
+            popup = createMentionPopup(renderer!.element)
+            anchorPopup(props.clientRect)
 
-            popup = createMentionPopup(renderer.element)
-            positionPopup(popup, props.clientRect?.())
+            // 监听弹窗高度变化（展开/折叠文件夹时），重新定位保持底部锚定
+            resizeObserver = new ResizeObserver(() => {
+              anchorPopup(props.clientRect)
+            })
+            resizeObserver.observe(popup!)
           } catch (e) {
             console.error('[FileMention] render popup failed:', e)
           }
@@ -109,13 +118,7 @@ export function createFileMentionSuggestion(
         onUpdate(props) {
           if (mentionItemCountRef) mentionItemCountRef.current = props.items.length
 
-          const result = lastResult
-          let sessionEntries = result?.sessionEntries ?? []
-          let workspaceEntries = result?.workspaceEntries ?? []
-          if (sessionEntries.length === 0 && workspaceEntries.length === 0 && (result?.entries.length ?? 0) > 0) {
-            sessionEntries = result!.entries.filter((e) => e.source === 'session')
-            workspaceEntries = result!.entries.filter((e) => e.source === 'workspace')
-          }
+          const { sessionEntries, workspaceEntries } = splitEntries(lastResult)
           renderer?.updateProps({
             sessionEntries,
             workspaceEntries,
@@ -123,7 +126,7 @@ export function createFileMentionSuggestion(
               props.command({ id: item.path, label: item.name })
             },
           })
-          positionPopup(popup, props.clientRect?.())
+          anchorPopup(props.clientRect)
         },
 
         onKeyDown(props) {
@@ -137,6 +140,8 @@ export function createFileMentionSuggestion(
           mentionActiveRef.current = false
           if (mentionItemCountRef) mentionItemCountRef.current = 0
           lastResult = null
+          resizeObserver?.disconnect()
+          resizeObserver = null
           popup?.remove()
           popup = null
           renderer?.destroy()

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -886,12 +886,18 @@ export interface FileIndexEntry {
   path: string
   /** 条目类型 */
   type: 'file' | 'dir'
+  /** 来源：会话文件或工作区文件 */
+  source: 'session' | 'workspace'
 }
 
 /** 文件搜索结果 */
 export interface FileSearchResult {
   entries: FileIndexEntry[]
   total: number
+  /** 会话文件条目（来自 session 工作目录） */
+  sessionEntries: FileIndexEntry[]
+  /** 工作区文件条目（来自 workspace files + 附加目录） */
+  workspaceEntries: FileIndexEntry[]
 }
 
 // ===== Agent 附件 =====


### PR DESCRIPTION
## 概述

对 @ 文件引用弹窗进行全面增强：会话/工作区双分组、树形层级、文件夹展开折叠、完整路径 tooltip、以及对中文/特殊字符路径的正确处理。

## 改动内容

- **FileMentionList.tsx** — 重写：会话文件 / 工作区文件双分组、递归树形渲染带缩进、Tab / → / ← 键控制文件夹展开折叠、路径显示、悬停显示完整路径的 tooltip
- **file-mention-suggestion.tsx** — 更新 props 适配分组数据、兼容旧 IPC、用 ResizeObserver 动态重定位弹窗、弹窗底部锚定向上生长
- **mention-popup-utils.ts** — 增加 `anchorBottom` 选项（底部锚定在光标处，向上生长）
- **main/ipc.ts** — 文件搜索返回分组结果（sessionEntries / workspaceEntries）并带 `source` 标记、新增 `sessionPaths` 参数支持会话级附加目录、空 query 每分组返回最多 100 条、附加目录根目录作为树形条目、"workspace-files" 重命名为 "工作文件"
- **preload/index.ts** — searchWorkspaceFiles 新增 `sessionPaths` 参数
- **AgentView.tsx** — 拆分附加目录为会话级与工作区级，正确打 source 标记
- **rich-text-input.tsx** — 新增 `sessionAttachedDirs` prop、htmlToMarkdown 中对文件路径做 `encodeURIComponent`
- **message.tsx** — `remarkMentions` 对 mention:// URL 路径做 encode、智能检测防止重复编码、`MentionChip` 用 `safeDecode` 正确显示中文文件名
- **types/agent.ts** — `FileIndexEntry` 新增 `source` 字段，`FileSearchResult` 新增 `sessionEntries` / `workspaceEntries`

## 📝 最新改动（回应 code review 反馈）

提交 [`af6312f`](https://github.com/Andreaseszhang/Proma/commit/af6312f) 针对 review 反馈修复了以下问题：

### 🐛 Bug 修复
- **`main/ipc.ts:2041`** — 修复 `matchEntries` 模糊匹配 bug：`nameLower[i] === q`（与整个查询字符串比较，永远为 false）修正为 `nameLower[i] === q[qi]`
- **`message.tsx:311`** — 修复 `remarkMentions` 中 `mValue` 的 TypeScript 类型错误，`||` 链改为 `??` 链并加默认值 `''`，消除 `string | undefined` 推断

### ⚠️ 代码规范（CLAUDE.md 项目规则）
- **`file-mention-suggestion.tsx:79`** — 移除 `any` 类型，改为 `SuggestionProps<FileIndexEntry>`（从 `@tiptap/suggestion` 导入）
- **`file-mention-suggestion.tsx:41,49`** — 移除两处调试用的 `console.log`，保留 `console.warn` / `console.error`

### ✨ 交互增强
- **`FileMentionList.tsx`** — 支持鼠标**双击文件夹**直接选中并插入 @ 引用（180ms 延迟识别单击/双击；单击仍是展开/折叠）

### 🧹 代码简化
- **`FileMentionList.tsx`** — 合并结构完全相同的 `SessionSection` 和 `WorkspaceSection` 为统一的 `FileSection(label)` 组件
- **`file-mention-suggestion.tsx`** — 简化 `splitEntries`，移除 IPC 已总是返回分组数据后永不命中的 fallback dead code
- **`FileMentionList.tsx`** — 空状态移除多余的 `TooltipProvider` + `MentionErrorBoundary` 包裹

### ✅ 验证
- `bun run typecheck` 全绿
- 未 force-push，保留完整 commit 历史

## 测试步骤

1. 启动开发模式：`bun run dev`
2. 打开一个含会话级和工作区级附加目录的工作区
3. 在输入框中输入 `@`
4. 验证弹出"会话文件 / 工作区文件"双分组列表
5. 验证 Tab 键展开/折叠文件夹（→ 展开，← 折叠）
6. **新增**：验证鼠标双击文件夹可直接选中并插入
7. 验证悬停文件查看完整路径 tooltip
8. 选择含中文和空格的路径文件并发送消息
9. 验证消息中 mention 正确渲染（无 URL 编码、无断裂的 chip）
10. 验证 @ 引用目录（文件和目录均可选中）