### PR TITLE
feat(ui): chat 与 agent 模式运行中状态条颜色统一为蓝色 【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -1762,7 +1762,7 @@ const ConversationItem = React.memo(function ConversationItem({
           {/* 流式状态左侧竖线条（与 Agent 保持一致） */}
           {streaming && (
             <span
-              className="absolute left-1 top-1.5 bottom-1.5 w-[2px] rounded-full bg-emerald-500 animate-pulse pointer-events-none"
+              className="absolute left-1 top-1.5 bottom-1.5 w-[2px] rounded-full bg-blue-500 animate-pulse pointer-events-none"
               aria-hidden="true"
             />
           )}

--- a/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
@@ -95,9 +95,7 @@ export function TabBarItem({
       ? 'bg-green-500'
       : isStreaming === 'blocked'
         ? 'bg-orange-500'
-        : type === 'chat'
-          ? 'bg-emerald-500'
-          : 'bg-blue-500'
+        : 'bg-blue-500'
     : undefined
   const indicatorPulse = isStreaming === 'running' || isStreaming === 'blocked'
   const previewItems = minimapCache.get(id) ?? []

--- a/apps/electron/src/renderer/components/tabs/TabSwitcher.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabSwitcher.tsx
@@ -226,7 +226,7 @@ export function TabSwitcher(): React.ReactElement | null {
         <div className="py-1.5">
           {displayTabs.map((tab, index) => {
             const status = indicatorMap.get(tab.id) ?? 'idle'
-            const indicatorColor = getIndicatorColor(status, tab.type)
+            const indicatorColor = getIndicatorColor(status)
             const indicatorPulse = status === 'running' || status === 'blocked'
             const wsName = tab.type === 'agent'
               ? (() => {
@@ -303,16 +303,12 @@ function Kbd({ children }: { children: React.ReactNode }): React.ReactElement {
  * 状态指示点颜色（与 TabBarItem 保持一致）
  * - completed → 绿色（已完成未查看）
  * - blocked → 橙色脉动（Agent 等待用户输入）
- * - running + chat → emerald 脉动
- * - running + agent → 蓝色脉动
+ * - running → 蓝色脉动
  * - idle → 无
  */
-function getIndicatorColor(
-  status: SessionIndicatorStatus,
-  type: TabItem['type'],
-): string | undefined {
+function getIndicatorColor(status: SessionIndicatorStatus): string | undefined {
   if (status === 'idle') return undefined
   if (status === 'completed') return 'bg-green-500'
   if (status === 'blocked') return 'bg-orange-500'
-  return type === 'chat' ? 'bg-emerald-500' : 'bg-blue-500'
+  return 'bg-blue-500'
 }


### PR DESCRIPTION
## 概述

之前 Chat 模式与 Agent 模式在"运行中"状态条上的呼吸灯颜色不一致——Chat 模式是 emerald（绿色），Agent 模式是 blue（蓝色），分散在 Tab 顶部、Ctrl+Tab 切换面板、左侧栏会话行三个位置都存在这种差异。

本 PR 将 Chat 模式的"运行中"颜色统一改为 blue，与 Agent 模式保持一致，让"正在运行"在整个应用中变成单一视觉信号，减少用户的视觉记忆负担。`completed`（绿色）与 `blocked`（橙色）状态色保留不变，仍承担各自独立的语义。

## 变更

- `apps/electron/src/renderer/components/tabs/TabBarItem.tsx` — 顶部 Tab 底部状态横线条，删除 `type === 'chat' ? bg-emerald-500 : bg-blue-500` 三元，running 统一为 `bg-blue-500`
- `apps/electron/src/renderer/components/tabs/TabSwitcher.tsx` — Ctrl+Tab 切换面板左侧竖线条，同步统一为 `bg-blue-500`；顺便简化 `getIndicatorColor(status, type)` → `getIndicatorColor(status)`，调用点同步更新，JSDoc 注释也跟随更新
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 侧边栏 Chat 会话行流式状态左侧竖线条，`bg-emerald-500` → `bg-blue-500`；Agent 会话行的 `RAIL_STATUS_CLASS.running` 本来就是 `bg-blue-500`，未改动
- `apps/electron/package.json` — 版本号 `0.10.2` → `0.10.3`（遵循 CLAUDE.md 的 patch bump 约束）

## 如何验证

1. 启动 `bun run dev`
2. **Chat 模式**：在某个 Chat 会话中发起流式对话，**当前 Tab 上方的状态条**与**左侧栏对应会话行左侧竖线**应显示蓝色呼吸灯
3. **Agent 模式**：在某个 Agent 会话中发起流式对话，状态条同样为蓝色呼吸灯（保持不变）
4. **Tab Switcher**：在流式过程中按 `Ctrl+Tab` 弹出切换面板，对应 Tab 左侧竖线应为蓝色呼吸灯
5. **`completed` 状态**：Agent 完成后 Tab 仍显示绿色（`bg-green-500`），表示"已完成未查看"，不受本 PR 影响
6. **`blocked` 状态**：Agent 等待用户输入时仍显示橙色（`bg-orange-500`），不受本 PR 影响

## 备注

- 本次变更没有引入任何与平台耦合的代码路径，纯 Tailwind class token 调整，Windows / macOS / Linux 视觉结果完全一致
- `typecheck` 已通过（`@proma/shared` / `@proma/core` / `@proma/ui` / `@proma/electron` 全部 exit 0）
- 消息区内联呼吸点 `StreamingIndicator`（`message.tsx:808`）使用的是 `bg-primary/60`（跟随主题色），跟这次的"状态条"是不同维度，未改动
