### PR TITLE
fix: 文件预览路径失效时增加 fallback 搜索机制【已审核 PR】

### DIFF
--- a/apps/electron/src/main/lib/file-preview-service.ts
+++ b/apps/electron/src/main/lib/file-preview-service.ts
@@ -18,6 +18,7 @@ import { BrowserWindow, shell, nativeTheme, ipcMain, dialog, screen } from 'elec
 import { resolve, basename, extname, join, dirname } from 'node:path'
 import {
   readFileSync,
+  readdirSync,
   statSync,
   writeFileSync,
   mkdirSync,
@@ -1455,24 +1456,112 @@ function watchExternalChange(previewWindow: BrowserWindow, state: PreviewWindowS
   }
 }
 
+const SKIP_DIRS = new Set(['node_modules', '.git', 'dist', '.next', '__pycache__', '.venv', 'build', '.cache', 'target'])
+const MAX_DIRS_SCANNED = 500
+
+/**
+ * 在目录中按文件名搜索（限制深度和总扫描目录数，避免阻塞主进程）
+ * 跳过 node_modules、.git、dist 等大型目录
+ */
+function searchFileInDir(dir: string, filename: string, maxDepth: number, counter = { count: 0 }): string | null {
+  if (maxDepth < 0 || counter.count >= MAX_DIRS_SCANNED) return null
+  counter.count++
+  const directCandidate = resolve(dir, filename)
+  if (existsSync(directCandidate)) return directCandidate
+  if (maxDepth === 0) return null
+
+  try {
+    const entries = readdirSync(dir, { withFileTypes: true })
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue
+      if (SKIP_DIRS.has(entry.name)) continue
+      if (entry.name.startsWith('.')) continue
+      if (counter.count >= MAX_DIRS_SCANNED) return null
+      const found = searchFileInDir(resolve(dir, entry.name), filename, maxDepth - 1, counter)
+      if (found) return found
+    }
+  } catch {
+    // 无权访问的目录跳过
+  }
+  return null
+}
+
 /**
  * 解析待预览的文件路径
- * - 绝对路径：直接 resolve
+ * - 绝对路径：先直接 resolve，若文件不存在且有 basePaths，按文件名在 basePaths 中搜索 fallback
  * - 相对路径：依次尝试 basePaths，返回第一个存在的；都不存在则返回基于第一个 base 的拼接结果
  *   （让后续 statSync 抛出更明确的错误，而不是被相对 process.cwd 误导）
  */
 function resolveTargetPath(filePath: string, basePaths?: string[]): string {
-  if (filePath.startsWith('/') || /^[A-Za-z]:[\\/]/.test(filePath)) {
-    return resolve(filePath)
-  }
-  if (basePaths && basePaths.length > 0) {
+  const isAbs = filePath.startsWith('/') || /^[A-Za-z]:[\\/]/.test(filePath)
+
+  // 第一步：直接解析
+  if (isAbs) {
+    const resolved = resolve(filePath)
+    if (existsSync(resolved)) {
+      return resolved
+    }
+  } else if (basePaths && basePaths.length > 0) {
     for (const base of basePaths) {
       if (!base) continue
       const candidate = resolve(base, filePath)
-      if (existsSync(candidate)) return candidate
+      if (existsSync(candidate)) {
+        return candidate
+      }
     }
-    return resolve(basePaths[0]!, filePath)
   }
+
+  // 第二步：直接解析失败，进入 fallback 搜索
+  const filename = basename(filePath)
+  const resolvedInput = isAbs ? resolve(filePath) : (basePaths?.[0] ? resolve(basePaths[0], filePath) : resolve(filePath))
+
+  // 收集搜索根目录
+  const searchRoots: string[] = [...(basePaths || [])]
+
+  // 从路径中提取 session workspace 根目录
+  const wsRootMatch = resolvedInput.match(/^(.+\/agent-workspaces\/[^/]+\/[0-9a-f-]+)\//)
+  if (wsRootMatch) {
+    const wsRoot = wsRootMatch[1]!
+    if (!searchRoots.includes(wsRoot)) {
+      searchRoots.push(wsRoot)
+    }
+  }
+
+  if (searchRoots.length === 0) {
+    if (isAbs) return resolve(filePath)
+    if (basePaths && basePaths.length > 0) return resolve(basePaths[0]!, filePath)
+    return resolve(filePath)
+  }
+
+  // 共享计数器，所有策略共用同一个上限
+  const counter = { count: 0 }
+
+  // 策略 1：按文件名递归搜索
+  for (const root of searchRoots) {
+    if (!root) continue
+    const found = searchFileInDir(root, filename, 8, counter)
+    if (found) {
+      return found
+    }
+  }
+
+  // 策略 2：尝试路径结构匹配（适用于 agent-workspaces 路径）
+  const wsMatch = resolvedInput.match(/\/agent-workspaces\/[^/]+\/[0-9a-f-]+\/(.+)$/)
+  if (wsMatch) {
+    const relativePart = wsMatch[1]!
+    for (const root of searchRoots) {
+      if (!root) continue
+      const candidate = resolve(root, relativePart)
+      // 校验 resolved path 未逃逸 root
+      if ((candidate.startsWith(root + '/') || candidate === root) && existsSync(candidate)) {
+        return candidate
+      }
+    }
+  }
+
+  // 所有 fallback 未找到
+  if (isAbs) return resolve(filePath)
+  if (basePaths && basePaths.length > 0) return resolve(basePaths[0]!, filePath)
   return resolve(filePath)
 }
 
@@ -1481,7 +1570,8 @@ function resolveTargetPath(filePath: string, basePaths?: string[]): string {
  * 不支持的文件类型会调用系统默认应用打开
  *
  * @param filePath 绝对路径或相对路径
- * @param basePaths 当 filePath 为相对路径时，依次尝试这些基础目录解析（主 cwd + 附加目录）
+ * @param basePaths 候选基础目录列表。相对路径时依次尝试拼接解析；
+ *                  绝对路径文件不存在时，在目录中按文件名搜索 fallback
  */
 export function openFilePreview(filePath: string, basePaths?: string[]): void {
   const safePath = resolveTargetPath(filePath, basePaths)
@@ -1491,7 +1581,16 @@ export function openFilePreview(filePath: string, basePaths?: string[]): void {
 
   // 不支持的类型，直接用系统默认应用打开
   if (previewType === 'unsupported') {
-    shell.openPath(safePath)
+    shell.openPath(safePath).then((errMsg) => {
+      if (errMsg) console.error('[文件预览] 系统打开失败:', errMsg)
+    })
+    return
+  }
+
+  // 检查文件是否存在
+  if (!existsSync(safePath)) {
+    console.warn(`[文件预览] 文件不存在: ${safePath}`)
+    dialog.showErrorBox('无法打开文件', `文件不存在：\n${safePath}`)
     return
   }
 
@@ -1499,7 +1598,9 @@ export function openFilePreview(filePath: string, basePaths?: string[]): void {
   const stat = statSync(safePath)
   if (stat.size > MAX_FILE_SIZE) {
     console.warn(`[文件预览] 文件过大 (${(stat.size / 1024 / 1024).toFixed(1)}MB)，使用系统应用打开`)
-    shell.openPath(safePath)
+    shell.openPath(safePath).then((errMsg) => {
+      if (errMsg) console.error('[文件预览] 系统打开失败:', errMsg)
+    })
     return
   }
 
@@ -1508,21 +1609,32 @@ export function openFilePreview(filePath: string, basePaths?: string[]): void {
   let html: string
   let initialContent = ''
 
-  if (previewType === 'pdf') {
-    html = pdfPreviewHtml(safePath, filename)
-  } else if (previewType === 'image') {
-    html = imagePreviewHtml(safePath, filename)
-  } else if (previewType === 'video') {
-    html = videoPreviewHtml(safePath, filename)
-  } else if (previewType === 'docx') {
-    const buffer = readFileSync(safePath)
-    const base64 = buffer.toString('base64')
-    html = docxPreviewHtml(safePath, filename, base64)
-  } else {
-    initialContent = readFileSync(safePath, 'utf-8')
-    html = previewType === 'markdown'
-      ? markdownPreviewHtml(safePath, filename, initialContent)
-      : codePreviewHtml(safePath, filename, initialContent, ext)
+  try {
+    if (previewType === 'pdf') {
+      html = pdfPreviewHtml(safePath, filename)
+    } else if (previewType === 'image') {
+      html = imagePreviewHtml(safePath, filename)
+    } else if (previewType === 'video') {
+      html = videoPreviewHtml(safePath, filename)
+    } else if (previewType === 'docx') {
+      const buffer = readFileSync(safePath)
+      const base64 = buffer.toString('base64')
+      html = docxPreviewHtml(safePath, filename, base64)
+    } else {
+      initialContent = readFileSync(safePath, 'utf-8')
+      html = previewType === 'markdown'
+        ? markdownPreviewHtml(safePath, filename, initialContent)
+        : codePreviewHtml(safePath, filename, initialContent, ext)
+    }
+  } catch (err) {
+    console.error(`[文件预览] 读取文件失败 (${safePath}):`, err)
+    shell.openPath(safePath).then((shellErrMsg) => {
+      if (shellErrMsg) {
+        console.error('[文件预览] 系统打开也失败:', shellErrMsg)
+        dialog.showErrorBox('无法打开文件', `读取文件失败，系统打开也失败：\n${safePath}\n${shellErrMsg}`)
+      }
+    })
+    return
   }
 
   const tmpHtmlPath = writeTempHtml(html)

--- a/apps/electron/src/renderer/components/agent/tool-result-renderers/write-result.tsx
+++ b/apps/electron/src/renderer/components/agent/tool-result-renderers/write-result.tsx
@@ -4,6 +4,7 @@
 
 import * as React from 'react'
 import { cn } from '@/lib/utils'
+import { FilePathChip } from '@/components/ai-elements/file-path-chip'
 
 interface WriteResultRendererProps {
   result: string
@@ -26,8 +27,13 @@ export function WriteResultRenderer({ result, isError, input }: WriteResultRende
     const filePath = typeof input.file_path === 'string' ? input.file_path : ''
     const filename = filePath.split(/[/\\]/).pop() ?? filePath
     return (
-      <div className="text-[12px] text-muted-foreground">
-        已写入 <span className="font-mono text-foreground/70">{filename || '文件'}</span>
+      <div className="flex items-center gap-1 text-[12px] text-muted-foreground">
+        已写入{' '}
+        {filePath ? (
+          <FilePathChip filePath={filePath} />
+        ) : (
+          <span className="font-mono text-foreground/70">{filename || '文件'}</span>
+        )}
       </div>
     )
   }

--- a/apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx
@@ -97,13 +97,12 @@ export function FilePathChip({ filePath, basePath, basePaths, className }: FileP
   }, [trimmedPath, isAbsolute, candidateBases])
 
   const handleClick = React.useCallback(() => {
-    // 绝对路径直接预览；相对路径把候选 basePaths 交给主进程依次尝试
-    const target = isAbsolute ? trimmedPath : trimmedPath
-    const bases = isAbsolute ? undefined : (candidateBases.length > 0 ? candidateBases : undefined)
+    const target = trimmedPath
+    const bases = candidateBases.length > 0 ? candidateBases : undefined
     window.electronAPI.previewFile(target, bases).catch((error: unknown) => {
       console.error('[FilePathChip] 预览文件失败:', error)
     })
-  }, [trimmedPath, isAbsolute, candidateBases])
+  }, [trimmedPath, candidateBases])
 
   return (
     <button

--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -471,10 +471,8 @@ const MarkdownInlineCode = React.memo(function MarkdownInlineCode({
   const text = typeof codeChildren === 'string' ? codeChildren : ''
 
   if (text) {
-    if (isAbsoluteFilePath(text)) {
-      return <FilePathChip filePath={text.trim()} />
-    }
-    // 相对路径：合并 basePath（主 cwd）+ basePaths（props 或 context 提供的附加目录）作为候选
+    // 合并 basePath（主 cwd）+ basePaths（props 或 context 提供的附加目录）作为候选
+    // 绝对路径和相对路径都需要：绝对路径可能因 session 清理等原因失效，需要 fallback 搜索
     const merged: string[] = []
     if (basePath) merged.push(basePath)
     const allExtra = basePaths || ctxBasePaths
@@ -483,6 +481,11 @@ const MarkdownInlineCode = React.memo(function MarkdownInlineCode({
         if (p && !merged.includes(p)) merged.push(p)
       }
     }
+
+    if (isAbsoluteFilePath(text)) {
+      return <FilePathChip filePath={text.trim()} basePaths={merged.length > 0 ? merged : undefined} />
+    }
+    // 相对路径
     if (merged.length > 0 && isRelativeFilePath(text)) {
       return <FilePathChip filePath={text.trim()} basePaths={merged} />
     }


### PR DESCRIPTION
## Overview

当 agent session 目录被清理或文件被移动后，消息中的绝对路径失效，点击文件路径 chip 无法预览。本 PR 为 `resolveTargetPath` 增加了 fallback 搜索机制，在原始路径不存在时自动在 workspace 范围内查找同名文件。

## Changes

- `apps/electron/src/main/lib/file-preview-service.ts`
  - 新增 `searchFileInDir` 递归搜索函数（深度 8，全局 500 目录扫描上限）
  - `resolveTargetPath` 增加两级 fallback：按文件名搜索 → 路径结构匹配
  - 绝对路径现在先检查 `existsSync`，不再盲信路径有效
  - `openFilePreview` 增加文件不存在时的 ErrorBox 提示
  - `shell.openPath` 改为处理 Promise 返回的错误信息
  - 文件读取包裹 try-catch，失败时 graceful fallback 到系统应用打开
  - 路径逃逸校验：`candidate.startsWith(root + '/')`

- `apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx`
  - `handleClick` 现在始终传递 `basePaths`（不再区分绝对/相对路径）
  - 清理 `useCallback` 依赖数组中多余的 `isAbsolute`

- `apps/electron/src/renderer/components/ai-elements/message.tsx`
  - 绝对路径的 `FilePathChip` 现在也传递 `basePaths`，支持 fallback 搜索

- `apps/electron/src/renderer/components/agent/tool-result-renderers/write-result.tsx`
  - Write 工具结果使用 `FilePathChip` 替代纯文本，支持点击预览

## How to Test

1. 在一个 session 中让 agent 创建文件，确认点击路径 chip 能正常预览
2. 手动删除或移动该文件的原始位置，确认点击仍能通过 fallback 找到并预览
3. 测试 Write 工具结果中的文件路径 chip 是否可点击
4. 确认不存在的文件点击后显示错误提示而非静默失败

## Notes

- 搜索范围限制在 `agent-workspaces` 下的 session 目录和传入的 basePaths 中
- 已移除对 `~/Desktop`、`~/Documents`、`~/Downloads` 的搜索（避免误匹配用户私人文件）
- 同名文件歧义场景（多个目录下有同名文件）返回第一个命中的，属于已知边缘限制