### PR TITLE
feat(scratchpad): add export as Markdown to session/workspace directory

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -6,7 +6,7 @@
 
 import { ipcMain, nativeTheme, shell, dialog, BrowserWindow, app } from 'electron'
 import { join, resolve, sep } from 'node:path'
-import { existsSync, realpathSync, rmSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, realpathSync, rmSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs'
 import { writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, INSTALLER_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, MEMORY_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS, DINGTALK_IPC_CHANNELS, WECHAT_IPC_CHANNELS } from '@proma/shared'
@@ -1046,6 +1046,38 @@ export function registerIpcHandlers(): void {
         console.error('[ScratchPad] 同步保存失败:', err)
         event.returnValue = false
       }
+    }
+  )
+
+  // 导出为 Markdown 到指定目录
+  ipcMain.handle(
+    SCRATCH_PAD_IPC_CHANNELS.EXPORT,
+    async (_, markdown: string, dirPath: string, filename: string): Promise<string> => {
+      if (!existsSync(dirPath)) {
+        mkdirSync(dirPath, { recursive: true })
+      }
+      const filePath = join(dirPath, filename)
+      writeFileSync(filePath, markdown, 'utf-8')
+      console.log('[ScratchPad] 已导出:', filePath)
+      return filePath
+    }
+  )
+
+  // 打开保存对话框，返回用户选择的路径
+  ipcMain.handle(
+    SCRATCH_PAD_IPC_CHANNELS.CHOOSE_EXPORT_PATH,
+    async (_, defaultName: string): Promise<string | null> => {
+      const win = BrowserWindow.getFocusedWindow()
+      if (!win) return null
+      const result = await dialog.showSaveDialog(win, {
+        title: '导出 Scratch Pad 为 Markdown',
+        defaultPath: defaultName,
+        filters: [
+          { name: 'Markdown', extensions: ['md'] },
+          { name: '所有文件', extensions: ['*'] },
+        ],
+      })
+      return result.canceled ? null : result.filePath
     }
   )
 

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -323,6 +323,12 @@ export interface ElectronAPI {
   /** 同步保存内容到 scratch-pad.md（beforeunload 场景） */
   saveScratchPadSync: (content: string) => boolean
 
+  /** 导出 ScratchPad 内容为 Markdown 文件到指定目录 */
+  exportScratchPad: (markdown: string, dirPath: string, filename: string) => Promise<string>
+
+  /** 打开原生保存对话框，返回用户选择的路径 */
+  chooseExportPath: (defaultName: string) => Promise<string | null>
+
   // ===== 应用图标切换 =====
 
   /** 设置应用图标变体（传入 variant ID，如 'blue'、'cyberpunk'，'default' 恢复默认） */
@@ -1195,6 +1201,14 @@ const electronAPI: ElectronAPI = {
 
   saveScratchPadSync: (content: string) => {
     return ipcRenderer.sendSync(SCRATCH_PAD_IPC_CHANNELS.SAVE_SYNC, content)
+  },
+
+  exportScratchPad: (markdown: string, dirPath: string, filename: string) => {
+    return ipcRenderer.invoke(SCRATCH_PAD_IPC_CHANNELS.EXPORT, markdown, dirPath, filename)
+  },
+
+  chooseExportPath: (defaultName: string) => {
+    return ipcRenderer.invoke(SCRATCH_PAD_IPC_CHANNELS.CHOOSE_EXPORT_PATH, defaultName)
   },
 
   // 应用图标切换

--- a/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
+++ b/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
@@ -10,10 +10,23 @@ import { useEditor, EditorContent } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import Placeholder from '@tiptap/extension-placeholder'
 import MarkdownIt from 'markdown-it'
+import TurndownService from 'turndown'
 import { useAtom, useAtomValue } from 'jotai'
-import { scratchPadContentAtom, scratchPadLoadedAtom } from '@/atoms/tab-atoms'
+import { FileDown } from 'lucide-react'
+import { scratchPadContentAtom, scratchPadLoadedAtom, tabsAtom, activeTabIdAtom } from '@/atoms/tab-atoms'
+import { currentAgentWorkspaceIdAtom, agentWorkspacesAtom } from '@/atoms/agent-atoms'
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuPortal,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from '@/components/ui/dropdown-menu'
 
 const md = new MarkdownIt({ breaks: true, linkify: true })
+const turndown = new TurndownService()
 
 export function ScratchPadView(): React.ReactElement {
   const [content, setContent] = useAtom(scratchPadContentAtom)
@@ -39,6 +52,82 @@ export function ScratchPadView(): React.ReactElement {
     },
     immediatelyRender: false,
   })
+
+  // 导出目标上下文
+  const workspaces = useAtomValue(agentWorkspacesAtom)
+  const currentWorkspaceId = useAtomValue(currentAgentWorkspaceIdAtom)
+  const tabs = useAtomValue(tabsAtom)
+  const activeTabId = useAtomValue(activeTabIdAtom)
+
+  const currentWorkspace = React.useMemo(
+    () => workspaces.find((w) => w.id === currentWorkspaceId) ?? null,
+    [workspaces, currentWorkspaceId],
+  )
+
+  const activeSessionId = React.useMemo(() => {
+    const activeTab = tabs.find((t) => t.id === activeTabId)
+    if (activeTab?.type === 'agent') return activeTab.sessionId
+    const agentTab = [...tabs].reverse().find((t) => t.type === 'agent')
+    return agentTab?.sessionId ?? null
+  }, [tabs, activeTabId])
+
+  const activeSessionTitle = React.useMemo(() => {
+    const agentTab = tabs.find((t) => t.sessionId === activeSessionId && t.type === 'agent')
+    return agentTab?.title ?? null
+  }, [tabs, activeSessionId])
+
+  const makeFilename = () => {
+    const now = new Date()
+    const pad = (n: number) => String(n).padStart(2, '0')
+    return `scratch-pad-${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}-${pad(now.getHours())}${pad(now.getMinutes())}.md`
+  }
+
+  const handleExport = React.useCallback(
+    async (target: 'session' | 'workspace') => {
+      if (!editor) return
+      const html = editor.getHTML()
+      if (!html || html === '<p></p>') return
+
+      const markdownContent = turndown.turndown(html)
+      const filename = makeFilename()
+
+      try {
+        let dirPath: string | null = null
+        if (target === 'session' && activeSessionId && currentWorkspaceId) {
+          dirPath = await window.electronAPI.getAgentSessionPath(currentWorkspaceId, activeSessionId)
+        } else if (target === 'workspace' && currentWorkspace?.slug) {
+          dirPath = await window.electronAPI.getWorkspaceFilesPath(currentWorkspace.slug)
+        }
+        if (!dirPath) return
+        await window.electronAPI.exportScratchPad(markdownContent, dirPath, filename)
+      } catch (err) {
+        console.error('[ScratchPad] 导出失败:', err)
+      }
+    },
+    [editor, activeSessionId, currentWorkspaceId, currentWorkspace],
+  )
+
+  const handleBrowseExport = React.useCallback(async () => {
+    if (!editor) return
+    const html = editor.getHTML()
+    if (!html || html === '<p></p>') return
+
+    const filename = makeFilename()
+    const filePath = await window.electronAPI.chooseExportPath(filename)
+    if (!filePath) return
+
+    try {
+      const markdownContent = turndown.turndown(html)
+      // 从完整路径中分离目录和文件名
+      const sep = filePath.includes('\\') ? '\\' : '/'
+      const lastSep = filePath.lastIndexOf(sep)
+      const dirPath = filePath.slice(0, lastSep)
+      const chosenFilename = filePath.slice(lastSep + 1)
+      await window.electronAPI.exportScratchPad(markdownContent, dirPath, chosenFilename)
+    } catch (err) {
+      console.error('[ScratchPad] 导出失败:', err)
+    }
+  }, [editor])
 
   // 仅在初始加载或编辑器重新挂载时同步内容到编辑器。
   // content 不加入 deps：用户每次输入都会更新 atom，若加入 deps 会导致
@@ -94,10 +183,53 @@ export function ScratchPadView(): React.ReactElement {
           )}
         </div>
       </div>
-      <div className="h-[28px] border-t border-border/40 px-4 flex items-center">
+      <div className="h-[28px] border-t border-border/40 px-4 flex items-center justify-between">
         <span className="text-[11px] text-muted-foreground/60">
           Scratch Pad — 内容自动保存到本地
         </span>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              className="text-[11px] text-muted-foreground/60 hover:text-foreground flex items-center gap-1 transition-colors"
+              title="导出为 Markdown"
+            >
+              <FileDown className="w-3 h-3" />
+              导出
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuPortal>
+          <DropdownMenuContent align="end" side="top" className="min-w-[240px] z-[9999]">
+            <DropdownMenuLabel className="text-[11px] text-muted-foreground font-normal">
+              导出为 Markdown
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onSelect={() => handleExport('session')}
+              disabled={!activeSessionId}
+              className="flex flex-col items-start"
+            >
+              <span className="text-xs">保存到会话目录</span>
+              <span className="text-[10px] text-muted-foreground">
+                {activeSessionTitle ?? '无活跃会话'}
+              </span>
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={() => handleExport('workspace')}
+              disabled={!currentWorkspace}
+              className="flex flex-col items-start"
+            >
+              <span className="text-xs">保存到工作区目录</span>
+              <span className="text-[10px] text-muted-foreground">
+                {currentWorkspace?.name ?? '无当前工作区'}
+              </span>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={handleBrowseExport}>
+              浏览选择位置...
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+          </DropdownMenuPortal>
+        </DropdownMenu>
       </div>
     </div>
   )

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -234,6 +234,10 @@ export const SCRATCH_PAD_IPC_CHANNELS = {
   SAVE: 'scratch-pad:save',
   /** 同步保存（beforeunload 场景） */
   SAVE_SYNC: 'scratch-pad:save-sync',
+  /** 导出为 Markdown 到指定目录 */
+  EXPORT: 'scratch-pad:export',
+  /** 打开保存对话框选择导出路径 */
+  CHOOSE_EXPORT_PATH: 'scratch-pad:choose-export-path',
 } as const
 
 /** 应用图标 IPC 通道 */

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,9 @@
     "": {
       "name": "proma",
       "dependencies": {
+        "@types/turndown": "^5.0.6",
         "jotai": "^2.17.1",
+        "turndown": "^7.2.4",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -22,7 +24,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.9.25",
+      "version": "0.9.30",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.129",
         "@pierre/diffs": "^1.1.20",
@@ -336,6 +338,8 @@
     "@malept/cross-spawn-promise": ["@malept/cross-spawn-promise@2.0.0", "", { "dependencies": { "cross-spawn": "^7.0.1" } }, "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg=="],
 
     "@malept/flatpak-bundler": ["@malept/flatpak-bundler@0.4.0", "", { "dependencies": { "debug": "^4.1.1", "fs-extra": "^9.0.0", "lodash": "^4.17.15", "tmp-promise": "^3.0.2" } }, "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q=="],
+
+    "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
@@ -699,6 +703,8 @@
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
+    "@types/turndown": ["@types/turndown@5.0.6", "", {}, "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg=="],
+
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
@@ -759,7 +765,7 @@
 
     "arg": ["arg@5.0.2", "", {}, "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="],
 
-    "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
 
@@ -1039,7 +1045,7 @@
 
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
-    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
@@ -1979,6 +1985,8 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "turndown": ["turndown@7.2.4", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ=="],
+
     "type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
@@ -2269,8 +2277,6 @@
 
     "hosted-git-info/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
-    "js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
-
     "lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "make-dir/pify": ["pify@3.0.0", "", {}, "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg=="],
@@ -2285,9 +2291,7 @@
 
     "make-fetch-happen/negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
 
-    "markdown-it/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
-
-    "markdown-it/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+    "mammoth/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
@@ -2312,6 +2316,8 @@
     "p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "typescript": "^5"
   },
   "dependencies": {
-    "jotai": "^2.17.1"
+    "@types/turndown": "^5.0.6",
+    "jotai": "^2.17.1",
+    "turndown": "^7.2.4"
   }
 }


### PR DESCRIPTION
## Summary

ScratchPad 底部增加"导出"下拉按钮，支持将内容转换为纯 Markdown 并保存到三个目标位置。

## Changes

- **UI**: 底部状态栏右侧新增 `导出` 按钮，下拉菜单显示目标名称（会话标题 / 工作区名称）
- **HTML→Markdown**: 新增 `turndown` 依赖，将 TipTap HTML 内容转换为标准 Markdown
- **IPC**: 新增 `scratch-pad:export` 和 `scratch-pad:choose-export-path` 两个 IPC 通道
- **保存位置**:
  - 当前活跃 Agent 会话目录（显示会话标题）
  - 当前工作区 workspace-files 目录（显示工作区名称）
  - 原生保存对话框自由选择位置

## Test plan

- [ ] 在有活跃 Agent 会话时导出到会话目录
- [ ] 在选中工作区时导出到工作区目录
- [ ] 通过"浏览选择位置"导出到自定义目录
- [ ] 无活跃会话时菜单项置灰
- [ ] 无当前工作区时菜单项置灰
- [ ] 空内容导出无反应
- [ ] 导出文件内容为有效 Markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)