### PR TITLE
Harden editable input file attachments

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.10.10",
+  "version": "0.10.11",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -98,36 +98,11 @@ import { sendWithCmdEnterAtom } from '@/atoms/shortcut-atoms'
 import type { AgentSendInput, AgentPendingFile, FileDialogLargeFile, ModelOption, SDKMessage } from '@proma/shared'
 import { MAX_ATTACHMENT_SIZE } from '@proma/shared'
 import { fileToBase64, formatFileNames, getFileParentPath } from '@/lib/file-utils'
+import { createClipboardPendingFile, createClipboardTextDraft, makeUniqueAttachmentName } from '@/lib/clipboard-text-attachment'
 
 /** 稳定的空 SDKMessage 数组引用，避免 ?? [] 每次创建新引用 */
 const EMPTY_SDK_MESSAGES: SDKMessage[] = []
 const LONG_TEXT_ATTACHMENT_THRESHOLD = 2000
-
-function formatClipboardTimestamp(date = new Date()): string {
-  const pad = (value: number): string => String(value).padStart(2, '0')
-  return `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}-${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}`
-}
-
-function looksLikeMarkdown(text: string): boolean {
-  return [
-    /^#{1,6}\s+\S/m,
-    /```[\s\S]*?```/,
-    /^\s*\|.+\|\s*\n\s*\|[\s:-]+\|/m,
-    /^---\n[\s\S]*?\n---\n/,
-    /^\s*> .+/m,
-    /^\s*[-*+]\s+\S/m,
-    /^\s*\d+\.\s+\S/m,
-    /\[[^\]]+\]\([^)]+\)/,
-  ].some((pattern) => pattern.test(text))
-}
-
-function createClipboardTextFile(text: string): File {
-  const isMarkdown = looksLikeMarkdown(text)
-  const extension = isMarkdown ? 'md' : 'txt'
-  const mediaType = isMarkdown ? 'text/markdown' : 'text/plain'
-  const filename = `clipboard-${formatClipboardTimestamp()}.${extension}`
-  return new File([text], filename, { type: mediaType })
-}
 
 interface SDKMessageRecord {
   type?: string
@@ -805,15 +780,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
 
   /** 为文件生成唯一文件名（避免粘贴多张图片时文件名重复导致覆盖） */
   const makeUniqueFilename = React.useCallback((originalName: string, existingNames: string[]): string => {
-    if (!existingNames.includes(originalName)) return originalName
-    const dotIdx = originalName.lastIndexOf('.')
-    const baseName = dotIdx > 0 ? originalName.slice(0, dotIdx) : originalName
-    const ext = dotIdx > 0 ? originalName.slice(dotIdx) : ''
-    let counter = 1
-    while (existingNames.includes(`${baseName}-${counter}${ext}`)) {
-      counter++
-    }
-    return `${baseName}-${counter}${ext}`
+    return makeUniqueAttachmentName(originalName, existingNames)
   }, [])
 
   const attachSessionFile = React.useCallback(async (filePath: string): Promise<void> => {
@@ -1012,8 +979,32 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     })
   }, [setPendingFiles])
 
+  const openClipboardPreviewFile = React.useCallback((filePath: string): void => {
+    const parentPath = getFileParentPath(filePath)
+    setPreviewFileMap((prev) => {
+      const m = new Map(prev)
+      m.set(sessionId, {
+        filePath,
+        previewOnly: true,
+        readOnly: false,
+        basePaths: parentPath ? [parentPath] : undefined,
+      })
+      return m
+    })
+    store.set(previewPanelOpenMapAtom, (prev) => {
+      const m = new Map(prev)
+      m.set(sessionId, true)
+      return m
+    })
+  }, [sessionId, setPreviewFileMap, store])
+
   /** 点击 clipboard 附件时，在右侧预览面板中显示内容 */
   const handleClipboardPreview = React.useCallback(async (file: AgentPendingFile) => {
+    if (file.sourcePath) {
+      openClipboardPreviewFile(file.sourcePath)
+      return
+    }
+
     const base64 = window.__pendingAgentFileData?.get(file.id)
     if (!base64) return
 
@@ -1022,17 +1013,31 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       const bytes = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0))
       const text = new TextDecoder('utf-8').decode(bytes)
       const tmpPath = await window.electronAPI.writeClipboardPreview(file.filename, text)
-      const tmpDir = tmpPath.substring(0, tmpPath.lastIndexOf('/'))
-      setPreviewFileMap((prev) => {
-        const m = new Map(prev)
-        m.set(sessionId, { filePath: tmpPath, previewOnly: true, readOnly: true, basePaths: [tmpDir] })
-        return m
-      })
-      store.set(previewPanelOpenMapAtom, (prev) => { const m = new Map(prev); m.set(sessionId, true); return m })
+      setPendingFiles((prev) => prev.map((item) => (
+        item.id === file.id ? { ...item, sourcePath: tmpPath } : item
+      )))
+      window.__pendingAgentFileData?.delete(file.id)
+      openClipboardPreviewFile(tmpPath)
     } catch (error) {
       console.error('[AgentView] clipboard 预览写入失败:', error)
     }
-  }, [sessionId, setPreviewFileMap, store])
+  }, [openClipboardPreviewFile, setPendingFiles])
+
+  const addClipboardTextDraft = React.useCallback(async (text: string): Promise<AgentPendingFile> => {
+    const draft = createClipboardTextDraft(text, pendingFilesRef.current.map((f) => f.filename))
+    const tmpPath = await window.electronAPI.writeClipboardPreview(draft.filename, text)
+    const pending = createClipboardPendingFile(
+      draft,
+      tmpPath,
+      `pending-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    )
+    setPendingFiles((prev) => {
+      const next = [...prev, pending]
+      pendingFilesRef.current = next
+      return next
+    })
+    return pending
+  }, [setPendingFiles])
 
   /** 粘贴文件处理 */
   const handlePasteFiles = React.useCallback((files: File[]): void => {
@@ -1041,18 +1046,17 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
 
   /** 粘贴超长文本时转为待发送附件，避免把大段内容直接塞进输入框 */
   const handlePasteLongText = React.useCallback((text: string): void => {
-    const file = createClipboardTextFile(text)
-    addFilesAsAttachments([file])
-      .then(() => {
+    addClipboardTextDraft(text)
+      .then((file) => {
         toast.success('已将超长文本转为附件', {
-          description: file.name,
+          description: `${file.filename}，点击附件可预览编辑。`,
         })
       })
       .catch((error) => {
         console.error('[AgentView] 超长文本转附件失败:', error)
         toast.error('超长文本转附件失败')
       })
-  }, [addFilesAsAttachments])
+  }, [addClipboardTextDraft])
 
   /** 拖放处理 */
   const handleDragOver = React.useCallback((e: React.DragEvent): void => {
@@ -1177,7 +1181,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     const text = inputContent.trim()
     // 如果输入为空但有建议，使用建议内容
     const effectiveText = text || suggestion || ''
-    if ((!effectiveText && pendingFiles.length === 0) || !agentChannelId || !hasAvailableModel) return
+    const pendingFilesSnapshot = pendingFilesRef.current
+    if ((!effectiveText && pendingFilesSnapshot.length === 0) || !agentChannelId || !hasAvailableModel) return
     const additionalDirectoriesForRun = new Set(attachedDirs)
     for (const dir of attachedFileDirectories) {
       additionalDirectoriesForRun.add(dir)
@@ -1186,7 +1191,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     // 上一条消息仍在处理中，直接追加发送
     if (streaming) {
       // 流式追加时不处理附件（仅支持纯文本）
-      if (pendingFiles.length > 0) {
+      if (pendingFilesSnapshot.length > 0) {
         toast.info('Agent 运行中暂不支持追加发送附件', {
           description: '请等待完成后再发送附件，或先撤除附件仅发送文本',
         })
@@ -1263,7 +1268,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
 
     // 1. 如果有 pending 文件，先保存到 session 目录
     let fileReferences = ''
-    if (pendingFiles.length > 0) {
+    if (pendingFilesSnapshot.length > 0) {
       const workspace = workspaces.find((w) => w.id === currentWorkspaceId)
       if (!workspace) {
         toast.warning('暂时无法发送附件', {
@@ -1273,8 +1278,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       }
 
       // 区分：已有 sourcePath 的文件（从侧面板添加）直接引用，其余需要保存
-      const existingFiles = pendingFiles.filter((f) => f.sourcePath)
-      const newFiles = pendingFiles.filter((f) => !f.sourcePath)
+      const existingFiles = pendingFilesSnapshot.filter((f) => f.sourcePath)
+      const newFiles = pendingFilesSnapshot.filter((f) => !f.sourcePath)
 
       const allRefs: Array<{ filename: string; targetPath: string }> = []
 
@@ -1327,7 +1332,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       fileReferences += `<attached_files>\n${refs}\n</attached_files>\n\n`
 
       // 清理
-      for (const f of pendingFiles) {
+      for (const f of pendingFilesSnapshot) {
         if (f.previewUrl?.startsWith('blob:')) URL.revokeObjectURL(f.previewUrl)
         window.__pendingAgentFileData?.delete(f.id)
       }
@@ -1438,7 +1443,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         return map
       })
     })
-  }, [inputContent, pendingFiles, attachedDirs, attachedFileDirectories, sessionId, agentChannelId, agentModelId, currentWorkspaceId, workspaces, streaming, suggestion, hasAvailableModel, store, setStreamingStates, setPendingFiles, setAgentStreamErrors, setPromptSuggestions, setInputContent, setLiveMessagesMap, permissionMode])
+  }, [inputContent, attachedDirs, attachedFileDirectories, sessionId, agentChannelId, agentModelId, currentWorkspaceId, workspaces, streaming, suggestion, hasAvailableModel, store, setStreamingStates, setPendingFiles, setAgentStreamErrors, setPromptSuggestions, setInputContent, setLiveMessagesMap, permissionMode])
 
   /** 停止生成 */
   const handleStop = React.useCallback((): void => {

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -1014,7 +1014,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       const text = new TextDecoder('utf-8').decode(bytes)
       const tmpPath = await window.electronAPI.writeClipboardPreview(file.filename, text)
       setPendingFiles((prev) => prev.map((item) => (
-        item.id === file.id ? { ...item, sourcePath: tmpPath } : item
+        item.id === file.id ? { ...item, sourcePath: tmpPath, isClipboardDraft: true } : item
       )))
       window.__pendingAgentFileData?.delete(file.id)
       openClipboardPreviewFile(tmpPath)
@@ -1277,8 +1277,13 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         return
       }
 
-      // 区分：已有 sourcePath 的文件（从侧面板添加）直接引用，其余需要保存
-      const existingFiles = pendingFilesSnapshot.filter((f) => f.sourcePath)
+      // 区分三类：
+      // - 剪贴板临时草稿（isClipboardDraft）：sourcePath 指向 os.tmpdir，可能被系统清理，
+      //   需读取最新内容（含预览面板 autosave 的编辑）拷贝进 session 目录持久化
+      // - 侧面板真实文件（仅 sourcePath）：原地引用，不复制
+      // - 新上传文件（无 sourcePath）：从内存数据保存到 session 目录
+      const existingFiles = pendingFilesSnapshot.filter((f) => f.sourcePath && !f.isClipboardDraft)
+      const clipboardDrafts = pendingFilesSnapshot.filter((f) => f.sourcePath && f.isClipboardDraft)
       const newFiles = pendingFilesSnapshot.filter((f) => !f.sourcePath)
 
       const allRefs: Array<{ filename: string; targetPath: string }> = []
@@ -1291,20 +1296,50 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         if (parentPath) additionalDirectoriesForRun.add(parentPath)
       }
 
-      // 新上传的文件保存到 session 目录
-      if (newFiles.length > 0) {
-        const filesToSave = newFiles.map((f) => ({
-          filename: f.filename,
-          data: window.__pendingAgentFileData?.get(f.id) || '',
-        }))
-        const missingDataFiles = filesToSave.filter((f) => !f.data).map((f) => f.filename)
-        if (missingDataFiles.length > 0) {
-          toast.error('附件数据已失效', {
-            description: `请移除后重新添加文件：${missingDataFiles.join('、')}`,
+      // 剪贴板草稿：读取临时文件最新内容，转为待保存数据
+      const draftFilesToSave: Array<{ filename: string; data: string }> = []
+      const staleDraftFiles: string[] = []
+      for (const f of clipboardDrafts) {
+        const sourcePath = f.sourcePath!
+        const parentPath = getFileParentPath(sourcePath)
+        try {
+          const read = await window.electronAPI.resolveAndReadFile(sourcePath, {
+            sessionId,
+            candidateBasePaths: parentPath ? [parentPath] : undefined,
           })
-          return
+          if (!read) {
+            staleDraftFiles.push(f.filename)
+            continue
+          }
+          const data = await fileToBase64(new File([read.content], f.filename, { type: f.mediaType }))
+          draftFilesToSave.push({ filename: f.filename, data })
+        } catch (error) {
+          console.error('[AgentView] 读取剪贴板草稿失败:', error)
+          staleDraftFiles.push(f.filename)
         }
+      }
+      if (staleDraftFiles.length > 0) {
+        toast.error('附件数据已失效', {
+          description: `请移除后重新粘贴：${staleDraftFiles.join('、')}`,
+        })
+        return
+      }
 
+      // 新上传的文件 + 剪贴板草稿一并保存到 session 目录
+      const inMemoryFilesToSave = newFiles.map((f) => ({
+        filename: f.filename,
+        data: window.__pendingAgentFileData?.get(f.id) || '',
+      }))
+      const missingDataFiles = inMemoryFilesToSave.filter((f) => !f.data).map((f) => f.filename)
+      if (missingDataFiles.length > 0) {
+        toast.error('附件数据已失效', {
+          description: `请移除后重新添加文件：${missingDataFiles.join('、')}`,
+        })
+        return
+      }
+
+      const filesToSave = [...inMemoryFilesToSave, ...draftFilesToSave]
+      if (filesToSave.length > 0) {
         try {
           const saved = await window.electronAPI.saveFilesToAgentSession({
             workspaceSlug: workspace.slug,

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -23,6 +23,7 @@ import { PreviewFindBar } from './PreviewFindBar'
 import { PIERRE_FILE_CSS } from '@/components/agent/tool-result-renderers/pierre-styles'
 
 const MD_EXTS = new Set(['.md', '.markdown'])
+const PLAIN_TEXT_EDIT_EXTS = new Set(['.txt', '.text', '.log'])
 const PDF_EXTS = new Set(['.pdf'])
 const DOCX_EXTS = new Set(['.docx'])
 const OFFICE_PREVIEW_EXTS = new Set(['.xlsx', '.pptx'])
@@ -227,6 +228,8 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
 
   const ext = getExtension(filePath)
   const isMarkdown = previewOnly && MD_EXTS.has(ext)
+  const isPlainTextEditable = previewOnly && PLAIN_TEXT_EDIT_EXTS.has(ext)
+  const isEditableText = isMarkdown || isPlainTextEditable
   const isPdf = previewOnly && PDF_EXTS.has(ext)
   const isDocx = previewOnly && DOCX_EXTS.has(ext)
   const isOfficePreview = previewOnly && OFFICE_PREVIEW_EXTS.has(ext)
@@ -763,13 +766,13 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   }, [isOfficePreview, markdownDraft, markdownEditing, newContent, officeText])
 
   const startMarkdownEdit = React.useCallback(() => {
-    if (!isMarkdown) return
+    if (!isEditableText) return
     setMarkdownDraft(newContent)
     lastSavedDraftRef.current = newContent
     setAutosaveStatus('idle')
     setMarkdownSourceMode(false)
     setMarkdownEditing(true)
-  }, [isMarkdown, newContent])
+  }, [isEditableText, newContent])
 
   // ref 形式的 persist：避免 callback / effect 因 refreshVersion 频繁变化而重建
   const persistRef = React.useRef<(draft: string, fp: string, fa: typeof fileAccess) => Promise<boolean>>(async () => false)
@@ -832,7 +835,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   }, [getContentCacheKey, refreshVersion, sessionId, setRefreshVersionMap])
 
   const saveMarkdownEdit = React.useCallback(async () => {
-    if (!isMarkdown || markdownSaving) return
+    if (!isEditableText || markdownSaving) return
     // autosaveTimerRef 由 autosave effect 创建；这里手动清是为了避免
     // "立即保存"返回后 effect cleanup 再次清掉一个已经 null 的句柄（无害但冗余），
     // 同时也确保不会在 await 期间触发延迟回调
@@ -849,7 +852,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     }
     setMarkdownSourceMode(false)
     setMarkdownEditing(false)
-  }, [fileAccess, filePath, isMarkdown, markdownDraft, markdownSaving, persistMarkdownDraft])
+  }, [fileAccess, filePath, isEditableText, markdownDraft, markdownSaving, persistMarkdownDraft])
 
   const handleManualRefresh = React.useCallback(() => {
     setRefreshVersionMap((prev) => {
@@ -869,7 +872,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   // timer 所有权：autosave effect 创建并在 cleanup 中清；saveMarkdownEdit / exitMarkdownEdit
   // 也会主动清以抢占 debounce。多处清理都是幂等的（设 null 后再清是 no-op）。
   React.useEffect(() => {
-    if (!markdownEditing || !isMarkdown) return
+    if (!markdownEditing || !isEditableText) return
     if (markdownDraft === lastSavedDraftRef.current) return
     if (autosaveTimerRef.current !== null) {
       window.clearTimeout(autosaveTimerRef.current)
@@ -887,7 +890,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
         autosaveTimerRef.current = null
       }
     }
-  }, [markdownDraft, markdownEditing, isMarkdown, filePath, fileAccess])
+  }, [markdownDraft, markdownEditing, isEditableText, filePath, fileAccess])
 
   // saved → 1.5s 后回到 idle，避免指示器一直停在"已保存"
   React.useEffect(() => {
@@ -910,7 +913,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
       const { draft, editing, filePath: fp, fileAccess: fa } = flushStateRef.current
       // 不过滤空 draft：startMarkdownEdit 已把 lastSavedDraftRef 设为 newContent，
       // 因此"原本就空、未编辑"的情况会被 dirty 比较自动跳过；而"非空清空"是合法操作必须落盘。
-      if (editing && isMarkdown && draft !== lastSavedDraftRef.current) {
+      if (editing && isEditableText && draft !== lastSavedDraftRef.current) {
         void persistRef.current(draft, fp, fa)
       }
     }
@@ -944,18 +947,20 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
           </div>
         )}
 
-        {previewOnly && isMarkdown && !readOnly && (
+        {previewOnly && isEditableText && !readOnly && (
           markdownEditing ? (
             <div className="ml-auto flex items-center gap-1">
-              <button
-                type="button"
-                onClick={() => setMarkdownSourceMode((v) => !v)}
-                disabled={markdownSaving}
-                className="p-1 rounded hover:bg-foreground/[0.06] text-foreground/40 hover:text-foreground/60 disabled:opacity-50 shrink-0"
-                title={markdownSourceMode ? '切换到富文本编辑' : '切换到源码编辑'}
-              >
-                {markdownSourceMode ? <Eye className="size-3.5" /> : <Code2 className="size-3.5" />}
-              </button>
+              {isMarkdown && (
+                <button
+                  type="button"
+                  onClick={() => setMarkdownSourceMode((v) => !v)}
+                  disabled={markdownSaving}
+                  className="p-1 rounded hover:bg-foreground/[0.06] text-foreground/40 hover:text-foreground/60 disabled:opacity-50 shrink-0"
+                  title={markdownSourceMode ? '切换到富文本编辑' : '切换到源码编辑'}
+                >
+                  {markdownSourceMode ? <Eye className="size-3.5" /> : <Code2 className="size-3.5" />}
+                </button>
+              )}
               <button
                 type="button"
                 onClick={exitMarkdownEdit}
@@ -991,7 +996,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
               type="button"
               onClick={startMarkdownEdit}
               className="ml-auto p-1 rounded hover:bg-foreground/[0.06] text-foreground/40 hover:text-foreground/60 shrink-0"
-              title="编辑 Markdown"
+              title={isMarkdown ? '编辑 Markdown' : '编辑文本'}
             >
               <Pencil className="size-3.5" />
             </button>
@@ -999,7 +1004,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
         )}
 
         <button type="button" onClick={handleCopy}
-          className={cn("p-1 rounded hover:bg-foreground/[0.06] text-foreground/40 hover:text-foreground/60 shrink-0", previewOnly && !isMarkdown && "ml-auto")}
+          className={cn("p-1 rounded hover:bg-foreground/[0.06] text-foreground/40 hover:text-foreground/60 shrink-0", previewOnly && !isEditableText && "ml-auto")}
           title="复制文件内容">
           {copied ? <Check className="size-3.5 text-green-500" /> : <Copy className="size-3.5" />}
         </button>
@@ -1152,6 +1157,24 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
                   shikiTheme={theme === 'dark' ? 'github-dark' : 'github-light'}
                 />
               )
+            ) : isPlainTextEditable && markdownEditing ? (
+              <textarea
+                value={markdownDraft}
+                onChange={(e) => setMarkdownDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Escape') {
+                    e.preventDefault()
+                    exitMarkdownEdit()
+                  }
+                  if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                    e.preventDefault()
+                    void saveMarkdownEdit()
+                  }
+                }}
+                autoFocus
+                spellCheck={false}
+                className="w-full min-h-full resize-none border-0 bg-transparent px-4 py-3 font-mono text-[13px] leading-relaxed text-foreground outline-none focus:outline-none"
+              />
             ) : newContent ? (
               newContent.length > MAX_PREVIEW_CHARS ? (
                 <pre className="p-3 text-[13px] leading-relaxed text-foreground/80 font-mono whitespace-pre-wrap [overflow-wrap:anywhere]">

--- a/apps/electron/src/renderer/lib/clipboard-text-attachment.test.ts
+++ b/apps/electron/src/renderer/lib/clipboard-text-attachment.test.ts
@@ -31,6 +31,7 @@ describe('长文本粘贴附件', () => {
       filename: 'clipboard-20260528-123456.txt',
       mediaType: 'text/plain',
       sourcePath: '/tmp/proma-preview/clipboard-20260528-123456.txt',
+      isClipboardDraft: true,
     })
   })
 })

--- a/apps/electron/src/renderer/lib/clipboard-text-attachment.test.ts
+++ b/apps/electron/src/renderer/lib/clipboard-text-attachment.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test'
+import { createClipboardPendingFile, createClipboardTextDraft } from './clipboard-text-attachment'
+
+describe('长文本粘贴附件', () => {
+  test('Given Markdown 长文本 When 转为草稿文件 Then 使用可编辑的 Markdown 文件元数据', () => {
+    const draft = createClipboardTextDraft('# 标题\n\n内容', [], new Date('2026-05-28T12:34:56'))
+
+    expect(draft).toEqual({
+      filename: 'clipboard-20260528-123456.md',
+      mediaType: 'text/markdown',
+      size: 16,
+    })
+  })
+
+  test('Given 同一秒内已有同名草稿 When 再次转为草稿文件 Then 文件名追加序号避免覆盖', () => {
+    const draft = createClipboardTextDraft(
+      '普通长文本',
+      ['clipboard-20260528-123456.txt'],
+      new Date('2026-05-28T12:34:56'),
+    )
+
+    expect(draft.filename).toBe('clipboard-20260528-123456-1.txt')
+  })
+
+  test('Given 草稿文件已经落盘 When 创建待发送附件 Then sourcePath 成为发送时的真实数据源', () => {
+    const draft = createClipboardTextDraft('普通长文本', [], new Date('2026-05-28T12:34:56'))
+    const pending = createClipboardPendingFile(draft, '/tmp/proma-preview/clipboard-20260528-123456.txt', 'pending-1')
+
+    expect(pending).toMatchObject({
+      id: 'pending-1',
+      filename: 'clipboard-20260528-123456.txt',
+      mediaType: 'text/plain',
+      sourcePath: '/tmp/proma-preview/clipboard-20260528-123456.txt',
+    })
+  })
+})

--- a/apps/electron/src/renderer/lib/clipboard-text-attachment.ts
+++ b/apps/electron/src/renderer/lib/clipboard-text-attachment.ts
@@ -1,0 +1,57 @@
+import type { AgentPendingFile } from '@proma/shared'
+
+export interface ClipboardTextDraft {
+  filename: string
+  mediaType: string
+  size: number
+}
+
+export function makeUniqueAttachmentName(originalName: string, existingNames: string[]): string {
+  if (!existingNames.includes(originalName)) return originalName
+  const dotIdx = originalName.lastIndexOf('.')
+  const baseName = dotIdx > 0 ? originalName.slice(0, dotIdx) : originalName
+  const ext = dotIdx > 0 ? originalName.slice(dotIdx) : ''
+  let counter = 1
+  while (existingNames.includes(`${baseName}-${counter}${ext}`)) {
+    counter++
+  }
+  return `${baseName}-${counter}${ext}`
+}
+
+export function createClipboardTextDraft(text: string, existingNames: string[], now = new Date()): ClipboardTextDraft {
+  const isMarkdown = looksLikeMarkdown(text)
+  const extension = isMarkdown ? 'md' : 'txt'
+  const mediaType = isMarkdown ? 'text/markdown' : 'text/plain'
+  const filename = makeUniqueAttachmentName(`clipboard-${formatClipboardTimestamp(now)}.${extension}`, existingNames)
+  const size = new TextEncoder().encode(text).byteLength
+  return { filename, mediaType, size }
+}
+
+export function createClipboardPendingFile(draft: ClipboardTextDraft, sourcePath: string, id: string): AgentPendingFile {
+  return {
+    id,
+    filename: draft.filename,
+    mediaType: draft.mediaType,
+    size: draft.size,
+    // 临时文件是待发送长文本的唯一真实数据源；预览/外部编辑后发送端引用该路径。
+    sourcePath,
+  }
+}
+
+function formatClipboardTimestamp(date: Date): string {
+  const pad = (value: number): string => String(value).padStart(2, '0')
+  return `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}-${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}`
+}
+
+function looksLikeMarkdown(text: string): boolean {
+  return [
+    /^#{1,6}\s+\S/m,
+    /```[\s\S]*?```/,
+    /^\s*\|.+\|\s*\n\s*\|[\s:-]+\|/m,
+    /^---\n[\s\S]*?\n---\n/,
+    /^\s*> .+/m,
+    /^\s*[-*+]\s+\S/m,
+    /^\s*\d+\.\s+\S/m,
+    /\[[^\]]+\]\([^)]+\)/,
+  ].some((pattern) => pattern.test(text))
+}

--- a/apps/electron/src/renderer/lib/clipboard-text-attachment.ts
+++ b/apps/electron/src/renderer/lib/clipboard-text-attachment.ts
@@ -33,8 +33,9 @@ export function createClipboardPendingFile(draft: ClipboardTextDraft, sourcePath
     filename: draft.filename,
     mediaType: draft.mediaType,
     size: draft.size,
-    // 临时文件是待发送长文本的唯一真实数据源；预览/外部编辑后发送端引用该路径。
+    // 临时文件是待发送长文本的唯一真实数据源；预览/外部编辑后发送端读取该路径最新内容拷贝进 session。
     sourcePath,
+    isClipboardDraft: true,
   }
 }
 

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.10.8",
+      "version": "0.10.11",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.143",
         "@anthropic-ai/sdk": "^0.93.0",

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -982,6 +982,12 @@ export interface AgentPendingFile {
   previewUrl?: string
   /** 文件原始路径（从侧面板添加时设置，发送时跳过复制直接引用） */
   sourcePath?: string
+  /**
+   * 标记 sourcePath 指向的是剪贴板临时预览文件（os.tmpdir）。
+   * 这类文件可能被系统清理，发送时需读取其最新内容拷贝进 session 目录，
+   * 而非像侧面板真实文件那样原地引用。
+   */
+  isClipboardDraft?: boolean
 }
 
 /** Agent 文件保存到 session 的输入 */


### PR DESCRIPTION
## Summary
- Persist long pasted Agent input text as editable temporary files instead of stale in-memory snapshots.
- Keep Markdown rendering/editing while adding plain-text editing and autosave for txt/text/log previews.
- Avoid opening preview automatically after paste; users can click the attachment to preview or edit.

## Validation
- bun run typecheck
- bun test apps/electron/src/renderer/lib/clipboard-text-attachment.test.ts apps/electron/src/renderer/lib/external-agent-run.test.ts apps/electron/src/renderer/components/agent/ProcessBlockGroup.test.ts