### PR TITLE
fix(electron): Fix WindowControls not clickable in Chat tab on Windows

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/electron/src/renderer/components/app-shell/AppShell.tsx
@@ -16,6 +16,7 @@ import { appModeAtom } from '@/atoms/app-mode'
 import { agentSidePanelWidthAtom, currentAgentSessionIdAtom, currentSessionSidePanelOpenAtom } from '@/atoms/agent-atoms'
 import { WindowControls } from '@/components/WindowControls'
 import { cn } from '@/lib/utils'
+import { detectIsWindows } from '@/lib/platform'
 
 const MIN_RIGHT_PANEL_WIDTH = 220
 const MAX_RIGHT_PANEL_WIDTH = 420
@@ -30,6 +31,7 @@ export interface AppShellProps {
 }
 
 export function AppShell({ contextValue }: AppShellProps): React.ReactElement {
+  const isWindows = React.useMemo(() => detectIsWindows(), [])
   const appMode = useAtomValue(appModeAtom)
   const currentSessionId = useAtomValue(currentAgentSessionIdAtom)
   const isPanelOpen = useAtomValue(currentSessionSidePanelOpenAtom)
@@ -78,7 +80,7 @@ export function AppShell({ contextValue }: AppShellProps): React.ReactElement {
   return (
     <AppShellProvider value={contextValue}>
       {/* 可拖动标题栏区域，用于窗口拖动 */}
-      <div className="titlebar-drag-region fixed top-0 left-0 right-0 h-[50px] z-50" />
+      <div className={cn("titlebar-drag-region fixed top-0 left-0 right-0 h-[50px] z-50", isWindows && "right-[112px]")} />
 
       {/* Windows 自定义窗口控制按钮（最小化/最大化/关闭） */}
       <WindowControls />

--- a/apps/electron/src/renderer/components/chat/ChatHeader.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatHeader.tsx
@@ -97,7 +97,7 @@ export function ChatHeader({ conversation }: ChatHeaderProps): React.ReactElemen
           </button>
         </div>
       ) : (
-        <div className="flex items-center gap-1.5 flex-1 min-w-0 pointer-events-auto">
+        <div className="flex items-center gap-1.5 flex-1 min-w-0">
           <span className="truncate text-sm font-medium text-foreground">
             {conversation.title}
           </span>
@@ -114,7 +114,7 @@ export function ChatHeader({ conversation }: ChatHeaderProps): React.ReactElemen
       )}
 
       {/* 右侧按钮组 */}
-      <div className="flex items-center gap-1 titlebar-no-drag ml-auto pointer-events-auto">
+      <div className="flex items-center gap-1 titlebar-no-drag ml-auto">
         <SystemPromptSelector />
         <Tooltip>
           <TooltipTrigger asChild>

--- a/apps/electron/src/renderer/components/chat/ChatHeader.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatHeader.tsx
@@ -65,7 +65,9 @@ export function ChatHeader({ conversation }: ChatHeaderProps): React.ReactElemen
   }
 
   return (
-    <div className="relative z-[51] flex items-center gap-2 px-4 h-[48px] titlebar-drag-region">
+    <div className="relative z-[51] flex items-center gap-2 px-4 h-[48px]">
+      {/* 左侧拖拽区域 - 不覆盖右侧窗口控制按钮 */}
+      <div className="absolute inset-0 left-0 right-[112px] titlebar-drag-region" />
       {editing ? (
         <div className="flex items-center gap-1.5 flex-1 min-w-0 titlebar-no-drag">
           <input
@@ -95,7 +97,7 @@ export function ChatHeader({ conversation }: ChatHeaderProps): React.ReactElemen
           </button>
         </div>
       ) : (
-        <div className="flex items-center gap-1.5 flex-1 min-w-0">
+        <div className="flex items-center gap-1.5 flex-1 min-w-0 pointer-events-auto">
           <span className="truncate text-sm font-medium text-foreground">
             {conversation.title}
           </span>
@@ -112,7 +114,7 @@ export function ChatHeader({ conversation }: ChatHeaderProps): React.ReactElemen
       )}
 
       {/* 右侧按钮组 */}
-      <div className="flex items-center gap-1 titlebar-no-drag ml-auto">
+      <div className="flex items-center gap-1 titlebar-no-drag ml-auto pointer-events-auto">
         <SystemPromptSelector />
         <Tooltip>
           <TooltipTrigger asChild>

--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -232,11 +232,11 @@ function TabBarInner({
           注意：不要把 titlebar-no-drag 加到下面的整条 flex 容器上，否则标签右侧空白会再次失去拖拽能力。
           前景 flex 容器也必须是 drag-region，因为它会覆盖在背景拖拽层之上。
           需要交互的单个 Tab 会在 TabBarItem 内部自己声明 titlebar-no-drag。 */}
-      <div className="absolute inset-0 titlebar-drag-region" />
+      <div className={cn("absolute inset-0 titlebar-drag-region", isWindows && "right-[112px]")} />
 
       <div
         ref={scrollRef}
-        className={cn("relative flex items-end flex-1 min-w-0 overflow-x-auto scrollbar-none titlebar-drag-region", isWindows && "pr-[112px]")}
+        className={cn("relative flex items-end flex-1 min-w-0 overflow-x-auto scrollbar-none", isWindows && "pr-[112px]")}
       >
         {tabs.map((tab) => (
           <TabBarItem


### PR DESCRIPTION
## 问题描述

Fixes #480

在 Windows 平台上，Chat tab 下的窗口控制按钮（最小化/最大化/关闭）点击不起作用，也没有 hover 效果，但 Agent tab 下正常工作。

## 根本原因

在 Windows 平台上，多个元素的 `titlebar-drag-region`（通过 `-webkit-app-region: drag` CSS 属性实现）覆盖了窗口控制按钮区域。即使 `WindowControls` 组件的 z-index 较高（`z-[100]`），Electron 的拖拽区域仍会拦截鼠标事件，导致点击和 hover 效果无法生效。

## 修复方案

通过限制拖拽区域的范围，确保右侧 112px（窗口控制按钮区域）不被任何 `titlebar-drag-region` 覆盖：

### 修改文件

1. **`ChatHeader.tsx`**：添加绝对定位的拖拽区域，限制在 `left-0 right-[112px]`
2. **`TabBar.tsx`**：背景拖拽区域在 Windows 平台添加 `right-[112px]`，移除前景容器的 `titlebar-drag-region`
3. **`AppShell.tsx`**：全局拖拽区域在 Windows 平台添加 `right-[112px]`，移除中间容器的 `pr-[112px]` 避免产生布局缝隙

## 测试

- [x] Windows 平台 Chat tab 下窗口控制按钮可正常点击
- [x] Windows 平台 Chat tab 下窗口控制按钮有 hover 效果
- [x] Windows 平台 Agent tab 下窗口控制按钮正常工作

## 截图

### 修复前
窗口控制按钮无法点击，无 hover 效果

### 修复后
窗口控制按钮可正常点击，有 hover 效果