### PR TITLE
fix: 权限模式改为按 session 持久化，隔离多 tab 状态

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -1259,11 +1259,24 @@ export function registerIpcHandlers(): void {
       if (!validModes.has(mode)) {
         throw new Error(`无效的权限模式: ${mode}`)
       }
-      if (!isAgentSessionActive(sessionId)) return
-      await updateAgentPermissionMode(sessionId, mode).catch((err) => {
-        console.warn(`[IPC] 运行中权限模式切换失败: sessionId=${sessionId}`, err)
-        throw err
-      })
+      // 会话不存在时直接抛错（避免 updateAgentSessionMeta 的通用异常被降级为 warn）
+      if (!getAgentSessionMeta(sessionId)) {
+        throw new Error(`Agent 会话不存在: ${sessionId}`)
+      }
+      // 持久化到 session meta（重启后可恢复，即使 session 未运行也要写）。
+      // 这里的 catch 仅用于兜底磁盘 I/O 类异常，不影响后续热切换。
+      try {
+        updateAgentSessionMeta(sessionId, { permissionMode: mode })
+      } catch (err) {
+        console.warn(`[IPC] 持久化 session 权限模式失败: sessionId=${sessionId}`, err)
+      }
+      // 若 session 正在跑，同步热切换运行时模式
+      if (isAgentSessionActive(sessionId)) {
+        await updateAgentPermissionMode(sessionId, mode).catch((err) => {
+          console.warn(`[IPC] 运行中权限模式切换失败: sessionId=${sessionId}`, err)
+          throw err
+        })
+      }
     }
   )
 
@@ -1480,6 +1493,14 @@ export function registerIpcHandlers(): void {
             const ws = getAgentWorkspace(meta.workspaceId)
             if (ws) {
               setWorkspacePermissionMode(ws.slug, targetMode)
+            }
+          }
+          // 持久化到 session meta，和 cycleMode 路径保持一致（重启后该 session 能恢复）
+          if (meta) {
+            try {
+              updateAgentSessionMeta(sessionId, { permissionMode: targetMode })
+            } catch (err) {
+              console.warn(`[IPC] ExitPlanMode 持久化 session 权限模式失败: sessionId=${sessionId}`, err)
             }
           }
           event.sender.send(AGENT_IPC_CHANNELS.STREAM_EVENT, {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -1236,7 +1236,7 @@ export function registerIpcHandlers(): void {
     }
   )
 
-  // 设置工作区权限模式（同时更新运行中的活跃 session）
+  // 设置工作区权限模式（持久化到工作区配置）
   ipcMain.handle(
     AGENT_IPC_CHANNELS.SET_PERMISSION_MODE,
     async (_, workspaceSlug: string, mode: PromaPermissionMode): Promise<void> => {
@@ -1246,17 +1246,24 @@ export function registerIpcHandlers(): void {
       }
       // 持久化到工作区配置
       setWorkspacePermissionMode(workspaceSlug, mode)
-      // 同步更新该工作区下所有运行中的 session
-      const sessions = listAgentSessions()
-      for (const session of sessions) {
-        if (!session.workspaceId || !isAgentSessionActive(session.id)) continue
-        const sessionWs = getAgentWorkspace(session.workspaceId)
-        if (sessionWs?.slug === workspaceSlug) {
-          updateAgentPermissionMode(session.id, mode).catch((err) => {
-            console.warn(`[IPC] 运行中权限模式切换失败: sessionId=${session.id}`, err)
-          })
-        }
+      // 注意：不再广播到该工作区下其他运行中的 session，
+      // 避免跨窗口状态污染（每个 session 独立维护自己的权限模式）
+    }
+  )
+
+  // 热切换指定会话的权限模式（运行中生效，不广播）
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.UPDATE_SESSION_PERMISSION_MODE,
+    async (_, sessionId: string, mode: PromaPermissionMode): Promise<void> => {
+      const validModes = new Set<string>(['auto', 'bypassPermissions', 'plan'])
+      if (!validModes.has(mode)) {
+        throw new Error(`无效的权限模式: ${mode}`)
       }
+      if (!isAgentSessionActive(sessionId)) return
+      await updateAgentPermissionMode(sessionId, mode).catch((err) => {
+        console.warn(`[IPC] 运行中权限模式切换失败: sessionId=${sessionId}`, err)
+        throw err
+      })
     }
   )
 

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -32,7 +32,7 @@ import { getAdapter, fetchTitle, normalizeAnthropicBaseUrlForSdk } from '@proma/
 import { getFetchFn } from './proxy-fetch'
 import { getEffectiveProxyUrl } from './proxy-settings-service'
 import { appendSDKMessages, updateAgentSessionMeta, getAgentSessionMeta, getAgentSessionMessages, getAgentSessionSDKMessages, truncateSDKMessages, resolveUserUuidFromSDK, rewindFilesFromSnapshot } from './agent-session-manager'
-import { getAgentWorkspace, getWorkspaceMcpConfig, ensurePluginManifest, getWorkspacePermissionMode, setWorkspacePermissionMode } from './agent-workspace-manager'
+import { getAgentWorkspace, getWorkspaceMcpConfig, ensurePluginManifest } from './agent-workspace-manager'
 import { getAgentWorkspacePath, getAgentSessionWorkspacePath, getSdkConfigDir, getWorkspaceFilesDir, getConfigDirName } from './config-paths'
 import { getWorkspaceAttachedDirectories } from './agent-workspace-manager'
 import { getRuntimeStatus } from './runtime-init'
@@ -1064,14 +1064,18 @@ export class AgentOrchestrator {
       }
 
       // 12. 读取应用设置 + 获取权限模式
+      // 注意：不从 workspace config 读取权限模式，避免跨窗口状态污染
       const appSettings = getSettings()
       const initialPermissionMode: PromaPermissionMode = permissionModeOverride
-        ?? (workspaceSlug
-          ? getWorkspacePermissionMode(workspaceSlug)
-          : (appSettings.agentPermissionMode ?? 'auto'))
+        ?? (appSettings.agentPermissionMode ?? 'auto')
       // 注册到 Map，支持运行中动态切换
       this.sessionPermissionModes.set(sessionId, initialPermissionMode)
       console.log(`[Agent 编排] 权限模式: ${initialPermissionMode}${permissionModeOverride ? '（外部覆盖）' : ''}`)
+
+      // 当初始模式为 plan 时，通知渲染进程展示计划模式 UI（如「Agent 正在规划」横幅）
+      if (initialPermissionMode === 'plan') {
+        this.eventBus.emit(sessionId, { kind: 'proma_event', event: { type: 'enter_plan_mode', sessionId } })
+      }
 
       /** 读取当前会话的实时权限模式（支持运行中切换） */
       const getPermissionMode = (): PromaPermissionMode =>

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -306,7 +306,7 @@ function convertLegacyMessage(legacy: AgentMessage): SDKMessage {
  */
 export function updateAgentSessionMeta(
   id: string,
-  updates: Partial<Pick<AgentSessionMeta, 'title' | 'channelId' | 'sdkSessionId' | 'workspaceId' | 'pinned' | 'archived' | 'attachedDirectories' | 'forkSourceDir' | 'forkSourceSdkSessionId' | 'resumeAtMessageUuid' | 'stoppedByUser'>>,
+  updates: Partial<Pick<AgentSessionMeta, 'title' | 'channelId' | 'sdkSessionId' | 'workspaceId' | 'pinned' | 'archived' | 'attachedDirectories' | 'forkSourceDir' | 'forkSourceSdkSessionId' | 'resumeAtMessageUuid' | 'stoppedByUser' | 'permissionMode'>>,
 ): AgentSessionMeta {
   const index = readIndex()
   const idx = index.sessions.findIndex((s) => s.id === id)

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -472,6 +472,9 @@ export interface ElectronAPI {
   /** 设置工作区权限模式 */
   setPermissionMode: (workspaceSlug: string, mode: PromaPermissionMode) => Promise<void>
 
+  /** 热切换指定会话的权限模式（运行中生效，仅影响该 session） */
+  updateSessionPermissionMode: (sessionId: string, mode: PromaPermissionMode) => Promise<void>
+
   /** 获取全局记忆配置 */
   getMemoryConfig: () => Promise<MemoryConfig>
 
@@ -1249,6 +1252,10 @@ const electronAPI: ElectronAPI = {
 
   setPermissionMode: (workspaceSlug: string, mode: PromaPermissionMode) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.SET_PERMISSION_MODE, workspaceSlug, mode)
+  },
+
+  updateSessionPermissionMode: (sessionId: string, mode: PromaPermissionMode) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.UPDATE_SESSION_PERMISSION_MODE, sessionId, mode)
   },
 
   getMemoryConfig: () => {

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -552,6 +552,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         modelId: snapshot.modelId,
         workspaceId: snapshot.workspaceId,
         startedAt: streamStartedAt,
+        permissionModeOverride: permissionMode,
       }
       window.electronAPI.sendAgentMessage(input).catch((error) => {
         console.error('[AgentView] 自动发送配置消息失败:', error)
@@ -564,8 +565,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         })
       })
     })
-  }, [messagesLoaded, pendingPrompt, sessionId, agentChannelId, agentModelId, currentWorkspaceId, streaming, setPendingPrompt, setStreamingStates])
-
+  }, [messagesLoaded, pendingPrompt, sessionId, agentChannelId, agentModelId, currentWorkspaceId, streaming, setPendingPrompt, setStreamingStates, permissionMode])
   // ===== 附件处理 =====
 
   /** 为文件生成唯一文件名（避免粘贴多张图片时文件名重复导致覆盖） */
@@ -1013,6 +1013,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       modelId: agentModelId || undefined,
       workspaceId: currentWorkspaceId || undefined,
       startedAt: streamStartedAt,
+      permissionModeOverride: permissionMode,
       ...(attachedDirs.length > 0 && { additionalDirectories: attachedDirs }),
       // 解析用户消息中的 Skill/MCP 引用，传递结构化元数据给后端
       ...(() => {
@@ -1038,7 +1039,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         return map
       })
     })
-  }, [inputContent, pendingFiles, attachedDirs, sessionId, agentChannelId, agentModelId, currentWorkspaceId, workspaces, streaming, suggestion, hasAvailableModel, store, setStreamingStates, setPendingFiles, setAgentStreamErrors, setPromptSuggestions, setInputContent, setLiveMessagesMap])
+  }, [inputContent, pendingFiles, attachedDirs, sessionId, agentChannelId, agentModelId, currentWorkspaceId, workspaces, streaming, suggestion, hasAvailableModel, store, setStreamingStates, setPendingFiles, setAgentStreamErrors, setPromptSuggestions, setInputContent, setLiveMessagesMap, permissionMode])
 
   /** 停止生成 */
   const handleStop = React.useCallback((): void => {
@@ -1104,6 +1105,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       modelId: agentModelId || undefined,
       workspaceId: currentWorkspaceId || undefined,
       startedAt: streamStartedAt,
+      permissionModeOverride: permissionMode,
     }).catch((error) => {
       console.error('[AgentView] /compact 发送失败:', error)
       // 回滚：移除合成用户消息 + 清除 isCompacting flag
@@ -1123,7 +1125,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         return map
       })
     })
-  }, [sessionId, agentChannelId, agentModelId, currentWorkspaceId, streaming, setStreamingStates, store])
+  }, [sessionId, agentChannelId, agentModelId, currentWorkspaceId, streaming, setStreamingStates, store, permissionMode])
 
   /** 复制错误信息到剪贴板 */
   const handleCopyError = React.useCallback(async (): Promise<void> => {
@@ -1179,8 +1181,9 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       modelId: agentModelId || undefined,
       workspaceId: currentWorkspaceId || undefined,
       startedAt: streamStartedAt,
+      permissionModeOverride: permissionMode,
     }).catch(console.error)
-  }, [messages, sessionId, agentChannelId, agentModelId, currentWorkspaceId, streaming, setAgentStreamErrors, setStreamingStates])
+  }, [messages, sessionId, agentChannelId, agentModelId, currentWorkspaceId, streaming, setAgentStreamErrors, setStreamingStates, permissionMode])
 
   /** 在新会话中重试：创建新会话 + 切换 tab + 发送引用旧会话的提示词 */
   const handleRetryInNewSession = React.useCallback(async (): Promise<void> => {
@@ -1218,11 +1221,12 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         channelId: agentChannelId,
         modelId: agentModelId || undefined,
         workspaceId: currentWorkspaceId || undefined,
+        permissionModeOverride: permissionMode,
       }).catch(console.error)
     } catch (error) {
       console.error('[AgentView] 在新会话中重试失败:', error)
     }
-  }, [sessionId, agentChannelId, agentModelId, currentWorkspaceId, openSession, setAgentSessions, setStreamingStates])
+  }, [sessionId, agentChannelId, agentModelId, currentWorkspaceId, openSession, setAgentSessions, setStreamingStates, permissionMode])
 
   /** 分叉会话：从指定消息处创建新会话并自动切换 */
   const handleFork = React.useCallback(async (upToMessageUuid: string): Promise<void> => {

--- a/apps/electron/src/renderer/components/agent/PermissionModeSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/PermissionModeSelector.tsx
@@ -10,7 +10,7 @@ import * as React from 'react'
 import { useAtom, useAtomValue } from 'jotai'
 import { Zap, Compass, Map as MapIcon } from 'lucide-react'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import { agentPermissionModeMapAtom, agentDefaultPermissionModeAtom, currentAgentWorkspaceIdAtom, agentWorkspacesAtom } from '@/atoms/agent-atoms'
+import { agentPermissionModeMapAtom, agentDefaultPermissionModeAtom, currentAgentWorkspaceIdAtom, agentWorkspacesAtom, agentSessionsAtom } from '@/atoms/agent-atoms'
 import type { PromaPermissionMode } from '@proma/shared'
 import { PROMA_PERMISSION_MODE_ORDER } from '@proma/shared'
 
@@ -47,6 +47,21 @@ export function PermissionModeSelector({ sessionId }: PermissionModeSelectorProp
   const mode = modeMap.get(sessionId) ?? defaultMode
   const currentWorkspaceId = useAtomValue(currentAgentWorkspaceIdAtom)
   const workspaces = useAtomValue(agentWorkspacesAtom)
+  const sessions = useAtomValue(agentSessionsAtom)
+
+  // 派生当前 session 的持久化权限模式。sessions 数组在流式中会因消息计数、running
+  // 状态等无关字段频繁更新，这里用 memo 把 effect 依赖收窄到 permissionMode 本身，
+  // 避免无关字段变化触发 effect 重跑（仍会引发组件 re-render，但 effect 的 dep 值相
+  // 等时不会重新执行 seed 逻辑）。
+  const persistedSessionMode = React.useMemo(
+    () => sessions.find((s) => s.id === sessionId)?.permissionMode,
+    [sessions, sessionId],
+  )
+  // sessions 列表尚未加载到此 session 时为 true（冷启动时机）
+  const sessionExistsInList = React.useMemo(
+    () => sessions.some((s) => s.id === sessionId),
+    [sessions, sessionId],
+  )
 
   // 获取当前工作区的 slug
   const workspaceSlug = React.useMemo(() => {
@@ -55,17 +70,33 @@ export function PermissionModeSelector({ sessionId }: PermissionModeSelectorProp
     return ws?.slug ?? null
   }, [currentWorkspaceId, workspaces])
 
-  // 初始化：如果当前 session 不在 Map 中，优先从 workspace 配置读取持久化的模式；
-  // 读取失败或没有 workspaceSlug 时，回退到全局 defaultMode。
+  // 初始化：如果当前 session 不在 Map 中，按以下优先级读回：
+  // 1. session meta.permissionMode（每个 tab 独立持久化，重启恢复各自的值）
+  // 2. workspace config（作为该工作区内新会话的默认）
+  // 3. 全局 defaultMode
   // 注意：只写入当前 session，不回写到 agentDefaultPermissionModeAtom，避免跨会话污染。
   React.useEffect(() => {
     if (modeMap.has(sessionId)) return
+    // sessions 列表尚未加载到此 session（冷启动时机），先不 seed，等 sessions 更新后重跑
+    if (!sessionExistsInList) return
 
-    const seedFromWorkspace = async (): Promise<void> => {
-      let seed: PromaPermissionMode = defaultMode
+    const seed = async (): Promise<void> => {
+      // 1. session meta
+      if (persistedSessionMode != null) {
+        setModeMap((prev: Map<string, PromaPermissionMode>) => {
+          if (prev.has(sessionId)) return prev
+          const next = new Map(prev)
+          next.set(sessionId, persistedSessionMode)
+          return next
+        })
+        return
+      }
+
+      // 2. workspace config（作为新会话默认）
+      let seedMode: PromaPermissionMode = defaultMode
       if (workspaceSlug) {
         try {
-          seed = await window.electronAPI.getPermissionMode(workspaceSlug)
+          seedMode = await window.electronAPI.getPermissionMode(workspaceSlug)
         } catch (error) {
           console.error('[PermissionModeSelector] 读取工作区权限模式失败:', error)
         }
@@ -73,14 +104,14 @@ export function PermissionModeSelector({ sessionId }: PermissionModeSelectorProp
       setModeMap((prev: Map<string, PromaPermissionMode>) => {
         if (prev.has(sessionId)) return prev
         const next = new Map(prev)
-        next.set(sessionId, seed)
+        next.set(sessionId, seedMode)
         return next
       })
     }
 
-    void seedFromWorkspace()
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- 仅 sessionId / workspaceSlug 变化时初始化
-  }, [sessionId, workspaceSlug])
+    void seed()
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- 只在 session/workspace/持久化模式/sessions 是否已载入变化时重跑
+  }, [sessionId, workspaceSlug, persistedSessionMode, sessionExistsInList])
 
   /** 循环切换模式 */
   const cycleMode = React.useCallback(async () => {

--- a/apps/electron/src/renderer/components/agent/PermissionModeSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/PermissionModeSelector.tsx
@@ -7,7 +7,7 @@
  */
 
 import * as React from 'react'
-import { useAtom, useAtomValue, useSetAtom } from 'jotai'
+import { useAtom, useAtomValue } from 'jotai'
 import { Zap, Compass, Map as MapIcon } from 'lucide-react'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { agentPermissionModeMapAtom, agentDefaultPermissionModeAtom, currentAgentWorkspaceIdAtom, agentWorkspacesAtom } from '@/atoms/agent-atoms'
@@ -44,7 +44,6 @@ interface PermissionModeSelectorProps {
 export function PermissionModeSelector({ sessionId }: PermissionModeSelectorProps): React.ReactElement | null {
   const [modeMap, setModeMap] = useAtom(agentPermissionModeMapAtom)
   const defaultMode = useAtomValue(agentDefaultPermissionModeAtom)
-  const setDefaultMode = useSetAtom(agentDefaultPermissionModeAtom)
   const mode = modeMap.get(sessionId) ?? defaultMode
   const currentWorkspaceId = useAtomValue(currentAgentWorkspaceIdAtom)
   const workspaces = useAtomValue(agentWorkspacesAtom)
@@ -56,32 +55,32 @@ export function PermissionModeSelector({ sessionId }: PermissionModeSelectorProp
     return ws?.slug ?? null
   }, [currentWorkspaceId, workspaces])
 
-  // 初始化：如果当前 session 不在 Map 中，从默认值写入，确保隔离
+  // 初始化：如果当前 session 不在 Map 中，优先从 workspace 配置读取持久化的模式；
+  // 读取失败或没有 workspaceSlug 时，回退到全局 defaultMode。
+  // 注意：只写入当前 session，不回写到 agentDefaultPermissionModeAtom，避免跨会话污染。
   React.useEffect(() => {
-    if (!modeMap.has(sessionId)) {
+    if (modeMap.has(sessionId)) return
+
+    const seedFromWorkspace = async (): Promise<void> => {
+      let seed: PromaPermissionMode = defaultMode
+      if (workspaceSlug) {
+        try {
+          seed = await window.electronAPI.getPermissionMode(workspaceSlug)
+        } catch (error) {
+          console.error('[PermissionModeSelector] 读取工作区权限模式失败:', error)
+        }
+      }
       setModeMap((prev: Map<string, PromaPermissionMode>) => {
         if (prev.has(sessionId)) return prev
         const next = new Map(prev)
-        next.set(sessionId, defaultMode)
+        next.set(sessionId, seed)
         return next
       })
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- 仅 sessionId 变化时初始化
-  }, [sessionId])
 
-  // 加载工作区权限模式（仅值变化时更新，避免切换会话时抖动）
-  React.useEffect(() => {
-    if (!workspaceSlug) return
-
-    window.electronAPI.getPermissionMode(workspaceSlug)
-      .then((savedMode) => {
-        if (savedMode !== defaultMode) setDefaultMode(savedMode)
-      })
-      .catch((error) => {
-        console.error('[PermissionModeSelector] 加载权限模式失败:', error)
-      })
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- 只在 workspaceSlug 变化时重新加载
-  }, [workspaceSlug])
+    void seedFromWorkspace()
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- 仅 sessionId / workspaceSlug 变化时初始化
+  }, [sessionId, workspaceSlug])
 
   /** 循环切换模式 */
   const cycleMode = React.useCallback(async () => {
@@ -103,6 +102,13 @@ export function PermissionModeSelector({ sessionId }: PermissionModeSelectorProp
       } catch (error) {
         console.error('[PermissionModeSelector] 保存权限模式失败:', error)
       }
+    }
+
+    // 热切换运行中的当前 session（主进程 isActive 判空 no-op，未运行时调用无副作用）
+    try {
+      await window.electronAPI.updateSessionPermissionMode(sessionId, nextMode)
+    } catch (error) {
+      console.error('[PermissionModeSelector] 运行中切换权限模式失败:', error)
     }
   }, [mode, sessionId, workspaceSlug, setModeMap])
 

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1325,6 +1325,8 @@ export const AGENT_IPC_CHANNELS = {
   SET_PERMISSION_MODE: 'agent:set-permission-mode',
   /** 获取权限模式（渲染进程 → 主进程） */
   GET_PERMISSION_MODE: 'agent:get-permission-mode',
+  /** 热切换指定会话的权限模式（运行中生效，不广播到其他会话） */
+  UPDATE_SESSION_PERMISSION_MODE: 'agent:update-session-permission-mode',
 
   // AskUserQuestion 交互式问答
   /** AskUser 响应（渲染进程 → 主进程） */

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -558,6 +558,8 @@ export interface AgentSessionMeta {
   manualWorking?: boolean
   /** 最后一次流式执行是否被用户主动中断 */
   stoppedByUser?: boolean
+  /** 该会话当前的权限模式（持久化到磁盘，重启后恢复）。未设置时回退到 workspace 默认值 */
+  permissionMode?: PromaPermissionMode
   /** 创建时间戳 */
   createdAt: number
   /** 更新时间戳 */


### PR DESCRIPTION
## Overview

重构权限模式（自动 / 完全自动 / 计划）的存储与切换模型，解决两个现存问题：

1. **跨窗口状态污染**：旧实现下，在任意 tab 切换权限模式会广播到同工作区所有正在跑的 session，导致用户无意间影响了不相关的窗口。一个窗口开计划模式，另一个窗口也会进入计划模式
2. **重启丢失状态**：权限模式只存在 workspace config 的单值字段里，多 tab 的独立状态无法区分；重启后所有 tab 起始模式一样

改造后：每个 session 独立持久化自己的权限模式到 `AgentSessionMeta.permissionMode`；workspace config 字段降级为"该工作区新 session 的默认值"；UI 侧每次发送消息都带 `permissionModeOverride`，渲染进程成为权威源。

## Changes

### commit 1 — `c1aa356 fix: 权限模式隔离到 session 维度，兼顾持久化与中途热切换`

- `apps/electron/src/main/ipc.ts`
  - `SET_PERMISSION_MODE` handler 删除广播逻辑（不再强制同步同工作区其他 active session）
  - 新增 `UPDATE_SESSION_PERMISSION_MODE` handler：只更新指定 sessionId 的运行时权限模式
- `apps/electron/src/main/lib/agent-orchestrator.ts`
  - 初始权限模式不再读 workspace config，改为 `permissionModeOverride ?? appSettings.default`
  - 初始模式为 `plan` 时主动 emit `enter_plan_mode` 事件，修复冷启动就是 plan 时横幅不展示的问题
- `apps/electron/src/preload/index.ts` — 新增 `updateSessionPermissionMode(sessionId, mode)` 方法
- `apps/electron/src/renderer/components/agent/AgentView.tsx` — 五个发送路径（auto-send / handleSend / /compact / retry / retryInNewSession）都带上 `permissionModeOverride: permissionMode`
- `apps/electron/src/renderer/components/agent/PermissionModeSelector.tsx`
  - session 初始化时按 workspace config 读回，但只写入当前 sessionId 的 atom 条目，不污染全局 default
  - `cycleMode` 在持久化之外调用新 IPC 做运行时热切换（仅影响当前 session）
- `packages/shared/src/types/agent.ts` — 新增 `UPDATE_SESSION_PERMISSION_MODE` IPC 常量

### commit 2 — `ea8e123 fix: 权限模式按 session 持久化，重启后各 tab 独立恢复`

- `packages/shared/src/types/agent.ts` — `AgentSessionMeta` 新增 `permissionMode?: PromaPermissionMode` 字段
- `apps/electron/src/main/lib/agent-session-manager.ts` — `updateAgentSessionMeta` Pick 白名单加入 `permissionMode`
- `apps/electron/src/main/ipc.ts`
  - `UPDATE_SESSION_PERMISSION_MODE` handler：先写 session meta 持久化，active 时再热切换；session 不存在时直接抛错
  - `EXIT_PLAN_MODE_RESPOND` handler 补写 session meta，避免通过 ExitPlanMode 切到的模式重启后丢失
- `apps/electron/src/renderer/components/agent/PermissionModeSelector.tsx`
  - 初始化读回优先级改为：**session meta > workspace config > 全局 default**
  - 用 `useMemo` 派生 `persistedSessionMode` / `sessionExistsInList`，effect 依赖收窄到 permissionMode 字段值，避免流式中无关字段变化触发重跑
  - 处理冷启动时序：`sessions` 列表尚未加载时暂不 seed，加载完成后自动重跑

## How to Test

1. **多 tab 隔离**：在同一工作区开两个 tab，tab A 切到"计划"，tab B 切到"完全自动"；确认两者互不影响
2. **中途切模式**：在 tab A 开始流式输出，中途切换模式；确认当前 session 的下一次 `canUseTool` 立刻使用新模式（不影响同工作区其他 session）
3. **重启持久化**：重启 App，确认每个 tab 恢复到上次保存的权限模式（而非统一默认值）
4. **ExitPlanMode 切换**：session 进入计划模式后通过 ExitPlanMode 切到 bypass；重启 App 确认该 session 仍是 bypass
5. **新 session 默认**：在某工作区切换权限模式后，新建 session；确认新 session 继承该 workspace 的值
6. **运行中的 session**：active 状态下切换模式，确认 orchestrator 的 `sessionPermissionModes` Map 和 SDK 侧都立即生效

## Notes

- Workspace config 的 `permissionMode` 字段保留，含义从"全工作区共享状态"降级为"新 session 的默认模板"，对老数据向前兼容
- `bypassPermissions` 通过外部 override 进入的场景（bridge-command-handler、feishu-bridge）不受影响，override 仍然优先
- typecheck 全部通过；ExitPlanMode → `permission_mode_changed` 事件和 `enter_plan_mode` 事件的渲染端 listener 本次未改动，延用现有实现

🤖 Generated with [Claude Code](https://claude.com/claude-code)