### PR TITLE
fix: minimap 面板增加悬停延迟，防止鼠标掠过时闪烁 【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
@@ -78,6 +78,7 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
   const [scrollMetrics, setScrollMetrics] = React.useState({ scrollTop: 0, scrollHeight: 1, clientHeight: 1 })
   const closeTimerRef = React.useRef<ReturnType<typeof setTimeout>>()
   const fadeTimerRef = React.useRef<ReturnType<typeof setTimeout>>()
+  const openTimerRef = React.useRef<ReturnType<typeof setTimeout>>()
   const searchInputRef = React.useRef<HTMLInputElement>(null)
   const trackRef = React.useRef<HTMLDivElement>(null)
 
@@ -87,6 +88,7 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
     return () => {
       if (closeTimerRef.current) clearTimeout(closeTimerRef.current)
       if (fadeTimerRef.current) clearTimeout(fadeTimerRef.current)
+      if (openTimerRef.current) clearTimeout(openTimerRef.current)
     }
   }, [])
 
@@ -143,14 +145,35 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
 
   // ── 鼠标进出控制（仅迷你地图区域） ──
 
+  /** 鼠标进入后需停留此时间（ms）才展开面板，防止掠过时闪烁 */
+  const OPEN_DELAY = 180
+
   const handleMouseEnter = (): void => {
     if (closeTimerRef.current) clearTimeout(closeTimerRef.current)
     if (fadeTimerRef.current) clearTimeout(fadeTimerRef.current)
     setIsLeaving(false)
-    setHovered(true)
+
+    // 面板已打开则无需重复触发
+    if (hovered) return
+
+    // 延迟打开：鼠标需在触发条上停留足够时间
+    if (!openTimerRef.current) {
+      openTimerRef.current = setTimeout(() => {
+        setHovered(true)
+        openTimerRef.current = undefined
+      }, OPEN_DELAY)
+    }
   }
 
   const handleMouseLeave = (): void => {
+    // 尚未打开就离开了 → 取消打开定时器
+    if (openTimerRef.current) {
+      clearTimeout(openTimerRef.current)
+      openTimerRef.current = undefined
+    }
+
+    if (!hovered) return
+
     closeTimerRef.current = setTimeout(() => {
       setIsLeaving(true)
       fadeTimerRef.current = setTimeout(() => {


### PR DESCRIPTION
## 概述

修复 minimap（迷你地图导航条）在鼠标掠过时频繁闪烁或意外保持打开的问题。在 `handleMouseEnter` 中增加 180ms 的悬停延迟，鼠标必须停留在触发条上超过该时间面板才会展开；鼠标在延迟内离开则取消展开。

## 改动

- `apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx` — 新增 `openTimerRef` 延迟打开定时器，`handleMouseEnter` 改为 180ms 延迟后才 `setHovered(true)`，`handleMouseLeave` 先取消待打开定时器再执行关闭逻辑，组件卸载时清理所有 timer refs

## 测试方法

1. 打开任意有足够多消息的 Chat 或 Agent 对话
2. 快速将鼠标从 minimap 条上掠过 → 面板不应弹出
3. 将鼠标停留在 minimap 条上约 0.2 秒 → 面板应正常展开
4. 面板打开后，将鼠标从触发条移到面板内 → 面板应保持打开
5. 面板打开后移开鼠标 → 面板应正常关闭

## 备注

- 延迟值设为 180ms，兼顾响应速度和防误触
- 面板已打开时 `handleMouseEnter` 直接返回，不会重复创建定时器
- 面板未打开时 `handleMouseLeave` 提前返回，不会启动关闭动画

🤖 Generated with [Claude Code](https://claude.com/claude-code)