### PR TITLE
feat(sidebar): 将右侧面板改为三栏 Tab 布局

### DIFF
--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -287,8 +287,8 @@ export const agentSidePanelWidthAtom = atomWithStorage<number>('proma-agent-side
 /** @deprecated 保留以兼容旧代码，但实际所有 session 都读全局 atom */
 export const agentSidePanelOpenMapAtom = atom<Map<string, boolean>>(new Map())
 
-/** 侧面板当前 Tab：'files' | 'changes'（per-session Map） */
-export const agentDiffPanelTabAtom = atom<Map<string, 'files' | 'changes'>>(new Map())
+/** 侧面板当前 Tab：'session' | 'workspace' | 'changes'（per-session Map） */
+export const agentDiffPanelTabAtom = atom<Map<string, 'session' | 'workspace' | 'changes'>>(new Map())
 
 /** Diff 视图模式：'split' | 'unified' */
 export const agentDiffViewModeAtom = atom<'split' | 'unified'>('split')

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -53,8 +53,8 @@ function getMediaTypeFromFilename(filename: string): string {
 interface SidePanelProps {
   sessionId: string
   sessionPath: string | null
-  activeTab: 'files' | 'changes'
-  onTabChange: (tab: 'files' | 'changes') => void
+  activeTab: 'session' | 'workspace' | 'changes'
+  onTabChange: (tab: 'session' | 'workspace' | 'changes') => void
   width?: number
 }
 
@@ -414,190 +414,178 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
             ) : (
               <div className="flex-1 flex items-center justify-center text-muted-foreground text-xs">等待会话初始化...</div>
             )
-          ) : (
-          <div className="flex-1 min-h-0 flex flex-col pt-0.5">
-                  {/* ===== 会话文件区（仅当 sessionPath 存在时显示） ===== */}
-                  {sessionPath && (
-                    <>
-                      <div className="flex items-center gap-1 pl-3 pr-2 h-[32px] flex-shrink-0">
-                        <FolderOpen className="size-3 text-muted-foreground" />
-                        <span className="text-[11px] font-medium text-muted-foreground">会话文件</span>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Info className="size-3 text-muted-foreground/50 cursor-help" />
-                          </TooltipTrigger>
-                          <TooltipContent side="bottom" className="max-w-[200px]">
-                            <p>当前会话的专属文件，仅本次对话的 Agent 可以访问</p>
-                          </TooltipContent>
-                        </Tooltip>
-                        <span className="text-[10px] text-muted-foreground/70 truncate flex-1 min-w-0" title={sessionPath}>
-                          {breadcrumb}
-                        </span>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="icon"
-                              className={filePanelActionButtonClass}
-                              onClick={() => window.electronAPI.openFile(sessionPath).catch(console.error)}
-                            >
-                              <FolderSearch />
-                            </Button>
-                          </TooltipTrigger>
-                          <TooltipContent side="bottom">
-                            <p>在 Finder 中打开</p>
-                          </TooltipContent>
-                        </Tooltip>
-                      </div>
-                      {/* ===== 文件搜索栏 ===== */}
-                      <FileSearchBar
-                        workspaceFilesPath={null}
-                        sessionPath={sessionPath}
-                        sessionAttachedDirs={attachedDirs}
-                        workspaceAttachedDirs={[]}
-                        placeholder="搜索会话文件..."
-                        sessionId={sessionId}
+          ) : activeTab === 'session' ? (
+            <div className="flex-1 min-h-0 flex flex-col pt-0.5 mx-2 mb-2">
+              {sessionPath ? (
+                <>
+                  <div className="flex items-center gap-1 px-2 h-[32px] flex-shrink-0">
+                    <FolderOpen className="size-3 text-muted-foreground" />
+                    <span className="text-[11px] font-medium text-muted-foreground">会话文件</span>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Info className="size-3 text-muted-foreground/50 cursor-help" />
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom" className="max-w-[200px]">
+                        <p>当前会话的专属文件，仅本次对话的 Agent 可以访问</p>
+                      </TooltipContent>
+                    </Tooltip>
+                    <span className="text-[10px] text-muted-foreground/70 truncate flex-1 min-w-0" title={sessionPath}>
+                      {breadcrumb}
+                    </span>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          className={filePanelActionButtonClass}
+                          onClick={() => window.electronAPI.openFile(sessionPath).catch(console.error)}
+                        >
+                          <FolderSearch />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom">
+                        <p>在 Finder 中打开</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </div>
+                  <FileSearchBar
+                    workspaceFilesPath={null}
+                    sessionPath={sessionPath}
+                    sessionAttachedDirs={attachedDirs}
+                    workspaceAttachedDirs={[]}
+                    placeholder="搜索会话文件..."
+                    sessionId={sessionId}
+                    onFilePreview={handleFilePreview}
+                  />
+                  <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin">
+                    {attachedFiles.length > 0 && (
+                      <AttachedFilesSection
+                        attachedFiles={attachedFiles}
+                        onDetach={handleDetachFile}
+                        onAddToChat={handleAddToChat}
                         onFilePreview={handleFilePreview}
+                        allowedPaths={basePathsRef.current}
+                        sessionId={sessionId}
                       />
-                      {/* 会话文件内容区（独立滚动） */}
-                      <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin">
-                        {/* 附加文件列表 */}
-                        {attachedFiles.length > 0 && (
-                          <AttachedFilesSection
-                            attachedFiles={attachedFiles}
-                            onDetach={handleDetachFile}
-                            onAddToChat={handleAddToChat}
-                            onFilePreview={handleFilePreview}
-                            allowedPaths={basePathsRef.current}
-                            sessionId={sessionId}
-                          />
-                        )}
-                        {/* 附加目录列表（可展开目录树） */}
-                        {attachedDirs.length > 0 && (
-                          <AttachedDirsSection
-                            attachedDirs={attachedDirs}
-                            onDetach={handleDetachDirectory}
-                            refreshVersion={filesVersion}
-                            onAddToChat={handleAddToChat}
-                            onFilePreview={handleFilePreview}
-                            allowedPaths={basePathsRef.current}
-                            sessionId={sessionId}
-                          />
-                        )}
-                        {/* 会话文件浏览器 */}
-                        <>
-                          {hasSessionAttachedItems && (
-                            <div className="text-[11px] font-medium text-muted-foreground mb-1 px-3 pt-2">工作文件（存储于该工作区目录）</div>
-                          )}
-                          <FileBrowser rootPath={sessionPath} hideToolbar embedded hideEmpty={hasSessionAttachedItems} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} />
-                        </>
-                        {/* 会话文件拖拽上传区域 */}
-                        <FileDropZone
-                          workspaceSlug={workspaceSlug ?? ''}
-                          sessionId={sessionId}
-                          target="session"
-                          onFilesUploaded={handleFilesUploaded}
-                          onFilesAttached={handleSessionFilesAttached}
-                          onAttachFolder={handleAttachFolder}
-                          onFoldersDropped={handleSessionFoldersDropped}
-                        />
-                      </div>
+                    )}
+                    {attachedDirs.length > 0 && (
+                      <AttachedDirsSection
+                        attachedDirs={attachedDirs}
+                        onDetach={handleDetachDirectory}
+                        refreshVersion={filesVersion}
+                        onAddToChat={handleAddToChat}
+                        onFilePreview={handleFilePreview}
+                        allowedPaths={basePathsRef.current}
+                        sessionId={sessionId}
+                      />
+                    )}
+                    <>
+                      {hasSessionAttachedItems && (
+                        <div className="text-[11px] font-medium text-muted-foreground mb-1 px-3 pt-2">工作文件（存储于该工作区目录）</div>
+                      )}
+                      <FileBrowser rootPath={sessionPath} hideToolbar embedded hideEmpty={hasSessionAttachedItems} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} />
+                    </>
+                    <FileDropZone
+                      workspaceSlug={workspaceSlug ?? ''}
+                      sessionId={sessionId}
+                      target="session"
+                      onFilesUploaded={handleFilesUploaded}
+                      onFilesAttached={handleSessionFilesAttached}
+                      onAttachFolder={handleAttachFolder}
+                      onFoldersDropped={handleSessionFoldersDropped}
+                    />
+                  </div>
+                </>
+              ) : (
+                <div className="flex-1 flex items-center justify-center text-muted-foreground text-xs">等待会话初始化...</div>
+              )}
+            </div>
+          ) : (
+            <div className="flex-1 min-h-0 flex flex-col pt-0.5">
+              <div className="flex-1 min-h-0 flex flex-col mx-2 mb-2">
+                <div className="flex items-center gap-1 px-2 h-[32px] flex-shrink-0">
+                  <FolderHeart className="size-3 text-muted-foreground" />
+                  <span className="text-[11px] font-medium text-muted-foreground">工作区文件</span>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Info className="size-3 text-muted-foreground/50 cursor-help" />
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom" className="max-w-[220px]">
+                      <p>工作区内所有会话可访问的文件和文件夹，每个新对话都可以自动读取</p>
+                    </TooltipContent>
+                  </Tooltip>
+                  <div className="flex-1" />
+                  {workspaceFilesPath && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          className={filePanelActionButtonClass}
+                          onClick={() => window.electronAPI.openFile(workspaceFilesPath).catch(console.error)}
+                        >
+                          <FolderSearch />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom">
+                        <p>在 Finder 中打开工作区文件目录</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+                </div>
+                <FileSearchBar
+                  workspaceFilesPath={workspaceFilesPath}
+                  sessionPath={null}
+                  sessionAttachedDirs={[]}
+                  workspaceAttachedDirs={wsAttachedDirs}
+                  placeholder="搜索工作区文件..."
+                  sessionId={sessionId}
+                  onFilePreview={handleFilePreview}
+                />
+                <div className="flex-1 min-h-0 overflow-y-auto pb-1 scrollbar-thin">
+                  {wsAttachedFiles.length > 0 && (
+                    <AttachedFilesSection
+                      attachedFiles={wsAttachedFiles}
+                      onDetach={handleDetachWorkspaceFile}
+                      onAddToChat={handleAddToChat}
+                      onFilePreview={handleFilePreview}
+                      allowedPaths={basePathsRef.current}
+                      sessionId={sessionId}
+                    />
+                  )}
+                  {wsAttachedDirs.length > 0 && (
+                    <AttachedDirsSection
+                      attachedDirs={wsAttachedDirs}
+                      onDetach={handleDetachWorkspaceDirectory}
+                      refreshVersion={filesVersion}
+                      onAddToChat={handleAddToChat}
+                      onFilePreview={handleFilePreview}
+                      allowedPaths={basePathsRef.current}
+                      sessionId={sessionId}
+                    />
+                  )}
+                  {workspaceFilesPath && (
+                    <>
+                      {hasWorkspaceAttachedItems && (
+                        <div className="text-[11px] font-medium text-muted-foreground mb-1 px-3 pt-2">工作文件（存储于该工作区目录）</div>
+                      )}
+                      <FileBrowser rootPath={workspaceFilesPath} hideToolbar embedded hideEmpty={hasWorkspaceAttachedItems} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} />
                     </>
                   )}
-                  {/* ===== 分隔线 ===== */}
-                  <div className="mx-3 my-3 border-t border-muted-foreground/20" />
-
-                  {/* ===== 工作区文件区 ===== */}
-                  <div className="flex-1 min-h-0 flex flex-col mx-2 mb-2">
-                    <div className="flex items-center gap-1 px-2 h-[32px] flex-shrink-0">
-                      <FolderHeart className="size-3 text-muted-foreground" />
-                      <span className="text-[11px] font-medium text-muted-foreground">工作区文件</span>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Info className="size-3 text-muted-foreground/50 cursor-help" />
-                        </TooltipTrigger>
-                        <TooltipContent side="bottom" className="max-w-[220px]">
-                          <p>工作区内所有会话可访问的文件和文件夹，每个新对话都可以自动读取</p>
-                        </TooltipContent>
-                      </Tooltip>
-                      <div className="flex-1" />
-                      {workspaceFilesPath && (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="icon"
-                              className={filePanelActionButtonClass}
-                              onClick={() => window.electronAPI.openFile(workspaceFilesPath).catch(console.error)}
-                            >
-                              <FolderSearch />
-                            </Button>
-                          </TooltipTrigger>
-                          <TooltipContent side="bottom">
-                            <p>在 Finder 中打开工作区文件目录</p>
-                          </TooltipContent>
-                        </Tooltip>
-                      )}
-                    </div>
-                    {/* ===== 文件搜索栏（工作区） ===== */}
-                    <FileSearchBar
-                      workspaceFilesPath={workspaceFilesPath}
-                      sessionPath={null}
-                      sessionAttachedDirs={[]}
-                      workspaceAttachedDirs={wsAttachedDirs}
-                      placeholder="搜索工作区文件..."
-                      sessionId={sessionId}
-                      onFilePreview={handleFilePreview}
-                    />
-                    {/* 工作区文件内容区（独立滚动） */}
-                    <div className="flex-1 min-h-0 overflow-y-auto pb-1 scrollbar-thin">
-                      {/* 工作区级附加文件 */}
-                      {wsAttachedFiles.length > 0 && (
-                        <AttachedFilesSection
-                          attachedFiles={wsAttachedFiles}
-                          onDetach={handleDetachWorkspaceFile}
-                          onAddToChat={handleAddToChat}
-                          onFilePreview={handleFilePreview}
-                          allowedPaths={basePathsRef.current}
-                          sessionId={sessionId}
-                        />
-                      )}
-                      {/* 工作区级附加目录 */}
-                      {wsAttachedDirs.length > 0 && (
-                        <AttachedDirsSection
-                          attachedDirs={wsAttachedDirs}
-                          onDetach={handleDetachWorkspaceDirectory}
-                          refreshVersion={filesVersion}
-                          onAddToChat={handleAddToChat}
-                          onFilePreview={handleFilePreview}
-                          allowedPaths={basePathsRef.current}
-                          sessionId={sessionId}
-                        />
-                      )}
-                      {/* 工作区文件浏览器 */}
-                      {workspaceFilesPath && (
-                        <>
-                          {hasWorkspaceAttachedItems && (
-                            <div className="text-[11px] font-medium text-muted-foreground mb-1 px-3 pt-2">工作文件（存储于该工作区目录）</div>
-                          )}
-                          <FileBrowser rootPath={workspaceFilesPath} hideToolbar embedded hideEmpty={hasWorkspaceAttachedItems} onAddToChat={handleAddToChat} onFilePreview={handleFilePreview} />
-                        </>
-                      )}
-                      {/* 工作区文件拖拽上传区域 */}
-                      <FileDropZone
-                        workspaceSlug={workspaceSlug ?? ''}
-                        target="workspace"
-                        onFilesUploaded={handleFilesUploaded}
-                        onFilesAttached={handleWorkspaceFilesAttached}
-                        onAttachFolder={handleAttachWorkspaceFolder}
-                        onFoldersDropped={handleWorkspaceFoldersDropped}
-                      />
-                    </div>
-                  </div>
+                  <FileDropZone
+                    workspaceSlug={workspaceSlug ?? ''}
+                    target="workspace"
+                    onFilesUploaded={handleFilesUploaded}
+                    onFilesAttached={handleWorkspaceFilesAttached}
+                    onAttachFolder={handleAttachWorkspaceFolder}
+                    onFoldersDropped={handleWorkspaceFoldersDropped}
+                  />
                 </div>
-              )}
+              </div>
+            </div>
+          )}
         </div>
     </div>
   )

--- a/apps/electron/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/electron/src/renderer/components/app-shell/AppShell.tsx
@@ -18,7 +18,7 @@ import { WindowControls } from '@/components/WindowControls'
 import { detectIsWindows } from '@/lib/platform'
 import { cn } from '@/lib/utils'
 
-const MIN_RIGHT_PANEL_WIDTH = 220
+const MIN_RIGHT_PANEL_WIDTH = 300
 const MAX_RIGHT_PANEL_WIDTH = 420
 
 function clampRightPanelWidth(width: number): number {

--- a/apps/electron/src/renderer/components/app-shell/RightSidePanel.tsx
+++ b/apps/electron/src/renderer/components/app-shell/RightSidePanel.tsx
@@ -3,7 +3,7 @@
  *
  * 在 Agent 模式下显示文件面板，样式与 LeftSidebar 一致。
  * 从全局 atom 读取当前会话 ID 和路径。
- * 管理「工作区文件 / 代码改动」Tab 切换。
+ * 管理「会话文件 / 工作区文件 / 代码改动」Tab 切换。
  */
 
 import * as React from 'react'
@@ -23,7 +23,7 @@ export function RightSidePanel({ width }: { width?: number }): React.ReactElemen
   const diffPanelTabMap = useAtomValue(agentDiffPanelTabAtom)
   const setDiffPanelTabMap = useSetAtom(agentDiffPanelTabAtom)
 
-  const setActiveTab = React.useCallback((tab: 'files' | 'changes') => {
+  const setActiveTab = React.useCallback((tab: 'session' | 'workspace' | 'changes') => {
     if (!currentSessionId) return
     setDiffPanelTabMap((prev) => {
       const map = new Map(prev)
@@ -37,7 +37,7 @@ export function RightSidePanel({ width }: { width?: number }): React.ReactElemen
   }
 
   const sessionPath = sessionPathMap.get(currentSessionId) ?? null
-  const activeTab = diffPanelTabMap.get(currentSessionId) ?? 'files'
+  const activeTab = diffPanelTabMap.get(currentSessionId) ?? 'session'
 
   return (
     <SidePanel

--- a/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
@@ -1,7 +1,7 @@
 /**
  * DiffPanelTabBar — 右侧面板顶部 Tab 栏
  *
- * 切换「工作区文件」和「代码改动」两个视图。最右侧有关闭按钮。
+ * 切换「会话文件」「工作区文件」和「代码改动」三个视图。最右侧有关闭按钮。
  */
 
 import * as React from 'react'
@@ -11,7 +11,7 @@ import { cn } from '@/lib/utils'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { agentDiffUnseenChangesAtom, currentAgentSessionIdAtom } from '@/atoms/agent-atoms'
 
-type DiffPanelTab = 'files' | 'changes'
+type DiffPanelTab = 'session' | 'workspace' | 'changes'
 
 interface DiffPanelTabBarProps {
   activeTab: DiffPanelTab
@@ -63,11 +63,24 @@ export function DiffPanelTabBar({ activeTab, onTabChange, onClose }: DiffPanelTa
       <div className="relative flex items-end flex-1 titlebar-no-drag">
         <button
           type="button"
-          onClick={() => onTabChange('files')}
+          onClick={() => onTabChange('session')}
           className={cn(
             'flex-1 px-3 h-[34px] rounded-t-lg text-xs transition-colors select-none cursor-pointer',
             'border-t border-l border-r',
-            activeTab === 'files'
+            activeTab === 'session'
+              ? 'bg-content-area text-foreground border-border/50'
+              : 'text-muted-foreground border-transparent hover:text-foreground hover:bg-muted/50',
+          )}
+        >
+          会话文件
+        </button>
+        <button
+          type="button"
+          onClick={() => onTabChange('workspace')}
+          className={cn(
+            'flex-1 px-3 h-[34px] rounded-t-lg text-xs transition-colors select-none cursor-pointer',
+            'border-t border-l border-r',
+            activeTab === 'workspace'
               ? 'bg-content-area text-foreground border-border/50'
               : 'text-muted-foreground border-transparent hover:text-foreground hover:bg-muted/50',
           )}
@@ -92,7 +105,7 @@ export function DiffPanelTabBar({ activeTab, onTabChange, onClose }: DiffPanelTa
             文件改动
           </span>
         </button>
-        {/* 右侧关闭按钮（常驻，两个 tab 下都可见） */}
+        {/* 右侧关闭按钮（常驻，三个 tab 下都可见） */}
         {onClose && (
           <Tooltip>
             <TooltipTrigger asChild>


### PR DESCRIPTION
## 背景

当前右侧面板采用上下堆叠布局：顶部是会话文件区，底部是工作区文件区，中间以分隔线隔开。这种布局存在几个问题：

1. **空间利用率低**：两个文件区域同时显示，每个区域的可视高度被压缩，文件树需要频繁滚动
2. **信息密度不均**：会话文件区通常内容较少，但占据了固定高度；工作区文件区内容多，却被压缩
3. **代码改动视图（Diff）与文件浏览视图切换不够直观**：用户需要在文件浏览和代码改动之间切换，但当前切换入口不够明显

## 改动内容

将右侧面板从上下堆叠布局改为**三栏 Tab 切换**布局：

| Tab | 内容 |
|-----|------|
| 会话文件 | 当前会话的专属文件，仅本次 Agent 可访问 |
| 工作区文件 | 工作区内所有会话可共享的文件 |
| 文件改动 | 代码 diff 视图（原有功能） |

### 涉及文件

- **`DiffPanelTabBar.tsx`**：扩展为三栏 Tab 切换（`session` / `workspace` / `changes`）
- **`SidePanel.tsx`**：根据 `activeTab` 条件渲染对应内容，统一页面间距
- **`RightSidePanel.tsx`**：默认 tab 从 `files` 改为 `session`
- **`AppShell.tsx`**：`MIN_RIGHT_PANEL_WIDTH` 从 220 调整为 300，适配三栏宽度
- **`agent-atoms.ts`**：更新 `agentDiffPanelTabAtom` 类型为 `'session' | 'workspace' | 'changes'`

### 设计决策

- **默认显示「会话文件」**：与当前行为一致，用户无需适应新默认
- **最小宽度 300px**：三个 Tab 按钮文字完整显示，避免换行
- **间距对齐**：会话文件区和工作区文件区的标题行、搜索栏、内容区保持一致的 `mx-2 mb-2` 和 `px-2` 间距