### PR TITLE
Preview files in session tabs

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.10.18",
+  "version": "0.10.19",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/atoms/tab-atoms.ts
+++ b/apps/electron/src/renderer/atoms/tab-atoms.ts
@@ -143,9 +143,12 @@ export function createPreviewTabId(sessionId: string): string {
   return `${PREVIEW_TAB_PREFIX}${sessionId}`
 }
 
+export function getFileBaseName(filePath: string): string {
+  return filePath.split(/[\\/]/).filter(Boolean).pop() || filePath
+}
+
 export function getPreviewTabTitle(filePath: string): string {
-  const fileName = filePath.split(/[\\/]/).filter(Boolean).pop() || filePath
-  return `预览：${fileName}`
+  return `预览：${getFileBaseName(filePath)}`
 }
 
 export function isPreviewTab(tab: TabItem): boolean {

--- a/apps/electron/src/renderer/atoms/tab-atoms.ts
+++ b/apps/electron/src/renderer/atoms/tab-atoms.ts
@@ -21,10 +21,13 @@ import type { SessionIndicatorStatus } from './agent-atoms'
 // ===== 类型定义 =====
 
 /** 标签页类型（Settings 不作为 Tab，保留独立视图） */
-export type TabType = 'chat' | 'agent' | 'scratch'
+export type TabType = 'chat' | 'agent' | 'scratch' | 'preview'
 
 /** Scratch Pad 专用的固定 sessionId */
 export const SCRATCH_PAD_ID = '__scratch-pad__'
+
+/** 会话预览 Tab 的 ID 前缀：运行时临时入口，不参与持久化 */
+const PREVIEW_TAB_PREFIX = '__preview__:'
 
 /** Scratch Pad 标签默认标题 */
 export const SCRATCH_PAD_TITLE = 'Scratch Pad'
@@ -136,6 +139,45 @@ function createScratchPadTab(): TabItem {
   }
 }
 
+export function createPreviewTabId(sessionId: string): string {
+  return `${PREVIEW_TAB_PREFIX}${sessionId}`
+}
+
+export function getPreviewTabTitle(filePath: string): string {
+  const fileName = filePath.split(/[\\/]/).filter(Boolean).pop() || filePath
+  return `预览：${fileName}`
+}
+
+export function isPreviewTab(tab: TabItem): boolean {
+  return tab.type === 'preview' || tab.id.startsWith(PREVIEW_TAB_PREFIX)
+}
+
+function isSessionTab(tab: TabItem): boolean {
+  return tab.type === 'chat' || tab.type === 'agent'
+}
+
+function getPersistentTabs(tabs: TabItem[]): TabItem[] {
+  return tabs.filter((tab) => tab.id !== SCRATCH_PAD_ID && !isPreviewTab(tab))
+}
+
+export function getPersistableTabState(
+  tabs: TabItem[],
+  activeTabId: string | null,
+): PersistedTabState {
+  const persistentTabs = getPersistentTabs(tabs)
+  const activeTab = activeTabId ? tabs.find((tab) => tab.id === activeTabId) : null
+  const persistentActiveTabId = activeTab && isPreviewTab(activeTab)
+    ? persistentTabs.find((tab) => tab.sessionId === activeTab.sessionId && tab.type === 'agent')?.id
+      ?? persistentTabs.at(-1)?.id
+      ?? null
+    : activeTabId
+
+  return {
+    tabs: persistentTabs,
+    activeTabId: persistentActiveTabId,
+  }
+}
+
 /** 打开或聚焦会话入口：始终用目标会话替换当前会话，避免顶部累积多个 Tab */
 export function openTab(
   tabs: TabItem[],
@@ -147,6 +189,26 @@ export function openTab(
     return {
       tabs: [scratchTab],
       activeTabId: SCRATCH_PAD_ID,
+    }
+  }
+
+  if (item.type === 'preview') {
+    const ownerAgentTab = tabs.find((t) => t.type === 'agent' && t.sessionId === item.sessionId) ?? {
+      id: item.sessionId,
+      type: 'agent' as const,
+      sessionId: item.sessionId,
+      title: 'Agent 会话',
+    }
+    const previewTab: TabItem = {
+      id: createPreviewTabId(item.sessionId),
+      type: 'preview',
+      sessionId: item.sessionId,
+      title: item.title,
+    }
+
+    return {
+      tabs: [scratchTab, ownerAgentTab, previewTab],
+      activeTabId: previewTab.id,
     }
   }
 
@@ -183,12 +245,14 @@ export function closeTab(
 
   const tabIndex = tabs.findIndex((t) => t.id === tabId)
   if (tabIndex === -1) return { tabs, activeTabId }
+  const closingTab = tabs[tabIndex]!
+  const boundPreviewId = isSessionTab(closingTab) ? createPreviewTabId(closingTab.sessionId) : null
 
-  const newTabs = tabs.filter((t) => t.id !== tabId)
+  const newTabs = tabs.filter((t) => t.id !== tabId && (!boundPreviewId || t.id !== boundPreviewId))
 
   // 如果关闭的是当前激活的标签，切换到相邻标签
   let newActiveTabId = activeTabId
-  if (activeTabId === tabId) {
+  if (activeTabId === tabId || (boundPreviewId !== null && activeTabId === boundPreviewId)) {
     if (newTabs.length > 0) {
       const nextIndex = Math.min(tabIndex, newTabs.length - 1)
       newActiveTabId = newTabs[nextIndex]!.id
@@ -222,14 +286,14 @@ export function updateTabTitle(
   title: string,
 ): TabItem[] {
   return tabs.map((t) =>
-    t.sessionId === sessionId ? { ...t, title } : t
+    t.sessionId === sessionId && !isPreviewTab(t) ? { ...t, title } : t
   )
 }
 
 /** 确保 Scratch Pad 标签存在并位于首位，同时只保留一个会话入口 */
 export function ensureScratchPadTab(tabs: TabItem[]): TabItem[] {
   const scratchTab = tabs.find((t) => t.id === SCRATCH_PAD_ID)
-  const sessionTab = tabs.filter((t) => t.id !== SCRATCH_PAD_ID).at(-1)
+  const sessionTab = tabs.filter((t) => t.id !== SCRATCH_PAD_ID && !isPreviewTab(t)).at(-1)
   if (scratchTab) {
     return sessionTab ? [scratchTab, sessionTab] : [scratchTab]
   }

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -95,6 +95,7 @@ import { useOpenSession } from '@/hooks/useOpenSession'
 import { AgentSessionProvider } from '@/contexts/session-context'
 import { draftSessionIdsAtom } from '@/atoms/draft-session-atoms'
 import { sendWithCmdEnterAtom } from '@/atoms/shortcut-atoms'
+import { activeTabIdAtom, getPreviewTabTitle, openTab, tabsAtom } from '@/atoms/tab-atoms'
 import type { AgentSendInput, AgentPendingFile, FileDialogLargeFile, ModelOption, SDKMessage } from '@proma/shared'
 import { MAX_ATTACHMENT_SIZE } from '@proma/shared'
 import { fileToBase64, formatFileNames, getFileParentPath } from '@/lib/file-utils'
@@ -993,12 +994,19 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     })
     store.set(previewPanelOpenMapAtom, (prev) => {
       const m = new Map(prev)
-      m.set(sessionId, true)
+      m.set(sessionId, false)
       return m
     })
+    const result = openTab(store.get(tabsAtom), {
+      type: 'preview',
+      sessionId,
+      title: getPreviewTabTitle(filePath),
+    })
+    store.set(tabsAtom, result.tabs)
+    store.set(activeTabIdAtom, result.activeTabId)
   }, [sessionId, setPreviewFileMap, store])
 
-  /** 点击 clipboard 附件时，在右侧预览面板中显示内容 */
+  /** 点击 clipboard 附件时，在当前会话的临时预览标签页中显示内容 */
   const handleClipboardPreview = React.useCallback(async (file: AgentPendingFile) => {
     if (file.sourcePath) {
       openClipboardPreviewFile(file.sourcePath)

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -33,7 +33,8 @@ import {
   agentDiffRefreshVersionAtom,
   fileBrowserAutoRevealAtom,
 } from '@/atoms/agent-atoms'
-import { previewPanelOpenMapAtom, previewFileMapAtom } from '@/atoms/preview-atoms'
+import { previewPanelOpenMapAtom, previewFileMapAtom, type PreviewFile } from '@/atoms/preview-atoms'
+import { activeTabIdAtom, getPreviewTabTitle, openTab, tabsAtom } from '@/atoms/tab-atoms'
 import { detectIsWindows } from '@/lib/platform'
 import type { FileEntry, AgentPendingFile } from '@proma/shared'
 
@@ -67,32 +68,49 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   // Tab 系统
   const previewFileMap = useAtomValue(previewFileMapAtom)
   const selectedFilePath = previewFileMap.get(sessionId)?.filePath
+  const tabs = useAtomValue(tabsAtom)
 
   // 预览面板 atoms
   const setPreviewFileMap = useSetAtom(previewFileMapAtom)
   const setPreviewOpenMap = useSetAtom(previewPanelOpenMapAtom)
+  const setTabs = useSetAtom(tabsAtom)
+  const setActiveTabId = useSetAtom(activeTabIdAtom)
 
   // 用 ref 存 basePaths 相关值，避免声明顺序问题
   const basePathsRef = React.useRef<string[]>([])
 
+  const openPreviewTabForFile = React.useCallback((file: PreviewFile) => {
+    setPreviewFileMap((prev) => {
+      const m = new Map(prev)
+      m.set(sessionId, file)
+      return m
+    })
+    setPreviewOpenMap((prev) => { const m = new Map(prev); m.set(sessionId, false); return m })
+    const result = openTab(tabs, {
+      type: 'preview',
+      sessionId,
+      title: getPreviewTabTitle(file.filePath),
+    })
+    setTabs(result.tabs)
+    setActiveTabId(result.activeTabId)
+  }, [sessionId, setActiveTabId, setPreviewFileMap, setPreviewOpenMap, setTabs, tabs])
+
   const handleFilePreview = React.useCallback((filePath: string) => {
     const bp = basePathsRef.current
-    setPreviewFileMap((prev) => {
-      const m = new Map(prev)
-      m.set(sessionId, { filePath, previewOnly: true, basePaths: bp.length > 0 ? bp : undefined })
-      return m
+    openPreviewTabForFile({
+      filePath,
+      previewOnly: true,
+      basePaths: bp.length > 0 ? bp : undefined,
     })
-    setPreviewOpenMap((prev) => { const m = new Map(prev); m.set(sessionId, true); return m })
-  }, [sessionId, setPreviewFileMap, setPreviewOpenMap])
+  }, [openPreviewTabForFile])
 
   const handleDiffFileClick = React.useCallback((filePath: string, _isUntracked: boolean, gitRoot?: string) => {
-    setPreviewFileMap((prev) => {
-      const m = new Map(prev)
-      m.set(sessionId, { filePath, dirPath: sessionPath || undefined, gitRoot })
-      return m
+    openPreviewTabForFile({
+      filePath,
+      dirPath: sessionPath || undefined,
+      gitRoot,
     })
-    setPreviewOpenMap((prev) => { const m = new Map(prev); m.set(sessionId, true); return m })
-  }, [sessionId, sessionPath, setPreviewFileMap, setPreviewOpenMap])
+  }, [openPreviewTabForFile, sessionPath])
 
   // 动画标志：isOpen 变化时启用过渡动画，切换会话时即时显示
   const prevIsOpenRef = React.useRef(isOpen)

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -6,7 +6,7 @@
  */
 
 import * as React from 'react'
-import { useAtom, useAtomValue, useSetAtom } from 'jotai'
+import { useAtom, useAtomValue, useSetAtom, useStore } from 'jotai'
 import { X, FolderOpen, ExternalLink, ChevronRight, MoreHorizontal, FolderSearch, Pencil, FolderInput, Info, FolderHeart, MessageSquarePlus } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -68,13 +68,11 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   // Tab 系统
   const previewFileMap = useAtomValue(previewFileMapAtom)
   const selectedFilePath = previewFileMap.get(sessionId)?.filePath
-  const tabs = useAtomValue(tabsAtom)
+  const store = useStore()
 
   // 预览面板 atoms
   const setPreviewFileMap = useSetAtom(previewFileMapAtom)
   const setPreviewOpenMap = useSetAtom(previewPanelOpenMapAtom)
-  const setTabs = useSetAtom(tabsAtom)
-  const setActiveTabId = useSetAtom(activeTabIdAtom)
 
   // 用 ref 存 basePaths 相关值，避免声明顺序问题
   const basePathsRef = React.useRef<string[]>([])
@@ -86,14 +84,14 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
       return m
     })
     setPreviewOpenMap((prev) => { const m = new Map(prev); m.set(sessionId, false); return m })
-    const result = openTab(tabs, {
+    const result = openTab(store.get(tabsAtom), {
       type: 'preview',
       sessionId,
       title: getPreviewTabTitle(file.filePath),
     })
-    setTabs(result.tabs)
-    setActiveTabId(result.activeTabId)
-  }, [sessionId, setActiveTabId, setPreviewFileMap, setPreviewOpenMap, setTabs, tabs])
+    store.set(tabsAtom, result.tabs)
+    store.set(activeTabIdAtom, result.activeTabId)
+  }, [sessionId, setPreviewFileMap, setPreviewOpenMap, store])
 
   const handleFilePreview = React.useCallback((filePath: string) => {
     const bp = basePathsRef.current

--- a/apps/electron/src/renderer/components/agent/tool-result-renderers/preview-open-button.tsx
+++ b/apps/electron/src/renderer/components/agent/tool-result-renderers/preview-open-button.tsx
@@ -3,13 +3,14 @@
  *
  * 显示在工具结果预览区域（Read/Edit/Write）的 chevron 旁边，
  * 使用 span 避免嵌套 button 的 HTML 问题，
- * 点击后将文件内容在右侧 PreviewPanel 中以完整视图打开。
+ * 点击后将文件内容在当前会话的临时预览标签页中打开。
  */
 
 import * as React from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { previewFileMapAtom, previewPanelOpenMapAtom } from '@/atoms/preview-atoms'
 import { currentAgentSessionIdAtom } from '@/atoms/agent-atoms'
+import { activeTabIdAtom, getPreviewTabTitle, openTab, tabsAtom } from '@/atoms/tab-atoms'
 import { cn } from '@/lib/utils'
 
 interface PreviewOpenButtonProps {
@@ -19,8 +20,11 @@ interface PreviewOpenButtonProps {
 
 export function PreviewOpenButton({ filePath, className }: PreviewOpenButtonProps): React.ReactElement | null {
   const sessionId = useAtomValue(currentAgentSessionIdAtom)
+  const tabs = useAtomValue(tabsAtom)
   const setPreviewFile = useSetAtom(previewFileMapAtom)
   const setPreviewOpen = useSetAtom(previewPanelOpenMapAtom)
+  const setTabs = useSetAtom(tabsAtom)
+  const setActiveTabId = useSetAtom(activeTabIdAtom)
 
   if (!sessionId || !filePath) return null
 
@@ -32,9 +36,16 @@ export function PreviewOpenButton({ filePath, className }: PreviewOpenButtonProp
     })
     setPreviewOpen((prev) => {
       const next = new Map(prev)
-      next.set(sessionId, true)
+      next.set(sessionId, false)
       return next
     })
+    const result = openTab(tabs, {
+      type: 'preview',
+      sessionId,
+      title: getPreviewTabTitle(filePath),
+    })
+    setTabs(result.tabs)
+    setActiveTabId(result.activeTabId)
   }
 
   return (
@@ -59,7 +70,7 @@ export function PreviewOpenButton({ filePath, className }: PreviewOpenButtonProp
           handleOpen()
         }
       }}
-      title="在预览面板中打开"
+      title="在预览标签页中打开"
     >
       预览
     </span>

--- a/apps/electron/src/renderer/components/agent/tool-result-renderers/preview-open-button.tsx
+++ b/apps/electron/src/renderer/components/agent/tool-result-renderers/preview-open-button.tsx
@@ -7,7 +7,7 @@
  */
 
 import * as React from 'react'
-import { useAtomValue, useSetAtom } from 'jotai'
+import { useAtomValue, useSetAtom, useStore } from 'jotai'
 import { previewFileMapAtom, previewPanelOpenMapAtom } from '@/atoms/preview-atoms'
 import { currentAgentSessionIdAtom } from '@/atoms/agent-atoms'
 import { activeTabIdAtom, getPreviewTabTitle, openTab, tabsAtom } from '@/atoms/tab-atoms'
@@ -20,11 +20,9 @@ interface PreviewOpenButtonProps {
 
 export function PreviewOpenButton({ filePath, className }: PreviewOpenButtonProps): React.ReactElement | null {
   const sessionId = useAtomValue(currentAgentSessionIdAtom)
-  const tabs = useAtomValue(tabsAtom)
+  const store = useStore()
   const setPreviewFile = useSetAtom(previewFileMapAtom)
   const setPreviewOpen = useSetAtom(previewPanelOpenMapAtom)
-  const setTabs = useSetAtom(tabsAtom)
-  const setActiveTabId = useSetAtom(activeTabIdAtom)
 
   if (!sessionId || !filePath) return null
 
@@ -39,13 +37,13 @@ export function PreviewOpenButton({ filePath, className }: PreviewOpenButtonProp
       next.set(sessionId, false)
       return next
     })
-    const result = openTab(tabs, {
+    const result = openTab(store.get(tabsAtom), {
       type: 'preview',
       sessionId,
       title: getPreviewTabTitle(filePath),
     })
-    setTabs(result.tabs)
-    setActiveTabId(result.activeTabId)
+    store.set(tabsAtom, result.tabs)
+    store.set(activeTabIdAtom, result.activeTabId)
   }
 
   return (

--- a/apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx
@@ -3,7 +3,7 @@
  *
  * 在 Agent 消息中检测到文件路径时，渲染为可点击的芯片。
  * 支持绝对路径和相对路径（相对于 basePath 解析）。
- * 点击后在右侧内联面板中预览文件。
+ * 点击后在当前会话的临时预览标签页中打开文件。
  */
 
 import * as React from 'react'
@@ -12,6 +12,7 @@ import { cn } from '@/lib/utils'
 import { FileTypeIcon } from '@/components/file-browser/FileTypeIcon'
 import { previewFileMapAtom, previewPanelOpenMapAtom } from '@/atoms/preview-atoms'
 import { currentAgentSessionIdAtom } from '@/atoms/agent-atoms'
+import { activeTabIdAtom, getPreviewTabTitle, openTab, tabsAtom } from '@/atoms/tab-atoms'
 
 /** 文件存在性缓存（模块级共享，避免重复 IPC）。key = filePath + basePaths */
 const fileExistsCache = new Map<string, boolean>()
@@ -171,9 +172,16 @@ export function FilePathChip({ filePath, basePath, basePaths, className }: FileP
     })
     store.set(previewPanelOpenMapAtom, (prev) => {
       const m = new Map(prev)
-      m.set(sessionId, true)
+      m.set(sessionId, false)
       return m
     })
+    const result = openTab(store.get(tabsAtom), {
+      type: 'preview',
+      sessionId,
+      title: getPreviewTabTitle(cleanPath),
+    })
+    store.set(tabsAtom, result.tabs)
+    store.set(activeTabIdAtom, result.activeTabId)
   }, [store, cleanPath, candidateBases])
 
   return (

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -189,9 +189,11 @@ interface DiffTabContentProps {
   basePaths?: string[]
   /** diff 模式下检测到内容为空（无差异）时回调，用于自动关闭预览面板 */
   onEmptyDiff?: () => void
+  /** 由外层场景注入的额外工具按钮，例如默认应用打开、返回会话 */
+  toolbarActions?: React.ReactNode
 }
 
-export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewOnly, readOnly, basePaths, onEmptyDiff }: DiffTabContentProps): React.ReactElement {
+export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewOnly, readOnly, basePaths, onEmptyDiff, toolbarActions }: DiffTabContentProps): React.ReactElement {
   const [viewMode, setViewMode] = useAtom(agentDiffViewModeAtom)
   const [oldContent, setOldContent] = React.useState('')
   const [newContent, setNewContent] = React.useState('')
@@ -1017,6 +1019,8 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
         >
           <RefreshCw className="size-3.5" />
         </button>
+
+        {toolbarActions}
       </div>
 
       <div className="relative flex-1 min-h-0">

--- a/apps/electron/src/renderer/components/diff/PreviewPanel.tsx
+++ b/apps/electron/src/renderer/components/diff/PreviewPanel.tsx
@@ -17,6 +17,12 @@ import {
   agentSessionPathMapAtom,
   currentSessionSidePanelOpenAtom,
 } from '@/atoms/agent-atoms'
+import {
+  activeTabIdAtom,
+  getPreviewTabTitle,
+  openTab,
+  tabsAtom,
+} from '@/atoms/tab-atoms'
 import { getActiveAccelerator, getAcceleratorDisplay } from '@/lib/shortcut-registry'
 import { detectIsWindows } from '@/lib/platform'
 import { cn } from '@/lib/utils'
@@ -33,6 +39,9 @@ const WINDOWS_WINDOW_CONTROLS_SAFE_AREA = 126
 export function PreviewPanel({ sessionId }: PreviewPanelProps): React.ReactElement {
   const fileMap = useAtomValue(previewFileMapAtom)
   const setOpenMap = useSetAtom(previewPanelOpenMapAtom)
+  const tabs = useAtomValue(tabsAtom)
+  const setTabs = useSetAtom(tabsAtom)
+  const setActiveTabId = useSetAtom(activeTabIdAtom)
   const isSidePanelOpen = useAtomValue(currentSessionSidePanelOpenAtom)
 
   const currentFile = fileMap.get(sessionId) ?? null
@@ -46,23 +55,21 @@ export function PreviewPanel({ sessionId }: PreviewPanelProps): React.ReactEleme
     setOpenMap((prev) => { const m = new Map(prev); m.set(sessionId, false); return m })
   }, [sessionId, setOpenMap])
 
-  const handleOpenDetachedPreview = React.useCallback(() => {
+  const handleOpenPreviewTab = React.useCallback(() => {
     if (!currentFile) return
-    const lastSep = Math.max(currentFile.filePath.lastIndexOf('/'), currentFile.filePath.lastIndexOf('\\'))
-    const fallbackDirPath = lastSep > 0 ? currentFile.filePath.slice(0, lastSep) : sessionPath
-    window.electronAPI.openDetachedPreview({
+    const result = openTab(tabs, {
+      type: 'preview',
       sessionId,
-      filePath: currentFile.filePath,
-      dirPath: currentFile.dirPath || sessionPath || fallbackDirPath,
-      gitRoot: currentFile.gitRoot,
-      previewOnly: currentFile.previewOnly,
-      readOnly: currentFile.readOnly,
-      basePaths: currentFile.basePaths,
-      title: currentFile.filePath.split(/[\\/]/).pop(),
-    }).catch((err) => {
-      console.error('[PreviewPanel] 打开独立预览窗口失败:', err)
+      title: getPreviewTabTitle(currentFile.filePath),
     })
-  }, [currentFile, sessionId, sessionPath])
+    setTabs(result.tabs)
+    setActiveTabId(result.activeTabId)
+    setOpenMap((prev) => {
+      const m = new Map(prev)
+      m.set(sessionId, false)
+      return m
+    })
+  }, [currentFile, sessionId, setActiveTabId, setOpenMap, setTabs, tabs])
 
   const fileName = currentFile ? currentFile.filePath.split(/[\\/]/).pop() || currentFile.filePath : '文件预览'
   const defaultAppTargetPath = currentFile ? getDefaultAppTargetPath(currentFile, sessionPath) : ''
@@ -81,15 +88,15 @@ export function PreviewPanel({ sessionId }: PreviewPanelProps): React.ReactEleme
           <TooltipTrigger asChild>
             <button
               type="button"
-              onClick={handleOpenDetachedPreview}
+              onClick={handleOpenPreviewTab}
               className="flex items-center justify-center size-6 shrink-0 text-muted-foreground hover:text-foreground hover:bg-muted/50 rounded transition-colors"
-              aria-label="在单独窗口打开预览"
+              aria-label="作为标签页打开预览"
             >
               <Maximize2 className="size-3.5" />
             </button>
           </TooltipTrigger>
           <TooltipContent side="bottom">
-            <p>在单独窗口打开预览</p>
+            <p>作为标签页打开预览</p>
           </TooltipContent>
         </Tooltip>
       )}

--- a/apps/electron/src/renderer/components/diff/PreviewTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/PreviewTabContent.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/atoms/agent-atoms'
 import {
   createPreviewTabId,
+  getFileBaseName,
   getPreviewTabTitle,
   tabsAtom,
 } from '@/atoms/tab-atoms'
@@ -21,10 +22,6 @@ import { getDefaultAppTargetPath, getPreviewFileAccess } from './preview-open-pa
 
 interface PreviewTabContentProps {
   sessionId: string
-}
-
-function getFileName(filePath: string): string {
-  return filePath.split(/[\\/]/).filter(Boolean).pop() || filePath
 }
 
 function getFallbackDirPath(filePath: string, sessionPath: string): string {
@@ -39,7 +36,7 @@ export function PreviewTabContent({ sessionId }: PreviewTabContentProps): React.
 
   const currentFile = fileMap.get(sessionId) ?? null
   const sessionPath = sessionPathMap.get(sessionId) ?? ''
-  const fileName = currentFile ? getFileName(currentFile.filePath) : '文件预览'
+  const fileName = currentFile ? getFileBaseName(currentFile.filePath) : '文件预览'
 
   React.useEffect(() => {
     const previewTabId = createPreviewTabId(sessionId)

--- a/apps/electron/src/renderer/components/diff/PreviewTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/PreviewTabContent.tsx
@@ -1,0 +1,102 @@
+/**
+ * PreviewTabContent — 会话绑定的临时预览 Tab。
+ *
+ * 复用内联预览的 PreviewFile 状态和 DiffTabContent 编辑能力，但不参与 Tab 持久化。
+ */
+
+import * as React from 'react'
+import { useAtomValue, useSetAtom } from 'jotai'
+import {
+  agentSessionPathMapAtom,
+} from '@/atoms/agent-atoms'
+import {
+  createPreviewTabId,
+  getPreviewTabTitle,
+  tabsAtom,
+} from '@/atoms/tab-atoms'
+import { previewFileMapAtom } from '@/atoms/preview-atoms'
+import { DefaultAppOpenButton } from './DefaultAppOpenButton'
+import { DiffTabContent } from './DiffTabContent'
+import { getDefaultAppTargetPath, getPreviewFileAccess } from './preview-open-path'
+
+interface PreviewTabContentProps {
+  sessionId: string
+}
+
+function getFileName(filePath: string): string {
+  return filePath.split(/[\\/]/).filter(Boolean).pop() || filePath
+}
+
+function getFallbackDirPath(filePath: string, sessionPath: string): string {
+  const lastSep = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'))
+  return lastSep > 0 ? filePath.slice(0, lastSep) : sessionPath
+}
+
+export function PreviewTabContent({ sessionId }: PreviewTabContentProps): React.ReactElement {
+  const fileMap = useAtomValue(previewFileMapAtom)
+  const sessionPathMap = useAtomValue(agentSessionPathMapAtom)
+  const setTabs = useSetAtom(tabsAtom)
+
+  const currentFile = fileMap.get(sessionId) ?? null
+  const sessionPath = sessionPathMap.get(sessionId) ?? ''
+  const fileName = currentFile ? getFileName(currentFile.filePath) : '文件预览'
+
+  React.useEffect(() => {
+    const previewTabId = createPreviewTabId(sessionId)
+    const title = getPreviewTabTitle(fileName)
+    setTabs((prev) => {
+      let changed = false
+      const next = prev.map((tab) => {
+        if (tab.id !== previewTabId || tab.title === title) return tab
+        changed = true
+        return { ...tab, title }
+      })
+      return changed ? next : prev
+    })
+  }, [fileName, sessionId, setTabs])
+
+  if (!currentFile) {
+    return (
+      <div className="flex h-full flex-col overflow-hidden bg-content-area">
+        <div className="flex h-11 shrink-0 items-center gap-2 border-b border-border/30 px-3">
+          <div className="min-w-0 flex-1 text-xs font-medium text-muted-foreground">
+            预览已关闭
+          </div>
+        </div>
+        <div className="flex flex-1 items-center justify-center text-xs text-muted-foreground">
+          当前会话没有可预览的文件
+        </div>
+      </div>
+    )
+  }
+
+  const dirPath = currentFile.dirPath || sessionPath || getFallbackDirPath(currentFile.filePath, sessionPath)
+  const defaultAppTargetPath = getDefaultAppTargetPath(currentFile, sessionPath)
+  const defaultAppAccess = getPreviewFileAccess(sessionId, currentFile, sessionPath)
+  const toolbarActions = (
+    <>
+      <DefaultAppOpenButton
+        filePath={defaultAppTargetPath}
+        access={defaultAppAccess}
+      />
+    </>
+  )
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden bg-content-area">
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <DiffTabContent
+          key={`${sessionId}:${currentFile.filePath}`}
+          filePath={currentFile.filePath}
+          dirPath={dirPath}
+          sessionId={sessionId}
+          gitRoot={currentFile.gitRoot}
+          previewOnly={currentFile.previewOnly}
+          readOnly={currentFile.readOnly}
+          basePaths={currentFile.basePaths}
+          toolbarActions={toolbarActions}
+        />
+      </div>
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
+++ b/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
@@ -100,7 +100,7 @@ export function ScratchPadView(): React.ReactElement {
 
   const activeSessionId = React.useMemo(() => {
     const activeTab = tabs.find((t) => t.id === activeTabId)
-    if (activeTab?.type === 'agent') return activeTab.sessionId
+    if (activeTab?.type === 'agent' || activeTab?.type === 'preview') return activeTab.sessionId
     const agentTab = [...tabs].reverse().find((t) => t.type === 'agent')
     return agentTab?.sessionId ?? null
   }, [tabs, activeTabId])

--- a/apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx
+++ b/apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx
@@ -366,7 +366,7 @@ export function GlobalShortcuts(): null {
 
       store.set(activeViewAtom, 'conversations')
 
-      if (target.type === 'agent') {
+      if (target.type === 'agent' || target.type === 'preview') {
         const sessionId = target.sessionId
         store.set(appModeAtom, 'agent')
         store.set(currentAgentSessionIdAtom, sessionId)

--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -76,7 +76,7 @@ export function TabBar(): React.ReactElement {
     if (tab.type === 'chat') {
       setAppMode('chat')
       setCurrentConversationId(tab.sessionId)
-    } else if (tab.type === 'agent') {
+    } else if (tab.type === 'agent' || tab.type === 'preview') {
       setAppMode('agent')
       setCurrentAgentSessionId(tab.sessionId)
 

--- a/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
@@ -9,7 +9,7 @@
 import * as React from 'react'
 import { createPortal } from 'react-dom'
 import { useAtomValue } from 'jotai'
-import { StickyNote, X } from 'lucide-react'
+import { FileText, StickyNote, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import type { TabType, TabMinimapItem } from '@/atoms/tab-atoms'
 import type { SessionIndicatorStatus } from '@/atoms/agent-atoms'
@@ -154,6 +154,10 @@ export function TabBarItem({
         onMouseDown={handleMouseDown}
         onPointerDown={onDragStart}
       >
+        {type === 'preview' && !isNarrow && (
+          <FileText className="size-3.5 shrink-0 text-muted-foreground" />
+        )}
+
         {/* 标题（窄状态下隐藏，用 spacer 撑开让关闭按钮靠右） */}
         {isNarrow ? (
           <span className="flex-1" />

--- a/apps/electron/src/renderer/components/tabs/TabContent.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabContent.tsx
@@ -10,6 +10,7 @@ import { useAtomValue } from 'jotai'
 import { tabsAtom } from '@/atoms/tab-atoms'
 import { ChatView } from '@/components/chat'
 import { AgentView } from '@/components/agent'
+import { PreviewTabContent } from '@/components/diff/PreviewTabContent'
 import { ScratchPadView } from '@/components/scratch-pad/ScratchPadView'
 import { TabErrorBoundary } from './TabErrorBoundary'
 
@@ -44,6 +45,14 @@ export function TabContent({ tabId }: TabContentProps): React.ReactElement {
     return (
       <TabErrorBoundary key={tab.sessionId} sessionId={tab.sessionId}>
         <ChatView conversationId={tab.sessionId} />
+      </TabErrorBoundary>
+    )
+  }
+
+  if (tab.type === 'preview') {
+    return (
+      <TabErrorBoundary key={tab.id} sessionId={tab.sessionId}>
+        <PreviewTabContent sessionId={tab.sessionId} />
       </TabErrorBoundary>
     )
   }

--- a/apps/electron/src/renderer/hooks/useOpenSession.ts
+++ b/apps/electron/src/renderer/hooks/useOpenSession.ts
@@ -34,11 +34,12 @@ export function useOpenSession(): OpenSessionFn {
       const result = openTab(tabs, { type, sessionId, title })
       setTabs(result.tabs)
       setActiveTabId(result.activeTabId)
-      setAppMode(type)
 
       if (type === 'chat') {
+        setAppMode('chat')
         setCurrentConversationId(sessionId)
-      } else if (type === 'agent') {
+      } else if (type === 'agent' || type === 'preview') {
+        setAppMode('agent')
         setCurrentAgentSessionId(sessionId)
 
         // 用户打开查看后只清除未读角标；是否完成由用户通过对勾确认。
@@ -58,6 +59,7 @@ export function useOpenSession(): OpenSessionFn {
           }).catch(console.error)
         }
       } else {
+        setAppMode('scratch')
         setCurrentConversationId(null)
         setCurrentAgentSessionId(null)
       }

--- a/apps/electron/src/renderer/hooks/useSyncActiveTabSideEffects.ts
+++ b/apps/electron/src/renderer/hooks/useSyncActiveTabSideEffects.ts
@@ -54,7 +54,7 @@ export function useSyncActiveTabSideEffects(): SyncActiveTabSideEffects {
         return
       }
 
-      // Agent
+      // Agent / 会话预览
       setAppMode('agent')
       setCurrentAgentSessionId(newActiveTab.sessionId)
       setCurrentConversationId(null)

--- a/apps/electron/src/renderer/lib/agent-completion-presence.ts
+++ b/apps/electron/src/renderer/lib/agent-completion-presence.ts
@@ -21,7 +21,7 @@ export function isAgentSessionActiveForCompletion({
 }: AgentCompletionPresenceInput): boolean {
   const activeTab = activeTabId ? tabs.find((tab) => tab.id === activeTabId) : null
   if (activeTab) {
-    return activeTab.type === 'agent' && activeTab.sessionId === sessionId
+    return (activeTab.type === 'agent' || activeTab.type === 'preview') && activeTab.sessionId === sessionId
   }
 
   return currentAgentSessionId === sessionId

--- a/apps/electron/src/renderer/lib/external-agent-run.ts
+++ b/apps/electron/src/renderer/lib/external-agent-run.ts
@@ -3,7 +3,7 @@ import type { AgentStreamState } from '@/atoms/agent-atoms'
 
 export interface ExternalAgentRunTab {
   id: string
-  type: 'chat' | 'agent' | 'scratch'
+  type: 'chat' | 'agent' | 'scratch' | 'preview'
   sessionId: string
   title: string
 }
@@ -33,10 +33,11 @@ export function buildExternalAgentRunActivation(
 ): ExternalAgentRunActivation {
   const session = input.sessions.find((item) => item.id === input.sessionId)
   const title = input.title ?? session?.title ?? '新 Agent 会话'
-  const existingTab = input.tabs.find((tab) => tab.type === 'agent' && tab.sessionId === input.sessionId)
+  const tabsWithoutPreview = input.tabs.filter((tab) => tab.type !== 'preview')
+  const existingTab = tabsWithoutPreview.find((tab) => tab.type === 'agent' && tab.sessionId === input.sessionId)
   const tabs = existingTab
-    ? input.tabs
-    : [...input.tabs, { id: input.sessionId, type: 'agent' as const, sessionId: input.sessionId, title }]
+    ? (tabsWithoutPreview.length === input.tabs.length ? input.tabs : tabsWithoutPreview)
+    : [...tabsWithoutPreview, { id: input.sessionId, type: 'agent' as const, sessionId: input.sessionId, title }]
   const activeTabId = existingTab?.id ?? input.sessionId
 
   return {

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -50,7 +50,7 @@ import {
 } from './atoms/markdown-font-size'
 import { useGlobalAgentListeners } from './hooks/useGlobalAgentListeners'
 import { useGlobalChatListeners } from './hooks/useGlobalChatListeners'
-import { tabsAtom, activeTabIdAtom, ensureScratchPadTab, scratchPadContentAtom, scratchPadLoadedAtom, SCRATCH_PAD_ID } from './atoms/tab-atoms'
+import { tabsAtom, activeTabIdAtom, ensureScratchPadTab, getPersistableTabState, scratchPadContentAtom, scratchPadLoadedAtom, SCRATCH_PAD_ID } from './atoms/tab-atoms'
 import type { TabItem } from './atoms/tab-atoms'
 import { chatToolsAtom } from './atoms/chat-tool-atoms'
 import { feishuBotStatesAtom } from './atoms/feishu-atoms'
@@ -628,6 +628,7 @@ function TabStatePersistenceInitializer(): null {
           'sessionId' in t &&
           'type' in t &&
           'title' in t &&
+          (t.type === 'chat' || t.type === 'agent') &&
           validSessionIds.has(t.sessionId),
       )
       if (validTabs.length === 0) {
@@ -657,10 +658,11 @@ function TabStatePersistenceInitializer(): null {
 
       // 同步 appMode 和 currentSessionId
       if (activeTab) {
-        store.set(appModeAtom, activeTab.type)
         if (activeTab.type === 'chat') {
+          store.set(appModeAtom, 'chat')
           store.set(currentConversationIdAtom, activeTab.sessionId)
         } else {
+          store.set(appModeAtom, 'agent')
           store.set(currentAgentSessionIdAtom, activeTab.sessionId)
         }
       }
@@ -677,10 +679,9 @@ function TabStatePersistenceInitializer(): null {
     const save = (): void => {
       const tabs = store.get(tabsAtom)
       const activeTabId = store.get(activeTabIdAtom)
-      // 过滤掉 scratch tab，它由代码注入，不参与 tabState 持久化
-      const persistTabs = tabs.filter((t) => t.id !== SCRATCH_PAD_ID)
+      const persistableTabState = getPersistableTabState(tabs, activeTabId)
       window.electronAPI.updateSettings({
-        tabState: { tabs: persistTabs, activeTabId },
+        tabState: persistableTabState,
       }).catch(console.error)
     }
 
@@ -699,9 +700,9 @@ function TabStatePersistenceInitializer(): null {
       // 使用同步 IPC 确保关闭前数据写入磁盘
       const tabs = store.get(tabsAtom)
       const activeTabId = store.get(activeTabIdAtom)
-      const persistTabs = tabs.filter((t) => t.id !== SCRATCH_PAD_ID)
+      const persistableTabState = getPersistableTabState(tabs, activeTabId)
       if (tabs.length > 0 && window.electronAPI.updateSettingsSync) {
-        const ok = window.electronAPI.updateSettingsSync({ tabState: { tabs: persistTabs, activeTabId } })
+        const ok = window.electronAPI.updateSettingsSync({ tabState: persistableTabState })
         if (!ok) {
           console.warn('[TabPersist] sync IPC failed, falling back to async save')
           save()


### PR DESCRIPTION
## Summary
- Convert session-bound previews into temporary tabs that reuse the existing preview/editor flow.
- Route fullscreen, file-tree, diff, attachment, and file-path-chip preview openings into the preview tab.
- Remove preview-tab-only visual indicators and duplicate return/header affordances; keep preview tabs non-persistent.
- Bump @proma/electron to 0.10.19.

## Validation
- bun run typecheck
- cd apps/electron && bun run build:renderer
- git diff --check

## Notes
- Test file changes were removed per request.