### PR TITLE
feat(file-browser): 目录头粘性悬停 + 缩进引导线 + 行高与重命名错误提示优化【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
@@ -90,6 +90,11 @@ interface FileBrowserProps {
   onFilePreview?: (filePath: string) => void
 }
 
+const TREE_ROW_HEIGHT = 32
+const TREE_ROW_HORIZONTAL_MARGIN = 8
+const TREE_INDENT_WIDTH = 16
+const MAX_STICKY_DEPTH = 4
+
 export function FileBrowser({ rootPath, hideToolbar, embedded, hideEmpty, onAddToChat, onFilePreview }: FileBrowserProps): React.ReactElement {
   const [entries, setEntries] = React.useState<FileEntry[]>([])
   const [loading, setLoading] = React.useState(false)
@@ -312,6 +317,7 @@ export function FileBrowser({ rootPath, hideToolbar, embedded, hideEmpty, onAddT
           onDelete={handleRequestDelete}
           onMove={handleMove}
           onRefresh={loadRoot}
+          onClearSelection={() => setSelectedPaths(new Set())}
           onAddToChat={onAddToChat}
           onFilePreview={onFilePreview}
         />
@@ -413,6 +419,7 @@ interface FileTreeItemProps {
   onDelete: (entry: FileEntry) => void
   onMove: (entry: FileEntry) => void
   onRefresh: () => Promise<void>
+  onClearSelection: () => void
   onAddToChat?: (entry: FileEntry) => void
   onFilePreview?: (filePath: string) => void
 }
@@ -437,6 +444,7 @@ function FileTreeItem({
   onDelete,
   onMove,
   onRefresh,
+  onClearSelection,
   onAddToChat,
   onFilePreview,
 }: FileTreeItemProps): React.ReactElement {
@@ -612,20 +620,39 @@ function FileTreeItem({
     }
   }
 
-  const paddingLeft = 8 + depth * 16
+  // 行使用 mx-2 形成左右各 8px 留白，留白处的点击 target 是本 wrapper 而非父级
+  // py-1 容器，所以父级 handleBackgroundClick 的 target===currentTarget 判定不会命中。
+  // 这里就近处理留白点击的清选语义，保持视觉上"点空白即清选"的一致体验。
+  const handleWrapperClick = (e: React.MouseEvent): void => {
+    if (e.target === e.currentTarget) {
+      onClearSelection()
+    }
+  }
+
+  const paddingLeft = 8 + depth * TREE_INDENT_WIDTH
+  const guideLeft = TREE_ROW_HORIZONTAL_MARGIN + paddingLeft + 7
+  const stickyDepth = Math.min(depth, MAX_STICKY_DEPTH)
+  const stickyTop = stickyDepth * TREE_ROW_HEIGHT
+  // 起点 10 已足够压住普通行内元素；保持外层目录在更上层以遮住下方滚过的内层。
+  const stickyZIndex = Math.max(1, 10 - stickyDepth)
   const showMenu = !isRenaming
   const menuSelectedCount = isSelected ? selectedCount : 1
 
   return (
-    <>
+    <div className="relative" onClick={handleWrapperClick}>
       <div
         ref={rowRef}
         className={cn(
-          'relative flex items-center gap-1 py-1 pr-2 text-sm cursor-pointer group mx-2 rounded-lg transition-colors',
+          'relative flex h-8 items-center gap-1 pr-2 text-sm cursor-pointer group mx-2 rounded-lg transition-colors',
+          entry.isDirectory && expanded && 'sticky bg-background/95 backdrop-blur-sm shadow-[0_1px_0_hsl(var(--border)/0.45)]',
           isSelected ? 'bg-accent' : 'hover:bg-accent/50',
           flash && 'file-browser-row-flash',
         )}
-        style={{ paddingLeft }}
+        style={{
+          paddingLeft,
+          top: entry.isDirectory && expanded ? stickyTop : undefined,
+          zIndex: entry.isDirectory && expanded ? stickyZIndex : undefined,
+        }}
         onClick={handleClick}
       >
         {recentlyModifiedSet.has(entry.path) && (
@@ -652,7 +679,7 @@ function FileTreeItem({
 
         {/* 文件名 / 重命名输入框 */}
         {isRenaming ? (
-          <div className="flex-1 min-w-0">
+          <div className="relative flex-1 min-w-0">
             <input
               ref={renameInputRef}
               value={editName}
@@ -667,7 +694,9 @@ function FileTreeItem({
               maxLength={255}
             />
             {renameError && (
-              <div className="text-[10px] text-destructive mt-0.5">{renameError}</div>
+              <div className="absolute left-0 top-full mt-0.5 text-[10px] leading-4 text-destructive whitespace-nowrap pointer-events-none">
+                {renameError}
+              </div>
             )}
           </div>
         ) : (
@@ -750,40 +779,50 @@ function FileTreeItem({
       </div>
 
       {/* 子项 */}
-      {expanded && children.length === 0 && childrenLoaded && (
-        <div
-          className="text-[11px] text-muted-foreground/50 py-1"
-          style={{ paddingLeft: paddingLeft + 24 }}
-        >
-          空文件夹
+      {expanded && (
+        <div className="relative">
+          <span
+            aria-hidden="true"
+            className="pointer-events-none absolute bottom-1 top-0 w-px bg-border/70"
+            style={{ left: guideLeft }}
+          />
+          {children.length === 0 && childrenLoaded && (
+            <div
+              className="text-[11px] text-muted-foreground/50 py-1"
+              style={{ paddingLeft: paddingLeft + 24 }}
+            >
+              空文件夹
+            </div>
+          )}
+          {children.map((child) => (
+            <FileTreeItem
+              key={child.path}
+              entry={child}
+              depth={depth + 1}
+              selectedPaths={selectedPaths}
+              selectedCount={selectedCount}
+              renamingPath={renamingPath}
+              moving={moving}
+              refreshVersion={refreshVersion}
+              revealAncestors={revealAncestors}
+              revealTarget={revealTarget}
+              revealTs={revealTs}
+              recentlyModifiedSet={recentlyModifiedSet}
+              onSelect={onSelect}
+              onShowInFolder={onShowInFolder}
+              onStartRename={onStartRename}
+              onCancelRename={onCancelRename}
+              onRename={onRename}
+              onDelete={onDelete}
+              onMove={onMove}
+              onRefresh={handleRefreshAfterDelete}
+              onClearSelection={onClearSelection}
+              onAddToChat={onAddToChat}
+              onFilePreview={onFilePreview}
+            />
+          ))}
         </div>
       )}
-      {expanded && children.map((child) => (
-        <FileTreeItem
-          key={child.path}
-          entry={child}
-          depth={depth + 1}
-          selectedPaths={selectedPaths}
-          selectedCount={selectedCount}
-          renamingPath={renamingPath}
-          moving={moving}
-          refreshVersion={refreshVersion}
-          revealAncestors={revealAncestors}
-          revealTarget={revealTarget}
-          revealTs={revealTs}
-          recentlyModifiedSet={recentlyModifiedSet}
-          onSelect={onSelect}
-          onShowInFolder={onShowInFolder}
-          onStartRename={onStartRename}
-          onCancelRename={onCancelRename}
-          onRename={onRename}
-          onDelete={onDelete}
-          onMove={onMove}
-          onRefresh={handleRefreshAfterDelete}
-          onAddToChat={onAddToChat}
-          onFilePreview={onFilePreview}
-        />
-      ))}
-    </>
+    </div>
   )
 }


### PR DESCRIPTION
## 概述

本 PR 对工作区文件浏览器（`FileBrowser.tsx`）做了一组聚焦的体验优化，目标是把它升级到接近 VS Code Outline 的观感：在长目录树滚动时父路径常驻可见、缩进有视觉引导线、行高规整、重命名错误提示位置更合理。改动范围只限单文件，无 API、类型或样式 token 的破坏性调整。

## 改动列表

- `apps/electron/src/renderer/components/file-browser/FileBrowser.tsx` — 共 +78 / -39，包含以下逻辑簇：
  - **常量抽取**：新增 `TREE_ROW_HEIGHT=32` / `TREE_ROW_HORIZONTAL_MARGIN=8` / `TREE_INDENT_WIDTH=16` / `MAX_STICKY_DEPTH=4`，替代原先散落的 magic number。
  - **目录行 sticky**：当目录处于 `expanded` 状态时，行采用 `position: sticky`，`top` 按深度分层（`depth × TREE_ROW_HEIGHT`，封顶 `MAX_STICKY_DEPTH=4`）；带半透明背景 + `backdrop-blur-sm` + 底部细分隔线，模拟 IDE 中的 sticky scroll 效果。
  - **行高规整**：行从原先依赖 `py-1` 自然撑高改为固定 `h-8`（32px），与 `TREE_ROW_HEIGHT` 一致，确保 sticky 分层的 top 偏移量精准对齐。
  - **缩进引导线**：每层 `expanded` 子项区域左侧绝对定位一条 `1px` 竖线（`bg-border/70`），辅助视觉对齐子项缩进，offset 由 `paddingLeft + chevron 半宽` 计算。
  - **空白处清选**：在每个 `FileTreeItem` 外层包一个 `relative` wrapper，监听其 `onClick`：当 target 等于 wrapper 自身（即点击到行 `mx-2` 形成的左右各 8px 留白时）调用新增的 `onClearSelection` prop 清空多选；该路径补齐父级 `handleBackgroundClick` 因 mx-2 留白处事件 target 不再是父容器而漏触发的边界场景。
  - **重命名错误提示**：错误信息保留在 input 容器内，但通过 `absolute left-0 top-full` 浮在输入框正下方，既不破坏 `h-8` 的行高约束、也不脱离用户视线焦点；`pointer-events-none` 避免遮挡其它行的点击。
  - **z-index 收敛**：sticky 行的 `zIndex = max(1, 10 - stickyDepth)`，外层目录在更上层、内层在更下层；起点选择 10 而非更高值，避免遮挡同窗口内其它就近渲染（侧边栏、装饰条等）的元素。

## 如何测试

1. `bun install && bun run dev`，进入任意带工作区目录的会话。
2. 在文件浏览器中展开多层嵌套目录（建议 ≥ 3 层），上下滚动子内容：
   - 父级目录行应在滚动时停留在视口顶部，按深度分层堆叠；
   - 各层 sticky 行之间不应互相遮挡按钮、菜单。
3. 选中任意若干文件后，点击行 `mx-2` 留白处（行最左侧/最右侧的 8px 区域）：选中状态应立即清空。
4. 对任意文件触发"重命名"，输入一个会冲突的名字：错误信息应出现在 input 正下方，不会把行撑高、不会顶动 sticky 偏移。
5. 多选/单选状态下三点菜单与原有交互保持一致；ChevronRight 旋转动画、最近修改竖条标记、自动定位高亮脉冲等已有功能不受影响。
6. `bun run typecheck` 应在 4 个 workspace 子包下全部退出码为 0。

## 备注

- 仅 UI 性质改动，无 IPC、storage、路由层修改。
- `position: sticky` 需要 ScrollArea Viewport 层不被 `transform` / `filter` 等会创建新 containing block 的属性包裹；当前 Radix `ScrollArea` 实现下验证通过。
- 深度 ≥ `MAX_STICKY_DEPTH = 4` 的目录不再继续累加 top，靠 z-index 接力，是为避免 sticky 链耗尽视口高度的折中。
- `onClearSelection` prop 当前在 `FileBrowser` 中以内联箭头函数传入；如未来发现 FileTreeItem 子树有不必要 re-render，可补一层 `useCallback`。
