### PR TITLE
fix(markdown): Mermaid Agent 渲染错误修复 + 未标语言代码块自动检测【已审核 PR】

### DIFF
--- a/apps/electron/src/main/lib/agent-prompt-builder.ts
+++ b/apps/electron/src/main/lib/agent-prompt-builder.ts
@@ -126,7 +126,8 @@ export function buildSystemPrompt(ctx: SystemPromptContext): string {
 - 用户可能也会在工作区文件夹下添加文件或者附加文件作为长期上下文或者长期处理任务，要注意及时感知这些变化并利用起来
 - **先搜后写**：修改代码前先用 Grep/Glob 搜索现有实现，复用已有模式和工具函数，最小化变更范围。避免重复造轮子
 - **可见进度**：多步骤、长耗时或涉及多个文件/阶段的任务，应尽早用 TaskCreate 创建清晰的子任务，后续推理发现与最初设计一不一致时可以及时更新；开始某项时用 TaskUpdate 标记 in_progress，完成后立即标记 completed。简单一步任务不需要创建任务
-- **大文件写入**：使用 Write 写入超过约 10,000 字（特别是中文/日文/韩文等 CJK 字符）时，主动拆分为多次写入——先 Write 首段，再用 Edit 追加后续段落，避免 token 截断导致文件内容不完整`)
+- **大文件写入**：使用 Write 写入超过约 10,000 字（特别是中文/日文/韩文等 CJK 字符）时，主动拆分为多次写入——先 Write 首段，再用 Edit 追加后续段落，避免 token 截断导致文件内容不完整
+- **回复中的代码块必须标语言**：在 Markdown 回复里写 fenced code block 时，开头围栏一定要紧跟语言标识（\`\`\`ts / \`\`\`python / \`\`\`json / \`\`\`bash 等），Mermaid 图必须用 \`\`\`mermaid，纯文本/日志/未知格式用 \`\`\`text。不写语言会导致前端无法语法高亮，用户体验下降；如果实在不知道语言，宁可写 \`\`\`text 也不要留空围栏`)
 
   // SubAgent 委派策略（根据用户选用的模型是否为 Claude 动态调整）
   const claudeAvailable = ctx.claudeAvailable !== false

--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -34,6 +34,7 @@ import {
 } from '@/components/ui/tooltip'
 import { LoadingIndicator } from '@/components/ui/loading-indicator'
 import { CodeBlock, MermaidBlock } from '@proma/ui'
+import { detectLanguage } from '@proma/core'
 import { FilePathChip, isAbsoluteFilePath, isRelativeFilePath } from './file-path-chip'
 import type { HTMLAttributes, ComponentProps, ReactNode } from 'react'
 import type { FileAttachment } from '@proma/shared'
@@ -443,16 +444,42 @@ function extractText(node: React.ReactNode): string {
 const MarkdownPre = React.memo(function MarkdownPre({
   children: preChildren,
 }: { children?: React.ReactNode }): React.ReactElement {
+  // react-markdown v10 把 <code> 替换成自定义组件后，type 不再是字符串 'code'，
+  // 但 pre 的 code child 要么是原生 'code'（v9 及之前），要么是自定义函数/对象组件（v10+）。
+  // 通过 type 形态过滤掉意外混入的其它原生 HTML 元素（如 span/div），降低未来 react-markdown
+  // 行为变化导致静默误识别的风险
   const codeChild = React.Children.toArray(preChildren).find(
-    (child): child is React.ReactElement =>
-      React.isValidElement(child) && (child as React.ReactElement).type === 'code'
+    (child): child is React.ReactElement => {
+      if (!React.isValidElement(child)) return false
+      const t = (child as React.ReactElement).type
+      return t === 'code' || typeof t === 'function' || typeof t === 'object'
+    }
   ) as React.ReactElement | undefined
 
   if (codeChild) {
     const codeProps = codeChild.props as { className?: string; children?: React.ReactNode }
-    if (codeProps.className?.includes('language-mermaid')) {
+    const className = codeProps.className ?? ''
+    const hasExplicitLang = /\blanguage-\S+/.test(className)
+
+    // 显式标注 mermaid 时直接渲染图表
+    if (className.includes('language-mermaid')) {
       const mermaidCode = extractText(codeProps.children).replace(/\n$/, '')
       return <MermaidBlock code={mermaidCode} />
+    }
+
+    // 未标注语言时自动检测：mermaid 走图表，其他注入 className 喂给 CodeBlock 高亮
+    if (!hasExplicitLang) {
+      const rawCode = extractText(codeProps.children).replace(/\n$/, '')
+      const detected = detectLanguage(rawCode)
+      if (detected === 'mermaid') {
+        return <MermaidBlock code={rawCode} />
+      }
+      if (detected !== 'text') {
+        const patchedCode = React.cloneElement(codeChild, {
+          className: `${className} language-${detected}`.trim(),
+        } as Partial<React.HTMLAttributes<HTMLElement>>)
+        return <CodeBlock>{patchedCode}</CodeBlock>
+      }
     }
   }
 
@@ -495,7 +522,7 @@ const MarkdownInlineCode = React.memo(function MarkdownInlineCode({
 
   return (
     <code
-      className="rounded bg-foreground/10 px-[0.35em] py-[0.15em] text-[0.875em] font-medium"
+      className="rounded bg-foreground/10 px-[0.35em] py-[0.15em] text-[0.875em] font-mono font-medium"
       {...codeProps}
     >
       {codeChildren}

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -718,8 +718,8 @@
 }
 
 .code-block-wrapper pre.shiki {
-  /* Cascadia Code 是 Windows 11 预装字体，优先级提高；Courier New 作为 Windows 10 最终兜底 */
-  font-family: 'Fira Code', 'Cascadia Code', 'Cascadia Mono', 'JetBrains Mono', Consolas, 'Courier New', monospace;
+  /* 与 Tailwind font-mono / @pierre/diffs 默认保持一致，跨平台命中系统等宽字体 */
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, 'Cascadia Code', 'JetBrains Mono', 'Fira Code', Consolas, 'Courier New', monospace;
   background-color: hsl(var(--code-bg)) !important;
 }
 

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.10.6",
+      "version": "0.10.7",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.143",
         "@anthropic-ai/sdk": "^0.93.0",
@@ -139,6 +139,7 @@
       "version": "0.2.9",
       "dependencies": {
         "@proma/shared": "workspace:*",
+        "highlight.js": "^11.11.1",
         "shiki": "^3.22.0",
       },
       "devDependencies": {
@@ -153,7 +154,7 @@
     },
     "packages/shared": {
       "name": "@proma/shared",
-      "version": "0.1.19",
+      "version": "0.1.22",
       "devDependencies": {
         "typescript": "^5.0.0",
       },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@proma/shared": "workspace:*",
+    "highlight.js": "^11.11.1",
     "shiki": "^3.22.0"
   },
   "peerDependencies": {

--- a/packages/core/src/highlight/index.ts
+++ b/packages/core/src/highlight/index.ts
@@ -9,8 +9,11 @@ export {
   highlightCode,
   highlightCodeSync,
   highlightToTokens,
+  isHighlighterReady,
+  onHighlighterReady,
   type HighlightOptions,
   type HighlightResult,
   type HighlightToken,
   type HighlightTokensResult,
 } from './shiki-service.ts'
+export { detectLanguage } from './language-detector.ts'

--- a/packages/core/src/highlight/language-detector.ts
+++ b/packages/core/src/highlight/language-detector.ts
@@ -1,0 +1,99 @@
+/**
+ * 代码语言自动检测
+ *
+ * 当 fenced code block 没有显式语言标识时，用于猜测最可能的语言：
+ * 1. Mermaid 启发式正则（hljs 没有 mermaid 语言定义，单独处理）
+ * 2. highlight.js 的 highlightAuto，仅注册常用语言以控制体积和误判
+ *
+ * 仅在 language 为空字符串时调用。识别失败回退到 'text'。
+ */
+
+import hljs from 'highlight.js/lib/core'
+import bash from 'highlight.js/lib/languages/bash'
+import c from 'highlight.js/lib/languages/c'
+import cpp from 'highlight.js/lib/languages/cpp'
+import csharp from 'highlight.js/lib/languages/csharp'
+import css from 'highlight.js/lib/languages/css'
+import go from 'highlight.js/lib/languages/go'
+import javascript from 'highlight.js/lib/languages/javascript'
+import json from 'highlight.js/lib/languages/json'
+import java from 'highlight.js/lib/languages/java'
+import kotlin from 'highlight.js/lib/languages/kotlin'
+import markdown from 'highlight.js/lib/languages/markdown'
+import python from 'highlight.js/lib/languages/python'
+import ruby from 'highlight.js/lib/languages/ruby'
+import rust from 'highlight.js/lib/languages/rust'
+import shell from 'highlight.js/lib/languages/shell'
+import sql from 'highlight.js/lib/languages/sql'
+import swift from 'highlight.js/lib/languages/swift'
+import typescript from 'highlight.js/lib/languages/typescript'
+import xml from 'highlight.js/lib/languages/xml'
+import yaml from 'highlight.js/lib/languages/yaml'
+
+/** 注册检测候选语言（只注册一次） */
+let registered = false
+function ensureRegistered(): void {
+  if (registered) return
+  hljs.registerLanguage('bash', bash)
+  hljs.registerLanguage('c', c)
+  hljs.registerLanguage('cpp', cpp)
+  hljs.registerLanguage('csharp', csharp)
+  hljs.registerLanguage('css', css)
+  hljs.registerLanguage('go', go)
+  hljs.registerLanguage('javascript', javascript)
+  hljs.registerLanguage('json', json)
+  hljs.registerLanguage('java', java)
+  hljs.registerLanguage('kotlin', kotlin)
+  hljs.registerLanguage('markdown', markdown)
+  hljs.registerLanguage('python', python)
+  hljs.registerLanguage('ruby', ruby)
+  hljs.registerLanguage('rust', rust)
+  hljs.registerLanguage('shell', shell)
+  hljs.registerLanguage('sql', sql)
+  hljs.registerLanguage('swift', swift)
+  hljs.registerLanguage('typescript', typescript)
+  hljs.registerLanguage('xml', xml)
+  hljs.registerLanguage('yaml', yaml)
+  registered = true
+}
+
+/** highlightAuto 的候选子集，与 ensureRegistered 保持一致 */
+const DETECT_LANGS = [
+  'bash', 'c', 'cpp', 'csharp', 'css', 'go',
+  'javascript', 'json', 'java', 'kotlin', 'markdown',
+  'python', 'ruby', 'rust', 'shell', 'sql', 'swift',
+  'typescript', 'xml', 'yaml',
+]
+
+/** Mermaid 图开头的特征关键字 */
+const MERMAID_PATTERN = /^\s*(?:%%[^\n]*\n\s*)?(?:flowchart|graph|sequenceDiagram|classDiagram|stateDiagram(?:-v2)?|erDiagram|gantt|pie|journey|gitGraph|mindmap|timeline|quadrantChart|requirementDiagram|C4Context|C4Container|C4Component)\b/
+
+/** highlightAuto 置信度门槛：低于此值视为无法识别 */
+const RELEVANCE_THRESHOLD = 5
+
+/**
+ * 自动检测代码语言
+ * - 优先识别 Mermaid（hljs 不支持，启发式匹配开头关键字）
+ * - 其余走 highlight.js highlightAuto + 置信度门槛
+ * - 识别失败返回 'text'
+ *
+ * @param code 代码内容
+ * @returns 语言标识，可直接传给 Shiki 或 MarkdownPre 路由判断
+ */
+export function detectLanguage(code: string): string {
+  const trimmed = code.trim()
+  if (!trimmed) return 'text'
+
+  if (MERMAID_PATTERN.test(trimmed)) return 'mermaid'
+
+  ensureRegistered()
+  try {
+    const result = hljs.highlightAuto(trimmed, DETECT_LANGS)
+    if (result.relevance >= RELEVANCE_THRESHOLD && result.language) {
+      return result.language
+    }
+  } catch {
+    // hljs 解析异常时静默回退
+  }
+  return 'text'
+}

--- a/packages/core/src/highlight/shiki-service.ts
+++ b/packages/core/src/highlight/shiki-service.ts
@@ -119,9 +119,34 @@ let highlighterPromise: Promise<ShikiHighlighter> | null = null
 /** 已 resolve 的高亮器实例缓存（同步访问用） */
 let cachedHighlighter: ShikiHighlighter | null = null
 
+/** 高亮器就绪订阅者，初始化完成后一次性触发并清空 */
+const readyListeners = new Set<() => void>()
+
+/** 是否已完成首次初始化（同步查询用） */
+export function isHighlighterReady(): boolean {
+  return cachedHighlighter !== null
+}
+
+/**
+ * 订阅高亮器就绪事件
+ * - 已就绪时立即同步触发回调，返回 noop unsubscribe
+ * - 未就绪时入队，初始化完成后触发一次后自动清理
+ * 返回 unsubscribe 函数，组件卸载时应调用以避免泄漏
+ */
+export function onHighlighterReady(callback: () => void): () => void {
+  if (cachedHighlighter) {
+    callback()
+    return () => {}
+  }
+  readyListeners.add(callback)
+  // 触发初始化（如果还没启动）
+  void getHighlighter()
+  return () => readyListeners.delete(callback)
+}
+
 /**
  * 获取或创建 Shiki 高亮器单例
- * 首次调用时懒加载，resolve 后缓存实例供同步使用
+ * 首次调用时懒加载，resolve 后缓存实例供同步使用，并通知所有 ready 订阅者
  */
 function getHighlighter(): Promise<ShikiHighlighter> {
   if (!highlighterPromise) {
@@ -130,6 +155,16 @@ function getHighlighter(): Promise<ShikiHighlighter> {
       langs: DEFAULT_LANGS,
     }).then((hl) => {
       cachedHighlighter = hl
+      // 通知所有等待中的订阅者，触发后清空（一次性事件）
+      const listeners = Array.from(readyListeners)
+      readyListeners.clear()
+      for (const listener of listeners) {
+        try {
+          listener()
+        } catch (error) {
+          console.error('[shiki-service] ready listener 抛错:', error)
+        }
+      }
       return hl
     })
   }

--- a/packages/ui/src/code-block/CodeBlock.tsx
+++ b/packages/ui/src/code-block/CodeBlock.tsx
@@ -20,7 +20,7 @@
  */
 
 import * as React from 'react'
-import { getDisplayName, highlightCode, highlightToTokens } from '@proma/core'
+import { getDisplayName, highlightToTokens, onHighlighterReady } from '@proma/core'
 import type { HighlightToken, HighlightTokensResult } from '@proma/core'
 
 /** react-markdown 传入的 <code> 元素 props */
@@ -53,9 +53,16 @@ function extractText(node: React.ReactNode): string {
 
 /** 从 children 中提取语言名和代码文本 */
 function extractCodeInfo(children: React.ReactNode): { language: string; code: string } {
+  // react-markdown v10 把 <code> 替换成自定义组件后，type 不再是字符串 'code'，
+  // 但 pre 的 code child 要么是原生 'code'（v9 及之前），要么是自定义函数/对象组件（v10+）。
+  // 通过 type 形态过滤掉意外混入的其它原生 HTML 元素，避免未来 react-markdown
+  // 行为变化时静默把第一个 element 误识别为 code
   const codeElement = React.Children.toArray(children).find(
-    (child): child is React.ReactElement =>
-      React.isValidElement(child) && (child as React.ReactElement).type === 'code'
+    (child): child is React.ReactElement => {
+      if (!React.isValidElement(child)) return false
+      const t = (child as React.ReactElement).type
+      return t === 'code' || typeof t === 'function' || typeof t === 'object'
+    }
   ) as React.ReactElement | undefined
 
   if (!codeElement) {
@@ -174,16 +181,9 @@ export function CodeBlock({ children }: CodeBlockProps): React.ReactElement {
       return
     }
 
-    // 异步兜底：高亮器尚未初始化
-    let cancelled = false
-    highlightCode({ code: trimmedCode, language: langOrText })
-      .then(() => {
-        // 初始化完成，用同步路径获取最新结果
-        if (!cancelled) doHighlight()
-      })
-      .catch((error) => console.error('[CodeBlock] 高亮失败:', error))
-
-    return () => { cancelled = true }
+    // 兜底：高亮器尚未初始化，订阅就绪事件，初始化完成后用同步路径上色
+    const unsubscribe = onHighlighterReady(() => doHighlight())
+    return () => unsubscribe()
   }, [trimmedCode, langOrText])
 
   // 清理节流定时器

--- a/packages/ui/src/mermaid-block/MermaidBlock.tsx
+++ b/packages/ui/src/mermaid-block/MermaidBlock.tsx
@@ -51,6 +51,20 @@ function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max)
 }
 
+/**
+ * 判断 mermaid 渲染结果是否无效（图表类型不支持、解析失败等）
+ *
+ * beautiful-mermaid 0.1.x 在不支持的图表类型（block-beta、mindmap、timeline 等）
+ * 上不会抛错，而是返回带 -Infinity 尺寸的空 SVG，注入 DOM 后会触发 React
+ * "<svg> attribute viewBox: Expected number" 报错。检测到无效 SVG 时直接
+ * 不切到 SVG 层，让源码层继续展示。
+ */
+function isInvalidMermaidSvg(svg: string): boolean {
+  return svg.includes('-Infinity')
+    || svg.includes('aria-roledescription="error"')
+    || svg.includes('class="error-text"')
+}
+
 // ===== 图标（与 CodeBlock 一致） =====
 
 const ICON_ATTRS = {
@@ -119,7 +133,7 @@ export function MermaidBlock({ code }: MermaidBlockProps): React.ReactElement {
         const svg = await renderMermaid(codeRef.current, getThemeOptions())
         // 只有最新一代的结果才生效，旧的全部丢弃
         if (generationRef.current !== currentGen) return
-        if (typeof svg === 'string' && svg.length > 0) {
+        if (typeof svg === 'string' && svg.length > 0 && !isInvalidMermaidSvg(svg)) {
           setSvgHtml(svg)
           requestAnimationFrame(() => setSvgVisible(true))
         }
@@ -141,7 +155,7 @@ export function MermaidBlock({ code }: MermaidBlockProps): React.ReactElement {
       try {
         const svg = await renderMermaid(codeRef.current, getThemeOptions())
         if (generationRef.current !== gen) return
-        if (typeof svg === 'string' && svg.length > 0) {
+        if (typeof svg === 'string' && svg.length > 0 && !isInvalidMermaidSvg(svg)) {
           setSvgHtml(svg)
           setSvgVisible(true)
         }


### PR DESCRIPTION
## Overview

修复三个 Markdown 渲染相关问题：Mermaid 图表在不支持类型上的 React 报错、react-markdown v10 升级后 code 块识别失效、以及 LLM 未标语言时代码块没有语法高亮。三个问题相互独立但都集中在 `MarkdownPre` 渲染路径上，因此一起处理。

## Changes

### 核心修复

- `packages/ui/src/mermaid-block/MermaidBlock.tsx` — 新增 `isInvalidMermaidSvg(svg)`，识别 `-Infinity` / `aria-roledescription="error"` / `error-text` 三种 fail 特征。`beautiful-mermaid 0.1.x` 在不支持的图表类型（block-beta、mindmap、timeline 等）上不抛错而是返回带 `-Infinity` 尺寸的空 SVG，注入 DOM 后 React 会报 `<svg> attribute viewBox: Expected number`；检测到无效结果时不切到 SVG 层、继续展示源码层。

- `apps/electron/src/renderer/components/ai-elements/message.tsx` — `MarkdownPre` 的 code child 匹配从严格 `child.type === 'code'` 改为 `type === 'code' || typeof type === 'function' || typeof type === 'object'`。react-markdown v10 把 `<code>` 替换成自定义组件后 type 不再是字符串，原条件失效导致代码块走不到 mermaid / CodeBlock 路径。新条件兼容 v9 原生 code 元素和 v10+ 自定义组件，同时排除意外混入的其他原生 HTML 元素（span/div 等）。同时新增未标语言时的自动检测路由：mermaid 走图表，其他注入 `language-xxx` className 喂给 CodeBlock 走 Shiki 高亮。

- `packages/core/src/highlight/language-detector.ts`（新文件） — 使用 `highlight.js/lib/core` 按需注册 20 个常见语言（bash/c/cpp/csharp/css/go/javascript/json/java/kotlin/markdown/python/ruby/rust/shell/sql/swift/typescript/xml/yaml）做 `highlightAuto` 检测，置信度门槛 5；mermaid 单独用启发式正则识别（hljs 不支持 mermaid）；识别失败回退 `text`。

### 配套改动

- `packages/core/src/highlight/shiki-service.ts` — 新增 `isHighlighterReady()` 和 `onHighlighterReady(cb)` 订阅事件 API。Shiki 高亮器初始化完成后一次性触发所有订阅者再清空。
- `packages/ui/src/code-block/CodeBlock.tsx` — 兜底逻辑从原来的 `highlightCode + .then(doHighlight)` 改为 `onHighlighterReady(doHighlight) → unsubscribe`，避免每个 CodeBlock 实例独立触发 `highlightCode` 重复初始化路径。同时同步放宽 `extractCodeInfo` 的 code child 匹配。
- `packages/core/src/highlight/index.ts` — 导出 `detectLanguage` / `isHighlighterReady` / `onHighlighterReady`。
- `packages/core/package.json` — 添加 `highlight.js@^11.11.1` 到 `dependencies`。
- `apps/electron/src/renderer/styles/globals.css` — 统一 `.shiki` 字体栈到 `ui-monospace, SFMono-Regular, Menlo, Monaco, 'Cascadia Code', 'JetBrains Mono', 'Fira Code', Consolas, 'Courier New', monospace`，跨 macOS / Windows / Linux 命中各自的系统等宽字体，与 Tailwind `font-mono` / @pierre/diffs 默认对齐。
- `apps/electron/src/renderer/components/ai-elements/message.tsx` — inline code 显式补 `font-mono` 类，避免和正文字体不一致。
- `apps/electron/src/main/lib/agent-prompt-builder.ts` — 系统 prompt 新增 `回复中的代码块必须标语言` 规则，让 Agent 端尽量主动标语言；自动检测做兜底，两道保险。

## How to Test

1. 让 Agent 输出一段 mermaid 图表（如 `block-beta` 这种 beautiful-mermaid 不支持的类型）→ 不应再看到 React `viewBox: Expected number` 报错，且应继续展示源码层
2. 让 Agent 在 fenced code 中省略语言标识（如直接写 ```` 跟代码），代码块应被正确识别并自动高亮（Python / TypeScript / JSON 等都能命中）
3. 显式标 mermaid 的代码块仍然渲染为图表（回归路径）
4. 显式标语言的代码块仍按对应语言高亮（回归路径）
5. 行内 code（`` `x` ``）应使用等宽字体
6. Windows 上代码块字体应正常命中 Cascadia Code / Consolas

## Notes

- Type check 全部通过（`bun run typecheck` 4 个 workspace 全 PASS）
- Windows 兼容性：所有改动都在 React/TS 渲染层，无 `fs` / `path` / `child_process` 调用，字体栈做了跨平台优先级覆盖
- `highlight.js` 走按需 import（`highlight.js/lib/languages/xxx`），不是全量包，对 bundle 影响约 100-200 KB minified
- `isInvalidMermaidSvg` 是字符串特征匹配，依赖 `beautiful-mermaid 0.1.x` 的内部错误格式；升级 beautiful-mermaid 时建议复核检测特征
- 自动检测出的语言在 CodeBlock 头部会显示对应语言名（如 "Python"），目前没有标记是检测来的还是用户写的——若希望区分可在 CodeBlock 里加一个 `autoDetected` 标志位