### PR TITLE
feat: 替换 Shiki 为 @pierre/diffs，优化文件预览性能，新增代码预览行号【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -50,6 +50,7 @@ import {
 } from '@/atoms/agent-atoms'
 import type { SessionIndicatorStatus } from '@/atoms/agent-atoms'
 import { previewPanelOpenMapAtom, previewFileMapAtom } from '@/atoms/preview-atoms'
+import { clearPreviewCacheForSession } from '@/components/diff/DiffTabContent'
 import {
   tabsAtom,
   activeTabIdAtom,
@@ -363,6 +364,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     setDiffUnseenFiles(deleteKey)
     setSessionChannelMap(deleteKey)
     setSessionModelMap(deleteKey)
+    clearPreviewCacheForSession(id)
   }, [setConvModels, setConvContextLength, setConvThinking, setConvParallel, setConvPromptId, setPreviewPanelOpen, setPreviewFile, setDiffPanelTab, setDiffRefreshVersion, setDiffUnseen, setDiffUnseenFiles, setSessionChannelMap, setSessionModelMap])
 
   const currentWorkspaceSlug = React.useMemo(() => {

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -1,37 +1,21 @@
 /**
  * DiffTabContent — 单文件 Diff 或纯文件预览内容
  *
- * previewOnly=true 时：代码高亮预览（Shiki）或 Markdown 渲染
+ * previewOnly=true 时：代码高亮预览（@pierre/diffs File）或 Markdown 渲染
  * previewOnly=false（默认）：显示 git diff（旧版本 vs 磁盘）
  */
 
 import * as React from 'react'
-import { Code2, Copy, Check, Eye, Pencil, Save, X } from 'lucide-react'
+import { Code2, Copy, Check, Eye, Pencil, RefreshCw, Save, X } from 'lucide-react'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import DOMPurify from 'dompurify'
+import { File as PierreFile } from '@pierre/diffs/react'
 import { cn } from '@/lib/utils'
 import { agentDiffViewModeAtom, agentDiffRefreshVersionAtom } from '@/atoms/agent-atoms'
 import { resolvedThemeAtom } from '@/atoms/theme'
-import { highlightCode } from '@proma/core'
 import { DiffView } from './DiffView'
 import { MarkdownRichEditor } from './MarkdownRichEditor'
-
-/** 扩展名 → Shiki 语言 ID */
-const EXT_LANG: Record<string, string> = {
-  '.md': 'markdown', '.markdown': 'markdown',
-  '.json': 'json', '.jsonc': 'json', '.json5': 'json',
-  '.xml': 'xml', '.html': 'html', '.htm': 'html', '.svg': 'xml',
-  '.yaml': 'yaml', '.yml': 'yaml', '.toml': 'toml', '.ini': 'ini', '.env': 'bash',
-  '.ts': 'typescript', '.tsx': 'tsx', '.js': 'javascript', '.jsx': 'jsx',
-  '.mjs': 'javascript', '.cjs': 'javascript',
-  '.py': 'python', '.go': 'go', '.rs': 'rust', '.java': 'java', '.kt': 'kotlin', '.swift': 'swift',
-  '.c': 'c', '.h': 'c', '.cpp': 'cpp', '.hpp': 'cpp', '.cs': 'csharp',
-  '.sh': 'bash', '.bash': 'bash', '.zsh': 'bash', '.fish': 'fish',
-  '.css': 'css', '.scss': 'scss', '.less': 'less',
-  '.sql': 'sql', '.rb': 'ruby', '.php': 'php',
-  '.diff': 'diff', '.patch': 'diff',
-  '.txt': 'text', '.log': 'text', '.csv': 'text',
-}
+import { PIERRE_FILE_CSS } from '@/components/agent/tool-result-renderers/pierre-styles'
 
 const MD_EXTS = new Set(['.md', '.markdown'])
 const PDF_EXTS = new Set(['.pdf'])
@@ -45,19 +29,47 @@ const IMAGE_EXTS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg', '.
  * key 设计：
  * - diff 模式：`diff:${filePath}@v${refreshVersion}`
  * - preview 模式：`preview:${filePath}@v${refreshVersion}`
- * refreshVersion 变化时（agent 写文件、git 突变、窗口聚焦）key 自然变化，
+ * refreshVersion 变化时（agent 写文件、git 突变）key 自然变化，
  * 老 entry 不会被命中，最终被 LRU 淘汰；无需主动失效。
  */
 type CacheEntry = {
   oldContent: string
   newContent: string
-  highlightedHtml?: string
-  highlightedLanguage?: string
-  highlightedTheme?: string
+  /** 非文本文件预览数据 */
+  pdfSrc?: string
+  imageDataUrl?: string
+  imagePath?: string
+  docxHtml?: string
+  officeHtml?: string
+  officeText?: string
 }
 const CACHE_MAX = 50
-const MAX_HIGHLIGHT_CHARS = 200_000
 const contentCache = new Map<string, CacheEntry>()
+
+/** 滚动位置持久化：key = `${sessionId}:${filePath}` */
+const scrollPositionCache = new Map<string, { top: number; left: number }>()
+
+function scrollCacheKey(sessionId: string, filePath: string): string {
+  return `${sessionId}:${filePath}`
+}
+
+/** 获取缓存的滚动位置 */
+export function getPreviewScrollPosition(sessionId: string, filePath: string): { top: number; left: number } | undefined {
+  return scrollPositionCache.get(scrollCacheKey(sessionId, filePath))
+}
+
+/**
+ * 清除指定 session 的滚动位置缓存，供 useCloseTab 调用。
+ *
+ * 注意：contentCache 不包含 sessionId，依赖 LRU 自动淘汰（CACHE_MAX=50）。
+ * 如需主动清理内容缓存，需将 key 格式改为 `${sessionId}:${mode}:${filePath}@v${version}`。
+ */
+export function clearPreviewCacheForSession(sessionId: string): void {
+  const prefix = `${sessionId}:`
+  for (const key of scrollPositionCache.keys()) {
+    if (key.startsWith(prefix)) scrollPositionCache.delete(key)
+  }
+}
 function cacheGet(key: string): CacheEntry | undefined {
   const v = contentCache.get(key)
   if (!v) return undefined
@@ -94,7 +106,6 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   const [viewMode, setViewMode] = useAtom(agentDiffViewModeAtom)
   const [oldContent, setOldContent] = React.useState('')
   const [newContent, setNewContent] = React.useState('')
-  const [highlightedHtml, setHighlightedHtml] = React.useState('')
   const [markdownEditing, setMarkdownEditing] = React.useState(false)
   const [markdownSourceMode, setMarkdownSourceMode] = React.useState(false)
   const [markdownDraft, setMarkdownDraft] = React.useState('')
@@ -113,6 +124,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   const imageContainerRef = React.useRef<HTMLDivElement>(null)
   const imageDragging = React.useRef(false)
   const imageDragStart = React.useRef({ x: 0, y: 0, scrollLeft: 0, scrollTop: 0 })
+  const scrollContainerRef = React.useRef<HTMLDivElement>(null)
   const [loading, setLoading] = React.useState(true)
   const [copied, setCopied] = React.useState(false)
   const refreshVersionMap = useAtomValue(agentDiffRefreshVersionAtom)
@@ -143,12 +155,25 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     return { sessionId, candidateBasePaths }
   }, [basePaths, dirPath, filePath, sessionId])
 
+  // props 变化时立即清空内容状态，避免在 useEffect 执行前渲染旧数据
   React.useEffect(() => {
+    setOldContent('')
+    setNewContent('')
+    setDocxHtml('')
+    setOfficeHtml('')
+    setOfficeText('')
+    setPdfSrc('')
+    setPdfZoom(100)
+    setImagePath('')
+    setImageDataUrl('')
+    setImageZoom(0.25)
+    setImageNaturalSize({ w: 0, h: 0 })
+    setLoading(true)
     setMarkdownEditing(false)
     setMarkdownSourceMode(false)
     setMarkdownDraft('')
     setMarkdownSaving(false)
-  }, [filePath, previewOnly])
+  }, [filePath, sessionId, previewOnly])
 
   // non-passive wheel listener for pinch-to-zoom on image
   React.useEffect(() => {
@@ -174,8 +199,6 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     return () => window.removeEventListener('message', handler)
   }, [isPdf])
 
-  const shikiTheme = theme === 'dark' ? 'one-dark-pro' : 'one-light'
-
   // 上次加载的内容（refreshVersion 触发时用来对比是否变化）
   const lastNewContentRef = React.useRef('')
   const lastOldContentRef = React.useRef('')
@@ -185,43 +208,35 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   // 命中缓存时跳过 loading 闪烁直接渲染；未命中走 IPC 拉取
   React.useEffect(() => {
     let cancelled = false
-    const lang = EXT_LANG[ext] || 'text'
 
-    // PDF / DOCX / Office 不走文本缓存（HTML 体积大、解析过程也不轻）
-    const cacheable = !isPdf && !isDocx && !isOfficePreview && !isLegacyOffice && !isImage
-    const cacheKey = cacheable
-      ? (previewOnly ? `preview:${filePath}@v${previewContentVersion}` : `diff:${filePath}@v${refreshVersion}`)
-      : null
-    const cached = cacheKey ? cacheGet(cacheKey) : undefined
+    // 所有文件类型均可缓存（含 PDF/DOCX/Office/Image）
+    const cacheKey = previewOnly
+      ? `preview:${filePath}@v${previewContentVersion}`
+      : `diff:${filePath}@v${refreshVersion}`
+    const cached = cacheGet(cacheKey)
 
     if (cached) {
       // 命中：直接同步渲染，不闪
+      restoreScrollRef.current = true
       lastNewContentRef.current = cached.newContent
       lastOldContentRef.current = cached.oldContent
       setOldContent(cached.oldContent)
       setNewContent(cached.newContent)
-      setHighlightedHtml(
-        cached.highlightedHtml &&
-          cached.highlightedLanguage === lang &&
-          cached.highlightedTheme === shikiTheme
-          ? cached.highlightedHtml
-          : ''
-      )
-      setDocxHtml('')
-      setOfficeHtml('')
-      setOfficeText('')
-      setPdfSrc('')
+      setDocxHtml(cached.docxHtml ?? '')
+      setOfficeHtml(cached.officeHtml ?? '')
+      setOfficeText(cached.officeText ?? '')
+      setPdfSrc(cached.pdfSrc ?? '')
       setPdfZoom(100)
-      setImagePath('')
-      setImageDataUrl('')
+      setImagePath(cached.imagePath ?? '')
+      setImageDataUrl(cached.imageDataUrl ?? '')
       setImageZoom(0.25)
       setImageNaturalSize({ w: 0, h: 0 })
       setLoading(false)
+      return // 缓存命中，直接返回，不执行 load()
     } else {
       setLoading(true)
       setOldContent('')
       setNewContent('')
-      setHighlightedHtml('')
       setDocxHtml('')
       setOfficeHtml('')
       setOfficeText('')
@@ -245,7 +260,9 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
             if (isPdf) {
               const result = await window.electronAPI.preparePdfPreview(filePath, fileAccess)
               if (cancelled) return
-              setPdfSrc(result?.tmpHtmlUrl ?? '')
+              const src = result?.tmpHtmlUrl ?? ''
+              setPdfSrc(src)
+              cacheSet(cacheKey, { oldContent: '', newContent: '', pdfSrc: src })
               return
             }
             if (isImage) {
@@ -254,23 +271,30 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
               if (resolved) {
                 setImagePath(filePath)
                 setImageDataUrl(resolved.url)
+                cacheSet(cacheKey, { oldContent: '', newContent: '', imagePath: filePath, imageDataUrl: resolved.url })
               } else {
                 setImagePath('')
                 setImageDataUrl('')
+                cacheSet(cacheKey, { oldContent: '', newContent: '', imagePath: '', imageDataUrl: '' })
               }
               return
             }
             if (isDocx) {
               const result = await window.electronAPI.docxToHtml(filePath, fileAccess)
               if (cancelled) return
-              setDocxHtml(DOMPurify.sanitize(result?.html ?? ''))
+              const html = DOMPurify.sanitize(result?.html ?? '')
+              setDocxHtml(html)
+              cacheSet(cacheKey, { oldContent: '', newContent: '', docxHtml: html })
               return
             }
             if (isOfficePreview) {
               const result = await window.electronAPI.officeToHtml(filePath, fileAccess)
               if (cancelled) return
-              setOfficeHtml(DOMPurify.sanitize(result?.html ?? ''))
-              setOfficeText(result?.text ?? '')
+              const html = DOMPurify.sanitize(result?.html ?? '')
+              const text = result?.text ?? ''
+              setOfficeHtml(html)
+              setOfficeText(text)
+              cacheSet(cacheKey, { oldContent: '', newContent: '', officeHtml: html, officeText: text })
               return
             }
             if (isLegacyOffice) {
@@ -296,38 +320,6 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
 
         if (previewOnly && !MD_EXTS.has(ext) && content) {
           if (!cancelled) setLoading(false)
-
-          if (
-            cached?.highlightedHtml &&
-            cached.highlightedLanguage === lang &&
-            cached.highlightedTheme === shikiTheme
-          ) {
-            if (!cancelled) setHighlightedHtml(cached.highlightedHtml)
-            return
-          }
-
-          if (content.length > MAX_HIGHLIGHT_CHARS) {
-            if (!cancelled) setHighlightedHtml('')
-            return
-          }
-
-          try {
-            const hl = await highlightCode({ code: content, language: lang, theme: shikiTheme })
-            if (cancelled) return
-            const sanitizedHtml = DOMPurify.sanitize(hl.html)
-            setHighlightedHtml(sanitizedHtml)
-            if (cacheKey) {
-              cacheSet(cacheKey, {
-                oldContent: old,
-                newContent: content,
-                highlightedHtml: sanitizedHtml,
-                highlightedLanguage: lang,
-                highlightedTheme: shikiTheme,
-              })
-            }
-          } catch (err) {
-            console.error('[DiffTabContent] Shiki highlight failed:', err)
-          }
         }
       } catch {
         // 加载失败静默处理
@@ -339,7 +331,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     load()
     return () => { cancelled = true }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filePath, dirPath, gitRoot, previewOnly, previewContentVersion, shikiTheme, fileAccess, isPdf, isDocx, isOfficePreview, isLegacyOffice, isImage, sessionId, ext])
+  }, [filePath, dirPath, gitRoot, previewOnly, previewContentVersion, fileAccess, isPdf, isDocx, isOfficePreview, isLegacyOffice, isImage, sessionId, ext])
 
   // refreshVersion 触发的静默刷新：仅 diff 模式、内容有变化时才更新 state
   const prevRefreshRef = React.useRef(-1)
@@ -374,6 +366,55 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     refresh()
     return () => { cancelled = true }
   }, [refreshVersion, previewOnly, filePath, dirPath, gitRoot, sessionId])
+
+  // scrollPosition persistent: module-level Map keyed by sessionId:filePath
+  // content changes (refreshVersion bump) → delete stored position;
+  // cached mount → restore; scroll → save.
+  const scrollKey = scrollCacheKey(sessionId, filePath)
+  const prevRefreshVersionRef = React.useRef(refreshVersion)
+
+  // WHEN content version changes (refreshVersion bump): delete stored scroll position
+  // 只在内容变化时清除，切换文件时保留位置以支持返回导航
+  React.useEffect(() => {
+    if (loading) return // still loading, don't clear yet
+    if (prevRefreshVersionRef.current !== refreshVersion) {
+      // refreshVersion changed for current file → content updated, clear position
+      scrollPositionCache.delete(scrollKey)
+      prevRefreshVersionRef.current = refreshVersion
+    }
+  }, [scrollKey, refreshVersion, loading])
+
+  // RESTORE scroll position after cached content renders
+  const restoreScrollRef = React.useRef(false)
+  React.useEffect(() => {
+    if (loading || !restoreScrollRef.current) return
+    restoreScrollRef.current = false
+    const pos = scrollPositionCache.get(scrollKey)
+    if (pos && scrollContainerRef.current) {
+      scrollContainerRef.current.scrollTop = pos.top
+      scrollContainerRef.current.scrollLeft = pos.left
+    }
+  }, [loading, scrollKey])
+
+  // SAVE scroll position on scroll (throttled via rAF)
+  const scrollRafRef = React.useRef(0)
+  const handleScroll = React.useCallback(() => {
+    if (scrollRafRef.current) return
+    scrollRafRef.current = requestAnimationFrame(() => {
+      scrollRafRef.current = 0
+      const el = scrollContainerRef.current
+      if (el) {
+        scrollPositionCache.set(scrollKey, { top: el.scrollTop, left: el.scrollLeft })
+      }
+    })
+  }, [scrollKey])
+
+  // Cleanup rAF on unmount to prevent stale writes
+  React.useEffect(() => {
+    return () => {
+      if (scrollRafRef.current) cancelAnimationFrame(scrollRafRef.current)
+    }
+  }, [])
 
   const handleCopy = React.useCallback(async () => {
     try {
@@ -427,6 +468,14 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
       setMarkdownSaving(false)
     }
   }, [fileAccess, filePath, isMarkdown, markdownDraft, markdownSaving, refreshVersion, sessionId, setRefreshVersionMap])
+
+  const handleManualRefresh = React.useCallback(() => {
+    setRefreshVersionMap((prev) => {
+      const m = new Map(prev)
+      m.set(sessionId, (prev.get(sessionId) ?? 0) + 1)
+      return m
+    })
+  }, [sessionId, setRefreshVersionMap])
 
   return (
     <div className="flex flex-col h-full">
@@ -501,9 +550,18 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
           title="复制文件内容">
           {copied ? <Check className="size-3.5 text-green-500" /> : <Copy className="size-3.5" />}
         </button>
+
+        <button
+          type="button"
+          onClick={handleManualRefresh}
+          className="p-1 rounded hover:bg-foreground/[0.06] text-foreground/40 hover:text-foreground/60 shrink-0"
+          title="刷新文件内容（检测外部编辑器的修改）"
+        >
+          <RefreshCw className="size-3.5" />
+        </button>
       </div>
 
-      <div className="flex-1 overflow-auto scrollbar-thin relative">
+      <div ref={scrollContainerRef} onScroll={handleScroll} className="flex-1 overflow-auto scrollbar-thin relative">
         {loading ? (
           <div className="flex items-center justify-center h-full text-muted-foreground text-[12px]">加载中...</div>
         ) : previewOnly ? (
@@ -655,17 +713,25 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
                 onRequestEdit={startMarkdownEdit}
                 disabled={markdownSaving}
                 fileAccess={markdownFileAccess}
-                shikiTheme={shikiTheme}
+                shikiTheme={theme === 'dark' ? 'one-dark-pro' : 'one-light'}
               />
             )
-          ) : highlightedHtml ? (
-            <div
-              className="p-3 text-[13px] leading-relaxed [&_pre]:!bg-transparent [&_pre]:!m-0 [&_pre]:!p-0 [&_code]:!text-[13px]"
-              dangerouslySetInnerHTML={{ __html: highlightedHtml }}
-            />
+          ) : newContent ? (
+            <div className="h-full">
+              <PierreFile
+                file={{ name: filePath.split('/').pop() ?? filePath, contents: newContent }}
+                options={{
+                  theme: { dark: 'one-dark-pro' as const, light: 'one-light' as const },
+                  disableFileHeader: true,
+                  overflow: 'scroll' as const,
+                  themeType: theme as 'light' | 'dark' | 'system',
+                  unsafeCSS: PIERRE_FILE_CSS,
+                }}
+              />
+            </div>
           ) : (
             <pre className="p-3 text-[13px] leading-relaxed text-foreground/80 font-mono whitespace-pre-wrap break-words">
-              {newContent || <span className="text-muted-foreground">（文件为空）</span>}
+              <span className="text-muted-foreground">（文件为空）</span>
             </pre>
           )
         ) : (

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -46,6 +46,9 @@ type CacheEntry = {
 const CACHE_MAX = 50
 const contentCache = new Map<string, CacheEntry>()
 
+/** 超过此字符数的文本文件将跳过 PierreFile 高亮，直接以纯文本展示，避免大文件卡顿 */
+const MAX_PREVIEW_CHARS = 500_000
+
 /** 滚动位置持久化：key = `${sessionId}:${filePath}` */
 const scrollPositionCache = new Map<string, { top: number; left: number }>()
 
@@ -144,6 +147,21 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     sessionId,
     candidateBasePaths: basePaths,
   }), [sessionId, basePaths])
+
+  // PierreFile props 缓存，避免每次渲染创建新对象导致内部重新高亮
+  const pierreFile = React.useMemo(() => ({
+    name: filePath.split('/').pop() ?? filePath,
+    contents: newContent,
+    cacheKey: `${filePath}:${newContent.length}:${previewContentVersion}`,
+  }), [filePath, newContent, previewContentVersion])
+
+  const pierreOptions = React.useMemo(() => ({
+    theme: { dark: 'one-dark-pro' as const, light: 'one-light' as const },
+    disableFileHeader: true,
+    overflow: 'scroll' as const,
+    themeType: theme as 'light' | 'dark' | 'system',
+    unsafeCSS: PIERRE_FILE_CSS,
+  }), [theme])
   const markdownFileAccess = React.useMemo(() => {
     const candidateBasePaths: string[] = []
     const slash = filePath.lastIndexOf('/')
@@ -717,18 +735,18 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
               />
             )
           ) : newContent ? (
-            <div className="h-full">
-              <PierreFile
-                file={{ name: filePath.split('/').pop() ?? filePath, contents: newContent }}
-                options={{
-                  theme: { dark: 'one-dark-pro' as const, light: 'one-light' as const },
-                  disableFileHeader: true,
-                  overflow: 'scroll' as const,
-                  themeType: theme as 'light' | 'dark' | 'system',
-                  unsafeCSS: PIERRE_FILE_CSS,
-                }}
-              />
-            </div>
+            newContent.length > MAX_PREVIEW_CHARS ? (
+              <pre className="p-3 text-[13px] leading-relaxed text-foreground/80 font-mono whitespace-pre-wrap break-words">
+                {newContent.slice(0, MAX_PREVIEW_CHARS)}
+                <span className="text-muted-foreground block mt-2">
+                  （文件过大，仅显示前 {MAX_PREVIEW_CHARS.toLocaleString()} 字符）
+                </span>
+              </pre>
+            ) : (
+              <div className="h-full">
+                <PierreFile file={pierreFile} options={pierreOptions} />
+              </div>
+            )
           ) : (
             <pre className="p-3 text-[13px] leading-relaxed text-foreground/80 font-mono whitespace-pre-wrap break-words">
               <span className="text-muted-foreground">（文件为空）</span>

--- a/apps/electron/src/renderer/components/diff/PreviewPanel.tsx
+++ b/apps/electron/src/renderer/components/diff/PreviewPanel.tsx
@@ -99,6 +99,7 @@ export function PreviewPanel({ sessionId }: PreviewPanelProps): React.ReactEleme
       <div className="flex-1 min-h-0 overflow-hidden">
         {currentFile ? (
           <DiffTabContent
+            key={`${sessionId}:${currentFile.filePath}`}
             filePath={currentFile.filePath}
             dirPath={currentFile.dirPath || sessionPath}
             sessionId={sessionId}

--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -160,12 +160,18 @@ function TabBarInner({
   // 滚动容器 ref
   const scrollRef = React.useRef<HTMLDivElement>(null)
 
-  // 鼠标滚轮横向滚动
-  const handleWheel = React.useCallback((e: React.WheelEvent) => {
-    if (scrollRef.current) {
+  // 鼠标滚轮横向滚动（使用原生事件监听器以支持 preventDefault）
+  React.useEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+
+    const handleWheel = (e: WheelEvent) => {
       e.preventDefault()
-      scrollRef.current.scrollLeft += e.deltaY || e.deltaX
+      el.scrollLeft += e.deltaY || e.deltaX
     }
+
+    el.addEventListener('wheel', handleWheel, { passive: false })
+    return () => el.removeEventListener('wheel', handleWheel)
   }, [])
 
   // 新增 tab 时自动滚动到最右
@@ -228,7 +234,6 @@ function TabBarInner({
 
       <div
         ref={scrollRef}
-        onWheel={handleWheel}
         className={cn("relative flex items-end flex-1 min-w-0 overflow-x-auto scrollbar-none titlebar-drag-region", isWindows && "pr-[140px]")}
       >
         {tabs.map((tab) => (

--- a/apps/electron/src/renderer/hooks/useCloseTab.tsx
+++ b/apps/electron/src/renderer/hooks/useCloseTab.tsx
@@ -26,6 +26,7 @@ import {
   agentDiffUnseenFilesAtom,
 } from '@/atoms/agent-atoms'
 import { previewPanelOpenMapAtom, previewFileMapAtom } from '@/atoms/preview-atoms'
+import { clearPreviewCacheForSession } from '@/components/diff/DiffTabContent'
 import {
   conversationModelsAtom,
   conversationContextLengthAtom,
@@ -84,6 +85,7 @@ export function useCloseTab(): UseCloseTabReturn {
     setDiffRefreshVersion(deleteKey)
     setDiffUnseen(deleteKey)
     setDiffUnseenFiles(deleteKey)
+    clearPreviewCacheForSession(tabId)
   }, [setConvModels, setConvContextLength, setConvThinking, setConvParallel, setConvPromptId, setPreviewPanelOpen, setPreviewFile, setDiffPanelTab, setDiffRefreshVersion, setDiffUnseen, setDiffUnseenFiles])
 
   const executeClose = React.useCallback((tabId: string) => {

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -39,6 +39,7 @@ import {
   unviewedCompletedSessionIdsAtom,
   workingDoneSessionIdsAtom,
   agentSessionPathMapAtom,
+  agentDiffRefreshVersionAtom,
 } from '@/atoms/agent-atoms'
 import {
   notificationsEnabledAtom,
@@ -49,7 +50,7 @@ import {
 import { appModeAtom } from '@/atoms/app-mode'
 import { tabsAtom, activeTabIdAtom, openTab, updateTabTitle } from '@/atoms/tab-atoms'
 import type { AgentStreamState } from '@/atoms/agent-atoms'
-import { agentDiffRefreshVersionAtom, agentDiffUnseenChangesAtom, agentDiffUnseenFilesAtom, agentDiffPanelTabAtom, agentSidePanelOpenAtom } from '@/atoms/agent-atoms'
+import { agentDiffUnseenChangesAtom, agentDiffUnseenFilesAtom, agentDiffPanelTabAtom, agentSidePanelOpenAtom } from '@/atoms/agent-atoms'
 import { autoPreviewEnabledAtom, previewPanelOpenMapAtom, previewFileMapAtom } from '@/atoms/preview-atoms'
 import type { NotificationSoundType } from '@/types/settings'
 import { toast } from 'sonner'
@@ -70,6 +71,20 @@ function getParentDir(path: string): string {
   const idx = normalized.lastIndexOf('/')
   if (idx <= 0) return ''
   return normalized.slice(0, idx)
+}
+
+/** cyrb53: 快速字符串 hash，遍历完整内容避免边缘碰撞 */
+function cyrb53(str: string): string {
+  let h1 = 0xdeadbeef
+  let h2 = 0x41c6ce57
+  for (let i = 0; i < str.length; i++) {
+    const ch = str.charCodeAt(i)
+    h1 = Math.imul(h1 ^ ch, 2654435761)
+    h2 = Math.imul(h2 ^ ch, 1597334677)
+  }
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909)
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909)
+  return (4294967296 * (2097151 & h2) + (h1 >>> 0)).toString(16)
 }
 
 function uniqueTruthyPaths(paths: Array<string | null | undefined>): string[] {
@@ -987,13 +1002,55 @@ export function useGlobalAgentListeners(): void {
       })
     }, 15_000)
 
-    // 窗口重新聚焦时刷新 diff（在外部编辑器改了文件后切回 Proma）
-    const onWindowFocus = () => {
+    // 窗口重新聚焦时检测当前预览文件是否有外部修改，有变化才刷新
+    /** sessionId:filePath → 内容 hash（用于检测外部编辑器修改） */
+    const fileContentHashMap = new Map<string, string>()
+    const HASH_MAX = 100
+    let focusCheckSeq = 0
+
+    const onWindowFocus = async () => {
       const activeSessionId = store.get(currentAgentSessionIdAtom)
       if (!activeSessionId) return
-      store.set(agentDiffRefreshVersionAtom, (prev) => {
-        const m = new Map(prev); m.set(activeSessionId, (prev.get(activeSessionId) ?? 0) + 1); return m
-      })
+
+      const previewFile = store.get(previewFileMapAtom).get(activeSessionId)
+      if (!previewFile) return
+
+      const hashKey = `${activeSessionId}:${previewFile.filePath}`
+      const seq = ++focusCheckSeq
+
+      try {
+        const result = await window.electronAPI.resolveAndReadFile(previewFile.filePath, {
+          sessionId: activeSessionId,
+          candidateBasePaths: previewFile.basePaths,
+        })
+
+        // 丢弃过期结果（快速切换窗口时）
+        if (seq !== focusCheckSeq) return
+
+        const content = result?.content ?? ''
+        // cyrb53 hash：遍历完整内容，避免边缘碰撞
+        const hash = cyrb53(content)
+        const prevHash = fileContentHashMap.get(hashKey)
+
+        if (prevHash !== undefined && prevHash !== hash) {
+          // 内容有变化，刷新 diff/preview
+          store.set(agentDiffRefreshVersionAtom, (prev) => {
+            const m = new Map(prev)
+            m.set(activeSessionId, (prev.get(activeSessionId) ?? 0) + 1)
+            return m
+          })
+        }
+        fileContentHashMap.set(hashKey, hash)
+
+        // LRU 淘汰：限制 Map 大小
+        if (fileContentHashMap.size > HASH_MAX) {
+          const oldestKey = fileContentHashMap.keys().next().value
+          if (oldestKey !== undefined) fileContentHashMap.delete(oldestKey)
+        }
+      } catch {
+        // 读取失败时删除旧 hash，下次成功读取时必定触发刷新
+        fileContentHashMap.delete(hashKey)
+      }
     }
     window.addEventListener('focus', onWindowFocus)
 


### PR DESCRIPTION
## 概述
将文件预览/代码高亮从 Shiki 迁移至 \`@pierre/diffs/react\` 的 \`PierreFile\` 组件，并添加代码行号、滚动位置持久化、智能刷新和性能优化。

本 PR 整合了原 PR #423（代码行号）的功能，并在此基础上增加了完整的缓存和性能优化体系。

## 改动内容

### 1. 替换高亮引擎并添加代码行号
- \`apps/electron/src/renderer/components/diff/DiffTabContent.tsx\`
  - 使用 \`PierreFile\` 替代原有的 Shiki HTML 渲染
  - **新增代码行号显示**（PierreFile 内置）
  - 支持 Worker Pool 缓存（通过 \`cacheKey\`）

### 2. 滚动位置持久化
- 新增模块级 \`scrollPositionCache\`，按 \`${sessionId}:${filePath}\` 缓存滚动位置
- 文件切换后返回时自动恢复滚动位置
- 内容刷新（Agent 写入文件）时清除旧位置

### 3. 智能刷新
- \`useGlobalAgentListeners.ts\`：窗口重新获得焦点时，对比文件内容 hash（cyrb53），仅在内容变化时触发刷新
- 避免无意义的重复渲染

### 4. 性能优化
- \`useMemo\` 缓存 \`PierreFile\` 的 \`file\` 和 \`options\` props，避免每次渲染创建新对象触发内部重新高亮
- 新增 \`MAX_PREVIEW_CHARS = 500_000\` 大文件保护，超过阈值降级为纯文本展示

### 5. 其他修复
- \`PreviewPanel.tsx\`：为 \`DiffTabContent\` 添加 \`key\` 属性，确保文件切换时正确重新挂载
- \`TabBar.tsx\`：修复滚轮横向滚动的 passive 事件监听器报错
- \`useCloseTab.tsx\` / \`LeftSidebar.tsx\`：关闭标签时清理对应 session 的滚动位置缓存

## 测试方式
1. 打开 Agent 会话，点击文件列表中的文件进行预览，确认**代码行号正常显示**
2. 滚动预览内容，切换到其他文件，再切回原文件，观察滚动位置是否恢复
3. 在外部编辑器修改文件内容，切换回 Proma 窗口，观察是否自动刷新且滚动位置重置
4. 打开大文件（>50万字符），观察是否降级为纯文本展示

## 注意事项
- \`@pierre/diffs\` 的 Worker Pool 缓存依赖 \`cacheKey\`，当 \`contents\` 或 \`name\` 变化时必须同步更新 \`cacheKey\`
- 内容缓存（\`contentCache\`）使用 LRU 策略（最大 50 条），不包含 sessionId，依赖自动淘汰