### PR TITLE
fix: set DeepSeek preset channel provider to 'deepseek'

### DIFF
--- a/apps/electron/src/main/lib/channel-manager.ts
+++ b/apps/electron/src/main/lib/channel-manager.ts
@@ -112,7 +112,7 @@ function decryptKey(encryptedKey: string): string {
 export function listChannels(): Channel[] {
   const config = readConfig()
 
-  // 首次使用：如果没有 DeepSeek 渠道，自动创建预设（使用 Anthropic 协议）
+  // 首次使用：如果没有 DeepSeek 渠道，自动创建预设
   const hasDeepSeek = config.channels.some(
     (c) => c.provider === 'deepseek' || c.baseUrl.includes('api.deepseek.com'),
   )
@@ -121,7 +121,7 @@ export function listChannels(): Channel[] {
     const presetChannel: Channel = {
       id: randomUUID(),
       name: 'DeepSeek',
-      provider: 'anthropic',
+      provider: 'deepseek',
       baseUrl: PROVIDER_DEFAULT_URLS.deepseek,
       apiKey: encryptApiKey(''),
       models: [


### PR DESCRIPTION
## Summary
- Changed the DeepSeek preset channel's `provider` from `'anthropic'` to `'deepseek'`
- The preset was incorrectly labeled as `'anthropic'` due to historical Anthropic-protocol compatibility, causing the channel description in settings to display "Anthropic" instead of "DeepSeek"

## Impact
- Channel description in settings now correctly shows "DeepSeek" instead of "Anthropic"
- All dependent logic (adapter, thinking capability detection, agent compatibility, URL preview) already handles both `'deepseek'` and `'anthropic'` provider types
- Existing users with the old preset are unaffected — the deduplication check in `listChannels()` covers both the provider and baseUrl conditions

## Test plan
- [ ] Fresh install: verify DeepSeek preset channel shows provider "DeepSeek" in settings
- [ ] Existing install with old preset: verify no duplicate channel is created
- [ ] Agent mode: verify DeepSeek channel is usable as Agent provider
- [ ] Chat: verify DeepSeek models work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)