### PR TITLE
[codex] Add Dock badge unread count

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -8,7 +8,7 @@ import { ipcMain, nativeTheme, shell, dialog, BrowserWindow, app } from 'electro
 import { join } from 'node:path'
 import { existsSync } from 'node:fs'
 import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, INSTALLER_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, MEMORY_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS, DINGTALK_IPC_CHANNELS, WECHAT_IPC_CHANNELS } from '@proma/shared'
-import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS, QUICK_TASK_IPC_CHANNELS, APP_ICON_IPC_CHANNELS } from '../types'
+import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS, QUICK_TASK_IPC_CHANNELS, APP_ICON_IPC_CHANNELS, DOCK_BADGE_IPC_CHANNELS } from '../types'
 import type { QuickTaskSubmitInput } from '../types'
 import type {
   RuntimeStatus,
@@ -122,6 +122,7 @@ import { extractTextFromAttachment } from './lib/document-parser'
 import { getTutorialContent, createWelcomeConversation } from './lib/tutorial-service'
 import { getUserProfile, updateUserProfile } from './lib/user-profile-service'
 import { getSettings, updateSettings } from './lib/settings-service'
+import { setDockBadgeCount } from './lib/dock-badge-service'
 import { updateWindowTitleBarOverlay } from './lib/titlebar-overlay'
 import { checkEnvironment } from './lib/environment-checker'
 import { fetchInstallerManifest, findInstallerSource } from './lib/installer-manifest'
@@ -756,6 +757,15 @@ export function registerIpcHandlers(): void {
         console.error('[图标] 切换失败:', error)
         return false
       }
+    }
+  )
+
+  // ===== Dock/Launcher 角标 =====
+
+  ipcMain.handle(
+    DOCK_BADGE_IPC_CHANNELS.SET_COUNT,
+    async (_, count: number): Promise<boolean> => {
+      return setDockBadgeCount(count)
     }
   )
 

--- a/apps/electron/src/main/lib/dock-badge-service.ts
+++ b/apps/electron/src/main/lib/dock-badge-service.ts
@@ -1,0 +1,25 @@
+/**
+ * Dock 角标服务
+ *
+ * 将渲染进程推导出的待处理数量同步到系统级应用角标。
+ */
+
+import { app } from 'electron'
+
+/**
+ * 设置应用 Dock/Launcher 角标数量。
+ *
+ * macOS 会显示在 Dock 图标上；Linux 仅 Unity Launcher 支持。
+ * 传入 0 会清除角标。
+ */
+export function setDockBadgeCount(count: number): boolean {
+  const normalizedCount = Number.isFinite(count)
+    ? Math.max(0, Math.floor(count))
+    : 0
+
+  if (process.platform !== 'darwin' && process.platform !== 'linux') {
+    return false
+  }
+
+  return app.setBadgeCount(normalizedCount)
+}

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -7,7 +7,7 @@
 
 import { contextBridge, ipcRenderer, webUtils } from 'electron'
 import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, INSTALLER_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, MEMORY_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS, DINGTALK_IPC_CHANNELS, WECHAT_IPC_CHANNELS } from '@proma/shared'
-import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS, APP_ICON_IPC_CHANNELS } from '../types'
+import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS, APP_ICON_IPC_CHANNELS, DOCK_BADGE_IPC_CHANNELS } from '../types'
 import type {
   RuntimeStatus,
   GitRepoStatus,
@@ -277,6 +277,9 @@ export interface ElectronAPI {
 
   /** 设置应用图标变体（传入 variant ID，如 'blue'、'cyberpunk'，'default' 恢复默认） */
   setAppIcon: (variantId: string) => Promise<boolean>
+
+  /** 设置 Dock/Launcher 角标数量（0 表示清除） */
+  setDockBadgeCount: (count: number) => Promise<boolean>
 
   // ===== 环境检测相关 =====
 
@@ -990,6 +993,11 @@ const electronAPI: ElectronAPI = {
   // 应用图标切换
   setAppIcon: (variantId: string) => {
     return ipcRenderer.invoke(APP_ICON_IPC_CHANNELS.SET, variantId)
+  },
+
+  // Dock/Launcher 角标
+  setDockBadgeCount: (count: number) => {
+    return ipcRenderer.invoke(DOCK_BADGE_IPC_CHANNELS.SET_COUNT, count)
   },
 
   // 环境检测

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -8,6 +8,7 @@
 import { atom } from 'jotai'
 import { atomFamily } from 'jotai/utils'
 import type { AgentSessionMeta, AgentEvent, AgentWorkspace, AgentPendingFile, RetryAttempt, PromaPermissionMode, PermissionRequest, AskUserRequest, ExitPlanModeRequest, ThinkingConfig, AgentEffort, TaskUsage, SDKMessage } from '@proma/shared'
+import { calculateDockBadgeCount, countPendingRequests } from '@/lib/dock-badge-count'
 
 /** 活动状态 */
 export type ActivityStatus = 'pending' | 'running' | 'completed' | 'error' | 'backgrounded'
@@ -476,6 +477,16 @@ export const unviewedCompletedSessionIdsAtom = atom<Set<string>>(new Set<string>
 
 /** Working 区域"已完成"组：本次 App 会话中完成且 Tab 仍打开的会话 ID（关闭 Tab 时移除） */
 export const workingDoneSessionIdsAtom = atom<Set<string>>(new Set<string>())
+
+/** Dock/Launcher 角标数量：未查看完成会话 + 待处理阻塞请求 */
+export const dockBadgeCountAtom = atom<number>((get) => {
+  return calculateDockBadgeCount({
+    unviewedCompletedCount: get(unviewedCompletedSessionIdsAtom).size,
+    pendingPermissionCount: countPendingRequests(get(allPendingPermissionRequestsAtom)),
+    pendingAskUserCount: countPendingRequests(get(allPendingAskUserRequestsAtom)),
+    pendingExitPlanCount: countPendingRequests(get(allPendingExitPlanRequestsAtom)),
+  })
+})
 
 /**
  * 每个会话的指示点状态（只包含非 idle 的会话）

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -643,7 +643,8 @@ export function useGlobalAgentListeners(): void {
 
         // 如果用户当前不在查看该会话，标记为"未查看的已完成"
         const currentSessionId = store.get(currentAgentSessionIdAtom)
-        if (data.sessionId !== currentSessionId) {
+        const isViewingCompletedSession = data.sessionId === currentSessionId && document.hasFocus()
+        if (!isViewingCompletedSession) {
           store.set(unviewedCompletedSessionIdsAtom, (prev: Set<string>) => {
             const next = new Set(prev)
             next.add(data.sessionId)

--- a/apps/electron/src/renderer/lib/dock-badge-count.test.ts
+++ b/apps/electron/src/renderer/lib/dock-badge-count.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test'
+import { calculateDockBadgeCount, countPendingRequests } from './dock-badge-count'
+
+describe('Dock 角标计数', () => {
+  test('given no attention items when calculating badge count then returns zero', () => {
+    const count = calculateDockBadgeCount({
+      unviewedCompletedCount: 0,
+      pendingPermissionCount: 0,
+      pendingAskUserCount: 0,
+      pendingExitPlanCount: 0,
+    })
+
+    expect(count).toBe(0)
+  })
+
+  test('given completed sessions and pending requests when calculating badge count then returns their total', () => {
+    const count = calculateDockBadgeCount({
+      unviewedCompletedCount: 2,
+      pendingPermissionCount: 3,
+      pendingAskUserCount: 1,
+      pendingExitPlanCount: 1,
+    })
+
+    expect(count).toBe(7)
+  })
+
+  test('given requests grouped by session when counting pending requests then sums all queues', () => {
+    const requestsBySession = new Map<string, readonly string[]>([
+      ['session-a', ['permission-a', 'permission-b']],
+      ['session-b', []],
+      ['session-c', ['permission-c']],
+    ])
+
+    expect(countPendingRequests(requestsBySession)).toBe(3)
+  })
+})

--- a/apps/electron/src/renderer/lib/dock-badge-count.ts
+++ b/apps/electron/src/renderer/lib/dock-badge-count.ts
@@ -1,0 +1,36 @@
+/**
+ * Dock 角标计数工具
+ *
+ * 只统计需要用户回来看一眼或处理的事项。
+ */
+
+export interface DockBadgeCountInput {
+  /** 已完成但尚未查看的 Agent 会话数量 */
+  unviewedCompletedCount: number
+  /** 待审批权限请求数量 */
+  pendingPermissionCount: number
+  /** 待回答 AskUser 请求数量 */
+  pendingAskUserCount: number
+  /** 待审批计划请求数量 */
+  pendingExitPlanCount: number
+}
+
+/** 统计按会话分组的待处理请求数量 */
+export function countPendingRequests<T>(requestsBySession: ReadonlyMap<string, readonly T[]>): number {
+  let total = 0
+  for (const requests of requestsBySession.values()) {
+    total += requests.length
+  }
+  return total
+}
+
+/** 计算 Dock 角标应该展示的总数 */
+export function calculateDockBadgeCount(input: DockBadgeCountInput): number {
+  return Math.max(
+    0,
+    input.unviewedCompletedCount
+      + input.pendingPermissionCount
+      + input.pendingAskUserCount
+      + input.pendingExitPlanCount,
+  )
+}

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -31,6 +31,8 @@ import {
   agentMaxBudgetUsdAtom,
   agentMaxTurnsAtom,
   agentSettingsReadyAtom,
+  dockBadgeCountAtom,
+  unviewedCompletedSessionIdsAtom,
 } from './atoms/agent-atoms'
 import { updateStatusAtom, initializeUpdater } from './atoms/updater'
 import {
@@ -333,6 +335,47 @@ function NotificationsInitializer(): null {
   useEffect(() => {
     initializeNotifications(setEnabled, setSoundEnabled, setSounds)
   }, [setEnabled, setSoundEnabled, setSounds])
+
+  return null
+}
+
+/**
+ * Dock/Launcher 角标同步组件
+ *
+ * 将需要用户处理或查看的事项数量同步到系统应用图标。
+ */
+function DockBadgeInitializer(): null {
+  const count = useAtomValue(dockBadgeCountAtom)
+  const notificationsEnabled = useAtomValue(notificationsEnabledAtom)
+  const currentSessionId = useAtomValue(currentAgentSessionIdAtom)
+  const setUnviewedCompleted = useSetAtom(unviewedCompletedSessionIdsAtom)
+  const badgeCount = notificationsEnabled ? count : 0
+
+  useEffect(() => {
+    window.electronAPI.setDockBadgeCount(badgeCount).catch((error) => {
+      console.error('[Dock 角标] 同步失败:', error)
+    })
+  }, [badgeCount])
+
+  useEffect(() => {
+    const clearCurrentSessionBadge = (): void => {
+      if (!document.hasFocus() || !currentSessionId) return
+      setUnviewedCompleted((prev) => {
+        if (!prev.has(currentSessionId)) return prev
+        const next = new Set(prev)
+        next.delete(currentSessionId)
+        return next
+      })
+    }
+
+    clearCurrentSessionBadge()
+    window.addEventListener('focus', clearCurrentSessionBadge)
+    document.addEventListener('visibilitychange', clearCurrentSessionBadge)
+    return () => {
+      window.removeEventListener('focus', clearCurrentSessionBadge)
+      document.removeEventListener('visibilitychange', clearCurrentSessionBadge)
+    }
+  }, [currentSessionId, setUnviewedCompleted])
 
   return null
 }
@@ -693,6 +736,7 @@ if (isQuickTaskWindow) {
       <ThemeInitializer />
       <AgentSettingsInitializer />
       <NotificationsInitializer />
+      <DockBadgeInitializer />
       <UiPreferencesInitializer />
       <ChatListenersInitializer />
       <AgentListenersInitializer />

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -122,6 +122,12 @@ export const APP_ICON_IPC_CHANNELS = {
   SET: 'app-icon:set',
 } as const
 
+/** Dock/Launcher 角标 IPC 通道 */
+export const DOCK_BADGE_IPC_CHANNELS = {
+  /** 设置系统应用角标数量 */
+  SET_COUNT: 'dock-badge:set-count',
+} as const
+
 /** 快速任务窗口 IPC 通道 */
 export const QUICK_TASK_IPC_CHANNELS = {
   /** 提交快速任务（渲染进程 → 主进程） */

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.9.11",
+      "version": "0.9.14",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.123",
       },


### PR DESCRIPTION
## Summary

Adds a system Dock/Launcher badge for Proma attention items. The renderer derives the count from existing Agent state, while the main process owns the Electron system API call.

## What changed

- Added a main-process Dock badge service and IPC/preload bridge.
- Added a Jotai-derived badge count for unviewed completed Agent sessions and pending blocking requests.
- Clears the current session completion badge when the user returns to the focused window.
- Added BDD-style unit coverage for badge counting helpers.
- Bumped `@proma/electron` patch version to `0.9.14` based on latest `main`.

## Validation

- `bun test`
- `bun run typecheck`
- `git diff --check`

## Notes

This branch was created from latest `main` to keep the PR focused on Dock badge behavior.
