### PR TITLE
fix: agent tab title not syncing after rename from header

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentHeader.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentHeader.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { agentSessionsAtom, agentSidePanelOpenAtom, workspaceFilesVersionAtom } from '@/atoms/agent-atoms'
 import { previewPanelOpenMapAtom } from '@/atoms/preview-atoms'
+import { tabsAtom, updateTabTitle } from '@/atoms/tab-atoms'
 import { registerShortcut } from '@/lib/shortcut-registry'
 
 /** AgentHeader 属性接口 */
@@ -23,6 +24,7 @@ export function AgentHeader({ sessionId }: AgentHeaderProps): React.ReactElement
   const sessions = useAtomValue(agentSessionsAtom)
   const session = sessions.find((s) => s.id === sessionId) ?? null
   const setAgentSessions = useSetAtom(agentSessionsAtom)
+  const setTabs = useSetAtom(tabsAtom)
   const [editing, setEditing] = React.useState(false)
   const [editTitle, setEditTitle] = React.useState('')
   const inputRef = React.useRef<HTMLInputElement>(null)
@@ -61,10 +63,13 @@ export function AgentHeader({ sessionId }: AgentHeaderProps): React.ReactElement
     }
 
     try {
-      await window.electronAPI.updateAgentSessionTitle(session.id, trimmed)
-      // 刷新会话列表以同步侧边栏
-      const sessions = await window.electronAPI.listAgentSessions()
-      setAgentSessions(sessions)
+      const updated = await window.electronAPI.updateAgentSessionTitle(session.id, trimmed)
+      // 同步更新标签页标题
+      setTabs((prev) => updateTabTitle(prev, session.id, trimmed))
+      // 同步更新侧边栏会话列表
+      setAgentSessions((prev) =>
+        prev.map((s) => (s.id === updated.id ? updated : s))
+      )
     } catch (error) {
       console.error('[AgentHeader] 更新标题失败:', error)
     }

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -953,21 +953,13 @@ export function useGlobalAgentListeners(): void {
     )
 
     // ===== 4. 标题更新 =====
-    const cleanupTitleUpdated = window.electronAPI.onAgentTitleUpdated(() => {
-      window.electronAPI
-        .listAgentSessions()
-        .then((sessions) => {
-          const prevSessions = store.get(agentSessionsAtom)
-          store.set(agentSessionsAtom, sessions)
-          // 同步更新标签页标题（比较新旧标题，有变化才更新）
-          for (const session of sessions) {
-            const prev = prevSessions.find((s) => s.id === session.id)
-            if (prev && prev.title !== session.title) {
-              store.set(tabsAtom, (tabs) => updateTabTitle(tabs, session.id, session.title))
-            }
-          }
-        })
-        .catch(console.error)
+    const cleanupTitleUpdated = window.electronAPI.onAgentTitleUpdated(({ sessionId, title }) => {
+      // 同步更新标签页标题
+      store.set(tabsAtom, (tabs) => updateTabTitle(tabs, sessionId, title))
+      // 同步更新侧边栏会话列表中的标题
+      store.set(agentSessionsAtom, (prev) =>
+        prev.map((s) => (s.id === sessionId ? { ...s, title } : s))
+      )
     })
 
     // 定期清理 60s 前的「最近修改」标记，避免 atom 无限增长


### PR DESCRIPTION
## Overview

Fixed a bug where renaming an agent session from the header (AgentHeader, the title bar at the top of the main page) did not update the tab bar at the top. The tab name would only reflect the new title after closing and reopening the tab. Renaming from LeftSidebar also had reliability issues due to a fragile global listener.

## Root Cause

Two issues:

1. **`AgentHeader.saveTitle()`** called `updateAgentSessionTitle()` but only refreshed `agentSessionsAtom` via a redundant `listAgentSessions()` roundtrip — it never directly called `updateTabTitle()` on `tabsAtom`, which is what the TabBar reads.

2. **`useGlobalAgentListeners.onAgentTitleUpdated`** callback ignored the `{ sessionId, title }` payload from the IPC event (the preload layer was already passing it correctly) and instead did a full `listAgentSessions()` refresh + `prev.title !== session.title` comparison. This comparison silently failed when `agentSessionsAtom` did not yet hold a snapshot of the old title.

## Changes

- `apps/electron/src/renderer/components/agent/AgentHeader.tsx` — Import `tabsAtom`/`updateTabTitle`, use the `updateAgentSessionTitle()` return value for `agentSessionsAtom` and call `updateTabTitle()` directly for `tabsAtom`. This aligns with the existing `LeftSidebar.handleAgentRename()` pattern.
- `apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts` — Accept `{ sessionId, title }` from the IPC callback and atomically update both `tabsAtom` and `agentSessionsAtom`, removing the fragile async full-refresh + comparison.

## How to Test

1. Open an agent session in Proma
2. Click the pencil icon in the AgentHeader (top of main page) → edit title → save
3. Verify the tab name in the top tab bar updates immediately
4. Repeat from the LeftSidebar rename (right-click a session → rename)
5. Verify the tab name updates immediately
6. Let the SDK auto-generate a title (first message in a new session) and verify the tab bar updates

## Notes

- All three rename paths (AgentHeader, LeftSidebar, SDK auto-title) now update `tabsAtom` without relying on fragile comparison logic
- Net code change: -3 lines (16 insertions, 19 deletions) — simpler and more direct