### PR TITLE
FileBrowser/SidePanel 目录树 sticky 行 VS Code 风格化与共享模块抽取

### DIFF
--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -17,7 +17,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { cn } from '@/lib/utils'
-import { FileBrowser, FileDropZone, FileTypeIcon } from '@/components/file-browser'
+import { FileBrowser, FileDropZone, FileTypeIcon, computeTreeRowLayout, AncestorGuides, STICKY_ROW_BASE_CLASS, canBeSticky } from '@/components/file-browser'
 import { DiffPanelTabBar } from '@/components/diff/DiffPanelTabBar'
 import { DiffChangesList } from '@/components/diff/DiffChangesList'
 import {
@@ -39,13 +39,6 @@ import type { FileEntry, AgentPendingFile } from '@proma/shared'
 function getPathBasename(filePath: string): string {
   return filePath.split(/[\\/]/).filter(Boolean).pop() || filePath
 }
-
-// 附加目录树布局常量——与 components/file-browser/FileBrowser.tsx 保持一致，
-// 使附加目录与主文件树拥有相同的 sticky 堆叠、铺满、引导线 UI。
-const TREE_ROW_HEIGHT = 32
-const TREE_ROW_HORIZONTAL_MARGIN = 8
-const TREE_INDENT_WIDTH = 16
-const MAX_STICKY_DEPTH = 4
 
 function getMediaTypeFromFilename(filename: string): string {
   const ext = filename.split('.').pop()?.toLowerCase() ?? ''
@@ -776,8 +769,7 @@ function AttachedDirTree({ dirPath, onDetach, selectedPaths, onSelect, refreshVe
   }
 
   // depth=0 的根行，与 FileBrowser 保持一致的布局：铺满、无外边距、可 sticky
-  const paddingLeft = TREE_ROW_HORIZONTAL_MARGIN + 8
-  const guideLeft = paddingLeft + 7
+  const { paddingLeft, guideLeft } = computeTreeRowLayout(0)
   const isSticky = expanded
 
   return (
@@ -786,8 +778,7 @@ function AttachedDirTree({ dirPath, onDetach, selectedPaths, onSelect, refreshVe
         data-sticky-row={isSticky ? 'true' : undefined}
         className={cn(
           'relative flex h-8 items-center gap-1 pr-2 text-sm cursor-pointer group transition-colors',
-          // sticky：不透明背景 + 底部阴影；多行紧贴时由 globals.css 中的 :has() 规则去除中间阴影
-          isSticky && 'sticky top-0 z-10 bg-background shadow-[0_1px_0_hsl(var(--border)/0.6)]',
+          isSticky && cn(STICKY_ROW_BASE_CLASS, 'top-0 z-10'),
           // sticky 行 hover 用不透明色，避免下方滚动内容透出；普通行保持半透明柔和感
           isSticky ? 'hover:bg-accent' : 'hover:bg-accent/50',
         )}
@@ -948,12 +939,8 @@ function AttachedDirItem({ entry, depth, selectedPaths, onSelect, refreshVersion
     }
   }
 
-  const paddingLeft = TREE_ROW_HORIZONTAL_MARGIN + 8 + depth * TREE_INDENT_WIDTH
-  const guideLeft = paddingLeft + 7
-  const stickyDepth = Math.min(depth, MAX_STICKY_DEPTH)
-  const stickyTop = stickyDepth * TREE_ROW_HEIGHT
-  const stickyZIndex = Math.max(1, 10 - stickyDepth)
-  const isSticky = entry.isDirectory && expanded
+  const { paddingLeft, guideLeft, stickyTop, stickyZIndex } = computeTreeRowLayout(depth)
+  const isSticky = entry.isDirectory && expanded && canBeSticky(depth)
 
   return (
     <>
@@ -961,8 +948,7 @@ function AttachedDirItem({ entry, depth, selectedPaths, onSelect, refreshVersion
         data-sticky-row={isSticky ? 'true' : undefined}
         className={cn(
           'relative flex h-8 items-center gap-1 pr-2 text-sm cursor-pointer group transition-colors',
-          // sticky：不透明背景 + 底部阴影；多行紧贴时由 globals.css 中的 :has() 规则去除中间阴影
-          isSticky && 'sticky bg-background shadow-[0_1px_0_hsl(var(--border)/0.6)]',
+          isSticky && STICKY_ROW_BASE_CLASS,
           // sticky 行 hover 用不透明色，避免下方滚动内容透出；普通行保持半透明柔和感
           isSelected
             ? 'bg-accent'
@@ -977,26 +963,9 @@ function AttachedDirItem({ entry, depth, selectedPaths, onSelect, refreshVersion
         }}
         onClick={handleClick}
       >
-        {/* sticky 行内仅绘制祖先链竖线，贯穿整行；
-            自己的子项引导线交给下方子项容器（或下一层 sticky 子行的祖先线）负责，
-            使每个文件夹自身行内不会出现从三角下方延伸出的线，符合 VS Code 行为。
-            选中态下 bg-accent 不透明背景会盖住原本的 border 色，换成 accent-foreground 以保证对比度。
-            与 components/file-browser/FileBrowser.tsx 保持一致。 */}
-        {isSticky && depth > 0 && (
-          <>
-            {Array.from({ length: depth }).map((_, i) => (
-              <span
-                key={`ancestor-guide-${i}`}
-                aria-hidden="true"
-                className={cn(
-                  'pointer-events-none absolute top-0 bottom-0 w-px',
-                  isSelected ? 'bg-accent-foreground/30' : 'bg-border/70',
-                )}
-                style={{ left: TREE_ROW_HORIZONTAL_MARGIN + 8 + i * TREE_INDENT_WIDTH + 7 }}
-              />
-            ))}
-          </>
-        )}
+        {/* sticky 行祖先链竖线，逻辑见 tree-row-layout.tsx 的 AncestorGuides。
+            选中态下 bg-accent 不透明背景会盖住原 border 色，组件内部已切到 accent-foreground。 */}
+        {isSticky && <AncestorGuides depth={depth} isSelected={isSelected} />}
         {entry.isDirectory ? (
           <ChevronRight
             className={cn(

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -40,6 +40,13 @@ function getPathBasename(filePath: string): string {
   return filePath.split(/[\\/]/).filter(Boolean).pop() || filePath
 }
 
+// 附加目录树布局常量——与 components/file-browser/FileBrowser.tsx 保持一致，
+// 使附加目录与主文件树拥有相同的 sticky 堆叠、铺满、引导线 UI。
+const TREE_ROW_HEIGHT = 32
+const TREE_ROW_HORIZONTAL_MARGIN = 8
+const TREE_INDENT_WIDTH = 16
+const MAX_STICKY_DEPTH = 4
+
 function getMediaTypeFromFilename(filename: string): string {
   const ext = filename.split('.').pop()?.toLowerCase() ?? ''
   const imageExts = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp', 'ico'])
@@ -768,10 +775,23 @@ function AttachedDirTree({ dirPath, onDetach, selectedPaths, onSelect, refreshVe
     setExpanded(!expanded)
   }
 
+  // depth=0 的根行，与 FileBrowser 保持一致的布局：铺满、无外边距、可 sticky
+  const paddingLeft = TREE_ROW_HORIZONTAL_MARGIN + 8
+  const guideLeft = paddingLeft + 7
+  const isSticky = expanded
+
   return (
-    <div>
+    <div className="relative">
       <div
-        className="flex items-center gap-1 py-1 pl-2 pr-2 text-sm cursor-pointer hover:bg-accent/50 group mx-2 rounded-lg"
+        data-sticky-row={isSticky ? 'true' : undefined}
+        className={cn(
+          'relative flex h-8 items-center gap-1 pr-2 text-sm cursor-pointer group transition-colors',
+          // sticky：不透明背景 + 底部阴影；多行紧贴时由 globals.css 中的 :has() 规则去除中间阴影
+          isSticky && 'sticky top-0 z-10 bg-background shadow-[0_1px_0_hsl(var(--border)/0.6)]',
+          // sticky 行 hover 用不透明色，避免下方滚动内容透出；普通行保持半透明柔和感
+          isSticky ? 'hover:bg-accent' : 'hover:bg-accent/50',
+        )}
+        style={{ paddingLeft }}
         onClick={toggleExpand}
       >
         <ChevronRight
@@ -794,14 +814,26 @@ function AttachedDirTree({ dirPath, onDetach, selectedPaths, onSelect, refreshVe
           <X className="size-3" />
         </Button>
       </div>
-      {expanded && children.length === 0 && loaded && (
-        <div className="text-[11px] text-muted-foreground/50 py-1" style={{ paddingLeft: 48 }}>
-          空文件夹
+      {expanded && (
+        <div className="relative">
+          <span
+            aria-hidden="true"
+            className="pointer-events-none absolute bottom-1 top-0 w-px bg-border/70"
+            style={{ left: guideLeft }}
+          />
+          {children.length === 0 && loaded && (
+            <div
+              className="text-[11px] text-muted-foreground/50 py-1"
+              style={{ paddingLeft: paddingLeft + 24 }}
+            >
+              空文件夹
+            </div>
+          )}
+          {children.map((child) => (
+            <AttachedDirItem key={child.path} entry={child} depth={1} selectedPaths={selectedPaths} onSelect={onSelect} refreshVersion={refreshVersion} onAddToChat={onAddToChat} onFilePreview={onFilePreview} allowedPaths={allowedPaths} sessionId={sessionId} />
+          ))}
         </div>
       )}
-      {expanded && children.map((child) => (
-        <AttachedDirItem key={child.path} entry={child} depth={1} selectedPaths={selectedPaths} onSelect={onSelect} refreshVersion={refreshVersion} onAddToChat={onAddToChat} onFilePreview={onFilePreview} allowedPaths={allowedPaths} sessionId={sessionId} />
-      ))}
     </div>
   )
 }
@@ -916,16 +948,33 @@ function AttachedDirItem({ entry, depth, selectedPaths, onSelect, refreshVersion
     }
   }
 
-  const paddingLeft = 8 + depth * 16
+  const paddingLeft = TREE_ROW_HORIZONTAL_MARGIN + 8 + depth * TREE_INDENT_WIDTH
+  const guideLeft = paddingLeft + 7
+  const stickyDepth = Math.min(depth, MAX_STICKY_DEPTH)
+  const stickyTop = stickyDepth * TREE_ROW_HEIGHT
+  const stickyZIndex = Math.max(1, 10 - stickyDepth)
+  const isSticky = entry.isDirectory && expanded
 
   return (
     <>
       <div
+        data-sticky-row={isSticky ? 'true' : undefined}
         className={cn(
-          'flex items-center gap-1 py-1 pr-2 text-sm cursor-pointer group mx-2 rounded-lg',
-          isSelected ? 'bg-accent' : 'hover:bg-accent/50',
+          'relative flex h-8 items-center gap-1 pr-2 text-sm cursor-pointer group transition-colors',
+          // sticky：不透明背景 + 底部阴影；多行紧贴时由 globals.css 中的 :has() 规则去除中间阴影
+          isSticky && 'sticky bg-background shadow-[0_1px_0_hsl(var(--border)/0.6)]',
+          // sticky 行 hover 用不透明色，避免下方滚动内容透出；普通行保持半透明柔和感
+          isSelected
+            ? 'bg-accent'
+            : isSticky
+              ? 'hover:bg-accent'
+              : 'hover:bg-accent/50',
         )}
-        style={{ paddingLeft }}
+        style={{
+          paddingLeft,
+          top: isSticky ? stickyTop : undefined,
+          zIndex: isSticky ? stickyZIndex : undefined,
+        }}
         onClick={handleClick}
       >
         {entry.isDirectory ? (
@@ -1029,17 +1078,26 @@ function AttachedDirItem({ entry, depth, selectedPaths, onSelect, refreshVersion
           )}
         </div>
       </div>
-      {expanded && children.length === 0 && loaded && (
-        <div
-          className="text-[11px] text-muted-foreground/50 py-1"
-          style={{ paddingLeft: paddingLeft + 24 }}
-        >
-          空文件夹
+      {expanded && (
+        <div className="relative">
+          <span
+            aria-hidden="true"
+            className="pointer-events-none absolute bottom-1 top-0 w-px bg-border/70"
+            style={{ left: guideLeft }}
+          />
+          {children.length === 0 && loaded && (
+            <div
+              className="text-[11px] text-muted-foreground/50 py-1"
+              style={{ paddingLeft: paddingLeft + 24 }}
+            >
+              空文件夹
+            </div>
+          )}
+          {children.map((child) => (
+            <AttachedDirItem key={child.path} entry={child} depth={depth + 1} selectedPaths={selectedPaths} onSelect={onSelect} refreshVersion={refreshVersion} onAddToChat={onAddToChat} onFilePreview={onFilePreview} allowedPaths={allowedPaths} sessionId={sessionId} />
+          ))}
         </div>
       )}
-      {expanded && children.map((child) => (
-        <AttachedDirItem key={child.path} entry={child} depth={depth + 1} selectedPaths={selectedPaths} onSelect={onSelect} refreshVersion={refreshVersion} onAddToChat={onAddToChat} onFilePreview={onFilePreview} allowedPaths={allowedPaths} sessionId={sessionId} />
-      ))}
     </>
   )
 }

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -977,6 +977,26 @@ function AttachedDirItem({ entry, depth, selectedPaths, onSelect, refreshVersion
         }}
         onClick={handleClick}
       >
+        {/* sticky 行内仅绘制祖先链竖线，贯穿整行；
+            自己的子项引导线交给下方子项容器（或下一层 sticky 子行的祖先线）负责，
+            使每个文件夹自身行内不会出现从三角下方延伸出的线，符合 VS Code 行为。
+            选中态下 bg-accent 不透明背景会盖住原本的 border 色，换成 accent-foreground 以保证对比度。
+            与 components/file-browser/FileBrowser.tsx 保持一致。 */}
+        {isSticky && depth > 0 && (
+          <>
+            {Array.from({ length: depth }).map((_, i) => (
+              <span
+                key={`ancestor-guide-${i}`}
+                aria-hidden="true"
+                className={cn(
+                  'pointer-events-none absolute top-0 bottom-0 w-px',
+                  isSelected ? 'bg-accent-foreground/30' : 'bg-border/70',
+                )}
+                style={{ left: TREE_ROW_HORIZONTAL_MARGIN + 8 + i * TREE_INDENT_WIDTH + 7 }}
+              />
+            ))}
+          </>
+        )}
         {entry.isDirectory ? (
           <ChevronRight
             className={cn(

--- a/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
@@ -665,11 +665,11 @@ function FileTreeItem({
         }}
         onClick={handleClick}
       >
-        {/* sticky 状态下画两种竖线：
-            1）祖先链竖线：贯穿整行，避免下一层 sticky 行的不透明背景遮挡上一层的子项引导线
-            2）自己的子项引导线：仅从三角中心下方（行中）画到行底，与下方子项容器的引导线无缝接续
+        {/* sticky 行内仅绘制祖先链竖线，贯穿整行；
+            自己的子项引导线交给下方子项容器（或下一层 sticky 子行的祖先线）负责，
+            使每个文件夹自身行内不会出现从三角下方延伸出的线，符合 VS Code 行为。
             选中态下 bg-accent 不透明背景会盖住原本的 border 色，换成 accent-foreground 以保证对比度 */}
-        {isSticky && (
+        {isSticky && depth > 0 && (
           <>
             {Array.from({ length: depth }).map((_, i) => (
               <span
@@ -682,14 +682,6 @@ function FileTreeItem({
                 style={{ left: TREE_ROW_HORIZONTAL_MARGIN + 8 + i * TREE_INDENT_WIDTH + 7 }}
               />
             ))}
-            <span
-              aria-hidden="true"
-              className={cn(
-                'pointer-events-none absolute bottom-0 w-px',
-                isSelected ? 'bg-accent-foreground/30' : 'bg-border/70',
-              )}
-              style={{ top: TREE_ROW_HEIGHT / 2, left: guideLeft }}
-            />
           </>
         )}
         {recentlyModifiedSet.has(entry.path) && (

--- a/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
@@ -667,20 +667,27 @@ function FileTreeItem({
       >
         {/* sticky 状态下画两种竖线：
             1）祖先链竖线：贯穿整行，避免下一层 sticky 行的不透明背景遮挡上一层的子项引导线
-            2）自己的子项引导线：仅从三角中心下方（行中）画到行底，与下方子项容器的引导线无缝接续 */}
+            2）自己的子项引导线：仅从三角中心下方（行中）画到行底，与下方子项容器的引导线无缝接续
+            选中态下 bg-accent 不透明背景会盖住原本的 border 色，换成 accent-foreground 以保证对比度 */}
         {isSticky && (
           <>
             {Array.from({ length: depth }).map((_, i) => (
               <span
                 key={`ancestor-guide-${i}`}
                 aria-hidden="true"
-                className="pointer-events-none absolute top-0 bottom-0 w-px bg-border/70"
+                className={cn(
+                  'pointer-events-none absolute top-0 bottom-0 w-px',
+                  isSelected ? 'bg-accent-foreground/30' : 'bg-border/70',
+                )}
                 style={{ left: TREE_ROW_HORIZONTAL_MARGIN + 8 + i * TREE_INDENT_WIDTH + 7 }}
               />
             ))}
             <span
               aria-hidden="true"
-              className="pointer-events-none absolute bottom-0 w-px bg-border/70"
+              className={cn(
+                'pointer-events-none absolute bottom-0 w-px',
+                isSelected ? 'bg-accent-foreground/30' : 'bg-border/70',
+              )}
               style={{ top: TREE_ROW_HEIGHT / 2, left: guideLeft }}
             />
           </>

--- a/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
@@ -629,15 +629,15 @@ function FileTreeItem({
     }
   }
 
-  const paddingLeft = 8 + depth * TREE_INDENT_WIDTH
-  const guideLeft = TREE_ROW_HORIZONTAL_MARGIN + paddingLeft + 7
+  // 统一铺满样式：paddingLeft 包含原本 mx-2 的 8px 外边距，避免 sticky/普通两种状态下文字位置偏移
+  const paddingLeft = TREE_ROW_HORIZONTAL_MARGIN + 8 + depth * TREE_INDENT_WIDTH
+  // 子项引导线位置：外边距已合进 paddingLeft，这里只需 +7 对齐箭头中心
+  const guideLeft = paddingLeft + 7
   const stickyDepth = Math.min(depth, MAX_STICKY_DEPTH)
   const stickyTop = stickyDepth * TREE_ROW_HEIGHT
   // 起点 10 已足够压住普通行内元素；保持外层目录在更上层以遮住下方滚过的内层。
   const stickyZIndex = Math.max(1, 10 - stickyDepth)
   const isSticky = entry.isDirectory && expanded
-  // sticky 状态下行铺满容器（去掉 mx-2 / rounded-lg），左侧文字需 +8 补偿失去的外边距
-  const effectivePaddingLeft = isSticky ? paddingLeft + TREE_ROW_HORIZONTAL_MARGIN : paddingLeft
   const showMenu = !isRenaming
   const menuSelectedCount = isSelected ? selectedCount : 1
 
@@ -648,10 +648,8 @@ function FileTreeItem({
         data-sticky-row={isSticky ? 'true' : undefined}
         className={cn(
           'relative flex h-8 items-center gap-1 pr-2 text-sm cursor-pointer group transition-colors',
-          isSticky
-            // sticky：铺满 + 不透明背景 + 底部阴影；多行紧贴时由 :has() 规则去除中间阴影
-            ? 'sticky bg-background shadow-[0_1px_0_hsl(var(--border)/0.6)]'
-            : 'mx-2 rounded-lg',
+          // sticky：不透明背景 + 底部阴影；多行紧贴时由 :has() 规则去除中间阴影
+          isSticky && 'sticky bg-background shadow-[0_1px_0_hsl(var(--border)/0.6)]',
           // sticky 行 hover 用不透明色，避免下方滚动内容透出；普通行保持半透明柔和感
           isSelected
             ? 'bg-accent'
@@ -661,17 +659,25 @@ function FileTreeItem({
           flash && 'file-browser-row-flash',
         )}
         style={{
-          paddingLeft: effectivePaddingLeft,
+          paddingLeft,
           top: isSticky ? stickyTop : undefined,
           zIndex: isSticky ? stickyZIndex : undefined,
         }}
         onClick={handleClick}
       >
+        {/* sticky 状态下在行内画一条层级竖线，位置与下方子项引导线对齐，实现 VS Code 那种横跨 sticky 区的连续竖线 */}
+        {isSticky && (
+          <span
+            aria-hidden="true"
+            className="pointer-events-none absolute top-0 bottom-0 w-px bg-border/70"
+            style={{ left: guideLeft }}
+          />
+        )}
         {recentlyModifiedSet.has(entry.path) && (
           <span
             aria-label="最近被 Agent 修改"
             className="absolute top-1/2 -translate-y-1/2 w-1.5 h-1.5 rounded-full bg-primary/80"
-            style={{ left: effectivePaddingLeft - 6 }}
+            style={{ left: paddingLeft - 6 }}
           />
         )}
         {/* 展开/收起图标 */}

--- a/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
@@ -635,6 +635,9 @@ function FileTreeItem({
   const stickyTop = stickyDepth * TREE_ROW_HEIGHT
   // 起点 10 已足够压住普通行内元素；保持外层目录在更上层以遮住下方滚过的内层。
   const stickyZIndex = Math.max(1, 10 - stickyDepth)
+  const isSticky = entry.isDirectory && expanded
+  // sticky 状态下行铺满容器（去掉 mx-2 / rounded-lg），左侧文字需 +8 补偿失去的外边距
+  const effectivePaddingLeft = isSticky ? paddingLeft + TREE_ROW_HORIZONTAL_MARGIN : paddingLeft
   const showMenu = !isRenaming
   const menuSelectedCount = isSelected ? selectedCount : 1
 
@@ -642,16 +645,25 @@ function FileTreeItem({
     <div className="relative" onClick={handleWrapperClick}>
       <div
         ref={rowRef}
+        data-sticky-row={isSticky ? 'true' : undefined}
         className={cn(
-          'relative flex h-8 items-center gap-1 pr-2 text-sm cursor-pointer group mx-2 rounded-lg transition-colors',
-          entry.isDirectory && expanded && 'sticky bg-background/95 backdrop-blur-sm shadow-[0_1px_0_hsl(var(--border)/0.45)]',
-          isSelected ? 'bg-accent' : 'hover:bg-accent/50',
+          'relative flex h-8 items-center gap-1 pr-2 text-sm cursor-pointer group transition-colors',
+          isSticky
+            // sticky：铺满 + 不透明背景 + 底部阴影；多行紧贴时由 :has() 规则去除中间阴影
+            ? 'sticky bg-background shadow-[0_1px_0_hsl(var(--border)/0.6)]'
+            : 'mx-2 rounded-lg',
+          // sticky 行 hover 用不透明色，避免下方滚动内容透出；普通行保持半透明柔和感
+          isSelected
+            ? 'bg-accent'
+            : isSticky
+              ? 'hover:bg-accent'
+              : 'hover:bg-accent/50',
           flash && 'file-browser-row-flash',
         )}
         style={{
-          paddingLeft,
-          top: entry.isDirectory && expanded ? stickyTop : undefined,
-          zIndex: entry.isDirectory && expanded ? stickyZIndex : undefined,
+          paddingLeft: effectivePaddingLeft,
+          top: isSticky ? stickyTop : undefined,
+          zIndex: isSticky ? stickyZIndex : undefined,
         }}
         onClick={handleClick}
       >
@@ -659,7 +671,7 @@ function FileTreeItem({
           <span
             aria-label="最近被 Agent 修改"
             className="absolute top-1/2 -translate-y-1/2 w-1.5 h-1.5 rounded-full bg-primary/80"
-            style={{ left: paddingLeft - 6 }}
+            style={{ left: effectivePaddingLeft - 6 }}
           />
         )}
         {/* 展开/收起图标 */}

--- a/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
@@ -46,6 +46,12 @@ import { cn } from '@/lib/utils'
 import { workspaceFilesVersionAtom, fileBrowserAutoRevealAtom, recentlyModifiedPathsAtom, currentAgentSessionIdAtom } from '@/atoms/agent-atoms'
 import type { FileEntry } from '@proma/shared'
 import { FileTypeIcon } from './FileTypeIcon'
+import {
+  computeTreeRowLayout,
+  AncestorGuides,
+  STICKY_ROW_BASE_CLASS,
+  canBeSticky,
+} from './tree-row-layout'
 
 /** 计算目标路径相对 rootPath 的祖先目录集合（不含 rootPath 自身、含目标的所有上级） */
 function computeRevealAncestors(rootPath: string, targetPath: string): Set<string> {
@@ -89,11 +95,6 @@ interface FileBrowserProps {
   /** 单击文件时在内联预览面板中显示（替代外部窗口预览） */
   onFilePreview?: (filePath: string) => void
 }
-
-const TREE_ROW_HEIGHT = 32
-const TREE_ROW_HORIZONTAL_MARGIN = 8
-const TREE_INDENT_WIDTH = 16
-const MAX_STICKY_DEPTH = 4
 
 export function FileBrowser({ rootPath, hideToolbar, embedded, hideEmpty, onAddToChat, onFilePreview }: FileBrowserProps): React.ReactElement {
   const [entries, setEntries] = React.useState<FileEntry[]>([])
@@ -629,15 +630,8 @@ function FileTreeItem({
     }
   }
 
-  // 统一铺满样式：paddingLeft 包含原本 mx-2 的 8px 外边距，避免 sticky/普通两种状态下文字位置偏移
-  const paddingLeft = TREE_ROW_HORIZONTAL_MARGIN + 8 + depth * TREE_INDENT_WIDTH
-  // 子项引导线位置：外边距已合进 paddingLeft，这里只需 +7 对齐箭头中心
-  const guideLeft = paddingLeft + 7
-  const stickyDepth = Math.min(depth, MAX_STICKY_DEPTH)
-  const stickyTop = stickyDepth * TREE_ROW_HEIGHT
-  // 起点 10 已足够压住普通行内元素；保持外层目录在更上层以遮住下方滚过的内层。
-  const stickyZIndex = Math.max(1, 10 - stickyDepth)
-  const isSticky = entry.isDirectory && expanded
+  const { paddingLeft, guideLeft, stickyTop, stickyZIndex } = computeTreeRowLayout(depth)
+  const isSticky = entry.isDirectory && expanded && canBeSticky(depth)
   const showMenu = !isRenaming
   const menuSelectedCount = isSelected ? selectedCount : 1
 
@@ -648,8 +642,7 @@ function FileTreeItem({
         data-sticky-row={isSticky ? 'true' : undefined}
         className={cn(
           'relative flex h-8 items-center gap-1 pr-2 text-sm cursor-pointer group transition-colors',
-          // sticky：不透明背景 + 底部阴影；多行紧贴时由 :has() 规则去除中间阴影
-          isSticky && 'sticky bg-background shadow-[0_1px_0_hsl(var(--border)/0.6)]',
+          isSticky && STICKY_ROW_BASE_CLASS,
           // sticky 行 hover 用不透明色，避免下方滚动内容透出；普通行保持半透明柔和感
           isSelected
             ? 'bg-accent'
@@ -665,25 +658,8 @@ function FileTreeItem({
         }}
         onClick={handleClick}
       >
-        {/* sticky 行内仅绘制祖先链竖线，贯穿整行；
-            自己的子项引导线交给下方子项容器（或下一层 sticky 子行的祖先线）负责，
-            使每个文件夹自身行内不会出现从三角下方延伸出的线，符合 VS Code 行为。
-            选中态下 bg-accent 不透明背景会盖住原本的 border 色，换成 accent-foreground 以保证对比度 */}
-        {isSticky && depth > 0 && (
-          <>
-            {Array.from({ length: depth }).map((_, i) => (
-              <span
-                key={`ancestor-guide-${i}`}
-                aria-hidden="true"
-                className={cn(
-                  'pointer-events-none absolute top-0 bottom-0 w-px',
-                  isSelected ? 'bg-accent-foreground/30' : 'bg-border/70',
-                )}
-                style={{ left: TREE_ROW_HORIZONTAL_MARGIN + 8 + i * TREE_INDENT_WIDTH + 7 }}
-              />
-            ))}
-          </>
-        )}
+        {/* sticky 行祖先链竖线，逻辑见 tree-row-layout.tsx 的 AncestorGuides */}
+        {isSticky && <AncestorGuides depth={depth} isSelected={isSelected} />}
         {recentlyModifiedSet.has(entry.path) && (
           <span
             aria-label="最近被 Agent 修改"

--- a/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
@@ -665,13 +665,25 @@ function FileTreeItem({
         }}
         onClick={handleClick}
       >
-        {/* sticky 状态下在行内画一条层级竖线，位置与下方子项引导线对齐，实现 VS Code 那种横跨 sticky 区的连续竖线 */}
+        {/* sticky 状态下画两种竖线：
+            1）祖先链竖线：贯穿整行，避免下一层 sticky 行的不透明背景遮挡上一层的子项引导线
+            2）自己的子项引导线：仅从三角中心下方（行中）画到行底，与下方子项容器的引导线无缝接续 */}
         {isSticky && (
-          <span
-            aria-hidden="true"
-            className="pointer-events-none absolute top-0 bottom-0 w-px bg-border/70"
-            style={{ left: guideLeft }}
-          />
+          <>
+            {Array.from({ length: depth }).map((_, i) => (
+              <span
+                key={`ancestor-guide-${i}`}
+                aria-hidden="true"
+                className="pointer-events-none absolute top-0 bottom-0 w-px bg-border/70"
+                style={{ left: TREE_ROW_HORIZONTAL_MARGIN + 8 + i * TREE_INDENT_WIDTH + 7 }}
+              />
+            ))}
+            <span
+              aria-hidden="true"
+              className="pointer-events-none absolute bottom-0 w-px bg-border/70"
+              style={{ top: TREE_ROW_HEIGHT / 2, left: guideLeft }}
+            />
+          </>
         )}
         {recentlyModifiedSet.has(entry.path) && (
           <span

--- a/apps/electron/src/renderer/components/file-browser/index.ts
+++ b/apps/electron/src/renderer/components/file-browser/index.ts
@@ -5,3 +5,4 @@
 export * from './FileBrowser'
 export * from './FileDropZone'
 export * from './FileTypeIcon'
+export * from './tree-row-layout'

--- a/apps/electron/src/renderer/components/file-browser/tree-row-layout.tsx
+++ b/apps/electron/src/renderer/components/file-browser/tree-row-layout.tsx
@@ -1,0 +1,80 @@
+/**
+ * 文件树行的共享布局常量与祖先链竖线渲染。
+ * FileBrowser 与 SidePanel 的附加目录树共用同一套 sticky / 引导线视觉。
+ */
+
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+const TREE_ROW_HEIGHT = 32
+const TREE_ROW_HORIZONTAL_MARGIN = 8
+const TREE_INDENT_WIDTH = 16
+/**
+ * sticky 栈最多堆叠的层数，超出此深度的目录行不再 sticky（随滚动消失），
+ * 避免多层重叠在同一 top 槽位导致下层覆盖上层。参考 VS Code Explorer 默认 = 7。
+ */
+const MAX_STICKY_DEPTH = 8
+
+/** depth 是否允许作为 sticky 行（超出栈深的层退化为普通滚动行）。 */
+export function canBeSticky(depth: number): boolean {
+  return depth < MAX_STICKY_DEPTH
+}
+
+/**
+ * sticky 目录行的基础视觉样式：position: sticky + 与列表容器一致的不透明底色。
+ * 不包含 top / z-index 定位——调用方需自行通过 inline style（用 computeTreeRowLayout 的结果）
+ * 或 Tailwind 的 top- / z- class 指定。深度 > 0 的递归节点用 inline style 传动态值；
+ * 固定 depth=0 的根行可直接拼 'top-0 z-10'。
+ * 阴影由 globals.css 中的 :has() 规则按 sticky 链路最末一行动态附加。
+ */
+export const STICKY_ROW_BASE_CLASS = 'sticky bg-content-area'
+
+export interface TreeRowLayout {
+  paddingLeft: number
+  guideLeft: number
+  stickyTop: number
+  stickyZIndex: number
+}
+
+export function computeTreeRowLayout(depth: number): TreeRowLayout {
+  // paddingLeft 合并原本 mx-2 的 8px 外边距，避免 sticky/普通两种状态下文字位置左右跳动
+  const paddingLeft = TREE_ROW_HORIZONTAL_MARGIN + 8 + depth * TREE_INDENT_WIDTH
+  // 调用方保证 depth < MAX_STICKY_DEPTH 才会启用 sticky，所以这里直接乘 depth 即可
+  return {
+    paddingLeft,
+    // 外边距已合进 paddingLeft，guideLeft 只需 +7 对齐箭头中心
+    guideLeft: paddingLeft + 7,
+    stickyTop: depth * TREE_ROW_HEIGHT,
+    // 起点 10 已足够压住普通行内元素；保持外层目录在更上层以遮住下方滚过的内层。
+    stickyZIndex: Math.max(1, 10 - depth),
+  }
+}
+
+interface AncestorGuidesProps {
+  depth: number
+  isSelected: boolean
+}
+
+/**
+ * sticky 行内按 depth 绘制祖先链竖线，贯穿整行。
+ * 自己的子项引导线不在这里绘制——交给下方子项容器（或下层 sticky 子行的祖先线）。
+ * 选中态下用 accent-foreground/30 替代 border/70，避免被 bg-accent 不透明背景吃掉对比度。
+ */
+export function AncestorGuides({ depth, isSelected }: AncestorGuidesProps): React.ReactElement | null {
+  if (depth <= 0) return null
+  return (
+    <>
+      {Array.from({ length: depth }).map((_, i) => (
+        <span
+          key={`ancestor-guide-${i}`}
+          aria-hidden="true"
+          className={cn(
+            'pointer-events-none absolute top-0 bottom-0 w-px',
+            isSelected ? 'bg-accent-foreground/30' : 'bg-border/70',
+          )}
+          style={{ left: TREE_ROW_HORIZONTAL_MARGIN + 8 + i * TREE_INDENT_WIDTH + 7 }}
+        />
+      ))}
+    </>
+  )
+}

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -898,10 +898,11 @@
   animation: file-browser-flash 1.2s ease-out;
 }
 
-/* ===== FileBrowser sticky 目录行：下一个直接子行也是 sticky 时去掉本行阴影 =====
-   DOM 结构：[wrapper] > ([sticky row] + [children-container] > [child-wrapper] > [sticky row])
-   使用 :has() 穿透下一层判定，避免多行 sticky 紧贴时 1px 阴影叠加成实线分割 */
-[data-sticky-row="true"]:has(+ div > div:first-of-type > [data-sticky-row="true"]) {
+/* ===== FileBrowser sticky 目录行：子项区内存在 sticky 后代时去掉本行阴影 =====
+   :has() 不限制子项顺序，只要本行的子项区里任意位置存在其他 sticky 目录，
+   表示该 sticky 后代随时可能被钉上来与本行紧贴，预先去掉本行 1px 底部阴影避免叠加出实线分割。
+   只有叶子 sticky（子项里不含其他 sticky 目录）会保留阴影，作为 sticky 区底部与滚动区的分隔 */
+[data-sticky-row="true"]:has(+ div [data-sticky-row="true"]) {
   box-shadow: none !important;
 }
 

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -898,6 +898,13 @@
   animation: file-browser-flash 1.2s ease-out;
 }
 
+/* ===== FileBrowser sticky 目录行：下一个直接子行也是 sticky 时去掉本行阴影 =====
+   DOM 结构：[wrapper] > ([sticky row] + [children-container] > [child-wrapper] > [sticky row])
+   使用 :has() 穿透下一层判定，避免多行 sticky 紧贴时 1px 阴影叠加成实线分割 */
+[data-sticky-row="true"]:has(+ div > div:first-of-type > [data-sticky-row="true"]) {
+  box-shadow: none !important;
+}
+
 /* ===== Office 内联预览 ===== */
 .office-preview-host {
   min-height: 100%;

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -898,12 +898,14 @@
   animation: file-browser-flash 1.2s ease-out;
 }
 
-/* ===== FileBrowser sticky 目录行：子项区内存在 sticky 后代时去掉本行阴影 =====
-   :has() 不限制子项顺序，只要本行的子项区里任意位置存在其他 sticky 目录，
-   表示该 sticky 后代随时可能被钉上来与本行紧贴，预先去掉本行 1px 底部阴影避免叠加出实线分割。
-   只有叶子 sticky（子项里不含其他 sticky 目录）会保留阴影，作为 sticky 区底部与滚动区的分隔 */
-[data-sticky-row="true"]:has(+ div [data-sticky-row="true"]) {
-  box-shadow: none !important;
+/* ===== FileBrowser sticky 目录行：每条 sticky 链路最末一行加一道软扩散阴影 =====
+   :has() 选择器只能向后看 sticky 行同一父级内的兄弟，所以 "栈最末" 实际语义是
+   "本节点子树内不再有更深的 sticky 子行"。
+   - 单棵展开链路：只有最深一层 sticky 子行有阴影（父行的子项容器内含子 sticky，被规则排除）。
+   - 多个平行展开（多个根目录同时打开）：每条链路各自一道阴影——这里把每棵独立树视为独立视觉单元。
+   要做到全局唯一一道阴影需要 JS 监听滚动 + 展开状态动态打标记，目前不做。 */
+[data-sticky-row="true"]:not(:has(~ * [data-sticky-row="true"])) {
+  box-shadow: 0 2px 4px -1px hsl(var(--foreground) / 0.08);
 }
 
 /* ===== Office 内联预览 ===== */


### PR DESCRIPTION
## Overview

把 FileBrowser 主文件树和 SidePanel 附加目录树的 sticky 目录行视觉统一对齐 VS Code Explorer 风格——铺满无圆角、不透明背景、祖先链竖线贯穿、多层堆叠时只在栈最末画一道软扩散阴影。同时把两份组件之间复制粘贴的 sticky 渲染逻辑抽到共享模块 `tree-row-layout.tsx`，消除手抄副本，避免后续调样式两边漂移。

## Changes

- `apps/electron/src/renderer/components/file-browser/tree-row-layout.tsx` —— **新增**共享模块，导出 `STICKY_ROW_BASE_CLASS`、`computeTreeRowLayout(depth)`、`<AncestorGuides depth isSelected />`、`canBeSticky(depth)`。布局常量（行高 32 / 缩进 16 / sticky 上限 8）模块内部化，不对外暴露。
- `apps/electron/src/renderer/components/file-browser/FileBrowser.tsx` —— `FileTreeItem` 切换到共享模块；sticky 行底色改为 `bg-content-area`；`isSticky` 加上 `canBeSticky(depth)` 限制。
- `apps/electron/src/renderer/components/agent/SidePanel.tsx` —— `AttachedDirTree`（depth=0 根行）和 `AttachedDirItem`（递归子项）同步切换到共享模块，删除本地常量与重复 JSX；删除过时的「与 FileBrowser 保持一致」手抄注释。
- `apps/electron/src/renderer/components/file-browser/index.ts` —— 导出新模块。
- `apps/electron/src/renderer/styles/globals.css` —— sticky 行阴影规则改为 `:not(:has(~ * [data-sticky-row="true"]))`，仅给 sticky 链路最末一行加 `0 2px 4px -1px hsl(var(--foreground)/0.08)` 的软扩散阴影；其他 sticky 行无阴影，多层堆叠紧贴一气呵成。

## How to Test

1. 启动 Agent，打开侧边栏的文件浏览器。
2. 展开多层嵌套目录（建议 4 层以上），向下滚动让上层目录被钉到顶部，确认：
   - sticky 行底色与列表底色一致，不再有色差。
   - sticky 行无圆角，铺满整行；hover 用不透明 `bg-accent`，下方滚动内容不会透出。
   - 整条 sticky 链路紧贴成一块，只在最末那行有一道柔和的下扩散阴影。
   - 选中态下 sticky 行的祖先链竖线仍能看清（用 `accent-foreground/30`）。
3. 展开极深目录（≥8 层），滚动后超出第 8 层的目录会随滚动消失而不是叠在同一位置；不再出现「上层被下层挡住」的视觉重叠。
4. 切换到工作区/会话级附加目录区域（SidePanel 中），重复上述场景，行为应与主文件树完全一致。
5. 切换到非默认主题（ocean / forest / deepviolet / desert，深浅各一）抽查一遍，sticky 行底色应在每个主题下都与容器对齐。

## Notes

- 多个根目录平行展开时，每条 sticky 链路会各自有一道阴影（CSS `:has()` 选择器只能向后看同一父级内的兄弟，不能跨 wrapper 树识别"全局最末"）。把每棵展开树视为独立视觉单元是预期行为；要做到全局唯一阴影需要 JS 监听滚动 + 展开状态动态打标记，本 PR 暂不引入这层复杂度。
- 整个 PR 类型严格：`bun run typecheck` 全部 4 个 package（shared/core/ui/electron）exit 0，无新增类型错误，无破坏性 API 变更。
- 改动范围仅限渲染层（className、style、装饰元素），不触碰任何 IPC、状态管理、storage、reveal/重命名/移动 等行为分支。
