### PR TITLE
fix: remove slide-in animation when creating new session

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -387,12 +387,15 @@ export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persi
   const channels = useAtomValue(channelsAtom)
   /** 淡入控制：切换会话时先隐藏，等布局完成后再显示。 */
   const [ready, setReady] = React.useState(false)
+  // 空会话无需淡入过渡（无消息则无滚动位置问题）
+  const [skipFadeIn, setSkipFadeIn] = React.useState(false)
   const prevSessionIdRef = React.useRef<string | null>(null)
 
   React.useEffect(() => {
     if (sessionId !== prevSessionIdRef.current) {
       prevSessionIdRef.current = sessionId
       setReady(false)
+      setSkipFadeIn(false)
     }
   }, [sessionId])
 
@@ -409,6 +412,7 @@ export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persi
     }
 
     if ((!persistedSDKMessages || persistedSDKMessages.length === 0) && !streaming) {
+      setSkipFadeIn(true)
       setReady(true)
       return
     }
@@ -585,7 +589,7 @@ export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persi
 
   return (
     <BasePathsProvider basePaths={attachedDirs}>
-    <Conversation resize={ready && !transitioning ? 'smooth' : 'instant'} className={ready ? 'opacity-100 transition-opacity duration-200' : 'opacity-0'}>
+    <Conversation resize={ready && !transitioning ? 'smooth' : 'instant'} className={ready ? (skipFadeIn ? 'opacity-100' : 'opacity-100 transition-opacity duration-200') : 'opacity-0'}>
       <ScrollPositionManager id={sessionId} ready={ready} />
       <ConversationContent>
         {!hasContent && !streaming ? (

--- a/apps/electron/src/renderer/components/chat/ChatMessages.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessages.tsx
@@ -237,6 +237,8 @@ export function ChatMessages({
    * 避免 "先看到顶部消息再跳到底部" 的闪烁。
    */
   const [ready, setReady] = React.useState(false)
+  // 空对话无需淡入过渡（无消息则无滚动位置问题）
+  const [skipFadeIn, setSkipFadeIn] = React.useState(false)
   const prevConversationIdRef = React.useRef<string | null>(null)
 
   // 对话切换时立即隐藏
@@ -244,6 +246,7 @@ export function ChatMessages({
     if (conversationId !== prevConversationIdRef.current) {
       prevConversationIdRef.current = conversationId
       setReady(false)
+      setSkipFadeIn(false)
     }
   }, [conversationId])
 
@@ -254,8 +257,9 @@ export function ChatMessages({
     // 必须等消息 IPC 加载完成，否则 messages=[] 会被误判为空对话
     if (!messagesLoaded) return
 
-    // 加载完后确实是空对话：直接显示
+    // 加载完后确实是空对话：直接显示（无需过渡动画）
     if (messages.length === 0 && !streaming) {
+      setSkipFadeIn(true)
       setReady(true)
       return
     }
@@ -336,7 +340,7 @@ export function ChatMessages({
   const dividerSet = new Set(contextDividers)
 
   return (
-    <Conversation resize={ready && !transitioning ? 'smooth' : 'instant'} className={ready ? 'opacity-100 transition-opacity duration-200' : 'opacity-0'}>
+    <Conversation resize={ready && !transitioning ? 'smooth' : 'instant'} className={ready ? (skipFadeIn ? 'opacity-100' : 'opacity-100 transition-opacity duration-200') : 'opacity-0'}>
       <ScrollPositionManager id={conversationId} ready={ready} />
       {/* 滚动到顶部时自动加载更多历史 */}
       <ScrollTopLoader

--- a/apps/electron/src/renderer/components/welcome/WelcomeEmptyState.tsx
+++ b/apps/electron/src/renderer/components/welcome/WelcomeEmptyState.tsx
@@ -53,7 +53,7 @@ export function WelcomeEmptyState(): React.ReactElement {
   }, [mode, setMode])
 
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-6 px-4 animate-in fade-in duration-500">
+    <div className="flex h-full flex-col items-center justify-center gap-6 px-4">
       {/* 问候语 */}
       <h1 className="text-[26px] font-semibold tracking-tight text-foreground">
         {displayName}，{greeting}


### PR DESCRIPTION
## Summary

- 移除 `WelcomeEmptyState` 上的 `animate-in fade-in duration-500`（消除空状态内容的入场动画）
- 在 `ChatMessages` 和 `AgentMessages` 中，对空会话跳过 200ms opacity 淡入过渡（`skipFadeIn` 状态），让新会话内容直接显示
- opacity 过渡在有消息的会话切换时依然保留（防止滚动位置闪烁），其他地方所有动画（Banner、Tooltip、Dropdown 等）完全不受影响

## Test plan

- [ ] 通过 Cmd+N 创建新 Chat 会话，确认输入框区域直接出现，无滑动/淡入动画
- [ ] 通过 Cmd+N 创建新 Agent 会话，同样确认无动画
- [ ] 切换有消息的现有会话，确认 opacity 淡入过渡依然正常（防止闪烁）
- [ ] 确认 PermissionBanner、AskUserBanner 的 `slide-in-from-bottom-2` 动画仍然正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)