### PR TITLE
feat: 新增持久化 Scratch Pad 草稿本标签页 【已审核 PR】

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -9,7 +9,7 @@ import { join, resolve, sep } from 'node:path'
 import { existsSync, realpathSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, INSTALLER_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, MEMORY_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS, DINGTALK_IPC_CHANNELS, WECHAT_IPC_CHANNELS } from '@proma/shared'
-import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS, QUICK_TASK_IPC_CHANNELS, VOICE_DICTATION_IPC_CHANNELS, APP_ICON_IPC_CHANNELS, DOCK_BADGE_IPC_CHANNELS } from '../types'
+import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS, SCRATCH_PAD_IPC_CHANNELS, QUICK_TASK_IPC_CHANNELS, VOICE_DICTATION_IPC_CHANNELS, APP_ICON_IPC_CHANNELS, DOCK_BADGE_IPC_CHANNELS } from '../types'
 import type {
   QuickTaskSubmitInput,
   VoiceDictationAudioChunkInput,
@@ -170,7 +170,7 @@ import { permissionService } from './lib/agent-permission-service'
 import { askUserService } from './lib/agent-ask-user-service'
 import { exitPlanService } from './lib/agent-exit-plan-service'
 import { getAgentTeamData, readAgentOutputFile } from './lib/agent-team-reader'
-import { getAgentSessionWorkspacePath, getAgentWorkspacesDir, getWorkspaceSkillsDir, getWorkspaceFilesDir } from './lib/config-paths'
+import { getAgentSessionWorkspacePath, getAgentWorkspacesDir, getWorkspaceSkillsDir, getWorkspaceFilesDir, getScratchPadPath } from './lib/config-paths'
 import {
   listAgentWorkspaces,
   createAgentWorkspace,
@@ -965,6 +965,55 @@ export function registerIpcHandlers(): void {
       })
     }
   })
+
+  // ===== Scratch Pad 持久化 =====
+
+  // 从磁盘加载 scratch-pad.md
+  ipcMain.handle(
+    SCRATCH_PAD_IPC_CHANNELS.LOAD,
+    async (): Promise<string> => {
+      const path = getScratchPadPath()
+      try {
+        if (!existsSync(path)) return ''
+        const { readFileSync } = require('node:fs')
+        return readFileSync(path, 'utf-8')
+      } catch (err) {
+        console.error('[ScratchPad] 加载失败:', err)
+        return ''
+      }
+    }
+  )
+
+  // 异步保存 scratch-pad.md
+  ipcMain.handle(
+    SCRATCH_PAD_IPC_CHANNELS.SAVE,
+    async (_, content: string): Promise<boolean> => {
+      const path = getScratchPadPath()
+      try {
+        const { writeFile } = require('node:fs/promises')
+        await writeFile(path, content, 'utf-8')
+        return true
+      } catch (err) {
+        console.error('[ScratchPad] 保存失败:', err)
+        return false
+      }
+    }
+  )
+
+  // 同步保存 scratch-pad.md（beforeunload 场景）
+  ipcMain.on(
+    SCRATCH_PAD_IPC_CHANNELS.SAVE_SYNC,
+    (event, content: string) => {
+      try {
+        const { writeFileSync } = require('node:fs')
+        writeFileSync(getScratchPadPath(), content, 'utf-8')
+        event.returnValue = true
+      } catch (err) {
+        console.error('[ScratchPad] 同步保存失败:', err)
+        event.returnValue = false
+      }
+    }
+  )
 
   // ===== 应用图标切换 =====
 

--- a/apps/electron/src/main/lib/config-paths.ts
+++ b/apps/electron/src/main/lib/config-paths.ts
@@ -557,3 +557,12 @@ export function getSdkConfigDir(): string {
 
   return dir
 }
+
+/**
+ * 获取 Scratch Pad 文件路径
+ *
+ * @returns ~/.proma/scratch-pad.md
+ */
+export function getScratchPadPath(): string {
+  return join(getConfigDir(), 'scratch-pad.md')
+}

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -7,7 +7,7 @@
 
 import { contextBridge, ipcRenderer, webUtils } from 'electron'
 import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, INSTALLER_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, MEMORY_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS, DINGTALK_IPC_CHANNELS, WECHAT_IPC_CHANNELS } from '@proma/shared'
-import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS, APP_ICON_IPC_CHANNELS, DOCK_BADGE_IPC_CHANNELS } from '../types'
+import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS, SCRATCH_PAD_IPC_CHANNELS, APP_ICON_IPC_CHANNELS, DOCK_BADGE_IPC_CHANNELS } from '../types'
 import type {
   RuntimeStatus,
   GitRepoStatus,
@@ -302,6 +302,17 @@ export interface ElectronAPI {
 
   /** 订阅用户手动切换主题事件（跨窗口同步，返回清理函数） */
   onThemeSettingsChanged: (callback: (payload: { themeMode: string; themeStyle: string }) => void) => () => void
+
+  // ===== Scratch Pad =====
+
+  /** 从磁盘加载 scratch-pad.md */
+  loadScratchPad: () => Promise<string>
+
+  /** 异步保存内容到 scratch-pad.md */
+  saveScratchPad: (content: string) => Promise<boolean>
+
+  /** 同步保存内容到 scratch-pad.md（beforeunload 场景） */
+  saveScratchPadSync: (content: string) => boolean
 
   // ===== 应用图标切换 =====
 
@@ -1121,6 +1132,19 @@ const electronAPI: ElectronAPI = {
     const listener = (_: unknown, payload: { themeMode: string; themeStyle: string }): void => callback(payload)
     ipcRenderer.on(SETTINGS_IPC_CHANNELS.ON_THEME_SETTINGS_CHANGED, listener)
     return () => { ipcRenderer.removeListener(SETTINGS_IPC_CHANNELS.ON_THEME_SETTINGS_CHANGED, listener) }
+  },
+
+  // Scratch Pad 持久化
+  loadScratchPad: () => {
+    return ipcRenderer.invoke(SCRATCH_PAD_IPC_CHANNELS.LOAD)
+  },
+
+  saveScratchPad: (content: string) => {
+    return ipcRenderer.invoke(SCRATCH_PAD_IPC_CHANNELS.SAVE, content)
+  },
+
+  saveScratchPadSync: (content: string) => {
+    return ipcRenderer.sendSync(SCRATCH_PAD_IPC_CHANNELS.SAVE_SYNC, content)
   },
 
   // 应用图标切换

--- a/apps/electron/src/renderer/atoms/app-mode.ts
+++ b/apps/electron/src/renderer/atoms/app-mode.ts
@@ -3,11 +3,12 @@
  *
  * - chat: 对话模式
  * - agent: Agent 模式（原 Flow）
+ * - scratch: 草稿本模式
  */
 
 import { atomWithStorage } from 'jotai/utils'
 
-export type AppMode = 'chat' | 'agent'
+export type AppMode = 'chat' | 'agent' | 'scratch'
 
 /** App 模式，自动持久化到 localStorage */
 export const appModeAtom = atomWithStorage<AppMode>('proma-app-mode', 'agent')

--- a/apps/electron/src/renderer/atoms/tab-atoms.ts
+++ b/apps/electron/src/renderer/atoms/tab-atoms.ts
@@ -21,7 +21,13 @@ import type { SessionIndicatorStatus } from './agent-atoms'
 // ===== 类型定义 =====
 
 /** 标签页类型（Settings 不作为 Tab，保留独立视图） */
-export type TabType = 'chat' | 'agent'
+export type TabType = 'chat' | 'agent' | 'scratch'
+
+/** Scratch Pad 专用的固定 sessionId */
+export const SCRATCH_PAD_ID = '__scratch-pad__'
+
+/** Scratch Pad 标签默认标题 */
+export const SCRATCH_PAD_TITLE = 'Scratch Pad'
 
 /** 标签页数据 */
 export interface TabItem {
@@ -68,6 +74,11 @@ export interface TabMinimapItem {
 }
 export const tabMinimapCacheAtom = atom<Map<string, TabMinimapItem[]>>(new Map())
 
+/** Scratch Pad 编辑内容（HTML 字符串，供 TipTap 编辑器使用） */
+export const scratchPadContentAtom = atom<string>('')
+/** Scratch Pad 内容是否已从磁盘加载 */
+export const scratchPadLoadedAtom = atom<boolean>(false)
+
 // ===== 派生 Atoms =====
 
 /** 当前活跃标签 */
@@ -84,6 +95,7 @@ export const tabStreamingMapAtom = atom<Map<string, boolean>>((get) => {
   const agentRunning = get(agentRunningSessionIdsAtom)
   const map = new Map<string, boolean>()
   for (const tab of tabs) {
+    if (tab.type === 'scratch') continue
     if (tab.type === 'chat') {
       map.set(tab.id, chatStreaming.has(tab.sessionId))
     } else if (tab.type === 'agent') {
@@ -101,6 +113,7 @@ export const tabIndicatorMapAtom = atom<Map<string, SessionIndicatorStatus>>((ge
   const unviewedCompletedIds = get(unviewedCompletedSessionIdsAtom)
   const map = new Map<string, SessionIndicatorStatus>()
   for (const tab of tabs) {
+    if (tab.type === 'scratch') continue
     if (tab.type === 'chat') {
       map.set(tab.id, chatStreaming.has(tab.sessionId) ? 'running' : 'idle')
     } else if (tab.type === 'agent') {
@@ -139,12 +152,15 @@ export function openTab(
   }
 }
 
-/** 关闭标签页 */
+/** 关闭标签页（scratch tab 不可关闭） */
 export function closeTab(
   tabs: TabItem[],
   activeTabId: string | null,
   tabId: string,
 ): { tabs: TabItem[]; activeTabId: string | null } {
+  // Scratch Pad 不可关闭
+  if (tabId === SCRATCH_PAD_ID) return { tabs, activeTabId }
+
   const tabIndex = tabs.findIndex((t) => t.id === tabId)
   if (tabIndex === -1) return { tabs, activeTabId }
 
@@ -164,13 +180,15 @@ export function closeTab(
   return { tabs: newTabs, activeTabId: newActiveTabId }
 }
 
-/** 重排标签顺序 */
+/** 重排标签顺序（scratch tab 固定在第 0 位，不可移动） */
 export function reorderTabs(
   tabs: TabItem[],
   fromIndex: number,
   toIndex: number,
 ): TabItem[] {
   if (fromIndex === toIndex) return tabs
+  // Scratch 不可移出第 0 位
+  if (tabs[0]?.id === SCRATCH_PAD_ID && (fromIndex === 0 || toIndex === 0)) return tabs
   const newTabs = [...tabs]
   const [moved] = newTabs.splice(fromIndex, 1)
   newTabs.splice(toIndex, 0, moved!)
@@ -186,4 +204,24 @@ export function updateTabTitle(
   return tabs.map((t) =>
     t.sessionId === sessionId ? { ...t, title } : t
   )
+}
+
+/** 确保 Scratch Pad 标签存在并位于首位 */
+export function ensureScratchPadTab(tabs: TabItem[]): TabItem[] {
+  const scratchTab = tabs.find((t) => t.id === SCRATCH_PAD_ID)
+  if (scratchTab) {
+    // 已存在，确保在第一位
+    const idx = tabs.indexOf(scratchTab)
+    if (idx === 0) return tabs
+    const rest = tabs.filter((t) => t.id !== SCRATCH_PAD_ID)
+    return [scratchTab, ...rest]
+  }
+  // 不存在，创建并插入第一位
+  const newTab: TabItem = {
+    id: SCRATCH_PAD_ID,
+    type: 'scratch',
+    sessionId: SCRATCH_PAD_ID,
+    title: SCRATCH_PAD_TITLE,
+  }
+  return [newTab, ...tabs]
 }

--- a/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
+++ b/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
@@ -1,0 +1,94 @@
+/**
+ * ScratchPadView — 草稿本编辑器
+ *
+ * 基于 TipTap 的轻量 Markdown 编辑器，内容持久化到 ~/.proma/scratch-pad.md。
+ * 自动保存由 ScratchPadPersistence 组件通过监听 scratchPadContentAtom 统一管理。
+ */
+
+import * as React from 'react'
+import { useEditor, EditorContent } from '@tiptap/react'
+import StarterKit from '@tiptap/starter-kit'
+import Placeholder from '@tiptap/extension-placeholder'
+import MarkdownIt from 'markdown-it'
+import { useAtom, useAtomValue } from 'jotai'
+import { scratchPadContentAtom, scratchPadLoadedAtom } from '@/atoms/tab-atoms'
+
+const md = new MarkdownIt({ breaks: true, linkify: true })
+
+export function ScratchPadView(): React.ReactElement {
+  const [content, setContent] = useAtom(scratchPadContentAtom)
+  const loaded = useAtomValue(scratchPadLoadedAtom)
+  const containerRef = React.useRef<HTMLDivElement>(null)
+
+  const editor = useEditor({
+    extensions: [
+      StarterKit.configure({
+        heading: { levels: [1, 2, 3] },
+      }),
+      Placeholder.configure({
+        placeholder: '在此随意书写… 支持 Markdown 快捷输入',
+      }),
+    ],
+    content: content || '',
+    onUpdate: ({ editor }) => {
+      setContent(editor.getHTML())
+    },
+    immediatelyRender: false,
+  })
+
+  // 内容从磁盘加载或编辑器重新挂载（切 tab 回来）时同步
+  React.useEffect(() => {
+    if (loaded && editor && content) {
+      editor.commands.setContent(content)
+    }
+  }, [loaded, editor])
+
+  // 粘贴时自动将 Markdown 转为 HTML 插入
+  React.useEffect(() => {
+    const el = containerRef.current
+    if (!el || !editor) return
+
+    const handlePaste = (e: ClipboardEvent): void => {
+      const text = e.clipboardData?.getData('text/plain')
+      if (!text) return
+      if (!/[#*>\-`[\]~|]/.test(text)) return
+
+      e.preventDefault()
+      e.stopPropagation()
+      try {
+        const html = md.render(text)
+        editor.chain().focus().insertContent(html).run()
+      } catch {
+        // 转换失败，回退到纯文本插入
+        editor.chain().focus().insertContent(text).run()
+      }
+    }
+
+    el.addEventListener('paste', handlePaste, true)
+    return () => el.removeEventListener('paste', handlePaste, true)
+  }, [editor])
+
+  return (
+    <div ref={containerRef} className="flex flex-col h-full">
+      <div className="flex-1 overflow-auto px-8 py-6">
+        <div className="max-w-3xl mx-auto h-full">
+          {loaded ? (
+            <EditorContent
+              editor={editor}
+              className="prose prose-sm dark:prose-invert max-w-none h-full [&_.ProseMirror]:min-h-[200px] [&_.ProseMirror]:outline-none [&_.ProseMirror]:text-sm [&_.ProseMirror_p.is-editor-empty:first-child::before]:text-muted-foreground/50 [&_.ProseMirror_p.is-editor-empty:first-child::before]:content-[attr(data-placeholder)] [&_.ProseMirror_p.is-editor-empty:first-child::before]:float-left [&_.ProseMirror_p.is-editor-empty:first-child::before]:pointer-events-none [&_.ProseMirror_p.is-editor-empty:first-child::before]:h-0"
+            />
+          ) : (
+            <div className="min-h-[200px] flex items-center justify-center">
+              <span className="text-sm text-muted-foreground/40">加载中…</span>
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="h-[28px] border-t border-border/40 px-4 flex items-center">
+        <span className="text-[11px] text-muted-foreground/60">
+          Scratch Pad — 内容自动保存到本地
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx
+++ b/apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx
@@ -159,7 +159,7 @@ export function GlobalShortcuts(): null {
   useShortcut(
     'toggle-mode',
     useCallback(
-      () => setAppMode(appMode === 'chat' ? 'agent' : 'chat'),
+      () => { if (appMode !== 'scratch') setAppMode(appMode === 'chat' ? 'agent' : 'chat') },
       [appMode, setAppMode],
     ),
   )

--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -86,6 +86,8 @@ export function TabBar(): React.ReactElement {
           agentWorkspaceId: session.workspaceId,
         }).catch(console.error)
       }
+    } else if (tab.type === 'scratch') {
+      // Scratch Pad 不改变侧边栏 chat/agent 状态
     }
   }, [setActiveTabId, tabs, agentSessions, setAppMode, setCurrentConversationId, setCurrentAgentSessionId, setCurrentAgentWorkspaceId, setUnviewedCompleted])
 

--- a/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
@@ -9,7 +9,7 @@
 import * as React from 'react'
 import { createPortal } from 'react-dom'
 import { useAtomValue } from 'jotai'
-import { MessageSquare, Bot, X } from 'lucide-react'
+import { MessageSquare, Bot, StickyNote, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import type { TabType, TabMinimapItem } from '@/atoms/tab-atoms'
 import type { SessionIndicatorStatus } from '@/atoms/agent-atoms'
@@ -73,6 +73,8 @@ export function TabBarItem({
   }, [])
 
   const handleMouseDown = (e: React.MouseEvent): void => {
+    // Scratch Pad 不可中键关闭
+    if (type === 'scratch') return
     if (e.button === 1) {
       e.preventDefault()
       onMiddleClick()
@@ -84,8 +86,11 @@ export function TabBarItem({
     onClose()
   }
 
-  const Icon = type === 'chat' ? MessageSquare : Bot
-  const indicatorColor = isStreaming !== 'idle'
+  const Icon = type === 'chat' ? MessageSquare : type === 'agent' ? Bot : StickyNote
+  const isScratch = type === 'scratch'
+  const indicatorColor = isScratch
+    ? undefined
+    : isStreaming !== 'idle'
     ? isStreaming === 'completed'
       ? 'bg-green-500'
       : isStreaming === 'blocked'
@@ -98,6 +103,35 @@ export function TabBarItem({
   const previewItems = minimapCache.get(id) ?? []
   // 当前 active Tab 不显示预览面板
   const showPreview = isHovered && !isActive
+
+  // Scratch Pad 是小图标标签
+  if (isScratch) {
+    return (
+      <div
+        className="relative flex-shrink-0 titlebar-no-drag"
+        onMouseEnter={onHoverEnter}
+        onMouseLeave={onHoverLeave}
+      >
+        <button
+          ref={buttonRef}
+          type="button"
+          className={cn(
+            'group relative flex items-center justify-center w-[36px] h-[34px]',
+            'rounded-t-lg text-xs transition-colors select-none cursor-pointer',
+            'border-t border-l border-r border-transparent',
+            isActive
+              ? 'bg-content-area text-foreground border-border/50'
+              : 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
+          )}
+          onClick={onActivate}
+          onMouseDown={handleMouseDown}
+          onPointerDown={onDragStart}
+        >
+          <Icon className="size-3.5" />
+        </button>
+      </div>
+    )
+  }
 
   return (
     <div
@@ -130,7 +164,8 @@ export function TabBarItem({
           <span className="flex-1 min-w-0 truncate text-left">{title}</span>
         )}
 
-        {/* 关闭按钮 */}
+        {/* 关闭按钮（scratch 类型不显示） */}
+        {!isScratch && (
         <span
           role="button"
           tabIndex={-1}
@@ -146,6 +181,7 @@ export function TabBarItem({
         >
           <X className="size-2.5" />
         </span>
+        )}
 
         {/* 底部状态横线条 */}
         {indicatorColor && (

--- a/apps/electron/src/renderer/components/tabs/TabContent.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabContent.tsx
@@ -10,6 +10,7 @@ import { useAtomValue } from 'jotai'
 import { tabsAtom } from '@/atoms/tab-atoms'
 import { ChatView } from '@/components/chat'
 import { AgentView } from '@/components/agent'
+import { ScratchPadView } from '@/components/scratch-pad/ScratchPadView'
 import { TabErrorBoundary } from './TabErrorBoundary'
 
 export interface TabContentProps {
@@ -33,6 +34,10 @@ export function TabContent({ tabId }: TabContentProps): React.ReactElement {
         标签页不存在
       </div>
     )
+  }
+
+  if (tab.type === 'scratch') {
+    return <ScratchPadView />
   }
 
   if (tab.type === 'chat') {

--- a/apps/electron/src/renderer/components/welcome/WelcomeEmptyState.tsx
+++ b/apps/electron/src/renderer/components/welcome/WelcomeEmptyState.tsx
@@ -9,7 +9,7 @@
 
 import * as React from 'react'
 import { useAtomValue, useAtom } from 'jotai'
-import { Lightbulb, MessageSquare, Bot } from 'lucide-react'
+import { Lightbulb, MessageSquare, Bot, StickyNote } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { userProfileAtom } from '@/atoms/user-profile'
 import { appModeAtom, type AppMode } from '@/atoms/app-mode'
@@ -28,6 +28,7 @@ function getGreeting(hour: number): string {
 const MODE_CONFIG: Record<AppMode, { icon: React.ReactNode; label: string }> = {
   chat: { icon: <MessageSquare size={15} />, label: 'Chat' },
   agent: { icon: <Bot size={15} />, label: 'Agent' },
+  scratch: { icon: <StickyNote size={15} />, label: 'Scratch Pad' },
 }
 
 export function WelcomeEmptyState(): React.ReactElement {

--- a/apps/electron/src/renderer/hooks/useSyncActiveTabSideEffects.ts
+++ b/apps/electron/src/renderer/hooks/useSyncActiveTabSideEffects.ts
@@ -47,6 +47,13 @@ export function useSyncActiveTabSideEffects(): SyncActiveTabSideEffects {
         return
       }
 
+      if (newActiveTab.type === 'scratch') {
+        // Scratch Pad 不改变侧边栏 chat/agent 状态
+        setCurrentConversationId(null)
+        setCurrentAgentSessionId(null)
+        return
+      }
+
       // Agent
       setAppMode('agent')
       setCurrentAgentSessionId(newActiveTab.sessionId)

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -46,7 +46,7 @@ import {
 } from './atoms/ui-preferences'
 import { useGlobalAgentListeners } from './hooks/useGlobalAgentListeners'
 import { useGlobalChatListeners } from './hooks/useGlobalChatListeners'
-import { tabsAtom, activeTabIdAtom } from './atoms/tab-atoms'
+import { tabsAtom, activeTabIdAtom, ensureScratchPadTab, scratchPadContentAtom, scratchPadLoadedAtom, SCRATCH_PAD_ID } from './atoms/tab-atoms'
 import type { TabItem } from './atoms/tab-atoms'
 import { chatToolsAtom } from './atoms/chat-tool-atoms'
 import { feishuBotStatesAtom } from './atoms/feishu-atoms'
@@ -62,6 +62,7 @@ import { showCapabilityChangeToasts } from './lib/capabilities-toast'
 import { UpdateDialog } from './components/settings/UpdateDialog'
 import { GlobalShortcuts } from './components/shortcuts/GlobalShortcuts'
 import { TabSwitcher } from './components/tabs/TabSwitcher'
+import { htmlToMarkdown, markdownToHtml } from './lib/markdown-rich-text'
 import './styles/globals.css'
 import 'katex/dist/katex.min.css'
 
@@ -645,7 +646,7 @@ function TabStatePersistenceInitializer(): null {
         }
       }
 
-      store.set(tabsAtom, validTabs)
+      store.set(tabsAtom, ensureScratchPadTab(validTabs))
       store.set(activeTabIdAtom, restoredActiveTabId)
 
       // 同步 appMode 和 currentSessionId
@@ -671,8 +672,10 @@ function TabStatePersistenceInitializer(): null {
     const save = (): void => {
       const tabs = store.get(tabsAtom)
       const activeTabId = store.get(activeTabIdAtom)
+      // 过滤掉 scratch tab，它由代码注入，不参与 tabState 持久化
+      const persistTabs = tabs.filter((t) => t.id !== SCRATCH_PAD_ID)
       window.electronAPI.updateSettings({
-        tabState: { tabs, activeTabId },
+        tabState: { tabs: persistTabs, activeTabId },
       }).catch(console.error)
     }
 
@@ -691,8 +694,9 @@ function TabStatePersistenceInitializer(): null {
       // 使用同步 IPC 确保关闭前数据写入磁盘
       const tabs = store.get(tabsAtom)
       const activeTabId = store.get(activeTabIdAtom)
+      const persistTabs = tabs.filter((t) => t.id !== SCRATCH_PAD_ID)
       if (tabs.length > 0 && window.electronAPI.updateSettingsSync) {
-        const ok = window.electronAPI.updateSettingsSync({ tabState: { tabs, activeTabId } })
+        const ok = window.electronAPI.updateSettingsSync({ tabState: { tabs: persistTabs, activeTabId } })
         if (!ok) {
           console.warn('[TabPersist] sync IPC failed, falling back to async save')
           save()
@@ -709,6 +713,108 @@ function TabStatePersistenceInitializer(): null {
       if (timer) clearTimeout(timer)
       window.removeEventListener('beforeunload', handleBeforeUnload)
     }
+  }, [store])
+
+  return null
+}
+
+/**
+ * Scratch Pad 初始化和持久化组件
+ *
+ * 启动时注入 scratch tab 到 tabsAtom 首位，
+ * 从磁盘加载 scratch-pad.md 内容，自动保存到磁盘。
+ */
+function ScratchPadPersistence(): null {
+  const store = useStore()
+  const loadedRef = useRef(false)
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout>>()
+
+  // 启动：加载文件内容、注入 scratch tab、恢复激活状态
+  useEffect(() => {
+    const init = async (): Promise<void> => {
+      try {
+        // 加载 scratch-pad.md 内容（磁盘存的是 markdown，转为 HTML 给编辑器用）
+        const [settings, loadedMd] = await Promise.all([
+          window.electronAPI.getSettings(),
+          window.electronAPI.loadScratchPad ? window.electronAPI.loadScratchPad() : Promise.resolve(''),
+        ])
+
+        const loadedHtml = loadedMd ? markdownToHtml(loadedMd) : ''
+        store.set(scratchPadContentAtom, loadedHtml)
+        store.set(scratchPadLoadedAtom, true)
+
+        // 将 scratch tab 注入首位
+        const currentTabs = store.get(tabsAtom)
+        const newTabs = ensureScratchPadTab(currentTabs)
+
+        // 如果 tabs 数组变了（新增了 scratch tab），写入 store
+        if (newTabs.length > currentTabs.length || newTabs[0]?.id !== currentTabs[0]?.id) {
+          store.set(tabsAtom, newTabs)
+        }
+
+        // 恢复 scratch 激活状态：如果上次关闭时在 scratch 页，则激活它
+        // 不改变 appMode，保留原有的 chat/agent 侧边栏状态
+        if (settings.scratchPadActive) {
+          store.set(activeTabIdAtom, SCRATCH_PAD_ID)
+        }
+
+        console.log('[ScratchPad] 初始化完成，已加载内容:', !!loadedMd)
+      } catch (err) {
+        console.error('[ScratchPad] 初始化失败:', err)
+      } finally {
+        loadedRef.current = true
+      }
+    }
+
+    init()
+  }, [store])
+
+  // 自动保存：监听 scratchPadContentAtom 变化，防抖写入磁盘
+  useEffect(() => {
+    const save = (): void => {
+      const html = store.get(scratchPadContentAtom)
+      if (window.electronAPI.saveScratchPad) {
+        const md = htmlToMarkdown(html)
+        window.electronAPI.saveScratchPad(md).catch(console.error)
+      }
+    }
+
+    const debouncedSave = (): void => {
+      if (!loadedRef.current) return
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
+      saveTimerRef.current = setTimeout(save, 500)
+    }
+
+    const unsub = store.sub(scratchPadContentAtom, debouncedSave)
+
+    // beforeunload 时同步写入
+    const handleBeforeUnload = (): void => {
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
+      const html = store.get(scratchPadContentAtom)
+      if (window.electronAPI.saveScratchPadSync) {
+        const md = htmlToMarkdown(html)
+        window.electronAPI.saveScratchPadSync(md)
+      }
+    }
+    window.addEventListener('beforeunload', handleBeforeUnload)
+
+    return () => {
+      unsub()
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
+      window.removeEventListener('beforeunload', handleBeforeUnload)
+    }
+  }, [store])
+
+  // 监听 activeTabIdAtom 变化，持久化 scratchPadActive 到 settings
+  useEffect(() => {
+    const unsub = store.sub(activeTabIdAtom, () => {
+      const activeTabId = store.get(activeTabIdAtom)
+      const isScratchActive = activeTabId === SCRATCH_PAD_ID
+      window.electronAPI.updateSettings({
+        scratchPadActive: isScratchActive,
+      }).catch(() => {})
+    })
+    return unsub
   }, [store])
 
   return null
@@ -750,6 +856,7 @@ if (isQuickTaskWindow) {
       <FeishuInitializer />
       <DingTalkInitializer />
       <TabStatePersistenceInitializer />
+      <ScratchPadPersistence />
       <GlobalShortcuts />
       <TabSwitcher />
       <App />

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -197,6 +197,8 @@ export interface AppSettings {
   shortcutOverrides?: ShortcutOverrides
   /** 是否显示用户消息悬浮置顶条（默认 true） */
   stickyUserMessageEnabled?: boolean
+  /** 上次是否在 Scratch Pad 页（用于重启恢复） */
+  scratchPadActive?: boolean
   /** 应用图标变体 ID（dock + window icon），'default' 或 logo 变体 id */
   appIconVariant?: string
   /** 语音输入设置（Access Token 以加密态存储，由专用服务解密后返回渲染进程） */
@@ -218,6 +220,16 @@ export const SETTINGS_IPC_CHANNELS = {
   ON_SYSTEM_THEME_CHANGED: 'settings:system-theme-changed',
   /** 用户手动切换主题时广播给所有窗口 */
   ON_THEME_SETTINGS_CHANGED: 'settings:theme-settings-changed',
+} as const
+
+/** Scratch Pad IPC 通道 */
+export const SCRATCH_PAD_IPC_CHANNELS = {
+  /** 从磁盘加载 scratch-pad.md 内容 */
+  LOAD: 'scratch-pad:load',
+  /** 保存内容到 scratch-pad.md */
+  SAVE: 'scratch-pad:save',
+  /** 同步保存（beforeunload 场景） */
+  SAVE_SYNC: 'scratch-pad:save-sync',
 } as const
 
 /** 应用图标 IPC 通道 */


### PR DESCRIPTION
## 概述

在标签栏最左侧新增一个持久化的"Scratch Pad"草稿本标签页——始终可用的草稿空间，基于 TipTap 的富文本编辑器。内容编辑时防抖 500ms 自动保存，关闭窗口时同步写入，不丢数据。磁盘上存储为纯 Markdown（`~/.proma/scratch-pad.md`），外部可直接打开阅读。

## 变更清单

### 类型与状态
- `tab-atoms.ts` — 新增 `scratch` 标签类型、`SCRATCH_PAD_ID` 常量、`scratchPadContentAtom`、`ensureScratchPadTab()` 辅助函数；close/reorder 操作对 scratch tab 加保护
- `app-mode.ts` — AppMode 扩展 `scratch`
- `settings.ts` — 新增 `SCRATCH_PAD_IPC_CHANNELS` 和 `scratchPadActive` 设置字段

### IPC 层
- `config-paths.ts` — `getScratchPadPath()` → `~/.proma/scratch-pad.md`
- `ipc.ts` — load/save/save-sync 三个 handler，全部使用 `node:fs`（兼容 esbuild 打包后的 Electron 主进程，不依赖 Bun 全局对象）
- `preload/index.ts` — 暴露 `loadScratchPad` / `saveScratchPad` / `saveScratchPadSync` API

### UI 组件
- `ScratchPadView.tsx`（新建）— TipTap 编辑器 + markdown-it 粘贴转 Markdown，`loaded` 门控防止加载闪烁
- `TabBarItem.tsx` — 固定 36px 纯图标标签（无关闭按钮、无中键关闭、不参与 flex 等分宽度）
- `TabContent.tsx` — 路由 `scratch` 类型到 `ScratchPadView`
- `TabBar.tsx` — 激活 scratch 时不改变侧边栏的 chat/agent 状态

### 持久化
- `main.tsx` — `ScratchPadPersistence` 组件：加载时 markdown→HTML 给编辑器，保存时 HTML→markdown 写入磁盘；通过 `ensureScratchPadTab()` 与 `TabStatePersistenceInitializer` 防范竞态
- `useSyncActiveTabSideEffects.ts` — scratch 类型清除会话 ID 但不改变 appMode

### 其他
- `WelcomeEmptyState.tsx` — 补全 Record<AppMode> 类型
- `GlobalShortcuts.tsx` — Cmd+Shift+M 切换模式时跳过 scratch

## 测试方法

1. 启动 Proma — 最左侧出现 📝 图标的 Scratch Pad 标签
2. 点击打开编辑器，侧边栏保持原有的 chat/agent 状态不变
3. 输入 Markdown（如 `# 标题`、`**加粗**`）— 实时渲染
4. 从外部粘贴 Markdown — 自动转换为格式化内容
5. 切换到其他标签再切回来 — 内容和格式完整保留
6. 关闭 Proma 重新打开 — 内容完全持久化
7. 尝试关闭或拖移 scratch 标签 — 无法操作

## 备注

- Scratch tab 不参与 `tabState` 持久化（每次启动由代码注入）
- `ensureScratchPadTab()` 是幂等的，从多个初始化路径调用安全
- 保存时通过项目已有的 `htmlToMarkdown`/`markdownToHtml` 做转换，磁盘文件是纯 Markdown