### PR TITLE
修复：离开「文件改动」标签页时自动清除未读提示灯【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
@@ -22,12 +22,27 @@ export function DiffPanelTabBar({ activeTab, onTabChange, onClose }: DiffPanelTa
   const setUnseenMap = useSetAtom(agentDiffUnseenChangesAtom)
   const currentSessionId = useAtomValue(currentAgentSessionIdAtom)
   const unseenChanges = unseenMap.get(currentSessionId ?? '') ?? false
+  const prevTabRef = React.useRef(activeTab)
 
-  const handleChangesClick = () => {
+  const clearUnseen = React.useCallback(() => {
     if (currentSessionId) {
       setUnseenMap((prev) => { const m = new Map(prev); m.set(currentSessionId, false); return m })
     }
-    onTabChange('changes')
+  }, [currentSessionId, setUnseenMap])
+
+  // 当用户正在「文件改动」标签页时（已看到改动内容），切走时自动清除未读标记
+  React.useEffect(() => {
+    if (prevTabRef.current === 'changes' && activeTab !== 'changes') {
+      clearUnseen()
+    }
+    prevTabRef.current = activeTab
+  }, [activeTab, clearUnseen])
+
+  const handleChangesClick = () => {
+    clearUnseen()
+    if (activeTab !== 'changes') {
+      onTabChange('changes')
+    }
   }
 
   return (


### PR DESCRIPTION
## 概述
修复右侧面板「文件改动」标签页的提示灯误报问题：用户正在查看改动时切到其他标签页，提示灯仍会亮起，但实际上用户已经看到了这些改动。

## 改动内容
- `apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx` — 添加 `useEffect` + `useRef` 追踪 tab 切换状态，当用户从 `changes` 切走时自动清除 `unseenChanges` 标志。同时提取 `clearUnseen` 回调消除重复代码，`handleChangesClick` 添加 guard 避免已在 changes 标签页时的无效调用

## 测试方法
1. 打开 Proma，进入 Agent 模式
2. 让 agent 执行文件写入操作（如编辑文件）
3. 确认自己在「文件改动」标签页，观察改动内容
4. 切到「工作区文件」标签页 → 「文件改动」不应再显示提示灯
5. 关闭右侧面板，让 agent 再次写入文件 → 重新打开面板，「文件改动」应正常显示提示灯（未查看场景正常提醒）