### PR TITLE
[codex] Fix file preview refresh

### DIFF
--- a/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
@@ -10,7 +10,7 @@ import { useAtomValue, useSetAtom } from 'jotai'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { FileTypeIcon } from '@/components/file-browser/FileTypeIcon'
-import { agentDiffUnseenFilesAtom, currentAgentSessionIdAtom } from '@/atoms/agent-atoms'
+import { agentDiffUnseenFilesAtom } from '@/atoms/agent-atoms'
 import type { ChangedFileEntry, ChangeSource, UntrackedFileEntry } from '@proma/shared'
 
 /** 按目录分组后的数据结构 */
@@ -72,21 +72,19 @@ export function DiffChangesList({
   // Agent 本轮刚修改但尚未查看的文件
   const unseenFilesMap = useAtomValue(agentDiffUnseenFilesAtom)
   const setUnseenFilesMap = useSetAtom(agentDiffUnseenFilesAtom)
-  const currentSessionId = useAtomValue(currentAgentSessionIdAtom)
-  const unseenFiles = unseenFilesMap.get(currentSessionId ?? '') ?? new Set<string>()
+  const unseenFiles = unseenFilesMap.get(sessionId) ?? new Set<string>()
 
   const markFileAsSeen = React.useCallback((filePath: string) => {
-    if (!currentSessionId) return
     setUnseenFilesMap((prev) => {
-      const s = prev.get(currentSessionId)
+      const s = prev.get(sessionId)
       if (!s?.has(filePath)) return prev
       const m = new Map(prev)
       const next = new Set(s)
       next.delete(filePath)
-      m.set(currentSessionId, next)
+      m.set(sessionId, next)
       return m
     })
-  }, [currentSessionId, setUnseenFilesMap])
+  }, [sessionId, setUnseenFilesMap])
 
   const fetchChanges = React.useCallback(async () => {
     if (!dirPath) return // sessionPath 为空时跳过，避免空字符串被过滤导致找不到仓库

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -10,7 +10,7 @@ import { Code2, Copy, Check, Eye, Pencil, Save, X } from 'lucide-react'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import DOMPurify from 'dompurify'
 import { cn } from '@/lib/utils'
-import { agentDiffViewModeAtom, agentDiffRefreshVersionAtom, currentAgentSessionIdAtom } from '@/atoms/agent-atoms'
+import { agentDiffViewModeAtom, agentDiffRefreshVersionAtom } from '@/atoms/agent-atoms'
 import { resolvedThemeAtom } from '@/atoms/theme'
 import { highlightCode } from '@proma/core'
 import { DiffView } from './DiffView'
@@ -42,7 +42,7 @@ const IMAGE_EXTS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg', '.
  * 简易 LRU 缓存：保留最近访问的 N 个 entries。
  * key 设计：
  * - diff 模式：`diff:${filePath}@v${refreshVersion}`
- * - preview 模式：`preview:${filePath}`
+ * - preview 模式：`preview:${filePath}@v${refreshVersion}`
  * refreshVersion 变化时（agent 写文件、git 突变、窗口聚焦）key 自然变化，
  * 老 entry 不会被命中，最终被 LRU 淘汰；无需主动失效。
  */
@@ -106,8 +106,8 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   const [copied, setCopied] = React.useState(false)
   const refreshVersionMap = useAtomValue(agentDiffRefreshVersionAtom)
   const setRefreshVersionMap = useSetAtom(agentDiffRefreshVersionAtom)
-  const currentSessionId = useAtomValue(currentAgentSessionIdAtom)
-  const refreshVersion = refreshVersionMap.get(currentSessionId ?? '') ?? 0
+  const refreshVersion = refreshVersionMap.get(sessionId) ?? 0
+  const previewContentVersion = previewOnly ? refreshVersion : 0
   const theme = useAtomValue(resolvedThemeAtom)
 
   const ext = getExtension(filePath)
@@ -167,7 +167,8 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   const lastNewContentRef = React.useRef('')
   const lastOldContentRef = React.useRef('')
 
-  // 主加载 effect：上下文变化（filePath/dirPath/gitRoot/previewOnly）时触发
+  // 主加载 effect：上下文变化（filePath/dirPath/gitRoot/previewOnly）时触发；
+  // 纯预览模式也跟随 refreshVersion 失效，保证同一文件二次写入后重新读盘。
   // 命中缓存时跳过 loading 闪烁直接渲染；未命中走 IPC 拉取
   React.useEffect(() => {
     let cancelled = false
@@ -175,7 +176,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     // PDF / DOCX 不走文本缓存（HTML 体积大、解析过程也不轻）
     const cacheable = !isPdf && !isDocx && !isImage
     const cacheKey = cacheable
-      ? (previewOnly ? `preview:${filePath}` : `diff:${filePath}@v${refreshVersion}`)
+      ? (previewOnly ? `preview:${filePath}@v${previewContentVersion}` : `diff:${filePath}@v${refreshVersion}`)
       : null
     const cached = cacheKey ? cacheGet(cacheKey) : undefined
 
@@ -278,7 +279,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     load()
     return () => { cancelled = true }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filePath, dirPath, gitRoot, previewOnly, shikiTheme, fileAccess, isPdf, isDocx, isImage, sessionId])
+  }, [filePath, dirPath, gitRoot, previewOnly, previewContentVersion, shikiTheme, fileAccess, isPdf, isDocx, isImage, sessionId])
 
   // refreshVersion 触发的静默刷新：仅 diff 模式、内容有变化时才更新 state
   const prevRefreshRef = React.useRef(-1)
@@ -350,7 +351,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
       lastOldContentRef.current = ''
       setOldContent('')
       setNewContent(markdownDraft)
-      cacheSet(`preview:${filePath}`, { oldContent: '', newContent: markdownDraft })
+      cacheSet(`preview:${filePath}@v${refreshVersion + 1}`, { oldContent: '', newContent: markdownDraft })
       setRefreshVersionMap((prev) => {
         const m = new Map(prev)
         m.set(sessionId, (prev.get(sessionId) ?? 0) + 1)
@@ -364,7 +365,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     } finally {
       setMarkdownSaving(false)
     }
-  }, [fileAccess, filePath, isMarkdown, markdownDraft, markdownSaving, sessionId, setRefreshVersionMap])
+  }, [fileAccess, filePath, isMarkdown, markdownDraft, markdownSaving, refreshVersion, sessionId, setRefreshVersionMap])
 
   return (
     <div className="flex flex-col h-full">


### PR DESCRIPTION
## Summary

Fix the inline file preview panel so it reloads when the Agent edits the same file again.

## Root Cause

Pure preview mode cached file contents by filePath only, while Agent writes only bumped the session refresh version. When the same file was edited a second time, the preview panel could keep rendering the old cached content, especially for code/JS previews and Markdown rendering.

## Changes

- Key preview-mode content cache by filePath plus the session refresh version.
- Read preview refresh state from the panel's sessionId instead of the global current session.
- Keep Markdown inline save cache entries aligned with the next refresh version.
- Scope diff unseen-file state to the list component's own sessionId.

## Validation

- bun run --filter='@proma/electron' typecheck passed in the main workspace.
- git diff --check passed in the clean PR worktree.