### PR TITLE
feat: Scratch Pad 支持语音输入回填到光标位置 (#492)

### DIFF
--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -28,9 +28,11 @@ import { lowlight } from '@/lib/lowlight'
 import { htmlToMarkdown } from '@/lib/markdown-rich-text'
 import { createFileMentionSuggestion } from '@/components/file-browser/file-mention-suggestion'
 import { createSkillMentionSuggestion, createMcpMentionSuggestion, createSessionMentionSuggestion } from '@/components/agent/mention-suggestions'
-
-const VOICE_DICTATION_INSERT_EVENT = 'proma:insert-voice-dictation-text'
-let lastFocusedRichTextInputId: string | null = null
+import {
+  VOICE_DICTATION_INSERT_EVENT,
+  getLastFocusedVoiceInputId,
+  setLastFocusedVoiceInputId,
+} from '@/lib/voice-input-focus'
 
 // ===== 行数计算 =====
 
@@ -308,7 +310,7 @@ export function RichTextInput({
       // 监听 IME 输入状态
       handleDOMEvents: {
         focus: () => {
-          lastFocusedRichTextInputId = inputIdRef.current
+          setLastFocusedVoiceInputId(inputIdRef.current)
           return false
         },
         compositionstart: () => {
@@ -549,7 +551,7 @@ export function RichTextInput({
     if (!editor || disabled) return
 
     const handler = (event: Event): void => {
-      if (lastFocusedRichTextInputId !== inputIdRef.current) return
+      if (getLastFocusedVoiceInputId() !== inputIdRef.current) return
 
       const customEvent = event as CustomEvent<{ text?: string }>
       const text = customEvent.detail?.text?.trim()

--- a/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
+++ b/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
@@ -38,6 +38,13 @@ import {
   createMarkdownImage,
   createMarkdownVideo,
 } from '@/components/diff/markdown-preview-extensions'
+import { SpeechButton } from '@/components/ai-elements/speech-button'
+import {
+  SCRATCH_PAD_VOICE_INPUT_ID,
+  VOICE_DICTATION_INSERT_EVENT,
+  getLastFocusedVoiceInputId,
+  setLastFocusedVoiceInputId,
+} from '@/lib/voice-input-focus'
 
 export function ScratchPadView(): React.ReactElement {
   const [content, setContent] = useAtom(scratchPadContentAtom)
@@ -164,6 +171,35 @@ export function ScratchPadView(): React.ReactElement {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loaded, editor])
 
+  // ===== 语音输入路由 =====
+
+  // 编辑器获得焦点时，把"语音输入目标"标记为 Scratch Pad；点击语音按钮 / 触发快捷键时编辑器会失焦，
+  // 但 ID 保持不变，从而确保识别完成回填的文本会路由到这里而不是被 RichTextInput / agent draft 抢走。
+  React.useEffect(() => {
+    if (!editor) return
+    const dom = editor.view.dom
+    const handleFocus = (): void => {
+      setLastFocusedVoiceInputId(SCRATCH_PAD_VOICE_INPUT_ID)
+    }
+    dom.addEventListener('focus', handleFocus, true)
+    return () => dom.removeEventListener('focus', handleFocus, true)
+  }, [editor])
+
+  // 监听语音输入回填事件：仅在"上次聚焦目标"是 Scratch Pad 时消费，插入到当前光标位置
+  React.useEffect(() => {
+    if (!editor) return
+    const handler = (event: Event): void => {
+      if (getLastFocusedVoiceInputId() !== SCRATCH_PAD_VOICE_INPUT_ID) return
+      const customEvent = event as CustomEvent<{ text?: string }>
+      const text = customEvent.detail?.text?.trim()
+      if (!text) return
+      editor.chain().focus().insertContent({ type: 'text', text }).run()
+      event.preventDefault()
+    }
+    window.addEventListener(VOICE_DICTATION_INSERT_EVENT, handler)
+    return () => window.removeEventListener(VOICE_DICTATION_INSERT_EVENT, handler)
+  }, [editor])
+
   // ===== 粘贴处理 =====
 
   // 粘贴时：图片转 data URL 插入；含 markdown 标记的文本走 markdownToHtml 转 HTML 注入
@@ -215,8 +251,8 @@ export function ScratchPadView(): React.ReactElement {
   }, [editor])
 
   return (
-    <div ref={containerRef} className="flex flex-col h-full">
-      <div className="flex-1 overflow-auto scrollbar-thin px-8 py-6">
+    <div ref={containerRef} className="relative flex flex-col h-full">
+      <div className="flex-1 overflow-auto scrollbar-thin px-8 pt-6 pb-20">
         <div className="max-w-3xl mx-auto h-full">
           {loaded ? (
             <EditorContent
@@ -229,6 +265,10 @@ export function ScratchPadView(): React.ReactElement {
             </div>
           )}
         </div>
+      </div>
+      {/* 底部居中悬浮：圆形语音输入按钮 */}
+      <div className="absolute left-1/2 -translate-x-1/2 bottom-10 z-20">
+        <SpeechButton className="size-11 rounded-full bg-background/95 border border-border/60 shadow-md backdrop-blur hover:bg-accent text-foreground/80" />
       </div>
       <div className="h-[28px] border-t border-border/40 px-4 flex items-center justify-between">
         <span className="text-[11px] text-muted-foreground/60">

--- a/apps/electron/src/renderer/lib/voice-input-focus.ts
+++ b/apps/electron/src/renderer/lib/voice-input-focus.ts
@@ -1,0 +1,27 @@
+/**
+ * 语音输入焦点路由
+ *
+ * 用于将"豆包流式语音输入"识别得到的文本回填到正确的目标输入框（RichTextInput / ScratchPad / 未来其他编辑器）。
+ *
+ * 思路：每个可接收语音输入的编辑器在获得焦点时注册自己的 ID，主进程派发 CustomEvent 时，
+ * 由各编辑器自行判断"上次聚焦的目标 ID 是否是自己"，是则消费事件并 preventDefault。
+ *
+ * 为什么不用 document.activeElement：用户点击语音按钮 / 触发快捷键时编辑器会失焦，
+ * 等识别完成回填时已经不再聚焦在编辑器上。
+ */
+
+let lastFocusedVoiceInputId: string | null = null
+
+export function setLastFocusedVoiceInputId(id: string | null): void {
+  lastFocusedVoiceInputId = id
+}
+
+export function getLastFocusedVoiceInputId(): string | null {
+  return lastFocusedVoiceInputId
+}
+
+/** Scratch Pad 编辑器的语音输入目标 ID */
+export const SCRATCH_PAD_VOICE_INPUT_ID = '__proma-scratch-pad__'
+
+/** 主进程派发到渲染进程、再由当前焦点编辑器消费的事件名 */
+export const VOICE_DICTATION_INSERT_EVENT = 'proma:insert-voice-dictation-text'


### PR DESCRIPTION
## Summary

Closes #492

为 Scratch Pad 添加语音输入支持，复用项目已有的"豆包流式语音输入"基础设施（SpeechButton + 系统级浮窗 + IPC + CustomEvent 回填）。

- **底部居中悬浮圆形麦克风按钮**：点击唤起系统级语音浮窗
- **复用 agent/chat 同款全局快捷键**（Ctrl+\`）
- **识别结果回填到当前光标位置**
- **录音 UI 完全复用** agent/chat 的 VoiceDictationApp 浮窗

## 设计要点

原本 `RichTextInput` 内部有个模块私有变量 `lastFocusedRichTextInputId` 用于路由语音文本回填。问题：用户在 Scratch Pad 按语音按钮时编辑器会失焦，但这个变量仍指向上次聚焦的 chat/agent 输入框，导致语音文本被错路由。

解决：抽取 \`lib/voice-input-focus.ts\` 共享焦点路由模块，让 Scratch Pad 也能注册自己的目标 ID（\`SCRATCH_PAD_VOICE_INPUT_ID\`）。Scratch Pad 编辑器获得焦点时设置 ID，监听事件时按 ID 匹配消费 + preventDefault，避免被其他 RichTextInput 抢走文本。

## 改动文件

- 新增：\`apps/electron/src/renderer/lib/voice-input-focus.ts\` — 共享语音输入焦点路由
- 修改：\`apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx\` — 改用共享模块（等价重构）
- 修改：\`apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx\` — 新增 SpeechButton + 焦点跟踪 + 事件监听

## Test plan

- [ ] Scratch Pad 底部出现圆形麦克风按钮，居中悬浮，不遮挡内容
- [ ] 点击按钮唤起豆包语音浮窗
- [ ] 在 Scratch Pad 中说话，识别结果插入到当前光标位置（不是末尾）
- [ ] 全局快捷键 Ctrl+\` 在 Scratch Pad 编辑器聚焦时同样能唤起浮窗
- [ ] 切换到 chat / agent 后再触发语音，文本回到 chat / agent 输入框，不会误插入 Scratch Pad
- [ ] 深色模式下按钮可见、可读
- [ ] 编辑长文档时底部内容可以滚动到按钮上方（不被遮挡）

🤖 Generated with [Claude Code](https://claude.com/claude-code)