### PR TITLE
fix(scratch-pad): 修复每次重启丢失段落间空行的问题

### DIFF
--- a/apps/electron/src/renderer/lib/markdown-rich-text.ts
+++ b/apps/electron/src/renderer/lib/markdown-rich-text.ts
@@ -303,7 +303,7 @@ export function htmlToMarkdown(html: string): string {
         return `<video controls src="${src}"${title ? ` title="${title}"` : ''}></video>\n`
       }
       case 'p':
-        return children + '\n'
+        return children + '\n\n'
       case 'br':
         return '\n'
       case 'strong':
@@ -373,6 +373,7 @@ export function htmlToMarkdown(html: string): string {
         return children
       case 'blockquote':
         return children
+          .replace(/\n+$/, '')
           .split('\n')
           .map((line) => `> ${line}`)
           .join('\n') + '\n'


### PR DESCRIPTION
## Summary
- 修复 Scratch Pad 每次 App 重启后段落间空白行逐次减少直至合并的问题
- 根因：`htmlToMarkdown` 的 `<p>` 标签转换只输出 `\n`（单换行），而 `markdownToHtml`（`breaks: false`）将单换行视为同段落文本合并，导致往返转换损毁段落分隔
- 改为 `\n\n`（双换行），符合 Markdown 段落分隔规范，实现无损往返

## Test plan
- [ ] 启动 App，在 Scratch Pad 中写入多段文字（段落间有空行）
- [ ] 关闭 App 再重新打开，确认段落保持分离
- [ ] 重复关闭/打开多次，确认空白行数量不再减少

🤖 Generated with [Claude Code](https://claude.com/claude-code)