### PR TITLE
refactor: Agent 设置页重构为 Tabs + Skills Master-Detail 布局

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -168,6 +168,8 @@ import {
   deleteWorkspaceSkill,
   importSkillFromWorkspace,
   updateSkillFromSource,
+  readWorkspaceSkillContent,
+  writeWorkspaceSkillContent,
   toggleWorkspaceSkill,
   getWorkspacePermissionMode,
   setWorkspacePermissionMode,
@@ -1143,6 +1145,20 @@ export function registerIpcHandlers(): void {
     AGENT_IPC_CHANNELS.UPDATE_SKILL_FROM_SOURCE,
     async (_, targetSlug: string, skillSlug: string): Promise<SkillMeta> => {
       return updateSkillFromSource(targetSlug, skillSlug)
+    }
+  )
+
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.READ_SKILL_CONTENT,
+    async (_, workspaceSlug: string, skillSlug: string): Promise<string> => {
+      return readWorkspaceSkillContent(workspaceSlug, skillSlug)
+    }
+  )
+
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.WRITE_SKILL_CONTENT,
+    async (_, workspaceSlug: string, skillSlug: string, content: string): Promise<void> => {
+      writeWorkspaceSkillContent(workspaceSlug, skillSlug, content)
     }
   )
 

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -725,6 +725,21 @@ function resolveSkillDir(workspaceSlug: string, skillSlug: string): string | nul
   return null
 }
 
+export function readWorkspaceSkillContent(workspaceSlug: string, skillSlug: string): string {
+  const dir = resolveSkillDir(workspaceSlug, skillSlug)
+  if (!dir) throw new Error(`Skill 不存在: ${workspaceSlug}/${skillSlug}`)
+  const mdPath = join(dir, 'SKILL.md')
+  if (!existsSync(mdPath)) throw new Error(`SKILL.md 不存在: ${mdPath}`)
+  return readFileSync(mdPath, 'utf-8')
+}
+
+export function writeWorkspaceSkillContent(workspaceSlug: string, skillSlug: string, content: string): void {
+  const dir = resolveSkillDir(workspaceSlug, skillSlug)
+  if (!dir) throw new Error(`Skill 不存在: ${workspaceSlug}/${skillSlug}`)
+  writeFileSync(join(dir, 'SKILL.md'), content, 'utf-8')
+  console.log(`[Agent 工作区] 已更新 SKILL.md: ${workspaceSlug}/${skillSlug}`)
+}
+
 /** 简单 semver 比较：a 是否比 b 更新 */
 function isNewerVersion(a: string, b: string): boolean {
   const pa = a.split('.').map(Number)

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -449,6 +449,12 @@ export interface ElectronAPI {
   /** 从源工作区同步更新已导入的 Skill */
   updateSkillFromSource: (targetSlug: string, skillSlug: string) => Promise<SkillMeta>
 
+  /** 读取 SKILL.md 全文内容 */
+  readSkillContent: (workspaceSlug: string, skillSlug: string) => Promise<string>
+
+  /** 写入 SKILL.md 全文内容 */
+  writeSkillContent: (workspaceSlug: string, skillSlug: string, content: string) => Promise<void>
+
   /** 订阅 Agent 流式事件（返回清理函数） */
   onAgentStreamEvent: (callback: (event: AgentStreamEvent) => void) => () => void
 
@@ -1210,6 +1216,23 @@ const electronAPI: ElectronAPI = {
       AGENT_IPC_CHANNELS.UPDATE_SKILL_FROM_SOURCE,
       targetSlug,
       skillSlug,
+    )
+  },
+
+  readSkillContent: (workspaceSlug: string, skillSlug: string) => {
+    return ipcRenderer.invoke(
+      AGENT_IPC_CHANNELS.READ_SKILL_CONTENT,
+      workspaceSlug,
+      skillSlug,
+    )
+  },
+
+  writeSkillContent: (workspaceSlug: string, skillSlug: string, content: string) => {
+    return ipcRenderer.invoke(
+      AGENT_IPC_CHANNELS.WRITE_SKILL_CONTENT,
+      workspaceSlug,
+      skillSlug,
+      content,
     )
   },
 

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -378,21 +378,6 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, onR
     }
   }
 
-  // 如果只有错误消息
-  if (enrichedBlocks.length === 0 && hasError && errorContent) {
-    return (
-      <ErrorMessage
-        message={errorContent}
-        onRetry={onRetry}
-        onRetryInNewSession={onRetryInNewSession}
-        onCompact={onCompact}
-      />
-    )
-  }
-
-  // 如果没有任何内容
-  if (enrichedBlocks.length === 0 && !hasError) return null
-
   // 从 turnMessages 中提取 result 消息的耗时和用量
   const { durationMs, usage } = extractTurnUsage(turn.turnMessages)
 
@@ -527,6 +512,21 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, onR
 
     return { taskActivities: _taskActivities, firstTaskIndex: _firstTaskIndex, historicalTaskSubjects: _historicalTaskSubjects }
   }, [topLevelBlocks, turn.turnMessages, allMessages])
+
+  // 如果只有错误消息
+  if (enrichedBlocks.length === 0 && hasError && errorContent) {
+    return (
+      <ErrorMessage
+        message={errorContent}
+        onRetry={onRetry}
+        onRetryInNewSession={onRetryInNewSession}
+        onCompact={onCompact}
+      />
+    )
+  }
+
+  // 如果没有任何内容
+  if (enrichedBlocks.length === 0 && !hasError) return null
 
   return (
     <Message from="assistant">

--- a/apps/electron/src/renderer/components/settings/AgentSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AgentSettings.tsx
@@ -1,58 +1,128 @@
 /**
  * AgentSettings - Agent 设置页
  *
- * 包含两个区块：
- * 1. MCP 服务器 — 管理当前工作区的 MCP 服务器配置
- * 2. Skills — 只读展示当前工作区的 Skill 列表
- *
- * 视图模式：list / create / edit（复用 ChannelSettings 的模式）
+ * Tab 布局：
+ * 1. Skills — Master-Detail 视图（左列列表 + 右列详情 + 内联编辑）
+ * 2. MCP 服务器 — 管理当前工作区的 MCP 服务器配置
+ * 3. 内置工具 — 只读展示内置工具状态
  */
 
 import * as React from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
-import { Plus, Plug, Pencil, Trash2, Sparkles, FolderOpen, MessageSquare, ShieldCheck, ChevronDown, ChevronRight, Brain, ImagePlus, Settings, RefreshCw, Search } from 'lucide-react'
+import { Plus, Plug, Pencil, Trash2, Sparkles, FolderOpen, MessageSquare, ShieldCheck, ChevronDown, ChevronRight, Brain, ImagePlus, Search, RefreshCw, Save, X } from 'lucide-react'
 import { toast } from 'sonner'
+import Markdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import {
   agentWorkspacesAtom,
   currentAgentWorkspaceIdAtom,
   agentChannelIdAtom,
-  agentModelIdAtom,
   agentSessionsAtom,
   currentAgentSessionIdAtom,
   agentPendingPromptAtom,
   workspaceCapabilitiesVersionAtom,
-  agentThinkingAtom,
-  agentEffortAtom,
-  agentMaxBudgetUsdAtom,
-  agentMaxTurnsAtom,
 } from '@/atoms/agent-atoms'
 import { settingsTabAtom, settingsOpenAtom } from '@/atoms/settings-tab'
 import { appModeAtom } from '@/atoms/app-mode'
 import { chatToolsAtom } from '@/atoms/chat-tool-atoms'
-import type { McpServerEntry, SkillMeta, OtherWorkspaceSkillsGroup, WorkspaceMcpConfig, ThinkingConfig, AgentEffort } from '@proma/shared'
-import { SettingsSection, SettingsCard, SettingsRow, SettingsSegmentedControl, SettingsInput } from './primitives'
+import type { McpServerEntry, SkillMeta, OtherWorkspaceSkillsGroup, WorkspaceMcpConfig } from '@proma/shared'
+import { SettingsSection, SettingsCard, SettingsRow } from './primitives'
 import { McpServerForm } from './McpServerForm'
 
-/** 组件视图模式 */
+// ===== Types =====
+
 type ViewMode = 'list' | 'create' | 'edit'
 
-/** 编辑中的服务器信息 */
 interface EditingServer {
   name: string
   entry: McpServerEntry
 }
 
+interface SkillGroup {
+  prefix: string
+  skills: SkillMeta[]
+}
+
+// ===== Helpers =====
+
+function groupSkillsByPrefix(skills: SkillMeta[]): SkillGroup[] {
+  const prefixMap = new Map<string, SkillMeta[]>()
+
+  for (const skill of skills) {
+    const dashIdx = skill.slug.indexOf('-')
+    const prefix = dashIdx > 0 ? skill.slug.slice(0, dashIdx) : ''
+    const key = prefix || skill.slug
+    const list = prefixMap.get(key) ?? []
+    list.push(skill)
+    prefixMap.set(key, list)
+  }
+
+  const groups: SkillGroup[] = []
+  const standalone: SkillMeta[] = []
+
+  for (const [prefix, list] of prefixMap) {
+    if (list.length >= 2) {
+      groups.push({ prefix, skills: list })
+    } else {
+      standalone.push(...list)
+    }
+  }
+
+  if (standalone.length > 0) {
+    groups.push({ prefix: '', skills: standalone })
+  }
+
+  return groups
+}
+
+function shortName(slug: string, prefix: string): string {
+  if (!prefix) return slug
+  return slug.startsWith(prefix + '-') ? slug.slice(prefix.length + 1) : slug
+}
+
+function extractSkillBody(content: string): string {
+  const match = content.match(/^---\s*\n[\s\S]*?\n---\s*\n([\s\S]*)$/)
+  return match?.[1] ?? content
+}
+
+function rebuildSkillMd(
+  originalContent: string,
+  updates: { name?: string; description?: string; body?: string },
+): string {
+  const fmMatch = originalContent.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/)
+  if (!fmMatch) return originalContent
+
+  let fmBlock = fmMatch[1] ?? ''
+  const currentBody = fmMatch[2] ?? ''
+
+  if (updates.name !== undefined) {
+    fmBlock = /^name:/m.test(fmBlock)
+      ? fmBlock.replace(/^name:.*$/m, `name: ${updates.name}`)
+      : `name: ${updates.name}\n${fmBlock}`
+  }
+  if (updates.description !== undefined) {
+    fmBlock = /^description:/m.test(fmBlock)
+      ? fmBlock.replace(/^description:.*$/m, `description: ${updates.description}`)
+      : `${fmBlock}\ndescription: ${updates.description}`
+  }
+
+  const newBody = updates.body !== undefined ? updates.body : currentBody
+  return `---\n${fmBlock}\n---\n${newBody}`
+}
+
+// ===== Main Component =====
+
 export function AgentSettings(): React.ReactElement {
   const workspaces = useAtomValue(agentWorkspacesAtom)
   const currentWorkspaceId = useAtomValue(currentAgentWorkspaceIdAtom)
   const agentChannelId = useAtomValue(agentChannelIdAtom)
-  const agentModelId = useAtomValue(agentModelIdAtom)
   const setAgentSessions = useSetAtom(agentSessionsAtom)
   const setCurrentSessionId = useSetAtom(currentAgentSessionIdAtom)
   const setPendingPrompt = useSetAtom(agentPendingPromptAtom)
@@ -60,15 +130,15 @@ export function AgentSettings(): React.ReactElement {
   const setAppMode = useSetAtom(appModeAtom)
   const bumpCapabilitiesVersion = useSetAtom(workspaceCapabilitiesVersionAtom)
 
-  // 派生当前工作区 slug
   const currentWorkspace = workspaces.find((w) => w.id === currentWorkspaceId)
   const workspaceSlug = currentWorkspace?.slug ?? ''
 
-  // 视图模式
+  // Tab & view state
+  const [activeTab, setActiveTab] = React.useState('skills')
   const [viewMode, setViewMode] = React.useState<ViewMode>('list')
   const [editingServer, setEditingServer] = React.useState<EditingServer | null>(null)
 
-  // MCP 配置
+  // Data
   const [mcpConfig, setMcpConfig] = React.useState<WorkspaceMcpConfig>({ servers: {} })
   const [skills, setSkills] = React.useState<SkillMeta[]>([])
   const [skillsDir, setSkillsDir] = React.useState('')
@@ -77,14 +147,15 @@ export function AgentSettings(): React.ReactElement {
   const [importingSkill, setImportingSkill] = React.useState<string | null>(null)
   const [updatingSkill, setUpdatingSkill] = React.useState<string | null>(null)
   const [loading, setLoading] = React.useState(true)
+  const [selectedSkillSlug, setSelectedSkillSlug] = React.useState<string | null>(null)
 
-  /** 加载 MCP 配置和 Skills */
+  const selectedSkill = skills.find((s) => s.slug === selectedSkillSlug) ?? null
+
   const loadData = React.useCallback(async () => {
     if (!workspaceSlug) {
       setLoading(false)
       return
     }
-
     try {
       const [config, skillList, dir] = await Promise.all([
         window.electronAPI.getWorkspaceMcpConfig(workspaceSlug),
@@ -101,7 +172,6 @@ export function AgentSettings(): React.ReactElement {
     }
   }, [workspaceSlug])
 
-  /** 懒加载其他工作区 Skill（打开导入弹窗时触发） */
   const loadOtherWorkspaces = React.useCallback(async () => {
     if (!workspaceSlug) return
     try {
@@ -113,35 +183,25 @@ export function AgentSettings(): React.ReactElement {
   }, [workspaceSlug])
 
   React.useEffect(() => {
-    if (showImportDialog) {
-      void loadOtherWorkspaces()
-    }
+    if (showImportDialog) void loadOtherWorkspaces()
   }, [showImportDialog, loadOtherWorkspaces])
 
-  React.useEffect(() => {
-    loadData()
-  }, [loadData])
+  React.useEffect(() => { loadData() }, [loadData])
 
-  // 无工作区时提示
   if (!currentWorkspace) {
     return (
       <div className="flex flex-col items-center justify-center py-20 text-center">
         <FolderOpen size={48} className="text-muted-foreground/50 mb-4" />
-        <p className="text-sm text-muted-foreground">
-          请先在 Agent 模式下选择或创建一个工作区
-        </p>
+        <p className="text-sm text-muted-foreground">请先在 Agent 模式下选择或创建一个工作区</p>
       </div>
     )
   }
 
-  /** 配置目录名称：开发模式用 .proma-dev，正式版用 .proma */
   const configDirName = import.meta.env.DEV ? '.proma-dev' : '.proma'
 
-  /** 构建 MCP 配置提示词 */
   const buildMcpPrompt = (): string => {
     const configPath = `~/${configDirName}/agent-workspaces/${workspaceSlug}/mcp.json`
     const currentConfig = JSON.stringify(mcpConfig, null, 2)
-
     return `请帮我配置当前工作区的 MCP 服务器，你要主动来帮我实现，你可以采用联网搜索深度研究来尝试，当前环境已经有 Claude Agent SDK 了，除非不确定的时候才来问我，否则默认将帮我完成安装，而不是指导我。
 
 ## 工作区信息
@@ -175,18 +235,16 @@ mcp.json 格式如下：
 请读取当前配置文件，根据我的需求添加或修改 MCP 服务器，然后写回文件。`
   }
 
-  /** 构建 Skill 配置提示词 */
   const buildSkillPrompt = (): string => {
-    const skillsDir = `~/${configDirName}/agent-workspaces/${workspaceSlug}/skills/`
+    const skillsDirPath = `~/${configDirName}/agent-workspaces/${workspaceSlug}/skills/`
     const skillList = skills.length > 0
       ? skills.map((s) => `- ${s.name}: ${s.description ?? '无描述'}`).join('\n')
       : '暂无 Skill'
-
-    return `请帮我配置当前工作区的 Skills，你要主动来帮我实，现你可以采用联网搜索深度研究来尝试，当前环境已经有 Claude Agent SDK 了，除非不确定的时候才来问我，否则默认将帮我完成安装，而不是指导我。
+    return `请帮我配置当前工作区的 Skills，你要主动来帮我实现，你可以采用联网搜索深度研究来尝试，当前环境已经有 Claude Agent SDK 了，除非不确定的时候才来问我，否则默认将帮我完成安装，而不是指导我。
 
 ## 工作区信息
 - 工作区: ${currentWorkspace.name}
-- Skills 目录: ${skillsDir}
+- Skills 目录: ${skillsDirPath}
 
 ## Skill 格式
 每个 Skill 是 skills/ 目录下的一个子目录，目录名即 slug。
@@ -207,32 +265,17 @@ ${skillList}
 请查看 skills/ 目录了解现有配置，根据我的需求创建或编辑 Skill。`
   }
 
-  /** 通过 Agent 对话完成配置 */
   const handleConfigViaChat = async (promptMessage: string): Promise<void> => {
     if (!agentChannelId) {
       alert('请先在渠道设置中选择 Agent 供应商')
       return
     }
-
     try {
-      // 创建新会话
-      const session = await window.electronAPI.createAgentSession(
-        undefined,
-        agentChannelId,
-        currentWorkspaceId ?? undefined,
-      )
-
-      // 刷新会话列表
+      const session = await window.electronAPI.createAgentSession(undefined, agentChannelId, currentWorkspaceId ?? undefined)
       const sessions = await window.electronAPI.listAgentSessions()
       setAgentSessions(sessions)
-
-      // 设置当前会话
       setCurrentSessionId(session.id)
-
-      // 设置 pending prompt
       setPendingPrompt({ sessionId: session.id, message: promptMessage })
-
-      // 跳转到 Agent 对话视图
       setAppMode('agent')
       setSettingsOpen(false)
     } catch (error) {
@@ -240,14 +283,11 @@ ${skillList}
     }
   }
 
-  /** 删除 MCP 服务器 */
-  const handleDelete = async (serverName: string): Promise<void> => {
-    // 内置 MCP 不可删除
+  // MCP handlers
+  const handleDeleteMcp = async (serverName: string): Promise<void> => {
     const entry = mcpConfig.servers[serverName]
     if (entry?.isBuiltin) return
-
     if (!confirm(`确定删除 MCP 服务器「${serverName}」？此操作不可恢复。`)) return
-
     try {
       const newServers = { ...mcpConfig.servers }
       delete newServers[serverName]
@@ -260,17 +300,12 @@ ${skillList}
     }
   }
 
-  /** 切换 MCP 服务器启用状态 */
-  const handleToggle = async (serverName: string): Promise<void> => {
+  const handleToggleMcp = async (serverName: string): Promise<void> => {
     try {
       const entry = mcpConfig.servers[serverName]
       if (!entry) return
-
       const newConfig: WorkspaceMcpConfig = {
-        servers: {
-          ...mcpConfig.servers,
-          [serverName]: { ...entry, enabled: !entry.enabled },
-        },
+        servers: { ...mcpConfig.servers, [serverName]: { ...entry, enabled: !entry.enabled } },
       }
       await window.electronAPI.saveWorkspaceMcpConfig(workspaceSlug, newConfig)
       setMcpConfig(newConfig)
@@ -280,20 +315,19 @@ ${skillList}
     }
   }
 
-  /** 删除 Skill */
+  // Skill handlers
   const handleDeleteSkill = async (skillSlug: string, skillName: string): Promise<void> => {
     if (!confirm(`确定删除 Skill「${skillName}」？此操作不可恢复。`)) return
-
     try {
       await window.electronAPI.deleteWorkspaceSkill(workspaceSlug, skillSlug)
       setSkills((prev) => prev.filter((s) => s.slug !== skillSlug))
+      if (selectedSkillSlug === skillSlug) setSelectedSkillSlug(null)
       bumpCapabilitiesVersion((v) => v + 1)
     } catch (error) {
       console.error('[Agent 设置] 删除 Skill 失败:', error)
     }
   }
 
-  /** 切换 Skill 启用/禁用 */
   const handleToggleSkill = async (skillSlug: string, enabled: boolean): Promise<void> => {
     try {
       await window.electronAPI.toggleWorkspaceSkill(workspaceSlug, skillSlug, enabled)
@@ -304,14 +338,12 @@ ${skillList}
     }
   }
 
-  /** 从其他工作区导入 Skill */
   const handleImportSkill = async (sourceSlug: string, skillSlug: string): Promise<void> => {
     if (!workspaceSlug || importingSkill) return
-
     setImportingSkill(skillSlug)
     try {
       const imported = await window.electronAPI.importSkillFromWorkspace(workspaceSlug, sourceSlug, skillSlug)
-      setSkills((prev) => prev.some((skill) => skill.slug === imported.slug) ? prev : [...prev, imported])
+      setSkills((prev) => prev.some((s) => s.slug === imported.slug) ? prev : [...prev, imported])
       bumpCapabilitiesVersion((v) => v + 1)
       setShowImportDialog(false)
       toast.success(`已导入 Skill: ${imported.name}`)
@@ -324,10 +356,8 @@ ${skillList}
     }
   }
 
-  /** 从源工作区同步更新已导入的 Skill */
   const handleUpdateSkill = async (skillSlug: string): Promise<void> => {
     if (!workspaceSlug || updatingSkill) return
-
     setUpdatingSkill(skillSlug)
     try {
       const updated = await window.electronAPI.updateSkillFromSource(workspaceSlug, skillSlug)
@@ -343,21 +373,26 @@ ${skillList}
     }
   }
 
-  /** 表单保存回调 */
-  const handleFormSaved = (): void => {
-    setViewMode('list')
-    setEditingServer(null)
+  const handleSkillContentSaved = (): void => {
     loadData()
     bumpCapabilitiesVersion((v) => v + 1)
   }
 
-  /** 取消表单 */
+  const handleFormSaved = (): void => {
+    setViewMode('list')
+    setEditingServer(null)
+    setActiveTab('mcp')
+    loadData()
+    bumpCapabilitiesVersion((v) => v + 1)
+  }
+
   const handleFormCancel = (): void => {
     setViewMode('list')
     setEditingServer(null)
+    setActiveTab('mcp')
   }
 
-  // 表单视图
+  // MCP form early-return
   if (viewMode === 'create' || viewMode === 'edit') {
     return (
       <McpServerForm
@@ -370,118 +405,146 @@ ${skillList}
   }
 
   const serverEntries = Object.entries(mcpConfig.servers ?? {}).filter(
-    ([name]) => name !== 'memos-cloud', // 记忆功能已迁移到独立配置，隐藏旧 MCP 条目
+    ([name]) => name !== 'memos-cloud',
   )
 
-  // 列表视图
   return (
-    <div className="space-y-8">
-      {/* 区块零：Agent 高级设置 */}
-      <AgentAdvancedSettings />
+    <div className="space-y-4">
+      <Tabs value={activeTab} onValueChange={setActiveTab}>
+        <TabsList className="w-full">
+          <TabsTrigger value="skills" className="flex-1">Skills</TabsTrigger>
+          <TabsTrigger value="mcp" className="flex-1">MCP</TabsTrigger>
+          <TabsTrigger value="tools" className="flex-1">内置工具</TabsTrigger>
+        </TabsList>
 
-      {/* 区块零点五：内置工具状态 */}
-      <BuiltinAgentTools />
-
-      {/* 区块一：MCP 服务器 */}
-      <SettingsSection
-        title="MCP 服务器"
-        description={`当前工作区: ${currentWorkspace.name}`}
-        action={
-          <Button size="sm" onClick={() => setViewMode('create')}>
-            <Plus size={16} />
-            <span>添加服务器</span>
-          </Button>
-        }
-      >
-        {loading ? (
-          <div className="text-sm text-muted-foreground py-8 text-center">加载中...</div>
-        ) : serverEntries.length === 0 ? (
-          <SettingsCard divided={false}>
-            <div className="text-sm text-muted-foreground py-12 text-center">
-              还没有配置任何 MCP 服务器，点击上方"添加服务器"开始
-            </div>
-          </SettingsCard>
-        ) : (
-          <SettingsCard>
-            {serverEntries.map(([name, entry]) => (
-              <McpServerRow
-                key={name}
-                name={name}
-                entry={entry}
-                onEdit={() => {
-                  setEditingServer({ name, entry })
-                  setViewMode('edit')
-                }}
-                onDelete={() => handleDelete(name)}
-                onToggle={() => handleToggle(name)}
-              />
-            ))}
-          </SettingsCard>
-        )}
-      </SettingsSection>
-
-      <Button
-        size="sm"
-        className="w-full"
-        onClick={() => handleConfigViaChat(buildMcpPrompt())}
-      >
-        <MessageSquare size={14} />
-        <span>跟 Proma Agent 对话完成配置</span>
-      </Button>
-
-      {/* 区块二：Skills（只读） */}
-      <SettingsSection
-        title="Skills"
-        description="将 SKILL.md 放入工作区 skills/ 目录即可被 Agent 自动发现"
-        action={
-          <div className="flex items-center gap-2">
-            <Button size="sm" variant="outline" onClick={() => setShowImportDialog(true)}>
-              <Plus size={16} />
-              <span>从其他工作区导入</span>
-            </Button>
-            {skillsDir && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    onClick={() => window.electronAPI.openFile(skillsDir)}
-                    className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
-                  >
-                    <FolderOpen size={16} />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent>打开 Skills 目录</TooltipContent>
-              </Tooltip>
+        {/* ===== Skills Tab ===== */}
+        <TabsContent value="skills" className="mt-4 space-y-4">
+          <SettingsSection
+            title="Skills"
+            description={`当前工作区: ${currentWorkspace.name}`}
+            action={
+              <div className="flex items-center gap-2">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button size="sm" onClick={() => handleConfigViaChat(buildSkillPrompt())}>
+                      <MessageSquare size={14} />
+                      <span>AI 配置</span>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" className="max-w-xs text-xs">
+                    Proma Agent 内置 Skills Finder，你可以在 Agent 模式下要求 Proma 帮你联网查找某类 Skills 并安装到当前的工作区使用；也可以跟 Proma Agent 一起探讨，利用 Proma Agent 内置的 Skills Creator 来一起创建高质量可复用的 Skills 到当前的工作区
+                  </TooltipContent>
+                </Tooltip>
+                <Button size="sm" variant="outline" onClick={() => setShowImportDialog(true)}>
+                  <Plus size={16} />
+                  <span>从其他工作区导入</span>
+                </Button>
+                {skillsDir && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        onClick={() => window.electronAPI.openFile(skillsDir)}
+                        className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+                      >
+                        <FolderOpen size={16} />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent>打开 Skills 目录</TooltipContent>
+                  </Tooltip>
+                )}
+              </div>
+            }
+          >
+            {loading ? (
+              <div className="text-sm text-muted-foreground py-8 text-center">加载中...</div>
+            ) : skills.length === 0 ? (
+              <SettingsCard divided={false}>
+                <div className="text-sm text-muted-foreground py-8 text-center">暂无 Skill</div>
+              </SettingsCard>
+            ) : (
+              <div className="flex border border-border rounded-lg overflow-hidden" style={{ minHeight: 420 }}>
+                <SkillListPanel
+                  skills={skills}
+                  selectedSlug={selectedSkillSlug}
+                  onSelect={setSelectedSkillSlug}
+                  onDelete={handleDeleteSkill}
+                  onToggle={handleToggleSkill}
+                  onUpdate={handleUpdateSkill}
+                  skillsDir={skillsDir}
+                />
+                <div className="flex-1 overflow-y-auto">
+                  {selectedSkill ? (
+                    <SkillDetailPanel
+                      skill={selectedSkill}
+                      workspaceSlug={workspaceSlug}
+                      onSaved={handleSkillContentSaved}
+                    />
+                  ) : (
+                    <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
+                      选择一个 Skill 查看详情
+                    </div>
+                  )}
+                </div>
+              </div>
             )}
-          </div>
-        }
-      >
-        {loading ? (
-          <div className="text-sm text-muted-foreground py-8 text-center">加载中...</div>
-        ) : skills.length === 0 ? (
-          <SettingsCard divided={false}>
-            <div className="text-sm text-muted-foreground py-8 text-center">
-              暂无 Skill
-            </div>
-          </SettingsCard>
-        ) : (
-          <SkillGroupedList
-            skills={skills}
-            skillsDir={skillsDir}
-            onDelete={handleDeleteSkill}
-            onToggle={handleToggleSkill}
-            onUpdate={handleUpdateSkill}
-          />
-        )}
+          </SettingsSection>
+        </TabsContent>
 
-        <Button
-          size="sm"
-          className="w-full"
-          onClick={() => handleConfigViaChat(buildSkillPrompt())}
-        >
-          <MessageSquare size={14} />
-          <span>跟 Proma Agent 对话完成配置</span>
-        </Button>
-      </SettingsSection>
+        {/* ===== MCP Tab ===== */}
+        <TabsContent value="mcp" className="mt-4 space-y-4">
+          <SettingsSection
+            title="MCP 服务器"
+            description={`当前工作区: ${currentWorkspace.name}`}
+            action={
+              <div className="flex items-center gap-2">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button size="sm" onClick={() => handleConfigViaChat(buildMcpPrompt())}>
+                      <MessageSquare size={14} />
+                      <span>AI 配置</span>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" className="max-w-xs text-xs">
+                    Proma Agent 可以帮助你联网查找公开的 MCP 并配置到当前工作区，你可以在 Agent 模式下用自然语言表达你想要的 MCP 并要求安装到当前工作区即可；也可以跟 Proma Agent 一起探讨创建你的专属 MCP 到当前工作区
+                  </TooltipContent>
+                </Tooltip>
+                <Button size="sm" variant="outline" onClick={() => { setActiveTab('mcp'); setViewMode('create') }}>
+                  <Plus size={16} />
+                  <span>添加服务器</span>
+                </Button>
+              </div>
+            }
+          >
+            {loading ? (
+              <div className="text-sm text-muted-foreground py-8 text-center">加载中...</div>
+            ) : serverEntries.length === 0 ? (
+              <SettingsCard divided={false}>
+                <div className="text-sm text-muted-foreground py-12 text-center">
+                  还没有配置任何 MCP 服务器，点击上方"添加服务器"开始
+                </div>
+              </SettingsCard>
+            ) : (
+              <SettingsCard>
+                {serverEntries.map(([name, entry]) => (
+                  <McpServerRow
+                    key={name}
+                    name={name}
+                    entry={entry}
+                    onEdit={() => { setEditingServer({ name, entry }); setViewMode('edit') }}
+                    onDelete={() => handleDeleteMcp(name)}
+                    onToggle={() => handleToggleMcp(name)}
+                  />
+                ))}
+              </SettingsCard>
+            )}
+          </SettingsSection>
+        </TabsContent>
+
+        {/* ===== Built-in Tools Tab ===== */}
+        <TabsContent value="tools" className="mt-4">
+          <BuiltinAgentTools />
+        </TabsContent>
+      </Tabs>
 
       <ImportSkillFromWorkspaceDialog
         open={showImportDialog}
@@ -495,14 +558,9 @@ ${skillList}
   )
 }
 
-// ===== MCP 服务器行子组件 =====
+// ===== MCP Server Row =====
 
-/** 传输类型显示标签 */
-const TRANSPORT_LABELS: Record<string, string> = {
-  stdio: 'stdio',
-  http: 'HTTP',
-  sse: 'SSE',
-}
+const TRANSPORT_LABELS: Record<string, string> = { stdio: 'stdio', http: 'HTTP', sse: 'SSE' }
 
 interface McpServerRowProps {
   name: string
@@ -514,7 +572,6 @@ interface McpServerRowProps {
 
 function McpServerRow({ name, entry, onEdit, onDelete, onToggle }: McpServerRowProps): React.ReactElement {
   const isBuiltin = entry.isBuiltin === true
-
   return (
     <SettingsRow
       label={name}
@@ -532,91 +589,39 @@ function McpServerRow({ name, entry, onEdit, onDelete, onToggle }: McpServerRowP
         <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-muted text-muted-foreground font-medium">
           {TRANSPORT_LABELS[entry.type] ?? entry.type}
         </span>
-        <button
-          onClick={onEdit}
-          className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors opacity-0 group-hover:opacity-100"
-          title="编辑"
-        >
+        <button onClick={onEdit} className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors opacity-0 group-hover:opacity-100" title="编辑">
           <Pencil size={14} />
         </button>
         {!isBuiltin && (
-          <button
-            onClick={onDelete}
-            className="p-1.5 rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors opacity-0 group-hover:opacity-100"
-            title="删除"
-          >
+          <button onClick={onDelete} className="p-1.5 rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors opacity-0 group-hover:opacity-100" title="删除">
             <Trash2 size={14} />
           </button>
         )}
-        <Switch
-          checked={entry.enabled}
-          onCheckedChange={onToggle}
-        />
+        <Switch checked={entry.enabled} onCheckedChange={onToggle} />
       </div>
     </SettingsRow>
   )
 }
 
-// ===== Skills 分组列表子组件 =====
+// ===== Skill List Panel (Left) =====
 
-/** 分组结果 */
-interface SkillGroup {
-  prefix: string
+interface SkillListPanelProps {
   skills: SkillMeta[]
-}
-
-/** 按前缀对 Skills 分组 */
-function groupSkillsByPrefix(skills: SkillMeta[]): SkillGroup[] {
-  const prefixMap = new Map<string, SkillMeta[]>()
-
-  for (const skill of skills) {
-    const dashIdx = skill.slug.indexOf('-')
-    const prefix = dashIdx > 0 ? skill.slug.slice(0, dashIdx) : ''
-    const key = prefix || skill.slug
-    const list = prefixMap.get(key) ?? []
-    list.push(skill)
-    prefixMap.set(key, list)
-  }
-
-  const groups: SkillGroup[] = []
-  const standalone: SkillMeta[] = []
-
-  for (const [prefix, list] of prefixMap) {
-    if (list.length >= 2) {
-      groups.push({ prefix, skills: list })
-    } else {
-      standalone.push(...list)
-    }
-  }
-
-  // 独立 skill 合为一个无前缀组
-  if (standalone.length > 0) {
-    groups.push({ prefix: '', skills: standalone })
-  }
-
-  return groups
-}
-
-/** 从 slug 中移除前缀得到短名称 */
-function shortName(slug: string, prefix: string): string {
-  if (!prefix) return slug
-  return slug.startsWith(prefix + '-') ? slug.slice(prefix.length + 1) : slug
-}
-
-interface SkillGroupedListProps {
-  skills: SkillMeta[]
-  skillsDir: string
+  selectedSlug: string | null
+  onSelect: (slug: string) => void
   onDelete: (slug: string, name: string) => void
   onToggle: (slug: string, enabled: boolean) => void
   onUpdate: (slug: string) => void
+  skillsDir: string
 }
 
-function SkillGroupedList({ skills, skillsDir, onDelete, onToggle, onUpdate }: SkillGroupedListProps): React.ReactElement {
+function SkillListPanel({ skills, selectedSlug, onSelect, onDelete, onToggle, onUpdate, skillsDir }: SkillListPanelProps): React.ReactElement {
   const groups = React.useMemo(() => groupSkillsByPrefix(skills), [skills])
-  const [expandedGroups, setExpandedGroups] = React.useState<Set<string>>(new Set())
-  const [expandedSkill, setExpandedSkill] = React.useState<string | null>(null)
+  const [expandedGroups, setExpandedGroups] = React.useState<Set<string>>(() =>
+    new Set(groups.filter((g) => g.prefix).map((g) => g.prefix)),
+  )
 
-  const toggleGroup = (prefix: string) => {
+  const toggleGroup = (prefix: string): void => {
     setExpandedGroups((prev) => {
       const next = new Set(prev)
       if (next.has(prefix)) next.delete(prefix)
@@ -625,193 +630,430 @@ function SkillGroupedList({ skills, skillsDir, onDelete, onToggle, onUpdate }: S
     })
   }
 
-  const openSkillFolder = (slug: string) => {
-    if (skillsDir) {
-      window.electronAPI.openFile(`${skillsDir}/${slug}`)
-    }
+  const openSkillFolder = (slug: string): void => {
+    if (skillsDir) window.electronAPI.openFile(`${skillsDir}/${slug}`)
   }
 
   return (
-    <div className="space-y-2 min-w-0">
+    <div className="w-56 flex-shrink-0 border-r border-border overflow-y-auto bg-muted/20">
       {groups.map((group) =>
         group.prefix ? (
-          <SkillGroupCard
-            key={group.prefix}
-            group={group}
-            expanded={expandedGroups.has(group.prefix)}
-            expandedSkill={expandedSkill}
-            onToggle={() => toggleGroup(group.prefix)}
-            onExpandSkill={(slug) => setExpandedSkill(expandedSkill === slug ? null : slug)}
-            onDelete={onDelete}
-            onToggleEnabled={onToggle}
-            onOpenFolder={openSkillFolder}
-            onUpdate={onUpdate}
-          />
-        ) : (
-          /* 独立 skill 不分组，平铺展示 */
-          <SettingsCard key="__standalone__">
-            {group.skills.map((skill) => (
-              <SkillItemRow
+          <div key={group.prefix}>
+            <button
+              onClick={() => toggleGroup(group.prefix)}
+              className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-muted/40 transition-colors"
+            >
+              {expandedGroups.has(group.prefix)
+                ? <ChevronDown size={12} className="text-muted-foreground flex-shrink-0" />
+                : <ChevronRight size={12} className="text-muted-foreground flex-shrink-0" />}
+              <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider truncate flex-1">{group.prefix}</span>
+              <span className="text-[10px] tabular-nums text-muted-foreground flex-shrink-0">{group.skills.length}</span>
+            </button>
+            {expandedGroups.has(group.prefix) && group.skills.map((skill) => (
+              <SkillCompactItem
                 key={skill.slug}
                 skill={skill}
-                displayName={skill.name}
-                expanded={expandedSkill === skill.slug}
-                onToggleExpand={() => setExpandedSkill(expandedSkill === skill.slug ? null : skill.slug)}
+                displayName={shortName(skill.slug, group.prefix)}
+                selected={selectedSlug === skill.slug}
+                onSelect={() => onSelect(skill.slug)}
                 onDelete={() => onDelete(skill.slug, skill.name)}
-                onToggleEnabled={(enabled) => onToggle(skill.slug, enabled)}
+                onToggle={(enabled) => onToggle(skill.slug, enabled)}
                 onOpenFolder={() => openSkillFolder(skill.slug)}
                 onUpdate={skill.hasUpdate ? () => onUpdate(skill.slug) : undefined}
               />
             ))}
-          </SettingsCard>
-        )
+          </div>
+        ) : (
+          group.skills.map((skill) => (
+            <SkillCompactItem
+              key={skill.slug}
+              skill={skill}
+              displayName={skill.name}
+              selected={selectedSlug === skill.slug}
+              onSelect={() => onSelect(skill.slug)}
+              onDelete={() => onDelete(skill.slug, skill.name)}
+              onToggle={(enabled) => onToggle(skill.slug, enabled)}
+              onOpenFolder={() => openSkillFolder(skill.slug)}
+              onUpdate={skill.hasUpdate ? () => onUpdate(skill.slug) : undefined}
+            />
+          ))
+        ),
       )}
     </div>
   )
 }
 
-interface SkillGroupCardProps {
-  group: SkillGroup
-  expanded: boolean
-  expandedSkill: string | null
-  onToggle: () => void
-  onExpandSkill: (slug: string) => void
-  onDelete: (slug: string, name: string) => void
-  onToggleEnabled: (slug: string, enabled: boolean) => void
-  onOpenFolder: (slug: string) => void
-  onUpdate: (slug: string) => void
+// ===== Skill Compact Item =====
+
+interface SkillCompactItemProps {
+  skill: SkillMeta
+  displayName: string
+  selected: boolean
+  onSelect: () => void
+  onDelete: () => void
+  onToggle: (enabled: boolean) => void
+  onOpenFolder: () => void
+  onUpdate?: () => void
 }
 
-function SkillGroupCard({ group, expanded, expandedSkill, onToggle, onExpandSkill, onDelete, onToggleEnabled, onOpenFolder, onUpdate }: SkillGroupCardProps): React.ReactElement {
+function SkillCompactItem({ skill, displayName, selected, onSelect, onDelete, onToggle, onOpenFolder, onUpdate }: SkillCompactItemProps): React.ReactElement {
   return (
-    <SettingsCard divided={false}>
-      {/* 分组头部 */}
-      <button
-        onClick={onToggle}
-        className="w-full flex items-center gap-3 px-4 py-2.5 text-left hover:bg-muted/30 transition-colors min-w-0"
-      >
-        {expanded
-          ? <ChevronDown size={14} className="text-muted-foreground flex-shrink-0" />
-          : <ChevronRight size={14} className="text-muted-foreground flex-shrink-0" />
-        }
-        <Sparkles size={16} className="text-amber-500 flex-shrink-0" />
-        <span className="text-sm font-medium text-foreground flex-1 min-w-0 truncate">{group.prefix}</span>
-        <span className="text-xs px-1.5 py-0.5 rounded-md bg-muted text-muted-foreground font-medium tabular-nums flex-shrink-0">
-          {group.skills.length}
-        </span>
-      </button>
-
-      {/* 展开的子项 */}
-      {expanded && (
-        <div className="overflow-hidden">
-          {group.skills.map((skill) => (
-            <SkillItemRow
-              key={skill.slug}
-              skill={skill}
-              displayName={shortName(skill.slug, group.prefix)}
-              expanded={expandedSkill === skill.slug}
-              onToggleExpand={() => onExpandSkill(skill.slug)}
-              onDelete={() => onDelete(skill.slug, skill.name)}
-              onToggleEnabled={(enabled) => onToggleEnabled(skill.slug, enabled)}
-              onOpenFolder={() => onOpenFolder(skill.slug)}
-              onUpdate={skill.hasUpdate ? () => onUpdate(skill.slug) : undefined}
-              indent
-            />
-          ))}
-        </div>
+    <button
+      onClick={onSelect}
+      className={cn(
+        'group w-full flex items-center gap-2 px-3 py-2 text-left transition-colors',
+        selected ? 'bg-accent text-accent-foreground' : 'hover:bg-muted/40',
+        !skill.enabled && 'opacity-50',
       )}
-    </SettingsCard>
+    >
+      <Sparkles size={14} className="text-amber-500 flex-shrink-0" />
+      <span className="text-sm truncate flex-1 min-w-0">{displayName}</span>
+      <div className="flex items-center gap-0.5 flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+        {onUpdate && (
+          <span
+            role="button"
+            onClick={(e) => { e.stopPropagation(); onUpdate() }}
+            className="p-1 rounded text-blue-500 hover:bg-blue-500/10 cursor-pointer"
+          >
+            <RefreshCw size={12} />
+          </span>
+        )}
+        <span
+          role="button"
+          onClick={(e) => { e.stopPropagation(); onOpenFolder() }}
+          className="p-1 rounded text-muted-foreground hover:text-foreground hover:bg-muted/50 cursor-pointer"
+        >
+          <FolderOpen size={12} />
+        </span>
+        <span
+          role="button"
+          onClick={(e) => { e.stopPropagation(); onDelete() }}
+          className="p-1 rounded text-muted-foreground hover:text-destructive hover:bg-destructive/10 cursor-pointer"
+        >
+          <Trash2 size={12} />
+        </span>
+      </div>
+      <Switch
+        checked={skill.enabled}
+        onCheckedChange={(checked) => { onToggle(checked) }}
+        onClick={(e) => e.stopPropagation()}
+        className="flex-shrink-0 scale-75"
+      />
+    </button>
   )
 }
 
-interface SkillItemRowProps {
+// ===== Skill Detail Panel (Right) =====
+
+interface SkillDetailPanelProps {
   skill: SkillMeta
-  displayName: string
-  expanded: boolean
-  onToggleExpand: () => void
-  onDelete: () => void
-  onToggleEnabled: (enabled: boolean) => void
-  onOpenFolder: () => void
-  onUpdate?: () => void
-  indent?: boolean
+  workspaceSlug: string
+  onSaved: () => void
 }
 
-function SkillItemRow({ skill, displayName, expanded, onToggleExpand, onDelete, onToggleEnabled, onOpenFolder, onUpdate, indent }: SkillItemRowProps): React.ReactElement {
-  return (
-    <div className={cn('group border-t border-border/50 overflow-hidden', !skill.enabled && 'opacity-50')}>
-      <div className={cn('flex items-center gap-2 px-4 py-2', indent && 'pl-8')}>
-        {indent && <Sparkles size={14} className="text-amber-400/60 flex-shrink-0" />}
-        {!indent && <Sparkles size={16} className="text-amber-500 flex-shrink-0" />}
+function SkillDetailPanel({ skill, workspaceSlug, onSaved }: SkillDetailPanelProps): React.ReactElement {
+  const [content, setContent] = React.useState<string | null>(null)
+  const [loadingContent, setLoadingContent] = React.useState(false)
+  const currentSlugRef = React.useRef(skill.slug)
 
-        {/* 名称 + 可展开描述 */}
-        <button
-          onClick={onToggleExpand}
-          className="flex-1 min-w-0 text-left overflow-hidden"
-        >
-          <div className="flex items-center gap-2">
-            <span className="text-sm font-medium text-foreground truncate">{displayName}</span>
-            {skill.hasUpdate && (
-              <span className="shrink-0 rounded-md bg-blue-500/10 px-1.5 py-0.5 text-[10px] font-medium text-blue-600 dark:text-blue-400">
-                可更新
-              </span>
-            )}
-          </div>
-          {expanded && skill.description && (
-            <div className="text-xs text-muted-foreground mt-1 break-words">
-              {skill.description}
+  const [isEditingMeta, setIsEditingMeta] = React.useState(false)
+  const [isEditingBody, setIsEditingBody] = React.useState(false)
+  const [editName, setEditName] = React.useState('')
+  const [editDescription, setEditDescription] = React.useState('')
+  const [editBody, setEditBody] = React.useState('')
+  const [saving, setSaving] = React.useState(false)
+
+  React.useEffect(() => {
+    currentSlugRef.current = skill.slug
+    setIsEditingMeta(false)
+    setIsEditingBody(false)
+    setLoadingContent(true)
+
+    window.electronAPI.readSkillContent(workspaceSlug, skill.slug)
+      .then((text) => {
+        if (currentSlugRef.current === skill.slug) setContent(text)
+      })
+      .catch((err) => {
+        console.error('[SkillDetail] 加载内容失败:', err)
+        if (currentSlugRef.current === skill.slug) setContent(null)
+      })
+      .finally(() => {
+        if (currentSlugRef.current === skill.slug) setLoadingContent(false)
+      })
+  }, [skill.slug, workspaceSlug])
+
+  const body = React.useMemo(() => extractSkillBody(content ?? ''), [content])
+
+  const startEditMeta = (): void => {
+    setEditName(skill.name)
+    setEditDescription(skill.description ?? '')
+    setIsEditingMeta(true)
+  }
+
+  const saveMeta = async (): Promise<void> => {
+    if (!content) return
+    setSaving(true)
+    try {
+      const newContent = rebuildSkillMd(content, { name: editName, description: editDescription })
+      await window.electronAPI.writeSkillContent(workspaceSlug, skill.slug, newContent)
+      setContent(newContent)
+      setIsEditingMeta(false)
+      onSaved()
+      toast.success('元数据已保存')
+    } catch (err) {
+      console.error('[SkillDetail] 保存元数据失败:', err)
+      toast.error('保存失败')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const startEditBody = (): void => {
+    setEditBody(body)
+    setIsEditingBody(true)
+  }
+
+  const saveBody = async (): Promise<void> => {
+    if (!content) return
+    setSaving(true)
+    try {
+      const newContent = rebuildSkillMd(content, { body: editBody })
+      await window.electronAPI.writeSkillContent(workspaceSlug, skill.slug, newContent)
+      setContent(newContent)
+      setIsEditingBody(false)
+      onSaved()
+      toast.success('说明已保存')
+    } catch (err) {
+      console.error('[SkillDetail] 保存说明失败:', err)
+      toast.error('保存失败')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loadingContent) {
+    return <div className="flex items-center justify-center h-full text-sm text-muted-foreground">加载中...</div>
+  }
+
+  const sourceLabel = skill.importSource
+    ? `从 ${skill.importSource.sourceWorkspaceName} 导入`
+    : '当前工作区'
+
+  return (
+    <div className="p-5 space-y-6">
+      {/* Header */}
+      <div className="flex items-start gap-3">
+        <div className="rounded-xl bg-amber-500/12 p-2.5 text-amber-500 shrink-0">
+          <Sparkles size={20} />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h3 className="text-base font-semibold text-foreground">{skill.name}</h3>
+          {skill.description && (
+            <p className="text-sm text-muted-foreground mt-1 line-clamp-2">{skill.description}</p>
+          )}
+        </div>
+      </div>
+
+      {/* Metadata Section */}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <h4 className="text-sm font-medium text-foreground">元数据</h4>
+          {!isEditingMeta ? (
+            <button onClick={startEditMeta} className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1 transition-colors">
+              <Pencil size={12} /> 编辑
+            </button>
+          ) : (
+            <div className="flex items-center gap-2">
+              <Button size="sm" variant="ghost" onClick={() => setIsEditingMeta(false)} disabled={saving}>
+                <X size={14} /> 取消
+              </Button>
+              <Button size="sm" onClick={() => void saveMeta()} disabled={saving}>
+                <Save size={14} /> {saving ? '保存中...' : '保存'}
+              </Button>
             </div>
           )}
-          {!expanded && skill.description && (
-            <div className="text-xs text-muted-foreground truncate">{skill.description}</div>
-          )}
-        </button>
-
-        {/* 操作按钮 */}
-        <div className="flex items-center gap-1 flex-shrink-0">
-          {onUpdate && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  onClick={onUpdate}
-                  className="p-1.5 rounded-md text-blue-500 hover:text-blue-600 hover:bg-blue-500/10 transition-colors"
-                >
-                  <RefreshCw size={14} />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent>从源工作区同步更新</TooltipContent>
-            </Tooltip>
-          )}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                onClick={onOpenFolder}
-                className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors opacity-0 group-hover:opacity-100"
-              >
-                <FolderOpen size={14} />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent>打开文件夹</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                onClick={onDelete}
-                className="p-1.5 rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors opacity-0 group-hover:opacity-100"
-              >
-                <Trash2 size={14} />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent>删除</TooltipContent>
-          </Tooltip>
-          <Switch
-            checked={skill.enabled}
-            onCheckedChange={onToggleEnabled}
-          />
         </div>
+
+        <SettingsCard divided>
+          <MetadataRow label="标识符" value={skill.slug} />
+          {isEditingMeta ? (
+            <>
+              <MetadataEditRow label="名称" value={editName} onChange={setEditName} />
+              <MetadataEditRow label="描述" value={editDescription} onChange={setEditDescription} multiline />
+            </>
+          ) : (
+            <>
+              <MetadataRow label="名称" value={skill.name} />
+              <MetadataRow label="描述" value={skill.description ?? '无描述'} />
+            </>
+          )}
+          <MetadataRow label="数据源" value={sourceLabel} />
+          <MetadataRow label="位置" value={`skills/${skill.slug}`} />
+          {skill.version && <MetadataRow label="版本" value={skill.version} />}
+        </SettingsCard>
+      </div>
+
+      {/* Body Section */}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <h4 className="text-sm font-medium text-foreground">说明</h4>
+          {!isEditingBody ? (
+            <button onClick={startEditBody} className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1 transition-colors">
+              <Pencil size={12} /> 编辑
+            </button>
+          ) : (
+            <div className="flex items-center gap-2">
+              <Button size="sm" variant="ghost" onClick={() => setIsEditingBody(false)} disabled={saving}>
+                <X size={14} /> 取消
+              </Button>
+              <Button size="sm" onClick={() => void saveBody()} disabled={saving}>
+                <Save size={14} /> {saving ? '保存中...' : '保存'}
+              </Button>
+            </div>
+          )}
+        </div>
+
+        <SettingsCard divided={false}>
+          <div className="p-4">
+            {isEditingBody ? (
+              <textarea
+                value={editBody}
+                onChange={(e) => setEditBody(e.target.value)}
+                className="w-full min-h-[300px] bg-transparent text-sm font-mono resize-y border border-border rounded-md p-3 focus:outline-none focus:ring-1 focus:ring-ring"
+                placeholder="输入 Skill 说明内容（支持 Markdown）..."
+              />
+            ) : (
+              <div className="prose prose-sm dark:prose-invert max-w-none">
+                <Markdown remarkPlugins={[remarkGfm]}>{body || '暂无说明内容'}</Markdown>
+              </div>
+            )}
+          </div>
+        </SettingsCard>
       </div>
     </div>
   )
 }
+
+// ===== Metadata Helpers =====
+
+function MetadataRow({ label, value }: { label: string; value: string }): React.ReactElement {
+  return (
+    <div className="flex items-start gap-4 px-4 py-2.5">
+      <span className="text-xs text-muted-foreground w-16 flex-shrink-0 pt-0.5">{label}</span>
+      <span className="text-sm text-foreground flex-1 min-w-0 break-words">{value}</span>
+    </div>
+  )
+}
+
+function MetadataEditRow({ label, value, onChange, multiline }: { label: string; value: string; onChange: (v: string) => void; multiline?: boolean }): React.ReactElement {
+  return (
+    <div className="flex items-start gap-4 px-4 py-2.5">
+      <span className="text-xs text-muted-foreground w-16 flex-shrink-0 pt-2">{label}</span>
+      {multiline ? (
+        <textarea
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="flex-1 min-w-0 text-sm bg-transparent border border-border rounded-md px-2 py-1 resize-y focus:outline-none focus:ring-1 focus:ring-ring"
+          rows={3}
+        />
+      ) : (
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="flex-1 min-w-0 text-sm bg-transparent border border-border rounded-md px-2 py-1 focus:outline-none focus:ring-1 focus:ring-ring"
+        />
+      )}
+    </div>
+  )
+}
+
+// ===== Built-in Agent Tools =====
+
+function BuiltinAgentTools(): React.ReactElement {
+  const tools = useAtomValue(chatToolsAtom)
+  const setSettingsTab = useSetAtom(settingsTabAtom)
+
+  const memoryTool = tools.find((t) => t.meta.id === 'memory')
+  const nanoBananaTool = tools.find((t) => t.meta.id === 'nano-banana')
+  const webSearchTool = tools.find((t) => t.meta.id === 'web-search')
+
+  interface BuiltinToolItem {
+    id: string
+    name: string
+    description: string
+    icon: React.ReactElement
+    enabled: boolean
+    available: boolean
+  }
+
+  const builtinTools: BuiltinToolItem[] = [
+    {
+      id: 'memory',
+      name: '记忆',
+      description: '长期记忆存储与检索',
+      icon: <Brain className="size-4" />,
+      enabled: memoryTool?.enabled ?? false,
+      available: memoryTool?.available ?? false,
+    },
+    {
+      id: 'nano-banana',
+      name: 'Nano Banana',
+      description: 'AI 图片生成与编辑',
+      icon: <ImagePlus className="size-4" />,
+      enabled: nanoBananaTool?.enabled ?? false,
+      available: nanoBananaTool?.available ?? false,
+    },
+    {
+      id: 'web-search',
+      name: '联网搜索',
+      description: '实时搜索互联网获取最新信息',
+      icon: <Search className="size-4" />,
+      enabled: webSearchTool?.enabled ?? false,
+      available: webSearchTool?.available ?? false,
+    },
+  ]
+
+  return (
+    <SettingsSection
+      title="内置工具"
+      description="启用后自动注入到 Agent 会话，在工具设置中配置"
+      action={
+        <Button size="sm" variant="outline" onClick={() => setSettingsTab('tools')}>
+          <Pencil size={14} />
+          <span>配置</span>
+        </Button>
+      }
+    >
+      <SettingsCard divided>
+        {builtinTools.map((tool) => {
+          const isActive = tool.enabled && tool.available
+          return (
+            <div key={tool.id} className="flex items-center justify-between p-4">
+              <div className="flex items-center gap-3 min-w-0">
+                <span className={cn('shrink-0', !isActive && 'opacity-40')}>{tool.icon}</span>
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className={cn('text-sm font-medium', !isActive && 'text-muted-foreground')}>{tool.name}</span>
+                    <span className={cn(
+                      'text-[10px] px-1.5 py-0.5 rounded-full',
+                      isActive ? 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' : 'bg-muted text-muted-foreground',
+                    )}>
+                      {isActive ? '已启用' : !tool.available ? '需配置' : '未启用'}
+                    </span>
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-0.5">{tool.description}</p>
+                </div>
+              </div>
+            </div>
+          )
+        })}
+      </SettingsCard>
+    </SettingsSection>
+  )
+}
+
+// ===== Import Skill Dialog =====
 
 interface ImportSkillFromWorkspaceDialogProps {
   open: boolean
@@ -832,7 +1074,7 @@ function ImportSkillFromWorkspaceDialog({
 }: ImportSkillFromWorkspaceDialogProps): React.ReactElement {
   const installedSlugs = React.useMemo(
     () => new Set(installedSkills.map((skill) => skill.slug)),
-    [installedSkills]
+    [installedSkills],
   )
 
   const availableWorkspaces = React.useMemo(
@@ -843,13 +1085,13 @@ function ImportSkillFromWorkspaceDialog({
           skills: workspace.skills.filter((skill) => !installedSlugs.has(skill.slug)),
         }))
         .filter((workspace) => workspace.skills.length > 0),
-    [otherWorkspaces, installedSlugs]
+    [otherWorkspaces, installedSlugs],
   )
   const [selectedWorkspaceSlug, setSelectedWorkspaceSlug] = React.useState('')
 
   const selectedWorkspace = React.useMemo(
     () => availableWorkspaces.find((workspace) => workspace.workspaceSlug === selectedWorkspaceSlug) ?? null,
-    [availableWorkspaces, selectedWorkspaceSlug]
+    [availableWorkspaces, selectedWorkspaceSlug],
   )
 
   React.useEffect(() => {
@@ -857,11 +1099,10 @@ function ImportSkillFromWorkspaceDialog({
       setSelectedWorkspaceSlug('')
       return
     }
-
     setSelectedWorkspaceSlug((current) =>
       availableWorkspaces.some((workspace) => workspace.workspaceSlug === current)
         ? current
-        : availableWorkspaces[0]?.workspaceSlug ?? ''
+        : availableWorkspaces[0]?.workspaceSlug ?? '',
     )
   }, [availableWorkspaces, open])
 
@@ -910,41 +1151,39 @@ function ImportSkillFromWorkspaceDialog({
                   </div>
                   <div className="pr-1">
                     <div className="grid gap-3 sm:grid-cols-2">
-                    {workspace.skills.map((skill) => (
-                      <SettingsCard key={skill.slug} divided={false} className="overflow-hidden">
-                        <div className="flex h-full flex-col gap-4 p-4">
-                          <div className="flex items-start gap-3">
-                            <div className="rounded-xl bg-amber-500/12 p-2 text-amber-500 shadow-sm">
-                              <Sparkles size={18} />
-                            </div>
-                            <div className="min-w-0 flex-1">
-                              <div className="flex items-center gap-2">
-                                <div className="truncate text-sm font-medium text-foreground">{skill.name}</div>
-                                {skill.version ? (
-                                  <span className="rounded-md bg-muted px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground">
-                                    v{skill.version}
-                                  </span>
-                                ) : null}
+                      {workspace.skills.map((skill) => (
+                        <SettingsCard key={skill.slug} divided={false} className="overflow-hidden">
+                          <div className="flex h-full flex-col gap-4 p-4">
+                            <div className="flex items-start gap-3">
+                              <div className="rounded-xl bg-amber-500/12 p-2 text-amber-500 shadow-sm">
+                                <Sparkles size={18} />
                               </div>
-                              <div className="mt-1 text-xs text-muted-foreground">{skill.slug}</div>
+                              <div className="min-w-0 flex-1">
+                                <div className="flex items-center gap-2">
+                                  <div className="truncate text-sm font-medium text-foreground">{skill.name}</div>
+                                  {skill.version ? (
+                                    <span className="rounded-md bg-muted px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground">
+                                      v{skill.version}
+                                    </span>
+                                  ) : null}
+                                </div>
+                                <div className="mt-1 text-xs text-muted-foreground">{skill.slug}</div>
+                              </div>
                             </div>
+                            <div className="line-clamp-3 min-h-[40px] text-sm leading-6 text-muted-foreground">
+                              {skill.description ?? '暂无描述'}
+                            </div>
+                            <Button
+                              size="sm"
+                              className="w-full"
+                              onClick={() => void onImport(workspace.workspaceSlug, skill.slug)}
+                              disabled={importingSkill !== null}
+                            >
+                              {importingSkill === skill.slug ? '导入中...' : '导入'}
+                            </Button>
                           </div>
-
-                          <div className="line-clamp-3 min-h-[40px] text-sm leading-6 text-muted-foreground">
-                            {skill.description ?? '暂无描述'}
-                          </div>
-
-                          <Button
-                            size="sm"
-                            className="w-full"
-                            onClick={() => void onImport(workspace.workspaceSlug, skill.slug)}
-                            disabled={importingSkill !== null}
-                          >
-                            {importingSkill === skill.slug ? '导入中...' : '导入'}
-                          </Button>
-                        </div>
-                      </SettingsCard>
-                    ))}
+                        </SettingsCard>
+                      ))}
                     </div>
                   </div>
                 </div>
@@ -954,248 +1193,5 @@ function ImportSkillFromWorkspaceDialog({
         </div>
       </DialogContent>
     </Dialog>
-  )
-}
-
-// ===== Agent 高级设置子组件 =====
-
-/** 思考模式选项 */
-const THINKING_OPTIONS = [
-  { value: 'default', label: '默认' },
-  { value: 'adaptive', label: '自适应' },
-  { value: 'disabled', label: '关闭' },
-]
-
-/** 推理深度选项 */
-const EFFORT_OPTIONS = [
-  { value: 'default', label: '默认' },
-  { value: 'low', label: '低' },
-  { value: 'medium', label: '中' },
-  { value: 'high', label: '高' },
-  { value: 'max', label: '最大' },
-]
-
-/** 从 ThinkingConfig 转为 UI 字符串 */
-function thinkingToValue(config: ThinkingConfig | undefined): string {
-  if (!config) return 'default'
-  return config.type === 'adaptive' ? 'adaptive' : config.type === 'disabled' ? 'disabled' : 'default'
-}
-
-/** 从 UI 字符串转为 ThinkingConfig（'default' 返回 undefined） */
-function valueToThinking(value: string): ThinkingConfig | undefined {
-  if (value === 'adaptive') return { type: 'adaptive' }
-  if (value === 'disabled') return { type: 'disabled' }
-  return undefined
-}
-
-/** 从 AgentEffort 转为 UI 字符串 */
-function effortToValue(effort: AgentEffort | undefined): string {
-  return effort ?? 'default'
-}
-
-/** 从 UI 字符串转为 AgentEffort（'default' 返回 undefined） */
-function valueToEffort(value: string): AgentEffort | undefined {
-  if (value === 'default') return undefined
-  return value as AgentEffort
-}
-
-/** 内置 Agent 工具状态展示 */
-function BuiltinAgentTools(): React.ReactElement {
-  const tools = useAtomValue(chatToolsAtom)
-  const setSettingsTab = useSetAtom(settingsTabAtom)
-
-  const memoryTool = tools.find((t) => t.meta.id === 'memory')
-  const nanoBananaTool = tools.find((t) => t.meta.id === 'nano-banana')
-  const webSearchTool = tools.find((t) => t.meta.id === 'web-search')
-
-  /** 跳转到工具设置页 */
-  const goToToolSettings = (): void => {
-    setSettingsTab('tools')
-  }
-
-  interface BuiltinToolItem {
-    id: string
-    name: string
-    description: string
-    icon: React.ReactElement
-    enabled: boolean
-    available: boolean
-  }
-
-  const builtinTools: BuiltinToolItem[] = [
-    {
-      id: 'memory',
-      name: '记忆',
-      description: '长期记忆存储与检索',
-      icon: <Brain className="size-4" />,
-      enabled: memoryTool?.enabled ?? false,
-      available: memoryTool?.available ?? false,
-    },
-    {
-      id: 'nano-banana',
-      name: 'Nano Banana',
-      description: 'AI 图片生成与编辑',
-      icon: <ImagePlus className="size-4" />,
-      enabled: nanoBananaTool?.enabled ?? false,
-      available: nanoBananaTool?.available ?? false,
-    },
-    {
-      id: 'web-search',
-      name: '联网搜索',
-      description: '实时搜索互联网获取最新信息',
-      icon: <Search className="size-4" />,
-      enabled: webSearchTool?.enabled ?? false,
-      available: webSearchTool?.available ?? false,
-    },
-  ]
-
-  return (
-    <SettingsSection
-      title="内置工具"
-      description="启用后自动注入到 Agent 会话，在工具设置中配置"
-      action={
-        <Button size="sm" variant="outline" onClick={goToToolSettings}>
-          <Settings size={14} />
-          <span>配置</span>
-        </Button>
-      }
-    >
-      <SettingsCard divided>
-        {builtinTools.map((tool) => {
-          const isActive = tool.enabled && tool.available
-          return (
-            <div key={tool.id} className="flex items-center justify-between p-4">
-              <div className="flex items-center gap-3 min-w-0">
-                <span className={cn('shrink-0', !isActive && 'opacity-40')}>
-                  {tool.icon}
-                </span>
-                <div className="min-w-0">
-                  <div className="flex items-center gap-2">
-                    <span className={cn('text-sm font-medium', !isActive && 'text-muted-foreground')}>
-                      {tool.name}
-                    </span>
-                    <span className={cn(
-                      'text-[10px] px-1.5 py-0.5 rounded-full',
-                      isActive
-                        ? 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400'
-                        : 'bg-muted text-muted-foreground',
-                    )}>
-                      {isActive ? '已启用' : !tool.available ? '需配置' : '未启用'}
-                    </span>
-                  </div>
-                  <p className="text-xs text-muted-foreground mt-0.5">{tool.description}</p>
-                </div>
-              </div>
-            </div>
-          )
-        })}
-      </SettingsCard>
-    </SettingsSection>
-  )
-}
-
-function AgentAdvancedSettings(): React.ReactElement {
-  const [collapsed, setCollapsed] = React.useState(true)
-
-  const thinking = useAtomValue(agentThinkingAtom)
-  const setThinking = useSetAtom(agentThinkingAtom)
-  const effort = useAtomValue(agentEffortAtom)
-  const setEffort = useSetAtom(agentEffortAtom)
-  const maxBudget = useAtomValue(agentMaxBudgetUsdAtom)
-  const setMaxBudget = useSetAtom(agentMaxBudgetUsdAtom)
-  const maxTurns = useAtomValue(agentMaxTurnsAtom)
-  const setMaxTurns = useSetAtom(agentMaxTurnsAtom)
-
-  // 数字输入使用字符串状态，失焦时持久化
-  const [budgetStr, setBudgetStr] = React.useState(maxBudget != null ? String(maxBudget) : '')
-  const [turnsStr, setTurnsStr] = React.useState(maxTurns != null ? String(maxTurns) : '')
-
-  // 同步外部变化（如初始化加载）
-  React.useEffect(() => {
-    setBudgetStr(maxBudget != null ? String(maxBudget) : '')
-  }, [maxBudget])
-  React.useEffect(() => {
-    setTurnsStr(maxTurns != null ? String(maxTurns) : '')
-  }, [maxTurns])
-
-  const handleThinkingChange = (value: string): void => {
-    const config = valueToThinking(value)
-    setThinking(config)
-    window.electronAPI.updateSettings({ agentThinking: config })
-  }
-
-  const handleEffortChange = (value: string): void => {
-    const effortValue = valueToEffort(value)
-    setEffort(effortValue)
-    window.electronAPI.updateSettings({ agentEffort: effortValue })
-  }
-
-  const handleBudgetBlur = (): void => {
-    const num = parseFloat(budgetStr)
-    const value = !isNaN(num) && num > 0 ? num : undefined
-    setMaxBudget(value)
-    window.electronAPI.updateSettings({ agentMaxBudgetUsd: value })
-  }
-
-  const handleTurnsBlur = (): void => {
-    const num = parseInt(turnsStr, 10)
-    const value = !isNaN(num) && num > 0 ? num : undefined
-    setMaxTurns(value)
-    window.electronAPI.updateSettings({ agentMaxTurns: value })
-  }
-
-  return (
-    <SettingsSection
-      title={
-        <button
-          onClick={() => setCollapsed(!collapsed)}
-          className="flex items-center gap-2 hover:text-foreground/80 transition-colors"
-        >
-          <span>Agent 高级设置</span>
-          {collapsed
-            ? <ChevronRight size={16} className="text-muted-foreground" />
-            : <ChevronDown size={16} className="text-muted-foreground" />
-          }
-        </button>
-      }
-      description={collapsed ? undefined : '控制 Agent 的思考模式、推理深度和资源限制'}
-    >
-      {!collapsed && (
-        <SettingsCard>
-          <SettingsSegmentedControl
-            label="思考模式"
-            description="自适应模式下 Agent 会根据任务复杂度自动决定是否启用深度思考"
-            value={thinkingToValue(thinking)}
-            onValueChange={handleThinkingChange}
-            options={THINKING_OPTIONS}
-          />
-          <SettingsSegmentedControl
-            label="推理深度"
-            description="控制 Agent 在每次回复中投入的推理计算量"
-            value={effortToValue(effort)}
-            onValueChange={handleEffortChange}
-            options={EFFORT_OPTIONS}
-          />
-          <SettingsInput
-            label="预算限制（美元/次）"
-            description="单次 Agent 会话的最大花费，留空则不限制"
-            value={budgetStr}
-            onChange={setBudgetStr}
-            onBlur={handleBudgetBlur}
-            placeholder="例如: 1.0"
-            type="number"
-          />
-          <SettingsInput
-            label="最大轮次"
-            description="单次 Agent 会话的最大交互轮次，留空则使用 SDK 默认值"
-            value={turnsStr}
-            onChange={setTurnsStr}
-            onBlur={handleTurnsBlur}
-            placeholder="例如: 30"
-            type="number"
-          />
-        </SettingsCard>
-      )}
-    </SettingsSection>
   )
 }

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1251,6 +1251,10 @@ export const AGENT_IPC_CHANNELS = {
   IMPORT_SKILL_FROM_WORKSPACE: 'agent:import-skill-from-workspace',
   /** 从源工作区同步更新已导入的 Skill */
   UPDATE_SKILL_FROM_SOURCE: 'agent:update-skill-from-source',
+  /** 读取 SKILL.md 全文内容 */
+  READ_SKILL_CONTENT: 'agent:read-skill-content',
+  /** 写入 SKILL.md 全文内容 */
+  WRITE_SKILL_CONTENT: 'agent:write-skill-content',
 
   // 流式事件（主进程 → 渲染进程推送）
   /** Agent 流式事件 */


### PR DESCRIPTION
## Summary
- 移除 AgentAdvancedSettings（思考模式、推理深度、预算、轮次设置）
- Agent 配置页改为三 Tab 布局：Skills | MCP | 内置工具
- Skills Tab 升级为左列列表 + 右列详情的 Master-Detail 视图，支持元数据内联编辑和 SKILL.md Markdown 渲染
- 新增 readSkillContent / writeSkillContent IPC API
- AI 配置按钮移至顶部 action 区域并添加 Tooltip 说明
- 修复 AssistantTurnRenderer 中 early-return 违反 React hooks 规则的问题

## Test plan
- [x] 三个 Tab 正常切换，状态持久
- [x] Skills Tab：列表展示、选中高亮、详情加载、元数据编辑保存、Markdown 渲染
- [x] Skills Tab：从其他工作区导入、删除、启禁用、打开目录
- [x] MCP Tab：列表/添加/编辑/删除/启禁用，表单返回后停留在 MCP Tab
- [x] 内置工具 Tab：工具状态展示、"配置"跳转到外层工具设置页
- [x] AI 配置按钮 Tooltip 正常显示，点击后跳转 Agent 对话
- [x] TypeScript 类型检查零错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)