### PR TITLE
feat: Agent 重试逻辑支持 502 错误码

### DIFF
--- a/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
@@ -393,19 +393,22 @@ export function mapSDKErrorToTypedError(
     const isRateLimited = httpStatus === 429
     const isUnavailable = httpStatus === 503
     const isOverloaded = httpStatus === 529
+    const isBadGateway = httpStatus === 502
     return {
       code: isRateLimited
         ? 'rate_limited'
         : (isOverloaded ? 'provider_error' : (isUnavailable ? 'service_unavailable' : 'service_error')),
       title: isRateLimited
         ? '请求频率限制'
-        : (isOverloaded ? '服务繁忙' : (isUnavailable ? '服务暂时不可用' : '服务错误')),
+        : (isOverloaded ? '服务繁忙' : (isUnavailable ? '服务暂时不可用' : (isBadGateway ? '网关异常' : '服务错误'))),
       message: detailedMessage || (
         isRateLimited
           ? '请求过于频繁，请稍后再试'
           : isOverloaded
             ? 'API 服务当前过载 (529)，通常很快恢复'
-            : `API 服务暂时异常 (${httpStatus})，请稍后再试`
+            : isBadGateway
+              ? 'API 网关暂时异常 (502)，通常很快恢复'
+              : `API 服务暂时异常 (${httpStatus})，请稍后再试`
       ),
       actions: [
         { key: 's', label: '设置', action: 'settings' },

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -152,9 +152,10 @@ function isAutoRetryableCatchError(
   if (rawErrorMessage) {
     if (rawErrorMessage.includes('context_management')) return true
   }
-  // 兜底：extractApiError 未识别但 stderr / 错误文本中包含 529 或 overloaded 关键字时也视为可重试
+  // 兜底：extractApiError 未识别但 stderr / 错误文本中包含 502 / 529 或 overloaded 关键字时也视为可重试
+  // 502 (Bad Gateway) 通常是上游网关瞬时异常，与 529 一样很快自行恢复
   const text = `${rawErrorMessage ?? ''}\n${stderr ?? ''}`
-  if (/\b529\b|overloaded/i.test(text)) return true
+  if (/\b502\b|\b529\b|overloaded/i.test(text)) return true
   // 瞬时网络错误（terminated / ECONNRESET / socket hang up 等）
   if (isTransientNetworkError(rawErrorMessage, stderr)) return true
   return false


### PR DESCRIPTION
## Summary

- b8a43a8 feat: Agent 重试逻辑增加 502 错误码识别

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归