### PR TITLE
优化自动预览开关文案，更清晰描述功能行为

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -286,7 +286,7 @@ function AutoPreviewPopover({ enabled, onToggle }: AutoPreviewPopoverProps): Rea
         onOpenAutoFocus={(e) => e.preventDefault()}
       >
         <div className="flex items-center justify-between gap-4">
-          <span className="text-xs text-foreground/70">自动预览</span>
+          <span className="text-xs text-foreground/70">自动预览修改中文件</span>
           <Switch
             checked={enabled}
             onCheckedChange={onToggle}


### PR DESCRIPTION
## 概述
将 Agent 输入框下方眼睛 icon 的 hover 文案从「自动预览」改为「自动预览修改中文件」，更清晰地描述该开关的实际行为。

## 改动
- `apps/electron/src/renderer/components/agent/AgentView.tsx` — Popover 内文案 `自动预览` → `自动预览修改中文件`

## 测试方式
1. 打开 Agent 会话
2. Hover 输入框下方的眼睛 icon
3. 确认 popover 显示「自动预览修改中文件」

🤖 Generated with [Claude Code](https://claude.com/claude-code)