### PR TITLE
feat: 设置页管理 Skill 子文件夹与资源文件

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -196,6 +196,12 @@ import {
   readWorkspaceSkillContent,
   writeWorkspaceSkillContent,
   toggleWorkspaceSkill,
+  listSkillFiles,
+  readSkillFile,
+  writeSkillFile,
+  createSkillEntry,
+  deleteSkillEntry,
+  renameSkillEntry,
   getWorkspaceAttachedDirectories,
   getWorkspaceAttachedFiles,
   attachWorkspaceDirectory,
@@ -1528,6 +1534,50 @@ export function registerIpcHandlers(): void {
     AGENT_IPC_CHANNELS.WRITE_SKILL_CONTENT,
     async (_, workspaceSlug: string, skillSlug: string, content: string): Promise<void> => {
       writeWorkspaceSkillContent(workspaceSlug, skillSlug, content)
+    }
+  )
+
+  // ===== Skill 子文件管理 =====
+
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.LIST_SKILL_FILES,
+    async (_, workspaceSlug: string, skillSlug: string) => {
+      return listSkillFiles(workspaceSlug, skillSlug)
+    }
+  )
+
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.READ_SKILL_FILE,
+    async (_, workspaceSlug: string, skillSlug: string, relativePath: string) => {
+      return readSkillFile(workspaceSlug, skillSlug, relativePath)
+    }
+  )
+
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.WRITE_SKILL_FILE,
+    async (_, workspaceSlug: string, skillSlug: string, relativePath: string, content: string): Promise<void> => {
+      writeSkillFile(workspaceSlug, skillSlug, relativePath, content)
+    }
+  )
+
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.CREATE_SKILL_ENTRY,
+    async (_, workspaceSlug: string, skillSlug: string, relativePath: string, type: 'file' | 'directory'): Promise<void> => {
+      createSkillEntry(workspaceSlug, skillSlug, relativePath, type)
+    }
+  )
+
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.DELETE_SKILL_ENTRY,
+    async (_, workspaceSlug: string, skillSlug: string, relativePath: string): Promise<void> => {
+      deleteSkillEntry(workspaceSlug, skillSlug, relativePath)
+    }
+  )
+
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.RENAME_SKILL_ENTRY,
+    async (_, workspaceSlug: string, skillSlug: string, fromRelative: string, toRelative: string): Promise<void> => {
+      renameSkillEntry(workspaceSlug, skillSlug, fromRelative, toRelative)
     }
   )
 

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -6,7 +6,7 @@
  * - 工作区目录：~/.proma/agent-workspaces/{slug}/（Agent 的 cwd）
  */
 
-import { readFileSync, writeFileSync, existsSync, readdirSync, cpSync, rmSync, mkdirSync, statSync, renameSync } from 'node:fs'
+import { readFileSync, writeFileSync, existsSync, readdirSync, cpSync, rmSync, mkdirSync, statSync, renameSync, openSync, readSync, closeSync } from 'node:fs'
 import { writeJsonFileAtomic, readJsonFileSafe } from './safe-file'
 import { randomUUID } from 'node:crypto'
 import { join, resolve, relative, isAbsolute, dirname } from 'node:path'
@@ -767,18 +767,19 @@ function resolveSkillChildPath(skillDir: string, relativePath: string, opts: { a
   return resolved
 }
 
-/** 用文件头判断是否为二进制文件（粗略：含 NUL 字节即视为二进制） */
+/** 用文件头判断是否为二进制文件（粗略：含 NUL 字节即视为二进制）。只读前 8KB，避免把大文件全量读入内存 */
 function isLikelyBinaryFile(absPath: string, size: number): boolean {
+  if (size === 0) return false
+  let fd: number | undefined
   try {
-    const sampleSize = Math.min(size, 8192)
-    if (sampleSize === 0) return false
-    const buf = readFileSync(absPath).subarray(0, sampleSize)
-    for (let i = 0; i < buf.length; i++) {
-      if (buf[i] === 0) return true
-    }
-    return false
+    fd = openSync(absPath, 'r')
+    const buf = Buffer.alloc(Math.min(size, 8192))
+    const n = readSync(fd, buf, 0, buf.length, 0)
+    return buf.subarray(0, n).includes(0)
   } catch {
     return true
+  } finally {
+    if (fd !== undefined) closeSync(fd)
   }
 }
 

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -760,7 +760,8 @@ function resolveSkillChildPath(skillDir: string, relativePath: string, opts: { a
   if (rel === '' || rel.startsWith('..') || isAbsolute(rel)) {
     throw new Error('非法路径：禁止访问 Skill 目录外')
   }
-  if (!opts.allowSkillMd && rel.split(/[\\/]/).join('/') === 'SKILL.md') {
+  // 用 lowercase 比较，避免 macOS/Windows 的大小写不敏感文件系统上 skill.md/Skill.MD 绕过保护
+  if (!opts.allowSkillMd && rel.split(/[\\/]/).join('/').toLowerCase() === 'skill.md') {
     throw new Error('SKILL.md 由专用接口管理，请通过 readWorkspaceSkillContent / writeWorkspaceSkillContent')
   }
   return resolved
@@ -862,6 +863,11 @@ export function writeSkillFile(workspaceSlug: string, skillSlug: string, relativ
   const dir = resolveSkillDir(workspaceSlug, skillSlug)
   if (!dir) throw new Error(`Skill 不存在: ${workspaceSlug}/${skillSlug}`)
   const abs = resolveSkillChildPath(dir, relativePath)
+
+  const byteLen = Buffer.byteLength(content, 'utf-8')
+  if (byteLen > SKILL_FILE_SIZE_LIMIT) {
+    throw new Error(`内容过大（${(byteLen / 1024 / 1024).toFixed(2)} MB），超过 10 MB 限制`)
+  }
 
   if (existsSync(abs) && statSync(abs).isDirectory()) {
     throw new Error(`目标是目录，无法写入文件内容: ${relativePath}`)

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -9,7 +9,7 @@
 import { readFileSync, writeFileSync, existsSync, readdirSync, cpSync, rmSync, mkdirSync, statSync, renameSync } from 'node:fs'
 import { writeJsonFileAtomic, readJsonFileSafe } from './safe-file'
 import { randomUUID } from 'node:crypto'
-import { join } from 'node:path'
+import { join, resolve, relative, isAbsolute, dirname } from 'node:path'
 import {
   getAgentWorkspacesIndexPath,
   getAgentWorkspacePath,
@@ -19,7 +19,7 @@ import {
   getDefaultSkillsDir,
   parseSkillVersion,
 } from './config-paths'
-import type { AgentWorkspace, WorkspaceMcpConfig, SkillMeta, SkillImportSource, OtherWorkspaceSkillsGroup, WorkspaceCapabilities } from '@proma/shared'
+import type { AgentWorkspace, WorkspaceMcpConfig, SkillMeta, SkillImportSource, OtherWorkspaceSkillsGroup, WorkspaceCapabilities, SkillFileNode, SkillFileContent } from '@proma/shared'
 
 interface AgentWorkspacesIndex {
   version: number
@@ -737,6 +737,205 @@ export function writeWorkspaceSkillContent(workspaceSlug: string, skillSlug: str
   if (!dir) throw new Error(`Skill 不存在: ${workspaceSlug}/${skillSlug}`)
   writeFileSync(join(dir, 'SKILL.md'), content, 'utf-8')
   console.log(`[Agent 工作区] 已更新 SKILL.md: ${workspaceSlug}/${skillSlug}`)
+}
+
+// ===== Skill 子文件管理 =====
+
+/** 单个子文件大小上限（10 MB），超过则拒绝读入到编辑器 */
+const SKILL_FILE_SIZE_LIMIT = 10 * 1024 * 1024
+/** 文件树递归深度上限，防止异常深嵌套 */
+const SKILL_TREE_MAX_DEPTH = 8
+
+/** 把相对路径限制在 Skill 根目录内，并拒绝直接覆盖 SKILL.md */
+function resolveSkillChildPath(skillDir: string, relativePath: string, opts: { allowSkillMd?: boolean } = {}): string {
+  if (typeof relativePath !== 'string' || relativePath.length === 0) {
+    throw new Error('相对路径不能为空')
+  }
+  if (isAbsolute(relativePath)) {
+    throw new Error('禁止传入绝对路径')
+  }
+  const normalized = relativePath.replace(/\\/g, '/')
+  const resolved = resolve(skillDir, normalized)
+  const rel = relative(skillDir, resolved)
+  if (rel === '' || rel.startsWith('..') || isAbsolute(rel)) {
+    throw new Error('非法路径：禁止访问 Skill 目录外')
+  }
+  if (!opts.allowSkillMd && rel.split(/[\\/]/).join('/') === 'SKILL.md') {
+    throw new Error('SKILL.md 由专用接口管理，请通过 readWorkspaceSkillContent / writeWorkspaceSkillContent')
+  }
+  return resolved
+}
+
+/** 用文件头判断是否为二进制文件（粗略：含 NUL 字节即视为二进制） */
+function isLikelyBinaryFile(absPath: string, size: number): boolean {
+  try {
+    const sampleSize = Math.min(size, 8192)
+    if (sampleSize === 0) return false
+    const buf = readFileSync(absPath).subarray(0, sampleSize)
+    for (let i = 0; i < buf.length; i++) {
+      if (buf[i] === 0) return true
+    }
+    return false
+  } catch {
+    return true
+  }
+}
+
+function buildSkillFileTree(rootDir: string, currentDir: string, depth: number): SkillFileNode[] {
+  if (depth > SKILL_TREE_MAX_DEPTH) return []
+  let entries: import('node:fs').Dirent[]
+  try {
+    entries = readdirSync(currentDir, { withFileTypes: true })
+  } catch {
+    return []
+  }
+
+  const nodes: SkillFileNode[] = []
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue // 跳过隐藏文件，如 .source.json
+    const absPath = join(currentDir, entry.name)
+    const rel = relative(rootDir, absPath).split(/[\\/]/).join('/')
+
+    if (rel === 'SKILL.md') continue // SKILL.md 由主编辑器管理
+
+    const isDir = entry.isDirectory()
+    if (isDir) {
+      nodes.push({
+        relativePath: rel,
+        name: entry.name,
+        type: 'directory',
+        children: buildSkillFileTree(rootDir, absPath, depth + 1),
+      })
+    } else if (entry.isFile()) {
+      let size = 0
+      try {
+        size = statSync(absPath).size
+      } catch {
+        // ignore
+      }
+      nodes.push({
+        relativePath: rel,
+        name: entry.name,
+        type: 'file',
+        size,
+        isText: !isLikelyBinaryFile(absPath, size),
+      })
+    }
+  }
+
+  // 目录优先 + 名称升序
+  nodes.sort((a, b) => {
+    if (a.type !== b.type) return a.type === 'directory' ? -1 : 1
+    return a.name.localeCompare(b.name)
+  })
+  return nodes
+}
+
+export function listSkillFiles(workspaceSlug: string, skillSlug: string): SkillFileNode[] {
+  const dir = resolveSkillDir(workspaceSlug, skillSlug)
+  if (!dir) throw new Error(`Skill 不存在: ${workspaceSlug}/${skillSlug}`)
+  return buildSkillFileTree(dir, dir, 0)
+}
+
+export function readSkillFile(workspaceSlug: string, skillSlug: string, relativePath: string): SkillFileContent {
+  const dir = resolveSkillDir(workspaceSlug, skillSlug)
+  if (!dir) throw new Error(`Skill 不存在: ${workspaceSlug}/${skillSlug}`)
+  const abs = resolveSkillChildPath(dir, relativePath)
+  if (!existsSync(abs)) throw new Error(`文件不存在: ${relativePath}`)
+
+  const st = statSync(abs)
+  if (!st.isFile()) throw new Error(`目标不是文件: ${relativePath}`)
+  if (st.size > SKILL_FILE_SIZE_LIMIT) {
+    throw new Error(`文件过大（${(st.size / 1024 / 1024).toFixed(2)} MB），超过 10 MB 限制`)
+  }
+
+  const binary = isLikelyBinaryFile(abs, st.size)
+  return {
+    relativePath: relative(dir, abs).split(/[\\/]/).join('/'),
+    isText: !binary,
+    size: st.size,
+    content: binary ? undefined : readFileSync(abs, 'utf-8'),
+  }
+}
+
+export function writeSkillFile(workspaceSlug: string, skillSlug: string, relativePath: string, content: string): void {
+  const dir = resolveSkillDir(workspaceSlug, skillSlug)
+  if (!dir) throw new Error(`Skill 不存在: ${workspaceSlug}/${skillSlug}`)
+  const abs = resolveSkillChildPath(dir, relativePath)
+
+  if (existsSync(abs) && statSync(abs).isDirectory()) {
+    throw new Error(`目标是目录，无法写入文件内容: ${relativePath}`)
+  }
+
+  // 自动创建父目录
+  const parent = dirname(abs)
+  if (!existsSync(parent)) {
+    mkdirSync(parent, { recursive: true })
+  }
+
+  writeFileSync(abs, content, 'utf-8')
+  console.log(`[Agent 工作区] 已更新 Skill 子文件: ${workspaceSlug}/${skillSlug}/${relativePath}`)
+}
+
+export function createSkillEntry(
+  workspaceSlug: string,
+  skillSlug: string,
+  relativePath: string,
+  type: 'file' | 'directory',
+): void {
+  const dir = resolveSkillDir(workspaceSlug, skillSlug)
+  if (!dir) throw new Error(`Skill 不存在: ${workspaceSlug}/${skillSlug}`)
+  const abs = resolveSkillChildPath(dir, relativePath)
+
+  if (existsSync(abs)) {
+    throw new Error(`目标已存在: ${relativePath}`)
+  }
+
+  if (type === 'directory') {
+    mkdirSync(abs, { recursive: true })
+  } else {
+    const parent = dirname(abs)
+    if (!existsSync(parent)) {
+      mkdirSync(parent, { recursive: true })
+    }
+    writeFileSync(abs, '', 'utf-8')
+  }
+  console.log(`[Agent 工作区] 已创建 Skill 子${type === 'directory' ? '目录' : '文件'}: ${workspaceSlug}/${skillSlug}/${relativePath}`)
+}
+
+export function deleteSkillEntry(workspaceSlug: string, skillSlug: string, relativePath: string): void {
+  const dir = resolveSkillDir(workspaceSlug, skillSlug)
+  if (!dir) throw new Error(`Skill 不存在: ${workspaceSlug}/${skillSlug}`)
+  const abs = resolveSkillChildPath(dir, relativePath)
+  if (!existsSync(abs)) {
+    throw new Error(`目标不存在: ${relativePath}`)
+  }
+  rmSync(abs, { recursive: true, force: true })
+  console.log(`[Agent 工作区] 已删除 Skill 子项: ${workspaceSlug}/${skillSlug}/${relativePath}`)
+}
+
+export function renameSkillEntry(
+  workspaceSlug: string,
+  skillSlug: string,
+  fromRelative: string,
+  toRelative: string,
+): void {
+  const dir = resolveSkillDir(workspaceSlug, skillSlug)
+  if (!dir) throw new Error(`Skill 不存在: ${workspaceSlug}/${skillSlug}`)
+  const fromAbs = resolveSkillChildPath(dir, fromRelative)
+  const toAbs = resolveSkillChildPath(dir, toRelative)
+  if (!existsSync(fromAbs)) {
+    throw new Error(`源不存在: ${fromRelative}`)
+  }
+  if (existsSync(toAbs)) {
+    throw new Error(`目标已存在: ${toRelative}`)
+  }
+  const parent = dirname(toAbs)
+  if (!existsSync(parent)) {
+    mkdirSync(parent, { recursive: true })
+  }
+  renameSync(fromAbs, toAbs)
+  console.log(`[Agent 工作区] Skill 子项重命名: ${workspaceSlug}/${skillSlug}: ${fromRelative} → ${toRelative}`)
 }
 
 /** 简单 semver 比较：a 是否比 b 更新 */

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -526,6 +526,24 @@ export interface ElectronAPI {
   /** 写入 SKILL.md 全文内容 */
   writeSkillContent: (workspaceSlug: string, skillSlug: string, content: string) => Promise<void>
 
+  /** 列出 Skill 目录下的子文件树（不含 SKILL.md） */
+  listSkillFiles: (workspaceSlug: string, skillSlug: string) => Promise<import('@proma/shared').SkillFileNode[]>
+
+  /** 读取 Skill 目录下的子文件内容 */
+  readSkillFile: (workspaceSlug: string, skillSlug: string, relativePath: string) => Promise<import('@proma/shared').SkillFileContent>
+
+  /** 写入 Skill 目录下的子文件内容（文本） */
+  writeSkillFile: (workspaceSlug: string, skillSlug: string, relativePath: string, content: string) => Promise<void>
+
+  /** 在 Skill 目录下创建文件或目录 */
+  createSkillEntry: (workspaceSlug: string, skillSlug: string, relativePath: string, type: 'file' | 'directory') => Promise<void>
+
+  /** 删除 Skill 目录下的文件或目录 */
+  deleteSkillEntry: (workspaceSlug: string, skillSlug: string, relativePath: string) => Promise<void>
+
+  /** 重命名/移动 Skill 目录下的文件或目录 */
+  renameSkillEntry: (workspaceSlug: string, skillSlug: string, fromRelative: string, toRelative: string) => Promise<void>
+
   /** 订阅 Agent 流式事件（返回清理函数） */
   onAgentStreamEvent: (callback: (event: AgentStreamEvent) => void) => () => void
 
@@ -1498,6 +1516,30 @@ const electronAPI: ElectronAPI = {
       skillSlug,
       content,
     )
+  },
+
+  listSkillFiles: (workspaceSlug: string, skillSlug: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.LIST_SKILL_FILES, workspaceSlug, skillSlug)
+  },
+
+  readSkillFile: (workspaceSlug: string, skillSlug: string, relativePath: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.READ_SKILL_FILE, workspaceSlug, skillSlug, relativePath)
+  },
+
+  writeSkillFile: (workspaceSlug: string, skillSlug: string, relativePath: string, content: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.WRITE_SKILL_FILE, workspaceSlug, skillSlug, relativePath, content)
+  },
+
+  createSkillEntry: (workspaceSlug: string, skillSlug: string, relativePath: string, type: 'file' | 'directory') => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.CREATE_SKILL_ENTRY, workspaceSlug, skillSlug, relativePath, type)
+  },
+
+  deleteSkillEntry: (workspaceSlug: string, skillSlug: string, relativePath: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.DELETE_SKILL_ENTRY, workspaceSlug, skillSlug, relativePath)
+  },
+
+  renameSkillEntry: (workspaceSlug: string, skillSlug: string, fromRelative: string, toRelative: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.RENAME_SKILL_ENTRY, workspaceSlug, skillSlug, fromRelative, toRelative)
   },
 
   onAgentStreamEvent: (callback: (event: AgentStreamEvent) => void) => {

--- a/apps/electron/src/renderer/components/settings/AgentSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AgentSettings.tsx
@@ -17,7 +17,7 @@ import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
-import { Tabs, TabsContent } from '@/components/ui/tabs'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import {
@@ -35,6 +35,7 @@ import { chatToolsAtom } from '@/atoms/chat-tool-atoms'
 import type { McpServerEntry, SkillMeta, OtherWorkspaceSkillsGroup, WorkspaceMcpConfig } from '@proma/shared'
 import { SettingsSection, SettingsCard, SettingsRow } from './primitives'
 import { McpServerForm } from './McpServerForm'
+import { SkillFilesPanel } from './SkillFilesPanel'
 
 // ===== Types =====
 
@@ -781,15 +782,22 @@ function SkillDetailPanel({ skill, workspaceSlug, onSaved }: SkillDetailPanelPro
 
   const [isEditingMeta, setIsEditingMeta] = React.useState(false)
   const [isEditingBody, setIsEditingBody] = React.useState(false)
+  const [metaExpanded, setMetaExpanded] = React.useState(false)
   const [editName, setEditName] = React.useState('')
   const [editDescription, setEditDescription] = React.useState('')
   const [editBody, setEditBody] = React.useState('')
   const [saving, setSaving] = React.useState(false)
 
+  const [detailTab, setDetailTab] = React.useState<'body' | 'files'>('body')
+  const [fileCount, setFileCount] = React.useState<number | null>(null)
+
   React.useEffect(() => {
     currentSlugRef.current = skill.slug
     setIsEditingMeta(false)
     setIsEditingBody(false)
+    setMetaExpanded(false)
+    setDetailTab('body')
+    setFileCount(null)
     setLoadingContent(true)
 
     window.electronAPI.readSkillContent(workspaceSlug, skill.slug)
@@ -863,9 +871,9 @@ function SkillDetailPanel({ skill, workspaceSlug, onSaved }: SkillDetailPanelPro
     : '当前工作区'
 
   return (
-    <div className="p-5 space-y-6">
+    <div className="flex flex-col h-full p-5 gap-4 min-h-0">
       {/* Header */}
-      <div className="flex items-start gap-3">
+      <div className="flex items-start gap-3 shrink-0">
         <div className="rounded-xl bg-amber-500/12 p-2.5 text-amber-500 shrink-0">
           <Sparkles size={20} />
         </div>
@@ -877,82 +885,128 @@ function SkillDetailPanel({ skill, workspaceSlug, onSaved }: SkillDetailPanelPro
         </div>
       </div>
 
-      {/* Metadata Section */}
-      <div className="space-y-2">
-        <div className="flex items-center justify-between">
-          <h4 className="text-sm font-medium text-foreground">元数据</h4>
-          {!isEditingMeta ? (
-            <button onClick={startEditMeta} className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1 transition-colors">
-              <Pencil size={12} /> 编辑
-            </button>
-          ) : (
-            <div className="flex items-center gap-2">
-              <Button size="sm" variant="ghost" onClick={() => setIsEditingMeta(false)} disabled={saving}>
-                <X size={14} /> 取消
-              </Button>
-              <Button size="sm" onClick={() => void saveMeta()} disabled={saving}>
-                <Save size={14} /> {saving ? '保存中...' : '保存'}
-              </Button>
-            </div>
-          )}
-        </div>
-
-        <SettingsCard divided>
-          <MetadataRow label="标识符" value={skill.slug} />
-          {isEditingMeta ? (
+      {/* Metadata：折叠摘要 + 可展开完整编辑 */}
+      <div className="shrink-0 space-y-2">
+        <button
+          type="button"
+          onClick={() => setMetaExpanded((v) => !v)}
+          className="w-full flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors px-3 py-2 rounded-md bg-muted/40 hover:bg-muted/60"
+        >
+          {metaExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+          <span className="font-mono text-foreground/80">skills/{skill.slug}</span>
+          <span className="text-muted-foreground/70">·</span>
+          <span>{sourceLabel}</span>
+          {skill.version && (
             <>
-              <MetadataEditRow label="名称" value={editName} onChange={setEditName} />
-              <MetadataEditRow label="描述" value={editDescription} onChange={setEditDescription} multiline />
-            </>
-          ) : (
-            <>
-              <MetadataRow label="名称" value={skill.name} />
-              <MetadataRow label="描述" value={skill.description ?? '无描述'} />
+              <span className="text-muted-foreground/70">·</span>
+              <span>v{skill.version}</span>
             </>
           )}
-          <MetadataRow label="数据源" value={sourceLabel} />
-          <MetadataRow label="位置" value={`skills/${skill.slug}`} />
-          {skill.version && <MetadataRow label="版本" value={skill.version} />}
-        </SettingsCard>
-      </div>
+          <span className="ml-auto">{metaExpanded ? '收起' : '展开元数据'}</span>
+        </button>
 
-      {/* Body Section */}
-      <div className="space-y-2">
-        <div className="flex items-center justify-between">
-          <h4 className="text-sm font-medium text-foreground">说明</h4>
-          {!isEditingBody ? (
-            <button onClick={startEditBody} className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1 transition-colors">
-              <Pencil size={12} /> 编辑
-            </button>
-          ) : (
-            <div className="flex items-center gap-2">
-              <Button size="sm" variant="ghost" onClick={() => setIsEditingBody(false)} disabled={saving}>
-                <X size={14} /> 取消
-              </Button>
-              <Button size="sm" onClick={() => void saveBody()} disabled={saving}>
-                <Save size={14} /> {saving ? '保存中...' : '保存'}
-              </Button>
+        {metaExpanded && (
+          <div className="space-y-2">
+            <div className="flex items-center justify-end">
+              {!isEditingMeta ? (
+                <button onClick={startEditMeta} className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1 transition-colors">
+                  <Pencil size={12} /> 编辑
+                </button>
+              ) : (
+                <div className="flex items-center gap-2">
+                  <Button size="sm" variant="ghost" onClick={() => setIsEditingMeta(false)} disabled={saving}>
+                    <X size={14} /> 取消
+                  </Button>
+                  <Button size="sm" onClick={() => void saveMeta()} disabled={saving}>
+                    <Save size={14} /> {saving ? '保存中...' : '保存'}
+                  </Button>
+                </div>
+              )}
             </div>
-          )}
-        </div>
-
-        <SettingsCard divided={false}>
-          <div className="p-4">
-            {isEditingBody ? (
-              <textarea
-                value={editBody}
-                onChange={(e) => setEditBody(e.target.value)}
-                className="w-full min-h-[300px] bg-transparent text-sm font-mono resize-y border border-border rounded-md p-3 focus:outline-none focus:ring-1 focus:ring-ring"
-                placeholder="输入 Skill 说明内容（支持 Markdown）..."
-              />
-            ) : (
-              <div className="prose prose-sm dark:prose-invert max-w-none">
-                <Markdown remarkPlugins={[remarkGfm]}>{body || '暂无说明内容'}</Markdown>
-              </div>
-            )}
+            <SettingsCard divided>
+              <MetadataRow label="标识符" value={skill.slug} />
+              {isEditingMeta ? (
+                <>
+                  <MetadataEditRow label="名称" value={editName} onChange={setEditName} />
+                  <MetadataEditRow label="描述" value={editDescription} onChange={setEditDescription} multiline />
+                </>
+              ) : (
+                <>
+                  <MetadataRow label="名称" value={skill.name} />
+                  <MetadataRow label="描述" value={skill.description ?? '无描述'} />
+                </>
+              )}
+              <MetadataRow label="数据源" value={sourceLabel} />
+              <MetadataRow label="位置" value={`skills/${skill.slug}`} />
+              {skill.version && <MetadataRow label="版本" value={skill.version} />}
+            </SettingsCard>
           </div>
-        </SettingsCard>
+        )}
       </div>
+
+      {/* Tab: 说明 / 资源文件 */}
+      <Tabs
+        value={detailTab}
+        onValueChange={(v) => setDetailTab(v as 'body' | 'files')}
+        className="flex-1 flex flex-col min-h-0"
+      >
+        <TabsList className="self-start shrink-0">
+          <TabsTrigger value="body">说明</TabsTrigger>
+          <TabsTrigger value="files">
+            资源文件
+            {fileCount !== null && (
+              <span className="ml-1.5 inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full bg-muted-foreground/15 text-[10px] font-medium">
+                {fileCount}
+              </span>
+            )}
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="body" className="flex-1 mt-3 min-h-0 overflow-auto">
+          <div className="space-y-2">
+            <div className="flex items-center justify-end">
+              {!isEditingBody ? (
+                <button onClick={startEditBody} className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1 transition-colors">
+                  <Pencil size={12} /> 编辑
+                </button>
+              ) : (
+                <div className="flex items-center gap-2">
+                  <Button size="sm" variant="ghost" onClick={() => setIsEditingBody(false)} disabled={saving}>
+                    <X size={14} /> 取消
+                  </Button>
+                  <Button size="sm" onClick={() => void saveBody()} disabled={saving}>
+                    <Save size={14} /> {saving ? '保存中...' : '保存'}
+                  </Button>
+                </div>
+              )}
+            </div>
+            <SettingsCard divided={false}>
+              <div className="p-4">
+                {isEditingBody ? (
+                  <textarea
+                    value={editBody}
+                    onChange={(e) => setEditBody(e.target.value)}
+                    className="w-full min-h-[300px] bg-transparent text-sm font-mono resize-y border border-border rounded-md p-3 focus:outline-none focus:ring-1 focus:ring-ring"
+                    placeholder="输入 Skill 说明内容（支持 Markdown）..."
+                  />
+                ) : (
+                  <div className="prose prose-sm dark:prose-invert max-w-none">
+                    <Markdown remarkPlugins={[remarkGfm]}>{body || '暂无说明内容'}</Markdown>
+                  </div>
+                )}
+              </div>
+            </SettingsCard>
+          </div>
+        </TabsContent>
+
+        <TabsContent value="files" className="flex-1 mt-3 min-h-0">
+          <SkillFilesPanel
+            workspaceSlug={workspaceSlug}
+            skillSlug={skill.slug}
+            onFileCountChange={setFileCount}
+          />
+        </TabsContent>
+      </Tabs>
     </div>
   )
 }

--- a/apps/electron/src/renderer/components/settings/SkillFilesPanel.tsx
+++ b/apps/electron/src/renderer/components/settings/SkillFilesPanel.tsx
@@ -33,24 +33,22 @@ interface SkillFilesPanelProps {
   onFileCountChange?: (count: number) => void
 }
 
-function countFiles(nodes: SkillFileNode[]): number {
-  let n = 0
+function countTree(nodes: SkillFileNode[]): { files: number; dirs: number } {
+  let files = 0
+  let dirs = 0
   for (const node of nodes) {
-    if (node.type === 'file') n += 1
-    else if (node.children) n += countFiles(node.children)
-  }
-  return n
-}
-
-function countDirs(nodes: SkillFileNode[]): number {
-  let n = 0
-  for (const node of nodes) {
-    if (node.type === 'directory') {
-      n += 1
-      if (node.children) n += countDirs(node.children)
+    if (node.type === 'file') {
+      files += 1
+    } else {
+      dirs += 1
+      if (node.children) {
+        const sub = countTree(node.children)
+        files += sub.files
+        dirs += sub.dirs
+      }
     }
   }
-  return n
+  return { files, dirs }
 }
 
 export function SkillFilesPanel({ workspaceSlug, skillSlug, onFileCountChange }: SkillFilesPanelProps): React.ReactElement {
@@ -76,7 +74,7 @@ export function SkillFilesPanel({ workspaceSlug, skillSlug, onFileCountChange }:
     try {
       const nodes = await window.electronAPI.listSkillFiles(workspaceSlug, skillSlug)
       setTree(nodes)
-      onFileCountChange?.(countFiles(nodes))
+      onFileCountChange?.(countTree(nodes).files)
     } catch (err) {
       console.error('[SkillFiles] 加载文件树失败:', err)
       toast.error('加载文件树失败')
@@ -226,33 +224,36 @@ export function SkillFilesPanel({ workspaceSlug, skillSlug, onFileCountChange }:
         <div className="text-xs text-muted-foreground">
           {loading
             ? '加载中...'
-            : `共 ${countFiles(tree)} 个文件${tree.length === 0 ? '' : `，${countDirs(tree)} 个目录`}`}
+            : (() => {
+                const { files, dirs } = countTree(tree)
+                return `共 ${files} 个文件${tree.length === 0 ? '' : `，${dirs} 个目录`}`
+              })()}
         </div>
         <div className="flex items-center gap-1">
-          <Tooltip text="新建文件（根目录）">
-            <button
-              onClick={() => startCreate('file', '')}
-              className="p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
-            >
-              <FilePlus size={14} />
-            </button>
-          </Tooltip>
-          <Tooltip text="新建目录（根目录）">
-            <button
-              onClick={() => startCreate('directory', '')}
-              className="p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
-            >
-              <FolderPlus size={14} />
-            </button>
-          </Tooltip>
-          <Tooltip text="刷新">
-            <button
-              onClick={() => void refreshTree()}
-              className="p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
-            >
-              <RefreshCw size={14} />
-            </button>
-          </Tooltip>
+          <button
+            type="button"
+            title="新建文件（根目录）"
+            onClick={() => startCreate('file', '')}
+            className="p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <FilePlus size={14} />
+          </button>
+          <button
+            type="button"
+            title="新建目录（根目录）"
+            onClick={() => startCreate('directory', '')}
+            className="p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <FolderPlus size={14} />
+          </button>
+          <button
+            type="button"
+            title="刷新"
+            onClick={() => void refreshTree()}
+            className="p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <RefreshCw size={14} />
+          </button>
         </div>
       </div>
 
@@ -582,14 +583,6 @@ function CreatePlaceholder({
         />
       </div>
     </li>
-  )
-}
-
-function Tooltip({ text, children }: { text: string; children: React.ReactNode }): React.ReactElement {
-  return (
-    <span title={text} className="inline-flex">
-      {children}
-    </span>
   )
 }
 

--- a/apps/electron/src/renderer/components/settings/SkillFilesPanel.tsx
+++ b/apps/electron/src/renderer/components/settings/SkillFilesPanel.tsx
@@ -1,0 +1,600 @@
+/**
+ * SkillFilesPanel — Skill 子文件树 + 编辑器面板
+ *
+ * 用于在 Skill 详情页管理 Skill 目录下的资源文件（references/、scripts/、assets/ 等）。
+ * SKILL.md 由主面板管理，不出现在文件树里。
+ */
+
+import * as React from 'react'
+import { toast } from 'sonner'
+import {
+  ChevronDown,
+  ChevronRight,
+  File as FileIcon,
+  Folder,
+  FolderOpen,
+  FilePlus,
+  FolderPlus,
+  Pencil,
+  Save,
+  Trash2,
+  X,
+  RefreshCw,
+} from 'lucide-react'
+import type { SkillFileNode, SkillFileContent } from '@proma/shared'
+import { Button } from '@/components/ui/button'
+import { SettingsCard } from './primitives'
+import { cn } from '@/lib/utils'
+
+interface SkillFilesPanelProps {
+  workspaceSlug: string
+  skillSlug: string
+  /** 文件总数（不含目录）变化时通知父组件，用于 Tab 徽章 */
+  onFileCountChange?: (count: number) => void
+}
+
+function countFiles(nodes: SkillFileNode[]): number {
+  let n = 0
+  for (const node of nodes) {
+    if (node.type === 'file') n += 1
+    else if (node.children) n += countFiles(node.children)
+  }
+  return n
+}
+
+function countDirs(nodes: SkillFileNode[]): number {
+  let n = 0
+  for (const node of nodes) {
+    if (node.type === 'directory') {
+      n += 1
+      if (node.children) n += countDirs(node.children)
+    }
+  }
+  return n
+}
+
+export function SkillFilesPanel({ workspaceSlug, skillSlug, onFileCountChange }: SkillFilesPanelProps): React.ReactElement {
+  const [tree, setTree] = React.useState<SkillFileNode[]>([])
+  const [loading, setLoading] = React.useState(true)
+  const [expanded, setExpanded] = React.useState<Set<string>>(new Set())
+  const [selected, setSelected] = React.useState<string | null>(null)
+
+  const [fileContent, setFileContent] = React.useState<SkillFileContent | null>(null)
+  const [loadingFile, setLoadingFile] = React.useState(false)
+  const [editing, setEditing] = React.useState(false)
+  const [editText, setEditText] = React.useState('')
+  const [saving, setSaving] = React.useState(false)
+
+  const [creating, setCreating] = React.useState<{ type: 'file' | 'directory'; parent: string } | null>(null)
+  const [createName, setCreateName] = React.useState('')
+
+  const [renaming, setRenaming] = React.useState<string | null>(null)
+  const [renameValue, setRenameValue] = React.useState('')
+
+  const refreshTree = React.useCallback(async (): Promise<void> => {
+    setLoading(true)
+    try {
+      const nodes = await window.electronAPI.listSkillFiles(workspaceSlug, skillSlug)
+      setTree(nodes)
+      onFileCountChange?.(countFiles(nodes))
+    } catch (err) {
+      console.error('[SkillFiles] 加载文件树失败:', err)
+      toast.error('加载文件树失败')
+    } finally {
+      setLoading(false)
+    }
+  }, [workspaceSlug, skillSlug, onFileCountChange])
+
+  React.useEffect(() => {
+    void refreshTree()
+    setSelected(null)
+    setFileContent(null)
+    setEditing(false)
+    setExpanded(new Set())
+  }, [refreshTree])
+
+  const openFile = React.useCallback(
+    async (relativePath: string): Promise<void> => {
+      setSelected(relativePath)
+      setEditing(false)
+      setLoadingFile(true)
+      try {
+        const result = await window.electronAPI.readSkillFile(workspaceSlug, skillSlug, relativePath)
+        setFileContent(result)
+        setEditText(result.content ?? '')
+      } catch (err) {
+        console.error('[SkillFiles] 读取文件失败:', err)
+        toast.error(err instanceof Error ? err.message : '读取文件失败')
+        setFileContent(null)
+      } finally {
+        setLoadingFile(false)
+      }
+    },
+    [workspaceSlug, skillSlug],
+  )
+
+  const toggleExpand = (path: string): void => {
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      if (next.has(path)) next.delete(path)
+      else next.add(path)
+      return next
+    })
+  }
+
+  const saveFile = async (): Promise<void> => {
+    if (!fileContent) return
+    setSaving(true)
+    try {
+      await window.electronAPI.writeSkillFile(workspaceSlug, skillSlug, fileContent.relativePath, editText)
+      setFileContent({ ...fileContent, content: editText, size: new Blob([editText]).size })
+      setEditing(false)
+      toast.success('已保存')
+      void refreshTree()
+    } catch (err) {
+      console.error('[SkillFiles] 保存文件失败:', err)
+      toast.error(err instanceof Error ? err.message : '保存失败')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const startCreate = (type: 'file' | 'directory', parent: string): void => {
+    setCreating({ type, parent })
+    setCreateName('')
+    if (parent) setExpanded((prev) => new Set(prev).add(parent))
+  }
+
+  const commitCreate = async (): Promise<void> => {
+    if (!creating) return
+    const name = createName.trim()
+    if (!name) {
+      setCreating(null)
+      return
+    }
+    if (name.includes('/') || name.includes('\\')) {
+      toast.error('名称不能包含 / 或 \\')
+      return
+    }
+    const relativePath = creating.parent ? `${creating.parent}/${name}` : name
+    try {
+      await window.electronAPI.createSkillEntry(workspaceSlug, skillSlug, relativePath, creating.type)
+      toast.success(`已创建${creating.type === 'directory' ? '目录' : '文件'}: ${name}`)
+      setCreating(null)
+      setCreateName('')
+      await refreshTree()
+      if (creating.type === 'file') void openFile(relativePath)
+    } catch (err) {
+      console.error('[SkillFiles] 创建失败:', err)
+      toast.error(err instanceof Error ? err.message : '创建失败')
+    }
+  }
+
+  const deleteEntry = async (node: SkillFileNode): Promise<void> => {
+    const label = node.type === 'directory' ? '目录及其内容' : '文件'
+    if (!window.confirm(`确认删除${label} "${node.relativePath}"？此操作不可撤销。`)) return
+    try {
+      await window.electronAPI.deleteSkillEntry(workspaceSlug, skillSlug, node.relativePath)
+      toast.success('已删除')
+      if (selected === node.relativePath || (node.type === 'directory' && selected?.startsWith(node.relativePath + '/'))) {
+        setSelected(null)
+        setFileContent(null)
+        setEditing(false)
+      }
+      void refreshTree()
+    } catch (err) {
+      console.error('[SkillFiles] 删除失败:', err)
+      toast.error(err instanceof Error ? err.message : '删除失败')
+    }
+  }
+
+  const startRename = (node: SkillFileNode): void => {
+    setRenaming(node.relativePath)
+    setRenameValue(node.name)
+  }
+
+  const commitRename = async (node: SkillFileNode): Promise<void> => {
+    const newName = renameValue.trim()
+    if (!newName || newName === node.name) {
+      setRenaming(null)
+      return
+    }
+    if (newName.includes('/') || newName.includes('\\')) {
+      toast.error('名称不能包含 / 或 \\')
+      return
+    }
+    const parentParts = node.relativePath.split('/').slice(0, -1)
+    const newRel = parentParts.length ? `${parentParts.join('/')}/${newName}` : newName
+    try {
+      await window.electronAPI.renameSkillEntry(workspaceSlug, skillSlug, node.relativePath, newRel)
+      toast.success('已重命名')
+      if (selected === node.relativePath) {
+        setSelected(newRel)
+        if (fileContent) setFileContent({ ...fileContent, relativePath: newRel })
+      }
+      setRenaming(null)
+      void refreshTree()
+    } catch (err) {
+      console.error('[SkillFiles] 重命名失败:', err)
+      toast.error(err instanceof Error ? err.message : '重命名失败')
+    }
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center justify-between px-1 pb-2 shrink-0">
+        <div className="text-xs text-muted-foreground">
+          {loading
+            ? '加载中...'
+            : `共 ${countFiles(tree)} 个文件${tree.length === 0 ? '' : `，${countDirs(tree)} 个目录`}`}
+        </div>
+        <div className="flex items-center gap-1">
+          <Tooltip text="新建文件（根目录）">
+            <button
+              onClick={() => startCreate('file', '')}
+              className="p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <FilePlus size={14} />
+            </button>
+          </Tooltip>
+          <Tooltip text="新建目录（根目录）">
+            <button
+              onClick={() => startCreate('directory', '')}
+              className="p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <FolderPlus size={14} />
+            </button>
+          </Tooltip>
+          <Tooltip text="刷新">
+            <button
+              onClick={() => void refreshTree()}
+              className="p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <RefreshCw size={14} />
+            </button>
+          </Tooltip>
+        </div>
+      </div>
+
+      <SettingsCard divided={false} className="flex-1 min-h-0">
+        <div className="grid grid-cols-[minmax(220px,1fr)_2fr] h-full min-h-[420px]">
+          {/* Tree */}
+          <div className="border-r border-border bg-muted/30 p-2 overflow-y-auto">
+            {loading ? (
+              <div className="px-2 py-4 text-xs text-muted-foreground">加载中...</div>
+            ) : tree.length === 0 && !creating ? (
+              <div className="px-2 py-6 text-xs text-muted-foreground flex flex-col items-center gap-3 text-center">
+                <div>该 Skill 暂无其他资源文件</div>
+                <div className="flex gap-2">
+                  <Button size="sm" variant="outline" onClick={() => startCreate('file', '')}>
+                    <FilePlus size={12} /> 新建文件
+                  </Button>
+                  <Button size="sm" variant="outline" onClick={() => startCreate('directory', '')}>
+                    <FolderPlus size={12} /> 新建目录
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <FileTree
+                nodes={tree}
+                expanded={expanded}
+                selected={selected}
+                renaming={renaming}
+                renameValue={renameValue}
+                setRenameValue={setRenameValue}
+                onCommitRename={commitRename}
+                onCancelRename={() => setRenaming(null)}
+                onToggle={toggleExpand}
+                onSelect={(node) => {
+                  if (node.type === 'file') void openFile(node.relativePath)
+                  else toggleExpand(node.relativePath)
+                }}
+                onStartCreate={startCreate}
+                onStartRename={startRename}
+                onDelete={deleteEntry}
+                creating={creating}
+                createName={createName}
+                setCreateName={setCreateName}
+                onCommitCreate={commitCreate}
+                onCancelCreate={() => setCreating(null)}
+              />
+            )}
+          </div>
+
+          {/* Editor */}
+          <div className="flex flex-col min-w-0">
+            {!selected ? (
+              <div className="flex-1 flex items-center justify-center text-xs text-muted-foreground p-6 text-center">
+                从左侧选择文件以查看或编辑
+              </div>
+            ) : loadingFile ? (
+              <div className="flex-1 flex items-center justify-center text-xs text-muted-foreground">
+                加载中...
+              </div>
+            ) : !fileContent ? (
+              <div className="flex-1 flex items-center justify-center text-xs text-muted-foreground p-6 text-center">
+                无法加载该文件
+              </div>
+            ) : !fileContent.isText ? (
+              <div className="flex-1 flex flex-col items-center justify-center text-xs text-muted-foreground p-6 text-center gap-2">
+                <FileIcon size={20} />
+                <div className="font-mono">{fileContent.relativePath}</div>
+                <div>二进制文件（{formatSize(fileContent.size)}），不支持内置编辑</div>
+              </div>
+            ) : (
+              <>
+                <div className="flex items-center justify-between px-3 py-2 border-b border-border bg-muted/20">
+                  <div className="text-xs font-mono text-muted-foreground truncate flex-1 min-w-0">
+                    {fileContent.relativePath}
+                  </div>
+                  <div className="flex items-center gap-1 shrink-0">
+                    <span className="text-[10px] text-muted-foreground">
+                      {formatSize(fileContent.size)}
+                    </span>
+                    {!editing ? (
+                      <Button size="sm" variant="ghost" onClick={() => setEditing(true)} className="h-7">
+                        <Pencil size={12} /> 编辑
+                      </Button>
+                    ) : (
+                      <>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => {
+                            setEditText(fileContent.content ?? '')
+                            setEditing(false)
+                          }}
+                          disabled={saving}
+                          className="h-7"
+                        >
+                          <X size={12} /> 取消
+                        </Button>
+                        <Button size="sm" onClick={() => void saveFile()} disabled={saving} className="h-7">
+                          <Save size={12} /> {saving ? '保存中...' : '保存'}
+                        </Button>
+                      </>
+                    )}
+                  </div>
+                </div>
+                {editing ? (
+                  <textarea
+                    value={editText}
+                    onChange={(e) => setEditText(e.target.value)}
+                    className="flex-1 bg-transparent text-xs font-mono resize-none p-3 focus:outline-none border-0"
+                    spellCheck={false}
+                  />
+                ) : (
+                  <pre className="flex-1 bg-transparent text-xs font-mono p-3 overflow-auto whitespace-pre-wrap m-0">
+                    {fileContent.content ?? ''}
+                  </pre>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+      </SettingsCard>
+    </div>
+  )
+}
+
+// ===== File Tree =====
+
+interface FileTreeProps {
+  nodes: SkillFileNode[]
+  expanded: Set<string>
+  selected: string | null
+  renaming: string | null
+  renameValue: string
+  setRenameValue: (v: string) => void
+  onCommitRename: (node: SkillFileNode) => void
+  onCancelRename: () => void
+  onToggle: (path: string) => void
+  onSelect: (node: SkillFileNode) => void
+  onStartCreate: (type: 'file' | 'directory', parent: string) => void
+  onStartRename: (node: SkillFileNode) => void
+  onDelete: (node: SkillFileNode) => void
+  creating: { type: 'file' | 'directory'; parent: string } | null
+  createName: string
+  setCreateName: (v: string) => void
+  onCommitCreate: () => void
+  onCancelCreate: () => void
+}
+
+function FileTree(props: FileTreeProps): React.ReactElement {
+  return (
+    <ul className="space-y-0.5">
+      {/* 根目录新建占位 */}
+      {props.creating && props.creating.parent === '' && (
+        <CreatePlaceholder
+          type={props.creating.type}
+          depth={0}
+          value={props.createName}
+          onChange={props.setCreateName}
+          onCommit={props.onCommitCreate}
+          onCancel={props.onCancelCreate}
+        />
+      )}
+      {props.nodes.map((node) => (
+        <TreeNode key={node.relativePath} node={node} depth={0} {...props} />
+      ))}
+    </ul>
+  )
+}
+
+interface TreeNodeProps extends FileTreeProps {
+  node: SkillFileNode
+  depth: number
+}
+
+function TreeNode(props: TreeNodeProps): React.ReactElement {
+  const { node, depth } = props
+  const isExpanded = props.expanded.has(node.relativePath)
+  const isSelected = props.selected === node.relativePath
+  const isRenaming = props.renaming === node.relativePath
+
+  return (
+    <li>
+      <div
+        className={cn(
+          'group flex items-center gap-1 px-1 py-0.5 rounded text-xs cursor-pointer select-none',
+          isSelected ? 'bg-accent text-foreground' : 'hover:bg-accent/60 text-foreground/80',
+        )}
+        style={{ paddingLeft: `${depth * 12 + 4}px` }}
+        onClick={() => !isRenaming && props.onSelect(node)}
+      >
+        <span className="shrink-0 w-3.5">
+          {node.type === 'directory' ? (
+            isExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />
+          ) : null}
+        </span>
+        <span className="shrink-0 text-muted-foreground">
+          {node.type === 'directory' ? (
+            isExpanded ? <FolderOpen size={12} /> : <Folder size={12} />
+          ) : (
+            <FileIcon size={12} />
+          )}
+        </span>
+        {isRenaming ? (
+          <input
+            autoFocus
+            value={props.renameValue}
+            onChange={(e) => props.setRenameValue(e.target.value)}
+            onBlur={() => props.onCommitRename(node)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') props.onCommitRename(node)
+              else if (e.key === 'Escape') props.onCancelRename()
+            }}
+            onClick={(e) => e.stopPropagation()}
+            className="flex-1 min-w-0 bg-background border border-border rounded px-1 text-xs"
+          />
+        ) : (
+          <span className="flex-1 truncate">{node.name}</span>
+        )}
+
+        {/* Action buttons */}
+        {!isRenaming && (
+          <div className="opacity-0 group-hover:opacity-100 flex items-center gap-0.5 shrink-0 transition-opacity">
+            {node.type === 'directory' && (
+              <>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    props.onStartCreate('file', node.relativePath)
+                  }}
+                  className="p-0.5 hover:text-foreground text-muted-foreground"
+                  title="在此新建文件"
+                >
+                  <FilePlus size={11} />
+                </button>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    props.onStartCreate('directory', node.relativePath)
+                  }}
+                  className="p-0.5 hover:text-foreground text-muted-foreground"
+                  title="在此新建目录"
+                >
+                  <FolderPlus size={11} />
+                </button>
+              </>
+            )}
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                props.onStartRename(node)
+              }}
+              className="p-0.5 hover:text-foreground text-muted-foreground"
+              title="重命名"
+            >
+              <Pencil size={11} />
+            </button>
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                props.onDelete(node)
+              }}
+              className="p-0.5 hover:text-destructive text-muted-foreground"
+              title="删除"
+            >
+              <Trash2 size={11} />
+            </button>
+          </div>
+        )}
+      </div>
+
+      {node.type === 'directory' && isExpanded && (
+        <ul className="space-y-0.5">
+          {props.creating && props.creating.parent === node.relativePath && (
+            <CreatePlaceholder
+              type={props.creating.type}
+              depth={depth + 1}
+              value={props.createName}
+              onChange={props.setCreateName}
+              onCommit={props.onCommitCreate}
+              onCancel={props.onCancelCreate}
+            />
+          )}
+          {(node.children ?? []).map((child) => (
+            <TreeNode key={child.relativePath} {...props} node={child} depth={depth + 1} />
+          ))}
+        </ul>
+      )}
+    </li>
+  )
+}
+
+function CreatePlaceholder({
+  type,
+  depth,
+  value,
+  onChange,
+  onCommit,
+  onCancel,
+}: {
+  type: 'file' | 'directory'
+  depth: number
+  value: string
+  onChange: (v: string) => void
+  onCommit: () => void
+  onCancel: () => void
+}): React.ReactElement {
+  return (
+    <li>
+      <div
+        className="flex items-center gap-1 px-1 py-0.5 rounded text-xs bg-muted"
+        style={{ paddingLeft: `${depth * 12 + 4}px` }}
+      >
+        <span className="shrink-0 w-3.5" />
+        <span className="shrink-0 text-muted-foreground">
+          {type === 'directory' ? <Folder size={12} /> : <FileIcon size={12} />}
+        </span>
+        <input
+          autoFocus
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onBlur={onCommit}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') onCommit()
+            else if (e.key === 'Escape') onCancel()
+          }}
+          placeholder={type === 'directory' ? '目录名' : '文件名'}
+          className="flex-1 min-w-0 bg-background border border-border rounded px-1 text-xs"
+        />
+      </div>
+    </li>
+  )
+}
+
+function Tooltip({ text, children }: { text: string; children: React.ReactNode }): React.ReactElement {
+  return (
+    <span title={text} className="inline-flex">
+      {children}
+    </span>
+  )
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / 1024 / 1024).toFixed(2)} MB`
+}

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -739,6 +739,33 @@ export interface OtherWorkspaceSkillsGroup {
   skills: SkillMeta[]
 }
 
+/** Skill 目录下的文件/子目录节点（递归树） */
+export interface SkillFileNode {
+  /** 相对于 Skill 根目录的相对路径，使用 POSIX 分隔符 */
+  relativePath: string
+  /** 末段名字（用于显示） */
+  name: string
+  /** 类型：文件 / 目录 */
+  type: 'file' | 'directory'
+  /** 文件大小（字节）；目录为 undefined */
+  size?: number
+  /** 是否为文本文件（可在内置编辑器中打开）；目录为 undefined */
+  isText?: boolean
+  /** 子节点（仅 type=directory 有值，已按目录优先 + 名称排序） */
+  children?: SkillFileNode[]
+}
+
+/** 读取 Skill 子文件的响应 */
+export interface SkillFileContent {
+  relativePath: string
+  /** 文本内容（仅 isText=true 时存在） */
+  content?: string
+  /** 是否为文本文件 */
+  isText: boolean
+  /** 文件大小（字节） */
+  size: number
+}
+
 /** 工作区能力摘要（MCP + Skill 计数） */
 export interface WorkspaceCapabilities {
   mcpServers: Array<{ name: string; enabled: boolean; type: McpTransportType }>
@@ -1263,6 +1290,18 @@ export const AGENT_IPC_CHANNELS = {
   READ_SKILL_CONTENT: 'agent:read-skill-content',
   /** 写入 SKILL.md 全文内容 */
   WRITE_SKILL_CONTENT: 'agent:write-skill-content',
+  /** 列出 Skill 目录下的子文件树（不含 SKILL.md） */
+  LIST_SKILL_FILES: 'agent:list-skill-files',
+  /** 读取 Skill 目录下的子文件内容 */
+  READ_SKILL_FILE: 'agent:read-skill-file',
+  /** 写入 Skill 目录下的子文件内容 */
+  WRITE_SKILL_FILE: 'agent:write-skill-file',
+  /** 在 Skill 目录下创建文件或目录 */
+  CREATE_SKILL_ENTRY: 'agent:create-skill-entry',
+  /** 删除 Skill 目录下的文件或目录 */
+  DELETE_SKILL_ENTRY: 'agent:delete-skill-entry',
+  /** 重命名/移动 Skill 目录下的文件或目录 */
+  RENAME_SKILL_ENTRY: 'agent:rename-skill-entry',
 
   // 流式事件（主进程 → 渲染进程推送）
   /** Agent 流式事件 */


### PR DESCRIPTION
## 背景

之前的 Skills 设置页只能读写 `SKILL.md` 根文件，对于含 `references/`、`scripts/`、`assets/` 等子目录的 Skill（如 `guizang-ppt-skill`、`skill-creator`、`pr-analyzer` 等），所有资源文件在 UI 中都不可见、不可编辑。用户在设置里完全看不到这些资源。

## 改动

### 后端
- `agent-workspace-manager.ts` 新增 6 个 Skill 子文件操作函数：`listSkillFiles` / `readSkillFile` / `writeSkillFile` / `createSkillEntry` / `deleteSkillEntry` / `renameSkillEntry`
- 统一通过 `resolveSkillChildPath` 进行路径越权校验（拒绝绝对路径、`..` 逃逸、Windows 反斜杠）
- 显式拒绝直接覆盖 `SKILL.md`（仍走原专用接口）
- 二进制文件嗅探（NUL 字节）+ 10MB 单文件上限 + 文件树递归 8 层上限
- 自动跳过 `.` 开头的隐藏文件（如 `.source.json` 等内部元数据）

### IPC / Preload / Shared 类型
- `packages/shared/src/types/agent.ts`：新增 `SkillFileNode` / `SkillFileContent` 类型 + 6 个 IPC 通道常量
- `apps/electron/src/main/ipc.ts`：注册 6 个 handler
- `apps/electron/src/preload/index.ts`：暴露 6 个 renderer API

### 前端
- 新增 `SkillFilesPanel.tsx`：左右分栏的文件树 + 编辑器
  - 文件树支持递归渲染、目录折叠、行内重命名、新建/删除
  - 编辑器支持文本预览/编辑（朴素 textarea），二进制文件显示提示
  - 顶部工具栏：新建文件 / 新建目录 / 刷新
- `AgentSettings.tsx` 重构 Skill 详情面板：
  - 元数据从纵向卡片折叠为一行摘要（点击展开为完整编辑卡片）
  - 新增二级 Tab：「说明」 / 「资源文件 N」（带文件数徽章）
  - 兼顾两种 Skill：简单 Skill（仅 SKILL.md）默认进入「说明」，体验不变；复杂 Skill 通过徽章和 Tab 切换获得全屏文件管理器

## 测试计划

- [ ] 设置 → Skills → 选 `guizang-ppt-skill`：能在「资源文件 7」tab 看到 references/、assets/ 和 README.md
- [ ] 编辑 `references/themes.md` 后保存并重新打开，内容持久化
- [ ] 在 references/ 下新建文件、重命名、删除均正常
- [ ] 选 `karpathy-guidelines`（只有 SKILL.md）：默认进入「说明」tab，徽章显示 0
- [ ] 尝试通过相对路径越权（如新建文件名 `../foo`）应被后端拒绝
- [ ] 元数据折叠条展开 → 编辑 → 保存仍正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)