### PR TITLE
fix: 恢复渠道 Logo 的 URL 品牌识别

### DIFF
--- a/apps/electron/src/renderer/components/chat/ModelSelector.tsx
+++ b/apps/electron/src/renderer/components/chat/ModelSelector.tsx
@@ -25,7 +25,7 @@ import {
 } from '@/atoms/chat-atoms'
 import { useConversationModelOptional } from '@/hooks/useConversationSettings'
 import { useConversationIdOptional } from '@/contexts/session-context'
-import { getModelLogo, getProviderLogo } from '@/lib/model-logo'
+import { getModelLogo, getChannelLogo, DefaultLogo } from '@/lib/model-logo'
 import { cn } from '@/lib/utils'
 import type { Channel, ModelOption } from '@proma/shared'
 
@@ -285,7 +285,10 @@ export function ModelSelector({
                     {/* 供应商标题行 - 灰色背景 */}
                     <div className="flex items-center gap-2 px-4 py-2 bg-muted/50 border-b border-border/30">
                       <img
-                        src={getProviderLogo(channels.find((c) => c.id === channelId)?.provider ?? 'anthropic')}
+                        src={(() => {
+                          const ch = channels.find((c) => c.id === channelId)
+                          return ch ? getChannelLogo(ch) : DefaultLogo
+                        })()}
                         alt={first.channelName}
                         className="size-5 rounded object-cover"
                       />

--- a/apps/electron/src/renderer/components/settings/ChannelSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelSettings.tsx
@@ -14,7 +14,7 @@ import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
 import { PROVIDER_LABELS, isAgentCompatibleProvider } from '@proma/shared'
 import type { Channel } from '@proma/shared'
-import { getProviderLogo, PromaLogo } from '@/lib/model-logo'
+import { getChannelLogo, PromaLogo } from '@/lib/model-logo'
 import { agentChannelIdAtom, agentModelIdAtom, agentChannelIdsAtom } from '@/atoms/agent-atoms'
 import { channelsAtom } from '@/atoms/chat-atoms'
 import { SettingsSection, SettingsCard, SettingsRow } from './primitives'
@@ -323,7 +323,7 @@ function ChannelRow({ channel, onEdit, onDelete, onToggle }: ChannelRowProps): R
   return (
     <SettingsRow
       label={channel.name}
-      icon={<img src={getProviderLogo(channel.provider)} alt="" className="w-8 h-8 rounded" />}
+      icon={<img src={getChannelLogo(channel)} alt="" className="w-8 h-8 rounded" />}
       description={description}
       className="group"
     >
@@ -374,7 +374,7 @@ function AgentProviderRow({ channel, enabled, onToggle }: AgentProviderRowProps)
   return (
     <SettingsRow
       label={channel.name}
-      icon={<img src={getProviderLogo(channel.provider)} alt="" className="w-8 h-8 rounded" />}
+      icon={<img src={getChannelLogo(channel)} alt="" className="w-8 h-8 rounded" />}
       description={description}
     >
       <Switch

--- a/apps/electron/src/renderer/lib/model-logo.ts
+++ b/apps/electron/src/renderer/lib/model-logo.ts
@@ -291,6 +291,64 @@ export function getProviderLogo(provider: ProviderType): string {
 }
 
 /**
+ * Base URL 域名 → Logo 映射
+ *
+ * 仅用于「泛化」provider 类型（anthropic / anthropic-compatible / custom），
+ * 这些类型无法从类型本身判断真实品牌，需要按 Base URL 域名识别。
+ *
+ * 注意：故意不包含 anthropic 域名规则——真 Anthropic 渠道会通过
+ * getProviderLogo('anthropic') 回退到 Claude；而第三方 anthropic-compatible
+ * 服务（常以 /anthropic 结尾）不应被误判为 Claude（见 #659）。
+ */
+const URL_LOGO_MAP: Array<[RegExp, string]> = [
+  [/proma\.cool/i, PromaLogo],
+  [/moonshot\.cn|kimi/i, KimiLogo],
+  [/bigmodel\.cn|zhipuai/i, ZhipuLogo],
+  [/minimax/i, MiniMaxLogo],
+  [/volces\.com|volcengine/i, DoubaoLogo],
+  [/dashscope|aliyuncs/i, QwenLogo],
+  [/deepseek/i, DeepSeekLogo],
+  [/openai\.com/i, OpenAILogo],
+  [/googleapis|generativelanguage/i, GeminiLogo],
+  [/grok|x\.ai/i, GrokLogo],
+  [/stepfun/i, StepLogo],
+  [/cohere/i, CohereLogo],
+  [/spark-api|xfyun/i, SparkDeskLogo],
+  [/hunyuan/i, HunyuanLogo],
+  [/ernie|baidu/i, WenxinLogo],
+  [/yi\.com|lingyiwanwu/i, YiLogo],
+]
+
+/** provider 类型本身无法判断真实品牌、需按 URL 识别的「泛化」类型 */
+const GENERIC_PROVIDERS: ReadonlySet<ProviderType> = new Set<ProviderType>([
+  'anthropic',
+  'anthropic-compatible',
+  'custom',
+])
+
+/**
+ * 获取渠道（Channel）的 Logo
+ *
+ * 识别策略：
+ * 1. 明确品牌的 provider 类型（deepseek/openai/google/...）→ 直接信任 provider Logo
+ * 2. 泛化类型（anthropic/anthropic-compatible/custom）→ 先按 Base URL 域名识别真实品牌，
+ *    识别不到再回退到 provider 默认 Logo
+ *
+ * 这样既能识别「用 Anthropic 协议接入第三方品牌」的渠道，又不会把第三方
+ * anthropic-compatible 服务误判为 Claude。
+ */
+export function getChannelLogo(channel: { provider: ProviderType; baseUrl: string }): string {
+  if (GENERIC_PROVIDERS.has(channel.provider) && channel.baseUrl) {
+    for (const [regex, logo] of URL_LOGO_MAP) {
+      if (regex.test(channel.baseUrl)) {
+        return logo
+      }
+    }
+  }
+  return getProviderLogo(channel.provider)
+}
+
+/**
  * 根据模型 ID 在渠道列表中查找显示名称
  *
  * 优先返回别名（name !== id），未找到则返回原始 modelId。


### PR DESCRIPTION
## Summary

- 01cf7f6 fix: 恢复渠道 Logo 的 URL 品牌识别，修复全被 Anthropic 覆盖问题

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归