### PR TITLE
fix: persist main window size and position across restarts

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -35,7 +35,7 @@ app.on('second-instance', (_event, argv) => {
   }
 })
 
-import { getSettings } from './lib/settings-service'
+import { getSettings, updateSettings } from './lib/settings-service'
 import { handlePromaFileRequest } from './lib/local-file-protocol'
 
 // 处理 EPIPE 错误：当 stdout/stderr 管道被关闭时（如 electronmon 重启），忽略写入错误
@@ -213,6 +213,22 @@ function getIconPath(): string {
   }
 }
 
+function saveMainWindowState(): void {
+  if (!mainWindow || mainWindow.isDestroyed()) return
+  const isMaximized = mainWindow.isMaximized()
+  // 最大化时用恢复尺寸（unmaximize 后的尺寸），避免记录最大化的全屏 bounds
+  const bounds = isMaximized ? mainWindow.getNormalBounds() : mainWindow.getBounds()
+  updateSettings({
+    mainWindowState: {
+      width: bounds.width,
+      height: bounds.height,
+      x: bounds.x,
+      y: bounds.y,
+      isMaximized,
+    },
+  })
+}
+
 function createWindow(): void {
   const iconPath = getIconPath()
   const iconExists = existsSync(iconPath)
@@ -235,9 +251,13 @@ function createWindow(): void {
       ? { titleBarStyle: 'hidden' as const }
       : {}
 
+  const savedState = getSettings().mainWindowState
+  const initialBounds = savedState
+    ? { width: savedState.width, height: savedState.height, x: savedState.x, y: savedState.y }
+    : { width: 1400, height: 900 }
+
   mainWindow = new BrowserWindow({
-    width: 1400,
-    height: 900,
+    ...initialBounds,
     minWidth: 800,
     minHeight: 600,
     icon: iconExists ? iconPath : undefined,
@@ -260,11 +280,25 @@ function createWindow(): void {
     mainWindow.loadFile(join(__dirname, 'renderer', 'index.html'))
   }
 
-  // 窗口就绪后最大化显示
+  // 窗口就绪后，按保存的状态决定是否最大化
   mainWindow.once('ready-to-show', () => {
-    mainWindow?.maximize()
+    if (savedState?.isMaximized ?? true) {
+      mainWindow?.maximize()
+    }
     mainWindow?.show()
   })
+
+  // 持久化窗口大小和位置（防抖 500ms，避免频繁写入）
+  let windowStateSaveTimer: ReturnType<typeof setTimeout> | null = null
+  const scheduleWindowStateSave = (): void => {
+    if (windowStateSaveTimer) clearTimeout(windowStateSaveTimer)
+    windowStateSaveTimer = setTimeout(() => {
+      windowStateSaveTimer = null
+      saveMainWindowState()
+    }, 500)
+  }
+  mainWindow.on('resize', scheduleWindowStateSave)
+  mainWindow.on('move', scheduleWindowStateSave)
 
   // 拦截页面内导航，外部链接用系统浏览器打开，防止 Electron 窗口被覆盖
   mainWindow.webContents.on('will-navigate', (event, url) => {
@@ -289,6 +323,12 @@ function createWindow(): void {
   if (process.platform === 'darwin') {
     mainWindow.on('close', (event) => {
       if (!getIsQuitting()) {
+        // 隐藏前先刷新挂起的窗口状态保存
+        if (windowStateSaveTimer) {
+          clearTimeout(windowStateSaveTimer)
+          windowStateSaveTimer = null
+        }
+        saveMainWindowState()
         event.preventDefault()
         mainWindow?.hide()
         app.hide()

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -207,6 +207,17 @@ export interface AppSettings {
   autoCleanupTempOnStart?: boolean
   /** 自动清理 N 天前已归档会话的 SDK 数据（0 = 禁用，默认 0） */
   autoCleanupArchivedDays?: number
+  /** 主窗口状态（大小、位置、是否最大化） */
+  mainWindowState?: MainWindowState
+}
+
+/** 主窗口大小、位置和最大化状态 */
+export interface MainWindowState {
+  width: number
+  height: number
+  x: number
+  y: number
+  isMaximized: boolean
 }
 
 /** 持久化的标签页状态 */


### PR DESCRIPTION
## Summary

- 新增 `MainWindowState` 类型，记录窗口宽高、位置和最大化状态
- 应用启动时从 `settings.json` 读取上次保存的窗口状态并恢复；首次启动无记录时仍默认最大化
- 监听 `resize`/`move` 事件，防抖 500ms 持久化到 settings；macOS 隐藏窗口前立即刷新保存
- 最大化状态下保存 `getNormalBounds()`，确保下次以非最大化尺寸恢复时尺寸合理

## Test plan

- [ ] 首次启动（无 `mainWindowState` 记录）：窗口应默认最大化
- [ ] 调整窗口大小/位置后关闭再打开：窗口应按上次的大小和位置恢复
- [ ] 最大化状态下关闭再打开：窗口应仍为最大化
- [ ] 非最大化状态下关闭再打开：窗口应以保存的尺寸和位置打开（非最大化）
- [ ] macOS：点击红色关闭按钮（隐藏窗口）后重新打开：状态应正确恢复
- [ ] 外接显示器断开场景：`ensureWindowOnScreen` 应确保窗口不会出现在不可见区域

🤖 Generated with [Claude Code](https://claude.com/claude-code)