### PR TITLE
fix: 修复 git-diff-service 硬编码路径分隔符导致 Windows 预览空白的问题

### DIFF
--- a/apps/electron/src/main/lib/git-diff-service.ts
+++ b/apps/electron/src/main/lib/git-diff-service.ts
@@ -7,7 +7,7 @@
 
 import { spawnSync } from 'child_process'
 import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from 'fs'
-import { isAbsolute, join, resolve } from 'path'
+import { basename, isAbsolute, join, resolve, sep } from 'path'
 import type { ChangedFileEntry, UnstagedChangesResult, UntrackedFileEntry } from '@proma/shared'
 import type { ChangeSource, ChangedFileStatus } from '@proma/shared'
 
@@ -23,7 +23,7 @@ const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024
 function normalizeSafePath(root: string, filePath: string): string | null {
   if (!filePath || typeof filePath !== 'string') return null
   const resolvedRoot = resolve(root)
-  const rootWithSep = resolvedRoot.endsWith('/') ? resolvedRoot : resolvedRoot + '/'
+  const rootWithSep = resolvedRoot.endsWith(sep) ? resolvedRoot : resolvedRoot + sep
 
   if (isAbsolute(filePath)) {
     let resolvedFile: string
@@ -98,14 +98,14 @@ function computeSource(
   let inWorkspace = false
 
   if (sessionPath) {
-    const normalized = sessionPath.endsWith('/') ? sessionPath : sessionPath + '/'
+    const normalized = sessionPath.endsWith(sep) ? sessionPath : sessionPath + sep
     if (absolutePath.startsWith(normalized)) {
       inSession = true
     }
   }
 
   if (workspaceFilesPath) {
-    const normalized = workspaceFilesPath.endsWith('/') ? workspaceFilesPath : workspaceFilesPath + '/'
+    const normalized = workspaceFilesPath.endsWith(sep) ? workspaceFilesPath : workspaceFilesPath + sep
     if (absolutePath.startsWith(normalized)) {
       inWorkspace = true
     }
@@ -173,8 +173,8 @@ export async function getUnstagedChanges(
 
   // 候选目录绝对路径（用于过滤：只显示落在某个候选目录内的文件）
   const candidateRoots = candidates.map((c) => {
-    const r = c.replace(/\/+$/, '')
-    return r + '/'
+    const r = c.replace(/[/\\]+$/, '')
+    return r + sep
   })
   const isUnderAnyCandidate = (absPath: string): boolean => {
     return candidateRoots.some((root) => absPath === root.slice(0, -1) || absPath.startsWith(root))
@@ -240,7 +240,7 @@ export async function getUnstagedChanges(
     isGitRepo: true,
     files: allFiles,
     untrackedFiles: allUntracked,
-    gitRootNames: gitRoots.map((r) => r.split('/').pop() || r),
+    gitRootNames: gitRoots.map((r) => basename(r)),
   }
 }
 


### PR DESCRIPTION
## Overview

修复 `git-diff-service.ts` 中因硬编码 `/` 路径分隔符导致的 Windows 兼容性问题。在 Windows 上，`realpathSync` 和 `path.join` 返回 `\` 分隔的路径，而 `normalizeSafePath` 和 `computeSource` 使用硬编码 `/` 做 `startsWith` 前缀匹配，导致所有路径被判定为"不安全"而拒绝，git diff 预览功能在 Windows 上完全失效。

## Changes

- `apps/electron/src/main/lib/git-diff-service.ts`
  - **`normalizeSafePath`** — `rootWithSep` 改用 `sep` 拼接，确保与 `realpathSync` 返回的分隔符一致
  - **`computeSource`** — `sessionPath`/`workspaceFilesPath` 前缀改用 `sep`，确保与 `join()` 结果的分隔符一致
  - **`candidateRoots`** — 正则改为 `[/\\\\]+$` 兼容两种分隔符，拼接改用 `sep`
  - **`gitRootNames`** — `split('/').pop()` 改为 `basename()`，跨平台正确提取仓库名

## Impact

- macOS/Linux：零影响（`sep === '/'`，行为不变）
- Windows：修复 git diff 预览、文件来源标识、候选目录过滤三项功能

## How to Test

1. Windows 环境启动 Proma
2. 在 Agent 模式下修改任意项目文件
3. 点击文件行，确认预览面板正常显示 diff 内容（不再空白）
4. 确认文件来源标识（session/workspace 标签）显示正确
5. macOS/Linux 回归：确认 diff 预览功能无变化

🤖 Generated with [Claude Code](https://claude.com/claude-code)