### PR TITLE
fix: 删除/归档 Agent 会话时释放重型 per-session 状态

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -48,6 +48,16 @@ import {
   agentDiffUnseenChangesAtom,
   agentDiffUnseenFilesAtom,
   agentDiffDataAtom,
+  agentStreamingStatesAtom,
+  liveMessagesMapAtom,
+  agentSessionPendingFilesAtom,
+  agentSessionStreamingStateAtomFamily,
+  agentSessionDraftAtomFamily,
+  agentSessionDraftHtmlAtomFamily,
+  agentPendingFilesAtomFamily,
+  backgroundTasksAtomFamily,
+  sessionPersistedPermissionModeAtom,
+  sessionExistsAtom,
 } from '@/atoms/agent-atoms'
 import type { SessionIndicatorStatus } from '@/atoms/agent-atoms'
 import { previewPanelOpenMapAtom, previewFileMapAtom } from '@/atoms/preview-atoms'
@@ -441,6 +451,9 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   const setDiffUnseenFiles = useSetAtom(agentDiffUnseenFilesAtom)
   const setDiffData = useSetAtom(agentDiffDataAtom)
   const setWorkingDone = useSetAtom(workingDoneSessionIdsAtom)
+  const setStreamingStates = useSetAtom(agentStreamingStatesAtom)
+  const setLiveMessagesMap = useSetAtom(liveMessagesMapAtom)
+  const setSessionPendingFiles = useSetAtom(agentSessionPendingFilesAtom)
 
   /** 清理 per-conversation/session Map atoms 条目 */
   const cleanupMapAtoms = React.useCallback((id: string) => {
@@ -464,8 +477,34 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     setDiffData(deleteKey)
     setSessionChannelMap(deleteKey)
     setSessionModelMap(deleteKey)
+
+    // 重型流式数据：streamingStates（累积 content + toolActivities）与 liveMessages（SDK 消息数组）
+    setStreamingStates(deleteKey)
+    setLiveMessagesMap(deleteKey)
+
+    // 待发送附件：先释放 blob URL 和 window 缓存中的 base64，再删 base map entry。
+    // 与文字草稿不同，附件涉及 ObjectURL 和大体积二进制数据，删除/归档时不保留。
+    const sessionPending = store.get(agentSessionPendingFilesAtom).get(id)
+    if (sessionPending && sessionPending.length > 0) {
+      for (const f of sessionPending) {
+        if (f.previewUrl?.startsWith('blob:')) URL.revokeObjectURL(f.previewUrl)
+        window.__pendingAgentFileData?.delete(f.id)
+      }
+      setSessionPendingFiles(deleteKey)
+    }
+
+    // atomFamily 内部缓存（Jotai 对 string key 强引用 Map，不显式 remove 永不释放）。
+    // 删除/归档是会话的终态，连同草稿一起清理，无需像关闭 Tab 那样保留可恢复输入。
+    agentSessionStreamingStateAtomFamily.remove(id)
+    agentSessionDraftAtomFamily.remove(id)
+    agentSessionDraftHtmlAtomFamily.remove(id)
+    agentPendingFilesAtomFamily.remove(id)
+    backgroundTasksAtomFamily.remove(id)
+    sessionPersistedPermissionModeAtom.remove(id)
+    sessionExistsAtom.remove(id)
+
     clearPreviewCacheForSession(id)
-  }, [setConvModels, setConvContextLength, setConvThinking, setConvParallel, setConvPromptId, setPreviewPanelOpen, setPreviewFile, setDiffPanelTab, setDiffRefreshVersion, setDiffUnseen, setDiffUnseenFiles, setDiffData, setSessionChannelMap, setSessionModelMap])
+  }, [setConvModels, setConvContextLength, setConvThinking, setConvParallel, setConvPromptId, setPreviewPanelOpen, setPreviewFile, setDiffPanelTab, setDiffRefreshVersion, setDiffUnseen, setDiffUnseenFiles, setDiffData, setSessionChannelMap, setSessionModelMap, setStreamingStates, setLiveMessagesMap, setSessionPendingFiles, store])
 
   const currentWorkspaceSlug = React.useMemo(() => {
     if (!currentWorkspaceId) return null


### PR DESCRIPTION
## 背景

PR #633 把 `useCloseTab` 的重型清理逻辑（`cleanupMapAtoms`）整体删除，关闭会话入口不再做 per-session 清理——这是符合新「后台持续运行、可恢复」模型的设计。但被删的那部分重型清理**没有在删除/归档路径补回**：

`useCloseTab` 原本是唯一执行以下清理的路径——
- `agentStreamingStatesAtom`（累积流式 content + toolActivities）
- `liveMessagesMapAtom`（SDK 消息数组）
- 待发送附件的 `URL.revokeObjectURL` + `window.__pendingAgentFileData` 释放（blob 二进制）
- 7 个 per-session `atomFamily` 缓存的 `.remove()`（Jotai 对 string key 强引用 Map，不显式 remove 永不释放）

`LeftSidebar` 自带的 `cleanupMapAtoms` 是轻量版，只清 conv models / diff / preview 等小 Map。合并 #633 后，**没有任何路径**会执行上述重型清理。对活跃可恢复会话保留状态合理，但当会话被**真正删除/归档**（终态）时，这些状态全部泄漏，长会话场景（开过几十上百个 Agent 会话）内存持续增长。

## 改动

把重型清理迁入 `LeftSidebar` 共享的 `cleanupMapAtoms`（删除、归档对话、归档 Agent 三条路径都经过它）：
- 清 `agentStreamingStatesAtom` / `liveMessagesMapAtom`
- 释放待发送附件 blob URL + `window.__pendingAgentFileData`
- `.remove()` 7 个 per-session atomFamily：streamingState / draft / draftHtml / pendingFiles / backgroundTasks / persistedPermissionMode / sessionExists

删除/归档是会话终态，连草稿一起清理（无需像关闭 Tab 那样保留可恢复输入）。chat 会话不持有 agent-only 状态，对其调 `.remove()` 是无害 no-op。

`useCloseTab` 中「真正删除/归档时由侧边栏路径负责清理 per-session 状态」的注释现在名副其实。

## 测试

- `tsc --noEmit` 通过
- `bun test apps/electron/src/renderer` 全过（35 pass / 0 fail）

## 测试计划

- [ ] 创建 Agent 会话、发起流式任务、添加图片附件，删除该会话后确认 streamingStates/liveMessages 中该 id 已移除、blob URL 已 revoke
- [ ] 归档 Agent 会话后确认同样清理生效
- [ ] 删除/归档 Chat 对话不报错（agent-only 清理为 no-op）
- [ ] 删除/归档当前激活会话后，RightSidePanel 正常切换到新激活会话（不因清理误置 null 而消失）