### PR TITLE
fix(feishu): 启用 2 人群免 @ 续聊（用 user_count 替代成员列表判定）

### DIFF
--- a/apps/electron/src/main/lib/feishu-bridge.ts
+++ b/apps/electron/src/main/lib/feishu-bridge.ts
@@ -706,6 +706,11 @@ class FeishuBridge {
       })
 
       if (!access.accepted) {
+        console.log(
+          `[飞书 Bridge] 群消息未触发 Agent（需 @Bot）——chatId=${chatId}, ` +
+          `userCount=${groupInfo?.userCount ?? 'N/A'}, isMentioned=${isMentioned}, ` +
+          `reason=${access.reason}。若这是仅你和 Bot 的群却仍要求 @，请确认已申请并发布 im:chat 权限。`,
+        )
         return
       }
 
@@ -1979,7 +1984,21 @@ class FeishuBridge {
       const name = chatResp?.data?.name ?? '未知群组'
       const description = chatResp?.data?.description
 
-      const info: FeishuGroupInfo = { chatId, name, description, members, cachedAt: Date.now() }
+      // user_count 是飞书侧权威的真人数量（不含机器人），免 @ 续聊判定优先用它。
+      // chat.get 需要 im:chat 权限；拿不到时记日志提示，判定会回退到成员列表。
+      const rawUserCount = chatResp?.data?.user_count
+      const userCount = rawUserCount != null ? Number(rawUserCount) : undefined
+      const normalizedUserCount = Number.isFinite(userCount) ? userCount : undefined
+      if (normalizedUserCount === undefined) {
+        console.warn(
+          `[飞书 Bridge] chat.get 未返回 user_count（chatId=${chatId}）——` +
+          `请确认已申请并发布 im:chat 权限（读取群基础信息），否则「仅你和 Bot 的群」无法免 @ 续聊。`,
+        )
+      }
+
+      const info: FeishuGroupInfo = {
+        chatId, name, description, members, userCount: normalizedUserCount, cachedAt: Date.now(),
+      }
       this.groupInfoCache.set(chatId, info)
 
       // 同时填充 userNameCache

--- a/apps/electron/src/main/lib/feishu/group-message-policy.ts
+++ b/apps/electron/src/main/lib/feishu/group-message-policy.ts
@@ -4,7 +4,7 @@ import type {
 } from '@proma/shared'
 
 export interface SingleUserGroupInput {
-  groupInfo: Pick<FeishuGroupInfo, 'members'> | null | undefined
+  groupInfo: Pick<FeishuGroupInfo, 'members' | 'userCount'> | null | undefined
   senderOpenId: string
   botOpenId?: string | null
   binding?: Pick<FeishuChatBinding, 'userId'> | null
@@ -20,18 +20,35 @@ export interface GroupMessageAccessResult {
   reason: 'session-mirror' | 'bot-mentioned' | 'single-user-group' | 'needs-mention'
 }
 
+/**
+ * 判定「群里只有 bot + 一个真人」，用于免 @ 续聊。
+ *
+ * 优先用 chat.get 返回的 user_count（飞书侧权威的真人数量，不含机器人）——
+ * 这甩掉了对 botOpenId 是否已拿到、以及成员列表读取权限的依赖。
+ * 仅当 user_count 不可用（旧缓存或 chat.get 失败）时，回退到「数成员列表减 bot」。
+ *
+ * 注意：加人后 user_count 自动 ≥2，会回到「必须 @」，符合
+ * 「只有 2 人群免 @，多人群谁都要 @（含建群者）」的预期。
+ */
 export function isSingleUserGroupForSender(input: SingleUserGroupInput): boolean {
+  const bindingUserId = input.binding?.userId
+  const bindingMismatch =
+    !!bindingUserId && bindingUserId !== 'unknown' && bindingUserId !== input.senderOpenId
+  if (bindingMismatch) return false
+
+  // 主路径：user_count 权威判定（恰好 1 个真人）
+  const userCount = input.groupInfo?.userCount
+  if (typeof userCount === 'number') {
+    return userCount === 1
+  }
+
+  // 回退路径：成员列表减 bot（依赖成员读取权限 + botOpenId 正确）
   const members = (input.groupInfo?.members ?? [])
     .filter((member) => member.openId !== input.botOpenId)
   if (members.length !== 1) return false
 
   const [onlyUser] = members
   if (!onlyUser || onlyUser.openId !== input.senderOpenId) return false
-
-  const bindingUserId = input.binding?.userId
-  if (bindingUserId && bindingUserId !== 'unknown' && bindingUserId !== input.senderOpenId) {
-    return false
-  }
 
   return true
 }

--- a/apps/electron/src/renderer/components/settings/FeishuSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/FeishuSettings.tsx
@@ -295,9 +295,9 @@ function PermissionsStep(): React.ReactElement {
             <div><span className="text-foreground/70">im:message:send_as_bot</span> — 以机器人身份发送消息</div>
             <div><span className="text-foreground/70">im:message.p2p_msg:readonly</span> — 接收用户发给机器人的单聊消息</div>
             <div><span className="text-foreground/70">im:message.group_at_msg:readonly</span> — 接收群聊中 @机器人 的消息</div>
-            <div><span className="text-foreground/70">im:message.group_msg</span> — 接收群聊所有用户消息（仅你和 Bot 的群免 @ 续聊、群聊上下文）</div>
+            <div><span className="text-foreground/70">im:message.group_msg</span> — 接收群聊所有用户消息（配合 im:chat 实现仅你和 Bot 的群免 @ 续聊、群聊上下文）</div>
             <div><span className="text-foreground/70">im:message.reactions:write_only</span> — 为消息添加状态表情（如⌨️/✅），让用户感知 Bot 正在处理 / 已完成</div>
-            <div><span className="text-foreground/70">im:chat</span> — 创建群 + 读取/更新群基础信息（群名、简介、邀请链接等）</div>
+            <div><span className="text-foreground/70">im:chat</span> — 创建群 + 读取/更新群基础信息（群名、简介、真人数量等；免 @ 续聊靠它判断群里只有你和 Bot）</div>
             <div><span className="text-foreground/70">im:chat.members:read</span> — 获取群成员列表（支持 @某人）</div>
             <div><span className="text-foreground/70">im:chat.members:write_only</span> — 添加 / 移除群成员（Bot 主动拉人入群）</div>
             <div><span className="text-foreground/70">im:chat.managers:write_only</span> — 指定 / 移除群管理员</div>
@@ -951,13 +951,22 @@ function SessionMirrorSection({ bots }: { bots: FeishuBotConfig[] }): React.Reac
           <div className="flex items-start gap-2 rounded-lg bg-amber-500/10 px-3 py-3 text-xs text-amber-800 dark:text-amber-300">
             <AlertTriangle size={15} className="mt-0.5 flex-shrink-0" />
             <div className="space-y-1 leading-relaxed">
-              <div className="font-medium text-amber-900 dark:text-amber-200">想在仅你和 Bot 的群里不 @Bot 也能继续发送消息，需要额外申请敏感权限。</div>
+              <div className="font-medium text-amber-900 dark:text-amber-200">想在仅你和 Bot 的群里不 @Bot 也能继续发送消息，需要额外申请两个权限。</div>
               <div>
-                请在飞书开放平台为同步 Bot 申请并发布
-                {' '}
-                <code className="rounded bg-amber-500/15 px-1 py-0.5 text-[11px] text-amber-900 dark:text-amber-100">im:message.group_msg</code>
-                {' '}
-                获取群组中所有消息。管理员审核通过前，飞书不会把非 @ 的群消息推送给 Proma；此时仍需要在群里 @Bot 才能触发 Agent。
+                请在飞书开放平台为同步 Bot 申请并发布以下权限：
+              </div>
+              <div className="flex flex-col gap-1 pl-1">
+                <div>
+                  <code className="rounded bg-amber-500/15 px-1 py-0.5 text-[11px] text-amber-900 dark:text-amber-100">im:message.group_msg</code>
+                  {' '}— 接收群聊中所有用户消息（否则飞书不会把非 @ 的群消息推送给 Proma）
+                </div>
+                <div>
+                  <code className="rounded bg-amber-500/15 px-1 py-0.5 text-[11px] text-amber-900 dark:text-amber-100">im:chat</code>
+                  {' '}— 读取群基础信息以判断群里只有你和 Bot（缺少时无法识别 2 人群，仍需 @Bot）
+                </div>
+              </div>
+              <div>
+                两者都审核通过并发布后才会生效；任一缺失或审核未过时，仍需要在群里 @Bot 才能触发 Agent。一键复制的权限配置里已包含这两项，单独手动添加时请勿遗漏。
               </div>
             </div>
           </div>

--- a/packages/shared/src/types/feishu.ts
+++ b/packages/shared/src/types/feishu.ts
@@ -203,6 +203,8 @@ export interface FeishuGroupInfo {
   description?: string
   /** 群成员列表 */
   members?: FeishuGroupMember[]
+  /** 群内真人数量（来自 chat.get 的 user_count，不含机器人）。免 @ 续聊判定的权威依据。 */
+  userCount?: number
   /** 缓存时间戳 */
   cachedAt: number
 }


### PR DESCRIPTION
## Summary

- f3431c6 fix(feishu): 启用 2 人群免 @ 续聊（用 user_count 替代成员列表判定）

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归