### PR TITLE
fix(bridge): 修正 /now 文件列表并补充会话文件树展示

### DIFF
--- a/apps/electron/src/main/lib/bridge-attachment-utils.ts
+++ b/apps/electron/src/main/lib/bridge-attachment-utils.ts
@@ -5,9 +5,9 @@
  * 以及 <attached_files> XML 构建能力。
  */
 
-import { mkdirSync, writeFileSync } from 'node:fs'
+import { mkdirSync, writeFileSync, readdirSync } from 'node:fs'
 import { join, resolve, basename, relative } from 'node:path'
-import { getAgentSessionWorkspacePath } from './config-paths'
+import { getAgentSessionWorkspacePath, resolveAgentSessionWorkspacePath } from './config-paths'
 
 /** 图片大小警告阈值 */
 export const MAX_IMAGE_SIZE = 10 * 1024 * 1024
@@ -127,4 +127,119 @@ export function buildAttachedFilesBlock(refs: Array<{ label: string; path: strin
   if (refs.length === 0) return ''
   const lines = refs.map(r => `- ${r.label}: ${r.path}`)
   return `<attached_files>\n${lines.join('\n')}\n</attached_files>\n\n`
+}
+
+/** 文件树渲染时忽略的非点前缀条目（点文件统一由 startsWith('.') 过滤） */
+const FILE_TREE_IGNORE = new Set(['node_modules'])
+
+/** 文件树展示选项 */
+interface FileTreeOptions {
+  /** 目录图标，默认 '📁 ' */
+  dirIcon?: string
+  /** 文件图标，默认 '📄 ' */
+  fileIcon?: string
+  /** 最大递归深度（根为 0），默认 3 */
+  maxDepth?: number
+  /** 总条目上限，默认 50 */
+  maxEntries?: number
+}
+
+// 树形连接符。用全角空格（U+3000）做对齐，避免飞书 markdown 折叠连续半角空格。
+const TREE_BRANCH = '├─　'   // 非末尾节点
+const TREE_LAST = '└─　'     // 末尾节点
+const TREE_VERTICAL = '│　'  // 祖先分支延续
+const TREE_BLANK = '　　' // 祖先分支已结束
+
+/** 触达条目上限时的提示文案 */
+const TREE_TRUNCATED_NOTICE = '（由于到达显示上限，文件夹子内容不在此展开）'
+
+function walkFileTree(
+  dir: string,
+  depth: number,
+  ancestorPrefix: string,
+  opts: Required<FileTreeOptions>,
+  out: string[],
+  counter: { count: number; truncated: boolean },
+): void {
+  if (depth > opts.maxDepth) return
+  if (counter.truncated) return
+
+  let entries: import('node:fs').Dirent[]
+  try {
+    entries = readdirSync(dir, { withFileTypes: true })
+  } catch {
+    return
+  }
+
+  const visible = entries
+    .filter((e) => !e.name.startsWith('.') && !FILE_TREE_IGNORE.has(e.name))
+    // 目录在前，同类按名称排序
+    .sort((a, b) => {
+      const ad = a.isDirectory() ? 0 : 1
+      const bd = b.isDirectory() ? 0 : 1
+      return ad !== bd ? ad - bd : a.name.localeCompare(b.name)
+    })
+
+  for (let i = 0; i < visible.length; i++) {
+    const e = visible[i]
+    if (!e) continue
+    if (counter.count >= opts.maxEntries) {
+      // 触达上限：停止展开，由顶层统一追加单次提示
+      counter.truncated = true
+      return
+    }
+    const isLast = i === visible.length - 1
+    counter.count++
+    const connector = isLast ? TREE_LAST : TREE_BRANCH
+    if (e.isDirectory()) {
+      out.push(`${ancestorPrefix}${connector}${opts.dirIcon}${e.name}/`)
+      const childPrefix = ancestorPrefix + (isLast ? TREE_BLANK : TREE_VERTICAL)
+      walkFileTree(join(dir, e.name), depth + 1, childPrefix, opts, out, counter)
+      if (counter.truncated) return
+    } else {
+      out.push(`${ancestorPrefix}${connector}${opts.fileIcon}${e.name}`)
+    }
+  }
+}
+
+/**
+ * 递归构建任意目录的文件树文本行
+ *
+ * 用树形连接符（├─ └─ │）体现文件夹-文件层级。
+ * 过滤所有点文件（.context、.claude、.git 等）及 node_modules。
+ * 每行以可见字符开头、用全角空格对齐，避免 markdown 折叠行首/连续空格。
+ * 条目数触达上限时停止展开并在末尾追加单次提示。
+ *
+ * @returns 文本行数组；目录不存在/为空时返回空数组
+ */
+export function buildFileTree(rootDir: string, options: FileTreeOptions = {}): string[] {
+  const opts: Required<FileTreeOptions> = {
+    dirIcon: options.dirIcon ?? '📁 ',
+    fileIcon: options.fileIcon ?? '📄 ',
+    maxDepth: options.maxDepth ?? 3,
+    maxEntries: options.maxEntries ?? 50,
+  }
+  const out: string[] = []
+  const counter = { count: 0, truncated: false }
+  walkFileTree(rootDir, 0, '', opts, out, counter)
+  if (counter.truncated) {
+    out.push(TREE_TRUNCATED_NOTICE)
+  }
+  return out
+}
+
+/**
+ * 构建会话目录的文件树文本行
+ *
+ * 递归遍历 ~/.proma/agent-workspaces/{slug}/{sessionId}/（只读，不创建目录）。
+ *
+ * @returns 文本行数组；目录不存在/无可见文件时返回空数组
+ */
+export function buildSessionFileTree(
+  workspaceSlug: string,
+  sessionId: string,
+  options: FileTreeOptions = {},
+): string[] {
+  const sessionDir = resolveAgentSessionWorkspacePath(workspaceSlug, sessionId)
+  return buildFileTree(sessionDir, options)
 }

--- a/apps/electron/src/main/lib/bridge-command-handler.ts
+++ b/apps/electron/src/main/lib/bridge-command-handler.ts
@@ -18,9 +18,8 @@ import {
 } from './agent-workspace-manager'
 import { runAgentHeadless, agentEventBus, stopAgent, isAgentSessionActive } from './agent-service'
 import { getSettings } from './settings-service'
-import { getAgentWorkspacePath } from './config-paths'
-import { buildAttachedFilesBlock } from './bridge-attachment-utils'
-import { readdirSync } from 'node:fs'
+import { resolveWorkspaceFilesDir } from './config-paths'
+import { buildAttachedFilesBlock, buildSessionFileTree, buildFileTree } from './bridge-attachment-utils'
 
 // ===== 接口定义 =====
 
@@ -516,25 +515,35 @@ export class BridgeCommandHandler {
         }
       }
 
-      // 工作区文件
+      // 工作区文件（递归，体现文件夹-文件层级）
       try {
-        const wsPath = getAgentWorkspacePath(workspace.slug)
-        const entries = readdirSync(wsPath, { withFileTypes: true })
-        const fileList = entries
-          .filter((e) => !e.name.startsWith('.') && e.name !== 'mcp.json' && e.name !== 'config.json' && e.name !== 'skills' && e.name !== 'skills-inactive')
-          .map((e) => e.isDirectory() ? `📁 ${e.name}/` : `📄 ${e.name}`)
-        if (fileList.length > 0) {
+        const wsPath = resolveWorkspaceFilesDir(workspace.slug)
+        const treeLines = buildFileTree(wsPath)
+        if (treeLines.length > 0) {
           lines.push('')
           lines.push('工作区文件:')
-          for (const f of fileList.slice(0, 20)) {
-            lines.push(`  ${f}`)
-          }
-          if (fileList.length > 20) {
-            lines.push(`  ... 还有 ${fileList.length - 20} 项`)
+          for (const l of treeLines) {
+            lines.push(`  ${l}`)
           }
         }
       } catch {
         // 忽略
+      }
+
+      // 会话文件（体现文件夹-文件层级）
+      if (binding) {
+        try {
+          const treeLines = buildSessionFileTree(workspace.slug, binding.sessionId)
+          if (treeLines.length > 0) {
+            lines.push('')
+            lines.push('会话文件:')
+            for (const l of treeLines) {
+              lines.push(`  ${l}`)
+            }
+          }
+        } catch {
+          // 忽略
+        }
       }
     } else {
       lines.push('工作区: 未设置')

--- a/apps/electron/src/main/lib/config-paths.ts
+++ b/apps/electron/src/main/lib/config-paths.ts
@@ -333,6 +333,33 @@ export function getWorkspaceFilesDir(slug: string): string {
 }
 
 /**
+ * 解析工作区文件目录路径（只读，不创建目录）
+ *
+ * 与 getWorkspaceFilesDir 的区别：不会触发 mkdir 副作用，
+ * 适用于 /now 等只读查询场景。
+ *
+ * @param slug 工作区 slug
+ * @returns ~/.proma/agent-workspaces/{slug}/workspace-files/
+ */
+export function resolveWorkspaceFilesDir(slug: string): string {
+  return join(getConfigDir(), 'agent-workspaces', slug, 'workspace-files')
+}
+
+/**
+ * 解析 Agent 会话工作目录路径（只读，不创建目录）
+ *
+ * 与 getAgentSessionWorkspacePath 的区别：不会触发 mkdir 副作用，
+ * 适用于 /now 等只读查询场景。
+ *
+ * @param slug 工作区 slug
+ * @param sessionId 会话 ID
+ * @returns ~/.proma/agent-workspaces/{slug}/{sessionId}/
+ */
+export function resolveAgentSessionWorkspacePath(slug: string, sessionId: string): string {
+  return join(getConfigDir(), 'agent-workspaces', slug, sessionId)
+}
+
+/**
  * 获取工作区不活跃 Skills 目录路径
  *
  * 禁用的 Skill 会被移动到此目录，Agent SDK 不会扫描该目录。

--- a/apps/electron/src/main/lib/feishu-bridge.ts
+++ b/apps/electron/src/main/lib/feishu-bridge.ts
@@ -37,12 +37,14 @@ import {
   getWorkspaceCapabilities,
 } from './agent-workspace-manager'
 import { getFeishuBotBindingsPath, getFeishuBotMetadataPath } from './config-paths'
-import { writeFileSync, readFileSync, existsSync, readdirSync } from 'node:fs'
+import { writeFileSync, readFileSync, existsSync } from 'node:fs'
 import {
   inferImageMediaType as inferImageMediaTypeShared,
   saveImageToSession as saveImageToSessionShared,
   saveFileToSession as saveFileToSessionShared,
   inferExtension,
+  buildSessionFileTree,
+  buildFileTree,
 } from './bridge-attachment-utils'
 import { getSettings } from './settings-service'
 import {
@@ -1386,26 +1388,39 @@ class FeishuBridge {
         lines.push('**Skills**: 无')
       }
 
-      // 工作区文件列表
-      const { getAgentWorkspacePath: getWsPath } = await import('./config-paths')
-      const wsPath = getWsPath(workspace.slug)
+      // 工作区文件列表（递归，体现文件夹-文件层级）
+      const { resolveWorkspaceFilesDir: resolveWsFilesDir } = await import('./config-paths')
+      const wsPath = resolveWsFilesDir(workspace.slug)
       try {
-        const entries = readdirSync(wsPath, { withFileTypes: true })
-        const fileList = entries
-          .filter((e) => !e.name.startsWith('.') && e.name !== 'mcp.json' && e.name !== 'config.json' && e.name !== 'skills' && e.name !== 'skills-inactive')
-          .map((e) => e.isDirectory() ? `${e.name}/` : e.name)
-        if (fileList.length > 0) {
+        const treeLines = buildFileTree(wsPath, { dirIcon: '', fileIcon: '' })
+        if (treeLines.length > 0) {
           lines.push('')
           lines.push('**工作区文件**:')
-          for (const f of fileList.slice(0, 20)) {
-            lines.push(`  ${f}`)
-          }
-          if (fileList.length > 20) {
-            lines.push(`  ... 还有 ${fileList.length - 20} 项`)
+          for (const l of treeLines) {
+            lines.push(`  ${l}`)
           }
         }
       } catch {
         // 目录不存在或无法读取，忽略
+      }
+
+      // 会话文件（体现文件夹-文件层级）
+      if (binding) {
+        try {
+          const treeLines = buildSessionFileTree(workspace.slug, binding.sessionId, {
+            dirIcon: '',
+            fileIcon: '',
+          })
+          if (treeLines.length > 0) {
+            lines.push('')
+            lines.push('**会话文件**:')
+            for (const l of treeLines) {
+              lines.push(`  ${l}`)
+            }
+          }
+        } catch {
+          // 忽略
+        }
       }
     } else {
       lines.push('**工作区**: 未设置')


### PR DESCRIPTION
## 问题根因

`/now` 指令的「工作区文件」列表原本扫描的是工作区**根目录** `~/.proma/agent-workspaces/{slug}/`。但每个会话都会在该根目录下创建以 sessionId（UUID）命名的子目录，导致这些会话目录被误当成工作区文件列出——表现为一堆 UUID 文件夹，而真实工作区内容（在 `workspace-files/` 子目录里）反而看不到。

此外原实现只做顶层扁平列举，文件夹内的文件无法展开。

## 具体修改

涉及 `apps/electron/src/main/lib/` 下 4 个文件：

- **bridge-attachment-utils.ts**：新增递归文件树构建器 `buildFileTree(rootDir, options)` 及会话封装 `buildSessionFileTree`。用树形连接符（`├─` `└─` `│`）+ 全角空格对齐体现文件夹-文件层级，规避飞书卡片 markdown 对行首/连续半角空格的折叠。过滤点文件与 `node_modules`；条目数触达上限（默认 50）时停止展开并追加单次提示。
- **config-paths.ts**：新增只读路径解析函数 `resolveWorkspaceFilesDir` / `resolveAgentSessionWorkspacePath`（不触发 mkdir），消除 `/now` 只读查询时创建目录的写副作用。
- **bridge-command-handler.ts**（微信/钉钉）与 **feishu-bridge.ts** 的 `/now` 处理器：工作区文件改为扫描 `workspace-files/` 并递归树展示；新增「会话文件」区块，展示当前会话目录的文件树。

## 审查情况

- 自审查：递归逻辑、符号链接不递归、`noUncheckedIndexedAccess` 守卫、未用导入清理均已确认；旧的扫描根目录调用已彻底清除。
- 类型检查：`bun run typecheck` 通过（exit 0），且在同步上游最新代码后的基线上复测仍通过。
- 真实数据验证：用实际工作区数据验证了「工作区文件递归展开」「点文件过滤」「会话空 .context 不展示」「超上限单次截断提示」四个场景。
- 用户已手动测试确认 OK。