### PR TITLE
fix：优化 Ctrl+Tab 切换器：为 Agent 和 Chat badge 添加图标 【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/tabs/TabSwitcher.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabSwitcher.tsx
@@ -32,6 +32,7 @@ import {
 } from '@/atoms/agent-atoms'
 import type { SessionIndicatorStatus } from '@/atoms/agent-atoms'
 import { draftSessionIdsAtom } from '@/atoms/draft-session-atoms'
+import { Bot, MessageSquare } from 'lucide-react'
 
 type SwitchSectionId = 'recent'
 type SwitchCandidateType = 'chat' | 'agent'
@@ -435,8 +436,18 @@ function SwitcherCandidateRow({
           aria-hidden="true"
         />
       )}
-      <span className="w-10 shrink-0 text-[10px] leading-4 text-center rounded-full bg-foreground/[0.06] text-foreground/45 font-medium">
-        {candidate.type === 'agent' ? 'Agent' : 'Chat'}
+      <span className="w-auto px-2 shrink-0 text-[10px] leading-4 rounded-full bg-foreground/[0.06] text-foreground/45 font-medium flex items-center gap-1">
+        {candidate.type === 'agent' ? (
+          <>
+            <Bot className="size-2.5" />
+            Agent
+          </>
+        ) : (
+          <>
+            <MessageSquare className="size-2.5" />
+            Chat
+          </>
+        )}
       </span>
       <span className="flex-1 min-w-0 truncate">{candidate.title}</span>
       {candidate.workspaceName && (


### PR DESCRIPTION
## 概述

在 Ctrl+Tab 切换器中，Agent 和 Chat 会话的区分仅依靠文字 badge，视觉识别度不够明显。本 PR 为 badge 添加了对应的图标，提升视觉区分度。

## 改动内容

- **TabSwitcher.tsx**
  - 从 `lucide-react` 引入 `Bot` 和 `MessageSquare` 图标
  - Agent 会话 badge：显示 🤖 Bot 图标 + "Agent" 文字
  - Chat 会话 badge：显示 💬 MessageSquare 图标 + "Chat" 文字
  - 调整 badge 样式：
    - 从固定宽度 `w-10` 改为自适应 `w-auto px-2`
    - 使用 `flex items-center gap-1` 布局图标和文字
    - 图标大小使用 `className="size-2.5"` 符合项目 Tailwind 规范

## 测试方法

1. 打开多个 Agent 和 Chat 会话
2. 按 `Ctrl+Tab` 打开切换器
3. 观察 badge 是否正确显示图标：
   - Agent 会话显示机器人图标
   - Chat 会话显示对话框图标
4. 检查图标和文字的对齐和间距是否合理

## 注意事项

- 图标大小与项目其他组件（如 ModeSwitcher）保持一致
- 使用 Tailwind class 而非 lucide-react 的 `size` prop，符合项目代码规范
- Badge 宽度自适应，不会影响整体布局