### PR TITLE
fix: 修复 Windows 长路径下 Edit/Write 工具行 +N/-M 统计不显示的问题 【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.10.23",
+  "version": "0.10.24",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/agent/ContentBlock.tsx
+++ b/apps/electron/src/renderer/components/agent/ContentBlock.tsx
@@ -261,22 +261,6 @@ function PromptRow({ prompt, dimmed = false }: { prompt: string; dimmed?: boolea
 
 // ===== 工具短语 diff 着色 =====
 
-/** 将 displayLabel 中的 +N 染绿、-N 染红（仅对 Edit/Write 工具生效，避免 `head -5` 等命令参数被误染） */
-function renderLabelWithDiffColors(label: string, toolName: string): React.ReactNode {
-  if (toolName !== 'Edit' && toolName !== 'Write') return label
-  const parts = label.split(/((?:^|(?<=\s))[+-]\d+)/g)
-  if (parts.length === 1) return label
-  return parts.map((part, i) => {
-    if (/^\+\d+$/.test(part)) {
-      return <span key={i} className="text-green-500">{part}</span>
-    }
-    if (/^-\d+$/.test(part)) {
-      return <span key={i} className="text-red-500">{part}</span>
-    }
-    return part
-  })
-}
-
 function TaskGetCollapsedSummary({ task }: { task: ParsedTaskGetResult }): React.ReactElement {
   const blockPreview = task.blocks.length > 0
     ? `${task.blocks[0]}${task.blocks.length > 1 ? ` +${task.blocks.length - 1}` : ''}`
@@ -513,7 +497,19 @@ function ToolUseBlock({ block, allMessages, animate = false, index = 0, dimmed =
           'min-w-0 truncate text-[14px]',
           taskGetSummary || taskListSummary ? 'shrink-0' : '',
           dimmed ? 'text-muted-foreground/70' : 'text-muted-foreground',
-        )}>{renderLabelWithDiffColors(displayLabel, block.name)}</span>
+        )}>{displayLabel}</span>
+
+        {phrase.diffStats && (isCompleted || !isStreaming) && (
+          <span className="shrink-0 text-[14px] tabular-nums">
+            {phrase.diffStats.additions > 0 && (
+              <span className="text-green-500">+{phrase.diffStats.additions}</span>
+            )}
+            {phrase.diffStats.additions > 0 && phrase.diffStats.deletions > 0 && ' '}
+            {phrase.diffStats.deletions > 0 && (
+              <span className="text-red-500">-{phrase.diffStats.deletions}</span>
+            )}
+          </span>
+        )}
 
         {taskGetSummary && (
           <span className="flex min-w-0 items-center gap-1.5">

--- a/apps/electron/src/renderer/components/agent/tool-phrase.ts
+++ b/apps/electron/src/renderer/components/agent/tool-phrase.ts
@@ -13,11 +13,13 @@ export interface ToolPhrase {
   label: string
   /** Loading 态短语，如 "正在读取 foo.ts..." */
   loadingLabel: string
+  /** 编辑/写入的增删行数统计，独立于 label，便于 UI 单独渲染且不被路径截断 */
+  diffStats?: { additions: number; deletions: number }
 }
 
-/** 从路径中提取文件名 */
+/** 从路径中提取文件名（同时兼容 POSIX `/` 与 Windows `\` 分隔符） */
 function filename(path: string): string {
-  return path.split('/').pop() ?? path
+  return path.split(/[/\\]/).pop() || path
 }
 
 /** 截断文本 */
@@ -53,11 +55,8 @@ export function getToolPhrase(toolName: string, input: Record<string, unknown>):
       const fp = input.file_path ?? input.filePath
       const name = typeof fp === 'string' ? filename(fp) : '文件'
       const diff = computeDiffStats('Edit', input)
-      if (diff) {
-        const parts = [name]
-        if (diff.additions > 0) parts.push(`+${diff.additions}`)
-        if (diff.deletions > 0) parts.push(`-${diff.deletions}`)
-        return phrase(`编辑 ${parts.join(' ')}`)
+      if (diff && (diff.additions > 0 || diff.deletions > 0)) {
+        return { ...phrase(`编辑 ${name}`), diffStats: diff }
       }
       return phrase(`编辑 ${name}`)
     }
@@ -68,7 +67,7 @@ export function getToolPhrase(toolName: string, input: Record<string, unknown>):
       const content = input.content
       if (typeof content === 'string' && content.length > 0) {
         const lines = content.split('\n').length
-        return phrase(`写入 ${name} +${lines}`)
+        return { ...phrase(`写入 ${name}`), diffStats: { additions: lines, deletions: 0 } }
       }
       return phrase(`写入 ${name}`)
     }

--- a/apps/electron/src/renderer/components/agent/tool-utils.ts
+++ b/apps/electron/src/renderer/components/agent/tool-utils.ts
@@ -269,8 +269,8 @@ export function getInputSummary(
     case 'Write': {
       const filePath = input.file_path
       if (typeof filePath === 'string') {
-        // 仅展示文件名，不展示完整路径
-        return filePath.split('/').pop() ?? filePath
+        // 仅展示文件名，不展示完整路径（兼容 Windows 反斜杠）
+        return filePath.split(/[/\\]/).pop() || filePath
       }
       return null
     }
@@ -278,7 +278,7 @@ export function getInputSummary(
     case 'NotebookEdit': {
       const notebookPath = input.notebook_path
       if (typeof notebookPath === 'string') {
-        return notebookPath.split('/').pop() ?? notebookPath
+        return notebookPath.split(/[/\\]/).pop() || notebookPath
       }
       return null
     }
@@ -341,7 +341,7 @@ export function getInputSummary(
       const name = input.name
       const scriptPath = input.scriptPath
       if (typeof name === 'string') return name
-      if (typeof scriptPath === 'string') return scriptPath.split('/').pop() ?? scriptPath
+      if (typeof scriptPath === 'string') return scriptPath.split(/[/\\]/).pop() || scriptPath
       return null
     }
 


### PR DESCRIPTION
- filename() 改用 split(/[/\]/) 兼容 Windows 反斜杠路径提取
- 将 diffStats 从 label 字符串中独立为结构化字段
- UI 层将 +N/-M 渲染为 shrink-0 的独立 span，确保不被路径截断
- 同步修复 tool-utils.ts 中 getInputSummary 的三处同源问题