### PR TITLE
fix(markdown): 适配 react-markdown v10 + 自动检测未标语言代码块

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/agent-prompt-builder.ts
+++ b/apps/electron/src/main/lib/agent-prompt-builder.ts
@@ -126,7 +126,8 @@ export function buildSystemPrompt(ctx: SystemPromptContext): string {
 - 用户可能也会在工作区文件夹下添加文件或者附加文件作为长期上下文或者长期处理任务，要注意及时感知这些变化并利用起来
 - **先搜后写**：修改代码前先用 Grep/Glob 搜索现有实现，复用已有模式和工具函数，最小化变更范围。避免重复造轮子
 - **可见进度**：多步骤、长耗时或涉及多个文件/阶段的任务，应尽早用 TaskCreate 创建清晰的子任务，后续推理发现与最初设计一不一致时可以及时更新；开始某项时用 TaskUpdate 标记 in_progress，完成后立即标记 completed。简单一步任务不需要创建任务
-- **大文件写入**：使用 Write 写入超过约 10,000 字（特别是中文/日文/韩文等 CJK 字符）时，主动拆分为多次写入——先 Write 首段，再用 Edit 追加后续段落，避免 token 截断导致文件内容不完整`)
+- **大文件写入**：使用 Write 写入超过约 10,000 字（特别是中文/日文/韩文等 CJK 字符）时，主动拆分为多次写入——先 Write 首段，再用 Edit 追加后续段落，避免 token 截断导致文件内容不完整
+- **回复中的代码块必须标语言**：在 Markdown 回复里写 fenced code block 时，开头围栏一定要紧跟语言标识（\`\`\`ts / \`\`\`python / \`\`\`json / \`\`\`bash 等），Mermaid 图必须用 \`\`\`mermaid，纯文本/日志/未知格式用 \`\`\`text。不写语言会导致前端无法语法高亮，用户体验下降；如果实在不知道语言，宁可写 \`\`\`text 也不要留空围栏`)
 
   // SubAgent 委派策略（根据用户选用的模型是否为 Claude 动态调整）
   const claudeAvailable = ctx.claudeAvailable !== false

--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -35,6 +35,7 @@ import {
 } from '@/components/ui/tooltip'
 import { LoadingIndicator } from '@/components/ui/loading-indicator'
 import { CodeBlock, MermaidBlock } from '@proma/ui'
+import { detectLanguage } from '@proma/core'
 import { FilePathChip, isAbsoluteFilePath, isRelativeFilePath } from './file-path-chip'
 import type { HTMLAttributes, ComponentProps, ReactNode } from 'react'
 import type { FileAttachment } from '@proma/shared'
@@ -444,17 +445,40 @@ function extractText(node: React.ReactNode): string {
 const MarkdownPre = React.memo(function MarkdownPre({
   children: preChildren,
 }: { children?: React.ReactNode }): React.ReactElement {
+  // react-markdown v10 把 <code> 替换成自定义组件后，type 不再是字符串 'code'，
+  // 但 pre 的 code child 要么是原生 'code'（v9 及之前），要么是自定义函数/对象组件（v10+）。
+  // 通过 type 形态过滤掉意外混入的其他原生 HTML 元素（如 span/div），降低未来 react-markdown
+  // 行为变化导致静默误识别的风险
   const codeChild = React.Children.toArray(preChildren).find(
-    (child): child is React.ReactElement =>
-      React.isValidElement(child) && (child as React.ReactElement).type === 'code'
+    (child): child is React.ReactElement => {
+      if (!React.isValidElement(child)) return false
+      const t = (child as React.ReactElement).type
+      return t === 'code' || typeof t === 'function' || typeof t === 'object'
+    }
   ) as React.ReactElement | undefined
 
   if (codeChild) {
     const codeProps = codeChild.props as { className?: string; children?: React.ReactNode }
-    if (shouldInspectMermaidCodeBlock(codeProps.className)) {
+    const className = codeProps.className ?? ''
+    const hasExplicitLang = /\blanguage-\S+/.test(className)
+
+    // 先用共享 mermaid 识别（覆盖 language-mermaid/mmd 以及未标语言但内容像 Mermaid 的情况）
+    if (shouldInspectMermaidCodeBlock(className)) {
       const mermaidCode = extractText(codeProps.children).replace(/\n$/, '')
-      if (shouldRenderMermaidCodeBlock(codeProps.className, mermaidCode)) {
+      if (shouldRenderMermaidCodeBlock(className, mermaidCode)) {
         return <MermaidBlock code={mermaidCode} />
+      }
+    }
+
+    // 未标注语言且非 Mermaid 时：highlight.js 自动检测，命中后注入 language-xxx 喂给 CodeBlock 高亮
+    if (!hasExplicitLang) {
+      const rawCode = extractText(codeProps.children).replace(/\n$/, '')
+      const detected = detectLanguage(rawCode)
+      if (detected !== 'text') {
+        const patchedCode = React.cloneElement(codeChild, {
+          className: `${className} language-${detected}`.trim(),
+        } as Partial<React.HTMLAttributes<HTMLElement>>)
+        return <CodeBlock>{patchedCode}</CodeBlock>
       }
     }
   }
@@ -498,7 +522,7 @@ const MarkdownInlineCode = React.memo(function MarkdownInlineCode({
 
   return (
     <code
-      className="rounded bg-foreground/10 px-[0.35em] py-[0.15em] text-[0.875em] font-medium"
+      className="rounded bg-foreground/10 px-[0.35em] py-[0.15em] text-[0.875em] font-mono font-medium"
       {...codeProps}
     >
       {codeChildren}

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -718,8 +718,8 @@
 }
 
 .code-block-wrapper pre.shiki {
-  /* Cascadia Code 是 Windows 11 预装字体，优先级提高；Courier New 作为 Windows 10 最终兜底 */
-  font-family: 'Fira Code', 'Cascadia Code', 'Cascadia Mono', 'JetBrains Mono', Consolas, 'Courier New', monospace;
+  /* 与 Tailwind font-mono / @pierre/diffs 默认保持一致，跨平台命中系统等宽字体 */
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, 'Cascadia Code', 'JetBrains Mono', 'Fira Code', Consolas, 'Courier New', monospace;
   background-color: hsl(var(--code-bg)) !important;
 }
 

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.10.6",
+      "version": "0.10.8",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.143",
         "@anthropic-ai/sdk": "^0.93.0",
@@ -136,9 +136,10 @@
     },
     "packages/core": {
       "name": "@proma/core",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "dependencies": {
         "@proma/shared": "workspace:*",
+        "highlight.js": "^11.11.1",
         "shiki": "^3.22.0",
       },
       "devDependencies": {
@@ -153,14 +154,14 @@
     },
     "packages/shared": {
       "name": "@proma/shared",
-      "version": "0.1.20",
+      "version": "0.1.22",
       "devDependencies": {
         "typescript": "^5.0.0",
       },
     },
     "packages/ui": {
       "name": "@proma/ui",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@proma/core": "workspace:*",
         "beautiful-mermaid": "1.1.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/core",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "license": "AGPL-3.0-only",
   "description": "proma core types,storage and core logic with agents",
   "type": "module",
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@proma/shared": "workspace:*",
+    "highlight.js": "^11.11.1",
     "shiki": "^3.22.0"
   },
   "peerDependencies": {

--- a/packages/core/src/highlight/index.ts
+++ b/packages/core/src/highlight/index.ts
@@ -9,8 +9,11 @@ export {
   highlightCode,
   highlightCodeSync,
   highlightToTokens,
+  isHighlighterReady,
+  onHighlighterReady,
   type HighlightOptions,
   type HighlightResult,
   type HighlightToken,
   type HighlightTokensResult,
 } from './shiki-service.ts'
+export { detectLanguage } from './language-detector.ts'

--- a/packages/core/src/highlight/language-detector.ts
+++ b/packages/core/src/highlight/language-detector.ts
@@ -1,0 +1,96 @@
+/**
+ * 代码语言自动检测
+ *
+ * 当 fenced code block 没有显式语言标识时，用于猜测最可能的语言。
+ * 使用 highlight.js 按需注册的常用语言做 highlightAuto，置信度门槛 5。
+ *
+ * Mermaid 不在此处识别 —— 调用方应先用 `apps/electron/.../mermaid-detection.ts`
+ * 中的 `shouldRenderMermaidCodeBlock` 判断，未命中再调用本函数检测其他语言。
+ * 这样避免与 mermaid-detection 维护两份 mermaid 关键字列表。
+ *
+ * 仅在 language 为空字符串时调用。识别失败回退到 'text'。
+ */
+
+import hljs from 'highlight.js/lib/core'
+import bash from 'highlight.js/lib/languages/bash'
+import c from 'highlight.js/lib/languages/c'
+import cpp from 'highlight.js/lib/languages/cpp'
+import csharp from 'highlight.js/lib/languages/csharp'
+import css from 'highlight.js/lib/languages/css'
+import go from 'highlight.js/lib/languages/go'
+import javascript from 'highlight.js/lib/languages/javascript'
+import json from 'highlight.js/lib/languages/json'
+import java from 'highlight.js/lib/languages/java'
+import kotlin from 'highlight.js/lib/languages/kotlin'
+import markdown from 'highlight.js/lib/languages/markdown'
+import python from 'highlight.js/lib/languages/python'
+import ruby from 'highlight.js/lib/languages/ruby'
+import rust from 'highlight.js/lib/languages/rust'
+import shell from 'highlight.js/lib/languages/shell'
+import sql from 'highlight.js/lib/languages/sql'
+import swift from 'highlight.js/lib/languages/swift'
+import typescript from 'highlight.js/lib/languages/typescript'
+import xml from 'highlight.js/lib/languages/xml'
+import yaml from 'highlight.js/lib/languages/yaml'
+
+/** 注册检测候选语言（只注册一次） */
+let registered = false
+function ensureRegistered(): void {
+  if (registered) return
+  hljs.registerLanguage('bash', bash)
+  hljs.registerLanguage('c', c)
+  hljs.registerLanguage('cpp', cpp)
+  hljs.registerLanguage('csharp', csharp)
+  hljs.registerLanguage('css', css)
+  hljs.registerLanguage('go', go)
+  hljs.registerLanguage('javascript', javascript)
+  hljs.registerLanguage('json', json)
+  hljs.registerLanguage('java', java)
+  hljs.registerLanguage('kotlin', kotlin)
+  hljs.registerLanguage('markdown', markdown)
+  hljs.registerLanguage('python', python)
+  hljs.registerLanguage('ruby', ruby)
+  hljs.registerLanguage('rust', rust)
+  hljs.registerLanguage('shell', shell)
+  hljs.registerLanguage('sql', sql)
+  hljs.registerLanguage('swift', swift)
+  hljs.registerLanguage('typescript', typescript)
+  hljs.registerLanguage('xml', xml)
+  hljs.registerLanguage('yaml', yaml)
+  registered = true
+}
+
+/** highlightAuto 的候选子集，与 ensureRegistered 保持一致 */
+const DETECT_LANGS = [
+  'bash', 'c', 'cpp', 'csharp', 'css', 'go',
+  'javascript', 'json', 'java', 'kotlin', 'markdown',
+  'python', 'ruby', 'rust', 'shell', 'sql', 'swift',
+  'typescript', 'xml', 'yaml',
+]
+
+/** highlightAuto 置信度门槛：低于此值视为无法识别 */
+const RELEVANCE_THRESHOLD = 5
+
+/**
+ * 自动检测代码语言
+ * - 走 highlight.js highlightAuto + 置信度门槛
+ * - 识别失败返回 'text'
+ *
+ * @param code 代码内容
+ * @returns 语言标识，可直接传给 Shiki
+ */
+export function detectLanguage(code: string): string {
+  const trimmed = code.trim()
+  if (!trimmed) return 'text'
+
+  ensureRegistered()
+  try {
+    const result = hljs.highlightAuto(trimmed, DETECT_LANGS)
+    if (result.relevance >= RELEVANCE_THRESHOLD && result.language) {
+      return result.language
+    }
+  } catch {
+    // hljs 解析异常时静默回退
+  }
+  return 'text'
+}

--- a/packages/core/src/highlight/shiki-service.ts
+++ b/packages/core/src/highlight/shiki-service.ts
@@ -119,9 +119,34 @@ let highlighterPromise: Promise<ShikiHighlighter> | null = null
 /** 已 resolve 的高亮器实例缓存（同步访问用） */
 let cachedHighlighter: ShikiHighlighter | null = null
 
+/** 高亮器就绪订阅者，初始化完成后一次性触发并清空 */
+const readyListeners = new Set<() => void>()
+
+/** 是否已完成首次初始化（同步查询用） */
+export function isHighlighterReady(): boolean {
+  return cachedHighlighter !== null
+}
+
+/**
+ * 订阅高亮器就绪事件
+ * - 已就绪时立即同步触发回调，返回 noop unsubscribe
+ * - 未就绪时入队，初始化完成后触发一次后自动清理
+ * 返回 unsubscribe 函数，组件卸载时应调用以避免泄漏
+ */
+export function onHighlighterReady(callback: () => void): () => void {
+  if (cachedHighlighter) {
+    callback()
+    return () => {}
+  }
+  readyListeners.add(callback)
+  // 触发初始化（如果还没启动）
+  void getHighlighter()
+  return () => readyListeners.delete(callback)
+}
+
 /**
  * 获取或创建 Shiki 高亮器单例
- * 首次调用时懒加载，resolve 后缓存实例供同步使用
+ * 首次调用时懒加载，resolve 后缓存实例供同步使用，并通知所有 ready 订阅者
  */
 function getHighlighter(): Promise<ShikiHighlighter> {
   if (!highlighterPromise) {
@@ -130,6 +155,16 @@ function getHighlighter(): Promise<ShikiHighlighter> {
       langs: DEFAULT_LANGS,
     }).then((hl) => {
       cachedHighlighter = hl
+      // 通知所有等待中的订阅者，触发后清空（一次性事件）
+      const listeners = Array.from(readyListeners)
+      readyListeners.clear()
+      for (const listener of listeners) {
+        try {
+          listener()
+        } catch (error) {
+          console.error('[shiki-service] ready listener 抛错:', error)
+        }
+      }
       return hl
     })
   }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/ui",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "license": "AGPL-3.0-only",
   "description": "Shared UI components for proma",
   "type": "module",

--- a/packages/ui/src/code-block/CodeBlock.tsx
+++ b/packages/ui/src/code-block/CodeBlock.tsx
@@ -20,7 +20,7 @@
  */
 
 import * as React from 'react'
-import { getDisplayName, highlightCode, highlightToTokens } from '@proma/core'
+import { getDisplayName, highlightToTokens, onHighlighterReady } from '@proma/core'
 import type { HighlightToken, HighlightTokensResult } from '@proma/core'
 
 /** react-markdown 传入的 <code> 元素 props */
@@ -53,9 +53,16 @@ function extractText(node: React.ReactNode): string {
 
 /** 从 children 中提取语言名和代码文本 */
 function extractCodeInfo(children: React.ReactNode): { language: string; code: string } {
+  // react-markdown v10 把 <code> 替换成自定义组件后，type 不再是字符串 'code'，
+  // 但 pre 的 code child 要么是原生 'code'（v9 及之前），要么是自定义函数/对象组件（v10+）。
+  // 通过 type 形态过滤掉意外混入的其他原生 HTML 元素，避免未来 react-markdown
+  // 行为变化时静默把第一个 element 误识别为 code
   const codeElement = React.Children.toArray(children).find(
-    (child): child is React.ReactElement =>
-      React.isValidElement(child) && (child as React.ReactElement).type === 'code'
+    (child): child is React.ReactElement => {
+      if (!React.isValidElement(child)) return false
+      const t = (child as React.ReactElement).type
+      return t === 'code' || typeof t === 'function' || typeof t === 'object'
+    }
   ) as React.ReactElement | undefined
 
   if (!codeElement) {
@@ -174,16 +181,9 @@ export function CodeBlock({ children }: CodeBlockProps): React.ReactElement {
       return
     }
 
-    // 异步兜底：高亮器尚未初始化
-    let cancelled = false
-    highlightCode({ code: trimmedCode, language: langOrText })
-      .then(() => {
-        // 初始化完成，用同步路径获取最新结果
-        if (!cancelled) doHighlight()
-      })
-      .catch((error) => console.error('[CodeBlock] 高亮失败:', error))
-
-    return () => { cancelled = true }
+    // 兜底：高亮器尚未初始化，订阅就绪事件，初始化完成后用同步路径上色
+    const unsubscribe = onHighlighterReady(() => doHighlight())
+    return () => unsubscribe()
   }, [trimmedCode, langOrText])
 
   // 清理节流定时器

--- a/packages/ui/src/mermaid-block/MermaidBlock.tsx
+++ b/packages/ui/src/mermaid-block/MermaidBlock.tsx
@@ -39,9 +39,12 @@ function getThemeOptions(themes: Record<string, DiagramColors>): RenderOptions {
 }
 
 function isUsableSvg(svg: unknown): svg is string {
-  return typeof svg === 'string' &&
-    svg.includes('<svg') &&
-    !/(?:^|[^a-z])(?:NaN|Infinity|-Infinity)(?:[^a-z]|$)/i.test(svg)
+  if (typeof svg !== 'string' || !svg.includes('<svg')) return false
+  if (/(?:^|[^a-z])(?:NaN|Infinity|-Infinity)(?:[^a-z]|$)/i.test(svg)) return false
+  // mermaid 解析失败时会返回带错误标记的 SVG，需要识别后走兜底
+  if (svg.includes('aria-roledescription="error"')) return false
+  if (svg.includes('class="error-text"')) return false
+  return true
 }
 
 async function renderWithOfficialMermaid(code: string): Promise<string> {


### PR DESCRIPTION
## Summary

PR #597（Mermaid 渲染增强）合并后落地本 PR，整合 PR #598 中**与 #597 不重叠**且独立有价值的改动。#598 中重叠部分（如 `isInvalidMermaidSvg` 的 `-Infinity` 检测）已经被 #597 的 `isUsableSvg` 覆盖；#598 中 mermaid 的简易自动识别也已被 #597 更全面的 `mermaid-detection.ts`（含 v11 新图型 + 9 个 Bun 单测）替代，因此本 PR 不再重复。

#598 中独立有价值的部分原样保留：

- **react-markdown v10 适配**（关键 bug 修复）：`message.tsx` / `CodeBlock.tsx` 中识别 pre 的 code child 时，旧的严格 `child.type === 'code'` 在 react-markdown v10 之后失效（v10 把 \`<code>\` 替换为自定义组件，type 不再是字符串）。放宽为 \`'code' || typeof type === 'function' | 'object'\`，兼容 v9/v10，同时通过 type 形态过滤掉意外混入的其他原生 HTML 元素。

- **未标语言代码块自动检测**：新增 \`packages/core/highlight/language-detector.ts\`，用 \`highlight.js\` 按需注册 20 种常用语言做 highlightAuto，置信度门槛 5。\`MarkdownPre\` 路由顺序：先用 #597 引入的 \`shouldRenderMermaidCodeBlock\` 走 Mermaid 识别，未命中且无显式 language 时再调 \`detectLanguage\` 注入 \`language-xxx\`。\`detectLanguage\` 内不维护 mermaid 关键字（避免与 \`mermaid-detection.ts\` 重复维护两份关键字列表）。

- **`onHighlighterReady` 订阅 API**：\`shiki-service.ts\` 新增 \`isHighlighterReady\` / \`onHighlighterReady\`，\`CodeBlock\` 改用订阅替代 per-instance \`highlightCode\` 异步兜底，避免每个实例独立触发高亮器初始化路径。

- **MermaidBlock SVG 校验加固**：在 #597 的 \`isUsableSvg\`（NaN / Infinity / -Infinity）之上，再加入 \`aria-roledescription=\"error\"\` 与 \`class=\"error-text\"\` 检测，覆盖官方 mermaid 渲染器返回错误 SVG 的形态。fail 时让 beautiful-mermaid → 官方 mermaid → 源码层的兜底链继续向下退档。

- **跨平台字体统一**：\`.shiki\` 字体栈改为 \`ui-monospace, SFMono-Regular, Menlo, Monaco, 'Cascadia Code', 'JetBrains Mono', 'Fira Code', Consolas, 'Courier New', monospace\`，与 Tailwind \`font-mono\` / @pierre/diffs 默认对齐。Inline code 显式补 \`font-mono\`。

- **Agent prompt 规则**：系统 prompt 新增「回复中的代码块必须标语言」，未知语言用 \`text\` 兜底，从源头降低未标语言代码块的出现频率（自动检测作为二道保险）。

## 与 #598 的关系

合并本 PR 后可直接关闭 #598 — 所有有价值改动均已整合，且 mermaid 部分用 #597 的方案替换了 #598 的同位置 hotfix（更彻底）。

## Test plan

- [x] \`bun run typecheck\` — 4 个 workspace 全 PASS
- [ ] Agent 输出未标语言的 Python / TypeScript / JSON 代码 → 应自动高亮
- [ ] Agent 输出未标语言但是 Mermaid 内容（如 \`flowchart TD\` 起头）→ 应渲染图表
- [ ] Agent 输出 \`block-beta\` 等 mermaid v11 新图型 → 应通过 #597 的官方 mermaid 兜底渲染成功
- [ ] 显式标 mermaid / 显式标语言的代码块回归路径正常
- [ ] Inline code 显示等宽字体
- [ ] Windows 上代码块字体命中 Cascadia Code / Consolas

## 版本号

- @proma/electron 0.10.7 → 0.10.8
- @proma/core 0.2.9 → 0.2.10
- @proma/ui 0.1.6 → 0.1.7

## 依赖

- 新增 \`highlight.js@^11.11.1\` 到 \`packages/core\`（按需 import 子语言，约 100-200KB minified）

🤖 Co-authored with [Andreaseszhang](https://github.com/Andreaseszhang) (原 #598 作者)