### PR TITLE
fix(mermaid): 移除滚轮缩放与拖拽交互，仅保留头部按钮

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/ui",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "license": "AGPL-3.0-only",
   "description": "Shared UI components for proma",
   "type": "module",

--- a/packages/ui/src/mermaid-block/MermaidBlock.tsx
+++ b/packages/ui/src/mermaid-block/MermaidBlock.tsx
@@ -11,6 +11,9 @@
  *   失败 → 保持源码展示
  *
  * 防竞态：generation 计数器，只有最新一代的渲染结果才会生效
+ *
+ * 缩放交互：仅头部按钮（缩小 / 重置 / 放大）。不响应滚轮和拖拽，
+ * 让滚轮事件正常冒泡到页面滚动；放大后用容器原生 overflow scrollbar 浏览。
  */
 
 import * as React from 'react'
@@ -27,6 +30,7 @@ const DEBOUNCE_MS = 350
 const ZOOM_MIN = 0.25
 const ZOOM_MAX = 3
 const ZOOM_STEP = 0.15
+const INITIAL_SCALE = 1
 let mermaidRenderId = 0
 
 function isDarkMode(): boolean {
@@ -117,28 +121,17 @@ const zoomOutPath = (
   </>
 )
 
-// ===== 缩放平移 =====
-
-interface ViewTransform {
-  scale: number
-  translateX: number
-  translateY: number
-}
-const INITIAL_TRANSFORM: ViewTransform = { scale: 1, translateX: 0, translateY: 0 }
-
 // ===== 主组件 =====
 
 export function MermaidBlock({ code }: MermaidBlockProps): React.ReactElement {
   const [renderedSvg, setRenderedSvg] = React.useState<string | null>(null)
   const [copied, setCopied] = React.useState(false)
-  const [transform, setTransform] = React.useState<ViewTransform>(INITIAL_TRANSFORM)
+  const [scale, setScale] = React.useState<number>(INITIAL_SCALE)
 
   const codeRef = React.useRef(code)
   const debounceRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
   /** generation 计数器：每次 code 变化递增，防止异步竞态 */
   const generationRef = React.useRef(0)
-  const dragRef = React.useRef<{ startX: number; startY: number; startTx: number; startTy: number } | null>(null)
-  const svgContainerRef = React.useRef<HTMLDivElement>(null)
 
   codeRef.current = code
 
@@ -160,7 +153,7 @@ export function MermaidBlock({ code }: MermaidBlockProps): React.ReactElement {
 
     if (debounceRef.current) clearTimeout(debounceRef.current)
     setRenderedSvg(null)
-    setTransform(INITIAL_TRANSFORM)
+    setScale(INITIAL_SCALE)
     debounceRef.current = setTimeout(() => {
       void renderCurrentCode(currentGen)
     }, DEBOUNCE_MS)
@@ -180,53 +173,13 @@ export function MermaidBlock({ code }: MermaidBlockProps): React.ReactElement {
     return () => observer.disconnect()
   }, [renderCurrentCode])
 
-  // ---- 滚轮缩放 ----
-  React.useEffect(() => {
-    const el = svgContainerRef.current
-    if (!el) return
-    const handleWheel = (e: WheelEvent) => {
-      e.preventDefault()
-      setTransform((prev) => ({
-        ...prev,
-        scale: clamp(prev.scale + (e.deltaY > 0 ? -ZOOM_STEP : ZOOM_STEP), ZOOM_MIN, ZOOM_MAX),
-      }))
-    }
-    el.addEventListener('wheel', handleWheel, { passive: false })
-    return () => el.removeEventListener('wheel', handleWheel)
-  }, [renderedSvg])
-
-  // ---- 拖拽平移 ----
-  const handleMouseDown = React.useCallback((e: React.MouseEvent) => {
-    if (e.button !== 0) return
-    e.preventDefault()
-    dragRef.current = {
-      startX: e.clientX, startY: e.clientY,
-      startTx: transform.translateX, startTy: transform.translateY,
-    }
-    const onMove = (ev: MouseEvent) => {
-      if (!dragRef.current) return
-      setTransform((prev) => ({
-        ...prev,
-        translateX: dragRef.current!.startTx + ev.clientX - dragRef.current!.startX,
-        translateY: dragRef.current!.startTy + ev.clientY - dragRef.current!.startY,
-      }))
-    }
-    const onUp = () => {
-      dragRef.current = null
-      window.removeEventListener('mousemove', onMove)
-      window.removeEventListener('mouseup', onUp)
-    }
-    window.addEventListener('mousemove', onMove)
-    window.addEventListener('mouseup', onUp)
-  }, [transform.translateX, transform.translateY])
-
   const handleZoomIn = React.useCallback(() => {
-    setTransform((prev) => ({ ...prev, scale: clamp(prev.scale + ZOOM_STEP, ZOOM_MIN, ZOOM_MAX) }))
+    setScale((prev) => clamp(prev + ZOOM_STEP, ZOOM_MIN, ZOOM_MAX))
   }, [])
   const handleZoomOut = React.useCallback(() => {
-    setTransform((prev) => ({ ...prev, scale: clamp(prev.scale - ZOOM_STEP, ZOOM_MIN, ZOOM_MAX) }))
+    setScale((prev) => clamp(prev - ZOOM_STEP, ZOOM_MIN, ZOOM_MAX))
   }, [])
-  const handleZoomReset = React.useCallback(() => setTransform(INITIAL_TRANSFORM), [])
+  const handleZoomReset = React.useCallback(() => setScale(INITIAL_SCALE), [])
 
   const handleCopy = React.useCallback(async () => {
     try {
@@ -238,7 +191,7 @@ export function MermaidBlock({ code }: MermaidBlockProps): React.ReactElement {
     }
   }, [code])
 
-  const zoomPercent = Math.round(transform.scale * 100)
+  const zoomPercent = Math.round(scale * 100)
 
   return (
     <div className="mermaid-block-wrapper group/mermaid rounded-lg overflow-hidden my-2 border border-border/50">
@@ -274,17 +227,10 @@ export function MermaidBlock({ code }: MermaidBlockProps): React.ReactElement {
             <code>{code}</code>
           </pre>
         ) : (
-          <div
-            ref={svgContainerRef}
-            className="bg-background overflow-auto select-none min-h-[180px]"
-            style={{ cursor: 'grab' }}
-            onMouseDown={handleMouseDown}
-          >
+          <div className="bg-background overflow-auto min-h-[180px]">
             <div
               className="flex justify-center items-center p-4 min-h-[180px] origin-center"
-              style={{
-                transform: `translate(${transform.translateX}px, ${transform.translateY}px) scale(${transform.scale})`,
-              }}
+              style={{ transform: `scale(${scale})` }}
             >
               <div
                 className="mermaid-svg [&>svg]:max-w-full [&>svg]:h-auto"


### PR DESCRIPTION
## Summary

之前 \`MermaidBlock\` 在 SVG 容器上同时挂了滚轮缩放（\`wheel\` + \`preventDefault\`）和鼠标拖拽平移。带来的交互问题：

- 用户在长消息里**用滚轮往下滚浏览**，鼠标一旦经过 Mermaid 图区域，滚动就被劫持成图的缩放，页面停下来不动
- 拖拽和滚轮原本是一套 pan/zoom 交互组合，单独保留任一项都别扭

改动：

- 移除 wheel effect、鼠标拖拽 handler、\`cursor: grab\` 样式
- **头部按钮（缩小 / 重置百分比 / 放大）保留**，作为唯一的缩放入口
- \`ViewTransform { scale, translateX, translateY }\` 简化为单字段 \`scale: number\`（translateX/Y 不再被任何 handler 写入，是死字段）
- SVG 容器仍 \`overflow-auto\`，放大后用浏览器**原生 scrollbar** 浏览图的其他部分（更符合操作系统约定，不需要"按住图拖拽"这种特殊交互）

## Test plan

- [x] \`bun run typecheck\` — 4 个 workspace 全 PASS
- [ ] 渲染包含 Mermaid 图表的长消息，鼠标滚轮经过图时**页面继续滚动**（不再卡住）
- [ ] 点击头部 "+" / "-" 按钮可以放大/缩小，百分比正确显示
- [ ] 点击中间百分比可以重置为 100%
- [ ] 放大后，图溢出容器，用容器内 **scrollbar 滚动**浏览其他部分（鼠标在图上滚也不再缩放）
- [ ] 复制按钮仍正常工作
- [ ] code 变化重新渲染时，缩放重置为 100%

## 版本号

- @proma/electron 0.10.8 → 0.10.9
- @proma/ui 0.1.7 → 0.1.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)