### PR TITLE
feat: 文件预览选中文本作为引用上下文发送

### DIFF
--- a/apps/electron/src/renderer/atoms/preview-atoms.ts
+++ b/apps/electron/src/renderer/atoms/preview-atoms.ts
@@ -43,3 +43,29 @@ export const currentSessionPreviewOpenAtom = atom<boolean>((get) => {
   if (!sessionId) return false
   return get(previewPanelOpenMapAtom).get(sessionId) ?? false
 })
+
+// ===== 引用选中文本（Quoted Selection）=====
+
+/** 从预览面板中选中的文本引用 */
+export interface QuotedSelection {
+  /** 选中的文本内容 */
+  text: string
+  /** 来源文件路径 */
+  filePath: string
+  /** 起始行号（1-based，代码文件可计算，markdown 等无法计算时为 undefined） */
+  startLine?: number
+  /** 结束行号（1-based） */
+  endLine?: number
+  /** 捕获时间戳 */
+  capturedAt: number
+}
+
+/** 每会话的引用选中文本 Map（每次新选中覆盖旧值） */
+export const quotedSelectionMapAtom = atom<Map<string, QuotedSelection>>(new Map())
+
+/** 当前会话的引用选中文本（派生） */
+export const currentQuotedSelectionAtom = atom<QuotedSelection | null>((get) => {
+  const sessionId = get(currentAgentSessionIdAtom)
+  if (!sessionId) return null
+  return get(quotedSelectionMapAtom).get(sessionId) ?? null
+})

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -28,6 +28,7 @@ import { ExitPlanModeBanner } from './ExitPlanModeBanner'
 import { PlanModeDashedBorder } from './PlanModeDashedBorder'
 import { ModelSelector } from '@/components/chat/ModelSelector'
 import { AttachmentPreviewItem } from '@/components/chat/AttachmentPreviewItem'
+import { QuotedSelectionChip } from '@/components/diff/QuotedSelectionChip'
 import { RichTextInput } from '@/components/ai-elements/rich-text-input'
 import { SpeechButton } from '@/components/ai-elements/speech-button'
 import { Button } from '@/components/ui/button'
@@ -48,7 +49,7 @@ import { cn } from '@/lib/utils'
 import { getActiveAccelerator, getAcceleratorDisplay } from '@/lib/shortcut-registry'
 import { FeishuNotifyToggle } from '@/components/chat/FeishuNotifyToggle'
 import { registerShortcut } from '@/lib/shortcut-registry'
-import { previewPanelOpenMapAtom, previewFileMapAtom, autoPreviewEnabledAtom } from '@/atoms/preview-atoms'
+import { previewPanelOpenMapAtom, previewFileMapAtom, autoPreviewEnabledAtom, quotedSelectionMapAtom, currentQuotedSelectionAtom } from '@/atoms/preview-atoms'
 import {
   agentStreamingStatesAtom,
   agentChannelIdAtom,
@@ -378,6 +379,18 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const permissionMode = permissionModeMap.get(sessionId) ?? persistedPermissionMode ?? defaultPermissionMode
   const isPermissionPlanMode = permissionMode === 'plan'
   const store = useStore()
+  const currentQuotedSelection = useAtomValue(currentQuotedSelectionAtom)
+  const setQuotedSelectionMap = useSetAtom(quotedSelectionMapAtom)
+
+  /** 移除当前引用选中文本 */
+  const handleRemoveQuotedSelection = React.useCallback(() => {
+    setQuotedSelectionMap((prev) => {
+      const m = new Map(prev)
+      m.delete(sessionId)
+      return m
+    })
+  }, [sessionId, setQuotedSelectionMap])
+
   const setPreviewFileMap = useSetAtom(previewFileMapAtom)
   const suggestionsMap = useAtomValue(agentPromptSuggestionsAtom)
   const suggestion = suggestionsMap.get(sessionId) ?? null
@@ -1290,6 +1303,28 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       setPendingFiles([])
     }
 
+    // 构建引用选中文本：内联 XML 拼入 prompt，对话框不展示（parseAttachedFiles 剥离）
+    const quotedSelection = store.get(quotedSelectionMapAtom).get(sessionId)
+    if (quotedSelection) {
+      const capturedAt = quotedSelection.capturedAt
+      // XML 转义：path 走完整实体编码（&, <, >, "），text 仅需防误闭合外层标签
+      const safePath = quotedSelection.filePath
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+      const safeText = quotedSelection.text.replace(/<\/quoted_file>/gi, '</quoted_file_>')
+      const quotedBlock = `<quoted_file path="${safePath}">\n${safeText}\n</quoted_file>\n\n`
+      fileReferences = fileReferences + quotedBlock
+
+      store.set(quotedSelectionMapAtom, (prev) => {
+        const m = new Map(prev)
+        const current = m.get(sessionId)
+        if (current && current.capturedAt === capturedAt) m.delete(sessionId)
+        return m
+      })
+    }
+
     // 2. 构建最终消息
     const finalMessage = fileReferences + effectiveText
 
@@ -1755,8 +1790,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
               </div>
             )}
 
-            {/* 附件预览区域 */}
-            {pendingFiles.length > 0 && (
+            {/* 附件 + 引用选中文本 Chip（同排并排） */}
+            {(pendingFiles.length > 0 || currentQuotedSelection) && (
               <div className="flex flex-wrap gap-2 px-3 pt-2.5 pb-1.5">
                 {pendingFiles.map((file) => (
                   <AttachmentPreviewItem
@@ -1768,6 +1803,13 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
                     onClick={file.filename.startsWith('clipboard-') ? () => handleClipboardPreview(file) : undefined}
                   />
                 ))}
+                {currentQuotedSelection && (
+                  <QuotedSelectionChip
+                    text={currentQuotedSelection.text}
+                    filePath={currentQuotedSelection.filePath}
+                    onRemove={handleRemoveQuotedSelection}
+                  />
+                )}
               </div>
             )}
 

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -12,7 +12,7 @@
  */
 
 import * as React from 'react'
-import { Bot, Loader2, AlertTriangle, FileText, FileImage, Download, Split, Undo2, RotateCw, Plus, Minimize2, Wrench, Settings, ExternalLink } from 'lucide-react'
+import { Bot, Loader2, AlertTriangle, FileText, FileImage, Download, Split, Undo2, RotateCw, Plus, Minimize2, Wrench, Settings, ExternalLink, Quote } from 'lucide-react'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { cn } from '@/lib/utils'
 import { ImageLightbox } from '@/components/ui/image-lightbox'
@@ -775,11 +775,38 @@ export interface AttachedFileRef {
   path: string
 }
 
-/** 解析消息中的 <attached_files> 块，返回文件列表和剩余文本 */
-export function parseAttachedFiles(content: string): { files: AttachedFileRef[]; text: string } {
+/** 解析的引用文件 */
+export interface QuotedFileRef {
+  /** 源文件路径 */
+  path: string
+  /** 源文件名 */
+  filename: string
+}
+
+/** 解析消息中的 <attached_files> 块和 <quoted_file> 块，返回文件列表、引用列表和剩余文本 */
+export function parseAttachedFiles(content: string): { files: AttachedFileRef[]; quotes: QuotedFileRef[]; text: string } {
+  const quoteRegex = /<quoted_file[^>]*>[\s\S]*?<\/quoted_file>\n*/g
+  const quotes: QuotedFileRef[] = []
+  let quoteMatch: RegExpExecArray | null
+  while ((quoteMatch = quoteRegex.exec(content)) !== null) {
+    const pathMatch = quoteMatch[0].match(/path="([^"]*)"/)
+    if (pathMatch) {
+      // 反解 XML 实体：&amp; 必须最后做，否则会被先一步解出的 & 误伤
+      const filePath = pathMatch[1]!
+        .replace(/&quot;/g, '"')
+        .replace(/&gt;/g, '>')
+        .replace(/&lt;/g, '<')
+        .replace(/&amp;/g, '&')
+      quotes.push({ path: filePath, filename: filePath.split('/').pop() ?? filePath })
+    }
+  }
+
   const regex = /<attached_files>\n?([\s\S]*?)\n?<\/attached_files>\n*/
   const match = content.match(regex)
-  if (!match) return { files: [], text: content }
+  if (!match) {
+    const cleanText = content.replace(/<quoted_file[^>]*>[\s\S]*?<\/quoted_file>\n*/g, '').trim()
+    return { files: [], quotes, text: cleanText }
+  }
 
   const files: AttachedFileRef[] = []
   const lines = match[1]!.split('\n')
@@ -790,8 +817,10 @@ export function parseAttachedFiles(content: string): { files: AttachedFileRef[];
     }
   }
 
-  const text = content.replace(regex, '').trim()
-  return { files, text }
+  let text = content.replace(regex, '')
+  text = text.replace(/<quoted_file[^>]*>[\s\S]*?<\/quoted_file>\n*/g, '')
+  text = text.trim()
+  return { files, quotes, text }
 }
 
 /** 判断文件是否为图片类型 */
@@ -866,12 +895,22 @@ function AttachedFileChip({ file }: { file: AttachedFileRef }): React.ReactEleme
   )
 }
 
+/** 引用文件 Chip（显示在用户消息中，表示该消息引用了某个文件的选中内容） */
+function QuoteChip({ quote }: { quote: QuotedFileRef }): React.ReactElement {
+  return (
+    <div className="inline-flex items-center gap-1.5 rounded-md bg-primary/8 border border-primary/20 px-2.5 py-1 text-[12px] text-muted-foreground">
+      <Quote className="size-3.5 shrink-0 text-primary/60" />
+      <span className="truncate max-w-[200px]">{quote.filename}</span>
+    </div>
+  )
+}
+
 // ===== 用户输入消息渲染 =====
 
 function UserInputMessage({ message }: { message: SDKUserMessage }): React.ReactElement {
   const userProfile = useAtomValue(userProfileAtom)
   const rawText = extractUserText(message) ?? ''
-  const { files: attachedFiles, text } = parseAttachedFiles(rawText)
+  const { files: attachedFiles, quotes, text } = parseAttachedFiles(rawText)
   const imageFiles = attachedFiles.filter((f) => isImageFile(f.filename))
   const nonImageFiles = attachedFiles.filter((f) => !isImageFile(f.filename))
   const meta = extractMeta(message as unknown as SDKMessage)
@@ -888,6 +927,14 @@ function UserInputMessage({ message }: { message: SDKUserMessage }): React.React
         </div>
       </div>
       <MessageContent>
+        {/* 引用文件 Chip */}
+        {quotes.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 mb-2">
+            {quotes.map((q, i) => (
+              <QuoteChip key={`${q.path}:${i}`} quote={q} />
+            ))}
+          </div>
+        )}
         {/* 图片缩略图 */}
         {imageFiles.length > 0 && (
           <div className="flex flex-wrap gap-2.5 mb-2">
@@ -1181,7 +1228,10 @@ export function getGroupId(group: MessageGroup): string {
  */
 export function getGroupPreview(group: MessageGroup): string {
   if (group.type === 'user') {
-    return (extractUserText(group.message) ?? '').replace(/<attached_files>[\s\S]*?<\/attached_files>\n*/, '').slice(0, 200)
+    return (extractUserText(group.message) ?? '')
+      .replace(/<attached_files>[\s\S]*?<\/attached_files>\n*/, '')
+      .replace(/<quoted_file[^>]*>[\s\S]*?<\/quoted_file>\n*/g, '')
+      .slice(0, 200)
   }
   if (group.type === 'system') {
     if (group.message.subtype === 'compact_boundary') return '上下文已压缩'

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -14,6 +14,7 @@ import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
 import { agentDiffViewModeAtom, agentDiffRefreshVersionAtom } from '@/atoms/agent-atoms'
 import { resolvedThemeAtom } from '@/atoms/theme'
+import { quotedSelectionMapAtom } from '@/atoms/preview-atoms'
 import { DiffView } from './DiffView'
 import { MarkdownRichEditor } from './MarkdownRichEditor'
 import { PIERRE_FILE_CSS } from '@/components/agent/tool-result-renderers/pierre-styles'
@@ -49,6 +50,9 @@ const contentCache = new Map<string, CacheEntry>()
 
 /** 超过此字符数的文本文件将跳过 PierreFile 高亮，直接以纯文本展示，避免大文件卡顿 */
 const MAX_PREVIEW_CHARS = 500_000
+
+/** 选中文本最大字符数（与 Bozeman DOM 模式一致） */
+const MAX_QUOTED_CHARS = 2000
 
 /** 滚动位置持久化：key = `${sessionId}:${filePath}` */
 const scrollPositionCache = new Map<string, { top: number; left: number }>()
@@ -94,6 +98,78 @@ function cacheSet(key: string, value: CacheEntry): void {
 function getExtension(filePath: string): string {
   const dot = filePath.lastIndexOf('.')
   return dot >= 0 ? filePath.slice(dot).toLowerCase() : ''
+}
+
+/** 判断选区是否在容器内（穿透 Shadow DOM 边界） */
+function isSelectionInside(container: HTMLElement, selection: Selection): boolean {
+  if (selection.rangeCount === 0) return false
+  const range = selection.getRangeAt(0)
+  let node: Node | null = range.commonAncestorContainer
+  while (node) {
+    if (node === container) return true
+    const root = node.getRootNode()
+    if (root instanceof ShadowRoot) {
+      // Shadow DOM 边界：从 shadowRoot.host 继续向上
+      node = root.host
+    } else {
+      // 普通 DOM：沿 parentNode 向上
+      node = node.parentNode
+    }
+  }
+  return false
+}
+
+/** 获取容器内的选区：先查光 DOM，再遍历缓存的 ShadowRoot 集合 */
+function getDeepSelection(container: HTMLElement, shadowRoots?: Set<ShadowRoot> | null): { text: string } | null {
+  const docSel = document.getSelection()
+  if (docSel && !docSel.isCollapsed && docSel.rangeCount > 0) {
+    if (isSelectionInside(container, docSel)) {
+      const text = docSel.toString().trim()
+      if (text) return { text }
+    }
+  }
+
+  if (shadowRoots) {
+    // 直接遍历缓存的 ShadowRoot（O(n) 其中 n = ShadowRoot 数量，通常 2-3 个）
+    for (const sr of shadowRoots) {
+      // 检查 host 是否仍在 DOM 中（可能已被移除）
+      if (!container.contains(sr.host)) continue
+      const shadowSel = (sr as { getSelection?: () => Selection | null }).getSelection?.()
+      if (shadowSel && !shadowSel.isCollapsed && shadowSel.rangeCount > 0) {
+        const text = shadowSel.toString().trim()
+        if (text) return { text }
+      }
+    }
+    return null
+  }
+
+  // 兜底：无缓存时递归遍历（组件初始化瞬间可能命中一次）
+  function walk(node: Node): { text: string } | null {
+    if (node instanceof HTMLElement && node.shadowRoot) {
+      const shadowSel = (node.shadowRoot as { getSelection?: () => Selection | null }).getSelection?.()
+      if (shadowSel && !shadowSel.isCollapsed && shadowSel.rangeCount > 0) {
+        const text = shadowSel.toString().trim()
+        if (text) return { text }
+      }
+      const result = walk(node.shadowRoot)
+      if (result) return result
+    }
+    for (const child of node.childNodes) {
+      const result = walk(child)
+      if (result) return result
+    }
+    return null
+  }
+  return walk(container)
+}
+
+/** 用 TreeWalker 发现容器内所有现有 ShadowRoot（仅初始化时调用一次） */
+function discoverShadowRoots(root: Node, target: Set<ShadowRoot>): void {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT)
+  while (walker.nextNode()) {
+    const el = walker.currentNode as HTMLElement
+    if (el.shadowRoot) target.add(el.shadowRoot)
+  }
 }
 
 interface DiffTabContentProps {
@@ -148,6 +224,156 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   const isOfficePreview = previewOnly && OFFICE_PREVIEW_EXTS.has(ext)
   const isLegacyOffice = previewOnly && LEGACY_OFFICE_EXTS.has(ext)
   const isImage = previewOnly && IMAGE_EXTS.has(ext)
+
+  // ===== 选中文本引用（Quoted Selection）=====
+
+  const setQuotedSelectionMap = useSetAtom(quotedSelectionMapAtom)
+  const filePathRef = React.useRef(filePath)
+  filePathRef.current = filePath
+  const shadowRootsRef = React.useRef<Set<ShadowRoot>>(new Set())
+  /** 当前正在展示的截断 toast id；选中回落到上限内或选区消失时主动 dismiss */
+  const lastToastIdRef = React.useRef<string | null>(null)
+
+  const dismissTruncationToast = React.useCallback(() => {
+    if (lastToastIdRef.current) {
+      toast.dismiss(lastToastIdRef.current)
+      lastToastIdRef.current = null
+    }
+  }, [])
+
+  /** 捕获预览面板中的文本选中，写入 quotedSelectionMapAtom */
+  const handleSelectionCapture = React.useCallback(() => {
+    if (!previewOnly) return
+    const container = scrollContainerRef.current
+    if (!container) return
+
+    const deepSel = getDeepSelection(container, shadowRootsRef.current)
+    if (!deepSel) {
+      // 选区消失：先撤掉截断 toast，再判断是否清 Chip
+      dismissTruncationToast()
+      // 若焦点在 ProseMirror 编辑器（输入框），保留 Chip；否则清除
+      const activeEl = document.activeElement
+      if (activeEl && (activeEl.closest?.('.ProseMirror') || activeEl.closest?.('[data-input-mode]'))) return
+      setQuotedSelectionMap((prev) => {
+        const m = new Map(prev)
+        if (!m.has(sessionId)) return prev
+        m.delete(sessionId)
+        return m
+      })
+      return
+    }
+
+    // 实时更新只存文本 + 路径，不计算行号
+    const truncated = deepSel.text.length > MAX_QUOTED_CHARS
+    setQuotedSelectionMap((prev) => {
+      const m = new Map(prev)
+      m.set(sessionId, {
+        text: truncated ? deepSel.text.slice(0, MAX_QUOTED_CHARS) : deepSel.text,
+        filePath: filePathRef.current,
+        capturedAt: Date.now(),
+      })
+      return m
+    })
+    // 超过上限时按千位分档 toast；跨档时撤掉上一档，回到上限内则全部撤掉
+    if (truncated) {
+      const k = Math.floor(deepSel.text.length / 1000) * 1000
+      const id = `quoted-chars-cap:${sessionId}:${k}`
+      if (lastToastIdRef.current && lastToastIdRef.current !== id) {
+        toast.dismiss(lastToastIdRef.current)
+      }
+      toast.warning(`已选中 >${k} 字符，仅能发送前 ${MAX_QUOTED_CHARS} 字符`, {
+        id,
+        duration: 3000,
+      })
+      lastToastIdRef.current = id
+    } else {
+      dismissTruncationToast()
+    }
+  }, [previewOnly, sessionId, setQuotedSelectionMap, dismissTruncationToast])
+
+  // 监听选区变化：document selectionchange + 容器内鼠标拖拽轮询
+  React.useEffect(() => {
+    if (!previewOnly) return
+    const container = scrollContainerRef.current
+    if (!container) return
+
+    // 初始化 ShadowRoot 缓存：TreeWalker 一次扫描 + MutationObserver 增量更新
+    const shadowRoots = shadowRootsRef.current
+    shadowRoots.clear()
+    discoverShadowRoots(container, shadowRoots)
+    const mo = new MutationObserver((mutations) => {
+      for (const m of mutations) {
+        for (const node of m.addedNodes) {
+          if (node instanceof HTMLElement && node.shadowRoot) shadowRoots.add(node.shadowRoot)
+          // 递归发现新增子树中的 shadowRoot
+          discoverShadowRoots(node, shadowRoots)
+        }
+        for (const node of m.removedNodes) {
+          if (node instanceof HTMLElement) {
+            if (node.shadowRoot) shadowRoots.delete(node.shadowRoot)
+            // 清理被移除子树中的所有 ShadowRoot 引用，避免 Set 持有已分离节点
+            const stale = new Set<ShadowRoot>()
+            discoverShadowRoots(node, stale)
+            for (const sr of stale) shadowRoots.delete(sr)
+          }
+        }
+      }
+    })
+    mo.observe(container, { childList: true, subtree: true })
+
+    let tracking = false
+    let rafId = 0
+
+    const scheduleCapture = () => {
+      // 快速路径：非拖拽时若 document 选区已折叠（输入框打字/点击），跳过昂贵的树遍历。
+      // @pierre/diffs 使用 open Shadow DOM，Chrome/Electron 会将 shadow 内选区反映到
+      // document.getSelection()，因此键盘选区（Shift+Arrow）也能通过此检查。
+      if (!tracking) {
+        const docSel = document.getSelection()
+        if (!docSel || docSel.isCollapsed) return
+        // 光 DOM 快速检查：选区不在预览容器内也跳过
+        if (!isSelectionInside(container, docSel)) return
+      }
+      if (rafId) return
+      rafId = requestAnimationFrame(() => {
+        rafId = 0
+        handleSelectionCapture()
+      })
+    }
+
+    const onMouseDown = (e: MouseEvent) => {
+      if (e.button === 0) tracking = true
+    }
+    const onMouseMove = () => {
+      if (tracking) scheduleCapture()
+    }
+    const onMouseUp = () => {
+      if (tracking) {
+        tracking = false
+        scheduleCapture()
+      }
+    }
+    const onSelectionChange = () => {
+      scheduleCapture()
+    }
+
+    container.addEventListener('mousedown', onMouseDown)
+    document.addEventListener('mousemove', onMouseMove)
+    document.addEventListener('mouseup', onMouseUp)
+    document.addEventListener('selectionchange', onSelectionChange)
+    return () => {
+      if (rafId) cancelAnimationFrame(rafId)
+      mo.disconnect()
+      shadowRoots.clear()
+      container.removeEventListener('mousedown', onMouseDown)
+      document.removeEventListener('mousemove', onMouseMove)
+      document.removeEventListener('mouseup', onMouseUp)
+      document.removeEventListener('selectionchange', onSelectionChange)
+      // unmount / 切预览 / 切 session 时撤掉残留的截断 toast，避免贴脸 3 秒
+      dismissTruncationToast()
+    }
+  }, [previewOnly, handleSelectionCapture, dismissTruncationToast])
+
   const fileAccess = React.useMemo(() => ({
     sessionId,
     candidateBasePaths: basePaths,

--- a/apps/electron/src/renderer/components/diff/QuotedSelectionChip.tsx
+++ b/apps/electron/src/renderer/components/diff/QuotedSelectionChip.tsx
@@ -1,0 +1,81 @@
+/**
+ * QuotedSelectionChip — 引用选中文本的 Chip 标签
+ *
+ * 显示在 Agent 输入框上方，展示预览面板中选中的文本片段及来源文件。
+ * 点击 X 按钮可移除引用。
+ */
+
+import * as React from 'react'
+import { X, Quote } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface QuotedSelectionChipProps {
+  /** 选中的文本（截断显示） */
+  text: string
+  /** 来源文件路径（截断显示） */
+  filePath: string
+  /** 移除回调 */
+  onRemove: () => void
+  className?: string
+}
+
+function truncateText(text: string, maxLen: number = 80): string {
+  const singleLine = text.replace(/\s+/g, ' ').trim()
+  return singleLine.length > maxLen
+    ? singleLine.slice(0, maxLen - 3) + '...'
+    : singleLine
+}
+
+function truncatePath(filePath: string, maxLen: number = 40): string {
+  if (filePath.length <= maxLen) return filePath
+  const name = filePath.split('/').pop() ?? filePath
+  return '.../' + name
+}
+
+export function QuotedSelectionChip({
+  text,
+  filePath,
+  onRemove,
+  className,
+}: QuotedSelectionChipProps): React.ReactElement {
+  const handleRemoveClick = React.useCallback((e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation()
+    onRemove()
+  }, [onRemove])
+
+  return (
+    <div
+      className={cn(
+        'group/chip relative flex items-start gap-2 shrink-0 max-w-[33%]',
+        'rounded-lg bg-primary/8 border border-primary/20',
+        'pl-2.5 pr-7 py-1.5 text-[13px]',
+        'transition-colors hover:bg-primary/12',
+        className,
+      )}
+    >
+      <Quote className="size-4 shrink-0 mt-0.5 text-primary/60" />
+      <div className="flex flex-col min-w-0">
+        <span className="text-foreground/80 line-clamp-2 leading-snug">
+          {truncateText(text)}
+        </span>
+        <span className="text-[11px] text-muted-foreground/60 mt-0.5">
+          {truncatePath(filePath)}
+        </span>
+      </div>
+      <button
+        type="button"
+        onClick={handleRemoveClick}
+        className={cn(
+          'absolute top-1 right-1 size-[18px] rounded-full',
+          'bg-foreground/10 text-foreground/50',
+          'flex items-center justify-center',
+          'opacity-0 group-hover/chip:opacity-100 transition-opacity duration-200',
+          'hover:bg-foreground/20 hover:text-foreground',
+        )}
+        aria-label="移除引用"
+      >
+        <X className="size-3" />
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
## 概览

在文件预览面板中**选中一段文本**后，会作为引用片段自动附加到下一条 Agent 消息上。Agent 收到的 prompt 中以内联 XML 形式带上选中片段和来源文件路径，避免反复让 Agent 自己读文件定位。

典型用法：在 diff/预览面板里选中一处可疑代码 → 输入框上方出现引用 Chip → 直接打字提问"这段为什么会 NPE？" → 发送时 Agent 同时拿到选中片段 + 用户提问。

## 改动

- `apps/electron/src/renderer/atoms/preview-atoms.ts` — 新增 `quotedSelectionMapAtom`（per-session Map）和派生的 `currentQuotedSelectionAtom`，与现有 preview/file map 同结构。
- `apps/electron/src/renderer/components/diff/DiffTabContent.tsx` — 选区捕获核心：
  - 穿透 Shadow DOM 边界（`@pierre/diffs` 用 open Shadow DOM）：TreeWalker 一次扫描发现 ShadowRoot + MutationObserver 增量维护缓存，`removedNodes` 时连带清理后代 ShadowRoot 引用防泄漏。
  - `requestAnimationFrame` 限流选区捕获，非拖拽时检测 `document` 选区折叠状态快速跳过昂贵的树遍历。
  - 点击输入框（ProseMirror）时保留 Chip，避免选区被冲掉误清。
  - 选中超过 2000 字符时按千位分档 toast（"已选中 >2000 字符…"/"已选中 >3000 字符…"…），同 id 的后续 toast 替换已存在的；回落到上限内 / 选区消失 / 组件 unmount 主动 dismiss。
- `apps/electron/src/renderer/components/diff/QuotedSelectionChip.tsx` — 新增组件，显示截断后的文本和来源文件名，hover 出现移除按钮。
- `apps/electron/src/renderer/components/agent/AgentView.tsx` — 输入框上方的 Chip 与附件并排显示；发送时拼 `<quoted_file path="...">…</quoted_file>` 注入 prompt 前置；按 `capturedAt` 时间戳比对再清除，防止竞态删错新选区。**path 走完整 4 字符 XML 实体转义（`&`/`<`/`>`/`"`），text 中的 `</quoted_file>` 改写为 `</quoted_file_>` 防止误闭合。**
- `apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx` — `parseAttachedFiles` 同时识别 `<attached_files>` 与 `<quoted_file>` 块；用户消息渲染时显示 `QuoteChip` 标识引用来源；`getGroupPreview` 同步剥离 `<quoted_file>` 块避免迷你地图出现裸 XML。

## 如何测试

1. 启动应用，进入任意 Agent 会话。
2. 让 Agent 写一段代码或打开任意文件预览。
3. 在预览面板中用鼠标拖选一段文本（建议在 `@pierre/diffs` 渲染的代码文件上验证 Shadow DOM 选区）。
4. 应看到：
   - 输入框上方出现引用 Chip，显示选中文本片段（截断到约 80 字符）和来源文件名。
   - Hover Chip 出现右上角 X 按钮可手动移除。
5. 输入文字（例如"这段在什么场景会触发？"）后发送。
6. 验证：
   - 已发送的用户消息上方显示 QuoteChip（带文件名 + Quote 图标）。
   - Agent 的回复中能感知到选中的代码片段。
7. 边界测试：
   - 选中超过 2000 字符 → 弹出 toast "已选中 >2000 字符，仅能发送前 2000 字符"。
   - 继续扩选到超过 3000 字符 → toast 文案更新为 "已选中 >3000 字符…"，旧 toast 自动撤回。
   - 收回选区到 2000 字符以内 → toast 立即消失。
   - 选中后点击输入框开始打字 → 引用 Chip 保留，不会因为选区消失而清空。
   - 关闭预览面板 / 切换 session → 截断 toast 立即撤回（如有）。

## 备注

- 本次 PR 在 fork 上由 20 个迭代 commit 演进而来（穿透 Shadow DOM → 性能优化 → UX 细节 → 代码审查反馈），squash 为一个 commit 提交，方便评审。
- 与上游 PR #495（修复 Agent 消息重复 key 警告）有过冲突；fork 自己在 `AgentMessages.tsx` 中也尝试了不同的 key 去重方案，rebase 时**采纳了上游的 WeakMap + 全局 fallback counter 实现**（更彻底，跨渲染保持 key 稳定），fork 自己的并行实现已舍弃。
- 安全方面：path/text 都做了 XML 实体转义与反解，避免选中代码本身包含 `</quoted_file>` 字符串时把外层标签提前闭合。
- `bun run typecheck` 全包通过。