### PR TITLE
fix: 修复 Agent 消息重复 key 警告并增强悬浮置顶条视觉区分度

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -45,10 +45,19 @@ function stableStringify(value: unknown): string {
   return `{${Object.keys(record).sort().map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`).join(',')}}`
 }
 
+/** 消息对象引用 → 稳定 key 缓存，避免内容相同的消息产生重复 key */
+const stableKeyCache = new WeakMap<object, string>()
+let stableKeyFallbackCounter = 0
+
 function getSDKMessageStableKey(message: SDKMessage): string {
   const record = message as Record<string, unknown>
   if (typeof record.uuid === 'string' && record.uuid.length > 0) {
     return `${message.type}:uuid:${record.uuid}`
+  }
+
+  // 已缓存的消息对象直接返回，保证跨渲染稳定
+  if (stableKeyCache.has(message)) {
+    return stableKeyCache.get(message)!
   }
 
   const parentToolUseId = typeof record.parent_tool_use_id === 'string'
@@ -56,22 +65,23 @@ function getSDKMessageStableKey(message: SDKMessage): string {
     : ''
   const sessionId = typeof record.session_id === 'string' ? record.session_id : ''
 
+  let key: string
+
   if (message.type === 'result') {
     const result = record as { subtype?: unknown; terminal_reason?: unknown; result?: unknown }
-    return `result:${sessionId}:${String(result.subtype ?? '')}:${String(result.terminal_reason ?? '')}:${String(result.result ?? '')}`
-  }
-
-  if (message.type === 'system') {
+    key = `result:${sessionId}:${String(result.subtype ?? '')}:${String(result.terminal_reason ?? '')}:${String(result.result ?? '')}:${++stableKeyFallbackCounter}`
+  } else if (message.type === 'system') {
     const sys = record as { subtype?: unknown; task_id?: unknown; tool_use_id?: unknown }
-    return `system:${sessionId}:${String(sys.subtype ?? '')}:${String(sys.task_id ?? '')}:${String(sys.tool_use_id ?? '')}:${stableStringify(record)}`
-  }
-
-  if ('message' in record) {
+    key = `system:${sessionId}:${String(sys.subtype ?? '')}:${String(sys.task_id ?? '')}:${String(sys.tool_use_id ?? '')}:${stableStringify(record)}:${++stableKeyFallbackCounter}`
+  } else if ('message' in record) {
     const inner = record.message as { content?: unknown } | undefined
-    return `${message.type}:${sessionId}:${parentToolUseId}:${stableStringify(inner?.content)}`
+    key = `${message.type}:${sessionId}:${parentToolUseId}:${stableStringify(inner?.content)}:${++stableKeyFallbackCounter}`
+  } else {
+    key = `${message.type}:${sessionId}:${parentToolUseId}:${stableStringify(record)}:${++stableKeyFallbackCounter}`
   }
 
-  return `${message.type}:${sessionId}:${parentToolUseId}:${stableStringify(record)}`
+  stableKeyCache.set(message, key)
+  return key
 }
 
 /** AgentMessages 属性接口 */

--- a/apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx
@@ -150,7 +150,7 @@ export function StickyUserMessage({ userMessages }: StickyUserMessageProps): Rea
       {/* 复用 ConversationContent(px-8) + Message(px-2.5) 的 padding 链，保证与内容区等宽 */}
       <div className="mx-8 px-2.5 pt-2">
         <div
-          className="ml-[46px] rounded-xl bg-background/95 backdrop-blur-sm border border-border/40 shadow-sm cursor-pointer hover:bg-accent/50 transition-colors"
+          className="ml-[46px] rounded-xl bg-background/85 backdrop-blur-md border border-border/50 shadow-md cursor-pointer hover:bg-accent/50 transition-colors"
           onClick={scrollToOriginal}
         >
           <div className="px-3.5 py-2.5">


### PR DESCRIPTION
## 概述

两个独立修复：

1. **Agent 消息重复 key 警告** — 当两条用户消息内容相同时，`getSDKMessageStableKey` 回退到基于内容的 key，导致 React 报 `Encountered two children with the same key` 警告
2. **悬浮置顶条视觉区分度不足** — 非悬停状态下，悬浮块与下方模型输出内容缺乏清晰的视觉边界

## 改动

- `AgentMessages.tsx` — `getSDKMessageStableKey` 新增 WeakMap 缓存 + 自增计数器，无 `uuid` 时保证 key 唯一且跨渲染稳定，与 `SDKMessageRenderer.tsx` 中 `getGroupId` 的模式一致
- `sticky-user-message.tsx` — 悬浮块样式从 `bg-background/95 backdrop-blur-sm shadow-sm` 调整为 `bg-background/85 backdrop-blur-md shadow-md`，增强毛玻璃效果和投影层次

## 测试方式

1. 在 Agent 会话中连续发送两条内容完全相同的消息，确认控制台不再出现 duplicate key 警告
2. 滚动对话使悬浮置顶条出现，确认非悬停状态下与下方内容有明显的视觉分层

## 备注

- key 去重方案与项目中 `getGroupId` 已有的 WeakMap + counter 模式一致
- 悬浮条采用毛玻璃效果（更高透明度 + 更强模糊），在保持现代感的同时确保下方内容不可辨识