### PR TITLE
fix: scratch-pad require() 改为顶层 import + 保存错误处理优化

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -6,7 +6,8 @@
 
 import { ipcMain, nativeTheme, shell, dialog, BrowserWindow, app } from 'electron'
 import { join, resolve, sep } from 'node:path'
-import { existsSync, realpathSync, rmSync } from 'node:fs'
+import { existsSync, realpathSync, rmSync, readFileSync, writeFileSync } from 'node:fs'
+import { writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, INSTALLER_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, MEMORY_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS, DINGTALK_IPC_CHANNELS, WECHAT_IPC_CHANNELS } from '@proma/shared'
 import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS, SCRATCH_PAD_IPC_CHANNELS, QUICK_TASK_IPC_CHANNELS, VOICE_DICTATION_IPC_CHANNELS, APP_ICON_IPC_CHANNELS, DOCK_BADGE_IPC_CHANNELS, STORAGE_IPC_CHANNELS } from '../types'
@@ -1012,7 +1013,6 @@ export function registerIpcHandlers(): void {
       const path = getScratchPadPath()
       try {
         if (!existsSync(path)) return ''
-        const { readFileSync } = require('node:fs')
         return readFileSync(path, 'utf-8')
       } catch (err) {
         console.error('[ScratchPad] 加载失败:', err)
@@ -1027,7 +1027,6 @@ export function registerIpcHandlers(): void {
     async (_, content: string): Promise<boolean> => {
       const path = getScratchPadPath()
       try {
-        const { writeFile } = require('node:fs/promises')
         await writeFile(path, content, 'utf-8')
         return true
       } catch (err) {
@@ -1042,7 +1041,6 @@ export function registerIpcHandlers(): void {
     SCRATCH_PAD_IPC_CHANNELS.SAVE_SYNC,
     (event, content: string) => {
       try {
-        const { writeFileSync } = require('node:fs')
         writeFileSync(getScratchPadPath(), content, 'utf-8')
         event.returnValue = true
       } catch (err) {

--- a/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
+++ b/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
@@ -41,7 +41,7 @@ export function ScratchPadView(): React.ReactElement {
     if (loaded && editor && content) {
       editor.commands.setContent(content)
     }
-  }, [loaded, editor])
+  }, [loaded, editor, content])
 
   // 粘贴时自动将 Markdown 转为 HTML 插入
   React.useEffect(() => {

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -776,7 +776,9 @@ function ScratchPadPersistence(): null {
       const html = store.get(scratchPadContentAtom)
       if (window.electronAPI.saveScratchPad) {
         const md = htmlToMarkdown(html)
-        window.electronAPI.saveScratchPad(md).catch(console.error)
+        window.electronAPI.saveScratchPad(md).then((ok) => {
+          if (!ok) console.error('[ScratchPad] 保存失败')
+        }).catch(console.error)
       }
     }
 


### PR DESCRIPTION
## 概述

针对 PR #425 (scratch-pad) 的代码审查优化，修复 3 个问题：

### 变更清单

1. **ipc.ts — `require()` 改为顶层 import**
   - `readFileSync` / `writeFileSync` 加入现有 `node:fs` 顶层导入
   - `writeFile` 新增 `node:fs/promises` 顶层导入
   - 移除 handler 内 3 处 `require()` 调用，与文件顶部已有的 `node:fs` import 风格一致

2. **ScratchPadView.tsx — 补全 useEffect 依赖数组**
   - `content` 在闭包内被引用，加入 `[loaded, editor, content]` 依赖

3. **main.tsx — 保存失败时检查返回值**
   - `saveScratchPad` 返回 boolean，现检查 `ok` 并 `console.error`

## 测试方法

- 启动 Proma，Scratch Pad 正常加载和保存
- 编辑器内容修改后关闭窗口，重新打开内容完整保留

🤖 Generated with [Claude Code](https://claude.com/claude-code)