### PR TITLE
fix(mention): 修复文件选择器不消失 & 非空格前缀无法触发

### DIFF
--- a/apps/electron/src/renderer/components/agent/mention-suggestions.tsx
+++ b/apps/electron/src/renderer/components/agent/mention-suggestions.tsx
@@ -40,6 +40,7 @@ function createMentionSuggestion<T>(
   return {
     char: config.char,
     allowSpaces: false,
+    allowedPrefixes: null,
 
     items: async ({ query }): Promise<T[]> => {
       const slug = workspaceSlugRef.current
@@ -54,11 +55,32 @@ function createMentionSuggestion<T>(
     render: () => {
       let renderer: ReactRenderer<MentionListRef> | null = null
       let popup: HTMLDivElement | null = null
+      let blurHandler: (() => void) | null = null
+      let editorDom: HTMLElement | null = null
+
+      function cleanup() {
+        if (blurHandler && editorDom) {
+          editorDom.removeEventListener('blur', blurHandler, true)
+          blurHandler = null
+        }
+        editorDom = null
+        mentionActiveRef.current = false
+        mentionItemCountRef.current = 0
+        popup?.remove()
+        popup = null
+        renderer?.destroy()
+        renderer = null
+      }
 
       return {
         onStart(props) {
+          if (popup || renderer) {
+            cleanup()
+          }
+
           mentionActiveRef.current = true
           mentionItemCountRef.current = props.items.length
+          editorDom = props.editor.view.dom
           renderer = new ReactRenderer(MentionList, {
             props: {
               items: props.items,
@@ -75,6 +97,15 @@ function createMentionSuggestion<T>(
           })
           popup = createMentionPopup(renderer.element)
           positionPopup(popup, props.clientRect?.())
+
+          blurHandler = () => {
+            setTimeout(() => {
+              if (!props.editor.view.hasFocus() && popup) {
+                cleanup()
+              }
+            }, 100)
+          }
+          editorDom.addEventListener('blur', blurHandler, true)
         },
 
         onUpdate(props) {
@@ -94,12 +125,7 @@ function createMentionSuggestion<T>(
         },
 
         onExit() {
-          mentionActiveRef.current = false
-          mentionItemCountRef.current = 0
-          popup?.remove()
-          popup = null
-          renderer?.destroy()
-          renderer = null
+          cleanup()
         },
       }
     },

--- a/apps/electron/src/renderer/components/file-browser/file-mention-suggestion.tsx
+++ b/apps/electron/src/renderer/components/file-browser/file-mention-suggestion.tsx
@@ -28,6 +28,7 @@ export function createFileMentionSuggestion(
   return {
     char: '@',
     allowSpaces: false,
+    allowedPrefixes: null,
 
     items: async ({ query }): Promise<FileIndexEntry[]> => {
       const wsPath = workspacePathRef.current
@@ -68,6 +69,8 @@ export function createFileMentionSuggestion(
       let popup: HTMLDivElement | null = null
       let resizeObserver: ResizeObserver | null = null
       let latestClientRect: (() => DOMRect | null) | null | undefined = null
+      let blurHandler: (() => void) | null = null
+      let editorRef: SuggestionProps<FileIndexEntry>['editor'] | null = null
 
       function splitEntries(result: FileSearchResult | null) {
         return {
@@ -95,10 +98,34 @@ export function createFileMentionSuggestion(
         positionPopup(popup, latestClientRect?.(), { anchorBottom: true })
       }
 
+      function cleanup() {
+        if (blurHandler && editorRef) {
+          editorRef.view.dom.removeEventListener('blur', blurHandler, true)
+          blurHandler = null
+        }
+        editorRef = null
+        mentionActiveRef.current = false
+        if (mentionItemCountRef) mentionItemCountRef.current = 0
+        lastResult = null
+        latestClientRect = null
+        resizeObserver?.disconnect()
+        resizeObserver = null
+        popup?.remove()
+        popup = null
+        renderer?.destroy()
+        renderer = null
+      }
+
       return {
         onStart(props) {
+          // 防御竞态：如果上一次弹窗未被正确清理，先清理残留
+          if (popup || renderer) {
+            cleanup()
+          }
+
           mentionActiveRef.current = true
           if (mentionItemCountRef) mentionItemCountRef.current = props.items.length
+          editorRef = props.editor
 
           try {
             latestClientRect = props.clientRect
@@ -110,8 +137,20 @@ export function createFileMentionSuggestion(
               anchorPopup()
             })
             resizeObserver.observe(popup!)
+
+            // 编辑器失焦时强制关闭弹窗（点击页面其他区域等场景）
+            blurHandler = () => {
+              // 延迟检查：点击弹窗本身不应关闭（焦点会回到编辑器）
+              setTimeout(() => {
+                if (!editorRef?.view.hasFocus() && popup) {
+                  cleanup()
+                }
+              }, 100)
+            }
+            props.editor.view.dom.addEventListener('blur', blurHandler, true)
           } catch (e) {
             console.error('[FileMention] render popup failed:', e)
+            cleanup()
           }
         },
 
@@ -138,16 +177,7 @@ export function createFileMentionSuggestion(
         },
 
         onExit() {
-          mentionActiveRef.current = false
-          if (mentionItemCountRef) mentionItemCountRef.current = 0
-          lastResult = null
-          latestClientRect = null
-          resizeObserver?.disconnect()
-          resizeObserver = null
-          popup?.remove()
-          popup = null
-          renderer?.destroy()
-          renderer = null
+          cleanup()
         },
       }
     },


### PR DESCRIPTION
## Summary
- 修复 @ 文件选择器偶尔不会自动消失的竞态 bug（async update 交错 + blur 未处理）
- 修复中文等非空格字符后输入 `/` `#` `@` `&` 无法触发 mention 选择器的问题

## Changes
- `file-mention-suggestion.tsx`: 提取 cleanup()，onStart 前清理残留，注册 blur 监听
- `mention-suggestions.tsx`: 同上防御性修复应用到 `/` `#` `&` 三个 mention
- 两个文件均设置 `allowedPrefixes: null` 允许任意前缀触发

## Test plan
- [x] 输入 @ 后快速按空格/删除，弹窗应消失
- [x] 弹窗打开时点击页面其他区域，弹窗应消失
- [x] 连续触发不会出现重叠弹窗
- [x] 正常选择文件/Skill/MCP 功能无回归
- [x] 中文文本后直接输入 `/` `#` `@` 可正常触发选择器

🤖 Generated with [Claude Code](https://claude.com/claude-code)