### PR TITLE
feat: Skill 设置面板 UI 优化与依赖修复

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -41,6 +41,7 @@
     "@pierre/diffs": "^1.1.20",
     "@xmldom/xmldom": "^0.8.11",
     "adm-zip": "^0.5.17",
+    "dompurify": "^3.4.5",
     "mammoth": "^1.12.0",
     "pdfjs-dist": "^4.10.38"
   },
@@ -88,6 +89,7 @@
     "@tiptap/starter-kit": "^3.19.0",
     "@tiptap/suggestion": "^3.19.0",
     "@types/adm-zip": "^0.5.8",
+    "@types/dompurify": "^3.2.0",
     "@types/markdown-it": "^14.1.2",
     "@types/node": "^20.0.0",
     "@types/pdf-parse": "^1.1.5",

--- a/apps/electron/src/renderer/components/settings/AgentSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AgentSettings.tsx
@@ -673,19 +673,25 @@ function SkillListPanel({ skills, selectedSlug, onSelect, onDelete, onToggle, on
               <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider truncate flex-1">{group.prefix}</span>
               <span className="text-[10px] tabular-nums text-muted-foreground flex-shrink-0">{group.skills.length}</span>
             </button>
-            {expandedGroups.has(group.prefix) && group.skills.map((skill) => (
-              <SkillCompactItem
-                key={skill.slug}
-                skill={skill}
-                displayName={shortName(skill.slug, group.prefix)}
-                selected={selectedSlug === skill.slug}
-                onSelect={() => onSelect(skill.slug)}
-                onDelete={() => onDelete(skill.slug, skill.name)}
-                onToggle={(enabled) => onToggle(skill.slug, enabled)}
-                onOpenFolder={() => openSkillFolder(skill.slug)}
-                onUpdate={skill.hasUpdate ? () => onUpdate(skill.slug) : undefined}
-              />
-            ))}
+            {expandedGroups.has(group.prefix) && (
+              <div className="relative">
+                <div className="absolute left-3 top-0 bottom-0 w-px bg-border/60 pointer-events-none z-10" />
+                {group.skills.map((skill) => (
+                  <SkillCompactItem
+                    key={skill.slug}
+                    skill={skill}
+                    displayName={shortName(skill.slug, group.prefix)}
+                    selected={selectedSlug === skill.slug}
+                    onSelect={() => onSelect(skill.slug)}
+                    onDelete={() => onDelete(skill.slug, skill.name)}
+                    onToggle={(enabled) => onToggle(skill.slug, enabled)}
+                    onOpenFolder={() => openSkillFolder(skill.slug)}
+                    onUpdate={skill.hasUpdate ? () => onUpdate(skill.slug) : undefined}
+                    indented
+                  />
+                ))}
+              </div>
+            )}
           </div>
         ) : (
           group.skills.map((skill) => (
@@ -718,14 +724,16 @@ interface SkillCompactItemProps {
   onToggle: (enabled: boolean) => void
   onOpenFolder: () => void
   onUpdate?: () => void
+  indented?: boolean
 }
 
-function SkillCompactItem({ skill, displayName, selected, onSelect, onDelete, onToggle, onOpenFolder, onUpdate }: SkillCompactItemProps): React.ReactElement {
+function SkillCompactItem({ skill, displayName, selected, onSelect, onDelete, onToggle, onOpenFolder, onUpdate, indented }: SkillCompactItemProps): React.ReactElement {
   return (
     <button
       onClick={onSelect}
       className={cn(
-        'group w-full flex items-center gap-2 px-3 py-2 text-left transition-colors',
+        'group w-full flex items-center gap-2 py-2 pr-3 text-left transition-colors',
+        indented ? 'pl-5' : 'pl-3',
         selected ? 'bg-accent text-accent-foreground' : 'hover:bg-muted/40',
         !skill.enabled && 'opacity-50',
       )}
@@ -782,7 +790,6 @@ function SkillDetailPanel({ skill, workspaceSlug, onSaved }: SkillDetailPanelPro
 
   const [isEditingMeta, setIsEditingMeta] = React.useState(false)
   const [isEditingBody, setIsEditingBody] = React.useState(false)
-  const [metaExpanded, setMetaExpanded] = React.useState(false)
   const [editName, setEditName] = React.useState('')
   const [editDescription, setEditDescription] = React.useState('')
   const [editBody, setEditBody] = React.useState('')
@@ -795,7 +802,6 @@ function SkillDetailPanel({ skill, workspaceSlug, onSaved }: SkillDetailPanelPro
     currentSlugRef.current = skill.slug
     setIsEditingMeta(false)
     setIsEditingBody(false)
-    setMetaExpanded(false)
     setDetailTab('body')
     setFileCount(null)
     setLoadingContent(true)
@@ -872,76 +878,42 @@ function SkillDetailPanel({ skill, workspaceSlug, onSaved }: SkillDetailPanelPro
 
   return (
     <div className="flex flex-col h-full p-5 gap-4 min-h-0">
-      {/* Header */}
-      <div className="flex items-start gap-3 shrink-0">
-        <div className="rounded-xl bg-amber-500/12 p-2.5 text-amber-500 shrink-0">
-          <Sparkles size={20} />
-        </div>
-        <div className="min-w-0 flex-1">
-          <h3 className="text-base font-semibold text-foreground">{skill.name}</h3>
-          {skill.description && (
-            <p className="text-sm text-muted-foreground mt-1 line-clamp-2">{skill.description}</p>
+      {/* Metadata：直接展示 */}
+      <div className="shrink-0 space-y-2">
+        <div className="flex items-center justify-between">
+          <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">元数据</h4>
+          {!isEditingMeta ? (
+            <button onClick={startEditMeta} className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1 transition-colors">
+              <Pencil size={12} /> 编辑
+            </button>
+          ) : (
+            <div className="flex items-center gap-2">
+              <Button size="sm" variant="ghost" onClick={() => setIsEditingMeta(false)} disabled={saving}>
+                <X size={14} /> 取消
+              </Button>
+              <Button size="sm" onClick={() => void saveMeta()} disabled={saving}>
+                <Save size={14} /> {saving ? '保存中...' : '保存'}
+              </Button>
+            </div>
           )}
         </div>
-      </div>
-
-      {/* Metadata：折叠摘要 + 可展开完整编辑 */}
-      <div className="shrink-0 space-y-2">
-        <button
-          type="button"
-          onClick={() => setMetaExpanded((v) => !v)}
-          className="w-full flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors px-3 py-2 rounded-md bg-muted/40 hover:bg-muted/60"
-        >
-          {metaExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-          <span className="font-mono text-foreground/80">skills/{skill.slug}</span>
-          <span className="text-muted-foreground/70">·</span>
-          <span>{sourceLabel}</span>
-          {skill.version && (
+        <SettingsCard divided>
+          <MetadataRow label="标识符" value={skill.slug} />
+          {isEditingMeta ? (
             <>
-              <span className="text-muted-foreground/70">·</span>
-              <span>v{skill.version}</span>
+              <MetadataEditRow label="名称" value={editName} onChange={setEditName} />
+              <MetadataEditRow label="描述" value={editDescription} onChange={setEditDescription} multiline />
+            </>
+          ) : (
+            <>
+              <MetadataRow label="名称" value={skill.name} />
+              <MetadataRow label="描述" value={skill.description ?? '无描述'} />
             </>
           )}
-          <span className="ml-auto">{metaExpanded ? '收起' : '展开元数据'}</span>
-        </button>
-
-        {metaExpanded && (
-          <div className="space-y-2">
-            <div className="flex items-center justify-end">
-              {!isEditingMeta ? (
-                <button onClick={startEditMeta} className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1 transition-colors">
-                  <Pencil size={12} /> 编辑
-                </button>
-              ) : (
-                <div className="flex items-center gap-2">
-                  <Button size="sm" variant="ghost" onClick={() => setIsEditingMeta(false)} disabled={saving}>
-                    <X size={14} /> 取消
-                  </Button>
-                  <Button size="sm" onClick={() => void saveMeta()} disabled={saving}>
-                    <Save size={14} /> {saving ? '保存中...' : '保存'}
-                  </Button>
-                </div>
-              )}
-            </div>
-            <SettingsCard divided>
-              <MetadataRow label="标识符" value={skill.slug} />
-              {isEditingMeta ? (
-                <>
-                  <MetadataEditRow label="名称" value={editName} onChange={setEditName} />
-                  <MetadataEditRow label="描述" value={editDescription} onChange={setEditDescription} multiline />
-                </>
-              ) : (
-                <>
-                  <MetadataRow label="名称" value={skill.name} />
-                  <MetadataRow label="描述" value={skill.description ?? '无描述'} />
-                </>
-              )}
-              <MetadataRow label="数据源" value={sourceLabel} />
-              <MetadataRow label="位置" value={`skills/${skill.slug}`} />
-              {skill.version && <MetadataRow label="版本" value={skill.version} />}
-            </SettingsCard>
-          </div>
-        )}
+          <MetadataRow label="数据源" value={sourceLabel} />
+          <MetadataRow label="位置" value={`skills/${skill.slug}`} />
+          {skill.version && <MetadataRow label="版本" value={skill.version} />}
+        </SettingsCard>
       </div>
 
       {/* Tab: 说明 / 资源文件 */}
@@ -963,22 +935,30 @@ function SkillDetailPanel({ skill, workspaceSlug, onSaved }: SkillDetailPanelPro
         </TabsList>
 
         <TabsContent value="body" className="flex-1 mt-3 min-h-0 overflow-auto">
-          <div className="space-y-2">
-            <div className="flex items-center justify-end">
-              {!isEditingBody ? (
-                <button onClick={startEditBody} className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1 transition-colors">
-                  <Pencil size={12} /> 编辑
-                </button>
-              ) : (
-                <div className="flex items-center gap-2">
-                  <Button size="sm" variant="ghost" onClick={() => setIsEditingBody(false)} disabled={saving}>
-                    <X size={14} /> 取消
-                  </Button>
-                  <Button size="sm" onClick={() => void saveBody()} disabled={saving}>
-                    <Save size={14} /> {saving ? '保存中...' : '保存'}
-                  </Button>
-                </div>
-              )}
+          <div className="flex flex-col h-full">
+            <div className="flex items-center justify-between px-1 pb-2 shrink-0 min-h-[28px]">
+              <div className="text-xs text-muted-foreground font-mono">SKILL.md</div>
+              <div className="flex items-center gap-1">
+                {!isEditingBody ? (
+                  <button
+                    type="button"
+                    title="编辑"
+                    onClick={startEditBody}
+                    className="p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1 text-xs"
+                  >
+                    <Pencil size={14} />
+                  </button>
+                ) : (
+                  <>
+                    <Button size="sm" variant="ghost" onClick={() => setIsEditingBody(false)} disabled={saving}>
+                      <X size={14} /> 取消
+                    </Button>
+                    <Button size="sm" onClick={() => void saveBody()} disabled={saving}>
+                      <Save size={14} /> {saving ? '保存中...' : '保存'}
+                    </Button>
+                  </>
+                )}
+              </div>
             </div>
             <SettingsCard divided={false}>
               <div className="p-4">

--- a/apps/electron/src/renderer/components/settings/SkillFilesPanel.tsx
+++ b/apps/electron/src/renderer/components/settings/SkillFilesPanel.tsx
@@ -220,7 +220,7 @@ export function SkillFilesPanel({ workspaceSlug, skillSlug, onFileCountChange }:
 
   return (
     <div className="flex flex-col h-full">
-      <div className="flex items-center justify-between px-1 pb-2 shrink-0">
+      <div className="flex items-center justify-between px-1 pb-2 shrink-0 min-h-[28px]">
         <div className="text-xs text-muted-foreground">
           {loading
             ? '加载中...'

--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,7 @@
         "@pierre/diffs": "^1.1.20",
         "@xmldom/xmldom": "^0.8.11",
         "adm-zip": "^0.5.17",
+        "dompurify": "^3.4.5",
         "mammoth": "^1.12.0",
         "pdfjs-dist": "^4.10.38",
       },
@@ -71,6 +72,7 @@
         "@tiptap/starter-kit": "^3.19.0",
         "@tiptap/suggestion": "^3.19.0",
         "@types/adm-zip": "^0.5.8",
+        "@types/dompurify": "^3.2.0",
         "@types/markdown-it": "^14.1.2",
         "@types/node": "^20.0.0",
         "@types/pdf-parse": "^1.1.5",
@@ -2146,6 +2148,8 @@
     "@malept/flatpak-bundler/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
 
     "@npmcli/move-file/rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
+
+    "@proma/electron/dompurify": ["dompurify@3.4.5", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA=="],
 
     "@radix-ui/react-alert-dialog/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 


### PR DESCRIPTION
## 问题根因

Skill 设置面板存在多处可改进的视觉与信息层级问题：

1. Skill 列表中同前缀分组（如 `obsidian-a` / `obsidian-b`）展开后，子项与顶层 Skill 视觉上没有差别，看不出从属关系
2. 右侧详情面板顶部的 logo + 名字 + 描述与下方元数据区的"名称""描述"完全重复
3. "说明" Tab 与"资源文件" Tab 切换时顶部工具栏的位置与按钮样式不一致，视觉上有跳动
4. `markdown-preview-extensions.tsx` 使用了 `dompurify` 但 `package.json` 中未声明，导致 `bun run dev` 启动时 Vite 报缺失依赖

## 具体修改

**`apps/electron/src/renderer/components/settings/AgentSettings.tsx`**
- Skill 列表分组展开后，子项使用绝对定位引导线 + button 内部 `pl-5` 缩进，让选中色（`bg-accent`）可覆盖整宽，引导线浮在最左 1px
- `SkillCompactItem` 新增 `indented` 可选 prop 控制左 padding
- 删除 `SkillDetailPanel` 顶部冗余的 logo + 名字 + 描述 Header
- "说明" Tab 工具栏改用与"资源文件" Tab 完全一致的容器结构（`px-1 pb-2 shrink-0 min-h-[28px]`），左侧显示 `SKILL.md` 文件名，右侧编辑按钮改为图标按钮样式
- 移除不再使用的 `metaExpanded` state 及对应 reset 调用

**`apps/electron/src/renderer/components/settings/SkillFilesPanel.tsx`**
- 顶部工具栏增加 `min-h-[28px]`，与"说明" Tab 对齐，防止 Tab 切换时高度跳动

**`apps/electron/package.json` / `bun.lock`**
- 新增 `dompurify ^3.4.5`（dependencies）和 `@types/dompurify ^3.2.0`（devDependencies）

## 审查情况

自审查：
- ✅ 选中态背景色现在能完整覆盖分组下子项整宽（前两次方案被父容器 padding 截断，已修复为 button 自身 padding + 绝对定位引导线方案）
- ✅ 两个 Tab 切换时顶部工具栏左右元素位置完全对齐
- ✅ 删除了未使用的 `metaExpanded` state，无残留代码
- ✅ `Sparkles` / `ChevronDown` / `ChevronRight` import 仍被其他位置使用，保留合理

用户测试：本地已确认 UI 表现符合预期。