### PR TITLE
[WIP] fix(agent): anthropic-compatible 渠道 Thinking 代理 + Chat 思考模式持久化

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -1330,6 +1330,8 @@ export class AgentOrchestrator {
           delete process.env.HTTPS_PROXY
           delete process.env.HTTP_PROXY
           console.log(`[Agent Thinking Proxy] 启用代理: ${thinkingProxyUrl} → ${originalBaseUrl}, budgetTokens=${budgetTokens}`)
+        } else {
+          console.warn(`[Agent Thinking Proxy] 跳过：isCompatThinking 渠道缺少自定义 Base URL，thinking 可能不兼容`)
         }
       }
 

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -1575,8 +1575,26 @@ export class AgentOrchestrator {
         // 启用文件检查点，支持 rewindFiles 回退
         enableFileCheckpointing: true,
         // SDK 0.2.52+ 新增选项（从 settings 读取）
-        ...(appSettings.agentThinking && { thinking: appSettings.agentThinking }),
-        effort: appSettings.agentEffort ?? 'high',
+        // thinking / effort 仅在渠道支持时传递：
+        // - anthropic / deepseek：原生支持 adaptive thinking
+        // - anthropic-compatible + agentThinkingEnabled：兼容端点不支持 adaptive，
+        //   需降级为 manual 模式（{type:'enabled', budgetTokens}）
+        // - 其它（kimi / zhipu / minimax 等）：不支持，不传
+        ...(() => {
+          const provider = channel.provider
+          const isNativeThinking = provider === 'anthropic' || provider === 'deepseek'
+          const isCompatThinking = provider === 'anthropic-compatible' && channel.agentThinkingEnabled === true
+          if (!isNativeThinking && !isCompatThinking) return {}
+          if (!appSettings.agentThinking) return {}
+          // anthropic-compatible 兼容端点不支持 adaptive，降级为 manual 模式
+          const thinking = isCompatThinking && appSettings.agentThinking.type === 'adaptive'
+            ? { type: 'enabled' as const, budgetTokens: 16384 }
+            : appSettings.agentThinking
+          return {
+            thinking,
+            effort: appSettings.agentEffort ?? 'high',
+          }
+        })(),
         ...(appSettings.agentMaxBudgetUsd != null && appSettings.agentMaxBudgetUsd > 0 && {
           maxBudgetUsd: appSettings.agentMaxBudgetUsd,
         }),

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -40,6 +40,7 @@ import { getAdapter, fetchTitle, normalizeAnthropicBaseUrlForSdk, getPromaUserAg
 import pkg from '../../../package.json' with { type: 'json' }
 import { getFetchFn } from './proxy-fetch'
 import { getEffectiveProxyUrl } from './proxy-settings-service'
+import { startThinkingProxy, stopThinkingProxy, forceStopThinkingProxy } from './thinking-proxy-service'
 import { appendSDKMessages, updateAgentSessionMeta, getAgentSessionMeta, getAgentSessionMessages, getAgentSessionSDKMessages, truncateSDKMessages, resolveUserUuidFromSDK, rewindFilesFromSnapshot } from './agent-session-manager'
 import { getAgentWorkspace, getWorkspaceMcpConfig, ensurePluginManifest } from './agent-workspace-manager'
 import { getAgentWorkspacePath, getAgentSessionWorkspacePath, getSdkConfigDir, getWorkspaceFilesDir, getConfigDirName } from './config-paths'
@@ -1303,6 +1304,35 @@ export class AgentOrchestrator {
       this.sessionPermissionModes.set(sessionId, initialPermissionMode)
       console.log(`[Agent 编排] 权限模式: ${initialPermissionMode}${permissionModeOverride ? '（外部覆盖）' : ''}`)
 
+      // 12.1 anthropic-compatible 渠道 + thinking 启用：启动本地代理拦截
+      // CLI 内部会将 thinking.type="enabled" 转为 "adaptive" 发给 API，
+      // 但讯飞等兼容端点不支持 adaptive，需要本地代理在 HTTP 层面替换回 "enabled"。
+      const isCompatThinking = channel.provider === 'anthropic-compatible' && channel.agentThinkingEnabled === true
+      if (isCompatThinking && appSettings.agentThinking && appSettings.agentThinking.type !== 'disabled') {
+        const budgetTokens = appSettings.agentThinking.type === 'enabled' && appSettings.agentThinking.budgetTokens
+          ? appSettings.agentThinking.budgetTokens
+          : 16384
+        const originalBaseUrl = channel.baseUrl && channel.baseUrl !== 'https://api.anthropic.com'
+          ? normalizeAnthropicBaseUrlForSdk(channel.baseUrl)
+          : undefined
+        if (originalBaseUrl) {
+          const thinkingProxyUrl = await startThinkingProxy(sessionId, {
+            targetBaseUrl: originalBaseUrl,
+            budgetTokens,
+          })
+          // CLI 连本地代理，代理转发到实际端点
+          sdkEnv.ANTHROPIC_BASE_URL = thinkingProxyUrl
+          process.env.ANTHROPIC_BASE_URL = thinkingProxyUrl
+          // CLI 不再直连 API，清除 HTTPS_PROXY 避免 CLI 通过 Clash 连本地代理
+          // 出站代理由 thinking-proxy-service 自行管理
+          delete sdkEnv.HTTPS_PROXY
+          delete sdkEnv.HTTP_PROXY
+          delete process.env.HTTPS_PROXY
+          delete process.env.HTTP_PROXY
+          console.log(`[Agent Thinking Proxy] 启用代理: ${thinkingProxyUrl} → ${originalBaseUrl}, budgetTokens=${budgetTokens}`)
+        }
+      }
+
       const emitPlanModeChanged = (active: boolean, source: 'initial' | 'tool' | 'permission'): void => {
         this.eventBus.emit(sessionId, {
           kind: 'proma_event',
@@ -1578,18 +1608,21 @@ export class AgentOrchestrator {
         // thinking / effort 仅在渠道支持时传递：
         // - anthropic / deepseek：原生支持 adaptive thinking
         // - anthropic-compatible + agentThinkingEnabled：兼容端点不支持 adaptive，
-        //   需降级为 manual 模式（{type:'enabled', budgetTokens}）
+        //   降级为 {type:'enabled', budgetTokens}，CLI 会转成 adaptive 发给 API，
+        //   由 thinking-proxy 在 HTTP 层拦截替换为 enabled。
         // - 其它（kimi / zhipu / minimax 等）：不支持，不传
         ...(() => {
           const provider = channel.provider
           const isNativeThinking = provider === 'anthropic' || provider === 'deepseek'
           const isCompatThinking = provider === 'anthropic-compatible' && channel.agentThinkingEnabled === true
+          console.log(`[Agent Thinking] provider=${provider}, agentThinkingEnabled=${channel.agentThinkingEnabled}, isNativeThinking=${isNativeThinking}, isCompatThinking=${isCompatThinking}`)
           if (!isNativeThinking && !isCompatThinking) return {}
           if (!appSettings.agentThinking) return {}
           // anthropic-compatible 兼容端点不支持 adaptive，降级为 manual 模式
           const thinking = isCompatThinking && appSettings.agentThinking.type === 'adaptive'
             ? { type: 'enabled' as const, budgetTokens: 16384 }
             : appSettings.agentThinking
+          console.log(`[Agent Thinking] resolved thinking=${JSON.stringify(thinking)}, effort=${appSettings.agentEffort ?? 'high'}`)
           return {
             thinking,
             effort: appSettings.agentEffort ?? 'high',
@@ -2209,6 +2242,8 @@ export class AgentOrchestrator {
       // askUserService 不在 turn 结束时清理——AskUserQuestion 的生命周期由用户交互决定，
       // 仅在会话真正删除时（DELETE_SESSION IPC）才清理。
       exitPlanService.clearSessionPending(sessionId)
+      // 清理 thinking proxy（会话结束不再需要）
+      stopThinkingProxy(sessionId).catch((err) => console.error('[Agent 编排] 关闭 thinking proxy 失败:', err))
     }
   }
 
@@ -2341,6 +2376,8 @@ export class AgentOrchestrator {
     this.activeSessions.clear()
     this.sessionPermissionModes.clear()
     this.queuedMessageUuids.clear()
+    // 清理 thinking proxy
+    forceStopThinkingProxy().catch((err) => console.error('[Agent 编排] 关闭 thinking proxy 失败:', err))
   }
 
   // ===== 队列消息管理 =====

--- a/apps/electron/src/main/lib/channel-manager.ts
+++ b/apps/electron/src/main/lib/channel-manager.ts
@@ -170,6 +170,7 @@ export function createChannel(input: ChannelCreateInput): Channel {
     apiKey: encryptApiKey(input.apiKey),
     models: input.models,
     enabled: input.enabled,
+    ...(input.agentThinkingEnabled != null && { agentThinkingEnabled: input.agentThinkingEnabled }),
     createdAt: now,
     updatedAt: now,
   }
@@ -206,6 +207,7 @@ export function updateChannel(id: string, input: ChannelUpdateInput): Channel {
     apiKey: input.apiKey ? encryptApiKey(input.apiKey) : existing.apiKey,
     models: input.models ?? existing.models,
     enabled: input.enabled ?? existing.enabled,
+    ...(input.agentThinkingEnabled != null ? { agentThinkingEnabled: input.agentThinkingEnabled } : {}),
     updatedAt: Date.now(),
   }
 

--- a/apps/electron/src/main/lib/thinking-proxy-service.ts
+++ b/apps/electron/src/main/lib/thinking-proxy-service.ts
@@ -170,10 +170,11 @@ async function handleProxyRequest(req: IncomingMessage, res: ServerResponse): Pr
 
   // 3. 构建转发目标 URL
   // req.url 可能是相对路径（/v1/messages）或完整 URL（http://127.0.0.1:PORT/v1/messages）
-  // 完整 URL 时 new URL 会忽略 base，导致转发回本地代理自身（死循环）
-  // 所以统一提取 pathname + search，再拼接到 targetBaseUrl
-  const reqUrl = new URL(req.url!, 'http://localhost')
-  const targetUrl = new URL(reqUrl.pathname + reqUrl.search, config.targetBaseUrl)
+  // 提取 pathname + search，直接拼接到 targetBaseUrl 末尾
+  // 不能用 new URL(pathname, base) 因为绝对路径会覆盖 base 的路径部分
+  const reqUrl = new URL(req.url || '/', 'http://localhost')
+  const targetUrlStr = config.targetBaseUrl.replace(/\/+$/, '') + reqUrl.pathname + reqUrl.search
+  const targetUrl = new URL(targetUrlStr)
 
   // 4. 构建转发请求头
   const forwardHeaders: Record<string, string> = {}

--- a/apps/electron/src/main/lib/thinking-proxy-service.ts
+++ b/apps/electron/src/main/lib/thinking-proxy-service.ts
@@ -266,8 +266,11 @@ async function forwardWithUndiciProxy(
     // 管道透传响应体（SSE 流）
     if (response.body) {
       const reader = response.body.getReader()
+      let aborted = false
+      // 客户端断开时中止读取，避免无限循环
+      clientRes.on('close', () => { aborted = true })
       try {
-        while (true) {
+        while (!aborted) {
           const { done, value } = await reader.read()
           if (done) break
           clientRes.write(value)

--- a/apps/electron/src/main/lib/thinking-proxy-service.ts
+++ b/apps/electron/src/main/lib/thinking-proxy-service.ts
@@ -169,7 +169,11 @@ async function handleProxyRequest(req: IncomingMessage, res: ServerResponse): Pr
   }
 
   // 3. 构建转发目标 URL
-  const targetUrl = new URL(req.url!, config.targetBaseUrl)
+  // req.url 可能是相对路径（/v1/messages）或完整 URL（http://127.0.0.1:PORT/v1/messages）
+  // 完整 URL 时 new URL 会忽略 base，导致转发回本地代理自身（死循环）
+  // 所以统一提取 pathname + search，再拼接到 targetBaseUrl
+  const reqUrl = new URL(req.url!, 'http://localhost')
+  const targetUrl = new URL(reqUrl.pathname + reqUrl.search, config.targetBaseUrl)
 
   // 4. 构建转发请求头
   const forwardHeaders: Record<string, string> = {}

--- a/apps/electron/src/main/lib/thinking-proxy-service.ts
+++ b/apps/electron/src/main/lib/thinking-proxy-service.ts
@@ -1,0 +1,295 @@
+/**
+ * Thinking 参数代理服务
+ *
+ * 在本地起一个 HTTP 代理服务器，拦截 CLI → API 的请求，
+ * 将 thinking.type="adaptive" 替换为 thinking.type="enabled" + budget_tokens。
+ *
+ * 用于 anthropic-compatible 渠道（讯飞等兼容端点不支持 adaptive thinking），
+ * 这些端点只接受 {type:"enabled", budget_tokens:N} 格式。
+ *
+ * 架构：
+ *   CLI → localhost:PORT (本地代理) → 替换 thinking 参数 → 实际 API 端点
+ *                                                      ↓ (如需)
+ *                                                  Clash TUN 代理
+ *
+ * 多会话安全：
+ *   使用引用计数管理代理生命周期。只有第一个会话启动代理，最后一个会话结束才关闭。
+ *   config（targetBaseUrl / budgetTokens）按请求动态查找，不同会话可以有不同的配置。
+ *
+ * Clash TUN 兼容：
+ *   CLI 连 127.0.0.1:PORT → 走本地回环，TUN 不劫持
+ *   代理向外转发时：走 Proma 配置的代理（getEffectiveProxyUrl）或直连
+ *   CLI 的 HTTPS_PROXY 不再生效（CLI 只和本地代理通信），代理自行管理出站代理
+ */
+
+import { createServer, type IncomingMessage, type ServerResponse, type Server } from 'node:http'
+import { request as httpRequest } from 'node:http'
+import { request as httpsRequest } from 'node:https'
+import type { AddressInfo } from 'node:net'
+import { ProxyAgent, fetch as undiciFetch } from 'undici'
+import { getEffectiveProxyUrl } from './proxy-settings-service'
+
+/** 代理配置 */
+export interface ThinkingProxyConfig {
+  /** 实际 API 端点 URL（讯飞等兼容端点） */
+  targetBaseUrl: string
+  /** thinking token 预算，默认 16384 */
+  budgetTokens: number
+}
+
+// 代理服务器实例（单例，多会话共享）
+let proxyServer: Server | null = null
+let proxyPort: number | null = null
+
+// 引用计数：多会话并发时，只有最后一个会话结束才关闭代理
+let refCount = 0
+
+// 按 sessionId 存储每个会话的代理配置，请求时按来源查找
+const sessionConfigs = new Map<string, ThinkingProxyConfig>()
+
+/**
+ * 启动 thinking 代理服务器（引用计数管理）
+ *
+ * @returns 本地代理 URL（如 http://127.0.0.1:34567）
+ */
+export async function startThinkingProxy(sessionId: string, config: ThinkingProxyConfig): Promise<string> {
+  sessionConfigs.set(sessionId, config)
+  refCount++
+
+  if (proxyServer && proxyPort) {
+    console.log(`[Thinking Proxy] 会话 ${sessionId} 复用代理 (refCount=${refCount})`)
+    return `http://127.0.0.1:${proxyPort}`
+  }
+
+  proxyServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    try {
+      await handleProxyRequest(req, res)
+    } catch (err) {
+      console.error('[Thinking Proxy] 请求处理失败:', err)
+      if (!res.headersSent) {
+        res.writeHead(500, { 'Content-Type': 'text/plain' })
+      }
+      res.end('Thinking proxy error')
+    }
+  })
+
+  proxyPort = await new Promise<number>((resolve, reject) => {
+    proxyServer!.listen(0, '127.0.0.1', () => {
+      const addr = proxyServer!.address() as AddressInfo
+      console.log(`[Thinking Proxy] 代理服务器启动，端口: ${addr.port}`)
+      resolve(addr.port)
+    })
+    proxyServer!.on('error', reject)
+  })
+
+  return `http://127.0.0.1:${proxyPort}`
+}
+
+/**
+ * 停止 thinking 代理（引用计数管理）
+ *
+ * 只有最后一个会话结束时才真正关闭代理服务器。
+ */
+export async function stopThinkingProxy(sessionId: string): Promise<void> {
+  sessionConfigs.delete(sessionId)
+  refCount = Math.max(0, refCount - 1)
+
+  if (refCount > 0) {
+    console.log(`[Thinking Proxy] 会话 ${sessionId} 释放代理引用 (refCount=${refCount})，代理保持运行`)
+    return
+  }
+
+  // 引用计数归零，关闭代理
+  if (proxyServer) {
+    await new Promise<void>((resolve) => {
+      proxyServer!.close(() => {
+        console.log('[Thinking Proxy] 代理服务器已关闭（无活跃会话）')
+        resolve()
+      })
+    })
+    proxyServer = null
+    proxyPort = null
+  }
+}
+
+/**
+ * 强制关闭代理（应用退出时调用）
+ */
+export async function forceStopThinkingProxy(): Promise<void> {
+  sessionConfigs.clear()
+  refCount = 0
+  if (proxyServer) {
+    await new Promise<void>((resolve) => {
+      proxyServer!.close(() => {
+        console.log('[Thinking Proxy] 代理服务器已强制关闭')
+        resolve()
+      })
+    })
+    proxyServer = null
+    proxyPort = null
+  }
+}
+
+/**
+ * 处理代理请求
+ */
+async function handleProxyRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  // 查找匹配的会话配置
+  // CLI 发请求时会带上原始请求头，通过 authorization 头关联到会话
+  // 由于多会话可能共用同一个代理，需要根据请求特征找到正确的 config
+  // 简化策略：所有 isCompatThinking 会话的 targetBaseUrl 通常相同（同一个讯飞端点），
+  // 取任意一个存活的 config 即可。如果不同会话有不同的端点，需要更精确的路由。
+  const config = sessionConfigs.values().next().value as ThinkingProxyConfig | undefined
+  if (!config) {
+    res.writeHead(500)
+    res.end('No proxy config')
+    return
+  }
+
+  // 1. 收集请求体
+  const bodyChunks: Buffer[] = []
+  for await (const chunk of req) {
+    bodyChunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk)
+  }
+  const rawBody = Buffer.concat(bodyChunks).toString('utf-8')
+
+  // 2. 转换 thinking 参数：adaptive → enabled + budget_tokens
+  let modifiedBody = rawBody
+  if (rawBody.includes('"adaptive"')) {
+    modifiedBody = rawBody.replace(
+      /"type"\s*:\s*"adaptive"/g,
+      `"type":"enabled","budget_tokens":${config.budgetTokens}`,
+    )
+    // 移除 thinking 对象内的 display 字段（兼容端点可能不支持）
+    modifiedBody = modifiedBody.replace(
+      /"thinking"\s*:\s*\{[^}]*"type"\s*:\s*"enabled"[^}]*"display"\s*:\s*"[^"]*"[^}]*\}/g,
+      (match) => match.replace(/,?\s*"display"\s*:\s*"[^"]*"/g, ''),
+    )
+    console.log(`[Thinking Proxy] 替换 thinking: adaptive → enabled (budget_tokens=${config.budgetTokens})`)
+  }
+
+  // 3. 构建转发目标 URL
+  const targetUrl = new URL(req.url!, config.targetBaseUrl)
+
+  // 4. 构建转发请求头
+  const forwardHeaders: Record<string, string> = {}
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (value && key.toLowerCase() !== 'host' && key.toLowerCase() !== 'connection') {
+      forwardHeaders[key] = Array.isArray(value) ? value.join(', ') : value
+    }
+  }
+  forwardHeaders['content-length'] = String(Buffer.byteLength(modifiedBody))
+  forwardHeaders['host'] = targetUrl.host
+
+  // 5. 转发请求
+  // 代理需要自行管理出站代理：CLI 的 HTTPS_PROXY 对本地代理无效
+  const proxyUrl = await getEffectiveProxyUrl()
+  const isHttps = targetUrl.protocol === 'https:'
+
+  if (proxyUrl && isHttps) {
+    await forwardWithUndiciProxy(targetUrl, forwardHeaders, modifiedBody, req.method!, proxyUrl, res)
+  } else if (proxyUrl && !isHttps) {
+    const proxyOptions = {
+      method: req.method!,
+      hostname: new URL(proxyUrl).hostname,
+      port: new URL(proxyUrl).port,
+      path: targetUrl.href,
+      headers: forwardHeaders,
+    }
+    const proxyReq = httpRequest(proxyOptions, (proxyRes) => {
+      pipeResponse(proxyRes, res)
+    })
+    proxyReq.on('error', (err) => {
+      console.error('[Thinking Proxy] HTTP 代理转发失败:', err)
+      if (!res.headersSent) res.writeHead(502)
+      res.end('Proxy forward error')
+    })
+    proxyReq.write(modifiedBody)
+    proxyReq.end()
+  } else {
+    const requestFn = isHttps ? httpsRequest : httpRequest
+    const directOptions = {
+      method: req.method!,
+      hostname: targetUrl.hostname,
+      port: targetUrl.port || (isHttps ? '443' : '80'),
+      path: targetUrl.pathname + targetUrl.search,
+      headers: forwardHeaders,
+    }
+    const directReq = requestFn(directOptions, (directRes) => {
+      pipeResponse(directRes, res)
+    })
+    directReq.on('error', (err) => {
+      console.error('[Thinking Proxy] 直连转发失败:', err)
+      if (!res.headersSent) res.writeHead(502)
+      res.end('Direct forward error')
+    })
+    directReq.write(modifiedBody)
+    directReq.end()
+  }
+}
+
+/**
+ * 使用 undici ProxyAgent 转发 HTTPS 请求（支持 Clash TUN HTTP CONNECT）
+ */
+async function forwardWithUndiciProxy(
+  targetUrl: URL,
+  headers: Record<string, string>,
+  body: string,
+  method: string,
+  proxyUrl: string,
+  clientRes: ServerResponse,
+): Promise<void> {
+  const dispatcher = new ProxyAgent(proxyUrl)
+  try {
+    const response = await undiciFetch(targetUrl.href, {
+      method,
+      headers,
+      body,
+      dispatcher,
+    })
+
+    const responseHeaders: Record<string, string> = {}
+    response.headers.forEach((value, key) => {
+      responseHeaders[key] = value
+    })
+    // 删除 transfer-encoding 和 content-length，让 Node.js 自动处理 chunked 编码
+    delete responseHeaders['transfer-encoding']
+    delete responseHeaders['content-length']
+
+    clientRes.writeHead(response.status, responseHeaders)
+
+    // 管道透传响应体（SSE 流）
+    if (response.body) {
+      const reader = response.body.getReader()
+      try {
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) break
+          clientRes.write(value)
+        }
+      } finally {
+        reader.releaseLock()
+      }
+    }
+    clientRes.end()
+  } catch (err) {
+    console.error('[Thinking Proxy] undici 代理转发失败:', err)
+    if (!clientRes.headersSent) clientRes.writeHead(502)
+    clientRes.end('Proxy forward error')
+  }
+}
+
+/**
+ * 管道透传响应（node:http/https 模块的 response）
+ */
+function pipeResponse(proxyRes: IncomingMessage, clientRes: ServerResponse): void {
+  const responseHeaders: Record<string, string | string[]> = {}
+  const hopByHop = ['connection', 'keep-alive', 'transfer-encoding', 'upgrade']
+  for (const [key, value] of Object.entries(proxyRes.headers)) {
+    if (!hopByHop.includes(key.toLowerCase()) && value) {
+      responseHeaders[key] = value
+    }
+  }
+  clientRes.writeHead(proxyRes.statusCode!, responseHeaders)
+  proxyRes.pipe(clientRes)
+}

--- a/apps/electron/src/renderer/components/settings/ChannelForm.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelForm.tsx
@@ -145,6 +145,7 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
   const [showApiKey, setShowApiKey] = React.useState(false)
   const [models, setModels] = React.useState<ChannelModel[]>(channel?.models ?? [])
   const [enabled, setEnabled] = React.useState(channel?.enabled ?? true)
+  const [agentThinkingEnabled, setAgentThinkingEnabled] = React.useState(channel?.agentThinkingEnabled ?? false)
 
   // 新模型输入
   const [newModelId, setNewModelId] = React.useState('')
@@ -195,6 +196,7 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
     currentBaseUrl: string,
     currentApiKey: string,
     currentEnabled: boolean,
+    currentAgentThinkingEnabled: boolean,
   ) => {
     if (!isEdit || !channel) return
     try {
@@ -205,6 +207,7 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
         apiKey: currentApiKey || undefined,
         models: currentModels,
         enabled: currentEnabled,
+        ...(currentProvider === 'anthropic-compatible' ? { agentThinkingEnabled: currentAgentThinkingEnabled } : { agentThinkingEnabled: false }),
       })
       const eligible = isAgentEligibleChannel(savedChannel)
       if (eligible !== lastAgentEligibleRef.current) {
@@ -226,11 +229,12 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
     nextBaseUrl: string,
     nextApiKey: string,
     nextEnabled: boolean,
+    nextAgentThinkingEnabled: boolean,
   ) => {
     if (!isEdit || !initializedRef.current) return
     if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current)
     autoSaveTimerRef.current = setTimeout(() => {
-      doAutoSave(nextModels, nextName, nextProvider, nextBaseUrl, nextApiKey, nextEnabled)
+      doAutoSave(nextModels, nextName, nextProvider, nextBaseUrl, nextApiKey, nextEnabled, nextAgentThinkingEnabled)
     }, AUTO_SAVE_DELAY)
   }, [isEdit, doAutoSave])
 
@@ -248,9 +252,9 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
 
   // 监听字段变化触发 auto-save
   React.useEffect(() => {
-    scheduleAutoSave(models, name, provider, baseUrl, apiKey, enabled)
+    scheduleAutoSave(models, name, provider, baseUrl, apiKey, enabled, agentThinkingEnabled)
     return () => { if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current) }
-  }, [models, name, provider, baseUrl, apiKey, enabled, scheduleAutoSave])
+  }, [models, name, provider, baseUrl, apiKey, enabled, agentThinkingEnabled, scheduleAutoSave])
 
   // 切换供应商时自动更新 Base URL，Anthropic 兼容渠道自动添加预设模型
   const handleProviderChange = (newProvider: string): void => {
@@ -258,6 +262,7 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
     setProvider(p)
     setBaseUrl(PROVIDER_DEFAULT_URLS[p])
     setTestResult(null)
+    setAgentThinkingEnabled(false)
     // 预设模型：首次切换到对应 provider 且无模型时自动填充
     if (models.length === 0) {
       if (p === 'deepseek') {
@@ -388,6 +393,7 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
         apiKey,
         models,
         enabled,
+        ...(provider === 'anthropic-compatible' ? { agentThinkingEnabled } : {}),
       }
       const savedChannel = await window.electronAPI.createChannel(input)
       if (isAgentEligibleChannel(savedChannel)) {
@@ -402,7 +408,7 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
     } finally {
       setSaving(false)
     }
-  }, [name, provider, baseUrl, apiKey, models, enabled, onAgentEligibilityChange])
+  }, [name, provider, baseUrl, apiKey, models, enabled, agentThinkingEnabled, onAgentEligibilityChange])
 
   /** 创建渠道（仅新建模式） */
   const handleCreate = async (): Promise<void> => {
@@ -580,6 +586,14 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
             checked={enabled}
             onCheckedChange={setEnabled}
           />
+          {provider === 'anthropic-compatible' && (
+            <SettingsToggle
+              label="Agent Thinking 支持"
+              description="开启后 Agent 模式将向此渠道发送 thinking 参数（需供应商支持扩展思维协议）"
+              checked={agentThinkingEnabled}
+              onCheckedChange={setAgentThinkingEnabled}
+            />
+          )}
         </SettingsCard>
       </SettingsSection>
 

--- a/apps/electron/src/renderer/hooks/useConversationSettings.ts
+++ b/apps/electron/src/renderer/hooks/useConversationSettings.ts
@@ -98,12 +98,26 @@ export function useConversationContextLength(): [ContextLengthValue, (v: Context
   return [value, setter]
 }
 
-/** 每个对话独立的思考模式 */
+/** 每个对话独立的思考模式（切换时同步更新全局默认值，确保重启后不丢失） */
 export function useConversationThinkingEnabled(): [boolean, (v: boolean) => void] {
   const conversationId = useConversationId()
   const defaultEnabled = useAtomValue(thinkingEnabledAtom)
   const value = useMapValue(conversationThinkingEnabledAtom, conversationId, defaultEnabled)
-  const setter = useMapSetter(conversationThinkingEnabledAtom, conversationId)
+  const setMap = useSetAtom(conversationThinkingEnabledAtom)
+  const setGlobal = useSetAtom(thinkingEnabledAtom)
+
+  const setter = React.useCallback(
+    (v: boolean) => {
+      setMap((prev) => {
+        const map = new Map(prev)
+        map.set(conversationId, v)
+        return map
+      })
+      setGlobal(v)
+    },
+    [conversationId, setMap, setGlobal],
+  )
+
   return [value, setter]
 }
 

--- a/packages/shared/src/types/channel.ts
+++ b/packages/shared/src/types/channel.ts
@@ -124,6 +124,8 @@ export interface Channel {
   models: ChannelModel[]
   /** 是否启用 */
   enabled: boolean
+  /** Agent 模式是否支持 thinking（仅 anthropic-compatible 类型渠道有效） */
+  agentThinkingEnabled?: boolean
   /** 创建时间戳 */
   createdAt: number
   /** 更新时间戳 */
@@ -141,6 +143,8 @@ export interface ChannelCreateInput {
   apiKey: string
   models: ChannelModel[]
   enabled: boolean
+  /** Agent 模式是否支持 thinking（仅 anthropic-compatible 类型渠道有效） */
+  agentThinkingEnabled?: boolean
 }
 
 /**
@@ -154,6 +158,8 @@ export interface ChannelUpdateInput {
   apiKey?: string
   models?: ChannelModel[]
   enabled?: boolean
+  /** Agent 模式是否支持 thinking（仅 anthropic-compatible 类型渠道有效） */
+  agentThinkingEnabled?: boolean
 }
 
 /**


### PR DESCRIPTION
## 概述

修复 anthropic-compatible 渠道（讯飞等兼容端点）在 Agent 模式下 Thinking 不工作的问题，以及 Chat 模式下思考模式重启后状态重置的问题。

**适用场景**：
1. Agent 模式下开启 Thinking，但对话中没有出现 thinking 内容（模型直接输出结果、没有思考过程）——说明渠道供应商不支持 `adaptive` thinking 协议。在渠道设置中打开「Agent Thinking 支持」开关即可修复。
2. Chat 模式下开启思考模式（大脑图标），重启 Proma 后状态重置为关——本次修复将思考模式持久化到 localStorage。

## 改动

### 第一部分：Agent Thinking 代理（5 files, +388 -6）

**根因**：CLI 内部会将 `thinking.type="enabled"` + `budgetTokens` 转为 `thinking.type="adaptive"` 发给 API。anthropic-compatible 端点不支持 `adaptive` thinking，只接受 `{type:"enabled", budget_tokens:N}` 格式，导致请求失败。

**方案**：在本地启动 HTTP 代理拦截 CLI → API 请求，将 `adaptive` 替换回 `enabled` + `budget_tokens`。不修改 SDK 或 CLI 源码，仅在 HTTP 层面做最终修正。

#### 新增 `thinking-proxy-service.ts`（303 行）

本地 HTTP 代理服务器，核心职责：
- 拦截 CLI → API 请求，将 `thinking.type="adaptive"` 替换为 `"enabled"` + `budget_tokens`
- 引用计数管理多会话并发生命周期（首个会话启动代理，末个会话结束才关闭）
- 支持 Clash TUN 代理转发（undici ProxyAgent for HTTPS，node:http for HTTP）
- SSE 流透传，客户端断开时中止 reader 避免无限循环
- 绑定 `127.0.0.1:随机端口`，TUN 不劫持回环地址

#### 修改 `agent-orchestrator.ts`（+61 -2）

- `isCompatThinking` 场景下启动 thinking proxy，`ANTHROPIC_BASE_URL` 指向本地代理
- 清除 CLI 的 `HTTPS_PROXY`（CLI 不再直连 API，出站代理由 thinking-proxy 自行管理）
- thinking 参数降级逻辑：`adaptive` → `{type:'enabled', budgetTokens:16384}`
- 会话结束时（`finally`）和应用退出时（`stopAll`）清理代理
- 非 anthropic/deepseek 渠道不传 thinking 参数

#### 修改 `channel-manager.ts`（+2）

- `createChannel` / `updateChannel` 支持 `agentThinkingEnabled` 字段读写

#### 修改 `ChannelForm.tsx`（+22 -4）

- 新增「Agent Thinking 支持」开关（仅 `anthropic-compatible` 渠道显示）
- 切换供应商时重置开关状态
- auto-save 逻辑集成新字段

#### 修改 `channel.ts`（+6）

- `Channel` / `ChannelCreateInput` / `ChannelUpdateInput` 新增 `agentThinkingEnabled?: boolean`

### 第二部分：Chat 思考模式持久化（1 file, +14 -2）

**根因**：Chat 思考模式状态存在内存 Map（`conversationThinkingEnabledAtom`）中，重启后 Map 清空，回退到全局默认值 `thinkingEnabledAtom`（默认 `false`）。虽然 `thinkingEnabledAtom` 用了 `atomWithStorage` 持久化，但用户切换 thinking 时从未更新过它。

**方案**：切换 thinking 时同步更新 `thinkingEnabledAtom`，`atomWithStorage` 自动持久化到 localStorage，重启后恢复。

#### 修改 `useConversationSettings.ts`（+14 -2）

- `useConversationThinkingEnabled` 切换时同时调用 `setGlobal(v)` 更新全局默认值
- 全局默认值通过 `atomWithStorage` 自动持久化到 localStorage

## 数据流

### Agent Thinking 代理

```
CLI → localhost:PORT (thinking-proxy) → 替换 adaptive→enabled → 兼容端点 API
                                                          ↓ (如需)
                                                      Clash TUN 代理
```

### Chat 思考模式持久化

```
切换大脑图标 → 内存 Map + 全局 atom → localStorage
重启后 → localStorage → 全局 atom → 内存 Map 默认值
```

## 测试

- [x] anthropic-compatible 渠道 + thinking 开启 + Agent 模式：API 返回 200，thinking 内容正常
- [x] 端到端测试：模拟 CLI 发送 `{type:"adaptive"}` 请求，代理替换为 `{type:"enabled","budget_tokens":16384}`，讯飞 API 正常响应
- [x] TypeScript 编译零错误
- [x] thinking 开关关闭时代理不启动
- [x] 多会话并发引用计数安全
- [x] SSE 流客户端断开时正确中止读取
- [x] req.url 为完整 URL 时不再转发死循环
- [x] base URL 路径拼接不再被覆盖导致 404
- [x] Chat 思考模式切换后持久化到 localStorage
- [x] 重启后从 localStorage 恢复思考模式状态
- [x] **rebase 到最新 main，不删除 main 已有功能（定时任务/后台任务唤醒等）**

## 备注

- 关闭原 PR #726（旧方案：添加 thinkingMode 配置到渠道），转向更轻量的 thinking-proxy 方案
- 仅修改 anthropic-compatible 渠道行为，anthropic/deepseek 等原生支持 adaptive 的渠道不受影响
- 代理在 HTTP 层面做最终拦截修正，不修改 SDK 或 CLI 源码
- 已 rebase 到最新 main（2026-06-08），确保不丢失 main 已有的定时任务系统、后台任务唤醒等功能