### PR TITLE
fix(agent): 自动预览未读红点与 DiffChangesList 范围对齐

### DIFF
--- a/apps/electron/src/renderer/atoms/preview-atoms.ts
+++ b/apps/electron/src/renderer/atoms/preview-atoms.ts
@@ -21,6 +21,8 @@ export interface PreviewFile {
   readOnly?: boolean
   /** 候选基础目录（用于相对路径解析） */
   basePaths?: string[]
+  /** 文件是否落在当前会话的 diff scope 内（与 getUnstagedChanges 的 candidates 对齐） */
+  inDiffScope?: boolean
 }
 
 // ===== Atoms =====

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -425,10 +425,27 @@ export function useGlobalAgentListeners(): void {
         }
       }
 
+      // 检查文件是否落在当前会话的 diff scope 内（与 getUnstagedChanges 的 candidates 对齐）
+      // 注：未纳入 dirPath，因为 DiffChangesList 调用时 dirPath 始终等于 sessionPath
+      const sessionScopePaths = uniqueTruthyPaths([
+        sessionPath,
+        workspaceFilesPath,
+        ...sessionAttachedDirs,
+        ...workspaceAttachedDirs,
+      ])
+      const absTarget = isAbsolutePath(targetPath)
+        ? targetPath
+        : (sessionPath ? `${sessionPath.replace(/[/\\]+$/, '')}/${targetPath}` : targetPath)
+      const inDiffScope = sessionScopePaths.some((root) => {
+        const r = root.replace(/[/\\]+$/, '') + '/'
+        return absTarget === root || absTarget.startsWith(r)
+      })
+
       return {
         filePath: targetPath,
         dirPath: dirPath || undefined,
         previewOnly,
+        inDiffScope,
         basePaths: basePaths.length > 0 ? basePaths : undefined,
       }
     }
@@ -654,7 +671,7 @@ export function useGlobalAgentListeners(): void {
                   : buildAutoPreviewFile(sessionId, writtenPath)
 
                 previewPromise.then((previewFile) => {
-                  if (!previewFile || previewFile.previewOnly) return
+                  if (!previewFile || previewFile.previewOnly || !previewFile.inDiffScope) return
 
                   store.set(agentDiffUnseenChangesAtom, (prev) => {
                     const m = new Map(prev); m.set(sessionId, true); return m


### PR DESCRIPTION
## 概述

修复 Agent 自动预览的「未读红点 / 未查看文件集 / 自动切到 changes Tab」副作用链与 `DiffChangesList` 实际展示范围不一致的问题。

此前只要 Agent 触发任何写类工具（`Write` / `Edit` / `MultiEdit` / `NotebookEdit` / `Update`）完成，红点就会被点亮、文件被加入 `agentDiffUnseenFilesAtom`、且在开启自动预览时切到 changes Tab。但是 `DiffChangesList` 调用 `getUnstagedChanges` 时传入的候选目录集合（`dirPath + sessionPath + workspaceFilesPath + extraPaths`）实际只覆盖：

- 会话目录 `sessionPath`
- 工作区共享文件目录 `workspaceFilesPath`
- 会话级附加目录 `sessionAttachedDirs`
- 工作区级附加目录 `workspaceAttachedDirs`

当 Agent 通过绝对路径写入上述 scope 之外的文件时，会出现**红点亮起、但 changes 列表里找不到对应文件**的视觉错配。

## 修复方案

在 `tool_result` 触发副作用前，先判定写入路径是否落在「会话 diff scope」内：

- 字段：在 `PreviewFile` 接口上新增可选字段 `inDiffScope?: boolean`
- 判定：在 `buildAutoPreviewFile` 中收集与 `getUnstagedChanges` 服务端 `candidates` 等价的根目录集合，对 `targetPath` 做绝对化后用 `startsWith` 判定
- Gate：在写入红点 / 未查看集 / 切换 Tab 之前，新增 `!previewFile.inDiffScope` 短路条件，scope 外的写操作直接 `return`，不触发任何副作用

注：未纳入 `dirPath`，因为 `DiffChangesList` 在 `SidePanel` 中调用时 `dirPath` 始终等于 `sessionPath`；未纳入 `attachedFiles`，因为服务端 `extraPaths` 也只放了 `attachedDirs`（保持与 `getUnstagedChanges` 完全对齐）。

## 改动文件

- `apps/electron/src/renderer/atoms/preview-atoms.ts` — `PreviewFile` 接口新增 `inDiffScope?: boolean` 字段，注释说明与 `getUnstagedChanges` 候选目录对齐
- `apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts` —
  - `buildAutoPreviewFile`：新增 `sessionScopePaths` 集合和 `inDiffScope` 计算逻辑，归一化路径末尾分隔符后做前缀匹配；将 `inDiffScope` 写入返回的 `PreviewFile`
  - `tool_result` 写类工具完成分支：将 `if (!previewFile || previewFile.previewOnly) return` 收紧为 `if (!previewFile || previewFile.previewOnly || !previewFile.inDiffScope) return`

## 验证方式

1. 启动 Agent 会话，开启自动预览
2. 让 Agent 编辑**会话目录或工作区目录内**的文件 → 预期：红点点亮、文件出现在 changes Tab、(若开启自动预览且侧边栏打开) Tab 自动切到 changes
3. 让 Agent 通过**绝对路径**编辑会话 scope 之外的文件（例如 `/tmp/foo.txt`）→ 预期：红点**不**点亮、不切换 Tab、`agentDiffUnseenFilesAtom` 中也不会出现该文件
4. 编辑会话级 / 工作区级附加目录中的文件 → 预期：与会话目录行为一致
5. `bun run typecheck` 全绿（已验证）

## 备注

- 类型检查：`@proma/shared` / `@proma/core` / `@proma/ui` / `@proma/electron` 全部通过
- 无行为变更的副作用：仅是把已点亮但本就显示不出来的红点收敛掉，对原本能正常工作的场景无影响
- 风险面：仅影响 `tool_result` 后的副作用副链，不影响消息流、不影响主进程逻辑、不影响 `getUnstagedChanges` 本身
