### PR TITLE
fix: refine file-mention browse limits and quota allocation

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -1979,7 +1979,8 @@ export function registerIpcHandlers(): void {
       const safeRoot = resolve(rootPath)
       const ignoreDirs = new Set(['node_modules', '.git', 'dist', '.next', '__pycache__', '.venv', 'build', '.cache'])
       const ignoreFiles = new Set(['.DS_Store', '.Spotlight-V100', '.Trashes', 'Thumbs.db', 'desktop.ini'])
-      const BROWSE_LIMIT_PER_GROUP = 5000
+      const BROWSE_LIMIT_PER_GROUP = 2000
+      const BROWSE_TOTAL_CAP = 3000
 
       // 按来源分组收集文件
       type Entry = { name: string; path: string; type: 'file' | 'dir'; source: 'session' | 'workspace' }
@@ -2097,8 +2098,10 @@ export function registerIpcHandlers(): void {
         const maxPerGroup = Math.max(limit, BROWSE_LIMIT_PER_GROUP)
         const sessionSlice = rootEntries.slice(0, maxPerGroup)
         const workspaceSlice = workspaceEntries.slice(0, maxPerGroup)
+        const combined = [...sessionSlice, ...workspaceSlice]
+        const capped = combined.length > BROWSE_TOTAL_CAP ? combined.slice(0, BROWSE_TOTAL_CAP) : combined
         return {
-          entries: [...sessionSlice, ...workspaceSlice],
+          entries: capped,
           total: rootEntries.length + workspaceEntries.length,
           sessionEntries: sessionSlice,
           workspaceEntries: workspaceSlice,
@@ -2121,7 +2124,10 @@ export function registerIpcHandlers(): void {
           sessionMatched.length > 0 ? 1 : 0,
           Math.round(limit * sessionMatched.length / totalMatched),
         )
-        const workspaceQuota = limit - sessionQuota
+        const workspaceQuota = Math.max(
+          workspaceMatched.length > 0 ? 1 : 0,
+          limit - sessionQuota,
+        )
         sessionSlice = sessionMatched.slice(0, sessionQuota)
         workspaceSlice = workspaceMatched.slice(0, workspaceQuota)
       }


### PR DESCRIPTION
## Summary

Follow-up to #381. Addresses review feedback on the file-mention large-folder fix:

- **降低 `BROWSE_LIMIT_PER_GROUP`**：5000 → 2000，覆盖绝大多数实际仓库的同时减少 IPC 序列化开销
- **新增 `BROWSE_TOTAL_CAP = 3000`**：空查询时对两组合并结果加总量上限，防止极端场景下返回 10,000 条数据
- **修复 workspace 侧配额保护**：比例分配时对 workspace 组也加 `Math.max(1, ...)` 最小值保护，与 session 侧对称

## Test plan

- [ ] 打开包含大量子文件夹的工作区，输入 `@` 空查询，确认所有顶层目录可见
- [ ] 确认返回总量不超过 3000 条
- [ ] 搜索 `@index` 等关键词，确认 session 和 workspace 分组都至少显示 1 条匹配（如有匹配）
- [ ] 对只有 workspace 匹配（session 无匹配）的场景，确认 workspace 结果正常显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)