### PR TITLE
fix(agent): 按 session 切片待发送附件并修复关闭 Tab 时的内存泄漏

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.9.45",
+  "version": "0.9.46",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -232,8 +232,35 @@ export const liveMessagesMapAtom = atom<Map<string, SDKMessage[]>>(new Map())
 
 export const agentPendingPromptAtom = atom<AgentPendingPrompt | null>(null)
 
-/** Agent 待发送文件列表 */
-export const agentPendingFilesAtom = atom<AgentPendingFile[]>([])
+/**
+ * Agent 待发送文件列表 Map — 以 sessionId 为 key
+ * 切换会话时保留各 session 自己的 pending files，与文字草稿语义一致
+ */
+export const agentSessionPendingFilesAtom = atom<Map<string, AgentPendingFile[]>>(new Map())
+
+/**
+ * 单个 session 的 pending files 派生 atom（读写）— 按 sessionId 切片
+ * read：返回当前 session 的数组（空数组兜底）
+ * write：接受新数组或 updater 函数，写回时空数组转为 delete，避免 Map 长期残留空 entry
+ */
+export const agentPendingFilesAtomFamily = atomFamily((sessionId: string) =>
+  atom(
+    (get) => get(agentSessionPendingFilesAtom).get(sessionId) ?? [],
+    (_get, set, update: AgentPendingFile[] | ((prev: AgentPendingFile[]) => AgentPendingFile[])) => {
+      set(agentSessionPendingFilesAtom, (prev) => {
+        const current = prev.get(sessionId) ?? []
+        const next = typeof update === 'function' ? update(current) : update
+        const map = new Map(prev)
+        if (next.length === 0) {
+          map.delete(sessionId)
+        } else {
+          map.set(sessionId, next)
+        }
+        return map
+      })
+    },
+  ),
+)
 
 /** 工作区能力版本号 — 每次修改 MCP/Skills 后自增，触发侧边栏重新获取 */
 export const workspaceCapabilitiesVersionAtom = atom(0)

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -61,7 +61,7 @@ import {
   agentSessionModelMapAtom,
   currentAgentWorkspaceIdAtom,
   agentPendingPromptAtom,
-  agentPendingFilesAtom,
+  agentPendingFilesAtomFamily,
   agentWorkspacesAtom,
   agentStreamErrorsAtom,
   agentSessionDraftsAtom,
@@ -341,7 +341,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     return meta.workspaceId ?? null     // 数据已加载，以会话自身为准
   }, [sessions, sessionId, globalWorkspaceId])
   const [pendingPrompt, setPendingPrompt] = useAtom(agentPendingPromptAtom)
-  const [pendingFiles, setPendingFiles] = useAtom(agentPendingFilesAtom)
+  const [pendingFiles, setPendingFiles] = useAtom(agentPendingFilesAtomFamily(sessionId))
   const workspaces = useAtomValue(agentWorkspacesAtom)
   // 保持 channelId 稳定：初始化前使用上次有效值，避免工具栏抖动
   const stableChannelIdRef = React.useRef(agentChannelId)

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -29,7 +29,7 @@ import {
   agentAttachedFilesMapAtom,
   workspaceAttachedDirectoriesMapAtom,
   workspaceAttachedFilesMapAtom,
-  agentPendingFilesAtom,
+  agentPendingFilesAtomFamily,
   agentDiffRefreshVersionAtom,
 } from '@/atoms/agent-atoms'
 import { previewPanelOpenMapAtom, previewFileMapAtom } from '@/atoms/preview-atoms'
@@ -313,8 +313,8 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   }, [setFilesVersion])
 
   // 添加文件到聊天
-  const pendingFiles = useAtomValue(agentPendingFilesAtom)
-  const setPendingFiles = useSetAtom(agentPendingFilesAtom)
+  const pendingFiles = useAtomValue(agentPendingFilesAtomFamily(sessionId))
+  const setPendingFiles = useSetAtom(agentPendingFilesAtomFamily(sessionId))
   const handleAddToChat = React.useCallback((entry: FileEntry) => {
     // 先在 setter 外部检查去重，避免在 updater 函数内执行不可逆副作用
     if (pendingFiles.some((f) => f.sourcePath === entry.path)) return

--- a/apps/electron/src/renderer/hooks/useCloseTab.tsx
+++ b/apps/electron/src/renderer/hooks/useCloseTab.tsx
@@ -11,7 +11,7 @@
  */
 
 import * as React from 'react'
-import { atom, useAtom, useAtomValue, useSetAtom } from 'jotai'
+import { atom, useAtom, useAtomValue, useSetAtom, useStore } from 'jotai'
 import {
   tabsAtom,
   activeTabIdAtom,
@@ -29,6 +29,8 @@ import {
   agentSessionStreamingStateAtomFamily,
   agentSessionDraftAtomFamily,
   agentSessionDraftHtmlAtomFamily,
+  agentSessionPendingFilesAtom,
+  agentPendingFilesAtomFamily,
   backgroundTasksAtomFamily,
   sessionPersistedPermissionModeAtom,
   sessionExistsAtom,
@@ -77,6 +79,8 @@ export function useCloseTab(): UseCloseTabReturn {
 
   const setStreamingStates = useSetAtom(agentStreamingStatesAtom)
   const setLiveMessagesMap = useSetAtom(liveMessagesMapAtom)
+  const setSessionPendingFiles = useSetAtom(agentSessionPendingFilesAtom)
+  const store = useStore()
 
   const cleanupMapAtoms = React.useCallback((tabId: string) => {
     const deleteKey = <T,>(prev: Map<string, T>): Map<string, T> => {
@@ -102,17 +106,28 @@ export function useCloseTab(): UseCloseTabReturn {
     // base map：草稿和错误信息体积小，保留可让用户重开 tab 时恢复输入与错误回显
     setStreamingStates(deleteKey)
     setLiveMessagesMap(deleteKey)
+    // 清理该 session 的待发送附件：释放 blob URL 和 window 缓存中的 base64，再删 base map entry
+    // 与文字草稿不同，附件涉及 ObjectURL 和大体积二进制数据，不保留语义
+    const sessionPending = store.get(agentSessionPendingFilesAtom).get(tabId)
+    if (sessionPending && sessionPending.length > 0) {
+      for (const f of sessionPending) {
+        if (f.previewUrl?.startsWith('blob:')) URL.revokeObjectURL(f.previewUrl)
+        window.__pendingAgentFileData?.delete(f.id)
+      }
+      setSessionPendingFiles(deleteKey)
+    }
     // 清理 atomFamily 内部 atom 缓存（Jotai 对 string key 强引用 Map，不显式 remove 永不释放）。
     // 注意：remove 仅清 family 缓存，不动 base map；下次 family(sessionId) 调用会自动重建派生
     // atom 并读出 base map 中保留的草稿值——这正是上面"不清草稿 base map"能恢复 UX 的前提。
     agentSessionStreamingStateAtomFamily.remove(tabId)
     agentSessionDraftAtomFamily.remove(tabId)
     agentSessionDraftHtmlAtomFamily.remove(tabId)
+    agentPendingFilesAtomFamily.remove(tabId)
     backgroundTasksAtomFamily.remove(tabId)
     sessionPersistedPermissionModeAtom.remove(tabId)
     sessionExistsAtom.remove(tabId)
     clearPreviewCacheForSession(tabId)
-  }, [setConvModels, setConvContextLength, setConvThinking, setConvParallel, setConvPromptId, setPreviewPanelOpen, setPreviewFile, setDiffPanelTab, setDiffRefreshVersion, setDiffUnseen, setDiffUnseenFiles, setStreamingStates, setLiveMessagesMap])
+  }, [setConvModels, setConvContextLength, setConvThinking, setConvParallel, setConvPromptId, setPreviewPanelOpen, setPreviewFile, setDiffPanelTab, setDiffRefreshVersion, setDiffUnseen, setDiffUnseenFiles, setStreamingStates, setLiveMessagesMap, setSessionPendingFiles, store])
 
   const executeClose = React.useCallback((tabId: string) => {
     const tab = tabs.find((t) => t.id === tabId)


### PR DESCRIPTION
## 概述
修复 Agent 待发送附件（pending files）的两个问题：

1. **会话错位**：原 `agentPendingFilesAtom` 是全局共享 atom，切换 Tab 时各会话的附件会互相串扰，与已有的 `agentSessionDraftAtomFamily`（草稿按会话切片）模式不一致。
2. **内存泄漏**：关闭 Tab 时未释放 blob URL，也未清理 `window.__pendingAgentFileData` 中的 base64，导致大体积二进制数据长期驻留。

## 改动
- `apps/electron/src/renderer/atoms/agent-atoms.ts`
  - 删除全局 `agentPendingFilesAtom`
  - 新增 `agentSessionPendingFilesAtom`（base map：`Map<sessionId, AgentPendingFile[]>`）
  - 新增 `agentPendingFilesAtomFamily(sessionId)` 派生 atom；写入空数组时自动 `map.delete(sessionId)`，避免 base map 长期残留空 entry
- `apps/electron/src/renderer/components/agent/AgentView.tsx`
  - 替换为 `agentPendingFilesAtomFamily(sessionId)`
- `apps/electron/src/renderer/components/agent/SidePanel.tsx`
  - 替换为 `agentPendingFilesAtomFamily(sessionId)`
- `apps/electron/src/renderer/hooks/useCloseTab.tsx`
  - 关闭 Tab 时遍历该 session 的 pending files，`URL.revokeObjectURL(previewUrl)` 并从 `window.__pendingAgentFileData` 删除对应 base64
  - 删除 base map 中该 session 的 entry，并调用 `agentPendingFilesAtomFamily.remove(tabId)` 清理 family 缓存
- `apps/electron/package.json`
  - 版本号 0.9.45 → 0.9.46

## 测试方法
1. 在 Agent A Tab 下添加若干待发送附件（图片或粘贴文本）
2. 切换到 Agent B Tab，确认 Agent B 的待发送附件区独立、看不到 Agent A 的附件
3. 在 Agent B 添加附件后切回 Agent A，确认 Agent A 的附件仍保留
4. 关闭 Agent A Tab 后新开会话，DevTools → Memory 检查 blob URL 与 base64 已释放，不再驻留

## 备注
- `bun run typecheck` 全部通过
- 与 `agentSessionDraftAtomFamily` 切片模式保持一致
- 关闭 Tab 时附件不保留语义（与草稿不同）：附件涉及不可恢复的 ObjectURL 与大体积 base64，再保留无意义且占用内存