### PR TITLE
feat: clipboard 附件点击预览 + paste 换行修复 + 预览面板换行修复【已审核 PR】

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -2008,6 +2008,43 @@ export function registerIpcHandlers(): void {
     }
   )
 
+  // 将剪贴板文本写入临时预览文件
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.WRITE_CLIPBOARD_PREVIEW,
+    async (_, filename: string, content: string): Promise<string> => {
+      if (typeof filename !== 'string' || !filename) {
+        throw new Error('filename 必须是非空字符串')
+      }
+      if (typeof content !== 'string') {
+        throw new Error('content 必须是字符串')
+      }
+
+      const { resolve } = await import('node:path')
+      const { join } = await import('node:path')
+      const { tmpdir } = await import('node:os')
+      const { existsSync, mkdirSync } = await import('node:fs')
+      const { writeFile } = await import('node:fs/promises')
+
+      const tmpDir = join(tmpdir(), 'proma-preview')
+      if (!existsSync(tmpDir)) {
+        mkdirSync(tmpDir, { recursive: true })
+      }
+
+      // 安全文件名：替换路径分隔符和特殊字符，防止目录穿越
+      const safeFilename = filename.replace(/[<>:"/\\|?*]/g, '_').replace(/^\.+/, '_')
+      const tmpPath = resolve(tmpDir, safeFilename)
+
+      // 确保 resolve 后的路径仍在 tmpDir 内，防止 .. 穿越
+      if (!tmpPath.startsWith(tmpDir + '/') && tmpPath !== tmpDir) {
+        throw new Error('文件名越界')
+      }
+
+      await writeFile(tmpPath, content, 'utf-8')
+      console.log(`[IPC] clipboard 预览文件已写入: ${tmpPath}`)
+      return tmpPath
+    }
+  )
+
   // 在系统文件管理器中显示文件
   ipcMain.handle(
     AGENT_IPC_CHANNELS.SHOW_IN_FOLDER,

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -614,6 +614,9 @@ export interface ElectronAPI {
   /** 用系统默认应用打开文件 */
   openFile: (filePath: string) => Promise<void>
 
+  /** 将剪贴板文本写入临时预览文件并返回绝对路径 */
+  writeClipboardPreview: (filename: string, content: string) => Promise<string>
+
   /** 用系统默认应用打开任意文件（无工作区限制） */
   systemOpenFile: (filePath: string, appName?: string, access?: import('@proma/shared').FileAccessOptions) => Promise<void>
 
@@ -1585,6 +1588,10 @@ const electronAPI: ElectronAPI = {
 
   openFile: (filePath: string) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.OPEN_FILE, filePath)
+  },
+
+  writeClipboardPreview: (filename: string, content: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.WRITE_CLIPBOARD_PREVIEW, filename, content)
   },
 
   systemOpenFile: (filePath: string, appName?: string, access?: import('@proma/shared').FileAccessOptions) => {

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -797,7 +797,9 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     if (!base64) return
 
     try {
-      const text = atob(base64)
+      // atob 解码得到二进制字符串，需用 TextDecoder 正确还原 UTF-8 文本
+      const bytes = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0))
+      const text = new TextDecoder('utf-8').decode(bytes)
       const tmpPath = await window.electronAPI.writeClipboardPreview(file.filename, text)
       const tmpDir = tmpPath.substring(0, tmpPath.lastIndexOf('/'))
       setPreviewFileMap((prev) => {

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -47,7 +47,7 @@ import { cn } from '@/lib/utils'
 import { getActiveAccelerator, getAcceleratorDisplay } from '@/lib/shortcut-registry'
 import { FeishuNotifyToggle } from '@/components/chat/FeishuNotifyToggle'
 import { registerShortcut } from '@/lib/shortcut-registry'
-import { previewPanelOpenMapAtom, autoPreviewEnabledAtom } from '@/atoms/preview-atoms'
+import { previewPanelOpenMapAtom, previewFileMapAtom, autoPreviewEnabledAtom } from '@/atoms/preview-atoms'
 import {
   agentStreamingStatesAtom,
   agentChannelIdAtom,
@@ -374,6 +374,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const permissionMode = permissionModeMap.get(sessionId) ?? persistedPermissionMode ?? defaultPermissionMode
   const isPermissionPlanMode = permissionMode === 'plan'
   const store = useStore()
+  const setPreviewFileMap = useSetAtom(previewFileMapAtom)
   const suggestionsMap = useAtomValue(agentPromptSuggestionsAtom)
   const suggestion = suggestionsMap.get(sessionId) ?? null
   const setPromptSuggestions = useSetAtom(agentPromptSuggestionsAtom)
@@ -789,6 +790,26 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       return prev.filter((f) => f.id !== id)
     })
   }, [setPendingFiles])
+
+  /** 点击 clipboard 附件时，在右侧预览面板中显示内容 */
+  const handleClipboardPreview = React.useCallback(async (file: AgentPendingFile) => {
+    const base64 = window.__pendingAgentFileData?.get(file.id)
+    if (!base64) return
+
+    try {
+      const text = atob(base64)
+      const tmpPath = await window.electronAPI.writeClipboardPreview(file.filename, text)
+      const tmpDir = tmpPath.substring(0, tmpPath.lastIndexOf('/'))
+      setPreviewFileMap((prev) => {
+        const m = new Map(prev)
+        m.set(sessionId, { filePath: tmpPath, previewOnly: true, basePaths: [tmpDir] })
+        return m
+      })
+      store.set(previewPanelOpenMapAtom, (prev) => { const m = new Map(prev); m.set(sessionId, true); return m })
+    } catch (error) {
+      console.error('[AgentView] clipboard 预览写入失败:', error)
+    }
+  }, [sessionId, setPreviewFileMap, store])
 
   /** 粘贴文件处理 */
   const handlePasteFiles = React.useCallback((files: File[]): void => {
@@ -1557,6 +1578,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
                     mediaType={file.mediaType}
                     previewUrl={file.previewUrl}
                     onRemove={() => handleRemoveFile(file.id)}
+                    onClick={file.filename.startsWith('clipboard-') ? () => handleClipboardPreview(file) : undefined}
                   />
                 ))}
               </div>

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -349,8 +349,14 @@ export function RichTextInput({
         const threshold = longTextPasteThresholdRef.current
         const plainText = event.clipboardData?.getData('text/plain') ?? ''
         const html = event.clipboardData?.getData('text/html') ?? ''
-        // 优先使用纯文本：保留原始换行符，htmlToMarkdown 对 <div> 块不添加换行会丢失换行
-        const text = plainText || (html ? htmlToMarkdown(html).trim() : '')
+        // 预处理 HTML：将 <div> 替换为 <p>，避免 htmlToMarkdown 对 <div> 不分段导致换行丢失
+        const text = html
+          ? (htmlToMarkdown(
+              html
+                .replace(/<div\b[^>]*>/gi, '<p>')
+                .replace(/<\/div>/gi, '</p>')
+            ).trim() || plainText)
+          : plainText
         if (
           threshold &&
           threshold > 0 &&

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -349,7 +349,8 @@ export function RichTextInput({
         const threshold = longTextPasteThresholdRef.current
         const plainText = event.clipboardData?.getData('text/plain') ?? ''
         const html = event.clipboardData?.getData('text/html') ?? ''
-        const text = html ? (htmlToMarkdown(html).trim() || plainText) : plainText
+        // 优先使用纯文本：保留原始换行符，htmlToMarkdown 对 <div> 块不添加换行会丢失换行
+        const text = plainText || (html ? htmlToMarkdown(html).trim() : '')
         if (
           threshold &&
           threshold > 0 &&

--- a/apps/electron/src/renderer/components/chat/AttachmentPreviewItem.tsx
+++ b/apps/electron/src/renderer/components/chat/AttachmentPreviewItem.tsx
@@ -21,6 +21,8 @@ interface AttachmentPreviewItemProps {
   previewUrl?: string
   /** 删除回调 */
   onRemove: () => void
+  /** 点击回调（用于打开文件预览等） */
+  onClick?: () => void
   className?: string
 }
 
@@ -39,6 +41,7 @@ export function AttachmentPreviewItem({
   mediaType,
   previewUrl,
   onRemove,
+  onClick,
   className,
 }: AttachmentPreviewItemProps): React.ReactElement {
   const [lightboxOpen, setLightboxOpen] = React.useState(false)
@@ -90,8 +93,13 @@ export function AttachmentPreviewItem({
         'rounded-lg bg-[#37a5aa]/10 border border-[#37a5aa]/20',
         'pl-2.5 pr-7 py-1.5 text-[13px] text-[#37a5aa]',
         'transition-colors hover:bg-[#37a5aa]/15',
+        onClick && 'cursor-pointer',
         className
       )}
+      onClick={onClick}
+      role={onClick ? 'button' : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onKeyDown={onClick ? (e: React.KeyboardEvent) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick() } } : undefined}
     >
       <Paperclip className="size-4 shrink-0" />
       <span className="max-w-[160px] truncate">{truncateName(filename)}</span>

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -660,11 +660,11 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
             )
           ) : highlightedHtml ? (
             <div
-              className="p-3 text-[13px] leading-relaxed [&_pre]:!bg-transparent [&_pre]:!m-0 [&_pre]:!p-0 [&_code]:!text-[13px]"
+              className="p-3 text-[13px] leading-relaxed [&_pre]:!bg-transparent [&_pre]:!m-0 [&_pre]:!p-0 [&_code]:!text-[13px] [&_pre]:!whitespace-pre-wrap [&_pre]:![overflow-wrap:anywhere]"
               dangerouslySetInnerHTML={{ __html: highlightedHtml }}
             />
           ) : (
-            <pre className="p-3 text-[13px] leading-relaxed text-foreground/80 font-mono whitespace-pre-wrap break-words">
+            <pre className="p-3 text-[13px] leading-relaxed text-foreground/80 font-mono whitespace-pre-wrap [overflow-wrap:anywhere]">
               {newContent || <span className="text-muted-foreground">（文件为空）</span>}
             </pre>
           )

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1348,6 +1348,8 @@ export const AGENT_IPC_CHANNELS = {
   READ_ATTACHED_FILE: 'agent:read-attached-file',
   /** 搜索工作区文件（用于 @ 引用） */
   SEARCH_WORKSPACE_FILES: 'agent:search-workspace-files',
+  /** 将文本内容写入临时预览文件并返回绝对路径 */
+  WRITE_CLIPBOARD_PREVIEW: 'agent:write-clipboard-preview',
 
   // 标题自动生成通知（主进程 → 渲染进程推送）
   /** 标题已更新（首次对话完成后自动生成） */


### PR DESCRIPTION
## Overview

三个相关联的改进：

1. **Clipboard 附件点击预览**：粘贴超长文本生成的 clipboard 附件（`.md`/`.txt` 标签）现在可点击，会在右侧文件预览面板中显示完整内容
2. **Paste 换行修复**：粘贴富文本时 `<div>` 布局的段落会丢失换行，通过在 HTML→Markdown 转换前将 `<div>` 预处理为 `<p>` 解决
3. **预览面板长文本换行**：纯文本和代码预览中的长行不再溢出面板边界，使用 `overflow-wrap: anywhere` 强制换行

## Changes

| 文件 | 变更 |
|------|------|
| `packages/shared/src/types/agent.ts` | 新增 `WRITE_CLIPBOARD_PREVIEW` IPC 通道常量 |
| `apps/electron/src/main/ipc.ts` | IPC handler：将文本写入 `/tmp/proma-preview/` 返回路径，含路径穿越防护和输入校验 |
| `apps/electron/src/preload/index.ts` | Preload 桥接 `writeClipboardPreview` API |
| `apps/electron/src/renderer/components/agent/AgentView.tsx` | `handleClipboardPreview`：读取 base64 → TextDecoder 解码 → 写入 temp → 设置预览 panel atoms |
| `apps/electron/src/renderer/components/chat/AttachmentPreviewItem.tsx` | 新增可选 `onClick` prop，clickable 时添加 cursor-pointer 和键盘支持 |
| `apps/electron/src/renderer/components/diff/DiffTabContent.tsx` | `break-words` → `overflow-wrap:anywhere`，Shiki 高亮和 plain text 两处均修复 |
| `apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx` | Paste：HTML 预处理 `<div>` → `<p>` 后再转 Markdown，保留换行+格式 |

## How to Test

1. Agent 模式中粘贴超过 500 字符的文本 → 应转为 teal 色 clipboard 附件标签
2. 点击 clipboard 附件标签 → 右侧预览面板应显示完整内容（含正确的中文编码和段落换行）
3. 从网页复制多段落文章粘贴 → clipboard 附件内容应保留段落分隔
4. 在预览面板中查看长行文本 → 应在面板边界处换行，无需横向滚动

## Notes

- 新增 IPC 通道遵循项目四层架构（shared → main → preload → renderer）
- 路径穿越防护：文件名清理 + `resolve()` 后校验必须在 `/tmp/proma-preview/` 内
- 中文编码修复：`atob` 后用 `TextDecoder('utf-8')` 正确还原，避免双重编码导致的乱码
- `<div>` → `<p>` 正则使用 `\b` 边界避免误匹配 `<diva>` 等标签
- 类型检查：@proma/shared ✓ @proma/core ✓ @proma/ui ✓ @proma/electron ✓