### PR TITLE
refactor(windows): fix env-detector followups from PR #479

### DIFF
--- a/apps/electron/src/main/lib/git-bash-detector.ts
+++ b/apps/electron/src/main/lib/git-bash-detector.ts
@@ -19,9 +19,11 @@ import type { GitBashStatus } from '@proma/shared'
 import { getGitForWindowsInstallPath } from './windows-env'
 
 /**
- * Git for Windows 常见安装路径
+ * 获取 Git for Windows 常见安装路径列表
+ *
+ * 在调用时读取 process.env，确保 loadWindowsEnv() 已执行后路径完整。
  */
-const COMMON_GIT_BASH_PATHS: string[] = (() => {
+function getCommonGitBashPaths(): string[] {
   const paths: string[] = []
   const scoop = process.env.SCOOP
   const localAppData = process.env.LOCALAPPDATA
@@ -50,7 +52,7 @@ const COMMON_GIT_BASH_PATHS: string[] = (() => {
   )
 
   return paths
-})()
+}
 
 /**
  * 验证 bash.exe 路径并获取版本
@@ -135,7 +137,7 @@ export async function detectGitBash(): Promise<GitBashStatus> {
   }
 
   // 策略 1：检查常见安装路径
-  for (const path of COMMON_GIT_BASH_PATHS) {
+  for (const path of getCommonGitBashPaths()) {
     const version = verifyBashPath(path)
     if (version) {
       console.log(`[Git Bash 检测] 找到 Git Bash (常见路径): ${path} (${version})`)

--- a/apps/electron/src/main/lib/node-detector.ts
+++ b/apps/electron/src/main/lib/node-detector.ts
@@ -8,53 +8,7 @@ import { execSync, spawnSync } from 'child_process'
 import { existsSync } from 'fs'
 import { join } from 'path'
 import type { NodeRuntimeStatus } from '@proma/shared'
-
-/**
- * 从 Windows 注册表读取 Node.js 安装路径
- *
- * @returns Node.js 安装目录路径，失败返回 null
- */
-function getNodePathFromRegistry(): string | null {
-  if (process.platform !== 'win32') return null
-
-  try {
-    // 尝试从 HKLM（系统级安装）读取
-    const hklmOutput = execSync(
-      'reg query "HKLM\\SOFTWARE\\Node.js" /v InstallPath',
-      {
-        encoding: 'utf-8',
-        timeout: 5000,
-        stdio: ['pipe', 'pipe', 'pipe'],
-      },
-    )
-
-    const match = hklmOutput.match(/InstallPath\s+REG_\w+\s+(.+)/)
-    if (match?.[1]) {
-      return match[1].trim()
-    }
-  } catch {
-    // HKLM 失败，尝试 HKCU（用户级安装）
-    try {
-      const hkcuOutput = execSync(
-        'reg query "HKCU\\SOFTWARE\\Node.js" /v InstallPath',
-        {
-          encoding: 'utf-8',
-          timeout: 5000,
-          stdio: ['pipe', 'pipe', 'pipe'],
-        },
-      )
-
-      const match = hkcuOutput.match(/InstallPath\s+REG_\w+\s+(.+)/)
-      if (match?.[1]) {
-        return match[1].trim()
-      }
-    } catch {
-      // 注册表读取失败，可能不是官方安装器安装
-    }
-  }
-
-  return null
-}
+import { getNodeInstallPathFromRegistry } from './windows-env'
 
 /**
  * 从系统 PATH 查找 Node.js
@@ -85,7 +39,7 @@ function findNodePath(): string | null {
     const commonPaths: string[] = []
 
     // 从注册表读取 Node.js 安装路径
-    const regInstallPath = getNodePathFromRegistry()
+    const regInstallPath = getNodeInstallPathFromRegistry()
     if (regInstallPath) {
       commonPaths.push(join(regInstallPath, 'node.exe'))
     }

--- a/apps/electron/src/main/lib/windows-env.ts
+++ b/apps/electron/src/main/lib/windows-env.ts
@@ -40,7 +40,7 @@ export function readRegistryValue(key: string, valueName: string): string | null
     )
 
     const escaped = valueName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-    const match = output.match(new RegExp(`${escaped}\\s+REG_\\w+\\s+(.+)`))
+    const match = output.match(new RegExp(`${escaped}\\s+REG_\\w+\\s+(.+)`, 'i'))
     return match?.[1]?.trim() || null
   } catch {
     return null
@@ -61,6 +61,25 @@ export function getGitForWindowsInstallPath(): string | null {
 
   // HKCU
   path = readRegistryValue('HKCU\\SOFTWARE\\GitForWindows', 'InstallPath')
+  return path
+}
+
+/**
+ * 从注册表读取 Node.js 安装路径
+ *
+ * 检测顺序：HKLM（系统级） → HKCU（用户级）
+ *
+ * @returns Node.js 安装目录路径，失败返回 null
+ */
+export function getNodeInstallPathFromRegistry(): string | null {
+  if (process.platform !== 'win32') return null
+
+  // HKLM
+  let path = readRegistryValue('HKLM\\SOFTWARE\\Node.js', 'InstallPath')
+  if (path) return path
+
+  // HKCU
+  path = readRegistryValue('HKCU\\SOFTWARE\\Node.js', 'InstallPath')
   return path
 }
 


### PR DESCRIPTION
## Summary

Follow-up fixes for [#479](https://github.com/ErlichLiu/Proma/pull/479) based on code review.

- **Timing fix**: Replace `COMMON_GIT_BASH_PATHS` IIFE in `git-bash-detector.ts` with a lazy `getCommonGitBashPaths()` function called inside `detectGitBash()`. The IIFE ran at module import time, before `loadWindowsEnv()` had a chance to populate `process.env.SCOOP` from the registry.

- **Shared registry helper**: Extract `getNodeInstallPathFromRegistry()` from `node-detector.ts` into `windows-env.ts` as an exported function, consistent with the existing `getGitForWindowsInstallPath()` pattern. Removes ~45 lines of duplicate registry-reading code.

- **Case-insensitive regex**: Add `'i'` flag to the `readRegistryValue` regex in `windows-env.ts` to handle edge cases where Windows returns registry value names in different casing.

## Test plan

- [ ] `bun run typecheck` passes ✅
- [ ] On Windows (packaged): verify `detectGitBash()` still finds Git Bash after `loadWindowsEnv()` has run
- [ ] On Windows (packaged): verify `detectNodeRuntime()` still finds Node.js via registry fallback