### PR TITLE
fix: Agent 重试策略覆盖 HTTP 529 过载错误

### DIFF
--- a/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
@@ -392,17 +392,20 @@ export function mapSDKErrorToTypedError(
   if (httpStatus != null && (httpStatus === 429 || httpStatus >= 500)) {
     const isRateLimited = httpStatus === 429
     const isUnavailable = httpStatus === 503
+    const isOverloaded = httpStatus === 529
     return {
       code: isRateLimited
         ? 'rate_limited'
-        : (isUnavailable ? 'service_unavailable' : 'service_error'),
+        : (isOverloaded ? 'provider_error' : (isUnavailable ? 'service_unavailable' : 'service_error')),
       title: isRateLimited
         ? '请求频率限制'
-        : (isUnavailable ? '服务暂时不可用' : '服务错误'),
+        : (isOverloaded ? '服务繁忙' : (isUnavailable ? '服务暂时不可用' : '服务错误')),
       message: detailedMessage || (
         isRateLimited
           ? '请求过于频繁，请稍后再试'
-          : `API 服务暂时异常 (${httpStatus})，请稍后再试`
+          : isOverloaded
+            ? 'API 服务当前过载 (529)，通常很快恢复'
+            : `API 服务暂时异常 (${httpStatus})，请稍后再试`
       ),
       actions: [
         { key: 's', label: '设置', action: 'settings' },

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -145,12 +145,16 @@ function isAutoRetryableCatchError(
   stderr?: string,
 ): boolean {
   if (apiError) {
+    // 529 是 Anthropic 的过载状态码，通常很快恢复；与 429 / 5xx 一并重试。
     if (apiError.statusCode === 429 || apiError.statusCode >= 500) return true
   }
   // 已知的可恢复错误模式（无 HTTP 状态码但可重试）
   if (rawErrorMessage) {
     if (rawErrorMessage.includes('context_management')) return true
   }
+  // 兜底：extractApiError 未识别但 stderr / 错误文本中包含 529 或 overloaded 关键字时也视为可重试
+  const text = `${rawErrorMessage ?? ''}\n${stderr ?? ''}`
+  if (/\b529\b|overloaded/i.test(text)) return true
   // 瞬时网络错误（terminated / ECONNRESET / socket hang up 等）
   if (isTransientNetworkError(rawErrorMessage, stderr)) return true
   return false


### PR DESCRIPTION
## Summary

- 594afc1 fix: Agent 重试策略覆盖 HTTP 529 过载错误

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归