### PR TITLE
fix: 移除 icon 按钮的 focus-visible ring，避免操作栏按钮点击后残留圆形边框

### DIFF
--- a/apps/electron/src/renderer/components/ui/button.tsx
+++ b/apps/electron/src/renderer/components/ui/button.tsx
@@ -24,8 +24,8 @@ const buttonVariants = cva(
         default: "h-9 px-4 py-2",
         sm: "h-8 rounded-md px-3 text-xs",
         lg: "h-10 rounded-md px-8",
-        icon: "h-9 w-9",
-        "icon-sm": "h-7 w-7",
+        icon: "h-9 w-9 focus-visible:ring-0",
+        "icon-sm": "h-7 w-7 focus-visible:ring-0",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Summary
- 在 button CVA 的 `icon` / `icon-sm` size variant 中覆盖 `focus-visible:ring-0`
- 解决 Agent/Chat 输入框底部操作栏中 `rounded-full` 按钮点击后残留圆形 focus ring 的问题
- `default`/`sm`/`lg` 尺寸按钮不受影响，保留键盘可访问性

## Test plan
- [ ] Agent 模式下点击操作栏各按钮（权限模式、thinking、语音、附件、发送等），确认无圆形边框残留
- [ ] Chat 模式下同样验证
- [ ] 键盘 Tab 导航到普通按钮（非 icon 尺寸），确认 focus ring 仍正常显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)