### PR TITLE
[codex] Improve agent tool actions

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/agent/ContentBlock.tsx
+++ b/apps/electron/src/renderer/components/agent/ContentBlock.tsx
@@ -494,7 +494,7 @@ function ToolUseBlock({ block, allMessages, animate = false, index = 0, dimmed =
       <button
         type="button"
         className={cn(
-          'flex w-full max-w-full items-center gap-2 py-0.5 text-left transition-opacity group',
+          'inline-flex max-w-full items-center gap-2 py-0.5 text-left transition-opacity group',
           'hover:opacity-70',
         )}
         onClick={() => setExpanded(!expanded)}
@@ -508,27 +508,27 @@ function ToolUseBlock({ block, allMessages, animate = false, index = 0, dimmed =
         <ToolIcon className={cn('size-3.5 shrink-0', dimmed ? 'text-muted-foreground/70' : 'text-muted-foreground')} />
 
         <span className={cn(
-          'truncate text-[14px]',
-          taskGetSummary || taskListSummary ? 'shrink-0' : 'min-w-0 flex-1',
+          'min-w-0 truncate text-[14px]',
+          taskGetSummary || taskListSummary ? 'shrink-0' : '',
           dimmed ? 'text-muted-foreground/70' : 'text-muted-foreground',
         )}>{renderLabelWithDiffColors(displayLabel, block.name)}</span>
 
         {taskGetSummary && (
-          <span className="flex min-w-0 flex-1 items-center gap-1.5">
+          <span className="flex min-w-0 items-center gap-1.5">
             <TaskGetCollapsedSummary task={taskGetSummary} />
           </span>
         )}
 
         {taskListSummary && (
-          <span className="flex min-w-0 flex-1 items-center gap-1.5">
+          <span className="flex min-w-0 items-center gap-1.5">
             <TaskListCollapsedSummary tasks={taskListSummary} />
           </span>
         )}
 
         <ChevronRight
           className={cn(
-            'ml-auto shrink-0 size-3 text-muted-foreground/40 opacity-0 group-hover:opacity-100 transition-all duration-150',
-            expanded && 'rotate-90 opacity-100',
+            'shrink-0 size-3 text-muted-foreground/45 transition-transform duration-150',
+            expanded && 'rotate-90',
           )}
         />
 

--- a/apps/electron/src/renderer/components/agent/ContentBlock.tsx
+++ b/apps/electron/src/renderer/components/agent/ContentBlock.tsx
@@ -533,7 +533,7 @@ function ToolUseBlock({ block, allMessages, animate = false, index = 0, dimmed =
         />
 
         {isPreviewable && (
-          <PreviewOpenButton filePath={filePath} expanded={expanded} />
+          <PreviewOpenButton filePath={filePath} />
         )}
       </button>
 

--- a/apps/electron/src/renderer/components/agent/tool-result-renderers/preview-open-button.tsx
+++ b/apps/electron/src/renderer/components/agent/tool-result-renderers/preview-open-button.tsx
@@ -14,12 +14,10 @@ import { cn } from '@/lib/utils'
 
 interface PreviewOpenButtonProps {
   filePath: string
-  /** 保留给调用方表达展开态，按钮本身始终可见 */
-  expanded?: boolean
   className?: string
 }
 
-export function PreviewOpenButton({ filePath, expanded: _expanded = false, className }: PreviewOpenButtonProps): React.ReactElement | null {
+export function PreviewOpenButton({ filePath, className }: PreviewOpenButtonProps): React.ReactElement | null {
   const sessionId = useAtomValue(currentAgentSessionIdAtom)
   const setPreviewFile = useSetAtom(previewFileMapAtom)
   const setPreviewOpen = useSetAtom(previewPanelOpenMapAtom)

--- a/apps/electron/src/renderer/components/agent/tool-result-renderers/preview-open-button.tsx
+++ b/apps/electron/src/renderer/components/agent/tool-result-renderers/preview-open-button.tsx
@@ -14,12 +14,12 @@ import { cn } from '@/lib/utils'
 
 interface PreviewOpenButtonProps {
   filePath: string
-  /** 是否已在展开状态（展开时始终可见，否则仅 hover 可见） */
+  /** 保留给调用方表达展开态，按钮本身始终可见 */
   expanded?: boolean
   className?: string
 }
 
-export function PreviewOpenButton({ filePath, expanded = false, className }: PreviewOpenButtonProps): React.ReactElement | null {
+export function PreviewOpenButton({ filePath, expanded: _expanded = false, className }: PreviewOpenButtonProps): React.ReactElement | null {
   const sessionId = useAtomValue(currentAgentSessionIdAtom)
   const setPreviewFile = useSetAtom(previewFileMapAtom)
   const setPreviewOpen = useSetAtom(previewPanelOpenMapAtom)
@@ -44,11 +44,10 @@ export function PreviewOpenButton({ filePath, expanded = false, className }: Pre
       role="button"
       tabIndex={0}
       className={cn(
-        'shrink-0 px-1.5 py-px rounded text-[11px] text-muted-foreground/50',
+        'inline-flex shrink-0 items-center px-1.5 py-px rounded text-[11px] text-muted-foreground/60',
         'hover:text-foreground/70 hover:bg-muted/50',
-        'transition-all duration-150 cursor-pointer',
-        'opacity-0 group-hover:opacity-100',
-        expanded && 'opacity-100',
+        'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+        'transition-colors duration-150 cursor-pointer',
         className,
       )}
       onClick={(e) => {
@@ -58,6 +57,7 @@ export function PreviewOpenButton({ filePath, expanded = false, className }: Pre
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault()
+          e.stopPropagation()
           handleOpen()
         }
       }}

--- a/apps/electron/src/renderer/components/chat/ChatToolBlock.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatToolBlock.tsx
@@ -83,7 +83,7 @@ export function ChatToolBlock({
         />
 
         {isPreviewable && (
-          <PreviewOpenButton filePath={filePath} expanded={expanded} />
+          <PreviewOpenButton filePath={filePath} />
         )}
       </button>
 


### PR DESCRIPTION
This PR makes Agent tool action controls follow the actual tool row width instead of being pushed to the far right.
It also keeps the file preview action visible without requiring hover and prevents keyboard preview activation from toggling the tool row.
The root cause was the tool row using full-width flex layout plus hover-only opacity on the preview control, which made short outputs feel disconnected from their actions.
Validated with `bun run typecheck`, `bun test`, `bun run --filter='@proma/electron' build:renderer`, and `git diff --check`.
