### PR TITLE
fix: 修复含子代理输出 turn 分叉时报 "Message not found" 错误

### DIFF
--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -639,23 +639,65 @@ export async function forkAgentSession(input: ForkSessionInput): Promise<AgentSe
     }
   }
 
-  // 2.5 确定目标消息所属的 SDK session ID
-  // 当会话经历过 "session not found" 恢复后，sdkSessionId 会被替换为新的，
-  // 但旧消息仍保留在 Proma JSONL 中，其 session_id 指向旧的 SDK session。
-  // 这里从 JSONL 中查找目标消息的实际 session_id，确保 fork 调用使用正确的 SDK session。
+  // 2.5 校验目标消息并确定其所属的 SDK session ID
+  // - 当会话经历过 "session not found" 恢复后，sdkSessionId 会被替换为新的，
+  //   但旧消息仍保留在 Proma JSONL 中，其 session_id 指向旧的 SDK session。
+  // - 若目标消息是 sub-agent 输出（parent_tool_use_id 非空），SDK forkSession
+  //   会过滤掉 sidechain 后再查 upToMessageId，必然报 "not found"，
+  //   这里自动回溯到最近的主线 assistant uuid。
   let forkSourceSdkSessionId = sourceMeta.sdkSessionId
+  let effectiveUpToMessageUuid = upToMessageUuid
   if (upToMessageUuid) {
     const allMessages = getAgentSessionSDKMessages(sessionId)
-    for (let i = allMessages.length - 1; i >= 0; i--) {
-      const m = allMessages[i]!
-      if ('uuid' in m && (m as { uuid?: string }).uuid === upToMessageUuid) {
-        const msgSessionId = (m as { session_id?: string }).session_id
-        if (msgSessionId && msgSessionId !== sourceMeta.sdkSessionId) {
-          console.log(`[Agent 会话] fork 目标消息属于旧 SDK session ${msgSessionId}（当前为 ${sourceMeta.sdkSessionId}），使用消息所属 session 进行 fork`)
-          forkSourceSdkSessionId = msgSessionId
+    const targetIdx = allMessages.findLastIndex(
+      (m) => 'uuid' in m && (m as { uuid?: string }).uuid === upToMessageUuid,
+    )
+
+    if (targetIdx < 0) {
+      throw new Error('未在会话历史中找到指定的消息，可能消息已被清理或截断')
+    }
+
+    const targetMsg = allMessages[targetIdx]!
+    const isSidechain =
+      targetMsg.type === 'assistant' &&
+      Boolean((targetMsg as { parent_tool_use_id?: string | null }).parent_tool_use_id)
+
+    if (isSidechain) {
+      // 向前回溯，寻找最近的主线 assistant 消息（parent_tool_use_id 为空）
+      let fallbackUuid: string | undefined
+      for (let i = targetIdx - 1; i >= 0; i--) {
+        const m = allMessages[i]!
+        if (m.type !== 'assistant') continue
+        if ((m as { parent_tool_use_id?: string | null }).parent_tool_use_id) continue
+        const u = (m as { uuid?: string }).uuid
+        if (u) {
+          fallbackUuid = u
+          break
         }
-        break
       }
+      if (!fallbackUuid) {
+        throw new Error('选中的是子代理执行过程中的消息，且向前找不到可分叉的主对话消息')
+      }
+      console.log(
+        `[Agent 会话] fork 目标消息 ${upToMessageUuid} 属于 sub-agent，自动回溯到主线消息 ${fallbackUuid}`,
+      )
+      effectiveUpToMessageUuid = fallbackUuid
+    }
+
+    // 重新定位 effectiveUpToMessageUuid 所在消息，取其 session_id
+    // 与上面的 findLastIndex 保持一致语义（重复 uuid 时取最后一条）
+    const effectiveMsg =
+      effectiveUpToMessageUuid === upToMessageUuid
+        ? targetMsg
+        : allMessages.findLast(
+            (m) => 'uuid' in m && (m as { uuid?: string }).uuid === effectiveUpToMessageUuid,
+          )
+    const msgSessionId = (effectiveMsg as { session_id?: string } | undefined)?.session_id
+    if (msgSessionId && msgSessionId !== sourceMeta.sdkSessionId) {
+      console.log(
+        `[Agent 会话] fork 目标消息属于旧 SDK session ${msgSessionId}（当前为 ${sourceMeta.sdkSessionId}），使用消息所属 session 进行 fork`,
+      )
+      forkSourceSdkSessionId = msgSessionId
     }
   }
 
@@ -665,7 +707,7 @@ export async function forkAgentSession(input: ForkSessionInput): Promise<AgentSe
   let forkResult: Awaited<ReturnType<typeof sdk.forkSession>>
   try {
     forkResult = await sdk.forkSession(forkSourceSdkSessionId, {
-      upToMessageId: upToMessageUuid,
+      upToMessageId: effectiveUpToMessageUuid,
       dir: sourceDir,
     })
   } catch (err) {
@@ -673,7 +715,7 @@ export async function forkAgentSession(input: ForkSessionInput): Promise<AgentSe
     if (sourceDir) {
       console.warn(`[Agent 会话] forkSession 指定 dir 失败，改用全局搜索:`, err)
       forkResult = await sdk.forkSession(forkSourceSdkSessionId, {
-        upToMessageId: upToMessageUuid,
+        upToMessageId: effectiveUpToMessageUuid,
       })
     } else {
       throw err
@@ -759,6 +801,9 @@ export async function forkAgentSession(input: ForkSessionInput): Promise<AgentSe
   // 6. 复制截断后的 SDKMessages 到新会话的 JSONL（用于 UI 展示历史）
   // 同时改写消息中所有源目录绝对路径为目标目录路径 — 否则 Claude 在历史里看到的所有
   // Read/Edit/Bash 工具调用都指向源会话目录，会继续在源目录而非新 cwd 下操作文件。
+  //
+  // 注意：UI 截断点用原始 upToMessageUuid，保留用户实际看到的所有内容（包括 sub-agent
+  // 过程消息），与 SDK forkSession 用 effectiveUpToMessageUuid（主线 uuid）解耦。
   const sourceMessages = getAgentSessionSDKMessages(sessionId)
   let messagesToCopy: SDKMessage[]
 

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -1616,8 +1616,14 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       })
     } catch (error) {
       console.error('[AgentView] 分叉会话失败:', error)
+      const rawMsg = error instanceof Error ? error.message : '未知错误'
+      // SDK 偶尔会因为 sidechain/消息归属问题抛 "not found in session"，
+      // 这里给出更可操作的中文提示，而不是把 SDK 内部英文报错直接透传给用户
+      const friendlyDesc = /not found in session/i.test(rawMsg)
+        ? '该消息无法作为分叉起点（可能属于子代理执行过程或已被清理）。请选择主对话中的其他消息再试。'
+        : rawMsg
       toast.error('分叉会话失败', {
-        description: error instanceof Error ? error.message : '未知错误',
+        description: friendlyDesc,
       })
     }
   }, [sessionId, openSession, setAgentSessions])

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -644,8 +644,12 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, onR
           .filter((b) => b.type === 'text' && 'text' in b)
           .map((b) => (b as { text: string }).text)
           .join('\n\n')
-        const lastUuid = turn.assistantMessages.length > 0
-          ? turn.assistantMessages[turn.assistantMessages.length - 1]?.uuid
+        // 仅取主线 assistant 消息的 uuid 作为 fork/rewind 截断点。
+        // SDK forkSession 内部会过滤掉 sidechain（parent_tool_use_id 非空的子代理消息），
+        // 若把子代理 uuid 传过去会触发 "Message <uuid> not found in session" 错误。
+        const mainlineAssistants = turn.assistantMessages.filter((m) => !m.parent_tool_use_id)
+        const lastUuid = mainlineAssistants.length > 0
+          ? mainlineAssistants[mainlineAssistants.length - 1]?.uuid
           : undefined
         const hasActions = !!(textContent || (onFork && lastUuid) || (onRewind && lastUuid))
         const hasDuration = durationMs != null


### PR DESCRIPTION
## Summary

修复点击「从此处分叉」时偶现的 `分叉会话失败 — Message <uuid> not found in session <sid>` toast。

**根因**：Claude Agent SDK 的 `forkSession` 内部会先过滤掉 sidechain（`parent_tool_use_id` 非空的子代理消息）再去匹配 `upToMessageId`。但 Proma 前端 `SDKMessageRenderer` 计算 fork 截断点时直接取了 `turn.assistantMessages` 的最后一条 uuid，若该 turn 末尾恰好是 sub-agent 输出（如委派给 explorer/researcher 后主 Agent 还未补输出就被合并），传入的就是 sidechain uuid，SDK 必然报 not found。

## 改动

- `SDKMessageRenderer.tsx`：计算 `lastUuid` 时仅取主线 assistant（`!parent_tool_use_id`），跳过子代理消息；若整个 turn 全是 sub-agent 输出，则不渲染 fork 按钮。
- `agent-session-manager.ts` 的 `forkAgentSession`：增加防御性校验。若传入的 `upToMessageUuid` 仍是 sidechain，自动向前回溯到最近的主线 assistant uuid 调用 SDK；UI 截断点仍使用原始 uuid，以保留用户实际看到的全部内容（包含 sub-agent 过程）。同时复用一次 `findLastIndex` 替代原线性扫描。
- `AgentView.tsx`：fork 失败时对 `not found in session` 错误给出可操作的中文提示，不再把 SDK 英文报错原样透传。

## Test plan

- [ ] 在普通 turn（无 sub-agent 调用）末尾点击「从此处分叉」，分叉成功。
- [ ] 委派 SubAgent 后主 Agent 仍有文字输出的 turn，点击分叉成功。
- [ ] 在末尾完全是 SubAgent 输出的 turn，验证 fork 按钮按预期隐藏（或在校验生效下仍能分叉到上一条主线消息）。
- [ ] 流式输出过程中点 fork，错误提示为友好中文文案。

🤖 Generated with [Claude Code](https://claude.com/claude-code)