### PR TITLE
Fix: 飞书等外部唤起的会话不再抢占前台 Tab 与激活

### DIFF
--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -372,15 +372,12 @@ export function useGlobalAgentListeners(): void {
           currentStreamState: store.get(agentStreamingStatesAtom).get(event.sessionId),
         })
 
+        // 外部来源（飞书/钉钉/微信/bridge）唤起的 run 不抢占前台：
+        // 不打开新 Tab、不切换激活 Tab、不切换 appMode/当前会话/当前工作区。
+        // 只更新驱动左侧边栏列表与状态指示条所需的状态，让用户自行决定是否切过去。
+        // 若该会话恰好是用户当前正在查看的会话，这里不动 Tab/激活，流式内容会通过
+        // agentStreamingStatesAtom 自然刷新，用户视角无任何跳动。
         store.set(agentSessionsAtom, sessions)
-        store.set(tabsAtom, activation.tabs)
-        store.set(activeTabIdAtom, activation.activeTabId)
-        store.set(appModeAtom, 'agent')
-        store.set(currentAgentSessionIdAtom, event.sessionId)
-        if (activation.workspaceId) {
-          store.set(currentAgentWorkspaceIdAtom, activation.workspaceId)
-          window.electronAPI.updateSettings({ agentWorkspaceId: activation.workspaceId }).catch(console.error)
-        }
         const activationModelId = activation.modelId
         if (activationModelId) {
           store.set(agentSessionModelMapAtom, (prev) => {


### PR DESCRIPTION
## Summary

- 8ddbfc6 fix(agent): 飞书等外部唤起的会话不再抢占前台 Tab 与激活

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归