### PR TITLE
[codex] fix migration import path check

### DIFF
--- a/apps/electron/src/main/lib/migration-service.ts
+++ b/apps/electron/src/main/lib/migration-service.ts
@@ -9,7 +9,7 @@
  */
 
 import { existsSync, mkdirSync, cpSync, readFileSync, writeFileSync, readdirSync, rmSync, type Dirent } from 'node:fs'
-import { join, resolve } from 'node:path'
+import { join, resolve, relative, isAbsolute, sep } from 'node:path'
 import { homedir, platform, arch, tmpdir } from 'node:os'
 import { randomUUID } from 'node:crypto'
 import AdmZip from 'adm-zip'
@@ -1321,7 +1321,8 @@ function _safeExtractAll(zip: AdmZip, targetDir: string): void {
   const resolvedTarget = resolve(targetDir)
   for (const entry of zip.getEntries()) {
     const entryPath = resolve(targetDir, entry.entryName)
-    if (!entryPath.startsWith(resolvedTarget + '/') && entryPath !== resolvedTarget) {
+    const relativeEntryPath = relative(resolvedTarget, entryPath)
+    if (relativeEntryPath === '..' || relativeEntryPath.startsWith(`..${sep}`) || isAbsolute(relativeEntryPath)) {
       throw new Error(`迁移文件包含非法路径，已拒绝解压: ${entry.entryName}`)
     }
   }


### PR DESCRIPTION
## Summary

Fix the migration import Zip Slip guard so valid nested entries are accepted on Windows.

## Root Cause

The guard compared resolved filesystem paths with resolvedTarget + '/'. That works on POSIX paths, but Windows resolve() produces backslash-separated paths, so entries such as config/channels.json were treated as escaping the import temp directory.

## Impact

Exported .proma-backup and .proma-share files can be imported on Windows without rejecting normal entries like config/channels.json, while path traversal entries remain blocked.

## Validation

- bun run --filter='@proma/electron' typecheck
- Local path-rule check covering Windows/POSIX nested paths and ../evil.json traversal cases