### PR TITLE
Support default app opening in Diff preview

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.10.14",
+  "version": "0.10.15",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -931,11 +931,16 @@ export function registerIpcHandlers(): void {
   // 查询某个文件在本机的默认打开应用信息（带图标）
   ipcMain.handle(
     IPC_CHANNELS.GET_DEFAULT_APP_FOR_FILE,
-    async (_, filePath: string): Promise<import('@proma/shared').DefaultAppInfo | null> => {
+    async (_, filePath: string, access?: FileAccessOptions | string[]): Promise<import('@proma/shared').DefaultAppInfo | null> => {
       if (!filePath || typeof filePath !== 'string') return null
       try {
+        const options = normalizeFileAccessOptions(access)
+        if (options && !isPathAllowed(filePath, options)) {
+          console.warn('[IPC] shell:get-default-app-for-file 拒绝越界路径:', filePath)
+          return null
+        }
         console.log('[IPC] get-default-app-for-file 收到请求:', filePath)
-        const result = await getDefaultAppInfoForFile(filePath)
+        const result = await getDefaultAppInfoForFile(filePath, options)
         console.log('[IPC] get-default-app-for-file 返回:', result ? `name=${result.name} appPath=${result.appPath} iconLen=${result.iconDataUrl?.length}` : 'null')
         return result
       } catch (err) {

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -678,7 +678,7 @@ export interface ElectronAPI {
   scanEditors: () => Promise<import('@proma/shared').EditorApp[]>
 
   /** 查询本机为该文件类型注册的默认打开应用（含图标 dataURL） */
-  getDefaultAppForFile: (filePath: string) => Promise<import('@proma/shared').DefaultAppInfo | null>
+  getDefaultAppForFile: (filePath: string, access?: import('@proma/shared').FileAccessOptions) => Promise<import('@proma/shared').DefaultAppInfo | null>
 
   /** 在系统文件管理器中显示文件 */
   showInFolder: (filePath: string) => Promise<void>
@@ -1748,8 +1748,8 @@ const electronAPI: ElectronAPI = {
     return ipcRenderer.invoke(IPC_CHANNELS.SCAN_EDITORS)
   },
 
-  getDefaultAppForFile: (filePath: string) => {
-    return ipcRenderer.invoke(IPC_CHANNELS.GET_DEFAULT_APP_FOR_FILE, filePath) as Promise<import('@proma/shared').DefaultAppInfo | null>
+  getDefaultAppForFile: (filePath: string, access?: import('@proma/shared').FileAccessOptions) => {
+    return ipcRenderer.invoke(IPC_CHANNELS.GET_DEFAULT_APP_FOR_FILE, filePath, access) as Promise<import('@proma/shared').DefaultAppInfo | null>
   },
 
   showInFolder: (filePath: string) => {

--- a/apps/electron/src/renderer/components/diff/DefaultAppOpenButton.tsx
+++ b/apps/electron/src/renderer/components/diff/DefaultAppOpenButton.tsx
@@ -27,7 +27,7 @@ export function DefaultAppOpenButton({
   variant = 'labeled',
   className,
 }: DefaultAppOpenButtonProps): React.ReactElement | null {
-  const info = useDefaultAppForFile(filePath)
+  const info = useDefaultAppForFile(filePath, access)
 
   const handleClick = React.useCallback(() => {
     window.electronAPI.systemOpenFile(filePath, undefined, access).catch((err) => {

--- a/apps/electron/src/renderer/components/diff/DetachedPreviewApp.tsx
+++ b/apps/electron/src/renderer/components/diff/DetachedPreviewApp.tsx
@@ -12,6 +12,7 @@ import { agentDiffRefreshVersionAtom } from '@/atoms/agent-atoms'
 import { cn } from '@/lib/utils'
 import { DiffTabContent } from './DiffTabContent'
 import { DefaultAppOpenButton } from './DefaultAppOpenButton'
+import { getDefaultAppTargetPath, getPreviewFileAccess } from './preview-open-path'
 
 function getPreviewId(): string | null {
   return new URLSearchParams(window.location.search).get('previewId')
@@ -79,6 +80,9 @@ export function DetachedPreviewApp(): React.ReactElement {
     )
   }
 
+  const defaultAppTargetPath = getDefaultAppTargetPath(data, data.dirPath)
+  const defaultAppAccess = getPreviewFileAccess(data.sessionId, data, data.dirPath)
+
   return (
     <div className="h-screen w-screen flex flex-col overflow-hidden bg-content-area text-foreground">
       <div className="h-11 flex items-center gap-2 px-3 border-b border-border/40 shrink-0">
@@ -89,8 +93,8 @@ export function DetachedPreviewApp(): React.ReactElement {
           </div>
         </div>
         <DefaultAppOpenButton
-          filePath={data.filePath}
-          access={{ sessionId: data.sessionId, candidateBasePaths: data.basePaths }}
+          filePath={defaultAppTargetPath}
+          access={defaultAppAccess}
         />
         <button
           type="button"

--- a/apps/electron/src/renderer/components/diff/PreviewPanel.tsx
+++ b/apps/electron/src/renderer/components/diff/PreviewPanel.tsx
@@ -22,6 +22,7 @@ import { detectIsWindows } from '@/lib/platform'
 import { cn } from '@/lib/utils'
 import { DiffTabContent } from './DiffTabContent'
 import { DefaultAppOpenButton } from './DefaultAppOpenButton'
+import { getDefaultAppTargetPath, getPreviewFileAccess } from './preview-open-path'
 
 interface PreviewPanelProps {
   sessionId: string
@@ -64,13 +65,15 @@ export function PreviewPanel({ sessionId }: PreviewPanelProps): React.ReactEleme
   }, [currentFile, sessionId, sessionPath])
 
   const fileName = currentFile ? currentFile.filePath.split(/[\\/]/).pop() || currentFile.filePath : '文件预览'
+  const defaultAppTargetPath = currentFile ? getDefaultAppTargetPath(currentFile, sessionPath) : ''
+  const defaultAppAccess = currentFile ? getPreviewFileAccess(sessionId, currentFile, sessionPath) : undefined
 
   const renderPreviewActions = (): React.ReactElement => (
     <div className="ml-auto flex items-center gap-0.5 shrink-0">
       {currentFile && (
         <DefaultAppOpenButton
-          filePath={currentFile.filePath}
-          access={{ sessionId, candidateBasePaths: currentFile.basePaths }}
+          filePath={defaultAppTargetPath}
+          access={defaultAppAccess}
         />
       )}
       {currentFile && (

--- a/apps/electron/src/renderer/components/diff/preview-open-path.ts
+++ b/apps/electron/src/renderer/components/diff/preview-open-path.ts
@@ -1,0 +1,52 @@
+import type { FileAccessOptions } from '@proma/shared'
+import type { PreviewFile } from '@/atoms/preview-atoms'
+
+function isAbsoluteFilePath(filePath: string): boolean {
+  return filePath.startsWith('/') || filePath.startsWith('\\\\') || /^[A-Za-z]:[\\/]/.test(filePath)
+}
+
+function joinFilePath(basePath: string, filePath: string): string {
+  const base = basePath.replace(/[\\/]+$/, '')
+  const child = filePath.replace(/^[\\/]+/, '')
+  return `${base}/${child}`
+}
+
+function uniqueTruthyPaths(paths: Array<string | null | undefined>): string[] {
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const path of paths) {
+    if (!path || seen.has(path)) continue
+    seen.add(path)
+    result.push(path)
+  }
+  return result
+}
+
+/**
+ * Diff 服务需要相对 git 路径；系统默认 App 打开文件则必须使用实际文件路径。
+ */
+export function getDefaultAppTargetPath(file: PreviewFile, sessionPath: string): string {
+  if (isAbsoluteFilePath(file.filePath)) return file.filePath
+
+  const basePath = file.previewOnly
+    ? (file.basePaths?.[0] ?? file.dirPath ?? sessionPath)
+    : (file.gitRoot ?? file.dirPath ?? sessionPath)
+
+  return basePath ? joinFilePath(basePath, file.filePath) : file.filePath
+}
+
+export function getPreviewFileAccess(
+  sessionId: string,
+  file: PreviewFile,
+  sessionPath: string,
+): FileAccessOptions {
+  return {
+    sessionId,
+    candidateBasePaths: uniqueTruthyPaths([
+      ...(file.basePaths ?? []),
+      file.gitRoot,
+      file.dirPath,
+      sessionPath,
+    ]),
+  }
+}

--- a/apps/electron/src/renderer/hooks/useDefaultAppForFile.ts
+++ b/apps/electron/src/renderer/hooks/useDefaultAppForFile.ts
@@ -6,7 +6,7 @@
  */
 
 import * as React from 'react'
-import type { DefaultAppInfo } from '@proma/shared'
+import type { DefaultAppInfo, FileAccessOptions } from '@proma/shared'
 
 const rendererCache = new Map<string, DefaultAppInfo | null>()
 
@@ -18,6 +18,7 @@ function extKeyOf(filePath: string): string {
 
 export function useDefaultAppForFile(
   filePath: string | null | undefined,
+  access?: FileAccessOptions,
 ): DefaultAppInfo | null {
   const [info, setInfo] = React.useState<DefaultAppInfo | null>(() => {
     if (!filePath) return null
@@ -37,11 +38,12 @@ export function useDefaultAppForFile(
       return
     }
     window.electronAPI
-      .getDefaultAppForFile(filePath)
+      .getDefaultAppForFile(filePath, access)
       .then((result) => {
         if (cancelled) return
         console.log('[useDefaultAppForFile] IPC 返回:', filePath, result ? `name=${result.name}` : 'null')
-        rendererCache.set(key, result)
+        // 带访问上下文时，null 可能来自路径授权失败，不能污染按后缀共享的默认 App 缓存。
+        if (result || !access) rendererCache.set(key, result)
         setInfo(result)
       })
       .catch((err) => {
@@ -53,7 +55,7 @@ export function useDefaultAppForFile(
     return () => {
       cancelled = true
     }
-  }, [filePath])
+  }, [filePath, access])
 
   return info
 }

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.10.14",
+      "version": "0.10.15",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.153",
         "@anthropic-ai/sdk": "^0.93.0",


### PR DESCRIPTION
This PR makes the preview default-app button work for Diff mode by resolving the displayed git-relative path to the actual file path before opening it. It threads the same file access context through the renderer, preload bridge, and main-process default-app lookup so path authorization remains consistent. It also bumps `@proma/electron` to `0.10.15`. Validated with `bun run typecheck`.