### PR TITLE
Fix Ctrl+Tab MRU switching

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.10.18",
+  "version": "0.10.19",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/tabs/TabSwitcher.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabSwitcher.tsx
@@ -13,8 +13,10 @@ import { cn } from '@/lib/utils'
 import {
   activeTabIdAtom,
   openTab,
+  tabMruAtom,
   tabsAtom,
 } from '@/atoms/tab-atoms'
+import { getInitialTabSwitchIndex, promoteTabMru } from '@/lib/tab-switching'
 import { appModeAtom } from '@/atoms/app-mode'
 import {
   conversationsAtom,
@@ -63,6 +65,8 @@ export function TabSwitcher(): ReactElement | null {
   const setTabs = useSetAtom(tabsAtom)
   const activeTabId = useAtomValue(activeTabIdAtom)
   const setActiveTabId = useSetAtom(activeTabIdAtom)
+  const tabMru = useAtomValue(tabMruAtom)
+  const setTabMru = useSetAtom(tabMruAtom)
 
   const conversations = useAtomValue(conversationsAtom)
   const streamingConversationIds = useAtomValue(streamingConversationIdsAtom)
@@ -161,13 +165,23 @@ export function TabSwitcher(): ReactElement | null {
   const selectedIndexRef = useRef(0)
   const activeTabIdRef = useRef<string | null>(activeTabId)
   const candidatesRef = useRef<SwitchCandidate[]>(switcherModel.candidates)
+  const tabMruRef = useRef<string[]>(tabMru)
   const tabsRef = useRef(tabs)
 
   isOpenRef.current = isOpen
   selectedIndexRef.current = selectedIndex
   activeTabIdRef.current = activeTabId
   candidatesRef.current = switcherModel.candidates
+  tabMruRef.current = tabMru
   tabsRef.current = tabs
+
+  useEffect(() => {
+    setTabMru((prev) => {
+      const next = promoteTabMru(prev, activeTabId)
+      tabMruRef.current = next
+      return next
+    })
+  }, [activeTabId, setTabMru])
 
   const closeSwitcher = useCallback((): void => {
     setIsOpen(false)
@@ -183,6 +197,12 @@ export function TabSwitcher(): ReactElement | null {
       })
       setTabs(nextTab.tabs)
       setActiveTabId(nextTab.activeTabId)
+      activeTabIdRef.current = nextTab.activeTabId
+      setTabMru((prev) => {
+        const next = promoteTabMru(prev, nextTab.activeTabId)
+        tabMruRef.current = next
+        return next
+      })
 
       if (candidate.type === 'chat') {
         setAppMode('chat')
@@ -215,6 +235,7 @@ export function TabSwitcher(): ReactElement | null {
       setCurrentAgentSessionId,
       setCurrentAgentWorkspaceId,
       setCurrentConversationId,
+      setTabMru,
       setTabs,
       setUnviewedCompleted,
     ],
@@ -228,10 +249,12 @@ export function TabSwitcher(): ReactElement | null {
   useEffect(() => {
     const getNextIndex = (direction: 1 | -1): number => {
       const candidates = candidatesRef.current
-      if (candidates.length === 0) return -1
-      const currentIndex = candidates.findIndex((candidate) => candidate.id === activeTabIdRef.current)
-      if (currentIndex === -1) return direction === 1 ? 0 : candidates.length - 1
-      return (currentIndex + direction + candidates.length) % candidates.length
+      return getInitialTabSwitchIndex(
+        candidates,
+        activeTabIdRef.current,
+        tabMruRef.current,
+        direction,
+      )
     }
 
     const hasAlternateTarget = (): boolean => {

--- a/apps/electron/src/renderer/lib/tab-switching.ts
+++ b/apps/electron/src/renderer/lib/tab-switching.ts
@@ -1,0 +1,60 @@
+const DEFAULT_TAB_MRU_LIMIT = 50
+
+interface TabSwitchCandidate {
+  id: string
+}
+
+function arraysEqual(left: readonly string[], right: readonly string[]): boolean {
+  if (left.length !== right.length) return false
+  return left.every((value, index) => value === right[index])
+}
+
+/** 将当前 Tab 提升到最近访问队首，用于 Ctrl+Tab 在最近两个 Tab 间快速往返。 */
+export function promoteTabMru(
+  mru: string[],
+  tabId: string | null,
+  limit = DEFAULT_TAB_MRU_LIMIT,
+): string[] {
+  if (!tabId) return mru
+
+  const next = [
+    tabId,
+    ...mru.filter((id) => id !== tabId),
+  ].slice(0, Math.max(1, limit))
+
+  return arraysEqual(mru, next) ? mru : next
+}
+
+/** 按 MRU 重新计算 Ctrl+Tab 首次命中的候选项，再映射回当前展示列表的 index。 */
+export function getInitialTabSwitchIndex<T extends TabSwitchCandidate>(
+  candidates: readonly T[],
+  activeTabId: string | null,
+  mru: readonly string[],
+  direction: 1 | -1,
+): number {
+  if (candidates.length === 0) return -1
+
+  const candidateIds = new Set(candidates.map((candidate) => candidate.id))
+  const orderedIds: string[] = []
+  const seenIds = new Set<string>()
+
+  for (const id of mru) {
+    if (!candidateIds.has(id) || seenIds.has(id)) continue
+    orderedIds.push(id)
+    seenIds.add(id)
+  }
+
+  for (const candidate of candidates) {
+    if (seenIds.has(candidate.id)) continue
+    orderedIds.push(candidate.id)
+    seenIds.add(candidate.id)
+  }
+
+  const activeIndex = activeTabId ? orderedIds.indexOf(activeTabId) : -1
+  const targetOrderIndex = activeIndex === -1
+    ? direction === 1 ? 0 : orderedIds.length - 1
+    : (activeIndex + direction + orderedIds.length) % orderedIds.length
+  const targetId = orderedIds[targetOrderIndex]
+
+  return candidates.findIndex((candidate) => candidate.id === targetId)
+}


### PR DESCRIPTION
## Summary
Fixes Ctrl+Tab so after switching from one tab to another, the next Ctrl+Tab recalculates from the updated active tab and can quickly toggle back.
The switcher now maintains an MRU order in Jotai and uses a small pure helper to choose the initial target while preserving the existing visual candidate order.
Bumped @proma/electron to 0.10.19 and removed the test file per request.

## Validation
- bun run typecheck