### PR TITLE
feat: 新增 Anthropic 兼容格式 provider，修复第三方兼容服务 URL 规范化问题

### DIFF
--- a/apps/electron/src/main/lib/channel-manager.ts
+++ b/apps/electron/src/main/lib/channel-manager.ts
@@ -267,6 +267,7 @@ export async function testChannel(channelId: string): Promise<ChannelTestResult>
   try {
     switch (channel.provider) {
       case 'anthropic':
+      case 'anthropic-compatible':
       case 'deepseek':
       case 'kimi-api':
       case 'kimi-coding':
@@ -303,7 +304,7 @@ async function testAnthropicCompatible(
 ): Promise<ChannelTestResult> {
   const isNonVersionedPath =
     provider === 'deepseek' || provider === 'kimi-api' || provider === 'kimi-coding'
-  const url = provider === 'minimax'
+  const url = (provider === 'minimax' || provider === 'anthropic-compatible')
     ? normalizeVersionedAnthropicBaseUrl(baseUrl)
     : isNonVersionedPath ? normalizeBaseUrl(baseUrl) : normalizeAnthropicBaseUrl(baseUrl)
   const fetchFn = getFetchFn(proxyUrl)
@@ -426,6 +427,7 @@ export async function testChannelDirect(input: FetchModelsInput): Promise<Channe
   try {
     switch (input.provider) {
       case 'anthropic':
+      case 'anthropic-compatible':
       case 'deepseek':
       case 'kimi-api':
       case 'kimi-coding':
@@ -462,6 +464,7 @@ export async function fetchModels(input: FetchModelsInput): Promise<FetchModelsR
   try {
     switch (input.provider) {
       case 'anthropic':
+      case 'anthropic-compatible':
       case 'deepseek':
       case 'kimi-api':
       case 'kimi-coding':
@@ -509,7 +512,7 @@ async function fetchAnthropicCompatibleModels(
 ): Promise<FetchModelsResult> {
   const isNonVersionedPath =
     provider === 'deepseek' || provider === 'kimi-api' || provider === 'kimi-coding'
-  const url = provider === 'minimax'
+  const url = (provider === 'minimax' || provider === 'anthropic-compatible')
     ? normalizeVersionedAnthropicBaseUrl(baseUrl)
     : isNonVersionedPath ? normalizeBaseUrl(baseUrl) : normalizeAnthropicBaseUrl(baseUrl)
   const fetchFn = getFetchFn(proxyUrl)

--- a/apps/electron/src/renderer/components/chat/ModelSelector.tsx
+++ b/apps/electron/src/renderer/components/chat/ModelSelector.tsx
@@ -25,7 +25,7 @@ import {
 } from '@/atoms/chat-atoms'
 import { useConversationModelOptional } from '@/hooks/useConversationSettings'
 import { useConversationIdOptional } from '@/contexts/session-context'
-import { getModelLogo, getChannelLogo } from '@/lib/model-logo'
+import { getModelLogo, getProviderLogo } from '@/lib/model-logo'
 import { cn } from '@/lib/utils'
 import type { Channel, ModelOption } from '@proma/shared'
 
@@ -285,7 +285,7 @@ export function ModelSelector({
                     {/* 供应商标题行 - 灰色背景 */}
                     <div className="flex items-center gap-2 px-4 py-2 bg-muted/50 border-b border-border/30">
                       <img
-                        src={getChannelLogo(channels.find((c) => c.id === channelId)?.baseUrl ?? '')}
+                        src={getProviderLogo(channels.find((c) => c.id === channelId)?.provider ?? 'anthropic')}
                         alt={first.channelName}
                         className="size-5 rounded object-cover"
                       />

--- a/apps/electron/src/renderer/components/settings/ChannelForm.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelForm.tsx
@@ -70,7 +70,7 @@ interface ChannelFormProps {
 }
 
 /** 所有可选供应商 */
-const PROVIDER_OPTIONS: ProviderType[] = ['anthropic', 'openai', 'deepseek', 'google', 'kimi-api', 'kimi-coding', 'zhipu', 'minimax', 'doubao', 'qwen', 'custom']
+const PROVIDER_OPTIONS: ProviderType[] = ['anthropic', 'openai', 'deepseek', 'google', 'kimi-api', 'kimi-coding', 'zhipu', 'minimax', 'doubao', 'qwen', 'anthropic-compatible', 'custom']
 
 /** 供应商选项（用于 SettingsSelect） */
 const PROVIDER_SELECT_OPTIONS = PROVIDER_OPTIONS.map((p) => ({
@@ -81,6 +81,7 @@ const PROVIDER_SELECT_OPTIONS = PROVIDER_OPTIONS.map((p) => ({
 /** 各供应商的 Chat 端点路径，用于 Base URL 预览 */
 const PROVIDER_CHAT_PATHS: Record<ProviderType, string> = {
   anthropic: '/v1/messages',
+  'anthropic-compatible': '/v1/messages',
   openai: '/chat/completions',
   deepseek: '/messages',
   google: '/v1beta/models/{model}:generateContent',
@@ -101,11 +102,11 @@ const PROVIDER_CHAT_PATHS: Record<ProviderType, string> = {
 function buildPreviewUrl(baseUrl: string, provider: ProviderType): string {
   let trimmed = baseUrl.trim().replace(/\/+$/, '')
 
-  if (provider === 'anthropic' || provider === 'deepseek' || provider === 'kimi-api' || provider === 'kimi-coding' || provider === 'minimax') {
+  if (provider === 'anthropic' || provider === 'anthropic-compatible' || provider === 'deepseek' || provider === 'kimi-api' || provider === 'kimi-coding' || provider === 'minimax') {
     // 去除用户误填的 /messages 后缀，与 normalizeAnthropicBaseUrl 保持一致
     trimmed = trimmed.replace(/\/messages$/, '')
-    // MiniMax 的 Anthropic 协议根路径为 /anthropic，实际 API 位于 /v1/messages
-    if (provider === 'minimax') {
+    // MiniMax / Anthropic 兼容格式：baseUrl 是 /anthropic 协议根路径，实际 API 位于 /v1/messages
+    if (provider === 'minimax' || provider === 'anthropic-compatible') {
       if (trimmed.match(/\/v\d+$/)) {
         return `${trimmed}/messages`
       }

--- a/apps/electron/src/renderer/components/settings/ChannelSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelSettings.tsx
@@ -14,7 +14,7 @@ import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
 import { PROVIDER_LABELS, isAgentCompatibleProvider } from '@proma/shared'
 import type { Channel } from '@proma/shared'
-import { getChannelLogo, PromaLogo } from '@/lib/model-logo'
+import { getProviderLogo, PromaLogo } from '@/lib/model-logo'
 import { agentChannelIdAtom, agentModelIdAtom, agentChannelIdsAtom } from '@/atoms/agent-atoms'
 import { channelsAtom } from '@/atoms/chat-atoms'
 import { SettingsSection, SettingsCard, SettingsRow } from './primitives'
@@ -323,7 +323,7 @@ function ChannelRow({ channel, onEdit, onDelete, onToggle }: ChannelRowProps): R
   return (
     <SettingsRow
       label={channel.name}
-      icon={<img src={getChannelLogo(channel.baseUrl)} alt="" className="w-8 h-8 rounded" />}
+      icon={<img src={getProviderLogo(channel.provider)} alt="" className="w-8 h-8 rounded" />}
       description={description}
       className="group"
     >
@@ -374,7 +374,7 @@ function AgentProviderRow({ channel, enabled, onToggle }: AgentProviderRowProps)
   return (
     <SettingsRow
       label={channel.name}
-      icon={<img src={getChannelLogo(channel.baseUrl)} alt="" className="w-8 h-8 rounded" />}
+      icon={<img src={getProviderLogo(channel.provider)} alt="" className="w-8 h-8 rounded" />}
       description={description}
     >
       <Switch

--- a/apps/electron/src/renderer/lib/model-logo.ts
+++ b/apps/electron/src/renderer/lib/model-logo.ts
@@ -230,6 +230,7 @@ const MODEL_LOGO_MAP: Record<string, string> = {
  */
 const PROVIDER_LOGO_MAP: Record<ProviderType, string> = {
   anthropic: ClaudeLogo,
+  'anthropic-compatible': DefaultLogo,
   openai: OpenAILogo,
   deepseek: DeepSeekLogo,
   google: GeminiLogo,

--- a/packages/core/src/providers/anthropic-adapter.ts
+++ b/packages/core/src/providers/anthropic-adapter.ts
@@ -262,8 +262,8 @@ export class AnthropicAdapter implements ProviderAdapter {
 
   /** 根据 provider 类型选择 URL 规范化方式 */
   private normalizeUrl(baseUrl: string): string {
-    // MiniMax：baseUrl 是 /anthropic 协议根路径，实际请求需要 /v1/messages。
-    if (this.providerType === 'minimax') {
+    // MiniMax / Anthropic 兼容格式：baseUrl 是 /anthropic 协议根路径，实际请求需要 /v1/messages。
+    if (this.providerType === 'minimax' || this.providerType === 'anthropic-compatible') {
       return normalizeVersionedAnthropicBaseUrl(baseUrl)
     }
     // DeepSeek / Kimi：baseUrl 本身已含非版本路径（如 /anthropic、/coding/v1），不追加 /v1

--- a/packages/core/src/providers/index.ts
+++ b/packages/core/src/providers/index.ts
@@ -25,6 +25,7 @@ export { GoogleAdapter } from './google-adapter.ts'
 /** 供应商适配器注册表 */
 const adapterRegistry = new Map<ProviderType, ProviderAdapter>([
   ['anthropic', new AnthropicAdapter()],
+  ['anthropic-compatible', new AnthropicAdapter('anthropic-compatible')],
   ['openai', new OpenAIAdapter()],
   ['deepseek', new AnthropicAdapter('deepseek')],   // DeepSeek 使用 Anthropic 兼容协议
   ['kimi-api', new AnthropicAdapter('kimi-api')],       // Kimi API 的 Anthropic 协议端点

--- a/packages/core/src/providers/thinking-capability.ts
+++ b/packages/core/src/providers/thinking-capability.ts
@@ -81,7 +81,7 @@ export function detectThinkingCapability(
   }
 
   // 其它非 Anthropic 供应商：不发 thinking
-  if (providerType !== 'anthropic') {
+  if (providerType !== 'anthropic' && providerType !== 'anthropic-compatible') {
     return { mode: 'manual-only', disableStrategy: 'explicit-disabled' }
   }
 

--- a/packages/shared/src/types/channel.ts
+++ b/packages/shared/src/types/channel.ts
@@ -10,6 +10,7 @@
  */
 export type ProviderType =
   | 'anthropic'
+  | 'anthropic-compatible'
   | 'openai'
   | 'deepseek'
   | 'google'
@@ -26,6 +27,7 @@ export type ProviderType =
  */
 export const PROVIDER_DEFAULT_URLS: Record<ProviderType, string> = {
   anthropic: 'https://api.anthropic.com',
+  'anthropic-compatible': '',
   openai: 'https://api.openai.com/v1',
   deepseek: 'https://api.deepseek.com/anthropic',
   google: 'https://generativelanguage.googleapis.com',
@@ -43,6 +45,7 @@ export const PROVIDER_DEFAULT_URLS: Record<ProviderType, string> = {
  */
 export const PROVIDER_LABELS: Record<ProviderType, string> = {
   anthropic: 'Anthropic',
+  'anthropic-compatible': 'Anthropic 兼容格式',
   openai: 'OpenAI',
   deepseek: 'DeepSeek',
   google: 'Google',
@@ -63,6 +66,7 @@ export const PROVIDER_LABELS: Record<ProviderType, string> = {
  */
 export const AGENT_COMPATIBLE_PROVIDERS: ReadonlySet<ProviderType> = new Set<ProviderType>([
   'anthropic',
+  'anthropic-compatible',
   'deepseek',
   'kimi-api',
   'kimi-coding',


### PR DESCRIPTION
## 概述

新增 `anthropic-compatible` provider 类型，用于支持以 `/v1/messages` 为端点的第三方 Anthropic 兼容服务。

修复 Issue #647：当 Base URL 以 `/anthropic` 结尾时，请求 `.../anthropic/messages` 返回 404 的问题。

## 改动内容

- **packages/shared**: 新增 `anthropic-compatible` 到 ProviderType、labels、defaults、Agent 兼容集合
- **packages/core/providers**: 注册适配器、URL 规范化追加 `/v1`、继承 Anthropic 思考模式逻辑
- **apps/electron**: 更新 ChannelForm 预览、channel-manager 测试/拉取 URL 规范化
- **apps/electron/renderer**: 修复 ChannelSettings 和 ModelSelector 的 logo 显示（改用 provider-based 查找）

## 测试计划

- [x] TypeScript 编译通过 (`bun run typecheck`)
- [x] Electron 构建成功 (`bun run build` + `electron-builder --win`)
- [x] `anthropic-compatible` provider 连接测试通过
- [x] `anthropic-compatible` provider 模型拉取正常
- [x] Logo 显示正确（DefaultLogo，不是 ClaudeLogo）
- [x] Agent 模式兼容

## 修复

Closes #647