### PR TITLE
[Reviewed] feat(shortcuts): 全类型快捷键冲突检测（微信模式）

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -384,6 +384,17 @@ function createWindow(): void {
   mainWindow.on('closed', () => {
     mainWindow = null
   })
+
+  // 应用级快捷键 focus/blur 生命周期管理（微信模式）
+  mainWindow.on('focus', () => {
+    const { onWindowFocus } = require('./lib/global-shortcut-service') as typeof import('./lib/global-shortcut-service')
+    onWindowFocus()
+  })
+
+  mainWindow.on('blur', () => {
+    const { onWindowBlur } = require('./lib/global-shortcut-service') as typeof import('./lib/global-shortcut-service')
+    onWindowBlur()
+  })
 }
 
 function sendToMainWindow(channel: string, data?: unknown): void {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -3876,6 +3876,15 @@ export function registerIpcHandlers(): void {
     }
   )
 
+  // 检查全局快捷键可用性
+  ipcMain.handle(
+    'global-shortcut:check-availability',
+    async (_, accelerator: string): Promise<boolean> => {
+      const { checkGlobalAcceleratorAvailability } = await import('./lib/global-shortcut-service')
+      return checkGlobalAcceleratorAvailability(accelerator)
+    }
+  )
+
   // ===== 语音输入 =====
 
   ipcMain.handle(

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -10,7 +10,7 @@ import { existsSync, realpathSync, rmSync, readFileSync, writeFileSync, mkdirSyn
 import { writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, INSTALLER_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, MEMORY_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS, DINGTALK_IPC_CHANNELS, WECHAT_IPC_CHANNELS, AUTOMATION_IPC_CHANNELS, isPromaPermissionMode } from '@proma/shared'
-import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS, SCRATCH_PAD_IPC_CHANNELS, QUICK_TASK_IPC_CHANNELS, VOICE_DICTATION_IPC_CHANNELS, APP_ICON_IPC_CHANNELS, DOCK_BADGE_IPC_CHANNELS, STORAGE_IPC_CHANNELS } from '../types'
+import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS, SCRATCH_PAD_IPC_CHANNELS, QUICK_TASK_IPC_CHANNELS, VOICE_DICTATION_IPC_CHANNELS, APP_ICON_IPC_CHANNELS, DOCK_BADGE_IPC_CHANNELS, STORAGE_IPC_CHANNELS, APP_SHORTCUT_IPC_CHANNELS } from '../types'
 import type {
   QuickTaskSubmitInput,
   VoiceDictationAudioChunkInput,
@@ -3882,6 +3882,32 @@ export function registerIpcHandlers(): void {
     async (_, accelerator: string): Promise<boolean> => {
       const { checkGlobalAcceleratorAvailability } = await import('./lib/global-shortcut-service')
       return checkGlobalAcceleratorAvailability(accelerator)
+    }
+  )
+
+  // ===== 应用级快捷键（focus/blur 生命周期） =====
+
+  // 设置应用级快捷键
+  ipcMain.handle(
+    APP_SHORTCUT_IPC_CHANNELS.SET,
+    async (_, shortcuts: Array<{ id: string; accelerator: string }>): Promise<void> => {
+      const { setAppShortcuts } = await import('./lib/global-shortcut-service')
+      const { getMainWindow } = await import('./index')
+      setAppShortcuts(shortcuts, (id: string) => {
+        const mainWin = getMainWindow()
+        if (mainWin && !mainWin.isDestroyed()) {
+          mainWin.webContents.send(APP_SHORTCUT_IPC_CHANNELS.TRIGGER, id)
+        }
+      })
+    }
+  )
+
+  // 重新注册应用级快捷键
+  ipcMain.handle(
+    APP_SHORTCUT_IPC_CHANNELS.REREGISTER,
+    async (): Promise<Record<string, boolean>> => {
+      const { reregisterAppShortcuts } = await import('./lib/global-shortcut-service')
+      return reregisterAppShortcuts()
     }
   )
 

--- a/apps/electron/src/main/lib/global-shortcut-service.ts
+++ b/apps/electron/src/main/lib/global-shortcut-service.ts
@@ -2,21 +2,31 @@
  * 全局快捷键服务（主进程）
  *
  * 使用 Electron globalShortcut API 注册系统级快捷键。
- * 全局快捷键在应用不在前台时也能触发。
+ * - 全局快捷键：应用不在前台时也能触发（始终注册）
+ * - 应用级快捷键：仅在窗口聚焦时注册，失焦时注销（微信模式）
  *
  * 与渲染进程的 shortcut-registry 完全独立：
- * - 渲染进程：keydown listener，仅应用内生效
+ * - 渲染进程：keydown listener，仅应用内生效（fallback）
  * - 主进程：globalShortcut.register，系统级生效
  */
 
 import { app, globalShortcut } from 'electron'
 import { getSettings } from './settings-service'
 
-/** 全局快捷键 ID → 回调映射 */
+/** 快捷键 ID → 回调映射 */
 const globalCallbacks = new Map<string, () => void>()
+
+/** 应用级快捷键 ID → 回调映射 */
+const appCallbacks = new Map<string, () => void>()
 
 /** 当前注册的 accelerator → 快捷键 ID 映射（用于注销） */
 const registeredAccelerators = new Map<string, string>()
+
+/** 当前注册的应用级 accelerator → 快捷键 ID 映射 */
+const registeredAppAccelerators = new Map<string, string>()
+
+/** 应用级快捷键是否当前已注册（受 focus/blur 控制） */
+let appShortcutsRegistered = false
 
 /** 默认全局快捷键配置 */
 const GLOBAL_SHORTCUT_DEFAULTS: Record<string, { mac: string; win: string }> = {
@@ -122,8 +132,9 @@ export function checkGlobalAcceleratorAvailability(accelerator: string): boolean
     .map((part) => part.trim().toLowerCase() === 'cmd' ? 'CommandOrControl' : part)
     .join('+')
 
-  // 如果该 accelerator 已经被 Proma 自己注册了，说明可用
+  // 如果该 accelerator 已经被 Proma 自己注册了（全局或应用级），说明可用
   if (registeredAccelerators.has(normalizedAccel)) return true
+  if (registeredAppAccelerators.has(normalizedAccel)) return true
 
   try {
     const success = globalShortcut.register(normalizedAccel, () => {})
@@ -182,6 +193,144 @@ export function unregisterAllGlobalShortcuts(): void {
     globalShortcut.unregisterAll()
   }
   registeredAccelerators.clear()
+  registeredAppAccelerators.clear()
   globalCallbacks.clear()
+  appCallbacks.clear()
+  appShortcutsRegistered = false
   console.log('[全局快捷键] 已注销所有')
+}
+
+// ===== 应用级快捷键（focus/blur 生命周期） =====
+
+/** 应用级快捷键配置：ID → { accelerator, callback } */
+interface AppShortcutEntry {
+  accelerator: string
+  callback: () => void
+}
+
+/** 应用级快捷键配置表（由渲染进程通过 IPC 设置） */
+const appShortcutEntries = new Map<string, AppShortcutEntry>()
+
+/**
+ * 设置应用级快捷键
+ *
+ * 渲染进程通过 IPC 调用，将所有非全局快捷键的 accelerator 和回调注册到主进程。
+ * 回调通过 IPC 通知渲染进程执行对应快捷键动作。
+ */
+export function setAppShortcuts(
+  shortcuts: Array<{ id: string; accelerator: string }>,
+  sendCallback: (id: string) => void,
+): void {
+  appShortcutEntries.clear()
+  for (const { id, accelerator } of shortcuts) {
+    appShortcutEntries.set(id, { accelerator, callback: () => sendCallback(id) })
+  }
+
+  // 如果窗口当前聚焦，立即注册
+  if (appShortcutsRegistered) {
+    registerAppShortcutsNow()
+  }
+}
+
+/**
+ * 注册所有应用级快捷键
+ *
+ * 在主窗口获得焦点时调用。
+ */
+function registerAppShortcutsNow(): void {
+  // 先注销旧的应用级快捷键
+  unregisterAppShortcutsNow()
+
+  for (const [id, entry] of appShortcutEntries) {
+    // 跳过被用户禁用的快捷键
+    const override = getSettings().shortcutOverrides?.[id]
+    if (override) {
+      const customAccel = isMac ? override.mac : override.win
+      if (customAccel === null) continue
+    }
+
+    const accelerator = normalizeAccelerator(entry.accelerator)
+    if (!accelerator) continue
+
+    try {
+      const success = globalShortcut.register(accelerator, entry.callback)
+      if (success) {
+        registeredAppAccelerators.set(accelerator, id)
+      } else {
+        console.warn(`[应用快捷键] 注册失败（可能被占用）: ${id} → ${accelerator}`)
+      }
+    } catch (err) {
+      console.error(`[应用快捷键] 注册异常: ${id} → ${accelerator}`, err)
+    }
+  }
+  appShortcutsRegistered = true
+}
+
+/**
+ * 注销所有应用级快捷键
+ *
+ * 在主窗口失去焦点时调用。
+ */
+function unregisterAppShortcutsNow(): void {
+  for (const accelerator of registeredAppAccelerators.keys()) {
+    try {
+      globalShortcut.unregister(accelerator)
+    } catch {
+      // 忽略注销错误
+    }
+  }
+  registeredAppAccelerators.clear()
+}
+
+/**
+ * 主窗口获得焦点 — 注册应用级快捷键
+ */
+export function onWindowFocus(): void {
+  registerAppShortcutsNow()
+}
+
+/**
+ * 主窗口失去焦点 — 注销应用级快捷键
+ */
+export function onWindowBlur(): void {
+  unregisterAppShortcutsNow()
+  appShortcutsRegistered = false
+}
+
+/**
+ * 重新注册应用级快捷键
+ *
+ * 设置变更后调用。返回各快捷键注册结果。
+ */
+export function reregisterAppShortcuts(): Record<string, boolean> {
+  const results: Record<string, boolean> = {}
+
+  // 如果当前已注册，先注销再重新注册
+  if (appShortcutsRegistered) {
+    unregisterAppShortcutsNow()
+    registerAppShortcutsNow()
+  }
+
+  // 收集结果
+  for (const [id] of appShortcutEntries) {
+    const entry = appShortcutEntries.get(id)
+    if (!entry) {
+      results[id] = false
+      continue
+    }
+    const accelerator = normalizeAccelerator(entry.accelerator)
+    results[id] = registeredAppAccelerators.has(accelerator)
+  }
+
+  return results
+}
+
+/**
+ * 标准化 accelerator 字符串为 Electron 格式
+ */
+function normalizeAccelerator(accelerator: string): string {
+  return accelerator
+    .split('+')
+    .map((part) => part.trim().toLowerCase() === 'cmd' ? 'CommandOrControl' : part)
+    .join('+')
 }

--- a/apps/electron/src/main/lib/global-shortcut-service.ts
+++ b/apps/electron/src/main/lib/global-shortcut-service.ts
@@ -105,6 +105,39 @@ function registerOne(id: string): boolean {
 }
 
 /**
+ * 检查某个 accelerator 是否可被注册为全局快捷键
+ *
+ * 原理：尝试注册一个 dummy callback，成功则立即注销并返回 true，
+ * 失败则返回 false。不会影响当前已注册的全局快捷键。
+ *
+ * 注意：传入的 accelerator 需要先通过 getGlobalAccelerator 转换为 Electron 标准格式
+ *（如将 Cmd 转为 CommandOrControl），否则 macOS 上检测会失败。
+ */
+export function checkGlobalAcceleratorAvailability(accelerator: string): boolean {
+  if (!accelerator) return false
+
+  // 转换为 Electron 标准格式（与 getGlobalAccelerator 保持一致）
+  const normalizedAccel = accelerator
+    .split('+')
+    .map((part) => part.trim().toLowerCase() === 'cmd' ? 'CommandOrControl' : part)
+    .join('+')
+
+  // 如果该 accelerator 已经被 Proma 自己注册了，说明可用
+  if (registeredAccelerators.has(normalizedAccel)) return true
+
+  try {
+    const success = globalShortcut.register(normalizedAccel, () => {})
+    if (success) {
+      globalShortcut.unregister(normalizedAccel)
+      return true
+    }
+    return false
+  } catch {
+    return false
+  }
+}
+
+/**
  * 注册全局快捷键回调
  *
  * 在 app.whenReady() 后调用。设置回调函数并尝试注册。

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -125,7 +125,7 @@ import type {
   TrayCreateSessionData,
   TrayOpenAgentSessionData,
 } from '../types'
-import { QUICK_TASK_IPC_CHANNELS, TRAY_IPC_CHANNELS, VOICE_DICTATION_IPC_CHANNELS } from '../types'
+import { QUICK_TASK_IPC_CHANNELS, TRAY_IPC_CHANNELS, VOICE_DICTATION_IPC_CHANNELS, APP_SHORTCUT_IPC_CHANNELS } from '../types'
 
 /**
  * 暴露给渲染进程的 API 接口定义
@@ -922,6 +922,12 @@ export interface ElectronAPI {
   reregisterGlobalShortcuts: () => Promise<Record<string, boolean>>
   /** 检查全局快捷键是否可被系统注册 */
   checkGlobalShortcutAvailability: (accelerator: string) => Promise<boolean>
+  /** 设置应用级快捷键（渲染进程 → 主进程，focus 时注册） */
+  setAppShortcuts: (shortcuts: Array<{ id: string; accelerator: string }>) => Promise<void>
+  /** 重新注册应用级快捷键（设置变更后） */
+  reregisterAppShortcuts: () => Promise<Record<string, boolean>>
+  /** 订阅应用级快捷键触发事件 */
+  onAppShortcutTrigger: (callback: (id: string) => void) => () => void
   /** 订阅快速任务窗口聚焦事件 */
   onQuickTaskFocus: (callback: () => void) => () => void
   /** 订阅快速任务打开会话事件（主窗口接收，由渲染进程负责创建会话） */
@@ -2153,6 +2159,20 @@ const electronAPI: ElectronAPI = {
 
   checkGlobalShortcutAvailability: (accelerator: string) => {
     return ipcRenderer.invoke('global-shortcut:check-availability', accelerator)
+  },
+
+  setAppShortcuts: (shortcuts: Array<{ id: string; accelerator: string }>) => {
+    return ipcRenderer.invoke(APP_SHORTCUT_IPC_CHANNELS.SET, shortcuts)
+  },
+
+  reregisterAppShortcuts: () => {
+    return ipcRenderer.invoke(APP_SHORTCUT_IPC_CHANNELS.REREGISTER)
+  },
+
+  onAppShortcutTrigger: (callback: (id: string) => void) => {
+    const listener = (_: unknown, id: string): void => callback(id)
+    ipcRenderer.on(APP_SHORTCUT_IPC_CHANNELS.TRIGGER, listener)
+    return () => { ipcRenderer.removeListener(APP_SHORTCUT_IPC_CHANNELS.TRIGGER, listener) }
   },
 
   onQuickTaskFocus: (callback: () => void) => {

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -920,6 +920,8 @@ export interface ElectronAPI {
   hideQuickTask: () => Promise<void>
   /** 重新注册全局快捷键（设置变更后） */
   reregisterGlobalShortcuts: () => Promise<Record<string, boolean>>
+  /** 检查全局快捷键是否可被系统注册 */
+  checkGlobalShortcutAvailability: (accelerator: string) => Promise<boolean>
   /** 订阅快速任务窗口聚焦事件 */
   onQuickTaskFocus: (callback: () => void) => () => void
   /** 订阅快速任务打开会话事件（主窗口接收，由渲染进程负责创建会话） */
@@ -2147,6 +2149,10 @@ const electronAPI: ElectronAPI = {
 
   reregisterGlobalShortcuts: () => {
     return ipcRenderer.invoke(QUICK_TASK_IPC_CHANNELS.REREGISTER_GLOBAL_SHORTCUTS)
+  },
+
+  checkGlobalShortcutAvailability: (accelerator: string) => {
+    return ipcRenderer.invoke('global-shortcut:check-availability', accelerator)
   },
 
   onQuickTaskFocus: (callback: () => void) => {

--- a/apps/electron/src/renderer/components/settings/ShortcutSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/ShortcutSettings.tsx
@@ -10,7 +10,7 @@
 
 import * as React from 'react'
 import { useAtom } from 'jotai'
-import { RotateCcw } from 'lucide-react'
+import { RotateCcw, Loader2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
@@ -273,29 +273,52 @@ export function ShortcutSettings(): React.ReactElement {
   const [sendWithCmdEnter, setSendWithCmdEnter] = useAtom(sendWithCmdEnterAtom)
   // 当前正在录制的快捷键 id，用于隐藏并列操作按钮，避免与录制中途的 state 冲突
   const [recordingId, setRecordingId] = React.useState<string | null>(null)
-  // 全局快捷键可用性状态：shortcutId → boolean（true=可用, false=被占用）
-  const [globalShortcutAvailability, setGlobalShortcutAvailability] = React.useState<Record<string, boolean>>({})
+  // 全局快捷键可用性状态：shortcutId → 'checking' | 'available' | 'unavailable' | 'unknown'
+  const [globalShortcutAvailability, setGlobalShortcutAvailability] = React.useState<
+    Record<string, 'checking' | 'available' | 'unavailable' | 'unknown'>
+  >({})
 
   // 检测全局快捷键可用性
   React.useEffect(() => {
+    const abortController = new AbortController()
+
     const checkAvailability = async () => {
       const globalShortcuts = DEFAULT_SHORTCUTS.filter((s) => s.global)
-      const results: Record<string, boolean> = {}
+      // 初始状态设为 checking
+      const initialState: Record<string, 'checking' | 'available' | 'unavailable' | 'unknown'> = {}
       for (const def of globalShortcuts) {
+        initialState[def.id] = 'checking'
+      }
+      setGlobalShortcutAvailability(initialState)
+
+      for (const def of globalShortcuts) {
+        if (abortController.signal.aborted) return
+
         const accel = getActiveAccelerator(def.id)
-        if (accel && accel !== null) {
-          try {
-            results[def.id] = await window.electronAPI.checkGlobalShortcutAvailability(accel)
-          } catch {
-            results[def.id] = true // 检测失败时默认认为可用
-          }
-        } else {
-          results[def.id] = true // 未启用时不显示冲突
+        if (!accel || accel === null) {
+          setGlobalShortcutAvailability((prev) => ({ ...prev, [def.id]: 'unknown' }))
+          continue
+        }
+
+        try {
+          const isAvailable = await window.electronAPI.checkGlobalShortcutAvailability(accel)
+          if (abortController.signal.aborted) return
+          setGlobalShortcutAvailability((prev) => ({
+            ...prev,
+            [def.id]: isAvailable ? 'available' : 'unavailable',
+          }))
+        } catch {
+          if (abortController.signal.aborted) return
+          setGlobalShortcutAvailability((prev) => ({ ...prev, [def.id]: 'unknown' }))
         }
       }
-      setGlobalShortcutAvailability(results)
     }
+
     checkAvailability()
+
+    return () => {
+      abortController.abort()
+    }
   }, [overrides]) // 当快捷键覆盖变化时重新检测
 
   const handleRecordingChange = React.useCallback(
@@ -671,17 +694,31 @@ export function ShortcutSettings(): React.ReactElement {
                             <Tooltip>
                               <TooltipTrigger asChild>
                                 <span className={`inline-flex items-center justify-center size-5 rounded-full text-[10px] font-bold ${
-                                  globalShortcutAvailability[def.id] === false
+                                  globalShortcutAvailability[def.id] === 'unavailable'
                                     ? 'bg-destructive/15 text-destructive'
-                                    : 'bg-emerald-500/15 text-emerald-600'
+                                    : globalShortcutAvailability[def.id] === 'checking'
+                                      ? 'bg-muted text-muted-foreground animate-pulse'
+                                      : globalShortcutAvailability[def.id] === 'unknown'
+                                        ? 'bg-amber-500/15 text-amber-600'
+                                        : 'bg-emerald-500/15 text-emerald-600'
                                 }`}>
-                                  {globalShortcutAvailability[def.id] === false ? '!' : '✓'}
+                                  {globalShortcutAvailability[def.id] === 'unavailable'
+                                    ? '!'
+                                    : globalShortcutAvailability[def.id] === 'checking'
+                                      ? '...'
+                                      : globalShortcutAvailability[def.id] === 'unknown'
+                                        ? '?'
+                                        : '✓'}
                                 </span>
                               </TooltipTrigger>
                               <TooltipContent side="top">
-                                {globalShortcutAvailability[def.id] === false
+                                {globalShortcutAvailability[def.id] === 'unavailable'
                                   ? '该快捷键可能已被系统或其他应用占用'
-                                  : '该快捷键当前可被系统注册'}
+                                  : globalShortcutAvailability[def.id] === 'checking'
+                                    ? '正在检测快捷键可用性...'
+                                    : globalShortcutAvailability[def.id] === 'unknown'
+                                      ? '无法检测快捷键可用性（检测失败）'
+                                      : '该快捷键当前可被系统注册'}
                               </TooltipContent>
                             </Tooltip>
                           )}

--- a/apps/electron/src/renderer/components/settings/ShortcutSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/ShortcutSettings.tsx
@@ -278,6 +278,27 @@ export function ShortcutSettings(): React.ReactElement {
     Record<string, 'checking' | 'available' | 'unavailable' | 'unknown'>
   >({})
 
+  // 计算所有快捷键的 Proma 内部冲突状态
+  const internalConflicts = React.useMemo(() => {
+    const conflicts: Record<string, string | null> = {}
+    for (const def of DEFAULT_SHORTCUTS) {
+      if (def.readonly) continue
+      const accel = getActiveAccelerator(def.id)
+      if (!accel) {
+        conflicts[def.id] = null
+        continue
+      }
+      const conflictId = checkConflict(accel, def.id)
+      if (conflictId) {
+        const conflictDef = DEFAULT_SHORTCUTS.find((s) => s.id === conflictId)
+        conflicts[def.id] = conflictDef?.name ?? conflictId
+      } else {
+        conflicts[def.id] = null
+      }
+    }
+    return conflicts
+  }, [overrides])
+
   // 检测全局快捷键可用性
   React.useEffect(() => {
     const abortController = new AbortController()
@@ -719,6 +740,19 @@ export function ShortcutSettings(): React.ReactElement {
                                     : globalShortcutAvailability[def.id] === 'unknown'
                                       ? '无法检测快捷键可用性（检测失败）'
                                       : '该快捷键当前可被系统注册'}
+                              </TooltipContent>
+                            </Tooltip>
+                          )}
+                          {/* 非全局快捷键 Proma 内部冲突指示器 */}
+                          {!def.global && !isDisabled && recordingId !== def.id && internalConflicts[def.id] && (
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <span className="inline-flex items-center justify-center size-5 rounded-full text-[10px] font-bold bg-destructive/15 text-destructive">
+                                  !
+                                </span>
+                              </TooltipTrigger>
+                              <TooltipContent side="top">
+                                与「{internalConflicts[def.id]}」冲突
                               </TooltipContent>
                             </Tooltip>
                           )}

--- a/apps/electron/src/renderer/components/settings/ShortcutSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/ShortcutSettings.tsx
@@ -304,7 +304,7 @@ export function ShortcutSettings(): React.ReactElement {
     const abortController = new AbortController()
 
     const checkAvailability = async () => {
-      const shortcutsToCheck = DEFAULT_SHORTCUTS.filter((s) => !s.readonly)
+      const shortcutsToCheck = DEFAULT_SHORTCUTS.filter((s) => !s.readonly && s.global)
       // 初始状态设为 checking
       const initialState: Record<string, 'checking' | 'available' | 'unavailable' | 'unknown'> = {}
       for (const def of shortcutsToCheck) {
@@ -318,12 +318,6 @@ export function ShortcutSettings(): React.ReactElement {
         const accel = getActiveAccelerator(def.id)
         if (!accel || accel === null) {
           setGlobalShortcutAvailability((prev) => ({ ...prev, [def.id]: 'unknown' }))
-          continue
-        }
-
-        // 非全局快捷键不需要检测系统可用性（系统级检测只针对全局快捷键）
-        if (!def.global) {
-          setGlobalShortcutAvailability((prev) => ({ ...prev, [def.id]: 'available' }))
           continue
         }
 
@@ -716,8 +710,8 @@ export function ShortcutSettings(): React.ReactElement {
                               <TooltipContent side="top">恢复默认快捷键</TooltipContent>
                             </Tooltip>
                           )}
-                          {/* 快捷键系统可用性指示器（全局快捷键检测系统占用，非全局快捷键默认显示可用） */}
-                          {!isDisabled && recordingId !== def.id && (
+                          {/* 系统可用性指示器（仅全局快捷键显示） */}
+                          {def.global && !isDisabled && recordingId !== def.id && (
                             <Tooltip>
                               <TooltipTrigger asChild>
                                 <span className={`inline-flex items-center justify-center size-5 rounded-full text-[10px] font-bold ${

--- a/apps/electron/src/renderer/components/settings/ShortcutSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/ShortcutSettings.tsx
@@ -10,7 +10,7 @@
 
 import * as React from 'react'
 import { useAtom } from 'jotai'
-import { RotateCcw, Loader2 } from 'lucide-react'
+import { RotateCcw } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'

--- a/apps/electron/src/renderer/components/settings/ShortcutSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/ShortcutSettings.tsx
@@ -273,6 +273,30 @@ export function ShortcutSettings(): React.ReactElement {
   const [sendWithCmdEnter, setSendWithCmdEnter] = useAtom(sendWithCmdEnterAtom)
   // 当前正在录制的快捷键 id，用于隐藏并列操作按钮，避免与录制中途的 state 冲突
   const [recordingId, setRecordingId] = React.useState<string | null>(null)
+  // 全局快捷键可用性状态：shortcutId → boolean（true=可用, false=被占用）
+  const [globalShortcutAvailability, setGlobalShortcutAvailability] = React.useState<Record<string, boolean>>({})
+
+  // 检测全局快捷键可用性
+  React.useEffect(() => {
+    const checkAvailability = async () => {
+      const globalShortcuts = DEFAULT_SHORTCUTS.filter((s) => s.global)
+      const results: Record<string, boolean> = {}
+      for (const def of globalShortcuts) {
+        const accel = getActiveAccelerator(def.id)
+        if (accel && accel !== null) {
+          try {
+            results[def.id] = await window.electronAPI.checkGlobalShortcutAvailability(accel)
+          } catch {
+            results[def.id] = true // 检测失败时默认认为可用
+          }
+        } else {
+          results[def.id] = true // 未启用时不显示冲突
+        }
+      }
+      setGlobalShortcutAvailability(results)
+    }
+    checkAvailability()
+  }, [overrides]) // 当快捷键覆盖变化时重新检测
 
   const handleRecordingChange = React.useCallback(
     (shortcutId: string, active: boolean) => {
@@ -640,6 +664,25 @@ export function ShortcutSettings(): React.ReactElement {
                                 </Button>
                               </TooltipTrigger>
                               <TooltipContent side="top">恢复默认快捷键</TooltipContent>
+                            </Tooltip>
+                          )}
+                          {/* 全局快捷键系统可用性指示器 */}
+                          {def.global && !isDisabled && recordingId !== def.id && (
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <span className={`inline-flex items-center justify-center size-5 rounded-full text-[10px] font-bold ${
+                                  globalShortcutAvailability[def.id] === false
+                                    ? 'bg-destructive/15 text-destructive'
+                                    : 'bg-emerald-500/15 text-emerald-600'
+                                }`}>
+                                  {globalShortcutAvailability[def.id] === false ? '!' : '✓'}
+                                </span>
+                              </TooltipTrigger>
+                              <TooltipContent side="top">
+                                {globalShortcutAvailability[def.id] === false
+                                  ? '该快捷键可能已被系统或其他应用占用'
+                                  : '该快捷键当前可被系统注册'}
+                              </TooltipContent>
                             </Tooltip>
                           )}
                         </>

--- a/apps/electron/src/renderer/components/settings/ShortcutSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/ShortcutSettings.tsx
@@ -299,12 +299,13 @@ export function ShortcutSettings(): React.ReactElement {
     return conflicts
   }, [overrides])
 
-  // 检测所有快捷键的系统可用性
+  // 检测所有快捷键的系统可用性（包括全局和应用级）
   React.useEffect(() => {
     const abortController = new AbortController()
 
     const checkAvailability = async () => {
-      const shortcutsToCheck = DEFAULT_SHORTCUTS.filter((s) => !s.readonly && s.global)
+      // 检测所有非 readonly 快捷键（不再限制为仅全局快捷键）
+      const shortcutsToCheck = DEFAULT_SHORTCUTS.filter((s) => !s.readonly)
       // 初始状态设为 checking
       const initialState: Record<string, 'checking' | 'available' | 'unavailable' | 'unknown'> = {}
       for (const def of shortcutsToCheck) {
@@ -374,6 +375,21 @@ export function ShortcutSettings(): React.ReactElement {
     [],
   )
 
+  // 重新注册应用级快捷键（设置变更后调用）
+  const reregisterAppShortcutsIfNeeded = React.useCallback(
+    async (shortcutId: string): Promise<void> => {
+      const def = DEFAULT_SHORTCUTS.find((s) => s.id === shortcutId)
+      if (def?.global) return // 全局快捷键走 reregisterGlobalShortcut
+
+      try {
+        await window.electronAPI.reregisterAppShortcuts()
+      } catch (error) {
+        console.error(error)
+      }
+    },
+    [],
+  )
+
   // 保存录制结果：持久化后更新 App 内快捷键缓存；全局快捷键额外重新注册。
   const handleSaveShortcut = React.useCallback(
     async (shortcutId: string, accelerator: string): Promise<boolean> => {
@@ -411,6 +427,9 @@ export function ShortcutSettings(): React.ReactElement {
             })
             return true
           }
+        } else {
+          // 应用级快捷键通过主进程 globalShortcut（focus/blur 生命周期）注册
+          await reregisterAppShortcutsIfNeeded(shortcutId)
         }
 
         toast.success('快捷键已保存', { id: 'shortcut-save-success' })
@@ -421,7 +440,7 @@ export function ShortcutSettings(): React.ReactElement {
         return false
       }
     },
-    [overrides, reregisterGlobalShortcut, setOverrides],
+    [overrides, reregisterGlobalShortcut, reregisterAppShortcutsIfNeeded, setOverrides],
   )
 
   // 恢复单个快捷键默认值
@@ -453,6 +472,8 @@ export function ShortcutSettings(): React.ReactElement {
             })
             return
           }
+        } else {
+          await reregisterAppShortcutsIfNeeded(shortcutId)
         }
 
         toast.success('已恢复默认快捷键', { id: 'shortcut-save-success' })
@@ -461,7 +482,7 @@ export function ShortcutSettings(): React.ReactElement {
         toast.error('恢复默认快捷键失败', { id: 'shortcut-save-error' })
       }
     },
-    [overrides, reregisterGlobalShortcut, setOverrides],
+    [overrides, reregisterGlobalShortcut, reregisterAppShortcutsIfNeeded, setOverrides],
   )
 
   // 禁用单个快捷键：将当前平台 override 置为 null
@@ -494,6 +515,8 @@ export function ShortcutSettings(): React.ReactElement {
             })
             return
           }
+        } else {
+          await reregisterAppShortcutsIfNeeded(shortcutId)
         }
 
         toast.success('快捷键已禁用', { id: 'shortcut-save-success' })
@@ -502,7 +525,7 @@ export function ShortcutSettings(): React.ReactElement {
         toast.error('禁用快捷键失败', { id: 'shortcut-save-error' })
       }
     },
-    [overrides, reregisterGlobalShortcut, setOverrides],
+    [overrides, reregisterGlobalShortcut, reregisterAppShortcutsIfNeeded, setOverrides],
   )
 
   // 恢复所有默认值（同时会清除所有"已禁用"标记）
@@ -517,6 +540,8 @@ export function ShortcutSettings(): React.ReactElement {
 
       try {
         const results = await window.electronAPI.reregisterGlobalShortcuts()
+        // 同时重新注册应用级快捷键
+        await window.electronAPI.reregisterAppShortcuts()
         const hasUnregisteredGlobal = Object.values(results).some((registered) => !registered)
         if (hasUnregisteredGlobal) {
           toast.warning('已恢复全部默认；部分全局快捷键当前未注册', {
@@ -710,8 +735,8 @@ export function ShortcutSettings(): React.ReactElement {
                               <TooltipContent side="top">恢复默认快捷键</TooltipContent>
                             </Tooltip>
                           )}
-                          {/* 系统可用性指示器（仅全局快捷键显示） */}
-                          {def.global && !isDisabled && recordingId !== def.id && (
+                          {/* 系统可用性指示器（所有快捷键） */}
+                          {!isDisabled && recordingId !== def.id && (
                             <Tooltip>
                               <TooltipTrigger asChild>
                                 <span className={`inline-flex items-center justify-center size-5 rounded-full text-[10px] font-bold ${

--- a/apps/electron/src/renderer/components/settings/ShortcutSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/ShortcutSettings.tsx
@@ -299,25 +299,31 @@ export function ShortcutSettings(): React.ReactElement {
     return conflicts
   }, [overrides])
 
-  // 检测全局快捷键可用性
+  // 检测所有快捷键的系统可用性
   React.useEffect(() => {
     const abortController = new AbortController()
 
     const checkAvailability = async () => {
-      const globalShortcuts = DEFAULT_SHORTCUTS.filter((s) => s.global)
+      const shortcutsToCheck = DEFAULT_SHORTCUTS.filter((s) => !s.readonly)
       // 初始状态设为 checking
       const initialState: Record<string, 'checking' | 'available' | 'unavailable' | 'unknown'> = {}
-      for (const def of globalShortcuts) {
+      for (const def of shortcutsToCheck) {
         initialState[def.id] = 'checking'
       }
       setGlobalShortcutAvailability(initialState)
 
-      for (const def of globalShortcuts) {
+      for (const def of shortcutsToCheck) {
         if (abortController.signal.aborted) return
 
         const accel = getActiveAccelerator(def.id)
         if (!accel || accel === null) {
           setGlobalShortcutAvailability((prev) => ({ ...prev, [def.id]: 'unknown' }))
+          continue
+        }
+
+        // 非全局快捷键不需要检测系统可用性（系统级检测只针对全局快捷键）
+        if (!def.global) {
+          setGlobalShortcutAvailability((prev) => ({ ...prev, [def.id]: 'available' }))
           continue
         }
 
@@ -710,8 +716,8 @@ export function ShortcutSettings(): React.ReactElement {
                               <TooltipContent side="top">恢复默认快捷键</TooltipContent>
                             </Tooltip>
                           )}
-                          {/* 全局快捷键系统可用性指示器 */}
-                          {def.global && !isDisabled && recordingId !== def.id && (
+                          {/* 快捷键系统可用性指示器（全局快捷键检测系统占用，非全局快捷键默认显示可用） */}
+                          {!isDisabled && recordingId !== def.id && (
                             <Tooltip>
                               <TooltipTrigger asChild>
                                 <span className={`inline-flex items-center justify-center size-5 rounded-full text-[10px] font-bold ${
@@ -743,8 +749,8 @@ export function ShortcutSettings(): React.ReactElement {
                               </TooltipContent>
                             </Tooltip>
                           )}
-                          {/* 非全局快捷键 Proma 内部冲突指示器 */}
-                          {!def.global && !isDisabled && recordingId !== def.id && internalConflicts[def.id] && (
+                          {/* Proma 内部冲突指示器 */}
+                          {!isDisabled && recordingId !== def.id && internalConflicts[def.id] && (
                             <Tooltip>
                               <TooltipTrigger asChild>
                                 <span className="inline-flex items-center justify-center size-5 rounded-full text-[10px] font-bold bg-destructive/15 text-destructive">

--- a/apps/electron/src/renderer/lib/shortcut-registry.ts
+++ b/apps/electron/src/renderer/lib/shortcut-registry.ts
@@ -194,13 +194,49 @@ function dispatchShortcut(e: KeyboardEvent): void {
 /**
  * 初始化快捷键注册表
  *
- * 挂载全局 keydown listener，仅执行一次
+ * 挂载全局 keydown listener，并将应用级快捷键注册到主进程（微信模式）。
+ * 主进程在窗口聚焦时通过 globalShortcut 注册应用级快捷键，失焦时注销。
  */
-export function initShortcutRegistry(): void {
+export async function initShortcutRegistry(): Promise<void> {
   if (initialized) return
   initialized = true
   rebuildCache()
   window.addEventListener('keydown', dispatchShortcut, true) // capture 阶段
+
+  // 将应用级快捷键注册到主进程
+  await syncAppShortcutsToMain()
+
+  // 监听主进程的应用级快捷键触发事件
+  window.electronAPI.onAppShortcutTrigger((id: string) => {
+    const handlerSet = handlers.get(id)
+    if (handlerSet && handlerSet.size > 0) {
+      for (const entry of handlerSet) {
+        entry.callback()
+      }
+    }
+  })
+}
+
+/**
+ * 将应用级快捷键同步到主进程
+ *
+ * 收集所有非全局、非 readonly 快捷键的当前 accelerator，
+ * 通过 IPC 发送给主进程，主进程在窗口聚焦时注册这些快捷键。
+ */
+async function syncAppShortcutsToMain(): Promise<void> {
+  const shortcuts: Array<{ id: string; accelerator: string }> = []
+  for (const def of DEFAULT_SHORTCUTS) {
+    if (def.global || def.readonly) continue
+    const accel = getActiveAccelerator(def.id)
+    if (!accel) continue
+    shortcuts.push({ id: def.id, accelerator: accel })
+  }
+
+  try {
+    await window.electronAPI.setAppShortcuts(shortcuts)
+  } catch (err) {
+    console.warn('[快捷键] 同步应用级快捷键到主进程失败:', err)
+  }
 }
 
 /**
@@ -231,11 +267,15 @@ export function registerShortcut(
 /**
  * 更新用户自定义快捷键配置
  *
- * 配置变更后自动重建匹配缓存
+ * 配置变更后自动重建匹配缓存，并同步到主进程
  */
 export function updateShortcutOverrides(overrides: ShortcutOverrides): void {
   currentOverrides = overrides
   rebuildCache()
+  // 同步应用级快捷键到主进程（非阻塞）
+  syncAppShortcutsToMain().catch((err) => {
+    console.warn('[快捷键] 同步应用级快捷键到主进程失败:', err)
+  })
 }
 
 /**

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -302,6 +302,16 @@ export const GLOBAL_SHORTCUT_IPC_CHANNELS = {
   CHECK_AVAILABILITY: 'global-shortcut:check-availability',
 } as const
 
+/** 应用级快捷键 IPC 通道 */
+export const APP_SHORTCUT_IPC_CHANNELS = {
+  /** 设置应用级快捷键（渲染进程 → 主进程） */
+  SET: 'app-shortcut:set',
+  /** 重新注册应用级快捷键（设置变更后） */
+  REREGISTER: 'app-shortcut:reregister',
+  /** 应用级快捷键触发通知（主进程 → 渲染进程） */
+  TRIGGER: 'app-shortcut:trigger',
+} as const
+
 /** 语音输入 IPC 通道 */
 export const VOICE_DICTATION_IPC_CHANNELS = {
   /** 获取语音输入设置 */

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -296,6 +296,12 @@ export const QUICK_TASK_IPC_CHANNELS = {
   REREGISTER_GLOBAL_SHORTCUTS: 'quick-task:reregister-global-shortcuts',
 } as const
 
+/** 全局快捷键 IPC 通道 */
+export const GLOBAL_SHORTCUT_IPC_CHANNELS = {
+  /** 检查全局快捷键可用性 */
+  CHECK_AVAILABILITY: 'global-shortcut:check-availability',
+} as const
+
 /** 语音输入 IPC 通道 */
 export const VOICE_DICTATION_IPC_CHANNELS = {
   /** 获取语音输入设置 */


### PR DESCRIPTION
## 概述

为 Proma 快捷键设置页面添加全类型冲突检测和可用性提示，采用微信模式实现。

## 问题

用户在设置快捷键时，无法知道：
1. 全局快捷键是否已被系统或其他应用占用
2. 应用级快捷键（打开设置、新建对话、切换侧边栏等）是否被系统或其他应用占用
3. Proma 内部是否存在快捷键冲突

原 PR 仅检测全局快捷键的系统占用，应用级/导航级/编辑级快捷键完全没有检测。

## 改动

### 核心架构变更：微信模式

采用微信的做法：**所有快捷键都通过 `globalShortcut.register` 注册**，但绑定窗口 focus/blur 生命周期：
- **窗口聚焦时**：注册所有快捷键（全局 + 应用级）
- **窗口失焦时**：注销应用级快捷键（全局快捷键保留）
- **应用退出时**：注销所有

这样所有快捷键都能用同样的 try-register 方式检测冲突，且应用级快捷键不会在应用不在前台时抢占系统按键。

### 主进程（main）
- `global-shortcut-service.ts`:
  - 新增 `setAppShortcuts()` — 渲染进程通过 IPC 设置应用级快捷键
  - 新增 `onWindowFocus()` / `onWindowBlur()` — 窗口焦点变化时注册/注销应用级快捷键
  - 新增 `reregisterAppShortcuts()` — 设置变更后重新注册
  - `checkGlobalAcceleratorAvailability()` 现在也检查应用级快捷键
- `index.ts`: 主窗口 focus/blur 事件绑定
- `ipc.ts`: 新增 `app-shortcut:set`、`app-shortcut:reregister`、`app-shortcut:trigger` IPC 通道

### 类型定义
- `types/settings.ts`: 新增 `APP_SHORTCUT_IPC_CHANNELS` 常量

### Preload
- `preload/index.ts`: 暴露 `setAppShortcuts`、`reregisterAppShortcuts`、`onAppShortcutTrigger` API

### 渲染进程（renderer）
- `shortcut-registry.ts`:
  - `initShortcutRegistry()` 改为 async，初始化时通过 IPC 将应用级快捷键注册到主进程
  - 新增 `syncAppShortcutsToMain()` — 收集非全局快捷键并同步到主进程
  - `updateShortcutOverrides()` 变更时自动同步
  - 监听主进程的 `app-shortcut:trigger` 事件执行对应快捷键动作
- `ShortcutSettings.tsx`:
  - 系统可用性检测范围从仅全局快捷键扩展到**所有非 readonly 快捷键**
  - 所有快捷键都显示系统可用性指示器（✓ / ! / ? / checking）
  - 保存/恢复/禁用快捷键时也重新注册应用级快捷键

## Commit 历史
- `feat(shortcuts): 全局快捷键系统冲突检测提示`
- `fix(shortcuts): 修复全局快捷键冲突检测健壮性问题`
- `fix(shortcuts): 非全局快捷键也显示 Proma 内部冲突提示`
- `fix(shortcuts): 所有快捷键都显示系统可用性指示器`
- `fix(shortcuts): 系统可用性指示器仅显示在全局快捷键上`
- `chore(shortcuts): 删除未使用的 Loader2 导入`
- `feat(shortcuts): 所有快捷键系统冲突检测（微信模式）`

## 测试
- [x] 全局快捷键显示系统可用性状态
- [x] 应用级快捷键显示系统可用性状态
- [x] 导航级快捷键显示系统可用性状态
- [x] Proma 内部冲突检测对所有快捷键生效
- [x] 窗口聚焦时应用级快捷键通过 globalShortcut 注册
- [x] 窗口失焦时应用级快捷键自动注销
- [x] 修改快捷键后应用级快捷键重新注册
- [x] TypeScript 类型检查通过

## 备注
- 系统可用性检测采用微信模式：应用级快捷键通过 globalShortcut 注册（窗口聚焦时注册、失焦时注销），既支持冲突检测又不会抢占系统快捷键
- 渲染进程的 keydown listener 保留作为 fallback，防止 globalShortcut 注册失败时完全无响应
- 与微信桌面版行为一致：所有快捷键都有冲突提示，用户可以清楚知道哪些快捷键可用