### PR TITLE
fix(mention): 修复 / Skill 选择器鼠标点击有时无效的竞态问题

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.10.25",
+  "version": "0.10.26",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/agent/MentionList.tsx
+++ b/apps/electron/src/renderer/components/agent/MentionList.tsx
@@ -87,6 +87,9 @@ function MentionListInner<T>(
             'w-full flex items-center gap-2 px-2.5 py-1.5 text-left text-xs hover:bg-accent transition-colors',
             index === localIndex && 'bg-accent text-accent-foreground',
           )}
+          // 阻止 mousedown 抢走编辑器焦点，否则会触发 blur → cleanup 提前销毁弹窗，
+          // 导致后续 onClick 永不触发（鼠标点击有时无效的根因，回车走键盘路径不受影响）
+          onMouseDown={(e) => e.preventDefault()}
           onClick={() => onSelect(item)}
         >
           {renderItem(item)}


### PR DESCRIPTION
## 概述

修复 Agent 输入框 `/` Skill 选择器（以及 `#` MCP、`&` 会话引用三种 mention 弹窗）**鼠标点击有时不生效**的 bug：用户鼠标点击某个 Skill 后偶尔无事发生、Skill 没插入输入框，但键盘回车选中一直正常。

根因是一个 **blur / click 竞态**：`mention-suggestions.tsx` 在弹窗弹出时给编辑器注册了 `blur` 监听，失焦后用 `setTimeout(100ms)` 销毁弹窗。鼠标点击选项时，`mousedown` 阶段会先把焦点从编辑器（contenteditable）抢到按钮上，触发 `blur` → 启动 100ms 销毁倒计时。而真正执行选中的 `onClick` 在事件链路末尾才触发。当按下到松开耗时 + 调度让 100ms 倒计时先跑完时，弹窗（连同按钮）会在 `click` 触发前被销毁，`onClick` 永不执行。因为依赖时序，表现为"有时好有时坏"。键盘回车走 `onKeyDown` 直接读索引调 `onSelect`，编辑器始终持有焦点，不碰 blur 路径，所以一直正常。

## 改动

- `apps/electron/src/renderer/components/agent/MentionList.tsx` — 给弹窗选项按钮新增 `onMouseDown={(e) => e.preventDefault()}`，阻止 mousedown 抢走编辑器焦点。编辑器不失焦 → 不触发 blur 销毁倒计时 → 弹窗稳定存活到 `click` 执行。该组件被 Skill(`/`)、MCP(`#`)、会话引用(`&`) 三种弹窗共用，一处修复覆盖三种场景。
- `apps/electron/package.json` — 版本号 `0.10.25` → `0.10.26`（遵循版本递增约定）。

## 测试方法

1. 启动应用进入 Agent 模式
2. 在输入框输入 `/`，弹出 Skill 列表
3. **用鼠标连续点击多个不同 Skill**（包括稍慢的按住-松开），确认每次都能稳定插入到输入框，不再出现"点了没反应"
4. 用键盘上下键 + 回车选中，确认仍然正常
5. 同样验证 `#`（MCP）和 `&`（会话引用）弹窗的鼠标点击

## 备注

- 选择在点击侧（`MentionList`）用 `preventDefault` 从源头消除焦点转移，而非去调 `mention-suggestions.tsx` 的 blur 延迟时间——后者只是改参数，竞态依然存在；前者是处理悬浮选择器"点击抢焦点"问题的标准做法，更彻底。
- `preventDefault` 仅阻止 mousedown 的默认聚焦行为，不影响 `onClick` 正常派发，选中逻辑完全不受影响。