### PR TITLE
fix(agent): inDiffScope 路径分隔符归一化，修复 #567 在 Windows 下的反向错配

### DIFF
--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -427,17 +427,21 @@ export function useGlobalAgentListeners(): void {
 
       // 检查文件是否落在当前会话的 diff scope 内（与 getUnstagedChanges 的 candidates 对齐）
       // 注：未纳入 dirPath，因为 DiffChangesList 调用时 dirPath 始终等于 sessionPath
+      // 路径分隔符统一为正斜杠，避免 Windows 下 client 与服务端（path.sep='\\'）方向不一致导致反向错配
+      const toForwardSlash = (p: string) => p.replace(/\\/g, '/')
       const sessionScopePaths = uniqueTruthyPaths([
         sessionPath,
         workspaceFilesPath,
         ...sessionAttachedDirs,
         ...workspaceAttachedDirs,
-      ])
-      const absTarget = isAbsolutePath(targetPath)
-        ? targetPath
-        : (sessionPath ? `${sessionPath.replace(/[/\\]+$/, '')}/${targetPath}` : targetPath)
+      ]).map(toForwardSlash)
+      const absTarget = toForwardSlash(
+        isAbsolutePath(targetPath)
+          ? targetPath
+          : (sessionPath ? `${sessionPath.replace(/[/\\]+$/, '')}/${targetPath}` : targetPath)
+      )
       const inDiffScope = sessionScopePaths.some((root) => {
-        const r = root.replace(/[/\\]+$/, '') + '/'
+        const r = root.replace(/\/+$/, '') + '/'
         return absTarget === root || absTarget.startsWith(r)
       })
 


### PR DESCRIPTION
## 概述

修复 PR #567 引入的 `inDiffScope` 路径分隔符不一致问题。

## 背景

#567 在 `buildAutoPreviewFile` 中新增 `inDiffScope` 判定，用于在 Agent 写入会话 scope 之外的文件时短路副作用（红点 / `agentDiffUnseenFilesAtom` / 切换 changes Tab），把副作用收敛到与服务端 `getUnstagedChanges` candidates 一致的范围内。

但客户端的实现在拼接候选根目录时**硬编码了 `/`**：

```ts
const r = root.replace(/[/\\]+$/, '') + '/'
return absTarget === root || absTarget.startsWith(r)
```

而服务端 `git-diff-service.ts` 使用 Node 的 `path.sep`（Windows 下是 `\`）拼接 candidates：

```ts
const r = c.replace(/[/\\]+$/, '')
return r + sep   // sep === '\\' on Windows
```

当 `sessionPath` / `workspaceFilesPath` / `attachedDirs` 中含有反斜杠路径（Windows 常见情况）时：
- 客户端 `startsWith` 比对失败 → `inDiffScope = false` → 副作用被短路
- 服务端 candidates 仍能命中 → 文件正常出现在 changes Tab

结果是与 #567 修复目标**完全相反**的错配：
> "changes Tab 看得到、但红点不亮、不切换 Tab、不进未查看集合"

## 修复方案

在比较前把 `sessionScopePaths` 与 `absTarget` 都用 `replace(/\\/g, '/')` 归一化为正斜杠（与同文件 `getParentDir` 已有约定一致）。归一化后两侧比较的是相同的 root 集合，语义等价。

```ts
const toForwardSlash = (p: string) => p.replace(/\\/g, '/')
const sessionScopePaths = uniqueTruthyPaths([
  sessionPath, workspaceFilesPath,
  ...sessionAttachedDirs, ...workspaceAttachedDirs,
]).map(toForwardSlash)
const absTarget = toForwardSlash(
  isAbsolutePath(targetPath)
    ? targetPath
    : (sessionPath ? `${sessionPath.replace(/[/\\]+$/, '')}/${targetPath}` : targetPath)
)
```

## 验证方式

1. **macOS / Linux**：原有行为完全不变（路径本就只含正斜杠，`replace(/\\/g, '/')` 是 no-op）
2. **Windows**：`sessionPath = "C:\\Users\\u\\proj\\sess"`、`targetPath = "C:\\Users\\u\\proj\\sess\\a.ts"` → `inDiffScope = true`，红点点亮、Tab 切换、加入未查看集合
3. `bun run typecheck`：本次改动相关包全绿（`feishu-bridge.ts` 上的 4 个错误是 main 上预存在的，与本 PR 无关）

## 风险面

- 仅影响 `tool_result` 写类工具完成后的 `inDiffScope` 比对
- 不影响服务端 `getUnstagedChanges`、不影响 `basePaths` / `dirPath` / 消息流 / IPC 边界
- 在非 Windows 平台上是 no-op
