### PR TITLE
[codex] fix Windows tray close fallback

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -82,7 +82,7 @@ for (const key of Object.keys(process.env)) {
 
 import { createApplicationMenu } from './menu'
 import { registerIpcHandlers } from './ipc'
-import { createTray, destroyTray } from './tray'
+import { createTray, destroyTray, getTray } from './tray'
 import { initializeRuntime } from './lib/runtime-init'
 import { seedDefaultSkills } from './lib/config-paths'
 import { upgradeDefaultSkillsInWorkspaces } from './lib/agent-workspace-manager'
@@ -362,7 +362,7 @@ function createWindow(): void {
   // Windows: 点击关闭按钮时隐藏窗口到托盘，而不是退出
   if (process.platform === 'win32') {
     mainWindow.on('close', (event) => {
-      if (!getIsQuitting()) {
+      if (!getIsQuitting() && getTray()) {
         // 隐藏前先刷新挂起的窗口状态保存
         if (windowStateSaveTimer) {
           clearTimeout(windowStateSaveTimer)

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.10.15",
+      "version": "0.10.16",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.153",
         "@anthropic-ai/sdk": "^0.93.0",


### PR DESCRIPTION
## Summary

- Keep the Windows close-to-tray behavior from PR #628 only when the tray was actually created.
- Allow the normal close/quit path when the tray is unavailable, so the main window is not hidden with no visible restore entry.
- Bump `@proma/electron` to `0.10.16` and sync `bun.lock`.

## Root Cause

PR #628 intercepts the Windows main-window `close` event and hides the window. `createTray()` can return `null` if the bundled tray icon is missing or tray creation fails, which would leave users with a hidden main window and no tray menu to reopen it.

## Validation

- `bun install --frozen-lockfile`
- `git diff --check`
- `bun run --filter='@proma/electron' typecheck`
- `bun run --filter='@proma/electron' build:main`
- `bun run typecheck`
