### PR TITLE
fix: 粘贴网址链接样式持久化 + 权限模式切换文件面板频闪

### DIFF
--- a/apps/electron/src/main/lib/workspace-watcher.ts
+++ b/apps/electron/src/main/lib/workspace-watcher.ts
@@ -52,6 +52,11 @@ export function startWorkspaceWatcher(win: BrowserWindow): void {
       if (!filename || win.isDestroyed()) return
 
       // filename 格式: {slug}/mcp.json 或 {slug}/skills/xxx/SKILL.md 或 {slug}/{sessionId}/file.txt
+      // config.json 是工作区配置文件（权限模式等），变更不应触发文件浏览器刷新
+      if (filename === 'config.json' || filename.endsWith('/config.json') || filename.endsWith('\\config.json')) {
+        return
+      }
+
       const isCapabilitiesChange =
         filename.endsWith('/mcp.json') ||
         filename.endsWith('\\mcp.json') ||

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -391,6 +391,22 @@ export function RichTextInput({
           return true
         },
       },
+      transformPastedHTML: (html: string) => {
+        // 去除粘贴 HTML 中的链接标签，防止链接 mark 粘性扩散到后续输入
+        const doc = new DOMParser().parseFromString(html, 'text/html')
+        const links = doc.querySelectorAll('a')
+        if (links.length === 0) return html
+        links.forEach((a) => {
+          const parent = a.parentNode
+          if (parent) {
+            while (a.firstChild) {
+              parent.insertBefore(a.firstChild, a)
+            }
+            parent.removeChild(a)
+          }
+        })
+        return doc.body.innerHTML
+      },
       handlePaste: (view, event) => {
         // 拦截粘贴的文件（图片等）
         const clipboardItems = event.clipboardData?.files


### PR DESCRIPTION
## 修复内容

### 1. 粘贴网址后链接样式持久化

**问题**：从浏览器复制网址粘贴到输入框后，空格再输入的文字一直带有蓝色链接样式，只有换行后才正常。

**根因**：剪贴板 HTML 中的 `<a>` 标签被 TipTap 转为 Link mark。ProseMirror 的 mark 具有粘性——光标在 link 末尾时新输入的字符会继承该 mark。

**修复** (`rich-text-input.tsx`)：在 `editorProps` 中新增 `transformPastedHTML` 函数，粘贴时用 DOMParser 解析 HTML，将 `<a>` 标签替换为纯文本内容，保留其他富文本格式（粗体、斜体、代码等）不受影响。

### 2. 权限模式切换时右侧文件面板频闪

**问题**：新对话开始时切换计划模式/自动模式/完全模式，右侧工作区文件面板频繁闪烁。

**根因**：`setWorkspacePermissionMode` 写入 `config.json` → workspace watcher 递归监听到变更 → 不匹配 `mcp.json`/`skills/` 规则 → 走 else 分支发送 `WORKSPACE_FILES_CHANGED` 事件 → FileBrowser 重新加载文件列表（清空再重建）→ 频闪。

**修复** (`workspace-watcher.ts`)：在文件变更处理中增加 `config.json` 过滤，该文件是工作区配置而非用户文件，变更不应触发文件浏览器刷新。

## 改动文件

| 文件 | 改动 |
|------|------|
| `apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx` | +16 行 |
| `apps/electron/src/main/lib/workspace-watcher.ts` | +5 行 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)