### PR TITLE
[codex] 修复文件改动提示灯跨会话误清除

### DIFF
--- a/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
@@ -11,10 +11,17 @@ import { cn } from '@/lib/utils'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { agentDiffUnseenChangesAtom, currentAgentSessionIdAtom } from '@/atoms/agent-atoms'
 
+type DiffPanelTab = 'files' | 'changes'
+
 interface DiffPanelTabBarProps {
-  activeTab: 'files' | 'changes'
-  onTabChange: (tab: 'files' | 'changes') => void
+  activeTab: DiffPanelTab
+  onTabChange: (tab: DiffPanelTab) => void
   onClose?: () => void
+}
+
+interface PreviousTabState {
+  sessionId: string | null
+  activeTab: DiffPanelTab
 }
 
 export function DiffPanelTabBar({ activeTab, onTabChange, onClose }: DiffPanelTabBarProps): React.ReactElement {
@@ -22,21 +29,26 @@ export function DiffPanelTabBar({ activeTab, onTabChange, onClose }: DiffPanelTa
   const setUnseenMap = useSetAtom(agentDiffUnseenChangesAtom)
   const currentSessionId = useAtomValue(currentAgentSessionIdAtom)
   const unseenChanges = unseenMap.get(currentSessionId ?? '') ?? false
-  const prevTabRef = React.useRef(activeTab)
+  const prevTabStateRef = React.useRef<PreviousTabState>({ sessionId: currentSessionId, activeTab })
 
-  const clearUnseen = React.useCallback(() => {
-    if (currentSessionId) {
-      setUnseenMap((prev) => { const m = new Map(prev); m.set(currentSessionId, false); return m })
-    }
+  const clearUnseen = React.useCallback((sessionId = currentSessionId) => {
+    if (!sessionId) return
+    setUnseenMap((prev) => {
+      if (prev.get(sessionId) === false) return prev
+      const m = new Map(prev)
+      m.set(sessionId, false)
+      return m
+    })
   }, [currentSessionId, setUnseenMap])
 
-  // 当用户正在「文件改动」标签页时（已看到改动内容），切走时自动清除未读标记
+  // 同一会话内，从「文件改动」切走时，说明用户已经看过当前改动。
   React.useEffect(() => {
-    if (prevTabRef.current === 'changes' && activeTab !== 'changes') {
-      clearUnseen()
+    const previous = prevTabStateRef.current
+    if (previous.sessionId === currentSessionId && previous.activeTab === 'changes' && activeTab !== 'changes') {
+      clearUnseen(currentSessionId)
     }
-    prevTabRef.current = activeTab
-  }, [activeTab, clearUnseen])
+    prevTabStateRef.current = { sessionId: currentSessionId, activeTab }
+  }, [activeTab, currentSessionId, clearUnseen])
 
   const handleChangesClick = () => {
     clearUnseen()


### PR DESCRIPTION
## 概述

这是 #441 合并后的 follow-up 修复。#441 在用户离开「文件改动」标签页时清除当前会话的未读提示灯，但 `DiffPanelTabBar` 组件不会随 session 切换重挂载，导致上一个会话的 tab 状态可能误作用到当前会话。

## 修复内容

- 将前一次 tab 状态扩展为 `{ sessionId, activeTab }`
- 只有同一个 session 内从 `changes` 切到其他 tab 时，才清除 `agentDiffUnseenChangesAtom`
- `clearUnseen` 支持显式传入 sessionId，并避免重复写入已经为 `false` 的状态

## 影响

切换到另一个 Agent 会话时，不会因为上一个会话停留在「文件改动」页而错误清掉当前会话的未读提示灯。

## 验证

- `bun run --filter='@proma/electron' typecheck`