### PR TITLE
fix(electron): resolve Windows titlebar buttons clickability issues

### DIFF
--- a/apps/electron/src/renderer/components/WindowControls.tsx
+++ b/apps/electron/src/renderer/components/WindowControls.tsx
@@ -15,7 +15,12 @@ export function WindowControls(): React.ReactElement | null {
     if (!isWindows) return
     window.electronAPI.windowIsMaximized().then(setIsMaximized)
     const unsub = window.electronAPI.onWindowResize(() => {
-      window.electronAPI.windowIsMaximized().then(setIsMaximized)
+      window.electronAPI.windowIsMaximized().then((next) => {
+        // 只在状态实际变化时 setState，避免每次 resize 都触发重渲染——
+        // Windows 上每次重渲染都会让 Chromium 重算可拖拽区域，期间存在数十 ms 的 stale 窗口，
+        // 用户在此窗口内点击按钮会被 OS 误判为标题栏点击。
+        setIsMaximized((prev) => (prev === next ? prev : next))
+      })
     })
     return unsub
   }, [isWindows])

--- a/apps/electron/src/renderer/components/agent/AgentHeader.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentHeader.tsx
@@ -83,7 +83,10 @@ export function AgentHeader({ sessionId }: AgentHeaderProps): React.ReactElement
   }
 
   return (
-    <div className="relative z-[51] flex items-center gap-2 px-4 h-[48px] titlebar-drag-region">
+    <div className="relative z-[51] flex items-center gap-2 px-4 h-[48px]">
+      {/* 拖拽层仅覆盖左侧区域，避开右上角 WindowControls（Windows 上 ~126px）。
+          否则 header 的 drag-region 会与按钮重叠，导致 OS hitmask 把单击当成标题栏点击。 */}
+      <div className="absolute inset-0 right-[126px] titlebar-drag-region pointer-events-none" />
       {editing ? (
         <div className="flex items-center gap-1.5 flex-1 min-w-0 titlebar-no-drag">
           <input

--- a/apps/electron/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/electron/src/renderer/components/app-shell/AppShell.tsx
@@ -15,6 +15,7 @@ import { AppShellProvider, type AppShellContextType } from '@/contexts/AppShellC
 import { appModeAtom } from '@/atoms/app-mode'
 import { agentSidePanelWidthAtom, currentAgentSessionIdAtom, currentSessionSidePanelOpenAtom } from '@/atoms/agent-atoms'
 import { WindowControls } from '@/components/WindowControls'
+import { detectIsWindows } from '@/lib/platform'
 import { cn } from '@/lib/utils'
 
 const MIN_RIGHT_PANEL_WIDTH = 220
@@ -34,6 +35,7 @@ export function AppShell({ contextValue }: AppShellProps): React.ReactElement {
   const currentSessionId = useAtomValue(currentAgentSessionIdAtom)
   const isPanelOpen = useAtomValue(currentSessionSidePanelOpenAtom)
   const showRightPanel = appMode === 'agent' && !!currentSessionId
+  const isWindows = React.useMemo(() => detectIsWindows(), [])
 
   // 右侧面板可拖拽宽度
   const [rightPanelWidth, setRightPanelWidth] = useAtom(agentSidePanelWidthAtom)
@@ -77,8 +79,16 @@ export function AppShell({ contextValue }: AppShellProps): React.ReactElement {
 
   return (
     <AppShellProvider value={contextValue}>
-      {/* 可拖动标题栏区域，用于窗口拖动 */}
-      <div className="titlebar-drag-region fixed top-0 left-0 right-0 h-[50px] z-50" />
+      {/* 可拖动标题栏区域，用于窗口拖动。
+          Windows 上必须避开右上角的 WindowControls 区域（buttons ~118px + 8px buffer = 126px），
+          否则 drag-region 与按钮区的 hitmask 重叠会让 OS 把单击当成标题栏点击，
+          表现为"按钮要双击才响应"。 */}
+      <div
+        className={cn(
+          'titlebar-drag-region fixed top-0 left-0 h-[50px] z-50',
+          isWindows ? 'right-[126px]' : 'right-0'
+        )}
+      />
 
       {/* Windows 自定义窗口控制按钮（最小化/最大化/关闭） */}
       <WindowControls />

--- a/apps/electron/src/renderer/components/chat/ChatHeader.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatHeader.tsx
@@ -65,7 +65,10 @@ export function ChatHeader({ conversation }: ChatHeaderProps): React.ReactElemen
   }
 
   return (
-    <div className="relative z-[51] flex items-center gap-2 px-4 h-[48px] titlebar-drag-region">
+    <div className="relative z-[51] flex items-center gap-2 px-4 h-[48px]">
+      {/* 拖拽层仅覆盖左侧区域，避开右上角 WindowControls（Windows 上 ~126px）。
+          否则 header 的 drag-region 会与按钮重叠，导致 OS hitmask 把单击当成标题栏点击。 */}
+      <div className="absolute inset-0 right-[126px] titlebar-drag-region pointer-events-none" />
       {editing ? (
         <div className="flex items-center gap-1.5 flex-1 min-w-0 titlebar-no-drag">
           <input

--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -230,13 +230,13 @@ function TabBarInner({
     <div className="flex items-end h-[34px] tabbar-bg relative">
       {/* 顶部 TabBar 的空白区域必须保持可拖拽，尤其是 macOS/Windows 自定义标题栏。
           注意：不要把 titlebar-no-drag 加到下面的整条 flex 容器上，否则标签右侧空白会再次失去拖拽能力。
-          前景 flex 容器也必须是 drag-region，因为它会覆盖在背景拖拽层之上。
+          Windows 上背景拖拽层避开右上角 WindowControls 区域（126px），防止 hitmask 重叠。
           需要交互的单个 Tab 会在 TabBarItem 内部自己声明 titlebar-no-drag。 */}
-      <div className="absolute inset-0 titlebar-drag-region" />
+      <div className={cn("absolute inset-0 titlebar-drag-region", isWindows && "right-[126px]")} />
 
       <div
         ref={scrollRef}
-        className={cn("relative flex items-end flex-1 min-w-0 overflow-x-auto scrollbar-none titlebar-drag-region", isWindows && "pr-[112px]")}
+        className={cn("relative flex items-end flex-1 min-w-0 overflow-x-auto scrollbar-none", isWindows && "pr-[126px]")}
       >
         {tabs.map((tab) => (
           <TabBarItem

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -326,8 +326,18 @@
   app-region: drag;
 }
 
-/* Windows 自定义窗口控制按钮 */
+/* Windows 自定义窗口控制按钮
+ *
+ * 可点击性关键点（解决 Windows 用户点击失效 / 需要双击的 bug）：
+ * 1. 容器本身就是 no-drag 矩形，不靠"在 drag 区里挖三个小洞"——避免 Chromium hitmask
+ *    在小矩形 + 高 DPI 缩放下的像素对齐误差。
+ * 2. AppShell 的 drag-region 在 Windows 上不再延伸到按钮区域（见 AppShell.tsx 的 right-[126px]），
+ *    drag 与 no-drag 区域彻底解耦，OS hitmask 不会再误判。
+ * 3. 按钮尺寸与位置使用整数 px，避免 125%/150%/175% DPI 下四舍五入收缩。
+ */
 .window-controls {
+  -webkit-app-region: no-drag;
+  app-region: no-drag;
   height: 28px;
   gap: 1px;
 }


### PR DESCRIPTION
Fix multiple causes where the custom minimize/maximize/close buttons were unresponsive or required double-clicks on Windows, especially at fractional DPI scaling (125%/150%/175%).

Root causes:
1. AppShell's global drag-region overlapped the WindowControls area; OS-level hitmask treated single clicks as title-bar clicks (hence the "double-click sometimes works" symptom — that triggered the OS maximize gesture).
2. ChatHeader and AgentHeader applied titlebar-drag-region to the whole header (h-[48px]), overlapping the buttons whenever a chat/agent view was active.
3. TabBar foreground scroll container also carried drag-region, layering another drag rect on top of the no-drag buttons.
4. .window-controls container itself was not no-drag, leaving Chromium to subtract three tiny per-button no-drag rects from a much larger drag region — fragile under DPI rounding.
5. Every window resize unconditionally re-rendered WindowControls, briefly leaving the drag-region stale.

Fix:
- AppShell / TabBar background / ChatHeader / AgentHeader drag regions all stop at right-[126px] on Windows so they never overlap with the buttons.
- TabBar foreground flex container no longer carries drag-region; the background layer alone provides drag, behind a clean no-drag button area.
- .window-controls container itself is now app-region: no-drag for defense-in-depth against DPI/hitmask edge cases.
- WindowControls only setState when isMaximized actually changes, avoiding pointless re-renders that re-compute the drag region.
- ChatHeader and AgentHeader use an absolute drag layer with pointer-events-none so DOM clicks still reach inner buttons.

Supersedes #481 (which only fixed AppShell + ChatHeader + TabBar background with right-[112px]; that value still overlapped the buttons by ~6px).