### PR TITLE
feat(sidebar): 在项目三点菜单中添加工作区重命名功能

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -975,7 +975,8 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       setWorkspaces((prev) => prev.map((w) => (w.id === updated.id ? updated : w)))
     } catch (error) {
       console.error('[侧边栏] 重命名工作区失败:', error)
-      toast.error('重命名失败')
+      const msg = error instanceof Error ? error.message : '重命名失败'
+      toast.error(msg)
     }
   }, [setWorkspaces])
 

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -968,6 +968,17 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     })
   }, [openSession, setActiveView, setUnviewedCompleted])
 
+  /** 重命名工作区（项目）名称 */
+  const handleWorkspaceRename = React.useCallback(async (workspaceId: string, newName: string): Promise<void> => {
+    try {
+      const updated = await window.electronAPI.updateAgentWorkspace(workspaceId, { name: newName })
+      setWorkspaces((prev) => prev.map((w) => (w.id === updated.id ? updated : w)))
+    } catch (error) {
+      console.error('[侧边栏] 重命名工作区失败:', error)
+      toast.error('重命名失败')
+    }
+  }, [setWorkspaces])
+
   /** 重命名 Agent 会话标题 */
   const handleAgentRename = React.useCallback(async (id: string, newTitle: string): Promise<void> => {
     try {
@@ -1594,6 +1605,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                     setSettingsTab('agent')
                     setSettingsOpen(true)
                   }}
+                  onRenameWorkspace={handleWorkspaceRename}
                   onSelectSession={handleSelectAgentSession}
                   onRequestDelete={handleRequestDelete}
                   onRequestMove={handleRequestMove}
@@ -2361,6 +2373,7 @@ interface AgentProjectGroupItemProps {
   onDrop: (e: React.DragEvent, workspaceId: string) => void
   onDragEnd: () => void
   onConfigureProject: (workspaceId: string) => void
+  onRenameWorkspace: (workspaceId: string, newName: string) => Promise<void>
   onSelectSession: (id: string, title: string) => void
   onRequestDelete: (id: string) => void
   onRequestMove: (id: string) => void
@@ -2389,6 +2402,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
   onDrop,
   onDragEnd,
   onConfigureProject,
+  onRenameWorkspace,
   onSelectSession,
   onRequestDelete,
   onRequestMove,
@@ -2397,6 +2411,37 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
   onToggleArchive,
 }: AgentProjectGroupItemProps): React.ReactElement {
   const isCurrent = group.workspace.id === currentWorkspaceId
+
+  const [renamingWorkspace, setRenamingWorkspace] = React.useState(false)
+  const [workspaceEditName, setWorkspaceEditName] = React.useState('')
+  const workspaceEditRef = React.useRef<HTMLInputElement>(null)
+
+  const handleStartWorkspaceRename = (): void => {
+    setWorkspaceEditName(group.workspace.name)
+    setRenamingWorkspace(true)
+    requestAnimationFrame(() => {
+      workspaceEditRef.current?.focus()
+      workspaceEditRef.current?.select()
+    })
+  }
+
+  const handleWorkspaceRenameCommit = async (): Promise<void> => {
+    const trimmed = workspaceEditName.trim()
+    setRenamingWorkspace(false)
+    if (trimmed && trimmed !== group.workspace.name) {
+      await onRenameWorkspace(group.workspace.id, trimmed)
+    }
+  }
+
+  const handleWorkspaceRenameKeyDown = (e: React.KeyboardEvent): void => {
+    if (e.key === 'Enter') {
+      if (e.nativeEvent.isComposing) return
+      e.preventDefault()
+      void handleWorkspaceRenameCommit()
+    } else if (e.key === 'Escape') {
+      setRenamingWorkspace(false)
+    }
+  }
   const recentCutoff = relativeTimeNow - PROJECT_SESSION_RECENT_WINDOW_MS
   // 折叠时：所有"活跃"会话（运行中 / 阻塞 / 未查看的已完成）必须展示，
   // 不受 PROJECT_SESSION_PREVIEW_LIMIT 与 3 天窗口限制；活跃部分内部按
@@ -2460,9 +2505,22 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
           )}
         >
           <FolderOpen size={13} className="flex-shrink-0 text-foreground/40" />
-          <span className="flex-1 min-w-0 truncate text-[13px] font-medium leading-[18px]">
-            {group.workspace.name}
-          </span>
+          {renamingWorkspace ? (
+            <input
+              ref={workspaceEditRef}
+              value={workspaceEditName}
+              onChange={(e) => setWorkspaceEditName(e.target.value)}
+              onKeyDown={handleWorkspaceRenameKeyDown}
+              onBlur={() => void handleWorkspaceRenameCommit()}
+              onClick={(e) => e.stopPropagation()}
+              className="flex-1 min-w-0 bg-transparent text-[13px] font-medium text-foreground border-b border-primary/50 outline-none px-0.5 leading-[18px]"
+              maxLength={50}
+            />
+          ) : (
+            <span className="flex-1 min-w-0 truncate text-[13px] font-medium leading-[18px]">
+              {group.workspace.name}
+            </span>
+          )}
         </button>
 
         <Tooltip>
@@ -2499,6 +2557,13 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
             >
               <FolderOpen size={14} />
               设为当前项目
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              className="text-xs py-1 [&>svg]:size-3.5"
+              onSelect={handleStartWorkspaceRename}
+            >
+              <Pencil size={14} />
+              重命名
             </DropdownMenuItem>
             <DropdownMenuItem
               className="text-xs py-1 [&>svg]:size-3.5"

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -2415,14 +2415,20 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
   const [renamingWorkspace, setRenamingWorkspace] = React.useState(false)
   const [workspaceEditName, setWorkspaceEditName] = React.useState('')
   const workspaceEditRef = React.useRef<HTMLInputElement>(null)
+  // Radix closes the dropdown and asynchronously restores focus to the trigger
+  // button. We guard against that spurious blur for the duration of the close
+  // animation (~150 ms) so the input isn't dismissed before the user types.
+  const skipWorkspaceBlurRef = React.useRef(false)
 
   const handleStartWorkspaceRename = (): void => {
     setWorkspaceEditName(group.workspace.name)
     setRenamingWorkspace(true)
-    requestAnimationFrame(() => {
+    skipWorkspaceBlurRef.current = true
+    setTimeout(() => {
       workspaceEditRef.current?.focus()
       workspaceEditRef.current?.select()
-    })
+      skipWorkspaceBlurRef.current = false
+    }, 150)
   }
 
   const handleWorkspaceRenameCommit = async (): Promise<void> => {
@@ -2433,12 +2439,18 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
     }
   }
 
+  const handleWorkspaceRenameBlur = (): void => {
+    if (skipWorkspaceBlurRef.current) return
+    void handleWorkspaceRenameCommit()
+  }
+
   const handleWorkspaceRenameKeyDown = (e: React.KeyboardEvent): void => {
     if (e.key === 'Enter') {
       if (e.nativeEvent.isComposing) return
       e.preventDefault()
       void handleWorkspaceRenameCommit()
     } else if (e.key === 'Escape') {
+      skipWorkspaceBlurRef.current = false
       setRenamingWorkspace(false)
     }
   }
@@ -2511,7 +2523,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
               value={workspaceEditName}
               onChange={(e) => setWorkspaceEditName(e.target.value)}
               onKeyDown={handleWorkspaceRenameKeyDown}
-              onBlur={() => void handleWorkspaceRenameCommit()}
+              onBlur={handleWorkspaceRenameBlur}
               onClick={(e) => e.stopPropagation()}
               className="flex-1 min-w-0 bg-transparent text-[13px] font-medium text-foreground border-b border-primary/50 outline-none px-0.5 leading-[18px]"
               maxLength={50}

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -2550,7 +2550,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
               <MoreHorizontal size={13} />
             </button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-44 z-[9999] min-w-0 p-0.5">
+          <DropdownMenuContent align="start" className="w-44 z-[9999] min-w-0 p-0.5">
             <DropdownMenuItem
               className="text-xs py-1 [&>svg]:size-3.5"
               onSelect={() => onSelectProject(group.workspace.id)}

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -2415,33 +2415,28 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
   const [renamingWorkspace, setRenamingWorkspace] = React.useState(false)
   const [workspaceEditName, setWorkspaceEditName] = React.useState('')
   const workspaceEditRef = React.useRef<HTMLInputElement>(null)
-  // Radix closes the dropdown and asynchronously restores focus to the trigger
-  // button. We guard against that spurious blur for the duration of the close
-  // animation (~150 ms) so the input isn't dismissed before the user types.
-  const skipWorkspaceBlurRef = React.useRef(false)
+  const justStartedRenamingRef = React.useRef(false)
 
   const handleStartWorkspaceRename = (): void => {
     setWorkspaceEditName(group.workspace.name)
     setRenamingWorkspace(true)
-    skipWorkspaceBlurRef.current = true
+    justStartedRenamingRef.current = true
     setTimeout(() => {
+      justStartedRenamingRef.current = false
       workspaceEditRef.current?.focus()
       workspaceEditRef.current?.select()
-      skipWorkspaceBlurRef.current = false
-    }, 150)
+    }, 300)
   }
 
   const handleWorkspaceRenameCommit = async (): Promise<void> => {
+    if (justStartedRenamingRef.current) return
     const trimmed = workspaceEditName.trim()
-    setRenamingWorkspace(false)
-    if (trimmed && trimmed !== group.workspace.name) {
-      await onRenameWorkspace(group.workspace.id, trimmed)
+    if (!trimmed || trimmed === group.workspace.name) {
+      setRenamingWorkspace(false)
+      return
     }
-  }
-
-  const handleWorkspaceRenameBlur = (): void => {
-    if (skipWorkspaceBlurRef.current) return
-    void handleWorkspaceRenameCommit()
+    await onRenameWorkspace(group.workspace.id, trimmed)
+    setRenamingWorkspace(false)
   }
 
   const handleWorkspaceRenameKeyDown = (e: React.KeyboardEvent): void => {
@@ -2450,7 +2445,6 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
       e.preventDefault()
       void handleWorkspaceRenameCommit()
     } else if (e.key === 'Escape') {
-      skipWorkspaceBlurRef.current = false
       setRenamingWorkspace(false)
     }
   }
@@ -2506,34 +2500,43 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
           <GripVertical size={12} />
         </span>
 
-        <button
-          type="button"
-          onClick={() => onSelectProject(group.workspace.id)}
-          className={cn(
-            'relative flex-1 min-w-0 flex items-center gap-1 px-1 py-1 rounded-md text-left transition-[padding,color,background-color] titlebar-no-drag group-hover/project:pl-4 group-hover/project:pr-11 hover:bg-foreground/[0.025]',
-            isCurrent
-              ? 'agent-project-item-current text-foreground'
-              : 'text-foreground/65 hover:text-foreground/88',
-          )}
-        >
-          <FolderOpen size={13} className="flex-shrink-0 text-foreground/40" />
-          {renamingWorkspace ? (
+        {renamingWorkspace ? (
+          <div
+            className={cn(
+              'relative flex-1 min-w-0 flex items-center gap-1 px-1 py-1 rounded-md text-left titlebar-no-drag group-hover/project:pl-4 group-hover/project:pr-11',
+              isCurrent
+                ? 'agent-project-item-current text-foreground'
+                : 'text-foreground/65',
+            )}
+          >
+            <FolderOpen size={13} className="flex-shrink-0 text-foreground/40" />
             <input
               ref={workspaceEditRef}
               value={workspaceEditName}
               onChange={(e) => setWorkspaceEditName(e.target.value)}
               onKeyDown={handleWorkspaceRenameKeyDown}
-              onBlur={handleWorkspaceRenameBlur}
-              onClick={(e) => e.stopPropagation()}
+              onBlur={() => void handleWorkspaceRenameCommit()}
               className="flex-1 min-w-0 bg-transparent text-[13px] font-medium text-foreground border-b border-primary/50 outline-none px-0.5 leading-[18px]"
               maxLength={50}
             />
-          ) : (
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => onSelectProject(group.workspace.id)}
+            className={cn(
+              'relative flex-1 min-w-0 flex items-center gap-1 px-1 py-1 rounded-md text-left transition-[padding,color,background-color] titlebar-no-drag group-hover/project:pl-4 group-hover/project:pr-11 hover:bg-foreground/[0.025]',
+              isCurrent
+                ? 'agent-project-item-current text-foreground'
+                : 'text-foreground/65 hover:text-foreground/88',
+            )}
+          >
+            <FolderOpen size={13} className="flex-shrink-0 text-foreground/40" />
             <span className="flex-1 min-w-0 truncate text-[13px] font-medium leading-[18px]">
               {group.workspace.name}
             </span>
-          )}
-        </button>
+          </button>
+        )}
 
         <Tooltip>
           <TooltipTrigger asChild>


### PR DESCRIPTION
## Summary

- 在 `AgentProjectGroupItem` 的 `MoreHorizontal` 下拉菜单里新增「重命名」选项（位于「设为当前项目」和「配置 MCP 与 Skills」之间）
- 点击后项目名称转为内联输入框，支持 Enter 确认 / Escape 取消 / blur 提交
- 调用 `updateAgentWorkspace` API 持久化并同步更新本地 atom 状态

## Test plan

- [ ] 鼠标悬停工作区行，点击三点菜单，确认出现「重命名」选项
- [ ] 点击「重命名」，输入框出现，内容为当前名称且自动选中
- [ ] 输入新名称后按 Enter，名称更新并持久化
- [ ] 按 Escape，取消重命名，名称不变
- [ ] 点击输入框外部（blur），提交新名称
- [ ] 名称为空时取消重命名，不调用 API

🤖 Generated with [Claude Code](https://claude.com/claude-code)