### PR TITLE
perf(sidebar): 补全菜单 handler 的 useCallback，消除流式期间 React.memo 失效【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -9,7 +9,7 @@
  */
 
 import * as React from 'react'
-import { useAtom, useSetAtom, useAtomValue } from 'jotai'
+import { useAtom, useSetAtom, useAtomValue, useStore } from 'jotai'
 import { toast } from 'sonner'
 import { Pin, PinOff, Settings, Plus, Trash2, Pencil, ChevronDown, ChevronRight, Plug, Zap, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Hammer, Bot, MessageSquare, MoreHorizontal } from 'lucide-react'
 import { cn } from '@/lib/utils'
@@ -260,6 +260,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   const [sidebarCollapsed, setSidebarCollapsed] = useAtom(sidebarCollapsedAtom)
   const openSession = useOpenSession()
   const syncActiveTabSideEffects = useSyncActiveTabSideEffects()
+  const store = useStore()
 
   // 归档 & 搜索状态
   const [viewMode, setViewMode] = useAtom(sidebarViewModeAtom)
@@ -548,7 +549,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   }, [])
 
   /** 重命名对话标题 */
-  const handleRename = async (id: string, newTitle: string): Promise<void> => {
+  const handleRename = React.useCallback(async (id: string, newTitle: string): Promise<void> => {
     try {
       const updated = await window.electronAPI.updateConversationTitle(id, newTitle)
       setConversations((prev) =>
@@ -559,12 +560,12 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     } catch (error) {
       console.error('[侧边栏] 重命名对话失败:', error)
     }
-  }
+  }, [setConversations, setTabs])
 
   /** 切换对话置顶状态 */
-  const handleTogglePin = async (id: string): Promise<void> => {
+  const handleTogglePin = React.useCallback(async (id: string): Promise<void> => {
     try {
-      const original = conversations.find((c) => c.id === id)
+      const original = store.get(conversationsAtom).find((c) => c.id === id)
       const updated = await window.electronAPI.togglePinConversation(id)
       setConversations((prev) =>
         prev.map((c) => (c.id === updated.id ? updated : c))
@@ -576,10 +577,10 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     } catch (error) {
       console.error('[侧边栏] 切换置顶失败:', error)
     }
-  }
+  }, [store, setConversations])
 
   /** 切换对话归档状态 */
-  const handleToggleArchive = async (id: string): Promise<void> => {
+  const handleToggleArchive = React.useCallback(async (id: string): Promise<void> => {
     try {
       const updated = await window.electronAPI.toggleArchiveConversation(id)
       setConversations((prev) =>
@@ -589,8 +590,10 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       // （appMode、currentXxxId 等），避免文件面板/工具栏等 per-tab
       // 状态被遗留为旧值或被错误地置 null。
       if (updated.archived) {
-        const wasActive = activeTabId === id
-        const tabResult = closeTab(tabs, activeTabId, id)
+        const currentTabs = store.get(tabsAtom)
+        const currentActiveTabId = store.get(activeTabIdAtom)
+        const wasActive = currentActiveTabId === id
+        const tabResult = closeTab(currentTabs, currentActiveTabId, id)
         setTabs(tabResult.tabs)
         setActiveTabId(tabResult.activeTabId)
         cleanupMapAtoms(id)
@@ -605,7 +608,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     } catch (error) {
       console.error('[侧边栏] 切换归档失败:', error)
     }
-  }
+  }, [store, setConversations, setTabs, setActiveTabId, cleanupMapAtoms, syncActiveTabSideEffects])
 
   /** 确认删除对话 */
   const handleConfirmDelete = async (): Promise<void> => {
@@ -732,7 +735,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   }, [openSession, setActiveView, setUnviewedCompleted])
 
   /** 重命名 Agent 会话标题 */
-  const handleAgentRename = async (id: string, newTitle: string): Promise<void> => {
+  const handleAgentRename = React.useCallback(async (id: string, newTitle: string): Promise<void> => {
     try {
       const updated = await window.electronAPI.updateAgentSessionTitle(id, newTitle)
       setAgentSessions((prev) =>
@@ -743,12 +746,12 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     } catch (error) {
       console.error('[侧边栏] 重命名 Agent 会话失败:', error)
     }
-  }
+  }, [setAgentSessions, setTabs])
 
   /** 切换 Agent 会话置顶状态 */
-  const handleTogglePinAgent = async (id: string): Promise<void> => {
+  const handleTogglePinAgent = React.useCallback(async (id: string): Promise<void> => {
     try {
-      const original = agentSessions.find((s) => s.id === id)
+      const original = store.get(agentSessionsAtom).find((s) => s.id === id)
       const updated = await window.electronAPI.togglePinAgentSession(id)
       setAgentSessions((prev) =>
         prev.map((s) => (s.id === updated.id ? updated : s))
@@ -760,15 +763,15 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     } catch (error) {
       console.error('[侧边栏] 切换 Agent 会话置顶失败:', error)
     }
-  }
+  }, [store, setAgentSessions])
 
   /** 切换 Agent 会话手动工作中状态 */
-  const handleToggleManualWorkingAgent = async (id: string): Promise<void> => {
+  const handleToggleManualWorkingAgent = React.useCallback(async (id: string): Promise<void> => {
     try {
-      const isCurrentlyInWorking = workingSessionIds.has(id)
+      const isCurrentlyInWorking = store.get(workingSessionIdsSetAtom).has(id)
       if (isCurrentlyInWorking) {
         // 从工作中移出：清除 manualWorking + 清除 workingDone
-        const session = agentSessions.find((s) => s.id === id)
+        const session = store.get(agentSessionsAtom).find((s) => s.id === id)
         if (session?.manualWorking) {
           const updated = await window.electronAPI.toggleManualWorkingAgentSession(id)
           setAgentSessions((prev) =>
@@ -783,7 +786,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         })
       } else {
         // 加入工作中
-        const original = agentSessions.find((s) => s.id === id)
+        const original = store.get(agentSessionsAtom).find((s) => s.id === id)
         const updated = await window.electronAPI.toggleManualWorkingAgentSession(id)
         setAgentSessions((prev) =>
           prev.map((s) => (s.id === updated.id ? updated : s))
@@ -796,10 +799,10 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       console.error('[Sidebar] Failed to toggle manual working:', error)
       toast.error('操作失败')
     }
-  }
+  }, [store, setAgentSessions, setWorkingDone])
 
   /** 切换 Agent 会话归档状态 */
-  const handleToggleArchiveAgent = async (id: string): Promise<void> => {
+  const handleToggleArchiveAgent = React.useCallback(async (id: string): Promise<void> => {
     try {
       const updated = await window.electronAPI.toggleArchiveAgentSession(id)
       setAgentSessions((prev) =>
@@ -809,8 +812,10 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       // 否则 RightSidePanel（依赖 currentAgentSessionIdAtom）会因为
       // 指针被错误置 null 而消失。
       if (updated.archived) {
-        const wasActive = activeTabId === id
-        const tabResult = closeTab(tabs, activeTabId, id)
+        const currentTabs = store.get(tabsAtom)
+        const currentActiveTabId = store.get(activeTabIdAtom)
+        const wasActive = currentActiveTabId === id
+        const tabResult = closeTab(currentTabs, currentActiveTabId, id)
         setTabs(tabResult.tabs)
         setActiveTabId(tabResult.activeTabId)
         cleanupMapAtoms(id)
@@ -832,7 +837,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     } catch (error) {
       console.error('[侧边栏] 切换 Agent 会话归档失败:', error)
     }
-  }
+  }, [store, setAgentSessions, setTabs, setActiveTabId, cleanupMapAtoms, setWorkingDone, syncActiveTabSideEffects])
 
   /** 请求迁移会话到其他工作区（弹出迁移对话框） */
   const handleRequestMove = React.useCallback((id: string): void => {


### PR DESCRIPTION
## Overview

这是对 [#555 (`perf(sidebar): 消除 hover 重渲染，列表项加 React.memo`)](https://github.com/ErlichLiu/Proma/pull/555) 的收尾补丁。

#555 移除了 hover 引起的整树重渲染、给 `ConversationItem` / `AgentSessionItem` 加了 `React.memo`，并把 4 个 select/delete/move handler 包成了 `useCallback`。但菜单里另外 **7 个 handler**（重命名 / 置顶 / 归档 / 标记工作中）仍以函数字面量直接传入 memo 子项，每次 `LeftSidebar` 渲染都创建新引用，导致 `React.memo` 浅比较失败。

后台 Agent 流式输出时这个问题被严重放大：`agentSessionIndicatorMapAtom`（派生自 `agentStreamingStatesAtom`）按 token 频率重建，`LeftSidebar` 高频重渲染，76 条会话的列表项被全量 reconcile，触控板滚动出现明显掉帧（约 5/10 概率，命中在后台有 Agent 在跑的时间窗口；后台空闲时滚动正常）。

补全 7 个 handler 的 `useCallback` 后，流式期间列表项的 `React.memo` 真正生效，**只有 indicator 真正变化的那一条**会重渲染，滚动从"全列 reconcile"降到"单条 reconcile"。

## Changes

- **`apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx`**
  - 引入 `useStore` 并在组件顶层取一次 `const store = useStore()`，store 引用在同一 Provider 下永远稳定
  - 7 个菜单 handler 改为 `React.useCallback`：
    - **Chat 模式**：`handleRename` / `handleTogglePin` / `handleToggleArchive`
    - **Agent 模式**：`handleAgentRename` / `handleTogglePinAgent` / `handleToggleManualWorkingAgent` / `handleToggleArchiveAgent`
  - 这些 handler 内部需要读取 `conversations` / `agentSessions` / `tabs` / `activeTabId` / `workingSessionIds`。如果直接放进 `useCallback` 的 deps，高频 atom 值变化时 useCallback 立刻失效，等于没包。改为在 handler 内用 `store.get(atom)` **即时读取**最新值，deps 只剩稳定的 setter 与 `store` 自身。该模式在仓库 `App.tsx` / `main.tsx` / `AgentView.tsx` / `useGlobalAgentListeners.ts` / `MigrateToAgentButton.tsx` 等位置已有 11+ 处先例，保持架构一致。

- **`apps/electron/package.json`**
  - 版本号 `0.10.2` → `0.10.3`（符合每次改动 patch +1 的规范）

## Behavior change & 附带修复

改动**总体行为等价**，但 `handleToggleArchive` / `handleToggleArchiveAgent` 顺带修了一个隐藏的 stale-closure 问题：

```ts
// 旧：闭包捕获渲染时刻的 activeTabId / tabs
const wasActive = activeTabId === id
const updated = await electronAPI.toggleArchive(id)
// ... 在 await 之后仍用旧的 activeTabId 判断 wasActive
```

`await` 期间用户如果切了 tab，`activeTabId` 早已在外面变化，但闭包内仍是旧值，导致 `wasActive` 误判，进而错误地调用或跳过 `syncActiveTabSideEffects`，产生文件面板/工具栏遗留旧 tab 状态等问题。新代码改为：

```ts
const currentTabs = store.get(tabsAtom)
const currentActiveTabId = store.get(activeTabIdAtom)
const wasActive = currentActiveTabId === id
// ...
```

`store.get()` 在事件触发的那一刻读取最新值，自然规避了 await 期间的状态漂移。

## How to Test

**复现卡顿（修复前）**

1. 切到 Agent 模式，左下"最近会话"列表里有 30+ 条会话（archived 不算）
2. 在某个会话里发起一次较长的对话，让 Agent 处于流式输出状态（持续 5 秒以上）
3. 在 Agent 还在打字时，用触控板**快速滚动**最近会话列表
4. 修复前：约 5/10 次能感觉到掉帧 / 卡顿
5. 修复后：滚动顺滑

**回归验证**

1. 右键某条会话，菜单里逐项点击：置顶 / 取消置顶 / 标记为工作中 / 取消工作中 / 归档 / 取消归档 / 重命名 / 删除 / 迁移工作区
2. Chat 与 Agent 两种模式都验证一遍
3. 全部行为应与修复前一致
4. 特别验证：在某个 Agent 会话里发送消息开始流式输出 → 立即点击别的 tab → 紧接着右键当前正在流式的会话点"归档"→ 等服务端响应回来后，UI 状态应正确（修复前可能因 stale closure 出现 tab 状态错位，修复后正常）

**类型检查**

```bash
cd apps/electron && bun run typecheck
# 应通过，零错误
```

## Notes

- 改动 53 行（30 ins / 25 del），不引入新依赖
- 已在独立审核通道（一个独立的 sonnet agent）跑过完整 review，结论 safe to merge：`useCallback` deps 完备、`useStore()` 用法与仓库既有模式一致、Windows 兼容性无影响
- 一个小的 follow-up（不阻塞合并）：`useSyncActiveTabSideEffects` hook 内部 deps 包含 `agentSessions`（中频 atom），导致依赖它的两个归档 handler 仍会在会话列表变化（创建/删除/标题更新）时重建一次。这不是流式 tick 级别的高频路径，不影响本次卡顿修复，可在后续单独优化