### PR TITLE
fix: 飞书实时同步改为允许息屏锁屏

### DIFF
--- a/apps/electron/src/main/lib/feishu/sleep-blocker.test.ts
+++ b/apps/electron/src/main/lib/feishu/sleep-blocker.test.ts
@@ -35,13 +35,13 @@ class FakeSleepBlocker implements SleepBlockerAdapter {
 }
 
 describe('飞书同步防休眠', () => {
-  test('Given 飞书实时同步已开启 When 同步防休眠状态 Then 启用显示器级防休眠', () => {
+  test('Given 飞书实时同步已开启 When 同步防休眠状态 Then 启用系统级防休眠（允许息屏锁屏）', () => {
     const adapter = new FakeSleepBlocker()
     const blocker = new FeishuSyncSleepBlocker(adapter)
 
     blocker.sync({ feishuSessionMirror: { mode: 'stream', botId: 'bot-1' } })
 
-    expect(adapter.startedTypes).toEqual(['prevent-display-sleep'])
+    expect(adapter.startedTypes).toEqual(['prevent-app-suspension'])
     expect(adapter.isStarted(1)).toBe(true)
   })
 
@@ -75,7 +75,7 @@ describe('飞书同步防休眠', () => {
     adapter.markStopped(1)
     blocker.sync({ feishuSessionMirror: { mode: 'stream', botId: 'bot-1' } })
 
-    expect(adapter.startedTypes).toEqual(['prevent-display-sleep', 'prevent-display-sleep'])
+    expect(adapter.startedTypes).toEqual(['prevent-app-suspension', 'prevent-app-suspension'])
     expect(adapter.isStarted(2)).toBe(true)
   })
 

--- a/apps/electron/src/main/lib/feishu/sleep-blocker.ts
+++ b/apps/electron/src/main/lib/feishu/sleep-blocker.ts
@@ -1,6 +1,6 @@
 import type { AppSettings } from '../../../types'
 
-export type SleepBlockerType = 'prevent-display-sleep'
+export type SleepBlockerType = 'prevent-app-suspension'
 
 export interface SleepBlockerAdapter {
   start(type: SleepBlockerType): number
@@ -46,7 +46,7 @@ export class FeishuSyncSleepBlocker {
       this.activeBlockerId = null
     }
 
-    this.activeBlockerId = this.adapter.start('prevent-display-sleep')
-    console.log('[飞书防休眠] 已启用，飞书实时同步期间阻止系统自动休眠')
+    this.activeBlockerId = this.adapter.start('prevent-app-suspension')
+    console.log('[飞书防休眠] 已启用，飞书实时同步期间阻止系统休眠（允许息屏锁屏）')
   }
 }


### PR DESCRIPTION
## Summary

- 9651295 fix: 飞书实时同步改为允许息屏锁屏

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归