### PR TITLE
feat(diff): 文件改动列表新增搜索过滤框

### DIFF
--- a/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
@@ -52,7 +52,7 @@ const SOURCE_CONFIG: Record<string, { color: string; label: string }> = {
   none: { color: 'bg-muted text-muted-foreground', label: '附加目录文件' },
 }
 
-export function DiffChangesList({
+export const DiffChangesList = React.memo(function DiffChangesList({
   dirPath,
   sessionPath,
   sessionId,
@@ -160,6 +160,8 @@ export function DiffChangesList({
     return untrackedFiles.filter((f) => f.filePath.toLowerCase().includes(q))
   }, [untrackedFiles, searchQuery])
 
+  const isEmpty = fileGroups.length === 0 && filteredUntrackedFiles.length === 0
+
   // 非 Git 仓库
   if (!isGitRepo) {
     return (
@@ -181,11 +183,12 @@ export function DiffChangesList({
   return (
     <div className="flex flex-col h-full overflow-y-auto">
       {/* 搜索框 — 有改动文件时才显示 */}
-      <div className="flex-shrink-0 sticky top-0 z-10 px-2 pt-1.5 pb-1">
-        <div className="flex items-center gap-1.5 px-2 h-7 rounded-md bg-muted/40 border border-transparent focus-within:border-primary/40 focus-within:bg-muted/70 transition-colors">
+      <div className="flex-shrink-0 sticky top-0 z-10 bg-content-area px-2 pt-1.5 pb-1">
+        <div className="flex items-center gap-1.5 px-2 h-7 rounded-md bg-muted/50 border border-transparent focus-within:border-primary/40 focus-within:bg-muted/70 transition-colors">
           <Search className="size-3 text-muted-foreground flex-shrink-0" />
           <input
             type="text"
+            aria-label="搜索改动文件"
             className="flex-1 bg-transparent text-[11px] outline-none placeholder:text-muted-foreground/40"
             placeholder="搜索改动文件..."
             value={searchQuery}
@@ -198,6 +201,7 @@ export function DiffChangesList({
               </span>
               <button
                 type="button"
+                aria-label="清除搜索"
                 className="flex-shrink-0 p-0.5 rounded-sm hover:bg-foreground/[0.08] text-muted-foreground/50 hover:text-muted-foreground transition-colors"
                 onClick={() => setSearchQuery('')}
               >
@@ -208,11 +212,12 @@ export function DiffChangesList({
         </div>
       </div>
 
-      {fileGroups.length === 0 && filteredUntrackedFiles.length === 0 ? (
+      {isEmpty && (
         <div className="flex flex-col items-center justify-center h-full text-muted-foreground p-4">
           <p className="text-[12px] text-center">没有匹配的文件</p>
         </div>
-      ) : (
+      )}
+      {!isEmpty && (
         <>
       {fileGroups.map((group) => {
         const isCollapsed = collapsedDirs.has(group.gitRoot)
@@ -282,7 +287,7 @@ export function DiffChangesList({
       )}
     </div>
   )
-}
+})
 
 /** 已追踪文件的行 */
 function FileRow({

--- a/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
@@ -5,7 +5,7 @@
  */
 
 import * as React from 'react'
-import { ChevronRight, Undo2 } from 'lucide-react'
+import { ChevronRight, Search, Undo2, X } from 'lucide-react'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -66,6 +66,7 @@ export function DiffChangesList({
   const [untrackedFiles, setUntrackedFiles] = React.useState<UntrackedFileEntry[]>([])
   const [isGitRepo, setIsGitRepo] = React.useState(true)
   const [collapsedDirs, setCollapsedDirs] = React.useState<Set<string>>(new Set())
+  const [searchQuery, setSearchQuery] = React.useState('')
   /** 单调递增的 fetch 序号，用于丢弃乱序到达的旧响应 */
   const fetchSeqRef = React.useRef(0)
 
@@ -134,9 +135,11 @@ export function DiffChangesList({
 
   // 按 Git 仓库分组（在所有 hooks 之后、条件返回之前调用）
   const fileGroups: FileGroup[] = React.useMemo(() => {
+    const q = searchQuery.toLowerCase().trim()
     // 用完整 gitRoot 做 key，避免同名目录冲突
     const groups = new Map<string, ChangedFileEntry[]>()
     for (const f of files) {
+      if (q && !f.filePath.toLowerCase().includes(q)) continue
       const key = f.gitRoot || ''
       if (!groups.has(key)) groups.set(key, [])
       groups.get(key)!.push(f)
@@ -149,7 +152,13 @@ export function DiffChangesList({
       totalDeletions: groupFiles.reduce((sum, f) => sum + f.deletions, 0),
       sources: [...new Set(groupFiles.map((f) => f.source))],
     }))
-  }, [files])
+  }, [files, searchQuery])
+
+  const filteredUntrackedFiles = React.useMemo(() => {
+    const q = searchQuery.toLowerCase().trim()
+    if (!q) return untrackedFiles
+    return untrackedFiles.filter((f) => f.filePath.toLowerCase().includes(q))
+  }, [untrackedFiles, searchQuery])
 
   // 非 Git 仓库
   if (!isGitRepo) {
@@ -171,6 +180,40 @@ export function DiffChangesList({
 
   return (
     <div className="flex flex-col h-full overflow-y-auto">
+      {/* 搜索框 — 有改动文件时才显示 */}
+      <div className="flex-shrink-0 sticky top-0 z-10 px-2 pt-1.5 pb-1">
+        <div className="flex items-center gap-1.5 px-2 h-7 rounded-md bg-muted/40 border border-transparent focus-within:border-primary/40 focus-within:bg-muted/70 transition-colors">
+          <Search className="size-3 text-muted-foreground flex-shrink-0" />
+          <input
+            type="text"
+            className="flex-1 bg-transparent text-[11px] outline-none placeholder:text-muted-foreground/40"
+            placeholder="搜索改动文件..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+          />
+          {searchQuery && (
+            <>
+              <span className="text-[10px] text-muted-foreground/50 flex-shrink-0 tabular-nums">
+                {fileGroups.reduce((sum, g) => sum + g.files.length, 0) + filteredUntrackedFiles.length}
+              </span>
+              <button
+                type="button"
+                className="flex-shrink-0 p-0.5 rounded-sm hover:bg-foreground/[0.08] text-muted-foreground/50 hover:text-muted-foreground transition-colors"
+                onClick={() => setSearchQuery('')}
+              >
+                <X className="size-3" />
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {fileGroups.length === 0 && filteredUntrackedFiles.length === 0 ? (
+        <div className="flex flex-col items-center justify-center h-full text-muted-foreground p-4">
+          <p className="text-[12px] text-center">没有匹配的文件</p>
+        </div>
+      ) : (
+        <>
       {fileGroups.map((group) => {
         const isCollapsed = collapsedDirs.has(group.gitRoot)
         return (
@@ -221,12 +264,12 @@ export function DiffChangesList({
       })}
 
       {/* 未追踪文件分组 */}
-      {untrackedFiles.length > 0 && (
+      {filteredUntrackedFiles.length > 0 && (
         <div>
           <div className="flex items-center px-2 py-2 text-[13px] font-medium text-muted-foreground border-t border-border/30">
             未追踪文件
           </div>
-          {untrackedFiles.map((file) => (
+          {filteredUntrackedFiles.map((file) => (
             <UntrackedFileRow
               key={`${file.gitRoot}:${file.filePath}`}
               file={file}
@@ -234,6 +277,8 @@ export function DiffChangesList({
             />
           ))}
         </div>
+      )}
+        </>
       )}
     </div>
   )


### PR DESCRIPTION
## 概述
在 RightSidebar 的「文件改动」列表顶部新增搜索过滤框，支持按文件名实时过滤改动文件和未追踪文件，并含一键清除按钮。无改动时搜索框自动隐藏。

## 改动
- `apps/electron/src/renderer/components/diff/DiffChangesList.tsx` — 新增搜索框 UI（Search 图标 + 输入框 + 清除按钮），搜索按文件路径过滤 `fileGroups` 和 `untrackedFiles`，全部过滤后显示「没有匹配的文件」。搜索框 sticky 吸顶，不透明背板防止滚动穿透。搜索框背景色和未选中 tab 一致（`bg-muted/50`），无改动时随组件提前返回而隐藏。包 `React.memo` 优化渲染。输入框和清除按钮加了 `aria-label`。

## 如何测试
1. 打开 Agent 模式，在右侧面板切到「文件改动」tab
2. 确认有文件改动时搜索框出现在列表顶部
3. 在搜索框输入关键词，确认文件列表实时过滤
4. 点击 X 按钮，确认一键清除搜索内容
5. 确认搜索过滤掉全部文件后显示「没有匹配的文件」
6. 确认没有任何改动时搜索框不显示
7. 切换不同主题，确认搜索框背景色和上方未选中 tab 颜色一致

## 备注
- 搜索框 UI 样式参考了 `FileSearchBar` 组件
- 对 untracked files 同样生效