### PR TITLE
feat: Markdown 预览支持左侧目录(TOC)与滚动导航

### DIFF
--- a/apps/electron/src/renderer/atoms/markdown-toc.ts
+++ b/apps/electron/src/renderer/atoms/markdown-toc.ts
@@ -1,0 +1,4 @@
+import { atomWithStorage } from 'jotai/utils'
+
+/** Markdown 预览目录（TOC）侧栏是否展开，持久化到 localStorage */
+export const markdownTocOpenAtom = atomWithStorage<boolean>('proma-markdown-toc-open', true)

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -6,7 +6,7 @@
  */
 
 import * as React from 'react'
-import { Code2, Copy, Check, Eye, Pencil, RefreshCw, Save, X } from 'lucide-react'
+import { Code2, Copy, Check, Eye, List, Pencil, RefreshCw, Save, X } from 'lucide-react'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import DOMPurify from 'dompurify'
 import { File as PierreFile } from '@pierre/diffs/react'
@@ -15,11 +15,13 @@ import { cn } from '@/lib/utils'
 import { agentDiffViewModeAtom, agentDiffRefreshVersionAtom } from '@/atoms/agent-atoms'
 import { resolvedThemeAtom } from '@/atoms/theme'
 import { quotedSelectionMapAtom } from '@/atoms/preview-atoms'
+import { markdownTocOpenAtom } from '@/atoms/markdown-toc'
 import { useShortcut } from '@/hooks/useShortcut'
 import { initShortcutRegistry } from '@/lib/shortcut-registry'
 import { DiffView } from './DiffView'
 import { MarkdownRichEditor } from './MarkdownRichEditor'
 import { PreviewFindBar } from './PreviewFindBar'
+import { MarkdownToc } from './MarkdownToc'
 import { PIERRE_FILE_CSS } from '@/components/agent/tool-result-renderers/pierre-styles'
 
 const MD_EXTS = new Set(['.md', '.markdown'])
@@ -229,6 +231,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   const refreshVersion = refreshVersionMap.get(sessionId) ?? 0
   const previewContentVersion = previewOnly ? refreshVersion : 0
   const theme = useAtomValue(resolvedThemeAtom)
+  const [tocOpen, setTocOpen] = useAtom(markdownTocOpenAtom)
 
   const ext = getExtension(filePath)
   const isMarkdown = previewOnly && MD_EXTS.has(ext)
@@ -263,6 +266,12 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     markdownEditing,
     markdownSourceMode,
   }), [docxHtml.length, filePath, loading, markdownEditing, markdownSourceMode, newContent.length, officeHtml.length, oldContent.length, previewOnly, viewMode])
+
+  // 目录提取只需在「文件本身或其内容」变化时重建，避免 loading/编辑态切换造成的抖动
+  const tocContentKey = React.useMemo(
+    () => JSON.stringify({ filePath, previewContentVersion, newLength: newContent.length }),
+    [filePath, previewContentVersion, newContent.length],
+  )
 
   // ===== 选中文本引用（Quoted Selection）=====
 
@@ -1022,10 +1031,24 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
           <RefreshCw className="size-3.5" />
         </button>
 
+        {isMarkdown && !markdownEditing && (
+          <button
+            type="button"
+            onClick={() => setTocOpen((v) => !v)}
+            className={cn(
+              'p-1 rounded hover:bg-foreground/[0.06] shrink-0',
+              tocOpen ? 'text-foreground/70' : 'text-foreground/40 hover:text-foreground/60',
+            )}
+            title={tocOpen ? '隐藏目录' : '显示目录'}
+          >
+            <List className="size-3.5" />
+          </button>
+        )}
+
         {toolbarActions}
       </div>
 
-      <div className="relative flex-1 min-h-0">
+      <div className="relative flex-1 min-h-0 flex">
         <PreviewFindBar
           open={findOpen}
           rootRef={scrollContainerRef}
@@ -1033,7 +1056,12 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
           unsupportedReason={isPdf ? '暂不支持 PDF 搜索' : undefined}
           onOpenChange={setFindOpen}
         />
-        <div ref={scrollContainerRef} onScroll={handleScroll} className="h-full overflow-auto scrollbar-thin relative">
+        <MarkdownToc
+          containerRef={scrollContainerRef}
+          contentKey={tocContentKey}
+          enabled={Boolean(isMarkdown && !markdownEditing && tocOpen)}
+        />
+        <div ref={scrollContainerRef} onScroll={handleScroll} className="h-full flex-1 min-w-0 overflow-auto scrollbar-thin relative">
           {loading ? (
             <div className="flex items-center justify-center h-full text-muted-foreground text-[12px]">加载中...</div>
           ) : previewOnly ? (

--- a/apps/electron/src/renderer/components/diff/MarkdownToc.tsx
+++ b/apps/electron/src/renderer/components/diff/MarkdownToc.tsx
@@ -1,0 +1,91 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+import { useTocHeadings } from '@/hooks/useTocHeadings'
+import { useScrollSpy } from '@/hooks/useScrollSpy'
+
+interface MarkdownTocProps {
+  /** 预览滚动容器，标题提取与跳转都基于它 */
+  containerRef: React.RefObject<HTMLElement>
+  /** 文件内容标识，变化时重建目录 */
+  contentKey: string
+  /** 仅 Markdown 只读预览时为 true */
+  enabled: boolean
+}
+
+/** 计算标题相对滚动容器的 top（不依赖 offsetParent 链） */
+function offsetTopWithin(node: HTMLElement, container: HTMLElement): number {
+  return node.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop
+}
+
+export function MarkdownToc({ containerRef, contentKey, enabled }: MarkdownTocProps): React.ReactElement | null {
+  const headings = useTocHeadings(containerRef, contentKey, enabled)
+  const activeId = useScrollSpy(containerRef, headings)
+  const listRef = React.useRef<HTMLDivElement>(null)
+
+  // 窄屏自动收起：Tailwind v3 未启用 container-queries 插件，改用
+  // ResizeObserver 监听预览区宽度（正文容器的父级 flex 容器）。
+  const [narrow, setNarrow] = React.useState(false)
+  React.useEffect(() => {
+    const region = containerRef.current?.parentElement
+    if (!region) return
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) setNarrow(entry.contentRect.width < 640)
+    })
+    observer.observe(region)
+    return () => observer.disconnect()
+  }, [containerRef])
+
+  // active 项保持在侧栏可视区内
+  React.useEffect(() => {
+    if (!activeId || !listRef.current) return
+    const item = listRef.current.querySelector<HTMLElement>(`[data-toc-id="${CSS.escape(activeId)}"]`)
+    item?.scrollIntoView({ block: 'nearest' })
+  }, [activeId])
+
+  const minLevel = React.useMemo(
+    () => (headings.length ? Math.min(...headings.map((h) => h.level)) : 1),
+    [headings],
+  )
+
+  if (!enabled || narrow || headings.length < 2) return null
+
+  const jumpTo = (heading: (typeof headings)[number]): void => {
+    const container = containerRef.current
+    if (!container) return
+    const top = offsetTopWithin(heading.el, container)
+    container.scrollTo({ top: Math.max(top - 8, 0), behavior: 'smooth' })
+  }
+
+  return (
+    <nav
+      aria-label="文档目录"
+      className="flex flex-col w-52 shrink-0 self-start max-h-full m-2 rounded-lg bg-muted/40"
+    >
+      <div className="px-3 pt-2 pb-1 text-[11px] font-medium text-foreground/40 select-none">目录</div>
+      <div ref={listRef} className="min-h-0 overflow-auto scrollbar-thin px-1 pb-2">
+        {headings.map((heading) => {
+          const active = heading.id === activeId
+          return (
+            <button
+              key={heading.id}
+              type="button"
+              data-toc-id={heading.id}
+              onClick={() => jumpTo(heading)}
+              title={heading.text}
+              style={{ paddingLeft: `${(heading.level - minLevel) * 12 + 8}px` }}
+              className={cn(
+                'block w-full text-left truncate rounded py-1 pr-2 text-[12px] leading-snug transition-colors',
+                'border-l-2 border-transparent',
+                active
+                  ? 'border-primary text-foreground font-medium bg-foreground/[0.04]'
+                  : 'text-foreground/55 hover:text-foreground/80 hover:bg-foreground/[0.03]',
+              )}
+            >
+              {heading.text}
+            </button>
+          )
+        })}
+      </div>
+    </nav>
+  )
+}

--- a/apps/electron/src/renderer/hooks/useScrollSpy.ts
+++ b/apps/electron/src/renderer/hooks/useScrollSpy.ts
@@ -1,0 +1,67 @@
+import * as React from 'react'
+import type { TocHeading } from './useTocHeadings'
+
+/**
+ * 滚动联动高亮：监听正文标题进入视口，返回当前所在章节的 id。
+ *
+ * 用 IntersectionObserver 以滚动容器为 root，`rootMargin` 把判定带压到容器
+ * 顶部 ~30% 区域：标题滚到该带内即视为「当前」。多个标题同时命中时取最靠上
+ * 的（DOM 顺序最小）。容器顶部尚无标题命中时，回退为最后一个已滚过顶部的标题。
+ *
+ * @param containerRef 预览滚动容器
+ * @param headings     useTocHeadings 提取的标题树
+ */
+export function useScrollSpy(
+  containerRef: React.RefObject<HTMLElement>,
+  headings: TocHeading[],
+): string | null {
+  const [activeId, setActiveId] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    const container = containerRef.current
+    if (!container || headings.length === 0) {
+      setActiveId(null)
+      return
+    }
+
+    const visible = new Set<string>()
+
+    const recompute = (): void => {
+      // DOM 顺序中第一个可见标题即当前章节
+      const firstVisible = headings.find((h) => visible.has(h.id))
+      if (firstVisible) {
+        setActiveId(firstVisible.id)
+        return
+      }
+      // 无标题在判定带内：取最后一个顶端已滚过容器顶部的标题
+      const containerTop = container.getBoundingClientRect().top
+      let candidate: string | null = headings[0]?.id ?? null
+      for (const h of headings) {
+        if (h.el.getBoundingClientRect().top - containerTop <= 1) {
+          candidate = h.id
+        }
+      }
+      setActiveId(candidate)
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          const id = (entry.target as HTMLElement).id
+          if (!id) continue
+          if (entry.isIntersecting) visible.add(id)
+          else visible.delete(id)
+        }
+        recompute()
+      },
+      { root: container, rootMargin: '0px 0px -70% 0px', threshold: 0 },
+    )
+
+    for (const h of headings) observer.observe(h.el)
+    recompute()
+
+    return () => observer.disconnect()
+  }, [containerRef, headings])
+
+  return activeId
+}

--- a/apps/electron/src/renderer/hooks/useTocHeadings.ts
+++ b/apps/electron/src/renderer/hooks/useTocHeadings.ts
@@ -1,0 +1,88 @@
+import * as React from 'react'
+import { createSlugger } from '../lib/slugify'
+
+export interface TocHeading {
+  id: string
+  level: number
+  text: string
+  el: HTMLElement
+}
+
+const HEADING_SELECTOR = 'h1, h2, h3, h4, h5, h6'
+
+/**
+ * 从滚动容器内的渲染结果中提取标题树，并为每个标题注入锚点 id。
+ *
+ * Markdown 预览由 TipTap 异步渲染，且 Shiki 代码块高亮、图片懒加载会持续
+ * 改动 DOM。因此用 MutationObserver 监听子树变化（debounce）重新提取，而非
+ * 在挂载时一次性读取——否则会漏标题或拿到错误的偏移。
+ *
+ * @param containerRef 预览滚动容器（DiffTabContent 的 scrollContainerRef）
+ * @param contentKey   文件内容标识，变化时强制重建 observer 与 id
+ * @param enabled      仅在 Markdown 只读预览时为 true
+ */
+export function useTocHeadings(
+  containerRef: React.RefObject<HTMLElement>,
+  contentKey: string,
+  enabled: boolean,
+): TocHeading[] {
+  const [headings, setHeadings] = React.useState<TocHeading[]>([])
+
+  React.useEffect(() => {
+    if (!enabled) {
+      setHeadings([])
+      return
+    }
+    const container = containerRef.current
+    if (!container) return
+
+    const extract = (): void => {
+      const slug = createSlugger()
+      const next: TocHeading[] = []
+      const nodes = container.querySelectorAll<HTMLElement>(HEADING_SELECTOR)
+      for (const el of Array.from(nodes)) {
+        const text = (el.textContent ?? '').trim()
+        if (!text) continue
+        const level = Number(el.tagName.slice(1))
+        if (!el.id) el.id = slug(text)
+        next.push({ id: el.id, level, text, el })
+      }
+      setHeadings((prev) => (sameHeadings(prev, next) ? prev : next))
+    }
+
+    extract()
+
+    let raf = 0
+    let timer: number | undefined
+    const schedule = (): void => {
+      window.clearTimeout(timer)
+      timer = window.setTimeout(() => {
+        cancelAnimationFrame(raf)
+        raf = requestAnimationFrame(extract)
+      }, 120)
+    }
+
+    const observer = new MutationObserver(schedule)
+    observer.observe(container, { childList: true, subtree: true })
+
+    return () => {
+      observer.disconnect()
+      window.clearTimeout(timer)
+      cancelAnimationFrame(raf)
+    }
+  }, [containerRef, contentKey, enabled])
+
+  return headings
+}
+
+function sameHeadings(a: TocHeading[], b: TocHeading[]): boolean {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i]
+    const y = b[i]
+    if (!x || !y || x.el !== y.el || x.id !== y.id || x.level !== y.level || x.text !== y.text) {
+      return false
+    }
+  }
+  return true
+}

--- a/apps/electron/src/renderer/lib/slugify.test.ts
+++ b/apps/electron/src/renderer/lib/slugify.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'bun:test'
+import { createSlugger, slugify } from './slugify'
+
+describe('slugify', () => {
+  test('lowercases and replaces spaces with hyphens', () => {
+    expect(slugify('Hello World')).toBe('hello-world')
+  })
+
+  test('strips punctuation but keeps alphanumerics', () => {
+    expect(slugify('What is TOC? (overview)')).toBe('what-is-toc-overview')
+  })
+
+  test('preserves CJK characters', () => {
+    expect(slugify('目录导航 设计')).toBe('目录导航-设计')
+  })
+
+  test('collapses repeated and trims edge hyphens', () => {
+    expect(slugify('  --foo   bar--  ')).toBe('foo-bar')
+  })
+
+  test('returns empty string for punctuation-only input', () => {
+    expect(slugify('!!!')).toBe('')
+  })
+})
+
+describe('createSlugger', () => {
+  test('appends incrementing suffixes for duplicates', () => {
+    const slug = createSlugger()
+    expect(slug('Intro')).toBe('intro')
+    expect(slug('Intro')).toBe('intro-1')
+    expect(slug('Intro')).toBe('intro-2')
+  })
+
+  test('falls back to "section" for empty slugs', () => {
+    const slug = createSlugger()
+    expect(slug('???')).toBe('section')
+    expect(slug('***')).toBe('section-1')
+  })
+})

--- a/apps/electron/src/renderer/lib/slugify.ts
+++ b/apps/electron/src/renderer/lib/slugify.ts
@@ -1,0 +1,40 @@
+/**
+ * GitHub 风格的标题 slug 生成
+ *
+ * 用于 Markdown 预览目录（TOC）为标题注入锚点 id：小写化、空格转连字符、
+ * 去除标点，保留中日韩等 Unicode 字母。`createSlugger` 维护去重计数器，
+ * 同名标题追加 `-1`、`-2` 后缀，与 GitHub 渲染行为一致。
+ */
+
+/** 将单个标题文本转为基础 slug（不含去重后缀） */
+export function slugify(text: string): string {
+  return text
+    .trim()
+    .toLowerCase()
+    .replace(/[\s　]+/g, '-')
+    // 去除标点/符号，保留 Unicode 字母数字、连字符、下划线
+    .replace(/[^\p{L}\p{N}_-]+/gu, '')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+/**
+ * 创建带去重能力的 slug 生成器
+ *
+ * 每次调用 `slug(text)` 返回唯一 slug：首次出现用基础 slug，
+ * 重复出现追加递增后缀。空标题回退为 `section`。
+ */
+export function createSlugger(): (text: string) => string {
+  const seen = new Map<string, number>()
+  return (text: string): string => {
+    const base = slugify(text) || 'section'
+    const count = seen.get(base)
+    if (count === undefined) {
+      seen.set(base, 0)
+      return base
+    }
+    const next = count + 1
+    seen.set(base, next)
+    return `${base}-${next}`
+  }
+}


### PR DESCRIPTION
## Summary

- 1eee69a feat: Markdown 预览支持左侧目录(TOC)与滚动导航

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归