### PR TITLE
[codex] fix large file attachment rendering

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -48,7 +48,9 @@ import type {
   AgentSaveWorkspaceFilesInput,
   AgentSavedFile,
   AgentAttachDirectoryInput,
+  AgentAttachFileInput,
   WorkspaceAttachDirectoryInput,
+  WorkspaceAttachFileInput,
   GetTaskOutputInput,
   GetTaskOutputResult,
   StopTaskInput,
@@ -191,8 +193,11 @@ import {
   writeWorkspaceSkillContent,
   toggleWorkspaceSkill,
   getWorkspaceAttachedDirectories,
+  getWorkspaceAttachedFiles,
   attachWorkspaceDirectory,
+  attachWorkspaceFile,
   detachWorkspaceDirectory,
+  detachWorkspaceFile,
 } from './lib/agent-workspace-manager'
 import { getMemoryConfig, setMemoryConfig } from './lib/memory-service'
 import { getAllToolInfos } from './lib/chat-tool-registry'
@@ -264,6 +269,9 @@ function getAuthorizedRoots(options?: FileAccessOptions): string[] {
     if (meta?.attachedDirectories) {
       roots.push(...meta.attachedDirectories)
     }
+    if (meta?.attachedFiles) {
+      roots.push(...meta.attachedFiles)
+    }
     if (meta?.workspaceId) {
       const workspace = getAgentWorkspace(meta.workspaceId)
       if (workspace?.slug) workspaceSlugs.add(workspace.slug)
@@ -277,6 +285,7 @@ function getAuthorizedRoots(options?: FileAccessOptions): string[] {
   for (const slug of workspaceSlugs) {
     roots.push(getWorkspaceFilesDir(slug))
     roots.push(...getWorkspaceAttachedDirectories(slug))
+    roots.push(...getWorkspaceAttachedFiles(slug))
   }
 
   return roots
@@ -1856,6 +1865,42 @@ export function registerIpcHandlers(): void {
     }
   )
 
+  // 附加外部文件到 Agent 会话
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.ATTACH_FILE,
+    async (_, input: AgentAttachFileInput): Promise<string[]> => {
+      const meta = getAgentSessionMeta(input.sessionId)
+      if (!meta) throw new Error(`会话不存在: ${input.sessionId}`)
+
+      const { realpathSync, statSync } = await import('node:fs')
+      const { resolve } = await import('node:path')
+      const safePath = realpathSync(resolve(input.filePath))
+      const stats = statSync(safePath)
+      if (!stats.isFile()) throw new Error('只能附加文件')
+
+      const existing = meta.attachedFiles ?? []
+      if (existing.includes(safePath)) return existing
+
+      const updated = [...existing, safePath]
+      updateAgentSessionMeta(input.sessionId, { attachedFiles: updated })
+      return updated
+    }
+  )
+
+  // 移除会话的附加文件
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.DETACH_FILE,
+    async (_, input: AgentAttachFileInput): Promise<string[]> => {
+      const meta = getAgentSessionMeta(input.sessionId)
+      if (!meta) throw new Error(`会话不存在: ${input.sessionId}`)
+
+      const existing = meta.attachedFiles ?? []
+      const updated = existing.filter((f) => f !== input.filePath)
+      updateAgentSessionMeta(input.sessionId, { attachedFiles: updated })
+      return updated
+    }
+  )
+
   // 附加外部目录到工作区（所有会话可访问）
   ipcMain.handle(
     AGENT_IPC_CHANNELS.ATTACH_WORKSPACE_DIRECTORY,
@@ -1876,11 +1921,41 @@ export function registerIpcHandlers(): void {
     }
   )
 
+  // 附加外部文件到工作区（所有会话可访问）
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.ATTACH_WORKSPACE_FILE,
+    async (_, input: WorkspaceAttachFileInput): Promise<string[]> => {
+      const { realpathSync, statSync } = await import('node:fs')
+      const { resolve } = await import('node:path')
+      const safePath = realpathSync(resolve(input.filePath))
+      const stats = statSync(safePath)
+      if (!stats.isFile()) throw new Error('只能附加文件')
+
+      return attachWorkspaceFile(input.workspaceSlug, safePath)
+    }
+  )
+
+  // 移除工作区的附加文件
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.DETACH_WORKSPACE_FILE,
+    async (_, input: WorkspaceAttachFileInput): Promise<string[]> => {
+      return detachWorkspaceFile(input.workspaceSlug, input.filePath)
+    }
+  )
+
   // 获取工作区附加目录列表
   ipcMain.handle(
     AGENT_IPC_CHANNELS.GET_WORKSPACE_DIRECTORIES,
     async (_, workspaceSlug: string): Promise<string[]> => {
       return getWorkspaceAttachedDirectories(workspaceSlug)
+    }
+  )
+
+  // 获取工作区附加文件列表
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.GET_WORKSPACE_ATTACHED_FILES,
+    async (_, workspaceSlug: string): Promise<string[]> => {
+      return getWorkspaceAttachedFiles(workspaceSlug)
     }
   )
 
@@ -1916,10 +1991,13 @@ export function registerIpcHandlers(): void {
       for (const item of items) {
         if (HIDDEN_FS_ENTRIES.has(item.name)) continue
         const fullPath = resolve(safePath, item.name)
+        const isDirectory = item.isDirectory()
+        const size = isDirectory ? undefined : statSync(fullPath).size
         entries.push({
           name: item.name,
           path: fullPath,
-          isDirectory: item.isDirectory(),
+          isDirectory,
+          size,
         })
       }
 
@@ -2134,7 +2212,7 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(
     AGENT_IPC_CHANNELS.LIST_ATTACHED_DIRECTORY,
     async (_, dirPath: string, access?: FileAccessOptions | string[]): Promise<FileEntry[]> => {
-      const { readdirSync } = await import('node:fs')
+      const { readdirSync, statSync } = await import('node:fs')
       const { resolve } = await import('node:path')
 
       const safePath = resolve(dirPath)
@@ -2148,10 +2226,13 @@ export function registerIpcHandlers(): void {
       for (const item of items) {
         if (HIDDEN_FS_ENTRIES.has(item.name)) continue
         const fullPath = resolve(safePath, item.name)
+        const isDirectory = item.isDirectory()
+        const size = isDirectory ? undefined : statSync(fullPath).size
         entries.push({
           name: item.name,
           path: fullPath,
-          isDirectory: item.isDirectory(),
+          isDirectory,
+          size,
         })
       }
 
@@ -2184,17 +2265,22 @@ export function registerIpcHandlers(): void {
         throw new Error(`文件不存在: ${filePath}`)
       })
 
-      // 收集所有允许的目录：会话附加目录 + 工作区附加目录 + 工作区文件目录
+      // 收集所有允许的路径：会话/工作区附加目录、附加文件 + 工作区文件目录
       const allowedDirs: string[] = []
+      const allowedFiles: string[] = []
 
       if (sessionId) {
         const meta = getAgentSessionMeta(sessionId)
         if (meta?.attachedDirectories) {
           allowedDirs.push(...meta.attachedDirectories)
         }
+        if (meta?.attachedFiles) {
+          allowedFiles.push(...meta.attachedFiles)
+        }
       }
       if (workspaceSlug) {
         allowedDirs.push(...getWorkspaceAttachedDirectories(workspaceSlug))
+        allowedFiles.push(...getWorkspaceAttachedFiles(workspaceSlug))
         allowedDirs.push(getWorkspaceFilesDir(workspaceSlug))
       }
 
@@ -2204,7 +2290,11 @@ export function registerIpcHandlers(): void {
       const resolvedAllowedDirs = await Promise.all(
         allowedDirs.map((dir) => realpath(resolve(dir)).catch(() => resolve(dir)))
       )
+      const resolvedAllowedFiles = await Promise.all(
+        allowedFiles.map((file) => realpath(resolve(file)).catch(() => resolve(file)))
+      )
       const isAllowed = resolvedAllowedDirs.some((dir) => safePath.startsWith(dir + sep) || safePath === dir)
+        || resolvedAllowedFiles.some((file) => safePath === file)
       if (!isAllowed) {
         throw new Error('访问路径不在允许范围内')
       }
@@ -2305,7 +2395,7 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(
     AGENT_IPC_CHANNELS.SEARCH_WORKSPACE_FILES,
     async (_, rootPath: string, query: string, limit = 20, additionalPaths?: string[], sessionPaths?: string[]): Promise<FileSearchResult> => {
-      const { readdirSync } = await import('node:fs')
+      const { readdirSync, statSync } = await import('node:fs')
       const { resolve, relative, basename } = await import('node:path')
 
       const safeRoot = resolve(rootPath)
@@ -2352,37 +2442,52 @@ export function registerIpcHandlers(): void {
         }
       }
 
-      // session 目录：相对路径
-      scan(safeRoot, 0, safeRoot, rootEntries, false, 'session')
+      function addAttachedPath(pathValue: string, target: Entry[], source: 'session' | 'workspace'): void {
+        try {
+          const attachedPath = resolve(pathValue)
+          const name = basename(attachedPath)
+          if (ignoreFiles.has(name)) return
 
-      // 会话级附加目录：绝对路径，标记为 session（归入会话文件分组）
-      if (sessionPaths && sessionPaths.length > 0) {
-        for (const sp of sessionPaths) {
-          const sRoot = resolve(sp)
-          // 添加附加目录本身作为顶层条目
-          rootEntries.push({
-            name: basename(sRoot),
-            path: sRoot,
+          const stats = statSync(attachedPath)
+          if (stats.isFile()) {
+            target.push({
+              name,
+              path: attachedPath,
+              type: 'file',
+              source,
+            })
+            return
+          }
+
+          if (!stats.isDirectory()) return
+          if (ignoreDirs.has(name)) return
+
+          target.push({
+            name: name === 'workspace-files' ? '工作文件' : name,
+            path: attachedPath,
             type: 'dir',
-            source: 'session',
+            source,
           })
-          scan(sRoot, 0, sRoot, rootEntries, true, 'session')
+          scan(attachedPath, 0, attachedPath, target, true, source)
+        } catch {
+          // 忽略不存在或无权限的附加路径
         }
       }
 
-      // 工作区文件 + 工作区级附加目录：绝对路径，标记为 workspace
+      // session 目录：相对路径
+      scan(safeRoot, 0, safeRoot, rootEntries, false, 'session')
+
+      // 会话级附加路径：绝对路径，标记为 session（归入会话文件分组）
+      if (sessionPaths && sessionPaths.length > 0) {
+        for (const sp of sessionPaths) {
+          addAttachedPath(sp, rootEntries, 'session')
+        }
+      }
+
+      // 工作区文件 + 工作区级附加路径：绝对路径，标记为 workspace
       if (additionalPaths && additionalPaths.length > 0) {
         for (const addPath of additionalPaths) {
-          const addRoot = resolve(addPath)
-          // 添加附加目录本身作为顶层条目
-          const rootName = basename(addRoot)
-          workspaceEntries.push({
-            name: rootName === 'workspace-files' ? '工作文件' : rootName,
-            path: addRoot,
-            type: 'dir',
-            source: 'workspace',
-          })
-          scan(addRoot, 0, addRoot, workspaceEntries, true, 'workspace')
+          addAttachedPath(addPath, workspaceEntries, 'workspace')
         }
       }
 

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -34,7 +34,7 @@ import { getEffectiveProxyUrl } from './proxy-settings-service'
 import { appendSDKMessages, updateAgentSessionMeta, getAgentSessionMeta, getAgentSessionMessages, getAgentSessionSDKMessages, truncateSDKMessages, resolveUserUuidFromSDK, rewindFilesFromSnapshot } from './agent-session-manager'
 import { getAgentWorkspace, getWorkspaceMcpConfig, ensurePluginManifest } from './agent-workspace-manager'
 import { getAgentWorkspacePath, getAgentSessionWorkspacePath, getSdkConfigDir, getWorkspaceFilesDir, getConfigDirName } from './config-paths'
-import { getWorkspaceAttachedDirectories } from './agent-workspace-manager'
+import { getWorkspaceAttachedDirectories, getWorkspaceAttachedFiles } from './agent-workspace-manager'
 import { getRuntimeStatus } from './runtime-init'
 import { getSettings } from './settings-service'
 import { buildSystemPrompt, buildDynamicContext, buildBuiltinAgents } from './agent-prompt-builder'
@@ -1309,11 +1309,21 @@ export class AgentOrchestrator {
         // 合并用户附加目录 + 工作区附加目录 + 工作区文件目录
         ...(() => {
           const allDirs = [...(additionalDirectories || [])]
+          for (const file of sessionMeta?.attachedFiles ?? []) {
+            const parentDir = dirname(file)
+            if (parentDir && !allDirs.includes(parentDir)) allDirs.push(parentDir)
+          }
           if (workspaceSlug) {
             // 工作区级附加目录
             const workspaceDirs = getWorkspaceAttachedDirectories(workspaceSlug)
             for (const dir of workspaceDirs) {
               if (!allDirs.includes(dir)) allDirs.push(dir)
+            }
+            // 工作区级附加文件：SDK 只接受目录，因此传入其父目录
+            const workspaceFiles = getWorkspaceAttachedFiles(workspaceSlug)
+            for (const file of workspaceFiles) {
+              const parentDir = dirname(file)
+              if (parentDir && !allDirs.includes(parentDir)) allDirs.push(parentDir)
             }
             // 工作区文件目录
             const wsFilesDir = getWorkspaceFilesDir(workspaceSlug)

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -14,7 +14,7 @@ import { join, dirname } from 'node:path'
 import { writeFileSync, mkdirSync, existsSync } from 'node:fs'
 import { BrowserWindow } from 'electron'
 import type { WebContents } from 'electron'
-import { AGENT_IPC_CHANNELS } from '@proma/shared'
+import { AGENT_IPC_CHANNELS, MAX_ATTACHMENT_SIZE } from '@proma/shared'
 import type {
   AgentSendInput,
   AgentGenerateTitleInput,
@@ -307,6 +307,14 @@ export function saveFilesToAgentSession(input: AgentSaveFilesInput): AgentSavedF
     usedPaths.add(targetPath)
 
     mkdirSync(dirname(targetPath), { recursive: true })
+
+    // 防御性检查：base64 字符串长度估算是否超 100MB 限制
+    // base64 编码膨胀率约 4/3，data.length * 0.75 ≈ 原始字节数
+    if (file.data.length * 0.75 > MAX_ATTACHMENT_SIZE) {
+      console.warn(`[Agent 服务] 文件超过 100MB 限制，跳过: ${file.filename} (预估 ${(file.data.length * 0.75 / 1024 / 1024).toFixed(1)}MB)`)
+      continue
+    }
+
     const buffer = Buffer.from(file.data, 'base64')
     writeFileSync(targetPath, buffer)
 
@@ -347,6 +355,12 @@ export function saveFilesToWorkspaceFiles(input: AgentSaveWorkspaceFilesInput): 
     usedPaths.add(targetPath)
 
     mkdirSync(dirname(targetPath), { recursive: true })
+
+    if (file.data.length * 0.75 > MAX_ATTACHMENT_SIZE) {
+      console.warn(`[Agent 服务] 工作区文件超过 100MB 限制，跳过: ${file.filename} (预估 ${(file.data.length * 0.75 / 1024 / 1024).toFixed(1)}MB)`)
+      continue
+    }
+
     const buffer = Buffer.from(file.data, 'base64')
     writeFileSync(targetPath, buffer)
 

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -306,7 +306,7 @@ function convertLegacyMessage(legacy: AgentMessage): SDKMessage {
  */
 export function updateAgentSessionMeta(
   id: string,
-  updates: Partial<Pick<AgentSessionMeta, 'title' | 'channelId' | 'sdkSessionId' | 'workspaceId' | 'pinned' | 'archived' | 'attachedDirectories' | 'forkSourceDir' | 'forkSourceSdkSessionId' | 'resumeAtMessageUuid' | 'stoppedByUser' | 'permissionMode'>>,
+  updates: Partial<Pick<AgentSessionMeta, 'title' | 'channelId' | 'sdkSessionId' | 'workspaceId' | 'pinned' | 'archived' | 'attachedDirectories' | 'attachedFiles' | 'forkSourceDir' | 'forkSourceSdkSessionId' | 'resumeAtMessageUuid' | 'stoppedByUser' | 'permissionMode'>>,
 ): AgentSessionMeta {
   const index = readIndex()
   const idx = index.sessions.findIndex((s) => s.id === id)

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -754,6 +754,7 @@ function isNewerVersion(a: string, b: string): boolean {
 
 interface WorkspaceConfig {
   attachedDirectories?: string[]
+  attachedFiles?: string[]
 }
 
 function getWorkspaceConfigPath(workspaceSlug: string): string {
@@ -773,6 +774,9 @@ function readWorkspaceConfig(workspaceSlug: string): WorkspaceConfig {
     return {
       attachedDirectories: Array.isArray(data.attachedDirectories)
         ? data.attachedDirectories.filter((dir): dir is string => typeof dir === 'string')
+        : undefined,
+      attachedFiles: Array.isArray(data.attachedFiles)
+        ? data.attachedFiles.filter((file): file is string => typeof file === 'string')
         : undefined,
     }
   } catch {
@@ -812,5 +816,35 @@ export function detachWorkspaceDirectory(workspaceSlug: string, directoryPath: s
   const updated = existing.filter((d) => d !== directoryPath)
   writeWorkspaceConfig(workspaceSlug, { ...config, attachedDirectories: updated })
   console.log(`[Agent 工作区] 已移除工作区目录: ${directoryPath} ← ${workspaceSlug}`)
+  return updated
+}
+
+// ===== 工作区级附加文件管理 =====
+
+export function getWorkspaceAttachedFiles(workspaceSlug: string): string[] {
+  const config = readWorkspaceConfig(workspaceSlug)
+  return config.attachedFiles ?? []
+}
+
+export function attachWorkspaceFile(workspaceSlug: string, filePath: string): string[] {
+  const config = readWorkspaceConfig(workspaceSlug)
+  const existing = config.attachedFiles ?? []
+
+  if (existing.includes(filePath)) {
+    return existing
+  }
+
+  const updated = [...existing, filePath]
+  writeWorkspaceConfig(workspaceSlug, { ...config, attachedFiles: updated })
+  console.log(`[Agent 工作区] 已附加工作区文件: ${filePath} → ${workspaceSlug}`)
+  return updated
+}
+
+export function detachWorkspaceFile(workspaceSlug: string, filePath: string): string[] {
+  const config = readWorkspaceConfig(workspaceSlug)
+  const existing = config.attachedFiles ?? []
+  const updated = existing.filter((f) => f !== filePath)
+  writeWorkspaceConfig(workspaceSlug, { ...config, attachedFiles: updated })
+  console.log(`[Agent 工作区] 已移除工作区文件: ${filePath} ← ${workspaceSlug}`)
   return updated
 }

--- a/apps/electron/src/main/lib/attachment-service.ts
+++ b/apps/electron/src/main/lib/attachment-service.ts
@@ -7,10 +7,10 @@
  * - 保存：base64 解码 → 写入文件
  * - 读取：文件 → base64 编码（用于 API 发送）
  * - 删除：单个文件或整个对话附件目录
- * - 文件选择对话框：Electron dialog → 读取选中文件
+ * - 文件选择对话框：Electron dialog → 小文件读取为 base64，大文件返回本地路径引用
  */
 
-import { readFileSync, writeFileSync, unlinkSync, existsSync, rmSync } from 'node:fs'
+import { readFileSync, writeFileSync, unlinkSync, existsSync, rmSync, statSync } from 'node:fs'
 import { extname, basename, join, isAbsolute, normalize } from 'node:path'
 import { randomUUID } from 'node:crypto'
 import { dialog, BrowserWindow } from 'electron'
@@ -24,7 +24,11 @@ import type {
   AttachmentSaveInput,
   AttachmentSaveResult,
   FileDialogResult,
+  FileDialogFile,
+  FileDialogLargeFile,
+  FileDialogSkippedFile,
 } from '@proma/shared'
+import { MAX_ATTACHMENT_SIZE } from '@proma/shared'
 
 /** 支持的图片 MIME 类型 */
 const IMAGE_MIME_TYPES = new Set([
@@ -106,6 +110,12 @@ export function getMimeType(ext: string): string {
  */
 export function saveAttachment(input: AttachmentSaveInput): AttachmentSaveResult {
   const { conversationId, filename, mediaType, data } = input
+
+  // 防御性检查：base64 数据量不应超过 100MB 限制
+  // base64 字符串长度 × 0.75 ≈ 原始字节数
+  if (data.length * 0.75 > MAX_ATTACHMENT_SIZE) {
+    throw new Error(`文件 ${filename} 超过 100MB 大小限制，无法保存`)
+  }
 
   // 确保目录存在
   const dir = getConversationAttachmentsDir(conversationId)
@@ -208,7 +218,7 @@ export function deleteConversationAttachments(conversationId: string): void {
  * 打开文件选择对话框
  *
  * 弹出 Electron 文件选择对话框，支持多选，
- * 读取选中的文件并返回 base64 编码数据。
+ * 读取选中的小文件并返回 base64 编码数据；超过内存导入上限的大文件仅返回路径。
  *
  * @returns 选中的文件列表
  */
@@ -228,20 +238,65 @@ export async function openFileDialog(): Promise<FileDialogResult> {
     return { files: [] }
   }
 
-  const files = result.filePaths.map((filePath) => {
-    const buffer = readFileSync(filePath)
+  const files: FileDialogFile[] = []
+  const largeFiles: FileDialogLargeFile[] = []
+  const skippedFiles: FileDialogSkippedFile[] = []
+
+  for (const filePath of result.filePaths) {
     const filename = basename(filePath)
     const ext = extname(filePath)
     const mediaType = getMimeType(ext)
 
-    return {
-      filename,
-      mediaType,
-      data: buffer.toString('base64'),
-      size: buffer.length,
+    let fileSize: number
+    try {
+      const fileStat = statSync(filePath)
+      if (!fileStat.isFile()) {
+        skippedFiles.push({
+          filename,
+          mediaType,
+          path: filePath,
+          reason: 'unreadable',
+          message: '不是普通文件',
+        })
+        continue
+      }
+      fileSize = fileStat.size
+    } catch (error) {
+      const message = error instanceof Error ? error.message : '无法获取文件大小'
+      console.warn(`[附件服务] 无法获取文件大小，跳过: ${filePath}`, error)
+      skippedFiles.push({ filename, mediaType, path: filePath, reason: 'unreadable', message })
+      continue
     }
-  })
 
-  console.log(`[附件服务] 文件对话框选择了 ${files.length} 个文件`)
-  return { files }
+    if (fileSize > MAX_ATTACHMENT_SIZE) {
+      largeFiles.push({
+        filename,
+        mediaType,
+        size: fileSize,
+        path: filePath,
+      })
+      continue
+    }
+
+    try {
+      const buffer = readFileSync(filePath)
+      files.push({
+        filename,
+        mediaType,
+        data: buffer.toString('base64'),
+        size: buffer.length,
+      })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : '读取文件失败'
+      console.warn(`[附件服务] 读取文件失败，跳过: ${filePath}`, error)
+      skippedFiles.push({ filename, mediaType, size: fileSize, path: filePath, reason: 'unreadable', message })
+    }
+  }
+
+  console.log(`[附件服务] 文件对话框选择了 ${files.length} 个内存附件，${largeFiles.length} 个大文件引用，${skippedFiles.length} 个跳过`)
+  return {
+    files,
+    ...(largeFiles.length > 0 && { largeFiles }),
+    ...(skippedFiles.length > 0 && { skippedFiles }),
+  }
 }

--- a/apps/electron/src/main/lib/migration-service.ts
+++ b/apps/electron/src/main/lib/migration-service.ts
@@ -722,12 +722,13 @@ function _checkAttachedDirectories(tempDir: string, manifest: MigrationManifest)
   const configPath = join(tempDir, 'config/workspace-config.json')
   if (!existsSync(configPath)) return []
 
-  const config = readJsonSafe<{ attachedDirectories?: string[] }>(configPath)
-  if (!config?.attachedDirectories?.length) return []
+  const config = readJsonSafe<{ attachedDirectories?: string[]; attachedFiles?: string[] }>(configPath)
+  const attachedPaths = [...(config?.attachedDirectories ?? []), ...(config?.attachedFiles ?? [])]
+  if (attachedPaths.length === 0) return []
 
   const currentHome = homedir()
 
-  return config.attachedDirectories.map((p) => {
+  return attachedPaths.map((p) => {
     let suggested: string | undefined
     if (manifest.sourceHomeDir && p.startsWith(manifest.sourceHomeDir)) {
       suggested = join(currentHome, p.slice(manifest.sourceHomeDir.length))
@@ -751,10 +752,11 @@ function _checkAttachedDirectoriesV2(tempDir: string, manifest: MigrationManifes
     const configPath = join(tempDir, `workspaces/${wsEntry.workspaceSlug}/config/workspace-config.json`)
     if (!existsSync(configPath)) continue
 
-    const config = readJsonSafe<{ attachedDirectories?: string[] }>(configPath)
-    if (!config?.attachedDirectories?.length) continue
+    const config = readJsonSafe<{ attachedDirectories?: string[]; attachedFiles?: string[] }>(configPath)
+    const attachedPaths = [...(config?.attachedDirectories ?? []), ...(config?.attachedFiles ?? [])]
+    if (attachedPaths.length === 0) continue
 
-    for (const p of config.attachedDirectories) {
+    for (const p of attachedPaths) {
       if (seen.has(p)) continue
       seen.add(p)
 
@@ -1064,12 +1066,12 @@ function _importWorkspaceConfig(tempDir: string, targetWorkspace: AgentWorkspace
   const srcConfig = join(tempDir, 'config/workspace-config.json')
   if (!existsSync(srcConfig)) return
 
-  const config = readJsonSafe<{ attachedDirectories?: string[] }>(srcConfig)
-  if (!config?.attachedDirectories) return
+  const config = readJsonSafe<{ attachedDirectories?: string[]; attachedFiles?: string[] }>(srcConfig)
+  if (!config?.attachedDirectories && !config?.attachedFiles) return
 
   // 应用路径映射
   const newDirs: string[] = []
-  for (const dir of config.attachedDirectories) {
+  for (const dir of config.attachedDirectories ?? []) {
     const mapped = pathMappings[dir]
     if (mapped === null) continue // 用户选择移除
     if (mapped !== undefined) {
@@ -1079,13 +1081,27 @@ function _importWorkspaceConfig(tempDir: string, targetWorkspace: AgentWorkspace
     }
     // 路径不存在且无映射：跳过（移除）
   }
+  const newFiles: string[] = []
+  for (const file of config.attachedFiles ?? []) {
+    const mapped = pathMappings[file]
+    if (mapped === null) continue
+    if (mapped !== undefined) {
+      newFiles.push(mapped)
+    } else if (existsSync(file)) {
+      newFiles.push(file)
+    }
+  }
 
   // 写入目标工作区 config
   const destConfigPath = join(getAgentWorkspacePath(targetWorkspace.slug), 'config.json')
   const existingConfig = existsSync(destConfigPath)
-    ? readJsonSafe<{ attachedDirectories?: string[] }>(destConfigPath) ?? {}
+    ? readJsonSafe<{ attachedDirectories?: string[]; attachedFiles?: string[] }>(destConfigPath) ?? {}
     : {}
-  const merged = { ...existingConfig, attachedDirectories: [...new Set([...(existingConfig.attachedDirectories ?? []), ...newDirs])] }
+  const merged = {
+    ...existingConfig,
+    attachedDirectories: [...new Set([...(existingConfig.attachedDirectories ?? []), ...newDirs])],
+    attachedFiles: [...new Set([...(existingConfig.attachedFiles ?? []), ...newFiles])],
+  }
   writeFileSync(destConfigPath, JSON.stringify(merged, null, 2), 'utf-8')
 }
 
@@ -1165,11 +1181,11 @@ function _importWorkspaceConfigV2(
   const srcConfig = join(tempDir, `workspaces/${sourceSlug}/config/workspace-config.json`)
   if (!existsSync(srcConfig)) return
 
-  const config = readJsonSafe<{ attachedDirectories?: string[] }>(srcConfig)
-  if (!config?.attachedDirectories) return
+  const config = readJsonSafe<{ attachedDirectories?: string[]; attachedFiles?: string[] }>(srcConfig)
+  if (!config?.attachedDirectories && !config?.attachedFiles) return
 
   const newDirs: string[] = []
-  for (const dir of config.attachedDirectories) {
+  for (const dir of config.attachedDirectories ?? []) {
     const mapped = pathMappings[dir]
     if (mapped === null) continue
     if (mapped !== undefined) {
@@ -1178,12 +1194,26 @@ function _importWorkspaceConfigV2(
       newDirs.push(dir)
     }
   }
+  const newFiles: string[] = []
+  for (const file of config.attachedFiles ?? []) {
+    const mapped = pathMappings[file]
+    if (mapped === null) continue
+    if (mapped !== undefined) {
+      newFiles.push(mapped)
+    } else if (existsSync(file)) {
+      newFiles.push(file)
+    }
+  }
 
   const destConfigPath = join(getAgentWorkspacePath(targetWorkspace.slug), 'config.json')
   const existingConfig = existsSync(destConfigPath)
-    ? readJsonSafe<{ attachedDirectories?: string[] }>(destConfigPath) ?? {}
+    ? readJsonSafe<{ attachedDirectories?: string[]; attachedFiles?: string[] }>(destConfigPath) ?? {}
     : {}
-  const merged = { ...existingConfig, attachedDirectories: [...new Set([...(existingConfig.attachedDirectories ?? []), ...newDirs])] }
+  const merged = {
+    ...existingConfig,
+    attachedDirectories: [...new Set([...(existingConfig.attachedDirectories ?? []), ...newDirs])],
+    attachedFiles: [...new Set([...(existingConfig.attachedFiles ?? []), ...newFiles])],
+  }
   writeFileSync(destConfigPath, JSON.stringify(merged, null, 2), 'utf-8')
 }
 

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -42,7 +42,9 @@ import type {
   AgentSaveWorkspaceFilesInput,
   AgentSavedFile,
   AgentAttachDirectoryInput,
+  AgentAttachFileInput,
   WorkspaceAttachDirectoryInput,
+  WorkspaceAttachFileInput,
   GetTaskOutputInput,
   GetTaskOutputResult,
   StopTaskInput,
@@ -580,14 +582,29 @@ export interface ElectronAPI {
   /** 移除会话的附加目录 */
   detachDirectory: (input: AgentAttachDirectoryInput) => Promise<string[]>
 
+  /** 附加外部文件到 Agent 会话 */
+  attachFile: (input: AgentAttachFileInput) => Promise<string[]>
+
+  /** 移除会话的附加文件 */
+  detachFile: (input: AgentAttachFileInput) => Promise<string[]>
+
   /** 附加外部目录到工作区（所有会话可访问） */
   attachWorkspaceDirectory: (input: WorkspaceAttachDirectoryInput) => Promise<string[]>
 
   /** 移除工作区的附加目录 */
   detachWorkspaceDirectory: (input: WorkspaceAttachDirectoryInput) => Promise<string[]>
 
+  /** 附加外部文件到工作区（所有会话可访问） */
+  attachWorkspaceFile: (input: WorkspaceAttachFileInput) => Promise<string[]>
+
+  /** 移除工作区的附加文件 */
+  detachWorkspaceFile: (input: WorkspaceAttachFileInput) => Promise<string[]>
+
   /** 获取工作区附加目录列表 */
   getWorkspaceDirectories: (workspaceSlug: string) => Promise<string[]>
+
+  /** 获取工作区附加文件列表 */
+  getWorkspaceAttachedFiles: (workspaceSlug: string) => Promise<string[]>
 
   // ===== Agent 文件系统操作 =====
 
@@ -1515,6 +1532,14 @@ const electronAPI: ElectronAPI = {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.DETACH_DIRECTORY, input)
   },
 
+  attachFile: (input: AgentAttachFileInput) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.ATTACH_FILE, input)
+  },
+
+  detachFile: (input: AgentAttachFileInput) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.DETACH_FILE, input)
+  },
+
   attachWorkspaceDirectory: (input: WorkspaceAttachDirectoryInput) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.ATTACH_WORKSPACE_DIRECTORY, input)
   },
@@ -1523,8 +1548,20 @@ const electronAPI: ElectronAPI = {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.DETACH_WORKSPACE_DIRECTORY, input)
   },
 
+  attachWorkspaceFile: (input: WorkspaceAttachFileInput) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.ATTACH_WORKSPACE_FILE, input)
+  },
+
+  detachWorkspaceFile: (input: WorkspaceAttachFileInput) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.DETACH_WORKSPACE_FILE, input)
+  },
+
   getWorkspaceDirectories: (workspaceSlug: string) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.GET_WORKSPACE_DIRECTORIES, workspaceSlug)
+  },
+
+  getWorkspaceAttachedFiles: (workspaceSlug: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.GET_WORKSPACE_ATTACHED_FILES, workspaceSlug)
   },
 
   // Agent 文件系统操作

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -242,6 +242,7 @@ export function isActivityGroup(item: ActivityGroup | ToolActivity): item is Act
 export interface AgentPendingPrompt {
   sessionId: string
   message: string
+  additionalDirectories?: string[]
 }
 
 // ===== Atoms =====
@@ -927,11 +928,24 @@ export const agentSessionDraftHtmlAtom = atom<Map<string, string>>(new Map())
 export const agentAttachedDirectoriesMapAtom = atom<Map<string, string[]>>(new Map())
 
 /**
+ * 会话附加文件 Map — 以 sessionId 为 key
+ * 存储每个会话通过"附加文件"功能关联的外部文件路径列表。
+ */
+export const agentAttachedFilesMapAtom = atom<Map<string, string[]>>(new Map())
+
+/**
  * 工作区级附加目录列表（按 workspaceId 存储）
  *
  * 工作区内所有会话共享这些附加目录。
  */
 export const workspaceAttachedDirectoriesMapAtom = atom<Map<string, string[]>>(new Map())
+
+/**
+ * 工作区级附加文件列表（按 workspaceId 存储）
+ *
+ * 工作区内所有会话共享这些附加文件。
+ */
+export const workspaceAttachedFilesMapAtom = atom<Map<string, string[]>>(new Map())
 
 /** 当前 Agent 会话的草稿内容（派生读写原子） */
 export const currentAgentSessionDraftAtom = atom(

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -67,7 +67,9 @@ import {
   agentDiffRefreshVersionAtom,
   agentSessionsAtom,
   agentAttachedDirectoriesMapAtom,
+  agentAttachedFilesMapAtom,
   workspaceAttachedDirectoriesMapAtom,
+  workspaceAttachedFilesMapAtom,
   liveMessagesMapAtom,
   agentThinkingAtom,
   stoppedByUserSessionsAtom,
@@ -87,8 +89,9 @@ import { useOpenSession } from '@/hooks/useOpenSession'
 import { AgentSessionProvider } from '@/contexts/session-context'
 import { draftSessionIdsAtom } from '@/atoms/draft-session-atoms'
 import { sendWithCmdEnterAtom } from '@/atoms/shortcut-atoms'
-import type { AgentSendInput, AgentPendingFile, ModelOption, SDKMessage } from '@proma/shared'
-import { fileToBase64 } from '@/lib/file-utils'
+import type { AgentSendInput, AgentPendingFile, FileDialogLargeFile, ModelOption, SDKMessage } from '@proma/shared'
+import { MAX_ATTACHMENT_SIZE } from '@proma/shared'
+import { fileToBase64, formatFileNames, getFileParentPath } from '@/lib/file-utils'
 
 /** 稳定的空 SDKMessage 数组引用，避免 ?? [] 每次创建新引用 */
 const EMPTY_SDK_MESSAGES: SDKMessage[] = []
@@ -355,8 +358,14 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const setAttachedDirsMap = useSetAtom(agentAttachedDirectoriesMapAtom)
   const attachedDirsMap = useAtomValue(agentAttachedDirectoriesMapAtom)
   const attachedDirs = attachedDirsMap.get(sessionId) ?? []
+  const setAttachedFilesMap = useSetAtom(agentAttachedFilesMapAtom)
+  const attachedFilesMap = useAtomValue(agentAttachedFilesMapAtom)
+  const attachedFiles = attachedFilesMap.get(sessionId) ?? []
   const wsAttachedDirsMap = useAtomValue(workspaceAttachedDirectoriesMapAtom)
   const wsAttachedDirs = currentWorkspaceId ? (wsAttachedDirsMap.get(currentWorkspaceId) ?? []) : []
+  const setWsAttachedFilesMap = useSetAtom(workspaceAttachedFilesMapAtom)
+  const wsAttachedFilesMap = useAtomValue(workspaceAttachedFilesMapAtom)
+  const wsAttachedFiles = currentWorkspaceId ? (wsAttachedFilesMap.get(currentWorkspaceId) ?? []) : []
 
   const draftsMap = useAtomValue(agentSessionDraftsAtom)
   const setDraftsMap = useSetAtom(agentSessionDraftsAtom)
@@ -486,6 +495,21 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       .catch(() => setWorkspaceFilesPath(null))
   }, [workspaceSlug])
 
+  // 获取工作区级附加文件（@ 引用和路径解析都需要）
+  React.useEffect(() => {
+    if (!workspaceSlug || !currentWorkspaceId) return
+    window.electronAPI
+      .getWorkspaceAttachedFiles(workspaceSlug)
+      .then((files) => {
+        setWsAttachedFilesMap((prev) => {
+          const map = new Map(prev)
+          map.set(currentWorkspaceId, files)
+          return map
+        })
+      })
+      .catch(console.error)
+  }, [workspaceSlug, currentWorkspaceId, setWsAttachedFilesMap])
+
   // 工作区级目录（workspace shared files + 工作区级附加目录），@ 引用标记为工作区文件
   const workspaceDirs = React.useMemo(() => {
     const dirs: string[] = []
@@ -496,14 +520,44 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     return dirs
   }, [workspaceFilesPath, wsAttachedDirs])
 
+  const attachedFileDirectories = React.useMemo(() => {
+    const dirs: string[] = []
+    for (const filePath of [...attachedFiles, ...wsAttachedFiles]) {
+      const parent = getFileParentPath(filePath)
+      if (parent && !dirs.includes(parent)) dirs.push(parent)
+    }
+    return dirs
+  }, [attachedFiles, wsAttachedFiles])
+
+  const workspaceMentionPaths = React.useMemo(() => {
+    const paths = [...workspaceDirs]
+    for (const filePath of wsAttachedFiles) {
+      if (!paths.includes(filePath)) paths.push(filePath)
+    }
+    return paths
+  }, [workspaceDirs, wsAttachedFiles])
+
+  const sessionMentionPaths = React.useMemo(() => {
+    const paths = [...attachedDirs]
+    for (const filePath of attachedFiles) {
+      if (!paths.includes(filePath)) paths.push(filePath)
+    }
+    return paths
+  }, [attachedDirs, attachedFiles])
+
   // 合并会话级 + 工作区级附加目录，供消息区文件路径解析使用
   const allAttachedDirs = React.useMemo(() => {
     const dirs = [...attachedDirs]
     for (const d of workspaceDirs) {
       if (d && !dirs.includes(d)) dirs.push(d)
     }
+    for (const filePath of [...attachedFiles, ...wsAttachedFiles]) {
+      if (filePath && !dirs.includes(filePath)) dirs.push(filePath)
+      const parent = getFileParentPath(filePath)
+      if (parent && !dirs.includes(parent)) dirs.push(parent)
+    }
     return dirs
-  }, [attachedDirs, workspaceDirs])
+  }, [attachedDirs, workspaceDirs, attachedFiles, wsAttachedFiles])
 
   // 监听消息刷新版本号
   const refreshMap = useAtomValue(agentMessageRefreshAtom)
@@ -579,6 +633,21 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     })
   }, [sessionId, sessions, setAttachedDirsMap])
 
+  // 从会话元数据初始化附加文件（仅冷启动水合，后续由 attachFile/detachFile 实时写入）
+  React.useEffect(() => {
+    const meta = sessions.find((s) => s.id === sessionId)
+    const files = meta?.attachedFiles ?? []
+    setAttachedFilesMap((prev) => {
+      const existing = prev.get(sessionId)
+      if (existing != null) return prev
+      const map = new Map(prev)
+      if (files.length > 0) {
+        map.set(sessionId, files)
+      }
+      return map
+    })
+  }, [sessionId, sessions, setAttachedFilesMap])
+
   // 自动发送 pending prompt（从快速任务窗口或设置页触发）
   // 等待 messagesLoaded 确保消息加载完成后再插入乐观消息，避免被加载结果覆盖。
   // 使用 queueMicrotask 延迟发送：避免 setState → 重渲染 → cleanup 取消 timer 的竞态。
@@ -594,6 +663,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       channelId: agentChannelId,
       modelId: agentModelId || undefined,
       workspaceId: currentWorkspaceId || undefined,
+      additionalDirectories: Array.from(new Set([...attachedDirs, ...attachedFileDirectories, ...(pendingPrompt.additionalDirectories ?? [])])),
     }
     setPendingPrompt(null)
 
@@ -636,6 +706,9 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         workspaceId: snapshot.workspaceId,
         startedAt: streamStartedAt,
         permissionModeOverride: permissionMode,
+        ...(snapshot.additionalDirectories && snapshot.additionalDirectories.length > 0 && {
+          additionalDirectories: snapshot.additionalDirectories,
+        }),
       }
       window.electronAPI.sendAgentMessage(input).catch((error) => {
         console.error('[AgentView] 自动发送配置消息失败:', error)
@@ -648,7 +721,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         })
       })
     })
-  }, [messagesLoaded, pendingPrompt, sessionId, agentChannelId, agentModelId, currentWorkspaceId, streaming, setPendingPrompt, setStreamingStates, permissionMode])
+  }, [messagesLoaded, pendingPrompt, sessionId, agentChannelId, agentModelId, currentWorkspaceId, streaming, setPendingPrompt, setStreamingStates, permissionMode, attachedDirs, attachedFileDirectories])
   // ===== 附件处理 =====
 
   /** 为文件生成唯一文件名（避免粘贴多张图片时文件名重复导致覆盖） */
@@ -664,13 +737,51 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     return `${baseName}-${counter}${ext}`
   }, [])
 
+  const attachSessionFile = React.useCallback(async (filePath: string): Promise<void> => {
+    const updated = await window.electronAPI.attachFile({ sessionId, filePath })
+    setAttachedFilesMap((prev) => {
+      const map = new Map(prev)
+      map.set(sessionId, updated)
+      return map
+    })
+  }, [sessionId, setAttachedFilesMap])
+
   /** 将 File 对象列表添加为待发送附件 */
-  const addFilesAsAttachments = React.useCallback(async (files: File[]): Promise<void> => {
+  const addFilesAsAttachments = React.useCallback(async (files: File[], sourcePaths?: Map<File, string>): Promise<void> => {
     // 收集已有的 pending 文件名，用于去重
     const usedNames: string[] = pendingFilesRef.current.map((f) => f.filename)
 
+    const pathBackedFiles: string[] = []
+    const rejectedLargeFiles: string[] = []
+
     for (const file of files) {
       try {
+        if (file.size > MAX_ATTACHMENT_SIZE) {
+          const sourcePath = sourcePaths?.get(file)
+          if (!sourcePath) {
+            rejectedLargeFiles.push(file.name)
+            continue
+          }
+          await attachSessionFile(sourcePath)
+
+          const previewUrl = file.type.startsWith('image/') ? URL.createObjectURL(file) : undefined
+          const uniqueFilename = makeUniqueFilename(file.name, usedNames)
+          usedNames.push(uniqueFilename)
+
+          const pending: AgentPendingFile = {
+            id: `pending-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+            filename: uniqueFilename,
+            mediaType: file.type || 'application/octet-stream',
+            size: file.size,
+            previewUrl,
+            sourcePath,
+          }
+
+          setPendingFiles((prev) => [...prev, pending])
+          pathBackedFiles.push(uniqueFilename)
+          continue
+        }
+
         const base64 = await fileToBase64(file)
         const previewUrl = file.type.startsWith('image/') ? URL.createObjectURL(file) : undefined
         const uniqueFilename = makeUniqueFilename(file.name, usedNames)
@@ -694,15 +805,66 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         console.error('[AgentView] 添加附件失败:', error)
       }
     }
-  }, [makeUniqueFilename, setPendingFiles])
+
+    if (pathBackedFiles.length > 0) {
+      toast.success(`已将大文件作为附加文件引用：${formatFileNames(pathBackedFiles)}`)
+    }
+    if (rejectedLargeFiles.length > 0) {
+      toast.error(`以下文件超过 100MB 且无法取得本地路径，已跳过：${formatFileNames(rejectedLargeFiles)}`)
+    }
+  }, [attachSessionFile, makeUniqueFilename, setPendingFiles])
+
+  const addLargeDialogFilesAsReferences = React.useCallback(async (files: FileDialogLargeFile[]): Promise<void> => {
+    if (files.length === 0) return
+    const usedNames: string[] = pendingFilesRef.current.map((f) => f.filename)
+    const added: string[] = []
+    const rejected: string[] = []
+
+    for (const file of files) {
+      try {
+        await attachSessionFile(file.path)
+        const uniqueFilename = makeUniqueFilename(file.filename, usedNames)
+        usedNames.push(uniqueFilename)
+
+        const pending: AgentPendingFile = {
+          id: `pending-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+          filename: uniqueFilename,
+          mediaType: file.mediaType,
+          size: file.size,
+          sourcePath: file.path,
+        }
+
+        setPendingFiles((prev) => [...prev, pending])
+        added.push(uniqueFilename)
+      } catch (error) {
+        console.error('[AgentView] 附加大文件失败:', error)
+        rejected.push(file.filename)
+      }
+    }
+
+    if (added.length > 0) {
+      toast.success(`已将大文件作为附加文件引用：${formatFileNames(added)}`)
+    }
+    if (rejected.length > 0) {
+      toast.error(`以下文件附加失败，已跳过：${formatFileNames(rejected)}`)
+    }
+  }, [attachSessionFile, makeUniqueFilename, setPendingFiles])
 
   /** 打开文件选择对话框 */
   const handleOpenFileDialog = React.useCallback(async (): Promise<void> => {
     try {
       const result = await window.electronAPI.openFileDialog()
-      if (result.files.length === 0) return
+      const largeFiles = result.largeFiles ?? []
+      const skippedFiles = result.skippedFiles ?? []
+      if (result.files.length === 0 && largeFiles.length === 0 && skippedFiles.length === 0) return
+
+      const oversized: string[] = []
 
       for (const fileInfo of result.files) {
+        if (fileInfo.size > MAX_ATTACHMENT_SIZE) {
+          oversized.push(fileInfo.filename)
+          continue
+        }
         const previewUrl = fileInfo.mediaType.startsWith('image/')
           ? `data:${fileInfo.mediaType};base64,${fileInfo.data}`
           : undefined
@@ -722,10 +884,18 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
 
         setPendingFiles((prev) => [...prev, pending])
       }
+
+      if (oversized.length > 0) {
+        toast.error(`以下文件超过 100MB 且无法取得本地路径，已跳过：${formatFileNames(oversized)}`)
+      }
+      await addLargeDialogFilesAsReferences(largeFiles)
+      if (skippedFiles.length > 0) {
+        toast.warning(`以下文件无法读取，已跳过：${formatFileNames(skippedFiles.map((f) => f.filename))}`)
+      }
     } catch (error) {
       console.error('[AgentView] 文件选择对话框失败:', error)
     }
-  }, [setPendingFiles])
+  }, [addLargeDialogFilesAsReferences, setPendingFiles])
 
   /** 附加文件夹（不复制，仅记录路径） */
   const handleAttachFolder = React.useCallback(async (): Promise<void> => {
@@ -829,7 +999,12 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         // 普通文件作为附件
         const regularFiles = filePaths.map((p) => pathMap.get(p)!).filter(Boolean)
         if (regularFiles.length > 0) {
-          addFilesAsAttachments(regularFiles)
+          const fileSourcePaths = new Map<File, string>()
+          for (const path of filePaths) {
+            const file = pathMap.get(path)
+            if (file) fileSourcePaths.set(file, path)
+          }
+          addFilesAsAttachments(regularFiles, fileSourcePaths)
         }
       } catch (error) {
         console.error('[AgentView] 路径检测失败，回退处理:', error)
@@ -887,6 +1062,10 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     // 如果输入为空但有建议，使用建议内容
     const effectiveText = text || suggestion || ''
     if ((!effectiveText && pendingFiles.length === 0) || !agentChannelId || !hasAvailableModel) return
+    const additionalDirectoriesForRun = new Set(attachedDirs)
+    for (const dir of attachedFileDirectories) {
+      additionalDirectoriesForRun.add(dir)
+    }
 
     // 上一条消息仍在处理中，直接追加发送
     if (streaming) {
@@ -979,7 +1158,10 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
 
         // 已有路径的文件直接引用
         for (const f of existingFiles) {
-          allRefs.push({ filename: f.filename, targetPath: f.sourcePath! })
+          const sourcePath = f.sourcePath!
+          allRefs.push({ filename: f.filename, targetPath: sourcePath })
+          const parentPath = getFileParentPath(sourcePath)
+          if (parentPath) additionalDirectoriesForRun.add(parentPath)
         }
 
         // 新上传的文件保存到 session 目录
@@ -1070,7 +1252,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       workspaceId: currentWorkspaceId || undefined,
       startedAt: streamStartedAt,
       permissionModeOverride: permissionMode,
-      ...(attachedDirs.length > 0 && { additionalDirectories: attachedDirs }),
+      ...(additionalDirectoriesForRun.size > 0 && { additionalDirectories: Array.from(additionalDirectoriesForRun) }),
       // 解析用户消息中的 Skill/MCP 引用，传递结构化元数据给后端
       ...(() => {
         const skills = [...effectiveText.matchAll(/\/skill:(\S+)/g)].map(m => m[1]).filter(Boolean) as string[]
@@ -1095,7 +1277,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         return map
       })
     })
-  }, [inputContent, pendingFiles, attachedDirs, sessionId, agentChannelId, agentModelId, currentWorkspaceId, workspaces, streaming, suggestion, hasAvailableModel, store, setStreamingStates, setPendingFiles, setAgentStreamErrors, setPromptSuggestions, setInputContent, setLiveMessagesMap, permissionMode])
+  }, [inputContent, pendingFiles, attachedDirs, attachedFileDirectories, sessionId, agentChannelId, agentModelId, currentWorkspaceId, workspaces, streaming, suggestion, hasAvailableModel, store, setStreamingStates, setPendingFiles, setAgentStreamErrors, setPromptSuggestions, setInputContent, setLiveMessagesMap, permissionMode])
 
   /** 停止生成 */
   const handleStop = React.useCallback((): void => {
@@ -1539,8 +1721,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
               enableMentions
               workspacePath={sessionPath}
               workspaceSlug={workspaceSlug}
-              attachedDirs={workspaceDirs}
-              sessionAttachedDirs={attachedDirs}
+              attachedDirs={workspaceMentionPaths}
+              sessionAttachedDirs={sessionMentionPaths}
               htmlValue={inputHtmlContent}
               onHtmlChange={setInputHtmlContent}
               sendWithCmdEnter={sendWithCmdEnter}

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -26,13 +26,27 @@ import {
   currentAgentWorkspaceIdAtom,
   agentWorkspacesAtom,
   agentAttachedDirectoriesMapAtom,
+  agentAttachedFilesMapAtom,
   workspaceAttachedDirectoriesMapAtom,
+  workspaceAttachedFilesMapAtom,
   agentPendingFilesAtom,
   agentDiffRefreshVersionAtom,
 } from '@/atoms/agent-atoms'
 import { previewPanelOpenMapAtom, previewFileMapAtom } from '@/atoms/preview-atoms'
 import { detectIsWindows } from '@/lib/platform'
 import type { FileEntry, AgentPendingFile } from '@proma/shared'
+
+function getPathBasename(filePath: string): string {
+  return filePath.split(/[\\/]/).filter(Boolean).pop() || filePath
+}
+
+function getMediaTypeFromFilename(filename: string): string {
+  const ext = filename.split('.').pop()?.toLowerCase() ?? ''
+  const imageExts = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp', 'ico'])
+  if (!imageExts.has(ext)) return 'application/octet-stream'
+  const mimeExt = ext === 'jpg' ? 'jpeg' : ext === 'svg' ? 'svg+xml' : ext
+  return `image/${mimeExt}`
+}
 
 interface SidePanelProps {
   sessionId: string
@@ -92,15 +106,26 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   const attachedDirsMap = useAtomValue(agentAttachedDirectoriesMapAtom)
   const setAttachedDirsMap = useSetAtom(agentAttachedDirectoriesMapAtom)
   const attachedDirs = attachedDirsMap.get(sessionId) ?? []
+  const attachedFilesMap = useAtomValue(agentAttachedFilesMapAtom)
+  const setAttachedFilesMap = useSetAtom(agentAttachedFilesMapAtom)
+  const attachedFiles = attachedFilesMap.get(sessionId) ?? []
 
   // 附加目录列表（工作区级）
   const wsAttachedDirsMap = useAtomValue(workspaceAttachedDirectoriesMapAtom)
   const setWsAttachedDirsMap = useSetAtom(workspaceAttachedDirectoriesMapAtom)
   const wsAttachedDirs = currentWorkspaceId ? (wsAttachedDirsMap.get(currentWorkspaceId) ?? []) : []
+  const wsAttachedFilesMap = useAtomValue(workspaceAttachedFilesMapAtom)
+  const setWsAttachedFilesMap = useSetAtom(workspaceAttachedFilesMapAtom)
+  const wsAttachedFiles = currentWorkspaceId ? (wsAttachedFilesMap.get(currentWorkspaceId) ?? []) : []
 
   const extraPathsMemo = React.useMemo(
     () => [...attachedDirs, ...wsAttachedDirs],
     [attachedDirs, wsAttachedDirs]
+  )
+
+  const fileAccessPathsMemo = React.useMemo(
+    () => [...extraPathsMemo, ...attachedFiles, ...wsAttachedFiles],
+    [extraPathsMemo, attachedFiles, wsAttachedFiles]
   )
 
   // 加载工作区级附加目录
@@ -116,6 +141,20 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
       })
       .catch(console.error)
   }, [workspaceSlug, currentWorkspaceId, setWsAttachedDirsMap])
+
+  // 加载工作区级附加文件
+  React.useEffect(() => {
+    if (!workspaceSlug || !currentWorkspaceId) return
+    window.electronAPI.getWorkspaceAttachedFiles(workspaceSlug)
+      .then((files) => {
+        setWsAttachedFilesMap((prev) => {
+          const map = new Map(prev)
+          map.set(currentWorkspaceId, files)
+          return map
+        })
+      })
+      .catch(console.error)
+  }, [workspaceSlug, currentWorkspaceId, setWsAttachedFilesMap])
 
   // === 会话级：附加/移除目录 ===
 
@@ -157,6 +196,36 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
       console.error('[SidePanel] 移除附加目录失败:', error)
     }
   }, [sessionId, setAttachedDirsMap])
+
+  const attachSessionFile = React.useCallback(async (filePath: string) => {
+    const updated = await window.electronAPI.attachFile({ sessionId, filePath })
+    setAttachedFilesMap((prev) => {
+      const map = new Map(prev)
+      map.set(sessionId, updated)
+      return map
+    })
+  }, [sessionId, setAttachedFilesMap])
+
+  const handleSessionFilesAttached = React.useCallback(async (filePaths: string[]) => {
+    for (const filePath of filePaths) {
+      try { await attachSessionFile(filePath) } catch (error) {
+        console.error('[SidePanel] 附加文件失败:', error)
+      }
+    }
+  }, [attachSessionFile])
+
+  const handleDetachFile = React.useCallback(async (filePath: string) => {
+    try {
+      const updated = await window.electronAPI.detachFile({ sessionId, filePath })
+      setAttachedFilesMap((prev) => {
+        const map = new Map(prev)
+        if (updated.length > 0) { map.set(sessionId, updated) } else { map.delete(sessionId) }
+        return map
+      })
+    } catch (error) {
+      console.error('[SidePanel] 移除附加文件失败:', error)
+    }
+  }, [sessionId, setAttachedFilesMap])
 
   // === 工作区级：附加/移除目录 ===
 
@@ -201,6 +270,38 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
     }
   }, [workspaceSlug, currentWorkspaceId, setWsAttachedDirsMap])
 
+  const attachWorkspaceFile = React.useCallback(async (filePath: string) => {
+    if (!workspaceSlug || !currentWorkspaceId) return
+    const updated = await window.electronAPI.attachWorkspaceFile({ workspaceSlug, filePath })
+    setWsAttachedFilesMap((prev) => {
+      const map = new Map(prev)
+      map.set(currentWorkspaceId, updated)
+      return map
+    })
+  }, [workspaceSlug, currentWorkspaceId, setWsAttachedFilesMap])
+
+  const handleWorkspaceFilesAttached = React.useCallback(async (filePaths: string[]) => {
+    for (const filePath of filePaths) {
+      try { await attachWorkspaceFile(filePath) } catch (error) {
+        console.error('[SidePanel] 附加工作区文件失败:', error)
+      }
+    }
+  }, [attachWorkspaceFile])
+
+  const handleDetachWorkspaceFile = React.useCallback(async (filePath: string) => {
+    if (!workspaceSlug || !currentWorkspaceId) return
+    try {
+      const updated = await window.electronAPI.detachWorkspaceFile({ workspaceSlug, filePath })
+      setWsAttachedFilesMap((prev) => {
+        const map = new Map(prev)
+        if (updated.length > 0) { map.set(currentWorkspaceId, updated) } else { map.delete(currentWorkspaceId) }
+        return map
+      })
+    } catch (error) {
+      console.error('[SidePanel] 移除工作区附加文件失败:', error)
+    }
+  }, [workspaceSlug, currentWorkspaceId, setWsAttachedFilesMap])
+
   // 文件上传完成后递增版本号，触发 FileBrowser 刷新
   const handleFilesUploaded = React.useCallback(() => {
     setFilesVersion((prev) => prev + 1)
@@ -214,40 +315,21 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   // 添加文件到聊天
   const pendingFiles = useAtomValue(agentPendingFilesAtom)
   const setPendingFiles = useSetAtom(agentPendingFilesAtom)
-  const handleAddToChat = React.useCallback(async (entry: FileEntry) => {
+  const handleAddToChat = React.useCallback((entry: FileEntry) => {
     // 先在 setter 外部检查去重，避免在 updater 函数内执行不可逆副作用
     if (pendingFiles.some((f) => f.sourcePath === entry.path)) return
 
-    let previewUrl: string | undefined
-    try {
-      const base64 = await window.electronAPI.readAttachedFile(entry.path, sessionId, workspaceSlug ?? undefined)
-      const ext = entry.name.split('.').pop()?.toLowerCase() ?? ''
-      const imageExts = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp', 'ico'])
-      const mimeExt = ext === 'jpg' ? 'jpeg' : ext === 'svg' ? 'svg+xml' : ext
-      const mediaType = imageExts.has(ext) ? `image/${mimeExt}` : 'application/octet-stream'
-
-      if (imageExts.has(ext)) {
-        const binary = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0))
-        const blob = new Blob([binary], { type: mediaType })
-        previewUrl = URL.createObjectURL(blob)
-      }
-
-      const pending: AgentPendingFile = {
-        id: `pending-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-        filename: entry.name,
-        mediaType,
-        size: Math.round(base64.length * 0.75),
-        previewUrl,
-        sourcePath: entry.path,
-      }
-
-      // 有 sourcePath 的文件发送时直接引用原路径，不需要存 base64
-      setPendingFiles((prev) => [...prev, pending])
-    } catch (error) {
-      if (previewUrl) URL.revokeObjectURL(previewUrl)
-      console.error('[SidePanel] 添加文件到聊天失败:', error)
+    const pending: AgentPendingFile = {
+      id: `pending-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      filename: entry.name,
+      mediaType: getMediaTypeFromFilename(entry.name),
+      size: entry.size ?? 0,
+      sourcePath: entry.path,
     }
-  }, [pendingFiles, setPendingFiles, sessionId, workspaceSlug])
+
+    // 有 sourcePath 的文件发送时直接引用原路径，不需要存 base64
+    setPendingFiles((prev) => [...prev, pending])
+  }, [pendingFiles, setPendingFiles])
 
   // 面包屑：显示根路径最后两段
   const breadcrumb = React.useMemo(() => {
@@ -269,7 +351,9 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   // RightSidePanel 完全由用户控制，不因 Agent 文件变更自动打开
 
   // 同步 basePaths ref（供 handleFilePreview 使用，避免 hooks 声明顺序问题）
-  basePathsRef.current = [sessionPath, workspaceFilesPath, ...extraPathsMemo].filter(Boolean) as string[]
+  basePathsRef.current = [sessionPath, workspaceFilesPath, ...fileAccessPathsMemo].filter(Boolean) as string[]
+  const hasSessionAttachedItems = attachedDirs.length > 0 || attachedFiles.length > 0
+  const hasWorkspaceAttachedItems = wsAttachedDirs.length > 0 || wsAttachedFiles.length > 0
 
   return (
     <div
@@ -367,6 +451,17 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
                       </div>
                       {/* 会话文件内容区（独立滚动） */}
                       <div className="flex-1 min-h-0 overflow-y-auto">
+                        {/* 附加文件列表 */}
+                        {attachedFiles.length > 0 && (
+                          <AttachedFilesSection
+                            attachedFiles={attachedFiles}
+                            onDetach={handleDetachFile}
+                            onAddToChat={handleAddToChat}
+                            onFilePreview={handleFilePreview}
+                            allowedPaths={basePathsRef.current}
+                            sessionId={sessionId}
+                          />
+                        )}
                         {/* 附加目录列表（可展开目录树） */}
                         {attachedDirs.length > 0 && (
                           <AttachedDirsSection
@@ -381,10 +476,10 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
                         )}
                         {/* 会话文件浏览器 */}
                         <>
-                          {attachedDirs.length > 0 && (
+                          {hasSessionAttachedItems && (
                             <div className="text-[11px] font-medium text-muted-foreground mb-1 px-3 pt-2">工作文件（存储于该工作区目录）</div>
                           )}
-                          <FileBrowser rootPath={sessionPath} hideToolbar embedded hideEmpty={attachedDirs.length > 0} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} />
+                          <FileBrowser rootPath={sessionPath} hideToolbar embedded hideEmpty={hasSessionAttachedItems} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} />
                         </>
                         {/* 会话文件拖拽上传区域 */}
                         <FileDropZone
@@ -392,6 +487,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
                           sessionId={sessionId}
                           target="session"
                           onFilesUploaded={handleFilesUploaded}
+                          onFilesAttached={handleSessionFilesAttached}
                           onAttachFolder={handleAttachFolder}
                           onFoldersDropped={handleSessionFoldersDropped}
                         />
@@ -437,6 +533,17 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
                     </div>
                     {/* 工作区文件内容区（独立滚动） */}
                     <div className="flex-1 min-h-0 overflow-y-auto pb-1">
+                      {/* 工作区级附加文件 */}
+                      {wsAttachedFiles.length > 0 && (
+                        <AttachedFilesSection
+                          attachedFiles={wsAttachedFiles}
+                          onDetach={handleDetachWorkspaceFile}
+                          onAddToChat={handleAddToChat}
+                          onFilePreview={handleFilePreview}
+                          allowedPaths={basePathsRef.current}
+                          sessionId={sessionId}
+                        />
+                      )}
                       {/* 工作区级附加目录 */}
                       {wsAttachedDirs.length > 0 && (
                         <AttachedDirsSection
@@ -452,10 +559,10 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
                       {/* 工作区文件浏览器 */}
                       {workspaceFilesPath && (
                         <>
-                          {wsAttachedDirs.length > 0 && (
+                          {hasWorkspaceAttachedItems && (
                             <div className="text-[11px] font-medium text-muted-foreground mb-1 px-3 pt-2">工作文件（存储于该工作区目录）</div>
                           )}
-                          <FileBrowser rootPath={workspaceFilesPath} hideToolbar embedded hideEmpty={wsAttachedDirs.length > 0} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} />
+                          <FileBrowser rootPath={workspaceFilesPath} hideToolbar embedded hideEmpty={hasWorkspaceAttachedItems} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} />
                         </>
                       )}
                       {/* 工作区文件拖拽上传区域 */}
@@ -463,6 +570,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
                         workspaceSlug={workspaceSlug ?? ''}
                         target="workspace"
                         onFilesUploaded={handleFilesUploaded}
+                        onFilesAttached={handleWorkspaceFilesAttached}
                         onAttachFolder={handleAttachWorkspaceFolder}
                         onFoldersDropped={handleWorkspaceFoldersDropped}
                       />
@@ -471,6 +579,92 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
                 </div>
               )}
         </div>
+    </div>
+  )
+}
+
+// ===== 附加文件容器 =====
+
+interface AttachedFilesSectionProps {
+  attachedFiles: string[]
+  onDetach: (filePath: string) => void
+  onAddToChat?: (entry: FileEntry) => void
+  onFilePreview?: (filePath: string) => void
+  allowedPaths?: string[]
+  sessionId: string
+}
+
+function AttachedFilesSection({ attachedFiles, onDetach, onAddToChat, onFilePreview, allowedPaths, sessionId }: AttachedFilesSectionProps): React.ReactElement {
+  return (
+    <div className="pt-2.5 pb-1 flex-shrink-0">
+      <div className="text-[11px] font-medium text-muted-foreground mb-1 px-3">附加文件（Agent 可以按原路径读取）</div>
+      {attachedFiles.map((filePath) => {
+        const name = getPathBasename(filePath)
+        const entry: FileEntry = { name, path: filePath, isDirectory: false }
+        return (
+          <div
+            key={filePath}
+            className="flex items-center gap-1 py-1 pl-2 pr-2 text-sm cursor-pointer hover:bg-accent/50 group mx-2 rounded-lg"
+            onClick={() => onFilePreview?.(filePath)}
+          >
+            <span className="w-3.5 flex-shrink-0" />
+            <FileTypeIcon name={name} isDirectory={false} />
+            <span className="text-xs truncate flex-1" title={filePath}>{name}</span>
+            <div
+              className="flex-shrink-0"
+              onClick={(e) => e.stopPropagation()}
+              onMouseDown={(e) => e.stopPropagation()}
+            >
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    className="h-6 w-6 rounded flex items-center justify-center hover:bg-accent/70 text-muted-foreground hover:text-foreground invisible group-hover:visible focus-visible:visible data-[state=open]:visible"
+                    title="更多操作"
+                    aria-label="更多操作"
+                  >
+                    <MoreHorizontal className="size-3.5" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start" className="w-40 z-[9999] min-w-0 p-0.5">
+                  {onAddToChat && (
+                    <DropdownMenuItem
+                      className="text-xs py-1 [&>svg]:size-3.5"
+                      onSelect={() => onAddToChat(entry)}
+                    >
+                      <MessageSquarePlus />
+                      添加到聊天
+                    </DropdownMenuItem>
+                  )}
+                  <DropdownMenuItem
+                    className="text-xs py-1 [&>svg]:size-3.5"
+                    onSelect={() => window.electronAPI.showAttachedInFolder(filePath, { sessionId, candidateBasePaths: allowedPaths }).catch(console.error)}
+                  >
+                    <FolderSearch />
+                    在文件夹中显示
+                  </DropdownMenuItem>
+                  {onFilePreview && (
+                    <DropdownMenuItem
+                      className="text-xs py-1 [&>svg]:size-3.5"
+                      onSelect={() => onFilePreview(filePath)}
+                    >
+                      <ExternalLink />
+                      打开文件
+                    </DropdownMenuItem>
+                  )}
+                  <DropdownMenuItem
+                    className="text-xs py-1 text-destructive focus:text-destructive [&>svg]:size-3.5"
+                    onSelect={() => onDetach(filePath)}
+                  >
+                    <X />
+                    移除附加
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          </div>
+        )
+      })}
     </div>
   )
 }

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -983,7 +983,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         style={{ width: 60, flexShrink: 0 }}
       >
         {/* macOS 需要避开左上角红绿灯；边栏覆盖全局标题栏拖拽层，因此留白自身也要可拖拽。 */}
-        <div className={cn('titlebar-drag-region', isMac ? 'pt-[50px]' : 'pt-2')} />
+        <div className={cn('w-full flex-shrink-0 titlebar-drag-region', isMac ? 'h-[50px]' : 'h-2')} />
 
         {/* 展开按钮：mini rail 的唯一布局控制入口 */}
         <div className="pt-2">
@@ -1156,24 +1156,24 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       style={{ width: width ?? 280, minWidth: 180, flexShrink: 1 }}
     >
       {/* macOS 需要避开左上角红绿灯；边栏覆盖全局标题栏拖拽层，因此留白自身也要可拖拽。 */}
-      <div className={cn('titlebar-drag-region', isMac ? 'pt-[30px]' : 'pt-1')}>
-        {/* 模式切换器 + 折叠按钮 */}
-        <div className="flex items-start gap-1.5 px-3">
-          <div className="flex-1 min-w-0">
-            <ModeSwitcher />
-          </div>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                onClick={() => setSidebarCollapsed(true)}
-                className="mt-2 size-10 flex-shrink-0 flex items-center justify-center rounded-[10px] bg-muted text-foreground/40 hover:bg-foreground/[0.08] hover:text-foreground/60 transition-colors titlebar-no-drag"
-              >
-                <PanelLeftClose size={14} />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="right">收起侧边栏 ({navigator.platform.includes('Mac') ? '⌘B' : 'Ctrl+B'})</TooltipContent>
-          </Tooltip>
+      <div className={cn('w-full flex-shrink-0 titlebar-drag-region', isMac ? 'h-[30px]' : 'h-1')} />
+
+      {/* 模式切换器 + 折叠按钮 */}
+      <div className="titlebar-drag-region flex items-start gap-1.5 px-3">
+        <div className="flex-1 min-w-0">
+          <ModeSwitcher />
         </div>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={() => setSidebarCollapsed(true)}
+              className="mt-2 size-10 flex-shrink-0 flex items-center justify-center rounded-[10px] bg-muted text-foreground/40 hover:bg-foreground/[0.08] hover:text-foreground/60 transition-colors titlebar-no-drag"
+            >
+              <PanelLeftClose size={14} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="right">收起侧边栏 ({navigator.platform.includes('Mac') ? '⌘B' : 'Ctrl+B'})</TooltipContent>
+        </Tooltip>
       </div>
 
       {/* Agent 模式：工作区选择器 */}

--- a/apps/electron/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatInput.tsx
@@ -39,8 +39,10 @@ import {
 } from '@/hooks/useConversationSettings'
 import { FeishuNotifyToggle } from './FeishuNotifyToggle'
 import { cn } from '@/lib/utils'
-import { fileToBase64 } from '@/lib/file-utils'
+import { fileToBase64, formatFileNames } from '@/lib/file-utils'
+import { MAX_ATTACHMENT_SIZE } from '@proma/shared'
 import { sendWithCmdEnterAtom } from '@/atoms/shortcut-atoms'
+import { toast } from 'sonner'
 
 interface ChatInputProps {
   /** 当前对话 ID */
@@ -92,7 +94,22 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
    * File → base64 → saveAttachment IPC → 创建 blob URL → 添加到 atom
    */
   const addFilesAsAttachments = React.useCallback(async (files: File[]): Promise<void> => {
+    const oversized: string[] = []
+    const okFiles: File[] = []
+
     for (const file of files) {
+      if (file.size > MAX_ATTACHMENT_SIZE) {
+        oversized.push(file.name)
+      } else {
+        okFiles.push(file)
+      }
+    }
+
+    if (oversized.length > 0) {
+      toast.error(`以下文件超过 100MB，Chat 附件暂不支持，已跳过：${formatFileNames(oversized)}`)
+    }
+
+    for (const file of okFiles) {
       try {
         const base64 = await fileToBase64(file)
 
@@ -128,9 +145,24 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
   const handleOpenFileDialog = React.useCallback(async (): Promise<void> => {
     try {
       const result = await window.electronAPI.openFileDialog()
-      if (result.files.length === 0) return
+      const largeFiles = result.largeFiles ?? []
+      const skippedFiles = result.skippedFiles ?? []
+      if (result.files.length === 0 && largeFiles.length === 0 && skippedFiles.length === 0) return
+
+      if (largeFiles.length > 0) {
+        toast.error(`以下文件超过 100MB，Chat 附件暂不支持，已跳过：${formatFileNames(largeFiles.map((f) => f.filename))}`)
+      }
+      if (skippedFiles.length > 0) {
+        toast.warning(`以下文件无法读取，已跳过：${formatFileNames(skippedFiles.map((f) => f.filename))}`)
+      }
+
+      const oversized: string[] = []
 
       for (const fileInfo of result.files) {
+        if (fileInfo.size > MAX_ATTACHMENT_SIZE) {
+          oversized.push(fileInfo.filename)
+          continue
+        }
         const previewUrl = fileInfo.mediaType.startsWith('image/')
           ? `data:${fileInfo.mediaType};base64,${fileInfo.data}`
           : undefined
@@ -150,6 +182,10 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
         window.__pendingAttachmentData.set(pendingAttachment.id, fileInfo.data)
 
         setPendingAttachments((prev) => [...prev, pendingAttachment])
+      }
+
+      if (oversized.length > 0) {
+        toast.error(`以下文件超过 100MB，Chat 附件暂不支持，已跳过：${formatFileNames(oversized)}`)
       }
     } catch (error) {
       console.error('[ChatInput] 文件选择对话框失败:', error)

--- a/apps/electron/src/renderer/components/chat/InlineEditForm.tsx
+++ b/apps/electron/src/renderer/components/chat/InlineEditForm.tsx
@@ -14,7 +14,9 @@ import { MessageAction } from '@/components/ai-elements/message'
 import { AttachmentPreviewItem } from './AttachmentPreviewItem'
 import { cn } from '@/lib/utils'
 import type { ChatMessage, FileAttachment } from '@proma/shared'
-import { fileToBase64 } from '@/lib/file-utils'
+import { MAX_ATTACHMENT_SIZE } from '@proma/shared'
+import { fileToBase64, formatFileNames } from '@/lib/file-utils'
+import { toast } from 'sonner'
 
 interface NewInlineAttachment {
   filename: string
@@ -121,7 +123,26 @@ export function InlineEditForm({ message, onSubmit, onCancel }: InlineEditFormPr
   const handleSelectAttachments = React.useCallback(async (): Promise<void> => {
     try {
       const result = await window.electronAPI.openFileDialog()
-      addPendingAttachments(result.files.map((file) => ({
+      const largeFiles = result.largeFiles ?? []
+      const skippedFiles = result.skippedFiles ?? []
+      if (largeFiles.length > 0) {
+        toast.error(`以下文件超过 100MB，Chat 附件暂不支持，已跳过：${formatFileNames(largeFiles.map((file) => file.filename))}`)
+      }
+      if (skippedFiles.length > 0) {
+        toast.warning(`以下文件无法读取，已跳过：${formatFileNames(skippedFiles.map((file) => file.filename))}`)
+      }
+      const oversized: string[] = []
+      const okFiles = result.files.filter((file) => {
+        if (file.size > MAX_ATTACHMENT_SIZE) {
+          oversized.push(file.filename)
+          return false
+        }
+        return true
+      })
+      if (oversized.length > 0) {
+        toast.error(`以下文件超过 100MB，Chat 附件暂不支持，已跳过：${formatFileNames(oversized)}`)
+      }
+      addPendingAttachments(okFiles.map((file) => ({
         filename: file.filename,
         mediaType: file.mediaType,
         size: file.size,
@@ -133,8 +154,20 @@ export function InlineEditForm({ message, onSubmit, onCancel }: InlineEditFormPr
   }, [addPendingAttachments])
 
   const handleDropFiles = React.useCallback(async (files: File[]): Promise<void> => {
+    const oversized: string[] = []
+    const okFiles = files.filter((file) => {
+      if (file.size > MAX_ATTACHMENT_SIZE) {
+        oversized.push(file.name)
+        return false
+      }
+      return true
+    })
+    if (oversized.length > 0) {
+      toast.error(`以下文件超过 100MB，Chat 附件暂不支持，已跳过：${formatFileNames(oversized)}`)
+    }
+
     const converted: NewInlineAttachment[] = []
-    for (const file of files) {
+    for (const file of okFiles) {
       try {
         const base64 = await fileToBase64(file)
         converted.push({

--- a/apps/electron/src/renderer/components/file-browser/FileDropZone.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileDropZone.tsx
@@ -10,18 +10,20 @@ import { toast } from 'sonner'
 import { Paperclip, FolderPlus, Loader2 } from 'lucide-react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
-import { fileToBase64 } from '@/lib/file-utils'
+import { fileToBase64, formatFileNames } from '@/lib/file-utils'
+import { MAX_ATTACHMENT_SIZE } from '@proma/shared'
 
 interface FileDropZoneProps {
   workspaceSlug: string
   sessionId?: string
   target?: 'session' | 'workspace'
   onFilesUploaded: () => void
+  onFilesAttached?: (filePaths: string[]) => Promise<void> | void
   onAttachFolder: () => void
   onFoldersDropped: (folderPaths: string[]) => void
 }
 
-export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onFilesUploaded, onAttachFolder, onFoldersDropped }: FileDropZoneProps): React.ReactElement {
+export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onFilesUploaded, onFilesAttached, onAttachFolder, onFoldersDropped }: FileDropZoneProps): React.ReactElement {
   const [isDragOver, setIsDragOver] = React.useState<'left' | 'right' | null>(null)
   const [isUploading, setIsUploading] = React.useState(false)
 
@@ -34,36 +36,71 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
       return
     }
 
+    const oversized: string[] = []
+    const attachedLargeFiles: string[] = []
+    const largeFilePaths: string[] = []
+    const okFiles: globalThis.File[] = []
+
+    for (const file of files) {
+      if (file.size > MAX_ATTACHMENT_SIZE) {
+        let sourcePath = ''
+        try { sourcePath = window.electronAPI.getPathForFile(file) } catch { /* ignored */ }
+        if (sourcePath && onFilesAttached) {
+          largeFilePaths.push(sourcePath)
+          attachedLargeFiles.push(file.name)
+        } else {
+          oversized.push(file.name)
+        }
+      } else {
+        okFiles.push(file)
+      }
+    }
+
+    if (oversized.length > 0) {
+      toast.error(`以下文件超过 100MB 且无法取得本地路径，已跳过：${formatFileNames(oversized)}`, {
+        description: '请选择本地文件，或改用附加文件夹。',
+      })
+    }
+
+    if (okFiles.length === 0 && largeFilePaths.length === 0) return
+
     setIsUploading(true)
     try {
+      if (largeFilePaths.length > 0 && onFilesAttached) {
+        await onFilesAttached(largeFilePaths)
+        toast.success(`已作为附加文件显示在右侧文件区：${formatFileNames(attachedLargeFiles)}`)
+      }
+
       const fileEntries: Array<{ filename: string; data: string }> = []
-      for (const file of files) {
+      for (const file of okFiles) {
         const base64 = await fileToBase64(file)
         fileEntries.push({ filename: file.name, data: base64 })
       }
 
-      if (isWorkspace) {
-        await window.electronAPI.saveFilesToWorkspaceFiles({
-          workspaceSlug,
-          files: fileEntries,
-        })
-      } else {
-        await window.electronAPI.saveFilesToAgentSession({
-          workspaceSlug,
-          sessionId: sessionId!,
-          files: fileEntries,
-        })
-      }
+      if (fileEntries.length > 0) {
+        if (isWorkspace) {
+          await window.electronAPI.saveFilesToWorkspaceFiles({
+            workspaceSlug,
+            files: fileEntries,
+          })
+        } else {
+          await window.electronAPI.saveFilesToAgentSession({
+            workspaceSlug,
+            sessionId: sessionId!,
+            files: fileEntries,
+          })
+        }
 
-      onFilesUploaded()
-      toast.success(`已添加 ${files.length} 个文件`)
+        onFilesUploaded()
+        toast.success(`已添加 ${okFiles.length} 个文件`)
+      }
     } catch (error) {
       console.error('[FileDropZone] 文件上传失败:', error)
       toast.error('文件上传失败')
     } finally {
       setIsUploading(false)
     }
-  }, [workspaceSlug, sessionId, isWorkspace, onFilesUploaded])
+  }, [workspaceSlug, sessionId, isWorkspace, onFilesUploaded, onFilesAttached])
 
   const handleDrop = React.useCallback(async (e: React.DragEvent, side: 'left' | 'right'): Promise<void> => {
     e.preventDefault()
@@ -108,9 +145,14 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
             await saveFiles(regularFiles)
           }
         } else {
-          // 右侧：只附加文件夹，不上传文件
+          // 右侧：附加文件夹，也支持将文件按原路径附加
           if (filePaths.length > 0) {
-            toast.info('文件请拖到左侧「添加文件」区')
+            if (onFilesAttached) {
+              await onFilesAttached(filePaths)
+              toast.success(`已附加 ${filePaths.length} 个文件`)
+            } else {
+              toast.info('文件请拖到左侧「添加文件」区')
+            }
           }
           if (directories.length > 0) {
             onFoldersDropped(directories)
@@ -131,7 +173,7 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
         toast.warning('无法识别文件夹，请使用按钮选择')
       }
     }
-  }, [saveFiles, onFoldersDropped, isUploading])
+  }, [saveFiles, onFoldersDropped, onFilesAttached, isUploading])
 
   const handleDragOver = React.useCallback((e: React.DragEvent, side: 'left' | 'right'): void => {
     e.preventDefault()
@@ -153,10 +195,43 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
   const handleSelectFiles = React.useCallback(async (): Promise<void> => {
     try {
       const result = await window.electronAPI.openFileDialog()
-      if (result.files.length === 0) return
+      const largeFiles = result.largeFiles ?? []
+      const skippedFiles = result.skippedFiles ?? []
+      if (result.files.length === 0 && largeFiles.length === 0 && skippedFiles.length === 0) return
+
+      if (largeFiles.length > 0) {
+        if (onFilesAttached) {
+          await onFilesAttached(largeFiles.map((f) => f.path))
+          toast.success(`已作为附加文件显示在右侧文件区：${formatFileNames(largeFiles.map((f) => f.filename))}`)
+        } else {
+          toast.error(`以下文件超过 100MB，未复制到工作文件夹：${formatFileNames(largeFiles.map((f) => f.filename))}`, {
+            description: '可在输入框中直接发送为附加文件，或使用附加文件夹。',
+          })
+        }
+      }
+      if (skippedFiles.length > 0) {
+        toast.warning(`以下文件无法读取，已跳过：${formatFileNames(skippedFiles.map((f) => f.filename))}`)
+      }
+
+      const oversized: string[] = []
+      const okFiles = result.files.filter((f) => {
+        if (f.size > MAX_ATTACHMENT_SIZE) {
+          oversized.push(f.filename)
+          return false
+        }
+        return true
+      })
+
+      if (oversized.length > 0) {
+        toast.error(`以下文件超过 100MB，未复制到工作文件夹：${formatFileNames(oversized)}`, {
+          description: '可在输入框中直接发送为附加文件，或使用附加文件夹。',
+        })
+      }
+
+      if (okFiles.length === 0) return
 
       setIsUploading(true)
-      const fileEntries = result.files.map((f) => ({
+      const fileEntries = okFiles.map((f) => ({
         filename: f.filename,
         data: f.data,
       }))
@@ -175,14 +250,14 @@ export function FileDropZone({ workspaceSlug, sessionId, target = 'session', onF
       }
 
       onFilesUploaded()
-      toast.success(`已添加 ${result.files.length} 个文件`)
+      toast.success(`已添加 ${okFiles.length} 个文件`)
     } catch (error) {
       console.error('[FileDropZone] 选择文件失败:', error)
       toast.error('文件上传失败')
     } finally {
       setIsUploading(false)
     }
-  }, [workspaceSlug, sessionId, isWorkspace, onFilesUploaded])
+  }, [workspaceSlug, sessionId, isWorkspace, onFilesUploaded, onFilesAttached])
 
   const zoneClass = (side: 'left' | 'right'): string =>
     cn(

--- a/apps/electron/src/renderer/components/quick-task/QuickTaskApp.tsx
+++ b/apps/electron/src/renderer/components/quick-task/QuickTaskApp.tsx
@@ -6,7 +6,9 @@
  */
 
 import React, { useState, useRef, useEffect, useCallback } from 'react'
-import { fileToBase64 } from '@/lib/file-utils'
+import { fileToBase64, formatFileNames } from '@/lib/file-utils'
+import { MAX_ATTACHMENT_SIZE } from '@proma/shared'
+import { toast } from 'sonner'
 
 /** 任务模式 */
 type TaskMode = 'chat' | 'agent'
@@ -16,7 +18,8 @@ interface QuickAttachment {
   id: string
   filename: string
   mediaType: string
-  base64: string
+  base64?: string
+  sourcePath?: string
   size: number
   previewUrl?: string
 }
@@ -147,8 +150,33 @@ export function QuickTaskApp(): React.ReactElement {
   // 添加文件为附件
   const addFiles = useCallback(async (files: File[]) => {
     const newAttachments: QuickAttachment[] = []
+    const pathBackedFiles: string[] = []
+    const rejectedLargeFiles: string[] = []
+
     for (const file of files) {
       try {
+        if (file.size > MAX_ATTACHMENT_SIZE) {
+          const sourcePath = mode === 'agent' ? window.electronAPI.getPathForFile(file) : ''
+          if (!sourcePath) {
+            rejectedLargeFiles.push(file.name)
+            continue
+          }
+
+          const previewUrl = file.type.startsWith('image/')
+            ? URL.createObjectURL(file)
+            : undefined
+          newAttachments.push({
+            id: crypto.randomUUID(),
+            filename: file.name,
+            mediaType: file.type || 'application/octet-stream',
+            sourcePath,
+            size: file.size,
+            previewUrl,
+          })
+          pathBackedFiles.push(file.name)
+          continue
+        }
+
         const base64 = await fileToBase64(file)
         const previewUrl = file.type.startsWith('image/')
           ? URL.createObjectURL(file)
@@ -165,10 +193,18 @@ export function QuickTaskApp(): React.ReactElement {
         console.error('[快速任务] 读取文件失败:', err)
       }
     }
+    if (pathBackedFiles.length > 0) {
+      toast.success(`已将大文件作为附加文件引用：${formatFileNames(pathBackedFiles)}`)
+    }
+    if (rejectedLargeFiles.length > 0) {
+      toast.error(`以下文件超过 100MB，已跳过：${formatFileNames(rejectedLargeFiles)}`, {
+        description: mode === 'chat' ? 'Chat 附件暂不支持大文件。' : '无法取得本地路径，不能作为附加文件引用。',
+      })
+    }
     if (newAttachments.length > 0) {
       setAttachments((prev) => [...prev, ...newAttachments])
     }
-  }, [])
+  }, [mode])
 
   // 移除附件
   const removeAttachment = useCallback((id: string) => {
@@ -217,14 +253,19 @@ export function QuickTaskApp(): React.ReactElement {
   const handleSubmit = useCallback(async () => {
     const trimmed = text.trim()
     if ((!trimmed && attachments.length === 0) || isSubmitting) return
+    const pathOnlyAttachments = attachments.filter((att) => att.sourcePath && !att.base64)
+    if (mode === 'chat' && pathOnlyAttachments.length > 0) {
+      toast.error(`Chat 暂不支持大文件附加，已保留在快速任务窗口：${formatFileNames(pathOnlyAttachments.map((att) => att.filename))}`)
+      return
+    }
 
     setIsSubmitting(true)
     try {
       await window.electronAPI.submitQuickTask({
         text: trimmed,
         mode,
-        files: attachments.map(({ filename, mediaType, base64, size }) => ({
-          filename, mediaType, base64, size,
+        files: attachments.map(({ filename, mediaType, base64, sourcePath, size }) => ({
+          filename, mediaType, base64, sourcePath, size,
         })),
       })
       setText('')

--- a/apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx
+++ b/apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx
@@ -30,6 +30,7 @@ import {
   agentChannelIdAtom,
   currentAgentWorkspaceIdAtom,
   agentWorkspacesAtom,
+  agentAttachedFilesMapAtom,
 } from '@/atoms/agent-atoms'
 import {
   chatPendingMessageAtom,
@@ -46,6 +47,7 @@ import {
   initShortcutRegistry,
   updateShortcutOverrides,
 } from '@/lib/shortcut-registry'
+import { getFileParentPath } from '@/lib/file-utils'
 
 /**
  * 快捷键初始化 + 全局 Handler 注册
@@ -214,22 +216,46 @@ export function GlobalShortcuts(): null {
 
           // 处理附件：保存到 session 目录，构建 file references
           let fileReferences = ''
+          const additionalDirectories = new Set<string>()
           if (data.files && data.files.length > 0 && workspaceId) {
             const workspaces = store.get(agentWorkspacesAtom)
             const workspace = workspaces.find((w) => w.id === workspaceId)
             if (workspace) {
               try {
-                const filesToSave = data.files.map((f) => ({
+                const allRefs: Array<{ filename: string; targetPath: string }> = []
+                for (const file of data.files) {
+                  if (!file.sourcePath) continue
+                  const attachedFiles = await window.electronAPI.attachFile({
+                    sessionId: meta.id,
+                    filePath: file.sourcePath,
+                  })
+                  store.set(agentAttachedFilesMapAtom, (prev) => {
+                    const map = new Map(prev)
+                    map.set(meta.id, attachedFiles)
+                    return map
+                  })
+                  allRefs.push({ filename: file.filename, targetPath: file.sourcePath })
+                  const parentPath = getFileParentPath(file.sourcePath)
+                  if (parentPath) additionalDirectories.add(parentPath)
+                }
+
+                const filesToSave = data.files.filter((f) => f.base64).map((f) => ({
                   filename: f.filename,
-                  data: f.base64,
+                  data: f.base64!,
                 }))
-                const saved = await window.electronAPI.saveFilesToAgentSession({
-                  workspaceSlug: workspace.slug,
-                  sessionId: meta.id,
-                  files: filesToSave,
-                })
-                const refs = saved.map((f) => `- ${f.filename}: ${f.targetPath}`).join('\n')
-                fileReferences = `<attached_files>\n${refs}\n</attached_files>\n\n`
+                if (filesToSave.length > 0) {
+                  const saved = await window.electronAPI.saveFilesToAgentSession({
+                    workspaceSlug: workspace.slug,
+                    sessionId: meta.id,
+                    files: filesToSave,
+                  })
+                  allRefs.push(...saved)
+                }
+
+                if (allRefs.length > 0) {
+                  const refs = allRefs.map((f) => `- ${f.filename}: ${f.targetPath}`).join('\n')
+                  fileReferences = `<attached_files>\n${refs}\n</attached_files>\n\n`
+                }
               } catch (error) {
                 console.error('[快速任务] 保存 Agent 附件失败:', error)
               }
@@ -250,6 +276,7 @@ export function GlobalShortcuts(): null {
           store.set(agentPendingPromptAtom, {
             sessionId: meta.id,
             message: fileReferences + data.text,
+            ...(additionalDirectories.size > 0 && { additionalDirectories: Array.from(additionalDirectories) }),
           })
         } else {
           // Chat 模式：创建对话 + 保存附件到磁盘
@@ -267,6 +294,10 @@ export function GlobalShortcuts(): null {
           const savedAttachments: import('@proma/shared').FileAttachment[] = []
           if (data.files && data.files.length > 0) {
             for (const file of data.files) {
+              if (!file.base64) {
+                console.warn('[快速任务] Chat 附件缺少 base64，已跳过:', file.filename)
+                continue
+              }
               try {
                 const result = await window.electronAPI.saveAttachment({
                   conversationId: meta.id,

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -35,7 +35,9 @@ import {
   currentAgentWorkspaceIdAtom,
   agentWorkspacesAtom,
   agentAttachedDirectoriesMapAtom,
+  agentAttachedFilesMapAtom,
   workspaceAttachedDirectoriesMapAtom,
+  workspaceAttachedFilesMapAtom,
   unviewedCompletedSessionIdsAtom,
   workingDoneSessionIdsAtom,
   agentSessionPathMapAtom,
@@ -385,15 +387,21 @@ export function useGlobalAgentListeners(): void {
       const workspaceId = getWorkspaceIdForSession(sid)
       const workspaceFilesPath = await getWorkspaceFilesPathForSession(sid)
       const sessionAttachedDirs = store.get(agentAttachedDirectoriesMapAtom).get(sid) ?? []
+      const sessionAttachedFiles = store.get(agentAttachedFilesMapAtom).get(sid) ?? []
       const workspaceAttachedDirs = workspaceId
         ? (store.get(workspaceAttachedDirectoriesMapAtom).get(workspaceId) ?? [])
+        : []
+      const workspaceAttachedFiles = workspaceId
+        ? (store.get(workspaceAttachedFilesMapAtom).get(workspaceId) ?? [])
         : []
       const basePaths = uniqueTruthyPaths([
         sessionPath,
         workspaceFilesPath,
         dirPath,
         ...sessionAttachedDirs,
+        ...sessionAttachedFiles,
         ...workspaceAttachedDirs,
+        ...workspaceAttachedFiles,
       ])
 
       let previewOnly = true

--- a/apps/electron/src/renderer/lib/file-utils.ts
+++ b/apps/electron/src/renderer/lib/file-utils.ts
@@ -2,9 +2,30 @@
  * 文件处理工具函数
  */
 
+import { MAX_ATTACHMENT_SIZE } from '@proma/shared'
+
+export function formatFileNames(names: string[], max = 3): string {
+  if (names.length <= max) return names.join('、')
+  return `${names.slice(0, max).join('、')} 等 ${names.length} 个文件`
+}
+
+export function getFileParentPath(filePath: string): string | null {
+  const slashIndex = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'))
+  if (slashIndex < 0) return null
+  if (slashIndex === 0) return filePath.slice(0, 1)
+  if (/^[A-Za-z]:[\\/]/.test(filePath) && slashIndex === 2) {
+    return filePath.slice(0, 3)
+  }
+  return filePath.slice(0, slashIndex)
+}
+
 /** 将 File 对象转为 base64 字符串 */
 export function fileToBase64(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
+    if (file.size > MAX_ATTACHMENT_SIZE) {
+      reject(new Error(`文件 ${file.name} 超过 100MB 大小限制`))
+      return
+    }
     const reader = new FileReader()
     reader.onload = () => {
       const result = reader.result as string

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -290,7 +290,7 @@ export interface QuickTaskSubmitInput {
   text: string
   /** 目标模式 */
   mode: 'chat' | 'agent'
-  /** 附件列表（base64 编码） */
+  /** 附件列表（base64 编码或本地路径引用） */
   files?: QuickTaskFile[]
 }
 
@@ -298,7 +298,8 @@ export interface QuickTaskSubmitInput {
 export interface QuickTaskFile {
   filename: string
   mediaType: string
-  base64: string
+  base64?: string
+  sourcePath?: string
   size: number
 }
 

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -548,6 +548,8 @@ export interface AgentSessionMeta {
   archived?: boolean
   /** 附加的外部目录路径列表（绝对路径，作为 SDK additionalDirectories 传递） */
   attachedDirectories?: string[]
+  /** 附加的外部文件路径列表（绝对路径，发送时以父目录作为 SDK additionalDirectories） */
+  attachedFiles?: string[]
   /** 分叉来源：源会话的 Proma 工作目录（SDK session 文件在此目录的项目空间中，首次 resume 后清除） */
   forkSourceDir?: string
   /** 分叉来源：源会话的 SDK session ID（用于 rewind 时读取源会话的 file-history-snapshot 和备份文件） */
@@ -876,6 +878,8 @@ export interface FileEntry {
   path: string
   /** 是否为目录 */
   isDirectory: boolean
+  /** 文件大小（字节）。目录为空 */
+  size?: number
   /** 子条目（懒加载，仅目录展开时填充） */
   children?: FileEntry[]
 }
@@ -943,12 +947,28 @@ export interface AgentAttachDirectoryInput {
   directoryPath: string
 }
 
+/** 附加/分离文件的输入参数 */
+export interface AgentAttachFileInput {
+  /** 会话 ID */
+  sessionId: string
+  /** 文件的绝对路径 */
+  filePath: string
+}
+
 /** 工作区级附加/分离目录的输入参数 */
 export interface WorkspaceAttachDirectoryInput {
   /** 工作区 slug */
   workspaceSlug: string
   /** 目录的绝对路径 */
   directoryPath: string
+}
+
+/** 工作区级附加/分离文件的输入参数 */
+export interface WorkspaceAttachFileInput {
+  /** 工作区 slug */
+  workspaceSlug: string
+  /** 文件的绝对路径 */
+  filePath: string
 }
 
 // ===== AskUserQuestion 交互式问答类型 =====
@@ -1277,12 +1297,22 @@ export const AGENT_IPC_CHANNELS = {
   ATTACH_DIRECTORY: 'agent:attach-directory',
   /** 移除会话的附加目录 */
   DETACH_DIRECTORY: 'agent:detach-directory',
+  /** 附加外部文件到 Agent 会话 */
+  ATTACH_FILE: 'agent:attach-file',
+  /** 移除会话的附加文件 */
+  DETACH_FILE: 'agent:detach-file',
   /** 附加外部目录到工作区（所有会话共享） */
   ATTACH_WORKSPACE_DIRECTORY: 'agent:attach-workspace-directory',
   /** 移除工作区的附加目录 */
   DETACH_WORKSPACE_DIRECTORY: 'agent:detach-workspace-directory',
+  /** 附加外部文件到工作区（所有会话共享） */
+  ATTACH_WORKSPACE_FILE: 'agent:attach-workspace-file',
+  /** 移除工作区的附加文件 */
+  DETACH_WORKSPACE_FILE: 'agent:detach-workspace-file',
   /** 获取工作区附加目录列表 */
   GET_WORKSPACE_DIRECTORIES: 'agent:get-workspace-directories',
+  /** 获取工作区附加文件列表 */
+  GET_WORKSPACE_ATTACHED_FILES: 'agent:get-workspace-attached-files',
 
   // 文件系统操作
   /** 获取 session 工作路径 */

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -9,6 +9,9 @@ import type { ProviderType } from './channel'
 
 // ===== 附件相关 =====
 
+/** 附件文件大小上限：100MB */
+export const MAX_ATTACHMENT_SIZE = 100 * 1024 * 1024
+
 /** 文件附件 */
 export interface FileAttachment {
   /** 附件唯一标识 */
@@ -43,13 +46,35 @@ export interface AttachmentSaveResult {
 
 /** 文件选择对话框结果 */
 export interface FileDialogResult {
-  /** 选择的文件列表 */
-  files: Array<{
-    filename: string
-    mediaType: string
-    data: string
-    size: number
-  }>
+  /** 已读取为 base64 的小文件列表 */
+  files: FileDialogFile[]
+  /** 超过内存导入上限的大文件，仅返回路径，供 Agent 作为附加文件引用 */
+  largeFiles?: FileDialogLargeFile[]
+  /** 无法读取或无法识别的文件 */
+  skippedFiles?: FileDialogSkippedFile[]
+}
+
+export interface FileDialogFile {
+  filename: string
+  mediaType: string
+  data: string
+  size: number
+}
+
+export interface FileDialogLargeFile {
+  filename: string
+  mediaType: string
+  size: number
+  path: string
+}
+
+export interface FileDialogSkippedFile {
+  filename: string
+  mediaType?: string
+  size?: number
+  path?: string
+  reason: 'unreadable'
+  message?: string
 }
 
 // ===== 消息相关 =====


### PR DESCRIPTION
## Summary

- Route files over 100MB through path-backed Agent attachments instead of base64 loading.
- Add session-level and workspace-level `attachedFiles` persistence, IPC, preload APIs, and right-side file panel rendering.
- Let Agent runs, file preview, and `@` file search resolve attached single files by including their exact paths or parent directories where appropriate.
- Update the workspace import/migration path handling so attached files are preserved alongside attached directories.

## Why

Large file import could still crash or silently fail because some paths attempted to read large files into memory, and the right-side file area only knew how to render attached directories. The new flow keeps large files as file-path references and makes those references visible and reusable in the file panel.

## User Impact

Users can attach files over 100MB without copying them into the workspace, see them in the right-side file area, add them to chat from the panel, and reuse workspace-level attached files across sessions.

## Validation

- `bun run --filter='@proma/shared' typecheck`
- `bun run --filter='@proma/electron' typecheck`
- `bun run --filter='@proma/electron' build`
- `git diff --check`