### PR TITLE
fix(windows): support Node.js/Git detection on non-C drives

### DIFF
--- a/apps/electron/src/main/lib/git-bash-detector.ts
+++ b/apps/electron/src/main/lib/git-bash-detector.ts
@@ -16,16 +16,41 @@ import { execSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import type { GitBashStatus } from '@proma/shared'
+import { getGitForWindowsInstallPath } from './windows-env'
 
 /**
  * Git for Windows 常见安装路径
  */
-const COMMON_GIT_BASH_PATHS = [
-  'C:\\Program Files\\Git\\bin\\bash.exe',
-  'C:\\Program Files (x86)\\Git\\bin\\bash.exe',
-  'C:\\Program Files\\Git\\usr\\bin\\bash.exe',
-  'C:\\Program Files (x86)\\Git\\usr\\bin\\bash.exe',
-]
+const COMMON_GIT_BASH_PATHS: string[] = (() => {
+  const paths: string[] = []
+  const scoop = process.env.SCOOP
+  const localAppData = process.env.LOCALAPPDATA
+  const programFiles = process.env.ProgramFiles || 'C:\\Program Files'
+
+  // 包管理器安装位置（优先检测）
+  if (scoop) {
+    paths.push(
+      join(scoop, 'apps', 'git', 'current', 'bin', 'bash.exe'),
+      join(scoop, 'apps', 'git', 'current', 'usr', 'bin', 'bash.exe'),
+    )
+  }
+  if (localAppData) {
+    paths.push(
+      join(localAppData, 'scoop', 'apps', 'git', 'current', 'bin', 'bash.exe'),
+      join(localAppData, 'scoop', 'apps', 'git', 'current', 'usr', 'bin', 'bash.exe'),
+    )
+  }
+
+  // 官方安装器默认位置
+  paths.push(
+    join(programFiles, 'Git', 'bin', 'bash.exe'),
+    'C:\\Program Files (x86)\\Git\\bin\\bash.exe',
+    join(programFiles, 'Git', 'usr', 'bin', 'bash.exe'),
+    'C:\\Program Files (x86)\\Git\\usr\\bin\\bash.exe',
+  )
+
+  return paths
+})()
 
 /**
  * 验证 bash.exe 路径并获取版本
@@ -56,52 +81,6 @@ function verifyBashPath(bashPath: string): string | null {
   } catch {
     return null
   }
-}
-
-/**
- * 从注册表读取 Git for Windows 安装路径
- *
- * @returns Git 安装根目录路径，失败返回 null
- */
-function getGitInstallPathFromRegistry(): string | null {
-  try {
-    // 尝试从 HKLM（系统级安装）读取
-    const hklmOutput = execSync(
-      'reg query "HKLM\\SOFTWARE\\GitForWindows" /v InstallPath',
-      {
-        encoding: 'utf-8',
-        timeout: 5000,
-        stdio: ['pipe', 'pipe', 'pipe'],
-      },
-    )
-
-    // 解析注册表输出（示例："InstallPath    REG_SZ    C:\Program Files\Git"）
-    const pathMatch = hklmOutput.match(/InstallPath\s+REG_SZ\s+(.+)/)
-    if (pathMatch?.[1]) {
-      return pathMatch[1].trim()
-    }
-  } catch {
-    // HKLM 失败，尝试 HKCU（用户级安装）
-    try {
-      const hkcuOutput = execSync(
-        'reg query "HKCU\\SOFTWARE\\GitForWindows" /v InstallPath',
-        {
-          encoding: 'utf-8',
-          timeout: 5000,
-          stdio: ['pipe', 'pipe', 'pipe'],
-        },
-      )
-
-      const pathMatch = hkcuOutput.match(/InstallPath\s+REG_SZ\s+(.+)/)
-      if (pathMatch?.[1]) {
-        return pathMatch[1].trim()
-      }
-    } catch {
-      // 注册表读取失败
-    }
-  }
-
-  return null
 }
 
 /**
@@ -170,7 +149,7 @@ export async function detectGitBash(): Promise<GitBashStatus> {
   }
 
   // 策略 2：从注册表读取安装路径
-  const gitInstallPath = getGitInstallPathFromRegistry()
+  const gitInstallPath = getGitForWindowsInstallPath()
   if (gitInstallPath) {
     const candidatePaths = [
       join(gitInstallPath, 'bin', 'bash.exe'),

--- a/apps/electron/src/main/lib/git-detector.ts
+++ b/apps/electron/src/main/lib/git-detector.ts
@@ -6,7 +6,9 @@
 
 import { execSync, spawnSync } from 'child_process'
 import { existsSync } from 'fs'
+import { join } from 'path'
 import type { GitRuntimeStatus, GitRepoStatus } from '@proma/shared'
+import { getGitForWindowsInstallPath } from './windows-env'
 
 /**
  * 从系统 PATH 查找 Git
@@ -32,13 +34,50 @@ function findGitPath(): string | null {
     // Git 未安装
   }
 
-  // Windows 上额外检查常见安装位置
+  // Windows 上额外检查其他安装位置
   if (process.platform === 'win32') {
-    const commonPaths = [
-      'C:\\Program Files\\Git\\cmd\\git.exe',
+    const commonPaths: string[] = []
+
+    // 从注册表读取 Git for Windows 安装路径
+    const regInstallPath = getGitForWindowsInstallPath()
+    if (regInstallPath) {
+      commonPaths.push(
+        join(regInstallPath, 'cmd', 'git.exe'),
+        join(regInstallPath, 'bin', 'git.exe'),
+      )
+    }
+
+    // 常见包管理器的默认安装位置
+    const scoop = process.env.SCOOP
+    const localAppData = process.env.LOCALAPPDATA
+    const programFiles = process.env.ProgramFiles || 'C:\\Program Files'
+
+    if (scoop) {
+      commonPaths.push(
+        join(scoop, 'apps', 'git', 'current', 'cmd', 'git.exe'),
+        join(scoop, 'apps', 'git', 'current', 'bin', 'git.exe'),
+        join(scoop, 'shims', 'git.exe'),
+      )
+    }
+    if (localAppData) {
+      commonPaths.push(
+        join(localAppData, 'scoop', 'apps', 'git', 'current', 'cmd', 'git.exe'),
+        join(localAppData, 'scoop', 'apps', 'git', 'current', 'bin', 'git.exe'),
+      )
+    }
+
+    // Chocolatey 默认位置
+    commonPaths.push(
+      'C:\\ProgramData\\chocolatey\\bin\\git.exe',
+    )
+
+    // 官方安装器默认位置
+    commonPaths.push(
+      join(programFiles, 'Git', 'cmd', 'git.exe'),
+      join(programFiles, 'Git', 'bin', 'git.exe'),
       'C:\\Program Files (x86)\\Git\\cmd\\git.exe',
-      'C:\\Program Files\\Git\\bin\\git.exe',
-    ]
+      'C:\\Program Files (x86)\\Git\\bin\\git.exe',
+    )
 
     for (const path of commonPaths) {
       if (existsSync(path)) {
@@ -200,11 +239,41 @@ export function detectGitBashWindows(): string | null {
     return null
   }
 
-  const commonPaths = [
-    'C:\\Program Files\\Git\\bin\\bash.exe',
+  const commonPaths: string[] = []
+
+  // 从注册表读取 Git 安装路径
+  const regInstallPath = getGitForWindowsInstallPath()
+  if (regInstallPath) {
+    commonPaths.push(
+      join(regInstallPath, 'bin', 'bash.exe'),
+      join(regInstallPath, 'usr', 'bin', 'bash.exe'),
+    )
+  }
+
+  // 常见包管理器的安装位置
+  const scoop = process.env.SCOOP
+  const localAppData = process.env.LOCALAPPDATA
+  const programFiles = process.env.ProgramFiles || 'C:\\Program Files'
+
+  if (scoop) {
+    commonPaths.push(
+      join(scoop, 'apps', 'git', 'current', 'bin', 'bash.exe'),
+      join(scoop, 'apps', 'git', 'current', 'usr', 'bin', 'bash.exe'),
+    )
+  }
+  if (localAppData) {
+    commonPaths.push(
+      join(localAppData, 'scoop', 'apps', 'git', 'current', 'bin', 'bash.exe'),
+      join(localAppData, 'scoop', 'apps', 'git', 'current', 'usr', 'bin', 'bash.exe'),
+    )
+  }
+
+  // 官方安装器默认位置
+  commonPaths.push(
+    join(programFiles, 'Git', 'bin', 'bash.exe'),
     'C:\\Program Files (x86)\\Git\\bin\\bash.exe',
-    'C:\\Program Files\\Git\\usr\\bin\\bash.exe',
-  ]
+    join(programFiles, 'Git', 'usr', 'bin', 'bash.exe'),
+  )
 
   for (const path of commonPaths) {
     if (existsSync(path)) {

--- a/apps/electron/src/main/lib/node-detector.ts
+++ b/apps/electron/src/main/lib/node-detector.ts
@@ -6,7 +6,55 @@
 
 import { execSync, spawnSync } from 'child_process'
 import { existsSync } from 'fs'
+import { join } from 'path'
 import type { NodeRuntimeStatus } from '@proma/shared'
+
+/**
+ * 从 Windows 注册表读取 Node.js 安装路径
+ *
+ * @returns Node.js 安装目录路径，失败返回 null
+ */
+function getNodePathFromRegistry(): string | null {
+  if (process.platform !== 'win32') return null
+
+  try {
+    // 尝试从 HKLM（系统级安装）读取
+    const hklmOutput = execSync(
+      'reg query "HKLM\\SOFTWARE\\Node.js" /v InstallPath',
+      {
+        encoding: 'utf-8',
+        timeout: 5000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      },
+    )
+
+    const match = hklmOutput.match(/InstallPath\s+REG_\w+\s+(.+)/)
+    if (match?.[1]) {
+      return match[1].trim()
+    }
+  } catch {
+    // HKLM 失败，尝试 HKCU（用户级安装）
+    try {
+      const hkcuOutput = execSync(
+        'reg query "HKCU\\SOFTWARE\\Node.js" /v InstallPath',
+        {
+          encoding: 'utf-8',
+          timeout: 5000,
+          stdio: ['pipe', 'pipe', 'pipe'],
+        },
+      )
+
+      const match = hkcuOutput.match(/InstallPath\s+REG_\w+\s+(.+)/)
+      if (match?.[1]) {
+        return match[1].trim()
+      }
+    } catch {
+      // 注册表读取失败，可能不是官方安装器安装
+    }
+  }
+
+  return null
+}
 
 /**
  * 从系统 PATH 查找 Node.js
@@ -32,12 +80,45 @@ function findNodePath(): string | null {
     // Node.js 未安装
   }
 
-  // Windows 上额外检查常见安装位置
+  // Windows 上额外检查其他安装位置
   if (process.platform === 'win32') {
-    const commonPaths = [
-      'C:\\Program Files\\nodejs\\node.exe',
+    const commonPaths: string[] = []
+
+    // 从注册表读取 Node.js 安装路径
+    const regInstallPath = getNodePathFromRegistry()
+    if (regInstallPath) {
+      commonPaths.push(join(regInstallPath, 'node.exe'))
+    }
+
+    // 常见包管理器的默认安装位置
+    const scoop = process.env.SCOOP
+    const localAppData = process.env.LOCALAPPDATA
+    const programFiles = process.env.ProgramFiles || 'C:\\Program Files'
+
+    if (scoop) {
+      commonPaths.push(
+        join(scoop, 'apps', 'nodejs', 'current', 'node.exe'),
+        join(scoop, 'apps', 'nodejs-lts', 'current', 'node.exe'),
+        join(scoop, 'shims', 'node.exe'),
+      )
+    }
+    if (localAppData) {
+      commonPaths.push(
+        join(localAppData, 'scoop', 'apps', 'nodejs', 'current', 'node.exe'),
+        join(localAppData, 'scoop', 'apps', 'nodejs-lts', 'current', 'node.exe'),
+      )
+    }
+
+    // Chocolatey 默认位置
+    commonPaths.push(
+      'C:\\ProgramData\\chocolatey\\bin\\node.exe',
+    )
+
+    // 官方安装器默认位置
+    commonPaths.push(
+      join(programFiles, 'nodejs', 'node.exe'),
       'C:\\Program Files (x86)\\nodejs\\node.exe',
-    ]
+    )
 
     for (const path of commonPaths) {
       if (existsSync(path)) {

--- a/apps/electron/src/main/lib/shell-env.ts
+++ b/apps/electron/src/main/lib/shell-env.ts
@@ -15,6 +15,7 @@
 import { execSync } from 'child_process'
 import { app } from 'electron'
 import type { ShellEnvResult } from '@proma/shared'
+import { loadWindowsEnv } from './windows-env'
 
 /**
  * 获取用户默认 Shell 路径
@@ -191,7 +192,12 @@ function applyFallbackPaths(): void {
  * @returns Shell 环境加载结果
  */
 export async function loadShellEnv(): Promise<ShellEnvResult> {
-  // 仅在 macOS 上执行
+  // Windows：从注册表加载完整 PATH
+  if (process.platform === 'win32') {
+    return loadWindowsEnv()
+  }
+
+  // 仅在 macOS 上执行后续逻辑
   if (process.platform !== 'darwin') {
     return {
       success: true,

--- a/apps/electron/src/main/lib/windows-env.ts
+++ b/apps/electron/src/main/lib/windows-env.ts
@@ -1,0 +1,174 @@
+/**
+ * Windows 环境变量加载模块
+ *
+ * 问题背景：
+ * Windows 上通过桌面快捷方式/开始菜单启动的 GUI 应用，
+ * 可能无法继承用户在系统环境变量中配置的完整 PATH。
+ * macOS 有 loadShellEnv() 解决此问题，Windows 缺少对应机制。
+ *
+ * 解决方案：
+ * 从 Windows 注册表读取用户级和系统级 PATH，
+ * 合并到 process.env.PATH，确保 scoop、chocolatey 等安装的工具可被发现。
+ */
+
+import { execSync } from 'child_process'
+import { existsSync } from 'fs'
+import { app } from 'electron'
+import type { ShellEnvResult } from '@proma/shared'
+
+/**
+ * Windows PATH 分隔符
+ */
+const PATH_SEP = ';'
+
+/**
+ * 从 Windows 注册表读取值
+ *
+ * @param key - 注册表键路径
+ * @param valueName - 值名称
+ * @returns 值内容，失败返回 null
+ */
+export function readRegistryValue(key: string, valueName: string): string | null {
+  try {
+    const output = execSync(
+      `reg query "${key}" /v "${valueName}"`,
+      {
+        encoding: 'utf-8',
+        timeout: 5000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      },
+    )
+
+    const escaped = valueName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const match = output.match(new RegExp(`${escaped}\\s+REG_\\w+\\s+(.+)`))
+    return match?.[1]?.trim() || null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * 从注册表读取 Git for Windows 安装路径
+ *
+ * 检测顺序：HKLM（系统级） → HKCU（用户级）
+ *
+ * @returns Git 安装目录路径，失败返回 null
+ */
+export function getGitForWindowsInstallPath(): string | null {
+  // HKLM
+  let path = readRegistryValue('HKLM\\SOFTWARE\\GitForWindows', 'InstallPath')
+  if (path) return path
+
+  // HKCU
+  path = readRegistryValue('HKCU\\SOFTWARE\\GitForWindows', 'InstallPath')
+  return path
+}
+
+/**
+ * 展开 Windows 环境变量中的 %VAR% 引用
+ *
+ * 例如 %SCOOP% → D:\Scoop
+ */
+function expandEnvVars(value: string): string {
+  return value.replace(/%([^%]+)%/g, (_, varName: string) => {
+    return process.env[varName] || `%${varName}%`
+  })
+}
+
+/**
+ * 规范化路径用于去重比较（忽略大小写和尾部斜杠）
+ */
+function normalizePathForCompare(p: string): string {
+  return p.replace(/[/\\]+$/, '').toLowerCase()
+}
+
+/**
+ * 合并注册表 PATH 到 process.env.PATH
+ *
+ * 策略：注册表中的路径优先（放在前面），与现有 PATH 合并去重
+ *
+ * @returns 新增的路径数量
+ */
+function mergeRegistryPath(registryPath: string): number {
+  const currentPath = process.env.PATH || ''
+  const currentEntries = currentPath.split(PATH_SEP).filter(Boolean)
+  const currentSet = new Set(currentEntries.map(normalizePathForCompare))
+
+  const registryEntries = registryPath
+    .split(PATH_SEP)
+    .filter(Boolean)
+    .map(expandEnvVars)
+    .filter((p) => existsSync(p))
+
+  let addedCount = 0
+  const newEntries: string[] = []
+
+  for (const entry of registryEntries) {
+    const normalized = normalizePathForCompare(entry)
+    if (!currentSet.has(normalized)) {
+      currentSet.add(normalized)
+      newEntries.push(entry)
+      addedCount++
+    }
+  }
+
+  if (addedCount > 0) {
+    // 注册表路径放在前面，优先级更高
+    process.env.PATH = [...newEntries, ...currentEntries].join(PATH_SEP)
+  }
+
+  return addedCount
+}
+
+/**
+ * 加载 Windows 注册表中的 PATH 到 process.env
+ *
+ * 从两个注册表位置读取：
+ * 1. 用户级 PATH：HKCU\Environment\Path
+ * 2. 系统级 PATH：HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\Path
+ *
+ * @returns 加载结果
+ */
+export async function loadWindowsEnv(): Promise<ShellEnvResult> {
+  // 仅在 Windows 上执行
+  if (process.platform !== 'win32') {
+    return { success: true, loadedCount: 0, error: null }
+  }
+
+  // 开发模式下跳过（从终端启动，PATH 已完整）
+  if (!app.isPackaged) {
+    return { success: true, loadedCount: 0, error: null }
+  }
+
+  console.log('[Windows 环境] 正在从注册表加载 PATH...')
+
+  try {
+    let totalAdded = 0
+
+    // 读取系统 PATH
+    const systemPath = readRegistryValue(
+      'HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment',
+      'Path',
+    )
+    if (systemPath) {
+      const added = mergeRegistryPath(systemPath)
+      totalAdded += added
+      console.log(`[Windows 环境] 系统 PATH: 新增 ${added} 个路径`)
+    }
+
+    // 读取用户 PATH
+    const userPath = readRegistryValue('HKCU\\Environment', 'Path')
+    if (userPath) {
+      const added = mergeRegistryPath(userPath)
+      totalAdded += added
+      console.log(`[Windows 环境] 用户 PATH: 新增 ${added} 个路径`)
+    }
+
+    console.log(`[Windows 环境] PATH 加载完成，共新增 ${totalAdded} 个路径`)
+    return { success: true, loadedCount: totalAdded, error: null }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error)
+    console.warn(`[Windows 环境] PATH 加载失败: ${errorMessage}`)
+    return { success: false, loadedCount: 0, error: errorMessage }
+  }
+}


### PR DESCRIPTION
## 概要

修复 Node.js 和 Git 安装在非 C 盘（如 `D:\Scoop`）时无法被检测到的问题，导致 Agent 模式无法使用。
#252 

## 问题原因

Windows GUI 进程（从桌面/开始菜单启动的 Electron 应用）继承的 PATH 可能不完整，缺少用户在系统环境变量中配置的路径。macOS 有 `loadShellEnv()` 解决此问题，但 Windows 上完全没有对应机制。此外，所有检测器的硬编码回退路径只检查 `C:\Program Files`。

## 改动内容

### 新增文件
- **`windows-env.ts`** — 从 Windows 注册表读取用户 + 系统 PATH（`HKCU\Environment\Path` + `HKLM\...\Environment\Path`），合并到 `process.env.PATH`（去重）。同时导出共享注册表工具函数 `readRegistryValue`、`getGitForWindowsInstallPath`。

### 修改文件
- **`shell-env.ts`** — Windows 平台调用 `loadWindowsEnv()`
- **`node-detector.ts`** — 增加 HKCU 注册表回退 + 扩展 fallback 路径（scoop、chocolatey、自定义安装目录）
- **`git-detector.ts`** — 增加注册表检测 + 扩展 fallback 路径，复用共享 `getGitForWindowsInstallPath()`
- **`git-bash-detector.ts`** — 扩展 fallback 路径，复用共享注册表函数

### 设计要点
- **通用方案**：从 Windows 注册表读取完整 PATH，适用于任何包管理器和安装位置
- **包管理器 fallback**：scoop/chocolatey 路径作为额外保障
- **消除重复**：`getGitForWindowsInstallPath()` 提取到 `windows-env.ts`，`git-detector.ts` 和 `git-bash-detector.ts` 共用
- **开发模式安全**：注册表 PATH 加载仅在打包模式执行（`app.isPackaged`），开发模式从终端启动已有完整 PATH

## 测试

- [x] `bun run typecheck` 全部通过
- [x] `bun run dev` — 验证运行时检测日志正确找到 Node.js/Git/Git Bash
- [x] Agent 模式 — 验证会话正常启动和执行命令