### PR TITLE
perf(minimap): 移除 scroll effect 中多余的 items 依赖，消除流式期间监听器重建 【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
@@ -135,7 +135,7 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
       el.removeEventListener('scroll', update)
       observer.disconnect()
     }
-  }, [scrollRef, items])
+  }, [scrollRef])
 
   // ── 面板打开时自动聚焦搜索框 ──
 


### PR DESCRIPTION
## Overview

在 `scroll-minimap.tsx` 的滚动监听 `useEffect` 中，`items`（消息列表数组）被错误地放入依赖数组。`items` 在流式输出期间随每条新消息更新引用，导致每次触发 effect 时都执行一次完整的监听器拆装周期（`removeEventListener` → `observer.disconnect()` → `addEventListener` → `observer.observe()`）。

实际上 `update` 函数完全不读取 `items`，它只通过 `querySelectorAll('[data-message-id]')` 动态扫描 DOM。`ResizeObserver` 本身已经会在新消息撑高容器时自然触发 `update`，无需借助 `items` 变化来驱动。

## Changes

- `apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx` — 将 `useEffect` 依赖数组从 `[scrollRef, items]` 改为 `[scrollRef]`，监听器只在容器节点变化时重建

## How to Test

1. 打开一个较长的 Agent 会话并触发流式输出
2. 观察 minimap 高亮在流式期间是否稳定（无闪烁）
3. 确认 minimap 仍能随滚动正常更新可见消息高亮

## Notes

- 改动范围极小（1 行），无功能影响
- 在长对话、慢机器上流式期间可减少数十至上百次无效监听器重建
- `ResizeObserver` 会在消息高度变化时自动触发 `update`，行为与之前完全一致