### PR TITLE
[Reviewed] fix(version-history): 修复版本历史偶尔显示'暂无版本历史'的问题

### DIFF
--- a/apps/electron/src/main/lib/github-release-service.ts
+++ b/apps/electron/src/main/lib/github-release-service.ts
@@ -44,7 +44,7 @@ let rateLimitUntil = 0
 async function fetchFromGitHub<T>(endpoint: string): Promise<T> {
   // Rate limit 冷却期内直接跳过
   if (Date.now() < rateLimitUntil) {
-    throw new Error('GitHub API rate limit cooldown')
+    throw new Error('GitHub API 请求过于频繁，请稍后再试')
   }
 
   const url = `${GITHUB_API_BASE}/repos/${GITHUB_REPO.owner}/${GITHUB_REPO.repo}${endpoint}`
@@ -61,13 +61,12 @@ async function fetchFromGitHub<T>(endpoint: string): Promise<T> {
   if (response.status === 403 || response.status === 429) {
     // Rate limited — 冷却 15 分钟
     rateLimitUntil = Date.now() + 15 * 60 * 1000
-    throw new Error('GitHub API rate limit exceeded, cooling down for 15 minutes')
+    throw new Error('GitHub API 请求过于频繁，请 15 分钟后重试')
   }
 
   if (!response.ok) {
-    const errorText = await response.text()
     throw new Error(
-      `GitHub API 请求失败: ${response.status} ${response.statusText}\n${errorText}`
+      `GitHub API 请求失败 (${response.status})，请检查网络连接后重试`
     )
   }
 

--- a/apps/electron/src/main/lib/github-release-service.ts
+++ b/apps/electron/src/main/lib/github-release-service.ts
@@ -155,7 +155,7 @@ export async function listReleases(
       return filtered.slice(0, perPage)
     }
     // 没有缓存时抛出异常，让前端知道加载失败
-    throw error
+    throw error instanceof Error ? error : new Error(String(error))
   }
 }
 

--- a/apps/electron/src/main/lib/github-release-service.ts
+++ b/apps/electron/src/main/lib/github-release-service.ts
@@ -155,7 +155,8 @@ export async function listReleases(
         : releaseCache.data.filter(r => !r.prerelease && !r.draft)
       return filtered.slice(0, perPage)
     }
-    return []
+    // 没有缓存时抛出异常，让前端知道加载失败
+    throw error
   }
 }
 

--- a/apps/electron/src/renderer/components/settings/VersionHistory.tsx
+++ b/apps/electron/src/renderer/components/settings/VersionHistory.tsx
@@ -34,15 +34,10 @@ export function VersionHistory(): React.ReactElement {
       console.error('[版本历史] 加载失败:', err)
       let errorMessage = err instanceof Error ? err.message : '加载失败'
       // 过滤掉 Electron IPC 的英文前缀，只保留中文错误信息
-      if (errorMessage.includes('Error invoking remote method')) {
-        const parts = errorMessage.split('Error:')
-        if (parts.length > 1) {
-          const lastPart = parts[parts.length - 1].trim()
-          // 确保截取后还有有效内容
-          if (lastPart) {
-            errorMessage = lastPart
-          }
-        }
+      // IPC 错误格式: "Error invoking remote method 'xxx': Error: 中文错误信息"
+      const ipcPrefixMatch = errorMessage.match(/Error invoking remote method[^:]*:\s*Error:\s*(.+)/s)
+      if (ipcPrefixMatch && ipcPrefixMatch[1]) {
+        errorMessage = ipcPrefixMatch[1].trim()
       }
       setError(errorMessage)
     } finally {

--- a/apps/electron/src/renderer/components/settings/VersionHistory.tsx
+++ b/apps/electron/src/renderer/components/settings/VersionHistory.tsx
@@ -37,7 +37,11 @@ export function VersionHistory(): React.ReactElement {
       if (errorMessage.includes('Error invoking remote method')) {
         const parts = errorMessage.split('Error:')
         if (parts.length > 1) {
-          errorMessage = parts[parts.length - 1].trim()
+          const lastPart = parts[parts.length - 1].trim()
+          // 确保截取后还有有效内容
+          if (lastPart) {
+            errorMessage = lastPart
+          }
         }
       }
       setError(errorMessage)

--- a/apps/electron/src/renderer/components/settings/VersionHistory.tsx
+++ b/apps/electron/src/renderer/components/settings/VersionHistory.tsx
@@ -89,6 +89,23 @@ export function VersionHistory(): React.ReactElement {
             <Loader2 className="h-6 w-6 animate-spin mx-auto text-muted-foreground" />
             <p className="text-sm text-muted-foreground mt-2">加载中...</p>
           </div>
+        ) : error ? (
+          <div className="p-8 text-center">
+            <p className="text-sm text-destructive">加载失败</p>
+            <p className="text-xs text-muted-foreground mt-1">{error}</p>
+            <button
+              onClick={loadReleases}
+              disabled={loading}
+              className="mt-3 inline-flex items-center gap-1.5 rounded-md bg-secondary px-3 py-1.5 text-xs font-medium text-secondary-foreground hover:bg-secondary/80 transition-colors disabled:opacity-50"
+            >
+              {loading ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <RefreshCw className="h-3.5 w-3.5" />
+              )}
+              重试
+            </button>
+          </div>
         ) : releases.length === 0 ? (
           <div className="p-8 text-center">
             <p className="text-sm text-muted-foreground">暂无版本历史</p>

--- a/apps/electron/src/renderer/components/settings/VersionHistory.tsx
+++ b/apps/electron/src/renderer/components/settings/VersionHistory.tsx
@@ -32,7 +32,15 @@ export function VersionHistory(): React.ReactElement {
       setReleases(data)
     } catch (err) {
       console.error('[版本历史] 加载失败:', err)
-      setError(err instanceof Error ? err.message : '加载失败')
+      let errorMessage = err instanceof Error ? err.message : '加载失败'
+      // 过滤掉 Electron IPC 的英文前缀，只保留中文错误信息
+      if (errorMessage.includes('Error invoking remote method')) {
+        const parts = errorMessage.split('Error:')
+        if (parts.length > 1) {
+          errorMessage = parts[parts.length - 1].trim()
+        }
+      }
+      setError(errorMessage)
     } finally {
       setLoading(false)
     }
@@ -75,11 +83,6 @@ export function VersionHistory(): React.ReactElement {
             刷新
           </button>
         </div>
-        {error && (
-          <p className="text-xs text-destructive mt-2">
-            {error}
-          </p>
-        )}
       </div>
 
       {/* 版本列表 */}
@@ -91,20 +94,8 @@ export function VersionHistory(): React.ReactElement {
           </div>
         ) : error ? (
           <div className="p-8 text-center">
-            <p className="text-sm text-destructive">加载失败</p>
+            <p className="text-sm text-muted-foreground">加载失败</p>
             <p className="text-xs text-muted-foreground mt-1">{error}</p>
-            <button
-              onClick={loadReleases}
-              disabled={loading}
-              className="mt-3 inline-flex items-center gap-1.5 rounded-md bg-secondary px-3 py-1.5 text-xs font-medium text-secondary-foreground hover:bg-secondary/80 transition-colors disabled:opacity-50"
-            >
-              {loading ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              ) : (
-                <RefreshCw className="h-3.5 w-3.5" />
-              )}
-              重试
-            </button>
           </div>
         ) : releases.length === 0 ? (
           <div className="p-8 text-center">


### PR DESCRIPTION
## 概述

修复设置页面「版本历史」偶尔错误显示「暂无版本历史」的问题。

## 问题

当 GitHub API 请求失败（网络不稳定、Rate limit 等）且没有本地缓存时，`listReleases` 返回空数组 `[]`，导致前端无法区分「加载失败」和「真的没有数据」，从而错误显示「暂无版本历史」。

## 改动

### `github-release-service.ts`

- `listReleases` 在无缓存且 API 失败时**抛出异常**（而非返回空数组），让前端能感知到加载失败
- 错误信息中文化：
  - Rate limit 冷却期：`GitHub API 请求过于频繁，请稍后再试`
  - Rate limit 触发：`GitHub API 请求过于频繁，请 15 分钟后重试`
  - 其他请求失败：`GitHub API 请求失败 (${status})，请检查网络连接后重试`
- 增强健壮性：确保抛出的 error 是 Error 实例（`throw error instanceof Error ? error : new Error(String(error))`）
- 有缓存时仍优先返回过期缓存（原有逻辑保留）

### `VersionHistory.tsx`

- 增加错误状态分支，显示「加载失败」+ 中文错误详情
- 过滤 Electron IPC 的英文前缀，只显示中文错误信息
- **改进 IPC 错误过滤逻辑**：用正则 `/Error invoking remote method[^:]*:\s*Error:\s*(.+)/s` 精确匹配，替代原来脆弱的 `split('Error:')` 方式，避免误伤错误信息中本身包含 `Error:` 的内容
- 移除标题栏下的重复错误显示
- 错误文字使用灰色（`text-muted-foreground`）替代红色

## 测试

- 模拟网络断开 → 版本历史显示「加载失败」+ 中文错误信息
- 正常网络 → 不受影响

## 备注

- 改动范围最小，仅影响版本历史组件