### PR TITLE
fix(memory): 修复 v0.9.40 三处内存泄露 (atomFamily / WebContents / stderr)

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.9.40",
+  "version": "0.9.41",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -1672,6 +1672,9 @@ export class AgentOrchestrator {
                   console.log(`[Agent 编排] 可重试错误 (assistant error): ${typedError.code} - ${lastRetryableError}`)
                   this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
                   accumulatedMessages.length = 0
+                  // 与 catch 路径（isAutoRetryableCatchError）和思考签名回填路径保持一致：
+                  // 重试前清空已累积的 stderr，避免 25 次重试上限内字符串无限增长
+                  stderrChunks.length = 0
                   shouldRetryFromError = true
                   break
                 }

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -48,6 +48,34 @@ export { eventBus as agentEventBus }
  */
 const sessionWebContents = new Map<string, WebContents>()
 
+/**
+ * 已挂载 destroyed 回收钩子的 webContents 集合。
+ *
+ * 同一个主窗口 webContents 可能被多次注册（飞书 Bridge 每条消息触发一次 runAgentHeadless），
+ * 用 WeakSet 去重避免 once listener 在同一 wc 上累积，触发 MaxListenersExceededWarning。
+ */
+const wcWithCleanupHook = new WeakSet<WebContents>()
+
+/**
+ * 注册 sessionId → webContents 映射，并在 webContents 销毁时自动清理所有相关条目。
+ *
+ * 仅依赖 finally 块清理无法覆盖窗口关闭、渲染进程崩溃、headless 路径主窗口被替换等
+ * webContents 提前销毁的场景——destroyed 事件兜底。
+ */
+function registerWebContents(sessionId: string, wc: WebContents): void {
+  // 同一 sessionId 切换 webContents 时直接覆盖；旧 wc 的 destroyed 钩子仍由 WeakSet 持有，
+  // 触发时会扫描 sessionWebContents 清理所有指向旧 wc 的条目（见下方实现）。
+  sessionWebContents.set(sessionId, wc)
+  if (wcWithCleanupHook.has(wc)) return
+  wcWithCleanupHook.add(wc)
+  wc.once('destroyed', () => {
+    // 单个 wc 可能映射到多个 sessionId（同窗口多 tab），需要清理所有指向它的条目
+    for (const [sid, mappedWc] of sessionWebContents) {
+      if (mappedWc === wc) sessionWebContents.delete(sid)
+    }
+  })
+}
+
 // ===== EventBus IPC 转发中间件 =====
 
 eventBus.use((sessionId, payload, next) => {
@@ -74,7 +102,7 @@ export async function runAgent(
   webContents: WebContents,
 ): Promise<void> {
   // 更新 webContents 映射（允许覆盖 — 由 orchestrator.activeSessions 处理真正的并发保护）
-  sessionWebContents.set(input.sessionId, webContents)
+  registerWebContents(input.sessionId, webContents)
   try {
     await orchestrator.sendMessage(input, {
       onError: (error) => {
@@ -146,7 +174,7 @@ export async function runAgentHeadless(
   const win = BrowserWindow.getAllWindows()[0]
   const wc = win && !win.isDestroyed() ? win.webContents : null
   if (wc) {
-    sessionWebContents.set(input.sessionId, wc)
+    registerWebContents(input.sessionId, wc)
   }
 
   try {

--- a/apps/electron/src/renderer/hooks/useCloseTab.tsx
+++ b/apps/electron/src/renderer/hooks/useCloseTab.tsx
@@ -24,6 +24,14 @@ import {
   agentDiffRefreshVersionAtom,
   agentDiffUnseenChangesAtom,
   agentDiffUnseenFilesAtom,
+  agentStreamingStatesAtom,
+  liveMessagesMapAtom,
+  agentSessionStreamingStateAtomFamily,
+  agentSessionDraftAtomFamily,
+  agentSessionDraftHtmlAtomFamily,
+  backgroundTasksAtomFamily,
+  sessionPersistedPermissionModeAtom,
+  sessionExistsAtom,
 } from '@/atoms/agent-atoms'
 import { previewPanelOpenMapAtom, previewFileMapAtom } from '@/atoms/preview-atoms'
 import { clearPreviewCacheForSession } from '@/components/diff/DiffTabContent'
@@ -67,6 +75,9 @@ export function useCloseTab(): UseCloseTabReturn {
   const setDiffUnseen = useSetAtom(agentDiffUnseenChangesAtom)
   const setDiffUnseenFiles = useSetAtom(agentDiffUnseenFilesAtom)
 
+  const setStreamingStates = useSetAtom(agentStreamingStatesAtom)
+  const setLiveMessagesMap = useSetAtom(liveMessagesMapAtom)
+
   const cleanupMapAtoms = React.useCallback((tabId: string) => {
     const deleteKey = <T,>(prev: Map<string, T>): Map<string, T> => {
       if (!prev.has(tabId)) return prev
@@ -85,8 +96,23 @@ export function useCloseTab(): UseCloseTabReturn {
     setDiffRefreshVersion(deleteKey)
     setDiffUnseen(deleteKey)
     setDiffUnseenFiles(deleteKey)
+    // tab.id === sessionId（见 tab-atoms.ts openTab）
+    // 清理重型流式数据：streamingStates（含累积 content 与 toolActivities）和 liveMessages（SDK 消息数组）
+    // 不清 agentSessionDraftsAtom / agentSessionDraftHtmlAtom / agentStreamErrorsAtom 这些
+    // base map：草稿和错误信息体积小，保留可让用户重开 tab 时恢复输入与错误回显
+    setStreamingStates(deleteKey)
+    setLiveMessagesMap(deleteKey)
+    // 清理 atomFamily 内部 atom 缓存（Jotai 对 string key 强引用 Map，不显式 remove 永不释放）。
+    // 注意：remove 仅清 family 缓存，不动 base map；下次 family(sessionId) 调用会自动重建派生
+    // atom 并读出 base map 中保留的草稿值——这正是上面"不清草稿 base map"能恢复 UX 的前提。
+    agentSessionStreamingStateAtomFamily.remove(tabId)
+    agentSessionDraftAtomFamily.remove(tabId)
+    agentSessionDraftHtmlAtomFamily.remove(tabId)
+    backgroundTasksAtomFamily.remove(tabId)
+    sessionPersistedPermissionModeAtom.remove(tabId)
+    sessionExistsAtom.remove(tabId)
     clearPreviewCacheForSession(tabId)
-  }, [setConvModels, setConvContextLength, setConvThinking, setConvParallel, setConvPromptId, setPreviewPanelOpen, setPreviewFile, setDiffPanelTab, setDiffRefreshVersion, setDiffUnseen, setDiffUnseenFiles])
+  }, [setConvModels, setConvContextLength, setConvThinking, setConvParallel, setConvPromptId, setPreviewPanelOpen, setPreviewFile, setDiffPanelTab, setDiffRefreshVersion, setDiffUnseen, setDiffUnseenFiles, setStreamingStates, setLiveMessagesMap])
 
   const executeClose = React.useCallback((tabId: string) => {
     const tab = tabs.find((t) => t.id === tabId)

--- a/release-notes/v0.9.41.md
+++ b/release-notes/v0.9.41.md
@@ -1,0 +1,29 @@
+# Proma v0.9.41
+
+> 对比基准：v0.9.40
+
+本次版本是 v0.9.40 的内存泄露热修复。v0.9.40 引入的「按 sessionId 切片 atomFamily」流式性能优化在长时间使用、频繁新建/关闭会话场景下会持续累积内存——三处独立的泄露路径联合修复后，渲染进程和主进程的长期内存基线显著下降。
+
+## 内存泄露热修复
+
+- **`atomFamily` + base Map 双层清理（渲染进程）** — `useCloseTab` 在关闭 tab 时显式调用 `agentSessionStreamingStateAtomFamily.remove` 等 6 个 family 的 `remove(sessionId)`，并清理 `agentStreamingStatesAtom` 和 `liveMessagesMapAtom` 两个重型 base Map 中对应的 entry。修复前每关闭一个会话都会在 Jotai 内部缓存留下一组永不释放的 atom 对象，加上 base Map 中保留的累积流式 `content` 与 `toolActivities`（单 session 50–200 KB），100 个会话后渲染进程可残留 5–20 MB 废数据。草稿和错误信息体积小且重开 tab 需恢复，base Map 仍保留——下次 `family(sessionId)` 调用会自动重建派生 atom 并读出原值
+
+- **`sessionWebContents` 注册 destroyed 兜底清理（主进程）** — `agent-service.ts` 通过 `registerWebContents` 在写入 `sessionWebContents` Map 时同步给 `WebContents` 挂一次性 `destroyed` 监听。修复前 finally 块只在「orchestrator 已结束此会话」时清理映射，窗口关闭、渲染进程崩溃或飞书 Bridge headless 路径主窗口被替换的场景会留下死引用永远挂在 Map 里。同一 wc 可能被多个 session 复用，监听器用 `WeakSet` 去重避免飞书高频场景累积触发 `MaxListenersExceededWarning`；销毁回调扫描清理所有指向同一 wc 的 sessionId 条目
+
+- **重试路径 stderr 累积修复（主进程）** — `agent-orchestrator.ts` 在 `assistant.error` 触发的自动重试路径补齐 `stderrChunks.length = 0`。修复前与 `catch` 路径（`isAutoRetryableCatchError`）和思考签名回填路径不一致：另两条都清空了 stderr，唯独这条 typed error 重试路径漏掉。在触发 25 次重试上限的故障会话上，每次新 SDK 进程的 stderr 持续追加到同一数组，长 stream 含大量工具输出时可累积 MB 级字符串
+
+## 升级建议
+
+- 之前在长时间运行后感到 Proma 内存占用持续走高的用户，本版升级后应有明显改善
+- 飞书 Bridge 用户尤其受益于 `sessionWebContents` destroyed 监听修复
+- 频繁触发自动重试的会话（网络抖动、限流等）也会从 stderr 清空修复中受益
+
+## 开发与文档
+
+- **版本更新** — `@proma/electron` 从 `0.9.40` 升级到 `0.9.41`
+
+## 下载
+
+- **macOS Apple Silicon** — `Proma-0.9.41-arm64.dmg`
+- **macOS Intel** — `Proma-0.9.41.dmg`
+- **Windows** — `Proma-Setup-0.9.41.exe`


### PR DESCRIPTION
## Summary

- 06b87ae fix(memory): 修复 v0.9.40 的三处内存泄露 (atomFamily / WebContents / stderr)

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归