### PR TITLE
fix(ui): FileDropZone review follow-ups

### DIFF
--- a/apps/electron/src/renderer/components/file-browser/FileDropZone.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileDropZone.tsx
@@ -1,8 +1,8 @@
 /**
  * FileDropZone — 文件拖拽上传区域
  *
- * 两个并排 drop zone：添加文件（回形针）+ 附加文件夹（文件夹）
- * 两个 zone 都接受文件和文件夹拖放。
+ * 两个并排 drop zone：左侧接受文件上传（回形针），右侧接受文件夹附加（文件夹）。
+ * 拖错区域会给出引导提示。
  */
 
 import * as React from 'react'
@@ -118,15 +118,17 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
         }
       } catch (error) {
         console.error('[FileDropZone] 路径检测失败，回退处理:', error)
-        // 回退：左侧按常规文件处理
         if (side === 'left') {
           await saveFiles(droppedFiles)
+        } else {
+          toast.warning('无法识别文件夹，请使用按钮选择')
         }
       }
     } else {
-      // 无路径信息回退：左侧按常规文件处理
       if (side === 'left') {
         await saveFiles(droppedFiles)
+      } else {
+        toast.warning('无法识别文件夹，请使用按钮选择')
       }
     }
   }, [saveFiles, onFoldersDropped, isUploading])
@@ -149,10 +151,6 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
   }, [])
 
   const handleSelectFiles = React.useCallback(async (): Promise<void> => {
-    if (!isWorkspace && !sessionId) {
-      console.error('[FileDropZone] session 模式下 sessionId 不能为空')
-      return
-    }
     try {
       const result = await window.electronAPI.openFileDialog()
       if (result.files.length === 0) return


### PR DESCRIPTION
## Summary

Follow-up fixes from PR #384 code review:

- **右侧回退路径加 toast 提示**：当右侧 drop zone 路径解析失败或无路径信息时，显示 `toast.warning` 提示用户使用按钮选择，而非静默丢弃
- **移除重复的 sessionId 校验**：`handleSelectFiles` 中的检查与 `saveFiles` 重复，移除冗余代码
- **修正顶部注释**：原注释"两个 zone 都接受文件和文件夹拖放"与实际行为不符，改为准确描述左文件/右文件夹的分区逻辑

## Test plan

- [ ] 拖拽文件到右侧区域，路径解析失败时应弹出 toast 提示
- [ ] 点击左侧"添加文件"按钮在 session 模式正常工作
- [ ] 基本拖拽上传/附加文件夹功能无回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)