### PR TITLE
fix(file-browser): FileSearchBar Windows 路径兼容 + 卸载时 abort + 列表 useMemo

### DIFF
--- a/apps/electron/src/renderer/components/file-browser/FileSearchBar.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileSearchBar.tsx
@@ -56,10 +56,11 @@ export function FileSearchBar({
 
   /** 将搜索结果的相对路径转为绝对路径，供 FileBrowser 自动定位使用 */
   const resolveAbsolutePath = React.useCallback((entry: FileIndexEntry): string => {
-    if (entry.path.startsWith('/')) return entry.path
+    if (entry.path.startsWith('/') || /^[A-Za-z]:[\\/]/.test(entry.path)) return entry.path
     const base = entry.source === 'workspace' ? workspaceFilesPath : sessionPath
     if (!base) return entry.path
-    return `${base.replace(/\/$/, '')}/${entry.path}`
+    const sep = base.includes('\\') && !base.includes('/') ? '\\' : '/'
+    return `${base.replace(/[\\/]+$/, '')}${sep}${entry.path}`
   }, [workspaceFilesPath, sessionPath])
 
   // 防抖搜索 — 分别搜索两个目录
@@ -150,6 +151,7 @@ export function FileSearchBar({
 
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current)
+      abortRef.current?.abort()
     }
   }, [query, workspaceFilesPath, sessionPath, sessionAttachedDirs, workspaceAttachedDirs, hasAnyRoot])
 
@@ -211,10 +213,10 @@ export function FileSearchBar({
     inputRef.current?.blur()
   }, [onFilePreview, sessionId, setAutoReveal, resolveAbsolutePath])
 
-  if (!hasAnyRoot) return null
+  const sessionResults = React.useMemo(() => results.filter((e) => e.source === 'session'), [results])
+  const workspaceResults = React.useMemo(() => results.filter((e) => e.source === 'workspace'), [results])
 
-  const sessionResults = results.filter((e) => e.source === 'session')
-  const workspaceResults = results.filter((e) => e.source === 'workspace')
+  if (!hasAnyRoot) return null
 
   return (
     <div ref={containerRef} className="relative mx-2 flex-shrink-0">
@@ -306,12 +308,17 @@ function ResultItem({
   onClick: (entry: FileIndexEntry) => void
   onHover: () => void
 }): React.ReactElement {
-  // 从完整路径中提取父目录（去掉文件名），避免路径里重复显示文件名
-  const dirPath = entry.path === entry.name
-    ? ''
-    : entry.path.endsWith(`/${entry.name}`)
-      ? entry.path.slice(0, -(entry.name.length + 1))
-      : entry.path
+  // 从完整路径中提取父目录（去掉文件名），避免路径里重复显示文件名。
+  // 兼容 POSIX (`/`) 与 Windows (`\`) 分隔符。
+  const dirPath = React.useMemo(() => {
+    if (entry.path === entry.name) return ''
+    const sepLen = entry.name.length + 1
+    const tail = entry.path.slice(-sepLen)
+    if (tail === `/${entry.name}` || tail === `\\${entry.name}`) {
+      return entry.path.slice(0, -sepLen)
+    }
+    return entry.path
+  }, [entry.path, entry.name])
 
   return (
     <Tooltip delayDuration={500}>


### PR DESCRIPTION
## 概述

跟进 #566 review 中识别的三个 follow-up 问题，仅触及 `FileSearchBar.tsx` 一个文件。

## 改动

### 1. Windows 路径兼容（medium）

`resolveAbsolutePath` 之前完全按 POSIX 风格处理：
- `entry.path.startsWith('/')` 判断绝对路径 — Windows 绝对路径形如 `C:\\...` 或 `C:/...` 会被误判为相对路径
- `base.replace(/\/$/, '')` 仅清正斜杠尾部 — Windows 上 `base` 可能用 `\\`
- `${base}/${entry.path}` 强制 `/` 拼接 — 在 Windows pure-backslash base 上会得到混合分隔符路径

修复后：
- 绝对路径判断同时识别 `/` 与盘符 (`/^[A-Za-z]:[\\\/]/`)
- 尾部分隔符清理同时处理 `\\` 与 `/`
- 分隔符选择：base 仅含 `\\` 时用 `\\`，其它情况统一 `/`（混合时也走 `/`，与 Electron 主进程返回路径的常见格式一致）

`ResultItem` 中 `dirPath` 的提取同样兼容两种分隔符。

### 2. AbortController 在组件卸载时未中止（low）

防抖搜索 effect 的 cleanup 之前只清了 timeout，没有 abort 当前正在进行的搜索请求：

```ts
return () => {
  if (debounceRef.current) clearTimeout(debounceRef.current)
  // ← 缺少 abortRef.current?.abort()
}
```

切换 session 时 in-flight 的 IPC 仍会完成。本 PR 在 cleanup 中补上 `abortRef.current?.abort()`。

### 3. `sessionResults` / `workspaceResults` 用 `useMemo` 包裹（low）

与同文件其他 memo 风格一致；同时调整 hooks 顺序遵守 Rules of Hooks（`useMemo` 提到 `hasAnyRoot` 早 return 之前）。

## 验证

- `bun run typecheck` ✅ 通过
- 行为不变（仅 Windows 上的 reveal 路径修复 + 卸载时少一次无意义 IPC）

## 备注

PR #566 已合并，本 PR 仅做 follow-up 修复，不影响其他功能。