### PR TITLE
[codex] Fix input paste links and workspace watcher refresh

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/workspace-watcher.ts
+++ b/apps/electron/src/main/lib/workspace-watcher.ts
@@ -52,11 +52,17 @@ export function startWorkspaceWatcher(win: BrowserWindow): void {
       if (!filename || win.isDestroyed()) return
 
       // filename 格式: {slug}/mcp.json 或 {slug}/skills/xxx/SKILL.md 或 {slug}/{sessionId}/file.txt
+      const normalizedFilename = filename.replace(/\\/g, '/')
+      const pathParts = normalizedFilename.split('/').filter(Boolean)
+
+      // 仅忽略工作区顶层 config.json；会话目录内同名文件仍属于用户文件。
+      if (pathParts.length === 2 && pathParts[1] === 'config.json') {
+        return
+      }
+
       const isCapabilitiesChange =
-        filename.endsWith('/mcp.json') ||
-        filename.endsWith('\\mcp.json') ||
-        filename.includes('/skills/') ||
-        filename.includes('\\skills/')
+        normalizedFilename.endsWith('/mcp.json') ||
+        normalizedFilename.includes('/skills/')
 
       if (isCapabilitiesChange) {
         // MCP/Skills 变化 → 通知侧边栏刷新

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -295,6 +295,8 @@ export function RichTextInput({
       Underline,
       Link.configure({
         openOnClick: false,
+        autolink: false,
+        linkOnPaste: false,
         HTMLAttributes: {
           class: 'text-primary underline',
         },

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.9.11",
+      "version": "0.9.14",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.123",
       },


### PR DESCRIPTION
## Summary

- Disable TipTap Link autolink and link-on-paste behavior in the rich text input so pasted URLs do not leave a sticky link mark for subsequent typing.
- Preserve pasted HTML link content instead of stripping anchors; the Link mark is now non-inclusive because autolink is disabled.
- Normalize workspace watcher paths and ignore only top-level workspace `config.json` changes.
- Keep session-level `config.json` files treated as normal user files.
- Bump `@proma/electron` to `0.9.14`.

## Why

PR #371 identified two issues: URL paste could make following text inherit link styling, and workspace config changes could unnecessarily refresh the right-side file panel. This implementation fixes the same behavior with narrower watcher filtering and less destructive paste handling.

## Validation

- `bun run typecheck`