### PR TITLE
@

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -36,7 +36,6 @@ app.on('second-instance', (_event, argv) => {
 })
 
 import { getSettings } from './lib/settings-service'
-import { resolveOverlayColors } from './lib/titlebar-overlay'
 import { handlePromaFileRequest } from './lib/local-file-protocol'
 
 // 处理 EPIPE 错误：当 stdout/stderr 管道被关闭时（如 electronmon 重启），忽略写入错误
@@ -233,17 +232,7 @@ function createWindow(): void {
         visualEffectState: 'followWindow' as const,
       }
     : isWindows
-      ? (() => {
-          const settings = getSettings()
-          return {
-            titleBarStyle: 'hidden' as const,
-            titleBarOverlay: resolveOverlayColors(
-              settings.themeMode,
-              settings.themeStyle,
-              nativeTheme.shouldUseDarkColors
-            ),
-          }
-        })()
+      ? { titleBarStyle: 'hidden' as const }
       : {}
 
   mainWindow = new BrowserWindow({

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -146,7 +146,7 @@ import { getTutorialContent, createWelcomeConversation } from './lib/tutorial-se
 import { getUserProfile, updateUserProfile } from './lib/user-profile-service'
 import { getSettings, updateSettings } from './lib/settings-service'
 import { setDockBadgeCount } from './lib/dock-badge-service'
-import { updateWindowTitleBarOverlay } from './lib/titlebar-overlay'
+
 import { checkEnvironment } from './lib/environment-checker'
 import { fetchInstallerManifest, findInstallerSource } from './lib/installer-manifest'
 import {
@@ -958,8 +958,6 @@ export function registerIpcHandlers(): void {
           if (win.webContents.id !== event.sender.id) {
             win.webContents.send(SETTINGS_IPC_CHANNELS.ON_THEME_SETTINGS_CHANGED, payload)
           }
-          // Windows: 更新标题栏 overlay 颜色
-          updateWindowTitleBarOverlay(win)
         })
       }
 
@@ -995,12 +993,6 @@ export function registerIpcHandlers(): void {
     BrowserWindow.getAllWindows().forEach((win) => {
       win.webContents.send(SETTINGS_IPC_CHANNELS.ON_SYSTEM_THEME_CHANGED, isDark)
     })
-    // Windows: system 模式下同步更新标题栏 overlay
-    if (process.platform === 'win32' && getSettings().themeMode === 'system') {
-      BrowserWindow.getAllWindows().forEach((win) => {
-        updateWindowTitleBarOverlay(win)
-      })
-    }
   })
 
   // ===== Scratch Pad 持久化 =====
@@ -3464,4 +3456,40 @@ export function registerIpcHandlers(): void {
     })
     return result.canceled ? null : result.filePath
   })
+
+  // ===== 窗口控制（Windows 自定义标题栏按钮）=====
+
+  ipcMain.handle(
+    IPC_CHANNELS.WINDOW_MINIMIZE,
+    async (event) => {
+      const win = BrowserWindow.fromWebContents(event.sender)
+      if (win && !win.isDestroyed()) win.minimize()
+    }
+  )
+
+  ipcMain.handle(
+    IPC_CHANNELS.WINDOW_MAXIMIZE,
+    async (event) => {
+      const win = BrowserWindow.fromWebContents(event.sender)
+      if (win && !win.isDestroyed()) {
+        win.isMaximized() ? win.unmaximize() : win.maximize()
+      }
+    }
+  )
+
+  ipcMain.handle(
+    IPC_CHANNELS.WINDOW_CLOSE,
+    async (event) => {
+      const win = BrowserWindow.fromWebContents(event.sender)
+      if (win && !win.isDestroyed()) win.close()
+    }
+  )
+
+  ipcMain.handle(
+    IPC_CHANNELS.WINDOW_IS_MAXIMIZED,
+    async (event) => {
+      const win = BrowserWindow.fromWebContents(event.sender)
+      return win && !win.isDestroyed() ? win.isMaximized() : false
+    }
+  )
 }

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -171,6 +171,19 @@ export interface ElectronAPI {
   /** 在系统默认浏览器中打开外部链接 */
   openExternal: (url: string) => Promise<void>
 
+  // ===== 窗口控制（Windows 自定义标题栏）=====
+
+  /** 最小化窗口 */
+  windowMinimize: () => Promise<void>
+  /** 最大化/还原窗口 */
+  windowMaximize: () => Promise<void>
+  /** 关闭窗口 */
+  windowClose: () => Promise<void>
+  /** 窗口是否处于最大化状态 */
+  windowIsMaximized: () => Promise<boolean>
+  /** 订阅窗口最大化/还原事件 */
+  onWindowResize: (callback: () => void) => () => void
+
   // ===== 渠道管理相关 =====
 
   /** 获取所有渠道列表（apiKey 保持加密态） */
@@ -1004,6 +1017,29 @@ const electronAPI: ElectronAPI = {
   // 通用工具
   openExternal: (url: string) => {
     return ipcRenderer.invoke(IPC_CHANNELS.OPEN_EXTERNAL, url)
+  },
+
+  // 窗口控制
+  windowMinimize: () => {
+    return ipcRenderer.invoke(IPC_CHANNELS.WINDOW_MINIMIZE)
+  },
+
+  windowMaximize: () => {
+    return ipcRenderer.invoke(IPC_CHANNELS.WINDOW_MAXIMIZE)
+  },
+
+  windowClose: () => {
+    return ipcRenderer.invoke(IPC_CHANNELS.WINDOW_CLOSE)
+  },
+
+  windowIsMaximized: () => {
+    return ipcRenderer.invoke(IPC_CHANNELS.WINDOW_IS_MAXIMIZED)
+  },
+
+  onWindowResize: (callback: () => void) => {
+    const handler = (): void => callback()
+    window.addEventListener('resize', handler)
+    return () => window.removeEventListener('resize', handler)
   },
 
   // 渠道管理

--- a/apps/electron/src/renderer/components/WindowControls.tsx
+++ b/apps/electron/src/renderer/components/WindowControls.tsx
@@ -1,0 +1,71 @@
+/**
+ * WindowControls - Windows 自定义窗口控制按钮（最小化/最大化/关闭）
+ * 仅 Windows 平台渲染，替换 Electron 原生 titleBarOverlay 按钮。
+ */
+
+import * as React from 'react'
+import { detectIsWindows } from '@/lib/platform'
+
+export function WindowControls(): React.ReactElement | null {
+  const isWindows = React.useMemo(() => detectIsWindows(), [])
+  const [isMaximized, setIsMaximized] = React.useState(false)
+
+  // 初始化最大化状态并监听窗口 resize 事件
+  React.useEffect(() => {
+    if (!isWindows) return
+    window.electronAPI.windowIsMaximized().then(setIsMaximized)
+    const unsub = window.electronAPI.onWindowResize(() => {
+      window.electronAPI.windowIsMaximized().then(setIsMaximized)
+    })
+    return unsub
+  }, [isWindows])
+
+  if (!isWindows) return null
+
+  return (
+    <div className="window-controls fixed top-[8px] right-[8px] z-[100] flex select-none">
+      {/* 最小化 */}
+      <button
+        type="button"
+        className="window-control-btn"
+        aria-label="最小化"
+        onClick={() => window.electronAPI.windowMinimize()}
+      >
+        <svg width="12" height="12" viewBox="0 0 12 12">
+          <rect x="1" y="5.5" width="10" height="1" fill="currentColor" />
+        </svg>
+      </button>
+
+      {/* 最大化/还原 */}
+      <button
+        type="button"
+        className="window-control-btn"
+        aria-label={isMaximized ? '还原' : '最大化'}
+        onClick={() => window.electronAPI.windowMaximize()}
+      >
+        {isMaximized ? (
+          <svg width="12" height="12" viewBox="0 0 12 12">
+            <rect x="3" y="0.5" width="8" height="8" rx="0.5" fill="none" stroke="currentColor" strokeWidth="1" />
+            <rect x="1" y="3.5" width="8" height="8" rx="0.5" fill="currentColor" stroke="currentColor" strokeWidth="1" />
+          </svg>
+        ) : (
+          <svg width="12" height="12" viewBox="0 0 12 12">
+            <rect x="1.5" y="1.5" width="9" height="9" rx="1" fill="none" stroke="currentColor" strokeWidth="1" />
+          </svg>
+        )}
+      </button>
+
+      {/* 关闭 */}
+      <button
+        type="button"
+        className="window-control-btn window-control-close"
+        aria-label="关闭"
+        onClick={() => window.electronAPI.windowClose()}
+      >
+        <svg width="12" height="12" viewBox="0 0 12 12">
+          <path d="M1.5 1.5l9 9M10.5 1.5l-9 9" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+        </svg>
+      </button>
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/electron/src/renderer/components/app-shell/AppShell.tsx
@@ -14,6 +14,7 @@ import { MainArea } from '@/components/tabs/MainArea'
 import { AppShellProvider, type AppShellContextType } from '@/contexts/AppShellContext'
 import { appModeAtom } from '@/atoms/app-mode'
 import { agentSidePanelWidthAtom, currentAgentSessionIdAtom, currentSessionSidePanelOpenAtom } from '@/atoms/agent-atoms'
+import { WindowControls } from '@/components/WindowControls'
 import { cn } from '@/lib/utils'
 
 const MIN_RIGHT_PANEL_WIDTH = 220
@@ -78,6 +79,9 @@ export function AppShell({ contextValue }: AppShellProps): React.ReactElement {
     <AppShellProvider value={contextValue}>
       {/* 可拖动标题栏区域，用于窗口拖动 */}
       <div className="titlebar-drag-region fixed top-0 left-0 right-0 h-[50px] z-50" />
+
+      {/* Windows 自定义窗口控制按钮（最小化/最大化/关闭） */}
+      <WindowControls />
 
       <div className="shell-bg h-screen w-screen flex overflow-hidden bg-gradient-to-br from-zinc-50 to-zinc-100 dark:from-zinc-950 dark:to-zinc-900">
         {/* 左侧边栏：可折叠，带圆角和内边距 */}

--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -236,7 +236,7 @@ function TabBarInner({
 
       <div
         ref={scrollRef}
-        className={cn("relative flex items-end flex-1 min-w-0 overflow-x-auto scrollbar-none titlebar-drag-region", isWindows && "pr-[140px]")}
+        className={cn("relative flex items-end flex-1 min-w-0 overflow-x-auto scrollbar-none titlebar-drag-region", isWindows && "pr-[112px]")}
       >
         {tabs.map((tab) => (
           <TabBarItem

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -326,6 +326,47 @@
   app-region: drag;
 }
 
+/* Windows 自定义窗口控制按钮 */
+.window-controls {
+  height: 28px;
+  gap: 1px;
+}
+
+.window-control-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 28px;
+  border-radius: 4px;
+  color: hsl(var(--muted-foreground));
+  background: transparent;
+  border: none;
+  cursor: default;
+  transition: background-color 0.15s ease, color 0.15s ease;
+  -webkit-app-region: no-drag;
+  app-region: no-drag;
+}
+
+.window-control-btn:hover {
+  background-color: hsl(var(--muted) / 0.35);
+  color: hsl(var(--foreground));
+}
+
+.window-control-btn:active {
+  background-color: hsl(var(--muted) / 0.5);
+}
+
+.window-control-close:hover {
+  background-color: #c42b1c;
+  color: #fff;
+}
+
+.window-control-close:active {
+  background-color: #a01d11;
+  color: #fff;
+}
+
 /* 深色特殊主题 dialog 光晕效果 */
 .theme-ocean-dark [data-radix-dialog-content],
 .theme-forest-dark [data-radix-dialog-content],

--- a/packages/shared/src/types/runtime.ts
+++ b/packages/shared/src/types/runtime.ts
@@ -334,6 +334,14 @@ export const IPC_CHANNELS = {
   OPEN_DETACHED_PREVIEW: 'preview:open-detached',
   /** 获取独立预览窗口数据 */
   GET_DETACHED_PREVIEW_DATA: 'preview:get-detached-data',
+  /** 最小化窗口 */
+  WINDOW_MINIMIZE: 'window:minimize',
+  /** 最大化/还原窗口 */
+  WINDOW_MAXIMIZE: 'window:maximize',
+  /** 关闭窗口 */
+  WINDOW_CLOSE: 'window:close',
+  /** 窗口是否最大化 */
+  WINDOW_IS_MAXIMIZED: 'window:is-maximized',
 } as const
 
 /**


### PR DESCRIPTION
feat: replace native Windows titleBarOverlay with custom-styled buttons

Replace Electron native titleBarOverlay buttons with a custom React component (WindowControls) that matches the app design. The native buttons looked out of place against the custom dark theme.

- Add window control IPC channels and handlers (min/max/close/isMaximized)
- Create WindowControls component with SVG icons and subtle hover states
- Remove titleBarOverlay config and legacy overlay color update calls
- Adjust TabBar right padding to fit the narrower custom buttons


@