### PR TITLE
refactor(diff): polish 代码块解析后处理（#554 跟进）

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.9.43",
+  "version": "0.9.44",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/diff/markdown-preview-extensions.tsx
+++ b/apps/electron/src/renderer/components/diff/markdown-preview-extensions.tsx
@@ -15,6 +15,7 @@ import katex from 'katex'
 import { highlightCode, highlightToTokens, getDisplayName } from '@proma/core'
 import type { HighlightTokensResult } from '@proma/core'
 import type { FileAccessOptions } from '@proma/shared'
+import { extractCodeText } from '../../lib/markdown-rich-text'
 
 type FileAccessRef = { current: FileAccessOptions | undefined }
 /** 传 null 表示当前编辑器无会话/文件上下文（如 ScratchPad），跳过路径解析。 */
@@ -882,20 +883,7 @@ export function createShikiCodeBlock(themeRef: ThemeRef): Node {
         preserveWhitespace: 'full',
         getContent: (element, schema) => {
           const code = (element as Element).querySelector('code')
-          if (code) {
-            // 遍历子节点，将 <br> 还原为 \n，避免浏览器解析时规范化空白导致空行丢失
-            const parts: string[] = []
-            for (const child of Array.from(code.childNodes)) {
-              if (child.nodeType === globalThis.Node.TEXT_NODE) {
-                parts.push(child.nodeValue || '')
-              } else if (child.nodeType === globalThis.Node.ELEMENT_NODE && (child as Element).tagName.toLowerCase() === 'br') {
-                parts.push('\n')
-              }
-            }
-            const text = parts.join('')
-            return text ? Fragment.from(schema.text(text)) : Fragment.empty
-          }
-          const text = element.textContent
+          const text = code ? extractCodeText(code) : (element.textContent || '')
           return text ? Fragment.from(schema.text(text)) : Fragment.empty
         },
       }]

--- a/apps/electron/src/renderer/lib/markdown-rich-text.ts
+++ b/apps/electron/src/renderer/lib/markdown-rich-text.ts
@@ -37,6 +37,23 @@ function escapeAttr(value: string): string {
     .replace(/\n/g, '&#10;')
 }
 
+export function extractCodeText(codeEl: Element): string {
+  const parts: string[] = []
+  for (const child of Array.from(codeEl.childNodes)) {
+    if (child.nodeType === globalThis.Node.TEXT_NODE) {
+      parts.push(child.nodeValue || '')
+    } else if (child.nodeType === globalThis.Node.ELEMENT_NODE) {
+      const el = child as Element
+      if (el.tagName.toLowerCase() === 'br') {
+        parts.push('\n')
+      } else {
+        parts.push(el.textContent || '')
+      }
+    }
+  }
+  return parts.join('')
+}
+
 function escapeMarkdownText(value: string): string {
   // /m 让 ^ 匹配每行行首，确保多行文本节点中每一行的块级标记都被转义。
   // 这是必须的：在 markdown 中，行首的 # > + - 和有序列表标记会被解析为块级元素。
@@ -174,6 +191,19 @@ markdownIt.renderer.rules.image = (tokens, idx) => {
   return `<img src="${escapeAttr(src)}" alt="${escapeAttr(alt)}"${titleAttr}>`
 }
 
+markdownIt.renderer.rules.fence = (tokens, idx) => {
+  const token = tokens[idx]
+  if (!token) return ''
+  const info = token.info ? token.info.trim() : ''
+  const langName = info.split(/\s+/)[0] || ''
+  const escaped = markdownIt.utils.escapeHtml(token.content)
+  // 浏览器解析 <pre> 时会规范化连续换行符（\n\n → \n），导致空行丢失。
+  // 用 <br> 作为独立 DOM 节点不会被规范化，由 extractCodeText 在解析侧还原为 \n。
+  const preserved = escaped.replace(/\n\n/g, '<br>\n')
+  const classAttr = langName ? ` class="language-${markdownIt.utils.escapeHtml(langName)}"` : ''
+  return `<pre><code${classAttr}>${preserved}</code></pre>\n`
+}
+
 function wrapMarkdownDetailsBlocks(markdown: string): string {
   return markdown.replace(DETAILS_BLOCK_RE, (raw: string, attrs = '', summary: string, body: string) => {
     const bodyMarkdown = body.trim()
@@ -276,13 +306,7 @@ function enhanceMarkdownHtml(html: string): string {
 
 export function markdownToHtml(markdown: string): string {
   if (!markdown) return ''
-  let html = markdownIt.render(preprocessMarkdown(markdown))
-  // 浏览器解析 <pre> 时可能规范化连续换行符，将 \n\n 替换为 <br>\n 确保空行保留
-  html = html.replace(/<pre><code([^>]*)>([\s\S]*?)<\/code><\/pre>/g, (match, attrs, content) => {
-    const newContent = content.replace(/\n\n/g, '<br>\n')
-    return `<pre><code${attrs}>${newContent}</code></pre>`
-  })
-  return enhanceMarkdownHtml(html)
+  return enhanceMarkdownHtml(markdownIt.render(preprocessMarkdown(markdown)))
 }
 
 /** 将 TipTap 输出的 HTML 转换为 Markdown 格式 */
@@ -356,19 +380,7 @@ export function htmlToMarkdown(html: string): string {
         const langClass = codeEl?.className || ''
         const langMatch = langClass.match(/language-(\S+)/)
         const lang = langMatch ? langMatch[1] : ''
-        // 提取代码内容，将 <br> 还原为 \n
-        let codeContent = ''
-        if (codeEl) {
-          for (const child of Array.from(codeEl.childNodes)) {
-            if (child.nodeType === Node.TEXT_NODE) {
-              codeContent += child.textContent || ''
-            } else if (child.nodeType === Node.ELEMENT_NODE && (child as Element).tagName.toLowerCase() === 'br') {
-              codeContent += '\n'
-            }
-          }
-        } else {
-          codeContent = children
-        }
+        const codeContent = codeEl ? extractCodeText(codeEl) : children
         return `\`\`\`${lang}\n${codeContent}\n\`\`\`\n`
       }
       case 'a': {


### PR DESCRIPTION
承接 #554，对刚刚修好的代码块解析路径做一次小范围 polish，从根因层收敛字符串处理逻辑。**不改变任何用户可见行为**，纯重构 + 健壮性提升。

## Why

#554 解决了两个真问题（codeBlock 内容丢失、空行规范化），合并前 review 时识别到三个值得跟进的小点：

1. `markdownToHtml` 末尾用 `/<pre><code…>/g` 字符串正则对 markdownIt 已渲染的 HTML 做二次替换。当前路径下安全（markdownIt 已转义 `<`/`>`），但属于"现在没问题、未来要小心"的代码——任何插件输出原始 `</code>` 都会让它错位。
2. `getContent` 钩子和 `htmlToMarkdown` 的 `<pre>` 分支各写了一遍几乎相同的 child-node 遍历逻辑；两个文件分别用了 `globalThis.Node.TEXT_NODE` 和裸 `Node.TEXT_NODE`，风格不统一。
3. 这两处遍历都只识别 `TEXT_NODE` 和 `<br>`，会**静默丢弃**其他子节点（例如未来若启用 server-side highlight，markdownIt 注入的 `<span class="hljs-…">` 包装内的代码会消失）。

## What

**1. 用自定义 markdownIt fence renderer 取代字符串正则**

直接 override `markdownIt.renderer.rules.fence`，在生成 HTML 时就走 `escapeHtml(token.content)` → 替换 `\n\n` → 拼 `<pre><code class="language-…">...`。
彻底删除 `markdownToHtml` 内的后置正则替换。从源头出发就不再需要去解析自己刚渲染出来的字符串。

**2. 提取共享 helper `extractCodeText`**

两处遍历合一，导出在 `markdown-rich-text.ts`，被 `markdown-preview-extensions.tsx` 的 `getContent` 和 `htmlToMarkdown` 的 `<pre>` 分支共同消费。
**新增 textContent 兜底分支**：非 `TEXT_NODE`/`<br>` 的元素子节点（例如 `<span class="hljs-…">`）现在会用 `textContent` 取出文本，而不是被无声丢弃。

**3. 统一 `globalThis.Node` 引用**

helper 内部统一使用 `globalThis.Node.TEXT_NODE` / `globalThis.Node.ELEMENT_NODE`，避免在 import 了 `@tiptap/core` 的 `Node` 类的文件中产生命名冲突；两文件现在通过共享 helper 自动达成一致。

## Files

- `apps/electron/src/renderer/lib/markdown-rich-text.ts`：导出 `extractCodeText`；override `fence` renderer；删除 `markdownToHtml` 后置正则；`<pre>` case 改用 helper
- `apps/electron/src/renderer/components/diff/markdown-preview-extensions.tsx`：`getContent` 改用 helper；删除内联遍历
- `apps/electron/package.json`：0.9.43 → 0.9.44

净变化：+35 / -35 行，但实际逻辑被显著简化（消除了一处字符串后处理 + 两处重复遍历）。

## Verify

- ✅ `bun run typecheck`（apps/electron）通过
- 行为等价性：fence 走 markdownIt 默认路径 + 自定义后处理，与原 default_rules.fence 输出形状一致（`<pre><code class="language-XXX">...</code></pre>\n`），下游 `enhanceMarkdownHtml` 无影响
- 边界情况：空代码块、含 `<` `>` `&` 的代码、含连续空行的代码、`c++` 等含特殊字符的语言名 — 均与 #554 修复后行为一致

Follow-up to #554. cc @yuanyuan06 — 感谢你之前的精彩根因分析 🙌