### PR TITLE
fix: Mini 地图点击用户消息无法跳转

### DIFF
--- a/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
@@ -188,7 +188,9 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
   const scrollToMessage = React.useCallback((id: string) => {
     const el = scrollRef.current
     if (!el) return
-    const target = el.querySelector<HTMLElement>(`[data-message-id="${id}"]`)
+    const target = Array.from(el.querySelectorAll<HTMLElement>('[data-message-id]')).find(
+      (node) => node.getAttribute('data-message-id') === id
+    )
     if (!target) return
 
     stopScroll()

--- a/apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx
@@ -116,7 +116,9 @@ export function StickyUserMessage({ userMessages }: StickyUserMessageProps): Rea
     const el = scrollRef.current
     if (!el || !stickyMessage?.id) return
 
-    const target = el.querySelector<HTMLElement>(`[data-message-id="${stickyMessage.id}"]`)
+    const target = Array.from(el.querySelectorAll<HTMLElement>('[data-message-id]')).find(
+      (node) => node.getAttribute('data-message-id') === stickyMessage.id
+    )
     if (!target) return
 
     stopScroll()


### PR DESCRIPTION
## Summary

修复 Mini 地图点击用户消息无法跳转到对应位置的问题。

**根因**：`scroll-minimap.tsx` 和 `sticky-user-message.tsx` 中都使用了 CSS 属性选择器 `[data-message-id=\"${id}\"]` 来查找目标元素。当用户消息的 ID 包含双引号等特殊字符时（Agent 模式下用户消息可能使用 `_promaStableKey` 作为 ID，而它是基于 `JSON.stringify` 生成的），会破坏 CSS 选择器的语法，导致 `querySelector` 返回 `null`，跳转失败。助手消息通常有服务器返回的 `uuid`（不含特殊字符），所以不受影响。

**修复**：将 CSS 属性选择器改为遍历所有带 `data-message-id` 的元素，通过 `getAttribute` 进行精确字符串匹配，避免了 CSS 特殊字符的注入问题。

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归