### PR TITLE
[codex] Add detached preview window

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -98,6 +98,7 @@ import type {
   WeChatBridgeState,
   SDKMessage,
   GetFileDiffInput,
+  DetachedPreviewWindowInput,
   RevertFileInput,
   FileAccessOptions,
   ResolvedFileUrl,
@@ -458,6 +459,30 @@ export function registerIpcHandlers(): void {
       const access = normalizeFileAccessOptions({ sessionId })
       if (!ensurePathAllowed(dirPath, access) || (gitRoot && !ensurePathAllowed(gitRoot, access))) return null
       return getDiffContents(dirPath, filePath, gitRoot)
+    }
+  )
+
+  // 打开独立预览窗口
+  ipcMain.handle(
+    IPC_CHANNELS.OPEN_DETACHED_PREVIEW,
+    async (event, input: DetachedPreviewWindowInput): Promise<string | null> => {
+      if (!input || typeof input.sessionId !== 'string' || typeof input.filePath !== 'string' || typeof input.dirPath !== 'string') {
+        console.warn('[IPC] preview:open-detached 收到无效参数')
+        return null
+      }
+      const { openDetachedPreviewWindow } = await import('./lib/detached-preview-window')
+      const sourceWindow = BrowserWindow.fromWebContents(event.sender)
+      return openDetachedPreviewWindow(input, sourceWindow)
+    }
+  )
+
+  // 获取独立预览窗口数据
+  ipcMain.handle(
+    IPC_CHANNELS.GET_DETACHED_PREVIEW_DATA,
+    async (_, previewId: string) => {
+      if (!previewId || typeof previewId !== 'string') return null
+      const { getDetachedPreviewWindowData } = await import('./lib/detached-preview-window')
+      return getDetachedPreviewWindowData(previewId)
     }
   )
 

--- a/apps/electron/src/main/lib/detached-preview-window.ts
+++ b/apps/electron/src/main/lib/detached-preview-window.ts
@@ -1,0 +1,151 @@
+/**
+ * 独立预览窗口管理
+ *
+ * 主窗口将当前预览 payload 交给主进程保存，独立窗口通过 previewId 读取。
+ * 避免把长路径和 basePaths 全部塞进 URL。
+ */
+
+import { app, BrowserWindow, screen, shell } from 'electron'
+import type { Rectangle } from 'electron'
+import { basename, join } from 'path'
+import type { DetachedPreviewWindowData, DetachedPreviewWindowInput } from '@proma/shared'
+
+const previewDataById = new Map<string, DetachedPreviewWindowData>()
+const previewWindowsById = new Map<string, BrowserWindow>()
+const previewIdBySignature = new Map<string, string>()
+
+function makePreviewId(): string {
+  return `preview-${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+function makeSignature(input: DetachedPreviewWindowInput): string {
+  return JSON.stringify({
+    sessionId: input.sessionId,
+    filePath: input.filePath,
+    dirPath: input.dirPath,
+    gitRoot: input.gitRoot,
+    previewOnly: input.previewOnly === true,
+    basePaths: input.basePaths ?? [],
+  })
+}
+
+function getWindowTitle(input: DetachedPreviewWindowInput): string {
+  return input.title?.trim() || basename(input.filePath) || '文件预览'
+}
+
+function centerBoundsNearSource(sourceWindow?: BrowserWindow | null): Rectangle {
+  const display = sourceWindow && !sourceWindow.isDestroyed()
+    ? screen.getDisplayMatching(sourceWindow.getBounds())
+    : screen.getPrimaryDisplay()
+  const { x, y, width: screenWidth, height: screenHeight } = display.workArea
+  const width = Math.max(640, Math.min(1100, Math.floor(screenWidth * 0.88)))
+  const height = Math.max(480, Math.min(760, Math.floor(screenHeight * 0.86)))
+
+  return {
+    x: x + Math.round((screenWidth - width) / 2),
+    y: y + Math.round((screenHeight - height) / 2),
+    width,
+    height,
+  }
+}
+
+function installDetachedPreviewShortcuts(win: BrowserWindow): void {
+  win.webContents.on('before-input-event', (event, input) => {
+    if (input.type !== 'keyDown') return
+
+    const key = input.key.toLowerCase()
+    const closeByEscape = key === 'escape' && !input.meta && !input.control && !input.alt
+    const closeByWindowShortcut = key === 'w' && (input.meta || input.control) && !input.alt
+    if (!closeByEscape && !closeByWindowShortcut) return
+
+    event.preventDefault()
+    if (!win.isDestroyed()) {
+      win.close()
+    }
+  })
+}
+
+export function openDetachedPreviewWindow(
+  input: DetachedPreviewWindowInput,
+  sourceWindow?: BrowserWindow | null,
+): string | null {
+  if (!input.sessionId || !input.filePath || !input.dirPath) return null
+
+  const signature = makeSignature(input)
+  const existingId = previewIdBySignature.get(signature)
+  const existingWindow = existingId ? previewWindowsById.get(existingId) : null
+  if (existingId && existingWindow && !existingWindow.isDestroyed()) {
+    if (existingWindow.isMinimized()) existingWindow.restore()
+    existingWindow.show()
+    existingWindow.focus()
+    return existingId
+  }
+
+  const id = makePreviewId()
+  const data: DetachedPreviewWindowData = {
+    ...input,
+    id,
+    title: getWindowTitle(input),
+  }
+  previewDataById.set(id, data)
+  previewIdBySignature.set(signature, id)
+
+  const bounds = centerBoundsNearSource(sourceWindow)
+  const win = new BrowserWindow({
+    ...bounds,
+    minWidth: 640,
+    minHeight: 480,
+    title: data.title,
+    show: false,
+    webPreferences: {
+      preload: join(__dirname, 'preload.cjs'),
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  })
+
+  previewWindowsById.set(id, win)
+  installDetachedPreviewShortcuts(win)
+
+  const isDev = !app.isPackaged
+  if (isDev) {
+    win.loadURL(`http://localhost:5173?window=detached-preview&previewId=${encodeURIComponent(id)}`)
+  } else {
+    win.loadFile(join(__dirname, 'renderer', 'index.html'), {
+      query: { window: 'detached-preview', previewId: id },
+    })
+  }
+
+  win.once('ready-to-show', () => {
+    if (!win.isDestroyed()) win.show()
+  })
+
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    if (url.startsWith('http://') || url.startsWith('https://')) {
+      shell.openExternal(url)
+    }
+    return { action: 'deny' }
+  })
+
+  win.webContents.on('will-navigate', (event, url) => {
+    if (isDev && url.startsWith('http://localhost:')) return
+    event.preventDefault()
+    if (url.startsWith('http://') || url.startsWith('https://')) {
+      shell.openExternal(url)
+    }
+  })
+
+  win.on('closed', () => {
+    previewWindowsById.delete(id)
+    previewDataById.delete(id)
+    if (previewIdBySignature.get(signature) === id) {
+      previewIdBySignature.delete(signature)
+    }
+  })
+
+  return id
+}
+
+export function getDetachedPreviewWindowData(id: string): DetachedPreviewWindowData | null {
+  return previewDataById.get(id) ?? null
+}

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -81,6 +81,8 @@ import type {
   RewindSessionInput,
   RewindSessionResult,
   AgentMessageSearchResult,
+  DetachedPreviewWindowData,
+  DetachedPreviewWindowInput,
   FeishuConfig,
   FeishuConfigInput,
   FeishuBridgeState,
@@ -156,6 +158,10 @@ export interface ElectronAPI {
   revertFile: (input: import('@proma/shared').RevertFileInput) => Promise<void>
   /** 获取文件新旧版本内容 */
   getDiffContents: (input: import('@proma/shared').GetFileDiffInput) => Promise<{ oldContent: string; newContent: string } | null>
+  /** 在独立窗口打开当前文件预览 */
+  openDetachedPreview: (input: DetachedPreviewWindowInput) => Promise<string | null>
+  /** 获取独立预览窗口数据 */
+  getDetachedPreviewData: (previewId: string) => Promise<DetachedPreviewWindowData | null>
 
   // ===== 通用工具 =====
 
@@ -935,6 +941,14 @@ const electronAPI: ElectronAPI = {
 
   getDiffContents: (input: import('@proma/shared').GetFileDiffInput) => {
     return ipcRenderer.invoke(IPC_CHANNELS.GET_DIFF_CONTENTS, input)
+  },
+
+  openDetachedPreview: (input: DetachedPreviewWindowInput) => {
+    return ipcRenderer.invoke(IPC_CHANNELS.OPEN_DETACHED_PREVIEW, input) as Promise<string | null>
+  },
+
+  getDetachedPreviewData: (previewId: string) => {
+    return ipcRenderer.invoke(IPC_CHANNELS.GET_DETACHED_PREVIEW_DATA, previewId) as Promise<DetachedPreviewWindowData | null>
   },
 
   // 通用工具

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -287,6 +287,9 @@ export const workspaceFilesVersionAtom = atom(0)
 /** 侧面板是否打开（全局共享，所有会话共用一个状态） */
 export const agentSidePanelOpenAtom = atomWithStorage<boolean>('proma-agent-sidepanel-open', true)
 
+/** 侧面板宽度（全局共享，用户拖拽后持久化） */
+export const agentSidePanelWidthAtom = atomWithStorage<number>('proma-agent-sidepanel-width', 280)
+
 /** @deprecated 保留以兼容旧代码，但实际所有 session 都读全局 atom */
 export const agentSidePanelOpenMapAtom = atom<Map<string, boolean>>(new Map())
 

--- a/apps/electron/src/renderer/atoms/preview-atoms.ts
+++ b/apps/electron/src/renderer/atoms/preview-atoms.ts
@@ -30,7 +30,7 @@ export const previewPanelOpenMapAtom = atom<Map<string, boolean>>(new Map())
 export const previewFileMapAtom = atom<Map<string, PreviewFile | null>>(new Map())
 
 /** 分栏比例（对话占比），持久化 */
-export const previewSplitRatioAtom = atomWithStorage<number>('proma-preview-split-ratio', 0.6)
+export const previewSplitRatioAtom = atomWithStorage<number>('proma-preview-split-ratio', 0.5)
 
 /** 自动预览开关，持久化 */
 export const autoPreviewEnabledAtom = atomWithStorage<boolean>('proma-auto-preview-enabled', true)

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -42,7 +42,7 @@ interface SidePanelProps {
   width?: number
 }
 
-export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, width = 320 }: SidePanelProps): React.ReactElement {
+export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, width = 280 }: SidePanelProps): React.ReactElement {
   // per-session 侧面板状态（默认打开）
   const [isOpen, setIsOpen] = useAtom(agentSidePanelOpenAtom)
   const isWindows = React.useMemo(() => detectIsWindows(), [])

--- a/apps/electron/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/electron/src/renderer/components/app-shell/AppShell.tsx
@@ -7,14 +7,21 @@
  */
 
 import * as React from 'react'
-import { useAtomValue } from 'jotai'
+import { useAtom, useAtomValue } from 'jotai'
 import { LeftSidebar } from './LeftSidebar'
 import { RightSidePanel } from './RightSidePanel'
 import { MainArea } from '@/components/tabs/MainArea'
 import { AppShellProvider, type AppShellContextType } from '@/contexts/AppShellContext'
 import { appModeAtom } from '@/atoms/app-mode'
-import { currentAgentSessionIdAtom, currentSessionSidePanelOpenAtom } from '@/atoms/agent-atoms'
+import { agentSidePanelWidthAtom, currentAgentSessionIdAtom, currentSessionSidePanelOpenAtom } from '@/atoms/agent-atoms'
 import { cn } from '@/lib/utils'
+
+const MIN_RIGHT_PANEL_WIDTH = 220
+const MAX_RIGHT_PANEL_WIDTH = 420
+
+function clampRightPanelWidth(width: number): number {
+  return Math.max(MIN_RIGHT_PANEL_WIDTH, Math.min(MAX_RIGHT_PANEL_WIDTH, width))
+}
 
 export interface AppShellProps {
   /** Context 值，用于传递给子组件 */
@@ -28,14 +35,21 @@ export function AppShell({ contextValue }: AppShellProps): React.ReactElement {
   const showRightPanel = appMode === 'agent' && !!currentSessionId
 
   // 右侧面板可拖拽宽度
-  const [rightPanelWidth, setRightPanelWidth] = React.useState(320)
+  const [rightPanelWidth, setRightPanelWidth] = useAtom(agentSidePanelWidthAtom)
   const dragging = React.useRef(false)
+  const clampedRightPanelWidth = clampRightPanelWidth(rightPanelWidth)
+
+  React.useEffect(() => {
+    if (clampedRightPanelWidth !== rightPanelWidth) {
+      setRightPanelWidth(clampedRightPanelWidth)
+    }
+  }, [clampedRightPanelWidth, rightPanelWidth, setRightPanelWidth])
 
   const handleMouseDown = React.useCallback((e: React.MouseEvent) => {
     e.preventDefault()
     dragging.current = true
     const startX = e.clientX
-    const startWidth = rightPanelWidth
+    const startWidth = clampedRightPanelWidth
     let rafId = 0
 
     const onMouseMove = (ev: MouseEvent) => {
@@ -44,7 +58,7 @@ export function AppShell({ contextValue }: AppShellProps): React.ReactElement {
       rafId = requestAnimationFrame(() => {
         rafId = 0
         const delta = startX - ev.clientX
-        const newWidth = Math.max(200, Math.min(500, startWidth + delta))
+        const newWidth = clampRightPanelWidth(startWidth + delta)
         setRightPanelWidth(newWidth)
       })
     }
@@ -58,7 +72,7 @@ export function AppShell({ contextValue }: AppShellProps): React.ReactElement {
 
     document.addEventListener('mousemove', onMouseMove)
     document.addEventListener('mouseup', onMouseUp)
-  }, [rightPanelWidth])
+  }, [clampedRightPanelWidth, setRightPanelWidth])
 
   return (
     <AppShellProvider value={contextValue}>
@@ -87,7 +101,7 @@ export function AppShell({ contextValue }: AppShellProps): React.ReactElement {
                 onMouseDown={handleMouseDown}
               />
             )}
-            <RightSidePanel width={rightPanelWidth} />
+            <RightSidePanel width={clampedRightPanelWidth} />
           </div>
         )}
       </div>

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -1174,7 +1174,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   return (
     <div
       className="relative h-full flex flex-col bg-background rounded-2xl shadow-xl transition-[width] duration-300"
-      style={{ width: width ?? 280, minWidth: 180, flexShrink: 1 }}
+      style={{ width: width ?? 240, minWidth: 170, flexShrink: 1 }}
     >
       <SidebarWindowDragStrip
         height={isMac ? SIDEBAR_DRAG_STRIP_HEIGHT.expandedMac : SIDEBAR_DRAG_STRIP_HEIGHT.expanded}

--- a/apps/electron/src/renderer/components/diff/DetachedPreviewApp.tsx
+++ b/apps/electron/src/renderer/components/diff/DetachedPreviewApp.tsx
@@ -1,0 +1,115 @@
+/**
+ * DetachedPreviewApp — 独立文件预览窗口
+ *
+ * 通过主进程保存的 previewId 读取当前文件预览上下文，复用 DiffTabContent。
+ */
+
+import * as React from 'react'
+import { AlertCircle, RefreshCw } from 'lucide-react'
+import { useSetAtom } from 'jotai'
+import type { DetachedPreviewWindowData } from '@proma/shared'
+import { agentDiffRefreshVersionAtom } from '@/atoms/agent-atoms'
+import { cn } from '@/lib/utils'
+import { DiffTabContent } from './DiffTabContent'
+
+function getPreviewId(): string | null {
+  return new URLSearchParams(window.location.search).get('previewId')
+}
+
+function getFileName(filePath: string): string {
+  return filePath.split('/').filter(Boolean).pop() || filePath
+}
+
+export function DetachedPreviewApp(): React.ReactElement {
+  const [data, setData] = React.useState<DetachedPreviewWindowData | null>(null)
+  const [loading, setLoading] = React.useState(true)
+  const [error, setError] = React.useState<string | null>(null)
+  const setRefreshVersionMap = useSetAtom(agentDiffRefreshVersionAtom)
+
+  React.useEffect(() => {
+    const previewId = getPreviewId()
+    if (!previewId) {
+      setError('缺少预览窗口 ID')
+      setLoading(false)
+      return
+    }
+
+    window.electronAPI.getDetachedPreviewData(previewId)
+      .then((payload) => {
+        if (!payload) {
+          setError('预览数据已失效')
+          return
+        }
+        setData(payload)
+        document.title = payload.title || getFileName(payload.filePath)
+      })
+      .catch((err) => {
+        console.error('[DetachedPreviewApp] 加载预览数据失败:', err)
+        setError('加载预览数据失败')
+      })
+      .finally(() => setLoading(false))
+  }, [])
+
+  const handleRefresh = React.useCallback(() => {
+    if (!data) return
+    setRefreshVersionMap((prev) => {
+      const map = new Map(prev)
+      map.set(data.sessionId, (prev.get(data.sessionId) ?? 0) + 1)
+      return map
+    })
+  }, [data, setRefreshVersionMap])
+
+  if (loading) {
+    return (
+      <div className="h-screen w-screen flex items-center justify-center bg-content-area text-xs text-muted-foreground">
+        正在打开预览...
+      </div>
+    )
+  }
+
+  if (!data || error) {
+    return (
+      <div className="h-screen w-screen flex items-center justify-center bg-content-area text-sm text-muted-foreground">
+        <div className="flex items-center gap-2">
+          <AlertCircle className="size-4" />
+          <span>{error ?? '无法打开预览'}</span>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-screen w-screen flex flex-col overflow-hidden bg-content-area text-foreground">
+      <div className="h-11 flex items-center gap-2 px-3 border-b border-border/40 shrink-0">
+        <div className="min-w-0 flex-1">
+          <div className="text-xs font-medium truncate">{getFileName(data.filePath)}</div>
+          <div className="text-[11px] text-muted-foreground truncate" title={data.filePath}>
+            {data.filePath}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={handleRefresh}
+          className={cn(
+            'size-7 flex items-center justify-center rounded-md text-muted-foreground',
+            'hover:bg-muted/60 hover:text-foreground transition-colors',
+          )}
+          title="刷新预览"
+        >
+          <RefreshCw className="size-3.5" />
+        </button>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-hidden">
+        <DiffTabContent
+          filePath={data.filePath}
+          dirPath={data.dirPath}
+          sessionId={data.sessionId}
+          gitRoot={data.gitRoot}
+          previewOnly={data.previewOnly}
+          basePaths={data.basePaths}
+        />
+      </div>
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/diff/PreviewPanel.tsx
+++ b/apps/electron/src/renderer/components/diff/PreviewPanel.tsx
@@ -7,7 +7,8 @@
 
 import * as React from 'react'
 import { useAtomValue, useSetAtom, useAtom } from 'jotai'
-import { X } from 'lucide-react'
+import { Maximize2, X } from 'lucide-react'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import {
   previewPanelOpenMapAtom,
   previewFileMapAtom,
@@ -34,6 +35,23 @@ export function PreviewPanel({ sessionId }: PreviewPanelProps): React.ReactEleme
     setOpenMap((prev) => { const m = new Map(prev); m.set(sessionId, false); return m })
   }, [sessionId, setOpenMap])
 
+  const handleOpenDetachedPreview = React.useCallback(() => {
+    if (!currentFile) return
+    const slash = currentFile.filePath.lastIndexOf('/')
+    const fallbackDirPath = slash > 0 ? currentFile.filePath.slice(0, slash) : sessionPath
+    window.electronAPI.openDetachedPreview({
+      sessionId,
+      filePath: currentFile.filePath,
+      dirPath: currentFile.dirPath || sessionPath || fallbackDirPath,
+      gitRoot: currentFile.gitRoot,
+      previewOnly: currentFile.previewOnly,
+      basePaths: currentFile.basePaths,
+      title: currentFile.filePath.split('/').pop(),
+    }).catch((err) => {
+      console.error('[PreviewPanel] 打开独立预览窗口失败:', err)
+    })
+  }, [currentFile, sessionId, sessionPath])
+
   return (
     <div className="flex flex-col h-full overflow-hidden bg-content-area titlebar-no-drag">
       {/* 顶部栏：文件名 + 关闭 */}
@@ -41,14 +59,40 @@ export function PreviewPanel({ sessionId }: PreviewPanelProps): React.ReactEleme
         <span className="text-xs text-muted-foreground truncate">
           {currentFile ? currentFile.filePath.split('/').pop() : '文件预览'}
         </span>
-        <button
-          type="button"
-          onClick={handleClosePanel}
-          className="ml-auto flex items-center justify-center size-6 shrink-0 text-muted-foreground hover:text-foreground hover:bg-muted/50 rounded transition-colors"
-          title="关闭预览面板"
-        >
-          <X className="size-3.5" />
-        </button>
+        <div className="ml-auto flex items-center gap-0.5">
+          {currentFile && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={handleOpenDetachedPreview}
+                  className="flex items-center justify-center size-6 shrink-0 text-muted-foreground hover:text-foreground hover:bg-muted/50 rounded transition-colors"
+                  aria-label="在单独窗口打开预览"
+                >
+                  <Maximize2 className="size-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                <p>在单独窗口打开预览</p>
+              </TooltipContent>
+            </Tooltip>
+          )}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={handleClosePanel}
+                className="flex items-center justify-center size-6 shrink-0 text-muted-foreground hover:text-foreground hover:bg-muted/50 rounded transition-colors"
+                aria-label="关闭预览面板"
+              >
+                <X className="size-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              <p>关闭预览面板</p>
+            </TooltipContent>
+          </Tooltip>
+        </div>
       </div>
 
       {/* 内容区 */}

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -68,6 +68,7 @@ import 'katex/dist/katex.min.css'
 // ===== 窗口类型检测 =====
 const isQuickTaskWindow = new URLSearchParams(window.location.search).get('window') === 'quick-task'
 const isVoiceDictationWindow = new URLSearchParams(window.location.search).get('window') === 'voice-dictation'
+const isDetachedPreviewWindow = new URLSearchParams(window.location.search).get('window') === 'detached-preview'
 
 /**
  * 主题初始化组件
@@ -730,6 +731,16 @@ if (isQuickTaskWindow) {
       <React.StrictMode>
         <ThemeInitializer />
         <VoiceDictationApp />
+        <Toaster position="top-right" />
+      </React.StrictMode>
+    )
+  })
+} else if (isDetachedPreviewWindow) {
+  import('./components/diff/DetachedPreviewApp').then(({ DetachedPreviewApp }) => {
+    ReactDOM.createRoot(document.getElementById('root')!).render(
+      <React.StrictMode>
+        <ThemeInitializer />
+        <DetachedPreviewApp />
         <Toaster position="top-right" />
       </React.StrictMode>
     )

--- a/packages/shared/src/types/runtime.ts
+++ b/packages/shared/src/types/runtime.ts
@@ -148,6 +148,29 @@ export interface GetFileDiffInput {
   sessionId?: string
 }
 
+/** 独立预览窗口输入 */
+export interface DetachedPreviewWindowInput {
+  /** 当前 Agent 会话 ID，用于主进程校验可访问路径 */
+  sessionId: string
+  /** 要预览的文件路径 */
+  filePath: string
+  /** Diff 模式下的工作目录；纯预览模式下作为路径解析候选 */
+  dirPath: string
+  /** 文件所属 Git 仓库根，多仓库场景下必须传入 */
+  gitRoot?: string
+  /** true = 纯文件预览，false/undefined = diff 模式 */
+  previewOnly?: boolean
+  /** 候选基础目录（previewOnly 模式下用于路径解析） */
+  basePaths?: string[]
+  /** 窗口标题 */
+  title?: string
+}
+
+/** 独立预览窗口数据 */
+export interface DetachedPreviewWindowData extends DetachedPreviewWindowInput {
+  id: string
+}
+
 /** Revert 文件变更的输入 */
 export interface RevertFileInput {
   dirPath: string
@@ -305,6 +328,10 @@ export const IPC_CHANNELS = {
   SYSTEM_OPEN_FILE: 'shell:system-open-file',
   /** 扫描系统中可用的编辑器应用 */
   SCAN_EDITORS: 'shell:scan-editors',
+  /** 打开独立预览窗口 */
+  OPEN_DETACHED_PREVIEW: 'preview:open-detached',
+  /** 获取独立预览窗口数据 */
+  GET_DETACHED_PREVIEW_DATA: 'preview:get-detached-data',
 } as const
 
 /**


### PR DESCRIPTION
## Summary

- Adjust Agent layout defaults so the center preview has more room: narrower left sidebar, narrower persisted right file panel, and a 50/50 chat-preview split.
- Persist dragged right file panel width with guarded min/max bounds.
- Add a detached preview window for the current file/diff, with preview-panel tooltips and close shortcuts (Esc, Cmd/Ctrl+W).

## Impact

Small-screen users get a roomier inline preview by default and can pop the current preview into its own window when they need more space.

## Validation

- bun run --filter='@proma/electron' typecheck
- bun run --filter='@proma/electron' build:main
- bun run --filter='@proma/electron' build:preload
- bun run --filter='@proma/electron' build:renderer

Note: build:renderer still reports the existing large chunk warning, but completes successfully.