### PR TITLE
[Ready] fix(version-history): 修复版本历史偶尔显示'暂无版本历史'的问题

### DIFF
--- a/apps/electron/src/main/lib/github-release-service.ts
+++ b/apps/electron/src/main/lib/github-release-service.ts
@@ -155,7 +155,8 @@ export async function listReleases(
         : releaseCache.data.filter(r => !r.prerelease && !r.draft)
       return filtered.slice(0, perPage)
     }
-    return []
+    // 没有缓存时抛出异常，让前端知道加载失败
+    throw error
   }
 }
 

--- a/apps/electron/src/renderer/components/settings/VersionHistory.tsx
+++ b/apps/electron/src/renderer/components/settings/VersionHistory.tsx
@@ -89,6 +89,23 @@ export function VersionHistory(): React.ReactElement {
             <Loader2 className="h-6 w-6 animate-spin mx-auto text-muted-foreground" />
             <p className="text-sm text-muted-foreground mt-2">加载中...</p>
           </div>
+        ) : error ? (
+          <div className="p-8 text-center">
+            <p className="text-sm text-destructive">加载失败</p>
+            <p className="text-xs text-muted-foreground mt-1">{error}</p>
+            <button
+              onClick={loadReleases}
+              disabled={loading}
+              className="mt-3 inline-flex items-center gap-1.5 rounded-md bg-secondary px-3 py-1.5 text-xs font-medium text-secondary-foreground hover:bg-secondary/80 transition-colors disabled:opacity-50"
+            >
+              {loading ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <RefreshCw className="h-3.5 w-3.5" />
+              )}
+              重试
+            </button>
+          </div>
         ) : releases.length === 0 ? (
           <div className="p-8 text-center">
             <p className="text-sm text-muted-foreground">暂无版本历史</p>


### PR DESCRIPTION
## 概述

修复设置页面「版本历史」偶尔错误显示「暂无版本历史」的问题。

## 问题

当 GitHub API 请求失败（网络不稳定、Rate limit 等）且没有本地缓存时，`listReleases` 返回空数组 `[]`，导致前端无法区分「加载失败」和「真的没有数据」，从而错误显示「暂无版本历史」。

## 改动

1. **`github-release-service.ts`**：`listReleases` 在没有缓存且 API 失败时**抛出异常**（而非返回空数组），让前端能感知到加载失败。

2. **`VersionHistory.tsx`**：增加错误状态分支，当加载失败时显示：
   - 「加载失败」提示
   - 错误详情
   - 「重试」按钮

## 测试

- 模拟网络断开 → 版本历史应显示「加载失败」+ 重试按钮
- 点击重试 → 网络恢复后正常显示版本列表
- 正常网络 → 不受影响

## 备注

- 有缓存时仍优先返回过期缓存（原有逻辑保留）
- 改动范围最小，仅影响版本历史组件