### PR TITLE
修复侧边栏拖拽分割条热区太小、hover 不稳定及样式不一致

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -1426,11 +1426,13 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                 </div>
               </div>
 
-              {/* 拖拽分割条：默认 1px 细线，hover 扩为 4px 热区 */}
+              {/* 拖拽分割条 */}
               <div
                 onMouseDown={handleAgentTopResizeStart}
-                className="h-px bg-border/60 hover:h-1 hover:bg-foreground/[0.08] cursor-row-resize titlebar-no-drag flex-shrink-0 transition-[height,background-color] duration-75"
-              />
+                className="h-[8px] cursor-row-resize active:bg-primary/50 transition-colors titlebar-no-drag flex-shrink-0 flex items-center"
+              >
+                <div className="mx-3 w-full border-t border-muted-foreground/20" />
+              </div>
             </>
           )}
 


### PR DESCRIPTION
## 概述

修复 Agent 模式下左侧边栏「工作中/置顶」区域与「最近会话」区域之间的拖拽分割条存在三个问题：

1. **拖拽热区太小** — 原方案仅 1px 高 (`h-px`)，hover 才扩为 4px (`hover:h-1`)，鼠标极难落位
2. **拖拽光标不稳定** — 1px 热区上 `cursor-row-resize` 时有时无
3. **样式偏离右侧面板** — 原 `bg-border/60` 细线 + `hover:bg-foreground/[0.08]` 样式与 AppShell 右侧面板拖拽手柄不一致

## 改动

- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 将拖拽分割条从 1px 细线替换为 8px 热区容器 + 内部居中细线的结构：
  - 外层：`h-[8px] cursor-row-resize active:bg-primary/50 transition-colors`，与 AppShell 右侧面板拖拽手柄 (`w-[8px] cursor-col-resize active:bg-primary/50`) 形成完美水平/垂直对称
  - 内层：`mx-3 w-full border-t border-muted-foreground/20`，与 SidePanel 内部分隔线视觉完全一致

## 测试方式

1. 打开 Proma，切换到 Agent 模式
2. 确保有工作中或置顶会话，下方有历史会话
3. 鼠标移到分割条区域，确认 8px 热区内光标稳定显示 `row-resize`
4. 按住拖拽，确认出现蓝色高亮 (`primary/50`) 并可正常调整上区高度
5. 检查右侧 SidePanel 分隔线样式，确保两侧视觉一致

## 备注

- SidePanel.tsx 无改动，仅作为样式参考
- 点击区域从 ~1px × width 提升到 8px × width，拖拽体验显著改善
- `titlebar-no-drag` 和 `flex-shrink-0` 保留，防止被错误识别为标题栏区域或被 flex 压缩

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>