### PR TITLE
fix(diff): DiffChangesList 切换会话不再错误提示「没有代码改动」【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.9.46",
+  "version": "0.9.47",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -7,7 +7,7 @@
 
 import { atom } from 'jotai'
 import { atomFamily, atomWithStorage } from 'jotai/utils'
-import type { AgentSessionMeta, AgentEvent, AgentWorkspace, AgentPendingFile, RetryAttempt, PromaPermissionMode, PermissionRequest, AskUserRequest, ExitPlanModeRequest, ThinkingConfig, AgentEffort, SDKMessage } from '@proma/shared'
+import type { AgentSessionMeta, AgentEvent, AgentWorkspace, AgentPendingFile, RetryAttempt, PromaPermissionMode, PermissionRequest, AskUserRequest, ExitPlanModeRequest, ThinkingConfig, AgentEffort, SDKMessage, UnstagedChangesResult } from '@proma/shared'
 import { PROMA_DEFAULT_PERMISSION_MODE } from '@proma/shared'
 import { calculateDockBadgeCount, countPendingRequests } from '@/lib/dock-badge-count'
 
@@ -293,6 +293,15 @@ export const agentDiffUnseenChangesAtom = atom(new Map<string, boolean>())
 
 /** Agent 本轮刚修改但用户尚未查看的文件路径 — 按 session 隔离，Map<sessionId, Set<filePath>> */
 export const agentDiffUnseenFilesAtom = atom(new Map<string, Set<string>>())
+
+/**
+ * Diff 数据缓存 — 按 session 隔离，存放上一次 IPC 拉取到的未暂存改动结果。
+ *
+ * 让 DiffChangesList 切走再切回时能立即拿到旧数据渲染（SWR 模式），
+ * 避免 mount 时空数组误命中"没有代码改动"分支造成 ~1s 闪烁。
+ * 数据新鲜度由 [[agentDiffRefreshVersionAtom]] 触发的后台 fetch 维护，无 TTL。
+ */
+export const agentDiffDataAtom = atom(new Map<string, UnstagedChangesResult>())
 
 /** 当前会话的侧面板是否打开（派生只读：全局共享，但仅在有当前会话且为 Agent 模式时显示） */
 export const currentSessionSidePanelOpenAtom = atom<boolean>((get) => {

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -388,6 +388,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
           {activeTab === 'changes' ? (
             sessionPath ? (
             <DiffChangesList
+              key={sessionId}
               dirPath={sessionPath}
               sessionId={sessionId}
               sessionPath={sessionPath}

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -47,6 +47,7 @@ import {
   agentDiffRefreshVersionAtom,
   agentDiffUnseenChangesAtom,
   agentDiffUnseenFilesAtom,
+  agentDiffDataAtom,
 } from '@/atoms/agent-atoms'
 import type { SessionIndicatorStatus } from '@/atoms/agent-atoms'
 import { previewPanelOpenMapAtom, previewFileMapAtom } from '@/atoms/preview-atoms'
@@ -363,6 +364,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   const setDiffRefreshVersion = useSetAtom(agentDiffRefreshVersionAtom)
   const setDiffUnseen = useSetAtom(agentDiffUnseenChangesAtom)
   const setDiffUnseenFiles = useSetAtom(agentDiffUnseenFilesAtom)
+  const setDiffData = useSetAtom(agentDiffDataAtom)
   const setWorkingDone = useSetAtom(workingDoneSessionIdsAtom)
 
   /** 清理 per-conversation/session Map atoms 条目 */
@@ -384,10 +386,11 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     setDiffRefreshVersion(deleteKey)
     setDiffUnseen(deleteKey)
     setDiffUnseenFiles(deleteKey)
+    setDiffData(deleteKey)
     setSessionChannelMap(deleteKey)
     setSessionModelMap(deleteKey)
     clearPreviewCacheForSession(id)
-  }, [setConvModels, setConvContextLength, setConvThinking, setConvParallel, setConvPromptId, setPreviewPanelOpen, setPreviewFile, setDiffPanelTab, setDiffRefreshVersion, setDiffUnseen, setDiffUnseenFiles, setSessionChannelMap, setSessionModelMap])
+  }, [setConvModels, setConvContextLength, setConvThinking, setConvParallel, setConvPromptId, setPreviewPanelOpen, setPreviewFile, setDiffPanelTab, setDiffRefreshVersion, setDiffUnseen, setDiffUnseenFiles, setDiffData, setSessionChannelMap, setSessionModelMap])
 
   const currentWorkspaceSlug = React.useMemo(() => {
     if (!currentWorkspaceId) return null

--- a/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
@@ -10,7 +10,7 @@ import { useAtomValue, useSetAtom } from 'jotai'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { FileTypeIcon } from '@/components/file-browser/FileTypeIcon'
-import { agentDiffUnseenFilesAtom } from '@/atoms/agent-atoms'
+import { agentDiffUnseenFilesAtom, agentDiffDataAtom } from '@/atoms/agent-atoms'
 import type { ChangedFileEntry, ChangeSource, UntrackedFileEntry } from '@proma/shared'
 
 /** 按目录分组后的数据结构 */
@@ -62,9 +62,15 @@ export const DiffChangesList = React.memo(function DiffChangesList({
   selectedFilePath,
   extraPaths,
 }: DiffChangesListProps): React.ReactElement {
-  const [files, setFiles] = React.useState<ChangedFileEntry[]>([])
-  const [untrackedFiles, setUntrackedFiles] = React.useState<UntrackedFileEntry[]>([])
-  const [isGitRepo, setIsGitRepo] = React.useState(true)
+  // Diff 数据缓存：mount 时若已有上次结果，立即用作初值，避免空数组闪 1s "没有代码改动"
+  const diffDataMap = useAtomValue(agentDiffDataAtom)
+  const setDiffDataMap = useSetAtom(agentDiffDataAtom)
+  const cached = diffDataMap.get(sessionId)
+  const [files, setFiles] = React.useState<ChangedFileEntry[]>(() => cached?.files ?? [])
+  const [untrackedFiles, setUntrackedFiles] = React.useState<UntrackedFileEntry[]>(() => cached?.untrackedFiles ?? [])
+  const [isGitRepo, setIsGitRepo] = React.useState(() => cached?.isGitRepo ?? true)
+  /** 首次 fetch 是否已返回——区分 loading 与真·空，避免 "没有代码改动" 误闪 */
+  const [hasFetched, setHasFetched] = React.useState<boolean>(() => cached !== undefined)
   const [collapsedDirs, setCollapsedDirs] = React.useState<Set<string>>(new Set())
   const [searchQuery, setSearchQuery] = React.useState('')
   /** 单调递增的 fetch 序号，用于丢弃乱序到达的旧响应 */
@@ -97,11 +103,19 @@ export const DiffChangesList = React.memo(function DiffChangesList({
       setIsGitRepo(result.isGitRepo)
       setFiles(result.files || [])
       setUntrackedFiles(result.untrackedFiles || [])
+      setHasFetched(true)
+      // 写回 atom 缓存：下一次 mount 可直接拿到旧值跳过空闪烁
+      setDiffDataMap((prev) => {
+        const next = new Map(prev)
+        next.set(sessionId, result)
+        return next
+      })
     } catch {
       if (requestId !== fetchSeqRef.current) return
       setIsGitRepo(true) // 避免网络等错误误判
+      setHasFetched(true)
     }
-  }, [dirPath, sessionPath, workspaceFilesPath, extraPaths, sessionId])
+  }, [dirPath, sessionPath, workspaceFilesPath, extraPaths, sessionId, setDiffDataMap])
 
   React.useEffect(() => {
     fetchChanges()
@@ -174,11 +188,11 @@ export const DiffChangesList = React.memo(function DiffChangesList({
     )
   }
 
-  // 空状态
+  // 空状态：首次 fetch 未完成时显示加载占位，避免误显示 "没有代码改动"
   if (files.length === 0 && untrackedFiles.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-full text-muted-foreground p-4">
-        <p className="text-[12px] text-center">没有代码改动</p>
+        <p className="text-[12px] text-center">{hasFetched ? '没有代码改动' : '加载中…'}</p>
       </div>
     )
   }

--- a/apps/electron/src/renderer/hooks/useCloseTab.tsx
+++ b/apps/electron/src/renderer/hooks/useCloseTab.tsx
@@ -24,6 +24,7 @@ import {
   agentDiffRefreshVersionAtom,
   agentDiffUnseenChangesAtom,
   agentDiffUnseenFilesAtom,
+  agentDiffDataAtom,
   agentStreamingStatesAtom,
   liveMessagesMapAtom,
   agentSessionStreamingStateAtomFamily,
@@ -76,6 +77,7 @@ export function useCloseTab(): UseCloseTabReturn {
   const setDiffRefreshVersion = useSetAtom(agentDiffRefreshVersionAtom)
   const setDiffUnseen = useSetAtom(agentDiffUnseenChangesAtom)
   const setDiffUnseenFiles = useSetAtom(agentDiffUnseenFilesAtom)
+  const setDiffData = useSetAtom(agentDiffDataAtom)
 
   const setStreamingStates = useSetAtom(agentStreamingStatesAtom)
   const setLiveMessagesMap = useSetAtom(liveMessagesMapAtom)
@@ -100,6 +102,7 @@ export function useCloseTab(): UseCloseTabReturn {
     setDiffRefreshVersion(deleteKey)
     setDiffUnseen(deleteKey)
     setDiffUnseenFiles(deleteKey)
+    setDiffData(deleteKey)
     // tab.id === sessionId（见 tab-atoms.ts openTab）
     // 清理重型流式数据：streamingStates（含累积 content 与 toolActivities）和 liveMessages（SDK 消息数组）
     // 不清 agentSessionDraftsAtom / agentSessionDraftHtmlAtom / agentStreamErrorsAtom 这些
@@ -127,7 +130,7 @@ export function useCloseTab(): UseCloseTabReturn {
     sessionPersistedPermissionModeAtom.remove(tabId)
     sessionExistsAtom.remove(tabId)
     clearPreviewCacheForSession(tabId)
-  }, [setConvModels, setConvContextLength, setConvThinking, setConvParallel, setConvPromptId, setPreviewPanelOpen, setPreviewFile, setDiffPanelTab, setDiffRefreshVersion, setDiffUnseen, setDiffUnseenFiles, setStreamingStates, setLiveMessagesMap, setSessionPendingFiles, store])
+  }, [setConvModels, setConvContextLength, setConvThinking, setConvParallel, setConvPromptId, setPreviewPanelOpen, setPreviewFile, setDiffPanelTab, setDiffRefreshVersion, setDiffUnseen, setDiffUnseenFiles, setDiffData, setStreamingStates, setLiveMessagesMap, setSessionPendingFiles, store])
 
   const executeClose = React.useCallback((tabId: string) => {
     const tab = tabs.find((t) => t.id === tabId)


### PR DESCRIPTION
## 概述

修复 Agent 侧面板 DiffChangesList 在切换会话或切走再切回时，会先闪 ~1s 「没有代码改动」再展示真实数据的 UX 问题。

根因是 DiffChangesList 每次 mount 都从空数组 + `isGitRepo=true` 初始化，先命中 「No changes」 分支后才被首次 IPC 返回覆盖。本 PR 引入跨 mount 的 SWR 缓存，并区分「首次 fetch 未完成」与「真·空状态」两种情况。

## 改动

- `apps/electron/src/renderer/atoms/agent-atoms.ts` — 新增 `agentDiffDataAtom: Map<string, UnstagedChangesResult>`，按 sessionId 切片缓存上一次 IPC 拉取到的未暂存改动结果。注释中说明数据新鲜度由既有的 `agentDiffRefreshVersionAtom` 维护，无 TTL。
- `apps/electron/src/renderer/components/diff/DiffChangesList.tsx`
  - `useState` initializer 从 `agentDiffDataAtom` 读 cached 作为初值，避免空数组首帧
  - 新增 `hasFetched` 状态：cached 存在时初值为 `true`，区分 loading 与真·空。仅在 `hasFetched` 为 `true` 才显示 「没有代码改动」，否则显示 「加载中…」
  - `fetchChanges` 成功 / 失败两条路径都 `setHasFetched(true)`，并把成功结果写回 atom 缓存
- `apps/electron/src/renderer/components/agent/SidePanel.tsx` — 给 `<DiffChangesList>` 增加 `key={sessionId}`。这一行至关重要：因为 `useState` initializer 仅在 mount 时执行，没有 `key` 的话 sessionId 切换不会重新读 cached，缓存初值就失效了。
- `apps/electron/src/renderer/hooks/useCloseTab.tsx` — `cleanupMapAtoms` 增加 `setDiffData(deleteKey)`，与既有的 `agentDiffPanelTabAtom` / `agentDiffRefreshVersionAtom` / `agentDiffUnseenChangesAtom` / `agentDiffUnseenFilesAtom` 等同类 per-session Map atom 的清理路径保持一致
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 同步补齐 `cleanupMapAtoms`（这里也有同模式的 per-session Map 清理路径）
- `apps/electron/package.json` — 版本号 `0.9.46` → `0.9.47`

## 如何测试

1. 打开任意带改动的 Agent 会话，确认 「Changes」 标签能正常显示文件列表
2. 切到另一个 tab / 另一个会话，再切回原会话——应**立即**展示原来的文件列表，不再先闪 「没有代码改动」
3. 全新会话首次进入 「Changes」 标签——应显示 「加载中…」 而不是误显示 「没有代码改动」
4. Agent 写工具完成时（依赖 `agentDiffRefreshVersionAtom` 触发后台 fetch），列表应正确刷新到最新状态
5. 关闭 Agent Tab 后，该会话对应的 `agentDiffDataAtom` 条目应被清理（不会随 session 累积）

## 备注

- TypeScript typecheck 4/4 全部通过（@proma/shared、@proma/core、@proma/ui、@proma/electron）
- 这是 SWR 模式的固有取舍：切回旧会话时可能短暂展示「上一次结果」< 1s，再被后台 fetch 覆盖。对 Diff 列表来说，瞬时陈旧远优于闪 「没有代码改动」 的体验
- `key={sessionId}` 让 `fetchSeqRef` 在切换会话时也会重置，旧会话 in-flight 的 IPC 响应到达时组件已 unmount，setState 自动 noop——竞态保护语义不受影响