### PR TITLE
feat: add preview panel expand button to Read/Edit/Write tool blocks

### DIFF
--- a/apps/electron/src/renderer/components/agent/ContentBlock.tsx
+++ b/apps/electron/src/renderer/components/agent/ContentBlock.tsx
@@ -21,9 +21,10 @@ import { useAtomValue } from 'jotai'
 import { thinkingExpandedAtom } from '@/atoms/chat-atoms'
 import { cn } from '@/lib/utils'
 import { MessageResponse } from '@/components/ai-elements/message'
-import { getToolIcon } from './tool-utils'
+import { getToolIcon, extractFilePath } from './tool-utils'
 import { getToolPhrase } from './tool-phrase'
 import { ToolResultRenderer } from './tool-result-renderers'
+import { PreviewOpenButton } from './tool-result-renderers/preview-open-button'
 import { formatDuration } from './AgentMessages'
 import type {
   SDKContentBlock,
@@ -304,6 +305,12 @@ function ToolUseBlock({ block, allMessages, animate = false, index = 0, dimmed =
 
   // 运行中显示进行时短语，完成或非流式（已终止）显示完成态短语
   const displayLabel = (isCompleted || !isStreaming) ? phrase.label : phrase.loadingLabel
+  const filePath = extractFilePath(block.input)
+  const isPreviewable = (
+    (block.name === 'Read' || block.name === 'Edit' || block.name === 'Write') &&
+    isCompleted &&
+    filePath
+  )
 
   const delay = animate && index < 10 ? `${index * 30}ms` : '0ms'
 
@@ -427,6 +434,10 @@ function ToolUseBlock({ block, allMessages, animate = false, index = 0, dimmed =
             expanded && 'rotate-90 opacity-100',
           )}
         />
+
+        {isPreviewable && (
+          <PreviewOpenButton filePath={filePath} expanded={expanded} />
+        )}
       </button>
 
       {expanded && toolResult?.result && (

--- a/apps/electron/src/renderer/components/agent/tool-result-renderers/preview-open-button.tsx
+++ b/apps/electron/src/renderer/components/agent/tool-result-renderers/preview-open-button.tsx
@@ -1,0 +1,69 @@
+/**
+ * PreviewOpenButton — 在预览面板中打开文件的扩展按钮
+ *
+ * 显示在工具结果预览区域（Read/Edit/Write）的 chevron 旁边，
+ * 使用 span 避免嵌套 button 的 HTML 问题，
+ * 点击后将文件内容在右侧 PreviewPanel 中以完整视图打开。
+ */
+
+import * as React from 'react'
+import { useAtomValue, useSetAtom } from 'jotai'
+import { previewFileMapAtom, previewPanelOpenMapAtom } from '@/atoms/preview-atoms'
+import { currentAgentSessionIdAtom } from '@/atoms/agent-atoms'
+import { cn } from '@/lib/utils'
+
+interface PreviewOpenButtonProps {
+  filePath: string
+  /** 是否已在展开状态（展开时始终可见，否则仅 hover 可见） */
+  expanded?: boolean
+  className?: string
+}
+
+export function PreviewOpenButton({ filePath, expanded = false, className }: PreviewOpenButtonProps): React.ReactElement | null {
+  const sessionId = useAtomValue(currentAgentSessionIdAtom)
+  const setPreviewFile = useSetAtom(previewFileMapAtom)
+  const setPreviewOpen = useSetAtom(previewPanelOpenMapAtom)
+
+  if (!sessionId || !filePath) return null
+
+  const handleOpen = () => {
+    setPreviewFile((prev) => {
+      const next = new Map(prev)
+      next.set(sessionId, { filePath, previewOnly: true, readOnly: true })
+      return next
+    })
+    setPreviewOpen((prev) => {
+      const next = new Map(prev)
+      next.set(sessionId, true)
+      return next
+    })
+  }
+
+  return (
+    <span
+      role="button"
+      tabIndex={0}
+      className={cn(
+        'shrink-0 px-1.5 py-px rounded text-[11px] text-muted-foreground/50',
+        'hover:text-foreground/70 hover:bg-muted/50',
+        'transition-all duration-150 cursor-pointer',
+        'opacity-0 group-hover:opacity-100',
+        expanded && 'opacity-100',
+        className,
+      )}
+      onClick={(e) => {
+        e.stopPropagation()
+        handleOpen()
+      }}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          handleOpen()
+        }
+      }}
+      title="在预览面板中打开"
+    >
+      预览
+    </span>
+  )
+}

--- a/apps/electron/src/renderer/components/chat/ChatToolBlock.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatToolBlock.tsx
@@ -13,9 +13,10 @@
 import * as React from 'react'
 import { ChevronRight, XCircle, Loader2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import { getToolIcon } from '@/components/agent/tool-utils'
+import { getToolIcon, extractFilePath } from '@/components/agent/tool-utils'
 import { getToolPhrase } from '@/components/agent/tool-phrase'
 import { ToolResultRenderer } from '@/components/agent/tool-result-renderers'
+import { PreviewOpenButton } from '@/components/agent/tool-result-renderers/preview-open-button'
 
 export interface ChatToolBlockProps {
   toolName: string
@@ -41,6 +42,12 @@ export function ChatToolBlock({
   const phrase = getToolPhrase(toolName, input)
   const ToolIcon = getToolIcon(toolName)
   const displayLabel = isCompleted ? phrase.label : phrase.loadingLabel
+  const filePath = extractFilePath(input)
+  const isPreviewable = (
+    (toolName === 'Read' || toolName === 'Edit' || toolName === 'Write') &&
+    isCompleted &&
+    filePath
+  )
 
   const delay = animate && index < 10 ? `${index * 30}ms` : '0ms'
 
@@ -74,6 +81,10 @@ export function ChatToolBlock({
             expanded && 'rotate-90 opacity-100',
           )}
         />
+
+        {isPreviewable && (
+          <PreviewOpenButton filePath={filePath} expanded={expanded} />
+        )}
       </button>
 
       {expanded && result && (


### PR DESCRIPTION
## Summary
- Add a "预览" text button next to the chevron in `ChatToolBlock` and `ToolUseBlock` for Read/Edit/Write tools
- Button appears on hover when collapsed, always visible when expanded
- Clicking opens the file in the right-side PreviewPanel with `previewOnly` mode

## Changes
- **New**: `preview-open-button.tsx` — shared component that sets preview atoms to open file in PreviewPanel
- **Modified**: `ChatToolBlock.tsx` — add `PreviewOpenButton` next to chevron
- **Modified**: `ContentBlock.tsx` — same for Agent mode's `ToolUseBlock`

## Test plan
- [ ] Hover over a completed Read/Edit/Write tool block → "预览" button appears next to chevron
- [ ] Expand the tool block → "预览" button remains visible
- [ ] Click "预览" → file opens in right-side PreviewPanel in preview-only mode
- [ ] Non-Read/Edit/Write tools (Bash, Grep, etc.) do not show the button

🤖 Generated with [Claude Code](https://claude.com/claude-code)