### PR TITLE
fix(diff): 归一化 CRLF 修复 Windows 下 diff 整文件全删全增【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.10.21",
+  "version": "0.10.22",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/git-diff-service.ts
+++ b/apps/electron/src/main/lib/git-diff-service.ts
@@ -15,6 +15,18 @@ import type { ChangeSource, ChangedFileStatus } from '@proma/shared'
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024
 
 /**
+ * 归一化换行符为 LF。
+ *
+ * diff 两侧内容来源不同：旧版本来自 `git show`（读对象库 blob，换行符为 LF），
+ * 新版本来自磁盘工作区文件（Windows 在 core.autocrlf=true 下检出为 CRLF）。
+ * 若不归一化，逐行 diff 会把每一行都判定为变更，导致整文件「全删全增」。
+ * 此处只影响 diff 显示比较，不改写磁盘文件。
+ */
+function normalizeLineEndings(content: string): string {
+  return content.replace(/\r\n/g, '\n')
+}
+
+/**
  * 校验并规范化 filePath，确保其位于 root 目录内。
  * 支持相对路径和绝对路径。绝对路径会被自动转为相对路径。
  * 拒绝 `..` 穿越和 root 外的路径。
@@ -345,7 +357,7 @@ export async function getDiffContents(dirPath: string, filePath: string, gitRoot
         // 读取失败保持空字符串
       }
     }
-    return { oldContent: '', newContent }
+    return { oldContent: '', newContent: normalizeLineEndings(newContent) }
   }
 
   const safePath = normalizeSafePath(root, filePath)
@@ -387,7 +399,7 @@ export async function getDiffContents(dirPath: string, filePath: string, gitRoot
     }
   }
 
-  return { oldContent, newContent }
+  return { oldContent: normalizeLineEndings(oldContent), newContent: normalizeLineEndings(newContent) }
 }
 
 /**
@@ -411,7 +423,7 @@ export async function getUntrackedContent(dirPath: string, filePath: string, git
       console.warn('[git-diff-service] 未追踪文件超过大小上限:', fullPath, st.size)
       return ''
     }
-    return readFileSync(fullPath, 'utf-8')
+    return normalizeLineEndings(readFileSync(fullPath, 'utf-8'))
   } catch {
     return ''
   }


### PR DESCRIPTION
## 概述

修复 Windows 平台上文件改动 diff 视图的一个误报：当 Agent 只改了一行代码时，Windows 上的 diff 渲染会把整个文件显示为「全部删除 + 全部新增」，而 macOS 上渲染正常。

**根因**：Windows 上 git 默认 `core.autocrlf=true`，导致 diff 两侧内容的换行符不一致：

- 旧版本通过 `git show HEAD:file` 读取对象库 blob，换行符是 **LF**（`git show` 不走 checkout 的 CRLF 转换）
- 新版本通过 `readFileSync` 读取磁盘工作区文件，Windows 检出后是 **CRLF**

两侧每行结尾一个 `\n`、一个 `\r\n`，`@pierre/diffs` 的逐行 Myers diff 会把每一行都判定为变更，于是整文件「全删全增」。macOS 上两侧通常都是 LF，所以不受影响。

这与 Agent 改没改、改了几行无关——只要是 Windows autocrlf 检出，任何被改动的文件都会触发全文件 diff。

## 改动

- `apps/electron/src/main/lib/git-diff-service.ts` — 新增 `normalizeLineEndings()`，在 diff 内容进入渲染前把 CRLF 统一归一化为 LF。应用到三个内容返回点：
  - `getDiffContents` 主路径（已追踪、被修改的文件）—— bug 核心
  - `getDiffContents` 无 git root 路径（纯文件预览）
  - `getUntrackedContent`（未追踪/新增文件，避免单侧 CRLF 带出多余 `\r`）
  - `getFileDiff` 未改动：它返回 git 原生 unified patch 文本，不参与逐行渲染
- `apps/electron/package.json` — 版本号 `0.10.21` → `0.10.22`

归一化只影响 diff 的**显示比较**，不改写磁盘文件本身，因此是安全的。唯一「损失」是无法在 diff 里看出纯换行符变更（CRLF↔LF），但这对代码 review 几乎从不需要，反而正是当前误报的来源。

附带修复：`DiffTabContent.tsx` 的 `oldContent === newContent` 空 diff 判断，归一化后纯换行符差异会被正确识别为「无差异」并自动收起预览面板。

## 测试方法

1. 在 Windows 环境下（git `core.autocrlf=true`），打开一个已 commit 的、以 CRLF 为换行符的文件
2. 让 Agent 或手动只修改其中一行
3. 在右侧「文件改动」面板查看该文件的 diff
4. **预期**：只显示改动的那一行，而不是整个文件全删全增

## 备注

- 该现象为 Windows-only，本 PR 改动已通过全包 `bun run typecheck`（4 个包全部 exit 0）
- 由于开发环境为 macOS，**未在 Windows 实机验证渲染效果**，逻辑上 CRLF→LF 归一化能消除每行的换行符差异，建议在 Windows 上确认一次实际 UI 表现