### PR TITLE
feat(preview): replace unpreviewable inline errors with toast notifications

### DIFF
--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -10,6 +10,7 @@ import { Code2, Copy, Check, Eye, Pencil, RefreshCw, Save, X } from 'lucide-reac
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import DOMPurify from 'dompurify'
 import { File as PierreFile } from '@pierre/diffs/react'
+import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
 import { agentDiffViewModeAtom, agentDiffRefreshVersionAtom } from '@/atoms/agent-atoms'
 import { resolvedThemeAtom } from '@/atoms/theme'
@@ -200,12 +201,12 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     setImageDataUrl('')
     setImageZoom(0.25)
     setImageNaturalSize({ w: 0, h: 0 })
-    setLoading(true)
+    setLoading(!isLegacyOffice)
     setMarkdownEditing(false)
     setMarkdownSourceMode(false)
     setMarkdownDraft('')
     setMarkdownSaving(false)
-  }, [filePath, sessionId, previewOnly])
+  }, [filePath, sessionId, previewOnly, isLegacyOffice])
 
   // non-passive wheel listener for pinch-to-zoom on image
   React.useEffect(() => {
@@ -266,7 +267,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
       setLoading(false)
       return // 缓存命中，直接返回，不执行 load()
     } else {
-      setLoading(true)
+      if (!isLegacyOffice) setLoading(true)
       setOldContent('')
       setNewContent('')
       setDocxHtml('')
@@ -411,6 +412,30 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
       onEmptyDiff?.()
     }
   }, [previewOnly, loading, oldContent, newContent, onEmptyDiff])
+
+  // previewOnly 模式：加载完成后若内容无法预览，弹 Toast 通知用户
+  const toastedPreviewFailRef = React.useRef('')
+  React.useEffect(() => {
+    if (!previewOnly || loading) return
+    const key = `${filePath}:${ext}`
+    if (toastedPreviewFailRef.current === key) return
+    let message: string | null = null
+    if (isLegacyOffice) {
+      message = `暂不支持 ${ext.toUpperCase().slice(1)} 格式内联预览`
+    } else if (isPdf && !pdfSrc) {
+      message = 'PDF 文件过大，无法在此预览'
+    } else if (isDocx && !docxHtml) {
+      message = '无法加载 DOCX 预览'
+    } else if (isOfficePreview && !officeHtml) {
+      message = `无法加载 ${ext === '.pptx' ? 'PPTX' : 'Excel'} 预览`
+    } else if (isImage && !imageDataUrl) {
+      message = '图片文件过大，无法在此预览'
+    }
+    if (message) {
+      toastedPreviewFailRef.current = key
+      toast.warning(message)
+    }
+  }, [previewOnly, loading, filePath, ext, isLegacyOffice, isPdf, pdfSrc, isDocx, docxHtml, isOfficePreview, officeHtml, isImage, imageDataUrl])
 
   // scrollPosition persistent: module-level Map keyed by sessionId:filePath
   // content changes (refreshVersion bump) → delete stored position;
@@ -633,12 +658,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
                   title={filePath.split('/').pop() || 'PDF'}
                 />
               </div>
-            ) : (
-              <div className="flex flex-col items-center justify-center h-full text-muted-foreground text-[12px] gap-1 px-4 text-center">
-                <p>该 PDF 文件过大，无法在此预览</p>
-                <p className="text-[11px] text-muted-foreground/60">请在系统中打开查看</p>
-              </div>
-            )
+            ) : null
           ) : isImage ? (
             imageDataUrl ? (
               <div className="relative h-full">
@@ -694,42 +714,22 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
                   </div>
                 </div>
               </div>
-            ) : (
-              <div className="flex flex-col items-center justify-center h-full text-muted-foreground text-[12px] gap-1 px-4 text-center">
-                {imagePath ? <p>加载中...</p> : (
-                  <>
-                    <p>该图片文件过大，无法在此预览</p>
-                    <p className="text-[11px] text-muted-foreground/60">请在系统中打开查看</p>
-                  </>
-                )}
-              </div>
-            )
+            ) : null
           ) : isDocx ? (
             docxHtml ? (
               <div
                 className="prose prose-sm dark:prose-invert max-w-none px-4 py-3"
                 dangerouslySetInnerHTML={{ __html: docxHtml }}
               />
-            ) : (
-              <div className="flex items-center justify-center h-full text-muted-foreground text-[12px]">无法加载 DOCX</div>
-            )
+            ) : null
           ) : isOfficePreview ? (
             officeHtml ? (
               <div
                 className="office-preview-host"
                 dangerouslySetInnerHTML={{ __html: officeHtml }}
               />
-            ) : (
-              <div className="flex items-center justify-center h-full text-muted-foreground text-[12px]">
-                无法加载 {ext === '.pptx' ? 'PPTX' : 'Excel'} 预览
-              </div>
-            )
-          ) : isLegacyOffice ? (
-            <div className="flex flex-col items-center justify-center h-full text-muted-foreground text-[12px] gap-1 px-4 text-center">
-              <p>暂不支持旧版 {ext.toUpperCase().slice(1)} 内联预览</p>
-              <p className="text-[11px] text-muted-foreground/60">请在系统中打开，或转换为 {ext === '.xls' ? 'XLSX' : ext === '.ppt' ? 'PPTX' : 'DOCX'} 后预览</p>
-            </div>
-          ) : isMarkdown ? (
+            ) : null
+          ) : isLegacyOffice ? null : isMarkdown ? (
             markdownEditing && markdownSourceMode ? (
               <textarea
                 value={markdownDraft}


### PR DESCRIPTION
## Summary

- **旧版 Office** (`.doc/.xls/.ppt`)：跳过 loading 状态（不触发 spinner），通过 `toast.warning` 告知用户不支持内联预览，预览区保持空白
- **PDF 过大 / DOCX 失败 / Office 失败 / 图片过大**：加载完成后若内容为空，统一弹 Toast 通知，移除原先闪出的 inline 错误 div
- 用 `toastedPreviewFailRef` 防止同一文件重复弹 Toast

## 改动细节

1. 添加 `import { toast } from 'sonner'`
2. reset effect 中 `isLegacyOffice` 时跳过 `setLoading(true)`，避免 spinner 一闪
3. 主加载 effect 的 else 分支同样跳过 `isLegacyOffice` 的 loading 状态
4. 新增统一 toast effect，覆盖全部不可预览场景
5. 5 处 inline 错误 div → `null`

## Test plan

- [ ] 打开 `.doc/.xls/.ppt` 文件：预览区空白 + 顶部 warning toast，无 spinner 闪烁
- [ ] 打开超大 PDF：加载后显示 toast 提示，预览区空白
- [ ] 切换多个不可预览文件：每文件只弹一次 toast，不重复

🤖 Generated with [Claude Code](https://claude.com/claude-code)