### PR TITLE
[codex] fix agent tab title sync

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentHeader.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentHeader.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { agentSessionsAtom, agentSidePanelOpenAtom, workspaceFilesVersionAtom } from '@/atoms/agent-atoms'
 import { previewPanelOpenMapAtom } from '@/atoms/preview-atoms'
+import { tabsAtom, updateTabTitle } from '@/atoms/tab-atoms'
 import { registerShortcut } from '@/lib/shortcut-registry'
 
 /** AgentHeader 属性接口 */
@@ -23,6 +24,7 @@ export function AgentHeader({ sessionId }: AgentHeaderProps): React.ReactElement
   const sessions = useAtomValue(agentSessionsAtom)
   const session = sessions.find((s) => s.id === sessionId) ?? null
   const setAgentSessions = useSetAtom(agentSessionsAtom)
+  const setTabs = useSetAtom(tabsAtom)
   const [editing, setEditing] = React.useState(false)
   const [editTitle, setEditTitle] = React.useState('')
   const inputRef = React.useRef<HTMLInputElement>(null)
@@ -61,10 +63,13 @@ export function AgentHeader({ sessionId }: AgentHeaderProps): React.ReactElement
     }
 
     try {
-      await window.electronAPI.updateAgentSessionTitle(session.id, trimmed)
-      // 刷新会话列表以同步侧边栏
-      const sessions = await window.electronAPI.listAgentSessions()
-      setAgentSessions(sessions)
+      const updated = await window.electronAPI.updateAgentSessionTitle(session.id, trimmed)
+      // 同步更新标签页标题
+      setTabs((prev) => updateTabTitle(prev, updated.id, updated.title))
+      // 同步更新侧边栏会话列表
+      setAgentSessions((prev) =>
+        prev.map((s) => (s.id === updated.id ? updated : s))
+      )
     } catch (error) {
       console.error('[AgentHeader] 更新标题失败:', error)
     }

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -953,19 +953,17 @@ export function useGlobalAgentListeners(): void {
     )
 
     // ===== 4. 标题更新 =====
-    const cleanupTitleUpdated = window.electronAPI.onAgentTitleUpdated(() => {
+    const cleanupTitleUpdated = window.electronAPI.onAgentTitleUpdated(({ sessionId, title }) => {
+      // 先使用事件 payload 立即同步标签页，避免依赖会话列表旧快照比较。
+      store.set(tabsAtom, (tabs) => updateTabTitle(tabs, sessionId, title))
+      store.set(agentSessionsAtom, (prev) =>
+        prev.map((s) => (s.id === sessionId ? { ...s, title } : s))
+      )
+      // 保留全量刷新语义：外部桥接会复用该事件通知新会话/绑定变化。
       window.electronAPI
         .listAgentSessions()
         .then((sessions) => {
-          const prevSessions = store.get(agentSessionsAtom)
           store.set(agentSessionsAtom, sessions)
-          // 同步更新标签页标题（比较新旧标题，有变化才更新）
-          for (const session of sessions) {
-            const prev = prevSessions.find((s) => s.id === session.id)
-            if (prev && prev.title !== session.title) {
-              store.set(tabsAtom, (tabs) => updateTabTitle(tabs, session.id, session.title))
-            }
-          }
         })
         .catch(console.error)
     })


### PR DESCRIPTION
## Overview

Fixes Agent session title synchronization so renaming from the Agent header updates the top tab title immediately, while SDK/external title update events remain reliable for both existing and newly discovered sessions.

## Root Cause

`AgentHeader.saveTitle()` refreshed `agentSessionsAtom` after updating the title, but the TabBar reads from `tabsAtom`, so the visible tab title stayed stale until the tab was reopened.

The global `onAgentTitleUpdated` listener also depended on comparing refreshed session data against the previous `agentSessionsAtom` snapshot. That missed cases where the old title was not present locally, and PR #411's direct-only replacement would have dropped the listener's existing full-refresh behavior that external bridges use to surface new sessions.

## Changes

- Update `tabsAtom` directly after `AgentHeader` renames a session, using the returned `AgentSessionMeta` title.
- Update the in-memory session list from the same returned metadata so the sidebar stays in sync.
- Use the `{ sessionId, title }` payload from `onAgentTitleUpdated` to update tabs immediately.
- Keep the listener's full `listAgentSessions()` refresh so external bridge/session-created notifications still populate unknown sessions and preserve ordering/metadata.

## Validation

- `bun install --frozen-lockfile`
- `bun run --filter='@proma/electron' typecheck`
