### PR TITLE
[codex] Fix settings dialog flicker

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.10.28",
+  "version": "0.10.29",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/App.tsx
+++ b/apps/electron/src/renderer/App.tsx
@@ -6,6 +6,7 @@ import { TutorialBanner } from './components/tutorial/TutorialBanner'
 import { EnvironmentCheckDialog } from './components/environment/EnvironmentCheckDialog'
 import { MigrationImportDialog } from './components/migration/MigrationImportDialog'
 import { TooltipProvider } from './components/ui/tooltip'
+import { SettingsDialog } from './components/settings/SettingsDialog'
 import { conversationsAtom } from './atoms/chat-atoms'
 import { environmentCheckDialogOpenAtom } from './atoms/environment'
 import { tabsAtom, activeTabIdAtom, openTab } from './atoms/tab-atoms'
@@ -98,6 +99,7 @@ export default function App(): React.ReactElement {
   return (
     <TooltipProvider delayDuration={200}>
       <AppShell contextValue={contextValue} />
+      <SettingsDialog />
       <TutorialBanner />
       <GlobalEnvironmentCheckDialog />
       <MigrationImportDialog />

--- a/apps/electron/src/renderer/components/tabs/MainArea.tsx
+++ b/apps/electron/src/renderer/components/tabs/MainArea.tsx
@@ -10,7 +10,6 @@ import * as React from 'react'
 import { useAtomValue, useSetAtom, useAtom } from 'jotai'
 import { tabsAtom, activeTabIdAtom, activeTabAtom } from '@/atoms/tab-atoms'
 import { Panel } from '@/components/app-shell/Panel'
-import { SettingsDialog } from '@/components/settings'
 import { WelcomeView } from '@/components/welcome/WelcomeView'
 import { previewPanelOpenMapAtom, previewSplitRatioAtom } from '@/atoms/preview-atoms'
 import { PreviewPanel } from '@/components/diff/PreviewPanel'
@@ -179,7 +178,6 @@ export function MainArea(): React.ReactElement {
           )}
         </div>
       </Panel>
-      <SettingsDialog />
     </>
   )
 }


### PR DESCRIPTION
## Summary

- Move the settings dialog mount from `MainArea` to the app root so it stays mounted independently of tab content changes.
- Bump `@proma/electron` from `0.10.28` to `0.10.29` for the renderer behavior fix.

## Root Cause

The settings dialog was rendered inside `MainArea`. Channel add/delete flows refresh model configuration state and can cause the main tab area to re-render or temporarily swap content, which can briefly unmount/remount the settings dialog and appear as a one-frame flash.

## Impact

The settings dialog lifecycle is now anchored at the main app root while still using the same Jotai `settingsOpenAtom`, so model configuration updates no longer depend on `MainArea` lifecycle.

## Validation

- `bun run --filter='@proma/electron' typecheck`
