### PR TITLE
refactor: 将滚动到底部按钮从右侧移至居中 【无需审核】

### DIFF
--- a/apps/electron/src/renderer/components/ai-elements/conversation.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/conversation.tsx
@@ -105,7 +105,7 @@ export function ConversationScrollButton({
   return (
     <Button
       className={cn(
-        'absolute bottom-[26px] right-[55px] rounded-[17px] size-9',
+        'absolute bottom-[26px] left-1/2 -translate-x-1/2 rounded-[17px] size-9',
         'border-[0.5px] border-border',
         className
       )}


### PR DESCRIPTION
## Overview
将 `ConversationScrollButton`（一键滚动到底部按钮）的定位从右侧改为水平居中，使其始终保持在输入框上方居中位置。

## Changes
- `apps/electron/src/renderer/components/ai-elements/conversation.tsx` — 将按钮定位从 `right-[55px]` 改为 `left-1/2 -translate-x-1/2`，实现水平居中。无论 Conversation 容器宽度如何变化（窗口缩放、侧边栏开关等），按钮始终保持居中。

## How to Test
1. 在 Chat 模式下发送消息，然后向上滚动，确认按钮出现在输入框上方的中间位置
2. 在 Agent 模式下重复测试
3. 缩放窗口，确认按钮跟随居中
4. 点击按钮确认滚动到底部功能正常

## Notes
- 同时适用于 Chat 和 Agent 两种模式（共用同一个 `ConversationScrollButton` 组件）
- 仅修改 CSS 定位，不涉及功能逻辑变更
🤖 Generated with [Claude Code](https://claude.com/claude-code)