### PR TITLE
fix: 修复文件面板打开时 minimap 仍显示面板切换按钮 【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentHeader.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentHeader.tsx
@@ -11,7 +11,6 @@ import { Pencil, Check, X, PanelRight } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { agentSessionsAtom, agentSidePanelOpenAtom, workspaceFilesVersionAtom } from '@/atoms/agent-atoms'
-import { previewPanelOpenMapAtom } from '@/atoms/preview-atoms'
 import { tabsAtom, updateTabTitle } from '@/atoms/tab-atoms'
 import { registerShortcut } from '@/lib/shortcut-registry'
 
@@ -32,9 +31,6 @@ export function AgentHeader({ sessionId }: AgentHeaderProps): React.ReactElement
   // 文件面板切换状态（全局共享）
   const [isPanelOpen, setSidePanelOpen] = useAtom(agentSidePanelOpenAtom)
   const filesVersion = useAtomValue(workspaceFilesVersionAtom)
-  const previewOpenMap = useAtomValue(previewPanelOpenMapAtom)
-  const setPreviewOpenMap = useSetAtom(previewPanelOpenMapAtom)
-  const previewOpen = previewOpenMap.get(sessionId) ?? false
   const hasFileChanges = filesVersion > 0
 
   const togglePanel = React.useCallback(() => {
@@ -132,8 +128,8 @@ export function AgentHeader({ sessionId }: AgentHeaderProps): React.ReactElement
               <Pencil className="size-3.5" />
             </button>
           </div>
-          {/* 文件面板打开按钮（面板关闭或预览面板打开时显示） */}
-          {(!isPanelOpen || previewOpen) && (
+          {/* 文件面板打开按钮（面板关闭时显示） */}
+          {!isPanelOpen && (
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button


### PR DESCRIPTION
## Overview

修复了 Agent 模式下 minimap 工具栏上文件面板打开按钮在右侧面板已展开时仍然显示的 UI bug。

**问题**：当文件预览或 diff 视图打开且右侧文件面板已展开时，minimap 上仍会显示打开文件面板的 PanelRight 按钮。右侧边栏本身已经有折叠按钮，这个按钮在面板已展开时是多余的。

## Changes

- `apps/electron/src/renderer/components/agent/AgentHeader.tsx`
  - 将 PanelRight 按钮的可见性条件从 `(!isPanelOpen || previewOpen)` 改为 `!isPanelOpen`
  - 移除不再使用的 `previewPanelOpenMapAtom` import 及相关变量（`previewOpenMap`、`setPreviewOpenMap`、`previewOpen`）

## How to Test

1. 打开 Agent 模式，确保右侧文件面板已展开
2. 打开一个文件预览或 diff 视图
3. 验证 minimap 工具栏上不再显示 PanelRight 按钮
4. 折叠右侧面板，验证按钮重新出现
5. 在面板折叠时打开文件预览，验证按钮仍然可用（需要入口打开面板）

## Notes

- 变更量极小：+2 / -6，仅影响 AgentHeader 这一个文件
- 类型检查全部通过（@proma/shared、@proma/core、@proma/ui、@proma/electron）
- `previewPanelOpenMapAtom` 仍被其他 8 个组件正常使用，不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)