### PR TITLE
feat: auto-close preview panel when diff becomes empty after commit

### DIFF
--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -450,7 +450,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
                         </Tooltip>
                       </div>
                       {/* 会话文件内容区（独立滚动） */}
-                      <div className="flex-1 min-h-0 overflow-y-auto">
+                      <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin">
                         {/* 附加文件列表 */}
                         {attachedFiles.length > 0 && (
                           <AttachedFilesSection
@@ -532,7 +532,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
                       )}
                     </div>
                     {/* 工作区文件内容区（独立滚动） */}
-                    <div className="flex-1 min-h-0 overflow-y-auto pb-1">
+                    <div className="flex-1 min-h-0 overflow-y-auto pb-1 scrollbar-thin">
                       {/* 工作区级附加文件 */}
                       {wsAttachedFiles.length > 0 && (
                         <AttachedFilesSection

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -105,9 +105,11 @@ interface DiffTabContentProps {
   readOnly?: boolean
   /** 候选基础目录（previewOnly 模式下用于路径解析） */
   basePaths?: string[]
+  /** diff 模式下检测到内容为空（无差异）时回调，用于自动关闭预览面板 */
+  onEmptyDiff?: () => void
 }
 
-export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewOnly, readOnly, basePaths }: DiffTabContentProps): React.ReactElement {
+export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewOnly, readOnly, basePaths, onEmptyDiff }: DiffTabContentProps): React.ReactElement {
   const [viewMode, setViewMode] = useAtom(agentDiffViewModeAtom)
   const [oldContent, setOldContent] = React.useState('')
   const [newContent, setNewContent] = React.useState('')
@@ -396,6 +398,19 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     refresh()
     return () => { cancelled = true }
   }, [refreshVersion, previewOnly, filePath, dirPath, gitRoot, sessionId, getContentCacheKey])
+
+  // diff 模式：内容加载完成后若新旧一致（无差异），通知父组件关闭预览面板
+  const emptyDiffFiredRef = React.useRef(false)
+  React.useEffect(() => {
+    emptyDiffFiredRef.current = false
+  }, [filePath, sessionId])
+  React.useEffect(() => {
+    if (previewOnly || loading || emptyDiffFiredRef.current) return
+    if (oldContent === newContent) {
+      emptyDiffFiredRef.current = true
+      onEmptyDiff?.()
+    }
+  }, [previewOnly, loading, oldContent, newContent, onEmptyDiff])
 
   // scrollPosition persistent: module-level Map keyed by sessionId:filePath
   // content changes (refreshVersion bump) → delete stored position;

--- a/apps/electron/src/renderer/components/diff/PreviewPanel.tsx
+++ b/apps/electron/src/renderer/components/diff/PreviewPanel.tsx
@@ -109,6 +109,7 @@ export function PreviewPanel({ sessionId }: PreviewPanelProps): React.ReactEleme
             previewOnly={currentFile.previewOnly}
             readOnly={currentFile.readOnly}
             basePaths={currentFile.basePaths}
+            onEmptyDiff={handleClosePanel}
           />
         ) : (
           <div className="flex items-center justify-center h-full text-muted-foreground text-xs">


### PR DESCRIPTION
## Summary
- Preview panel now auto-closes when the diff content becomes empty (e.g., after changes are committed externally)
- Added `onEmptyDiff` callback to `DiffTabContent` that fires when `oldContent === newContent` in diff mode
- `PreviewPanel` passes its close handler as the callback, seamlessly closing the panel

## How it works
When a user commits changes in terminal and switches back to Proma, the window focus event triggers a diff refresh. If HEAD now matches the working tree (i.e., the diff is empty), `DiffTabContent` notifies `PreviewPanel` to close automatically instead of showing a blank white panel.

## Test plan
- [ ] Agent writes a file → preview panel opens showing the diff
- [ ] Commit the changes in terminal → switch back to Proma → preview panel closes automatically  
- [ ] Pure file preview mode (non-git repos) is unaffected
- [ ] Detached preview windows are unaffected (no auto-close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)