### PR TITLE
feat(minimap): hover 展开面板时自动定位到当前阅读位置 【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
@@ -72,6 +72,8 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
   const [hovered, setHovered] = React.useState(false)
   const [isLeaving, setIsLeaving] = React.useState(false)
   const [visibleIds, setVisibleIds] = React.useState<Set<string>>(new Set())
+  /** 主区视口几何中心当前对应的消息 id —— 面板打开时作为列表居中锚点 */
+  const [centerVisibleId, setCenterVisibleId] = React.useState<string | undefined>(undefined)
   const [canScroll, setCanScroll] = React.useState(false)
   const [searchQuery, setSearchQuery] = React.useState('')
   const [isDragging, setIsDragging] = React.useState(false)
@@ -81,6 +83,7 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
   const openTimerRef = React.useRef<ReturnType<typeof setTimeout>>()
   const searchInputRef = React.useRef<HTMLInputElement>(null)
   const trackRef = React.useRef<HTMLDivElement>(null)
+  const listRef = React.useRef<HTMLDivElement>(null)
 
   // ── 组件卸载时清理计时器 ──
 
@@ -104,8 +107,10 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
       setScrollMetrics({ scrollTop, scrollHeight, clientHeight })
       if (scrollHeight <= 0) return
 
+      const viewportCenter = scrollTop + clientHeight / 2
       const nodes = el.querySelectorAll<HTMLElement>('[data-message-id]')
       const ids = new Set<string>()
+      let centerId: string | undefined
       for (const node of nodes) {
         const top = getOffsetTopRelativeTo(node, el)
         const bottom = top + node.offsetHeight
@@ -113,8 +118,12 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
           const id = node.getAttribute('data-message-id')
           if (id) ids.add(id)
         }
+        if (centerId === undefined && top <= viewportCenter && bottom > viewportCenter) {
+          centerId = node.getAttribute('data-message-id') ?? undefined
+        }
       }
       setVisibleIds(ids)
+      setCenterVisibleId(centerId)
     }
 
     update()
@@ -135,6 +144,26 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
       const timer = setTimeout(() => searchInputRef.current?.focus(), 80)
       return () => clearTimeout(timer)
     }
+  }, [hovered])
+
+  // ── 面板打开时把当前可见消息滚到列表中间，避免每次都从顶部开始 ──
+
+  React.useEffect(() => {
+    if (!hovered) return
+    const timer = setTimeout(() => {
+      const list = listRef.current
+      if (!list) return
+      const target = list.querySelector<HTMLElement>('[data-minimap-visible="true"]')
+      if (!target) return
+      // listRef 没有 position 设置，offsetTop / getOffsetTopRelativeTo 都不可靠，
+      // 直接用 getBoundingClientRect 计算 target 相对 list 视口的偏移
+      const listRect = list.getBoundingClientRect()
+      const targetRect = target.getBoundingClientRect()
+      const offsetInList = (targetRect.top - listRect.top) + list.scrollTop
+      const offset = offsetInList - (list.clientHeight - target.offsetHeight) / 2
+      list.scrollTo({ top: Math.max(0, offset), behavior: 'auto' })
+    }, 0)
+    return () => clearTimeout(timer)
   }, [hovered])
 
   // ── 面板关闭时清空搜索 ──
@@ -216,6 +245,14 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
     const q = searchQuery.toLowerCase()
     return items.filter((item) => item.preview.toLowerCase().includes(q))
   }, [items, searchQuery])
+
+  /** 列表居中锚点：优先用主区视口中心对应的消息；该消息被搜索过滤掉时退回第一条可见消息 */
+  const anchorId = React.useMemo(() => {
+    if (centerVisibleId && filteredItems.some((item) => item.id === centerVisibleId)) {
+      return centerVisibleId
+    }
+    return filteredItems.find((item) => visibleIds.has(item.id))?.id
+  }, [centerVisibleId, filteredItems, visibleIds])
 
   // ── 滚动条滑块拖拽 ──
 
@@ -344,7 +381,7 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
             </div>
 
             {/* 消息列表 */}
-            <div className="overflow-y-auto flex-1 p-1.5 space-y-0.5 scrollbar-thin">
+            <div ref={listRef} className="overflow-y-auto flex-1 p-1.5 space-y-0.5 scrollbar-thin">
               {filteredItems.length === 0 ? (
                 <div className="py-6 text-center text-xs text-muted-foreground">
                   未找到匹配消息
@@ -354,6 +391,7 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
                   <button
                     key={item.id}
                     type="button"
+                    data-minimap-visible={item.id === anchorId ? 'true' : undefined}
                     className={cn(
                       'flex items-start gap-2 w-full rounded-md px-2 py-1.5 text-left transition-colors hover:bg-accent',
                       visibleIds.has(item.id) && 'bg-accent/50'


### PR DESCRIPTION
## 概述

迷你地图（ScrollMinimap）右侧面板悬浮展开后，过去每次都从消息列表顶部开始显示。在长对话场景下，用户当前正在阅读的消息（带 `bg-accent/50` 高亮）经常落在面板视口之外，需要二次手动滚动才能定位到当前位置——这是这次改动要解决的痛点。

改动后：面板打开瞬间，会把主区视口几何中心覆盖到的那条消息滚到面板列表的垂直中央，保证用户一打开就能看到自己当前所在位置。

## 核心思路

1. **追踪 `centerVisibleId`**：在已有的主区滚动监听里同步计算 `viewportCenter = scrollTop + clientHeight / 2`，遍历消息节点找到 `top <= viewportCenter < bottom` 的那条消息 id
2. **`anchorId` 选择策略**：优先用 `centerVisibleId`；若搜索过滤后该 id 不在 `filteredItems` 里，退回第一条可见消息，保证总有合适锚点
3. **打 `data-minimap-visible="true"` 标记**：给 anchorId 对应的列表按钮加属性
4. **打开瞬间居中**：面板从关闭变为打开（`hovered: false → true`）时通过 `listRef` 把该按钮滚到面板列表垂直中央，使用 `getBoundingClientRect` 计算偏移以避开 `offsetParent` 链问题

## 为什么用视口中心而不是第一条可见消息

用户视线集中在视口中部偏下。如果用最先进入视口的消息作锚点，面板里高亮的会是用户已经读过的内容，**仍然需要再向下滚才能看到当前位置**——这正是改动前的痛点之一。试过之后发现需要这一层调整。

## 改动文件

- `apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx` —— 新增 `centerVisibleId` 追踪、`anchorId` useMemo、面板打开 effect、`listRef`、`data-minimap-visible` 标记
- `apps/electron/package.json` —— 版本号 `0.10.2 → 0.10.3`

## 测试方法

1. 启动开发模式：`bun run dev`
2. 打开一个**长对话**（消息超过一屏，最好 30 条以上）
3. 在主区滚动到对话中间某条消息
4. 把鼠标移到右侧迷你地图区域，停留 180ms 触发面板展开
5. **预期**：面板打开后，列表中带高亮的当前可见消息出现在面板的垂直中央附近，无需再次手动滚动
6. 边界场景：
   - 对话很短（不需要滚动）：`canScroll` 为 false，迷你地图不显示，无影响
   - 搜索框输入关键词：消息列表按搜索过滤，不会触发面板内重定位（仅 `hovered` 变化时定位，搜索时不抖动）
   - 主区继续滚动时面板已打开：列表不会跟着跳，避免抖动

## 副作用范围

- 定位 effect 仅依赖 `hovered`，主区滚动导致 `anchorId` 变化时不会触发面板内重新定位，避免视觉抖动
- `centerVisibleId` 的计算复用了已有的滚动监听循环，仅多了一个 `if` 判断和一次 `getAttribute`，开销可忽略
- React 18 自动批处理：`setVisibleIds` 与 `setCenterVisibleId` 连续调用合并为一次渲染
- 不影响 `TabPreviewPanel`（它复用 `minimapItems` 但不复用 `ScrollMinimap` 组件）

## 备注

- TypeScript 类型检查通过：`bun run typecheck` 零错误
- 已经做过两轮独立 context 的代码审查，最终发现一个轻微 Warning：面板的 `zoom-in-95` 动画期间（约 150ms）`getBoundingClientRect` 受 transform 影响，定位会有约 5% 精度偏差（最大约 21px，约 0.5-1 行高度）。当前选择不引入打开延迟，体验上仍明显优于改前从顶部开始