### PR TITLE
[codex] Route DeepSeek subagents to flash

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.10.16",
+  "version": "0.10.17",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/agent-model-routing.test.ts
+++ b/apps/electron/src/main/lib/agent-model-routing.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  applyAgentModelRoutingToEnv,
+  DEEPSEEK_SUBAGENT_MODEL_ID,
+  resolveAgentModelRouting,
+} from './agent-model-routing'
+
+describe('Agent 辅助模型路由', () => {
+  test('Given DeepSeek V4 Pro When 解析模型路由 Then SubAgent 固定到 DeepSeek V4 Flash', () => {
+    const policy = resolveAgentModelRouting({
+      modelId: 'deepseek-v4-pro',
+      provider: 'deepseek',
+    })
+
+    expect(policy.deepSeekFamily).toBe(true)
+    expect(policy.subagentModel).toBe(DEEPSEEK_SUBAGENT_MODEL_ID)
+  })
+
+  test('Given DeepSeek 兼容渠道模型 When 解析模型路由 Then 仍识别为 DeepSeek 系列', () => {
+    const policy = resolveAgentModelRouting({
+      modelId: 'gateway/deepseek-v4-pro',
+      provider: 'custom',
+    })
+
+    expect(policy.deepSeekFamily).toBe(true)
+    expect(policy.subagentModel).toBe(DEEPSEEK_SUBAGENT_MODEL_ID)
+  })
+
+  test('Given 非 DeepSeek 模型 When 应用模型路由 Then 删除残留的 SubAgent 模型环境变量', () => {
+    const env: Record<string, string | undefined> = {
+      CLAUDE_CODE_SUBAGENT_MODEL: 'deepseek-v4-flash',
+    }
+
+    const policy = resolveAgentModelRouting({
+      modelId: 'claude-sonnet-4-6',
+      provider: 'anthropic',
+    })
+    applyAgentModelRoutingToEnv(env, policy)
+
+    expect(policy.deepSeekFamily).toBe(false)
+    expect(env.CLAUDE_CODE_SUBAGENT_MODEL).toBeUndefined()
+  })
+
+  test('Given DeepSeek 模型 When 应用模型路由 Then 注入 SDK SubAgent 模型环境变量', () => {
+    const env: Record<string, string | undefined> = {}
+
+    applyAgentModelRoutingToEnv(env, resolveAgentModelRouting({
+      modelId: 'deepseek-v4-flash',
+      provider: 'deepseek',
+    }))
+
+    expect(env.CLAUDE_CODE_SUBAGENT_MODEL).toBe(DEEPSEEK_SUBAGENT_MODEL_ID)
+  })
+})

--- a/apps/electron/src/main/lib/agent-model-routing.ts
+++ b/apps/electron/src/main/lib/agent-model-routing.ts
@@ -1,0 +1,44 @@
+import type { ProviderType } from '@proma/shared'
+
+export const DEEPSEEK_SUBAGENT_MODEL_ID = 'deepseek-v4-flash'
+export interface AgentModelRoutingInput {
+  modelId?: string
+  provider?: ProviderType
+}
+
+export interface AgentModelRoutingPolicy {
+  /** 是否命中 DeepSeek 系列主模型 */
+  deepSeekFamily: boolean
+  /** 命中时写入 CLAUDE_CODE_SUBAGENT_MODEL；未命中时删除该环境变量以保留 SDK 默认解析 */
+  subagentModel?: string
+}
+
+/**
+ * 解析 Agent 辅助模型路由策略。
+ *
+ * DeepSeek 系列主模型使用 deepseek-v4-flash 承担 SubAgent，避免复杂主模型
+ * 被高频探索 / 审查子任务消耗；其它模型不写该变量，交回 SDK 按
+ * per-invocation model、subagent frontmatter、主模型的顺序解析。
+ */
+export function resolveAgentModelRouting(input: AgentModelRoutingInput): AgentModelRoutingPolicy {
+  const model = input.modelId?.trim().toLowerCase() ?? ''
+  const deepSeekFamily = input.provider === 'deepseek' ||
+    model.startsWith('deepseek-') ||
+    model.includes('/deepseek-')
+
+  return {
+    deepSeekFamily,
+    ...(deepSeekFamily && { subagentModel: DEEPSEEK_SUBAGENT_MODEL_ID }),
+  }
+}
+
+export function applyAgentModelRoutingToEnv(
+  env: Record<string, string | undefined>,
+  policy: AgentModelRoutingPolicy,
+): void {
+  if (policy.subagentModel) {
+    env.CLAUDE_CODE_SUBAGENT_MODEL = policy.subagentModel
+  } else {
+    delete env.CLAUDE_CODE_SUBAGENT_MODEL
+  }
+}

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -49,6 +49,7 @@ import { permissionService } from './agent-permission-service'
 import type { PermissionResult, CanUseToolOptions } from './agent-permission-service'
 import { askUserService } from './agent-ask-user-service'
 import { exitPlanService, type ExitPlanPermissionResult } from './agent-exit-plan-service'
+import { applyAgentModelRoutingToEnv, resolveAgentModelRouting } from './agent-model-routing'
 import { getMemoryConfig } from './memory-service'
 import { searchMemory, addMemory, formatSearchResult } from './memos-client'
 import { validateToolInput } from './agent-tool-input-validator'
@@ -1068,7 +1069,9 @@ export class AgentOrchestrator {
       process.env.ANTHROPIC_BASE_URL = normalizeAnthropicBaseUrlForSdk(channel.baseUrl)
     }
 
+    const modelRouting = resolveAgentModelRouting({ modelId: modelId || DEFAULT_MODEL_ID, provider: channel.provider })
     const sdkEnv = await this.buildSdkEnv(apiKey, channel.baseUrl, channel.provider)
+    applyAgentModelRoutingToEnv(sdkEnv, modelRouting)
 
     // 4. 读取已有的 SDK session ID（用于 resume）
     const sessionMeta = getAgentSessionMeta(sessionId)
@@ -1496,6 +1499,7 @@ export class AgentOrchestrator {
             permissionMode: initialPermissionMode,
             memoryEnabled: (() => { const mc = getMemoryConfig(); return mc.enabled && !!mc.apiKey })(),
             claudeAvailable,
+            deepSeekSubagentModel: modelRouting.subagentModel,
           }),
         },
         resumeSessionId: existingSdkSessionId,
@@ -1526,7 +1530,8 @@ export class AgentOrchestrator {
           betas: ['context-1m-2025-08-07'] as SdkBeta[],
         }),
         // 内置 SubAgent 定义（code-reviewer / explorer / researcher）
-        // claudeAvailable=false 时 SubAgent 省略 model 字段，自动继承主 Agent 模型
+        // SubAgent 模型最终由 CLAUDE_CODE_SUBAGENT_MODEL 兜底控制：
+        // DeepSeek 系列固定 deepseek-v4-flash，其它模型删除该 env，保留 SDK 默认解析。
         agents: buildBuiltinAgents(claudeAvailable),
         onStderr: (data: string) => {
           stderrChunks.push(data)

--- a/apps/electron/src/main/lib/agent-prompt-builder.ts
+++ b/apps/electron/src/main/lib/agent-prompt-builder.ts
@@ -13,6 +13,7 @@ import type { PromaPermissionMode, AgentDefinition } from '@proma/shared'
 import { getUserProfile } from './user-profile-service'
 import { getWorkspaceMcpConfig, getWorkspaceSkills } from './agent-workspace-manager'
 import { getConfigDirName } from './config-paths'
+import { DEEPSEEK_SUBAGENT_MODEL_ID } from './agent-model-routing'
 
 // ===== 内置 SubAgent 定义 =====
 
@@ -90,6 +91,8 @@ interface SystemPromptContext {
   memoryEnabled: boolean
   /** 用户选用的模型是否为 Claude 系列（影响 SubAgent 模型策略描述，缺省视为 true） */
   claudeAvailable?: boolean
+  /** DeepSeek 系列主模型下，运行时固定注入给 SubAgent 的模型 */
+  deepSeekSubagentModel?: string
 }
 
 /**
@@ -131,7 +134,51 @@ export function buildSystemPrompt(ctx: SystemPromptContext): string {
 
   // SubAgent 委派策略（根据用户选用的模型是否为 Claude 动态调整）
   const claudeAvailable = ctx.claudeAvailable !== false
-  if (claudeAvailable) {
+  if (ctx.deepSeekSubagentModel === DEEPSEEK_SUBAGENT_MODEL_ID) {
+    sections.push(`## SubAgent 委派策略
+
+**核心原则：先探索再行动，用 SubAgent 保持主上下文干净。**
+
+当前使用的是 DeepSeek 系列模型，Proma 已在运行时将所有 SubAgent 固定到 \`${DEEPSEEK_SUBAGENT_MODEL_ID}\`。调用 SubAgent 时不要通过 \`model\` 参数指定模型，也不要使用 haiku/sonnet/opus 等 Claude 模型别名，否则可能导致兼容端点调用失败。
+
+### 内置 SubAgent
+
+系统已预定义以下子代理，可直接通过 Agent 工具按名称调用：
+
+- **explorer**（${DEEPSEEK_SUBAGENT_MODEL_ID}）：代码库探索。快速搜索文件、理解项目结构、收集相关上下文。动手修改前优先调用
+- **researcher**（${DEEPSEEK_SUBAGENT_MODEL_ID}）：技术调研。方案对比、依赖评估、架构分析，输出结构化调研报告
+- **code-reviewer**（${DEEPSEEK_SUBAGENT_MODEL_ID}）：代码审查。任务完成后调用，检查代码质量和规范一致性
+
+### 何时委派 SubAgent
+
+- 需要探索代码库、搜索多个文件、理解项目结构时 → 委派 \`explorer\`
+- 需要调研技术方案、对比多个选项时 → 委派 \`researcher\`
+- 代码修改完成后做质量检查 → 委派 \`code-reviewer\`
+- 需要并行处理多个独立子任务时 → 同时委派多个 SubAgent
+- 以上内置 SubAgent 不满足需求时，也可以自行定义临时 SubAgent，但不要指定 \`model\` 参数
+
+### 不需要委派的场景
+
+- 简单的单文件读取或编辑
+- 用户明确指定了操作目标
+- 任务本身就很简单直接
+
+### 委派时的要求
+
+- 给 SubAgent 清晰的任务描述，说明要收集什么信息、返回什么格式
+- 可以同时启动多个 SubAgent 并行工作
+- SubAgent 返回结果后，在主上下文中整合并做决策
+
+### 典型工作流（复杂任务）
+
+1. 委派 \`explorer\` 探索代码库、收集上下文
+2. 根据探索结果，委派 \`researcher\` 分析方案
+3. 整合所有信息，将调研结果输出到 \`.context/note.md\`
+4. 不确定的部分调用头脑风暴 Skill 与用户确认
+5. 对于重大架构变更或不确定的决策点，通过 AskUserQuestion 与用户确认；其他步骤直接执行，不要逐步等待确认
+6. 执行实施，将进度更新到 \`.context/todo.md\`
+7. 完成后委派 \`code-reviewer\` 做最终质量检查`)
+  } else if (claudeAvailable) {
     sections.push(`## SubAgent 委派策略
 
 **核心原则：先探索再行动，用 SubAgent 保持主上下文干净。根据任务复杂度选择合适的模型。**

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.10.16",
+      "version": "0.10.17",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.153",
         "@anthropic-ai/sdk": "^0.93.0",


### PR DESCRIPTION
Routes DeepSeek-family Agent runs so SubAgents use `deepseek-v4-flash` through `CLAUDE_CODE_SUBAGENT_MODEL`, while clearing stale env values for other model families to preserve default SDK behavior.
Adds a small model-routing policy module, updates the DeepSeek SubAgent prompt guidance, and bumps `@proma/electron` to `0.10.17`.
Validated with the focused Bun test, Electron typecheck, and main-process build.