### PR TITLE
fix(sidebar): 工作中 Tab 上下间距对称，与新会话间距一致【无需审核】

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -1482,7 +1482,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
               >
                 {/* Tab 切换按钮 */}
                 <div className="pt-2 px-3 flex-shrink-0">
-                  <div className="flex items-center gap-1 mb-0.5">
+                  <div className="flex items-center gap-1 mb-1.5">
                     <button
                       onClick={() => setAgentSubTab('working')}
                       className={cn(


### PR DESCRIPTION
## 概述

Agent 模式侧边栏中，「工作中 / 置顶」Tab 切换行的上下间距不对称：上方（到「新会话」按钮）有 8px，下方（到 Tab 内容列表）只有 4px，视觉上略显拥挤、不平衡。本 PR 将下方间距补齐到 8px，使 Tab 行上下留白对称、与「新会话」到「工作中」之间的间距保持一致。

## 改动

- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 将 Tab 切换按钮行的下外边距从 `mb-0.5`（2px）调整为 `mb-1.5`（6px）。叠加 Tab 内容区原有的 `pt-0.5`（2px），下方总间距变为 8px，与上方 Tab 容器的 `pt-2`（8px）对称。

## 测试方法

1. `bun run dev` 启动应用
2. 切换到 Agent 模式，确保侧边栏存在「工作中 / 置顶」Tab（有进行中或置顶会话时显示）
3. 观察「新会话」按钮 → 「工作中」Tab 行 → 下方 Tab 列表三者之间的纵向间距
4. 确认「工作中」Tab 行上下两侧留白对称、间距一致（均为 8px）

## 备注

- 纯 CSS class 调整，无逻辑改动，热重载即可生效
- 不影响 Chat 模式与归档视图的布局