### PR TITLE
fix：修复 Control+Tab 切换器选中态抖动【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.10.21",
+  "version": "0.10.22",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/tabs/TabSwitcher.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabSwitcher.tsx
@@ -417,7 +417,7 @@ function SwitcherCandidateRow({
       type="button"
       className={cn(
         'relative flex items-center gap-3 w-full pl-5 pr-5 py-2.5 text-[15px] text-left cursor-default transition-colors',
-        active ? 'bg-primary/15 text-foreground font-medium' : hoverEnabled ? 'text-muted-foreground hover:bg-muted/40' : 'text-muted-foreground',
+        active ? 'bg-primary/15 text-foreground' : hoverEnabled ? 'text-muted-foreground hover:bg-muted/40' : 'text-muted-foreground',
       )}
       onMouseEnter={onMouseEnter}
       onMouseDown={(event) => {


### PR DESCRIPTION
## Summary
- 移除 Ctrl+Tab 会话切换器选中行的字重变化，避免长标题临界宽度下触发布局重算
- 递增 @proma/electron patch 版本至 0.10.22

## Test
- bun run --filter='@proma/electron' typecheck
- git diff --check