### PR TITLE
feat(feishu): Phase 2 防抖+串行+引用消息上下文+附件诊断+AskUser屏蔽

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.9.45",
+  "version": "0.9.46",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/feishu-bridge.ts
+++ b/apps/electron/src/main/lib/feishu-bridge.ts
@@ -1216,18 +1216,38 @@ class FeishuBridge {
     // 保存飞书图片和文件到 session 工作目录，构建文件引用
     const attachedRefs: string[] = []
     const workspace = binding.workspaceId ? getAgentWorkspace(binding.workspaceId) : undefined
+
+    // 诊断：附件应保存但 workspace 为空时立即报错（用户能在 Console 看到）
+    const hasAnyAttachment = imageAttachments.length > 0 || fileAttachments.length > 0
+    if (hasAnyAttachment && !workspace) {
+      console.error(`[飞书 Bridge] 附件保存失败：binding.workspaceId=${binding.workspaceId} 找不到对应工作区！图片数=${imageAttachments.length}, 文件数=${fileAttachments.length}`)
+    }
+    if (hasAnyAttachment && workspace) {
+      console.log(`[飞书 Bridge] 准备保存附件：工作区=${workspace.slug}, sessionId=${binding.sessionId.slice(-8)}, 图片数=${imageAttachments.length}, 文件数=${fileAttachments.length}`)
+    }
+
     if (workspace) {
       for (const img of imageAttachments) {
-        const savedPath = saveImageToSessionShared(
-          workspace.slug, binding.sessionId, `feishu-${img.imageKey}`, img.mediaType, img.data,
-        )
-        attachedRefs.push(`- feishu-${img.imageKey}.${inferExtension(img.mediaType)}: ${savedPath}`)
+        try {
+          const savedPath = saveImageToSessionShared(
+            workspace.slug, binding.sessionId, `feishu-${img.imageKey}`, img.mediaType, img.data,
+          )
+          attachedRefs.push(`- feishu-${img.imageKey}.${inferExtension(img.mediaType)}: ${savedPath}`)
+          console.log(`[飞书 Bridge] 已保存图片: ${savedPath}`)
+        } catch (err) {
+          console.error(`[飞书 Bridge] 图片保存失败 imageKey=${img.imageKey}:`, err)
+        }
       }
       for (const file of fileAttachments) {
-        const savedPath = saveFileToSessionShared(
-          workspace.slug, binding.sessionId, file.fileName, file.data,
-        )
-        attachedRefs.push(`- ${file.fileName}: ${savedPath}`)
+        try {
+          const savedPath = saveFileToSessionShared(
+            workspace.slug, binding.sessionId, file.fileName, file.data,
+          )
+          attachedRefs.push(`- ${file.fileName}: ${savedPath}`)
+          console.log(`[飞书 Bridge] 已保存文件: ${savedPath}`)
+        } catch (err) {
+          console.error(`[飞书 Bridge] 文件保存失败 fileName=${file.fileName}:`, err)
+        }
       }
     }
     const fileReferences = attachedRefs.length > 0

--- a/apps/electron/src/main/lib/feishu-bridge.ts
+++ b/apps/electron/src/main/lib/feishu-bridge.ts
@@ -30,7 +30,7 @@ import type {
 } from '@proma/shared'
 import { FEISHU_IPC_CHANNELS, AGENT_IPC_CHANNELS } from '@proma/shared'
 import { getDecryptedBotAppSecret } from './feishu-config'
-import { agentEventBus, runAgentHeadless, stopAgent, isAgentSessionActive } from './agent-service'
+import { agentEventBus, runAgentHeadless, stopAgent } from './agent-service'
 import { createAgentSession, listAgentSessions, getAgentSessionMeta } from './agent-session-manager'
 import {
   listAgentWorkspacesByUpdatedAt,
@@ -160,13 +160,16 @@ class FeishuBridge {
   private readonly runCoordinator = new RunCoordinator(DEFAULT_MAX_CONCURRENT_RUNS)
 
   /**
+   * 每个 sessionId 一个串行执行链：保证同一 sessionId 的 runAgentHeadless
+   * 严格按提交顺序串行执行。Promise.chain 模式天然解决 orchestrator
+   * activeSessions 时序竞态——前一个 await 真完成后下一个才开始。
+   */
+  private readonly sessionRunChains = new Map<string, Promise<void>>()
+
+  /**
    * sessionId → resolver：在 Agent runAgentHeadless 的 onComplete / onError
    * 回调里调用以唤醒 runMergedBatch 的 await，让 RunCoordinator.acquire 拿到
    * 的槽位真正等到 Agent 结束再释放。
-   *
-   * 解决"runAgentHeadless 是 fire-and-forget，handleUserMessage 内部 await
-   * 返回时 Agent 还没真正跑完"导致 release/unblock 提前执行的问题
-   * （PR review code-reviewer 找到的 blocking bug）。
    */
   private readonly runFinishedResolvers = new Map<string, () => void>()
   /** sessionId → 通知模式 */
@@ -322,6 +325,7 @@ class FeishuBridge {
     // resolve 所有 pending run-finished promise，避免 runMergedBatch 阻塞
     for (const resolver of this.runFinishedResolvers.values()) resolver()
     this.runFinishedResolvers.clear()
+    this.sessionRunChains.clear()
     // 关闭所有正在跑的流式卡（不等返回，避免阻塞 stop）
     for (const stream of this.streamingCards.values()) {
       void stream.close().catch(() => {})
@@ -797,27 +801,34 @@ class FeishuBridge {
       console.log(`[飞书 Bridge] 合并 batch: scope=${scope}, 消息数=${batch.length}, textChars=${mergedText.length}`)
     }
 
-    // 先 acquire 全局并发槽位（可能等待）；拿到后 block 该 scope 防止
-    // run 期间新消息触发并行 flush
+    // 全局并发槽位（多 chat 之间）
     const release = await this.runCoordinator.acquire(scope, first.msgCtx.chatId)
     this.messageQueue.block(scope)
     try {
-      // 拿到 binding 才有 sessionId；handleUserMessage 内部会自动建会话
       const binding = await this.ensureBinding(msgCtx)
       if (!binding) return
 
-      // 关键：orchestrator 的并发守卫基于 activeSessions.has(sessionId)。
-      // 上一次 run 即使 onComplete 已触发，orchestrator finally 也可能没走
-      // 完，此时立即调 runAgentHeadless 会撞 "上一条消息仍在处理中" 错误。
-      // 在这里轮询等 activeSessions 真正清空再继续，避免业务层报错。
-      await this.waitUntilSessionIdle(binding.sessionId)
+      // 关键设计：用 sessionRunChains 串行同 sessionId 的 run。
+      // Promise.chain 保证前一个 run 的 finishedPromise 完全 resolve 后，
+      // 下一个 run 才开始。即使 finishedPromise resolve 时 orchestrator
+      // finally 还没走完，也能在 await 期间走完，从而避免撞 activeSessions
+      // 并发守卫。
+      const sessionId = binding.sessionId
+      const previousRun = this.sessionRunChains.get(sessionId) ?? Promise.resolve()
+      const currentRun = previousRun.then(async () => {
+        // 等几个 tick 让 orchestrator finally 走完（防御性）
+        await new Promise<void>((resolve) => setTimeout(resolve, 0))
+        await this.executeRun(sessionId, msgCtx, mergedText, mergedImages, mergedFiles, parentMessageId)
+      }).catch((err) => {
+        console.error(`[飞书 Bridge] sessionRunChain 异常: ${sessionId}`, err)
+      })
+      this.sessionRunChains.set(sessionId, currentRun)
+      await currentRun
 
-      const finishedPromise = this.makeRunFinishedPromise(binding.sessionId)
-      await this.handleUserMessage(msgCtx, mergedText, mergedImages, mergedFiles, parentMessageId)
-
-      // handleUserMessage 内部 runAgentHeadless 是 fire-and-forget；这里等
-      // onComplete / onError 回调真正触发再释放并发槽位（block-and-merge 的核心保障）
-      await finishedPromise
+      // 链清理：当前 run 是最后一个时清掉 map 项防泄漏
+      if (this.sessionRunChains.get(sessionId) === currentRun) {
+        this.sessionRunChains.delete(sessionId)
+      }
     } finally {
       release()
       this.messageQueue.unblock(scope)
@@ -825,15 +836,20 @@ class FeishuBridge {
   }
 
   /**
-   * 轮询等待 orchestrator.activeSessions 真正清空（finally 走完）。
-   * 50ms 一次，最多等 10s 兜底。
+   * 实际执行一次 Agent run：调 handleUserMessage 触发 runAgentHeadless，
+   * 然后等 onComplete / onError 回调真正触发后才返回。
    */
-  private async waitUntilSessionIdle(sessionId: string): Promise<void> {
-    for (let i = 0; i < 200; i++) {
-      if (!isAgentSessionActive(sessionId)) return
-      await new Promise((resolve) => setTimeout(resolve, 50))
-    }
-    console.warn(`[飞书 Bridge] waitUntilSessionIdle 10s 超时，session 仍活: ${sessionId}`)
+  private async executeRun(
+    sessionId: string,
+    msgCtx: FeishuMessageContext,
+    text: string,
+    imageAttachments: FeishuImageAttachment[],
+    fileAttachments: FeishuFileAttachment[],
+    parentMessageId?: string,
+  ): Promise<void> {
+    const finishedPromise = this.makeRunFinishedPromise(sessionId)
+    await this.handleUserMessage(msgCtx, text, imageAttachments, fileAttachments, parentMessageId)
+    await finishedPromise
   }
 
   /**

--- a/apps/electron/src/main/lib/feishu-bridge.ts
+++ b/apps/electron/src/main/lib/feishu-bridge.ts
@@ -172,6 +172,12 @@ class FeishuBridge {
    * 的槽位真正等到 Agent 结束再释放。
    */
   private readonly runFinishedResolvers = new Map<string, () => void>()
+
+  /**
+   * sessionId 集合：标记本次 run 撞上 orchestrator 并发守卫，executeRun
+   * 应重试而不是把错误暴露给用户。
+   */
+  private readonly lastRunHitConcurrencyGuard = new Set<string>()
   /** sessionId → 通知模式 */
   private sessionNotifyModes = new Map<string, FeishuNotifyMode>()
   /** 默认通知目标 chatId（最后一个与 Bot 交互的飞书聊天） */
@@ -326,6 +332,7 @@ class FeishuBridge {
     for (const resolver of this.runFinishedResolvers.values()) resolver()
     this.runFinishedResolvers.clear()
     this.sessionRunChains.clear()
+    this.lastRunHitConcurrencyGuard.clear()
     // 关闭所有正在跑的流式卡（不等返回，避免阻塞 stop）
     for (const stream of this.streamingCards.values()) {
       void stream.close().catch(() => {})
@@ -838,6 +845,8 @@ class FeishuBridge {
   /**
    * 实际执行一次 Agent run：调 handleUserMessage 触发 runAgentHeadless，
    * 然后等 onComplete / onError 回调真正触发后才返回。
+   * 若撞上 orchestrator 并发守卫（lastRunHitConcurrencyGuard 标记），
+   * 自动重试最多 5 次，每次间隔 500ms 退避。
    */
   private async executeRun(
     sessionId: string,
@@ -847,9 +856,25 @@ class FeishuBridge {
     fileAttachments: FeishuFileAttachment[],
     parentMessageId?: string,
   ): Promise<void> {
-    const finishedPromise = this.makeRunFinishedPromise(sessionId)
-    await this.handleUserMessage(msgCtx, text, imageAttachments, fileAttachments, parentMessageId)
-    await finishedPromise
+    const MAX_RETRIES = 5
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      const finishedPromise = this.makeRunFinishedPromise(sessionId)
+      await this.handleUserMessage(msgCtx, text, imageAttachments, fileAttachments, parentMessageId)
+      await finishedPromise
+
+      if (!this.lastRunHitConcurrencyGuard.has(sessionId)) {
+        return // 正常完成
+      }
+      // 撞了并发守卫，清除标记重试
+      this.lastRunHitConcurrencyGuard.delete(sessionId)
+      if (attempt >= MAX_RETRIES) {
+        console.error(`[飞书 Bridge] executeRun 重试 ${MAX_RETRIES} 次仍撞并发守卫，放弃: ${sessionId.slice(-8)}`)
+        return
+      }
+      const delay = 500 * (attempt + 1)
+      console.log(`[飞书 Bridge] executeRun 重试 #${attempt + 1}，等待 ${delay}ms`)
+      await new Promise<void>((resolve) => setTimeout(resolve, delay))
+    }
   }
 
   /**
@@ -905,13 +930,21 @@ class FeishuBridge {
 
   /**
    * 由 runAgentHeadless 的 onComplete / onError 回调调用，唤醒 runMergedBatch 的 await。
-   * 立即 resolve 即可——下一个 batch 会通过 waitUntilSessionIdle 等 orchestrator
-   * finally 走完才调 runAgentHeadless，所以这里不需要再轮询 isActive。
-   * 多次调用幂等（resolver 取出后已 delete）。
+   *
+   * 关键：onComplete 在 orchestrator 的 finally 之前同步触发，此时
+   * activeSessions 还没 delete。立即 resolve 会让下一个 batch 撞 isActive=true
+   * 守卫。延迟一个 setTimeout(0) 让 orchestrator 同步 finally 走完，
+   * 再 resolve 才安全。
    */
   private notifyAgentRunFinished(sessionId: string): void {
     const resolver = this.runFinishedResolvers.get(sessionId)
-    if (resolver) resolver()
+    if (!resolver) return
+    // 延迟到下一个 tick：让 orchestrator 的 finally { activeSessions.delete }
+    // 走完，再唤醒 batch_B
+    setTimeout(() => {
+      const r = this.runFinishedResolvers.get(sessionId)
+      if (r) r()
+    }, 0)
   }
 
   private async handleCommand(msgCtx: FeishuMessageContext, text: string): Promise<void> {
@@ -1464,6 +1497,15 @@ class FeishuBridge {
 
       runAgentHeadless(input, {
         onError: (error) => {
+          // 检测 orchestrator 并发守卫错误：这是 Proma 内部并发竞态，
+          // 不应该把错误暴露给飞书侧用户。返回特殊标记让 executeRun 重试。
+          const isConcurrencyGuardError = error.includes('上一条消息仍在处理中')
+          if (isConcurrencyGuardError) {
+            console.warn(`[飞书 Bridge] 触发并发守卫，将重试: ${binding!.sessionId.slice(-8)}`)
+            this.lastRunHitConcurrencyGuard.add(binding!.sessionId)
+            this.notifyAgentRunFinished(binding!.sessionId)
+            return
+          }
           const errPrefix = this.resolveContextPrefix(chatId)
           // 优先把错误显示到流式卡上；没有流式卡才发独立错误卡
           if (this.streamingCards.has(binding!.sessionId)) {

--- a/apps/electron/src/main/lib/feishu-bridge.ts
+++ b/apps/electron/src/main/lib/feishu-bridge.ts
@@ -873,11 +873,33 @@ class FeishuBridge {
 
   /**
    * 由 runAgentHeadless 的 onComplete / onError 回调调用，唤醒 runMergedBatch 的 await。
-   * 多次调用幂等（同一 sessionId 只第一次生效）。
+   *
+   * 关键：onComplete 触发的时机在 orchestrator 的 finally 之前，此时
+   * activeSessions 还没 delete。如果立刻 resolve finishedPromise，runMergedBatch
+   * 会马上 unblock 让下一波 batch 进 handleUserMessage → orchestrator 撞
+   * 并发守卫 onError → 用户消息丢失。
+   *
+   * 解法：轮询 isAgentSessionActive 变 false（orchestrator finally 完成）
+   * 再 resolve；50ms 一次，最多等 5s（兜底防 orchestrator 卡死）。
    */
   private notifyAgentRunFinished(sessionId: string): void {
     const resolver = this.runFinishedResolvers.get(sessionId)
-    if (resolver) resolver()
+    if (!resolver) return
+    let attempts = 0
+    const tick = (): void => {
+      if (!isAgentSessionActive(sessionId) || attempts >= 100) {
+        if (attempts >= 100) {
+          console.warn(`[飞书 Bridge] 等 orchestrator 清理 activeSessions 5s 超时，强制 resolve: ${sessionId}`)
+        }
+        // 双重读：可能 setTimeout 期间已被另一路 resolve（如 stop）取走
+        const r = this.runFinishedResolvers.get(sessionId)
+        if (r) r()
+        return
+      }
+      attempts++
+      setTimeout(tick, 50)
+    }
+    tick()
   }
 
   private async handleCommand(msgCtx: FeishuMessageContext, text: string): Promise<void> {
@@ -1289,13 +1311,11 @@ class FeishuBridge {
       if (!binding) return
     }
 
-    // 兜底并发保护：理论上 RunCoordinator + ScopedQueue.block 已避免 batch
-    // flush 时 session 仍活着，这里 silent skip 防极端竞态（错过的消息会在
-    // unblock 后的下一波 quiet window 里被重新 flush）
-    if (isAgentSessionActive(binding.sessionId)) {
-      console.warn(`[飞书 Bridge] handleUserMessage 时 session 仍活，已跳过: ${binding.sessionId}`)
-      return
-    }
+    // 注：之前在此处有 isAgentSessionActive silent skip 兜底，会在
+    // 时序"onComplete 触发但 orchestrator finally 还没清 activeSessions"
+    // 间隙下吃掉合法 batch（实测重现：第 1 条任务跑完后第 2 条丢失）。
+    // 当前架构靠 RunCoordinator 的 per-scope 串行 + ScopedQueue.block/unblock
+    // + finishedPromise 三层保证不会真正并发，移除此兜底以避免误丢消息。
 
     // 保存飞书图片和文件到 session 工作目录，构建文件引用
     const attachedRefs: string[] = []

--- a/apps/electron/src/main/lib/feishu-bridge.ts
+++ b/apps/electron/src/main/lib/feishu-bridge.ts
@@ -69,6 +69,14 @@ import {
   type RunState,
 } from './feishu/card-run-state'
 import { renderCard as renderRunCard } from './feishu/card-renderer-v2'
+import { ScopedQueue } from './feishu/scoped-queue'
+import { RunCoordinator } from './feishu/run-coordinator'
+import {
+  buildAgentUserMessage,
+  fetchQuotedMessage,
+  type BridgeContext,
+  type QuotedMessage,
+} from './feishu/prompt-builder'
 
 // ===== 类型定义 =====
 
@@ -99,6 +107,19 @@ interface SessionBuffer {
   startedAt: number
 }
 
+/** 进入 ScopedQueue 防抖队列的飞书消息载荷 */
+interface QueuedFeishuMessage {
+  msgCtx: FeishuMessageContext
+  text: string
+  imageAttachments: FeishuImageAttachment[]
+  fileAttachments: FeishuFileAttachment[]
+  /** 用户长按"回复"指向的消息 id（飞书 message.parent_id） */
+  parentMessageId?: string
+}
+
+const MESSAGE_DEBOUNCE_MS = 600
+const DEFAULT_MAX_CONCURRENT_RUNS = 3
+
 // ===== Bridge =====
 
 class FeishuBridge {
@@ -128,6 +149,26 @@ class FeishuBridge {
   private streamingCards = new Map<string, CardStream>()
   /** 用过流式卡的 sessionId 集合（complete 时判定是否需要降级回复卡） */
   private streamingCardsUsedSessions = new Set<string>()
+
+  /** 防抖队列：scope → 累积的待处理消息（合并 batch 触发一次 Agent） */
+  private readonly messageQueue = new ScopedQueue<QueuedFeishuMessage>(
+    MESSAGE_DEBOUNCE_MS,
+    (scope, batch) => this.flushMessageBatch(scope, batch),
+  )
+
+  /** Run 协调：per-scope 串行 + 全局并发上限 */
+  private readonly runCoordinator = new RunCoordinator(DEFAULT_MAX_CONCURRENT_RUNS)
+
+  /**
+   * sessionId → resolver：在 Agent runAgentHeadless 的 onComplete / onError
+   * 回调里调用以唤醒 runMergedBatch 的 await，让 RunCoordinator.acquire 拿到
+   * 的槽位真正等到 Agent 结束再释放。
+   *
+   * 解决"runAgentHeadless 是 fire-and-forget，handleUserMessage 内部 await
+   * 返回时 Agent 还没真正跑完"导致 release/unblock 提前执行的问题
+   * （PR review code-reviewer 找到的 blocking bug）。
+   */
+  private readonly runFinishedResolvers = new Map<string, () => void>()
   /** sessionId → 通知模式 */
   private sessionNotifyModes = new Map<string, FeishuNotifyMode>()
   /** 默认通知目标 chatId（最后一个与 Bot 交互的飞书聊天） */
@@ -275,6 +316,12 @@ class FeishuBridge {
     this.chatBindings.clear()
     this.sessionToChat.clear()
     this.sessionBuffers.clear()
+    // 清空防抖队列与 run 协调状态
+    this.messageQueue.cancelAll()
+    this.runCoordinator.abortAll()
+    // resolve 所有 pending run-finished promise，避免 runMergedBatch 阻塞
+    for (const resolver of this.runFinishedResolvers.values()) resolver()
+    this.runFinishedResolvers.clear()
     // 关闭所有正在跑的流式卡（不等返回，避免阻塞 stop）
     for (const stream of this.streamingCards.values()) {
       void stream.close().catch(() => {})
@@ -678,17 +725,159 @@ class FeishuBridge {
     if (this.processingChats.has(chatId)) return
     this.processingChats.add(chatId)
     try {
-      // 命令路由
+      // 命令路由：命令跳过防抖立即执行；同时取消该 scope 累积的普通消息
       if (text.startsWith('/')) {
+        this.messageQueue.cancel(this.resolveScope(chatId))
         await this.handleCommand(msgCtx, text)
         return
       }
 
-      // 普通消息（文本/图片/文件）→ 转发到会话
-      await this.handleUserMessage(msgCtx, text, imageAttachments, fileAttachments)
+      // 普通消息：push 到防抖队列，600ms quiet window 后合并 batch 触发 Agent
+      // 取出用户长按"回复"指向的消息 id（用于 PromptBuilder 拉取被引消息）
+      const parentMessageId = (message.parent_id as string | undefined) || undefined
+
+      const scope = this.resolveScope(chatId)
+      const queued = this.messageQueue.push(scope, {
+        msgCtx,
+        text,
+        imageAttachments,
+        fileAttachments,
+        parentMessageId,
+      })
+      console.log(`[飞书 Bridge] 消息入队: scope=${scope}, 队列长度=${queued}`)
     } finally {
       this.processingChats.delete(chatId)
     }
+  }
+
+  /**
+   * 解析飞书 scope（与 ScopedQueue + RunCoordinator 共享 scope 语义）。
+   * 当前飞书桥不区分话题群 thread，全部按 chatId 处理；未来若支持话题群
+   * 再扩展为 `chatId:threadId`。
+   */
+  private resolveScope(chatId: string): string {
+    return chatId
+  }
+
+  /**
+   * ScopedQueue.onFlush 回调：把 batch 内多条消息合并为单次 Agent 调用。
+   * 这里执行：
+   *   1. 申请并发槽位（runCoordinator.acquire）
+   *   2. 在 messageQueue 上 block 该 scope（run 期间新消息只累积不 flush）
+   *   3. 合并 batch 的 text / attachments / parentMessageId
+   *   4. 调用原有的 handleUserMessage 走完所有现有流程
+   *   5. finally 释放槽位 + unblock 队列（重新 arm quiet window）
+   *
+   * fire-and-forget：onFlush 不能阻塞 ScopedQueue 的内部 timer。
+   */
+  private flushMessageBatch(scope: string, batch: QueuedFeishuMessage[]): void {
+    if (batch.length === 0) return
+    void this.runMergedBatch(scope, batch).catch((error) => {
+      console.error('[飞书 Bridge] flushMessageBatch 异常', { scope, err: error })
+    })
+  }
+
+  private async runMergedBatch(scope: string, batch: QueuedFeishuMessage[]): Promise<void> {
+    const first = batch[0]!
+    const last = batch[batch.length - 1]!
+
+    // 合并：text 用空行拼接；attachments 数组连接；parentMessageId 取最新一条
+    const mergedText = batch
+      .map((m) => m.text.trim())
+      .filter((t) => t.length > 0)
+      .join('\n\n')
+    const mergedImages = batch.flatMap((m) => m.imageAttachments)
+    const mergedFiles = batch.flatMap((m) => m.fileAttachments)
+    const parentMessageId = [...batch].reverse().find((m) => m.parentMessageId)?.parentMessageId
+
+    // batch 内的 msgCtx 取最新一条（messageId 用于 thread reply，senderName 等也用最新值）
+    const msgCtx: FeishuMessageContext = { ...last.msgCtx }
+
+    if (batch.length > 1) {
+      console.log(`[飞书 Bridge] 合并 batch: scope=${scope}, 消息数=${batch.length}, textChars=${mergedText.length}`)
+    }
+
+    // 先 acquire 全局并发槽位（可能等待）；拿到后 block 该 scope 防止
+    // run 期间新消息触发并行 flush
+    const release = await this.runCoordinator.acquire(scope, first.msgCtx.chatId)
+    this.messageQueue.block(scope)
+    try {
+      // 拿到 binding 才有 sessionId；handleUserMessage 内部会自动建会话
+      // 这里先去拿 binding（可能触发 createNewSession 异步），再创建 finished
+      // promise 绑定到该 sessionId
+      const binding = await this.ensureBinding(msgCtx)
+      if (!binding) return
+      const finishedPromise = this.makeRunFinishedPromise(binding.sessionId)
+
+      await this.handleUserMessage(msgCtx, mergedText, mergedImages, mergedFiles, parentMessageId)
+
+      // handleUserMessage 内部 runAgentHeadless 是 fire-and-forget；这里等
+      // onComplete / onError 回调真正触发再释放并发槽位（block-and-merge 的核心保障）
+      await finishedPromise
+    } finally {
+      release()
+      this.messageQueue.unblock(scope)
+    }
+  }
+
+  /**
+   * 确保 chatId 已有 chatBinding；若没有就先创建会话。
+   * 单独抽出来让 runMergedBatch 能在创建 finishedPromise 前拿到 sessionId。
+   */
+  private async ensureBinding(msgCtx: FeishuMessageContext): Promise<FeishuChatBinding | undefined> {
+    const existing = this.chatBindings.get(msgCtx.chatId)
+    if (existing) return existing
+    await this.createNewSession(msgCtx, 'agent')
+    return this.chatBindings.get(msgCtx.chatId)
+  }
+
+  /**
+   * 注册一个 finished promise，由 runAgentHeadless 的 onComplete / onError
+   * 回调（通过 notifyAgentRunFinished）触发 resolve。
+   *
+   * 兜底：30s 内若回调没触发自动 resolve，避免 runCoordinator 死锁。
+   */
+  private makeRunFinishedPromise(sessionId: string): Promise<void> {
+    return new Promise<void>((resolve) => {
+      // 同 sessionId 已有 pending resolver 是异常状态（说明前一个 batch 的 run
+      // 还没结束就被另一个 batch 抢入）。绝不能调用旧 resolver——会让前一个
+      // batch 提前 release/unblock 并发槽位，相当于把原 blocking bug 引回来。
+      // 正确处置：警告 + 跳过本次注册（让前 batch 走自己的超时兜底自然清理）。
+      if (this.runFinishedResolvers.has(sessionId)) {
+        console.warn(`[飞书 Bridge] makeRunFinishedPromise: sessionId ${sessionId} 已有 pending resolver，跳过本次注册（让本批次仅靠超时兜底）`)
+        // 直接给本次注册一个 30s 超时 resolver，不进 Map 防覆盖
+        setTimeout(() => resolve(), 30_000)
+        return
+      }
+
+      let resolved = false
+      let timer: NodeJS.Timeout | undefined
+      const finalize = (): void => {
+        if (resolved) return
+        resolved = true
+        if (timer) clearTimeout(timer)
+        this.runFinishedResolvers.delete(sessionId)
+        resolve()
+      }
+      this.runFinishedResolvers.set(sessionId, finalize)
+
+      // 兜底超时：30s 内 Agent 没结束（极端场景），强制释放并发槽位
+      timer = setTimeout(() => {
+        if (!resolved) {
+          console.warn(`[飞书 Bridge] Agent run finished promise 30s 超时，强制释放: ${sessionId}`)
+          finalize()
+        }
+      }, 30_000)
+    })
+  }
+
+  /**
+   * 由 runAgentHeadless 的 onComplete / onError 回调调用，唤醒 runMergedBatch 的 await。
+   * 多次调用幂等（同一 sessionId 只第一次生效）。
+   */
+  private notifyAgentRunFinished(sessionId: string): void {
+    const resolver = this.runFinishedResolvers.get(sessionId)
+    if (resolver) resolver()
   }
 
   private async handleCommand(msgCtx: FeishuMessageContext, text: string): Promise<void> {
@@ -1088,25 +1277,23 @@ class FeishuBridge {
     text: string,
     imageAttachments: FeishuImageAttachment[] = [],
     fileAttachments: FeishuFileAttachment[] = [],
+    parentMessageId?: string,
   ): Promise<void> {
     const { chatId } = msgCtx
     let binding = this.chatBindings.get(chatId)
 
-    // 自动创建会话
+    // 自动创建会话（runMergedBatch 已通过 ensureBinding 预建，此分支仅作兜底）
     if (!binding) {
       await this.createNewSession(msgCtx, 'agent')
       binding = this.chatBindings.get(chatId)
       if (!binding) return
     }
 
-    // 并发保护：如果该会话的 Agent 仍在运行，直接拒绝，不要触碰 buffer
+    // 兜底并发保护：理论上 RunCoordinator + ScopedQueue.block 已避免 batch
+    // flush 时 session 仍活着，这里 silent skip 防极端竞态（错过的消息会在
+    // unblock 后的下一波 quiet window 里被重新 flush）
     if (isAgentSessionActive(binding.sessionId)) {
-      try {
-        const prefix = this.resolveContextPrefix(chatId)
-        await this.sendCardMessage(chatId, buildErrorCard(`${prefix}上一条消息仍在处理中，请稍候再试`))
-      } catch (error) {
-        console.error(`[飞书 Bridge] 发送忙碌错误卡片失败:`, error)
-      }
+      console.warn(`[飞书 Bridge] handleUserMessage 时 session 仍活，已跳过: ${binding.sessionId}`)
       return
     }
 
@@ -1169,41 +1356,54 @@ class FeishuBridge {
       // 构建消息：附件引用 + 文本
       const hasAnyAttachment = imageAttachments.length > 0 || fileAttachments.length > 0
       const userText = text || (hasAnyAttachment ? '请查看上面附加的文件。' : '')
-      let agentMessage = fileReferences + userText
 
-      // 群聊时注入发送者、群组上下文以及聊天历史到消息
+      // 拉取被引用消息（用户长按"回复"触发；parent_id 由 handleFeishuMessage 透传）
+      let quoted: QuotedMessage | undefined
+      if (parentMessageId && this.client) {
+        quoted = await fetchQuotedMessage(this.client, parentMessageId)
+        if (quoted) {
+          console.log(`[飞书 Bridge] 引用消息已注入: type=${quoted.contentType}, chars=${quoted.content.length}`)
+        }
+      }
+
+      // 群聊上下文 + 历史摘要（保留原 Phase 1 逻辑，作为 group_extra 块）
+      let groupExtraBlock: string | undefined
       if (msgCtx.chatType === 'group') {
         const contextParts: string[] = []
-        if (msgCtx.groupName) {
-          contextParts.push(`[群聊: ${msgCtx.groupName}]`)
-        }
-        if (msgCtx.senderName) {
-          contextParts.push(`[发送者: ${msgCtx.senderName}]`)
-        }
+        if (msgCtx.groupName) contextParts.push(`[群聊: ${msgCtx.groupName}]`)
+        if (msgCtx.senderName) contextParts.push(`[发送者: ${msgCtx.senderName}]`)
 
-        // 注入群成员列表（方便 Agent @某人）
         const groupInfo = this.groupInfoCache.get(chatId)
         if (groupInfo?.members && groupInfo.members.length > 0) {
-          const membersExceptBot = groupInfo.members
-            .filter((m) => m.openId !== this.botOpenId)
-          const memberList = membersExceptBot
-            .map((m) => `${m.name}(${m.openId})`)
-            .join(', ')
+          const membersExceptBot = groupInfo.members.filter((m) => m.openId !== this.botOpenId)
+          const memberList = membersExceptBot.map((m) => `${m.name}(${m.openId})`).join(', ')
           contextParts.push(`[群成员: ${memberList}]`)
           contextParts.push('[提示: 如需 @某人，请直接使用 @姓名 格式，如 @Alice，系统会自动转换为飞书 @mention]')
         }
 
-        // 获取群聊历史消息作为上下文
         const chatHistory = await this.fetchChatHistory(chatId)
         const historyContext = this.formatChatHistoryContext(chatHistory)
 
         const parts: string[] = []
         if (contextParts.length > 0) parts.push(contextParts.join(' '))
         if (historyContext) parts.push(historyContext)
-        if (fileReferences) parts.push(fileReferences.trimEnd())
-        parts.push(userText)
-        agentMessage = parts.join('\n')
+        groupExtraBlock = parts.length > 0 ? parts.join('\n') : undefined
       }
+
+      const bridgeContext: BridgeContext = {
+        chatId: msgCtx.chatId,
+        chatType: msgCtx.chatType,
+        senderOpenId: msgCtx.senderOpenId,
+        senderName: msgCtx.senderName,
+      }
+
+      const agentMessage = buildAgentUserMessage({
+        userText,
+        context: bridgeContext,
+        quoted,
+        attachedFilesBlock: fileReferences.trim() || undefined,
+        groupExtraBlock,
+      })
 
       // Agent 模式 — fire-and-forget，不阻塞事件回调
       // 群聊时注入动态 MCP 工具（允许 Agent 主动拉取更多群聊历史）
@@ -1241,9 +1441,13 @@ class FeishuBridge {
           }
           this.sessionBuffers.delete(binding!.sessionId)
           this.streamingCardsUsedSessions.delete(binding!.sessionId)
+          // 释放 runCoordinator 槽位 + unblock 防抖队列（不依赖 onComplete，
+          // 因为出错路径 Proma orchestrator 也会调 onComplete，但保险起见两端都触发）
+          this.notifyAgentRunFinished(binding!.sessionId)
         },
         onComplete: () => {
-          // complete 事件由 EventBus listener 处理
+          // 真正释放 runCoordinator 槽位的位置：Agent SDK 已结束本轮 query
+          this.notifyAgentRunFinished(binding!.sessionId)
         },
         onTitleUpdated: (_title) => {
           // 标题更新可选通知

--- a/apps/electron/src/main/lib/feishu-bridge.ts
+++ b/apps/electron/src/main/lib/feishu-bridge.ts
@@ -158,26 +158,6 @@ class FeishuBridge {
 
   /** Run 协调：per-scope 串行 + 全局并发上限 */
   private readonly runCoordinator = new RunCoordinator(DEFAULT_MAX_CONCURRENT_RUNS)
-
-  /**
-   * 每个 sessionId 一个串行执行链：保证同一 sessionId 的 runAgentHeadless
-   * 严格按提交顺序串行执行。Promise.chain 模式天然解决 orchestrator
-   * activeSessions 时序竞态——前一个 await 真完成后下一个才开始。
-   */
-  private readonly sessionRunChains = new Map<string, Promise<void>>()
-
-  /**
-   * sessionId → resolver：在 Agent runAgentHeadless 的 onComplete / onError
-   * 回调里调用以唤醒 runMergedBatch 的 await，让 RunCoordinator.acquire 拿到
-   * 的槽位真正等到 Agent 结束再释放。
-   */
-  private readonly runFinishedResolvers = new Map<string, () => void>()
-
-  /**
-   * sessionId 集合：标记本次 run 撞上 orchestrator 并发守卫，executeRun
-   * 应重试而不是把错误暴露给用户。
-   */
-  private readonly lastRunHitConcurrencyGuard = new Set<string>()
   /** sessionId → 通知模式 */
   private sessionNotifyModes = new Map<string, FeishuNotifyMode>()
   /** 默认通知目标 chatId（最后一个与 Bot 交互的飞书聊天） */
@@ -328,11 +308,6 @@ class FeishuBridge {
     // 清空防抖队列与 run 协调状态
     this.messageQueue.cancelAll()
     this.runCoordinator.abortAll()
-    // resolve 所有 pending run-finished promise，避免 runMergedBatch 阻塞
-    for (const resolver of this.runFinishedResolvers.values()) resolver()
-    this.runFinishedResolvers.clear()
-    this.sessionRunChains.clear()
-    this.lastRunHitConcurrencyGuard.clear()
     // 关闭所有正在跑的流式卡（不等返回，避免阻塞 stop）
     for (const stream of this.streamingCards.values()) {
       void stream.close().catch(() => {})
@@ -576,7 +551,9 @@ class FeishuBridge {
     const userId = (sender?.sender_id as Record<string, unknown>)?.open_id as string ?? 'unknown'
     const mentions = message.mentions as FeishuMention[] | undefined
 
-    // chatId 级处理锁：同一聊天同时只处理一条消息，防止 bot 回复被重入处理
+    // 早期 fast-path：如果该 chat 正在处理消息（含图片下载等耗时 IO），
+    // 提前 return 避免无谓的资源下载。真正的并发保护在 line 711 的
+    // processingChats.add/delete try/finally 块里。
     if (this.processingChats.has(chatId)) {
       console.log('[飞书 Bridge] 跳过重入消息 (chatId lock):', chatId)
       return
@@ -808,143 +785,17 @@ class FeishuBridge {
       console.log(`[飞书 Bridge] 合并 batch: scope=${scope}, 消息数=${batch.length}, textChars=${mergedText.length}`)
     }
 
-    // 全局并发槽位（多 chat 之间）
+    // 全局并发槽位（跨 chat）+ per-scope 串行（block/unblock）
+    // RunCoordinator.acquire() 内部已基于 waiters 队列保证 per-scope 串行：
+    // 同一 scope 第二次 acquire 必须等第一次 release 后才返回。
     const release = await this.runCoordinator.acquire(scope, first.msgCtx.chatId)
     this.messageQueue.block(scope)
     try {
-      const binding = await this.ensureBinding(msgCtx)
-      if (!binding) return
-
-      // 关键设计：用 sessionRunChains 串行同 sessionId 的 run。
-      // Promise.chain 保证前一个 run 的 finishedPromise 完全 resolve 后，
-      // 下一个 run 才开始。即使 finishedPromise resolve 时 orchestrator
-      // finally 还没走完，也能在 await 期间走完，从而避免撞 activeSessions
-      // 并发守卫。
-      const sessionId = binding.sessionId
-      const previousRun = this.sessionRunChains.get(sessionId) ?? Promise.resolve()
-      const currentRun = previousRun.then(async () => {
-        // 等几个 tick 让 orchestrator finally 走完（防御性）
-        await new Promise<void>((resolve) => setTimeout(resolve, 0))
-        await this.executeRun(sessionId, msgCtx, mergedText, mergedImages, mergedFiles, parentMessageId)
-      }).catch((err) => {
-        console.error(`[飞书 Bridge] sessionRunChain 异常: ${sessionId}`, err)
-      })
-      this.sessionRunChains.set(sessionId, currentRun)
-      await currentRun
-
-      // 链清理：当前 run 是最后一个时清掉 map 项防泄漏
-      if (this.sessionRunChains.get(sessionId) === currentRun) {
-        this.sessionRunChains.delete(sessionId)
-      }
+      await this.handleUserMessage(msgCtx, mergedText, mergedImages, mergedFiles, parentMessageId)
     } finally {
       release()
       this.messageQueue.unblock(scope)
     }
-  }
-
-  /**
-   * 实际执行一次 Agent run：调 handleUserMessage 触发 runAgentHeadless，
-   * 然后等 onComplete / onError 回调真正触发后才返回。
-   * 若撞上 orchestrator 并发守卫（lastRunHitConcurrencyGuard 标记），
-   * 自动重试最多 5 次，每次间隔 500ms 退避。
-   */
-  private async executeRun(
-    sessionId: string,
-    msgCtx: FeishuMessageContext,
-    text: string,
-    imageAttachments: FeishuImageAttachment[],
-    fileAttachments: FeishuFileAttachment[],
-    parentMessageId?: string,
-  ): Promise<void> {
-    const MAX_RETRIES = 5
-    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-      const finishedPromise = this.makeRunFinishedPromise(sessionId)
-      await this.handleUserMessage(msgCtx, text, imageAttachments, fileAttachments, parentMessageId)
-      await finishedPromise
-
-      if (!this.lastRunHitConcurrencyGuard.has(sessionId)) {
-        return // 正常完成
-      }
-      // 撞了并发守卫，清除标记重试
-      this.lastRunHitConcurrencyGuard.delete(sessionId)
-      if (attempt >= MAX_RETRIES) {
-        console.error(`[飞书 Bridge] executeRun 重试 ${MAX_RETRIES} 次仍撞并发守卫，放弃: ${sessionId.slice(-8)}`)
-        return
-      }
-      const delay = 500 * (attempt + 1)
-      console.log(`[飞书 Bridge] executeRun 重试 #${attempt + 1}，等待 ${delay}ms`)
-      await new Promise<void>((resolve) => setTimeout(resolve, delay))
-    }
-  }
-
-  /**
-   * 确保 chatId 已有 chatBinding；若没有就先创建会话。
-   * 单独抽出来让 runMergedBatch 能在创建 finishedPromise 前拿到 sessionId。
-   */
-  private async ensureBinding(msgCtx: FeishuMessageContext): Promise<FeishuChatBinding | undefined> {
-    const existing = this.chatBindings.get(msgCtx.chatId)
-    if (existing) return existing
-    await this.createNewSession(msgCtx, 'agent')
-    return this.chatBindings.get(msgCtx.chatId)
-  }
-
-  /**
-   * 注册一个 finished promise，由 runAgentHeadless 的 onComplete / onError
-   * 回调（通过 notifyAgentRunFinished）触发 resolve。
-   *
-   * 兜底：30s 内若回调没触发自动 resolve，避免 runCoordinator 死锁。
-   */
-  private makeRunFinishedPromise(sessionId: string): Promise<void> {
-    return new Promise<void>((resolve) => {
-      // 同 sessionId 已有 pending resolver 是异常状态（说明前一个 batch 的 run
-      // 还没结束就被另一个 batch 抢入）。绝不能调用旧 resolver——会让前一个
-      // batch 提前 release/unblock 并发槽位，相当于把原 blocking bug 引回来。
-      // 正确处置：警告 + 跳过本次注册（让前 batch 走自己的超时兜底自然清理）。
-      if (this.runFinishedResolvers.has(sessionId)) {
-        console.warn(`[飞书 Bridge] makeRunFinishedPromise: sessionId ${sessionId} 已有 pending resolver，跳过本次注册（让本批次仅靠超时兜底）`)
-        // 直接给本次注册一个 30s 超时 resolver，不进 Map 防覆盖
-        setTimeout(() => resolve(), 30_000)
-        return
-      }
-
-      let resolved = false
-      let timer: NodeJS.Timeout | undefined
-      const finalize = (): void => {
-        if (resolved) return
-        resolved = true
-        if (timer) clearTimeout(timer)
-        this.runFinishedResolvers.delete(sessionId)
-        resolve()
-      }
-      this.runFinishedResolvers.set(sessionId, finalize)
-
-      // 兜底超时：30s 内 Agent 没结束（极端场景），强制释放并发槽位
-      timer = setTimeout(() => {
-        if (!resolved) {
-          console.warn(`[飞书 Bridge] Agent run finished promise 30s 超时，强制释放: ${sessionId}`)
-          finalize()
-        }
-      }, 30_000)
-    })
-  }
-
-  /**
-   * 由 runAgentHeadless 的 onComplete / onError 回调调用，唤醒 runMergedBatch 的 await。
-   *
-   * 关键：onComplete 在 orchestrator 的 finally 之前同步触发，此时
-   * activeSessions 还没 delete。立即 resolve 会让下一个 batch 撞 isActive=true
-   * 守卫。延迟一个 setTimeout(0) 让 orchestrator 同步 finally 走完，
-   * 再 resolve 才安全。
-   */
-  private notifyAgentRunFinished(sessionId: string): void {
-    const resolver = this.runFinishedResolvers.get(sessionId)
-    if (!resolver) return
-    // 延迟到下一个 tick：让 orchestrator 的 finally { activeSessions.delete }
-    // 走完，再唤醒 batch_B
-    setTimeout(() => {
-      const r = this.runFinishedResolvers.get(sessionId)
-      if (r) r()
-    }, 0)
   }
 
   private async handleCommand(msgCtx: FeishuMessageContext, text: string): Promise<void> {
@@ -1349,7 +1200,7 @@ class FeishuBridge {
     const { chatId } = msgCtx
     let binding = this.chatBindings.get(chatId)
 
-    // 自动创建会话（runMergedBatch 已通过 ensureBinding 预建，此分支仅作兜底）
+    // 自动创建会话
     if (!binding) {
       await this.createNewSession(msgCtx, 'agent')
       binding = this.chatBindings.get(chatId)
@@ -1495,40 +1346,33 @@ class FeishuBridge {
         ...(customMcpServers && { customMcpServers }),
       }
 
-      runAgentHeadless(input, {
-        onError: (error) => {
-          // 检测 orchestrator 并发守卫错误：这是 Proma 内部并发竞态，
-          // 不应该把错误暴露给飞书侧用户。返回特殊标记让 executeRun 重试。
-          const isConcurrencyGuardError = error.includes('上一条消息仍在处理中')
-          if (isConcurrencyGuardError) {
-            console.warn(`[飞书 Bridge] 触发并发守卫，将重试: ${binding!.sessionId.slice(-8)}`)
-            this.lastRunHitConcurrencyGuard.add(binding!.sessionId)
-            this.notifyAgentRunFinished(binding!.sessionId)
-            return
-          }
-          const errPrefix = this.resolveContextPrefix(chatId)
-          // 优先把错误显示到流式卡上；没有流式卡才发独立错误卡
-          if (this.streamingCards.has(binding!.sessionId)) {
-            this.markStreamingError(binding!.sessionId, error)
-          } else {
-            this.sendCardMessage(chatId, buildErrorCard(`${errPrefix}${error}`)).catch(console.error)
-          }
-          this.sessionBuffers.delete(binding!.sessionId)
-          this.streamingCardsUsedSessions.delete(binding!.sessionId)
-          // 释放 runCoordinator 槽位 + unblock 防抖队列（不依赖 onComplete，
-          // 因为出错路径 Proma orchestrator 也会调 onComplete，但保险起见两端都触发）
-          this.notifyAgentRunFinished(binding!.sessionId)
-        },
-        onComplete: () => {
-          // 真正释放 runCoordinator 槽位的位置：Agent SDK 已结束本轮 query
-          this.notifyAgentRunFinished(binding!.sessionId)
-        },
-        onTitleUpdated: (_title) => {
-          // 标题更新可选通知
-        },
-      }).catch((error) => {
+      // 直接 await runAgentHeadless 的 Promise——它会在 orchestrator.sendMessage
+      // 完整 await 结束（包含 finally { activeSessions.delete }）后才 resolve。
+      // 这是消除并发守卫竞态的核心：上层 runMergedBatch 看到本 Promise resolve
+      // 时，orchestrator 已经清理干净，下一个 batch 立刻调 sendMessage 不会撞守卫。
+      try {
+        await runAgentHeadless(input, {
+          onError: (error) => {
+            const errPrefix = this.resolveContextPrefix(chatId)
+            // 优先把错误显示到流式卡上；没有流式卡才发独立错误卡
+            if (this.streamingCards.has(binding!.sessionId)) {
+              this.markStreamingError(binding!.sessionId, error)
+            } else {
+              this.sendCardMessage(chatId, buildErrorCard(`${errPrefix}${error}`)).catch(console.error)
+            }
+            this.sessionBuffers.delete(binding!.sessionId)
+            this.streamingCardsUsedSessions.delete(binding!.sessionId)
+          },
+          onComplete: () => {
+            // complete 事件由 EventBus listener 处理
+          },
+          onTitleUpdated: (_title) => {
+            // 标题更新可选通知
+          },
+        })
+      } catch (error) {
         console.error('[飞书 Bridge] Agent 运行异常:', error)
-      })
+      }
     } else {
       // Chat 模式 — TODO: Phase 4 实现
       await this.sendMessage(chatId, 'Chat 模式暂未实现，请使用 /agent 切换到 Agent 模式。')

--- a/apps/electron/src/main/lib/feishu-bridge.ts
+++ b/apps/electron/src/main/lib/feishu-bridge.ts
@@ -803,12 +803,16 @@ class FeishuBridge {
     this.messageQueue.block(scope)
     try {
       // 拿到 binding 才有 sessionId；handleUserMessage 内部会自动建会话
-      // 这里先去拿 binding（可能触发 createNewSession 异步），再创建 finished
-      // promise 绑定到该 sessionId
       const binding = await this.ensureBinding(msgCtx)
       if (!binding) return
-      const finishedPromise = this.makeRunFinishedPromise(binding.sessionId)
 
+      // 关键：orchestrator 的并发守卫基于 activeSessions.has(sessionId)。
+      // 上一次 run 即使 onComplete 已触发，orchestrator finally 也可能没走
+      // 完，此时立即调 runAgentHeadless 会撞 "上一条消息仍在处理中" 错误。
+      // 在这里轮询等 activeSessions 真正清空再继续，避免业务层报错。
+      await this.waitUntilSessionIdle(binding.sessionId)
+
+      const finishedPromise = this.makeRunFinishedPromise(binding.sessionId)
       await this.handleUserMessage(msgCtx, mergedText, mergedImages, mergedFiles, parentMessageId)
 
       // handleUserMessage 内部 runAgentHeadless 是 fire-and-forget；这里等
@@ -818,6 +822,18 @@ class FeishuBridge {
       release()
       this.messageQueue.unblock(scope)
     }
+  }
+
+  /**
+   * 轮询等待 orchestrator.activeSessions 真正清空（finally 走完）。
+   * 50ms 一次，最多等 10s 兜底。
+   */
+  private async waitUntilSessionIdle(sessionId: string): Promise<void> {
+    for (let i = 0; i < 200; i++) {
+      if (!isAgentSessionActive(sessionId)) return
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    }
+    console.warn(`[飞书 Bridge] waitUntilSessionIdle 10s 超时，session 仍活: ${sessionId}`)
   }
 
   /**
@@ -873,33 +889,13 @@ class FeishuBridge {
 
   /**
    * 由 runAgentHeadless 的 onComplete / onError 回调调用，唤醒 runMergedBatch 的 await。
-   *
-   * 关键：onComplete 触发的时机在 orchestrator 的 finally 之前，此时
-   * activeSessions 还没 delete。如果立刻 resolve finishedPromise，runMergedBatch
-   * 会马上 unblock 让下一波 batch 进 handleUserMessage → orchestrator 撞
-   * 并发守卫 onError → 用户消息丢失。
-   *
-   * 解法：轮询 isAgentSessionActive 变 false（orchestrator finally 完成）
-   * 再 resolve；50ms 一次，最多等 5s（兜底防 orchestrator 卡死）。
+   * 立即 resolve 即可——下一个 batch 会通过 waitUntilSessionIdle 等 orchestrator
+   * finally 走完才调 runAgentHeadless，所以这里不需要再轮询 isActive。
+   * 多次调用幂等（resolver 取出后已 delete）。
    */
   private notifyAgentRunFinished(sessionId: string): void {
     const resolver = this.runFinishedResolvers.get(sessionId)
-    if (!resolver) return
-    let attempts = 0
-    const tick = (): void => {
-      if (!isAgentSessionActive(sessionId) || attempts >= 100) {
-        if (attempts >= 100) {
-          console.warn(`[飞书 Bridge] 等 orchestrator 清理 activeSessions 5s 超时，强制 resolve: ${sessionId}`)
-        }
-        // 双重读：可能 setTimeout 期间已被另一路 resolve（如 stop）取走
-        const r = this.runFinishedResolvers.get(sessionId)
-        if (r) r()
-        return
-      }
-      attempts++
-      setTimeout(tick, 50)
-    }
-    tick()
+    if (resolver) resolver()
   }
 
   private async handleCommand(msgCtx: FeishuMessageContext, text: string): Promise<void> {

--- a/apps/electron/src/main/lib/feishu/prompt-builder.ts
+++ b/apps/electron/src/main/lib/feishu/prompt-builder.ts
@@ -69,7 +69,17 @@ export const BRIDGE_USER_MESSAGE_PRELUDE = `<!-- 你正在通过 Proma 飞书桥
 - <interactive_card>：被引用消息是卡片时，附上原 card JSON 供你理解结构
 - <attached_files>：用户上传的图片/文件已保存到本地，给你绝对路径
 
-用户的实际问题在这些块之后。回答时围绕用户问题展开；XML 块只用来理解上下文。 -->`
+用户的实际问题在这些块之后。回答时围绕用户问题展开；XML 块只用来理解上下文。
+
+【飞书桥重要约束】
+1. **禁用 AskUserQuestion 工具**：飞书桥目前没有交互问答的 UI 通道，调用这个工具
+   会让会话卡死。如果信息不足，请基于现有信息给出最佳推断（可在回复里说明你的
+   假设），或直接告知用户需要的额外信息让他们补充，让用户在下一条消息里补全。
+   绝对不要调用 AskUserQuestion。
+2. **附件优先用 Read 工具读取**：<attached_files> 给的是已保存到本地的绝对路径，
+   你可以直接 Read（图片走多模态读取）/ 用 Bash 的 file/cat 等命令查看。
+3. **回复格式**：飞书侧使用 markdown 富文本卡片渲染，可以放心用 markdown 格式。
+-->`
 
 /**
  * 把上下文 / 引用 / 附件 / 用户文本组装成最终的 AgentSendInput.userMessage。

--- a/apps/electron/src/main/lib/feishu/prompt-builder.ts
+++ b/apps/electron/src/main/lib/feishu/prompt-builder.ts
@@ -1,0 +1,236 @@
+/**
+ * 飞书消息上下文 → Agent 系统提示词 + user message 的构造器。
+ *
+ * 解决的真实问题：
+ *   1. Agent 看不到引用回复——用户在飞书里"长按 → 回复"某条消息时，
+ *      飞书把被引用消息的 messageId 放在 message.parent_id 里。原来
+ *      Proma 只把 user text 给 Agent，丢掉了"用户在问哪条消息"这个上下文。
+ *   2. Agent 不知道 chat 类型与发送者——群聊 vs 私聊、用户名等元数据
+ *      此前是隐式的（仅在群聊 prefix 里出现）。
+ *   3. Agent 看不到被引用的卡片内容——用户引用 Bot 发的卡片提问时，
+ *      只看到一串 "[card]" 占位文本。
+ *
+ * 借鉴 zara/feishu-claude-code-bridge `src/agent/claude/adapter.ts`
+ * 的 BRIDGE_SYSTEM_PROMPT 约定 + `src/bot/quote.ts` 的引用消息抓取，
+ * 但 Proma 用动态系统提示词构建，BRIDGE_SYSTEM_PROMPT 作为
+ * AgentSendInput.userMessage 的前置 XML 块（不是 system prompt）。
+ *
+ * 约定的 XML 块（教 Agent 见 BRIDGE_USER_MESSAGE_PRELUDE）：
+ *   <bridge_context>       chat_id / chat_type / sender 元数据
+ *   <quoted_message>       被引用消息内容（含 merge_forward 展开）
+ *   <interactive_card>     被引用消息是卡片时，注入完整 card JSON
+ *   <attached_files>       本地附件列表（已有，由 handleUserMessage 构造）
+ */
+
+import type { Client as LarkClient } from '@larksuiteoapi/node-sdk'
+
+/** 引用消息的简化结构，由 Bridge 调 im.message.get 拉取得到。 */
+export interface QuotedMessage {
+  messageId: string
+  senderOpenId?: string
+  senderName?: string
+  createdAt?: number
+  contentType: string
+  /** 文本内容（已从飞书 content JSON 解出） */
+  content: string
+  /** 如果被引用消息本身是 interactive 卡片，这里是原 card JSON 字符串 */
+  cardJson?: string
+}
+
+export interface BridgeContext {
+  chatId: string
+  chatType: 'p2p' | 'group' | 'topic'
+  senderOpenId: string
+  senderName?: string
+  /** 话题群的 thread_id；普通群/p2p 留空 */
+  threadId?: string
+}
+
+export interface BuildOptions {
+  /** 用户原始文本（已合并多消息 batch 时由调用方拼好） */
+  userText: string
+  /** chat / sender 元数据 */
+  context: BridgeContext
+  /** 引用回复目标（用户长按"回复"指向的消息）；可选 */
+  quoted?: QuotedMessage
+  /** 附件路径引用块；handleUserMessage 已有逻辑构造，原样拼入 */
+  attachedFilesBlock?: string
+  /** 群聊额外注入：群名 / 成员列表 / 历史摘要 */
+  groupExtraBlock?: string
+}
+
+/** 教 Agent 如何看待 bridge 注入的 XML 块。会被前置到每条 userMessage。 */
+export const BRIDGE_USER_MESSAGE_PRELUDE = `<!-- 你正在通过 Proma 飞书桥处理来自飞书的用户消息。bridge 会用 XML 块注入
+当前对话的元数据。下面这些 XML 块**对用户不可见**，不要照抄到回复里。
+
+可能出现的 XML 块：
+- <bridge_context>：chat_id / chat_type / sender 等飞书侧元数据
+- <quoted_message>：用户长按"回复"指向的那条消息（你的回答应该围绕它展开）
+- <interactive_card>：被引用消息是卡片时，附上原 card JSON 供你理解结构
+- <attached_files>：用户上传的图片/文件已保存到本地，给你绝对路径
+
+用户的实际问题在这些块之后。回答时围绕用户问题展开；XML 块只用来理解上下文。 -->`
+
+/**
+ * 把上下文 / 引用 / 附件 / 用户文本组装成最终的 AgentSendInput.userMessage。
+ *
+ * 输出结构（自上而下）：
+ *   BRIDGE_USER_MESSAGE_PRELUDE
+ *   <bridge_context>...</bridge_context>
+ *   <quoted_message>...</quoted_message>     // 仅当 quoted 存在
+ *   <interactive_card>...</interactive_card> // 仅当被引用消息是卡片
+ *   <attached_files>...</attached_files>     // 仅当有附件
+ *   <group_extra>...</group_extra>           // 仅当群聊（群名/成员/历史）
+ *   <user_message>用户文本</user_message>
+ */
+export function buildAgentUserMessage(opts: BuildOptions): string {
+  const parts: string[] = [BRIDGE_USER_MESSAGE_PRELUDE]
+
+  parts.push(buildBridgeContextBlock(opts.context))
+
+  if (opts.quoted) {
+    parts.push(buildQuotedMessageBlock(opts.quoted))
+    if (opts.quoted.cardJson) {
+      parts.push(buildInteractiveCardBlock(opts.quoted.cardJson))
+    }
+  }
+
+  if (opts.attachedFilesBlock && opts.attachedFilesBlock.trim()) {
+    parts.push(opts.attachedFilesBlock.trim())
+  }
+
+  if (opts.groupExtraBlock && opts.groupExtraBlock.trim()) {
+    parts.push(`<group_extra>\n${opts.groupExtraBlock.trim()}\n</group_extra>`)
+  }
+
+  parts.push(`<user_message>\n${opts.userText}\n</user_message>`)
+
+  return parts.join('\n\n')
+}
+
+function buildBridgeContextBlock(ctx: BridgeContext): string {
+  const lines = [
+    `chat_id: ${ctx.chatId}`,
+    `chat_type: ${ctx.chatType}`,
+    `sender_id: ${ctx.senderOpenId}`,
+  ]
+  if (ctx.senderName) lines.push(`sender_name: ${ctx.senderName}`)
+  if (ctx.threadId) lines.push(`thread_id: ${ctx.threadId}`)
+  return `<bridge_context>\n${lines.join('\n')}\n</bridge_context>`
+}
+
+function buildQuotedMessageBlock(q: QuotedMessage): string {
+  const attrs = [
+    `id="${q.messageId}"`,
+    q.senderOpenId ? `sender_id="${q.senderOpenId}"` : '',
+    q.senderName ? `sender_name="${escapeAttr(q.senderName)}"` : '',
+    q.createdAt ? `created_at="${new Date(q.createdAt).toISOString()}"` : '',
+    `type="${q.contentType}"`,
+  ].filter(Boolean).join(' ')
+  return `<quoted_message ${attrs}>\n${q.content}\n</quoted_message>`
+}
+
+function buildInteractiveCardBlock(cardJson: string): string {
+  return `<interactive_card>\n${cardJson}\n</interactive_card>`
+}
+
+function escapeAttr(s: string): string {
+  return s.replace(/"/g, '&quot;').replace(/[<>]/g, (c) => (c === '<' ? '&lt;' : '&gt;'))
+}
+
+/**
+ * 从飞书 im.message.get 拿到被引消息的 raw 字段后，转换成 QuotedMessage。
+ * 调用方应处理网络错误并返回 undefined，让 prompt 不带 quoted 块即可。
+ */
+export async function fetchQuotedMessage(
+  client: LarkClient,
+  parentMessageId: string,
+): Promise<QuotedMessage | undefined> {
+  try {
+    const resp = await client.im.v1.message.get({
+      path: { message_id: parentMessageId },
+    })
+    const item = resp.data?.items?.[0]
+    if (!item) return undefined
+
+    const contentType = item.msg_type ?? 'unknown'
+    const bodyContent = item.body?.content ?? ''
+    const senderId = item.sender?.id
+    const createTime = typeof item.create_time === 'string'
+      ? Number(item.create_time)
+      : item.create_time
+
+    let content = ''
+    let cardJson: string | undefined
+
+    if (contentType === 'text') {
+      content = safeJsonField(bodyContent, 'text') ?? bodyContent
+    } else if (contentType === 'post') {
+      // post 是富文本，飞书内容是 { title, content: [[{tag, text|content}]] }
+      // 简化：拼接所有 text 段
+      content = extractPostText(bodyContent)
+    } else if (contentType === 'interactive') {
+      content = '（被引用的是交互式卡片，详见 <interactive_card>）'
+      cardJson = bodyContent
+    } else if (contentType === 'image') {
+      content = `（被引用的是图片消息，image_key=${safeJsonField(bodyContent, 'image_key') ?? '?'}）`
+    } else if (contentType === 'file') {
+      content = `（被引用的是文件消息，file_name=${safeJsonField(bodyContent, 'file_name') ?? '?'}）`
+    } else {
+      // 兜底：原始 JSON 截断
+      content = bodyContent.length > 500 ? bodyContent.slice(0, 500) + '…' : bodyContent
+    }
+
+    return {
+      messageId: parentMessageId,
+      senderOpenId: senderId,
+      createdAt: typeof createTime === 'number' ? createTime : undefined,
+      contentType,
+      content,
+      cardJson,
+    }
+  } catch (err) {
+    console.warn('[飞书 PromptBuilder] 拉取被引消息失败', {
+      parentMessageId,
+      err: err instanceof Error ? err.message : String(err),
+    })
+    return undefined
+  }
+}
+
+function safeJsonField(bodyContent: string, field: string): string | undefined {
+  try {
+    const obj = JSON.parse(bodyContent) as Record<string, unknown>
+    const v = obj[field]
+    return typeof v === 'string' ? v : undefined
+  } catch {
+    return undefined
+  }
+}
+
+interface PostNode {
+  tag?: string
+  text?: string
+  content?: string
+}
+
+function extractPostText(bodyContent: string): string {
+  try {
+    const obj = JSON.parse(bodyContent) as {
+      title?: string
+      content?: PostNode[][]
+    }
+    const lines: string[] = []
+    if (obj.title) lines.push(obj.title)
+    if (Array.isArray(obj.content)) {
+      for (const line of obj.content) {
+        if (!Array.isArray(line)) continue
+        const seg = line.map((n) => n.text ?? n.content ?? '').join('')
+        if (seg) lines.push(seg)
+      }
+    }
+    return lines.join('\n')
+  } catch {
+    return bodyContent
+  }
+}

--- a/apps/electron/src/main/lib/feishu/run-coordinator.ts
+++ b/apps/electron/src/main/lib/feishu/run-coordinator.ts
@@ -1,0 +1,94 @@
+/**
+ * 飞书 Agent run 的并发协调器。
+ *
+ * 两层并发控制：
+ * 1. **per-scope 串行**：同一 scope（chatId 或 chatId:threadId）任一时刻
+ *    只允许一个 Agent run。新消息在 ScopedQueue 里 block-accumulate，
+ *    run 结束后 unblock 重新 quiet window 后合并 flush。
+ * 2. **全局上限**：跨 scope 同时跑的 Agent 数不超过 maxConcurrent，
+ *    超过则在 acquire() 处等待（队列化）。
+ *
+ * 设计参考 zara/feishu-claude-code-bridge `src/bot/active-runs.ts` +
+ * `src/bot/process-pool.ts`，但本期不做"新消息打断旧 run"的抢占——
+ * 飞书桥用 block-and-merge 模式更友好（参考 ScopedQueue 注释）。
+ *
+ * 抢占接口（abort）已留好，未来若加"用户主动抢占按钮"可直接复用。
+ */
+
+export interface ActiveRunHandle {
+  scope: string
+  sessionId: string
+  startedAt: number
+}
+
+export class RunCoordinator {
+  private readonly active = new Map<string, ActiveRunHandle>()
+  private readonly maxConcurrent: () => number
+  private readonly waiters: Array<() => void> = []
+
+  constructor(maxConcurrent: number | (() => number)) {
+    this.maxConcurrent = typeof maxConcurrent === 'function'
+      ? maxConcurrent
+      : () => maxConcurrent
+  }
+
+  /** 当前是否已有该 scope 的 run。 */
+  isActive(scope: string): boolean {
+    return this.active.has(scope)
+  }
+
+  /** 当前正在跑的 run 数量（跨 scope 总和）。 */
+  size(): number {
+    return this.active.size
+  }
+
+  /**
+   * 申请一个并发槽位 + 注册 ActiveRun。返回 release 函数。
+   * 槽位不足时排队等待，先到先得。
+   *
+   * 调用方约定：拿到 release 后必须放在 try/finally 里调用，否则
+   * waiters 永远等不到唤醒。
+   */
+  async acquire(scope: string, sessionId: string): Promise<() => void> {
+    while (this.active.size >= this.maxConcurrent()) {
+      await new Promise<void>((resolve) => this.waiters.push(resolve))
+    }
+    const handle: ActiveRunHandle = { scope, sessionId, startedAt: Date.now() }
+    this.active.set(scope, handle)
+    let released = false
+    return () => {
+      if (released) return
+      released = true
+      const cur = this.active.get(scope)
+      if (cur && cur.sessionId === sessionId) {
+        this.active.delete(scope)
+      }
+      const next = this.waiters.shift()
+      if (next) next()
+    }
+  }
+
+  /**
+   * 强制中止某个 scope 的 run（仅注销注册表，不杀 SDK；调用方需自行调
+   * stopAgent）。供未来"用户抢占"按钮 / 命令使用，本期未启用。
+   */
+  abort(scope: string): ActiveRunHandle | undefined {
+    const handle = this.active.get(scope)
+    if (!handle) return undefined
+    this.active.delete(scope)
+    const next = this.waiters.shift()
+    if (next) next()
+    return handle
+  }
+
+  /** bridge stop 时调用：清空注册表 + 唤醒所有等待者（让它们 race 到 abort）。 */
+  abortAll(): ActiveRunHandle[] {
+    const handles = [...this.active.values()]
+    this.active.clear()
+    while (this.waiters.length > 0) {
+      const w = this.waiters.shift()
+      if (w) w()
+    }
+    return handles
+  }
+}

--- a/apps/electron/src/main/lib/feishu/scoped-queue.ts
+++ b/apps/electron/src/main/lib/feishu/scoped-queue.ts
@@ -1,0 +1,131 @@
+/**
+ * Per-scope 防抖累积队列。
+ *
+ * Scope 通常是 chatId（p2p / 普通群）或 `chatId:threadId`（话题群），
+ * 同一 scope 内的消息在 quiet window 内会被合并成一个 batch 一起处理。
+ *
+ * 关键语义（参考 zara/feishu-claude-code-bridge `src/bot/pending-queue.ts`）：
+ * - push: 加消息到队列，arm/重置 quiet window timer
+ * - block: Agent run 期间禁止 timer 触发，新消息继续累积
+ * - unblock: run 结束后重新 arm 一次 quiet window，让"run 期间累积的消息"
+ *   再次走 quiet window 才合并 flush（避免用户刚发完 Agent 就立刻抢答）
+ *
+ * 这个模式解决两个真实痛点：
+ *   1. 用户连发 3 条 → 不会触发 3 个并行 Agent
+ *   2. Agent 跑期间用户又发了 → 不打断当前 run，等结束再合并处理新消息
+ */
+
+export interface QueuedMessage<T> {
+  scope: string
+  payload: T
+  enqueuedAt: number
+}
+
+export type FlushHandler<T> = (scope: string, batch: T[]) => void
+
+interface PendingEntry<T> {
+  messages: T[]
+  timer?: NodeJS.Timeout
+}
+
+export class ScopedQueue<T> {
+  private readonly map = new Map<string, PendingEntry<T>>()
+  private readonly blocked = new Set<string>()
+  private readonly delayMs: number
+  private readonly onFlush: FlushHandler<T>
+
+  constructor(delayMs: number, onFlush: FlushHandler<T>) {
+    this.delayMs = delayMs
+    this.onFlush = onFlush
+  }
+
+  /**
+   * 累积一条消息到 scope 队列，重置 quiet window timer。
+   * 若该 scope 已 block，timer 不会被 arm（消息只累积，不 flush）。
+   * 返回当前队列里同一 scope 的消息数量（含本次）。
+   */
+  push(scope: string, payload: T): number {
+    const existing = this.map.get(scope)
+    if (existing) {
+      if (existing.timer) clearTimeout(existing.timer)
+      existing.messages.push(payload)
+      existing.timer = this.blocked.has(scope) ? undefined : this.armTimer(scope)
+      return existing.messages.length
+    }
+    this.map.set(scope, {
+      messages: [payload],
+      timer: this.blocked.has(scope) ? undefined : this.armTimer(scope),
+    })
+    return 1
+  }
+
+  /**
+   * 取消 scope 的待 flush 队列并返回当前累积的消息。
+   * 用于命令直通场景：命令应跳过防抖立即处理，同时丢弃此前累积的普通消息。
+   */
+  cancel(scope: string): T[] {
+    const entry = this.map.get(scope)
+    if (!entry) return []
+    if (entry.timer) clearTimeout(entry.timer)
+    this.map.delete(scope)
+    return entry.messages
+  }
+
+  /**
+   * 清空所有 scope 的队列与 block 标记。bridge stop 时调用。
+   */
+  cancelAll(): void {
+    for (const entry of this.map.values()) {
+      if (entry.timer) clearTimeout(entry.timer)
+    }
+    this.map.clear()
+    this.blocked.clear()
+  }
+
+  /**
+   * 暂停 scope 的 timer：累积仍在，但不会触发 flush。
+   * Agent run 开始时调用。
+   */
+  block(scope: string): void {
+    if (this.blocked.has(scope)) return
+    this.blocked.add(scope)
+    const entry = this.map.get(scope)
+    if (entry?.timer) {
+      clearTimeout(entry.timer)
+      entry.timer = undefined
+    }
+  }
+
+  /**
+   * 恢复 scope 的 timer：若期间累积了消息，arm 一个全新的 quiet window。
+   * Agent run 结束时调用。
+   */
+  unblock(scope: string): void {
+    if (!this.blocked.has(scope)) return
+    this.blocked.delete(scope)
+    const entry = this.map.get(scope)
+    if (!entry || entry.messages.length === 0) return
+    if (entry.timer) clearTimeout(entry.timer)
+    entry.timer = this.armTimer(scope)
+  }
+
+  /** 当前 scope 是否还有待 flush 的消息。 */
+  hasPending(scope: string): boolean {
+    return (this.map.get(scope)?.messages.length ?? 0) > 0
+  }
+
+  private armTimer(scope: string): NodeJS.Timeout {
+    return setTimeout(() => this.flush(scope), this.delayMs)
+  }
+
+  private flush(scope: string): void {
+    const entry = this.map.get(scope)
+    if (!entry) return
+    this.map.delete(scope)
+    try {
+      this.onFlush(scope, entry.messages)
+    } catch (err) {
+      console.error('[飞书 ScopedQueue] flush 处理失败', { scope, err })
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- b609960 fix(feishu): 附件保存加诊断 log + prompt 屏蔽 AskUserQuestion
- 8a7ef85 refactor(feishu): Phase 2 大幅简化——删除 156 行补丁式并发控制代码
- 16cdf72 fix(feishu): 并发守卫错误自动重试，不暴露给飞书侧用户
- df3d2e1 fix(feishu): 用 sessionRunChains Promise 链彻底解决并发守卫竞态
- 66701e4 fix(feishu): 第 2 条消息撞 orchestrator 并发守卫报错
- 8a085d0 fix(feishu): 修复 Phase 2 第 2 条消息丢失（onComplete vs activeSessions 时序）
- 70e2c2a feat(feishu): Phase 2 防抖累积 + 单 chat 串行 + 引用消息上下文注入

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归