### PR TITLE
[codex] Support Agent think tag rendering

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.10.17",
+  "version": "0.10.18",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -13,7 +13,6 @@ import {
   Message,
   MessageHeader,
   MessageContent,
-  MessageResponse,
   BasePathsProvider,
 } from '@/components/ai-elements/message'
 import {
@@ -36,6 +35,8 @@ import { Spinner } from '@/components/ui/spinner'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { groupIntoTurns, MessageGroupRenderer, getGroupId, getGroupPreview, extractUserText, parseAttachedFiles as sdkParseAttachedFiles, isImageFile as sdkIsImageFile, CompactingIndicator, buildHistoricalTaskSubjects, type MessageGroup } from './SDKMessageRenderer'
 import { buildLiveGroupSet } from './live-group-set'
+import { ContentBlock } from './ContentBlock'
+import { parseThinkTagsFromText } from './thinking-tag-parser'
 import type { AgentEventUsage, RetryAttempt, SDKMessage } from '@proma/shared'
 import type { AgentStreamState } from '@/atoms/agent-atoms'
 
@@ -450,6 +451,11 @@ export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persi
   // 会导致 fallback 气泡与持久化消息同时渲染一帧（重复内容闪烁）。
   // 用原始 streamingContent 作为守卫：内容已清空且不在流式中，立即归零。
   const smoothContent = (streaming || streamingContent) ? rawSmoothContent : ''
+  const smoothContentBlocks = React.useMemo(() => {
+    if (!smoothContent) return []
+    return parseThinkTagsFromText(smoothContent)
+  }, [smoothContent])
+  const hasSmoothTextContent = smoothContentBlocks.some((block) => block.type === 'text')
 
   /**
    * 流式完成过渡：streaming 结束到持久化消息加载完成之间，
@@ -656,7 +662,20 @@ export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persi
                   {retrying && <RetryingNotice retrying={retrying} />}
                   {smoothContent ? (
                     <>
-                      <MessageResponse basePath={sessionPath || undefined} basePaths={attachedDirs}>{smoothContent}</MessageResponse>
+                      <div className={cn('space-y-2')}>
+                        {smoothContentBlocks.map((block, index) => (
+                          <ContentBlock
+                            key={index}
+                            block={block}
+                            allMessages={allSDKMessages}
+                            basePath={sessionPath || undefined}
+                            basePaths={attachedDirs}
+                            index={index}
+                            dimmed={hasSmoothTextContent && block.type !== 'text'}
+                            isStreaming={streaming}
+                          />
+                        ))}
+                      </div>
                       {streaming && <AgentRunningIndicator startedAt={startedAt} />}
                     </>
                   ) : (

--- a/apps/electron/src/renderer/components/agent/ContentBlock.tsx
+++ b/apps/electron/src/renderer/components/agent/ContentBlock.tsx
@@ -199,6 +199,8 @@ export interface ContentBlockProps {
   allMessages: SDKMessage[]
   /** 相对路径解析基准（文件链接用） */
   basePath?: string
+  /** 多个可解析相对路径的基准目录 */
+  basePaths?: string[]
   /** 是否启用入场动画 */
   animate?: boolean
   /** 在父级中的索引（用于动画延迟） */
@@ -648,13 +650,13 @@ function ThinkingBlock({ block, dimmed = false }: ThinkingBlockProps): React.Rea
 
 // ===== ContentBlock 主组件 =====
 
-export function ContentBlock({ block, allMessages, basePath, animate = false, index = 0, dimmed = false, childBlocks, isStreaming }: ContentBlockProps): React.ReactElement | null {
+export function ContentBlock({ block, allMessages, basePath, basePaths, animate = false, index = 0, dimmed = false, childBlocks, isStreaming }: ContentBlockProps): React.ReactElement | null {
   // text 块 — 主要内容，不受 dimmed 影响
   if (block.type === 'text') {
     const textBlock = block as SDKTextBlock
     if (!textBlock.text) return null
     return (
-      <MessageResponse basePath={basePath}>{textBlock.text}</MessageResponse>
+      <MessageResponse basePath={basePath} basePaths={basePaths}>{textBlock.text}</MessageResponse>
     )
   }
 

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -21,6 +21,7 @@ import { TaskProgressCard } from './TaskProgressCard'
 import { TurnFileChangesSummary } from './TurnFileChangesSummary'
 import { ProcessBlockGroup, buildAssistantTurnRenderItems, buildCompletedToolResultIds } from './ProcessBlockGroup'
 import { extractToolResultText, parseTaskCreateResult, TASK_TOOL_NAMES } from './task-progress'
+import { normalizeThinkTagsInContentBlocks } from './thinking-tag-parser'
 import { DurationBadge } from './AgentMessages'
 import {
   Message,
@@ -539,7 +540,9 @@ export function AssistantTurnRenderer({ turn, allMessages, historicalTaskSubject
     const blocks = aMsg.message?.content
     if (Array.isArray(blocks)) {
       for (const block of blocks) {
-        enrichedBlocks.push({ block, parentToolUseId: aMsg.parent_tool_use_id })
+        for (const normalizedBlock of normalizeThinkTagsInContentBlocks([block])) {
+          enrichedBlocks.push({ block: normalizedBlock, parentToolUseId: aMsg.parent_tool_use_id })
+        }
       }
     }
   }
@@ -768,8 +771,10 @@ export function SDKMessageRenderer({
       return <ErrorMessage message={aMsg} />
     }
 
-    const blocks = aMsg.message?.content
-    if (!Array.isArray(blocks) || blocks.length === 0) return null
+    const rawBlocks = aMsg.message?.content
+    if (!Array.isArray(rawBlocks) || rawBlocks.length === 0) return null
+    const blocks = normalizeThinkTagsInContentBlocks(rawBlocks)
+    if (blocks.length === 0) return null
 
     const model = aMsg._channelModelId || aMsg.message?.model || sessionModelId
     const meta = extractMeta(message)
@@ -1312,9 +1317,9 @@ export function getGroupPreview(group: MessageGroup): string {
   // assistant-turn：收集所有 text 块
   const texts: string[] = []
   for (const aMsg of group.assistantMessages) {
-    const blocks = aMsg.message?.content
-    if (!Array.isArray(blocks)) continue
-    for (const block of blocks) {
+    const rawBlocks = aMsg.message?.content
+    if (!Array.isArray(rawBlocks)) continue
+    for (const block of normalizeThinkTagsInContentBlocks(rawBlocks)) {
       if (block.type === 'text' && 'text' in block) {
         texts.push((block as { text: string }).text)
       }

--- a/apps/electron/src/renderer/components/agent/thinking-tag-parser.ts
+++ b/apps/electron/src/renderer/components/agent/thinking-tag-parser.ts
@@ -1,0 +1,64 @@
+import type { SDKContentBlock, SDKTextBlock } from '@proma/shared'
+
+const THINK_OPEN_TAG = '<think>'
+const THINK_CLOSE_TAG = '</think>'
+
+function appendTextBlock(blocks: SDKContentBlock[], text: string): void {
+  if (!text.trim()) return
+  blocks.push({ type: 'text', text })
+}
+
+function appendThinkingBlock(blocks: SDKContentBlock[], thinking: string): void {
+  const content = thinking.trim()
+  if (!content) return
+  blocks.push({ type: 'thinking', thinking: content })
+}
+
+/**
+ * 兼容部分模型把思考内容包在 <think> 标签里的返回格式。
+ * 未闭合的 <think> 在流式阶段按思考块处理，等闭合标签到达后会自然拆出后续正文。
+ */
+export function parseThinkTagsFromText(text: string): SDKContentBlock[] {
+  const lowerText = text.toLowerCase()
+  const blocks: SDKContentBlock[] = []
+  let cursor = 0
+
+  while (cursor < text.length) {
+    const openIndex = lowerText.indexOf(THINK_OPEN_TAG, cursor)
+    if (openIndex === -1) {
+      appendTextBlock(blocks, text.slice(cursor))
+      break
+    }
+
+    appendTextBlock(blocks, text.slice(cursor, openIndex))
+
+    const contentStart = openIndex + THINK_OPEN_TAG.length
+    const closeIndex = lowerText.indexOf(THINK_CLOSE_TAG, contentStart)
+    if (closeIndex === -1) {
+      appendThinkingBlock(blocks, text.slice(contentStart))
+      break
+    }
+
+    appendThinkingBlock(blocks, text.slice(contentStart, closeIndex))
+    cursor = closeIndex + THINK_CLOSE_TAG.length
+  }
+
+  return blocks
+}
+
+export function splitThinkTagsInTextBlock(block: SDKTextBlock): SDKContentBlock[] {
+  if (!block.text.toLowerCase().includes(THINK_OPEN_TAG)) return [block]
+  return parseThinkTagsFromText(block.text)
+}
+
+export function normalizeThinkTagsInContentBlocks(blocks: SDKContentBlock[]): SDKContentBlock[] {
+  const normalized: SDKContentBlock[] = []
+  for (const block of blocks) {
+    if (block.type === 'text' && 'text' in block && typeof block.text === 'string') {
+      normalized.push(...splitThinkTagsInTextBlock(block as SDKTextBlock))
+    } else {
+      normalized.push(block)
+    }
+  }
+  return normalized
+}

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.10.17",
+      "version": "0.10.18",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.153",
         "@anthropic-ai/sdk": "^0.93.0",


### PR DESCRIPTION
Adds renderer-side parsing for model responses that wrap reasoning in `<think>` tags, converting them into existing Agent thinking blocks instead of showing raw tags. This keeps normal answer text as text blocks while preserving current Thinking styling, process grouping, minimap preview behavior, and streaming fallback rendering. Also passes multiple base paths through `ContentBlock` so fallback-rendered text keeps file-link resolution, and bumps `@proma/electron` to `0.10.18`. Validation: `git diff --check` and `bun run --filter='@proma/electron' typecheck`.