### PR TITLE
[codex] Use SDK auto approval by default

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -9,7 +9,7 @@ import { join, resolve, sep, dirname } from 'node:path'
 import { existsSync, realpathSync, rmSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs'
 import { writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, INSTALLER_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, MEMORY_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS, DINGTALK_IPC_CHANNELS, WECHAT_IPC_CHANNELS } from '@proma/shared'
+import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, INSTALLER_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, MEMORY_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS, DINGTALK_IPC_CHANNELS, WECHAT_IPC_CHANNELS, isPromaPermissionMode } from '@proma/shared'
 import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS, SCRATCH_PAD_IPC_CHANNELS, QUICK_TASK_IPC_CHANNELS, VOICE_DICTATION_IPC_CHANNELS, APP_ICON_IPC_CHANNELS, DOCK_BADGE_IPC_CHANNELS, STORAGE_IPC_CHANNELS } from '../types'
 import type {
   QuickTaskSubmitInput,
@@ -1617,8 +1617,7 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(
     AGENT_IPC_CHANNELS.UPDATE_SESSION_PERMISSION_MODE,
     async (_, sessionId: string, mode: PromaPermissionMode): Promise<void> => {
-      const validModes = new Set<string>(['auto', 'bypassPermissions', 'plan'])
-      if (!validModes.has(mode)) {
+      if (!isPromaPermissionMode(mode)) {
         throw new Error(`无效的权限模式: ${mode}`)
       }
       // 会话不存在时直接抛错（避免 updateAgentSessionMeta 的通用异常被降级为 warn）

--- a/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
@@ -17,6 +17,7 @@ import type {
   SdkBeta,
   JsonSchemaOutputFormat,
   SDKMessage,
+  PromaPermissionMode,
 } from '@proma/shared'
 import {
   THINKING_SIGNATURE_ERROR_MESSAGE,
@@ -121,8 +122,8 @@ export interface ClaudeAgentQueryOptions extends AgentQueryInput {
   env: Record<string, string | undefined>
   /** 最大轮次（undefined = SDK 默认） */
   maxTurns?: number
-  /** SDK 权限模式（直接使用 SDK 原生模式） */
-  sdkPermissionMode: 'acceptEdits' | 'bypassPermissions' | 'plan' | 'auto' | 'default' | 'dontAsk'
+  /** SDK 权限模式（Proma 当前三种模式直接映射 SDK 原生模式） */
+  sdkPermissionMode: PromaPermissionMode
   /** 是否跳过权限检查 */
   allowDangerouslySkipPermissions: boolean
   /** 自定义权限处理器（匹配 SDK CanUseTool 签名） */

--- a/apps/electron/src/main/lib/agent-exit-plan-service.ts
+++ b/apps/electron/src/main/lib/agent-exit-plan-service.ts
@@ -110,7 +110,7 @@ export class AgentExitPlanService {
         return { sessionId, targetMode: 'bypassPermissions' }
       }
       case 'approve_edit': {
-        // 批准 + 保持手动审批模式
+        // 批准 + 切换到自动审批模式
         pending.resolve({
           behavior: 'allow' as const,
           updatedInput: pending.toolInput,

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -837,7 +837,7 @@ export class AgentOrchestrator {
   /**
    * 持久化累积的 SDKMessage（Phase 4: 直接存储原始 SDKMessage）
    *
-   * 只持久化 assistant、user、result 和 compact_boundary system 消息
+   * 只持久化 assistant、user、result 和需要长期可见的 system 消息
    * （跳过 tool_progress、compacting 等临时消息）。
    */
   private persistSDKMessages(
@@ -849,7 +849,7 @@ export class AgentOrchestrator {
 
     const toPersist = accumulatedMessages.filter(
       (m) => m.type === 'assistant' || m.type === 'user' || m.type === 'result'
-        || (m.type === 'system' && (m as import('@proma/shared').SDKSystemMessage).subtype === 'compact_boundary')
+        || (m.type === 'system' && ['compact_boundary', 'permission_denied'].includes((m as import('@proma/shared').SDKSystemMessage).subtype ?? ''))
     ).filter((m) => {
       // 过滤 SDK 内部生成的 user 文本消息（如 Skill 展开 prompt），与实时流过滤逻辑一致
       if (m.type === 'user') {
@@ -1204,10 +1204,10 @@ export class AgentOrchestrator {
       }
 
       // 12. 读取应用设置并确定权限模式
-      // 权限模式只属于当前 session；新会话默认完全自动模式。
+      // 权限模式只属于当前 session；新会话默认自动审批模式。
       const appSettings = getSettings()
       const initialPermissionMode: PromaPermissionMode = permissionModeOverride
-        ?? 'bypassPermissions'
+        ?? 'auto'
       // 注册到 Map，支持运行中动态切换
       this.sessionPermissionModes.set(sessionId, initialPermissionMode)
       console.log(`[Agent 编排] 权限模式: ${initialPermissionMode}${permissionModeOverride ? '（外部覆盖）' : ''}`)
@@ -1732,7 +1732,7 @@ export class AgentOrchestrator {
               }
             } else if (msg.type === 'system') {
               const sysMsg = msg as import('@proma/shared').SDKSystemMessage
-              if (sysMsg.subtype === 'compact_boundary') {
+              if (sysMsg.subtype === 'compact_boundary' || sysMsg.subtype === 'permission_denied') {
                 accumulatedMessages.push(msg)
               }
             }

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -22,6 +22,8 @@ import { createRequire } from 'node:module'
 import { app } from 'electron'
 import type { AgentSendInput, AgentMessage, AgentGenerateTitleInput, AgentProviderAdapter, AgentSessionMeta, TypedError, RetryAttempt, SDKMessage, SDKAssistantMessage, AgentStreamPayload, RewindSessionResult, SdkBeta, ProviderType } from '@proma/shared'
 import {
+  PROMA_DEFAULT_PERMISSION_MODE,
+  PROMA_PERMISSION_MODE_CONFIG,
   SAFE_TOOLS,
   THINKING_SIGNATURE_ERROR_CODE,
   THINKING_SIGNATURE_ERROR_MESSAGE,
@@ -1207,7 +1209,7 @@ export class AgentOrchestrator {
       // 权限模式只属于当前 session；新会话默认自动审批模式。
       const appSettings = getSettings()
       const initialPermissionMode: PromaPermissionMode = permissionModeOverride
-        ?? 'auto'
+        ?? PROMA_DEFAULT_PERMISSION_MODE
       // 注册到 Map，支持运行中动态切换
       this.sessionPermissionModes.set(sessionId, initialPermissionMode)
       console.log(`[Agent 编排] 权限模式: ${initialPermissionMode}${permissionModeOverride ? '（外部覆盖）' : ''}`)
@@ -1410,7 +1412,7 @@ export class AgentOrchestrator {
         sdkCliPath: cliPath,
         env: sdkEnv,
         ...(maxTurns != null && { maxTurns }),
-        sdkPermissionMode: initialPermissionMode,
+        sdkPermissionMode: PROMA_PERMISSION_MODE_CONFIG[initialPermissionMode].sdkMode,
         // 当提供 canUseTool 回调时必须为 false，否则 CLI 同时收到
         // --allow-dangerously-skip-permissions 和 --permission-prompt-tool stdio
         // 两个矛盾的指令，导致 ExitPlanMode/AskUserQuestion 等交互式工具失败。

--- a/apps/electron/src/main/lib/agent-permission-service.ts
+++ b/apps/electron/src/main/lib/agent-permission-service.ts
@@ -76,6 +76,8 @@ export interface CanUseToolOptions {
   suggestions?: PermissionUpdate[]
   blockedPath?: string
   decisionReason?: string
+  decisionReasonType?: string
+  classifierApprovable?: boolean
   toolUseID: string
   agentID?: string
   title?: string
@@ -317,6 +319,8 @@ export class AgentPermissionService {
       command,
       dangerLevel: this.assessDangerLevel(toolName, input),
       decisionReason: options.decisionReason,
+      decisionReasonType: options.decisionReasonType,
+      classifierApprovable: options.classifierApprovable,
       sdkDisplayName: options.displayName,
       sdkTitle: options.title,
       sdkDescription: options.description,

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -289,7 +289,7 @@ export const RECENTLY_MODIFIED_TTL_MS = 60_000
 // ===== 权限系统 Atoms =====
 
 /** 新会话默认权限模式 */
-export const agentDefaultPermissionModeAtom = atom<PromaPermissionMode>('bypassPermissions')
+export const agentDefaultPermissionModeAtom = atom<PromaPermissionMode>('auto')
 
 /** Per-session 权限模式 Map — sessionId → PromaPermissionMode */
 export const agentPermissionModeMapAtom = atom<Map<string, PromaPermissionMode>>(new Map())

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -8,6 +8,7 @@
 import { atom } from 'jotai'
 import { atomFamily, atomWithStorage } from 'jotai/utils'
 import type { AgentSessionMeta, AgentEvent, AgentWorkspace, AgentPendingFile, RetryAttempt, PromaPermissionMode, PermissionRequest, AskUserRequest, ExitPlanModeRequest, ThinkingConfig, AgentEffort, SDKMessage } from '@proma/shared'
+import { PROMA_DEFAULT_PERMISSION_MODE } from '@proma/shared'
 import { calculateDockBadgeCount, countPendingRequests } from '@/lib/dock-badge-count'
 
 /** 活动状态 */
@@ -289,7 +290,7 @@ export const RECENTLY_MODIFIED_TTL_MS = 60_000
 // ===== 权限系统 Atoms =====
 
 /** 新会话默认权限模式 */
-export const agentDefaultPermissionModeAtom = atom<PromaPermissionMode>('auto')
+export const agentDefaultPermissionModeAtom = atom<PromaPermissionMode>(PROMA_DEFAULT_PERMISSION_MODE)
 
 /** Per-session 权限模式 Map — sessionId → PromaPermissionMode */
 export const agentPermissionModeMapAtom = atom<Map<string, PromaPermissionMode>>(new Map())

--- a/apps/electron/src/renderer/components/agent/ExitPlanModeBanner.tsx
+++ b/apps/electron/src/renderer/components/agent/ExitPlanModeBanner.tsx
@@ -2,8 +2,8 @@
  * ExitPlanModeBanner — Agent ExitPlanMode 计划审批横幅
  *
  * 仿照 Claude Code 的计划审批 UI，提供 4 个选项：
- * 1. 批准并自动执行 — 切换到 bypassPermissions
- * 2. 批准，手动审批编辑 — 切换到 auto
+ * 1. 批准并完全自动执行 — 切换到 bypassPermissions
+ * 2. 批准并自动审批 — 切换到 auto
  * 3. 拒绝计划 — deny
  * 4. 提供反馈 — 自由输入修改意见
  *
@@ -36,15 +36,15 @@ interface PlanOption {
 const PLAN_OPTIONS: PlanOption[] = [
   {
     action: 'approve_auto',
-    label: '批准并自动执行',
-    description: '自动批准所有后续操作',
+    label: '批准并完全自动执行',
+    description: '后续工具调用全部自动允许',
     icon: <Check className="size-3.5" />,
     variant: 'default',
   },
   {
     action: 'approve_edit',
-    label: '批准，手动审批编辑',
-    description: '后续文件修改需要逐一确认',
+    label: '批准并自动审批',
+    description: '使用 SDK 自动审批器判断后续操作',
     icon: <ShieldCheck className="size-3.5" />,
     variant: 'secondary',
   },

--- a/apps/electron/src/renderer/components/agent/PermissionModeSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/PermissionModeSelector.tsx
@@ -23,7 +23,7 @@ const MODE_CONFIG: Record<PromaPermissionMode, {
 }> = {
   auto: {
     icon: Compass,
-    label: '自动模式',
+    label: '自动审批',
     description: 'SDK 内置审批器自动判断，危险操作才需确认',
   },
   bypassPermissions: {
@@ -51,7 +51,7 @@ export function PermissionModeSelector({ sessionId }: PermissionModeSelectorProp
 
   // 初始化：如果当前 session 不在 Map 中，按以下优先级读回：
   // 1. session meta.permissionMode（每个 tab 独立持久化，重启恢复各自的值）
-  // 2. 默认完全自动模式
+  // 2. 默认自动审批
   // 注意：只写入当前 session，不回写到 agentDefaultPermissionModeAtom，避免跨会话污染。
   React.useEffect(() => {
     if (!sessionExistsInList) return
@@ -102,6 +102,7 @@ export function PermissionModeSelector({ sessionId }: PermissionModeSelectorProp
             type="button"
             variant="ghost"
             size="icon"
+            aria-label={config.label}
             onClick={() => { cycleMode(); requestAnimationFrame(() => document.querySelector<HTMLElement>('.ProseMirror')?.focus()) }}
             className="size-[36px] rounded-full text-foreground/60 hover:text-foreground"
           >
@@ -109,7 +110,7 @@ export function PermissionModeSelector({ sessionId }: PermissionModeSelectorProp
           </Button>
         </TooltipTrigger>
         <TooltipContent side="bottom" className="max-w-[200px]">
-          <p className="font-medium">{config.label}模式</p>
+          <p className="font-medium">{config.label}</p>
           <p className="text-xs text-muted-foreground mt-0.5">{config.description}</p>
           <p className="text-xs text-muted-foreground mt-1">点击切换模式</p>
         </TooltipContent>

--- a/apps/electron/src/renderer/components/agent/PermissionModeSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/PermissionModeSelector.tsx
@@ -13,29 +13,12 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { Button } from '@/components/ui/button'
 import { agentPermissionModeMapAtom, agentDefaultPermissionModeAtom, sessionPersistedPermissionModeAtom, sessionExistsAtom } from '@/atoms/agent-atoms'
 import type { PromaPermissionMode } from '@proma/shared'
-import { PROMA_PERMISSION_MODE_ORDER } from '@proma/shared'
+import { PROMA_PERMISSION_MODE_CONFIG, PROMA_PERMISSION_MODE_ORDER } from '@proma/shared'
 
-/** 模式配置 */
-const MODE_CONFIG: Record<PromaPermissionMode, {
-  icon: React.ComponentType<{ className?: string }>
-  label: string
-  description: string
-}> = {
-  auto: {
-    icon: Compass,
-    label: '自动审批',
-    description: 'SDK 内置审批器自动判断，危险操作才需确认',
-  },
-  bypassPermissions: {
-    icon: Zap,
-    label: '完全自动',
-    description: '所有工具调用自动允许',
-  },
-  plan: {
-    icon: MapIcon,
-    label: '计划模式',
-    description: '仅规划不执行，查看工具使用计划',
-  },
+const MODE_ICONS: Record<PromaPermissionMode, React.ComponentType<{ className?: string }>> = {
+  auto: Compass,
+  bypassPermissions: Zap,
+  plan: MapIcon,
 }
 
 interface PermissionModeSelectorProps {
@@ -91,8 +74,8 @@ export function PermissionModeSelector({ sessionId }: PermissionModeSelectorProp
     }
   }, [mode, sessionId, setModeMap])
 
-  const config = MODE_CONFIG[mode]
-  const Icon = config.icon
+  const config = PROMA_PERMISSION_MODE_CONFIG[mode]
+  const Icon = MODE_ICONS[mode]
 
   return (
     <TooltipProvider delayDuration={300}>

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -88,6 +88,44 @@ function CompactBoundaryDivider(): React.ReactElement {
   )
 }
 
+function formatSystemToolName(toolName: string): string {
+  const parts = toolName.split('__')
+  if (parts[0] === 'mcp' && parts.length >= 3) {
+    return `${parts[1]} / ${parts.slice(2).join('__')}`
+  }
+  return toolName
+}
+
+function PermissionDeniedNotice({ message }: { message: SDKSystemMessage }): React.ReactElement {
+  const toolName = typeof message.tool_name === 'string' ? formatSystemToolName(message.tool_name) : undefined
+  const denialMessage = typeof message.message === 'string' ? message.message : undefined
+  const reason = typeof message.decision_reason === 'string' ? message.decision_reason : undefined
+
+  return (
+    <div className="my-3 px-1">
+      <div className="flex items-start gap-2.5 rounded-md border border-amber-500/20 bg-amber-500/5 px-3 py-2.5 text-xs text-foreground/80">
+        <AlertTriangle className="mt-0.5 size-3.5 shrink-0 text-amber-500" />
+        <div className="min-w-0 space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-medium text-foreground">自动审批已拒绝操作</span>
+            {toolName && (
+              <span className="rounded bg-background/60 px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground">
+                {toolName}
+              </span>
+            )}
+          </div>
+          {denialMessage && (
+            <p className="break-words text-muted-foreground">{denialMessage}</p>
+          )}
+          {reason && reason !== denialMessage && (
+            <p className="break-words text-muted-foreground/70">{reason}</p>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
 // ===== system 消息：正在压缩指示器（与 CompactBoundaryDivider 同款横线样式，pill 内带 spinner） =====
 
 export function CompactingIndicator(): React.ReactElement {
@@ -234,7 +272,7 @@ export type MessageGroup =
  * 规则：
  * 1. user（真正用户输入）→ 单独的 user group
  * 2. assistant + user(tool_result) + assistant... → 合并为一个 assistant-turn
- * 3. system（compact_boundary / compacting）→ 独立渲染，其他归入当前 turn
+ * 3. system（compact_boundary / compacting / permission_denied）→ 独立渲染，其他归入当前 turn
  * 4. 其他类型（result, tool_progress 等）→ 归入当前 assistant-turn
  * 5. 后处理：合并相邻同模型的 assistant-turn（处理子代理切换模型导致的碎片化）
  */
@@ -284,9 +322,9 @@ export function groupIntoTurns(messages: SDKMessage[], sessionModelId?: string):
       }
     } else if (msg.type === 'system') {
       const sysMsg = msg as SDKSystemMessage
-      // 仅需要独立渲染的 system 消息才中断 turn（compact_boundary / compacting）
+      // 仅需要独立渲染的 system 消息才中断 turn（compact_boundary / compacting / permission_denied）
       // 其他 system 消息（如 init、task_started、task_progress）归入当前 turn，不中断分组
-      if (sysMsg.subtype === 'compact_boundary' || sysMsg.subtype === 'compacting') {
+      if (sysMsg.subtype === 'compact_boundary' || sysMsg.subtype === 'compacting' || sysMsg.subtype === 'permission_denied') {
         flushTurn()
         groups.push({ type: 'system', message: sysMsg })
       } else if (currentTurn) {
@@ -331,7 +369,7 @@ function mergeAdjacentSameModelTurns(groups: MessageGroup[]): MessageGroup[] {
     for (let i = result.length - 1; i >= 0; i--) {
       const prev = result[i]!
       if (prev.type === 'user') break // 真正的用户输入阻断合并
-      if (prev.type === 'system' && (prev.message as SDKSystemMessage).subtype === 'compact_boundary') break // 压缩边界阻断合并
+      if (prev.type === 'system' && ['compact_boundary', 'permission_denied'].includes((prev.message as SDKSystemMessage).subtype ?? '')) break
       if (prev.type === 'assistant-turn') {
         if (prev.model === group.model) {
           mergeTargetIdx = i
@@ -716,6 +754,9 @@ export function SDKMessageRenderer({
 
     if (subtype === 'compact_boundary') {
       return <CompactBoundaryDivider />
+    }
+    if (subtype === 'permission_denied') {
+      return <PermissionDeniedNotice message={sysMsg} />
     }
 
     // compacting 事件已由 isCompacting flag 驱动的尾部指示器接管（见 AgentMessages），此处不再渲染持久条目
@@ -1145,6 +1186,7 @@ export function getGroupPreview(group: MessageGroup): string {
   if (group.type === 'system') {
     if (group.message.subtype === 'compact_boundary') return '上下文已压缩'
     if (group.message.subtype === 'compacting') return '正在压缩上下文...'
+    if (group.message.subtype === 'permission_denied') return '自动审批已拒绝操作'
     return ''
   }
   // assistant-turn：收集所有 text 块
@@ -1176,6 +1218,7 @@ export function MessageGroupRenderer({ group, allMessages, basePath, onFork, onR
     const subtype = group.message.subtype
     if (subtype === 'compact_boundary') return <div data-message-id={groupId}><CompactBoundaryDivider /></div>
     if (subtype === 'compacting') return <div data-message-id={groupId}><CompactingIndicator /></div>
+    if (subtype === 'permission_denied') return <div data-message-id={groupId}><PermissionDeniedNotice message={group.message} /></div>
     return null
   }
 

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -780,7 +780,7 @@ export function useGlobalAgentListeners(): void {
               return next
             })
           } else if (event.type === 'permission_mode_changed') {
-            // 权限模式变更（如 Plan 模式退出时切换到完全自动）
+            // 权限模式变更（如 Plan 模式退出后切换到自动审批或完全自动）
             console.log(`[GlobalAgentListeners] 权限模式变更: ${event.mode}`)
             store.set(agentPermissionModeMapAtom, (prev: Map<string, import('@proma/shared').PromaPermissionMode>) => {
               const next = new Map(prev)

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -250,7 +250,7 @@ export interface SDKResultMessage {
   session_id?: string
 }
 
-/** SDK system 消息（init / compact_boundary / task_started / task_progress / task_notification） */
+/** SDK system 消息（init / compact_boundary / permission_denied / task_started / task_progress / task_notification） */
 export interface SDKSystemMessage {
   type: 'system'
   subtype?: string
@@ -266,6 +266,11 @@ export interface SDKSystemMessage {
   summary?: string
   output_file?: string
   last_tool_name?: string
+  /** permission_denied 相关字段 */
+  tool_name?: string
+  message?: string
+  decision_reason_type?: string
+  decision_reason?: string
   usage?: { total_tokens?: number; tool_uses?: number; duration_ms?: number }
   [key: string]: unknown
 }
@@ -556,7 +561,7 @@ export interface AgentSessionMeta {
   manualWorking?: boolean
   /** 最后一次流式执行是否被用户主动中断 */
   stoppedByUser?: boolean
-  /** 该会话当前的权限模式（持久化到磁盘，重启后恢复）。未设置时新会话默认 bypassPermissions */
+  /** 该会话当前的权限模式（持久化到磁盘，重启后恢复）。未设置时新会话默认 auto */
   permissionMode?: PromaPermissionMode
   /** 创建时间戳 */
   createdAt: number
@@ -1118,6 +1123,10 @@ export interface PermissionRequest {
   dangerLevel: DangerLevel
   /** SDK 提供的原因说明 */
   decisionReason?: string
+  /** SDK 提供的原因分类，如 classifier / safetyCheck / rule */
+  decisionReasonType?: string
+  /** SDK auto safety check 是否允许交给 classifier 审批 */
+  classifierApprovable?: boolean
   /** SDK 提供的工具显示名称，如 "Write" */
   sdkDisplayName?: string
   /** SDK 提供的操作标题，如 "Write to /path/to/file.ts" */

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1085,21 +1085,57 @@ export interface ExitPlanModeResponse {
 
 // ===== 权限系统类型 =====
 
-/** Proma 权限模式（直接映射 SDK 原生模式） */
-export type PromaPermissionMode = 'auto' | 'bypassPermissions' | 'plan'
+/** 当前 Proma 支持的权限模式，值直接映射 SDK 原生 permissionMode */
+export const PROMA_PERMISSION_MODES = ['auto', 'bypassPermissions', 'plan'] as const
+
+export type PromaPermissionMode = typeof PROMA_PERMISSION_MODES[number]
+
+export const PROMA_DEFAULT_PERMISSION_MODE: PromaPermissionMode = 'auto'
+
+export interface PromaPermissionModeConfig {
+  /** 对应 Claude Agent SDK 的 permissionMode */
+  sdkMode: PromaPermissionMode
+  label: string
+  description: string
+}
+
+/** Proma 权限模式的单一配置来源 */
+export const PROMA_PERMISSION_MODE_CONFIG = {
+  auto: {
+    sdkMode: 'auto',
+    label: '自动审批',
+    description: 'SDK 内置审批器自动判断，危险操作才需确认',
+  },
+  bypassPermissions: {
+    sdkMode: 'bypassPermissions',
+    label: '完全自动',
+    description: '所有工具调用自动允许',
+  },
+  plan: {
+    sdkMode: 'plan',
+    label: '计划模式',
+    description: '仅规划不执行，查看工具使用计划',
+  },
+} as const satisfies Record<PromaPermissionMode, PromaPermissionModeConfig>
 
 /** 权限模式定义顺序（用于循环切换） */
-export const PROMA_PERMISSION_MODE_ORDER: readonly PromaPermissionMode[] = ['auto', 'bypassPermissions', 'plan']
+export const PROMA_PERMISSION_MODE_ORDER: readonly PromaPermissionMode[] = PROMA_PERMISSION_MODES
+
+/** 旧版权限模式迁移表。不要把这些旧值重新暴露为当前产品模式。 */
+export const PROMA_LEGACY_PERMISSION_MODE_MIGRATIONS: Readonly<Record<string, PromaPermissionMode>> = {
+  acceptEdits: 'auto',
+  smart: 'auto',
+  supervised: 'auto',
+}
+
+export function isPromaPermissionMode(mode: string): mode is PromaPermissionMode {
+  return (PROMA_PERMISSION_MODES as readonly string[]).includes(mode)
+}
 
 /** 迁移旧权限模式值到新模式 */
 export function migratePermissionMode(mode: string): PromaPermissionMode {
-  if (mode === 'auto' || mode === 'bypassPermissions' || mode === 'plan') return mode
-  const migration: Record<string, PromaPermissionMode> = {
-    acceptEdits: 'auto',
-    smart: 'auto',
-    supervised: 'auto',
-  }
-  return migration[mode] ?? 'auto'
+  if (isPromaPermissionMode(mode)) return mode
+  return PROMA_LEGACY_PERMISSION_MODE_MIGRATIONS[mode] ?? PROMA_DEFAULT_PERMISSION_MODE
 }
 
 /** 危险等级 */

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1121,21 +1121,14 @@ export const PROMA_PERMISSION_MODE_CONFIG = {
 /** 权限模式定义顺序（用于循环切换） */
 export const PROMA_PERMISSION_MODE_ORDER: readonly PromaPermissionMode[] = PROMA_PERMISSION_MODES
 
-/** 旧版权限模式迁移表。不要把这些旧值重新暴露为当前产品模式。 */
-export const PROMA_LEGACY_PERMISSION_MODE_MIGRATIONS: Readonly<Record<string, PromaPermissionMode>> = {
-  acceptEdits: 'auto',
-  smart: 'auto',
-  supervised: 'auto',
-}
-
 export function isPromaPermissionMode(mode: string): mode is PromaPermissionMode {
   return (PROMA_PERMISSION_MODES as readonly string[]).includes(mode)
 }
 
-/** 迁移旧权限模式值到新模式 */
+/** 规范化权限模式：不匹配当前三种模式时统一回到默认自动审批 */
 export function migratePermissionMode(mode: string): PromaPermissionMode {
   if (isPromaPermissionMode(mode)) return mode
-  return PROMA_LEGACY_PERMISSION_MODE_MIGRATIONS[mode] ?? PROMA_DEFAULT_PERMISSION_MODE
+  return PROMA_DEFAULT_PERMISSION_MODE
 }
 
 /** 危险等级 */


### PR DESCRIPTION
## Summary

- Default new Agent sessions to the Claude Agent SDK `auto` permission mode instead of `bypassPermissions`.
- Rename the UI mode from `自动模式` to `自动审批` and clarify the Plan approval options.
- Persist and render SDK `permission_denied` system messages so auto-approval denials are visible in the conversation.
- Carry SDK auto decision metadata through Proma permission request types for future UI/policy use.

## Why

Proma previously fell back to full trust for new sessions by using `bypassPermissions`. The SDK now provides `auto`, which can approve safe work automatically while still denying or escalating risky operations. This makes automatic editing safer and easier to explain in the product UI.

## Validation

- `bun run typecheck`
- `bun test`
- `git diff --check`
