### PR TITLE
fix(sidebar): 修复最近会话列表空白处无法两指滚动【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.10.26",
+  "version": "0.10.27",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -1522,7 +1522,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                 </div>
 
                 {/* Tab 内容（自己滚动） */}
-                <div className="flex-1 overflow-y-auto scrollbar-thin px-3 pb-1 min-h-0">
+                <div className="flex-1 overflow-y-auto scrollbar-thin px-3 pb-1 min-h-0 titlebar-no-drag">
                   {agentSubTab === 'working' && (
                     <div className="pt-0.5 pb-0.5">
                       {hasWorkingSessions ? (() => {
@@ -1619,7 +1619,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
           </div>
 
           {/* 下区：历史会话列表 */}
-          <div className="flex-1 overflow-y-auto px-3 pb-3 scrollbar-thin min-h-0">
+          <div className="flex-1 overflow-y-auto px-3 pb-3 scrollbar-thin min-h-0 titlebar-no-drag">
             {agentSessionGroups.map((group) => (
               <div key={group.label} className="mb-1">
                 <div className="px-3 pt-2 pb-1 text-[11px] font-medium text-foreground/40 select-none">
@@ -1661,7 +1661,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
           )}
 
           {/* Chat 模式 / 归档视图：单列表布局 */}
-          <div className="flex-1 overflow-y-auto px-3 pt-2 pb-3 scrollbar-thin">
+          <div className="flex-1 overflow-y-auto px-3 pt-2 pb-3 scrollbar-thin titlebar-no-drag">
             {mode === 'chat' ? (
               /* Chat 模式：对话按日期分组 */
               conversationGroups.map((group) => (


### PR DESCRIPTION
## 概述

修复 macOS 下左侧「最近会话」列表只有鼠标悬停在会话 tab 上才能两指滚动、落在 tab 间距 / 日期分组标题 / 列表空白处时无法滚动的问题。

根因是 Electron 的 `-webkit-app-region: drag` 窗口拖拽区按「绘制矩形」作用于窗口拖拽蒙版，不受 DOM 嵌套约束。侧边栏顶部有 `sidebar-window-drag-strip` / `titlebar-drag-region` 拖拽层，而会话列表的滚动容器本身未声明 `no-drag`。每个会话 tab（`AgentSessionItem` / `ConversationItem`）自带 `titlebar-no-drag`，相当于在拖拽蒙版上「挖洞」，所以鼠标在 tab 上时滚轮正常；但 tab 之间的间距、分组标题、padding 等空白处仍属于窗口拖拽区，macOS 把这些区域的两指滑动当成窗口拖拽手势截走，导致滚轮事件不派发给 DOM，列表滚不动。

## 改动

- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 给三个滚动容器整体加 `titlebar-no-drag`，使容器内所有区域（含间距、分组标题、padding、空占位）都成为 no-drag 区：
  - Agent 上区「工作中 / 置顶」Tab 内容滚动容器
  - Agent 下区「最近会话」列表滚动容器
  - Chat 模式 / 归档视图单列表滚动容器
- `apps/electron/package.json` — 版本号 `0.10.26` → `0.10.27`（patch +1）

窗口拖拽入口仍保留在顶部 `sidebar-window-drag-strip`、`titlebar-drag-region` 留白与 ModeSwitcher 行，拖动窗口功能无损。

## 测试方法

1. 在 macOS 上 `bun run dev` 启动应用
2. Agent 模式下，鼠标放在「最近会话」列表的 **tab 之间空白处 / 日期分组标题上**，两指滚动 → 列表应能正常上下滚动
3. 同样验证「工作中 / 置顶」Tab 内容区、以及 Chat 模式 / 归档视图列表的空白处可滚动
4. 验证侧边栏顶部留白区域仍可拖动窗口

## 备注

- 该修复基于上游最新 main（含 #690 会话切换缓存）切出，二者无冲突
- 已通过独立 code review 验证根因与修复有效性；另发现「最近会话」固定标题行（滚动容器之外）悬停时仍会被吞滚轮，属同类但影响极小，本 PR 暂未处理