### PR TITLE
fix(ui): 统一侧边栏列表项与子标签选中态圆角为 rounded-md

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -113,7 +113,7 @@ function SidebarItem({ icon, label, active, suffix, onClick }: SidebarItemProps)
     <button
       onClick={onClick}
       className={cn(
-        'w-full flex items-center justify-between px-3 py-2 rounded-[10px] text-[13px] transition-colors duration-100 titlebar-no-drag',
+        'w-full flex items-center justify-between px-3 py-2 rounded-md text-[13px] transition-colors duration-100 titlebar-no-drag',
         active
           ? 'bg-primary/10 text-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
           : 'text-foreground/60 hover:bg-primary/5 hover:text-foreground'
@@ -1750,7 +1750,7 @@ const ConversationItem = React.memo(function ConversationItem({
             startEdit()
           }}
           className={cn(
-            'group relative w-full flex items-center gap-2 px-3 py-[7px] rounded-[10px] transition-colors duration-100 titlebar-no-drag text-left',
+            'group relative w-full flex items-center gap-2 px-3 py-[7px] rounded-md transition-colors duration-100 titlebar-no-drag text-left',
             active
               ? 'session-item-selected bg-primary/10 shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
               : 'hover:bg-primary/5'
@@ -1959,7 +1959,7 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
             startEdit()
           }}
           className={cn(
-            'group relative w-full flex items-center gap-2 px-3 py-[7px] rounded-[10px] transition-colors duration-100 titlebar-no-drag text-left',
+            'group relative w-full flex items-center gap-2 px-3 py-[7px] rounded-md transition-colors duration-100 titlebar-no-drag text-left',
             active
               ? 'session-item-selected bg-primary/10 shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
               : 'hover:bg-primary/5'


### PR DESCRIPTION
## Overview
统一侧边栏中"工作中"/"置顶"子标签与下方会话列表项的选中态圆角，消除同一视觉区域内圆角弧度不一致的违和感。

## Changes
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — `SidebarItem`、`ConversationItem`、`AgentSessionItem` 三处选中态圆角从 `rounded-[10px]` 改为 `rounded-md`，与"工作中"/"置顶"子标签的 `rounded-md` 保持一致

## How to Test
1. 打开 Proma，进入 Agent 模式
2. 观察侧边栏中"工作中"/"置顶"子标签选中态与下方会话列表项选中态的圆角
3. 确认两者圆角弧度一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)