### PR TITLE
fix(sidebar): 扩大 Agent 模式分割条 hover 热区并去掉 cursor 变化【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.10.21",
+  "version": "0.10.23",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -1594,10 +1594,10 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                 </div>
               </div>
 
-              {/* 拖拽分割条 */}
+              {/* 拖拽分割条：外层撑大 hover/拖拽 hitbox，内层渲染细线保持视觉简洁 */}
               <div
                 onMouseDown={handleAgentTopResizeStart}
-                className="h-[8px] cursor-row-resize active:bg-primary/50 transition-colors titlebar-no-drag flex-shrink-0 flex items-center"
+                className="h-[14px] hover:bg-primary/10 active:bg-primary/50 transition-colors titlebar-no-drag flex-shrink-0 flex items-center"
               >
                 <div className="mx-3 w-full border-t border-muted-foreground/20" />
               </div>


### PR DESCRIPTION
## 概述

左侧 Sidebar 在 Agent 模式下，"工作中/置顶"区域与"最近会话"区域之间有一条用于调整高度的分割条（drag handle）。当前实现外层只有 `h-[8px]`，内层仅渲染一条 1px 的灰色 border，鼠标悬浮时要精确对准才会触发 cursor 反馈，体验上"得找半天才能找到那个微妙的点"。

本 PR 重新平衡了视觉简洁与可操作性：把外层 hitbox 撑大，同时改用浅色背景 hover 反馈替代光标变化，避免 mousedown 之外又出现一个新的"光标突变"瞬间。

## 改动

- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx`
  - 拖拽分割条外层从 `h-[8px]` 改为 `h-[14px]`，hover/拖拽 hitbox 同步增大约 75%
  - 移除 `cursor-row-resize`，新增 `hover:bg-primary/10`：进入 hitbox 范围立即出现一层浅主色背景作为可拖拽提示
  - 内层 1px `border-t` 通过 `flex items-center` 居中，可视分割线位置完全不变
  - 注释更新为"外层撑大 hover/拖拽 hitbox，内层渲染细线保持视觉简洁"

- `apps/electron/package.json`
  - 版本从 `0.10.21` 递增到 `0.10.23`（按 CLAUDE.md 约定每次改动 patch +1）

## 如何测试

1. 切到 Agent 模式
2. 在左侧 Sidebar 同时存在"工作中"或"置顶"会话与历史会话（确保上下两区都可见）
3. 鼠标移到两区之间的分割线附近：
   - **预期**：进入 14px 高的横条范围立即看到浅色背景出现
   - **预期**：鼠标光标保持默认箭头，不会变成 row-resize
4. 在分割条上按住鼠标拖动：
   - **预期**：上下两区高度可正常调整，受 `AGENT_TOP_MIN_HEIGHT (80)` 与容器高度 70% 上限约束
   - **预期**：拖动过程中分割条显示 `active:bg-primary/50` 的更明显高亮

## 备注

- `WorkspaceSelector.tsx` 里另一处 resize handle 仍保留 `cursor-row-resize`，本 PR 不动它，以最小化变更范围
- `handleAgentTopResizeStart` 内部仍会在 mousedown 时把 `document.body.style.cursor` 设为 `row-resize`，按下瞬间整个页面光标会短暂变化。如果后续希望全程无光标变化，可以再做一次清理；本 PR 不在范围内