### PR TITLE
fix: harden markdown editor screenshot service and code block UX (follow-up #514)

### DIFF
--- a/apps/electron/src/main/lib/screenshot-service.ts
+++ b/apps/electron/src/main/lib/screenshot-service.ts
@@ -25,10 +25,45 @@ const SCREENSHOT_PADDING_TOP = 24
 
 /* ── 离屏窗口单例 ── */
 
+/** 空闲多久后自动销毁离屏窗口，释放内存 */
+const SCREENSHOT_IDLE_TTL_MS = 5 * 60 * 1000
+
 let _screenshotWin: BrowserWindow | null = null
 let _screenshotScale = 0
+let _idleTimer: ReturnType<typeof setTimeout> | null = null
+let _appQuitHookRegistered = false
+
+function destroyScreenshotWindow(): void {
+  if (_idleTimer) {
+    clearTimeout(_idleTimer)
+    _idleTimer = null
+  }
+  if (_screenshotWin && !_screenshotWin.isDestroyed()) {
+    _screenshotWin.destroy()
+  }
+  _screenshotWin = null
+  _screenshotScale = 0
+}
+
+function scheduleIdleDestroy(): void {
+  if (_idleTimer) clearTimeout(_idleTimer)
+  _idleTimer = setTimeout(destroyScreenshotWindow, SCREENSHOT_IDLE_TTL_MS)
+}
+
+function ensureAppQuitHook(): void {
+  if (_appQuitHookRegistered) return
+  _appQuitHookRegistered = true
+  // 进程退出前清理离屏窗口，避免 BrowserWindow 残留。lazy require 避免与 main 启动顺序耦合。
+  const { app } = require('electron') as typeof import('electron')
+  app.on('before-quit', destroyScreenshotWindow)
+}
 
 function getScreenshotWindow(scale: number): BrowserWindow {
+  ensureAppQuitHook()
+  if (_idleTimer) {
+    clearTimeout(_idleTimer)
+    _idleTimer = null
+  }
   if (_screenshotWin && !_screenshotWin.isDestroyed() && _screenshotScale === scale) return _screenshotWin
   if (_screenshotWin && !_screenshotWin.isDestroyed()) {
     _screenshotWin.destroy()
@@ -56,13 +91,15 @@ function getScreenshotWindow(scale: number): BrowserWindow {
 
 /* ── 串行锁（防并发截图） ── */
 
-let _lock = Promise.resolve()
+let _lock: Promise<unknown> = Promise.resolve()
 
 function withLock<T>(fn: () => Promise<T>): Promise<T> {
-  let resolve: () => void
+  let resolve: (value?: unknown) => void
   const prev = _lock
   _lock = new Promise((r) => { resolve = r })
-  return prev.then(() => fn().finally(() => resolve!()))
+  // prev 即便已 rejected（fn 自身的 try/catch 兜底下不应发生，但加固调用方意外抛错路径），
+  // 也用 .catch 吞掉以确保后续锁能继续推进。
+  return prev.catch(() => undefined).then(() => fn().finally(() => resolve!()))
 }
 
 /* ── 最大分段高度（参考屏幕工作区） ── */
@@ -326,6 +363,8 @@ export function captureScreenshot(input: ScreenshotInput): Promise<ScreenshotRes
       const msg = err instanceof Error ? err.message : '截图失败'
       console.error('[截图服务]', err)
       return { success: false, message: msg }
+    } finally {
+      scheduleIdleDestroy()
     }
   })
 }

--- a/apps/electron/src/renderer/components/diff/markdown-preview-extensions.tsx
+++ b/apps/electron/src/renderer/components/diff/markdown-preview-extensions.tsx
@@ -11,7 +11,7 @@ import { TableCell } from '@tiptap/extension-table-cell'
 import { TableHeader } from '@tiptap/extension-table-header'
 import DOMPurify from 'dompurify'
 import katex from 'katex'
-import { highlightCode, highlightToTokens } from '@proma/core'
+import { highlightCode, highlightToTokens, getDisplayName } from '@proma/core'
 import type { HighlightTokensResult } from '@proma/core'
 import type { FileAccessOptions } from '@proma/shared'
 
@@ -162,29 +162,31 @@ function buildShikiDecorations(doc: ProseMirrorNode, theme: string): DecorationS
 }
 
 function requestMissingShikiLanguages(view: EditorView, theme: string, pending: Set<string>): void {
-  const requests: Array<Promise<void>> = []
-
+  // 同一文档可能含多个相同 language 的代码块，先按 language 去重再判定，
+  // 避免重复同步调用 highlightToTokens（每个 codeBlock 一次）。
+  const languages = new Set<string>()
   view.state.doc.descendants((node) => {
     if (node.type.name !== 'codeBlock') return true
+    languages.add(normalizeCodeLanguage(node.attrs.language))
+    return false
+  })
 
-    const language = normalizeCodeLanguage(node.attrs.language)
-    const code = node.textContent || ' '
-    const syncResult = highlightToTokens({ code, language, theme })
-    if (syncResult && !shouldLoadShikiLanguage(language, syncResult.language)) return false
+  const requests: Array<Promise<void>> = []
+  for (const language of languages) {
+    const syncResult = highlightToTokens({ code: ' ', language, theme })
+    if (syncResult && !shouldLoadShikiLanguage(language, syncResult.language)) continue
 
     const key = `${theme}:${language}`
-    if (pending.has(key)) return false
+    if (pending.has(key)) continue
 
     pending.add(key)
     requests.push(
-      highlightCode({ code, language, theme })
+      highlightCode({ code: ' ', language, theme })
         .then(() => {})
         .catch((error) => console.error('[MarkdownRichEditor] Shiki 高亮失败:', error))
         .finally(() => pending.delete(key)),
     )
-
-    return false
-  })
+  }
 
   if (requests.length === 0) return
 
@@ -517,7 +519,7 @@ function createShikiCodeBlockView(initialNode: ProseMirrorNode, _themeRef: Theme
   const render = (node: ProseMirrorNode) => {
     const language = String(node.attrs.language ?? 'text') || 'text'
     currentCode = node.textContent
-    label.textContent = language === 'text' ? 'Code' : language
+    label.textContent = language === 'text' ? 'Code' : getDisplayName(language)
   }
 
   render(initialNode)

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.9.35",
+      "version": "0.9.38",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.143",
         "@anthropic-ai/sdk": "^0.93.0",


### PR DESCRIPTION
## Summary

Follow-up hardening for #514（已合并）。Addresses 4 defects surfaced during PR review:

| # | Severity | Location | Fix |
|---|----------|----------|-----|
| 1 | Medium | `screenshot-service.ts:withLock` | `prev.then(...)` → `prev.catch(() => undefined).then(...)`，避免链上 rejection 导致后续截图请求永久 pending |
| 2 | Low | `screenshot-service.ts:getScreenshotWindow` | 新增 `SCREENSHOT_IDLE_TTL_MS = 5min` 空闲销毁定时器 + `app.on('before-quit')` 退出时释放离屏 BrowserWindow |
| 3 | Low | `bun.lock` | `apps/electron` workspace 版本号从 `0.9.35` 同步到 `0.9.38`（与 `package.json` 对齐） |
| 4 | Low | `markdown-preview-extensions.tsx:requestMissingShikiLanguages` | 按 `language` 去重后再逐个判定，避免同语言多代码块重复同步调用 `highlightToTokens` |
| 5 | Low | `markdown-preview-extensions.tsx:render` | code block 头部标签恢复使用 `getDisplayName(language)`，`ts` 显示为 `TypeScript` 而非裸字符串 |

## 不在本 PR 范围

审查中提到但**未**在本 PR 修复（需单独 PR）：

- `sanitizeScreenshotFragment` 黑名单正则改 DOMPurify（CSP 已兜底，风险低）
- `collectRuntimeStyles()` 注入全量 CSS（属于优化，且当前未超出 12MB 限制）
- `escapeMarkdownText` 与各节点 serializer 的 escape 实现统一（重构性质，影响面较大）

## Test plan

- [x] `bun run typecheck` (root) — 全部 workspace 通过
- [x] `bun test src/renderer/lib/markdown-rich-text.test.ts` — 7/7 pass
- [ ] 手动验证截图导出在长文档与并发触发下表现正常
- [ ] 手动验证 5min 不操作后 offscreen 窗口确实被销毁
- [ ] 手动验证代码块语言标签显示为 `TypeScript` 等友好名称

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>