### PR TITLE
[codex] Update Claude Agent SDK integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,9 @@ Proma 目前设有 PR 赠金计划。提交 PR 时可以在描述中留下邮箱
 
 ![Proma PR Bounty](https://img.erlich.fun/personal-blog/uPic/PR%20%E8%B5%A0%E9%87%91%201.png)
 
+## 作者
+
+- 个人网站：[erlich.fun](https://erlich.fun)
 
 ## Star History
 

--- a/apps/electron/electron-builder.yml
+++ b/apps/electron/electron-builder.yml
@@ -41,6 +41,7 @@ files:
   - node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64/**/*
   - node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64/**/*
   - node_modules/@anthropic-ai/claude-agent-sdk-win32-x64/**/*
+  - node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64/**/*
   # PDF 内联预览使用本地 PDF.js 资源，避免运行时依赖 CDN。
   - node_modules/pdfjs-dist/**/*
   # 排除 workspace 包的 symlink（代码已被 esbuild/Vite 打包到 dist/ 中）

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.10.10",
+  "version": "0.10.11",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {
@@ -35,7 +35,7 @@
     "dist:debug": "bun run scripts/dist.ts --current-arch --verbose"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.143",
+    "@anthropic-ai/claude-agent-sdk": "0.3.153",
     "@anthropic-ai/sdk": "^0.93.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@pierre/diffs": "^1.1.20",
@@ -46,10 +46,10 @@
     "pdfjs-dist": "^4.10.38"
   },
   "optionalDependencies": {
-    "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.143",
-    "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.143",
-    "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.143",
-    "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.143"
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.153",
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.153",
+    "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.153",
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.153"
   },
   "devDependencies": {
     "@emoji-mart/data": "^1.2.1",

--- a/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
@@ -323,6 +323,24 @@ export function mapSDKErrorToTypedError(
       message: '您的账户存在账单问题',
       canRetry: false,
     },
+    'model_not_found': {
+      code: 'invalid_model',
+      title: '模型不可用',
+      message: '当前渠道无法使用所选模型，请检查模型名称或切换模型',
+      canRetry: false,
+    },
+    'invalid_request': {
+      code: 'invalid_request',
+      title: '请求无效',
+      message: 'API 请求参数无效，请检查当前渠道与模型配置',
+      canRetry: false,
+    },
+    'rate_limit': {
+      code: 'rate_limited',
+      title: '请求频率限制',
+      message: '请求过于频繁，请稍后再试',
+      canRetry: true,
+    },
     'rate_limited': {
       code: 'rate_limited',
       title: '请求频率限制',
@@ -357,6 +375,12 @@ export function mapSDKErrorToTypedError(
       code: 'service_unavailable',
       title: '服务暂时不可用',
       message: 'API 服务暂时不可用，请稍后再试',
+      canRetry: true,
+    },
+    'server_error': {
+      code: 'service_error',
+      title: '服务错误',
+      message: 'API 服务暂时异常，请稍后再试',
       canRetry: true,
     },
     'prompt_too_long': {

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -215,6 +215,7 @@ function getRetryDelayMs(attempt: number, elapsedRetryDelayMs: number): number {
  */
 function resolveSDKCliPath(): string {
   const subpkg = `claude-agent-sdk-${process.platform}-${process.arch}`
+  const scopedSubpkg = `@anthropic-ai/${subpkg}`
   const binaryName = process.platform === 'win32' ? 'claude.exe' : 'claude'
   let binaryPath: string | null = null
 
@@ -227,18 +228,29 @@ function resolveSDKCliPath(): string {
     const anthropicDir = dirname(dirname(sdkEntryPath))
     binaryPath = join(anthropicDir, subpkg, binaryName)
     console.log(`[Agent 编排] SDK binary 路径 (createRequire): ${binaryPath}`)
+    if (!existsSync(binaryPath)) {
+      const subpkgPackagePath = cjsRequire.resolve(`${scopedSubpkg}/package.json`)
+      binaryPath = join(dirname(subpkgPackagePath), binaryName)
+      console.log(`[Agent 编排] SDK binary 路径 (platform package): ${binaryPath}`)
+    }
   } catch (e) {
     console.warn('[Agent 编排] createRequire 解析 SDK 路径失败:', e)
   }
 
   // 策略 2：全局 require（esbuild CJS bundle 可能保留）
-  if (!binaryPath) {
+  if (!binaryPath || !existsSync(binaryPath)) {
     try {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const sdkEntryPath = require.resolve('@anthropic-ai/claude-agent-sdk')
       const anthropicDir = dirname(dirname(sdkEntryPath))
       binaryPath = join(anthropicDir, subpkg, binaryName)
       console.log(`[Agent 编排] SDK binary 路径 (require.resolve): ${binaryPath}`)
+      if (!existsSync(binaryPath)) {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const subpkgPackagePath = require.resolve(`${scopedSubpkg}/package.json`)
+        binaryPath = join(dirname(subpkgPackagePath), binaryName)
+        console.log(`[Agent 编排] SDK binary 路径 (require platform package): ${binaryPath}`)
+      }
     } catch (e) {
       console.warn('[Agent 编排] require.resolve 解析 SDK 路径失败:', e)
     }
@@ -247,7 +259,7 @@ function resolveSDKCliPath(): string {
   // 策略 3：从当前模块目录手动查找（打包后 __dirname 指向 app/dist/，上一级即 app/）
   // 注意：不使用 process.cwd()，因为打包后的 Electron 应用 cwd 通常是 '/'
   // 或用户主目录，与 app 安装目录无关。
-  if (!binaryPath) {
+  if (!binaryPath || !existsSync(binaryPath)) {
     binaryPath = join(__dirname, '..', 'node_modules', '@anthropic-ai', subpkg, binaryName)
     console.log(`[Agent 编排] SDK binary 路径 (手动): ${binaryPath}`)
   }
@@ -1312,6 +1324,10 @@ export class AgentOrchestrator {
         'TaskCreate', 'TaskUpdate', 'TaskList', 'TaskGet',
         'ListMcpResourcesTool', 'ReadMcpResourceTool',
       ])
+      const DEFERRED_OR_PROACTIVE_TOOLS = new Set([
+        'REPL', 'Workflow', 'ScheduleWakeup', 'Monitor', 'PushNotification',
+        'CronCreate', 'CronDelete', 'RemoteTrigger',
+      ])
 
       /** Plan 模式是否已被 Agent 进入（初始 plan 模式时天然为 true，其他模式需 EnterPlanMode 触发） */
       let planModeEntered = initialPermissionMode === 'plan'
@@ -1417,6 +1433,9 @@ export class AgentOrchestrator {
             // MCP 工具（以 mcp__ 开头）允许调用（调研用）
             if (toolName.startsWith('mcp__')) {
               return { behavior: 'allow' as const, updatedInput: input }
+            }
+            if (DEFERRED_OR_PROACTIVE_TOOLS.has(toolName)) {
+              return { behavior: 'deny' as const, message: '计划模式下不允许启动后台、定时、通知或脚本执行能力，请在计划审批通过后再执行' }
             }
             // 其余工具拒绝
             return { behavior: 'deny' as const, message: '计划模式下不允许执行写操作，请在计划审批通过后再执行' }

--- a/apps/electron/src/main/lib/agent-permission-service.ts
+++ b/apps/electron/src/main/lib/agent-permission-service.ts
@@ -352,6 +352,26 @@ export class AgentPermissionService {
         return typeof input.description === 'string'
           ? `启动子任务: ${input.description}`
           : '启动子任务'
+      case 'REPL':
+        return typeof input.description === 'string'
+          ? `执行 REPL: ${input.description}`
+          : '执行 REPL 代码'
+      case 'Workflow':
+        return typeof input.name === 'string'
+          ? `运行工作流: ${input.name}`
+          : '运行工作流'
+      case 'ScheduleWakeup':
+        return typeof input.reason === 'string'
+          ? `安排会话唤醒: ${input.reason}`
+          : '安排会话唤醒'
+      case 'Monitor':
+        return typeof input.description === 'string'
+          ? `启动监控任务: ${input.description}`
+          : '启动监控任务'
+      case 'PushNotification':
+        return typeof input.message === 'string'
+          ? `发送通知: ${input.message}`
+          : '发送通知'
       default:
         return `使用工具: ${toolName}`
     }
@@ -373,6 +393,11 @@ export class AgentPermissionService {
 
     // Task 工具默认为 normal
     if (toolName === 'Task') return 'normal'
+
+    // 新 SDK 的后台/定时/通知/脚本能力都可能产生会话外影响，需要明确审批
+    if (['REPL', 'Workflow', 'ScheduleWakeup', 'Monitor', 'PushNotification', 'CronCreate', 'CronDelete', 'RemoteTrigger'].includes(toolName)) {
+      return 'normal'
+    }
 
     return 'normal'
   }

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -74,6 +74,8 @@ export interface AgentStreamState {
   costUsd?: number
   /** 模型上下文窗口大小 */
   contextWindow?: number
+  /** 当前 thinking block 的 token 估算值（SDK 实时估算，非计费值） */
+  thinkingEstimatedTokens?: number
   /** 是否正在压缩上下文 */
   isCompacting?: boolean
   /**
@@ -652,6 +654,12 @@ export function applyAgentEvent(
 
     case 'task_notification':
       return prev
+
+    case 'thinking_tokens':
+      return {
+        ...prev,
+        thinkingEstimatedTokens: event.estimatedTokens,
+      }
 
     case 'tool_use_summary':
       // 工具使用摘要 — 目前不影响流式状态，仅用于 UI 展示

--- a/apps/electron/src/renderer/components/agent/tool-phrase.ts
+++ b/apps/electron/src/renderer/components/agent/tool-phrase.ts
@@ -247,6 +247,44 @@ export function getToolPhrase(toolName: string, input: Record<string, unknown>):
       return phrase('等待用户输入')
     }
 
+    case 'REPL': {
+      const description = input.description
+      const code = input.code
+      if (typeof description === 'string' && description.trim()) return phrase(`执行 REPL ${truncate(description, 50)}`)
+      if (typeof code === 'string') return phrase(`执行 REPL ${truncate(code, 50)}`)
+      return phrase('执行 REPL')
+    }
+
+    case 'Workflow': {
+      const name = input.name
+      const scriptPath = input.scriptPath
+      if (typeof name === 'string') return phrase(`运行工作流 ${name}`)
+      if (typeof scriptPath === 'string') return phrase(`运行工作流 ${filename(scriptPath)}`)
+      return phrase('运行工作流')
+    }
+
+    case 'ScheduleWakeup': {
+      const delaySeconds = input.delaySeconds
+      const reason = input.reason
+      if (typeof delaySeconds === 'number' && typeof reason === 'string') {
+        return phrase(`安排 ${delaySeconds}s 后唤醒 · ${truncate(reason, 40)}`)
+      }
+      if (typeof delaySeconds === 'number') return phrase(`安排 ${delaySeconds}s 后唤醒`)
+      return phrase('安排唤醒')
+    }
+
+    case 'Monitor': {
+      const description = input.description
+      if (typeof description === 'string') return phrase(`监控 ${truncate(description, 50)}`)
+      return phrase('监控任务')
+    }
+
+    case 'PushNotification': {
+      const message = input.message
+      if (typeof message === 'string') return phrase(`发送通知 ${truncate(message, 50)}`)
+      return phrase('发送通知')
+    }
+
     case 'CronCreate': {
       const cron = input.cron
       const prompt = input.prompt

--- a/apps/electron/src/renderer/components/agent/tool-utils.ts
+++ b/apps/electron/src/renderer/components/agent/tool-utils.ts
@@ -67,6 +67,11 @@ export const TOOL_ICONS: Record<string, LucideIcon> = {
   TaskOutput: Layers,
   TaskStop: OctagonX,
   AskUserQuestion: MessageCircleQuestion,
+  REPL: Terminal,
+  Workflow: GitBranch,
+  ScheduleWakeup: CalendarClock,
+  Monitor: Radio,
+  PushNotification: Send,
   CronCreate: CalendarClock,
   CronDelete: CalendarX,
   CronList: CalendarDays,
@@ -115,6 +120,11 @@ const TOOL_DISPLAY_NAMES: Record<string, string> = {
   TaskOutput: '获取任务输出',
   TaskStop: '停止任务',
   AskUserQuestion: '等待用户输入',
+  REPL: '执行 REPL',
+  Workflow: '运行工作流',
+  ScheduleWakeup: '安排唤醒',
+  Monitor: '监控任务',
+  PushNotification: '发送通知',
   CronCreate: '创建定时任务',
   CronDelete: '删除定时任务',
   CronList: '列出定时任务',
@@ -316,6 +326,42 @@ export function getInputSummary(
           return first.question.length > 60 ? first.question.slice(0, 60) + '…' : first.question
         }
       }
+      return null
+    }
+
+    case 'REPL': {
+      const description = input.description
+      const code = input.code
+      if (typeof description === 'string' && description.trim()) return description
+      if (typeof code === 'string') return code.length > 60 ? code.slice(0, 60) + '…' : code
+      return null
+    }
+
+    case 'Workflow': {
+      const name = input.name
+      const scriptPath = input.scriptPath
+      if (typeof name === 'string') return name
+      if (typeof scriptPath === 'string') return scriptPath.split('/').pop() ?? scriptPath
+      return null
+    }
+
+    case 'ScheduleWakeup': {
+      const delaySeconds = input.delaySeconds
+      const reason = input.reason
+      if (typeof delaySeconds === 'number' && typeof reason === 'string') return `${delaySeconds}s · ${reason}`
+      if (typeof delaySeconds === 'number') return `${delaySeconds}s`
+      return null
+    }
+
+    case 'Monitor': {
+      const description = input.description
+      if (typeof description === 'string') return description.length > 60 ? description.slice(0, 60) + '…' : description
+      return null
+    }
+
+    case 'PushNotification': {
+      const message = input.message
+      if (typeof message === 'string') return message.length > 60 ? message.slice(0, 60) + '…' : message
       return null
     }
 

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -284,6 +284,13 @@ function payloadToLegacyEvents(payload: AgentStreamPayload): AgentEvent[] {
           } : undefined,
         }]
       }
+      if (sMsg.subtype === 'thinking_tokens' && typeof sMsg.estimated_tokens === 'number') {
+        return [{
+          type: 'thinking_tokens',
+          estimatedTokens: sMsg.estimated_tokens,
+          estimatedTokensDelta: typeof sMsg.estimated_tokens_delta === 'number' ? sMsg.estimated_tokens_delta : 0,
+        }]
+      }
       return []
     }
 
@@ -580,6 +587,8 @@ export function useGlobalAgentListeners(): void {
           // 它通过下方 legacyEvents 分支写入 agentPromptSuggestionsAtom，显示在输入框上方
           if (msgRecord.type === 'prompt_suggestion') {
             // 跳过写入 liveMessages
+          } else if (msgRecord.type === 'system' && msgRecord.subtype === 'thinking_tokens') {
+            // thinking_tokens 是高频进度估算，只更新流式状态，不进入消息转录。
           } else if (!msgRecord.isReplay) {
             // 为实时消息补充 _createdAt 时间戳（与持久化时的逻辑一致），
             // 避免 AssistantTurnRenderer 因缺少时间戳导致 header 时间消失

--- a/bun.lock
+++ b/bun.lock
@@ -22,9 +22,9 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.10.8",
+      "version": "0.10.11",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.143",
+        "@anthropic-ai/claude-agent-sdk": "0.3.153",
         "@anthropic-ai/sdk": "^0.93.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@pierre/diffs": "^1.1.20",
@@ -128,10 +128,10 @@
         "zod": "^4.0.0",
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.143",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.143",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.143",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.143",
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.153",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.153",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.153",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.153",
       },
     },
     "packages/core": {
@@ -154,14 +154,14 @@
     },
     "packages/shared": {
       "name": "@proma/shared",
-      "version": "0.1.22",
+      "version": "0.1.23",
       "devDependencies": {
         "typescript": "^5.0.0",
       },
     },
     "packages/ui": {
       "name": "@proma/ui",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@proma/core": "workspace:*",
         "beautiful-mermaid": "1.1.3",
@@ -179,6 +179,13 @@
       },
     },
   },
+  "overrides": {
+    "@anthropic-ai/claude-agent-sdk": "0.3.153",
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.153",
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.153",
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.153",
+    "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.153",
+  },
   "packages": {
     "7zip-bin": ["7zip-bin@5.2.0", "", {}, "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A=="],
 
@@ -186,23 +193,23 @@
 
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
 
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.143", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.143", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.143", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.143", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.143", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.143", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.143", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.143", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.143" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-JnxOTRpSBpFqKFMfV5cW4QjpeDOHUNr31rRislmOVWEPsRmCjsy9jYwKxDf7kxcwxyZ6h/YHz1ACvMaUWy6o6A=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.153", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.153", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.153", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.153", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.153", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.153", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.153", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.153", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.153" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-+WYWQ5ih2dOuiJY4yql5pje3w8iA+aS7eZXJSFo6LZxmEiH4nV4n/fjhJCWPcqyo7TdvhAjS2cPqwIslNw3c7A=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.143", "", { "os": "darwin", "cpu": "arm64" }, "sha512-41WuTuP+bk4NxrjpG9IJGffsjh1ivyiiAmqgb5QoxPltDAA0p3gs+iZ3lTgDmY4Ga68wDoN05Lt18oCE+DQb7g=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.153", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4K2K/n/qikp24ufO38owSEj5RPMWjBmf83BSUxLlzOhOXt7dHXs1CitmY9ZYM58Wmn3qhJs9DaS//ptO1siskQ=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.143", "", { "os": "darwin", "cpu": "x64" }, "sha512-3WrJ6MjjwQKvPnPbzUOm08qftlHYobkp/tmM1P/Vk/ldSjoPfFIgLFfzSzUmCKJiKEh2ZlHLJr8ORNrTxXhgQg=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.153", "", { "os": "darwin", "cpu": "x64" }, "sha512-kY5DPMAK+ZkphoIUjOiP6sSB57Lw2H1RUNK2HVEDowagbl9T47DSbkjYE4NWYqfy22aebPj02VAIbFfFmYxnMw=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.143", "", { "os": "linux", "cpu": "arm64" }, "sha512-/9oP/FCewrPnwVN+QUS5rlO3kMa07w+hOrpWrz24aEpBYhcHzr0zoNMBriPDAkTr3ao/z1k40UZ2dHmgsSODzA=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.153", "", { "os": "linux", "cpu": "arm64" }, "sha512-XoIP6xJn+QlfBta96yfxdtaeJ/BstA2S9abZJYeWs/wwNjQNWs83repg/v1VPuGn7i44teSzLtzoAv9t1w4Ybg=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.143", "", { "os": "linux", "cpu": "arm64" }, "sha512-9UeV1W2vjOVwJSJrq9aw3UeMo82Ir59FfJ5mchh7OXZEaevkANvHYn25bTCnIpqfqOx7qFEosJW2ELIoV1nprg=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.153", "", { "os": "linux", "cpu": "arm64" }, "sha512-5fD6MagyX+1tZdpVjZ6rN178pR7K10c+JyTsEh4HUJR3tnVO9uZYcmEcsKLX1TjWX+mz5+TW9rwDP5AMHXsjNA=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.143", "", { "os": "linux", "cpu": "x64" }, "sha512-kwqnbHo4Zj6TzO1V/83uLhsTt0xBp/BN5V/aHIX+khM4UuNO6NOKNaZvr8Int3sF0ARF95Hjr4l/hMKxry6DhQ=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.153", "", { "os": "linux", "cpu": "x64" }, "sha512-U2eY8iBLF0vrvuHnh33UA3LA/aIVgSk2Pw5KY7N5lH5fYzcnDBoT8bG32lelQIoaUDY0znOWIc0vqN5/Yih51w=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.143", "", { "os": "linux", "cpu": "x64" }, "sha512-rr4334GOLl9caYDeyWsbwMaVJCiNvKHE9nLdey8opIkq7/FHHu712U6tDk0tcoCdsGU/S3/BBaZParOgF+s5qw=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.153", "", { "os": "linux", "cpu": "x64" }, "sha512-4o+1RnNAL31iZDDT46AWl/t5lUSVJ5Gq8o2IxPgNBltPHAL3aUmTTDLxjDb+gFVEyegyy9FwK0yPJGpNp4CxKA=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.143", "", { "os": "win32", "cpu": "arm64" }, "sha512-q5UaLZ9ABbqQN8UXpqHUqjW6akI1zMrV5Jvtq0yueKP4nIRbBBZBQ80M4bpdrc0+SiRmjVRV3p8lsCCAd8azgg=="],
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.153", "", { "os": "win32", "cpu": "arm64" }, "sha512-GQsZTvf4pJVVAgaXwpN/W7RpO7dtUd3VCM3zxD7RQ1X+Dc8tUNPMWr7JCHEYwrUWiS1jeSjLOsrAuRFopSP43Q=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.143", "", { "os": "win32", "cpu": "x64" }, "sha512-46L2mkskvIRfwzHP3p0uUE5u9Oc7Eb/DRVmXuGNk5Z8jiahlDSv0SHP1vnWSWw5nWIu4DWOKyXZelRmYc9LxCg=="],
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.153", "", { "os": "win32", "cpu": "x64" }, "sha512-t/+IEFLsp+fY1G5EZhzVBNKI1mm28rPNcyrlJHy3wCbl1aA/Myd7mWnNCRckDGENZz4V7KyqCslLsCt5gT2iPg=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.93.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-q9vaSZQVFx6B/gPxetGYfLXSJD5v0sOmh0OpZDq7yCrTSA+Rscvrtyol7JJTW40wEpQB4U1B4JXzxQitbQ3CAA=="],
 

--- a/package.json
+++ b/package.json
@@ -31,5 +31,12 @@
   },
   "dependencies": {
     "jotai": "^2.17.1"
+  },
+  "overrides": {
+    "@anthropic-ai/claude-agent-sdk": "0.3.153",
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.153",
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.153",
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.153",
+    "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.153"
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/shared",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "license": "AGPL-3.0-only",
   "description": "Shared types, configs and utilities for proma",
   "type": "module",

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -247,6 +247,9 @@ export interface SDKResultMessage {
   total_cost_usd?: number
   modelUsage?: Record<string, { contextWindow?: number }>
   errors?: string[]
+  terminal_reason?: string
+  background_tasks?: SDKBackgroundTaskSummary[]
+  session_crons?: SDKSessionCronSummary[]
   session_id?: string
 }
 
@@ -273,6 +276,37 @@ export interface SDKSystemMessage {
   decision_reason?: string
   usage?: { total_tokens?: number; tool_uses?: number; duration_ms?: number }
   [key: string]: unknown
+}
+
+/** SDK thinking token 估算消息（Claude Agent SDK 0.3.156+） */
+export interface SDKThinkingTokensMessage {
+  type: 'system'
+  subtype: 'thinking_tokens'
+  estimated_tokens: number
+  estimated_tokens_delta: number
+  uuid?: string
+  session_id?: string
+}
+
+/** SDK 后台任务摘要（result / hook 中可能出现） */
+export interface SDKBackgroundTaskSummary {
+  id: string
+  type: string
+  status: string
+  description: string
+  command?: string
+  agent_type?: string
+  server?: string
+  tool?: string
+  name?: string
+}
+
+/** SDK 会话级定时任务摘要（result / hook 中可能出现） */
+export interface SDKSessionCronSummary {
+  id: string
+  schedule: string
+  recurring: boolean
+  prompt: string
 }
 
 /** SDK tool_progress 消息（工具执行心跳） */
@@ -307,6 +341,7 @@ export type SDKMessage =
   | SDKAssistantMessage
   | SDKUserMessage
   | SDKResultMessage
+  | SDKThinkingTokensMessage
   | SDKSystemMessage
   | SDKToolProgressMessage
   | SDKPromptSuggestionMessage
@@ -467,6 +502,7 @@ export type AgentEvent =
   | { type: 'task_started'; taskId: string; toolUseId?: string; description: string; taskType?: string; turnId?: string }
   | { type: 'task_progress'; toolUseId: string; elapsedSeconds?: number; turnId?: string; taskId?: string; description?: string; lastToolName?: string; usage?: TaskUsage }
   | { type: 'task_notification'; taskId: string; toolUseId?: string; status: 'completed' | 'failed' | 'stopped'; summary: string; outputFile?: string; usage?: TaskUsage; turnId?: string }
+  | { type: 'thinking_tokens'; estimatedTokens: number; estimatedTokensDelta: number }
   | { type: 'shell_backgrounded'; toolUseId: string; shellId: string; intent?: string; command?: string; turnId?: string }
   | { type: 'shell_killed'; shellId: string; turnId?: string }
   // 工具使用摘要


### PR DESCRIPTION
Updates the Claude Agent SDK integration to 0.3.153, which keeps DeepSeek and MiniMax Agent requests compatible by avoiding the 0.3.156 system-role message regression.
Adds SDK 0.3.x event/type handling for thinking token estimates, background task summaries, proactive tools, and clearer API error mapping.
Hardens native SDK binary resolution and packaging by covering Bun hoisted platform packages plus the Windows arm64 optional package.
Validated with `bun run typecheck`, `bun test`, `bun run electron:build`, `CSC_IDENTITY_AUTO_DISCOVERY=false bun run --filter='@proma/electron' dist:fast`, and a packaged binary version check showing Claude Code 2.1.153.
