### PR TITLE
[codex] Fix Office file previews

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.2.129",
     "@pierre/diffs": "^1.1.20",
+    "@xmldom/xmldom": "^0.8.11",
     "adm-zip": "^0.5.17",
     "mammoth": "^1.12.0",
     "pdfjs-dist": "^4.10.38"

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -2050,7 +2050,7 @@ export function registerIpcHandlers(): void {
         console.warn('[IPC] file:prepare-pdf-preview 拒绝越界路径:', resolved ?? filePath)
         return null
       }
-      const result = preparePdfPreview(resolved)
+      const result = await preparePdfPreview(resolved)
       return result ? { tmpHtmlUrl: result.tmpHtmlUrl } : null
     }
   )
@@ -2069,6 +2069,22 @@ export function registerIpcHandlers(): void {
       }
       const result = await convertDocxToHtml(resolved)
       return result
+    }
+  )
+
+  // XLSX/PPTX 转 HTML（内联预览使用 OOXML 解析）
+  ipcMain.handle(
+    'file:office-to-html',
+    async (_, filePath: string, access?: FileAccessOptions | string[]): Promise<import('@proma/shared').OfficePreviewResult | null> => {
+      const { convertOfficeToHtml, resolveFilePath } = await import('./lib/file-preview-service')
+      const options = normalizeFileAccessOptions(access)
+      const allowedBasePaths = getAllowedCandidateBasePaths(options)
+      const resolved = resolveFilePath(filePath, allowedBasePaths)
+      if (!resolved || !isPathAllowed(resolved, options)) {
+        console.warn('[IPC] file:office-to-html 拒绝越界路径:', resolved ?? filePath)
+        return null
+      }
+      return convertOfficeToHtml(resolved)
     }
   )
 

--- a/apps/electron/src/main/lib/file-preview-service.ts
+++ b/apps/electron/src/main/lib/file-preview-service.ts
@@ -5,17 +5,23 @@
  * 供 PreviewPanel 内联面板使用。
  */
 
-import { basename, join, dirname, resolve } from 'node:path'
+import { basename, join, dirname, extname, resolve, posix as pathPosix } from 'node:path'
 import { readFileSync, readdirSync, statSync, mkdirSync, existsSync, writeFileSync } from 'node:fs'
 import { tmpdir, homedir } from 'node:os'
 import { createRequire } from 'node:module'
-import { registerPromaDirectoryPath, registerPromaFilePath } from './local-file-protocol'
+import AdmZip from 'adm-zip'
+import { DOMParser } from '@xmldom/xmldom'
+import type { OfficePreviewResult } from '@proma/shared'
 
 const require = createRequire(__filename)
 const PDFJS_PACKAGE = 'pdfjs-dist'
 
 /** 文件大小限制：50MB */
 const MAX_FILE_SIZE = 50 * 1024 * 1024
+const MAX_XLSX_SHEETS = 8
+const MAX_XLSX_ROWS = 100
+const MAX_XLSX_COLUMNS = 40
+const MAX_PPTX_SLIDES = 80
 
 // ─── 临时文件 ───
 
@@ -130,6 +136,381 @@ function resolveTargetPath(filePath: string, basePaths?: string[]): string {
   return resolve(filePath)
 }
 
+// ─── Office Open XML 预览 ───
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+function parseXml(xml: string): Document {
+  return new DOMParser().parseFromString(xml, 'application/xml')
+}
+
+function getElementsByLocalName(root: Node, localName: string): Element[] {
+  const result: Element[] = []
+
+  function walk(node: Node): void {
+    const children = node.childNodes
+    if (!children) return
+    for (let i = 0; i < children.length; i++) {
+      const child = children.item(i)
+      if (child.nodeType === 1) {
+        const element = child as Element
+        if (element.localName === localName || element.nodeName === localName) {
+          result.push(element)
+        }
+      }
+      walk(child)
+    }
+  }
+
+  walk(root)
+  return result
+}
+
+function getDirectChildElementsByLocalName(root: Element | Document, localName: string): Element[] {
+  const result: Element[] = []
+  const children = root.childNodes
+  if (!children) return result
+  for (let i = 0; i < children.length; i++) {
+    const child = children.item(i)
+    if (child.nodeType !== 1) continue
+    const element = child as Element
+    if (element.localName === localName || element.nodeName === localName) {
+      result.push(element)
+    }
+  }
+  return result
+}
+
+function getFirstTextByLocalName(root: Element, localName: string): string {
+  return getElementsByLocalName(root, localName)[0]?.textContent ?? ''
+}
+
+function readZipText(zip: AdmZip, path: string): string | null {
+  const entry = zip.getEntry(path)
+  return entry ? entry.getData().toString('utf-8') : null
+}
+
+function normalizeZipTarget(baseDir: string, target: string): string {
+  const normalizedTarget = target.replace(/\\/g, '/')
+  if (normalizedTarget.startsWith('/')) return normalizedTarget.slice(1)
+  return pathPosix.normalize(pathPosix.join(baseDir, normalizedTarget))
+}
+
+function parseRelationships(zip: AdmZip, relsPath: string, baseDir: string): Map<string, string> {
+  const relsXml = readZipText(zip, relsPath)
+  const rels = new Map<string, string>()
+  if (!relsXml) return rels
+
+  const relsDoc = parseXml(relsXml)
+  for (const rel of getElementsByLocalName(relsDoc, 'Relationship')) {
+    const id = rel.getAttribute('Id')
+    const target = rel.getAttribute('Target')
+    if (!id || !target) continue
+    rels.set(id, normalizeZipTarget(baseDir, target))
+  }
+  return rels
+}
+
+function parseSharedStrings(zip: AdmZip): string[] {
+  const sharedXml = readZipText(zip, 'xl/sharedStrings.xml')
+  if (!sharedXml) return []
+
+  const doc = parseXml(sharedXml)
+  return getElementsByLocalName(doc, 'si').map((si) => (
+    getElementsByLocalName(si, 't').map((node) => node.textContent ?? '').join('')
+  ))
+}
+
+function isDateNumFmtId(numFmtId: number): boolean {
+  return (
+    (numFmtId >= 14 && numFmtId <= 22) ||
+    (numFmtId >= 27 && numFmtId <= 36) ||
+    (numFmtId >= 45 && numFmtId <= 47) ||
+    (numFmtId >= 50 && numFmtId <= 58)
+  )
+}
+
+function isDateFormatCode(formatCode: string): boolean {
+  const normalized = formatCode
+    .replace(/"[^"]*"/g, '')
+    .replace(/\\./g, '')
+    .replace(/\[[^\]]*]/g, '')
+    .toLowerCase()
+  return /[ymdhHsS]/.test(normalized)
+}
+
+function parseXlsxDateStyleIndexes(zip: AdmZip): Set<number> {
+  const stylesXml = readZipText(zip, 'xl/styles.xml')
+  const dateStyleIndexes = new Set<number>()
+  if (!stylesXml) return dateStyleIndexes
+
+  const doc = parseXml(stylesXml)
+  const customFormats = new Map<number, string>()
+  for (const numFmt of getElementsByLocalName(doc, 'numFmt')) {
+    const id = Number(numFmt.getAttribute('numFmtId'))
+    const code = numFmt.getAttribute('formatCode') ?? ''
+    if (Number.isFinite(id) && code) customFormats.set(id, code)
+  }
+
+  const cellXfs = getElementsByLocalName(doc, 'cellXfs')[0]
+  if (!cellXfs) return dateStyleIndexes
+
+  getDirectChildElementsByLocalName(cellXfs, 'xf').forEach((xf, index) => {
+    const numFmtId = Number(xf.getAttribute('numFmtId'))
+    if (!Number.isFinite(numFmtId)) return
+    const customFormatCode = customFormats.get(numFmtId)
+    if (isDateNumFmtId(numFmtId) || (customFormatCode && isDateFormatCode(customFormatCode))) {
+      dateStyleIndexes.add(index)
+    }
+  })
+
+  return dateStyleIndexes
+}
+
+function formatExcelSerialDate(rawValue: string): string {
+  const serial = Number(rawValue)
+  if (!Number.isFinite(serial)) return rawValue
+
+  const millis = Math.round((serial - 25569) * 86400 * 1000)
+  const date = new Date(millis)
+  if (Number.isNaN(date.getTime())) return rawValue
+
+  const year = date.getUTCFullYear()
+  if (year < 1900 || year > 9999) return rawValue
+
+  const pad = (value: number) => String(value).padStart(2, '0')
+  const dateText = `${year}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}`
+  const hasTime = Math.abs(serial - Math.floor(serial)) > 0.000001
+  if (!hasTime) return dateText
+  return `${dateText} ${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}`
+}
+
+function columnIndexFromCellRef(cellRef: string): number {
+  const letters = cellRef.match(/[A-Za-z]+/)?.[0]?.toUpperCase()
+  if (!letters) return 0
+  let index = 0
+  for (const char of letters) {
+    index = index * 26 + (char.charCodeAt(0) - 64)
+  }
+  return Math.max(0, index - 1)
+}
+
+function columnNameFromIndex(index: number): string {
+  let value = index + 1
+  let name = ''
+  while (value > 0) {
+    const remainder = (value - 1) % 26
+    name = String.fromCharCode(65 + remainder) + name
+    value = Math.floor((value - 1) / 26)
+  }
+  return name
+}
+
+function getXlsxCellText(cell: Element, sharedStrings: string[], dateStyleIndexes: Set<number>): string {
+  const type = cell.getAttribute('t')
+  if (type === 'inlineStr') {
+    return getElementsByLocalName(cell, 't').map((node) => node.textContent ?? '').join('')
+  }
+
+  const value = getFirstTextByLocalName(cell, 'v')
+  if (!value) return ''
+
+  if (type === 's') {
+    const sharedIndex = Number(value)
+    return Number.isInteger(sharedIndex) ? sharedStrings[sharedIndex] ?? '' : ''
+  }
+  if (type === 'b') return value === '1' ? 'TRUE' : 'FALSE'
+
+  const styleIndex = Number(cell.getAttribute('s'))
+  if (!type && Number.isInteger(styleIndex) && dateStyleIndexes.has(styleIndex)) {
+    return formatExcelSerialDate(value)
+  }
+
+  return value
+}
+
+function parseXlsxSheetRows(
+  zip: AdmZip,
+  sheetPath: string,
+  sharedStrings: string[],
+  dateStyleIndexes: Set<number>,
+): { rows: string[][]; truncatedRows: boolean; truncatedColumns: boolean } {
+  const sheetXml = readZipText(zip, sheetPath)
+  if (!sheetXml) return { rows: [], truncatedRows: false, truncatedColumns: false }
+
+  const doc = parseXml(sheetXml)
+  const rows: string[][] = []
+  let truncatedRows = false
+  let truncatedColumns = false
+
+  for (const row of getElementsByLocalName(doc, 'row')) {
+    if (rows.length >= MAX_XLSX_ROWS) {
+      truncatedRows = true
+      break
+    }
+
+    const values: string[] = []
+    for (const cell of getDirectChildElementsByLocalName(row, 'c')) {
+      const cellRef = cell.getAttribute('r') ?? ''
+      const colIndex = columnIndexFromCellRef(cellRef)
+      if (colIndex >= MAX_XLSX_COLUMNS) {
+        truncatedColumns = true
+        continue
+      }
+      values[colIndex] = getXlsxCellText(cell, sharedStrings, dateStyleIndexes)
+    }
+
+    while (values.length > 0 && !values[values.length - 1]) values.pop()
+    if (values.some((value) => value.trim().length > 0)) rows.push(values)
+  }
+
+  return { rows, truncatedRows, truncatedColumns }
+}
+
+function renderXlsxTable(rows: string[][]): string {
+  if (rows.length === 0) {
+    return '<div class="office-empty">这个工作表没有可预览的数据</div>'
+  }
+
+  const columnCount = Math.max(...rows.map((row) => row.length), 1)
+  const headerCells = Array.from({ length: columnCount }, (_, index) => (
+    `<th>${escapeHtml(columnNameFromIndex(index))}</th>`
+  )).join('')
+  const bodyRows = rows.map((row, rowIndex) => {
+    const cells = Array.from({ length: columnCount }, (_, index) => (
+      `<td>${escapeHtml(row[index] ?? '')}</td>`
+    )).join('')
+    return `<tr><th class="office-row-heading">${rowIndex + 1}</th>${cells}</tr>`
+  }).join('')
+
+  return `<div class="office-table-wrap"><table><thead><tr><th></th>${headerCells}</tr></thead><tbody>${bodyRows}</tbody></table></div>`
+}
+
+function convertXlsxToHtml(filePath: string, resolvedPath: string): OfficePreviewResult {
+  const zip = new AdmZip(resolvedPath)
+  const workbookXml = readZipText(zip, 'xl/workbook.xml')
+  if (!workbookXml) throw new Error('Invalid XLSX: workbook.xml missing')
+
+  const workbookDoc = parseXml(workbookXml)
+  const relationships = parseRelationships(zip, 'xl/_rels/workbook.xml.rels', 'xl')
+  const sharedStrings = parseSharedStrings(zip)
+  const dateStyleIndexes = parseXlsxDateStyleIndexes(zip)
+  const sheets = getElementsByLocalName(workbookDoc, 'sheet')
+
+  let truncatedSheets = false
+  let truncatedRows = false
+  let truncatedColumns = false
+  const textParts: string[] = []
+  const htmlParts: string[] = []
+
+  sheets.slice(0, MAX_XLSX_SHEETS).forEach((sheet, sheetIndex) => {
+    const name = sheet.getAttribute('name') || `Sheet ${sheetIndex + 1}`
+    const relationshipId = sheet.getAttribute('r:id') ?? sheet.getAttribute('id')
+    const sheetPath = relationshipId ? relationships.get(relationshipId) : undefined
+    if (!sheetPath) return
+
+    const parsed = parseXlsxSheetRows(zip, sheetPath, sharedStrings, dateStyleIndexes)
+    truncatedRows ||= parsed.truncatedRows
+    truncatedColumns ||= parsed.truncatedColumns
+    textParts.push(`[${name}]`)
+    textParts.push(...parsed.rows.map((row) => row.join('\t')))
+    htmlParts.push(`<section class="office-sheet"><h3>${escapeHtml(name)}</h3>${renderXlsxTable(parsed.rows)}</section>`)
+  })
+
+  if (htmlParts.length === 0) {
+    throw new Error('Invalid XLSX: no worksheet data resolved')
+  }
+
+  truncatedSheets = sheets.length > MAX_XLSX_SHEETS
+  const notices = [
+    truncatedSheets ? `仅显示前 ${MAX_XLSX_SHEETS} 个工作表` : null,
+    truncatedRows ? `每个工作表最多显示 ${MAX_XLSX_ROWS} 行` : null,
+    truncatedColumns ? `每行最多显示 ${MAX_XLSX_COLUMNS} 列` : null,
+  ].filter(Boolean)
+  const noticeHtml = notices.length > 0
+    ? `<div class="office-preview-notice">${escapeHtml(notices.join('，'))}</div>`
+    : ''
+  const title = escapeHtml(basename(filePath))
+  const html = `<div class="office-preview office-preview-spreadsheet"><div class="office-preview-title">${title}</div>${noticeHtml}${htmlParts.join('')}</div>`
+
+  return {
+    resolvedPath,
+    kind: 'spreadsheet',
+    html,
+    text: textParts.join('\n').trim(),
+  }
+}
+
+function getPptxSlidePaths(zip: AdmZip): string[] {
+  const presentationXml = readZipText(zip, 'ppt/presentation.xml')
+  const relationships = parseRelationships(zip, 'ppt/_rels/presentation.xml.rels', 'ppt')
+  if (presentationXml) {
+    const doc = parseXml(presentationXml)
+    const slidePaths = getElementsByLocalName(doc, 'sldId')
+      .map((slide) => slide.getAttribute('r:id') ?? slide.getAttribute('id'))
+      .map((relationshipId) => relationshipId ? relationships.get(relationshipId) : undefined)
+      .filter((path): path is string => Boolean(path))
+    if (slidePaths.length > 0) return slidePaths
+  }
+
+  return zip.getEntries()
+    .map((entry) => entry.entryName)
+    .filter((entryName) => /^ppt\/slides\/slide\d+\.xml$/.test(entryName))
+    .sort((a, b) => {
+      const aIndex = Number(a.match(/slide(\d+)\.xml$/)?.[1] ?? 0)
+      const bIndex = Number(b.match(/slide(\d+)\.xml$/)?.[1] ?? 0)
+      return aIndex - bIndex
+    })
+}
+
+function getPptxSlideText(zip: AdmZip, slidePath: string): string[] {
+  const slideXml = readZipText(zip, slidePath)
+  if (!slideXml) return []
+
+  const doc = parseXml(slideXml)
+  return getElementsByLocalName(doc, 'p')
+    .map((paragraph) => getElementsByLocalName(paragraph, 't').map((textNode) => textNode.textContent ?? '').join('').trim())
+    .filter(Boolean)
+}
+
+function convertPptxToHtml(filePath: string, resolvedPath: string): OfficePreviewResult {
+  const zip = new AdmZip(resolvedPath)
+  const slidePaths = getPptxSlidePaths(zip)
+  const visibleSlidePaths = slidePaths.slice(0, MAX_PPTX_SLIDES)
+  const textParts: string[] = []
+  const slideHtml = visibleSlidePaths.map((slidePath, index) => {
+    const lines = getPptxSlideText(zip, slidePath)
+    textParts.push(`幻灯片 ${index + 1}`)
+    textParts.push(...lines)
+    const title = lines[0] || '（无标题）'
+    const body = lines.length > 1
+      ? `<ul>${lines.slice(1).map((line) => `<li>${escapeHtml(line)}</li>`).join('')}</ul>`
+      : '<div class="office-empty">这页没有更多可提取文本</div>'
+    return `<section class="office-slide"><div class="office-slide-index">幻灯片 ${index + 1}</div><h3>${escapeHtml(title)}</h3>${body}</section>`
+  }).join('')
+
+  const noticeHtml = slidePaths.length > MAX_PPTX_SLIDES
+    ? `<div class="office-preview-notice">仅显示前 ${MAX_PPTX_SLIDES} 页幻灯片</div>`
+    : ''
+  const emptyHtml = slideHtml || '<div class="office-empty">这个 PPTX 没有可提取的文本内容</div>'
+  const title = escapeHtml(basename(filePath))
+  const html = `<div class="office-preview office-preview-presentation"><div class="office-preview-title">${title}</div>${noticeHtml}${emptyHtml}</div>`
+
+  return {
+    resolvedPath,
+    kind: 'presentation',
+    html,
+    text: textParts.join('\n').trim(),
+  }
+}
+
 // ─── 导出：内联预览 API ───
 
 /** 解析文件路径并读取内容（供内联文本/代码预览使用） */
@@ -153,7 +534,7 @@ export function resolveFilePath(filePath: string, basePaths?: string[]): string 
 }
 
 /** 为内联 PDF 预览生成临时 HTML 文件（使用 proma-file:// 加载 PDF，无体积膨胀） */
-export function preparePdfPreview(filePath: string, basePaths?: string[]): { resolvedPath: string; tmpHtmlUrl: string } | null {
+export async function preparePdfPreview(filePath: string, basePaths?: string[]): Promise<{ resolvedPath: string; tmpHtmlUrl: string } | null> {
   const safePath = resolveTargetPath(filePath, basePaths)
   if (!existsSync(safePath)) return null
   const st = statSync(safePath)
@@ -163,7 +544,10 @@ export function preparePdfPreview(filePath: string, basePaths?: string[]): { res
   let pdfScriptUrl: string
   let pdfWorkerUrl: string
   let standardFontDataUrl: string
+  let registerFilePath: (path: string) => string
   try {
+    const { registerPromaDirectoryPath, registerPromaFilePath } = await import('./local-file-protocol')
+    registerFilePath = registerPromaFilePath
     fileUrl = registerPromaFilePath(safePath)
     pdfScriptUrl = registerPromaFilePath(require.resolve(`${PDFJS_PACKAGE}/build/pdf.min.mjs`))
     pdfWorkerUrl = registerPromaFilePath(require.resolve(`${PDFJS_PACKAGE}/build/pdf.worker.min.mjs`))
@@ -244,7 +628,7 @@ export function preparePdfPreview(filePath: string, basePaths?: string[]): { res
   <\/script>
 <\/body><\/html>`
   const tmpHtmlPath = writeTempHtml(html)
-  const tmpHtmlUrl = registerPromaFilePath(tmpHtmlPath)
+  const tmpHtmlUrl = registerFilePath(tmpHtmlPath)
   return { resolvedPath: safePath, tmpHtmlUrl }
 }
 
@@ -261,5 +645,50 @@ export async function convertDocxToHtml(filePath: string, basePaths?: string[]):
   } catch (err) {
     console.error('[file-preview] convertDocxToHtml failed:', err)
     return null
+  }
+}
+
+function renderOfficeTextFallback(filePath: string, text: string, kind: OfficePreviewResult['kind']): string {
+  const title = escapeHtml(basename(filePath))
+  const paragraphs = text
+    .split(/\n{2,}/)
+    .map((paragraph) => paragraph.trim())
+    .filter(Boolean)
+  const body = paragraphs.length > 0
+    ? paragraphs.map((paragraph) => `<p>${escapeHtml(paragraph).replace(/\n/g, '<br>')}</p>`).join('')
+    : '<div class="office-empty">没有可提取的文本内容</div>'
+  return `<div class="office-preview office-preview-${kind}"><div class="office-preview-title">${title}</div>${body}</div>`
+}
+
+/** 将 XLSX/PPTX 转成可内联展示的 HTML 预览 */
+export async function convertOfficeToHtml(filePath: string, basePaths?: string[]): Promise<OfficePreviewResult | null> {
+  const safePath = resolveTargetPath(filePath, basePaths)
+  if (!existsSync(safePath)) return null
+
+  try {
+    const st = statSync(safePath)
+    if (st.size > MAX_FILE_SIZE) return null
+
+    const ext = extname(safePath).toLowerCase()
+    if (ext === '.xlsx') return convertXlsxToHtml(filePath, safePath)
+    if (ext === '.pptx') return convertPptxToHtml(filePath, safePath)
+    return null
+  } catch (err) {
+    console.error('[file-preview] convertOfficeToHtml structured preview failed:', err)
+    try {
+      const officeParser = await import('officeparser')
+      const text = await officeParser.parseOfficeAsync(safePath)
+      const ext = extname(safePath).toLowerCase()
+      const kind: OfficePreviewResult['kind'] = ext === '.pptx' ? 'presentation' : 'spreadsheet'
+      return {
+        resolvedPath: safePath,
+        kind,
+        html: renderOfficeTextFallback(filePath, text, kind),
+        text,
+      }
+    } catch (fallbackErr) {
+      console.error('[file-preview] convertOfficeToHtml text fallback failed:', fallbackErr)
+      return null
+    }
   }
 }

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -630,6 +630,9 @@ export interface ElectronAPI {
   /** DOCX 转 HTML（内联预览） */
   docxToHtml: (filePath: string, access?: import('@proma/shared').FileAccessOptions) => Promise<{ resolvedPath: string; html: string } | null>
 
+  /** XLSX/PPTX 转 HTML（内联预览） */
+  officeToHtml: (filePath: string, access?: import('@proma/shared').FileAccessOptions) => Promise<import('@proma/shared').OfficePreviewResult | null>
+
   /** 重命名文件/目录 */
   renameFile: (filePath: string, newName: string) => Promise<void>
 
@@ -1578,6 +1581,10 @@ const electronAPI: ElectronAPI = {
 
   docxToHtml: (filePath: string, access?: import('@proma/shared').FileAccessOptions) => {
     return ipcRenderer.invoke('file:docx-to-html', filePath, access) as Promise<{ resolvedPath: string; html: string } | null>
+  },
+
+  officeToHtml: (filePath: string, access?: import('@proma/shared').FileAccessOptions) => {
+    return ipcRenderer.invoke('file:office-to-html', filePath, access) as Promise<import('@proma/shared').OfficePreviewResult | null>
   },
 
   renameFile: (filePath: string, newName: string) => {

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -36,6 +36,8 @@ const EXT_LANG: Record<string, string> = {
 const MD_EXTS = new Set(['.md', '.markdown'])
 const PDF_EXTS = new Set(['.pdf'])
 const DOCX_EXTS = new Set(['.docx'])
+const OFFICE_PREVIEW_EXTS = new Set(['.xlsx', '.pptx'])
+const LEGACY_OFFICE_EXTS = new Set(['.doc', '.xls', '.ppt'])
 const IMAGE_EXTS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg', '.bmp', '.ico'])
 
 /**
@@ -91,6 +93,8 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   const [markdownDraft, setMarkdownDraft] = React.useState('')
   const [markdownSaving, setMarkdownSaving] = React.useState(false)
   const [docxHtml, setDocxHtml] = React.useState('')
+  const [officeHtml, setOfficeHtml] = React.useState('')
+  const [officeText, setOfficeText] = React.useState('')
   const [pdfSrc, setPdfSrc] = React.useState('')
   const [pdfZoom, setPdfZoom] = React.useState(100)
   const pdfIframeRef = React.useRef<HTMLIFrameElement>(null)
@@ -114,6 +118,8 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   const isMarkdown = previewOnly && MD_EXTS.has(ext)
   const isPdf = previewOnly && PDF_EXTS.has(ext)
   const isDocx = previewOnly && DOCX_EXTS.has(ext)
+  const isOfficePreview = previewOnly && OFFICE_PREVIEW_EXTS.has(ext)
+  const isLegacyOffice = previewOnly && LEGACY_OFFICE_EXTS.has(ext)
   const isImage = previewOnly && IMAGE_EXTS.has(ext)
   const fileAccess = React.useMemo(() => ({
     sessionId,
@@ -173,8 +179,8 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   React.useEffect(() => {
     let cancelled = false
 
-    // PDF / DOCX 不走文本缓存（HTML 体积大、解析过程也不轻）
-    const cacheable = !isPdf && !isDocx && !isImage
+    // PDF / DOCX / Office 不走文本缓存（HTML 体积大、解析过程也不轻）
+    const cacheable = !isPdf && !isDocx && !isOfficePreview && !isLegacyOffice && !isImage
     const cacheKey = cacheable
       ? (previewOnly ? `preview:${filePath}@v${previewContentVersion}` : `diff:${filePath}@v${refreshVersion}`)
       : null
@@ -188,6 +194,8 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
       setNewContent(cached.newContent)
       setHighlightedHtml('')
       setDocxHtml('')
+      setOfficeHtml('')
+      setOfficeText('')
       setPdfSrc('')
       setPdfZoom(100)
       setImagePath('')
@@ -201,6 +209,8 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
       setNewContent('')
       setHighlightedHtml('')
       setDocxHtml('')
+      setOfficeHtml('')
+      setOfficeText('')
       setPdfSrc('')
       setPdfZoom(100)
       setImagePath('')
@@ -242,6 +252,16 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
               setDocxHtml(DOMPurify.sanitize(result?.html ?? ''))
               return
             }
+            if (isOfficePreview) {
+              const result = await window.electronAPI.officeToHtml(filePath, fileAccess)
+              if (cancelled) return
+              setOfficeHtml(DOMPurify.sanitize(result?.html ?? ''))
+              setOfficeText(result?.text ?? '')
+              return
+            }
+            if (isLegacyOffice) {
+              return
+            }
             const result = await window.electronAPI.resolveAndReadFile(filePath, fileAccess)
             if (cancelled) return
             content = result?.content ?? ''
@@ -279,7 +299,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     load()
     return () => { cancelled = true }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filePath, dirPath, gitRoot, previewOnly, previewContentVersion, shikiTheme, fileAccess, isPdf, isDocx, isImage, sessionId])
+  }, [filePath, dirPath, gitRoot, previewOnly, previewContentVersion, shikiTheme, fileAccess, isPdf, isDocx, isOfficePreview, isLegacyOffice, isImage, sessionId])
 
   // refreshVersion 触发的静默刷新：仅 diff 模式、内容有变化时才更新 state
   const prevRefreshRef = React.useRef(-1)
@@ -317,13 +337,14 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
 
   const handleCopy = React.useCallback(async () => {
     try {
-      await navigator.clipboard.writeText(markdownEditing ? markdownDraft : newContent)
+      const copyText = markdownEditing ? markdownDraft : (isOfficePreview ? officeText : newContent)
+      await navigator.clipboard.writeText(copyText)
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
     } catch {
       // 复制失败
     }
-  }, [markdownDraft, markdownEditing, newContent])
+  }, [isOfficePreview, markdownDraft, markdownEditing, newContent, officeText])
 
   const startMarkdownEdit = React.useCallback(() => {
     if (!isMarkdown) return
@@ -549,6 +570,22 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
             ) : (
               <div className="flex items-center justify-center h-full text-muted-foreground text-[12px]">无法加载 DOCX</div>
             )
+          ) : isOfficePreview ? (
+            officeHtml ? (
+              <div
+                className="office-preview-host"
+                dangerouslySetInnerHTML={{ __html: officeHtml }}
+              />
+            ) : (
+              <div className="flex items-center justify-center h-full text-muted-foreground text-[12px]">
+                无法加载 {ext === '.pptx' ? 'PPTX' : 'Excel'} 预览
+              </div>
+            )
+          ) : isLegacyOffice ? (
+            <div className="flex flex-col items-center justify-center h-full text-muted-foreground text-[12px] gap-1 px-4 text-center">
+              <p>暂不支持旧版 {ext.toUpperCase().slice(1)} 内联预览</p>
+              <p className="text-[11px] text-muted-foreground/60">请在系统中打开，或转换为 {ext === '.xls' ? 'XLSX' : ext === '.ppt' ? 'PPTX' : 'DOCX'} 后预览</p>
+            </div>
           ) : isMarkdown ? (
             markdownEditing && markdownSourceMode ? (
               <textarea

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -844,6 +844,130 @@
   animation: file-browser-flash 1.2s ease-out;
 }
 
+/* ===== Office 内联预览 ===== */
+.office-preview-host {
+  min-height: 100%;
+  padding: 12px;
+  color: hsl(var(--foreground));
+  font-size: 12px;
+}
+
+.office-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.office-preview-title {
+  color: hsl(var(--foreground) / 0.72);
+  font-weight: 600;
+  line-height: 1.4;
+  word-break: break-word;
+}
+
+.office-preview-notice,
+.office-empty {
+  color: hsl(var(--muted-foreground));
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.office-preview-notice {
+  border: 1px solid hsl(var(--border) / 0.45);
+  border-radius: 8px;
+  background: hsl(var(--muted) / 0.24);
+  padding: 8px 10px;
+}
+
+.office-sheet,
+.office-slide {
+  border: 1px solid hsl(var(--border) / 0.5);
+  border-radius: 8px;
+  background: hsl(var(--background) / 0.72);
+  overflow: hidden;
+}
+
+.office-sheet h3,
+.office-slide h3 {
+  margin: 0;
+  color: hsl(var(--foreground));
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.45;
+}
+
+.office-sheet h3 {
+  padding: 10px 12px;
+  border-bottom: 1px solid hsl(var(--border) / 0.45);
+}
+
+.office-table-wrap {
+  overflow: auto;
+  max-width: 100%;
+}
+
+.office-table-wrap table {
+  width: max-content;
+  min-width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.office-table-wrap th,
+.office-table-wrap td {
+  max-width: 280px;
+  min-width: 72px;
+  border-right: 1px solid hsl(var(--border) / 0.35);
+  border-bottom: 1px solid hsl(var(--border) / 0.35);
+  padding: 6px 8px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: left;
+}
+
+.office-table-wrap thead th,
+.office-row-heading {
+  position: sticky;
+  z-index: 1;
+  background: hsl(var(--muted) / 0.36);
+  color: hsl(var(--muted-foreground));
+  font-weight: 500;
+}
+
+.office-table-wrap thead th {
+  top: 0;
+}
+
+.office-row-heading {
+  left: 0;
+  min-width: 44px;
+  text-align: right;
+}
+
+.office-slide {
+  padding: 12px;
+}
+
+.office-slide-index {
+  margin-bottom: 6px;
+  color: hsl(var(--muted-foreground));
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.office-slide ul {
+  margin: 8px 0 0;
+  padding-left: 18px;
+  color: hsl(var(--foreground) / 0.82);
+  line-height: 1.6;
+}
+
+.office-slide li + li {
+  margin-top: 4px;
+}
+
 /* ===== 语音输入浮窗拖动区域 ===== */
 .voice-dictation-drag-region {
   -webkit-app-region: drag;

--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.129",
         "@pierre/diffs": "^1.1.20",
+        "@xmldom/xmldom": "^0.8.11",
         "adm-zip": "^0.5.17",
         "mammoth": "^1.12.0",
         "pdfjs-dist": "^4.10.38",

--- a/packages/shared/src/types/runtime.ts
+++ b/packages/shared/src/types/runtime.ts
@@ -173,6 +173,17 @@ export interface ResolvedFileUrl {
   url: string
 }
 
+/** Office 文件内联预览类型 */
+export type OfficePreviewKind = 'spreadsheet' | 'presentation'
+
+/** Office 文件内联预览结果 */
+export interface OfficePreviewResult {
+  resolvedPath: string
+  kind: OfficePreviewKind
+  html: string
+  text: string
+}
+
 /**
  * Git Bash 运行时状态（Windows 平台）
  */


### PR DESCRIPTION
## Summary

Fixes the inline preview path for Office files.

- Adds a dedicated XLSX/PPTX preview IPC path instead of reading XLSX files as UTF-8 text.
- Renders XLSX files as bounded worksheet tables and PPTX files as slide-grouped text previews.
- Shows an explicit unsupported-state message for legacy DOC/XLS/PPT formats so binary files are not displayed as garbled text.
- Keeps the existing preview cache invalidation behavior from `main` so pure previews refresh after file writes.

## Root Cause

XLSX files were falling through to the generic text preview path, which attempted to read the zipped Office document as UTF-8. That produced broken preview content for Excel files. PPTX had text extraction support elsewhere, but no inline preview branch.

## Validation

- `bun run typecheck`
- `bun run build:main`
- `bun run build:preload`
- `bun run build:renderer`
- Verified generated temporary XLSX and PPTX fixtures through `convertOfficeToHtml`.
