### PR TITLE
feat: 折叠侧栏 Agent 按钮悬停弹出工作区列表

### DIFF
--- a/apps/electron/src/renderer/components/agent/CollapsedWorkspacePopover.tsx
+++ b/apps/electron/src/renderer/components/agent/CollapsedWorkspacePopover.tsx
@@ -1,0 +1,173 @@
+/**
+ * CollapsedWorkspacePopover — 折叠态侧栏的工作区快速切换弹层
+ *
+ * 鼠标悬停在折叠侧栏的 Agent 模式按钮上时弹出，提供：
+ * - 当前所有工作区列表，点击即切换
+ * - 顶部 `+` 按钮支持 inline 新建
+ *
+ * 不包含重命名/删除/拖拽/高度调整等低频操作——这些留给展开态的 WorkspaceSelector。
+ * 切换/创建逻辑通过 useWorkspaceActions 与展开态共享，确保行为一致。
+ * 悬停控制复用 ContextUsageBadge 中的 cancelClose / scheduleClose 模式。
+ */
+
+import * as React from 'react'
+import { FolderOpen, Plus } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { useWorkspaceActions } from '@/hooks/useWorkspaceActions'
+
+/** Popover hover 关闭延迟（ms），与项目其他 hover popover 一致 */
+const HOVER_CLOSE_DELAY = 150
+
+interface CollapsedWorkspacePopoverProps {
+  children: React.ReactNode
+}
+
+export function CollapsedWorkspacePopover({
+  children,
+}: CollapsedWorkspacePopoverProps): React.ReactElement {
+  const { workspaces, currentWorkspaceId, selectWorkspace, createWorkspace } = useWorkspaceActions()
+
+  const [open, setOpen] = React.useState(false)
+  const closeTimerRef = React.useRef<number | null>(null)
+
+  const cancelClose = React.useCallback(() => {
+    if (closeTimerRef.current != null) {
+      window.clearTimeout(closeTimerRef.current)
+      closeTimerRef.current = null
+    }
+  }, [])
+
+  const scheduleClose = React.useCallback(() => {
+    cancelClose()
+    closeTimerRef.current = window.setTimeout(() => setOpen(false), HOVER_CLOSE_DELAY)
+  }, [cancelClose])
+
+  React.useEffect(() => cancelClose, [cancelClose])
+
+  // 新建状态
+  const [creating, setCreating] = React.useState(false)
+  const [newName, setNewName] = React.useState('')
+  const createInputRef = React.useRef<HTMLInputElement>(null)
+
+  const handleSelect = (workspaceId: string): void => {
+    selectWorkspace(workspaceId)
+    setOpen(false)
+  }
+
+  const handleStartCreate = (e: React.MouseEvent): void => {
+    e.stopPropagation()
+    setCreating(true)
+    setNewName('')
+    requestAnimationFrame(() => {
+      createInputRef.current?.focus()
+    })
+  }
+
+  const handleCreate = async (): Promise<void> => {
+    const trimmed = newName.trim()
+    if (!trimmed) {
+      setCreating(false)
+      return
+    }
+    const workspace = await createWorkspace(trimmed)
+    setCreating(false)
+    if (workspace) setOpen(false)
+  }
+
+  const handleCreateKeyDown = (e: React.KeyboardEvent): void => {
+    if (e.key === 'Enter') {
+      if (e.nativeEvent.isComposing) return
+      e.preventDefault()
+      handleCreate()
+    } else if (e.key === 'Escape') {
+      e.preventDefault()
+      setCreating(false)
+    }
+  }
+
+  // 新建态下不允许 hover 离开就关闭，避免输入过程中弹层消失
+  const handleContentMouseLeave = (): void => {
+    if (creating) return
+    scheduleClose()
+  }
+
+  return (
+    <Popover open={open} onOpenChange={(v) => {
+      setOpen(v)
+      if (!v) setCreating(false)
+    }}>
+      <PopoverTrigger asChild>
+        <span
+          onMouseEnter={() => {
+            cancelClose()
+            setOpen(true)
+          }}
+          onMouseLeave={scheduleClose}
+        >
+          {children}
+        </span>
+      </PopoverTrigger>
+      <PopoverContent
+        side="right"
+        align="start"
+        sideOffset={8}
+        className="w-56 p-0 overflow-hidden"
+        onMouseEnter={cancelClose}
+        onMouseLeave={handleContentMouseLeave}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
+        {/* 头部 */}
+        <div className="flex items-center justify-between px-2.5 py-1.5 border-b border-border/40">
+          <span className="text-[11px] font-medium text-foreground/50 uppercase tracking-wide">
+            Agent 模式 · 工作区
+          </span>
+          <button
+            type="button"
+            onClick={handleStartCreate}
+            className="p-1 rounded hover:bg-foreground/[0.06] text-foreground/35 hover:text-foreground/60 transition-colors"
+            title="新建工作区"
+          >
+            <Plus size={13} />
+          </button>
+        </div>
+
+        {/* 工作区列表 */}
+        <div className="flex flex-col p-1 max-h-[320px] overflow-y-auto scrollbar-thin">
+          {workspaces.map((ws) => (
+            <button
+              key={ws.id}
+              type="button"
+              onClick={() => handleSelect(ws.id)}
+              className={cn(
+                'w-full flex items-center gap-2 px-2 py-[5px] rounded-md text-[13px] transition-colors duration-100 text-left',
+                ws.id === currentWorkspaceId
+                  ? 'bg-foreground/[0.08] text-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
+                  : 'text-foreground/70 hover:bg-foreground/[0.04]',
+              )}
+            >
+              <FolderOpen size={13} className="flex-shrink-0 text-foreground/40" />
+              <span className="flex-1 min-w-0 truncate">{ws.name}</span>
+            </button>
+          ))}
+
+          {creating && (
+            <div className="flex items-center gap-2 px-2 py-[5px]">
+              <FolderOpen size={13} className="flex-shrink-0 text-foreground/40" />
+              <input
+                ref={createInputRef}
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                onKeyDown={handleCreateKeyDown}
+                onBlur={() => setCreating(false)}
+                placeholder="工作区名称..."
+                className="flex-1 min-w-0 bg-transparent text-[13px] text-foreground border-b border-primary/50 outline-none px-0.5"
+                maxLength={50}
+              />
+            </div>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
@@ -20,16 +20,14 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
-import {
-  agentWorkspacesAtom,
-  currentAgentWorkspaceIdAtom,
-} from '@/atoms/agent-atoms'
 import { workspaceListHeightAtom } from '@/atoms/sidebar-atoms'
+import { useWorkspaceActions } from '@/hooks/useWorkspaceActions'
+import { agentWorkspacesAtom } from '@/atoms/agent-atoms'
 import type { AgentWorkspace } from '@proma/shared'
 
 export function WorkspaceSelector(): React.ReactElement {
-  const [workspaces, setWorkspaces] = useAtom(agentWorkspacesAtom)
-  const [currentWorkspaceId, setCurrentWorkspaceId] = useAtom(currentAgentWorkspaceIdAtom)
+  const { workspaces, currentWorkspaceId, selectWorkspace, createWorkspace } = useWorkspaceActions()
+  const [, setWorkspaces] = useAtom(agentWorkspacesAtom)
   const [listHeight, setListHeight] = useAtom(workspaceListHeightAtom)
 
   // 高度拖拽调整
@@ -78,8 +76,6 @@ export function WorkspaceSelector(): React.ReactElement {
   const [creating, setCreating] = React.useState(false)
   const [newName, setNewName] = React.useState('')
   const createInputRef = React.useRef<HTMLInputElement>(null)
-  /** 防止连续 Enter 触发多次创建请求 */
-  const createInFlightRef = React.useRef(false)
 
   // 重命名状态
   const [editingId, setEditingId] = React.useState<string | null>(null)
@@ -96,11 +92,7 @@ export function WorkspaceSelector(): React.ReactElement {
   /** 切换工作区 */
   const handleSelect = (workspace: AgentWorkspace): void => {
     if (editingId) return
-    setCurrentWorkspaceId(workspace.id)
-
-    window.electronAPI.updateSettings({
-      agentWorkspaceId: workspace.id,
-    }).catch(console.error)
+    selectWorkspace(workspace.id)
   }
 
   // ===== 新建 =====
@@ -114,30 +106,8 @@ export function WorkspaceSelector(): React.ReactElement {
   }
 
   const handleCreate = async (): Promise<void> => {
-    const trimmed = newName.trim()
-    if (!trimmed) {
-      setCreating(false)
-      return
-    }
-    if (createInFlightRef.current) return
-    createInFlightRef.current = true
-
-    try {
-      const workspace = await window.electronAPI.createAgentWorkspace(trimmed)
-      setWorkspaces((prev) => [workspace, ...prev])
-      setCurrentWorkspaceId(workspace.id)
-      setCreating(false)
-
-      window.electronAPI.updateSettings({
-        agentWorkspaceId: workspace.id,
-      }).catch(console.error)
-    } catch (error) {
-      const msg = error instanceof Error ? error.message : '创建失败'
-      toast.error(msg)
-      setCreating(false)
-    } finally {
-      createInFlightRef.current = false
-    }
+    await createWorkspace(newName)
+    setCreating(false)
   }
 
   const handleCreateKeyDown = (e: React.KeyboardEvent): void => {
@@ -208,10 +178,7 @@ export function WorkspaceSelector(): React.ReactElement {
       setWorkspaces(remaining)
 
       if (deleteTargetId === currentWorkspaceId && remaining.length > 0) {
-        setCurrentWorkspaceId(remaining[0]!.id)
-        window.electronAPI.updateSettings({
-          agentWorkspaceId: remaining[0]!.id,
-        }).catch(console.error)
+        selectWorkspace(remaining[0]!.id)
       }
     } catch (error) {
       console.error('[WorkspaceSelector] 删除工作区失败:', error)

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -69,6 +69,7 @@ import { promptConfigAtom, selectedPromptIdAtom, conversationPromptIdAtom } from
 import { useOpenSession } from '@/hooks/useOpenSession'
 import { useSyncActiveTabSideEffects } from '@/hooks/useSyncActiveTabSideEffects'
 import { WorkspaceSelector } from '@/components/agent/WorkspaceSelector'
+import { CollapsedWorkspacePopover } from '@/components/agent/CollapsedWorkspacePopover'
 import { MoveSessionDialog } from '@/components/agent/MoveSessionDialog'
 import { detectIsMac } from '@/lib/platform'
 import {
@@ -1043,24 +1044,21 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
 
         {/* 模式切换 */}
         <div className="flex flex-col items-center gap-1.5">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                aria-label="切换到 Agent 模式"
-                onClick={() => handleRailModeSwitch('agent')}
-                className={cn(
-                  'relative size-10 flex items-center justify-center rounded-[12px] transition-colors titlebar-no-drag',
-                  mode === 'agent'
-                    ? 'bg-primary/10 text-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
-                    : 'text-foreground/45 hover:bg-foreground/[0.06] hover:text-foreground/75'
-                )}
-              >
-                <Bot size={18} />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="right">Agent 模式</TooltipContent>
-          </Tooltip>
+          <CollapsedWorkspacePopover>
+            <button
+              type="button"
+              aria-label="切换到 Agent 模式（悬停查看工作区）"
+              onClick={() => handleRailModeSwitch('agent')}
+              className={cn(
+                'relative size-10 flex items-center justify-center rounded-[12px] transition-colors titlebar-no-drag',
+                mode === 'agent'
+                  ? 'bg-primary/10 text-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
+                  : 'text-foreground/45 hover:bg-foreground/[0.06] hover:text-foreground/75'
+              )}
+            >
+              <Bot size={18} />
+            </button>
+          </CollapsedWorkspacePopover>
 
           <Tooltip>
             <TooltipTrigger asChild>

--- a/apps/electron/src/renderer/hooks/useWorkspaceActions.ts
+++ b/apps/electron/src/renderer/hooks/useWorkspaceActions.ts
@@ -1,0 +1,65 @@
+/**
+ * useWorkspaceActions — 工作区切换与创建的共享逻辑
+ *
+ * 抽离 WorkspaceSelector 与 CollapsedWorkspacePopover 共用的切换/创建逻辑，
+ * 避免两处实现漂移。重命名 / 删除 / 拖拽排序仅展开态需要，留在 WorkspaceSelector 内。
+ */
+
+import * as React from 'react'
+import { useAtom } from 'jotai'
+import { toast } from 'sonner'
+import {
+  agentWorkspacesAtom,
+  currentAgentWorkspaceIdAtom,
+} from '@/atoms/agent-atoms'
+import type { AgentWorkspace } from '@proma/shared'
+
+interface UseWorkspaceActionsResult {
+  workspaces: AgentWorkspace[]
+  currentWorkspaceId: string | null
+  /** 切换到指定工作区；已是当前工作区时无副作用 */
+  selectWorkspace: (workspaceId: string) => void
+  /** 创建并切到新工作区；成功返回新工作区，失败已 toast 并返回 null */
+  createWorkspace: (name: string) => Promise<AgentWorkspace | null>
+}
+
+export function useWorkspaceActions(): UseWorkspaceActionsResult {
+  const [workspaces, setWorkspaces] = useAtom(agentWorkspacesAtom)
+  const [currentWorkspaceId, setCurrentWorkspaceId] = useAtom(currentAgentWorkspaceIdAtom)
+  const createInFlightRef = React.useRef(false)
+
+  const selectWorkspace = React.useCallback(
+    (workspaceId: string): void => {
+      if (workspaceId === currentWorkspaceId) return
+      setCurrentWorkspaceId(workspaceId)
+      window.electronAPI.updateSettings({ agentWorkspaceId: workspaceId }).catch(console.error)
+    },
+    [currentWorkspaceId, setCurrentWorkspaceId],
+  )
+
+  const createWorkspace = React.useCallback(
+    async (name: string): Promise<AgentWorkspace | null> => {
+      const trimmed = name.trim()
+      if (!trimmed) return null
+      if (createInFlightRef.current) return null
+      createInFlightRef.current = true
+
+      try {
+        const workspace = await window.electronAPI.createAgentWorkspace(trimmed)
+        setWorkspaces((prev) => [workspace, ...prev])
+        setCurrentWorkspaceId(workspace.id)
+        window.electronAPI.updateSettings({ agentWorkspaceId: workspace.id }).catch(console.error)
+        return workspace
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : '创建失败'
+        toast.error(msg)
+        return null
+      } finally {
+        createInFlightRef.current = false
+      }
+    },
+    [setWorkspaces, setCurrentWorkspaceId],
+  )
+
+  return { workspaces, currentWorkspaceId, selectWorkspace, createWorkspace }
+}


### PR DESCRIPTION
## 问题根因

Proma 界面空间有限，为了日常使用预览功能，通常需要收起左侧栏。

但左侧栏在收起状态下切换工作区并新建会话需要走「展开侧栏 → 在工作区面板里点击 → 新建会话 → 再手动收起」四步，操作繁琐。

希望侧边栏在折叠态下能够满足工作区切换，通过悬停 Agent 模式弹窗的方式实现。

## 具体修改

新增 2 个文件 + 修改 2 个文件：

- **新增** `apps/electron/src/renderer/hooks/useWorkspaceActions.ts`
  - 共享 hook，封装 `selectWorkspace` / `createWorkspace`
  - 切换/创建逻辑抽离到此处，避免折叠态弹层与展开态 WorkspaceSelector 双份实现漂移
  - 重命名/删除/拖拽是展开态专属功能，仍留在 WorkspaceSelector 内

- **新增** `apps/electron/src/renderer/components/agent/CollapsedWorkspacePopover.tsx`
  - 折叠态专用的 hover 弹层组件，包裹 Agent 模式按钮
  - 鼠标悬停弹出，复用现有 `Popover` 组件 + ContextUsageBadge 同款 `cancelClose / scheduleClose` 模式（150ms 延迟关闭）
  - 内容：标题「Agent 模式 · 工作区」+ 工作区列表（点击切换）+ `+` 按钮（inline 输入框新建）
  - 不引入新依赖

- **修改** `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx`
  - 折叠态 Agent 按钮改用 `CollapsedWorkspacePopover` 包裹（移除原 Tooltip，弹层标题已传达模式信息）
  - Chat 按钮、其他 rail 按钮、展开态侧栏完全不动

- **修改** `apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx`
  - 切换/创建路径迁移到 `useWorkspaceActions`（净 -35 行）
  - 重命名/删除/拖拽逻辑保持原样

## 审查情况

**自审查：** 已对照展开态行为逐项核对——切换、新建、防连续 Enter、IME 防误触发、Escape 取消、新建态下保持弹层不关——全部一致。Popover 风格、视觉 token、悬停延迟均与项目其他 Popover 对齐（参考 `ContextUsageBadge.tsx`）。无新增依赖。

**用户测试：** 已通过 dev server 实测确认交互符合预期。
