### PR TITLE
fix(windows): 修复 Windows 代码块文字渲染模糊问题

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -26,6 +26,12 @@ protocol.registerSchemesAsPrivileged([
   { scheme: 'proma-file', privileges: { standard: true, secure: true, supportFetchAPI: true, corsEnabled: true, stream: true } },
 ])
 
+// Windows: 禁用 LCD 次像素抗锯齿（ClearType），改用灰度 AA。
+// ClearType 是为浅色背景+深色文字设计的，在深色代码块背景下会产生彩色边缘，导致文字模糊。
+if (process.platform === 'win32') {
+  app.commandLine.appendSwitch('disable-lcd-text')
+}
+
 // Windows 文件关联：当用户双击文件时，新实例的参数会通过 second-instance 传给已有实例
 app.on('second-instance', (_event, argv) => {
   showAndFocusMainWindow()

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -306,6 +306,9 @@
   }
   body {
     @apply bg-background text-foreground;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
   }
 }
 
@@ -716,8 +719,12 @@
 }
 
 .code-block-wrapper pre.shiki {
-  font-family: 'Fira Code', 'Cascadia Code', 'JetBrains Mono', Consolas, monospace;
+  /* Cascadia Code 是 Windows 11 预装字体，优先级提高；Courier New 作为 Windows 10 最终兜底 */
+  font-family: 'Fira Code', 'Cascadia Code', 'Cascadia Mono', 'JetBrains Mono', Consolas, 'Courier New', monospace;
   background-color: hsl(var(--code-bg)) !important;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
 }
 
 .code-block-wrapper pre.shiki code {


### PR DESCRIPTION
## 问题

Windows 用户反馈预览界面中代码块文字极度模糊，几乎无法阅读。

根因：Chromium 在 Windows 上默认使用 ClearType LCD 次像素抗锯齿，该渲染技术为**浅色背景 + 深色文字**场景设计。代码块使用深色背景（`--code-bg: hsl(210, 13%, 12%)`），浅色代码文字通过 ClearType 渲染时会产生彩色 fringing（红/蓝色边缘），视觉上各颜色通道相互抵消，导致感知亮度大幅下降，文字几乎不可见。

## 修复

- **`apps/electron/src/main/index.ts`**: Windows 下在 `app.ready` 前追加 Chromium 开关 `disable-lcd-text`，切换到灰度抗锯齿，消除深色背景下的彩色边缘
- **`apps/electron/src/renderer/styles/globals.css`**:
  - `body` 全局添加 `-webkit-font-smoothing: antialiased` 和 `text-rendering: optimizeLegibility`
  - 代码块 `.shiki` 同步添加 font-smoothing 规则
  - 字体栈补充 `Cascadia Mono`（Windows 11 预装）和 `Courier New`（Windows 10 最终兜底）

## 测试

- [ ] Windows 用户确认代码块文字清晰可见
- [ ] macOS 无视觉回归