### PR TITLE
feat(agent): 在 Assistant Turn 底部汇总本轮文件改动

### DIFF
--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -18,6 +18,7 @@ import { cn } from '@/lib/utils'
 import { ImageLightbox } from '@/components/ui/image-lightbox'
 import { ContentBlock } from './ContentBlock'
 import { TaskProgressCard } from './TaskProgressCard'
+import { TurnFileChangesSummary } from './TurnFileChangesSummary'
 import { extractToolResultText, parseTaskCreateResult, TASK_TOOL_NAMES } from './task-progress'
 import { DurationBadge } from './AgentMessages'
 import {
@@ -649,6 +650,10 @@ export function AssistantTurnRenderer({ turn, allMessages, historicalTaskSubject
           </div>
         )}
       </MessageContent>
+      {/* 文件改动汇总：流式结束后展示本轮所有 Edit/Write/MultiEdit/NotebookEdit 文件 */}
+      {!isStreaming && (
+        <TurnFileChangesSummary turnMessages={turn.turnMessages} basePath={basePath} />
+      )}
       {/* 操作栏：流式输出完成后显示操作按钮 */}
       {!isStreaming && (() => {
         const textContent = topLevelBlocks

--- a/apps/electron/src/renderer/components/agent/TurnFileChangesSummary.tsx
+++ b/apps/electron/src/renderer/components/agent/TurnFileChangesSummary.tsx
@@ -1,0 +1,92 @@
+/**
+ * TurnFileChangesSummary — Turn 底部文件改动汇总
+ *
+ * 在 AssistantTurnRenderer 的 MessageActions 之上，以 chip 横排展示本轮所有
+ * 修改类工具调用（Edit / Write / MultiEdit / NotebookEdit）所触及的文件。
+ *
+ * 子代理（Agent/Task）的修改也会冒泡到此处——因为 SDK 的子代理 assistant
+ * 消息同样存在于 turn.turnMessages 中（通过 parent_tool_use_id 关联）。
+ *
+ * 文件 chip 直接复用 FilePathChip（与 Agent 消息中的渲染完全一致）。
+ */
+
+import * as React from 'react'
+import type {
+  SDKMessage,
+  SDKAssistantMessage,
+  SDKUserMessage,
+  SDKToolUseBlock,
+  SDKToolResultBlock,
+} from '@proma/shared'
+import { FilePathChip } from '@/components/ai-elements/file-path-chip'
+
+const MUTATING_TOOLS = new Set(['Edit', 'Write', 'MultiEdit', 'NotebookEdit'])
+
+function getFilePath(toolName: string, input: Record<string, unknown>): string | null {
+  if (toolName === 'NotebookEdit') {
+    const fp = input.notebook_path
+    return typeof fp === 'string' ? fp : null
+  }
+  const fp = input.file_path ?? input.filePath ?? input.path
+  return typeof fp === 'string' ? fp : null
+}
+
+function collectFilePaths(turnMessages: SDKMessage[]): string[] {
+  const failed = new Set<string>()
+  for (const msg of turnMessages) {
+    if (msg.type !== 'user') continue
+    const blocks = (msg as SDKUserMessage).message?.content
+    if (!Array.isArray(blocks)) continue
+    for (const block of blocks) {
+      if (block.type !== 'tool_result') continue
+      const rb = block as SDKToolResultBlock
+      if (rb.is_error === true) failed.add(rb.tool_use_id)
+    }
+  }
+
+  const seen = new Set<string>()
+  const paths: string[] = []
+  for (const msg of turnMessages) {
+    if (msg.type !== 'assistant') continue
+    const blocks = (msg as SDKAssistantMessage).message?.content
+    if (!Array.isArray(blocks)) continue
+    for (const block of blocks) {
+      if (block.type !== 'tool_use') continue
+      const tu = block as SDKToolUseBlock
+      if (!MUTATING_TOOLS.has(tu.name)) continue
+      if (failed.has(tu.id)) continue
+
+      const filePath = getFilePath(tu.name, tu.input as Record<string, unknown>)
+      if (!filePath || seen.has(filePath)) continue
+      seen.add(filePath)
+      paths.push(filePath)
+    }
+  }
+  return paths
+}
+
+export interface TurnFileChangesSummaryProps {
+  turnMessages: SDKMessage[]
+  basePath?: string
+}
+
+export function TurnFileChangesSummary({
+  turnMessages,
+  basePath,
+}: TurnFileChangesSummaryProps): React.ReactElement | null {
+  const paths = React.useMemo(() => collectFilePaths(turnMessages), [turnMessages])
+
+  if (paths.length === 0) return null
+
+  return (
+    <div className="pl-[46px] mt-3">
+      <div className="pt-3 border-t-2 border-dashed border-border/60">
+        <div className="flex flex-wrap gap-1.5">
+          {paths.map((filePath) => (
+            <FilePathChip key={filePath} filePath={filePath} basePath={basePath} />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## 变更摘要

在 Agent 模式的 Assistant Turn 底部新增文件改动汇总区域，以 `FilePathChip` 横排展示本轮所有修改的文件，方便用户集中预览查看。

### 主要改动

- **新增组件** `TurnFileChangesSummary`
  - 扫描当前 turn 的 `turnMessages`，提取所有 `Edit` / `Write` / `MultiEdit` / `NotebookEdit` 工具调用所触及的文件路径
  - 自动过滤失败的工具调用（`is_error === true`）
  - 按文件路径去重，保持首次出现的顺序
  - 子代理（Agent / Task）的修改通过 `parent_tool_use_id` 自然冒泡到当前 turn，无需额外处理
  
- **集成到 `AssistantTurnRenderer`**
  - 在 `MessageContent` 与 `MessageActions` 之间插入汇总区域
  - 仅在流式输出结束后展示（`!isStreaming`）

- **视觉设计**
  - 复用已有的 `FilePathChip` 组件（VS Code 风格图标、蓝色主题、点击预览）
  - 顶部以虚线分隔，宽度与消息内容区域对齐（`pl-[46px]`）
  - 文件 chip 支持自动换行，避免区域过高

### 截图

- 汇总区域以 chip 横排展示本轮所有修改文件
- 点击任意 chip 可在右侧内联面板预览对应文件

### 测试建议

1. 在 Agent 模式下触发文件编辑（Edit / Write），确认 turn 底部正确展示文件 chip
2. 验证子代理修改的文件也能正确汇总到父 turn
3. 验证流式输出过程中汇总区域不显示，结束后才出现
4. 验证点击 chip 可正常唤起文件预览面板

🤖 Generated with [Claude Code](https://claude.com/claude-code)