### PR TITLE
feat(agent): add bottom collapse button for subagent tool calls

### DIFF
--- a/apps/electron/src/renderer/components/agent/ContentBlock.tsx
+++ b/apps/electron/src/renderer/components/agent/ContentBlock.tsx
@@ -396,6 +396,16 @@ function ToolUseBlock({ block, allMessages, animate = false, index = 0, dimmed =
                 resultText={toolResult?.result}
               />
             )}
+
+            {/* 底部收起按钮 */}
+            <button
+              type="button"
+              onClick={() => setChildrenExpanded(false)}
+              className="flex items-center gap-1 text-xs text-foreground/40 hover:text-foreground/70 transition-colors"
+            >
+              <ChevronUp className="size-3" />
+              <span>收起</span>
+            </button>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

在 subagent (Agent/Task) 工具调用的展开内容底部添加了"收起"按钮，用户无需滚动回顶部即可折叠子代理内容。

## Changes

- **`apps/electron/src/renderer/components/agent/ContentBlock.tsx`**: 在 `ToolUseBlock` 的 `isAgentTool` 展开区域底部新增一个"收起"按钮（`ChevronUp` + 文字）
- 样式与交互与已有的 `ThinkingBlock` 底部收起按钮一致

## Test plan

- [ ] 展开 subagent 调用后，底部出现"收起"按钮
- [ ] 点击"收起"后内容折叠
- [ ] 按钮 hover 样式正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)