### PR TITLE
fix(diff): 修复代码块内容解析为空及空行丢失问题

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.9.42",
+  "version": "0.9.43",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/diff/markdown-preview-extensions.tsx
+++ b/apps/electron/src/renderer/components/diff/markdown-preview-extensions.tsx
@@ -1,5 +1,6 @@
 import { Node, mergeAttributes, nodeInputRule } from '@tiptap/core'
 import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
+import { Fragment } from '@tiptap/pm/model'
 import { Plugin, PluginKey } from '@tiptap/pm/state'
 import { Decoration, DecorationSet } from '@tiptap/pm/view'
 import type { EditorView, ViewMutationRecord } from '@tiptap/pm/view'
@@ -539,9 +540,11 @@ function createShikiCodeBlockView(initialNode: ProseMirrorNode, _themeRef: Theme
 
   const editPre = document.createElement('pre')
   setClass(editPre, 'markdown-code-edit-layer m-0 min-h-[3.2em] overflow-x-auto bg-transparent p-4 font-mono text-[13px] leading-[1.6]')
+  editPre.style.whiteSpace = 'pre'
 
   const contentDOM = document.createElement('code')
   setClass(contentDOM, 'block min-h-[1.6em] whitespace-pre bg-transparent p-0 font-mono text-[13px] leading-[1.6]')
+  contentDOM.style.whiteSpace = 'pre'
   editPre.appendChild(contentDOM)
   body.appendChild(editPre)
 
@@ -874,7 +877,28 @@ export function createShikiCodeBlock(themeRef: ThemeRef): Node {
     },
 
     parseHTML() {
-      return [{ tag: 'pre', preserveWhitespace: 'full' }]
+      return [{
+        tag: 'pre',
+        preserveWhitespace: 'full',
+        getContent: (element, schema) => {
+          const code = (element as Element).querySelector('code')
+          if (code) {
+            // 遍历子节点，将 <br> 还原为 \n，避免浏览器解析时规范化空白导致空行丢失
+            const parts: string[] = []
+            for (const child of Array.from(code.childNodes)) {
+              if (child.nodeType === globalThis.Node.TEXT_NODE) {
+                parts.push(child.nodeValue || '')
+              } else if (child.nodeType === globalThis.Node.ELEMENT_NODE && (child as Element).tagName.toLowerCase() === 'br') {
+                parts.push('\n')
+              }
+            }
+            const text = parts.join('')
+            return text ? Fragment.from(schema.text(text)) : Fragment.empty
+          }
+          const text = element.textContent
+          return text ? Fragment.from(schema.text(text)) : Fragment.empty
+        },
+      }]
     },
 
     addCommands() {

--- a/apps/electron/src/renderer/lib/markdown-rich-text.ts
+++ b/apps/electron/src/renderer/lib/markdown-rich-text.ts
@@ -276,7 +276,13 @@ function enhanceMarkdownHtml(html: string): string {
 
 export function markdownToHtml(markdown: string): string {
   if (!markdown) return ''
-  return enhanceMarkdownHtml(markdownIt.render(preprocessMarkdown(markdown)))
+  let html = markdownIt.render(preprocessMarkdown(markdown))
+  // 浏览器解析 <pre> 时可能规范化连续换行符，将 \n\n 替换为 <br>\n 确保空行保留
+  html = html.replace(/<pre><code([^>]*)>([\s\S]*?)<\/code><\/pre>/g, (match, attrs, content) => {
+    const newContent = content.replace(/\n\n/g, '<br>\n')
+    return `<pre><code${attrs}>${newContent}</code></pre>`
+  })
+  return enhanceMarkdownHtml(html)
 }
 
 /** 将 TipTap 输出的 HTML 转换为 Markdown 格式 */
@@ -348,9 +354,21 @@ export function htmlToMarkdown(html: string): string {
       case 'pre': {
         const codeEl = el.querySelector('code')
         const langClass = codeEl?.className || ''
-        const langMatch = langClass.match(/language-(\w+)/)
+        const langMatch = langClass.match(/language-(\S+)/)
         const lang = langMatch ? langMatch[1] : ''
-        const codeContent = codeEl ? processNode(codeEl) : children
+        // 提取代码内容，将 <br> 还原为 \n
+        let codeContent = ''
+        if (codeEl) {
+          for (const child of Array.from(codeEl.childNodes)) {
+            if (child.nodeType === Node.TEXT_NODE) {
+              codeContent += child.textContent || ''
+            } else if (child.nodeType === Node.ELEMENT_NODE && (child as Element).tagName.toLowerCase() === 'br') {
+              codeContent += '\n'
+            }
+          }
+        } else {
+          codeContent = children
+        }
         return `\`\`\`${lang}\n${codeContent}\n\`\`\`\n`
       }
       case 'a': {


### PR DESCRIPTION
TipTap DOMParser 解析 <pre><code> 时会为 <code> 内容附加 StarterKit 的 Code mark，而 codeBlock 节点 content 定义为 text*（不允许 marks），导致 带 Code mark 的内容无法放入 codeBlock，代码块显示为空。

修复：
- parseHTML 添加 getContent 钩子，直接提取 <code> 纯文本绕过递归解析
- 修复 getContent 返回类型（Fragment 而非 Node[]）

浏览器解析 <pre> 时会规范化连续换行符（\n\n → \n），导致代码块空行丢失。

修复：
- markdownToHtml: \n\n 替换为 <br>\n，<br> 作为独立 DOM 元素不会被规范化
- getContent 钩子: <br> 还原为 \n
- htmlToMarkdown: <br> 还原为 \n

另外将 htmlToMarkdown 语言名正则从 \w+ 改为 \S+，支持 c++ 等特殊字符。