### PR TITLE
[codex] Render Feishu Agent runs live

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -69,6 +69,8 @@ export interface SessionCallbacks {
   onComplete: (messages?: AgentMessage[], opts?: { stoppedByUser?: boolean; startedAt?: number; resultSubtype?: string }) => void
   /** 发送标题更新 */
   onTitleUpdated: (title: string) => void
+  /** 用户消息已持久化，外部入口可据此通知前端切到实时会话 */
+  onRunStarted?: (opts: { startedAt: number }) => void
 }
 
 // ===== 工具函数 =====
@@ -1045,6 +1047,7 @@ export class AgentOrchestrator {
       _createdAt: Date.now(),
     } as unknown as SDKMessage
     appendSDKMessages(sessionId, [userSDKMsg])
+    callbacks.onRunStarted?.({ startedAt: streamStartedAt })
 
     // 6. 状态初始化
     const accumulatedMessages: SDKMessage[] = []

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -25,11 +25,13 @@ import type {
   AgentStreamPayload,
   AgentQueueMessageInput,
   PromaPermissionMode,
+  AgentExternalRunSource,
 } from '@proma/shared'
 import { ClaudeAgentAdapter, scanAndKillOrphanedClaudeSubprocesses } from './adapters/claude-agent-adapter'
 import { AgentEventBus } from './agent-event-bus'
 import { AgentOrchestrator } from './agent-orchestrator'
 import { getAgentSessionWorkspacePath, getWorkspaceFilesDir } from './config-paths'
+import { getAgentSessionMeta } from './agent-session-manager'
 
 // ===== 实例创建 =====
 
@@ -74,6 +76,21 @@ function registerWebContents(sessionId: string, wc: WebContents): void {
       if (mappedWc === wc) sessionWebContents.delete(sid)
     }
   })
+}
+
+function isMainRendererWindow(win: BrowserWindow): boolean {
+  if (win.isDestroyed()) return false
+  const url = win.webContents.getURL()
+  if (!url) return false
+  if (url.startsWith('data:')) return false
+  return !url.includes('window=quick-task')
+    && !url.includes('window=voice-dictation')
+    && !url.includes('window=detached-preview')
+}
+
+function getMainRendererWebContents(): WebContents | null {
+  const win = BrowserWindow.getAllWindows().find(isMainRendererWindow)
+  return win && !win.webContents.isDestroyed() ? win.webContents : null
 }
 
 // ===== EventBus IPC 转发中间件 =====
@@ -172,23 +189,25 @@ export async function runAgentHeadless(
     onError: (error: string) => void
     onComplete: () => void
     onTitleUpdated: (title: string) => void
+    source?: AgentExternalRunSource
   },
 ): Promise<void> {
   // 尝试注册主窗口 webContents，让流式事件同步推送到桌面端
-  const win = BrowserWindow.getAllWindows()[0]
-  const wc = win && !win.isDestroyed() ? win.webContents : null
+  const wc = getMainRendererWebContents()
+  const startedAt = input.startedAt ?? Date.now()
+  const runInput: AgentSendInput = input.startedAt === startedAt ? input : { ...input, startedAt }
   if (wc) {
-    registerWebContents(input.sessionId, wc)
+    registerWebContents(runInput.sessionId, wc)
   }
 
   try {
-    await orchestrator.sendMessage(input, {
+    await orchestrator.sendMessage(runInput, {
       onError: (error) => {
         callbacks.onError(error)
         // 同步到渲染进程
         if (wc && !wc.isDestroyed()) {
           wc.send(AGENT_IPC_CHANNELS.STREAM_ERROR, {
-            sessionId: input.sessionId,
+            sessionId: runInput.sessionId,
             error,
           })
         }
@@ -198,7 +217,7 @@ export async function runAgentHeadless(
         // 同步到渲染进程
         if (wc && !wc.isDestroyed()) {
           wc.send(AGENT_IPC_CHANNELS.STREAM_COMPLETE, {
-            sessionId: input.sessionId,
+            sessionId: runInput.sessionId,
             messages,
             stoppedByUser: opts?.stoppedByUser ?? false,
             startedAt: opts?.startedAt,
@@ -208,17 +227,32 @@ export async function runAgentHeadless(
       },
       onTitleUpdated: (title) => {
         callbacks.onTitleUpdated(title)
-        eventBus.emit(input.sessionId, {
+        eventBus.emit(runInput.sessionId, {
           kind: 'proma_event',
           event: { type: 'title_updated', title },
         })
         // 同步到渲染进程
         if (wc && !wc.isDestroyed()) {
           wc.send(AGENT_IPC_CHANNELS.TITLE_UPDATED, {
-            sessionId: input.sessionId,
+            sessionId: runInput.sessionId,
             title,
           })
         }
+      },
+      onRunStarted: ({ startedAt: persistedStartedAt }) => {
+        const session = getAgentSessionMeta(runInput.sessionId)
+        eventBus.emit(runInput.sessionId, {
+          kind: 'proma_event',
+          event: {
+            type: 'external_run_started',
+            source: callbacks.source ?? 'bridge',
+            sessionId: runInput.sessionId,
+            title: session?.title,
+            workspaceId: runInput.workspaceId ?? session?.workspaceId,
+            modelId: runInput.modelId,
+            startedAt: persistedStartedAt,
+          },
+        })
       },
     })
   } catch (err) {
@@ -227,12 +261,12 @@ export async function runAgentHeadless(
     callbacks.onError(errorMessage)
     callbacks.onComplete()
     if (wc && !wc.isDestroyed()) {
-      wc.send(AGENT_IPC_CHANNELS.STREAM_ERROR, { sessionId: input.sessionId, error: errorMessage })
-      wc.send(AGENT_IPC_CHANNELS.STREAM_COMPLETE, { sessionId: input.sessionId, messages: [], stoppedByUser: false })
+      wc.send(AGENT_IPC_CHANNELS.STREAM_ERROR, { sessionId: runInput.sessionId, error: errorMessage })
+      wc.send(AGENT_IPC_CHANNELS.STREAM_COMPLETE, { sessionId: runInput.sessionId, messages: [], stoppedByUser: false, startedAt })
     }
   } finally {
-    if (!orchestrator.isActive(input.sessionId)) {
-      sessionWebContents.delete(input.sessionId)
+    if (!orchestrator.isActive(runInput.sessionId)) {
+      sessionWebContents.delete(runInput.sessionId)
     }
   }
 }

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -194,8 +194,8 @@ export async function runAgentHeadless(
 ): Promise<void> {
   // 尝试注册主窗口 webContents，让流式事件同步推送到桌面端
   const wc = getMainRendererWebContents()
-  const startedAt = input.startedAt ?? Date.now()
-  const runInput: AgentSendInput = input.startedAt === startedAt ? input : { ...input, startedAt }
+  const runInput: AgentSendInput = input.startedAt != null ? input : { ...input, startedAt: Date.now() }
+  const startedAt = runInput.startedAt!
   if (wc) {
     registerWebContents(runInput.sessionId, wc)
   }

--- a/apps/electron/src/main/lib/feishu-bridge.ts
+++ b/apps/electron/src/main/lib/feishu-bridge.ts
@@ -1593,6 +1593,7 @@ class FeishuBridge {
       // 时，orchestrator 已经清理干净，下一个 batch 立刻调 sendMessage 不会撞守卫。
       try {
         await runAgentHeadless(input, {
+          source: 'feishu',
           onError: (error) => {
             const errPrefix = this.resolveContextPrefix(chatId)
             // 优先把错误显示到流式卡上；没有流式卡才发独立错误卡

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -56,7 +56,8 @@ import { agentDiffUnseenChangesAtom, agentDiffUnseenFilesAtom, agentDiffPanelTab
 import { autoPreviewEnabledAtom, previewPanelOpenMapAtom, previewFileMapAtom } from '@/atoms/preview-atoms'
 import type { NotificationSoundType } from '@/types/settings'
 import { toast } from 'sonner'
-import type { AgentStreamEvent, AgentStreamCompletePayload, AgentEvent, AgentStreamPayload, SDKAssistantMessage, SDKUserMessage, SDKSystemMessage, SDKContentBlock, SDKUserContentBlock } from '@proma/shared'
+import type { AgentStreamEvent, AgentStreamCompletePayload, AgentEvent, AgentStreamPayload, SDKAssistantMessage, SDKUserMessage, SDKSystemMessage, SDKContentBlock, SDKUserContentBlock, PromaEvent, AgentSessionMeta } from '@proma/shared'
+import { buildExternalAgentRunActivation } from '@/lib/external-agent-run'
 
 /** 触发右侧文件浏览器自动定位的写入类工具集合 */
 const WRITE_TOOLS = new Set(['Write', 'Edit', 'MultiEdit', 'NotebookEdit', 'Update'])
@@ -343,6 +344,62 @@ export function useGlobalAgentListeners(): void {
       return sessions.find((s) => s.id === sessionId)?.title ?? '未命名会话'
     }
 
+    const activateExternalAgentRun = (event: Extract<PromaEvent, { type: 'external_run_started' }>): void => {
+      const applyActivation = (sessions: AgentSessionMeta[]): void => {
+        const activation = buildExternalAgentRunActivation({
+          tabs: store.get(tabsAtom),
+          sessions,
+          sessionId: event.sessionId,
+          title: event.title,
+          workspaceId: event.workspaceId,
+          modelId: event.modelId,
+          startedAt: event.startedAt,
+          currentStreamState: store.get(agentStreamingStatesAtom).get(event.sessionId),
+        })
+
+        store.set(agentSessionsAtom, sessions)
+        store.set(tabsAtom, activation.tabs)
+        store.set(activeTabIdAtom, activation.activeTabId)
+        store.set(appModeAtom, 'agent')
+        store.set(currentAgentSessionIdAtom, event.sessionId)
+        if (activation.workspaceId) {
+          store.set(currentAgentWorkspaceIdAtom, activation.workspaceId)
+          window.electronAPI.updateSettings({ agentWorkspaceId: activation.workspaceId }).catch(console.error)
+        }
+        const activationModelId = activation.modelId
+        if (activationModelId) {
+          store.set(agentSessionModelMapAtom, (prev) => {
+            const map = new Map(prev)
+            map.set(event.sessionId, activationModelId)
+            return map
+          })
+        }
+        store.set(unviewedCompletedSessionIdsAtom, (prev) => {
+          if (!prev.has(event.sessionId)) return prev
+          const next = new Set(prev)
+          next.delete(event.sessionId)
+          return next
+        })
+        store.set(agentStreamingStatesAtom, (prev) => {
+          const map = new Map(prev)
+          map.set(event.sessionId, activation.streamState)
+          return map
+        })
+      }
+
+      const knownSessions = store.get(agentSessionsAtom)
+      if (knownSessions.some((session) => session.id === event.sessionId)) {
+        applyActivation(knownSessions)
+        return
+      }
+
+      window.electronAPI.listAgentSessions()
+        .then((sessions) => {
+          unstable_batchedUpdates(() => applyActivation(sessions))
+        })
+        .catch(console.error)
+    }
+
     /** 发送阻塞通知（带提示音 + 会话导航） */
     const sendBlockingNotification = (sessionId: string, title: string, body: string, soundType: NotificationSoundType) => {
       const enabled = store.get(notificationsEnabledAtom)
@@ -503,6 +560,10 @@ export function useGlobalAgentListeners(): void {
 
         unstable_batchedUpdates(() => {
         const { sessionId, payload } = streamEvent
+
+        if (payload.kind === 'proma_event' && payload.event.type === 'external_run_started') {
+          activateExternalAgentRun(payload.event)
+        }
 
         // 如果收到未知会话的事件（跨工作区场景），立即刷新会话列表
         const knownSessions = store.get(agentSessionsAtom)

--- a/apps/electron/src/renderer/lib/external-agent-run.test.ts
+++ b/apps/electron/src/renderer/lib/external-agent-run.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'bun:test'
+import type { AgentSessionMeta } from '@proma/shared'
+import { buildExternalAgentRunActivation } from './external-agent-run'
+import type { ExternalAgentRunTab } from './external-agent-run'
+
+const session: AgentSessionMeta = {
+  id: 'agent-1',
+  title: '飞书任务',
+  channelId: 'channel-1',
+  workspaceId: 'workspace-1',
+  createdAt: 1,
+  updatedAt: 2,
+}
+
+describe('外部 Agent 运行激活', () => {
+  test('Given 飞书触发的新会话 When 前端收到运行开始事件 Then 打开并激活 Agent 标签', () => {
+    const result = buildExternalAgentRunActivation({
+      tabs: [],
+      sessions: [session],
+      sessionId: session.id,
+      startedAt: 100,
+      modelId: 'claude-sonnet-4-6',
+    })
+
+    expect(result.tabs).toEqual([
+      { id: session.id, type: 'agent', sessionId: session.id, title: session.title },
+    ])
+    expect(result.activeTabId).toBe(session.id)
+    expect(result.workspaceId).toBe(session.workspaceId)
+    expect(result.streamState).toMatchObject({
+      running: true,
+      model: 'claude-sonnet-4-6',
+      startedAt: 100,
+    })
+  })
+
+  test('Given 会话标签已存在 When 再次收到外部运行开始事件 Then 复用原标签并保留已有工具活动', () => {
+    const tabs: ExternalAgentRunTab[] = [
+      { id: session.id, type: 'agent', sessionId: session.id, title: session.title },
+    ]
+    const currentStreamState = {
+      running: true,
+      content: '已有输出',
+      toolActivities: [{
+        toolUseId: 'tool-1',
+        toolName: 'Bash',
+        input: {},
+        done: false,
+      }],
+      model: 'old-model',
+    }
+
+    const result = buildExternalAgentRunActivation({
+      tabs,
+      sessions: [session],
+      sessionId: session.id,
+      startedAt: 200,
+      currentStreamState,
+    })
+
+    expect(result.tabs).toBe(tabs)
+    expect(result.activeTabId).toBe(session.id)
+    expect(result.streamState.toolActivities).toBe(currentStreamState.toolActivities)
+    expect(result.streamState.content).toBe('已有输出')
+    expect(result.streamState.startedAt).toBe(200)
+  })
+})

--- a/apps/electron/src/renderer/lib/external-agent-run.test.ts
+++ b/apps/electron/src/renderer/lib/external-agent-run.test.ts
@@ -64,4 +64,33 @@ describe('外部 Agent 运行激活', () => {
     expect(result.streamState.content).toBe('已有输出')
     expect(result.streamState.startedAt).toBe(200)
   })
+
+  test('Given 会话不在本地 sessions 列表中 When 激活 Then 使用 fallback 标题', () => {
+    const result = buildExternalAgentRunActivation({
+      tabs: [],
+      sessions: [],
+      sessionId: 'unknown-session',
+      startedAt: 300,
+    })
+
+    expect(result.title).toBe('新 Agent 会话')
+    expect(result.tabs[0]!.title).toBe('新 Agent 会话')
+    expect(result.activeTabId).toBe('unknown-session')
+    expect(result.workspaceId).toBeUndefined()
+  })
+
+  test('Given 无 currentStreamState When 激活 Then streamState 使用空默认值', () => {
+    const result = buildExternalAgentRunActivation({
+      tabs: [],
+      sessions: [session],
+      sessionId: session.id,
+      startedAt: 400,
+    })
+
+    expect(result.streamState.running).toBe(true)
+    expect(result.streamState.content).toBe('')
+    expect(result.streamState.toolActivities).toEqual([])
+    expect(result.streamState.model).toBeUndefined()
+    expect(result.streamState.startedAt).toBe(400)
+  })
 })

--- a/apps/electron/src/renderer/lib/external-agent-run.ts
+++ b/apps/electron/src/renderer/lib/external-agent-run.ts
@@ -1,0 +1,57 @@
+import type { AgentSessionMeta } from '@proma/shared'
+import type { AgentStreamState } from '@/atoms/agent-atoms'
+
+export interface ExternalAgentRunTab {
+  id: string
+  type: 'chat' | 'agent' | 'scratch'
+  sessionId: string
+  title: string
+}
+
+export interface ExternalAgentRunActivationInput {
+  tabs: ExternalAgentRunTab[]
+  sessions: AgentSessionMeta[]
+  sessionId: string
+  title?: string
+  workspaceId?: string
+  modelId?: string
+  startedAt: number
+  currentStreamState?: AgentStreamState
+}
+
+export interface ExternalAgentRunActivation {
+  tabs: ExternalAgentRunTab[]
+  activeTabId: string
+  title: string
+  workspaceId?: string
+  modelId?: string
+  streamState: AgentStreamState
+}
+
+export function buildExternalAgentRunActivation(
+  input: ExternalAgentRunActivationInput,
+): ExternalAgentRunActivation {
+  const session = input.sessions.find((item) => item.id === input.sessionId)
+  const title = input.title ?? session?.title ?? '新 Agent 会话'
+  const existingTab = input.tabs.find((tab) => tab.type === 'agent' && tab.sessionId === input.sessionId)
+  const tabs = existingTab
+    ? input.tabs
+    : [...input.tabs, { id: input.sessionId, type: 'agent' as const, sessionId: input.sessionId, title }]
+  const activeTabId = existingTab?.id ?? input.sessionId
+
+  return {
+    tabs,
+    activeTabId,
+    title,
+    workspaceId: input.workspaceId ?? session?.workspaceId,
+    modelId: input.modelId,
+    streamState: {
+      ...input.currentStreamState,
+      running: true,
+      content: input.currentStreamState?.content ?? '',
+      toolActivities: input.currentStreamState?.toolActivities ?? [],
+      model: input.modelId ?? input.currentStreamState?.model,
+      startedAt: input.startedAt,
+    },
+  }
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/shared",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "license": "AGPL-3.0-only",
   "description": "Shared types, configs and utilities for proma",
   "type": "module",

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -518,7 +518,10 @@ export type PromaEvent =
   | { type: 'model_resolved'; model: string }
   | { type: 'permission_mode_changed'; mode: PromaPermissionMode }
   | { type: 'title_updated'; title: string }
+  | { type: 'external_run_started'; source: AgentExternalRunSource; sessionId: string; title?: string; workspaceId?: string; modelId?: string; startedAt: number }
 
+/** 外部入口触发 Agent 运行的来源 */
+export type AgentExternalRunSource = 'feishu' | 'dingtalk' | 'wechat' | 'bridge'
 
 /** IPC 传输的统一 payload（替代 AgentEvent） */
 export type AgentStreamPayload =


### PR DESCRIPTION
## Summary
- Make Feishu-triggered headless Agent runs emit an external run-start event so the desktop can open and render the same live Agent session.
- Route headless stream forwarding to the main renderer window instead of arbitrary auxiliary windows.
- Add BDD coverage for activating and reusing Agent tabs for external runs, and bump affected package patch versions.

## Validation
- bun test apps/electron/src/renderer/lib/external-agent-run.test.ts apps/electron/src/main/lib/feishu/session-mirror.test.ts
- bun run typecheck
