### PR TITLE
fix: cleanup stale attached directories on startup

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -169,6 +169,7 @@ import {
   moveSessionToWorkspace,
   forkAgentSession,
   autoArchiveAgentSessions,
+  cleanupStaleAttachedPaths,
   searchAgentSessionMessages,
   searchAgentSessionReferences,
 } from './lib/agent-session-manager'
@@ -213,6 +214,7 @@ import {
   getWorktreeRepos,
   addWorktreeRepo,
   removeWorktreeRepo,
+  cleanupStaleWorkspaceAttachedPaths,
 } from './lib/agent-workspace-manager'
 import { getMemoryConfig, setMemoryConfig } from './lib/memory-service'
 import { getAllToolInfos } from './lib/chat-tool-registry'
@@ -3767,6 +3769,14 @@ export function registerIpcHandlers(): void {
 
   runAutoArchive()
   setInterval(runAutoArchive, 24 * 60 * 60 * 1000)
+
+  // 启动时清理不存在的附加目录/文件（如已删除的 worktree）
+  try {
+    cleanupStaleAttachedPaths()
+    cleanupStaleWorkspaceAttachedPaths()
+  } catch (error) {
+    console.error('[启动清理] 清理失效附加路径失败:', error)
+  }
 
   // ===== 存储管理 =====
 

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -1275,7 +1275,48 @@ export function autoArchiveAgentSessions(daysThreshold: number): number {
 }
 
 /**
- * 搜索 Agent 会话消息内容
+ * 清理所有会话中不存在的附加目录和附加文件
+ * @returns 清理的条目总数
+ */
+export function cleanupStaleAttachedPaths(): number {
+  const index = readIndex()
+  let count = 0
+
+  for (const session of index.sessions) {
+    let changed = false
+
+    if (session.attachedDirectories?.length) {
+      const valid = session.attachedDirectories.filter((d) => existsSync(d))
+      if (valid.length < session.attachedDirectories.length) {
+        count += session.attachedDirectories.length - valid.length
+        session.attachedDirectories = valid.length > 0 ? valid : undefined
+        changed = true
+      }
+    }
+
+    if (session.attachedFiles?.length) {
+      const valid = session.attachedFiles.filter((f) => existsSync(f))
+      if (valid.length < session.attachedFiles.length) {
+        count += session.attachedFiles.length - valid.length
+        session.attachedFiles = valid.length > 0 ? valid : undefined
+        changed = true
+      }
+    }
+
+    if (changed) {
+      session.updatedAt = Date.now()
+    }
+  }
+
+  if (count > 0) {
+    writeIndex(index)
+    console.log(`[Agent 会话] 清理了 ${count} 个不存在的附加路径`)
+  }
+
+  return count
+}
+
+/**
  *
  * 按行流式读取每个会话的 JSONL 文件，命中即早退。兼容旧 AgentMessage 和新 SDKMessage 格式。
  * 每个会话最多返回 1 条匹配，总计达到 maxResults 即停止扫描后续会话。

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -1163,3 +1163,45 @@ export function removeWorktreeRepo(workspaceSlug: string, repoPath: string): imp
   console.log(`[Agent 工作区] 已移除 worktree 仓库: ${repoPath} ← ${workspaceSlug}`)
   return updated
 }
+
+/**
+ * 清理所有工作区中不存在的附加目录和附加文件
+ * @returns 清理的条目总数
+ */
+export function cleanupStaleWorkspaceAttachedPaths(): number {
+  const workspaces = listAgentWorkspaces()
+  let count = 0
+
+  for (const ws of workspaces) {
+    const config = readWorkspaceConfig(ws.slug)
+    let changed = false
+
+    if (config.attachedDirectories?.length) {
+      const valid = config.attachedDirectories.filter((d) => existsSync(d))
+      if (valid.length < config.attachedDirectories.length) {
+        count += config.attachedDirectories.length - valid.length
+        config.attachedDirectories = valid.length > 0 ? valid : undefined
+        changed = true
+      }
+    }
+
+    if (config.attachedFiles?.length) {
+      const valid = config.attachedFiles.filter((f) => existsSync(f))
+      if (valid.length < config.attachedFiles.length) {
+        count += config.attachedFiles.length - valid.length
+        config.attachedFiles = valid.length > 0 ? valid : undefined
+        changed = true
+      }
+    }
+
+    if (changed) {
+      writeWorkspaceConfig(ws.slug, config)
+    }
+  }
+
+  if (count > 0) {
+    console.log(`[Agent 工作区] 清理了 ${count} 个不存在的附加路径`)
+  }
+
+  return count
+}


### PR DESCRIPTION
## Summary

- 应用启动时自动扫描所有会话和工作区配置，移除指向不存在路径的 attachedDirectories 和 attachedFiles 条目
- 解决 worktree 删除后右侧面板仍显示已失效附加目录的问题

## Test plan

- [ ] 添加一个附加目录，手动删除该目录，重启应用，确认附加目录条目被自动清理
- [ ] 工作区级附加目录同理验证
- [ ] 正常存在的附加目录不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)