### PR TITLE
fix(windows): align titlebar overlay color with TabBar background

### DIFF
--- a/apps/electron/src/main/lib/titlebar-overlay.ts
+++ b/apps/electron/src/main/lib/titlebar-overlay.ts
@@ -10,15 +10,17 @@ interface OverlayColors {
 
 const OVERLAY_HEIGHT = 40
 
+// Colors are computed as: alpha-composite of hsl(--muted / 0.5) over hsl(--content-area),
+// matching the actual rendered TabBar background color to eliminate the visual seam on Windows.
 const THEME_COLORS: Record<string, { color: string; symbolColor: string }> = {
-  'default-light': { color: '#ffffff', symbolColor: '#0a0a0a' },
-  'default-dark': { color: '#121212', symbolColor: '#fafafa' },
-  'ocean-light': { color: '#ecf2f7', symbolColor: '#1b2632' },
-  'ocean-dark': { color: '#182434', symbolColor: '#e7ebef' },
-  'forest-light': { color: '#eff5f1', symbolColor: '#1d3026' },
-  'forest-dark': { color: '#212c26', symbolColor: '#e3e8e5' },
-  'slate-light': { color: '#e3e1dc', symbolColor: '#312f2a' },
-  'slate-dark': { color: '#1d1b20', symbolColor: '#e9e6e3' },
+  'default-light': { color: '#fafafa', symbolColor: '#0a0a0a' },
+  'default-dark': { color: '#1c1c1c', symbolColor: '#fafafa' },
+  'ocean-light': { color: '#e6eef5', symbolColor: '#1b2632' },
+  'ocean-dark': { color: '#131c26', symbolColor: '#e7ebef' },
+  'forest-light': { color: '#ecf1ee', symbolColor: '#1d3026' },
+  'forest-dark': { color: '#16201b', symbolColor: '#e3e8e5' },
+  'slate-light': { color: '#e6e4df', symbolColor: '#312f2a' },
+  'slate-dark': { color: '#1f1c21', symbolColor: '#e9e6e3' },
 }
 
 export function resolveOverlayColors(


### PR DESCRIPTION
## 问题

Windows 下右上角的原生标题栏区域（最小化/最大化/关闭按钮，约 140px 宽）呈现出与左侧 TabBar 颜色不一致的色块，在非深色主题下尤为明显（晴空碧海、森息晨光、云朵舞者等亮色主题）。

Closes #436

## 根因分析

`titlebar-overlay.ts` 中 `THEME_COLORS` 的颜色值参考的是 `--background`（侧边栏色），而不是 TabBar 的实际渲染颜色。

TabBar 的实际可见颜色是 `hsl(--muted / 0.5)` 以 alpha 混合到 `hsl(--content-area)` 背景上的结果。由于 overlay 颜色与 TabBar 颜色不一致，两个区域之间会出现明显的色差边界。

例如晴空碧海亮色主题：
- 旧 overlay 颜色：`#ecf2f7`（`--background` 侧边栏色）
- TabBar 实际颜色：`#e6eef5`（`muted/0.5` 混合到 `content-area`）
- 差值肉眼可见，右侧形成割裂感

## 修复方案

对每个主题预先计算 `alpha-composite(hsl(--muted) × 0.5, hsl(--content-area))` 的结果，将 `THEME_COLORS` 更新为与 TabBar 实际渲染色精确匹配的值：

| 主题 | 旧颜色 | 新颜色 |
|------|--------|--------|
| default-light | `#ffffff` | `#fafafa` |
| default-dark | `#121212` | `#1c1c1c` |
| ocean-light | `#ecf2f7` | `#e6eef5` |
| ocean-dark | `#182434` | `#131c26` |
| forest-light | `#eff5f1` | `#ecf1ee` |
| forest-dark | `#212c26` | `#16201b` |
| slate-light | `#e3e1dc` | `#e6e4df` |
| slate-dark | `#1d1b20` | `#1f1c21` |

## 测试计划

- [ ] 切换到晴空碧海亮色主题，确认右上角 overlay 与 TabBar 颜色一致
- [ ] 切换到森息晨光亮色主题，验证同上
- [ ] 切换到云朵舞者亮色主题，验证同上
- [ ] 深色主题（所有）：确认无回退
- [ ] 默认亮色/深色主题：确认无回退

🤖 Generated with [Claude Code](https://claude.com/claude-code)