### PR TITLE
fix: persist working session state across app restarts

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -1732,6 +1732,21 @@ export function registerIpcHandlers(): void {
     }
   )
 
+  // 确认 Agent 会话已完成（清除 completedButUnconfirmed 和 manualWorking）
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.CONFIRM_WORKING_DONE,
+    async (_, id: string): Promise<AgentSessionMeta> => {
+      const sessions = listAgentSessions()
+      const current = sessions.find((s) => s.id === id)
+      if (!current) throw new Error(`Agent session not found: ${id}`)
+      const updates: Partial<AgentSessionMeta> = {}
+      if (current.manualWorking) updates.manualWorking = false
+      if (current.completedButUnconfirmed) updates.completedButUnconfirmed = false
+      if (Object.keys(updates).length === 0) return current
+      return updateAgentSessionMeta(id, updates)
+    }
+  )
+
   // 切换 Agent 会话归档状态
   ipcMain.handle(
     AGENT_IPC_CHANNELS.TOGGLE_ARCHIVE,

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -31,7 +31,7 @@ import { ClaudeAgentAdapter, scanAndKillOrphanedClaudeSubprocesses } from './ada
 import { AgentEventBus } from './agent-event-bus'
 import { AgentOrchestrator } from './agent-orchestrator'
 import { getAgentSessionWorkspacePath, getWorkspaceFilesDir } from './config-paths'
-import { getAgentSessionMeta } from './agent-session-manager'
+import { getAgentSessionMeta, updateAgentSessionMeta } from './agent-session-manager'
 
 // ===== 实例创建 =====
 
@@ -120,6 +120,10 @@ export async function runAgent(
 ): Promise<void> {
   // 更新 webContents 映射（允许覆盖 — 由 orchestrator.activeSessions 处理真正的并发保护）
   registerWebContents(input.sessionId, webContents)
+  // 开始新一轮执行时清除"完成未确认"标记
+  try {
+    updateAgentSessionMeta(input.sessionId, { completedButUnconfirmed: false })
+  } catch { /* 新会话可能尚未写入索引 */ }
   try {
     await orchestrator.sendMessage(input, {
       onError: (error) => {
@@ -131,6 +135,10 @@ export async function runAgent(
         }
       },
       onComplete: (messages, opts) => {
+        // 持久化"完成但未确认"状态，确保重启后仍显示在工作中列表
+        try {
+          updateAgentSessionMeta(input.sessionId, { completedButUnconfirmed: true })
+        } catch { /* 会话可能已被删除 */ }
         if (!webContents.isDestroyed()) {
           webContents.send(AGENT_IPC_CHANNELS.STREAM_COMPLETE, {
             sessionId: input.sessionId,

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -377,7 +377,7 @@ function convertLegacyMessage(legacy: AgentMessage): SDKMessage {
  */
 export function updateAgentSessionMeta(
   id: string,
-  updates: Partial<Pick<AgentSessionMeta, 'title' | 'channelId' | 'sdkSessionId' | 'workspaceId' | 'pinned' | 'archived' | 'attachedDirectories' | 'attachedFiles' | 'forkSourceDir' | 'forkSourceSdkSessionId' | 'resumeAtMessageUuid' | 'stoppedByUser' | 'permissionMode'>>,
+  updates: Partial<Pick<AgentSessionMeta, 'title' | 'channelId' | 'sdkSessionId' | 'workspaceId' | 'pinned' | 'archived' | 'attachedDirectories' | 'attachedFiles' | 'forkSourceDir' | 'forkSourceSdkSessionId' | 'resumeAtMessageUuid' | 'stoppedByUser' | 'permissionMode' | 'completedButUnconfirmed'>>,
 ): AgentSessionMeta {
   const index = readIndex()
   const idx = index.sessions.findIndex((s) => s.id === id)
@@ -1260,7 +1260,7 @@ export function autoArchiveAgentSessions(daysThreshold: number): number {
   let count = 0
 
   for (const session of index.sessions) {
-    if (!session.pinned && !session.archived && session.updatedAt < threshold) {
+    if (!session.pinned && !session.manualWorking && !session.completedButUnconfirmed && !session.archived && session.updatedAt < threshold) {
       session.archived = true
       count++
     }

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -430,6 +430,9 @@ export interface ElectronAPI {
   /** 切换 Agent 会话手动工作中状态 */
   toggleManualWorkingAgentSession: (id: string) => Promise<AgentSessionMeta>
 
+  /** 确认 Agent 会话已完成（清除 completedButUnconfirmed 和 manualWorking） */
+  confirmWorkingDoneAgentSession: (id: string) => Promise<AgentSessionMeta>
+
   /** 切换 Agent 会话归档状态 */
   toggleArchiveAgentSession: (id: string) => Promise<AgentSessionMeta>
 
@@ -1403,6 +1406,10 @@ const electronAPI: ElectronAPI = {
 
   toggleManualWorkingAgentSession: (id: string) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.TOGGLE_MANUAL_WORKING, id)
+  },
+
+  confirmWorkingDoneAgentSession: (id: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.CONFIRM_WORKING_DONE, id)
   },
 
   toggleArchiveAgentSession: (id: string) => {

--- a/apps/electron/src/renderer/atoms/working-atoms.ts
+++ b/apps/electron/src/renderer/atoms/working-atoms.ts
@@ -62,6 +62,15 @@ export const workingSessionGroupsAtom = atom<WorkingSessionGroups>((get) => {
     includedIds.add(id)
   }
 
+  // completedButUnconfirmed 会话：跨重启恢复到工作中列表
+  for (const session of sessions) {
+    if (!session.completedButUnconfirmed || draftIds.has(session.id) || includedIds.has(session.id)) continue
+    const status = indicatorMap.get(session.id)
+    if (status === 'blocked') { todo.push(session); includedIds.add(session.id) }
+    else if (status === 'running') { running.push(session); includedIds.add(session.id) }
+    else { done.push(session); includedIds.add(session.id) }
+  }
+
   // manualWorking 会话：按当前 indicator 分配到对应子组
   for (const session of sessions) {
     if (!session.manualWorking || draftIds.has(session.id) || includedIds.has(session.id)) continue

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -932,11 +932,9 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   /** 确认已完成：从 Working 中移出，但会话仍可通过搜索或最近工作找到 */
   const handleConfirmWorkingDoneAgent = React.useCallback(async (id: string): Promise<void> => {
     try {
-      const session = store.get(agentSessionsAtom).find((s) => s.id === id)
-      if (session?.manualWorking) {
-        const updated = await window.electronAPI.toggleManualWorkingAgentSession(id)
-        setAgentSessions((prev) => replaceAgentSessionInFreshnessOrder(prev, updated))
-      }
+      // 通过 IPC 清除持久化的 completedButUnconfirmed 和 manualWorking 状态
+      const updated = await window.electronAPI.confirmWorkingDoneAgentSession(id)
+      setAgentSessions((prev) => replaceAgentSessionInFreshnessOrder(prev, updated))
 
       setWorkingDone((prev) => {
         if (!prev.has(id)) return prev
@@ -958,7 +956,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       console.error('[侧边栏] 标记完成失败:', error)
       toast.error('标记完成失败')
     }
-  }, [store, setAgentSessions, setWorkingDone, setUnviewedCompleted])
+  }, [setAgentSessions, setWorkingDone, setUnviewedCompleted])
 
   /** 切换 Agent 会话归档状态 */
   const handleToggleArchiveAgent = React.useCallback(async (id: string): Promise<void> => {

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -599,6 +599,8 @@ export interface AgentSessionMeta {
   resumeAtMessageUuid?: string
   /** 手动标记为工作中 */
   manualWorking?: boolean
+  /** Agent 执行完成但用户尚未确认（跨重启保留在工作中列表） */
+  completedButUnconfirmed?: boolean
   /** 最后一次流式执行是否被用户主动中断 */
   stoppedByUser?: boolean
   /** 该会话当前的权限模式（持久化到磁盘，重启后恢复）。未设置时新会话默认 auto */
@@ -1280,6 +1282,8 @@ export const AGENT_IPC_CHANNELS = {
   TOGGLE_PIN: 'agent:toggle-pin',
   /** 切换会话手动工作中状态 */
   TOGGLE_MANUAL_WORKING: 'agent:toggle-manual-working',
+  /** 确认会话已完成（清除 completedButUnconfirmed 和 manualWorking） */
+  CONFIRM_WORKING_DONE: 'agent:confirm-working-done',
   /** 切换会话归档状态 */
   TOGGLE_ARCHIVE: 'agent:toggle-archive',
   /** 搜索会话消息内容 */


### PR DESCRIPTION
## Summary

- 新增 `completedButUnconfirmed` 持久化字段，Agent 完成时写入磁盘，重启后恢复到"工作中"列表
- 修复自动归档逻辑，豁免 `manualWorking` 和 `completedButUnconfirmed` 会话（之前超过 7 天未更新会被误归档）
- 新增 `CONFIRM_WORKING_DONE` IPC channel，用户确认完成时一次性清除所有持久化标记

## Test plan

- [ ] 启动 Agent 会话并等待完成，确认出现在"工作中"区域
- [ ] 重启应用，确认该会话仍在"工作中"区域的 done 组
- [ ] 点击"确认完成"按钮，确认会话从"工作中"移出
- [ ] 手动标记会话为"工作中"，等待超过 7 天（或调低阈值测试），确认不被自动归档
- [ ] 在已完成会话中发送新消息，确认 `completedButUnconfirmed` 被清除后重新开始执行

🤖 Generated with [Claude Code](https://claude.com/claude-code)