### PR TITLE
fix(ui): 修复 SkillCompactItem button 嵌套 button 的 DOM 警告

### DIFF
--- a/apps/electron/src/renderer/components/settings/AgentSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AgentSettings.tsx
@@ -729,10 +729,18 @@ interface SkillCompactItemProps {
 
 function SkillCompactItem({ skill, displayName, selected, onSelect, onDelete, onToggle, onOpenFolder, onUpdate, indented }: SkillCompactItemProps): React.ReactElement {
   return (
-    <button
+    <div
+      role="button"
+      tabIndex={0}
       onClick={onSelect}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          onSelect()
+        }
+      }}
       className={cn(
-        'group w-full flex items-center gap-2 py-2 pr-3 text-left transition-colors',
+        'group w-full flex items-center gap-2 py-2 pr-3 text-left transition-colors cursor-pointer focus:outline-none focus-visible:ring-1 focus-visible:ring-ring',
         indented ? 'pl-5' : 'pl-3',
         selected ? 'bg-accent text-accent-foreground' : 'hover:bg-muted/40',
         !skill.enabled && 'opacity-50',
@@ -771,7 +779,7 @@ function SkillCompactItem({ skill, displayName, selected, onSelect, onDelete, on
         onClick={(e) => e.stopPropagation()}
         className="flex-shrink-0 scale-75"
       />
-    </button>
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary

- b733bad fix(ui): 修复 SkillCompactItem button 嵌套 button 的 DOM 警告

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归