### PR TITLE
[codex] fix clipboard preview review issues

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -2077,8 +2077,7 @@ export function registerIpcHandlers(): void {
         throw new Error('content 必须是字符串')
       }
 
-      const { resolve } = await import('node:path')
-      const { join } = await import('node:path')
+      const { isAbsolute, join, relative, resolve } = await import('node:path')
       const { tmpdir } = await import('node:os')
       const { existsSync, mkdirSync } = await import('node:fs')
       const { writeFile } = await import('node:fs/promises')
@@ -2092,8 +2091,9 @@ export function registerIpcHandlers(): void {
       const safeFilename = filename.replace(/[<>:"/\\|?*]/g, '_').replace(/^\.+/, '_')
       const tmpPath = resolve(tmpDir, safeFilename)
 
-      // 确保 resolve 后的路径仍在 tmpDir 内，防止 .. 穿越
-      if (!tmpPath.startsWith(tmpDir + '/') && tmpPath !== tmpDir) {
+      // 确保 resolve 后的路径仍在 tmpDir 内，兼容 Windows 路径分隔符
+      const relativePath = relative(tmpDir, tmpPath)
+      if (!relativePath || relativePath.startsWith('..') || isAbsolute(relativePath)) {
         throw new Error('文件名越界')
       }
 

--- a/apps/electron/src/main/lib/detached-preview-window.ts
+++ b/apps/electron/src/main/lib/detached-preview-window.ts
@@ -25,6 +25,7 @@ function makeSignature(input: DetachedPreviewWindowInput): string {
     dirPath: input.dirPath,
     gitRoot: input.gitRoot,
     previewOnly: input.previewOnly === true,
+    readOnly: input.readOnly === true,
     basePaths: input.basePaths ?? [],
   })
 }

--- a/apps/electron/src/renderer/atoms/preview-atoms.ts
+++ b/apps/electron/src/renderer/atoms/preview-atoms.ts
@@ -17,6 +17,8 @@ export interface PreviewFile {
   gitRoot?: string
   /** true = 纯文件预览（不显示 diff 控件），false/undefined = diff 模式 */
   previewOnly?: boolean
+  /** true = 预览只读，不允许从预览面板写回临时/源文件 */
+  readOnly?: boolean
   /** 候选基础目录（用于相对路径解析） */
   basePaths?: string[]
 }

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -981,7 +981,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       const tmpDir = tmpPath.substring(0, tmpPath.lastIndexOf('/'))
       setPreviewFileMap((prev) => {
         const m = new Map(prev)
-        m.set(sessionId, { filePath: tmpPath, previewOnly: true, basePaths: [tmpDir] })
+        m.set(sessionId, { filePath: tmpPath, previewOnly: true, readOnly: true, basePaths: [tmpDir] })
         return m
       })
       store.set(previewPanelOpenMapAtom, (prev) => { const m = new Map(prev); m.set(sessionId, true); return m })

--- a/apps/electron/src/renderer/components/chat/AttachmentPreviewItem.tsx
+++ b/apps/electron/src/renderer/components/chat/AttachmentPreviewItem.tsx
@@ -45,6 +45,13 @@ export function AttachmentPreviewItem({
   className,
 }: AttachmentPreviewItemProps): React.ReactElement {
   const [lightboxOpen, setLightboxOpen] = React.useState(false)
+  const handleRemoveClick = React.useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation()
+    onRemove()
+  }, [onRemove])
+  const handleRemoveKeyDown = React.useCallback((event: React.KeyboardEvent<HTMLButtonElement>) => {
+    event.stopPropagation()
+  }, [])
 
   if (isImage(mediaType) && previewUrl) {
     // 图片预览 — 紧凑缩略图，点击可预览大图
@@ -64,7 +71,8 @@ export function AttachmentPreviewItem({
         {/* hover 关闭按钮 */}
         <button
           type="button"
-          onClick={onRemove}
+          onClick={handleRemoveClick}
+          onKeyDown={handleRemoveKeyDown}
           className={cn(
             'absolute top-1 right-1 size-[18px] rounded-full',
             'bg-black/50 text-white backdrop-blur-sm',
@@ -99,14 +107,20 @@ export function AttachmentPreviewItem({
       onClick={onClick}
       role={onClick ? 'button' : undefined}
       tabIndex={onClick ? 0 : undefined}
-      onKeyDown={onClick ? (e: React.KeyboardEvent) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick() } } : undefined}
+      onKeyDown={onClick ? (e: React.KeyboardEvent) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          onClick()
+        }
+      } : undefined}
     >
       <Paperclip className="size-4 shrink-0" />
       <span className="max-w-[160px] truncate">{truncateName(filename)}</span>
       {/* 关闭按钮 */}
       <button
         type="button"
-        onClick={onRemove}
+        onClick={handleRemoveClick}
+        onKeyDown={handleRemoveKeyDown}
         className={cn(
           'absolute top-1/2 right-1.5 -translate-y-1/2 size-[18px] rounded-full',
           'flex items-center justify-center',

--- a/apps/electron/src/renderer/components/diff/DetachedPreviewApp.tsx
+++ b/apps/electron/src/renderer/components/diff/DetachedPreviewApp.tsx
@@ -107,6 +107,7 @@ export function DetachedPreviewApp(): React.ReactElement {
           sessionId={data.sessionId}
           gitRoot={data.gitRoot}
           previewOnly={data.previewOnly}
+          readOnly={data.readOnly}
           basePaths={data.basePaths}
         />
       </div>

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -86,11 +86,13 @@ interface DiffTabContentProps {
   sessionId: string
   gitRoot?: string
   previewOnly?: boolean
+  /** 禁用预览内编辑，适用于 clipboard 等临时快照 */
+  readOnly?: boolean
   /** 候选基础目录（previewOnly 模式下用于路径解析） */
   basePaths?: string[]
 }
 
-export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewOnly, basePaths }: DiffTabContentProps): React.ReactElement {
+export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewOnly, readOnly, basePaths }: DiffTabContentProps): React.ReactElement {
   const [viewMode, setViewMode] = useAtom(agentDiffViewModeAtom)
   const [oldContent, setOldContent] = React.useState('')
   const [newContent, setNewContent] = React.useState('')
@@ -453,7 +455,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
           </div>
         )}
 
-        {previewOnly && isMarkdown && (
+        {previewOnly && isMarkdown && !readOnly && (
           markdownEditing ? (
             <div className="ml-auto flex items-center gap-1">
               <button

--- a/apps/electron/src/renderer/components/diff/PreviewPanel.tsx
+++ b/apps/electron/src/renderer/components/diff/PreviewPanel.tsx
@@ -46,6 +46,7 @@ export function PreviewPanel({ sessionId }: PreviewPanelProps): React.ReactEleme
       dirPath: currentFile.dirPath || sessionPath || fallbackDirPath,
       gitRoot: currentFile.gitRoot,
       previewOnly: currentFile.previewOnly,
+      readOnly: currentFile.readOnly,
       basePaths: currentFile.basePaths,
       title: currentFile.filePath.split('/').pop(),
     }).catch((err) => {
@@ -105,6 +106,7 @@ export function PreviewPanel({ sessionId }: PreviewPanelProps): React.ReactEleme
             sessionId={sessionId}
             gitRoot={currentFile.gitRoot}
             previewOnly={currentFile.previewOnly}
+            readOnly={currentFile.readOnly}
             basePaths={currentFile.basePaths}
           />
         ) : (

--- a/packages/shared/src/types/runtime.ts
+++ b/packages/shared/src/types/runtime.ts
@@ -160,6 +160,8 @@ export interface DetachedPreviewWindowInput {
   gitRoot?: string
   /** true = 纯文件预览，false/undefined = diff 模式 */
   previewOnly?: boolean
+  /** true = 预览只读，不允许从预览面板写回临时/源文件 */
+  readOnly?: boolean
   /** 候选基础目录（previewOnly 模式下用于路径解析） */
   basePaths?: string[]
   /** 窗口标题 */


### PR DESCRIPTION
## Summary

Fixes the review issues found after merging PR #435.

## Changes

- Make clipboard preview temp-path validation cross-platform by using path.relative() instead of a hard-coded slash separator.
- Stop remove-button click and keyboard events from bubbling to the clickable attachment container, so deleting a clipboard attachment does not also open preview.
- Mark clipboard temp previews as read-only and pass that state through inline and detached preview paths, preventing Markdown preview edits from writing only to the temporary snapshot while the pending attachment still sends the old content.

## Validation

- bun run --filter='@proma/electron' typecheck
- bun run --filter='@proma/shared' typecheck
- git diff --check