### PR TITLE
fix: use scrollbar-thin for ScratchPad to match Agent panel style

### DIFF
--- a/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
+++ b/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
@@ -70,7 +70,7 @@ export function ScratchPadView(): React.ReactElement {
 
   return (
     <div ref={containerRef} className="flex flex-col h-full">
-      <div className="flex-1 overflow-auto px-8 py-6">
+      <div className="flex-1 overflow-auto scrollbar-thin px-8 py-6">
         <div className="max-w-3xl mx-auto h-full">
           {loaded ? (
             <EditorContent


### PR DESCRIPTION
## Summary

- ScratchPad 的滚动条从浏览器默认样式改为 `scrollbar-thin`（6px 细条半透明），与 Agent 面板（WorkspaceSelector、DiffTabContent 等）保持一致

## Test plan

- [x] ScratchPad 内容超出时滚动条样式与 Agent 面板一致
- [x] 无功能回归