### PR TITLE
improve: sidebar 工作中/置顶 tab 样式优化 【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -1022,9 +1022,9 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                     <button
                       onClick={() => setAgentSubTab('working')}
                       className={cn(
-                        'px-2.5 py-0.5 rounded-md text-[12px] font-medium transition-colors titlebar-no-drag inline-flex items-center',
+                        'flex-1 justify-center px-2.5 py-0.5 rounded-md text-[12px] font-medium transition-colors titlebar-no-drag inline-flex items-center',
                         agentSubTab === 'working'
-                          ? 'bg-foreground/[0.08] text-foreground/80'
+                          ? 'tab-item-selected bg-foreground/[0.08] text-foreground/80'
                           : 'text-foreground/40 hover:text-foreground/60 hover:bg-foreground/[0.04]'
                       )}
                     >
@@ -1043,9 +1043,9 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                     <button
                       onClick={() => setAgentSubTab('pinned')}
                       className={cn(
-                        'px-2.5 py-0.5 rounded-md text-[12px] font-medium transition-colors titlebar-no-drag inline-flex items-center',
+                        'flex-1 justify-center px-2.5 py-0.5 rounded-md text-[12px] font-medium transition-colors titlebar-no-drag inline-flex items-center',
                         agentSubTab === 'pinned'
-                          ? 'bg-foreground/[0.08] text-foreground/80'
+                          ? 'tab-item-selected bg-foreground/[0.08] text-foreground/80'
                           : 'text-foreground/40 hover:text-foreground/60 hover:bg-foreground/[0.04]'
                       )}
                     >
@@ -1681,7 +1681,7 @@ function AgentSessionItem({
             )}
             <span className="truncate">{session.title}</span>
             {workspaceName && (
-              <span className="flex-shrink-0 px-1.5 py-0 rounded-full bg-foreground/[0.06] text-[10px] leading-4 text-foreground/40 font-medium truncate max-w-[80px]">
+              <span className="flex-shrink-0 px-1.5 py-0 rounded-full bg-primary/10 text-[10px] leading-4 workspace-badge font-medium truncate max-w-[80px]">
                 {workspaceName}
               </span>
             )}

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -381,46 +381,54 @@
 /* ===== 碧海主题：会话/工作区选中状态 ===== */
 /* 晴空碧海：浅蓝背景 + 深蓝文字 */
 .theme-ocean-light .session-item-selected,
-.theme-ocean-light .workspace-item-selected {
+.theme-ocean-light .workspace-item-selected,
+.theme-ocean-light .tab-item-selected {
   background: hsl(205 35% 82%) !important;  /* 浅蓝色背景 */
   color: hsl(205 50% 25%) !important;       /* 深蓝色文字 */
 }
 .theme-ocean-light .session-item-selected *,
-.theme-ocean-light .workspace-item-selected * {
+.theme-ocean-light .workspace-item-selected *,
+.theme-ocean-light .tab-item-selected * {
   color: inherit !important;
 }
 
 /* 苍穹暮色：深蓝背景 + 亮蓝文字 */
 .theme-ocean-dark .session-item-selected.session-item-selected,
-.theme-ocean-dark .workspace-item-selected.workspace-item-selected {
+.theme-ocean-dark .workspace-item-selected.workspace-item-selected,
+.theme-ocean-dark .tab-item-selected.tab-item-selected {
   background-color: hsl(210 40% 18%) !important;  /* 深蓝色背景 */
   color: hsl(205 70% 75%) !important;       /* 亮蓝色文字 */
 }
 .theme-ocean-dark .session-item-selected *,
-.theme-ocean-dark .workspace-item-selected * {
+.theme-ocean-dark .workspace-item-selected *,
+.theme-ocean-dark .tab-item-selected * {
   color: inherit !important;
 }
 
 /* ===== 森系主题：会话/工作区选中状态 ===== */
 /* 森息晨光：浅绿背景 + 深绿文字 */
 .theme-forest-light .session-item-selected,
-.theme-forest-light .workspace-item-selected {
+.theme-forest-light .workspace-item-selected,
+.theme-forest-light .tab-item-selected {
   background: hsl(145 25% 82%) !important;  /* 浅绿色背景 */
   color: hsl(150 35% 25%) !important;       /* 深绿色文字 */
 }
 .theme-forest-light .session-item-selected *,
-.theme-forest-light .workspace-item-selected * {
+.theme-forest-light .workspace-item-selected *,
+.theme-forest-light .tab-item-selected * {
   color: inherit !important;
 }
 
 /* 森息夜语：深绿背景 + 亮绿文字 */
 .theme-forest-dark .session-item-selected.session-item-selected,
-.theme-forest-dark .workspace-item-selected.workspace-item-selected {
+.theme-forest-dark .workspace-item-selected.workspace-item-selected,
+.theme-forest-dark .tab-item-selected.tab-item-selected {
   background-color: hsl(150 25% 18%) !important;  /* 深绿色背景 */
   color: hsl(150 40% 70%) !important;       /* 亮绿色文字 */
 }
 .theme-forest-dark .session-item-selected *,
-.theme-forest-dark .workspace-item-selected * {
+.theme-forest-dark .workspace-item-selected *,
+.theme-forest-dark .tab-item-selected * {
   color: inherit !important;
 }
 
@@ -437,24 +445,58 @@
 /* ===== 莫兰迪主题：会话/工作区选中状态 ===== */
 /* 莫兰迪夜：淡紫灰背景 + 温暖杏粉文字 */
 .theme-slate-dark .session-item-selected.session-item-selected,
-.theme-slate-dark .workspace-item-selected.workspace-item-selected {
+.theme-slate-dark .workspace-item-selected.workspace-item-selected,
+.theme-slate-dark .tab-item-selected.tab-item-selected {
   background-color: hsl(260 10% 22%) !important;  /* 淡紫灰背景 */
   color: hsl(15 30% 75%) !important;        /* 淡杏粉文字 */
 }
 .theme-slate-dark .session-item-selected *,
-.theme-slate-dark .workspace-item-selected * {
+.theme-slate-dark .workspace-item-selected *,
+.theme-slate-dark .tab-item-selected * {
   color: inherit !important;
 }
 
 /* ===== 云朵舞者主题：会话/工作区选中状态 ===== */
 .theme-slate-light .session-item-selected,
-.theme-slate-light .workspace-item-selected {
+.theme-slate-light .workspace-item-selected,
+.theme-slate-light .tab-item-selected {
   background: hsl(40 8% 84%) !important;    /* 温暖灰背景 */
   color: hsl(40 10% 25%) !important;        /* 深暖灰文字 */
 }
 .theme-slate-light .session-item-selected *,
-.theme-slate-light .workspace-item-selected * {
+.theme-slate-light .workspace-item-selected *,
+.theme-slate-light .tab-item-selected * {
   color: inherit !important;
+}
+
+/* ===== 工作区 Badge 文字颜色（追踪 workspace-item-selected 的字色） ===== */
+/* 默认主题（light / dark / system）兜底色：与原先 text-foreground/40 保持一致 */
+.workspace-badge {
+  color: hsl(var(--foreground) / 0.4);
+}
+/* 晴空碧海 */
+.theme-ocean-light .workspace-badge {
+  color: hsl(205 50% 25%);
+}
+/* 苍穹暮色 */
+.theme-ocean-dark .workspace-badge {
+  color: hsl(205 70% 75%);
+}
+/* 森息晨光 */
+.theme-forest-light .workspace-badge {
+  color: hsl(150 35% 25%);
+}
+/* 森息夜语 */
+.theme-forest-dark .workspace-badge {
+  color: hsl(150 40% 70%);
+}
+/* 云朵舞者 */
+.theme-slate-light .workspace-badge {
+  color: hsl(40 10% 25%);
+}
+/* 莫兰迪夜 */
+.theme-slate-dark .workspace-badge {
+  color: hsl(15 30% 75%);
 }
 
 /* ===== TabBar 背景 ===== */


### PR DESCRIPTION
## Overview
优化 Agent 侧边栏「工作中」和「置顶」tab 的 UI 样式，使其与工作区列表的选中态共用主题色系统，视觉更统一。

## Changes
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 工作中/置顶按钮使用 `flex-1 justify-center` 均分区域各自居中；选中态绑定 `tab-item-selected` 类；工作区 badge 改用 `workspace-badge` + `bg-primary/10`
- `apps/electron/src/renderer/styles/globals.css` — 将 `tab-item-selected` 加入所有主题的选中态规则（与 `session-item-selected`/`workspace-item-selected` 共享配色）；新增 `workspace-badge` 类，六个主题分别定义 badge 字色

## How to Test
1. 启动 Proma，进入 Agent 模式
2. 确认「工作中」和「置顶」按钮各占一半宽度，文字居中
3. 切换不同主题（晴空碧海/苍穹暮色/森息晨光/森息夜语/云朵舞者/莫兰迪夜），验证选中态颜色与工作区列表一致
4. 在暗色主题下，验证工作区名称 badge 文字清晰可读（不再深色过暗）

## Notes
- badge 字色直接追踪 `tab-item-selected` 的字色值，保证浅色/暗色主题下都有足够对比度
- 不包含 `bun.lock` 的无关变更