### PR TITLE
fix(sidebar): 修复会话三点菜单被迷你地图预览遮挡导致点不动【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -1836,9 +1836,11 @@ const ConversationItem = React.memo(function ConversationItem({
 }: ConversationItemProps): React.ReactElement {
   const [editing, setEditing] = React.useState(false)
   const [editTitle, setEditTitle] = React.useState('')
+  const [menuOpen, setMenuOpen] = React.useState(false)
   const inputRef = React.useRef<HTMLInputElement>(null)
   const justStartedEditing = React.useRef(false)
-  const preview = useSessionMiniMapHover()
+  // 菜单打开时关闭迷你地图预览，避免预览面板盖住菜单项导致点不动
+  const preview = useSessionMiniMapHover(300, menuOpen)
 
   /** 进入编辑模式 */
   const startEdit = (): void => {
@@ -1963,7 +1965,7 @@ const ConversationItem = React.memo(function ConversationItem({
               className="flex-shrink-0"
               onClick={(e) => e.stopPropagation()}
             >
-              <DropdownMenu>
+              <DropdownMenu onOpenChange={setMenuOpen}>
                 <DropdownMenuTrigger asChild>
                   <button
                     className={cn(
@@ -2059,9 +2061,11 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
 }: AgentSessionItemProps): React.ReactElement {
   const [editing, setEditing] = React.useState(false)
   const [editTitle, setEditTitle] = React.useState('')
+  const [menuOpen, setMenuOpen] = React.useState(false)
   const inputRef = React.useRef<HTMLInputElement>(null)
   const justStartedEditing = React.useRef(false)
-  const preview = useSessionMiniMapHover(300, disableMiniMap)
+  // 菜单打开时关闭迷你地图预览，避免预览面板盖住菜单项导致点不动
+  const preview = useSessionMiniMapHover(300, disableMiniMap || menuOpen)
 
   const startEdit = (): void => {
     setEditTitle(session.title)
@@ -2228,7 +2232,7 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
               className="flex-shrink-0"
               onClick={(e) => e.stopPropagation()}
             >
-              <DropdownMenu>
+              <DropdownMenu onOpenChange={setMenuOpen}>
                 <DropdownMenuTrigger asChild>
                   <button
                     className={cn(


### PR DESCRIPTION
## 概述

修复 Agent / Chat 会话列表中，点击会话项三点（⋯）按钮弹出的下拉菜单"有时点不动、有时又能点"的问题。

根因是会话项的「迷你地图悬浮预览面板」（`SessionMiniMapPopover`）与三点下拉菜单（Radix `DropdownMenu`）同为 `z-[9999]`，且都通过 Portal 挂到 `document.body`。预览面板在鼠标悬停 300ms 后弹出、定位在会话项右侧（`left = rect.right + 8`），正好与向右展开的下拉菜单重叠。z-index 相同的情况下，DOM 中后插入的元素覆盖在上面，于是预览面板挡住了菜单项，导致点击落到透明的预览面板上。

- 悬停不足 300ms 就点开菜单 → 预览还没弹出 → 菜单可点 ✅
- 悬停超过 300ms 再点开菜单 → 预览已弹出并遮挡 → 菜单点不动 ❌

这解释了"时好时坏"的现象。

## 改动

- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx`
  - `AgentSessionItem` 与 `ConversationItem` 各新增 `menuOpen` 状态
  - 三点按钮的 `<DropdownMenu>` 加上 `onOpenChange={setMenuOpen}`
  - 将 `menuOpen` 接入 `useSessionMiniMapHover` 的 `disabled` 参数（Agent 项为 `disableMiniMap || menuOpen`，Chat 项为 `menuOpen`）。菜单一打开，hook 立即清掉计时器并强制关闭预览面板，消除遮挡
  - 其中 `ConversationItem` 原为无参调用 `useSessionMiniMapHover()`，改为显式 `useSessionMiniMapHover(300, menuOpen)`，`300` 即该 hook 的默认 `delayMs`，悬停延迟语义不变
- `apps/electron/package.json` — 版本 `0.10.27` → `0.10.28`

## 测试方法

1. 启动应用，进入 Agent 模式，将鼠标悬停在左侧某个会话项上超过 300ms，等迷你地图预览面板弹出
2. 此时点击该会话项的三点（⋯）按钮打开下拉菜单
3. 验证：预览面板立即消失，下拉菜单的每个菜单项（置顶 / 工作中 / 迁移 / 重命名 / 归档 / 删除）都能正常点击
4. 关闭菜单后，预览不会自动重新弹出，需再次主动悬停才出现（预期行为）
5. 在 Chat 模式的对话项上重复 1–3 验证同样修复

## 备注

- 折叠侧栏的 `RailRecentButton` 只有导航按钮、没有三点菜单，无需改动
- 已通过独立 code-reviewer 子代理审核：时序无竞态（`onOpenChange` 同步触发 disabled Effect，在菜单内容绘制前关闭预览）、无回归
- `bun run typecheck` 通过