### PR TITLE
perf: 将 Git 命令从 spawnSync 改为异步 spawn，避免 IPC 阻塞主线程

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -838,7 +838,7 @@ export function registerIpcHandlers(): void {
     IPC_CHANNELS.LIST_WORKTREES,
     async (_, repoPath: string, _sessionId: string) => {
       if (!repoPath || typeof repoPath !== 'string') return []
-      return listWorktrees(repoPath)
+      return await listWorktrees(repoPath)
     }
   )
 

--- a/apps/electron/src/main/lib/git-diff-service.ts
+++ b/apps/electron/src/main/lib/git-diff-service.ts
@@ -2,10 +2,10 @@
  * Git Diff 服务
  *
  * 提供工作区文件变更检测、diff 获取、文件还原等 Git 操作。
- * 复用 git-detector.ts 中 runGitCommand 的 spawnSync 模式。
+ * 使用异步 spawn 模式，避免阻塞主进程。
  */
 
-import { spawnSync } from 'child_process'
+import { spawn } from 'child_process'
 import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from 'fs'
 import { basename, isAbsolute, join, resolve, sep } from 'path'
 import type { ChangedFileEntry, UnstagedChangesResult, UntrackedFileEntry } from '@proma/shared'
@@ -61,37 +61,62 @@ function normalizeSafePath(root: string, filePath: string): string | null {
 }
 
 /**
- * 执行 Git 命令
+ * 异步执行 Git 命令
  *
  * @param args - Git 命令参数
  * @param cwd - 工作目录
  * @returns 命令输出，如果失败返回 null
  */
-function runGitCommand(args: string[], cwd: string): string | null {
-  try {
-    const result = spawnSync('git', args, {
-      cwd,
-      encoding: 'utf-8',
-      timeout: 10000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-      env: {
-        ...process.env,
-        GIT_TERMINAL_PROMPT: '0',
-      },
-    })
+function runGitCommand(args: string[], cwd: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    try {
+      const child = spawn('git', args, {
+        cwd,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: {
+          ...process.env,
+          GIT_TERMINAL_PROMPT: '0',
+        },
+      })
 
-    if (result.error) {
-      console.error('[git-diff-service] git 命令错误:', result.error)
-      return null
-    }
-    if (result.status === 0) {
-      return result.stdout.trim()
-    }
-  } catch {
-    // 命令执行失败
-  }
+      let stdout = ''
+      let stderr = ''
 
-  return null
+      child.stdout?.on('data', (data) => {
+        stdout += data.toString()
+      })
+
+      child.stderr?.on('data', (data) => {
+        stderr += data.toString()
+      })
+
+      child.on('close', (code) => {
+        if (code === 0) {
+          resolve(stdout.trim())
+        } else {
+          resolve(null)
+        }
+      })
+
+      child.on('error', (err) => {
+        console.error('[git-diff-service] git 命令错误:', err)
+        resolve(null)
+      })
+
+      // 10 秒超时
+      const timeout = setTimeout(() => {
+        child.kill('SIGTERM')
+        console.warn('[git-diff-service] git 命令超时')
+        resolve(null)
+      }, 10000)
+
+      child.on('close', () => {
+        clearTimeout(timeout)
+      })
+    } catch {
+      resolve(null)
+    }
+  })
 }
 
 /**
@@ -171,7 +196,8 @@ export async function getUnstagedChanges(
   )
   const gitRoots: string[] = []
   for (const cand of candidates) {
-    for (const root of findAllGitRoots(cand)) {
+    const roots = await findAllGitRoots(cand)
+    for (const root of roots) {
       if (!gitRoots.includes(root)) gitRoots.push(root)
     }
   }
@@ -194,8 +220,8 @@ export async function getUnstagedChanges(
 
   for (const gitRoot of gitRoots) {
     // 获取变更文件列表 (M=modified, D=deleted, A=added, R=renamed, C=copied, T=type)
-    const nameStatus = runGitCommand(['diff', '--name-status'], gitRoot)
-    const numStat = runGitCommand(['diff', '--numstat'], gitRoot)
+    const nameStatus = await runGitCommand(['diff', '--name-status'], gitRoot)
+    const numStat = await runGitCommand(['diff', '--numstat'], gitRoot)
     const numStatMap = parseNumstat(numStat)
 
     if (nameStatus) {
@@ -237,7 +263,7 @@ export async function getUnstagedChanges(
     }
 
     // 获取未追踪文件
-    const untrackedOutput = runGitCommand(['ls-files', '--others', '--exclude-standard'], gitRoot)
+    const untrackedOutput = await runGitCommand(['ls-files', '--others', '--exclude-standard'], gitRoot)
     if (untrackedOutput) {
       for (const rel of untrackedOutput.split('\n').filter(Boolean)) {
         const absPath = join(gitRoot, rel)
@@ -303,11 +329,11 @@ function findAllGitRootsDown(dirPath: string, maxDepth: number): string[] {
 }
 
 /** 查找 Git 仓库根目录（支持向上搜索子目录内的 repos），返回所有找到的根 */
-function findAllGitRoots(baseDir: string): string[] {
+async function findAllGitRoots(baseDir: string): Promise<string[]> {
   if (!existsSync(baseDir)) return []
 
   // 1. 向上搜索：git rev-parse --show-toplevel
-  const toplevel = runGitCommand(['rev-parse', '--show-toplevel'], baseDir)
+  const toplevel = await runGitCommand(['rev-parse', '--show-toplevel'], baseDir)
   const roots: string[] = []
   if (toplevel && existsSync(toplevel)) {
     const normalized = normalizeGitRoot(toplevel)
@@ -324,22 +350,23 @@ function findAllGitRoots(baseDir: string): string[] {
 }
 
 /** 查找 Git 仓库根目录，先向上后向下搜索，失败返回 null */
-function findGitRoot(baseDir: string): string | null {
-  return findAllGitRoots(baseDir)[0] ?? null
+async function findGitRoot(baseDir: string): Promise<string | null> {
+  const roots = await findAllGitRoots(baseDir)
+  return roots[0] ?? null
 }
 
 /**
  * 获取单个文件的 unified diff
  */
 export async function getFileDiff(dirPath: string, filePath: string, gitRoot?: string): Promise<string> {
-  const root = gitRoot || findGitRoot(dirPath)
+  const root = gitRoot || await findGitRoot(dirPath)
   if (!root) return ''
   const safePath = normalizeSafePath(root, filePath)
   if (!safePath) {
     console.warn('[git-diff-service] getFileDiff 拒绝不安全路径:', filePath)
     return ''
   }
-  const diff = runGitCommand(['diff', '--', safePath], root)
+  const diff = await runGitCommand(['diff', '--', safePath], root)
   return diff || ''
 }
 
@@ -347,7 +374,7 @@ export async function getFileDiff(dirPath: string, filePath: string, gitRoot?: s
  * 获取文件的旧版本（git HEAD 或指定 baseRef）和新版本（磁盘）内容
  */
 export async function getDiffContents(dirPath: string, filePath: string, gitRoot?: string, baseRef?: string): Promise<{ oldContent: string; newContent: string } | null> {
-  const root = gitRoot || findGitRoot(dirPath)
+  const root = gitRoot || await findGitRoot(dirPath)
 
   // 无 git root：纯文件预览（无 git HEAD 可比较），仅读磁盘文件，安全检查依赖 dirPath
   if (!root) {
@@ -383,14 +410,9 @@ export async function getDiffContents(dirPath: string, filePath: string, gitRoot
   const ref = baseRef || 'HEAD'
   let oldContent = ''
   try {
-    const result = spawnSync('git', ['show', `${ref}:${safePath}`], {
-      cwd: root,
-      encoding: 'utf-8',
-      timeout: 10000,
-      env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
-    })
-    if (result.status === 0) {
-      oldContent = result.stdout
+    const oldGitContent = await runGitCommand(['show', `${ref}:${safePath}`], root)
+    if (oldGitContent !== null) {
+      oldContent = oldGitContent
     }
   } catch {
     // 文件在 HEAD 中不存在（新文件）
@@ -423,7 +445,7 @@ export async function getDiffContents(dirPath: string, filePath: string, gitRoot
  */
 export async function getUntrackedContent(dirPath: string, filePath: string, gitRoot?: string): Promise<string> {
   if (!filePath || typeof filePath !== 'string') return ''
-  const root = gitRoot || findGitRoot(dirPath) || dirPath
+  const root = gitRoot || await findGitRoot(dirPath) || dirPath
   const safePath = normalizeSafePath(root, filePath)
   if (!safePath) {
     console.warn('[git-diff-service] getUntrackedContent 拒绝不安全路径:', filePath)
@@ -446,13 +468,13 @@ export async function getUntrackedContent(dirPath: string, filePath: string, git
  * 还原文件的未暂存变更
  */
 export async function revertFile(dirPath: string, filePath: string, gitRoot?: string): Promise<void> {
-  const root = gitRoot || findGitRoot(dirPath)
+  const root = gitRoot || await findGitRoot(dirPath)
   if (!root) throw new Error('未找到 Git 仓库')
   const safePath = normalizeSafePath(root, filePath)
   if (!safePath) {
     throw new Error(`不安全的路径: ${filePath}`)
   }
-  const result = runGitCommand(['checkout', '--', safePath], root)
+  const result = await runGitCommand(['checkout', '--', safePath], root)
   if (result === null) {
     throw new Error(`还原失败: git checkout -- ${safePath}`)
   }
@@ -461,8 +483,8 @@ export async function revertFile(dirPath: string, filePath: string, gitRoot?: st
 /**
  * 列出指定仓库的所有 Git Worktree
  */
-export function listWorktrees(repoPath: string): import('@proma/shared').WorktreeInfo[] {
-  const output = runGitCommand(['worktree', 'list', '--porcelain'], repoPath)
+export async function listWorktrees(repoPath: string): Promise<import('@proma/shared').WorktreeInfo[]> {
+  const output = await runGitCommand(['worktree', 'list', '--porcelain'], repoPath)
   if (!output) return []
 
   const worktrees: import('@proma/shared').WorktreeInfo[] = []
@@ -513,10 +535,10 @@ export async function getWorktreeChanges(
   }
 
   // 尝试 fetch 远端 main 以确保 baseBranch 最新
-  runGitCommand(['fetch', 'origin', 'main', '--quiet'], worktreePath)
+  await runGitCommand(['fetch', 'origin', 'main', '--quiet'], worktreePath)
 
   // 确认是 git 仓库
-  const toplevel = runGitCommand(['rev-parse', '--show-toplevel'], worktreePath)
+  const toplevel = await runGitCommand(['rev-parse', '--show-toplevel'], worktreePath)
   if (!toplevel) {
     return { isGitRepo: false, files: [], untrackedFiles: [], gitRootNames: [] }
   }
@@ -526,8 +548,8 @@ export async function getWorktreeChanges(
   const fileMap = new Map<string, import('@proma/shared').ChangedFileEntry>()
 
   // 1. 已 commit 但未合并的改动: git diff baseBranch...HEAD
-  const committedStatus = runGitCommand(['diff', `${baseBranch}...HEAD`, '--name-status'], gitRoot)
-  const committedNumstat = runGitCommand(['diff', `${baseBranch}...HEAD`, '--numstat'], gitRoot)
+  const committedStatus = await runGitCommand(['diff', `${baseBranch}...HEAD`, '--name-status'], gitRoot)
+  const committedNumstat = await runGitCommand(['diff', `${baseBranch}...HEAD`, '--numstat'], gitRoot)
   const committedStats = parseNumstat(committedNumstat)
 
   if (committedStatus) {
@@ -563,8 +585,8 @@ export async function getWorktreeChanges(
   }
 
   // 2. 未提交的改动: git diff (working tree vs HEAD)
-  const uncommittedStatus = runGitCommand(['diff', '--name-status'], gitRoot)
-  const uncommittedNumstat = runGitCommand(['diff', '--numstat'], gitRoot)
+  const uncommittedStatus = await runGitCommand(['diff', '--name-status'], gitRoot)
+  const uncommittedNumstat = await runGitCommand(['diff', '--numstat'], gitRoot)
   const uncommittedStats = parseNumstat(uncommittedNumstat)
 
   if (uncommittedStatus) {
@@ -608,7 +630,7 @@ export async function getWorktreeChanges(
 
   // 3. 新文件（未追踪）
   const untrackedFiles: import('@proma/shared').UntrackedFileEntry[] = []
-  const untrackedOutput = runGitCommand(['ls-files', '--others', '--exclude-standard'], gitRoot)
+  const untrackedOutput = await runGitCommand(['ls-files', '--others', '--exclude-standard'], gitRoot)
   if (untrackedOutput) {
     for (const rel of untrackedOutput.split('\n').filter(Boolean)) {
       if (!fileMap.has(rel)) {


### PR DESCRIPTION
## 问题

切换到「文件改动」Tab 时，整个 Proma 页面卡住，无法点击任何元素，必须等 Git 命令执行完才能恢复交互。

## 根因

`git-diff-service.ts` 中的 `runGitCommand` 使用 `spawnSync` 同步执行 Git 命令，阻塞了 Electron 主进程的事件循环。当用户切换到「文件改动」Tab 时，IPC 调用 `getUnstagedChanges`，主进程同步执行 `git diff` 等命令，期间所有 UI 事件都无法处理。

## 修复

- 将 `runGitCommand` 从 `spawnSync` 改为 `spawn` + `Promise`
- `findAllGitRoots` / `findGitRoot` 改为 async
- 所有调用 `runGitCommand` 的地方加上 `await`
- `ipc.ts` 中 `listWorktrees` 调用补上 `await`

## 改动范围

仅影响 `git-diff-service.ts` 和 `ipc.ts` 两个文件，所有导出函数原本就是 `async`，接口契约不变。

## 测试建议

- [ ] 切换到「文件改动」Tab，UI 应保持响应
- [ ] 文件改动列表应正确显示
- [ ] 点击文件应能正常预览 diff
- [ ] 还原文件功能应正常工作