### PR TITLE
fix(scratch-pad): 修复空格无法输入和换行被吞的 content 同步循环

### DIFF
--- a/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
+++ b/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
@@ -20,6 +20,10 @@ export function ScratchPadView(): React.ReactElement {
   const loaded = useAtomValue(scratchPadLoadedAtom)
   const containerRef = React.useRef<HTMLDivElement>(null)
 
+  // 用 ref 追踪最新内容，避免在 useEffect deps 里包含 content 导致循环
+  const contentRef = React.useRef(content)
+  contentRef.current = content
+
   const editor = useEditor({
     extensions: [
       StarterKit.configure({
@@ -36,12 +40,18 @@ export function ScratchPadView(): React.ReactElement {
     immediatelyRender: false,
   })
 
-  // 内容从磁盘加载或编辑器重新挂载（切 tab 回来）时同步
+  // 仅在初始加载或编辑器重新挂载时同步内容到编辑器。
+  // content 不加入 deps：用户每次输入都会更新 atom，若加入 deps 会导致
+  // setContent → onUpdate → atom 变化 → setContent 死循环，
+  // HTML 规范化解析会吞掉尾部空格和空段落，并重置光标位置。
   React.useEffect(() => {
-    if (loaded && editor && content) {
-      editor.commands.setContent(content)
+    if (!loaded || !editor) return
+    const latestContent = contentRef.current
+    if (latestContent && editor.getHTML() !== latestContent) {
+      editor.commands.setContent(latestContent)
     }
-  }, [loaded, editor, content])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loaded, editor])
 
   // 粘贴时自动将 Markdown 转为 HTML 插入
   React.useEffect(() => {
@@ -75,7 +85,7 @@ export function ScratchPadView(): React.ReactElement {
           {loaded ? (
             <EditorContent
               editor={editor}
-              className="prose prose-sm dark:prose-invert max-w-none h-full [&_.ProseMirror]:min-h-[200px] [&_.ProseMirror]:outline-none [&_.ProseMirror]:text-sm [&_.ProseMirror_p.is-editor-empty:first-child::before]:text-muted-foreground/50 [&_.ProseMirror_p.is-editor-empty:first-child::before]:content-[attr(data-placeholder)] [&_.ProseMirror_p.is-editor-empty:first-child::before]:float-left [&_.ProseMirror_p.is-editor-empty:first-child::before]:pointer-events-none [&_.ProseMirror_p.is-editor-empty:first-child::before]:h-0"
+              className="prose prose-sm dark:prose-invert max-w-none h-full [&_.ProseMirror]:min-h-full [&_.ProseMirror]:outline-none [&_.ProseMirror]:text-sm [&_.ProseMirror_p.is-editor-empty:first-child::before]:text-muted-foreground/50 [&_.ProseMirror_p.is-editor-empty:first-child::before]:content-[attr(data-placeholder)] [&_.ProseMirror_p.is-editor-empty:first-child::before]:float-left [&_.ProseMirror_p.is-editor-empty:first-child::before]:pointer-events-none [&_.ProseMirror_p.is-editor-empty:first-child::before]:h-0"
             />
           ) : (
             <div className="min-h-[200px] flex items-center justify-center">


### PR DESCRIPTION
## 问题

ScratchPad 编辑器存在两个输入异常：
- 空格无法正常输入（输入后被吞掉）
- 按 Enter 产生的换行被吞掉

## 根因分析

`useEffect` 将 `content` atom 加入依赖数组，导致以下死循环：

```
用户按键（空格/Enter）
  → TipTap onUpdate → setContent(editor.getHTML()) → atom 更新
  → content 变化触发 useEffect → editor.commands.setContent(content)
  → ProseMirror DOMParser 解析 HTML（规范化）
    ├─ 尾部空格被 HTML 解析器吃掉（"Hello " → "Hello"）
    └─ 空段落 <p></p> 被剥离（换行被吞）
  → 光标位置重置 → onUpdate 再次触发 → 循环
```

## 修复方案

- 将 `content` 从 `useEffect` 依赖数组移除
- 引入 `contentRef` 追踪最新内容值（避免 stale closure）
- 添加 `editor.getHTML() !== latestContent` 比对，只在内容真正不同时调用 `setContent`

`useEffect` 现在只在 `loaded`/`editor` 变化时触发（初始加载 + Tab 重新挂载），用户输入不再触发 `setContent`，消除循环。

## 测试

- [x] 打开 Scratch Pad，正常输入空格
- [x] 按 Enter 换行不被吞掉
- [x] 切换 Tab 后回来内容正常恢复
- [x] 首次加载内容从磁盘正确同步

🤖 Generated with [Claude Code](https://claude.com/claude-code)