### PR TITLE
fix: 移除特殊风格卡片选中边框的过渡动画，消除对号与边框不同步

### DIFF
--- a/apps/electron/src/renderer/components/settings/AppearanceSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AppearanceSettings.tsx
@@ -357,7 +357,7 @@ function StyleCard({
         type="button"
         onClick={onSelect}
         className={cn(
-          'relative rounded-lg transition-all overflow-hidden',
+          'relative rounded-lg overflow-hidden',
           'w-[99px] h-[183px]',
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1',
           isSelected


### PR DESCRIPTION
## 概述

修复外观设置中"特殊风格"卡片切换时的视觉不同步问题：点击卡片后，对号（✓）瞬间出现在新卡片上，但选中边框（ring）受 CSS `transition-all` 约束需要 150ms 过渡，导致边框明显滞后于对号。

## 改动

- `apps/electron/src/renderer/components/settings/AppearanceSettings.tsx` — `StyleCard` 按钮移除 `transition-all`，让选中边框（ring-2）与对号同步到位，不再有延迟

## 根因

- 对号通过 React 条件渲染 `{isSelected && ...}` 直接插入 DOM，0ms 到位
- 选中边框通过 `ring-2 ring-primary` CSS class 切换，受 `transition-all`（150ms）约束
- 两者状态同时变更但视觉到达时间不同，产生割裂感

## 影响分析

按钮上受 `transition-all` 影响的属性仅有 `box-shadow`（ring 和 shadow），移除后：
- 选中/取消选中：边框和光晕瞬间到位，与对号完全同步
- hover 态（`ring-border/50` → `ring-border`）：变化极细微，无过渡几乎不可感知
- focus-visible：聚焦环瞬间显示，符合无障碍惯例

无副作用、无类型错误、无回归风险。

## 测试方法

1. 打开设置 → 外观设置
2. 在不同特殊风格卡片之间点击切换
3. 观察对号和选中边框是否同步出现在新卡片上
4. 确认旧卡片的边框和对号同时消失

🤖 Generated with [Claude Code](https://claude.com/claude-code)