### PR TITLE
Add Feishu sync sleep blocker

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -95,6 +95,7 @@ import { getIsQuitting, setQuitting } from './lib/app-lifecycle'
 import { registerBridge, startAllBridges, stopAllBridges } from './lib/bridge-registry'
 import { feishuBridgeManager } from './lib/feishu-bridge-manager'
 import { getFeishuMultiBotConfig } from './lib/feishu-config'
+import { stopFeishuSyncSleepBlocker, syncFeishuSyncSleepBlocker } from './lib/feishu-sleep-blocker'
 import { dingtalkBridgeManager } from './lib/dingtalk-bridge-manager'
 import { getDingTalkMultiBotConfig } from './lib/dingtalk-config'
 import { wechatBridge } from './lib/wechat-bridge'
@@ -460,6 +461,9 @@ async function bootstrap(): Promise<void> {
     safeRun('createVoiceDictationWindow', createVoiceDictationWindow)
   }
 
+  // 飞书实时同步开启时，默认阻止系统自动休眠，保证远程群内继续可用。
+  safeRun('syncFeishuSyncSleepBlocker', () => syncFeishuSyncSleepBlocker(getSettings()))
+
   // 注册全局快捷键
   safeRun('registerGlobalShortcut:quick-task', () =>
     registerGlobalShortcut('quick-task', toggleQuickTaskWindow),
@@ -567,6 +571,8 @@ app.on('before-quit', () => {
   stopChatToolsWatcher()
   // 停止所有 Bridge
   stopAllBridges()
+  // 释放飞书同步防休眠
+  stopFeishuSyncSleepBlocker()
   // 注销全局快捷键
   unregisterAllGlobalShortcuts()
   // 销毁快速任务窗口

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -238,6 +238,7 @@ import {
   getDecryptedBotAppSecret,
 } from './lib/feishu-config'
 import { feishuBridgeManager } from './lib/feishu-bridge-manager'
+import { syncFeishuSyncSleepBlocker } from './lib/feishu-sleep-blocker'
 import { presenceService } from './lib/feishu-presence'
 import { getDingTalkConfig, saveDingTalkConfig, getDecryptedClientSecret, getDingTalkMultiBotConfig, saveDingTalkBotConfig, removeDingTalkBot, getDecryptedBotClientSecret } from './lib/dingtalk-config'
 import { dingtalkBridgeManager } from './lib/dingtalk-bridge-manager'
@@ -1222,6 +1223,10 @@ export function registerIpcHandlers(): void {
     async (event, updates: Partial<AppSettings>): Promise<AppSettings> => {
       const result = await updateSettings(updates)
 
+      if (updates.feishuSessionMirror !== undefined) {
+        syncFeishuSyncSleepBlocker(result)
+      }
+
       // 主题相关设置变化时，广播给所有窗口（跨窗口同步，如 Quick Task 面板）
       if (updates.themeMode !== undefined || updates.themeStyle !== undefined) {
         const payload = { themeMode: result.themeMode, themeStyle: result.themeStyle }
@@ -1242,7 +1247,10 @@ export function registerIpcHandlers(): void {
     SETTINGS_IPC_CHANNELS.UPDATE_SYNC,
     (event, updates: Partial<AppSettings>) => {
       try {
-        updateSettings(updates)
+        const result = updateSettings(updates)
+        if (updates.feishuSessionMirror !== undefined) {
+          syncFeishuSyncSleepBlocker(result)
+        }
         event.returnValue = true
       } catch {
         event.returnValue = false

--- a/apps/electron/src/main/lib/feishu-sleep-blocker.ts
+++ b/apps/electron/src/main/lib/feishu-sleep-blocker.ts
@@ -1,0 +1,30 @@
+import { powerSaveBlocker } from 'electron'
+import type { AppSettings } from '../../types'
+import { FeishuSyncSleepBlocker } from './feishu/sleep-blocker'
+import type { SleepBlockerAdapter, SleepBlockerType } from './feishu/sleep-blocker'
+
+const electronSleepBlocker: SleepBlockerAdapter = {
+  start: (type: SleepBlockerType): number => powerSaveBlocker.start(type),
+  stop: (id: number): void => {
+    powerSaveBlocker.stop(id)
+  },
+  isStarted: (id: number): boolean => powerSaveBlocker.isStarted(id),
+}
+
+const blocker = new FeishuSyncSleepBlocker(electronSleepBlocker)
+
+export function syncFeishuSyncSleepBlocker(settings: Pick<AppSettings, 'feishuSessionMirror'>): void {
+  try {
+    blocker.sync(settings)
+  } catch (error) {
+    console.error('[飞书防休眠] 同步状态失败:', error)
+  }
+}
+
+export function stopFeishuSyncSleepBlocker(): void {
+  try {
+    blocker.stop()
+  } catch (error) {
+    console.error('[飞书防休眠] 关闭失败:', error)
+  }
+}

--- a/apps/electron/src/main/lib/feishu/sleep-blocker.test.ts
+++ b/apps/electron/src/main/lib/feishu/sleep-blocker.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  FeishuSyncSleepBlocker,
+  shouldPreventSleepForFeishuSync,
+  type SleepBlockerAdapter,
+  type SleepBlockerType,
+} from './sleep-blocker'
+
+class FakeSleepBlocker implements SleepBlockerAdapter {
+  readonly startedTypes: SleepBlockerType[] = []
+  readonly stoppedIds: number[] = []
+  private nextId = 1
+  private activeIds = new Set<number>()
+
+  start(type: SleepBlockerType): number {
+    const id = this.nextId
+    this.nextId += 1
+    this.startedTypes.push(type)
+    this.activeIds.add(id)
+    return id
+  }
+
+  stop(id: number): void {
+    this.stoppedIds.push(id)
+    this.activeIds.delete(id)
+  }
+
+  isStarted(id: number): boolean {
+    return this.activeIds.has(id)
+  }
+
+  markStopped(id: number): void {
+    this.activeIds.delete(id)
+  }
+}
+
+describe('飞书同步防休眠', () => {
+  test('Given 飞书实时同步已开启 When 同步防休眠状态 Then 启用显示器级防休眠', () => {
+    const adapter = new FakeSleepBlocker()
+    const blocker = new FeishuSyncSleepBlocker(adapter)
+
+    blocker.sync({ feishuSessionMirror: { mode: 'stream', botId: 'bot-1' } })
+
+    expect(adapter.startedTypes).toEqual(['prevent-display-sleep'])
+    expect(adapter.isStarted(1)).toBe(true)
+  })
+
+  test('Given 防休眠已启用 When 重复同步开启状态 Then 不重复创建 blocker', () => {
+    const adapter = new FakeSleepBlocker()
+    const blocker = new FeishuSyncSleepBlocker(adapter)
+
+    blocker.sync({ feishuSessionMirror: { mode: 'stream', botId: 'bot-1' } })
+    blocker.sync({ feishuSessionMirror: { mode: 'stream', botId: 'bot-1' } })
+
+    expect(adapter.startedTypes).toHaveLength(1)
+    expect(adapter.isStarted(1)).toBe(true)
+  })
+
+  test('Given 飞书实时同步从开启切到关闭 When 同步防休眠状态 Then 释放系统防休眠', () => {
+    const adapter = new FakeSleepBlocker()
+    const blocker = new FeishuSyncSleepBlocker(adapter)
+
+    blocker.sync({ feishuSessionMirror: { mode: 'stream', botId: 'bot-1' } })
+    blocker.sync({ feishuSessionMirror: { mode: 'off' } })
+
+    expect(adapter.stoppedIds).toEqual([1])
+    expect(adapter.isStarted(1)).toBe(false)
+  })
+
+  test('Given 系统中的 blocker 已失效 When 飞书同步仍开启 Then 重新启用防休眠', () => {
+    const adapter = new FakeSleepBlocker()
+    const blocker = new FeishuSyncSleepBlocker(adapter)
+
+    blocker.sync({ feishuSessionMirror: { mode: 'stream', botId: 'bot-1' } })
+    adapter.markStopped(1)
+    blocker.sync({ feishuSessionMirror: { mode: 'stream', botId: 'bot-1' } })
+
+    expect(adapter.startedTypes).toEqual(['prevent-display-sleep', 'prevent-display-sleep'])
+    expect(adapter.isStarted(2)).toBe(true)
+  })
+
+  test('Given 未开启飞书实时同步 When 判断防休眠需求 Then 不阻止休眠', () => {
+    expect(shouldPreventSleepForFeishuSync({ feishuSessionMirror: { mode: 'off' } })).toBe(false)
+    expect(shouldPreventSleepForFeishuSync({ feishuSessionMirror: undefined })).toBe(false)
+  })
+})

--- a/apps/electron/src/main/lib/feishu/sleep-blocker.ts
+++ b/apps/electron/src/main/lib/feishu/sleep-blocker.ts
@@ -1,0 +1,52 @@
+import type { AppSettings } from '../../../types'
+
+export type SleepBlockerType = 'prevent-display-sleep'
+
+export interface SleepBlockerAdapter {
+  start(type: SleepBlockerType): number
+  stop(id: number): void
+  isStarted(id: number): boolean
+}
+
+export function shouldPreventSleepForFeishuSync(
+  settings: Pick<AppSettings, 'feishuSessionMirror'>,
+): boolean {
+  return settings.feishuSessionMirror?.mode === 'stream'
+}
+
+export class FeishuSyncSleepBlocker {
+  private activeBlockerId: number | null = null
+
+  constructor(private readonly adapter: SleepBlockerAdapter) {}
+
+  sync(settings: Pick<AppSettings, 'feishuSessionMirror'>): void {
+    if (shouldPreventSleepForFeishuSync(settings)) {
+      this.start()
+      return
+    }
+
+    this.stop()
+  }
+
+  stop(): void {
+    if (this.activeBlockerId === null) return
+
+    const blockerId = this.activeBlockerId
+    this.activeBlockerId = null
+
+    if (this.adapter.isStarted(blockerId)) {
+      this.adapter.stop(blockerId)
+      console.log('[飞书防休眠] 已关闭')
+    }
+  }
+
+  private start(): void {
+    if (this.activeBlockerId !== null) {
+      if (this.adapter.isStarted(this.activeBlockerId)) return
+      this.activeBlockerId = null
+    }
+
+    this.activeBlockerId = this.adapter.start('prevent-display-sleep')
+    console.log('[飞书防休眠] 已启用，飞书实时同步期间阻止系统自动休眠')
+  }
+}

--- a/apps/electron/src/renderer/components/settings/FeishuSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/FeishuSettings.tsx
@@ -906,7 +906,7 @@ function SessionMirrorSection({ bots }: { bots: FeishuBotConfig[] }): React.Reac
   return (
     <SettingsSection
       title="同步到飞书"
-      description="开启后，每个新的 Proma Agent Session 会创建一个仅包含你和指定 Bot 的飞书群，并把输出同步到群内卡片。借此可以实现几乎完整的 Proma 移动端体验，可以脱离电脑随时在飞书上继续完成工作。"
+      description="开启后，每个新的 Proma Agent Session 会创建一个仅包含你和指定 Bot 的飞书群，并把输出同步到群内卡片，同时默认阻止电脑自动休眠，方便你脱离电脑在飞书上继续完成工作。"
     >
       <SettingsCard divided={false}>
         <div className="px-4 py-4 space-y-4">

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.9.44",
+      "version": "0.10.6",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.143",
         "@anthropic-ai/sdk": "^0.93.0",


### PR DESCRIPTION
## Summary
- Enables Electron powerSaveBlocker while Feishu Session mirror sync is in stream mode, restoring it on startup and releasing it when sync is disabled or the app quits.
- Updates the Feishu sync settings copy and bumps @proma/electron to 0.10.6 with bun.lock.

## Validation
- bun test apps/electron/src/main/lib/feishu/sleep-blocker.test.ts apps/electron/src/main/lib/feishu/session-mirror.test.ts
- bun run --filter='@proma/electron' typecheck
- bun run --filter='@proma/electron' build:main