### PR TITLE
[codex] add agent long text paste attachments

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -92,6 +92,33 @@ import { fileToBase64 } from '@/lib/file-utils'
 
 /** 稳定的空 SDKMessage 数组引用，避免 ?? [] 每次创建新引用 */
 const EMPTY_SDK_MESSAGES: SDKMessage[] = []
+const LONG_TEXT_ATTACHMENT_THRESHOLD = 500
+
+function formatClipboardTimestamp(date = new Date()): string {
+  const pad = (value: number): string => String(value).padStart(2, '0')
+  return `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}-${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}`
+}
+
+function looksLikeMarkdown(text: string): boolean {
+  return [
+    /^#{1,6}\s+\S/m,
+    /```[\s\S]*?```/,
+    /^\s*\|.+\|\s*\n\s*\|[\s:-]+\|/m,
+    /^---\n[\s\S]*?\n---\n/,
+    /^\s*> .+/m,
+    /^\s*[-*+]\s+\S/m,
+    /^\s*\d+\.\s+\S/m,
+    /\[[^\]]+\]\([^)]+\)/,
+  ].some((pattern) => pattern.test(text))
+}
+
+function createClipboardTextFile(text: string): File {
+  const isMarkdown = looksLikeMarkdown(text)
+  const extension = isMarkdown ? 'md' : 'txt'
+  const mediaType = isMarkdown ? 'text/markdown' : 'text/plain'
+  const filename = `clipboard-${formatClipboardTimestamp()}.${extension}`
+  return new File([text], filename, { type: mediaType })
+}
 
 interface SDKMessageRecord {
   type?: string
@@ -766,6 +793,21 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   /** 粘贴文件处理 */
   const handlePasteFiles = React.useCallback((files: File[]): void => {
     addFilesAsAttachments(files)
+  }, [addFilesAsAttachments])
+
+  /** 粘贴超长文本时转为待发送附件，避免把大段内容直接塞进输入框 */
+  const handlePasteLongText = React.useCallback((text: string): void => {
+    const file = createClipboardTextFile(text)
+    addFilesAsAttachments([file])
+      .then(() => {
+        toast.success('已将超长文本转为附件', {
+          description: file.name,
+        })
+      })
+      .catch((error) => {
+        console.error('[AgentView] 超长文本转附件失败:', error)
+        toast.error('超长文本转附件失败')
+      })
   }, [addFilesAsAttachments])
 
   /** 拖放处理 */
@@ -1524,6 +1566,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
               onChange={setInputContent}
               onSubmit={handleSend}
               onPasteFiles={handlePasteFiles}
+              onPasteLongText={handlePasteLongText}
+              longTextPasteThreshold={LONG_TEXT_ATTACHMENT_THRESHOLD}
               placeholder={
                 agentChannelId && hasAvailableModel
                   ? sendWithCmdEnter

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -79,6 +79,10 @@ interface RichTextInputProps {
   onSubmit: () => void
   /** 粘贴文件回调（拦截粘贴的文件） */
   onPasteFiles?: (files: File[]) => void
+  /** 粘贴超长文本回调（由调用方决定是否转换为附件） */
+  onPasteLongText?: (text: string) => void
+  /** 触发超长文本粘贴回调的字符数阈值 */
+  longTextPasteThreshold?: number
   /** 占位文字 */
   placeholder?: string
   /** 是否显示建议样式（斜体占位符） */
@@ -119,6 +123,8 @@ export function RichTextInput({
   onChange,
   onSubmit,
   onPasteFiles,
+  onPasteLongText,
+  longTextPasteThreshold,
   placeholder = '有什么可以帮助到你的呢？',
   suggestionActive = false,
   className,
@@ -148,6 +154,11 @@ export function RichTextInput({
   // 保持 onPasteFiles 引用最新
   const onPasteFilesRef = useRef(onPasteFiles)
   onPasteFilesRef.current = onPasteFiles
+  // 保持超长文本粘贴配置最新
+  const onPasteLongTextRef = useRef(onPasteLongText)
+  onPasteLongTextRef.current = onPasteLongText
+  const longTextPasteThresholdRef = useRef(longTextPasteThreshold)
+  longTextPasteThresholdRef.current = longTextPasteThreshold
   // 保持 onHtmlChange 引用最新
   const onHtmlChangeRef = useRef(onHtmlChange)
   onHtmlChangeRef.current = onHtmlChange
@@ -312,6 +323,21 @@ export function RichTextInput({
         if (clipboardItems && clipboardItems.length > 0 && onPasteFilesRef.current) {
           event.preventDefault()
           onPasteFilesRef.current(Array.from(clipboardItems))
+          return true
+        }
+
+        const threshold = longTextPasteThresholdRef.current
+        const plainText = event.clipboardData?.getData('text/plain') ?? ''
+        const html = event.clipboardData?.getData('text/html') ?? ''
+        const text = html ? (htmlToMarkdown(html).trim() || plainText) : plainText
+        if (
+          threshold &&
+          threshold > 0 &&
+          (plainText.length >= threshold || text.length >= threshold) &&
+          onPasteLongTextRef.current
+        ) {
+          event.preventDefault()
+          onPasteLongTextRef.current(text)
           return true
         }
         return false


### PR DESCRIPTION
## Summary

- Add long-text paste handling to the shared rich text input, with caller-controlled threshold and callback behavior.
- In Agent mode, convert pasted text over 500 characters into a pending .md or .txt attachment instead of inserting it directly into the editor.
- Preserve rich clipboard content by converting HTML clipboard data to Markdown before attachment creation when available.

## Impact

This keeps the Agent input lightweight when users paste long articles, logs, or structured snippets. The generated attachment is sent through the existing Agent <attached_files> flow, so the Agent can read it as a session file.

## Validation

- bun run --filter='@proma/electron' typecheck passed in the main working tree with this patch.
- A second typecheck attempt in the isolated /private/tmp worktree could not resolve dependencies because that worktree has no installed node_modules / workspace package links.