### PR TITLE
[WIP] feat(channel): 为 Anthropic 协议渠道添加自定义思考模式配置

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -439,6 +439,9 @@ const DEFAULT_SESSION_TITLE = '新 Agent 会话'
 /** 默认模型 ID */
 const DEFAULT_MODEL_ID = 'claude-sonnet-4-6'
 
+/** 默认 thinking budget tokens */
+const DEFAULT_THINKING_BUDGET = 16384
+
 /**
  * 判断模型是否支持 1M context window beta（context-1m-2025-08-07）
  * 当前支持：Claude Sonnet 4 / 4.5 / 4.6、Opus 4.6 / 4.7 / 4.8、DeepSeek V4 系列、
@@ -1563,9 +1566,9 @@ export class AgentOrchestrator {
                 : channel.thinkingMode === 'adaptive'
                   ? { type: 'adaptive' as const }
                   : channel.thinkingMode === 'manual'
-                    ? { type: 'enabled' as const, budgetTokens: channel.thinkingBudgetTokens ?? 16384 }
+                    ? { type: 'enabled' as const, budgetTokens: channel.thinkingBudgetTokens ?? DEFAULT_THINKING_BUDGET }
                     : channel.thinkingMode === 'effort-based'
-                      ? { type: 'enabled' as const, budgetTokens: channel.thinkingBudgetTokens ?? 16384 }
+                      ? { type: 'enabled' as const, effort: 'max' as const }
                       : undefined,
             }
           : appSettings.agentThinking

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -36,6 +36,7 @@ import { isTransientNetworkError } from './error-patterns'
 import { AgentEventBus } from './agent-event-bus'
 import { decryptApiKey, getChannelById, listChannels } from './channel-manager'
 import { getAdapter, fetchTitle, normalizeAnthropicBaseUrlForSdk, getPromaUserAgent } from '@proma/core'
+import { detectThinkingCapability } from '@proma/core'
 import pkg from '../../../package.json' with { type: 'json' }
 import { getFetchFn } from './proxy-fetch'
 import { getEffectiveProxyUrl } from './proxy-settings-service'
@@ -1558,7 +1559,7 @@ export class AgentOrchestrator {
         })(),
         // 启用文件检查点，支持 rewindFiles 回退
         enableFileCheckpointing: true,
-        // SDK thinking 配置：优先使用渠道的 thinkingMode，否则回退到全局设置
+        // SDK thinking 配置：优先使用渠道的 thinkingMode，否则根据模型能力推断
         ...(channel.thinkingMode && channel.thinkingMode !== 'auto'
           ? {
               thinking: channel.thinkingMode === 'disabled'
@@ -1571,8 +1572,24 @@ export class AgentOrchestrator {
                       ? { type: 'enabled' as const, effort: 'max' as const }
                       : undefined,
             }
-          : appSettings.agentThinking
-            ? { thinking: appSettings.agentThinking }
+          : input.thinkingEnabled !== false
+            ? (() => {
+                // channel.thinkingMode === 'auto' 或未配置：根据模型能力推断
+                const capability = detectThinkingCapability(channel.provider, modelId || DEFAULT_MODEL_ID, channel.thinkingMode)
+                if (capability.mode === 'none') {
+                  return undefined
+                }
+                if (capability.mode === 'adaptive-only' || capability.mode === 'adaptive-preferred') {
+                  return { thinking: { type: 'adaptive' as const } }
+                }
+                if (capability.mode === 'manual-only') {
+                  return { thinking: { type: 'enabled' as const, budgetTokens: channel.thinkingBudgetTokens ?? DEFAULT_THINKING_BUDGET } }
+                }
+                if (capability.mode === 'effort-based-max') {
+                  return { thinking: { type: 'enabled' as const, effort: 'max' as const } }
+                }
+                return undefined
+              })()
             : {}),
         effort: appSettings.agentEffort ?? 'high',
         ...(appSettings.agentMaxBudgetUsd != null && appSettings.agentMaxBudgetUsd > 0 && {

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -1555,8 +1555,22 @@ export class AgentOrchestrator {
         })(),
         // 启用文件检查点，支持 rewindFiles 回退
         enableFileCheckpointing: true,
-        // SDK 0.2.52+ 新增选项（从 settings 读取）
-        ...(appSettings.agentThinking && { thinking: appSettings.agentThinking }),
+        // SDK thinking 配置：优先使用渠道的 thinkingMode，否则回退到全局设置
+        ...(channel.thinkingMode && channel.thinkingMode !== 'auto'
+          ? {
+              thinking: channel.thinkingMode === 'disabled'
+                ? { type: 'disabled' as const }
+                : channel.thinkingMode === 'adaptive'
+                  ? { type: 'adaptive' as const }
+                  : channel.thinkingMode === 'manual'
+                    ? { type: 'enabled' as const, budgetTokens: channel.thinkingBudgetTokens ?? 16384 }
+                    : channel.thinkingMode === 'effort-based'
+                      ? { type: 'enabled' as const, budgetTokens: channel.thinkingBudgetTokens ?? 16384 }
+                      : undefined,
+            }
+          : appSettings.agentThinking
+            ? { thinking: appSettings.agentThinking }
+            : {}),
         effort: appSettings.agentEffort ?? 'high',
         ...(appSettings.agentMaxBudgetUsd != null && appSettings.agentMaxBudgetUsd > 0 && {
           maxBudgetUsd: appSettings.agentMaxBudgetUsd,

--- a/apps/electron/src/main/lib/channel-manager.ts
+++ b/apps/electron/src/main/lib/channel-manager.ts
@@ -170,6 +170,8 @@ export function createChannel(input: ChannelCreateInput): Channel {
     apiKey: encryptApiKey(input.apiKey),
     models: input.models,
     enabled: input.enabled,
+    thinkingMode: input.thinkingMode,
+    thinkingBudgetTokens: input.thinkingBudgetTokens,
     createdAt: now,
     updatedAt: now,
   }
@@ -206,6 +208,8 @@ export function updateChannel(id: string, input: ChannelUpdateInput): Channel {
     apiKey: input.apiKey ? encryptApiKey(input.apiKey) : existing.apiKey,
     models: input.models ?? existing.models,
     enabled: input.enabled ?? existing.enabled,
+    thinkingMode: input.thinkingMode ?? existing.thinkingMode,
+    thinkingBudgetTokens: input.thinkingBudgetTokens ?? existing.thinkingBudgetTokens,
     updatedAt: Date.now(),
   }
 

--- a/apps/electron/src/main/lib/channel-manager.ts
+++ b/apps/electron/src/main/lib/channel-manager.ts
@@ -130,6 +130,8 @@ export function listChannels(): Channel[] {
         { id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash', enabled: true },
       ],
       enabled: false,
+      thinkingMode: 'auto',
+      thinkingBudgetTokens: 16384,
       createdAt: now,
       updatedAt: now,
     }

--- a/apps/electron/src/main/lib/chat-service.ts
+++ b/apps/electron/src/main/lib/chat-service.ts
@@ -319,6 +319,8 @@ export async function sendMessage(
         attachments,
         readImageAttachments: getImageAttachmentData,
         thinkingEnabled,
+        channelThinkingMode: channel.thinkingMode,
+        thinkingBudgetTokens: channel.thinkingBudgetTokens,
         tools,
         continuationMessages: continuationMessages.length > 0 ? continuationMessages : undefined,
       })
@@ -395,6 +397,8 @@ export async function sendMessage(
         attachments,
         readImageAttachments: getImageAttachmentData,
         thinkingEnabled,
+        channelThinkingMode: channel.thinkingMode,
+        thinkingBudgetTokens: channel.thinkingBudgetTokens,
         // 不传 tools，强制模型生成文本回复而非继续调用工具
         continuationMessages,
       })
@@ -592,6 +596,7 @@ export async function generateTitle(input: GenerateTitleInput): Promise<string |
       apiKey,
       modelId,
       prompt: TITLE_PROMPT + userMessage,
+      channelThinkingMode: channel.thinkingMode,
     })
 
     const proxyUrl = await getEffectiveProxyUrl()

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -809,7 +809,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         workspaceId: snapshot.workspaceId,
         startedAt: streamStartedAt,
         permissionModeOverride: permissionMode,
-        thinkingEnabled: agentThinking?.type !== 'disabled',
+        thinkingEnabled: agentThinking?.type === 'adaptive',
         ...(snapshot.additionalDirectories && snapshot.additionalDirectories.length > 0 && {
           additionalDirectories: snapshot.additionalDirectories,
         }),
@@ -1508,7 +1508,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       workspaceId: currentWorkspaceId || undefined,
       startedAt: streamStartedAt,
       permissionModeOverride: permissionMode,
-      thinkingEnabled: agentThinking?.type !== 'disabled',
+      thinkingEnabled: agentThinking?.type === 'adaptive',
       ...(additionalDirectoriesForRun.size > 0 && { additionalDirectories: Array.from(additionalDirectoriesForRun) }),
       // 解析用户消息中的 Skill/MCP/会话引用，传递结构化元数据给后端
       ...(() => {

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -339,8 +339,16 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const [agentThinking, setAgentThinking] = useAtom(agentThinkingAtom)
   const setSettingsOpen = useSetAtom(settingsOpenAtom)
   const setDraftSessionIds = useSetAtom(draftSessionIdsAtom)
+  const setChannels = useSetAtom(channelsAtom)
   const globalWorkspaceId = useAtomValue(currentAgentWorkspaceIdAtom)
   const sessions = useAtomValue(agentSessionsAtom)
+  // 页面切换时重新加载渠道列表，确保 thinkingMode 状态同步
+  React.useEffect(() => {
+    window.electronAPI.listChannels().then((latestChannels) => {
+      setChannels(latestChannels)
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
   // 从会话元数据派生 workspaceId：会话数据已加载时以自身为准，未加载时回退全局 atom
   const currentWorkspaceId = React.useMemo(() => {
     const meta = sessions.find((s) => s.id === sessionId)

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -793,6 +793,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         workspaceId: snapshot.workspaceId,
         startedAt: streamStartedAt,
         permissionModeOverride: permissionMode,
+        thinkingEnabled: agentThinking?.type !== 'disabled',
         ...(snapshot.additionalDirectories && snapshot.additionalDirectories.length > 0 && {
           additionalDirectories: snapshot.additionalDirectories,
         }),
@@ -1491,6 +1492,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       workspaceId: currentWorkspaceId || undefined,
       startedAt: streamStartedAt,
       permissionModeOverride: permissionMode,
+      thinkingEnabled: agentThinking?.type !== 'disabled',
       ...(additionalDirectoriesForRun.size > 0 && { additionalDirectories: Array.from(additionalDirectoriesForRun) }),
       // 解析用户消息中的 Skill/MCP/会话引用，传递结构化元数据给后端
       ...(() => {

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -141,10 +141,11 @@ function getUserTextFromSDKMessage(message: SDKMessage): string | null {
 
 interface AgentThinkingPopoverProps {
   agentThinking: import('@proma/shared').ThinkingConfig | undefined
+  isDisabled: boolean
   onToggle: () => void
 }
 
-function AgentThinkingPopover({ agentThinking, onToggle }: AgentThinkingPopoverProps): React.ReactElement {
+function AgentThinkingPopover({ agentThinking, isDisabled, onToggle }: AgentThinkingPopoverProps): React.ReactElement {
   const [thinkingExpanded, setThinkingExpanded] = useAtom(thinkingExpandedAtom)
   const [open, setOpen] = React.useState(false)
   const hoverTimeout = React.useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -175,11 +176,16 @@ function AgentThinkingPopover({ agentThinking, onToggle }: AgentThinkingPopoverP
           size="icon"
           className={cn(
             'size-[36px] rounded-full',
-            isEnabled ? 'text-green-500' : 'text-foreground/60 hover:text-foreground'
+            isDisabled
+              ? 'text-foreground/30 cursor-not-allowed'
+              : isEnabled
+                ? 'text-green-500'
+                : 'text-foreground/60 hover:text-foreground'
           )}
-          onClick={onToggle}
+          onClick={isDisabled ? undefined : onToggle}
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
+          disabled={isDisabled}
         >
           <Brain className="size-5" />
         </Button>
@@ -199,6 +205,7 @@ function AgentThinkingPopover({ agentThinking, onToggle }: AgentThinkingPopoverP
             <Switch
               checked={isEnabled}
               onCheckedChange={onToggle}
+              disabled={isDisabled}
               className="h-4 w-7 [&>span]:size-3 [&>span]:data-[state=checked]:translate-x-3"
             />
           </div>
@@ -208,6 +215,7 @@ function AgentThinkingPopover({ agentThinking, onToggle }: AgentThinkingPopoverP
             <Switch
               checked={thinkingExpanded}
               onCheckedChange={setThinkingExpanded}
+              disabled={isDisabled}
               className="h-4 w-7 [&>span]:size-3 [&>span]:data-[state=checked]:translate-x-3"
             />
           </div>
@@ -1854,6 +1862,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       node: (
         <AgentThinkingPopover
           agentThinking={agentThinking}
+          isDisabled={globalChannels.find((c) => c.id === agentChannelId)?.thinkingMode === 'disabled'}
           onToggle={() => {
             const next = agentThinking?.type === 'adaptive'
               ? { type: 'disabled' as const }

--- a/apps/electron/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatInput.tsx
@@ -80,6 +80,7 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
     })
   }, [conversationId, setDraftsMap])
 
+  const setChannels = useSetAtom(channelsAtom)
   const [selectedModel] = useConversationModel()
   const [thinkingEnabled, setThinkingEnabled] = useConversationThinkingEnabled()
   const channels = useAtomValue(channelsAtom)
@@ -87,6 +88,14 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
   const isThinkingDisabled = channel?.thinkingMode === 'disabled'
   const setPendingAttachments = onSetPendingAttachments
   const [isDragOver, setIsDragOver] = React.useState(false)
+
+  // 页面切换时重新加载渠道列表，确保 thinkingMode 状态同步
+  React.useEffect(() => {
+    window.electronAPI.listChannels().then((latestChannels) => {
+      setChannels(latestChannels)
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const canSend = (content.trim().length > 0 || pendingAttachments.length > 0)
     && selectedModel !== null

--- a/apps/electron/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatInput.tsx
@@ -32,6 +32,7 @@ import {
 import { getActiveAccelerator, getAcceleratorDisplay } from '@/lib/shortcut-registry'
 import {
   conversationDraftsAtom,
+  channelsAtom,
 } from '@/atoms/chat-atoms'
 import type { PendingAttachment } from '@/atoms/chat-atoms'
 import {
@@ -81,6 +82,9 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
 
   const [selectedModel] = useConversationModel()
   const [thinkingEnabled, setThinkingEnabled] = useConversationThinkingEnabled()
+  const channels = useAtomValue(channelsAtom)
+  const channel = channels.find((c) => c.id === selectedModel?.channelId)
+  const isThinkingDisabled = channel?.thinkingMode === 'disabled'
   const setPendingAttachments = onSetPendingAttachments
   const [isDragOver, setIsDragOver] = React.useState(false)
 
@@ -297,15 +301,20 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
               size="icon"
               className={cn(
                 'size-[36px] shrink-0 rounded-full',
-                thinkingEnabled ? 'text-green-500' : 'text-foreground/60 hover:text-foreground'
+                isThinkingDisabled
+                  ? 'text-foreground/30 cursor-not-allowed'
+                  : thinkingEnabled
+                    ? 'text-green-500'
+                    : 'text-foreground/60 hover:text-foreground'
               )}
-              onClick={() => setThinkingEnabled(!thinkingEnabled)}
+              onClick={() => !isThinkingDisabled && setThinkingEnabled(!thinkingEnabled)}
+              disabled={isThinkingDisabled}
             >
               <Brain className="size-5" />
             </Button>
           </TooltipTrigger>
           <TooltipContent side="top">
-            <p>{thinkingEnabled ? '关闭思考模式' : '开启思考模式'}</p>
+            <p>{isThinkingDisabled ? '思考模式已禁用（渠道配置）' : thinkingEnabled ? '关闭思考模式' : '开启思考模式'}</p>
           </TooltipContent>
         </Tooltip>
       ),

--- a/apps/electron/src/renderer/components/settings/ChannelForm.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelForm.tsx
@@ -591,8 +591,8 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
             checked={enabled}
             onCheckedChange={setEnabled}
           />
-          {/* 思考模式配置（仅 Anthropic 兼容渠道显示） */}
-          {(provider === 'anthropic' || provider === 'anthropic-compatible' || provider === 'deepseek') && (
+          {/* 思考模式配置（Anthropic 兼容渠道显示） */}
+          {ANTHROPIC_PROTOCOL_PROVIDERS.has(provider) && (
             <>
               <SettingsSelect
                 label="思考模式"
@@ -611,7 +611,7 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
                 <SettingsInput
                   label="Thinking Budget Tokens"
                   value={thinkingBudgetTokens.toString()}
-                  onChange={(v) => setThinkingBudgetTokens(parseInt(v) || 16384)}
+                  onChange={(v) => setThinkingBudgetTokens(parseInt(v, 10) || 16384)}
                   placeholder="16384"
                   type="number"
                   description="manual 模式下的思考预算 token 数"

--- a/apps/electron/src/renderer/components/settings/ChannelForm.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelForm.tsx
@@ -41,6 +41,7 @@ import type {
   ChannelTestResult,
   FetchModelsResult,
   ProviderType,
+  ThinkingModeConfig,
 } from '@proma/shared'
 import { normalizeAnthropicProviderUrl } from '@proma/core'
 import { getProviderLogo } from '@/lib/model-logo'
@@ -145,6 +146,8 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
   const [showApiKey, setShowApiKey] = React.useState(false)
   const [models, setModels] = React.useState<ChannelModel[]>(channel?.models ?? [])
   const [enabled, setEnabled] = React.useState(channel?.enabled ?? true)
+  const [thinkingMode, setThinkingMode] = React.useState<ThinkingModeConfig>(channel?.thinkingMode ?? 'auto')
+  const [thinkingBudgetTokens, setThinkingBudgetTokens] = React.useState<number>(channel?.thinkingBudgetTokens ?? 16384)
 
   // 新模型输入
   const [newModelId, setNewModelId] = React.useState('')
@@ -195,6 +198,8 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
     currentBaseUrl: string,
     currentApiKey: string,
     currentEnabled: boolean,
+    currentThinkingMode: ThinkingModeConfig,
+    currentThinkingBudgetTokens: number,
   ) => {
     if (!isEdit || !channel) return
     try {
@@ -205,6 +210,8 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
         apiKey: currentApiKey || undefined,
         models: currentModels,
         enabled: currentEnabled,
+        thinkingMode: currentThinkingMode,
+        thinkingBudgetTokens: currentThinkingBudgetTokens,
       })
       const eligible = isAgentEligibleChannel(savedChannel)
       if (eligible !== lastAgentEligibleRef.current) {
@@ -226,11 +233,13 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
     nextBaseUrl: string,
     nextApiKey: string,
     nextEnabled: boolean,
+    nextThinkingMode: ThinkingModeConfig,
+    nextThinkingBudgetTokens: number,
   ) => {
     if (!isEdit || !initializedRef.current) return
     if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current)
     autoSaveTimerRef.current = setTimeout(() => {
-      doAutoSave(nextModels, nextName, nextProvider, nextBaseUrl, nextApiKey, nextEnabled)
+      doAutoSave(nextModels, nextName, nextProvider, nextBaseUrl, nextApiKey, nextEnabled, nextThinkingMode, nextThinkingBudgetTokens)
     }, AUTO_SAVE_DELAY)
   }, [isEdit, doAutoSave])
 
@@ -248,9 +257,9 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
 
   // 监听字段变化触发 auto-save
   React.useEffect(() => {
-    scheduleAutoSave(models, name, provider, baseUrl, apiKey, enabled)
+    scheduleAutoSave(models, name, provider, baseUrl, apiKey, enabled, thinkingMode, thinkingBudgetTokens)
     return () => { if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current) }
-  }, [models, name, provider, baseUrl, apiKey, enabled, scheduleAutoSave])
+  }, [models, name, provider, baseUrl, apiKey, enabled, thinkingMode, thinkingBudgetTokens, scheduleAutoSave])
 
   // 切换供应商时自动更新 Base URL，Anthropic 兼容渠道自动添加预设模型
   const handleProviderChange = (newProvider: string): void => {
@@ -388,6 +397,8 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
         apiKey,
         models,
         enabled,
+        thinkingMode,
+        thinkingBudgetTokens,
       }
       const savedChannel = await window.electronAPI.createChannel(input)
       if (isAgentEligibleChannel(savedChannel)) {
@@ -402,7 +413,7 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
     } finally {
       setSaving(false)
     }
-  }, [name, provider, baseUrl, apiKey, models, enabled, onAgentEligibilityChange])
+  }, [name, provider, baseUrl, apiKey, models, enabled, thinkingMode, thinkingBudgetTokens, onAgentEligibilityChange])
 
   /** 创建渠道（仅新建模式） */
   const handleCreate = async (): Promise<void> => {
@@ -580,6 +591,34 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
             checked={enabled}
             onCheckedChange={setEnabled}
           />
+          {/* 思考模式配置（仅 Anthropic 兼容渠道显示） */}
+          {(provider === 'anthropic' || provider === 'anthropic-compatible' || provider === 'deepseek') && (
+            <>
+              <SettingsSelect
+                label="思考模式"
+                value={thinkingMode}
+                onValueChange={(value) => setThinkingMode(value as ThinkingModeConfig)}
+                options={[
+                  { value: 'auto', label: '自动推断（推荐）' },
+                  { value: 'manual', label: 'Manual（旧版 extended thinking）' },
+                  { value: 'adaptive', label: 'Adaptive（Claude 4.6+）' },
+                  { value: 'disabled', label: '禁用思考' },
+                  { value: 'effort-based', label: 'Effort-based（DeepSeek V4）' },
+                ]}
+                description="自动推断根据模型 ID 自动选择，自定义可强制指定"
+              />
+              {thinkingMode === 'manual' && (
+                <SettingsInput
+                  label="Thinking Budget Tokens"
+                  value={thinkingBudgetTokens.toString()}
+                  onChange={(v) => setThinkingBudgetTokens(parseInt(v) || 16384)}
+                  placeholder="16384"
+                  type="number"
+                  description="manual 模式下的思考预算 token 数"
+                />
+              )}
+            </>
+          )}
         </SettingsCard>
       </SettingsSection>
 

--- a/apps/electron/src/renderer/components/settings/ChannelForm.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelForm.tsx
@@ -26,6 +26,7 @@ import {
 import { toast } from 'sonner'
 import { useSetAtom } from 'jotai'
 import { channelFormDirtyAtom } from '@/atoms/settings-tab'
+import { channelsAtom } from '@/atoms/chat-atoms'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -166,6 +167,7 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
   const [showExitDialog, setShowExitDialog] = React.useState(false)
 
   const setChannelFormDirty = useSetAtom(channelFormDirtyAtom)
+  const setChannels = useSetAtom(channelsAtom)
   const lastAgentEligibleRef = React.useRef(channel ? isAgentEligibleChannel(channel) : false)
 
   React.useEffect(() => {
@@ -212,6 +214,16 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
         enabled: currentEnabled,
         thinkingMode: currentThinkingMode,
         thinkingBudgetTokens: currentThinkingBudgetTokens,
+      })
+      // 刷新 channelsAtom，确保 UI 层获取最新渠道配置
+      setChannels((prev) => {
+        const index = prev.findIndex((c) => c.id === channel.id)
+        if (index >= 0) {
+          const next = [...prev]
+          next[index] = savedChannel
+          return next
+        }
+        return prev
       })
       const eligible = isAgentEligibleChannel(savedChannel)
       if (eligible !== lastAgentEligibleRef.current) {

--- a/packages/core/src/providers/anthropic-adapter.ts
+++ b/packages/core/src/providers/anthropic-adapter.ts
@@ -301,20 +301,30 @@ export class AnthropicAdapter implements ProviderAdapter {
   buildStreamRequest(input: StreamRequestInput): ProviderRequest {
     const url = this.normalizeUrl(input.baseUrl)
     const messages = toAnthropicMessages(input)
-    const capability = detectThinkingCapability(this.providerType, input.modelId)
+    const capability = detectThinkingCapability(
+      this.providerType,
+      input.modelId,
+      input.channelThinkingMode,
+    )
+
+    // UI 开关决定 thinking 是否启用，channelThinkingMode 只决定协议格式
+    // disabled 模式始终不发 thinking
+    const shouldEnableThinking = input.thinkingEnabled && input.channelThinkingMode !== 'disabled'
 
     // manual 模式：budget_tokens 必须 < max_tokens，所以开启时放大上限
     // adaptive / effort-based 模式：max_tokens 作为「思考+回答」的总硬上限，给充足空间
-    const manualThinkingBudget = 16384
+    const manualThinkingBudget = input.channelThinkingMode === 'manual' && input.thinkingBudgetTokens !== undefined
+      ? input.thinkingBudgetTokens
+      : 16384
     let maxTokens: number
     if (this.providerType === 'minimax') {
       maxTokens = 2048
-    } else if (!input.thinkingEnabled) {
+    } else if (!shouldEnableThinking) {
       maxTokens = 8192
     } else if (capability.mode === 'manual-only') {
       maxTokens = manualThinkingBudget + 16384
     } else {
-      maxTokens = 32000
+      maxTokens = 64000
     }
 
     const body: Record<string, unknown> = {
@@ -331,13 +341,13 @@ export class AnthropicAdapter implements ProviderAdapter {
     // - effort-based-max（DeepSeek v4 系列）：{type: 'enabled'} + output_config.effort='max'
     //   DeepSeek v4 默认就开启思考，所以关闭时必须显式 {type: 'disabled'}
     if (capability.mode === 'effort-based-max') {
-      if (input.thinkingEnabled) {
+      if (shouldEnableThinking) {
         body.thinking = { type: 'enabled' }
         body.output_config = { effort: 'max' }
       } else {
         body.thinking = { type: 'disabled' }
       }
-    } else if (input.thinkingEnabled) {
+    } else if (shouldEnableThinking) {
       if (capability.mode === 'adaptive-only' || capability.mode === 'adaptive-preferred') {
         body.thinking = {
           type: 'adaptive',
@@ -362,7 +372,7 @@ export class AnthropicAdapter implements ProviderAdapter {
 
     // 工具续接消息
     if (input.continuationMessages && input.continuationMessages.length > 0) {
-      appendContinuationMessages(messages, input.continuationMessages, !!input.thinkingEnabled)
+      appendContinuationMessages(messages, input.continuationMessages, !!shouldEnableThinking)
     }
 
     const requestBody = JSON.stringify(body)

--- a/packages/core/src/providers/anthropic-adapter.ts
+++ b/packages/core/src/providers/anthropic-adapter.ts
@@ -309,13 +309,14 @@ export class AnthropicAdapter implements ProviderAdapter {
 
     // UI 开关决定 thinking 是否启用，channelThinkingMode 只决定协议格式
     // disabled 模式始终不发 thinking
-    const shouldEnableThinking = input.thinkingEnabled && input.channelThinkingMode !== 'disabled'
+    const shouldEnableThinking = input.thinkingEnabled && capability.mode !== 'none'
 
     // manual 模式：budget_tokens 必须 < max_tokens，所以开启时放大上限
     // adaptive / effort-based 模式：max_tokens 作为「思考+回答」的总硬上限，给充足空间
+    const DEFAULT_THINKING_BUDGET = 16384
     const manualThinkingBudget = input.channelThinkingMode === 'manual' && input.thinkingBudgetTokens !== undefined
       ? input.thinkingBudgetTokens
-      : 16384
+      : DEFAULT_THINKING_BUDGET
     let maxTokens: number
     if (this.providerType === 'minimax') {
       maxTokens = 2048

--- a/packages/core/src/providers/thinking-capability.ts
+++ b/packages/core/src/providers/thinking-capability.ts
@@ -11,7 +11,7 @@
  *
  * 本模块根据模型 ID 推断思考协议，供适配器构造请求体时分支使用。
  */
-import type { ProviderType } from '@proma/shared'
+import type { ProviderType, ThinkingModeConfig } from '@proma/shared'
 
 /** 思考协议能力 */
 export type ThinkingMode =
@@ -39,6 +39,24 @@ export interface ThinkingCapability {
 }
 
 /**
+ * 根据自定义配置获取思考协议能力
+ */
+function getCapabilityFromConfig(config: ThinkingModeConfig): ThinkingCapability {
+  switch (config) {
+    case 'manual':
+      return { mode: 'manual-only', disableStrategy: 'explicit-disabled' }
+    case 'adaptive':
+      return { mode: 'adaptive-preferred', disableStrategy: 'explicit-disabled' }
+    case 'disabled':
+      return { mode: 'none', disableStrategy: 'omit-field' }
+    case 'effort-based':
+      return { mode: 'effort-based-max', disableStrategy: 'explicit-disabled' }
+    default:
+      return { mode: 'manual-only', disableStrategy: 'explicit-disabled' }
+  }
+}
+
+/**
  * 匹配模型 ID（不区分大小写，允许 -latest、-20250101 等后缀）
  */
 function startsWith(modelId: string, prefix: string): boolean {
@@ -54,14 +72,22 @@ function startsWith(modelId: string, prefix: string): boolean {
  *   'anthropic'，不是 'deepseek'；只靠 providerType 匹配会落到 manual-only，导致
  *   思考关闭时不发 `thinking` 字段、而 DeepSeek v4 默认开思考 → 报「thinking must be passed back」）
  * - 再按 providerType 兜底
+ * - 如果渠道配置了自定义 thinking 模式，优先使用配置
  *
  * @param providerType 供应商类型
  * @param modelId 模型 ID
+ * @param channelThinkingMode 渠道自定义思考模式配置（可选）
  */
 export function detectThinkingCapability(
   providerType: ProviderType,
   modelId: string,
+  channelThinkingMode?: ThinkingModeConfig,
 ): ThinkingCapability {
+  // 如果渠道配置了自定义 thinking 模式（且不是 auto），优先使用配置
+  if (channelThinkingMode && channelThinkingMode !== 'auto') {
+    return getCapabilityFromConfig(channelThinkingMode)
+  }
+
   // DeepSeek v4 系列（按模型 ID 识别，不依赖 providerType）：
   // effort-based-max 模式会在思考关闭时显式发 `{type:'disabled'}`，这是 DeepSeek v4 的硬要求
   if (startsWith(modelId, 'deepseek-v4')) {

--- a/packages/core/src/providers/thinking-capability.ts
+++ b/packages/core/src/providers/thinking-capability.ts
@@ -107,7 +107,7 @@ export function detectThinkingCapability(
 
   // 其它非 Anthropic 供应商：不发 thinking
   if (providerType !== 'anthropic' && providerType !== 'anthropic-compatible') {
-    return { mode: 'manual-only', disableStrategy: 'explicit-disabled' }
+    return { mode: 'none', disableStrategy: 'omit-field' }
   }
 
   // Claude Mythos Preview：adaptive 是默认且唯一，不接受 disabled

--- a/packages/core/src/providers/types.ts
+++ b/packages/core/src/providers/types.ts
@@ -214,6 +214,10 @@ export interface StreamRequestInput {
   readImageAttachments: ImageAttachmentReader
   /** 是否启用思考模式（各适配器根据供应商 API 自行转换） */
   thinkingEnabled?: boolean
+  /** 渠道自定义思考模式配置（可选） */
+  channelThinkingMode?: 'auto' | 'manual' | 'adaptive' | 'disabled' | 'effort-based'
+  /** 思考模式 budget tokens（manual 模式下使用） */
+  thinkingBudgetTokens?: number
   /** 工具定义列表（可选，启用 function calling） */
   tools?: ToolDefinition[]
   /** 工具续接消息（tool use 循环中，前一轮的 tool_use + tool_result） */
@@ -230,6 +234,8 @@ export interface TitleRequestInput {
   modelId: string
   /** 标题生成 prompt（已包含用户消息） */
   prompt: string
+  /** 渠道自定义思考模式配置（可选） */
+  channelThinkingMode?: 'auto' | 'manual' | 'adaptive' | 'disabled' | 'effort-based'
 }
 
 // ===== 适配器接口 =====

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -59,6 +59,7 @@ export interface AgentWorkspace {
 export type ThinkingConfig =
   | { type: 'adaptive' }
   | { type: 'enabled'; budgetTokens: number }
+  | { type: 'enabled'; effort: 'max' }
   | { type: 'disabled' }
 
 /**
@@ -850,6 +851,8 @@ export interface AgentSendInput {
   mentionedSessionIds?: string[]
   /** 渲染进程生成的流式开始时间戳，主进程原样回传到 STREAM_COMPLETE，确保竞态保护比较的是同一个值 */
   startedAt?: number
+  /** 是否启用思考模式（UI 开关状态，仅当 channel.thinkingMode === 'auto' 时生效） */
+  thinkingEnabled?: boolean
 }
 
 // ===== Agent 队列消息 =====

--- a/packages/shared/src/types/channel.ts
+++ b/packages/shared/src/types/channel.ts
@@ -26,6 +26,21 @@ export type ProviderType =
   | 'custom'
 
 /**
+ * 思考模式配置
+ * - auto: 自动推断（根据模型 ID 自动选择）
+ * - manual: 旧版 extended thinking（{type: 'enabled', budget_tokens}）
+ * - adaptive: Claude 4.6+ adaptive thinking（{type: 'adaptive', display: 'summarized'}）
+ * - disabled: 禁用思考
+ * - effort-based: DeepSeek V4 系列（{type: 'enabled'} + output_config.effort='max'）
+ */
+export type ThinkingModeConfig =
+  | 'auto'
+  | 'manual'
+  | 'adaptive'
+  | 'disabled'
+  | 'effort-based'
+
+/**
  * 各供应商的默认 Base URL
  */
 export const PROVIDER_DEFAULT_URLS: Record<ProviderType, string> = {
@@ -124,6 +139,10 @@ export interface Channel {
   models: ChannelModel[]
   /** 是否启用 */
   enabled: boolean
+  /** 思考模式配置（可选，默认 auto） */
+  thinkingMode?: ThinkingModeConfig
+  /** 思考模式 budget tokens（manual 模式下使用） */
+  thinkingBudgetTokens?: number
   /** 创建时间戳 */
   createdAt: number
   /** 更新时间戳 */
@@ -141,6 +160,10 @@ export interface ChannelCreateInput {
   apiKey: string
   models: ChannelModel[]
   enabled: boolean
+  /** 思考模式配置（可选，默认 auto） */
+  thinkingMode?: ThinkingModeConfig
+  /** 思考模式 budget tokens（manual 模式下使用） */
+  thinkingBudgetTokens?: number
 }
 
 /**
@@ -154,6 +177,10 @@ export interface ChannelUpdateInput {
   apiKey?: string
   models?: ChannelModel[]
   enabled?: boolean
+  /** 思考模式配置（可选） */
+  thinkingMode?: ThinkingModeConfig
+  /** 思考模式 budget tokens（可选） */
+  thinkingBudgetTokens?: number
 }
 
 /**


### PR DESCRIPTION
## 概述

为使用 Anthropic 协议的渠道（anthropic / anthropic-compatible / deepseek）添加自定义思考模式配置，支持 Agent 模式优先使用渠道配置。

本次修复补充了 8 个健壮性问题，并修复了 Agent 模式下 thinking 开关无效的问题。

## 问题

1. **未知模型无法触发 thinking**：当 `thinkingMode='auto'`（默认）时，模型 ID 不匹配 `claude-` 或 `deepseek-v4` 前缀，被判定为 `mode: 'none'`，不发 thinking 字段。
2. **UI 开关与渠道配置冲突**：即使渠道配置了 `thinkingMode=manual/adaptive/effort-based`，如果 UI 的 thinking 开关关闭，请求体中仍不包含 thinking 字段。
3. **非 Anthropic 供应商错误发送 thinking**：`detectThinkingCapability` 对非 anthropic/anthropic-compatible 供应商返回 `manual-only`，导致 OpenAI/Google 等渠道的请求体中包含 thinking 字段。
4. **Agent effort-based 模式格式错误**：Agent 模式下 effort-based 错误发送 `{type: 'enabled', budgetTokens}`，应为 `{type: 'enabled', effort: 'max'}`。
5. **预设渠道缺少 thinkingMode 默认值**：自动创建的 DeepSeek 预设渠道没有 `thinkingMode` 和 `thinkingBudgetTokens` 字段。
6. **Agent 模式下 thinking 开关无效**：当 `channel.thinkingMode === 'auto'` 时，Agent 模式直接使用 `appSettings.agentThinking`（用户 UI 偏好），没有根据模型能力推断正确的 thinking 协议格式。导致 xopkimik26 等非 Claude/DeepSeek 前缀的模型收到不支持的 `{type: 'adaptive'}`，thinking 不生效。
7. **thinkingMode='disabled' 时 UI 未禁用**：当渠道配置为 `disabled` 时，Chat 和 Agent 模式的大脑图标仍显示为可点击状态，用户误以为可以开启 thinking。

## 改动

### 数据模型

**`packages/shared/src/types/agent.ts`**
- `AgentSendInput` 新增 `thinkingEnabled?: boolean` 字段（UI 开关状态）
- `ThinkingConfig` 新增 `{ type: 'enabled'; effort: 'max' }` 变体

**`packages/shared/src/types/channel.ts`**
- 新增 `ThinkingModeConfig` 类型：`'auto' | 'manual' | 'adaptive' | 'disabled' | 'effort-based'`
- `Channel` / `ChannelCreateInput` / `ChannelUpdateInput` 新增 `thinkingMode` 和 `thinkingBudgetTokens` 字段

**`packages/core/src/providers/types.ts`**
- `StreamRequestInput` 新增 `channelThinkingMode` 和 `thinkingBudgetTokens`
- `TitleRequestInput` 新增 `channelThinkingMode`

### 协议识别

**`packages/core/src/providers/thinking-capability.ts`**
- 新增 `getCapabilityFromConfig()`：将 `ThinkingModeConfig` 映射到 `ThinkingCapability`
- `detectThinkingCapability()` 新增 `channelThinkingMode` 参数：
  - `auto`：按模型 ID 自动推断（`claude-*` → manual, `deepseek-v4*` → effort-based）
  - `manual`/`adaptive`/`effort-based`/`disabled`：强制使用配置，不再推断
- **修复**：非 Anthropic 供应商返回 `mode: 'none'`，避免发送不支持的 thinking 字段

### 适配器

**`packages/core/src/providers/anthropic-adapter.ts`**
- `shouldEnableThinking = thinkingEnabled && capability.mode !== 'none'`（统一使用 capability 判断）
- `manual` 模式支持自定义 `thinkingBudgetTokens`（默认 16384，提取为常量）
- `effort-based` 和 `manual` 关闭时显式发 `{type: 'disabled'}`，避免服务商默认开启 thinking

### 服务端

**`apps/electron/src/main/lib/chat-service.ts`**
- 发送消息和生成标题时传递 `channelThinkingMode` 和 `thinkingBudgetTokens`

**`apps/electron/src/main/lib/channel-manager.ts`**
- 旧渠道数据迁移：补充 `thinkingMode='auto'` 和 `thinkingBudgetTokens=16384`
- 创建/更新时校验 `thinkingMode` 有效性和 `thinkingBudgetTokens` 范围（1-100000）
- **修复**：预设渠道默认包含 `thinkingMode: 'auto'` 和 `thinkingBudgetTokens: 16384`

**`apps/electron/src/main/lib/agent-orchestrator.ts`**
- Agent 模式下优先使用渠道的 `thinkingMode` 配置，回退到全局 `appSettings.agentThinking`
- **修复**：`effort-based` 模式正确发送 `{type: 'enabled', effort: 'max'}`，与适配器保持一致
- **修复**：提取 `DEFAULT_THINKING_BUDGET` 常量，消除魔法数字
- **修复**：当 `channel.thinkingMode === 'auto'` 时，根据 `thinkingEnabled` 和 `detectThinkingCapability` 推断格式：
  - `thinkingEnabled === false` → 不发 thinking
  - `thinkingEnabled === true` → 根据模型能力推断：
    - `adaptive-only/preferred` → `{type: 'adaptive'}`
    - `manual-only` → `{type: 'enabled', budgetTokens}`
    - `effort-based-max` → `{type: 'enabled', effort: 'max'}`
    - `none` → 不发 thinking

### UI

**`apps/electron/src/renderer/components/settings/ChannelForm.tsx`**
- **修复**：所有 Anthropic 协议供应商（Kimi、智谱、MiniMax、小米等）均显示「思考模式」选择器
- `manual` 模式下显示「Thinking Budget Tokens」输入框（范围 1-100000）
- **修复**：`parseInt` 添加 radix 参数，避免潜在解析歧义
- 自动保存 thinkingMode 和 thinkingBudgetTokens

**`apps/electron/src/renderer/components/chat/ChatInput.tsx`**
- **修复**：获取当前渠道的 `thinkingMode`，`disabled` 时禁用 thinking 按钮（灰色、不可点击、tooltip 显示"思考模式已禁用（渠道配置）"）

**`apps/electron/src/renderer/components/agent/AgentView.tsx`**
- **修复**：发送消息时传入 `thinkingEnabled: agentThinking?.type !== 'disabled'`，将 UI 开关状态传递到主进程
- **修复**：`AgentThinkingPopover` 添加 `isDisabled` 属性，`disabled` 时禁用按钮和 Switch

## 各模式行为

| thinkingMode | 大脑图标 | 可点击 | 启用时请求体 | 关闭时请求体 |
|-------------|---------|--------|------------|------------|
| `auto` | 跟随 UI | ✅ | 按模型 ID 自动推断 | 省略 thinking |
| `manual` | 跟随 UI | ✅ | `{type: 'enabled', budget_tokens}` | `{type: 'disabled'}` |
| `adaptive` | 跟随 UI | ✅ | `{type: 'adaptive', display: 'summarized'}` | 省略 thinking |
| `effort-based` | 跟随 UI | ✅ | `{type: 'enabled'} + output_config.effort='max'` | `{type: 'disabled'}` |
| `disabled` | 灰色 | ❌ | 不发 thinking | 不发 thinking |

## Agent 模式 thinking 行为

### channel.thinkingMode 为具体值时（非 auto）

| channel.thinkingMode | 模型 | 发送的 thinking | UI 状态 |
|---------------------|------|----------------|---------|
| `disabled` | 任意 | 不发 thinking | 灰色，不可点击 |
| `manual` | 任意 | `{type: 'enabled', budgetTokens}` | 跟随 UI |
| `adaptive` | 任意 | `{type: 'adaptive'}` | 跟随 UI |
| `effort-based` | 任意 | `{type: 'enabled', effort: 'max'}` | 跟随 UI |

### channel.thinkingMode === 'auto' 时（根据模型能力推断）

| thinkingEnabled | 模型 | 推断结果 | 发送的 thinking |
|-----------------|------|----------|----------------|
| `true` | claude-opus-4-7 | adaptive-only | `{type: 'adaptive'}` |
| `true` | claude-opus-4-6 | adaptive-preferred | `{type: 'adaptive'}` |
| `true` | claude-sonnet-4-6 | adaptive-preferred | `{type: 'adaptive'}` |
| `true` | claude-4.5 及以下 | manual-only | `{type: 'enabled', budgetTokens}` |
| `true` | deepseek-v4-pro | effort-based-max | `{type: 'enabled', effort: 'max'}` |
| `true` | deepseek-v4-flash | effort-based-max | `{type: 'enabled', effort: 'max'}` |
| `true` | deepseek-v3 | manual-only | `{type: 'enabled', budgetTokens}` |
| `true` | xopkimik26 | manual-only | `{type: 'enabled', budgetTokens}` |
| `true` | kimi-k2.6 | none | 不发 thinking |
| `true` | OpenAI/Google 等 | none | 不发 thinking |
| `false` | 任意 | - | 不发 thinking |

## Chat 模式 thinking 行为

| channel.thinkingMode | thinkingEnabled | 模型 | 发送的 thinking |
|---------------------|-----------------|------|----------------|
| `disabled` | - | 任意 | 不发 thinking |
| `manual` | - | 任意 | `{type: 'enabled', budgetTokens}` |
| `adaptive` | - | 任意 | `{type: 'adaptive'}` |
| `effort-based` | - | 任意 | `{type: 'enabled', effort: 'max'}` |
| `auto` | `true` | 按模型 ID 推断 | 同 Agent 模式推断结果 |
| `auto` | `false` | 任意 | 不发 thinking |

## 测试

- [x] anthropic-compatible 渠道，模型选 `xopkimik26`，thinkingMode 选 `manual`
- [x] 关闭 UI thinking 开关，抓包验证请求体仍包含 `thinking: {type: 'enabled', budget_tokens: ...}`
- [x] 验证 `disabled` 模式下大脑图标灰色且不可点击
- [x] 验证旧渠道迁移后 `thinkingBudgetTokens` 有默认值 16384
- [x] 验证 thinkingBudgetTokens 输入超过 100000 时被截断
- [x] 验证 Agent 模式下优先使用渠道 thinkingMode 配置
- [x] 验证非 Anthropic 供应商（OpenAI/Google）不发 thinking 字段
- [x] 验证 Agent effort-based 模式发送 `{effort: 'max'}`
- [x] 验证所有 Anthropic 协议供应商均显示思考模式配置
- [x] 验证 Agent 模式下 xopkimik26 的 thinking 开关可正常开启/关闭
- [x] 验证 thinkingMode='disabled' 时 Chat 模式大脑图标灰色不可点击
- [x] 验证 thinkingMode='disabled' 时 Agent 模式大脑图标灰色不可点击

## 备注

- 仅修改 Anthropic 适配器，Google/OpenAI 等适配器未涉及
- 未知模型（非 claude-/deepseek-v4 前缀）在 auto 模式下保守推断为 manual-only，用户可手动配置 thinkingMode
- Agent 模式下渠道配置优先于全局设置
- 本次修复确保 xopkimik26 等非标准模型在 anthropic-compatible 渠道下不会错误发送 thinking 字段
- Agent 模式的 thinking 行为现在与 Chat 模式完全一致：UI 开关控制是否启用，模型能力决定协议格式
- thinkingMode='disabled' 时 UI 层强制禁用 thinking 开关，避免用户误操作