### PR TITLE
[codex] 支持菜单栏会话快捷操作

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.9.14",
+  "version": "0.9.15",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -58,6 +58,7 @@ import { wechatBridge } from './lib/wechat-bridge'
 import { getWeChatConfig } from './lib/wechat-config'
 import { createQuickTaskWindow, toggleQuickTaskWindow, destroyQuickTaskWindow } from './lib/quick-task-window'
 import { registerGlobalShortcut, unregisterAllGlobalShortcuts } from './lib/global-shortcut-service'
+import { TRAY_IPC_CHANNELS } from '../types'
 
 // ===== Bridge 注册（新增 Bridge 只需在此添加一个 registerBridge 调用） =====
 
@@ -128,6 +129,10 @@ function ensureWindowOnScreen(win: BrowserWindow): void {
 
 /** 显示并聚焦主窗口，确保窗口在可见区域；若窗口已销毁则重新创建 */
 function showAndFocusMainWindow(): void {
+  if (process.platform === 'darwin') {
+    app.show()
+  }
+
   if (!mainWindow || mainWindow.isDestroyed()) {
     createWindow()
     return
@@ -253,6 +258,25 @@ function createWindow(): void {
   })
 }
 
+function sendToMainWindow(channel: string, data?: unknown): void {
+  showAndFocusMainWindow()
+
+  const win = mainWindow
+  if (!win || win.isDestroyed()) return
+
+  const send = (): void => {
+    if (!win.isDestroyed()) {
+      win.webContents.send(channel, data)
+    }
+  }
+
+  if (win.webContents.isLoading()) {
+    win.webContents.once('did-finish-load', send)
+  } else {
+    send()
+  }
+}
+
 app.whenReady().then(async () => {
   // 初始化运行时环境（Shell 环境 + Bun + Git 检测）
   // 必须在其他初始化之前执行，确保环境变量正确加载
@@ -285,11 +309,22 @@ app.whenReady().then(async () => {
     }
   }
 
-  // Create system tray icon
-  createTray()
-
   // Create main window (will be shown when ready)
   createWindow()
+
+  // Create system tray icon
+  createTray({
+    showMainWindow: showAndFocusMainWindow,
+    openAgentSession: (sessionId, title) => {
+      sendToMainWindow(TRAY_IPC_CHANNELS.OPEN_AGENT_SESSION, { sessionId, title })
+    },
+    createChatSession: () => {
+      sendToMainWindow(TRAY_IPC_CHANNELS.CREATE_SESSION, { mode: 'chat' })
+    },
+    createAgentSession: () => {
+      sendToMainWindow(TRAY_IPC_CHANNELS.CREATE_SESSION, { mode: 'agent' })
+    },
+  })
 
   // 启动工作区文件监听（Agent MCP/Skills + 文件浏览器自动刷新）
   if (mainWindow) {

--- a/apps/electron/src/main/lib/tray-menu-model.ts
+++ b/apps/electron/src/main/lib/tray-menu-model.ts
@@ -1,0 +1,50 @@
+import type { AgentSessionMeta, AgentWorkspace } from '@proma/shared'
+
+export const TRAY_RECENT_LIMIT = 3
+export const TRAY_MORE_LIMIT = 10
+
+export interface TrayRecentSessionItem {
+  id: string
+  title: string
+  subtitle: string
+}
+
+export interface TrayMenuModel {
+  recentSessions: TrayRecentSessionItem[]
+  moreSessions: TrayRecentSessionItem[]
+}
+
+function getWorkspaceLabel(session: AgentSessionMeta, workspacesById: Map<string, AgentWorkspace>): string {
+  if (!session.workspaceId) return '未选择工作区'
+  const workspace = workspacesById.get(session.workspaceId)
+  return workspace?.name ?? '未知工作区'
+}
+
+function toRecentSessionItem(
+  session: AgentSessionMeta,
+  workspacesById: Map<string, AgentWorkspace>,
+): TrayRecentSessionItem {
+  return {
+    id: session.id,
+    title: session.title.trim() || '未命名会话',
+    subtitle: getWorkspaceLabel(session, workspacesById),
+  }
+}
+
+export function createTrayMenuModel(
+  sessions: AgentSessionMeta[],
+  workspaces: AgentWorkspace[],
+): TrayMenuModel {
+  const workspacesById = new Map(workspaces.map((workspace) => [workspace.id, workspace]))
+  const activeSessions = sessions
+    .filter((session) => !session.archived)
+    .slice()
+    .sort((a, b) => b.updatedAt - a.updatedAt)
+    .slice(0, TRAY_MORE_LIMIT)
+    .map((session) => toRecentSessionItem(session, workspacesById))
+
+  return {
+    recentSessions: activeSessions.slice(0, TRAY_RECENT_LIMIT),
+    moreSessions: activeSessions.slice(TRAY_RECENT_LIMIT),
+  }
+}

--- a/apps/electron/src/main/tray.ts
+++ b/apps/electron/src/main/tray.ts
@@ -1,8 +1,18 @@
 import { Tray, Menu, app, nativeImage, BrowserWindow } from 'electron'
 import { join } from 'path'
 import { existsSync } from 'fs'
+import { listAgentSessions } from './lib/agent-session-manager'
+import { listAgentWorkspaces } from './lib/agent-workspace-manager'
+import { createTrayMenuModel, type TrayRecentSessionItem } from './lib/tray-menu-model'
 
 let tray: Tray | null = null
+
+export interface TrayActions {
+  showMainWindow: () => void
+  openAgentSession: (sessionId: string, title: string) => void
+  createChatSession: () => void
+  createAgentSession: () => void
+}
 
 /**
  * 获取托盘图标路径
@@ -29,11 +39,81 @@ function showMainWindow(): void {
   mainWindow.focus()
 }
 
+function getDefaultTrayActions(): TrayActions {
+  return {
+    showMainWindow,
+    openAgentSession: () => showMainWindow(),
+    createChatSession: () => showMainWindow(),
+    createAgentSession: () => showMainWindow(),
+  }
+}
+
+function createRecentSessionMenuItem(
+  item: TrayRecentSessionItem,
+  actions: TrayActions,
+): Electron.MenuItemConstructorOptions {
+  return {
+    label: item.title,
+    sublabel: item.subtitle,
+    click: () => actions.openAgentSession(item.id, item.title),
+  }
+}
+
+function buildTrayMenu(actions: TrayActions): Menu {
+  const model = createTrayMenuModel(listAgentSessions(), listAgentWorkspaces())
+  const recentItems = model.recentSessions.map((item) => createRecentSessionMenuItem(item, actions))
+  const moreItems = model.moreSessions.map((item) => createRecentSessionMenuItem(item, actions))
+
+  const template: Electron.MenuItemConstructorOptions[] = [
+    { label: '最近', enabled: false },
+    ...(recentItems.length > 0
+      ? recentItems
+      : [{ label: '暂无最近会话', enabled: false }]),
+    ...(moreItems.length > 0
+      ? [{
+          label: '更多',
+          submenu: moreItems,
+        }]
+      : []),
+    { type: 'separator' },
+    {
+      label: '新建对话',
+      click: () => actions.createChatSession(),
+    },
+    {
+      label: '新建 Agent 会话',
+      click: () => actions.createAgentSession(),
+    },
+    { type: 'separator' },
+    {
+      label: '打开 Proma',
+      click: () => actions.showMainWindow(),
+    },
+    { type: 'separator' },
+    {
+      label: '退出 Proma',
+      click: () => {
+        app.quit()
+      },
+    },
+  ]
+
+  return Menu.buildFromTemplate(template)
+}
+
+function updateTrayMenu(actions: TrayActions): Menu | null {
+  if (!tray) return null
+  const contextMenu = buildTrayMenu(actions)
+  tray.setContextMenu(contextMenu)
+  return contextMenu
+}
+
 /**
  * 创建系统托盘图标和菜单
  */
-export function createTray(): Tray | null {
+export function createTray(actionsInput?: Partial<TrayActions>): Tray | null {
   const iconPath = getTrayIconPath()
+  const actions = { ...getDefaultTrayActions(), ...actionsInput }
 
   if (!existsSync(iconPath)) {
     console.warn('Tray icon not found at:', iconPath)
@@ -55,28 +135,18 @@ export function createTray(): Tray | null {
     // 设置 tooltip
     tray.setToolTip('Proma')
 
-    // 创建右键菜单
-    const contextMenu = Menu.buildFromTemplate([
-      {
-        label: '显示 Proma',
-        click: () => showMainWindow()
-      },
-      {
-        type: 'separator'
-      },
-      {
-        label: '退出 Proma',
-        click: () => {
-          app.quit()
-        }
-      }
-    ])
-
-    tray.setContextMenu(contextMenu)
+    updateTrayMenu(actions)
 
     // 点击行为：始终弹出菜单（与右键一致）
     tray.on('click', () => {
-      tray?.popUpContextMenu()
+      const contextMenu = updateTrayMenu(actions)
+      if (contextMenu) {
+        tray?.popUpContextMenu(contextMenu)
+      }
+    })
+
+    tray.on('right-click', () => {
+      updateTrayMenu(actions)
     })
 
     console.log('System tray created')

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -99,8 +99,15 @@ import type {
   AgentQueueMessageInput,
   PendingRequestsSnapshot,
 } from '@proma/shared'
-import type { UserProfile, AppSettings, QuickTaskSubmitInput, QuickTaskOpenSessionData } from '../types'
-import { QUICK_TASK_IPC_CHANNELS } from '../types'
+import type {
+  UserProfile,
+  AppSettings,
+  QuickTaskSubmitInput,
+  QuickTaskOpenSessionData,
+  TrayCreateSessionData,
+  TrayOpenAgentSessionData,
+} from '../types'
+import { QUICK_TASK_IPC_CHANNELS, TRAY_IPC_CHANNELS } from '../types'
 
 /**
  * 暴露给渲染进程的 API 接口定义
@@ -776,6 +783,13 @@ export interface ElectronAPI {
   onQuickTaskFocus: (callback: () => void) => () => void
   /** 订阅快速任务打开会话事件（主窗口接收，由渲染进程负责创建会话） */
   onQuickTaskOpenSession: (callback: (data: QuickTaskOpenSessionData) => void) => () => void
+
+  // ===== 菜单栏 =====
+
+  /** 订阅菜单栏打开 Agent 会话事件 */
+  onTrayOpenAgentSession: (callback: (data: TrayOpenAgentSessionData) => void) => () => void
+  /** 订阅菜单栏创建会话事件 */
+  onTrayCreateSession: (callback: (data: TrayCreateSessionData) => void) => () => void
 }
 
 /**
@@ -1726,6 +1740,18 @@ const electronAPI: ElectronAPI = {
     const listener = (_: unknown, data: QuickTaskOpenSessionData): void => callback(data)
     ipcRenderer.on('quick-task:open-session', listener)
     return () => { ipcRenderer.removeListener('quick-task:open-session', listener) }
+  },
+
+  onTrayOpenAgentSession: (callback: (data: TrayOpenAgentSessionData) => void) => {
+    const listener = (_: unknown, data: TrayOpenAgentSessionData): void => callback(data)
+    ipcRenderer.on(TRAY_IPC_CHANNELS.OPEN_AGENT_SESSION, listener)
+    return () => { ipcRenderer.removeListener(TRAY_IPC_CHANNELS.OPEN_AGENT_SESSION, listener) }
+  },
+
+  onTrayCreateSession: (callback: (data: TrayCreateSessionData) => void) => {
+    const listener = (_: unknown, data: TrayCreateSessionData): void => callback(data)
+    ipcRenderer.on(TRAY_IPC_CHANNELS.CREATE_SESSION, listener)
+    return () => { ipcRenderer.removeListener(TRAY_IPC_CHANNELS.CREATE_SESSION, listener) }
   },
 }
 

--- a/apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx
+++ b/apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx
@@ -302,5 +302,55 @@ export function GlobalShortcuts(): null {
     return cleanup
   }, [store])
 
+  // ===== 菜单栏 → 打开 / 创建会话 =====
+
+  useEffect(() => {
+    const cleanupOpen = window.electronAPI.onTrayOpenAgentSession(async (data) => {
+      try {
+        const sessions = await window.electronAPI.listAgentSessions()
+        const session = sessions.find((item) => item.id === data.sessionId)
+        if (!session) return
+
+        store.set(agentSessionsAtom, sessions)
+        store.set(appModeAtom, 'agent')
+        store.set(activeViewAtom, 'conversations')
+        store.set(currentAgentSessionIdAtom, session.id)
+
+        if (session.workspaceId) {
+          store.set(currentAgentWorkspaceIdAtom, session.workspaceId)
+          window.electronAPI.updateSettings({
+            agentWorkspaceId: session.workspaceId,
+          }).catch(console.error)
+        }
+
+        const currentTabs = store.get(tabsAtom)
+        const result = openTab(currentTabs, {
+          type: 'agent',
+          sessionId: session.id,
+          title: session.title || data.title,
+        })
+        store.set(tabsAtom, result.tabs)
+        store.set(activeTabIdAtom, result.activeTabId)
+      } catch (error) {
+        console.error('[菜单栏] 打开 Agent 会话失败:', error)
+      }
+    })
+
+    const cleanupCreate = window.electronAPI.onTrayCreateSession(async (data) => {
+      store.set(appModeAtom, data.mode)
+      store.set(activeViewAtom, 'conversations')
+      if (data.mode === 'agent') {
+        await createAgent()
+      } else {
+        await createChat()
+      }
+    })
+
+    return () => {
+      cleanupOpen()
+      cleanupCreate()
+    }
+  }, [store, createAgent, createChat])
+
   return null
 }

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -162,3 +162,25 @@ export interface QuickTaskOpenSessionData {
   text: string
   files?: QuickTaskFile[]
 }
+
+/** 菜单栏打开 Agent 会话事件 */
+export interface TrayOpenAgentSessionData {
+  /** Agent 会话 ID */
+  sessionId: string
+  /** 标签页标题 */
+  title: string
+}
+
+/** 菜单栏创建会话事件 */
+export interface TrayCreateSessionData {
+  /** 目标模式 */
+  mode: 'chat' | 'agent'
+}
+
+/** 菜单栏 IPC 事件通道 */
+export const TRAY_IPC_CHANNELS = {
+  /** 打开已有 Agent 会话 */
+  OPEN_AGENT_SESSION: 'tray:open-agent-session',
+  /** 创建新会话 */
+  CREATE_SESSION: 'tray:create-session',
+} as const

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.9.14",
+      "version": "0.9.15",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.123",
       },


### PR DESCRIPTION
## 变更内容

- 将系统托盘菜单扩展为 Proma 会话快捷入口。
- 展示最近 Agent 会话和更多会话子菜单，副标题显示工作区名称。
- 新增“新建对话”和“新建 Agent 会话”入口，并通过主进程到渲染进程的事件桥接打开或创建会话。
- 移除用量区域，菜单文案统一为中文。
- 递增 @proma/electron patch 版本到 0.9.15。

## 验证

- bun run typecheck
- bun run --cwd apps/electron build:main