### PR TITLE
[codex] Add Opus 4.8 1M context support

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.10.13",
+  "version": "0.10.14",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -435,7 +435,7 @@ const DEFAULT_MODEL_ID = 'claude-sonnet-4-6'
 
 /**
  * 判断模型是否支持 1M context window beta（context-1m-2025-08-07）
- * 当前支持：Claude Sonnet 4 / 4.5 / 4.6、Opus 4.6 / 4.7、DeepSeek V4 系列
+ * 当前支持：Claude Sonnet 4 / 4.5 / 4.6、Opus 4.6 / 4.7 / 4.8、DeepSeek V4 系列
  * 参考：https://docs.anthropic.com/en/docs/build-with-claude/context-windows
  */
 function supports1MContext(modelId: string): boolean {
@@ -444,7 +444,7 @@ function supports1MContext(modelId: string): boolean {
   // Claude: Sonnet 4+ 与 Opus 4.6+ 都支持
   if (m.includes('claude')) {
     if (m.includes('sonnet-4')) return true
-    if (m.includes('opus-4-6') || m.includes('opus-4-7')) return true
+    if (m.includes('opus-4-6') || m.includes('opus-4-7') || m.includes('opus-4-8')) return true
     return false
   }
   // DeepSeek V4 系列（deepseek-v4-pro、deepseek-v4-flash）
@@ -1508,7 +1508,7 @@ export class AgentOrchestrator {
         ...(appSettings.agentMaxBudgetUsd != null && appSettings.agentMaxBudgetUsd > 0 && {
           maxBudgetUsd: appSettings.agentMaxBudgetUsd,
         }),
-        // 1M context window: 支持的模型自动启用 beta（Claude: Sonnet 4+ / Opus 4.6+、DeepSeek V4 系列）
+        // 1M context window: 支持的模型自动启用 beta（Claude: Sonnet 4+ / Opus 4.6+ / 4.7 / 4.8、DeepSeek V4 系列）
         // 未启用时 SDK 默认 200K 并在约 150K 触发压缩；启用后上限提升至 1M
         ...(supports1MContext(modelId || DEFAULT_MODEL_ID) && {
           betas: ['context-1m-2025-08-07'] as SdkBeta[],

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -109,8 +109,13 @@ function inferContextWindow(model?: string): number | undefined {
   const m = model.toLowerCase()
   // Claude Haiku 为 200k
   if (m.includes('claude-haiku')) return 200_000
-  // Claude Sonnet 4+、Opus 4.6+、DeepSeek V4 系列均为 1M 上下文
-  if (m.includes('claude-sonnet-4-6') || m.includes('claude-opus-4-6') || m.includes('claude-opus-4-7')) return 1_000_000
+  // Claude Sonnet 4.6、Opus 4.6 / 4.7 / 4.8、DeepSeek V4 系列均为 1M 上下文
+  if (
+    m.includes('claude-sonnet-4-6') ||
+    m.includes('claude-opus-4-6') ||
+    m.includes('claude-opus-4-7') ||
+    m.includes('claude-opus-4-8')
+  ) return 1_000_000
   if (m.includes('deepseek-v4')) return 1_000_000
   return 200_000
 }

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.10.13",
+      "version": "0.10.14",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.153",
         "@anthropic-ai/sdk": "^0.93.0",


### PR DESCRIPTION
## Summary

- Add `claude-opus-4-8` to the Agent 1M context support whitelist so Proma automatically sends the `context-1m-2025-08-07` beta when this model is selected.
- Update renderer-side context window fallback so usage UI treats `claude-opus-4-8` as a 1M context model while streaming.
- Bump `@proma/electron` patch version to `0.10.14` and update `bun.lock`.

## Why

Claude Opus 4.8 now supports a 1M-token context window on supported Claude API surfaces. Proma previously only hardcoded Opus 4.6 and 4.7, so selecting `claude-opus-4-8` would miss the long-context beta path and show the wrong fallback context window.

## Validation

- `bun install --frozen-lockfile`
- `bun run --filter='@proma/electron' typecheck`
- `git diff --check`
