### PR TITLE
[codex] Make agent permission mode session-scoped

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -170,8 +170,6 @@ import {
   readWorkspaceSkillContent,
   writeWorkspaceSkillContent,
   toggleWorkspaceSkill,
-  getWorkspacePermissionMode,
-  setWorkspacePermissionMode,
   getWorkspaceAttachedDirectories,
   attachWorkspaceDirectory,
   detachWorkspaceDirectory,
@@ -1243,29 +1241,6 @@ export function registerIpcHandlers(): void {
     }
   )
 
-  // 获取工作区权限模式
-  ipcMain.handle(
-    AGENT_IPC_CHANNELS.GET_PERMISSION_MODE,
-    async (_, workspaceSlug: string): Promise<PromaPermissionMode> => {
-      return getWorkspacePermissionMode(workspaceSlug)
-    }
-  )
-
-  // 设置工作区权限模式（持久化到工作区配置）
-  ipcMain.handle(
-    AGENT_IPC_CHANNELS.SET_PERMISSION_MODE,
-    async (_, workspaceSlug: string, mode: PromaPermissionMode): Promise<void> => {
-      const validModes = new Set<string>(['auto', 'bypassPermissions', 'plan'])
-      if (!validModes.has(mode)) {
-        throw new Error(`无效的权限模式: ${mode}`)
-      }
-      // 持久化到工作区配置
-      setWorkspacePermissionMode(workspaceSlug, mode)
-      // 注意：不再广播到该工作区下其他运行中的 session，
-      // 避免跨窗口状态污染（每个 session 独立维护自己的权限模式）
-    }
-  )
-
   // 热切换指定会话的权限模式（运行中生效，不广播）
   ipcMain.handle(
     AGENT_IPC_CHANNELS.UPDATE_SESSION_PERMISSION_MODE,
@@ -1504,12 +1479,6 @@ export function registerIpcHandlers(): void {
         // 如果用户选择了新的权限模式，通知渲染进程更新 UI
         if (targetMode) {
           const meta = getAgentSessionMeta(sessionId)
-          if (meta?.workspaceId) {
-            const ws = getAgentWorkspace(meta.workspaceId)
-            if (ws) {
-              setWorkspacePermissionMode(ws.slug, targetMode)
-            }
-          }
           // 持久化到 session meta，和 cycleMode 路径保持一致（重启后该 session 能恢复）
           if (meta) {
             try {

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -1063,11 +1063,11 @@ export class AgentOrchestrator {
         console.log(`[Agent 编排] 无 resume，已回填历史上下文（最近 ${MAX_CONTEXT_MESSAGES} 条消息）`)
       }
 
-      // 12. 读取应用设置 + 获取权限模式
-      // 注意：不从 workspace config 读取权限模式，避免跨窗口状态污染
+      // 12. 读取应用设置并确定权限模式
+      // 权限模式只属于当前 session；新会话默认完全自动模式。
       const appSettings = getSettings()
       const initialPermissionMode: PromaPermissionMode = permissionModeOverride
-        ?? (appSettings.agentPermissionMode ?? 'auto')
+        ?? 'bypassPermissions'
       // 注册到 Map，支持运行中动态切换
       this.sessionPermissionModes.set(sessionId, initialPermissionMode)
       console.log(`[Agent 编排] 权限模式: ${initialPermissionMode}${permissionModeOverride ? '（外部覆盖）' : ''}`)

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -19,8 +19,7 @@ import {
   getDefaultSkillsDir,
   parseSkillVersion,
 } from './config-paths'
-import type { AgentWorkspace, WorkspaceMcpConfig, SkillMeta, SkillImportSource, OtherWorkspaceSkillsGroup, WorkspaceCapabilities, PromaPermissionMode } from '@proma/shared'
-import { migratePermissionMode } from '@proma/shared'
+import type { AgentWorkspace, WorkspaceMcpConfig, SkillMeta, SkillImportSource, OtherWorkspaceSkillsGroup, WorkspaceCapabilities } from '@proma/shared'
 
 interface AgentWorkspacesIndex {
   version: number
@@ -751,10 +750,9 @@ function isNewerVersion(a: string, b: string): boolean {
   return false
 }
 
-// ===== 权限模式管理 =====
+// ===== 工作区配置管理 =====
 
 interface WorkspaceConfig {
-  permissionMode?: PromaPermissionMode
   attachedDirectories?: string[]
 }
 
@@ -771,7 +769,12 @@ function readWorkspaceConfig(workspaceSlug: string): WorkspaceConfig {
 
   try {
     const raw = readFileSync(configPath, 'utf-8')
-    return JSON.parse(raw) as WorkspaceConfig
+    const data = JSON.parse(raw) as Partial<WorkspaceConfig>
+    return {
+      attachedDirectories: Array.isArray(data.attachedDirectories)
+        ? data.attachedDirectories.filter((dir): dir is string => typeof dir === 'string')
+        : undefined,
+    }
   } catch {
     return {}
   }
@@ -780,19 +783,6 @@ function readWorkspaceConfig(workspaceSlug: string): WorkspaceConfig {
 function writeWorkspaceConfig(workspaceSlug: string, config: WorkspaceConfig): void {
   const configPath = getWorkspaceConfigPath(workspaceSlug)
   writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8')
-}
-
-/** 获取工作区权限模式，默认 'auto'，支持旧值自动迁移 */
-export function getWorkspacePermissionMode(workspaceSlug: string): PromaPermissionMode {
-  const config = readWorkspaceConfig(workspaceSlug)
-  return config.permissionMode ? migratePermissionMode(config.permissionMode) : 'auto'
-}
-
-export function setWorkspacePermissionMode(workspaceSlug: string, mode: PromaPermissionMode): void {
-  const config = readWorkspaceConfig(workspaceSlug)
-  const updated: WorkspaceConfig = { ...config, permissionMode: mode }
-  writeWorkspaceConfig(workspaceSlug, updated)
-  console.log(`[Agent 工作区] 权限模式已更新: ${workspaceSlug} → ${mode}`)
 }
 
 // ===== 工作区级附加目录管理 =====

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -468,12 +468,6 @@ export interface ElectronAPI {
   /** 响应权限请求 */
   respondPermission: (response: PermissionResponse) => Promise<void>
 
-  /** 获取工作区权限模式 */
-  getPermissionMode: (workspaceSlug: string) => Promise<PromaPermissionMode>
-
-  /** 设置工作区权限模式 */
-  setPermissionMode: (workspaceSlug: string, mode: PromaPermissionMode) => Promise<void>
-
   /** 热切换指定会话的权限模式（运行中生效，仅影响该 session） */
   updateSessionPermissionMode: (sessionId: string, mode: PromaPermissionMode) => Promise<void>
 
@@ -1259,14 +1253,6 @@ const electronAPI: ElectronAPI = {
   // Agent 权限系统
   respondPermission: (response: PermissionResponse) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.PERMISSION_RESPOND, response)
-  },
-
-  getPermissionMode: (workspaceSlug: string) => {
-    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.GET_PERMISSION_MODE, workspaceSlug)
-  },
-
-  setPermissionMode: (workspaceSlug: string, mode: PromaPermissionMode) => {
-    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.SET_PERMISSION_MODE, workspaceSlug, mode)
   },
 
   updateSessionPermissionMode: (sessionId: string, mode: PromaPermissionMode) => {

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -320,8 +320,8 @@ export const RECENTLY_MODIFIED_TTL_MS = 60_000
 
 // ===== 权限系统 Atoms =====
 
-/** 工作区默认权限模式（初始化和新会话使用） */
-export const agentDefaultPermissionModeAtom = atom<PromaPermissionMode>('auto')
+/** 新会话默认权限模式 */
+export const agentDefaultPermissionModeAtom = atom<PromaPermissionMode>('bypassPermissions')
 
 /** Per-session 权限模式 Map — sessionId → PromaPermissionMode */
 export const agentPermissionModeMapAtom = atom<Map<string, PromaPermissionMode>>(new Map())

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -70,6 +70,7 @@ import {
   agentPlanModeSessionsAtom,
   agentPermissionModeMapAtom,
   agentDefaultPermissionModeAtom,
+  sessionPersistedPermissionModeAtom,
   agentSessionPathMapAtom,
   allPendingAskUserRequestsAtom,
   allPendingExitPlanRequestsAtom,
@@ -281,7 +282,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const isPlanMode = planModeSessions.has(sessionId)
   const permissionModeMap = useAtomValue(agentPermissionModeMapAtom)
   const defaultPermissionMode = useAtomValue(agentDefaultPermissionModeAtom)
-  const permissionMode = permissionModeMap.get(sessionId) ?? defaultPermissionMode
+  const persistedPermissionMode = useAtomValue(sessionPersistedPermissionModeAtom(sessionId))
+  const permissionMode = permissionModeMap.get(sessionId) ?? persistedPermissionMode ?? defaultPermissionMode
   const isPermissionPlanMode = permissionMode === 'plan'
   const store = useStore()
   const suggestionsMap = useAtomValue(agentPromptSuggestionsAtom)

--- a/apps/electron/src/renderer/components/agent/PermissionModeSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/PermissionModeSelector.tsx
@@ -10,7 +10,7 @@ import * as React from 'react'
 import { useAtom, useAtomValue } from 'jotai'
 import { Zap, Compass, Map as MapIcon } from 'lucide-react'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import { agentPermissionModeMapAtom, agentDefaultPermissionModeAtom, currentAgentWorkspaceIdAtom, agentWorkspacesAtom, sessionPersistedPermissionModeAtom, sessionExistsAtom } from '@/atoms/agent-atoms'
+import { agentPermissionModeMapAtom, agentDefaultPermissionModeAtom, sessionPersistedPermissionModeAtom, sessionExistsAtom } from '@/atoms/agent-atoms'
 import type { PromaPermissionMode } from '@proma/shared'
 import { PROMA_PERMISSION_MODE_ORDER } from '@proma/shared'
 
@@ -44,65 +44,24 @@ interface PermissionModeSelectorProps {
 export function PermissionModeSelector({ sessionId }: PermissionModeSelectorProps): React.ReactElement | null {
   const [modeMap, setModeMap] = useAtom(agentPermissionModeMapAtom)
   const defaultMode = useAtomValue(agentDefaultPermissionModeAtom)
-  const mode = modeMap.get(sessionId) ?? defaultMode
-  const currentWorkspaceId = useAtomValue(currentAgentWorkspaceIdAtom)
-  const workspaces = useAtomValue(agentWorkspacesAtom)
   const persistedSessionMode = useAtomValue(sessionPersistedPermissionModeAtom(sessionId))
+  const mode = modeMap.get(sessionId) ?? persistedSessionMode ?? defaultMode
   const sessionExistsInList = useAtomValue(sessionExistsAtom(sessionId))
-
-  // 获取当前工作区的 slug
-  const workspaceSlug = React.useMemo(() => {
-    if (!currentWorkspaceId) return null
-    const ws = workspaces.find((w) => w.id === currentWorkspaceId)
-    return ws?.slug ?? null
-  }, [currentWorkspaceId, workspaces])
 
   // 初始化：如果当前 session 不在 Map 中，按以下优先级读回：
   // 1. session meta.permissionMode（每个 tab 独立持久化，重启恢复各自的值）
-  // 2. workspace config（作为该工作区内新会话的默认）
-  // 3. 全局 defaultMode
+  // 2. 默认完全自动模式
   // 注意：只写入当前 session，不回写到 agentDefaultPermissionModeAtom，避免跨会话污染。
   React.useEffect(() => {
-    if (modeMap.has(sessionId)) return
     if (!sessionExistsInList) return
 
-    let cancelled = false
-
-    const seed = async (): Promise<void> => {
-      // 1. session meta
-      if (persistedSessionMode != null) {
-        if (cancelled) return
-        setModeMap((prev: Map<string, PromaPermissionMode>) => {
-          if (prev.has(sessionId)) return prev
-          const next = new Map(prev)
-          next.set(sessionId, persistedSessionMode)
-          return next
-        })
-        return
-      }
-
-      // 2. workspace config（作为新会话默认）
-      let seedMode: PromaPermissionMode = defaultMode
-      if (workspaceSlug) {
-        try {
-          seedMode = await window.electronAPI.getPermissionMode(workspaceSlug)
-        } catch (error) {
-          console.error('[PermissionModeSelector] 读取工作区权限模式失败:', error)
-        }
-      }
-      if (cancelled) return
-      setModeMap((prev: Map<string, PromaPermissionMode>) => {
-        if (prev.has(sessionId)) return prev
-        const next = new Map(prev)
-        next.set(sessionId, seedMode)
-        return next
-      })
-    }
-
-    void seed()
-    return () => { cancelled = true }
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- 只在 session/workspace/持久化模式/sessions 是否已载入变化时重跑
-  }, [sessionId, workspaceSlug, persistedSessionMode, sessionExistsInList])
+    setModeMap((prev: Map<string, PromaPermissionMode>) => {
+      if (prev.has(sessionId)) return prev
+      const next = new Map(prev)
+      next.set(sessionId, persistedSessionMode ?? defaultMode)
+      return next
+    })
+  }, [sessionId, persistedSessionMode, sessionExistsInList, defaultMode, setModeMap])
 
   /** 循环切换模式 */
   const cycleMode = React.useCallback(async () => {
@@ -118,15 +77,6 @@ export function PermissionModeSelector({ sessionId }: PermissionModeSelectorProp
       return next
     })
 
-    // 持久化到工作区配置
-    if (workspaceSlug) {
-      try {
-        await window.electronAPI.setPermissionMode(workspaceSlug, nextMode)
-      } catch (error) {
-        console.error('[PermissionModeSelector] 保存权限模式失败:', error)
-      }
-    }
-
     // 热切换运行中的当前 session；失败时回滚 modeMap 保持 UI/后端一致
     try {
       await window.electronAPI.updateSessionPermissionMode(sessionId, nextMode)
@@ -138,7 +88,7 @@ export function PermissionModeSelector({ sessionId }: PermissionModeSelectorProp
         return next
       })
     }
-  }, [mode, sessionId, workspaceSlug, setModeMap])
+  }, [mode, sessionId, setModeMap])
 
   const config = MODE_CONFIG[mode]
   const Icon = config.icon

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -25,7 +25,6 @@ import {
   currentAgentSessionIdAtom,
   workspaceCapabilitiesVersionAtom,
   workspaceFilesVersionAtom,
-  agentDefaultPermissionModeAtom,
   agentThinkingAtom,
   agentEffortAtom,
   agentMaxBudgetUsdAtom,
@@ -55,7 +54,7 @@ import { appModeAtom } from './atoms/app-mode'
 import type { FeishuBotBridgeState, FeishuBridgeState, FeishuNotificationSentPayload, DingTalkBotBridgeState, DingTalkBridgeState } from '@proma/shared'
 import { Toaster } from './components/ui/sonner'
 import { toast } from 'sonner'
-import { diffCapabilities, migratePermissionMode } from '@proma/shared'
+import { diffCapabilities } from '@proma/shared'
 import type { WorkspaceCapabilities } from '@proma/shared'
 import { showCapabilityChangeToasts } from './lib/capabilities-toast'
 import { UpdateDialog } from './components/settings/UpdateDialog'
@@ -136,7 +135,6 @@ function AgentSettingsInitializer(): null {
   const setCurrentWorkspaceId = useSetAtom(currentAgentWorkspaceIdAtom)
   const bumpCapabilities = useSetAtom(workspaceCapabilitiesVersionAtom)
   const bumpFiles = useSetAtom(workspaceFilesVersionAtom)
-  const setPermissionMode = useSetAtom(agentDefaultPermissionModeAtom)
   const setThinking = useSetAtom(agentThinkingAtom)
   const setEffort = useSetAtom(agentEffortAtom)
   const setMaxBudget = useSetAtom(agentMaxBudgetUsdAtom)
@@ -213,10 +211,6 @@ function AgentSettingsInitializer(): null {
         }
       }
 
-      if (settings.agentPermissionMode) {
-        // 迁移旧权限模式值（acceptEdits/smart/supervised → auto）
-        setPermissionMode(migratePermissionMode(settings.agentPermissionMode))
-      }
       if (settings.agentThinking) {
         setThinking(settings.agentThinking)
       }
@@ -249,7 +243,7 @@ function AgentSettingsInitializer(): null {
       console.error(err)
       setAgentSettingsReady(true) // 即使出错也标记就绪，避免永远阻塞
     })
-  }, [setAgentChannelId, setAgentModelId, setAgentChannelIds, setAgentWorkspaces, setCurrentWorkspaceId, setPermissionMode, setThinking, setEffort, setMaxBudget, setMaxTurns, setChannels, setChannelsLoaded, setAgentSettingsReady])
+  }, [setAgentChannelId, setAgentModelId, setAgentChannelIds, setAgentWorkspaces, setCurrentWorkspaceId, setThinking, setEffort, setMaxBudget, setMaxTurns, setChannels, setChannelsLoaded, setAgentSettingsReady])
 
   // 工作区切换时重置能力缓存，预加载基线
   useEffect(() => {

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -4,7 +4,7 @@
  * 主题模式、IPC 通道等设置相关定义。
  */
 
-import type { EnvironmentCheckResult, PromaPermissionMode, ThinkingConfig, AgentEffort } from '@proma/shared'
+import type { EnvironmentCheckResult, ThinkingConfig, AgentEffort } from '@proma/shared'
 
 /** 通知音场景类型 */
 export type NotificationSoundType = 'taskComplete' | 'permissionRequest' | 'exitPlanMode'
@@ -70,8 +70,6 @@ export interface AppSettings {
   notificationSounds?: NotificationSoundSettings
   /** 标签页持久化状态（重启恢复） */
   tabState?: PersistedTabSettings
-  /** Agent 权限模式（全局默认，工作区级覆盖此值） */
-  agentPermissionMode?: PromaPermissionMode
   /** Agent 思考模式 */
   agentThinking?: ThinkingConfig
   /** Agent 推理深度 */

--- a/bun.lock
+++ b/bun.lock
@@ -126,7 +126,7 @@
     },
     "packages/shared": {
       "name": "@proma/shared",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "devDependencies": {
         "typescript": "^5.0.0",
       },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/shared",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "license": "Apache-2.0",
   "description": "Shared types, configs and utilities for proma",
   "type": "module",

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -558,7 +558,7 @@ export interface AgentSessionMeta {
   manualWorking?: boolean
   /** 最后一次流式执行是否被用户主动中断 */
   stoppedByUser?: boolean
-  /** 该会话当前的权限模式（持久化到磁盘，重启后恢复）。未设置时回退到 workspace 默认值 */
+  /** 该会话当前的权限模式（持久化到磁盘，重启后恢复）。未设置时新会话默认 bypassPermissions */
   permissionMode?: PromaPermissionMode
   /** 创建时间戳 */
   createdAt: number
@@ -1331,10 +1331,6 @@ export const AGENT_IPC_CHANNELS = {
   // 权限系统
   /** 权限响应（渲染进程 → 主进程） */
   PERMISSION_RESPOND: 'agent:permission:respond',
-  /** 设置权限模式（渲染进程 → 主进程） */
-  SET_PERMISSION_MODE: 'agent:set-permission-mode',
-  /** 获取权限模式（渲染进程 → 主进程） */
-  GET_PERMISSION_MODE: 'agent:get-permission-mode',
   /** 热切换指定会话的权限模式（运行中生效，不广播到其他会话） */
   UPDATE_SESSION_PERMISSION_MODE: 'agent:update-session-permission-mode',
 


### PR DESCRIPTION
## Summary

- Remove workspace-level permission mode persistence and its renderer/main IPC surface.
- Keep permission mode state and persistence scoped to each Agent session.
- Default new Agent sessions to `bypassPermissions` (the UI's 完全自动 mode).
- Keep workspace `config.json` focused on workspace-level attached directories.
- Bump `@proma/electron` to `0.9.14` and `@proma/shared` to `0.1.19`.

## Why

Permission mode had already moved toward per-session semantics, but the selector still wrote the workspace-level `config.json`. That write could trigger workspace file watcher refreshes and also left stale cross-session behavior in place.

## Validation

- `bun run typecheck`