### PR TITLE
fix(voice-dictation): show input window on all virtual desktops

### DIFF
--- a/apps/electron/src/main/lib/voice-dictation-window.ts
+++ b/apps/electron/src/main/lib/voice-dictation-window.ts
@@ -59,6 +59,7 @@ export function createVoiceDictationWindow(): void {
       partition: VOICE_DICTATION_PARTITION,
     },
   })
+  voiceDictationWindow.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true })
   installVoiceDictationMediaPermissions(voiceDictationWindow)
   installVoiceDictationPositionPersistence(voiceDictationWindow)
 
@@ -265,19 +266,25 @@ export function getVoiceDictationWindow(): BrowserWindow | null {
 }
 
 function getInitialVoiceDictationBounds(): Electron.Rectangle {
+  const cursorPoint = screen.getCursorScreenPoint()
+  const currentDisplay = screen.getDisplayNearestPoint(cursorPoint)
   const savedPosition = getSavedVoiceDictationPosition()
+
   if (savedPosition) {
+    const { workArea } = currentDisplay
+    const relativeX = savedPosition.relativeX ?? 0.5
+    const relativeY = savedPosition.relativeY ?? 0.28
+    const targetX = Math.round(workArea.x + relativeX * (workArea.width - WINDOW_WIDTH))
+    const targetY = Math.round(workArea.y + relativeY * (workArea.height - WINDOW_HEIGHT))
     return clampBoundsToVisibleWorkArea({
-      x: savedPosition.x,
-      y: savedPosition.y,
+      x: targetX,
+      y: targetY,
       width: WINDOW_WIDTH,
       height: WINDOW_HEIGHT,
     })
   }
 
-  const cursorPoint = screen.getCursorScreenPoint()
-  const display = screen.getDisplayNearestPoint(cursorPoint)
-  const { x, y, width, height } = display.workArea
+  const { x, y, width, height } = currentDisplay.workArea
 
   return clampBoundsToVisibleWorkArea({
     x: Math.round(x + (width - WINDOW_WIDTH) / 2),
@@ -287,12 +294,14 @@ function getInitialVoiceDictationBounds(): Electron.Rectangle {
   })
 }
 
-function getSavedVoiceDictationPosition(): Electron.Point | null {
+function getSavedVoiceDictationPosition(): { x: number; y: number; relativeX?: number; relativeY?: number } | null {
   const position = getSettings().voiceDictation?.windowPosition
   if (!position || !Number.isFinite(position.x) || !Number.isFinite(position.y)) return null
   return {
     x: Math.round(position.x),
     y: Math.round(position.y),
+    relativeX: Number.isFinite(position.relativeX) ? position.relativeX : undefined,
+    relativeY: Number.isFinite(position.relativeY) ? position.relativeY : undefined,
   }
 }
 
@@ -361,6 +370,14 @@ function flushPendingVoiceDictationPositionSave(): void {
 function saveVoiceDictationPosition(): void {
   if (!voiceDictationWindow || voiceDictationWindow.isDestroyed()) return
   const { x, y } = voiceDictationWindow.getBounds()
+  const display = screen.getDisplayNearestPoint({ x: x + WINDOW_WIDTH / 2, y: y + 48 })
+  const { workArea } = display
+  const relativeX = workArea.width > WINDOW_WIDTH
+    ? (x - workArea.x) / (workArea.width - WINDOW_WIDTH)
+    : 0.5
+  const relativeY = workArea.height > WINDOW_HEIGHT
+    ? (y - workArea.y) / (workArea.height - WINDOW_HEIGHT)
+    : 0.28
   const settings = getSettings()
   updateSettings({
     voiceDictation: {
@@ -368,6 +385,8 @@ function saveVoiceDictationPosition(): void {
       windowPosition: {
         x,
         y,
+        relativeX: clamp(relativeX, 0, 1),
+        relativeY: clamp(relativeY, 0, 1),
       },
     },
   })

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -35,6 +35,10 @@ export type VoiceDictationOutputMode = 'auto' | 'clipboard' | 'proma-input'
 export interface VoiceDictationWindowPosition {
   x: number
   y: number
+  /** 窗口相对于所在屏幕 workArea 的归一化水平偏移 (0~1) */
+  relativeX?: number
+  /** 窗口相对于所在屏幕 workArea 的归一化垂直偏移 (0~1) */
+  relativeY?: number
 }
 
 /** 语音输入设置（渲染进程读取到的是解密后的值） */


### PR DESCRIPTION
## Summary

- 语音输入浮窗在 macOS 虚拟桌面切换后不可见，因为窗口被困在创建时的 Space
- 添加 `setVisibleOnAllWorkspaces(true)` 使窗口在所有虚拟桌面可见（Windows 上 `alwaysOnTop` 已天然覆盖，此调用为 no-op）
- 保存窗口相对于屏幕 workArea 的归一化偏移（0~1），恢复时基于鼠标所在屏幕计算位置，同时修复多物理屏幕的定位问题

## Test plan

- [ ] macOS: 在桌面 A 唤起语音输入 → 切换到桌面 B → 再次唤起，确认窗口在 B 桌面可见
- [ ] macOS: 拖动窗口到右下角 → 关闭 → 重新唤起，确认位置恢复正确
- [ ] macOS: 多物理屏幕场景下，在副屏唤起语音输入，确认位置正确
- [ ] Windows: 确认虚拟桌面切换后窗口仍可见（alwaysOnTop 天然行为）

🤖 Generated with [Claude Code](https://claude.com/claude-code)