### PR TITLE
调整特殊风格主题卡片尺寸与图片微调

### DIFF
--- a/apps/electron/src/renderer/components/settings/AppearanceSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AppearanceSettings.tsx
@@ -80,7 +80,7 @@ const SPECIAL_STYLES: readonly SpecialStyle[] = [
     name: '云朵舞者',
     variant: 'light',
     image: themeCloudDancer,
-    imageScale: 1.2,
+    imageScale: 1.3,
   },
   {
     id: 'ocean-light',
@@ -93,6 +93,7 @@ const SPECIAL_STYLES: readonly SpecialStyle[] = [
     name: '森息晨光',
     variant: 'light',
     image: themeForestMorning,
+    imageScale: 1.45,
   },
   {
     id: 'ocean-dark',
@@ -111,7 +112,8 @@ const SPECIAL_STYLES: readonly SpecialStyle[] = [
     name: '莫兰迪夜',
     variant: 'dark',
     image: themeMorandiNight,
-    objectPosition: '60% center',
+    imageScale: 1.15,
+    objectPosition: '44% 58%',
   },
 ]
 
@@ -356,7 +358,7 @@ function StyleCard({
         onClick={onSelect}
         className={cn(
           'relative rounded-lg transition-all overflow-hidden',
-          'w-[90px] h-[260px]',
+          'w-[99px] h-[183px]',
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1',
           isSelected
             ? 'ring-2 ring-primary shadow-lg shadow-primary/20'
@@ -383,7 +385,7 @@ function StyleCard({
           </div>
         )}
       </button>
-      <span className="text-sm font-medium text-foreground">
+      <span className="text-base font-medium text-foreground">
         {style.name}
       </span>
     </div>


### PR DESCRIPTION
## 概述

优化设置/外观/特殊风格中 6 张主题预览卡片的尺寸和图片裁剪，使卡片更紧凑、消除图片白边、标签文字更清晰。

## 改动

- `apps/electron/src/renderer/components/settings/AppearanceSettings.tsx` — 唯一改动文件

### 卡片容器调整

| 属性 | 旧值 | 新值 |
|------|------|------|
| 宽高 | `90×260px` | `99×183px` |
| 标签字号 | `text-sm` | `text-base` |

### SPECIAL_STYLES 图片参数调优

| 主题 | 参数 | 旧值 | 新值 |
|------|------|------|------|
| 云朵舞者 | `imageScale` | 1.2 | 1.3 |
| 森息晨光 | `imageScale` | (无) | 1.45 |
| 莫兰迪夜 | `imageScale` | (无) | 1.15 |
| 莫兰迪夜 | `objectPosition` | `60% center` | `44% 58%` |

## 测试方法

1. 打开 Proma → 设置 → 外观设置 → 特殊风格
2. 检查 6 张主题预览卡片：尺寸一致、无白边、标签清晰
3. 点击切换各主题，确认选中态正常

## 备注

- 纯视觉参数调优，无逻辑变更，不涉及 IPC/存储
- 类型检查全部通过