### PR TITLE
fix(electron): Windows 窗口关闭时最小化到托盘

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -359,6 +359,22 @@ function createWindow(): void {
     })
   }
 
+  // Windows: 点击关闭按钮时隐藏窗口到托盘，而不是退出
+  if (process.platform === 'win32') {
+    mainWindow.on('close', (event) => {
+      if (!getIsQuitting()) {
+        // 隐藏前先刷新挂起的窗口状态保存
+        if (windowStateSaveTimer) {
+          clearTimeout(windowStateSaveTimer)
+          windowStateSaveTimer = null
+        }
+        saveMainWindowState()
+        event.preventDefault()
+        mainWindow?.hide()
+      }
+    })
+  }
+
   mainWindow.on('closed', () => {
     mainWindow = null
   })


### PR DESCRIPTION
修复 Windows 下点击关闭按钮时应用直接退出的问题。现在行为与 macOS 一致：关闭窗口时隐藏到系统托盘，可通过托盘菜单重新打开。