### PR TITLE
Fix Agent pinned session ordering

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.10.18",
+  "version": "0.10.19",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/agent/AgentHeader.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentHeader.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { agentSessionsAtom, agentSidePanelOpenAtom, workspaceFilesVersionAtom } from '@/atoms/agent-atoms'
 import { tabsAtom, updateTabTitle } from '@/atoms/tab-atoms'
+import { replaceAgentSessionInFreshnessOrder } from '@/lib/agent-session-list'
 import { registerShortcut } from '@/lib/shortcut-registry'
 
 /** AgentHeader 属性接口 */
@@ -63,9 +64,7 @@ export function AgentHeader({ sessionId }: AgentHeaderProps): React.ReactElement
       // 同步更新标签页标题
       setTabs((prev) => updateTabTitle(prev, updated.id, updated.title))
       // 同步更新侧边栏会话列表
-      setAgentSessions((prev) =>
-        prev.map((s) => (s.id === updated.id ? updated : s))
-      )
+      setAgentSessions((prev) => replaceAgentSessionInFreshnessOrder(prev, updated))
     } catch (error) {
       console.error('[AgentHeader] 更新标题失败:', error)
     }

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -90,6 +90,10 @@ import {
 import { detectIsMac } from '@/lib/platform'
 import { getActiveAccelerator, getAcceleratorDisplay } from '@/lib/shortcut-registry'
 import {
+  replaceAgentSessionInFreshnessOrder,
+  sortAgentSessionsByUpdatedAtDesc,
+} from '@/lib/agent-session-list'
+import {
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
@@ -541,7 +545,16 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
 
   /** 置顶 Agent 会话列表（仅活跃模式显示，按当前工作区过滤，排除 draft 和 Working） */
   const pinnedAgentSessions = React.useMemo(
-    () => viewMode === 'active' ? agentSessions.filter((s) => s.pinned && !draftSessionIds.has(s.id) && !workingSessionIds.has(s.id) && (!currentWorkspaceId || s.workspaceId === currentWorkspaceId)) : [],
+    () => {
+      if (viewMode !== 'active') return []
+      const filtered = agentSessions.filter((s) =>
+        s.pinned
+        && !draftSessionIds.has(s.id)
+        && !workingSessionIds.has(s.id)
+        && (!currentWorkspaceId || s.workspaceId === currentWorkspaceId)
+      )
+      return sortAgentSessionsByUpdatedAtDesc(filtered)
+    },
     [agentSessions, viewMode, draftSessionIds, currentWorkspaceId, workingSessionIds]
   )
 
@@ -851,9 +864,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   const handleAgentRename = React.useCallback(async (id: string, newTitle: string): Promise<void> => {
     try {
       const updated = await window.electronAPI.updateAgentSessionTitle(id, newTitle)
-      setAgentSessions((prev) =>
-        prev.map((s) => (s.id === updated.id ? updated : s))
-      )
+      setAgentSessions((prev) => replaceAgentSessionInFreshnessOrder(prev, updated))
       // 同步更新标签页标题
       setTabs((prev) => updateTabTitle(prev, id, newTitle))
     } catch (error) {
@@ -866,12 +877,20 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     try {
       const original = store.get(agentSessionsAtom).find((s) => s.id === id)
       const updated = await window.electronAPI.togglePinAgentSession(id)
-      setAgentSessions((prev) =>
-        prev.map((s) => (s.id === updated.id ? updated : s))
-      )
-      // 归档会话被置顶时会自动取消归档
-      if (original?.archived && updated.pinned && !updated.archived) {
-        toast.success('已取消归档并置顶')
+      setAgentSessions((prev) => replaceAgentSessionInFreshnessOrder(prev, updated))
+      if (updated.pinned) {
+        const isRunning = store.get(agentSessionIndicatorMapAtom).get(id) === 'running'
+        if (isRunning) {
+          toast.success('已置顶', {
+            description: '当前 Agent 正在执行中，移出工作中后会显示到置顶区域',
+          })
+        } else if (original?.archived && !updated.archived) {
+          toast.success('已置顶', { description: '已自动取消归档' })
+        } else {
+          toast.success('已置顶')
+        }
+      } else {
+        toast.success('已取消置顶')
       }
     } catch (error) {
       console.error('[侧边栏] 切换 Agent 会话置顶失败:', error)
@@ -887,9 +906,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         const session = store.get(agentSessionsAtom).find((s) => s.id === id)
         if (session?.manualWorking) {
           const updated = await window.electronAPI.toggleManualWorkingAgentSession(id)
-          setAgentSessions((prev) =>
-            prev.map((s) => (s.id === updated.id ? updated : s))
-          )
+          setAgentSessions((prev) => replaceAgentSessionInFreshnessOrder(prev, updated))
         }
         setWorkingDone((prev) => {
           if (!prev.has(id)) return prev
@@ -901,9 +918,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         // 加入工作中
         const original = store.get(agentSessionsAtom).find((s) => s.id === id)
         const updated = await window.electronAPI.toggleManualWorkingAgentSession(id)
-        setAgentSessions((prev) =>
-          prev.map((s) => (s.id === updated.id ? updated : s))
-        )
+        setAgentSessions((prev) => replaceAgentSessionInFreshnessOrder(prev, updated))
         if (original?.archived && updated.manualWorking && !updated.archived) {
           toast.success('已取消归档并标记为工作中')
         }
@@ -920,9 +935,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       const session = store.get(agentSessionsAtom).find((s) => s.id === id)
       if (session?.manualWorking) {
         const updated = await window.electronAPI.toggleManualWorkingAgentSession(id)
-        setAgentSessions((prev) =>
-          prev.map((s) => (s.id === updated.id ? updated : s))
-        )
+        setAgentSessions((prev) => replaceAgentSessionInFreshnessOrder(prev, updated))
       }
 
       setWorkingDone((prev) => {
@@ -951,9 +964,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   const handleToggleArchiveAgent = React.useCallback(async (id: string): Promise<void> => {
     try {
       const updated = await window.electronAPI.toggleArchiveAgentSession(id)
-      setAgentSessions((prev) =>
-        prev.map((s) => (s.id === updated.id ? updated : s))
-      )
+      setAgentSessions((prev) => replaceAgentSessionInFreshnessOrder(prev, updated))
       // 归档时自动关闭该会话的标签页，并同步新激活标签的副作用，
       // 否则 RightSidePanel（依赖 currentAgentSessionIdAtom）会因为
       // 指针被错误置 null 而消失。
@@ -992,9 +1003,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
 
   /** 迁移会话到另一个工作区后的回调 */
   const handleSessionMoved = (updatedSession: AgentSessionMeta, targetWorkspaceName: string): void => {
-    setAgentSessions((prev) =>
-      prev.map((s) => (s.id === updatedSession.id ? updatedSession : s))
-    )
+    setAgentSessions((prev) => replaceAgentSessionInFreshnessOrder(prev, updatedSession))
     // 如果迁移的是当前选中的会话，取消选中并关闭标签页
     if (currentAgentSessionId === updatedSession.id) {
       const tabResult = closeTab(tabs, activeTabId, updatedSession.id)
@@ -1019,9 +1028,10 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   const filteredAgentSessions = React.useMemo(
     () => {
       const byWorkspace = agentSessions.filter((s) => s.workspaceId === currentWorkspaceId && !draftSessionIds.has(s.id))
-      return viewMode === 'archived'
+      const filtered = viewMode === 'archived'
         ? byWorkspace.filter((s) => s.archived)
         : byWorkspace.filter((s) => !s.archived && !s.pinned && !workingSessionIds.has(s.id))
+      return sortAgentSessionsByUpdatedAtDesc(filtered)
     },
     [agentSessions, currentWorkspaceId, viewMode, draftSessionIds, workingSessionIds]
   )

--- a/apps/electron/src/renderer/lib/agent-session-list.ts
+++ b/apps/electron/src/renderer/lib/agent-session-list.ts
@@ -1,0 +1,17 @@
+import type { AgentSessionMeta } from '@proma/shared'
+
+/** 按最近更新时间排序 Agent 会话，保持与主进程 listAgentSessions 一致。 */
+export function sortAgentSessionsByUpdatedAtDesc(
+  sessions: readonly AgentSessionMeta[],
+): AgentSessionMeta[] {
+  return [...sessions].sort((a, b) => b.updatedAt - a.updatedAt)
+}
+
+/** 用后端返回的新元数据替换本地条目，并按最近更新时间重新排序。 */
+export function replaceAgentSessionInFreshnessOrder(
+  sessions: readonly AgentSessionMeta[],
+  updated: AgentSessionMeta,
+): AgentSessionMeta[] {
+  const others = sessions.filter((session) => session.id !== updated.id)
+  return sortAgentSessionsByUpdatedAtDesc([updated, ...others])
+}

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.10.18",
+      "version": "0.10.19",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.153",
         "@anthropic-ai/sdk": "^0.93.0",


### PR DESCRIPTION
## Summary
Fixes Agent pinned sessions not immediately surfacing when more than three sessions are pinned by keeping renderer lists in the same `updatedAt` order as the main process.
Adds success toasts for pin and unpin, including a running-Agent note that pinned sessions appear after leaving Working.
Bumps `@proma/electron` to `0.10.19`.

## Validation
- `bun run --filter='@proma/electron' typecheck`
- `git diff --check`
