### PR TITLE
fix: settings sidebar list supports scroll when zoomed in

### DIFF
--- a/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
+++ b/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
@@ -255,7 +255,7 @@ export function SettingsPanel({
       {/* 下方主体：左导航 + 右内容 */}
       <div className="flex flex-1 min-h-0">
         {/* 左侧 Tab 导航 */}
-        <div className="w-[160px] border-r border-border/50 pt-3 px-2 flex-shrink-0">
+        <div className="w-[160px] border-r border-border/50 pt-3 px-2 flex-shrink-0 overflow-y-auto">
           <nav className="flex flex-col gap-0.5">
             {tabs.map((tab) => (
               <button


### PR DESCRIPTION
## Summary

- 修复设置弹窗左侧导航列表在界面被放大时无法滚动的问题
- 在左侧容器 div 上添加 `overflow-y-auto`，使列表内容超出高度时可垂直滚动

## Root Cause

`SettingsPanel.tsx` 左侧导航容器缺少 `overflow-y-auto`，当用户将界面缩放较大时，导航列表超出可视区域却无法滚动，导致底部菜单项无法访问。

## Test plan

- [ ] 将应用界面缩放到较大比例
- [ ] 打开设置弹窗，验证左侧列表可以正常滚动
- [ ] 验证正常缩放比例下样式不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)