### PR TITLE
fix(scratchpad): follow-up fixes for export feature

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -5,7 +5,7 @@
  */
 
 import { ipcMain, nativeTheme, shell, dialog, BrowserWindow, app } from 'electron'
-import { join, resolve, sep } from 'node:path'
+import { join, resolve, sep, dirname } from 'node:path'
 import { existsSync, realpathSync, rmSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs'
 import { writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -1053,10 +1053,20 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(
     SCRATCH_PAD_IPC_CHANNELS.EXPORT,
     async (_, markdown: string, dirPath: string, filename: string): Promise<string> => {
-      if (!existsSync(dirPath)) {
-        mkdirSync(dirPath, { recursive: true })
+      let filePath: string
+      if (!filename) {
+        // 完整文件路径模式（来自保存对话框）
+        filePath = dirPath
+        const dir = dirname(filePath)
+        if (!existsSync(dir)) {
+          mkdirSync(dir, { recursive: true })
+        }
+      } else {
+        if (!existsSync(dirPath)) {
+          mkdirSync(dirPath, { recursive: true })
+        }
+        filePath = join(dirPath, filename)
       }
-      const filePath = join(dirPath, filename)
       writeFileSync(filePath, markdown, 'utf-8')
       console.log('[ScratchPad] 已导出:', filePath)
       return filePath

--- a/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
+++ b/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
@@ -84,9 +84,8 @@ export function ScratchPadView(): React.ReactElement {
 
   const handleExport = React.useCallback(
     async (target: 'session' | 'workspace') => {
-      if (!editor) return
+      if (!editor || editor.isEmpty) return
       const html = editor.getHTML()
-      if (!html || html === '<p></p>') return
 
       const markdownContent = turndown.turndown(html)
       const filename = makeFilename()
@@ -108,22 +107,16 @@ export function ScratchPadView(): React.ReactElement {
   )
 
   const handleBrowseExport = React.useCallback(async () => {
-    if (!editor) return
-    const html = editor.getHTML()
-    if (!html || html === '<p></p>') return
+    if (!editor || editor.isEmpty) return
 
     const filename = makeFilename()
     const filePath = await window.electronAPI.chooseExportPath(filename)
     if (!filePath) return
 
     try {
-      const markdownContent = turndown.turndown(html)
-      // 从完整路径中分离目录和文件名
-      const sep = filePath.includes('\\') ? '\\' : '/'
-      const lastSep = filePath.lastIndexOf(sep)
-      const dirPath = filePath.slice(0, lastSep)
-      const chosenFilename = filePath.slice(lastSep + 1)
-      await window.electronAPI.exportScratchPad(markdownContent, dirPath, chosenFilename)
+      const markdownContent = turndown.turndown(editor.getHTML())
+      // 传空 filename 触发 IPC 的完整路径模式，由 Node.js path.dirname 安全处理
+      await window.electronAPI.exportScratchPad(markdownContent, filePath, '')
     } catch (err) {
       console.error('[ScratchPad] 导出失败:', err)
     }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/node": "^20.0.0",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
+    "@types/turndown": "^5.0.6",
     "dompurify": "^3.4.2",
     "typescript": "^5.0.0"
   },
@@ -30,7 +31,6 @@
     "typescript": "^5"
   },
   "dependencies": {
-    "@types/turndown": "^5.0.6",
     "jotai": "^2.17.1",
     "turndown": "^7.2.4"
   }


### PR DESCRIPTION
Follow-up to #468

## Changes

1. **Path parsing**: delegate to Node.js path.dirname instead of manual string splitting
2. **Empty content check**: use editor.isEmpty instead of html string comparison
3. **Dependency**: move @types/turndown to devDependencies

### Files changed
- apps/electron/src/main/ipc.ts — add dirname import, support full-path mode in EXPORT handler
- apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx — use editor.isEmpty, pass full path
- package.json — move @types/turndown to devDependencies