### PR TITLE
feat: multi-repo worktree config support

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -210,6 +210,9 @@ import {
   attachWorkspaceFile,
   detachWorkspaceDirectory,
   detachWorkspaceFile,
+  getWorktreeRepos,
+  addWorktreeRepo,
+  removeWorktreeRepo,
 } from './lib/agent-workspace-manager'
 import { getMemoryConfig, setMemoryConfig } from './lib/memory-service'
 import { getAllToolInfos } from './lib/chat-tool-registry'
@@ -2524,6 +2527,29 @@ export function registerIpcHandlers(): void {
     AGENT_IPC_CHANNELS.GET_WORKSPACE_ATTACHED_FILES,
     async (_, workspaceSlug: string): Promise<string[]> => {
       return getWorkspaceAttachedFiles(workspaceSlug)
+    }
+  )
+
+  // ===== Worktree 仓库配置管理 =====
+
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.GET_WORKTREE_REPOS,
+    async (_, workspaceSlug: string) => {
+      return getWorktreeRepos(workspaceSlug)
+    }
+  )
+
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.ADD_WORKTREE_REPO,
+    async (_, workspaceSlug: string, repo: import('@proma/shared').WorkspaceWorktreeRepo) => {
+      return addWorktreeRepo(workspaceSlug, repo)
+    }
+  )
+
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.REMOVE_WORKTREE_REPO,
+    async (_, workspaceSlug: string, repoPath: string) => {
+      return removeWorktreeRepo(workspaceSlug, repoPath)
     }
   )
 

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -1035,6 +1035,7 @@ function isNewerVersion(a: string, b: string): boolean {
 interface WorkspaceConfig {
   attachedDirectories?: string[]
   attachedFiles?: string[]
+  worktreeRepos?: import('@proma/shared').WorkspaceWorktreeRepo[]
 }
 
 function getWorkspaceConfigPath(workspaceSlug: string): string {
@@ -1057,6 +1058,9 @@ function readWorkspaceConfig(workspaceSlug: string): WorkspaceConfig {
         : undefined,
       attachedFiles: Array.isArray(data.attachedFiles)
         ? data.attachedFiles.filter((file): file is string => typeof file === 'string')
+        : undefined,
+      worktreeRepos: Array.isArray(data.worktreeRepos)
+        ? data.worktreeRepos.filter((r) => r && typeof r.name === 'string' && typeof r.repoPath === 'string' && typeof r.worktreesPath === 'string')
         : undefined,
     }
   } catch {
@@ -1126,5 +1130,36 @@ export function detachWorkspaceFile(workspaceSlug: string, filePath: string): st
   const updated = existing.filter((f) => f !== filePath)
   writeWorkspaceConfig(workspaceSlug, { ...config, attachedFiles: updated })
   console.log(`[Agent 工作区] 已移除工作区文件: ${filePath} ← ${workspaceSlug}`)
+  return updated
+}
+
+// ===== 工作区级 Worktree 仓库管理 =====
+
+export function getWorktreeRepos(workspaceSlug: string): import('@proma/shared').WorkspaceWorktreeRepo[] {
+  const config = readWorkspaceConfig(workspaceSlug)
+  const repos = config.worktreeRepos ?? []
+  return repos.sort((a, b) => (a.priority ?? 99) - (b.priority ?? 99))
+}
+
+export function addWorktreeRepo(workspaceSlug: string, repo: import('@proma/shared').WorkspaceWorktreeRepo): import('@proma/shared').WorkspaceWorktreeRepo[] {
+  const config = readWorkspaceConfig(workspaceSlug)
+  const existing = config.worktreeRepos ?? []
+
+  if (existing.some((r) => r.repoPath === repo.repoPath)) {
+    return existing
+  }
+
+  const updated = [...existing, repo]
+  writeWorkspaceConfig(workspaceSlug, { ...config, worktreeRepos: updated })
+  console.log(`[Agent 工作区] 已添加 worktree 仓库: ${repo.name} (${repo.repoPath}) → ${workspaceSlug}`)
+  return updated
+}
+
+export function removeWorktreeRepo(workspaceSlug: string, repoPath: string): import('@proma/shared').WorkspaceWorktreeRepo[] {
+  const config = readWorkspaceConfig(workspaceSlug)
+  const existing = config.worktreeRepos ?? []
+  const updated = existing.filter((r) => r.repoPath !== repoPath)
+  writeWorkspaceConfig(workspaceSlug, { ...config, worktreeRepos: updated })
+  console.log(`[Agent 工作区] 已移除 worktree 仓库: ${repoPath} ← ${workspaceSlug}`)
   return updated
 }

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -657,6 +657,12 @@ export interface ElectronAPI {
 
   /** 获取工作区附加文件列表 */
   getWorkspaceAttachedFiles: (workspaceSlug: string) => Promise<string[]>
+  /** 获取工作区 worktree 仓库配置列表 */
+  getWorktreeRepos: (workspaceSlug: string) => Promise<import('@proma/shared').WorkspaceWorktreeRepo[]>
+  /** 添加 worktree 仓库到工作区配置 */
+  addWorktreeRepo: (workspaceSlug: string, repo: import('@proma/shared').WorkspaceWorktreeRepo) => Promise<import('@proma/shared').WorkspaceWorktreeRepo[]>
+  /** 从工作区配置移除 worktree 仓库 */
+  removeWorktreeRepo: (workspaceSlug: string, repoPath: string) => Promise<import('@proma/shared').WorkspaceWorktreeRepo[]>
 
   // ===== Agent 文件系统操作 =====
 
@@ -1729,6 +1735,18 @@ const electronAPI: ElectronAPI = {
 
   getWorkspaceAttachedFiles: (workspaceSlug: string) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.GET_WORKSPACE_ATTACHED_FILES, workspaceSlug)
+  },
+
+  getWorktreeRepos: (workspaceSlug: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.GET_WORKTREE_REPOS, workspaceSlug)
+  },
+
+  addWorktreeRepo: (workspaceSlug: string, repo: import('@proma/shared').WorkspaceWorktreeRepo) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.ADD_WORKTREE_REPO, workspaceSlug, repo)
+  },
+
+  removeWorktreeRepo: (workspaceSlug: string, repoPath: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.REMOVE_WORKTREE_REPO, workspaceSlug, repoPath)
   },
 
   // Agent 文件系统操作

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -107,7 +107,6 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   // Worktree 选择状态
   const [selectedWorktreeMap, setSelectedWorktreeMap] = useAtom(agentSelectedWorktreeAtom)
   const selectedWorktreePath = selectedWorktreeMap.get(sessionId) ?? null
-  const PROMA_DEV_REPO_PATH = '/Users/erlich/proma-dev/repo'
 
   const handleWorktreeSelect = React.useCallback((worktree: import('@proma/shared').WorktreeInfo | null) => {
     setSelectedWorktreeMap((prev) => {
@@ -422,7 +421,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
             <>
               <WorktreeSelector
                 sessionId={sessionId}
-                repoPath={PROMA_DEV_REPO_PATH}
+                workspaceSlug={workspaceSlug || ''}
                 selectedPath={selectedWorktreePath}
                 onSelect={handleWorktreeSelect}
               />

--- a/apps/electron/src/renderer/components/diff/WorktreeSelector.tsx
+++ b/apps/electron/src/renderer/components/diff/WorktreeSelector.tsx
@@ -1,22 +1,27 @@
 import * as React from 'react'
 import { GitBranch, ChevronDown, RefreshCw } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import type { WorktreeInfo } from '@proma/shared'
+import type { WorktreeInfo, WorkspaceWorktreeRepo } from '@proma/shared'
 
 interface WorktreeSelectorProps {
   sessionId: string
-  repoPath: string
+  workspaceSlug: string
   selectedPath: string | null
   onSelect: (worktree: WorktreeInfo | null) => void
 }
 
+interface RepoWorktrees {
+  repo: WorkspaceWorktreeRepo
+  worktrees: WorktreeInfo[]
+}
+
 export function WorktreeSelector({
   sessionId,
-  repoPath,
+  workspaceSlug,
   selectedPath,
   onSelect,
 }: WorktreeSelectorProps): React.ReactElement {
-  const [worktrees, setWorktrees] = React.useState<WorktreeInfo[]>([])
+  const [repoWorktrees, setRepoWorktrees] = React.useState<RepoWorktrees[]>([])
   const [isOpen, setIsOpen] = React.useState(false)
   const [isLoading, setIsLoading] = React.useState(false)
   const dropdownRef = React.useRef<HTMLDivElement>(null)
@@ -24,14 +29,31 @@ export function WorktreeSelector({
   const fetchWorktrees = React.useCallback(async () => {
     setIsLoading(true)
     try {
-      const list = await window.electronAPI.listWorktrees(repoPath, sessionId)
-      setWorktrees(list.filter((wt) => !wt.isMain))
+      const repos = await window.electronAPI.getWorktreeRepos(workspaceSlug)
+      if (repos.length === 0) {
+        setRepoWorktrees([])
+        return
+      }
+
+      const results: RepoWorktrees[] = []
+      for (const repo of repos) {
+        try {
+          const list = await window.electronAPI.listWorktrees(repo.repoPath, sessionId)
+          const nonMain = list.filter((wt) => !wt.isMain)
+          if (nonMain.length > 0) {
+            results.push({ repo, worktrees: nonMain })
+          }
+        } catch {
+          // skip repos that fail
+        }
+      }
+      setRepoWorktrees(results)
     } catch {
-      setWorktrees([])
+      setRepoWorktrees([])
     } finally {
       setIsLoading(false)
     }
-  }, [repoPath, sessionId])
+  }, [workspaceSlug, sessionId])
 
   React.useEffect(() => {
     fetchWorktrees()
@@ -49,10 +71,12 @@ export function WorktreeSelector({
     }
   }, [isOpen])
 
-  const selectedWorktree = worktrees.find((wt) => wt.path === selectedPath)
+  const allWorktrees = repoWorktrees.flatMap((rw) => rw.worktrees)
+  const selectedWorktree = allWorktrees.find((wt) => wt.path === selectedPath)
   const displayLabel = selectedWorktree ? selectedWorktree.branch : '会话改动'
+  const hasMultipleRepos = repoWorktrees.length > 1
 
-  if (worktrees.length === 0 && !isLoading) return <></>
+  if (allWorktrees.length === 0 && !isLoading) return <></>
 
   return (
     <div ref={dropdownRef} className="relative px-3 py-1.5 border-b border-border/50">
@@ -83,7 +107,7 @@ export function WorktreeSelector({
       </div>
 
       {isOpen && (
-        <div className="absolute left-2 right-2 top-full mt-0.5 z-50 bg-popover border border-border rounded-md shadow-md py-1 max-h-[200px] overflow-y-auto">
+        <div className="absolute left-2 right-2 top-full mt-0.5 z-50 bg-popover border border-border rounded-md shadow-md py-1 max-h-[240px] overflow-y-auto">
           <button
             onClick={() => {
               onSelect(null)
@@ -96,22 +120,31 @@ export function WorktreeSelector({
           >
             会话改动
           </button>
-          {worktrees.map((wt) => (
-            <button
-              key={wt.path}
-              onClick={() => {
-                onSelect(wt)
-                setIsOpen(false)
-              }}
-              className={cn(
-                'w-full text-left px-3 py-1.5 text-xs hover:bg-accent/50 transition-colors flex items-center gap-2',
-                selectedPath === wt.path && 'bg-accent/30 font-medium',
+          {repoWorktrees.map((rw) => (
+            <React.Fragment key={rw.repo.repoPath}>
+              {hasMultipleRepos && (
+                <div className="px-3 pt-2 pb-0.5 text-[10px] font-medium text-muted-foreground/70 uppercase tracking-wider">
+                  {rw.repo.name}
+                </div>
               )}
-            >
-              <GitBranch className="w-3 h-3 shrink-0 text-muted-foreground" />
-              <span className="truncate">{wt.branch}</span>
-              <span className="text-muted-foreground ml-auto shrink-0">{wt.head}</span>
-            </button>
+              {rw.worktrees.map((wt) => (
+                <button
+                  key={wt.path}
+                  onClick={() => {
+                    onSelect(wt)
+                    setIsOpen(false)
+                  }}
+                  className={cn(
+                    'w-full text-left px-3 py-1.5 text-xs hover:bg-accent/50 transition-colors flex items-center gap-2',
+                    selectedPath === wt.path && 'bg-accent/30 font-medium',
+                  )}
+                >
+                  <GitBranch className="w-3 h-3 shrink-0 text-muted-foreground" />
+                  <span className="truncate">{wt.branch}</span>
+                  <span className="text-muted-foreground ml-auto shrink-0">{wt.head}</span>
+                </button>
+              ))}
+            </React.Fragment>
           ))}
         </div>
       )}

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1077,6 +1077,18 @@ export interface WorkspaceAttachFileInput {
   filePath: string
 }
 
+/** Worktree 仓库配置 */
+export interface WorkspaceWorktreeRepo {
+  /** 显示名称 */
+  name: string
+  /** 主仓库绝对路径 */
+  repoPath: string
+  /** Worktree 存放目录绝对路径 */
+  worktreesPath: string
+  /** 优先级（数字越小越优先） */
+  priority?: number
+}
+
 // ===== AskUserQuestion 交互式问答类型 =====
 
 /** AskUserQuestion 工具的选项定义 */
@@ -1386,6 +1398,12 @@ export const AGENT_IPC_CHANNELS = {
   GET_WORKSPACE_DIRECTORIES: 'agent:get-workspace-directories',
   /** 获取工作区附加文件列表 */
   GET_WORKSPACE_ATTACHED_FILES: 'agent:get-workspace-attached-files',
+  /** 获取工作区 worktree 仓库配置列表 */
+  GET_WORKTREE_REPOS: 'agent:get-worktree-repos',
+  /** 添加 worktree 仓库到工作区配置 */
+  ADD_WORKTREE_REPO: 'agent:add-worktree-repo',
+  /** 从工作区配置移除 worktree 仓库 */
+  REMOVE_WORKTREE_REPO: 'agent:remove-worktree-repo',
 
   // 文件系统操作
   /** 获取 session 工作路径 */


### PR DESCRIPTION
## Summary

- Add `worktreeRepos` field to workspace config.json for managing multiple git worktree repositories
- Upgrade WorktreeSelector to read from config instead of hardcoded path, with grouped display for multi-repo scenarios
- New IPC channels: GET_WORKTREE_REPOS / ADD_WORKTREE_REPO / REMOVE_WORKTREE_REPO

## Context

Follows PR #649 (worktree Changes UI). This PR removes the hardcoded repo path and adds proper multi-repo support, enabling both `~/proma-dev/` and `~/conductor/` worktree structures to be scanned.

## Test plan

- [x] `bun run typecheck` passes
- [ ] Configure worktreeRepos in config.json, verify WorktreeSelector shows worktrees from all configured repos
- [ ] Verify grouped display when multiple repos have active worktrees

🤖 Generated with [Claude Code](https://claude.com/claude-code)