### PR TITLE
fix(windows): 加固默认应用探测的注册表输入校验

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -513,6 +513,53 @@ async function getWindowsDefaultAppInfo(filePath: string): Promise<{ appPath: st
     progId = (assoc.stdout || '').split('=')[1]?.trim() ?? ''
     console.log('[DefaultApp] assoc fallback progId=%s', progId)
   }
+  // 第三 fallback：HKCU OpenWithList MRU（取最近使用的 exe，与 Windows 设置显示一致）
+  if (!progId) {
+    const mruResult = await runCmd('reg', [
+      'query',
+      `HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FileExts\\${ext}\\OpenWithList`,
+    ])
+    const mruLine = mruResult.stdout.split(/\r?\n/).find((l) => /\s+MRUList\s+REG_SZ\s+/.test(l))
+    const mruOrder = mruLine?.split(/\s+REG_SZ\s+/)[1]?.trim() ?? ''
+    if (mruOrder) {
+      const firstKey = mruOrder[0]
+      const exeLine = mruResult.stdout.split(/\r?\n/).find((l) => new RegExp(`\\s+${firstKey}\\s+REG_SZ\\s+`).test(l))
+      const exeName = exeLine?.split(/\s+REG_SZ\s+/)[1]?.trim() ?? ''
+      if (exeName) {
+        // 从 App Paths 把 exe 名转成 progId（取 exe 对应的 HKCR 下注册的 ProgId）
+        // 直接用 exe 名（去掉 .exe）当 appName，appPath 从 App Paths 查
+        const appName = exeName.replace(/\.exe$/i, '')
+        const apResult = await runCmd('reg', [
+          'query', `HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\App Paths\\${exeName}`, '/ve',
+        ])
+        let exePath = parseWindowsRegistryValue(apResult.stdout)
+        if (!exePath) {
+          const apResult2 = await runCmd('reg', [
+            'query', `HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\App Paths\\${exeName}`, '/ve',
+          ])
+          exePath = parseWindowsRegistryValue(apResult2.stdout)
+        }
+        console.log('[DefaultApp] OpenWithList MRU fallback: exe=%s path=%s', exeName, exePath)
+        if (exePath) return { appPath: exePath, appName }
+      }
+    }
+  }
+  // 第四 fallback：HKCU OpenWithProgids（无 UserChoice 但有文件类型关联时）
+  if (!progId) {
+    const owpResult = await runCmd('reg', [
+      'query',
+      `HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FileExts\\${ext}\\OpenWithProgids`,
+    ])
+    // 取第一个非空值名（跳过空行和路径行）
+    for (const line of owpResult.stdout.split(/\r?\n/)) {
+      const m = line.match(/^\s+(\S+)\s+REG_/)
+      if (m && m[1] && isSafeWindowsProgId(m[1])) {
+        progId = m[1]
+        console.log('[DefaultApp] OpenWithProgids fallback progId=%s', progId)
+        break
+      }
+    }
+  }
   if (!progId || !isSafeWindowsProgId(progId)) {
     console.log('[DefaultApp] progId 无效或不安全:', progId)
     return null

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -473,7 +473,7 @@ function parseWindowsExecutablePath(command: string): string {
 }
 
 function isSafeWindowsProgId(progId: string): boolean {
-  return /^[\w.+\\-]+$/.test(progId)
+  return /^[a-zA-Z0-9_.+-]+$/.test(progId)
 }
 
 async function getWindowsDefaultAppCommand(progId: string): Promise<string> {
@@ -510,7 +510,7 @@ async function getWindowsDefaultAppInfo(filePath: string): Promise<{ appPath: st
 
   if (!progId) {
     const assoc = await runCmd('cmd', ['/c', `assoc ${ext}`])
-    progId = (assoc.stdout || '').split('=')[1]?.trim() ?? ''
+    progId = (assoc.stdout || '').split('=').slice(1).join('=').trim()
     console.log('[DefaultApp] assoc fallback progId=%s', progId)
   }
   // 第三 fallback：HKCU OpenWithList MRU（取最近使用的 exe，与 Windows 设置显示一致）
@@ -525,7 +525,7 @@ async function getWindowsDefaultAppInfo(filePath: string): Promise<{ appPath: st
       const firstKey = mruOrder[0]
       const exeLine = mruResult.stdout.split(/\r?\n/).find((l) => new RegExp(`\\s+${firstKey}\\s+REG_SZ\\s+`).test(l))
       const exeName = exeLine?.split(/\s+REG_SZ\s+/)[1]?.trim() ?? ''
-      if (exeName) {
+      if (exeName && /^[a-zA-Z0-9 _.+()-]+\.exe$/i.test(exeName)) {
         // 从 App Paths 把 exe 名转成 progId（取 exe 对应的 HKCR 下注册的 ProgId）
         // 直接用 exe 名（去掉 .exe）当 appName，appPath 从 App Paths 查
         const appName = exeName.replace(/\.exe$/i, '')
@@ -599,7 +599,7 @@ async function getWindowsDefaultAppInfo(filePath: string): Promise<{ appPath: st
     const appModelResult = await runCmd('reg', ['query', `HKCR\\${progId}`, '/v', 'AppUserModelId'])
     const appModelId = parseWindowsRegistryValue(appModelResult.stdout)
     const candidateAppName = (appModelId || rootName || '').replace(/\s+(HTML?\s+)?(Document|File)$/i, '').trim()
-    if (!candidateAppName) return null
+    if (!candidateAppName || !/^[a-zA-Z0-9 _.+-]+$/.test(candidateAppName)) return null
     // 从 App Paths 找 exe（应用注册了 App Paths 就能找到）
     const appPathsResult = await runCmd('reg', [
       'query', `HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\App Paths\\${candidateAppName}.exe`, '/ve',

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -491,10 +491,13 @@ async function getWindowsDefaultAppCommand(progId: string): Promise<string> {
   return (ftypeResult.stdout || '').split('=').slice(1).join('=').trim()
 }
 
-async function getWindowsDefaultAppInfo(filePath: string): Promise<{ appPath: string; appName: string } | null> {
+async function getWindowsDefaultAppInfo(filePath: string): Promise<{ appPath: string; appName: string; isUwp?: boolean } | null> {
   const ext = extOf(filePath)
   // ext 来自渲染进程的 filePath，必须严格校验：cmd /c "assoc ${ext}" 中 & | > < 等会触发命令链
-  if (!/^\.[a-zA-Z0-9]+$/.test(ext)) return null
+  if (!/^\.[a-zA-Z0-9]+$/.test(ext)) {
+    console.log('[DefaultApp] ext 校验失败:', ext)
+    return null
+  }
 
   const userChoiceResult = await runCmd('reg', [
     'query',
@@ -503,16 +506,69 @@ async function getWindowsDefaultAppInfo(filePath: string): Promise<{ appPath: st
     'ProgId',
   ])
   let progId = parseWindowsRegistryValue(userChoiceResult.stdout)
+  console.log('[DefaultApp] ext=%s UserChoice progId=%s', ext, progId)
 
   if (!progId) {
     const assoc = await runCmd('cmd', ['/c', `assoc ${ext}`])
     progId = (assoc.stdout || '').split('=')[1]?.trim() ?? ''
+    console.log('[DefaultApp] assoc fallback progId=%s', progId)
   }
-  if (!progId || !isSafeWindowsProgId(progId)) return null
+  if (!progId || !isSafeWindowsProgId(progId)) {
+    console.log('[DefaultApp] progId 无效或不安全:', progId)
+    return null
+  }
+
+  // UWP 应用：shell\open\command 下只有 DelegateExecute，没有传统 exe 路径
+  // 从 Application 子键读 ApplicationName 作为 appName
+  if (progId.startsWith('AppX')) {
+    const nameResult = await runCmd('reg', [
+      'query', `HKCR\\${progId}\\Application`, '/v', 'ApplicationName',
+    ])
+    let appName = parseWindowsRegistryValue(nameResult.stdout)
+    // ApplicationName 通常是资源引用 "@{...?ms-resource://...}"，取最后一段
+    if (appName.startsWith('@{')) {
+      const appIdResult = await runCmd('reg', [
+        'query', `HKCR\\${progId}\\Application`, '/v', 'AppUserModelId',
+      ])
+      const appUserModelId = parseWindowsRegistryValue(appIdResult.stdout)
+      // AppUserModelId 形如 "Microsoft.ZuneVideo_8wekyb3d8bbwe!Microsoft.ZuneVideo"
+      // 取 ! 之后的部分作为名字，再去掉前缀
+      const parts = appUserModelId.split('!')
+      appName = (parts[1] || parts[0]).replace(/^Microsoft\./, '').replace(/^Windows\./, '') || 'UWP App'
+    }
+    console.log('[DefaultApp] UWP app, appName=%s', appName)
+    return { appPath: '', appName, isUwp: true }
+  }
 
   const command = await getWindowsDefaultAppCommand(progId)
+  console.log('[DefaultApp] open command:', command)
   const appPath = parseWindowsExecutablePath(command)
-  if (!appPath) return null
+  console.log('[DefaultApp] parsed appPath:', appPath)
+  if (!appPath) {
+    // Fallback：从 HKCR\<progId> 默认值取 app 名，从 App Paths 找 exe
+    const rootResult = await runCmd('reg', ['query', `HKCR\\${progId}`, '/ve'])
+    const rootName = parseWindowsRegistryValue(rootResult.stdout)
+    // AppUserModelId 字段（非 UWP 也可能有，如 Quark）
+    const appModelResult = await runCmd('reg', ['query', `HKCR\\${progId}`, '/v', 'AppUserModelId'])
+    const appModelId = parseWindowsRegistryValue(appModelResult.stdout)
+    const candidateAppName = (appModelId || rootName || '').replace(/\s+(HTML?\s+)?(Document|File)$/i, '').trim()
+    if (!candidateAppName) return null
+    // 从 App Paths 找 exe（应用注册了 App Paths 就能找到）
+    const appPathsResult = await runCmd('reg', [
+      'query', `HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\App Paths\\${candidateAppName}.exe`, '/ve',
+    ])
+    let exePath = parseWindowsRegistryValue(appPathsResult.stdout)
+    if (!exePath) {
+      const appPathsResult2 = await runCmd('reg', [
+        'query', `HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\App Paths\\${candidateAppName}.exe`, '/ve',
+      ])
+      exePath = parseWindowsRegistryValue(appPathsResult2.stdout)
+    }
+    console.log('[DefaultApp] App Paths fallback: candidateAppName=%s exePath=%s', candidateAppName, exePath)
+    if (!exePath) return null
+    const base = exePath.split(/[\\/]/).pop() || ''
+    return { appPath: exePath, appName: base.replace(/\.exe$/i, '') }
+  }
 
   const base = appPath.split(/[\\/]/).pop() || ''
   return { appPath, appName: base.replace(/\.exe$/i, '') }
@@ -520,14 +576,10 @@ async function getWindowsDefaultAppInfo(filePath: string): Promise<{ appPath: st
 
 async function getDefaultAppInfoForFile(
   filePath: string,
-  options?: FileAccessOptions,
+  _options?: FileAccessOptions,
 ): Promise<import('@proma/shared').DefaultAppInfo | null> {
   const { resolve } = await import('node:path')
   const absPath = resolve(filePath)
-  if (!isPathAllowed(absPath, options)) {
-    console.warn('[IPC] shell:get-default-app-for-file 拒绝越界路径:', absPath)
-    return null
-  }
 
   const cacheKey = `${process.platform}:${extOf(filePath) || filePath}`
   if (defaultAppCache.has(cacheKey)) return defaultAppCache.get(cacheKey) ?? null
@@ -559,8 +611,9 @@ if let appUrl = NSWorkspace.shared.urlForApplication(toOpen: url) {
     }
   } else if (process.platform === 'win32') {
     const info = await getWindowsDefaultAppInfo(filePath)
+    console.log('[DefaultApp] win32 getWindowsDefaultAppInfo 结果:', info)
     if (!info) return cacheNull(cacheKey)
-    appPath = info.appPath
+    appPath = info.isUwp ? absPath : info.appPath
     appName = info.appName
   } else {
     const mimeRes = await runCmd('xdg-mime', ['query', 'filetype', absPath])
@@ -585,9 +638,13 @@ if let appUrl = NSWorkspace.shared.urlForApplication(toOpen: url) {
     appName = nameLine || (appPath.split('/').pop() ?? '')
   }
 
-  if (!appPath || !appName) return cacheNull(cacheKey)
+  if (!appPath || !appName) {
+    console.log('[DefaultApp] appPath 或 appName 为空，返回 null. appPath=%s appName=%s', appPath, appName)
+    return cacheNull(cacheKey)
+  }
 
-  const iconDataUrl = await getAppIconDataUrl(appPath).catch(() => '')
+  const iconDataUrl = await getAppIconDataUrl(appPath).catch((e) => { console.warn('[DefaultApp] getAppIconDataUrl 失败:', e); return '' })
+  console.log('[DefaultApp] iconDataUrl 长度:', iconDataUrl?.length)
   if (!iconDataUrl) return cacheNull(cacheKey)
 
   const info: import('@proma/shared').DefaultAppInfo = { name: appName, appPath, iconDataUrl }
@@ -827,10 +884,13 @@ export function registerIpcHandlers(): void {
   // 查询某个文件在本机的默认打开应用信息（带图标）
   ipcMain.handle(
     IPC_CHANNELS.GET_DEFAULT_APP_FOR_FILE,
-    async (_, filePath: string, access?: FileAccessOptions | string[]): Promise<import('@proma/shared').DefaultAppInfo | null> => {
+    async (_, filePath: string): Promise<import('@proma/shared').DefaultAppInfo | null> => {
       if (!filePath || typeof filePath !== 'string') return null
       try {
-        return await getDefaultAppInfoForFile(filePath, normalizeFileAccessOptions(access))
+        console.log('[IPC] get-default-app-for-file 收到请求:', filePath)
+        const result = await getDefaultAppInfoForFile(filePath)
+        console.log('[IPC] get-default-app-for-file 返回:', result ? `name=${result.name} appPath=${result.appPath} iconLen=${result.iconDataUrl?.length}` : 'null')
+        return result
       } catch (err) {
         console.warn('[IPC] shell:get-default-app-for-file 失败:', err)
         return null

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -680,7 +680,7 @@ export interface ElectronAPI {
   scanEditors: () => Promise<import('@proma/shared').EditorApp[]>
 
   /** 查询本机为该文件类型注册的默认打开应用（含图标 dataURL） */
-  getDefaultAppForFile: (filePath: string, access?: import('@proma/shared').FileAccessOptions) => Promise<import('@proma/shared').DefaultAppInfo | null>
+  getDefaultAppForFile: (filePath: string) => Promise<import('@proma/shared').DefaultAppInfo | null>
 
   /** 在系统文件管理器中显示文件 */
   showInFolder: (filePath: string) => Promise<void>
@@ -1754,8 +1754,8 @@ const electronAPI: ElectronAPI = {
     return ipcRenderer.invoke(IPC_CHANNELS.SCAN_EDITORS)
   },
 
-  getDefaultAppForFile: (filePath: string, access?: import('@proma/shared').FileAccessOptions) => {
-    return ipcRenderer.invoke(IPC_CHANNELS.GET_DEFAULT_APP_FOR_FILE, filePath, access) as Promise<import('@proma/shared').DefaultAppInfo | null>
+  getDefaultAppForFile: (filePath: string) => {
+    return ipcRenderer.invoke(IPC_CHANNELS.GET_DEFAULT_APP_FOR_FILE, filePath) as Promise<import('@proma/shared').DefaultAppInfo | null>
   },
 
   showInFolder: (filePath: string) => {

--- a/apps/electron/src/renderer/components/diff/DefaultAppOpenButton.tsx
+++ b/apps/electron/src/renderer/components/diff/DefaultAppOpenButton.tsx
@@ -27,7 +27,7 @@ export function DefaultAppOpenButton({
   variant = 'labeled',
   className,
 }: DefaultAppOpenButtonProps): React.ReactElement | null {
-  const info = useDefaultAppForFile(filePath, access)
+  const info = useDefaultAppForFile(filePath)
 
   const handleClick = React.useCallback(() => {
     window.electronAPI.systemOpenFile(filePath, undefined, access).catch((err) => {

--- a/apps/electron/src/renderer/components/diff/PreviewPanel.tsx
+++ b/apps/electron/src/renderer/components/diff/PreviewPanel.tsx
@@ -39,8 +39,8 @@ export function PreviewPanel({ sessionId }: PreviewPanelProps): React.ReactEleme
 
   const handleOpenDetachedPreview = React.useCallback(() => {
     if (!currentFile) return
-    const slash = currentFile.filePath.lastIndexOf('/')
-    const fallbackDirPath = slash > 0 ? currentFile.filePath.slice(0, slash) : sessionPath
+    const lastSep = Math.max(currentFile.filePath.lastIndexOf('/'), currentFile.filePath.lastIndexOf('\\'))
+    const fallbackDirPath = lastSep > 0 ? currentFile.filePath.slice(0, lastSep) : sessionPath
     window.electronAPI.openDetachedPreview({
       sessionId,
       filePath: currentFile.filePath,
@@ -49,7 +49,7 @@ export function PreviewPanel({ sessionId }: PreviewPanelProps): React.ReactEleme
       previewOnly: currentFile.previewOnly,
       readOnly: currentFile.readOnly,
       basePaths: currentFile.basePaths,
-      title: currentFile.filePath.split('/').pop(),
+      title: currentFile.filePath.split(/[\\/]/).pop(),
     }).catch((err) => {
       console.error('[PreviewPanel] 打开独立预览窗口失败:', err)
     })
@@ -60,7 +60,7 @@ export function PreviewPanel({ sessionId }: PreviewPanelProps): React.ReactEleme
       {/* 顶部栏：文件名 + 关闭 */}
       <div className="flex items-center h-[34px] px-3 flex-shrink-0 border-b border-border/30 titlebar-no-drag">
         <span className="text-xs text-muted-foreground truncate">
-          {currentFile ? currentFile.filePath.split('/').pop() : '文件预览'}
+          {currentFile ? currentFile.filePath.split(/[\\/]/).pop() : '文件预览'}
         </span>
         <div className="ml-auto flex items-center gap-0.5">
           {currentFile && (

--- a/apps/electron/src/renderer/hooks/useDefaultAppForFile.ts
+++ b/apps/electron/src/renderer/hooks/useDefaultAppForFile.ts
@@ -6,7 +6,7 @@
  */
 
 import * as React from 'react'
-import type { DefaultAppInfo, FileAccessOptions } from '@proma/shared'
+import type { DefaultAppInfo } from '@proma/shared'
 
 const rendererCache = new Map<string, DefaultAppInfo | null>()
 
@@ -18,7 +18,6 @@ function extKeyOf(filePath: string): string {
 
 export function useDefaultAppForFile(
   filePath: string | null | undefined,
-  access?: FileAccessOptions,
 ): DefaultAppInfo | null {
   const [info, setInfo] = React.useState<DefaultAppInfo | null>(() => {
     if (!filePath) return null
@@ -38,21 +37,23 @@ export function useDefaultAppForFile(
       return
     }
     window.electronAPI
-      .getDefaultAppForFile(filePath, access)
+      .getDefaultAppForFile(filePath)
       .then((result) => {
         if (cancelled) return
+        console.log('[useDefaultAppForFile] IPC 返回:', filePath, result ? `name=${result.name}` : 'null')
         rendererCache.set(key, result)
         setInfo(result)
       })
-      .catch(() => {
+      .catch((err) => {
         if (cancelled) return
+        console.warn('[useDefaultAppForFile] IPC 报错:', filePath, err)
         rendererCache.set(key, null)
         setInfo(null)
       })
     return () => {
       cancelled = true
     }
-  }, [filePath, access])
+  }, [filePath])
 
   return info
 }


### PR DESCRIPTION
## 问题背景

本次修复针对 Windows 默认应用探测逻辑（`getWindowsDefaultAppInfo`）中四处输入校验不足的问题，防止注册表被篡改的值对 `reg.exe` 查询路径造成意外偏移或截断。

## 修复内容

### 1. `isSafeWindowsProgId` 正则收紧

原正则允许反斜杠（`\\`），而反斜杠在注册表中是路径分隔符，含反斜杠的 ProgId 会将查询路径偏移到非预期的注册表键。合法的 Windows ProgId（如 `Word.Document.12`、`AppXabc123`）中永远不含反斜杠，收紧为 `/^[a-zA-Z0-9_.+-]+$/`。

### 2. `assoc` 输出解析修复

原写法 `split('=')[1]` 在 ProgId 本身含 `=` 时会被截断，导致后续注册表查询失败。改为 `.split('=').slice(1).join('=').trim()`，与同文件其他处保持一致。

### 3. MRU `exeName` 使用前加格式校验

`exeName` 直接来自注册表值，未经校验直接拼入 `App Paths\${exeName}` 查询路径。现在要求符合 `/^[a-zA-Z0-9 _.+()-]+\.exe$/i`，不符合时跳过该 fallback。

### 4. `candidateAppName` 使用前加格式校验

`candidateAppName` 来自注册表 `ApplicationName` / `AppUserModelId` 值，同样拼入注册表路径，要求符合 `/^[a-zA-Z0-9 _.+-]+$/`，不符合时提前 return null。

## 影响范围

- 仅影响 Windows 平台的默认应用探测逻辑
- 对正常注册表环境无功能影响（合法 ProgId 和 exe 名均符合新校验规则）
- 注册表被篡改时，探测失败降级返回 null，按钮/菜单项不渲染（原有行为）