### PR TITLE
feat(ui): 指示条改为包边设计

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -198,9 +198,9 @@ function groupByDate<T extends { updatedAt: number }>(items: T[]): Array<{ label
 
 const RAIL_STATUS_CLASS: Record<SessionIndicatorStatus, string> = {
   idle: 'hidden',
-  running: 'bg-blue-500 animate-pulse',
-  blocked: 'bg-orange-500',
-  completed: 'bg-emerald-500',
+  running: 'border-blue-500 animate-pulse',
+  blocked: 'border-orange-500',
+  completed: 'border-emerald-500',
 }
 
 const SIDEBAR_DRAG_STRIP_HEIGHT = {
@@ -261,7 +261,7 @@ function RailRecentButton({
           >
             <span
               className={cn(
-                'absolute left-1 top-1.5 bottom-1.5 w-[2px] rounded-full pointer-events-none',
+                'absolute inset-y-0 left-0 w-0 border-l-[3px] rounded-l-[12px] pointer-events-none',
                 RAIL_STATUS_CLASS[item.status]
               )}
             />
@@ -2017,9 +2017,9 @@ const ConversationItem = React.memo(function ConversationItem({
 /** 会话行左侧状态色块的颜色 — 与 SessionIndicatorStatus 呼应 */
 type SessionLeftAccent = 'orange' | 'blue' | 'green'
 const SESSION_LEFT_ACCENT_CLASS: Record<SessionLeftAccent, string> = {
-  orange: 'bg-orange-500',
-  blue: 'bg-blue-500',
-  green: 'bg-green-500',
+  orange: 'border-orange-500',
+  blue: 'border-blue-500',
+  green: 'border-green-500',
 }
 
 interface AgentSessionItemProps {
@@ -2179,7 +2179,7 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
           {leftAccent && (
             <span
               className={cn(
-                'absolute left-1 top-1.5 bottom-1.5 w-[2px] rounded-full pointer-events-none',
+                'absolute inset-y-0 left-0 w-0 border-l-[3px] rounded-l-md pointer-events-none',
                 SESSION_LEFT_ACCENT_CLASS[leftAccent]
               )}
             />

--- a/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
@@ -93,12 +93,11 @@ export function TabBarItem({
     ? undefined
     : isStreaming !== 'idle'
     ? isStreaming === 'completed'
-      ? 'bg-green-500'
+      ? 'border-green-500'
       : isStreaming === 'blocked'
-        ? 'bg-orange-500'
-        : 'bg-blue-500'
+        ? 'border-orange-500'
+        : 'border-blue-500'
     : undefined
-  const indicatorPulse = isStreaming === 'running' || isStreaming === 'blocked'
   const previewItems = minimapCache.get(id) ?? []
   // 当前 active Tab 不显示预览面板
   const showPreview = isHovered && !isActive
@@ -190,13 +189,12 @@ export function TabBarItem({
         </span>
         )}
 
-        {/* 底部状态横线条 */}
+        {/* 状态包边 */}
         {indicatorColor && (
           <span
             className={cn(
-              'absolute left-2 right-2 bottom-0 h-[2px] rounded-full pointer-events-none',
+              'absolute inset-0 rounded-t-lg border-t-2 border-l-2 border-r-2 border-b-0 pointer-events-none',
               indicatorColor,
-              indicatorPulse && 'animate-pulse',
             )}
             aria-hidden="true"
           />


### PR DESCRIPTION
## Summary
- 左侧侧边栏指示条从内部悬浮细线改为贴合容器左边缘的 border-left 包边，跟随容器圆角
- Tab 状态指示从底部横线改为三边 border 包边（顶+左+右），去除呼吸动画
- 视觉上更接近 Markdown 目录选中态的设计语言，提升状态可见性

## Test plan
- [ ] 验证左侧 Rail 按钮的 running/blocked/completed 状态包边显示正常
- [ ] 验证侧边栏会话列表项的 leftAccent 包边效果
- [ ] 验证 Tab 的 running/blocked/completed 三种状态包边颜色正确、无呼吸动画
- [ ] 确认 idle 状态下无多余边框显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)