### PR TITLE
fix(ui): 自动审批拒绝提示框左侧对齐消息气泡

### DIFF
--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -102,7 +102,7 @@ function PermissionDeniedNotice({ message }: { message: SDKSystemMessage }): Rea
   const reason = typeof message.decision_reason === 'string' ? message.decision_reason : undefined
 
   return (
-    <div className="my-3 px-1">
+    <div className="my-3 pl-[46px] pr-1">
       <div className="flex items-start gap-2.5 rounded-md border border-amber-500/20 bg-amber-500/5 px-3 py-2.5 text-xs text-foreground/80">
         <AlertTriangle className="mt-0.5 size-3.5 shrink-0 text-amber-500" />
         <div className="min-w-0 space-y-1">


### PR DESCRIPTION
## Summary
- `PermissionDeniedNotice` 外层容器原本是 `my-3 px-1`，没有左侧缩进，导致提示框宽度撑满消息列表，比头像缩进的 assistant 消息气泡更宽（参见截图问题）
- 改为 `my-3 pl-[46px] pr-1`，与 `MessageContent` 的 `pl-[46px]` 保持一致，让拒绝提示框左边与消息气泡正文对齐

## Test plan
- [ ] 触发一次自动审批被拒（如 auto mode 下 classifier 不可用时的 Bash 调用）
- [ ] 视觉检查提示框左边是否与上方 assistant 消息气泡正文左边对齐
- [ ] 检查窄/宽窗口下提示框右边界是否合理（不超出消息列表容器）