### PR TITLE
fix: 权限模式默认改为完全自动

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -1211,7 +1211,7 @@ export class AgentOrchestrator {
       }
 
       // 12. 读取应用设置并确定权限模式
-      // 权限模式只属于当前 session；新会话默认自动审批模式。
+      // 权限模式只属于当前 session；新会话默认完全自动模式。
       const appSettings = getSettings()
       const initialPermissionMode: PromaPermissionMode = permissionModeOverride
         ?? PROMA_DEFAULT_PERMISSION_MODE

--- a/apps/electron/src/renderer/components/agent/PermissionModeSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/PermissionModeSelector.tsx
@@ -34,7 +34,7 @@ export function PermissionModeSelector({ sessionId }: PermissionModeSelectorProp
 
   // 初始化：如果当前 session 不在 Map 中，按以下优先级读回：
   // 1. session meta.permissionMode（每个 tab 独立持久化，重启恢复各自的值）
-  // 2. 默认自动审批
+  // 2. 默认完全自动模式
   // 注意：只写入当前 session，不回写到 agentDefaultPermissionModeAtom，避免跨会话污染。
   React.useEffect(() => {
     if (!sessionExistsInList) return

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1117,7 +1117,7 @@ export const PROMA_PERMISSION_MODES = ['auto', 'bypassPermissions', 'plan'] as c
 
 export type PromaPermissionMode = typeof PROMA_PERMISSION_MODES[number]
 
-export const PROMA_DEFAULT_PERMISSION_MODE: PromaPermissionMode = 'auto'
+export const PROMA_DEFAULT_PERMISSION_MODE: PromaPermissionMode = 'bypassPermissions'
 
 export interface PromaPermissionModeConfig {
   /** 对应 Claude Agent SDK 的 permissionMode */


### PR DESCRIPTION
## Summary

- 225ecee fix: 默认权限模式改为完全自动，避免第三方模型 auto classifier 失效

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归