### PR TITLE
fix(diff): 修复 #565 引入的 React.memo 失效与计数重复计算

### DIFF
--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -82,6 +82,15 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
     setPreviewOpenMap((prev) => { const m = new Map(prev); m.set(sessionId, true); return m })
   }, [sessionId, setPreviewFileMap, setPreviewOpenMap])
 
+  const handleDiffFileClick = React.useCallback((filePath: string, _isUntracked: boolean, gitRoot?: string) => {
+    setPreviewFileMap((prev) => {
+      const m = new Map(prev)
+      m.set(sessionId, { filePath, dirPath: sessionPath || undefined, gitRoot })
+      return m
+    })
+    setPreviewOpenMap((prev) => { const m = new Map(prev); m.set(sessionId, true); return m })
+  }, [sessionId, sessionPath, setPreviewFileMap, setPreviewOpenMap])
+
   // 动画标志：isOpen 变化时启用过渡动画，切换会话时即时显示
   const prevIsOpenRef = React.useRef(isOpen)
   const prevSessionIdRef = React.useRef(sessionId)
@@ -385,14 +394,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
               extraPaths={extraPathsMemo}
               refreshVersion={diffRefreshVersion}
               selectedFilePath={selectedFilePath}
-              onFileClick={(filePath, _isUntracked, gitRoot) => {
-                setPreviewFileMap((prev) => {
-                  const m = new Map(prev)
-                  m.set(sessionId, { filePath, dirPath: sessionPath || undefined, gitRoot })
-                  return m
-                })
-                setPreviewOpenMap((prev) => { const m = new Map(prev); m.set(sessionId, true); return m })
-              }}
+              onFileClick={handleDiffFileClick}
             />
             ) : (
               <div className="flex-1 flex items-center justify-center text-muted-foreground text-xs">等待会话初始化...</div>

--- a/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
@@ -134,17 +134,19 @@ export const DiffChangesList = React.memo(function DiffChangesList({
   }, [])
 
   // 按 Git 仓库分组（在所有 hooks 之后、条件返回之前调用）
-  const fileGroups: FileGroup[] = React.useMemo(() => {
+  const { fileGroups, matchedFilesCount } = React.useMemo(() => {
     const q = searchQuery.toLowerCase().trim()
     // 用完整 gitRoot 做 key，避免同名目录冲突
     const groups = new Map<string, ChangedFileEntry[]>()
+    let matched = 0
     for (const f of files) {
       if (q && !f.filePath.toLowerCase().includes(q)) continue
       const key = f.gitRoot || ''
       if (!groups.has(key)) groups.set(key, [])
       groups.get(key)!.push(f)
+      matched++
     }
-    return [...groups.entries()].map(([gitRoot, groupFiles]) => ({
+    const result: FileGroup[] = [...groups.entries()].map(([gitRoot, groupFiles]) => ({
       gitRoot,
       dirName: gitRoot ? gitRoot.split('/').pop() || gitRoot : '/',
       files: groupFiles,
@@ -152,6 +154,7 @@ export const DiffChangesList = React.memo(function DiffChangesList({
       totalDeletions: groupFiles.reduce((sum, f) => sum + f.deletions, 0),
       sources: [...new Set(groupFiles.map((f) => f.source))],
     }))
+    return { fileGroups: result, matchedFilesCount: matched }
   }, [files, searchQuery])
 
   const filteredUntrackedFiles = React.useMemo(() => {
@@ -197,7 +200,7 @@ export const DiffChangesList = React.memo(function DiffChangesList({
           {searchQuery && (
             <>
               <span className="text-[10px] text-muted-foreground/50 flex-shrink-0 tabular-nums">
-                {fileGroups.reduce((sum, g) => sum + g.files.length, 0) + filteredUntrackedFiles.length}
+                {matchedFilesCount + filteredUntrackedFiles.length}
               </span>
               <button
                 type="button"
@@ -219,70 +222,70 @@ export const DiffChangesList = React.memo(function DiffChangesList({
       )}
       {!isEmpty && (
         <>
-      {fileGroups.map((group) => {
-        const isCollapsed = collapsedDirs.has(group.gitRoot)
-        return (
-          <div key={group.gitRoot}>
-            {/* 文件夹 bar */}
-            <button
-              type="button"
-              onClick={() => toggleDir(group.gitRoot)}
-              className="flex items-center gap-1 w-full px-2 py-2 text-[13px] font-medium text-foreground/60 hover:bg-foreground/[0.04] transition-colors"
-            >
-              <ChevronRight
-                className={cn('size-3 transition-transform', !isCollapsed && 'rotate-90')}
-              />
-              <span className="truncate">{group.dirName}</span>
-              {/* 文件夹层级的来源 badges */}
-              {group.sources.map((src) => {
-                const cfg = SOURCE_CONFIG[src] ?? SOURCE_CONFIG.none!
-                return (
-                  <span key={src} className={cn('rounded px-1 py-0.5 text-[12px] leading-none shrink-0', cfg.color)}>
-                    {cfg.label}
+          {fileGroups.map((group) => {
+            const isCollapsed = collapsedDirs.has(group.gitRoot)
+            return (
+              <div key={group.gitRoot}>
+                {/* 文件夹 bar */}
+                <button
+                  type="button"
+                  onClick={() => toggleDir(group.gitRoot)}
+                  className="flex items-center gap-1 w-full px-2 py-2 text-[13px] font-medium text-foreground/60 hover:bg-foreground/[0.04] transition-colors"
+                >
+                  <ChevronRight
+                    className={cn('size-3 transition-transform', !isCollapsed && 'rotate-90')}
+                  />
+                  <span className="truncate">{group.dirName}</span>
+                  {/* 文件夹层级的来源 badges */}
+                  {group.sources.map((src) => {
+                    const cfg = SOURCE_CONFIG[src] ?? SOURCE_CONFIG.none!
+                    return (
+                      <span key={src} className={cn('rounded px-1 py-0.5 text-[12px] leading-none shrink-0', cfg.color)}>
+                        {cfg.label}
+                      </span>
+                    )
+                  })}
+                  <span className="ml-auto shrink-0 flex items-center gap-1.5">
+                    <span className="text-foreground/30">{group.files.length} changed files</span>
+                    {group.totalAdditions > 0 && <span className="text-foreground/30">+{group.totalAdditions}</span>}
+                    {group.totalDeletions > 0 && <span className="text-foreground/30">-{group.totalDeletions}</span>}
                   </span>
-                )
-              })}
-              <span className="ml-auto shrink-0 flex items-center gap-1.5">
-                <span className="text-foreground/30">{group.files.length} changed files</span>
-                {group.totalAdditions > 0 && <span className="text-foreground/30">+{group.totalAdditions}</span>}
-                {group.totalDeletions > 0 && <span className="text-foreground/30">-{group.totalDeletions}</span>}
-              </span>
-            </button>
+                </button>
 
-            {/* 文件列表 */}
-            {!isCollapsed && group.files.map((file) => {
-              const absPath = `${file.gitRoot || dirPath}/${file.filePath}`.replace(/\/+/g, '/')
-              return (
-              <FileRow
-                key={`${file.gitRoot}:${file.filePath}`}
-                file={file}
-                isSelected={absPath === selectedFilePath || file.filePath === selectedFilePath}
-                isUnseen={unseenFiles.has(absPath)}
-                onClick={() => { markFileAsSeen(absPath); onFileClick(file.filePath, false, file.gitRoot) }}
-                onRevert={() => handleRevert(file.filePath, file.gitRoot)}
-                dirPath={dirPath}
-              />
-              )
-            })}
-          </div>
-        )
-      })}
+                {/* 文件列表 */}
+                {!isCollapsed && group.files.map((file) => {
+                  const absPath = `${file.gitRoot || dirPath}/${file.filePath}`.replace(/\/+/g, '/')
+                  return (
+                    <FileRow
+                      key={`${file.gitRoot}:${file.filePath}`}
+                      file={file}
+                      isSelected={absPath === selectedFilePath || file.filePath === selectedFilePath}
+                      isUnseen={unseenFiles.has(absPath)}
+                      onClick={() => { markFileAsSeen(absPath); onFileClick(file.filePath, false, file.gitRoot) }}
+                      onRevert={() => handleRevert(file.filePath, file.gitRoot)}
+                      dirPath={dirPath}
+                    />
+                  )
+                })}
+              </div>
+            )
+          })}
 
-      {/* 未追踪文件分组 */}
-      {filteredUntrackedFiles.length > 0 && (
-        <div>
-          <div className="flex items-center px-2 py-2 text-[13px] font-medium text-muted-foreground border-t border-border/30">
-            未追踪文件
-          </div>
-          {filteredUntrackedFiles.map((file) => (
-            <UntrackedFileRow
-              key={`${file.gitRoot}:${file.filePath}`}
-              file={file}
-              onClick={() => onFileClick(file.filePath, true, file.gitRoot)}
-            />
-          ))}
-        </div>
-      )}
+          {/* 未追踪文件分组 */}
+          {filteredUntrackedFiles.length > 0 && (
+            <div>
+              <div className="flex items-center px-2 py-2 text-[13px] font-medium text-muted-foreground border-t border-border/30">
+                未追踪文件
+              </div>
+              {filteredUntrackedFiles.map((file) => (
+                <UntrackedFileRow
+                  key={`${file.gitRoot}:${file.filePath}`}
+                  file={file}
+                  onClick={() => onFileClick(file.filePath, true, file.gitRoot)}
+                />
+              ))}
+            </div>
+          )}
         </>
       )}
     </div>


### PR DESCRIPTION
## 背景

PR #565 给 `DiffChangesList` 加了搜索过滤框，但 review 时发现三个遗留问题：

1. **`React.memo` 实际不生效** — 父组件 `SidePanel.tsx:380` 把 `onFileClick` 写成内联匿名函数，每次 render 都是新引用，浅比较立即失败。这次 `React.memo` 包裹反而是纯负优化（多一次比较）
2. **`<>...</>` Fragment 内部 JSX 缩进断层** — 引入 Fragment 包裹后，原 `fileGroups.map` / 未追踪文件 block 的 6 空格缩进没有跟着 +2，整段层级看起来错位
3. **搜索时命中数重复计算** — `fileGroups.reduce((sum, g) => sum + g.files.length, 0)` 在 JSX 中每次渲染都跑，明明 `useMemo` 已经遍历过一次

## 改动

### `apps/electron/src/renderer/components/agent/SidePanel.tsx`
- 抽出 `handleDiffFileClick` 用 `useCallback` 稳定，依赖 `[sessionId, sessionPath, setPreviewFileMap, setPreviewOpenMap]`，让 `DiffChangesList` 的 `React.memo` 浅比较真正命中

### `apps/electron/src/renderer/components/diff/DiffChangesList.tsx`
- `useMemo` 同时返回 `fileGroups` 和 `matchedFilesCount`，命中数在分组遍历时一并累加，去掉 JSX 中的 `reduce`
- 修正 `<>...</>` 内所有子节点的缩进，整段层级回归

## 验证
- `bun run typecheck` 与改动相关的两个文件无新增错误（仓库存在 4 个无关的 `feishu-bridge.ts` 错误，非本 PR 引入）
- 手动检查：`onFileClick` 引用稳定后，父组件 re-render（如其他 atoms 变化）不会再穿透 `React.memo`

## 关联
关联 #565（已合并）