### PR TITLE
[codex] 支持豆包流式语音输入

### DIFF
--- a/apps/electron/electron-builder.yml
+++ b/apps/electron/electron-builder.yml
@@ -67,6 +67,8 @@ mac:
   gatekeeperAssess: false
   entitlements: resources/entitlements.mac.plist
   entitlementsInherit: resources/entitlements.mac.plist
+  extendInfo:
+    NSMicrophoneUsageDescription: "Proma 需要访问麦克风，用于将你的语音实时转写为文本。"
   # 架构由 CLI 参数控制（CI 矩阵分别传 --arm64 / --x64），
   # 每个 runner 只构建其宿主架构对应的产物，与 bun 按 os/cpu 装好的
   # @anthropic-ai/claude-agent-sdk-darwin-{arch} native binary 对齐。

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.9.14",
+  "version": "0.9.15",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {
@@ -120,6 +120,7 @@
     "use-stick-to-bottom": "^1.1.2",
     "vite": "^6.0.3",
     "word-extractor": "1.0.4",
+    "ws": "8.19.0",
     "zod": "^4.0.0"
   },
   "electronmon": {

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -57,6 +57,12 @@ import { getDingTalkMultiBotConfig } from './lib/dingtalk-config'
 import { wechatBridge } from './lib/wechat-bridge'
 import { getWeChatConfig } from './lib/wechat-config'
 import { createQuickTaskWindow, toggleQuickTaskWindow, destroyQuickTaskWindow } from './lib/quick-task-window'
+import {
+  createVoiceDictationWindow,
+  toggleVoiceDictationWindow,
+  destroyVoiceDictationWindow,
+  shouldSuppressVoiceDictationActivate,
+} from './lib/voice-dictation-window'
 import { registerGlobalShortcut, unregisterAllGlobalShortcuts } from './lib/global-shortcut-service'
 
 // ===== Bridge 注册（新增 Bridge 只需在此添加一个 registerBridge 调用） =====
@@ -306,15 +312,23 @@ app.whenReady().then(async () => {
 
   // 预创建快速任务窗口（隐藏状态，首次唤起秒开）
   createQuickTaskWindow()
+  createVoiceDictationWindow()
 
   // 注册全局快捷键
   registerGlobalShortcut('quick-task', toggleQuickTaskWindow)
   registerGlobalShortcut('show-main-window', showAndFocusMainWindow)
+  registerGlobalShortcut('voice-dictation', () => {
+    toggleVoiceDictationWindow({ targetIsProma: mainWindow?.isFocused() === true })
+  })
 
   // 启动所有已注册的 Bridge（飞书/钉钉/微信等）
   await startAllBridges()
 
   app.on('activate', () => {
+    if (shouldSuppressVoiceDictationActivate()) {
+      return
+    }
+
     // 直接检查 mainWindow 引用，避免 getAllWindows() 包含 DevTools 等其他窗口导致误判
     if (!mainWindow || mainWindow.isDestroyed()) {
       createWindow()
@@ -355,6 +369,7 @@ app.on('before-quit', () => {
   unregisterAllGlobalShortcuts()
   // 销毁快速任务窗口
   destroyQuickTaskWindow()
+  destroyVoiceDictationWindow()
   // Clean up system tray before quitting
   destroyTray()
 })

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -8,8 +8,19 @@ import { ipcMain, nativeTheme, shell, dialog, BrowserWindow, app } from 'electro
 import { join } from 'node:path'
 import { existsSync } from 'node:fs'
 import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, INSTALLER_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, MEMORY_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS, DINGTALK_IPC_CHANNELS, WECHAT_IPC_CHANNELS } from '@proma/shared'
-import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS, QUICK_TASK_IPC_CHANNELS, APP_ICON_IPC_CHANNELS, DOCK_BADGE_IPC_CHANNELS } from '../types'
-import type { QuickTaskSubmitInput } from '../types'
+import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS, QUICK_TASK_IPC_CHANNELS, VOICE_DICTATION_IPC_CHANNELS, APP_ICON_IPC_CHANNELS, DOCK_BADGE_IPC_CHANNELS } from '../types'
+import type {
+  QuickTaskSubmitInput,
+  VoiceDictationAudioChunkInput,
+  VoiceDictationCommitInput,
+  VoiceDictationCommitResult,
+  VoiceDictationResizeInput,
+  VoiceDictationSettings,
+  VoiceDictationSettingsUpdate,
+  VoiceDictationStartInput,
+  VoiceDictationStopInput,
+  VoiceDictationTestResult,
+} from '../types'
 import type {
   RuntimeStatus,
   GitRepoStatus,
@@ -2605,6 +2616,103 @@ export function registerIpcHandlers(): void {
     async (): Promise<Record<string, boolean>> => {
       const { reregisterAllGlobalShortcuts } = await import('./lib/global-shortcut-service')
       return reregisterAllGlobalShortcuts()
+    }
+  )
+
+  // ===== 语音输入 =====
+
+  ipcMain.handle(
+    VOICE_DICTATION_IPC_CHANNELS.GET_SETTINGS,
+    async (): Promise<VoiceDictationSettings> => {
+      const { getVoiceDictationSettings } = await import('./lib/voice-dictation-settings-service')
+      return getVoiceDictationSettings()
+    }
+  )
+
+  ipcMain.handle(
+    VOICE_DICTATION_IPC_CHANNELS.UPDATE_SETTINGS,
+    async (_, updates: VoiceDictationSettingsUpdate): Promise<VoiceDictationSettings> => {
+      const { updateVoiceDictationSettings } = await import('./lib/voice-dictation-settings-service')
+      return updateVoiceDictationSettings(updates)
+    }
+  )
+
+  ipcMain.handle(
+    VOICE_DICTATION_IPC_CHANNELS.TEST_CONNECTION,
+    async (_, updates?: VoiceDictationSettingsUpdate): Promise<VoiceDictationTestResult> => {
+      const { getVoiceDictationSettings } = await import('./lib/voice-dictation-settings-service')
+      const { testDoubaoAsrConnection } = await import('./lib/doubao-asr-service')
+      const settings = { ...getVoiceDictationSettings(), ...(updates ?? {}) }
+      return testDoubaoAsrConnection(settings)
+    }
+  )
+
+  ipcMain.handle(
+    VOICE_DICTATION_IPC_CHANNELS.TOGGLE,
+    async (event): Promise<void> => {
+      const { toggleVoiceDictationWindow } = await import('./lib/voice-dictation-window')
+      const sourceWindow = BrowserWindow.fromWebContents(event.sender)
+      toggleVoiceDictationWindow({ targetIsProma: !!sourceWindow })
+    }
+  )
+
+  ipcMain.handle(
+    VOICE_DICTATION_IPC_CHANNELS.START,
+    async (event, input: VoiceDictationStartInput): Promise<void> => {
+      const { getVoiceDictationSettings } = await import('./lib/voice-dictation-settings-service')
+      const { startDoubaoAsrSession } = await import('./lib/doubao-asr-service')
+      const win = BrowserWindow.fromWebContents(event.sender)
+      if (!win) throw new Error('语音输入窗口不存在')
+      await startDoubaoAsrSession(input.sessionId, getVoiceDictationSettings(), win)
+    }
+  )
+
+  ipcMain.handle(
+    VOICE_DICTATION_IPC_CHANNELS.SEND_AUDIO,
+    async (_, input: VoiceDictationAudioChunkInput): Promise<void> => {
+      const { sendDoubaoAsrAudio } = await import('./lib/doubao-asr-service')
+      sendDoubaoAsrAudio(input.sessionId, input.data)
+    }
+  )
+
+  ipcMain.handle(
+    VOICE_DICTATION_IPC_CHANNELS.STOP,
+    async (_, input: VoiceDictationStopInput): Promise<void> => {
+      const { stopDoubaoAsrSession } = await import('./lib/doubao-asr-service')
+      await stopDoubaoAsrSession(input.sessionId)
+    }
+  )
+
+  ipcMain.handle(
+    VOICE_DICTATION_IPC_CHANNELS.CANCEL,
+    async (_, input: VoiceDictationStopInput): Promise<void> => {
+      const { cancelDoubaoAsrSession } = await import('./lib/doubao-asr-service')
+      cancelDoubaoAsrSession(input.sessionId)
+    }
+  )
+
+  ipcMain.handle(
+    VOICE_DICTATION_IPC_CHANNELS.COMMIT,
+    async (_, input: VoiceDictationCommitInput): Promise<VoiceDictationCommitResult> => {
+      const { getVoiceDictationSettings } = await import('./lib/voice-dictation-settings-service')
+      const { commitVoiceDictationText } = await import('./lib/text-output-service')
+      return commitVoiceDictationText(input.text, getVoiceDictationSettings())
+    }
+  )
+
+  ipcMain.handle(
+    VOICE_DICTATION_IPC_CHANNELS.HIDE,
+    async (): Promise<void> => {
+      const { hideVoiceDictationWindow } = await import('./lib/voice-dictation-window')
+      hideVoiceDictationWindow()
+    }
+  )
+
+  ipcMain.handle(
+    VOICE_DICTATION_IPC_CHANNELS.RESIZE,
+    async (_, input: VoiceDictationResizeInput): Promise<void> => {
+      const { resizeVoiceDictationWindow } = await import('./lib/voice-dictation-window')
+      resizeVoiceDictationWindow(input.height)
     }
   )
 }

--- a/apps/electron/src/main/lib/doubao-asr-service.ts
+++ b/apps/electron/src/main/lib/doubao-asr-service.ts
@@ -1,0 +1,405 @@
+/**
+ * 豆包大模型流式 ASR 服务
+ *
+ * 主进程负责连接 OpenSpeech WebSocket，因为浏览器 WebSocket 无法设置
+ * 豆包要求的自定义鉴权 Header。
+ */
+
+import type { BrowserWindow } from 'electron'
+import { randomUUID } from 'node:crypto'
+import { gzipSync, gunzipSync } from 'node:zlib'
+import WebSocket from 'ws'
+import type {
+  VoiceDictationSettings,
+  VoiceDictationTranscriptEvent,
+  VoiceDictationStateEvent,
+} from '../../types'
+import { VOICE_DICTATION_IPC_CHANNELS } from '../../types'
+
+const PROTOCOL_VERSION = 0b0001
+const HEADER_SIZE = 0b0001
+
+const MESSAGE_TYPE_FULL_CLIENT_REQUEST = 0b0001
+const MESSAGE_TYPE_AUDIO_ONLY_REQUEST = 0b0010
+const MESSAGE_TYPE_FULL_SERVER_RESPONSE = 0b1001
+const MESSAGE_TYPE_SERVER_ERROR = 0b1111
+
+const FLAG_NO_SEQUENCE = 0b0000
+const FLAG_LAST_NO_SEQUENCE = 0b0010
+const FLAG_SERVER_SEQUENCE = 0b0001
+const FLAG_SERVER_LAST_SEQUENCE = 0b0011
+
+const SERIALIZATION_NONE = 0b0000
+const SERIALIZATION_JSON = 0b0001
+
+const COMPRESSION_NONE = 0b0000
+const COMPRESSION_GZIP = 0b0001
+
+const ASYNC_ENDPOINT = 'wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_async'
+const DUPLEX_ENDPOINT = 'wss://openspeech.bytedance.com/api/v3/sauc/bigmodel'
+
+interface ServerUtterance {
+  text?: string
+  definite?: boolean
+}
+
+interface ServerResult {
+  text?: string
+  confidence?: number
+  utterances?: ServerUtterance[]
+}
+
+interface ServerPayload {
+  result?: ServerResult | ServerResult[]
+  text?: string
+  message?: string
+  error?: string
+}
+
+interface ParsedServerMessage {
+  text: string
+  isFinal: boolean
+}
+
+interface ActiveSession {
+  sessionId: string
+  ws: WebSocket
+  win: BrowserWindow
+  closed: boolean
+}
+
+const activeSessions = new Map<string, ActiveSession>()
+
+function getEndpoint(settings: VoiceDictationSettings): string {
+  return settings.endpointMode === 'duplex' ? DUPLEX_ENDPOINT : ASYNC_ENDPOINT
+}
+
+function buildHeader(
+  messageType: number,
+  flags: number,
+  serialization: number,
+  compression: number,
+): Buffer {
+  return Buffer.from([
+    (PROTOCOL_VERSION << 4) | HEADER_SIZE,
+    (messageType << 4) | flags,
+    (serialization << 4) | compression,
+    0x00,
+  ])
+}
+
+function buildFrame(
+  messageType: number,
+  flags: number,
+  serialization: number,
+  compression: number,
+  payload: Buffer,
+): Buffer {
+  const header = buildHeader(messageType, flags, serialization, compression)
+  const size = Buffer.alloc(4)
+  size.writeUInt32BE(payload.length, 0)
+  return Buffer.concat([header, size, payload])
+}
+
+function buildClientRequest(settings: VoiceDictationSettings): Buffer {
+  const audio: Record<string, unknown> = {
+    format: 'pcm',
+    codec: 'raw',
+    rate: 16000,
+    bits: 16,
+    channel: 1,
+  }
+  if (settings.language) {
+    audio.language = settings.language
+  }
+
+  const request = {
+    user: {
+      uid: 'proma-desktop',
+    },
+    audio,
+    request: {
+      model_name: 'bigmodel',
+      enable_nonstream: true,
+      show_utterances: true,
+      result_type: 'full',
+      enable_itn: true,
+      enable_punc: true,
+      enable_ddc: true,
+      end_window_size: 800,
+    },
+  }
+
+  const payload = gzipSync(Buffer.from(JSON.stringify(request), 'utf-8'))
+  return buildFrame(
+    MESSAGE_TYPE_FULL_CLIENT_REQUEST,
+    FLAG_NO_SEQUENCE,
+    SERIALIZATION_JSON,
+    COMPRESSION_GZIP,
+    payload,
+  )
+}
+
+function buildAudioFrame(audio: Buffer, isLast: boolean): Buffer {
+  const payload = gzipSync(audio)
+  return buildFrame(
+    MESSAGE_TYPE_AUDIO_ONLY_REQUEST,
+    isLast ? FLAG_LAST_NO_SEQUENCE : FLAG_NO_SEQUENCE,
+    SERIALIZATION_NONE,
+    COMPRESSION_GZIP,
+    payload,
+  )
+}
+
+function sendState(win: BrowserWindow, event: VoiceDictationStateEvent): void {
+  if (!win.isDestroyed()) {
+    win.webContents.send(VOICE_DICTATION_IPC_CHANNELS.STATE, event)
+  }
+}
+
+function sendTranscript(win: BrowserWindow, event: VoiceDictationTranscriptEvent): void {
+  if (!win.isDestroyed()) {
+    win.webContents.send(VOICE_DICTATION_IPC_CHANNELS.TRANSCRIPT, event)
+  }
+}
+
+function getResultText(result: ServerResult): string {
+  return result.text ?? result.utterances?.map((item) => item.text ?? '').join('') ?? ''
+}
+
+function getAuthoritativeResult(results: ServerResult[]): ServerResult | null {
+  const candidates = results
+    .map((result) => ({ result, text: getResultText(result) }))
+    .filter((item) => item.text.trim().length > 0)
+
+  if (candidates.length === 0) return null
+  if (candidates.length === 1) return candidates[0]!.result
+
+  // result 数组表示识别候选，不是需要拼接的分句；拼接会制造重复文本。
+  return [...candidates]
+    .sort((left, right) => (right.result.confidence ?? 0) - (left.result.confidence ?? 0))[0]!
+    .result
+}
+
+function isResultFinal(result: ServerResult): boolean {
+  return result.utterances?.some((item) => item.definite === true) ?? false
+}
+
+function parseServerPayload(value: unknown, fallbackFinal: boolean): ParsedServerMessage | null {
+  if (typeof value !== 'object' || value === null) return null
+  const payload = value as ServerPayload
+  const results = Array.isArray(payload.result)
+    ? payload.result
+    : payload.result
+      ? [payload.result]
+      : []
+
+  if (results.length === 0) {
+    const message = payload.text ?? payload.message ?? payload.error
+    return message ? { text: message, isFinal: fallbackFinal } : null
+  }
+
+  if (payload.text) {
+    return {
+      text: payload.text,
+      isFinal: fallbackFinal || results.some(isResultFinal),
+    }
+  }
+
+  const authoritativeResult = getAuthoritativeResult(results)
+  const text = authoritativeResult ? getResultText(authoritativeResult) : ''
+  const utteranceFinal = authoritativeResult ? isResultFinal(authoritativeResult) : false
+  if (!text) return null
+  return {
+    text,
+    isFinal: fallbackFinal || utteranceFinal,
+  }
+}
+
+function parseServerMessage(data: Buffer): ParsedServerMessage | null {
+  if (data.length < 8) return null
+
+  const headerSize = (data[0]! & 0x0f) * 4
+  const messageType = data[1]! >> 4
+  const flags = data[1]! & 0x0f
+  const serialization = data[2]! >> 4
+  const compression = data[2]! & 0x0f
+  let offset = headerSize
+
+  const hasSequence = flags === FLAG_SERVER_SEQUENCE || flags === FLAG_SERVER_LAST_SEQUENCE
+  if (hasSequence) {
+    offset += 4
+  }
+
+  if (messageType === MESSAGE_TYPE_SERVER_ERROR) {
+    if (data.length < offset + 8) return null
+    const code = data.readUInt32BE(offset)
+    offset += 4
+    const size = data.readUInt32BE(offset)
+    offset += 4
+    const message = data.subarray(offset, offset + size).toString('utf-8')
+    return { text: `豆包 ASR 错误 ${code}: ${message}`, isFinal: true }
+  }
+
+  if (messageType !== MESSAGE_TYPE_FULL_SERVER_RESPONSE || data.length < offset + 4) {
+    return null
+  }
+
+  const payloadSize = data.readUInt32BE(offset)
+  offset += 4
+  const payload = data.subarray(offset, offset + payloadSize)
+  const decoded = compression === COMPRESSION_GZIP ? gunzipSync(payload) : payload
+
+  if (serialization !== SERIALIZATION_JSON) return null
+  const parsed = JSON.parse(decoded.toString('utf-8')) as unknown
+  return parseServerPayload(parsed, flags === FLAG_SERVER_LAST_SEQUENCE)
+}
+
+/** 测试豆包 ASR 连接，仅验证 WebSocket 握手和鉴权 Header。 */
+export async function testDoubaoAsrConnection(
+  settings: VoiceDictationSettings,
+): Promise<{ success: boolean; message: string }> {
+  if (!settings.appId || !settings.accessToken || !settings.resourceId) {
+    return { success: false, message: '请先填写 APP ID、Access Token 和 Resource ID' }
+  }
+
+  return await new Promise((resolve) => {
+    const ws = new WebSocket(getEndpoint(settings), {
+      headers: {
+        'X-Api-App-Key': settings.appId,
+        'X-Api-Access-Key': settings.accessToken,
+        'X-Api-Resource-Id': settings.resourceId,
+        'X-Api-Connect-Id': randomUUID(),
+      },
+    })
+
+    const timer = setTimeout(() => {
+      ws.terminate()
+      resolve({ success: false, message: '连接超时，请检查网络或凭证' })
+    }, 8000)
+
+    ws.once('open', () => {
+      clearTimeout(timer)
+      ws.close()
+      resolve({ success: true, message: '豆包 ASR 连接成功' })
+    })
+
+    ws.once('error', (error: Error) => {
+      clearTimeout(timer)
+      resolve({ success: false, message: `连接失败: ${error.message}` })
+    })
+  })
+}
+
+export async function startDoubaoAsrSession(
+  sessionId: string,
+  settings: VoiceDictationSettings,
+  win: BrowserWindow,
+): Promise<void> {
+  if (!settings.appId || !settings.accessToken || !settings.resourceId) {
+    throw new Error('请先填写豆包 ASR 凭证')
+  }
+
+  await stopDoubaoAsrSession(sessionId)
+  sendState(win, { sessionId, status: 'connecting', message: '正在连接豆包 ASR...' })
+
+  await new Promise<void>((resolve, reject) => {
+    const ws = new WebSocket(getEndpoint(settings), {
+      headers: {
+        'X-Api-App-Key': settings.appId,
+        'X-Api-Access-Key': settings.accessToken,
+        'X-Api-Resource-Id': settings.resourceId,
+        'X-Api-Connect-Id': randomUUID(),
+      },
+    })
+
+    const active: ActiveSession = { sessionId, ws, win, closed: false }
+    activeSessions.set(sessionId, active)
+
+    const timer = setTimeout(() => {
+      ws.terminate()
+      activeSessions.delete(sessionId)
+      reject(new Error('连接豆包 ASR 超时'))
+    }, 10000)
+
+    ws.once('open', () => {
+      clearTimeout(timer)
+      ws.send(buildClientRequest(settings))
+      sendState(win, { sessionId, status: 'recording', message: '正在听写' })
+      resolve()
+    })
+
+    ws.on('message', (message: Buffer | ArrayBuffer | Buffer[]) => {
+      const buffer = Array.isArray(message)
+        ? Buffer.concat(message)
+        : Buffer.isBuffer(message)
+          ? message
+          : Buffer.from(message)
+      try {
+        const parsed = parseServerMessage(buffer)
+        if (parsed) {
+          sendTranscript(win, {
+            sessionId,
+            text: parsed.text,
+            isFinal: parsed.isFinal,
+          })
+        }
+      } catch (error) {
+        const messageText = error instanceof Error ? error.message : '未知解析错误'
+        sendState(win, {
+          sessionId,
+          status: 'error',
+          message: `解析 ASR 响应失败: ${messageText}`,
+        })
+      }
+    })
+
+    ws.on('close', () => {
+      active.closed = true
+      activeSessions.delete(sessionId)
+    })
+
+    ws.once('error', (error: Error) => {
+      clearTimeout(timer)
+      activeSessions.delete(sessionId)
+      sendState(win, { sessionId, status: 'error', message: error.message })
+      reject(error)
+    })
+  })
+}
+
+export function sendDoubaoAsrAudio(sessionId: string, data: ArrayBuffer): void {
+  const active = activeSessions.get(sessionId)
+  if (!active || active.closed || active.ws.readyState !== WebSocket.OPEN) return
+  const audio = Buffer.from(data)
+  if (audio.length === 0) return
+  active.ws.send(buildAudioFrame(audio, false))
+}
+
+export async function stopDoubaoAsrSession(sessionId: string): Promise<void> {
+  const active = activeSessions.get(sessionId)
+  if (!active || active.closed) return
+
+  if (active.ws.readyState === WebSocket.OPEN) {
+    active.ws.send(buildAudioFrame(Buffer.alloc(0), true))
+    setTimeout(() => {
+      if (!active.closed) active.ws.close()
+    }, 800)
+  } else {
+    active.ws.terminate()
+  }
+}
+
+export function cancelDoubaoAsrSession(sessionId: string): void {
+  const active = activeSessions.get(sessionId)
+  if (!active) return
+  active.ws.terminate()
+  activeSessions.delete(sessionId)
+}
+
+export function cancelAllDoubaoAsrSessions(): void {
+  for (const session of activeSessions.values()) {
+    session.ws.terminate()
+  }
+  activeSessions.clear()
+}

--- a/apps/electron/src/main/lib/global-shortcut-service.ts
+++ b/apps/electron/src/main/lib/global-shortcut-service.ts
@@ -22,6 +22,7 @@ const registeredAccelerators = new Map<string, string>()
 const GLOBAL_SHORTCUT_DEFAULTS: Record<string, { mac: string; win: string }> = {
   'quick-task': { mac: 'Alt+Space', win: 'Alt+Space' },
   'show-main-window': { mac: 'CommandOrControl+Shift+P', win: 'CommandOrControl+Shift+P' },
+  'voice-dictation': { mac: 'Ctrl+`', win: 'Ctrl+`' },
 }
 
 const isMac = process.platform === 'darwin'
@@ -30,7 +31,7 @@ const isMac = process.platform === 'darwin'
  * 获取某全局快捷键当前生效的 Electron accelerator 字符串
  *
  * 优先使用用户自定义，否则使用默认值。
- * 将 Cmd/Ctrl 统一转为 Electron 的 CommandOrControl。
+ * 将 Cmd 统一转为 Electron 的 CommandOrControl；Ctrl 保持为物理 Control 键。
  */
 function getGlobalAccelerator(id: string): string {
   const settings = getSettings()
@@ -53,7 +54,6 @@ function getGlobalAccelerator(id: string): string {
   // 转换为 Electron 标准格式
   return accelerator
     .replace(/Cmd\+/gi, 'CommandOrControl+')
-    .replace(/Ctrl\+/gi, 'CommandOrControl+')
 }
 
 /**

--- a/apps/electron/src/main/lib/text-insertion-service.ts
+++ b/apps/electron/src/main/lib/text-insertion-service.ts
@@ -1,0 +1,270 @@
+/**
+ * 系统文本插入服务
+ *
+ * 通过临时剪贴板 + 系统粘贴快捷键，把文本写入当前前台应用的光标位置。
+ */
+
+import { clipboard, systemPreferences } from 'electron'
+import type { NativeImage } from 'electron'
+import { execFile } from 'child_process'
+import { setTimeout as sleep } from 'timers/promises'
+
+const CLIPBOARD_READY_DELAY_MS = 80
+const CLIPBOARD_RESTORE_DELAY_MS = 10_000
+const MAC_PASTE_TIMEOUT_MS = 2_000
+const WINDOWS_PASTE_TIMEOUT_MS = 3_000
+
+interface ClipboardSnapshot {
+  text: string
+  html: string
+  rtf: string
+  image: NativeImage | null
+  buffers: ClipboardBufferSnapshot[]
+}
+
+interface ClipboardBufferSnapshot {
+  format: string
+  buffer: Buffer
+}
+
+interface ExecError extends Error {
+  code?: unknown
+  signal?: unknown
+  killed?: boolean
+  stderr?: string
+}
+
+export interface TextInsertionResult {
+  success: boolean
+  mode: 'cursor' | 'clipboard'
+  message: string
+  error?: string
+}
+
+/** 优先粘贴到当前光标位置，失败时保留文本在剪贴板。 */
+export async function pasteTextAtCurrentCursor(text: string): Promise<TextInsertionResult> {
+  const snapshot = captureClipboardSnapshot()
+  clipboard.writeText(text)
+
+  try {
+    await sleep(CLIPBOARD_READY_DELAY_MS)
+    await triggerSystemPaste()
+    scheduleClipboardRestore(snapshot, text)
+    return {
+      success: true,
+      mode: 'cursor',
+      message: '已写入当前光标位置',
+    }
+  } catch (error) {
+    const message = getErrorMessage(error)
+    console.warn('[语音输入] 自动粘贴失败，已保留文本到剪贴板:', message)
+    return {
+      success: false,
+      mode: 'clipboard',
+      message: '自动粘贴失败，已复制到剪贴板',
+      error: message,
+    }
+  }
+}
+
+function captureClipboardSnapshot(): ClipboardSnapshot {
+  const image = clipboard.readImage()
+  return {
+    text: clipboard.readText(),
+    html: clipboard.readHTML(),
+    rtf: clipboard.readRTF(),
+    image: image.isEmpty() ? null : image,
+    buffers: captureClipboardBuffers(),
+  }
+}
+
+function captureClipboardBuffers(): ClipboardBufferSnapshot[] {
+  const snapshots: ClipboardBufferSnapshot[] = []
+  for (const format of clipboard.availableFormats()) {
+    try {
+      const buffer = clipboard.readBuffer(format)
+      if (buffer.byteLength > 0) {
+        snapshots.push({ format, buffer })
+      }
+    } catch {
+      // 某些系统私有格式无法通过 Electron 读取，跳过即可。
+    }
+  }
+  return snapshots
+}
+
+function scheduleClipboardRestore(snapshot: ClipboardSnapshot, insertedText: string): void {
+  const timer = setTimeout(() => {
+    try {
+      if (clipboard.readText() !== insertedText) return
+      restoreClipboardSnapshot(snapshot)
+    } catch (error) {
+      console.warn('[语音输入] 恢复剪贴板失败:', getErrorMessage(error))
+    }
+  }, CLIPBOARD_RESTORE_DELAY_MS)
+  timer.unref?.()
+}
+
+function restoreClipboardSnapshot(snapshot: ClipboardSnapshot): void {
+  if (!snapshot.text && !snapshot.html && !snapshot.rtf && !snapshot.image) {
+    if (restoreClipboardBuffers(snapshot.buffers)) return
+    clipboard.clear()
+    return
+  }
+
+  clipboard.write({
+    text: snapshot.text || undefined,
+    html: snapshot.html || undefined,
+    rtf: snapshot.rtf || undefined,
+    image: snapshot.image || undefined,
+  })
+}
+
+function restoreClipboardBuffers(buffers: ClipboardBufferSnapshot[]): boolean {
+  if (buffers.length === 0) return false
+
+  clipboard.clear()
+  let restored = false
+  for (const item of buffers) {
+    try {
+      clipboard.writeBuffer(item.format, item.buffer)
+      restored = true
+    } catch {
+      // 写回失败时继续尝试其他格式，最后还有结构化格式兜底。
+    }
+  }
+  return restored
+}
+
+async function triggerSystemPaste(): Promise<void> {
+  if (process.platform === 'darwin') {
+    await triggerMacPaste()
+    return
+  }
+
+  if (process.platform === 'win32') {
+    await triggerWindowsPaste()
+    return
+  }
+
+  throw new Error('当前系统暂不支持自动粘贴')
+}
+
+async function triggerMacPaste(): Promise<void> {
+  if (!systemPreferences.isTrustedAccessibilityClient(true)) {
+    throw new Error('需要在 macOS 系统设置中允许 Proma 使用辅助功能')
+  }
+
+  await execFileAsync(
+    '/usr/bin/osascript',
+    ['-e', 'tell application "System Events" to keystroke "v" using command down'],
+    MAC_PASTE_TIMEOUT_MS,
+  )
+}
+
+async function triggerWindowsPaste(): Promise<void> {
+  await execFileAsync(
+    'powershell.exe',
+    [
+      '-NoProfile',
+      '-NonInteractive',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-Command',
+      WINDOWS_SEND_INPUT_SCRIPT,
+    ],
+    WINDOWS_PASTE_TIMEOUT_MS,
+  )
+}
+
+function execFileAsync(file: string, args: string[], timeout: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    execFile(file, args, { timeout, windowsHide: true }, (error, _stdout, stderr) => {
+      if (error) {
+        const execError = error as ExecError
+        execError.stderr = stderr
+        reject(execError)
+        return
+      }
+      resolve()
+    })
+  })
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    const execError = error as ExecError
+    return execError.stderr?.trim() || error.message
+  }
+  return String(error)
+}
+
+const WINDOWS_SEND_INPUT_SCRIPT = String.raw`
+$signature = @"
+using System;
+using System.Runtime.InteropServices;
+
+public static class PromaKeyboardInput
+{
+    private const int INPUT_KEYBOARD = 1;
+    private const uint KEYEVENTF_KEYUP = 0x0002;
+    private const ushort VK_CONTROL = 0x11;
+    private const ushort VK_V = 0x56;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct INPUT
+    {
+        public int type;
+        public InputUnion U;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    private struct InputUnion
+    {
+        [FieldOffset(0)]
+        public KEYBDINPUT ki;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct KEYBDINPUT
+    {
+        public ushort wVk;
+        public ushort wScan;
+        public uint dwFlags;
+        public uint time;
+        public UIntPtr dwExtraInfo;
+    }
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
+
+    public static void Paste()
+    {
+        INPUT[] inputs = new INPUT[4];
+
+        inputs[0].type = INPUT_KEYBOARD;
+        inputs[0].U.ki.wVk = VK_CONTROL;
+
+        inputs[1].type = INPUT_KEYBOARD;
+        inputs[1].U.ki.wVk = VK_V;
+
+        inputs[2].type = INPUT_KEYBOARD;
+        inputs[2].U.ki.wVk = VK_V;
+        inputs[2].U.ki.dwFlags = KEYEVENTF_KEYUP;
+
+        inputs[3].type = INPUT_KEYBOARD;
+        inputs[3].U.ki.wVk = VK_CONTROL;
+        inputs[3].U.ki.dwFlags = KEYEVENTF_KEYUP;
+
+        uint sent = SendInput((uint)inputs.Length, inputs, Marshal.SizeOf(typeof(INPUT)));
+        if (sent != inputs.Length)
+        {
+            throw new InvalidOperationException("SendInput failed: " + Marshal.GetLastWin32Error());
+        }
+    }
+}
+"@
+
+Add-Type -TypeDefinition $signature
+[PromaKeyboardInput]::Paste()
+`

--- a/apps/electron/src/main/lib/text-output-service.ts
+++ b/apps/electron/src/main/lib/text-output-service.ts
@@ -1,0 +1,55 @@
+/**
+ * 文本输出服务
+ *
+ * 语音输入完成后优先写入 Proma 输入框，否则尝试写入当前光标位置。
+ */
+
+import { BrowserWindow, clipboard } from 'electron'
+import { VOICE_DICTATION_IPC_CHANNELS } from '../../types'
+import type { VoiceDictationCommitResult, VoiceDictationSettings } from '../../types'
+import { getMainWindow } from '../index'
+import { pasteTextAtCurrentCursor } from './text-insertion-service'
+
+let targetWasPromaInput = false
+
+/** 在显示语音浮窗前记录目标是否为 Proma 主窗口。 */
+export function captureVoiceDictationTarget(forcePromaInput?: boolean): boolean {
+  const mainWindow = getMainWindow()
+  targetWasPromaInput = forcePromaInput ?? BrowserWindow.getFocusedWindow() === mainWindow
+
+  if (!targetWasPromaInput && mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.hide()
+  }
+
+  return targetWasPromaInput
+}
+
+export async function commitVoiceDictationText(
+  text: string,
+  settings: VoiceDictationSettings,
+): Promise<VoiceDictationCommitResult> {
+  const trimmed = text.trim()
+  if (!trimmed) {
+    return { mode: 'clipboard', success: false, message: '没有可输出的语音文本' }
+  }
+
+  const mainWindow = getMainWindow()
+  const shouldWriteProma =
+    settings.outputMode === 'proma-input' ||
+    (settings.outputMode === 'auto' && targetWasPromaInput)
+
+  if (shouldWriteProma && mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send(VOICE_DICTATION_IPC_CHANNELS.INSERT_TEXT, { text: trimmed })
+    return { mode: 'proma-input', success: true, message: '已写入 Proma 输入框' }
+  }
+
+  if (settings.outputMode === 'auto') {
+    const result = await pasteTextAtCurrentCursor(trimmed)
+    return result.success
+      ? { mode: 'cursor', success: true, message: result.message }
+      : { mode: 'clipboard', success: true, message: result.message }
+  }
+
+  clipboard.writeText(trimmed)
+  return { mode: 'clipboard', success: true, message: '已复制到剪贴板' }
+}

--- a/apps/electron/src/main/lib/voice-dictation-settings-service.ts
+++ b/apps/electron/src/main/lib/voice-dictation-settings-service.ts
@@ -1,0 +1,73 @@
+/**
+ * 语音输入设置服务
+ *
+ * 独立处理豆包 ASR 凭证，避免通过通用 settings IPC 暴露加密细节。
+ */
+
+import { safeStorage } from 'electron'
+import type { VoiceDictationSettings, VoiceDictationSettingsUpdate } from '../../types'
+import { getSettings, updateSettings } from './settings-service'
+
+const DEFAULT_VOICE_DICTATION_SETTINGS: VoiceDictationSettings = {
+  enabled: false,
+  provider: 'doubao',
+  appId: '',
+  accessToken: '',
+  resourceId: 'volc.seedasr.sauc.duration',
+  language: '',
+  endpointMode: 'async',
+  outputMode: 'auto',
+}
+
+function encryptSecret(value: string): string {
+  if (!value) return ''
+  if (!safeStorage.isEncryptionAvailable()) {
+    console.warn('[语音输入] safeStorage 加密不可用，将以明文存储 Access Token')
+    return value
+  }
+  return safeStorage.encryptString(value).toString('base64')
+}
+
+function decryptSecret(value: string): string {
+  if (!value) return ''
+  if (!safeStorage.isEncryptionAvailable()) return value
+  try {
+    return safeStorage.decryptString(Buffer.from(value, 'base64'))
+  } catch (error) {
+    console.error('[语音输入] 解密 Access Token 失败:', error)
+    return ''
+  }
+}
+
+/** 获取解密后的语音输入设置 */
+export function getVoiceDictationSettings(): VoiceDictationSettings {
+  const raw = getSettings().voiceDictation ?? {}
+  const encryptedAccessToken = raw.accessToken ?? raw.accessKey ?? ''
+  return {
+    ...DEFAULT_VOICE_DICTATION_SETTINGS,
+    ...raw,
+    appId: raw.appId ?? raw.appKey ?? '',
+    accessToken: decryptSecret(encryptedAccessToken),
+  }
+}
+
+/** 保存语音输入设置，Access Token 加密后落盘 */
+export function updateVoiceDictationSettings(
+  updates: VoiceDictationSettingsUpdate,
+): VoiceDictationSettings {
+  const current = getVoiceDictationSettings()
+  const next: VoiceDictationSettings = {
+    ...current,
+    ...updates,
+    provider: 'doubao',
+  }
+
+  updateSettings({
+    voiceDictation: {
+      ...next,
+      accessToken: encryptSecret(next.accessToken),
+    },
+  })
+
+  return next
+}

--- a/apps/electron/src/main/lib/voice-dictation-window.ts
+++ b/apps/electron/src/main/lib/voice-dictation-window.ts
@@ -1,0 +1,175 @@
+/**
+ * 语音输入浮窗管理
+ *
+ * 独立于快速任务窗口，专注系统级语音听写。
+ */
+
+import { app, BrowserWindow, screen } from 'electron'
+import { join } from 'path'
+import { VOICE_DICTATION_IPC_CHANNELS } from '../../types'
+import { captureVoiceDictationTarget } from './text-output-service'
+
+let voiceDictationWindow: BrowserWindow | null = null
+let voiceDictationTargetIsProma = false
+let voiceDictationTargetCaptured = false
+let suppressMainWindowActivateUntil = 0
+
+const WINDOW_WIDTH = 480
+const WINDOW_HEIGHT = 188
+const MIN_WINDOW_HEIGHT = 176
+const WINDOW_MARGIN = 12
+const ACTIVATE_SUPPRESSION_MS = 1800
+
+interface VoiceDictationToggleOptions {
+  targetIsProma?: boolean
+}
+
+export function createVoiceDictationWindow(): void {
+  if (voiceDictationWindow && !voiceDictationWindow.isDestroyed()) return
+
+  voiceDictationWindow = new BrowserWindow({
+    width: WINDOW_WIDTH,
+    height: WINDOW_HEIGHT,
+    frame: false,
+    transparent: false,
+    backgroundColor: '#111113',
+    alwaysOnTop: true,
+    skipTaskbar: true,
+    focusable: false,
+    resizable: false,
+    movable: false,
+    minimizable: false,
+    maximizable: false,
+    fullscreenable: false,
+    acceptFirstMouse: true,
+    show: false,
+    hasShadow: true,
+    webPreferences: {
+      preload: join(__dirname, 'preload.cjs'),
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  })
+
+  const isDev = !app.isPackaged
+  if (isDev) {
+    voiceDictationWindow.loadURL('http://localhost:5173?window=voice-dictation')
+  } else {
+    voiceDictationWindow.loadFile(join(__dirname, 'renderer', 'index.html'), {
+      query: { window: 'voice-dictation' },
+    })
+  }
+
+  voiceDictationWindow.on('closed', () => {
+    voiceDictationWindow = null
+  })
+
+  console.log('[语音输入] 浮窗预创建完成')
+}
+
+export function toggleVoiceDictationWindow(options: VoiceDictationToggleOptions = {}): void {
+  if (!voiceDictationWindow || voiceDictationWindow.isDestroyed()) {
+    captureTargetForNextSession(options.targetIsProma)
+    createVoiceDictationWindow()
+    voiceDictationWindow?.once('ready-to-show', () => {
+      positionAndShow()
+    })
+    return
+  }
+
+  if (voiceDictationWindow.isVisible()) {
+    voiceDictationWindow.webContents.send(VOICE_DICTATION_IPC_CHANNELS.TOGGLE_STOP)
+  } else {
+    captureTargetForNextSession(options.targetIsProma)
+    positionAndShow()
+  }
+}
+
+function captureTargetForNextSession(targetIsProma?: boolean): void {
+  voiceDictationTargetIsProma = captureVoiceDictationTarget(targetIsProma)
+  voiceDictationTargetCaptured = true
+}
+
+function positionAndShow(): void {
+  if (!voiceDictationWindow || voiceDictationWindow.isDestroyed()) return
+
+  if (!voiceDictationTargetCaptured) {
+    captureTargetForNextSession()
+  }
+
+  const cursorPoint = screen.getCursorScreenPoint()
+  const display = screen.getDisplayNearestPoint(cursorPoint)
+  const { x, y, width, height } = display.workArea
+
+  voiceDictationWindow.setBounds({
+    x: Math.round(x + (width - WINDOW_WIDTH) / 2),
+    y: Math.round(y + height * 0.28),
+    width: WINDOW_WIDTH,
+    height: WINDOW_HEIGHT,
+  })
+
+  // 语音浮窗只是系统级提示层，不应抢焦点或改变 Proma 主窗口前后台状态。
+  voiceDictationWindow.showInactive()
+  voiceDictationWindow.webContents.send(VOICE_DICTATION_IPC_CHANNELS.SHOWN)
+}
+
+export function resizeVoiceDictationWindow(height: number): void {
+  if (!voiceDictationWindow || voiceDictationWindow.isDestroyed()) return
+  const bounds = voiceDictationWindow.getBounds()
+  const display = screen.getDisplayMatching(bounds)
+  const maxHeight = Math.max(MIN_WINDOW_HEIGHT, display.workArea.height - WINDOW_MARGIN * 2)
+  const nextHeight = Math.max(MIN_WINDOW_HEIGHT, Math.min(maxHeight, Math.round(height)))
+  const maxY = display.workArea.y + display.workArea.height - nextHeight - WINDOW_MARGIN
+  voiceDictationWindow.setBounds({
+    ...bounds,
+    y: Math.min(bounds.y, maxY),
+    height: nextHeight,
+  })
+}
+
+export function hideVoiceDictationWindow(): void {
+  const shouldRestoreExternalFocus = voiceDictationTargetCaptured && !voiceDictationTargetIsProma
+  suppressPromaActivationBriefly()
+  if (voiceDictationWindow && !voiceDictationWindow.isDestroyed() && voiceDictationWindow.isVisible()) {
+    voiceDictationWindow.hide()
+  }
+  if (process.platform === 'darwin' && shouldRestoreExternalFocus) {
+    app.hide()
+  }
+  voiceDictationTargetCaptured = false
+  voiceDictationTargetIsProma = false
+}
+
+function suppressPromaActivationBriefly(): void {
+  if (process.platform !== 'darwin') return
+  suppressMainWindowActivateUntil = Date.now() + ACTIVATE_SUPPRESSION_MS
+}
+
+export function shouldSuppressVoiceDictationActivate(): boolean {
+  if (process.platform !== 'darwin') return false
+
+  const isVoiceWindowVisible =
+    !!voiceDictationWindow &&
+    !voiceDictationWindow.isDestroyed() &&
+    voiceDictationWindow.isVisible()
+
+  if (isVoiceWindowVisible) return true
+
+  if (Date.now() <= suppressMainWindowActivateUntil) {
+    return true
+  }
+
+  suppressMainWindowActivateUntil = 0
+  return false
+}
+
+export function getVoiceDictationWindow(): BrowserWindow | null {
+  return voiceDictationWindow
+}
+
+export function destroyVoiceDictationWindow(): void {
+  if (voiceDictationWindow && !voiceDictationWindow.isDestroyed()) {
+    voiceDictationWindow.destroy()
+    voiceDictationWindow = null
+  }
+}

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -99,8 +99,24 @@ import type {
   AgentQueueMessageInput,
   PendingRequestsSnapshot,
 } from '@proma/shared'
-import type { UserProfile, AppSettings, QuickTaskSubmitInput, QuickTaskOpenSessionData } from '../types'
-import { QUICK_TASK_IPC_CHANNELS } from '../types'
+import type {
+  UserProfile,
+  AppSettings,
+  QuickTaskSubmitInput,
+  QuickTaskOpenSessionData,
+  VoiceDictationAudioChunkInput,
+  VoiceDictationCommitInput,
+  VoiceDictationCommitResult,
+  VoiceDictationResizeInput,
+  VoiceDictationSettings,
+  VoiceDictationSettingsUpdate,
+  VoiceDictationStartInput,
+  VoiceDictationStateEvent,
+  VoiceDictationStopInput,
+  VoiceDictationTestResult,
+  VoiceDictationTranscriptEvent,
+} from '../types'
+import { QUICK_TASK_IPC_CHANNELS, VOICE_DICTATION_IPC_CHANNELS } from '../types'
 
 /**
  * 暴露给渲染进程的 API 接口定义
@@ -776,6 +792,41 @@ export interface ElectronAPI {
   onQuickTaskFocus: (callback: () => void) => () => void
   /** 订阅快速任务打开会话事件（主窗口接收，由渲染进程负责创建会话） */
   onQuickTaskOpenSession: (callback: (data: QuickTaskOpenSessionData) => void) => () => void
+
+  // ===== 语音输入 =====
+
+  /** 获取语音输入设置 */
+  getVoiceDictationSettings: () => Promise<VoiceDictationSettings>
+  /** 更新语音输入设置 */
+  updateVoiceDictationSettings: (updates: VoiceDictationSettingsUpdate) => Promise<VoiceDictationSettings>
+  /** 测试语音输入连接 */
+  testVoiceDictationConnection: (updates?: VoiceDictationSettingsUpdate) => Promise<VoiceDictationTestResult>
+  /** 唤起或停止语音输入浮窗 */
+  toggleVoiceDictation: () => Promise<void>
+  /** 开始语音输入会话 */
+  startVoiceDictation: (input: VoiceDictationStartInput) => Promise<void>
+  /** 发送语音音频分片 */
+  sendVoiceDictationAudio: (input: VoiceDictationAudioChunkInput) => Promise<void>
+  /** 停止语音输入会话 */
+  stopVoiceDictation: (input: VoiceDictationStopInput) => Promise<void>
+  /** 取消语音输入会话 */
+  cancelVoiceDictation: (input: VoiceDictationStopInput) => Promise<void>
+  /** 输出最终语音文本 */
+  commitVoiceDictation: (input: VoiceDictationCommitInput) => Promise<VoiceDictationCommitResult>
+  /** 隐藏语音输入窗口 */
+  hideVoiceDictation: () => Promise<void>
+  /** 调整语音输入窗口高度 */
+  resizeVoiceDictation: (input: VoiceDictationResizeInput) => Promise<void>
+  /** 订阅语音输入窗口显示事件 */
+  onVoiceDictationShown: (callback: () => void) => () => void
+  /** 订阅语音输入停止请求事件 */
+  onVoiceDictationToggleStop: (callback: () => void) => () => void
+  /** 订阅语音输入转写事件 */
+  onVoiceDictationTranscript: (callback: (event: VoiceDictationTranscriptEvent) => void) => () => void
+  /** 订阅语音输入状态事件 */
+  onVoiceDictationState: (callback: (event: VoiceDictationStateEvent) => void) => () => void
+  /** 订阅主窗口插入语音文本事件 */
+  onVoiceDictationInsertText: (callback: (data: { text: string }) => void) => () => void
 }
 
 /**
@@ -1726,6 +1777,82 @@ const electronAPI: ElectronAPI = {
     const listener = (_: unknown, data: QuickTaskOpenSessionData): void => callback(data)
     ipcRenderer.on('quick-task:open-session', listener)
     return () => { ipcRenderer.removeListener('quick-task:open-session', listener) }
+  },
+
+  // ===== 语音输入 =====
+
+  getVoiceDictationSettings: () => {
+    return ipcRenderer.invoke(VOICE_DICTATION_IPC_CHANNELS.GET_SETTINGS)
+  },
+
+  updateVoiceDictationSettings: (updates: VoiceDictationSettingsUpdate) => {
+    return ipcRenderer.invoke(VOICE_DICTATION_IPC_CHANNELS.UPDATE_SETTINGS, updates)
+  },
+
+  testVoiceDictationConnection: (updates?: VoiceDictationSettingsUpdate) => {
+    return ipcRenderer.invoke(VOICE_DICTATION_IPC_CHANNELS.TEST_CONNECTION, updates)
+  },
+
+  toggleVoiceDictation: () => {
+    return ipcRenderer.invoke(VOICE_DICTATION_IPC_CHANNELS.TOGGLE)
+  },
+
+  startVoiceDictation: (input: VoiceDictationStartInput) => {
+    return ipcRenderer.invoke(VOICE_DICTATION_IPC_CHANNELS.START, input)
+  },
+
+  sendVoiceDictationAudio: (input: VoiceDictationAudioChunkInput) => {
+    return ipcRenderer.invoke(VOICE_DICTATION_IPC_CHANNELS.SEND_AUDIO, input)
+  },
+
+  stopVoiceDictation: (input: VoiceDictationStopInput) => {
+    return ipcRenderer.invoke(VOICE_DICTATION_IPC_CHANNELS.STOP, input)
+  },
+
+  cancelVoiceDictation: (input: VoiceDictationStopInput) => {
+    return ipcRenderer.invoke(VOICE_DICTATION_IPC_CHANNELS.CANCEL, input)
+  },
+
+  commitVoiceDictation: (input: VoiceDictationCommitInput) => {
+    return ipcRenderer.invoke(VOICE_DICTATION_IPC_CHANNELS.COMMIT, input)
+  },
+
+  hideVoiceDictation: () => {
+    return ipcRenderer.invoke(VOICE_DICTATION_IPC_CHANNELS.HIDE)
+  },
+
+  resizeVoiceDictation: (input: VoiceDictationResizeInput) => {
+    return ipcRenderer.invoke(VOICE_DICTATION_IPC_CHANNELS.RESIZE, input)
+  },
+
+  onVoiceDictationShown: (callback: () => void) => {
+    const listener = (): void => callback()
+    ipcRenderer.on(VOICE_DICTATION_IPC_CHANNELS.SHOWN, listener)
+    return () => { ipcRenderer.removeListener(VOICE_DICTATION_IPC_CHANNELS.SHOWN, listener) }
+  },
+
+  onVoiceDictationToggleStop: (callback: () => void) => {
+    const listener = (): void => callback()
+    ipcRenderer.on(VOICE_DICTATION_IPC_CHANNELS.TOGGLE_STOP, listener)
+    return () => { ipcRenderer.removeListener(VOICE_DICTATION_IPC_CHANNELS.TOGGLE_STOP, listener) }
+  },
+
+  onVoiceDictationTranscript: (callback: (event: VoiceDictationTranscriptEvent) => void) => {
+    const listener = (_: unknown, event: VoiceDictationTranscriptEvent): void => callback(event)
+    ipcRenderer.on(VOICE_DICTATION_IPC_CHANNELS.TRANSCRIPT, listener)
+    return () => { ipcRenderer.removeListener(VOICE_DICTATION_IPC_CHANNELS.TRANSCRIPT, listener) }
+  },
+
+  onVoiceDictationState: (callback: (event: VoiceDictationStateEvent) => void) => {
+    const listener = (_: unknown, event: VoiceDictationStateEvent): void => callback(event)
+    ipcRenderer.on(VOICE_DICTATION_IPC_CHANNELS.STATE, listener)
+    return () => { ipcRenderer.removeListener(VOICE_DICTATION_IPC_CHANNELS.STATE, listener) }
+  },
+
+  onVoiceDictationInsertText: (callback: (data: { text: string }) => void) => {
+    const listener = (_: unknown, data: { text: string }): void => callback(data)
+    ipcRenderer.on(VOICE_DICTATION_IPC_CHANNELS.INSERT_TEXT, listener)
+    return () => { ipcRenderer.removeListener(VOICE_DICTATION_IPC_CHANNELS.INSERT_TEXT, listener) }
   },
 }
 

--- a/apps/electron/src/renderer/atoms/settings-tab.ts
+++ b/apps/electron/src/renderer/atoms/settings-tab.ts
@@ -11,7 +11,7 @@
 
 import { atom } from 'jotai'
 
-export type SettingsTab = 'general' | 'channels' | 'proxy' | 'appearance' | 'about' | 'agent' | 'prompts' | 'tools' | 'bots' | 'tutorial' | 'shortcuts'
+export type SettingsTab = 'general' | 'channels' | 'proxy' | 'appearance' | 'about' | 'agent' | 'prompts' | 'tools' | 'bots' | 'tutorial' | 'shortcuts' | 'voice-input'
 
 /** 当前设置标签页（不持久化，每次打开设置默认显示渠道） */
 export const settingsTabAtom = atom<SettingsTab>('channels')

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -28,6 +28,7 @@ import { PlanModeDashedBorder } from './PlanModeDashedBorder'
 import { ModelSelector } from '@/components/chat/ModelSelector'
 import { AttachmentPreviewItem } from '@/components/chat/AttachmentPreviewItem'
 import { RichTextInput } from '@/components/ai-elements/rich-text-input'
+import { SpeechButton } from '@/components/ai-elements/speech-button'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
@@ -1474,6 +1475,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
                     window.electronAPI.updateSettings({ agentThinking: next })
                   }}
                 />
+                <SpeechButton className="size-[36px] rounded-full" />
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -28,6 +28,9 @@ import { cn } from '@/lib/utils'
 import { createFileMentionSuggestion } from '@/components/file-browser/file-mention-suggestion'
 import { createSkillMentionSuggestion, createMcpMentionSuggestion } from '@/components/agent/mention-suggestions'
 
+const VOICE_DICTATION_INSERT_EVENT = 'proma:insert-voice-dictation-text'
+let lastFocusedRichTextInputId: string | null = null
+
 // 创建 lowlight 实例，使用常见语言
 const lowlight = createLowlight(common)
 
@@ -227,6 +230,7 @@ export function RichTextInput({
   sendWithCmdEnter = false,
 }: RichTextInputProps): React.ReactElement {
   const [isExpanded, setIsExpanded] = useState(false)
+  const inputIdRef = useRef(`rich-text-input-${Math.random().toString(36).slice(2)}`)
   // 手动折叠状态：用户主动折叠输入框
   const [isManuallyCollapsed, setIsManuallyCollapsed] = useState(false)
   // 跟踪编辑器自己设置的值，用于区分外部设置和内部更新
@@ -370,6 +374,10 @@ export function RichTextInput({
       },
       // 监听 IME 输入状态
       handleDOMEvents: {
+        focus: () => {
+          lastFocusedRichTextInputId = inputIdRef.current
+          return false
+        },
         compositionstart: () => {
           isComposingRef.current = true
           return false
@@ -580,6 +588,25 @@ export function RichTextInput({
       return () => clearTimeout(timer)
     }
   }, [editor, disabled, autoFocusTrigger])
+
+  // 语音输入回填：优先插入到当前编辑器的光标位置。
+  useEffect(() => {
+    if (!editor || disabled) return
+
+    const handler = (event: Event): void => {
+      if (lastFocusedRichTextInputId !== inputIdRef.current) return
+
+      const customEvent = event as CustomEvent<{ text?: string }>
+      const text = customEvent.detail?.text?.trim()
+      if (!text) return
+
+      editor.chain().focus().insertContent(text).run()
+      event.preventDefault()
+    }
+
+    window.addEventListener(VOICE_DICTATION_INSERT_EVENT, handler)
+    return () => window.removeEventListener(VOICE_DICTATION_INSERT_EVENT, handler)
+  }, [editor, disabled])
 
   // 是否显示折叠按钮：启用 collapsible 且内容已自动扩展
   const showCollapseToggle = collapsible && isExpanded

--- a/apps/electron/src/renderer/components/ai-elements/speech-button.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/speech-button.tsx
@@ -1,17 +1,10 @@
 /**
  * AI Elements - 语音输入按钮
  *
- * 使用 Web Speech API（Electron Chromium 原生支持）。
- * 如果 SpeechRecognition 不可用则不渲染。
- *
- * 功能：
- * - 点击开始/停止录音
- * - 录音中 animate-pulse 红色效果
- * - 中文语音识别 (zh-CN)
- * - 识别结果通过 onTranscript 回调返回
+ * 通过主进程唤起系统级豆包流式语音输入浮窗。
  */
 
-import { useState, useCallback, useRef, useEffect } from 'react'
+import { useCallback } from 'react'
 import { MicIcon } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
@@ -21,131 +14,23 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 
-/** SpeechRecognition 接口（Chromium 实现） */
-interface SpeechRecognitionInstance extends EventTarget {
-  lang: string
-  continuous: boolean
-  interimResults: boolean
-  start: () => void
-  stop: () => void
-  abort: () => void
-  onresult: ((event: SpeechRecognitionResultEvent) => void) | null
-  onerror: ((event: SpeechRecognitionErrorEvent) => void) | null
-  onend: (() => void) | null
-}
-
-interface SpeechRecognitionResultEvent extends Event {
-  resultIndex: number
-  results: SpeechRecognitionResultList
-}
-
-interface SpeechRecognitionResultList {
-  length: number
-  item: (index: number) => SpeechRecognitionResult
-  [index: number]: SpeechRecognitionResult
-}
-
-interface SpeechRecognitionResult {
-  length: number
-  item: (index: number) => SpeechRecognitionAlternative
-  [index: number]: SpeechRecognitionAlternative
-  isFinal: boolean
-}
-
-interface SpeechRecognitionAlternative {
-  transcript: string
-  confidence: number
-}
-
-interface SpeechRecognitionErrorEvent extends Event {
-  error: string
-  message: string
-}
-
-/** 获取 SpeechRecognition 构造函数 */
-function getSpeechRecognition(): (new () => SpeechRecognitionInstance) | null {
-  const win = window as unknown as Record<string, unknown>
-  return (win.SpeechRecognition ?? win.webkitSpeechRecognition ?? null) as
-    | (new () => SpeechRecognitionInstance)
-    | null
-}
-
 interface SpeechButtonProps {
-  /** 识别结果回调 */
-  onTranscript: (text: string) => void
+  /** @deprecated 语音结果统一由全局语音输入回填到当前输入框 */
+  onTranscript?: (text: string) => void
   /** 是否禁用 */
   disabled?: boolean
   className?: string
 }
 
 export function SpeechButton({
-  onTranscript,
   disabled = false,
   className,
-}: SpeechButtonProps): React.ReactElement | null {
-  const [isRecording, setIsRecording] = useState(false)
-  const recognitionRef = useRef<SpeechRecognitionInstance | null>(null)
-  const onTranscriptRef = useRef(onTranscript)
-  onTranscriptRef.current = onTranscript
-
-  // 检测 SpeechRecognition 是否可用
-  const SpeechRecognitionCtor = getSpeechRecognition()
-
-  // 清理录音实例
-  useEffect(() => {
-    return () => {
-      if (recognitionRef.current) {
-        recognitionRef.current.abort()
-        recognitionRef.current = null
-      }
-    }
+}: SpeechButtonProps): React.ReactElement {
+  const handleClick = useCallback((): void => {
+    window.electronAPI.toggleVoiceDictation().catch((error) => {
+      console.error('[语音输入] 唤起浮窗失败:', error)
+    })
   }, [])
-
-  const handleClick = useCallback(() => {
-    if (isRecording) {
-      // 停止录音
-      recognitionRef.current?.stop()
-      setIsRecording(false)
-      return
-    }
-
-    if (!SpeechRecognitionCtor) return
-
-    // 开始录音
-    const recognition = new SpeechRecognitionCtor()
-    recognition.lang = 'zh-CN'
-    recognition.continuous = false
-    recognition.interimResults = false
-
-    recognition.onresult = (event: SpeechRecognitionResultEvent) => {
-      const result = event.results[event.resultIndex]
-      if (result?.isFinal) {
-        const transcript = result[0]?.transcript
-        if (transcript) {
-          onTranscriptRef.current(transcript)
-        }
-      }
-    }
-
-    recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
-      console.error('[SpeechButton] 语音识别错误:', event.error)
-      setIsRecording(false)
-    }
-
-    recognition.onend = () => {
-      setIsRecording(false)
-      recognitionRef.current = null
-    }
-
-    recognitionRef.current = recognition
-    recognition.start()
-    setIsRecording(true)
-  }, [isRecording, SpeechRecognitionCtor])
-
-  // SpeechRecognition 不可用时不渲染
-  if (!SpeechRecognitionCtor) {
-    return null
-  }
 
   return (
     <Tooltip>
@@ -155,24 +40,17 @@ export function SpeechButton({
           variant="ghost"
           size="icon"
           className={cn(
-            'relative size-8 transition-all duration-200',
-            isRecording && 'animate-pulse bg-red-500 text-white hover:bg-red-600',
+            'relative size-8 transition-all duration-200 text-foreground/60 hover:text-foreground',
             className
           )}
           onClick={handleClick}
           disabled={disabled}
         >
           <MicIcon className="size-4" />
-          {isRecording && (
-            <span className="absolute -right-1 -top-1 flex size-3">
-              <span className="absolute inline-flex size-full animate-ping rounded-full bg-red-400 opacity-75" />
-              <span className="relative inline-flex size-3 rounded-full bg-red-500" />
-            </span>
-          )}
         </Button>
       </TooltipTrigger>
       <TooltipContent side="top">
-        <p>{isRecording ? '停止录音' : '语音输入'}</p>
+        <p>语音输入</p>
       </TooltipContent>
     </Tooltip>
   )

--- a/apps/electron/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatInput.tsx
@@ -178,11 +178,6 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
     // 附件清理由 ChatView 的 handleSend 负责
   }, [canSend, content, onSend])
 
-  /** 语音识别结果 */
-  const handleSpeechTranscript = React.useCallback((text: string): void => {
-    setContent(content + (content ? ' ' : '') + text)
-  }, [content, setContent])
-
   /** 粘贴文件回调 */
   const handlePasteFiles = React.useCallback((files: File[]): void => {
     addFilesAsAttachments(files)
@@ -318,7 +313,7 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
 
               <FeishuNotifyToggle sessionId={conversationId} />
 
-              <SpeechButton onTranscript={handleSpeechTranscript} />
+              <SpeechButton className="size-[36px] rounded-full" />
 
               <ToolSelectorPopover />
 

--- a/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
+++ b/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
@@ -21,6 +21,7 @@ import {
   GraduationCap,
   X,
   Keyboard,
+  Mic,
 } from "lucide-react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { settingsTabAtom, channelFormDirtyAtom, settingsCloseRequestedAtom } from "@/atoms/settings-tab";
@@ -49,6 +50,7 @@ import { ToolSettings } from "./ToolSettings";
 import { BotHubSettings } from "./BotHubSettings";
 import { TutorialViewer } from "../tutorial/TutorialViewer";
 import { ShortcutSettings } from "./ShortcutSettings";
+import { VoiceInputSettings } from "./VoiceInputSettings";
 
 /** 设置 Tab 定义 */
 interface TabItem {
@@ -91,6 +93,11 @@ const SHORTCUTS_TAB: TabItem = {
   label: "快捷键管理",
   icon: <Keyboard size={16} />,
 };
+const VOICE_INPUT_TAB: TabItem = {
+  id: "voice-input",
+  label: "语音输入",
+  icon: <Mic size={16} />,
+};
 
 /** 尾部 Tabs */
 const TAIL_TABS: TabItem[] = [
@@ -123,6 +130,8 @@ function renderTabContent(tab: SettingsTab): React.ReactElement {
       return <TutorialViewer />;
     case "shortcuts":
       return <ShortcutSettings />;
+    case "voice-input":
+      return <VoiceInputSettings />;
   }
 }
 
@@ -195,6 +204,7 @@ export function SettingsPanel({
         ...BASE_TABS,
         AGENT_TAB,
         TOOLS_TAB,
+        VOICE_INPUT_TAB,
         BOTS_TAB,
         TUTORIAL_TAB,
         SHORTCUTS_TAB,
@@ -204,6 +214,7 @@ export function SettingsPanel({
     return [
       ...BASE_TABS,
       TOOLS_TAB,
+      VOICE_INPUT_TAB,
       BOTS_TAB,
       TUTORIAL_TAB,
       SHORTCUTS_TAB,

--- a/apps/electron/src/renderer/components/settings/VoiceInputSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/VoiceInputSettings.tsx
@@ -1,0 +1,193 @@
+/**
+ * VoiceInputSettings — 语音输入设置
+ */
+
+import * as React from 'react'
+import { ExternalLink, Loader2, TestTube2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import {
+  SettingsCard,
+  SettingsInput,
+  SettingsSecretInput,
+  SettingsSection,
+  SettingsSelect,
+  SettingsToggle,
+} from './primitives'
+import type { VoiceDictationSettings } from '../../../types'
+
+const ENDPOINT_OPTIONS = [
+  { value: 'async', label: '双向流式优化版' },
+  { value: 'duplex', label: '双向流式标准版' },
+]
+
+const OUTPUT_OPTIONS = [
+  { value: 'auto', label: '自动：Proma 激活时写入对话框，否则写入当前光标' },
+  { value: 'clipboard', label: '仅复制到剪贴板' },
+  { value: 'proma-input', label: '仅写入 Proma 输入框' },
+]
+
+const LANGUAGE_OPTIONS = [
+  { value: 'auto', label: '自动识别' },
+  { value: 'zh-CN', label: '中文普通话' },
+  { value: 'en-US', label: '英语' },
+  { value: 'yue-CN', label: '粤语' },
+  { value: 'ja-JP', label: '日语' },
+  { value: 'ko-KR', label: '韩语' },
+]
+
+const VOLCENGINE_SPEECH_SERVICE_URL = 'https://console.volcengine.com/speech/service/'
+
+export function VoiceInputSettings(): React.ReactElement {
+  const [settings, setSettings] = React.useState<VoiceDictationSettings | null>(null)
+  const [saving, setSaving] = React.useState(false)
+  const [testing, setTesting] = React.useState(false)
+
+  React.useEffect(() => {
+    window.electronAPI.getVoiceDictationSettings()
+      .then(setSettings)
+      .catch((error) => {
+        console.error('[语音输入] 加载设置失败:', error)
+        toast.error('加载语音输入设置失败')
+      })
+  }, [])
+
+  const update = React.useCallback(async (updates: Partial<VoiceDictationSettings>) => {
+    if (!settings) return
+    const optimistic = { ...settings, ...updates, provider: 'doubao' as const }
+    setSettings(optimistic)
+    setSaving(true)
+    try {
+      const saved = await window.electronAPI.updateVoiceDictationSettings(optimistic)
+      setSettings(saved)
+      window.electronAPI.reregisterGlobalShortcuts().catch(console.error)
+    } catch (error) {
+      console.error('[语音输入] 保存设置失败:', error)
+      toast.error('保存语音输入设置失败')
+    } finally {
+      setSaving(false)
+    }
+  }, [settings])
+
+  const handleTest = React.useCallback(async () => {
+    if (!settings) return
+    setTesting(true)
+    try {
+      const result = await window.electronAPI.testVoiceDictationConnection(settings)
+      if (result.success) {
+        toast.success(result.message)
+      } else {
+        toast.error(result.message)
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : '未知错误'
+      toast.error(`测试连接失败: ${message}`)
+    } finally {
+      setTesting(false)
+    }
+  }, [settings])
+
+  if (!settings) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Loader2 className="size-4 animate-spin" />
+        正在加载语音输入设置...
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <SettingsSection
+        title="豆包流式语音输入"
+        description="通过全局快捷键唤起浮窗，实时识别语音，停止后写入 Proma 输入框或当前光标位置。"
+        action={
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleTest}
+            disabled={testing || !settings.appId || !settings.accessToken || !settings.resourceId}
+          >
+            {testing ? <Loader2 className="mr-1.5 size-3.5 animate-spin" /> : <TestTube2 className="mr-1.5 size-3.5" />}
+            测试连接
+          </Button>
+        }
+      >
+        <div className="rounded-lg bg-muted/55 px-4 py-3 text-sm text-muted-foreground shadow-sm">
+          <div className="mb-1.5 font-medium text-foreground">配置方式</div>
+          <div className="space-y-1 leading-relaxed">
+            <p>
+              打开
+              <a
+                href={VOLCENGINE_SPEECH_SERVICE_URL}
+                target="_blank"
+                rel="noreferrer"
+                className="mx-1 inline-flex items-center gap-1 text-primary underline-offset-4 hover:underline"
+              >
+                火山引擎语音服务控制台
+                <ExternalLink className="size-3" />
+              </a>
+              ，选择旧版服务界面。
+            </p>
+            <p>找到“豆包流式语音识别模型2.0”类目，选择已申请对应权限的应用。</p>
+            <p>在页面下方对照填写 APP ID、Access Token 和 Resource ID，然后点击“测试连接”。</p>
+          </div>
+        </div>
+        <SettingsCard>
+          <SettingsToggle
+            label="启用语音输入"
+            description="启用后可使用 Ctrl+～ 打开语音输入浮窗，再按一次停止。"
+            checked={settings.enabled}
+            onCheckedChange={(enabled) => update({ enabled })}
+          />
+          <SettingsInput
+            label="豆包 APP ID"
+            description="对应 X-Api-App-Key，请填写火山引擎控制台中的 APP ID。"
+            value={settings.appId}
+            onChange={(appId) => update({ appId })}
+            placeholder="请输入 APP ID"
+          />
+          <SettingsSecretInput
+            label="豆包 Access Token"
+            description="对应 X-Api-Access-Key，保存时会加密。"
+            value={settings.accessToken}
+            onChange={(accessToken) => update({ accessToken })}
+            placeholder="请输入 Access Token"
+          />
+          <SettingsInput
+            label="Resource ID"
+            description="默认使用豆包语音识别模型 2.0 小时版。"
+            value={settings.resourceId}
+            onChange={(resourceId) => update({ resourceId })}
+            placeholder="volc.seedasr.sauc.duration"
+          />
+          <SettingsSelect
+            label="连接模式"
+            description="优化版只在结果变化时返回新包，实时体验更好。"
+            value={settings.endpointMode}
+            onValueChange={(endpointMode) => update({ endpointMode: endpointMode as VoiceDictationSettings['endpointMode'] })}
+            options={ENDPOINT_OPTIONS}
+          />
+          <SettingsSelect
+            label="识别语言"
+            description="自动识别适合中英文和方言混合输入。"
+            value={settings.language || 'auto'}
+            onValueChange={(language) => update({ language: language === 'auto' ? '' : language })}
+            options={LANGUAGE_OPTIONS}
+          />
+          <SettingsSelect
+            label="输出方式"
+            description="默认写入当前光标位置；如果唤起时 Proma 是当前激活窗口，会写入当前 Chat 或 Agent 输入框。自动粘贴失败时会保留到剪贴板。"
+            value={settings.outputMode}
+            onValueChange={(outputMode) => update({ outputMode: outputMode as VoiceDictationSettings['outputMode'] })}
+            options={OUTPUT_OPTIONS}
+          />
+        </SettingsCard>
+      </SettingsSection>
+
+      {saving && (
+        <p className="text-xs text-muted-foreground">正在保存语音输入设置...</p>
+      )}
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx
+++ b/apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx
@@ -23,6 +23,8 @@ import {
 import { shortcutOverridesAtom, sendWithCmdEnterAtom } from '@/atoms/shortcut-atoms'
 import {
   agentPendingPromptAtom,
+  agentSessionDraftHtmlAtom,
+  agentSessionDraftsAtom,
   agentSessionsAtom,
   currentAgentSessionIdAtom,
   agentChannelIdAtom,
@@ -31,6 +33,7 @@ import {
 } from '@/atoms/agent-atoms'
 import {
   chatPendingMessageAtom,
+  conversationDraftsAtom,
   conversationsAtom,
   currentConversationIdAtom,
   selectedModelAtom,
@@ -302,5 +305,69 @@ export function GlobalShortcuts(): null {
     return cleanup
   }, [store])
 
+  // ===== 语音输入 → 写入当前 Proma 输入框 =====
+
+  useEffect(() => {
+    const cleanup = window.electronAPI.onVoiceDictationInsertText(({ text }) => {
+      const trimmed = text.trim()
+      if (!trimmed) return
+
+      const insertedAtCursor = !window.dispatchEvent(new CustomEvent('proma:insert-voice-dictation-text', {
+        cancelable: true,
+        detail: { text: trimmed },
+      }))
+      if (insertedAtCursor) {
+        window.dispatchEvent(new CustomEvent('proma:focus-input'))
+        return
+      }
+
+      const tabs = store.get(tabsAtom)
+      const activeTabId = store.get(activeTabIdAtom)
+      const activeTab = tabs.find((tab) => tab.id === activeTabId)
+      const currentMode = store.get(appModeAtom)
+      const fallbackTarget =
+        currentMode === 'agent'
+          ? { type: 'agent' as const, sessionId: store.get(currentAgentSessionIdAtom) }
+          : { type: 'chat' as const, sessionId: store.get(currentConversationIdAtom) }
+      const target = activeTab ?? fallbackTarget
+
+      if (!target.sessionId) return
+
+      store.set(activeViewAtom, 'conversations')
+
+      if (target.type === 'agent') {
+        const sessionId = target.sessionId
+        store.set(appModeAtom, 'agent')
+        store.set(currentAgentSessionIdAtom, sessionId)
+        store.set(agentSessionDraftsAtom, (prev) => {
+          const map = new Map(prev)
+          const current = map.get(sessionId) ?? ''
+          map.set(sessionId, current ? `${current}\n${trimmed}` : trimmed)
+          return map
+        })
+        store.set(agentSessionDraftHtmlAtom, (prev) => {
+          const map = new Map(prev)
+          map.delete(sessionId)
+          return map
+        })
+        window.dispatchEvent(new CustomEvent('proma:focus-input'))
+        return
+      }
+
+      if (target.type === 'chat') {
+        const conversationId = target.sessionId
+        store.set(appModeAtom, 'chat')
+        store.set(currentConversationIdAtom, conversationId)
+        store.set(conversationDraftsAtom, (prev) => {
+          const map = new Map(prev)
+          const current = map.get(conversationId) ?? ''
+          map.set(conversationId, current ? `${current}\n${trimmed}` : trimmed)
+          return map
+        })
+        window.dispatchEvent(new CustomEvent('proma:focus-input'))
+      }
+    })
+    return cleanup
+  }, [store])
   return null
 }

--- a/apps/electron/src/renderer/components/voice-dictation/VoiceDictationApp.tsx
+++ b/apps/electron/src/renderer/components/voice-dictation/VoiceDictationApp.tsx
@@ -1,0 +1,442 @@
+/**
+ * VoiceDictationApp — 系统级语音输入浮窗
+ */
+
+import * as React from 'react'
+import { Check, Clipboard, Loader2, Mic, Square, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import type { VoiceDictationCommitResult, VoiceDictationSettings, VoiceDictationStateEvent, VoiceDictationTranscriptEvent } from '../../../types'
+import { CHUNK_BYTES, concatAudioBuffers, floatTo16BitPcm, splitChunk } from './voice-audio-utils'
+import { normalizeVoiceDictationText } from './voice-text-normalizer'
+import { useVoiceWindowLayout } from './use-voice-window-layout'
+
+const MAX_QUEUED_CHUNKS = 60
+const STOP_COMMIT_TIMEOUT_MS = 1400
+const FINAL_COMMIT_DELAY_MS = 180
+
+export function VoiceDictationApp(): React.ReactElement {
+  const [sessionId, setSessionId] = React.useState<string | null>(null)
+  const [status, setStatus] = React.useState<VoiceDictationStateEvent['status']>('idle')
+  const [message, setMessage] = React.useState('按快捷键开始语音输入')
+  const [transcript, setTranscript] = React.useState('')
+  const [commitResult, setCommitResult] = React.useState<VoiceDictationCommitResult | null>(null)
+  const [volume, setVolume] = React.useState(0)
+
+  const sessionIdRef = React.useRef<string | null>(null)
+  const transcriptRef = React.useRef('')
+  const streamRef = React.useRef<MediaStream | null>(null)
+  const audioContextRef = React.useRef<AudioContext | null>(null)
+  const processorRef = React.useRef<ScriptProcessorNode | null>(null)
+  const pendingAudioRef = React.useRef<ArrayBuffer[]>([])
+  const queuedAudioRef = React.useRef<ArrayBuffer[]>([])
+  const asrReadyRef = React.useRef(false)
+  const stoppingRef = React.useRef(false)
+  const settingsRef = React.useRef<VoiceDictationSettings | null>(null)
+  const commitTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+  const commitInFlightRef = React.useRef(false)
+
+  const {
+    rootRef,
+    panelRef,
+    headerRef,
+    hintBarRef,
+    transcriptBoxRef,
+    transcriptMaxHeight,
+  } = useVoiceWindowLayout({
+    commitResultMessage: commitResult?.message ?? null,
+    message,
+    status,
+    transcript,
+  })
+
+  React.useEffect(() => {
+    document.body.style.background = 'hsl(var(--background))'
+    document.documentElement.style.background = 'hsl(var(--background))'
+    document.body.style.overflow = 'hidden'
+    document.documentElement.style.overflow = 'hidden'
+  }, [])
+
+  React.useEffect(() => {
+    window.electronAPI.getVoiceDictationSettings()
+      .then((settings) => {
+        settingsRef.current = settings
+      })
+      .catch(console.error)
+  }, [])
+
+  const cleanupAudio = React.useCallback((clearBufferedAudio = true) => {
+    processorRef.current?.disconnect()
+    processorRef.current = null
+    audioContextRef.current?.close().catch(() => {})
+    audioContextRef.current = null
+    streamRef.current?.getTracks().forEach((track) => track.stop())
+    streamRef.current = null
+    if (clearBufferedAudio) {
+      pendingAudioRef.current = []
+      queuedAudioRef.current = []
+      asrReadyRef.current = false
+    }
+    setVolume(0)
+  }, [])
+
+  const sendAudioChunk = React.useCallback((sessionId: string, chunk: ArrayBuffer) => {
+    if (!asrReadyRef.current) {
+      queuedAudioRef.current.push(chunk)
+      if (queuedAudioRef.current.length > MAX_QUEUED_CHUNKS) {
+        queuedAudioRef.current.shift()
+      }
+      return
+    }
+
+    window.electronAPI.sendVoiceDictationAudio({
+      sessionId,
+      data: chunk,
+    }).catch(console.error)
+  }, [])
+
+  const flushQueuedAudio = React.useCallback(() => {
+    const currentSessionId = sessionIdRef.current
+    if (!currentSessionId) return
+    const chunks = queuedAudioRef.current
+    queuedAudioRef.current = []
+    for (const chunk of chunks) {
+      sendAudioChunk(currentSessionId, chunk)
+    }
+  }, [sendAudioChunk])
+
+  const flushPendingAudio = React.useCallback(() => {
+    const currentSessionId = sessionIdRef.current
+    if (!currentSessionId || pendingAudioRef.current.length === 0) return
+    const audio = concatAudioBuffers(pendingAudioRef.current)
+    pendingAudioRef.current = []
+    if (audio.byteLength > 0) {
+      sendAudioChunk(currentSessionId, audio)
+    }
+  }, [sendAudioChunk])
+
+  const commitAndHide = React.useCallback(async () => {
+    if (commitInFlightRef.current) return
+    commitInFlightRef.current = true
+    if (commitTimerRef.current) {
+      clearTimeout(commitTimerRef.current)
+      commitTimerRef.current = null
+    }
+    const text = transcriptRef.current.trim()
+    if (!text) {
+      setStatus('idle')
+      setMessage('没有识别到语音内容')
+      cleanupAudio()
+      setTimeout(() => window.electronAPI.hideVoiceDictation().catch(console.error), 180)
+      return
+    }
+
+    setStatus('stopping')
+    setMessage('正在输出文本...')
+    try {
+      const result = await window.electronAPI.commitVoiceDictation({ text })
+      setCommitResult(result)
+      setStatus('completed')
+      setMessage(result.message)
+      cleanupAudio()
+      setTimeout(() => window.electronAPI.hideVoiceDictation().catch(console.error), 280)
+    } catch (error) {
+      commitInFlightRef.current = false
+      const textMessage = error instanceof Error ? error.message : '未知错误'
+      setStatus('error')
+      setMessage(`输出失败: ${textMessage}`)
+    }
+  }, [cleanupAudio])
+
+  const scheduleCommit = React.useCallback((delay: number) => {
+    if (commitInFlightRef.current) return
+    if (commitTimerRef.current) {
+      clearTimeout(commitTimerRef.current)
+    }
+    commitTimerRef.current = setTimeout(() => {
+      commitAndHide().catch(console.error)
+    }, delay)
+  }, [commitAndHide])
+
+  const stopRecording = React.useCallback(async () => {
+    if (stoppingRef.current) return
+    stoppingRef.current = true
+    const currentSessionId = sessionIdRef.current
+    setStatus('stopping')
+    setMessage('正在收尾识别...')
+    cleanupAudio(false)
+    flushPendingAudio()
+    flushQueuedAudio()
+    if (currentSessionId && asrReadyRef.current) {
+      window.electronAPI.stopVoiceDictation({ sessionId: currentSessionId }).catch(console.error)
+    }
+    scheduleCommit(STOP_COMMIT_TIMEOUT_MS)
+  }, [cleanupAudio, flushPendingAudio, flushQueuedAudio, scheduleCommit])
+
+  const cancelAndHide = React.useCallback(() => {
+    stoppingRef.current = true
+    const currentSessionId = sessionIdRef.current
+    if (commitTimerRef.current) {
+      clearTimeout(commitTimerRef.current)
+      commitTimerRef.current = null
+    }
+    window.electronAPI.hideVoiceDictation().catch(console.error)
+    cleanupAudio()
+    if (currentSessionId) {
+      window.electronAPI.cancelVoiceDictation({ sessionId: currentSessionId }).catch(console.error)
+    }
+  }, [cleanupAudio])
+
+  const startAudioCapture = React.useCallback(async () => {
+    const stream = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        channelCount: 1,
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: true,
+      },
+    })
+    streamRef.current = stream
+
+    const AudioContextCtor = window.AudioContext || window.webkitAudioContext
+    const audioContext = new AudioContextCtor()
+    audioContextRef.current = audioContext
+    const source = audioContext.createMediaStreamSource(stream)
+    const processor = audioContext.createScriptProcessor(4096, 1, 1)
+    processorRef.current = processor
+
+    processor.onaudioprocess = (event) => {
+      if (!sessionIdRef.current || stoppingRef.current) return
+      const input = event.inputBuffer.getChannelData(0)
+      let peak = 0
+      for (let i = 0; i < input.length; i += 1) {
+        peak = Math.max(peak, Math.abs(input[i] ?? 0))
+      }
+      setVolume(Math.min(1, peak * 4))
+
+      const pcm = floatTo16BitPcm(input, audioContext.sampleRate)
+      pendingAudioRef.current.push(pcm)
+      let merged = concatAudioBuffers(pendingAudioRef.current)
+      const nextPending: ArrayBuffer[] = []
+      while (merged.byteLength >= CHUNK_BYTES) {
+        const { chunk, rest } = splitChunk(merged, CHUNK_BYTES)
+        if (!chunk) break
+        sendAudioChunk(sessionIdRef.current, chunk)
+        merged = rest
+      }
+      if (merged.byteLength > 0) nextPending.push(merged)
+      pendingAudioRef.current = nextPending
+    }
+
+    source.connect(processor)
+    processor.connect(audioContext.destination)
+  }, [sendAudioChunk])
+
+  const startRecording = React.useCallback(async () => {
+    const refreshSettings = window.electronAPI.getVoiceDictationSettings()
+      .then((latest) => {
+        settingsRef.current = latest
+        return latest
+      })
+
+    stoppingRef.current = false
+    commitInFlightRef.current = false
+    if (commitTimerRef.current) {
+      clearTimeout(commitTimerRef.current)
+      commitTimerRef.current = null
+    }
+    asrReadyRef.current = false
+    queuedAudioRef.current = []
+    pendingAudioRef.current = []
+    setTranscript('')
+    transcriptRef.current = ''
+    setCommitResult(null)
+    setStatus('recording')
+    setMessage('请开始说话')
+
+    const nextSessionId = crypto.randomUUID()
+    setSessionId(nextSessionId)
+    sessionIdRef.current = nextSessionId
+
+    const audioCapture = startAudioCapture().catch((error) => {
+      const textMessage = error instanceof Error ? error.message : '未知错误'
+      setStatus('error')
+      setMessage(textMessage)
+      cleanupAudio()
+      throw error
+    })
+
+    const cachedSettings = settingsRef.current
+    const settings = cachedSettings?.enabled ? cachedSettings : await refreshSettings
+    settingsRef.current = settings
+    if (!settings.enabled) {
+      setStatus('error')
+      setMessage('请先在设置中启用语音输入')
+      cleanupAudio()
+      return
+    }
+
+    window.electronAPI.startVoiceDictation({ sessionId: nextSessionId })
+      .then(() => {
+        if (sessionIdRef.current !== nextSessionId) return
+        asrReadyRef.current = true
+        flushQueuedAudio()
+        if (stoppingRef.current) {
+          flushPendingAudio()
+          flushQueuedAudio()
+          window.electronAPI.stopVoiceDictation({ sessionId: nextSessionId }).catch(console.error)
+          scheduleCommit(STOP_COMMIT_TIMEOUT_MS)
+          return
+        }
+        setStatus('recording')
+        setMessage('正在听写')
+      })
+      .catch((error) => {
+        const textMessage = error instanceof Error ? error.message : '未知错误'
+        setStatus('error')
+        setMessage(textMessage)
+        cleanupAudio()
+      })
+
+    await audioCapture
+  }, [cleanupAudio, flushPendingAudio, flushQueuedAudio, scheduleCommit, startAudioCapture])
+
+  React.useEffect(() => {
+    const cleanupShown = window.electronAPI.onVoiceDictationShown(() => {
+      startRecording().catch((error) => {
+        const textMessage = error instanceof Error ? error.message : '未知错误'
+        setStatus('error')
+        setMessage(textMessage)
+        cleanupAudio()
+      })
+    })
+
+    const cleanupStop = window.electronAPI.onVoiceDictationToggleStop(() => {
+      stopRecording().catch(console.error)
+    })
+
+    const cleanupTranscript = window.electronAPI.onVoiceDictationTranscript((event: VoiceDictationTranscriptEvent) => {
+      if (event.sessionId !== sessionIdRef.current) return
+      const normalizedText = normalizeVoiceDictationText(event.text)
+      setTranscript(normalizedText)
+      transcriptRef.current = normalizedText
+      if (stoppingRef.current && event.isFinal) {
+        scheduleCommit(FINAL_COMMIT_DELAY_MS)
+      }
+    })
+
+    const cleanupState = window.electronAPI.onVoiceDictationState((event: VoiceDictationStateEvent) => {
+      if (event.sessionId && event.sessionId !== sessionIdRef.current) return
+      if (event.status === 'connecting') {
+        setStatus('recording')
+        return
+      }
+      setStatus(event.status)
+      if (event.message) setMessage(event.message)
+    })
+
+    return () => {
+      cleanupShown()
+      cleanupStop()
+      cleanupTranscript()
+      cleanupState()
+      const currentSessionId = sessionIdRef.current
+      if (currentSessionId) {
+        window.electronAPI.cancelVoiceDictation({ sessionId: currentSessionId }).catch(console.error)
+      }
+      if (commitTimerRef.current) clearTimeout(commitTimerRef.current)
+      cleanupAudio()
+    }
+  }, [cleanupAudio, scheduleCommit, startRecording, stopRecording])
+
+  const busy = status === 'connecting' || status === 'recording' || status === 'stopping'
+  return (
+    <div ref={rootRef} className="box-border flex h-screen w-screen flex-col overflow-hidden bg-background px-3 pt-3 pb-4">
+      <div ref={panelRef} className="flex min-h-0 w-full flex-col overflow-hidden">
+        <div ref={headerRef} className="flex shrink-0 items-center justify-between px-3 pt-1 pb-3">
+          <div className="flex items-center gap-3 min-w-0">
+            <div className={`relative flex size-8 items-center justify-center rounded-full ${status === 'error' ? 'bg-destructive/12 text-destructive' : 'bg-primary/12 text-primary'}`}>
+              {status === 'recording' && (
+                <span
+                  className="absolute inset-0 rounded-full bg-primary/20 transition-transform duration-100"
+                  style={{ transform: `scale(${1 + volume * 0.35})` }}
+                />
+              )}
+              {status === 'connecting' || status === 'stopping'
+                ? <Loader2 className="size-4 animate-spin" />
+                : status === 'completed'
+                  ? <Check className="size-4" />
+                  : <Mic className="size-4" />}
+            </div>
+            <div className="min-w-0">
+              <div className="truncate text-sm font-medium text-foreground">Proma 语音输入</div>
+              <div className="truncate text-xs text-muted-foreground">{message}</div>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-1.5">
+            {busy && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="size-8 rounded-full text-destructive"
+                onClick={() => stopRecording().catch(console.error)}
+              >
+                <Square className="size-3.5" fill="currentColor" strokeWidth={0} />
+              </Button>
+            )}
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="size-8 rounded-full text-muted-foreground"
+              onClick={cancelAndHide}
+            >
+              <X className="size-4" />
+            </Button>
+          </div>
+        </div>
+
+        <div className="min-h-0 px-3">
+          <div className="overflow-hidden rounded-lg bg-muted/45">
+            <div ref={hintBarRef} className="flex min-h-8 shrink-0 items-center justify-between gap-3 px-3 py-1.5 text-xs leading-4 text-muted-foreground">
+              <span className="truncate">
+                Ctrl+～ 停止 · 外部写入光标 · Proma 激活时写入 Chat / Agent
+              </span>
+              {commitResult && (
+                <span className="flex shrink-0 items-center gap-1.5">
+                  <Clipboard className="size-3.5" />
+                  {commitResult.message}
+                </span>
+              )}
+            </div>
+            <div className="h-px bg-border/70" />
+            <div
+              ref={transcriptBoxRef}
+              className="box-border min-h-[34px] px-3 pt-2.5 text-[15px] leading-7 text-foreground [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
+              style={{
+                maxHeight: transcriptMaxHeight ?? undefined,
+                overflowY: transcriptMaxHeight === null ? 'visible' : 'auto',
+              }}
+            >
+              <div className="whitespace-pre-wrap break-words">
+                {transcript || (
+                  <span className="text-muted-foreground/60">
+                    {status === 'idle' ? '等待 Ctrl+～ 唤起' : '请开始说话'}
+                  </span>
+                )}
+              </div>
+              {transcript && <div aria-hidden="true" className="h-12" />}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+declare global {
+  interface Window {
+    webkitAudioContext?: typeof AudioContext
+  }
+}

--- a/apps/electron/src/renderer/components/voice-dictation/use-voice-window-layout.ts
+++ b/apps/electron/src/renderer/components/voice-dictation/use-voice-window-layout.ts
@@ -1,0 +1,148 @@
+/**
+ * 语音输入浮窗布局测量
+ */
+
+import * as React from 'react'
+
+const WINDOW_HEIGHT_BUFFER = 16
+const MIN_TRANSCRIPT_HEIGHT = 34
+const MAX_TRANSCRIPT_HEIGHT = 260
+const MAX_WINDOW_HEIGHT = 540
+
+interface VoiceWindowLayoutInput {
+  commitResultMessage: string | null
+  message: string
+  status: string
+  transcript: string
+}
+
+export interface VoiceWindowLayoutRefs {
+  rootRef: React.RefObject<HTMLDivElement>
+  panelRef: React.RefObject<HTMLDivElement>
+  headerRef: React.RefObject<HTMLDivElement>
+  hintBarRef: React.RefObject<HTMLDivElement>
+  transcriptBoxRef: React.RefObject<HTMLDivElement>
+}
+
+export interface VoiceWindowLayoutResult extends VoiceWindowLayoutRefs {
+  transcriptMaxHeight: number | null
+}
+
+export function useVoiceWindowLayout(input: VoiceWindowLayoutInput): VoiceWindowLayoutResult {
+  const { commitResultMessage, message, status, transcript } = input
+  const [transcriptMaxHeight, setTranscriptMaxHeight] = React.useState<number | null>(null)
+
+  const rootRef = React.useRef<HTMLDivElement | null>(null)
+  const panelRef = React.useRef<HTMLDivElement | null>(null)
+  const headerRef = React.useRef<HTMLDivElement | null>(null)
+  const hintBarRef = React.useRef<HTMLDivElement | null>(null)
+  const transcriptBoxRef = React.useRef<HTMLDivElement | null>(null)
+  const lastWindowHeightRef = React.useRef(0)
+
+  const scrollTranscriptToBottom = React.useCallback(() => {
+    const transcriptBox = transcriptBoxRef.current
+    if (!transcriptBox) return
+    const maxScrollTop = Math.max(0, transcriptBox.scrollHeight - transcriptBox.clientHeight)
+    transcriptBox.scrollTop = maxScrollTop
+  }, [])
+
+  const requestTranscriptBottomScroll = React.useCallback(() => {
+    requestAnimationFrame(() => {
+      scrollTranscriptToBottom()
+      requestAnimationFrame(scrollTranscriptToBottom)
+    })
+  }, [scrollTranscriptToBottom])
+
+  const resizeVoiceWindow = React.useCallback(() => {
+    const root = rootRef.current
+    const header = headerRef.current
+    const hintBar = hintBarRef.current
+    const transcriptBox = transcriptBoxRef.current
+    if (!root || !header || !hintBar || !transcriptBox) return
+
+    const rootStyle = window.getComputedStyle(root)
+    const rootVerticalPadding =
+      Number.parseFloat(rootStyle.paddingTop) +
+      Number.parseFloat(rootStyle.paddingBottom)
+    const transcriptNaturalHeight = Math.max(MIN_TRANSCRIPT_HEIGHT, transcriptBox.scrollHeight)
+    const fixedHeight = Math.ceil(
+      rootVerticalPadding +
+      header.getBoundingClientRect().height +
+      hintBar.getBoundingClientRect().height +
+      1,
+    )
+    const maxWindowHeight = Math.max(
+      220,
+      Math.min(MAX_WINDOW_HEIGHT, window.screen.availHeight - 24),
+    )
+    const availableTranscriptHeight = Math.max(
+      MIN_TRANSCRIPT_HEIGHT,
+      maxWindowHeight - fixedHeight - WINDOW_HEIGHT_BUFFER,
+    )
+    const viewportMaxTranscriptHeight = Math.min(MAX_TRANSCRIPT_HEIGHT, availableTranscriptHeight)
+    const nextTranscriptMaxHeight =
+      transcriptNaturalHeight > viewportMaxTranscriptHeight
+        ? viewportMaxTranscriptHeight
+        : null
+    const nextTranscriptHeight = nextTranscriptMaxHeight ?? transcriptNaturalHeight
+    const nextHeight = Math.ceil(fixedHeight + nextTranscriptHeight + WINDOW_HEIGHT_BUFFER)
+
+    setTranscriptMaxHeight((current) => {
+      if (current === null && nextTranscriptMaxHeight === null) return current
+      if (current !== null && nextTranscriptMaxHeight !== null && Math.abs(current - nextTranscriptMaxHeight) < 2) {
+        return current
+      }
+      return nextTranscriptMaxHeight
+    })
+
+    if (Math.abs(nextHeight - lastWindowHeightRef.current) < 2) return
+    lastWindowHeightRef.current = nextHeight
+    window.electronAPI.resizeVoiceDictation({ height: nextHeight }).catch(console.error)
+  }, [])
+
+  React.useLayoutEffect(() => {
+    resizeVoiceWindow()
+    const observer = new ResizeObserver(() => {
+      resizeVoiceWindow()
+      requestTranscriptBottomScroll()
+    })
+    if (rootRef.current) observer.observe(rootRef.current)
+    if (panelRef.current) observer.observe(panelRef.current)
+    if (headerRef.current) observer.observe(headerRef.current)
+    if (hintBarRef.current) observer.observe(hintBarRef.current)
+    if (transcriptBoxRef.current) observer.observe(transcriptBoxRef.current)
+    return () => observer.disconnect()
+  }, [requestTranscriptBottomScroll, resizeVoiceWindow])
+
+  React.useLayoutEffect(() => {
+    const frame = requestAnimationFrame(() => {
+      resizeVoiceWindow()
+      scrollTranscriptToBottom()
+      requestAnimationFrame(scrollTranscriptToBottom)
+    })
+    return () => cancelAnimationFrame(frame)
+  }, [commitResultMessage, message, resizeVoiceWindow, scrollTranscriptToBottom, status, transcript])
+
+  React.useLayoutEffect(() => {
+    requestTranscriptBottomScroll()
+  }, [requestTranscriptBottomScroll, transcript, transcriptMaxHeight])
+
+  React.useEffect(() => {
+    const handleWindowResize = (): void => {
+      lastWindowHeightRef.current = 0
+      resizeVoiceWindow()
+      requestTranscriptBottomScroll()
+    }
+    window.addEventListener('resize', handleWindowResize)
+    return () => window.removeEventListener('resize', handleWindowResize)
+  }, [requestTranscriptBottomScroll, resizeVoiceWindow])
+
+  return {
+    rootRef,
+    panelRef,
+    headerRef,
+    hintBarRef,
+    transcriptBoxRef,
+    transcriptMaxHeight,
+  }
+}

--- a/apps/electron/src/renderer/components/voice-dictation/voice-audio-utils.ts
+++ b/apps/electron/src/renderer/components/voice-dictation/voice-audio-utils.ts
@@ -1,0 +1,45 @@
+/**
+ * 语音输入音频工具
+ */
+
+export const TARGET_SAMPLE_RATE = 16000
+export const CHUNK_BYTES = TARGET_SAMPLE_RATE * 2 * 0.2
+
+export function floatTo16BitPcm(samples: Float32Array, inputSampleRate: number): ArrayBuffer {
+  const ratio = inputSampleRate / TARGET_SAMPLE_RATE
+  const outputLength = Math.floor(samples.length / ratio)
+  const buffer = new ArrayBuffer(outputLength * 2)
+  const view = new DataView(buffer)
+
+  for (let i = 0; i < outputLength; i += 1) {
+    const start = Math.floor(i * ratio)
+    const end = Math.min(Math.floor((i + 1) * ratio), samples.length)
+    let sum = 0
+    for (let j = start; j < end; j += 1) {
+      sum += samples[j] ?? 0
+    }
+    const sample = Math.max(-1, Math.min(1, sum / Math.max(1, end - start)))
+    view.setInt16(i * 2, sample < 0 ? sample * 0x8000 : sample * 0x7fff, true)
+  }
+
+  return buffer
+}
+
+export function concatAudioBuffers(buffers: ArrayBuffer[]): ArrayBuffer {
+  const total = buffers.reduce((sum, buffer) => sum + buffer.byteLength, 0)
+  const output = new Uint8Array(total)
+  let offset = 0
+  for (const buffer of buffers) {
+    output.set(new Uint8Array(buffer), offset)
+    offset += buffer.byteLength
+  }
+  return output.buffer
+}
+
+export function splitChunk(buffer: ArrayBuffer, size: number): { chunk: ArrayBuffer | null; rest: ArrayBuffer } {
+  if (buffer.byteLength < size) return { chunk: null, rest: buffer }
+  return {
+    chunk: buffer.slice(0, size),
+    rest: buffer.slice(size),
+  }
+}

--- a/apps/electron/src/renderer/components/voice-dictation/voice-text-normalizer.ts
+++ b/apps/electron/src/renderer/components/voice-dictation/voice-text-normalizer.ts
@@ -1,0 +1,61 @@
+/**
+ * 语音输入文本规范化
+ *
+ * 只做确定性口语清洗，不调用二次模型。
+ */
+
+const LEADING_THINKING_PATTERNS: RegExp[] = [
+  /^(?:让我想想啊?|我想一下|我想想|等一下|稍等一下)[，,。.\s]*/u,
+  /^(?:我刚刚(?:记得|想起来)来着|刚刚想起来了?)[，,。.\s]*/u,
+]
+
+const CLAUSE_FILLER_PATTERN = /(^|[，。！？；、,.!?\s])(?:嗯+|呃+|额+|啊+|哎+|诶+|哦+|喔+|那个|这个|就是|然后)[，、,\s]*/gu
+const CLAUSE_THINKING_PATTERN = /(^|[，。！？；、,.!?\s])(?:让我想想啊?|我想一下|我想想|等一下|稍等一下|我刚刚(?:记得|想起来)来着|刚刚想起来了?)[，,。.\s]*/gu
+const DEMONSTRATIVE_FILLER_PATTERN = /(?:这个|那个)(?=(?:光标|功能|问题|位置|输入|内容|界面|窗口|按钮|文字|文本|地方|时候|模式|配置|逻辑|体验|过程|设置|边框))/gu
+
+function collapseRepeatedPronouns(text: string): string {
+  return text.replace(/(这个|那个|我|你|他|她|它|这|那)\1/gu, '$1')
+}
+
+function collapseAccidentalRepeats(text: string): string {
+  return text
+    .replace(/([我你他她它这那给还有是的了就不在要会能把被和跟再也都来去可])\1+/gu, '$1')
+    .replace(/做做(?=[的了得过出成到])/gu, '做')
+    .replace(/想{3,}/gu, '想想')
+}
+
+function normalizePunctuation(text: string): string {
+  return text
+    .replace(/\s+/g, ' ')
+    .replace(/\s*([，。！？；、,.!?])\s*/g, '$1')
+    .replace(/[，,]{2,}/g, '，')
+    .replace(/[。．.]{2,}/g, '。')
+    .replace(/[！？!?]{2,}/g, (match) => match.includes('？') || match.includes('?') ? '？' : '！')
+    .replace(/^[，。！？；、,.!?\s]+/u, '')
+    .trim()
+}
+
+/** 清理常见口语停顿词和犹豫表达，保留原始语义。 */
+export function normalizeVoiceDictationText(text: string): string {
+  let normalized = text.trim()
+  if (!normalized) return ''
+
+  let changed = true
+  while (changed) {
+    changed = false
+    for (const pattern of LEADING_THINKING_PATTERNS) {
+      const next = normalized.replace(pattern, '')
+      if (next !== normalized) {
+        normalized = next
+        changed = true
+      }
+    }
+  }
+
+  normalized = normalized.replace(CLAUSE_FILLER_PATTERN, '$1')
+  normalized = normalized.replace(CLAUSE_THINKING_PATTERN, '$1')
+  normalized = collapseRepeatedPronouns(normalized)
+  normalized = collapseAccidentalRepeats(normalized)
+  normalized = normalized.replace(DEMONSTRATIVE_FILLER_PATTERN, '')
+  return normalizePunctuation(normalized)
+}

--- a/apps/electron/src/renderer/lib/shortcut-defaults.ts
+++ b/apps/electron/src/renderer/lib/shortcut-defaults.ts
@@ -165,6 +165,15 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
     category: 'global',
     global: true,
   },
+  {
+    id: 'voice-dictation',
+    name: '语音输入',
+    description: '唤起豆包流式语音输入浮窗',
+    defaultMac: 'Ctrl+`',
+    defaultWin: 'Ctrl+`',
+    category: 'global',
+    global: true,
+  },
 ]
 
 /** 按 ID 索引的快捷键 Map（用于快速查找） */

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -67,6 +67,7 @@ import 'katex/dist/katex.min.css'
 
 // ===== 窗口类型检测 =====
 const isQuickTaskWindow = new URLSearchParams(window.location.search).get('window') === 'quick-task'
+const isVoiceDictationWindow = new URLSearchParams(window.location.search).get('window') === 'voice-dictation'
 
 /**
  * 主题初始化组件
@@ -720,6 +721,16 @@ if (isQuickTaskWindow) {
       <React.StrictMode>
         <ThemeInitializer />
         <QuickTaskApp />
+      </React.StrictMode>
+    )
+  })
+} else if (isVoiceDictationWindow) {
+  import('./components/voice-dictation/VoiceDictationApp').then(({ VoiceDictationApp }) => {
+    ReactDOM.createRoot(document.getElementById('root')!).render(
+      <React.StrictMode>
+        <ThemeInitializer />
+        <VoiceDictationApp />
+        <Toaster position="top-right" />
       </React.StrictMode>
     )
   })

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -22,6 +22,99 @@ export interface NotificationSoundSettings {
   exitPlanMode?: NotificationSoundId
 }
 
+/** 语音输入供应商 */
+export type VoiceDictationProvider = 'doubao'
+
+/** 豆包 ASR 连接模式 */
+export type VoiceDictationEndpointMode = 'async' | 'duplex'
+
+/** 语音输入输出方式 */
+export type VoiceDictationOutputMode = 'auto' | 'clipboard' | 'proma-input'
+
+/** 语音输入设置（渲染进程读取到的是解密后的值） */
+export interface VoiceDictationSettings {
+  /** 是否启用语音输入 */
+  enabled: boolean
+  /** 语音识别供应商 */
+  provider: VoiceDictationProvider
+  /** 豆包 APP ID，对应 X-Api-App-Key 请求头 */
+  appId: string
+  /** 豆包 Access Token，对应 X-Api-Access-Key 请求头 */
+  accessToken: string
+  /** 豆包 Resource ID */
+  resourceId: string
+  /** 语言，空字符串表示自动 */
+  language: string
+  /** WebSocket 端点模式 */
+  endpointMode: VoiceDictationEndpointMode
+  /** 输出方式 */
+  outputMode: VoiceDictationOutputMode
+}
+
+/** 语音输入设置更新 */
+export type VoiceDictationSettingsUpdate = Partial<VoiceDictationSettings>
+
+/** 落盘配置，保留旧字段用于从 MVP 早期版本平滑迁移 */
+export interface VoiceDictationPersistedSettings extends Partial<VoiceDictationSettings> {
+  /** @deprecated 使用 appId */
+  appKey?: string
+  /** @deprecated 使用 accessToken */
+  accessKey?: string
+}
+
+/** 语音输入转写事件 */
+export interface VoiceDictationTranscriptEvent {
+  sessionId: string
+  text: string
+  isFinal: boolean
+}
+
+/** 语音输入状态事件 */
+export interface VoiceDictationStateEvent {
+  sessionId?: string
+  status: 'idle' | 'connecting' | 'recording' | 'stopping' | 'completed' | 'error'
+  message?: string
+}
+
+/** 开始语音输入会话参数 */
+export interface VoiceDictationStartInput {
+  sessionId: string
+}
+
+/** 语音音频分片 */
+export interface VoiceDictationAudioChunkInput {
+  sessionId: string
+  data: ArrayBuffer
+}
+
+/** 结束语音输入会话参数 */
+export interface VoiceDictationStopInput {
+  sessionId: string
+}
+
+/** 输出语音输入文本参数 */
+export interface VoiceDictationCommitInput {
+  text: string
+}
+
+/** 调整语音输入浮窗尺寸参数 */
+export interface VoiceDictationResizeInput {
+  height: number
+}
+
+/** 输出语音输入文本结果 */
+export interface VoiceDictationCommitResult {
+  mode: 'proma-input' | 'cursor' | 'clipboard'
+  success: boolean
+  message: string
+}
+
+/** 语音输入测试结果 */
+export interface VoiceDictationTestResult {
+  success: boolean
+  message: string
+}
+
 /** 用户自定义快捷键覆盖（持久化到 settings.json） */
 export interface ShortcutOverrides {
   [shortcutId: string]: {
@@ -90,6 +183,8 @@ export interface AppSettings {
   stickyUserMessageEnabled?: boolean
   /** 应用图标变体 ID（dock + window icon），'default' 或 logo 变体 id */
   appIconVariant?: string
+  /** 语音输入设置（Access Token 以加密态存储，由专用服务解密后返回渲染进程） */
+  voiceDictation?: VoiceDictationPersistedSettings
 }
 
 /** 持久化的标签页状态 */
@@ -136,6 +231,42 @@ export const QUICK_TASK_IPC_CHANNELS = {
   FOCUS: 'quick-task:focus',
   /** 重新注册全局快捷键（设置变更后） */
   REREGISTER_GLOBAL_SHORTCUTS: 'quick-task:reregister-global-shortcuts',
+} as const
+
+/** 语音输入 IPC 通道 */
+export const VOICE_DICTATION_IPC_CHANNELS = {
+  /** 获取语音输入设置 */
+  GET_SETTINGS: 'voice-dictation:get-settings',
+  /** 更新语音输入设置 */
+  UPDATE_SETTINGS: 'voice-dictation:update-settings',
+  /** 测试豆包 ASR 连接 */
+  TEST_CONNECTION: 'voice-dictation:test-connection',
+  /** 唤起或停止语音输入浮窗 */
+  TOGGLE: 'voice-dictation:toggle',
+  /** 开始语音输入会话 */
+  START: 'voice-dictation:start',
+  /** 发送音频分片 */
+  SEND_AUDIO: 'voice-dictation:send-audio',
+  /** 停止语音输入会话 */
+  STOP: 'voice-dictation:stop',
+  /** 取消语音输入会话 */
+  CANCEL: 'voice-dictation:cancel',
+  /** 输出最终文本 */
+  COMMIT: 'voice-dictation:commit',
+  /** 隐藏语音输入窗口 */
+  HIDE: 'voice-dictation:hide',
+  /** 调整语音输入窗口高度 */
+  RESIZE: 'voice-dictation:resize',
+  /** 窗口显示后通知渲染进程开始 */
+  SHOWN: 'voice-dictation:shown',
+  /** 全局快捷键请求当前录音停止 */
+  TOGGLE_STOP: 'voice-dictation:toggle-stop',
+  /** 转写文本事件 */
+  TRANSCRIPT: 'voice-dictation:transcript',
+  /** 状态事件 */
+  STATE: 'voice-dictation:state',
+  /** 主窗口插入文本 */
+  INSERT_TEXT: 'voice-dictation:insert-text',
 } as const
 
 /** 快速任务提交输入 */

--- a/apps/electron/src/types/ws.d.ts
+++ b/apps/electron/src/types/ws.d.ts
@@ -1,0 +1,12 @@
+declare module 'ws' {
+  import { EventEmitter } from 'node:events'
+
+  export default class WebSocket extends EventEmitter {
+    static readonly OPEN: number
+    readonly readyState: number
+    constructor(url: string, options?: { headers?: Record<string, string> })
+    send(data: Buffer | ArrayBuffer | Uint8Array): void
+    close(code?: number, reason?: string): void
+    terminate(): void
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.9.14",
+      "version": "0.9.15",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.123",
       },
@@ -98,6 +98,7 @@
         "use-stick-to-bottom": "^1.1.2",
         "vite": "^6.0.3",
         "word-extractor": "1.0.4",
+        "ws": "8.19.0",
         "zod": "^4.0.0",
       },
       "optionalDependencies": {

--- a/docs/plans/2026-05-05-doubao-streaming-voice-input-mvp-design.md
+++ b/docs/plans/2026-05-05-doubao-streaming-voice-input-mvp-design.md
@@ -1,0 +1,332 @@
+# 豆包流式语音输入 MVP 设计
+
+## 背景
+
+Proma 希望增加一个类似 Typeless 的系统级语音输入能力：用户安装后可以通过全局快捷键在任意应用中唤起语音输入，看到轻量浮动提示，并将语音转写结果输入到当前文本位置。区别于传统“录完再识别”，MVP 需要支持豆包的流式语音识别，让用户说话时能实时看到识别文本。
+
+当前代码库已有几个可复用基础：
+
+- 主进程全局快捷键服务：`apps/electron/src/main/lib/global-shortcut-service.ts`
+- 快速任务浮窗：`apps/electron/src/main/lib/quick-task-window.ts` 与 `apps/electron/src/renderer/components/quick-task/QuickTaskApp.tsx`
+- 设置持久化：`apps/electron/src/types/settings.ts` 与 `apps/electron/src/main/lib/settings-service.ts`
+- Chat / Agent 输入框草稿基于 Jotai，并使用 `RichTextInput` 作为受控输入组件
+
+现有 `SpeechButton` 基于浏览器 Web Speech API，只适合应用内按钮级语音输入，不适合作为本功能基础。MVP 应新增独立的语音输入服务，而不是继续扩展该组件。
+
+## 目标
+
+MVP 只解决一条主路径：
+
+1. 用户在设置里配置豆包语音识别凭证。
+2. 用户按全局快捷键唤起语音输入浮窗。
+3. Proma 获取麦克风音频，按 16kHz / 16-bit / mono PCM 分包发送给豆包大模型流式 ASR。
+4. 浮窗实时显示 partial / final 转写结果。
+5. 用户停止后，Proma 将最终文本写入目标位置。
+6. 如果目标是 Proma 当前 Chat / Agent 输入框，直接写入对应草稿；否则优先通过系统粘贴写入当前光标位置，失败时保留到剪贴板。
+
+## 非目标
+
+以下能力暂不进入 MVP：
+
+- 按住说话、松开停止的 push-to-talk。Electron `globalShortcut` 原生更适合 tap-to-toggle，监听全局 keyup 需要额外原生 hook，先不增加打包复杂度。
+- AI 润色、自动去口癖、翻译、语气改写。
+- 语音输入历史记录。
+- 多供应商 STT 抽象。
+- 离线识别。
+- 外部应用中边说边实时改写当前输入框。MVP 只在浮窗流式显示，停止后一次性输出最终文本。
+
+## 豆包 ASR 接入选择
+
+优先使用豆包“大模型流式语音识别 API”的双向流式优化版：
+
+- Endpoint: `wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_async`
+- 降级 Endpoint: `wss://openspeech.bytedance.com/api/v3/sauc/bigmodel`
+- 协议：WebSocket 二进制帧
+- 鉴权 Header：
+  - `X-Api-App-Key`
+  - `X-Api-Access-Key`
+  - `X-Api-Resource-Id`
+  - `X-Api-Connect-Id`
+- 推荐音频包：200ms 左右
+- 音频格式：`pcm` / `raw` / `16000` / `16` / `1`
+
+官方文档说明：双向流式会尽快返回识别字符，优化版只在结果变化时返回新包，性能更好。MVP 默认使用优化版，连接失败或用户显式切换时可回退普通双向流式。
+
+参考：
+
+- 火山引擎大模型流式语音识别 API：https://www.volcengine.com/docs/6561/1354869
+- OpenTypeless 豆包 ASR 配置说明：https://www.opentypeless.com/en/docs/stt-volcengine-doubao
+
+## 用户体验
+
+### 设置入口
+
+在设置中新增“语音输入”页或在“快捷键/通用”附近新增语音输入区块：
+
+- 配置说明：
+  - 打开火山引擎语音服务控制台：https://console.volcengine.com/speech/service/
+  - 选择旧版服务界面
+  - 找到“豆包流式语音识别模型2.0”类目
+  - 选择正确的应用，并确保已主动申请对应权限
+  - 在页面下方对照填写 APP ID 和 Access Token，随后点击测试连接
+- 启用语音输入：开关
+- 豆包 APP ID：对应 `X-Api-App-Key`
+- 豆包 Access Token：对应 `X-Api-Access-Key`
+- Resource ID：默认 `volc.seedasr.sauc.duration`
+- 语言：默认自动；可选 `zh-CN`、`en-US` 等
+- 快捷键：默认 `Ctrl+～`（反引号键），与 Typeless 的唤起方式保持一致
+- 输出方式：
+  - 自动：Proma 当前激活时写入当前 Chat / Agent 输入框，否则写入当前光标位置
+  - 仅复制到剪贴板
+  - 仅写入 Proma 输入框
+
+凭证不复用现有豆包 LLM 渠道。现有豆包渠道使用 Ark OpenAI-compatible API Key，而 OpenSpeech ASR 使用 APP ID / Access Token / Resource ID，语义不同，应独立配置并加密存储。
+
+### 浮窗状态
+
+浮窗采用轻量无边框窗口，宽约 480px，默认位于屏幕上方偏下位置。窗口使用真实背景色，不使用透明背景；文本不显示滚动条，窗口高度随转写内容增长但保持在当前屏幕可用高度内，底部提示始终保留。状态包括：
+
+- 待开始：提示快捷键、麦克风状态、当前供应商
+- 连接中：显示加载状态
+- 录音中：声波 / 音量条、实时文本、停止按钮
+- 完成：最终文本、已写入 / 已复制提示
+- 错误：错误原因、重试和复制已有文本
+
+文案和日志使用中文，保留 ASR、WebSocket、Resource ID 等必要术语。
+
+## 架构
+
+### 主进程模块
+
+新增 `apps/electron/src/main/lib/voice-dictation-window.ts`
+
+- 预创建语音输入浮窗
+- 通过全局快捷键切换显示
+- 定位到鼠标所在显示器上方偏下
+- 如果 Proma 不在前台，使用非激活方式显示浮窗，不主动唤起 Proma 主窗口
+- 发送 `voice-dictation:shown` / `voice-dictation:hidden` 事件给浮窗 renderer
+
+新增 `apps/electron/src/main/lib/doubao-asr-service.ts`
+
+- 管理豆包 WebSocket 连接
+- 组装二进制协议帧
+- gzip 压缩请求与音频 payload
+- 解析服务端 full server response / error response
+- 向 renderer 推送 partial / final / error
+
+新增 `apps/electron/src/main/lib/text-output-service.ts`
+
+- 协调 Proma 内部写入、外部系统粘贴和剪贴板回退
+- 给 Proma 内部输入框派发主窗口事件
+
+新增 `apps/electron/src/main/lib/text-insertion-service.ts`
+
+- 临时写入系统剪贴板
+- macOS 通过辅助功能权限和 `System Events` 触发 `Cmd+V`
+- Windows 通过 Win32 `SendInput` 触发 `Ctrl+V`
+- 自动粘贴成功后尽量恢复用户原剪贴板
+- 自动粘贴失败时保留语音文本到剪贴板
+
+### 渲染进程模块
+
+新增 `apps/electron/src/renderer/components/voice-dictation/VoiceDictationApp.tsx`
+
+- 浮窗 UI
+- 请求麦克风权限
+- 使用 `AudioWorklet` 或等价实现采集音频
+- 转 16kHz PCM s16le
+- 每 200ms 通过 IPC 发送音频包给主进程
+- 麦克风先于 ASR WebSocket 完成就绪；ASR 连接期间本地缓存音频，连接成功后补发，避免用户等待启动环节
+- 接收 ASR 文本事件并更新 UI
+
+状态策略：
+
+- 浮窗录音状态、音量、临时转写文本属于独立窗口内的短生命周期状态，保留在 `VoiceDictationApp` 本地。
+- Chat / Agent 草稿继续复用现有输入框状态和插入事件。
+- 语音输入配置由主进程设置服务持久化到本地配置文件，设置页按需读取和保存。
+
+新增设置组件：
+
+- `VoiceInputSettings.tsx`
+
+### Shared / 类型
+
+新增类型和 IPC 常量，优先放在 Electron app 本地类型中；如果未来要复用到包级能力，再迁移到 `@proma/shared`。
+
+建议类型：
+
+```ts
+export interface VoiceDictationSettings {
+  enabled: boolean
+  provider: 'doubao'
+  appId?: string
+  accessToken?: string
+  resourceId: string
+  language?: string
+  endpointMode: 'async' | 'duplex'
+  outputMode: 'auto' | 'clipboard' | 'proma-input'
+}
+
+export interface VoiceDictationTranscriptEvent {
+  sessionId: string
+  text: string
+  isFinal: boolean
+  utterances?: Array<{
+    text: string
+    definite: boolean
+    startTime?: number
+    endTime?: number
+  }>
+}
+```
+
+## 数据流
+
+```mermaid
+sequenceDiagram
+  participant User as 用户
+  participant Main as 主进程
+  participant Window as 语音浮窗
+  participant ASR as 豆包 ASR
+  participant Target as 目标输入位置
+
+  User->>Main: 按全局快捷键
+  Main->>Window: 显示并进入待录音状态
+  Window->>Window: 请求麦克风并采集 PCM
+  Window->>Main: voice-dictation:start
+  Main->>ASR: 建立 WebSocket + 鉴权 Header
+  Main->>ASR: full client request
+  loop 每 200ms
+    Window->>Main: audio chunk
+    Main->>ASR: audio only request
+    ASR->>Main: partial/final response
+    Main->>Window: transcript event
+  end
+  User->>Main: 再次按快捷键或点停止
+  Main->>ASR: final audio package
+  ASR->>Main: final response
+  Main->>Target: 写入 Proma 草稿或复制到剪贴板
+  Main->>Window: 完成状态
+```
+
+## 输出策略
+
+MVP 输出策略采用保守实现：
+
+1. 唤起浮窗前记录 Proma 主窗口是否是当前激活目标。
+2. 如果当前活跃的是 Proma 且存在 Chat / Agent 输入框，停止后通过 IPC 发送 `voice-dictation:insert-text` 到主窗口，由 `GlobalShortcuts` 或专门监听器写入对应 Jotai 草稿。
+3. 否则将最终文本临时写入剪贴板，并触发系统粘贴快捷键写入当前光标。
+4. 自动粘贴成功后，如果用户没有修改剪贴板，延迟恢复原剪贴板内容。
+5. 如果系统粘贴失败，保留最终文本到剪贴板，浮窗显示“自动粘贴失败，已复制到剪贴板”。
+
+macOS 首次自动粘贴需要辅助功能权限。Proma 会在粘贴前主动触发授权提示；授权前本次输出降级为剪贴板，授权后下次即可自动粘贴。Windows 普通窗口通过 `SendInput` 发送 `Ctrl+V`，如果目标窗口以管理员权限运行，系统可能会拦截普通权限进程的输入注入。
+
+## 权限与打包
+
+macOS 打包需要新增麦克风权限说明：
+
+- `NSMicrophoneUsageDescription`
+
+MVP UI 应明确解释：麦克风用于语音识别，外部应用场景默认写入当前光标位置并以剪贴板兜底；Proma 当前激活时写入当前 Chat / Agent 输入框。
+
+Electron 官方参考：
+
+- `systemPreferences.getMediaAccessStatus('microphone')`
+- `systemPreferences.askForMediaAccess('microphone')`
+- `systemPreferences.isTrustedAccessibilityClient(prompt)`
+
+## 依赖策略
+
+需要新增 Node WebSocket 客户端，因为浏览器 `WebSocket` 不能设置豆包要求的自定义鉴权 Header。
+
+候选依赖：
+
+- `ws`
+- `@types/ws`
+
+正式安装前必须按项目规则重新搜索并确认版本。当前调研显示 `ws` 最新稳定版本在 8.x，包成熟、无运行时依赖，适合主进程使用。
+
+不建议在 MVP 引入：
+
+- `uiohook-napi`：可做全局 keydown / keyup，但会增加原生模块、打包、签名复杂度。
+- 豆包第三方 ASR SDK：协议不复杂，自研轻量实现更可控，也更方便日志与错误处理。
+
+## 错误处理
+
+错误分层：
+
+- 配置错误：缺少 APP ID / Access Token / Resource ID。
+- 权限错误：麦克风未授权。
+- 网络错误：WebSocket 建连失败、连接中断、超时。
+- 协议错误：豆包 error response，显示错误码与简短信息。
+- 音频错误：无音频输入、采样失败、音频格式不符合要求。
+- 输出错误：Proma 内部写入不可用时，保留剪贴板回退。
+
+日志策略：
+
+- 主进程记录 `X-Tt-Logid`，用于排查豆包服务端问题。
+- 不记录完整音频数据。
+- 默认不持久化转写文本；后续如做历史记录再增加明确开关。
+
+## BDD 验收场景
+
+```gherkin
+Feature: 豆包流式语音输入
+
+  Scenario: 首次启用语音输入
+    Given 用户已填写豆包 APP ID、Access Token 和 Resource ID
+    When 用户点击测试连接
+    Then Proma 应建立一次豆包 ASR WebSocket 连接
+    And 设置页应显示连接成功或可定位的错误信息
+
+  Scenario: 使用全局快捷键开始语音输入
+    Given 语音输入已启用
+    When 用户按下语音输入全局快捷键
+    Then Proma 应显示语音输入浮窗
+    And 浮窗应请求麦克风权限或进入录音状态
+
+  Scenario: 流式显示识别结果
+    Given 语音输入浮窗正在录音
+    When 豆包返回 partial 识别文本
+    Then 浮窗应实时更新当前识别文本
+    And 未确定文本不应直接写入外部应用
+
+  Scenario: 停止后写入 Proma 输入框
+    Given 当前目标是 Proma Chat 输入框
+    And 浮窗已有最终识别文本
+    When 用户停止语音输入
+    Then Chat 输入框草稿应追加最终识别文本
+
+  Scenario: 停止后写入外部应用当前光标
+    Given 当前目标不是 Proma 输入框
+    And 当前前台应用有可输入的光标
+    When 用户停止语音输入
+    Then Proma 应把最终文本写入当前光标位置
+    And 浮窗应提示已写入当前光标位置
+
+  Scenario: 自动粘贴失败后回退到剪贴板
+    Given 当前目标不是 Proma 输入框
+    And 系统拒绝自动粘贴快捷键
+    When 用户停止语音输入
+    Then Proma 应把最终文本保留在剪贴板
+    And 浮窗应提示自动粘贴失败
+```
+
+## 实施顺序
+
+1. 新增语音输入设置类型、IPC 常量、设置页 UI。
+2. 新增语音浮窗窗口管理，并注册全局快捷键。
+3. 新增浮窗 renderer，先用本地 mock transcript 打通 UI 状态。
+4. 新增豆包 ASR 主进程服务，打通 WebSocket 协议与 gzip 帧解析。
+5. 新增音频采集与 16kHz PCM 分包。
+6. 新增 Proma 内部输入框插入事件。
+7. 新增系统粘贴输出和剪贴板回退。
+8. 补 BDD 风格单元测试和必要的手动验证清单。
+
+## 后续增强
+
+- push-to-talk：评估 `uiohook-napi` 或平台原生实现。
+- AI 润色：复用现有 Chat Provider，把 ASR final 文本送入轻量润色 prompt。
+- 自定义词表 / 热词：映射到豆包 `context` 或相关 corpus 配置。
+- 历史记录：默认本地 JSONL，提供开关。
+- 多供应商 STT：在豆包稳定后抽象 `SpeechRecognitionProvider`。


### PR DESCRIPTION
## 变更内容

- 新增豆包流式语音输入主链路：全局快捷键唤起、浮窗录音、流式 ASR、停止后输出文本。
- 新增语音输入设置页，支持填写 APP ID / Access Token、连接测试，并将入口上移到设置导航中更靠前的位置。
- 支持外部场景通过系统粘贴写入当前光标位置，失败时保留剪贴板；Proma 激活时写入 Chat / Agent 输入框。
- 优化浮窗 UI：非透明背景、长文本滚动与底部安全空间、快速停止/关闭体验。
- 移除语音输入相关测试文件，仅保留运行时代码与设计文档。

## 验证

- bun run typecheck
- bun run electron:build
- git diff --check

备注：构建仍有项目既有的 Vite chunk size warning。