### PR TITLE
feat(scratchpad): support rich rendering for code blocks, todos and math

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -78,6 +78,8 @@
     "@tiptap/extension-link": "^3.19.0",
     "@tiptap/extension-mention": "^3.19.0",
     "@tiptap/extension-placeholder": "^3.19.0",
+    "@tiptap/extension-task-item": "3.19.0",
+    "@tiptap/extension-task-list": "3.19.0",
     "@tiptap/extension-underline": "^3.19.0",
     "@tiptap/pm": "^3.19.0",
     "@tiptap/react": "^3.19.0",

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -21,19 +21,16 @@ import Underline from '@tiptap/extension-underline'
 import Link from '@tiptap/extension-link'
 import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
 import Mention from '@tiptap/extension-mention'
-import { common, createLowlight } from 'lowlight'
 import { ChevronsDownUp, ChevronsUpDown } from 'lucide-react'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
+import { lowlight } from '@/lib/lowlight'
 import { htmlToMarkdown } from '@/lib/markdown-rich-text'
 import { createFileMentionSuggestion } from '@/components/file-browser/file-mention-suggestion'
 import { createSkillMentionSuggestion, createMcpMentionSuggestion, createSessionMentionSuggestion } from '@/components/agent/mention-suggestions'
 
 const VOICE_DICTATION_INSERT_EVENT = 'proma:insert-voice-dictation-text'
 let lastFocusedRichTextInputId: string | null = null
-
-// 创建 lowlight 实例，使用常见语言
-const lowlight = createLowlight(common)
 
 // ===== 行数计算 =====
 

--- a/apps/electron/src/renderer/components/diff/markdown-preview-extensions.tsx
+++ b/apps/electron/src/renderer/components/diff/markdown-preview-extensions.tsx
@@ -1,11 +1,15 @@
-import { Node, mergeAttributes } from '@tiptap/core'
+import { Node, mergeAttributes, nodeInputRule } from '@tiptap/core'
 import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
+import TaskListExt from '@tiptap/extension-task-list'
+import TaskItemExt from '@tiptap/extension-task-item'
 import DOMPurify from 'dompurify'
 import katex from 'katex'
-import { highlightCode, highlightCodeSync } from '@proma/core'
+import { getDisplayName, highlightCode, highlightCodeSync } from '@proma/core'
 import type { FileAccessOptions } from '@proma/shared'
 
 type FileAccessRef = { current: FileAccessOptions | undefined }
+/** 传 null 表示当前编辑器无会话/文件上下文（如 ScratchPad），跳过路径解析。 */
+type FileAccessRefOrNull = FileAccessRef | null
 type ThemeRef = { current: string }
 
 function isExternalUrl(src: string): boolean {
@@ -36,8 +40,14 @@ function setClass(el: HTMLElement, className: string): void {
   el.className = className
 }
 
-function resolveMediaSrc(src: string, fileAccessRef: FileAccessRef, apply: (src: string) => void): () => void {
+function resolveMediaSrc(src: string, fileAccessRef: FileAccessRefOrNull, apply: (src: string) => void): () => void {
+  // 外链 / data-URL / blob / file 协议：直接 apply，不走 IPC
   if (!src || isExternalUrl(src)) {
+    apply(src)
+    return () => {}
+  }
+  // 无会话上下文：直接显示原始 src（ScratchPad 等无文件解析需求的场景）
+  if (fileAccessRef === null) {
     apply(src)
     return () => {}
   }
@@ -87,7 +97,7 @@ function createStaticHtmlView(
   }
 }
 
-function createMarkdownImageView(initialNode: ProseMirrorNode, fileAccessRef: FileAccessRef) {
+function createMarkdownImageView(initialNode: ProseMirrorNode, fileAccessRef: FileAccessRefOrNull) {
   const figure = document.createElement('figure')
   figure.contentEditable = 'false'
   setClass(figure, 'not-prose my-3')
@@ -137,7 +147,7 @@ function createMarkdownImageView(initialNode: ProseMirrorNode, fileAccessRef: Fi
   }
 }
 
-function createMarkdownVideoView(initialNode: ProseMirrorNode, fileAccessRef: FileAccessRef) {
+function createMarkdownVideoView(initialNode: ProseMirrorNode, fileAccessRef: FileAccessRefOrNull) {
   const figure = document.createElement('figure')
   figure.contentEditable = 'false'
   setClass(figure, 'not-prose my-3')
@@ -213,15 +223,35 @@ function createMathView(initialNode: ProseMirrorNode, displayMode: boolean) {
 function createShikiCodeBlockView(initialNode: ProseMirrorNode, themeRef: ThemeRef) {
   const dom = document.createElement('div')
   dom.contentEditable = 'false'
-  setClass(dom, 'not-prose my-3 overflow-hidden rounded-md border border-border/40 bg-muted/30')
+  setClass(dom, 'not-prose my-3 overflow-hidden rounded-md border border-border/40')
 
+  // 头部栏：语言标签 + 复制按钮
   const header = document.createElement('div')
-  setClass(header, 'flex h-8 items-center justify-between border-b border-border/30 px-3 text-xs text-muted-foreground')
+  setClass(header, 'flex h-8 items-center justify-between border-b border-border/30 px-3 text-xs text-muted-foreground bg-muted/30')
   const label = document.createElement('span')
+  label.className = 'font-medium select-none'
   header.appendChild(label)
 
+  const copyBtn = document.createElement('button')
+  copyBtn.type = 'button'
+  copyBtn.className = 'flex items-center gap-1 px-1.5 py-0.5 rounded hover:bg-foreground/10 transition-colors text-muted-foreground hover:text-foreground'
+  copyBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg><span>复制</span>'
+  let copyTimeout: ReturnType<typeof setTimeout> | null = null
+  copyBtn.addEventListener('click', () => {
+    const code = (dom as any).__currentCode ?? ''
+    navigator.clipboard.writeText(code).then(() => {
+      copyBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg><span>已复制</span>'
+      if (copyTimeout) clearTimeout(copyTimeout)
+      copyTimeout = setTimeout(() => {
+        copyBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg><span>复制</span>'
+      }, 2000)
+    }).catch(() => {})
+  })
+  header.appendChild(copyBtn)
+
   const body = document.createElement('div')
-  setClass(body, '[&_.shiki]:!m-0 [&_.shiki]:!rounded-none [&_.shiki]:!bg-transparent [&_.shiki]:overflow-x-auto [&_.shiki]:p-4 [&_.shiki_code]:text-[13px] [&_.shiki_code]:leading-[1.6]')
+  setClass(body, '[&_.shiki]:!m-0 [&_.shiki]:!rounded-none [&_.shiki]:!bg-transparent [&_.shiki]:overflow-x-auto [&_.shiki]:p-4 [&_.shiki_code]:text-[13px] [&_.shiki_code]:leading-[1.6] [&_.shiki_code]:font-mono')
+  body.style.backgroundColor = 'hsl(var(--code-bg))'
 
   dom.appendChild(header)
   dom.appendChild(body)
@@ -230,7 +260,8 @@ function createShikiCodeBlockView(initialNode: ProseMirrorNode, themeRef: ThemeR
 
   const renderFallback = (code: string) => {
     const pre = document.createElement('pre')
-    pre.className = 'm-0 overflow-x-auto p-4 text-[13px] leading-[1.6]'
+    pre.className = 'm-0 overflow-x-auto p-4 text-[13px] leading-[1.6] font-mono'
+    pre.style.backgroundColor = 'hsl(var(--code-bg))'
     const codeEl = document.createElement('code')
     codeEl.textContent = code
     pre.appendChild(codeEl)
@@ -241,7 +272,8 @@ function createShikiCodeBlockView(initialNode: ProseMirrorNode, themeRef: ThemeR
     const currentGeneration = ++generation
     const code = node.textContent
     const language = String(node.attrs.language ?? 'text') || 'text'
-    label.textContent = language === 'text' ? 'Code' : language
+    label.textContent = getDisplayName(language)
+    ;(dom as any).__currentCode = code
 
     const sync = highlightCodeSync({ code, language, theme: themeRef.current })
     if (sync) {
@@ -270,6 +302,7 @@ function createShikiCodeBlockView(initialNode: ProseMirrorNode, themeRef: ThemeR
     },
     destroy() {
       generation += 1
+      if (copyTimeout) clearTimeout(copyTimeout)
     },
     ignoreMutation() {
       return true
@@ -277,7 +310,7 @@ function createShikiCodeBlockView(initialNode: ProseMirrorNode, themeRef: ThemeR
   }
 }
 
-export function createMarkdownImage(fileAccessRef: FileAccessRef): Node {
+export function createMarkdownImage(fileAccessRef: FileAccessRefOrNull): Node {
   return Node.create({
     name: 'markdownImage',
     group: 'block',
@@ -316,7 +349,7 @@ export function createMarkdownImage(fileAccessRef: FileAccessRef): Node {
   })
 }
 
-export function createMarkdownVideo(fileAccessRef: FileAccessRef): Node {
+export function createMarkdownVideo(fileAccessRef: FileAccessRefOrNull): Node {
   return Node.create({
     name: 'markdownVideo',
     group: 'block',
@@ -450,6 +483,20 @@ export const MathInline = Node.create({
   addNodeView() {
     return ({ node }) => createMathView(node, false)
   },
+
+  /**
+   * 输入触发：`$x^2$ ` 末尾空格触发；内层不能含 `$` 或换行。
+   * 匹配到的整段（含 `$..$`）会被替换为节点，尾随空格保留在节点之后。
+   */
+  addInputRules() {
+    return [
+      nodeInputRule({
+        find: /(?:^|[\s(])\$([^$\n]{1,200})\$$/,
+        type: this.type,
+        getAttributes: (match) => ({ latex: match[1] ?? '' }),
+      }),
+    ]
+  },
 })
 
 export const MathBlock = Node.create({
@@ -474,6 +521,20 @@ export const MathBlock = Node.create({
 
   addNodeView() {
     return ({ node }) => createMathView(node, true)
+  },
+
+  /**
+   * 输入触发：在段落首输入 `$$<latex>$$` 后按下一个非 `$` 字符（通常是空格或回车前）触发。
+   * 使用基于行首锚定的规则：`^\$\$([\s\S]+?)\$\$$`。
+   */
+  addInputRules() {
+    return [
+      nodeInputRule({
+        find: /^\$\$([\s\S]+?)\$\$$/,
+        type: this.type,
+        getAttributes: (match) => ({ latex: (match[1] ?? '').trim() }),
+      }),
+    ]
   },
 })
 
@@ -516,49 +577,23 @@ export function createShikiCodeBlock(themeRef: ThemeRef): Node {
   })
 }
 
-export const TaskList = Node.create({
-  name: 'taskList',
-  group: 'block',
-  content: 'taskItem+',
-
-  parseHTML() {
-    return [{ tag: 'ul[data-type="taskList"]' }]
-  },
-
-  renderHTML({ HTMLAttributes }) {
-    return ['ul', mergeAttributes(HTMLAttributes, { 'data-type': 'taskList', class: 'not-prose my-2 space-y-1 pl-0' }), 0]
-  },
+/**
+ * 任务列表 — 使用 @tiptap/extension-task-list / task-item 官方扩展。
+ * 默认 parseHTML 即 `ul[data-type="taskList"]` / `li[data-type="taskItem"]`，
+ * 与 markdown-rich-text.ts 的 enhanceMarkdownHtml 输出一致。
+ *
+ * 官方扩展自带：
+ *  - inputRule `^\s*\[([\sxX])\]\s$`（在 listItem 中输入 `[ ]` 或 `[x]` + 空格 → 转为 taskItem）
+ *  - Enter 拆分 / Tab 缩进 / Shift+Tab 升级
+ *  - checkbox 双向勾选
+ */
+export const TaskList = TaskListExt.configure({
+  HTMLAttributes: { class: 'not-prose my-2 space-y-1 pl-0' },
 })
 
-export const TaskItem = Node.create({
-  name: 'taskItem',
-  content: 'paragraph block*',
-  defining: true,
-
-  addAttributes() {
-    return {
-      checked: {
-        default: false,
-        parseHTML: (element) => element.getAttribute('data-checked') === 'true',
-        renderHTML: (attrs) => ({ 'data-checked': attrs.checked ? 'true' : 'false' }),
-      },
-    }
-  },
-
-  parseHTML() {
-    return [{ tag: 'li[data-type="taskItem"]' }]
-  },
-
-  renderHTML({ node, HTMLAttributes }) {
-    return [
-      'li',
-      mergeAttributes(HTMLAttributes, { 'data-type': 'taskItem', class: 'flex items-start gap-2' }),
-      ['label', { contenteditable: 'false', class: 'mt-[0.2em] inline-flex shrink-0 items-center' },
-        ['input', { type: 'checkbox', checked: node.attrs.checked ? 'checked' : undefined, disabled: 'disabled' }],
-      ],
-      ['div', { class: 'min-w-0 flex-1 [&>*:first-child]:mt-0 [&>*:last-child]:mb-0' }, 0],
-    ]
-  },
+export const TaskItem = TaskItemExt.configure({
+  nested: true,
+  HTMLAttributes: { class: 'flex items-start gap-2' },
 })
 
 export const MarkdownTableBlock = Node.create({

--- a/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
+++ b/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
@@ -3,14 +3,15 @@
  *
  * 基于 TipTap 的轻量 Markdown 编辑器，内容持久化到 ~/.proma/scratch-pad.md。
  * 自动保存由 ScratchPadPersistence 组件通过监听 scratchPadContentAtom 统一管理。
+ *
+ * 支持：Markdown 快捷输入、图片粘贴、Todo 列表（- [ ] 触发）、代码高亮（lowlight）、数学公式（$..$ / $$..$$ 触发）、导出为 Markdown
  */
 
 import * as React from 'react'
 import { useEditor, EditorContent } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import Placeholder from '@tiptap/extension-placeholder'
-import MarkdownIt from 'markdown-it'
-import TurndownService from 'turndown'
+import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
 import { useAtom, useAtomValue } from 'jotai'
 import { FileDown } from 'lucide-react'
 import { scratchPadContentAtom, scratchPadLoadedAtom, tabsAtom, activeTabIdAtom } from '@/atoms/tab-atoms'
@@ -24,9 +25,19 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
 } from '@/components/ui/dropdown-menu'
-
-const md = new MarkdownIt({ breaks: true, linkify: true })
-const turndown = new TurndownService()
+import { lowlight } from '@/lib/lowlight'
+import { htmlToMarkdown, markdownToHtml } from '@/lib/markdown-rich-text'
+import {
+  MarkdownTableBlock,
+  MathBlock,
+  MathInline,
+  RawHtmlBlock,
+  RawHtmlInline,
+  TaskItem,
+  TaskList,
+  createMarkdownImage,
+  createMarkdownVideo,
+} from '@/components/diff/markdown-preview-extensions'
 
 export function ScratchPadView(): React.ReactElement {
   const [content, setContent] = useAtom(scratchPadContentAtom)
@@ -37,21 +48,37 @@ export function ScratchPadView(): React.ReactElement {
   const contentRef = React.useRef(content)
   contentRef.current = content
 
+  const extensions = React.useMemo(() => [
+    StarterKit.configure({
+      heading: { levels: [1, 2, 3] },
+      codeBlock: false, // 用 CodeBlockLowlight 替代：支持 ``` 触发、可编辑、可删除
+    }),
+    Placeholder.configure({
+      placeholder: '在此随意书写… 支持 Markdown 快捷输入',
+    }),
+    CodeBlockLowlight.configure({ lowlight }),
+    // ScratchPad 无会话/文件上下文，传 null 跳过路径解析（仅支持 data-URL / 外链 / file: 协议）
+    createMarkdownImage(null),
+    createMarkdownVideo(null),
+    RawHtmlBlock,
+    RawHtmlInline,
+    MathBlock,
+    MathInline,
+    TaskList,
+    TaskItem,
+    MarkdownTableBlock,
+  ], [])
+
   const editor = useEditor({
-    extensions: [
-      StarterKit.configure({
-        heading: { levels: [1, 2, 3] },
-      }),
-      Placeholder.configure({
-        placeholder: '在此随意书写… 支持 Markdown 快捷输入',
-      }),
-    ],
+    extensions,
     content: content || '',
     onUpdate: ({ editor }) => {
       setContent(editor.getHTML())
     },
     immediatelyRender: false,
   })
+
+  // ===== 导出 =====
 
   // 导出目标上下文
   const workspaces = useAtomValue(agentWorkspacesAtom)
@@ -85,9 +112,9 @@ export function ScratchPadView(): React.ReactElement {
   const handleExport = React.useCallback(
     async (target: 'session' | 'workspace') => {
       if (!editor || editor.isEmpty) return
-      const html = editor.getHTML()
-
-      const markdownContent = turndown.turndown(html)
+      // htmlToMarkdown 能正确处理本编辑器的所有自定义节点（math/task/markdownImage/table 等），
+      // 而通用 turndown 不认识这些 data-type 节点，会丢内容。
+      const markdownContent = htmlToMarkdown(editor.getHTML())
       const filename = makeFilename()
 
       try {
@@ -114,13 +141,15 @@ export function ScratchPadView(): React.ReactElement {
     if (!filePath) return
 
     try {
-      const markdownContent = turndown.turndown(editor.getHTML())
+      const markdownContent = htmlToMarkdown(editor.getHTML())
       // 传空 filename 触发 IPC 的完整路径模式，由 Node.js path.dirname 安全处理
       await window.electronAPI.exportScratchPad(markdownContent, filePath, '')
     } catch (err) {
       console.error('[ScratchPad] 导出失败:', err)
     }
   }, [editor])
+
+  // ===== 内容同步 =====
 
   // 仅在初始加载或编辑器重新挂载时同步内容到编辑器。
   // content 不加入 deps：用户每次输入都会更新 atom，若加入 deps 会导致
@@ -135,20 +164,45 @@ export function ScratchPadView(): React.ReactElement {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loaded, editor])
 
-  // 粘贴时自动将 Markdown 转为 HTML 插入
+  // ===== 粘贴处理 =====
+
+  // 粘贴时：图片转 data URL 插入；含 markdown 标记的文本走 markdownToHtml 转 HTML 注入
   React.useEffect(() => {
     const el = containerRef.current
     if (!el || !editor) return
 
     const handlePaste = (e: ClipboardEvent): void => {
+      // 检测剪贴板中的图片
+      const items = e.clipboardData?.items
+      if (items) {
+        for (const item of items) {
+          if (item.type.startsWith('image/')) {
+            e.preventDefault()
+            e.stopPropagation()
+            const file = item.getAsFile()
+            if (!file) return
+            const reader = new FileReader()
+            reader.onload = () => {
+              editor.chain().focus().insertContent({
+                type: 'markdownImage',
+                attrs: { src: reader.result as string, alt: '', title: '' },
+              }).run()
+            }
+            reader.readAsDataURL(file)
+            return
+          }
+        }
+      }
+
       const text = e.clipboardData?.getData('text/plain')
       if (!text) return
-      if (!/[#*>\-`[\]~|]/.test(text)) return
+      // markdown 触发字符：#标题 *强调 >引用 -列表 `代码 [链接 ~删除 |表格 $公式
+      if (!/[#*>\-`[\]~|$]/.test(text)) return
 
       e.preventDefault()
       e.stopPropagation()
       try {
-        const html = md.render(text)
+        const html = markdownToHtml(text)
         editor.chain().focus().insertContent(html).run()
       } catch {
         // 转换失败，回退到纯文本插入

--- a/apps/electron/src/renderer/lib/lowlight.ts
+++ b/apps/electron/src/renderer/lib/lowlight.ts
@@ -1,0 +1,10 @@
+/**
+ * 共享 lowlight 单例。
+ *
+ * 任何使用 `@tiptap/extension-code-block-lowlight` 的 TipTap 编辑器都应从这里 import，
+ * 避免重复创建实例并加载相同的语法包。
+ */
+
+import { common, createLowlight } from 'lowlight'
+
+export const lowlight = createLowlight(common)

--- a/bun.lock
+++ b/bun.lock
@@ -5,9 +5,7 @@
     "": {
       "name": "proma",
       "dependencies": {
-        "@types/turndown": "^5.0.6",
         "jotai": "^2.17.1",
-        "turndown": "^7.2.4",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -63,6 +61,8 @@
         "@tiptap/extension-link": "^3.19.0",
         "@tiptap/extension-mention": "^3.19.0",
         "@tiptap/extension-placeholder": "^3.19.0",
+        "@tiptap/extension-task-item": "3.19.0",
+        "@tiptap/extension-task-list": "3.19.0",
         "@tiptap/extension-underline": "^3.19.0",
         "@tiptap/pm": "^3.19.0",
         "@tiptap/react": "^3.19.0",
@@ -338,8 +338,6 @@
     "@malept/cross-spawn-promise": ["@malept/cross-spawn-promise@2.0.0", "", { "dependencies": { "cross-spawn": "^7.0.1" } }, "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg=="],
 
     "@malept/flatpak-bundler": ["@malept/flatpak-bundler@0.4.0", "", { "dependencies": { "debug": "^4.1.1", "fs-extra": "^9.0.0", "lodash": "^4.17.15", "tmp-promise": "^3.0.2" } }, "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q=="],
-
-    "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
@@ -625,6 +623,10 @@
 
     "@tiptap/extension-strike": ["@tiptap/extension-strike@3.19.0", "", { "peerDependencies": { "@tiptap/core": "^3.19.0" } }, "sha512-xYpabHsv7PccLUBQaP8AYiFCnYbx6P93RHPd0lgNwhdOjYFd931Zy38RyoxPHAgbYVmhf1iyx7lpuLtBnhS5dA=="],
 
+    "@tiptap/extension-task-item": ["@tiptap/extension-task-item@3.19.0", "", { "peerDependencies": { "@tiptap/extension-list": "^3.19.0" } }, "sha512-1il70SoaoEA5jKr2QS30CpZoB7EzdSLugROMBPRUPc0feIBKAf6yUPhxlFyU4ez/uT4Pazsf1HAgHI3AOr+MtQ=="],
+
+    "@tiptap/extension-task-list": ["@tiptap/extension-task-list@3.19.0", "", { "peerDependencies": { "@tiptap/extension-list": "^3.19.0" } }, "sha512-Slb6YZi7XpVT966oAJhqzZu4LVuHtUeZgMxA0bdc8FSZBxntcr8OQWmPbqvR437RAR/Xd7b5quXS3JmSeksyvA=="],
+
     "@tiptap/extension-text": ["@tiptap/extension-text@3.19.0", "", { "peerDependencies": { "@tiptap/core": "^3.19.0" } }, "sha512-K95+SnbZy0h6hNFtfy23n8t/nOcTFEf69In9TSFVVmwn/Nwlke+IfiESAkqbt1/7sKJeegRXYO7WzFEmFl9Q/g=="],
 
     "@tiptap/extension-underline": ["@tiptap/extension-underline@3.19.0", "", { "peerDependencies": { "@tiptap/core": "^3.19.0" } }, "sha512-800MGEWfG49j10wQzAFiW/ele1HT04MamcL8iyuPNu7ZbjbGN2yknvdrJlRy7hZlzIrVkZMr/1tz62KN33VHIw=="],
@@ -702,8 +704,6 @@
     "@types/responselike": ["@types/responselike@1.0.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
-
-    "@types/turndown": ["@types/turndown@5.0.6", "", {}, "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
@@ -1984,8 +1984,6 @@
     "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "turndown": ["turndown@7.2.4", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ=="],
 
     "type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@types/node": "^20.0.0",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
-    "@types/turndown": "^5.0.6",
     "dompurify": "^3.4.2",
     "typescript": "^5.0.0"
   },
@@ -31,7 +30,6 @@
     "typescript": "^5"
   },
   "dependencies": {
-    "jotai": "^2.17.1",
-    "turndown": "^7.2.4"
+    "jotai": "^2.17.1"
   }
 }

--- a/packages/core/src/highlight/index.ts
+++ b/packages/core/src/highlight/index.ts
@@ -5,6 +5,7 @@
  */
 
 export {
+  getDisplayName,
   highlightCode,
   highlightCodeSync,
   highlightToTokens,

--- a/packages/core/src/highlight/shiki-service.ts
+++ b/packages/core/src/highlight/shiki-service.ts
@@ -68,6 +68,31 @@ export interface HighlightResult {
   language: string
 }
 
+/** 不规则语言显示名称（无法通过首字母大写自动生成） */
+const DISPLAY_NAMES: Record<string, string> = {
+  js: 'JavaScript', javascript: 'JavaScript',
+  ts: 'TypeScript', typescript: 'TypeScript',
+  tsx: 'TSX', jsx: 'JSX',
+  py: 'Python', rb: 'Ruby',
+  cpp: 'C++', 'c++': 'C++',
+  cs: 'C#', csharp: 'C#',
+  kt: 'Kotlin', rs: 'Rust',
+  sh: 'Shell', zsh: 'Shell',
+  yml: 'YAML', md: 'Markdown',
+  tf: 'Terraform',
+  html: 'HTML', css: 'CSS', scss: 'SCSS', less: 'LESS',
+  json: 'JSON', xml: 'XML', sql: 'SQL',
+  graphql: 'GraphQL', php: 'PHP',
+  plaintext: 'Text', text: 'Text',
+}
+
+/** 获取语言显示名称，未匹配的自动首字母大写 */
+export function getDisplayName(lang: string): string {
+  if (!lang) return 'Code'
+  const key = lang.toLowerCase()
+  return DISPLAY_NAMES[key] ?? key.charAt(0).toUpperCase() + key.slice(1)
+}
+
 /** 单个高亮 token */
 export interface HighlightToken {
   /** 文本内容 */

--- a/packages/ui/src/code-block/CodeBlock.tsx
+++ b/packages/ui/src/code-block/CodeBlock.tsx
@@ -20,7 +20,7 @@
  */
 
 import * as React from 'react'
-import { highlightCode, highlightToTokens } from '@proma/core'
+import { getDisplayName, highlightCode, highlightToTokens } from '@proma/core'
 import type { HighlightToken, HighlightTokensResult } from '@proma/core'
 
 /** react-markdown 传入的 <code> 元素 props */
@@ -69,34 +69,6 @@ function extractCodeInfo(children: React.ReactNode): { language: string; code: s
     language: langMatch?.[1] ?? '',
     code: extractText(props.children),
   }
-}
-
-/**
- * 不规则语言显示名称（无法通过首字母大写自动生成的）
- * 其余语言自动 capitalize 首字母
- */
-const DISPLAY_NAMES: Record<string, string> = {
-  js: 'JavaScript', javascript: 'JavaScript',
-  ts: 'TypeScript', typescript: 'TypeScript',
-  tsx: 'TSX', jsx: 'JSX',
-  py: 'Python', rb: 'Ruby',
-  cpp: 'C++', 'c++': 'C++',
-  cs: 'C#', csharp: 'C#',
-  kt: 'Kotlin', rs: 'Rust',
-  sh: 'Shell', zsh: 'Shell',
-  yml: 'YAML', md: 'Markdown',
-  tf: 'Terraform',
-  html: 'HTML', css: 'CSS', scss: 'SCSS', less: 'LESS',
-  json: 'JSON', xml: 'XML', sql: 'SQL',
-  graphql: 'GraphQL', php: 'PHP',
-  plaintext: 'Text', text: 'Text',
-}
-
-/** 获取语言显示名称，未匹配的自动首字母大写 */
-function getDisplayName(lang: string): string {
-  if (!lang) return 'Code'
-  const key = lang.toLowerCase()
-  return DISPLAY_NAMES[key] ?? key.charAt(0).toUpperCase() + key.slice(1)
 }
 
 // ===== SVG 图标路径常量 =====


### PR DESCRIPTION
## Summary

ScratchPad（草稿板）现在能正确渲染并编辑代码块、Todo 任务、数学公式，并补齐自定义节点的导出能力。

- **代码块**：用 `CodeBlockLowlight` 替换之前的 Shiki NodeView，恢复 ` ``` ` 触发、可编辑、可删除（之前 NodeView 用 `contentEditable=false` 导致整块无法编辑）。
- **Todo**：接入 `@tiptap/extension-task-list` / `extension-task-item` 官方扩展，`- [ ] ` 输入触发、Enter 续行、Tab 缩进、勾选切换全部恢复。
- **数学公式**：`MathInline` / `MathBlock` 加入 `addInputRules`，`$x^2$ ` 与行首 `$$..$$` 自动触发 KaTeX 渲染。
- **粘贴 markdown**：ScratchPad 之前用自己实例化的 `MarkdownIt`，缺少 task/math/table 增强；统一改走 `markdownToHtml`，所有自定义节点正确生成。
- **导出**：之前用 `turndown.turndown(html)` 导出 markdown，遇到我们的 `data-type="math-block"` 等自定义节点会丢失；改成 `htmlToMarkdown`（已知所有节点的反向序列化）。同时移除根 `package.json` 的 `turndown` / `@types/turndown` 依赖。

### 复用 / 重构收尾

- `packages/core/src/highlight/shiki-service.ts` 新增 `getDisplayName(lang)`，统一 UI（`packages/ui/src/code-block/CodeBlock.tsx`）和渲染层（`markdown-preview-extensions.tsx`）的语言名映射。
- 新增 `apps/electron/src/renderer/lib/lowlight.ts` 单例，`rich-text-input.tsx` 与 `ScratchPadView.tsx` 共享，避免重复加载语法包。
- `createMarkdownImage` / `createMarkdownVideo` 参数从 `FileAccessRef` 扩成 `FileAccessRef | null`，`null` 表示当前编辑器无会话/文件上下文（ScratchPad 即此场景），干掉 `useRef(undefined)` 这种 hack。

## Test plan

- [ ] 在草稿板输入 ` ```ts ` 触发代码块，输入代码后可编辑、可整块删除
- [ ] 输入 `- [ ] task` 触发 Todo，勾选状态可切换；Enter 续行、Tab 缩进生效
- [ ] 输入 `$E=mc^2$ ` 触发行内公式；行首 `$$\int_0^\infty e^{-x^2}\,dx$$` 触发块级公式
- [ ] 粘贴含 task list / 表格 / 公式 / 代码块的 markdown，各节点正确渲染
- [ ] 粘贴截图（Cmd+Shift+5 后 Ctrl+V），图片以 data-URL 插入
- [ ] 打开 chat 输入框，确认代码块依然按之前体验工作（共享 lowlight）
- [ ] 导出为 markdown（会话/工作区/浏览选择），打开导出文件确认 task `[x]` / `$$..$$` / ``` 代码块 等都保留
- [ ] `bun run typecheck` 全绿（已在本机验证）

🤖 Generated with [Claude Code](https://claude.com/claude-code)