### PR TITLE
fix(sidebar): 修复三点菜单关闭动画期间浮层漂移 & 拉长迷你地图触发延迟

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -1820,10 +1820,30 @@ function SessionItemActions({
     setArchiveConfirming(true)
   }
 
+  const closeTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
   const handleMenuOpenChange = (open: boolean): void => {
-    setMenuOpen(open)
+    if (open) {
+      if (closeTimerRef.current !== null) {
+        clearTimeout(closeTimerRef.current)
+        closeTimerRef.current = null
+      }
+      setMenuOpen(true)
+    } else {
+      // Delay hiding the trigger so Radix Popper can still read its rect during the close animation (~150ms).
+      closeTimerRef.current = setTimeout(() => {
+        closeTimerRef.current = null
+        setMenuOpen(false)
+      }, 200)
+    }
     onMenuOpenChange?.(open)
   }
+
+  React.useEffect(() => {
+    return () => {
+      if (closeTimerRef.current !== null) clearTimeout(closeTimerRef.current)
+    }
+  }, [])
 
   const forceVisible = archiveConfirming || menuOpen
 

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -1957,7 +1957,7 @@ const ConversationItem = React.memo(function ConversationItem({
   const inputRef = React.useRef<HTMLInputElement>(null)
   const justStartedEditing = React.useRef(false)
   // 菜单打开时关闭迷你地图预览，避免预览面板盖住菜单项导致点不动
-  const preview = useSessionMiniMapHover(300, menuOpen)
+  const preview = useSessionMiniMapHover(600, menuOpen)
 
   /** 进入编辑模式 */
   const startEdit = (): void => {
@@ -2176,7 +2176,7 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
   const inputRef = React.useRef<HTMLInputElement>(null)
   const justStartedEditing = React.useRef(false)
   // 菜单打开时关闭迷你地图预览，避免预览面板盖住菜单项导致点不动
-  const preview = useSessionMiniMapHover(300, disableMiniMap || menuOpen)
+  const preview = useSessionMiniMapHover(600, disableMiniMap || menuOpen)
 
   const startEdit = (): void => {
     setEditTitle(session.title)

--- a/apps/electron/src/renderer/components/session-preview/SessionMiniMapPopover.tsx
+++ b/apps/electron/src/renderer/components/session-preview/SessionMiniMapPopover.tsx
@@ -74,7 +74,7 @@ const PREVIEW_MD_COMPONENTS: Components = {
   a: ({ children }) => <span>{children}</span>,
 }
 
-export function useSessionMiniMapHover(delayMs = 300, disabled = false): UseSessionMiniMapHoverReturn {
+export function useSessionMiniMapHover(delayMs = 600, disabled = false): UseSessionMiniMapHoverReturn {
   const anchorRef = React.useRef<HTMLElement | null>(null)
   const [isOpen, setIsOpen] = React.useState(false)
   const [isLeaving, setIsLeaving] = React.useState(false)


### PR DESCRIPTION
## Summary

- 修复会话列表三点菜单关闭时浮层短暂漂到左上角 (0,0) 的问题：`onOpenChange(false)` 同步触发后，React 立即清除 `menuOpen` → 按钮组变 `display:none` → Radix Popper 在关闭动画期间读不到 trigger 的位置矩形。改为延迟 200ms 再清除 `menuOpen`，覆盖动画窗口（~150ms）。
- 迷你地图悬浮触发延迟从 300ms 延长至 600ms，降低鼠标快速扫过列表时意外触发预览、以及迷你地图与三点菜单同时弹出的概率。

## Test plan

- [ ] 点击会话条目的三点菜单，打开后鼠标移开，确认关闭动画期间浮层不漂移
- [ ] 快速连续点击不同会话的三点菜单，确认不出现闪烁
- [ ] 悬浮在会话条目上，确认需要停留 ~600ms 后迷你地图才弹出
- [ ] 快速扫过列表时，确认迷你地图不会意外触发

🤖 Generated with [Claude Code](https://claude.com/claude-code)