### PR TITLE
feat: 特殊风格主题卡片 — 名称叠加预览图底部，使用各自主题色遮罩

### DIFF
--- a/apps/electron/src/renderer/components/settings/AppearanceSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AppearanceSettings.tsx
@@ -117,6 +117,17 @@ const SPECIAL_STYLES: readonly SpecialStyle[] = [
   },
 ]
 
+/** 浅色主题各自的 primary 色（用于遮罩渐变，与 CSS 变量 --primary 保持一致） */
+const STYLE_PRIMARY_COLORS: Record<SpecialStyleId, string> = {
+  'slate-light': 'hsla(18, 20%, 67%, 0.7)',
+  'ocean-light': 'hsla(205, 50%, 50%, 0.7)',
+  'forest-light': 'hsla(150, 35%, 38%, 0.7)',
+  // 下面三个是深色主题，不会用到，但 Record 类型要求完整
+  'ocean-dark': 'hsla(205, 87%, 24%, 0.7)',
+  'forest-dark': 'hsla(151, 55%, 21%, 0.7)',
+  'slate-dark': 'hsla(15, 25%, 68%, 0.7)',
+}
+
 /** 图标变体定义 */
 interface IconVariant {
   id: string
@@ -352,42 +363,49 @@ function StyleCard({
   onSelect: () => void
 }): React.ReactElement {
   return (
-    <div className="flex flex-col items-center gap-1.5">
-      <button
-        type="button"
-        onClick={onSelect}
-        className={cn(
-          'relative rounded-lg overflow-hidden',
-          'w-[99px] h-[183px]',
-          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1',
-          isSelected
-            ? 'ring-2 ring-primary shadow-lg shadow-primary/20'
-            : 'ring-1 ring-border/50 hover:ring-border'
-        )}
+    <button
+      type="button"
+      onClick={onSelect}
+      className={cn(
+        'relative rounded-lg overflow-hidden',
+        'w-[99px] h-[183px]',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1',
+        isSelected
+          ? 'ring-2 ring-primary shadow-lg shadow-primary/20'
+          : 'ring-1 ring-border/50 hover:ring-border'
+      )}
+    >
+      <div
+        className="w-full h-full"
+        style={style.imageScale ? { transform: `scale(${style.imageScale})` } : undefined}
       >
-        <div
-          className="w-full h-full"
-          style={style.imageScale ? { transform: `scale(${style.imageScale})` } : undefined}
-        >
-          <img
-            src={style.image}
-            alt={style.name}
-            loading="lazy"
-            decoding="async"
-            className="w-full h-full object-cover"
-            style={style.objectPosition ? { objectPosition: style.objectPosition } : undefined}
-            draggable={false}
-          />
+        <img
+          src={style.image}
+          alt={style.name}
+          loading="lazy"
+          decoding="async"
+          className="w-full h-full object-cover"
+          style={style.objectPosition ? { objectPosition: style.objectPosition } : undefined}
+          draggable={false}
+        />
+      </div>
+      <div
+        className="absolute bottom-0 left-0 right-0 h-10 flex items-end justify-center pb-1.5"
+        style={{
+          background: style.variant === 'light'
+            ? `linear-gradient(to top, ${STYLE_PRIMARY_COLORS[style.id]}, transparent)`
+            : 'linear-gradient(to top, rgba(0,0,0,0.6), transparent)',
+        }}
+      >
+        <span className="text-xs font-medium text-white">
+          {style.name}
+        </span>
+      </div>
+      {isSelected && (
+        <div className="absolute top-1 right-1 size-4 rounded-full bg-primary flex items-center justify-center z-10">
+          <Check className="size-2.5 text-primary-foreground" />
         </div>
-        {isSelected && (
-          <div className="absolute top-1 right-1 size-4 rounded-full bg-primary flex items-center justify-center">
-            <Check className="size-2.5 text-primary-foreground" />
-          </div>
-        )}
-      </button>
-      <span className="text-base font-medium text-foreground">
-        {style.name}
-      </span>
-    </div>
+      )}
+    </button>
   )
 }

--- a/apps/electron/src/renderer/components/settings/AppearanceSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AppearanceSettings.tsx
@@ -117,15 +117,14 @@ const SPECIAL_STYLES: readonly SpecialStyle[] = [
   },
 ]
 
-/** 浅色主题各自的 primary 色（用于遮罩渐变，与 CSS 变量 --primary 保持一致） */
-const STYLE_PRIMARY_COLORS: Record<SpecialStyleId, string> = {
-  'slate-light': 'hsla(18, 20%, 67%, 0.7)',
-  'ocean-light': 'hsla(205, 50%, 50%, 0.7)',
-  'forest-light': 'hsla(150, 35%, 38%, 0.7)',
-  // 下面三个是深色主题，不会用到，但 Record 类型要求完整
-  'ocean-dark': 'hsla(205, 87%, 24%, 0.7)',
-  'forest-dark': 'hsla(151, 55%, 21%, 0.7)',
-  'slate-dark': 'hsla(15, 25%, 68%, 0.7)',
+/** 各主题遮罩颜色（实心背景 + 浅色文字，与 CSS --primary 对应） */
+const STYLE_MASK_COLORS: Record<SpecialStyleId, { bg: string; text: string }> = {
+  'slate-light':  { bg: 'hsl(18, 20%, 67%)',  text: 'hsl(18, 20%, 88%)' },
+  'ocean-light':  { bg: 'hsl(205, 50%, 50%)', text: 'hsl(205, 50%, 82%)' },
+  'forest-light': { bg: 'hsl(150, 35%, 38%)', text: 'hsl(150, 35%, 75%)' },
+  'ocean-dark':   { bg: 'rgba(0,0,0,0.8)', text: 'hsl(205, 50%, 82%)' },
+  'forest-dark':  { bg: 'rgba(0,0,0,0.8)', text: 'hsl(150, 35%, 75%)' },
+  'slate-dark':   { bg: 'rgba(0,0,0,0.8)', text: 'hsl(18, 20%, 88%)' },
 }
 
 /** 图标变体定义 */
@@ -390,14 +389,13 @@ function StyleCard({
         />
       </div>
       <div
-        className="absolute bottom-0 left-0 right-0 h-10 flex items-end justify-center pb-1.5"
-        style={{
-          background: style.variant === 'light'
-            ? `linear-gradient(to top, ${STYLE_PRIMARY_COLORS[style.id]}, transparent)`
-            : 'linear-gradient(to top, rgba(0,0,0,0.6), transparent)',
-        }}
+        className="absolute bottom-0 left-0 right-0 h-5 flex items-end justify-center pb-0.5"
+        style={{ background: STYLE_MASK_COLORS[style.id].bg }}
       >
-        <span className="text-xs font-medium text-white">
+        <span
+          className="text-xs font-medium"
+          style={{ color: STYLE_MASK_COLORS[style.id].text }}
+        >
           {style.name}
         </span>
       </div>


### PR DESCRIPTION
## 概述
重构「外观设置 → 特殊风格」中的主题预览卡片，将原本干巴巴悬在卡片下方的纯文字名称，改为叠加在预览图底部的实心遮罩样式。每个浅色主题使用各自的主题色（与选中态边框 `--primary` 一致）作为遮罩背景，文字为该主题色的浅色版本，视觉上更精致、更具辨识度。

## 改动
- `apps/electron/src/renderer/components/settings/AppearanceSettings.tsx` — 重构 `StyleCard` 组件
  - 名称从卡片下方移至预览图内部底部，叠加实心遮罩层（高 20px）
  - 新增 `STYLE_MASK_COLORS` 常量，为每个主题独立定义遮罩背景色和文字色
  - 浅色主题遮罩使用各自 `--primary` 色（云朵舞者暖杏、晴空碧海蓝色、森息晨光绿色）
  - 深色主题遮罩保持黑色底色，文字色与对应的浅色主题文字色一致（森息夜语 → 浅绿、苍穹暮色 → 浅蓝、莫兰迪夜 → 浅杏）
  - 外层无用的 wrapper `<div>` 已去除，组件更简洁

## 视觉效果

| 主题 | 遮罩背景 | 文字色 |
|------|---------|--------|
| 云朵舞者 | 暖杏色 `hsl(18,20%,67%)` | 浅杏 `hsl(18,20%,88%)` |
| 晴空碧海 | 蓝色 `hsl(205,50%,50%)` | 浅蓝 `hsl(205,50%,82%)` |
| 森息晨光 | 绿色 `hsl(150,35%,38%)` | 浅绿 `hsl(150,35%,75%)` |
| 苍穹暮色 / 森息夜语 / 莫兰迪夜 | 黑色 `rgba(0,0,0,0.8)` | 对应浅色主题文字色 |

## 如何测试
1. 打开 Proma 设置 → 外观
2. 切换到「特殊风格」模式
3. 查看 6 张主题预览卡片，确认名称已浮在预览图底部
4. 确认浅色主题遮罩颜色各不相同，深色主题为黑色遮罩
5. 选中不同卡片，确认遮罩颜色始终独立不串色

## 备注
- 代码审查中发现的深色主题 bg 死代码问题已同步修复
- 遮罩颜色硬编码在 `STYLE_MASK_COLORS` 中，不受当前主题 CSS 变量影响，每个卡片始终显示自己的颜色

🤖 Generated with [Claude Code](https://claude.com/claude-code)