### PR TITLE
fix: @ 文件引用大文件夹子目录显示不全 【已审核 PR】

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -1978,6 +1978,7 @@ export function registerIpcHandlers(): void {
       const safeRoot = resolve(rootPath)
       const ignoreDirs = new Set(['node_modules', '.git', 'dist', '.next', '__pycache__', '.venv', 'build', '.cache'])
       const ignoreFiles = new Set(['.DS_Store', '.Spotlight-V100', '.Trashes', 'Thumbs.db', 'desktop.ini'])
+      const BROWSE_LIMIT_PER_GROUP = 5000
 
       // 按来源分组收集文件
       type Entry = { name: string; path: string; type: 'file' | 'dir'; source: 'session' | 'workspace' }
@@ -2077,16 +2078,26 @@ export function registerIpcHandlers(): void {
         })
       }
 
+      // 目录优先排序：确保截断前所有目录（特别是顶层目录）排在前面
+      function sortDirsFirst(entries: Entry[]): void {
+        entries.sort((a, b) => {
+          if (a.type === 'dir' && b.type !== 'dir') return -1
+          if (a.type !== 'dir' && b.type === 'dir') return 1
+          return a.path.length - b.path.length || a.name.localeCompare(b.name)
+        })
+      }
+
       const q = query.toLowerCase()
 
       if (!q) {
-        // 空 query：每个分组返回较多条目，避免截断
-        const perGroup = Math.max(limit, 100)
-        const sessionSlice = rootEntries.slice(0, perGroup)
-        const workspaceSlice = workspaceEntries.slice(0, perGroup)
-        const combined = [...sessionSlice, ...workspaceSlice].slice(0, perGroup * 2)
+        // 空 query：目录优先排序后再截断，保证文件夹结构完整可见
+        sortDirsFirst(rootEntries)
+        sortDirsFirst(workspaceEntries)
+        const maxPerGroup = Math.max(limit, BROWSE_LIMIT_PER_GROUP)
+        const sessionSlice = rootEntries.slice(0, maxPerGroup)
+        const workspaceSlice = workspaceEntries.slice(0, maxPerGroup)
         return {
-          entries: combined,
+          entries: [...sessionSlice, ...workspaceSlice],
           total: rootEntries.length + workspaceEntries.length,
           sessionEntries: sessionSlice,
           workspaceEntries: workspaceSlice,
@@ -2098,13 +2109,24 @@ export function registerIpcHandlers(): void {
       sortGroup(sessionMatched, q)
       sortGroup(workspaceMatched, q)
 
-      const halfLimit = Math.max(1, Math.floor(limit / 2))
-      const sessionSlice = sessionMatched.slice(0, halfLimit)
-      const workspaceSlice = workspaceMatched.slice(0, halfLimit)
-      const combined = [...sessionSlice, ...workspaceSlice].slice(0, limit)
+      const totalMatched = sessionMatched.length + workspaceMatched.length
+      let sessionSlice: Entry[]
+      let workspaceSlice: Entry[]
+      if (totalMatched <= limit) {
+        sessionSlice = sessionMatched
+        workspaceSlice = workspaceMatched
+      } else {
+        const sessionQuota = Math.max(
+          sessionMatched.length > 0 ? 1 : 0,
+          Math.round(limit * sessionMatched.length / totalMatched),
+        )
+        const workspaceQuota = limit - sessionQuota
+        sessionSlice = sessionMatched.slice(0, sessionQuota)
+        workspaceSlice = workspaceMatched.slice(0, workspaceQuota)
+      }
 
       return {
-        entries: combined,
+        entries: [...sessionSlice, ...workspaceSlice],
         total: sessionMatched.length + workspaceMatched.length,
         sessionEntries: sessionSlice,
         workspaceEntries: workspaceSlice,

--- a/apps/electron/src/renderer/components/file-browser/file-mention-suggestion.tsx
+++ b/apps/electron/src/renderer/components/file-browser/file-mention-suggestion.tsx
@@ -41,7 +41,7 @@ export function createFileMentionSuggestion(
         const result = await window.electronAPI.searchWorkspaceFiles(
           wsPath,
           query ?? '',
-          20,
+          200,
           additionalPaths.length > 0 ? additionalPaths : undefined,
           sessionPaths.length > 0 ? sessionPaths : undefined,
         )


### PR DESCRIPTION
## Overview

修复输入框 @ 文件引用功能在大文件夹场景下子目录显示不全的问题。

**根因**：后端 IPC 处理器使用 DFS 扫描目录后，未排序直接截断。先扫描的大文件夹（含大量文件）会吃光配额，导致后面的兄弟目录不可见。前端 limit 也偏小。

## Changes

- `apps/electron/src/main/ipc.ts` — 新增 `sortDirsFirst()` 排序函数，确保截断前所有目录排在文件前面；空查询浏览上限从 100 提升到 5000；搜索词查询改为按匹配数比例分配配额
- `apps/electron/src/renderer/components/file-browser/file-mention-suggestion.tsx` — limit 从 20 提升到 200

## 详细分析

### DFS 扫描 + 不排序截断的典型场景

```
会话目录/
├── a/ (80 个文件)     ← 先扫描，占 82 个位置
├── b/ (50 个文件)     ← 占满剩余 18 个位置
├── c/ (1 个文件)      ← 被 slice(0, 100) 完全切掉
└── d/ (1 个文件)      ← 被 slice(0, 100) 完全切掉
```

### 修复方案

1. **`sortDirsFirst()`** — 截断前将目录排在文件前面，同类型按路径深度 + 名称排序。确保所有层级目录在截断线以上
2. **上限 100 → 5000** — `BROWSE_LIMIT_PER_GROUP` 命名常量，几乎覆盖所有实际仓库
3. **比例分配** — 搜索时不再等分 limit（如 100/100），改为按两组实际匹配占比分配（如一组 500 条一组 5 条 → 199/1），避免空间浪费

## How to Test

1. 在 Proma 中打开一个包含大量子文件夹的工作区（如 node_modules 的父目录不属于 ignoreDirs 的普通文件夹）
2. 在输入框中输入 `@`，不输入搜索词
3. 确认所有顶层文件夹都可见，且可以 Tab/点击展开查看子文件夹
4. 输入 `@` 后接搜索词（如 `@index`），确认搜索结果的会话文件和工作区文件分组都显示了合理数量的匹配项

## Notes

- `bun.lock` 有无关变更（Bun 版本元数据），已排除
- 虚拟滚动（大量 DOM 节点性能优化）建议作为后续改进