### PR TITLE
Fix stale Agent active session lock

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -995,6 +995,30 @@ export class AgentOrchestrator {
     // 否则用本地 runGeneration 作为回退（headless 模式等无渲染进程场景）
     const streamStartedAt = input.startedAt ?? runGeneration
     this.activeSessions.set(sessionId, runGeneration)
+    const releaseActiveRun = (): void => {
+      // 在发送 STREAM_COMPLETE 前释放 active slot，避免渲染进程已进入空闲态、
+      // 主进程仍在 finally 前短暂拒绝下一条消息。
+      if (this.activeSessions.get(sessionId) !== runGeneration) return
+      this.activeSessions.delete(sessionId)
+      this.sessionPermissionModes.delete(sessionId)
+      this.queuedMessageUuids.delete(sessionId)
+    }
+    const completeRun = (
+      messages?: AgentMessage[],
+      opts?: { stoppedByUser?: boolean; startedAt?: number; resultSubtype?: string },
+    ): void => {
+      releaseActiveRun()
+      callbacks.onComplete(messages, opts)
+    }
+    const failRun = (
+      error: string,
+      messages?: AgentMessage[],
+      opts?: { stoppedByUser?: boolean; startedAt?: number; resultSubtype?: string },
+    ): void => {
+      releaseActiveRun()
+      callbacks.onError(error)
+      callbacks.onComplete(messages, opts)
+    }
 
     // 3. 构建环境变量
     // 同步凭证到 process.env（SDK in-process 代码可能直接读取 process.env）
@@ -1567,7 +1591,7 @@ export class AgentOrchestrator {
             // 等待期间如果会话被中止，退出
             if (!this.activeSessions.has(sessionId)) {
               this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
-              callbacks.onComplete(getAgentSessionMessages(sessionId), { startedAt: streamStartedAt })
+              completeRun(getAgentSessionMessages(sessionId), { startedAt: streamStartedAt })
               return
             }
           }
@@ -1713,7 +1737,7 @@ export class AgentOrchestrator {
                 // 透传归一化后的错误消息到前端，避免 SDK 原始 API Error 直接暴露给用户。
                 this.eventBus.emit(sessionId, { kind: 'sdk_message', message: errorSDKMsg })
                 try { updateAgentSessionMeta(sessionId, {}) } catch { /* 忽略 */ }
-                callbacks.onComplete(getAgentSessionMessages(sessionId), { startedAt: streamStartedAt })
+                completeRun(getAgentSessionMessages(sessionId), { startedAt: streamStartedAt })
                 return
               }
             }
@@ -1819,7 +1843,7 @@ export class AgentOrchestrator {
           }
 
           // 发送完成信号
-          callbacks.onComplete(getAgentSessionMessages(sessionId), { startedAt: streamStartedAt, resultSubtype: capturedResultSubtype })
+          completeRun(getAgentSessionMessages(sessionId), { startedAt: streamStartedAt, resultSubtype: capturedResultSubtype })
 
           break  // 成功完成，退出重试循环
 
@@ -1840,7 +1864,7 @@ export class AgentOrchestrator {
             this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
             // 持久化中断状态到会话 meta
             try { updateAgentSessionMeta(sessionId, { stoppedByUser: wasStoppedByUser }) } catch { /* 会话可能已删除 */ }
-            callbacks.onComplete(getAgentSessionMessages(sessionId), { stoppedByUser: wasStoppedByUser, startedAt: streamStartedAt })
+            completeRun(getAgentSessionMessages(sessionId), { stoppedByUser: wasStoppedByUser, startedAt: streamStartedAt })
             return
           }
 
@@ -1980,8 +2004,7 @@ export class AgentOrchestrator {
             })
           }
 
-          callbacks.onError(userFacingError)
-          callbacks.onComplete(getAgentSessionMessages(sessionId), { startedAt: streamStartedAt })
+          failRun(userFacingError, getAgentSessionMessages(sessionId), { startedAt: streamStartedAt })
 
           // 根据错误类型决定是否保留 sdkSessionId
           const shouldClearSession = !apiError || apiError.statusCode >= 500
@@ -2023,17 +2046,12 @@ export class AgentOrchestrator {
         } as unknown as SDKMessage
         appendSDKMessages(sessionId, [retryErrorSDKMsg])
 
-        callbacks.onError(`${retryFailureMessage}: ${lastRetryableError}`)
-        callbacks.onComplete(getAgentSessionMessages(sessionId), { startedAt: streamStartedAt })
+        failRun(`${retryFailureMessage}: ${lastRetryableError}`, getAgentSessionMessages(sessionId), { startedAt: streamStartedAt })
       }
 
     } finally {
       // 只在 generation 匹配时才清理，防止旧流的 finally 误删新流的注册
-      if (this.activeSessions.get(sessionId) === runGeneration) {
-        this.activeSessions.delete(sessionId)
-        this.sessionPermissionModes.delete(sessionId)
-        this.queuedMessageUuids.delete(sessionId)
-      }
+      releaseActiveRun()
       permissionService.clearSessionPending(sessionId)
       // askUserService 不在 turn 结束时清理——AskUserQuestion 的生命周期由用户交互决定，
       // 仅在会话真正删除时（DELETE_SESSION IPC）才清理。


### PR DESCRIPTION
Fixes a race where the renderer could receive Agent stream completion before the main process cleared the active session lock. Terminal Agent paths now release the current generation's active slot before emitting complete or error callbacks, keeping the UI idle state aligned with the backend guard. This prevents valid follow-up messages from being rejected with the stale "上一条消息仍在处理中" error. Bumps @proma/electron to 0.10.5. Validated with `bun run typecheck`, `bun test`, and `git diff --check`.