### PR TITLE
[codex] Improve automation task sidebar and autosave

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -4089,6 +4089,7 @@ export function registerIpcHandlers(): void {
   // 渲染进程可能被注入内容污染（XSS via markdown / MCP tool output），主进程必须自己校验入参，
   // 否则 NaN / -Infinity / 越界值会污染 ~/.proma/automations.json，无法回滚。
   const isNonEmptyString = (v: unknown): v is string => typeof v === 'string' && v.length > 0
+  const isNonBlankString = (v: unknown): v is string => typeof v === 'string' && v.trim().length > 0
   const isFiniteInt = (v: unknown): v is number => typeof v === 'number' && Number.isFinite(v) && Number.isInteger(v)
   const validScheduleType = (v: unknown): v is 'interval' | 'daily' | 'weekly' =>
     v === 'interval' || v === 'daily' || v === 'weekly'
@@ -4138,6 +4139,8 @@ export function registerIpcHandlers(): void {
     async (_, input: UpdateAutomationInput): Promise<Automation | undefined> => {
       if (!input || typeof input !== 'object') throw new Error('input 必须是对象')
       if (!isNonEmptyString(input.id)) throw new Error('id 必填')
+      if (input.name !== undefined && !isNonBlankString(input.name)) throw new Error('name 不能为空')
+      if (input.prompt !== undefined && !isNonBlankString(input.prompt)) throw new Error('prompt 不能为空')
       validateAutomationFields(input)
       const a = updateAutomation(input)
       broadcastAutomationsChanged()

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -826,7 +826,7 @@ export class AgentOrchestrator {
    * 在 completeRun 时 fire-and-forget 调用。从 JSONL 读最近的 assistant 文本，
    * 解析 JSON 指令，执行对应操作（create/delete/toggle/list），广播变更。
    */
-  private async processAutomationCommands(sessionId: string, channelId: string, workspaceId?: string): Promise<void> {
+  private async processAutomationCommands(sessionId: string, channelId: string, modelId?: string, workspaceId?: string): Promise<void> {
     try {
       // 快速跳过：由定时任务触发的会话不会产生新的 automation 指令（系统提示词已明确禁止）
       const meta = getAgentSessionMeta(sessionId)
@@ -869,6 +869,7 @@ export class AgentOrchestrator {
               timeOfDay: cmd.timeOfDay as string | undefined,
               dayOfWeek: cmd.dayOfWeek as number | undefined,
               channelId,
+              modelId: modelId || undefined,
               workspaceId,
               sourceSessionId: sessionId,
               active: true,
@@ -1123,7 +1124,7 @@ export class AgentOrchestrator {
     ): void => {
       releaseActiveRun()
       // 扫描 Agent 回复中的 Proma 定时任务指令（HTML 注释块）
-      void this.processAutomationCommands(sessionId, channelId, workspaceId).catch(() => {})
+      void this.processAutomationCommands(sessionId, channelId, modelId, workspaceId).catch(() => {})
       callbacks.onComplete(messages, opts)
     }
     const failRun = (

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -43,7 +43,8 @@ import { channelsAtom } from '@/atoms/chat-atoms'
 import { agentProcessGroupsKeepExpandedAtom } from '@/atoms/agent-atoms'
 import { agentSessionsAtom } from '@/atoms/agent-atoms'
 import { activeSessionIdAtom } from '@/atoms/tab-atoms'
-import { automationsAtom, automationFormAtom } from '@/atoms/automation-atoms'
+import { automationsAtom, automationFormAtom, automationToDraft } from '@/atoms/automation-atoms'
+import { activeViewAtom } from '@/atoms/active-view'
 import { environmentCheckDialogOpenAtom } from '@/atoms/environment'
 import { settingsOpenAtom, settingsTabAtom } from '@/atoms/settings-tab'
 import type {
@@ -976,11 +977,16 @@ function QuoteChip({ quote }: { quote: QuotedFileRef }): React.ReactElement {
 
 const SCHEDULED_RUN_MARKER = '<!--PROMA_SCHEDULED_RUN-->'
 
+function stripScheduledRunMarker(text: string): string {
+  return text.replaceAll(SCHEDULED_RUN_MARKER, '').trim()
+}
+
 function ScheduledRunBadge(): React.ReactElement {
   const activeSessionId = useAtomValue(activeSessionIdAtom)
   const sessions = useAtomValue(agentSessionsAtom)
   const automations = useAtomValue(automationsAtom)
   const setForm = useSetAtom(automationFormAtom)
+  const setActiveView = useSetAtom(activeViewAtom)
 
   const session = sessions.find((s) => s.id === activeSessionId)
   const automation = session?.sourceAutomationId
@@ -989,22 +995,10 @@ function ScheduledRunBadge(): React.ReactElement {
 
   const handleClick = (): void => {
     if (!automation) return
+    setActiveView('automations')
     setForm({
       open: true,
-      draft: {
-        id: automation.id,
-        name: automation.name,
-        prompt: automation.prompt,
-        scheduleType: automation.scheduleType,
-        intervalMinutes: automation.intervalMinutes,
-        timeOfDay: automation.timeOfDay,
-        dayOfWeek: automation.dayOfWeek,
-        channelId: automation.channelId,
-        modelId: automation.modelId,
-        workspaceId: automation.workspaceId,
-        permissionMode: automation.permissionMode ?? 'bypassPermissions',
-        active: automation.active,
-      },
+      draft: automationToDraft(automation),
     })
   }
 
@@ -1025,7 +1019,7 @@ function UserInputMessage({ message }: { message: SDKUserMessage }): React.React
   const userProfile = useAtomValue(userProfileAtom)
   const rawText = extractUserText(message) ?? ''
   const isScheduledRun = rawText.includes(SCHEDULED_RUN_MARKER)
-  const { files: attachedFiles, quotes, text } = parseAttachedFiles(rawText.replace(SCHEDULED_RUN_MARKER, '').trim())
+  const { files: attachedFiles, quotes, text } = parseAttachedFiles(stripScheduledRunMarker(rawText))
   const imageFiles = attachedFiles.filter((f) => isImageFile(f.filename))
   const nonImageFiles = attachedFiles.filter((f) => !isImageFile(f.filename))
   const meta = extractMeta(message as unknown as SDKMessage)
@@ -1036,9 +1030,11 @@ function UserInputMessage({ message }: { message: SDKUserMessage }): React.React
         <UserAvatar avatar={userProfile.avatar} size={35} />
         <div className="flex flex-col justify-between h-[35px]">
           <span className="text-sm font-semibold text-foreground/60 leading-none">{userProfile.userName}</span>
-          {meta.createdAt && (
+          {(meta.createdAt || isScheduledRun) && (
             <span className="flex items-center gap-2 leading-none">
-              <span className="text-[10px] text-foreground/[0.38]">{formatMessageTime(meta.createdAt)}</span>
+              {meta.createdAt && (
+                <span className="text-[10px] text-foreground/[0.38]">{formatMessageTime(meta.createdAt)}</span>
+              )}
               {isScheduledRun && (
                 <ScheduledRunBadge />
               )}
@@ -1350,7 +1346,7 @@ export function getGroupId(group: MessageGroup): string {
  */
 export function getGroupPreview(group: MessageGroup): string {
   if (group.type === 'user') {
-    return (extractUserText(group.message) ?? '')
+    return stripScheduledRunMarker(extractUserText(group.message) ?? '')
       .replace(/<attached_files>[\s\S]*?<\/attached_files>\n*/, '')
       .replace(/<quoted_file[^>]*>[\s\S]*?<\/quoted_file>\n*/g, '')
       .slice(0, 200)

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -11,7 +11,7 @@
 import * as React from 'react'
 import { useAtom, useSetAtom, useAtomValue, useStore } from 'jotai'
 import { toast } from 'sonner'
-import { Pin, PinOff, Settings, Plus, Trash2, Pencil, ChevronDown, ChevronRight, Plug, Zap, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, GripVertical, Clock } from 'lucide-react'
+import { Pin, PinOff, Settings, Plus, Trash2, Pencil, ChevronDown, ChevronRight, Plug, Zap, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, GripVertical, Clock, AlarmClock } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { ModeSwitcher } from './ModeSwitcher'
@@ -146,6 +146,49 @@ function SidebarItem({ icon, label, active, suffix, onClick }: SidebarItemProps)
         <span>{label}</span>
       </div>
       {suffix}
+    </button>
+  )
+}
+
+function formatAutomationCount(count: number): string {
+  return count > 99 ? '99+' : String(count)
+}
+
+interface AutomationSidebarEntryProps {
+  count: number
+  active: boolean
+  onClick: () => void
+}
+
+function AutomationSidebarEntry({ count, active, onClick }: AutomationSidebarEntryProps): React.ReactElement {
+  return (
+    <button
+      type="button"
+      aria-label={`自动任务，${count} 个任务已创建`}
+      onClick={onClick}
+      className={cn(
+        'group w-full flex items-center justify-between px-3 py-2 rounded-md text-[13px] transition-colors duration-100 titlebar-no-drag',
+        active
+          ? 'bg-primary/10 text-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
+          : 'text-foreground/60 hover:bg-primary/5 hover:text-foreground',
+      )}
+    >
+      <span className="flex items-center gap-3 min-w-0">
+        <span className="flex-shrink-0 w-[18px] h-[18px]">
+          <AlarmClock size={16} className={cn('block', active ? 'text-primary' : 'text-foreground/45')} />
+        </span>
+        <span className="truncate">自动任务</span>
+      </span>
+      <span
+        className={cn(
+          'ml-2 flex h-5 min-w-[22px] flex-shrink-0 items-center justify-center rounded-full px-1.5 text-[11px] font-medium tabular-nums',
+          active
+            ? 'bg-primary/[0.14] text-primary'
+            : 'bg-foreground/[0.045] text-foreground/[0.42] group-hover:text-foreground/65',
+        )}
+      >
+        {formatAutomationCount(count)}
+      </span>
     </button>
   )
 }
@@ -337,7 +380,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   const [activeView, setActiveView] = useAtom(activeViewAtom)
   const setAutomationForm = useSetAtom(automationFormAtom)
   const automations = useAtomValue(automationsAtom)
-  const activeAutomationCount = automations.filter((a) => a.active).length
+  const automationCount = automations.length
   const setSettingsTab = useSetAtom(settingsTabAtom)
   const setSettingsOpen = useSetAtom(settingsOpenAtom)
   const [activeItem, setActiveItem] = React.useState<SidebarItemId>('all-chats')
@@ -593,6 +636,12 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     setActiveItem(item)
     setActiveView(ITEM_TO_VIEW[item])
   }
+
+  /** 打开自动任务列表 */
+  const handleOpenAutomations = React.useCallback((): void => {
+    setAutomationForm({ open: false, draft: null })
+    setActiveView('automations')
+  }, [setAutomationForm, setActiveView])
 
   // 切换模式时重置归档视图
   React.useEffect(() => {
@@ -1381,24 +1430,33 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
             <TooltipTrigger asChild>
               <button
                 type="button"
-                aria-label="定时任务"
-                onClick={() => { setAutomationForm({ open: false, draft: null }); setActiveView('automations') }}
+                aria-label={`自动任务，${automationCount} 个任务已创建`}
+                onClick={handleOpenAutomations}
                 className={cn(
-                  'relative size-10 flex items-center justify-center rounded-[12px] transition-colors titlebar-no-drag border border-dashed',
+                  'relative size-10 flex items-center justify-center rounded-[12px] transition-colors titlebar-no-drag border',
                   activeView === 'automations'
-                    ? 'bg-primary/10 text-foreground/70 border-[hsl(var(--dashed-border-hover))]'
-                    : 'bg-primary/5 hover:bg-primary/10 text-foreground/45 hover:text-foreground/70 border-[hsl(var(--dashed-border))] hover:border-[hsl(var(--dashed-border-hover))]',
+                    ? 'border-primary/80 bg-primary text-primary-foreground shadow-sm'
+                    : 'border-border/45 bg-foreground/[0.025] text-foreground/45 hover:border-border/70 hover:bg-foreground/[0.045] hover:text-primary',
                 )}
               >
-                <Clock size={16} />
-                {activeAutomationCount > 0 && (
-                  <span className="absolute -top-1 -right-1 min-w-[16px] h-4 px-1 flex items-center justify-center rounded-full bg-primary text-[10px] font-medium text-primary-foreground">
-                    {activeAutomationCount}
+                <AlarmClock size={16} />
+                {automationCount > 0 && (
+                  <span
+                    className={cn(
+                      'absolute -top-1 -right-1 flex h-4 min-w-[16px] items-center justify-center rounded-full px-1 text-[10px] font-medium tabular-nums',
+                      activeView === 'automations'
+                        ? 'bg-primary-foreground text-primary'
+                        : 'bg-primary text-primary-foreground',
+                    )}
+                  >
+                    {formatAutomationCount(automationCount)}
                   </span>
                 )}
               </button>
             </TooltipTrigger>
-            <TooltipContent side="right">定时任务</TooltipContent>
+            <TooltipContent side="right">
+              自动任务（{automationCount} 个任务已创建）
+            </TooltipContent>
           </Tooltip>
         </div>
 
@@ -1501,34 +1559,20 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
           </TooltipTrigger>
           <TooltipContent side="bottom">搜索 ({getAcceleratorDisplay(getActiveAccelerator('global-search'))})</TooltipContent>
         </Tooltip>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              aria-label="定时任务"
-              onClick={() => { setAutomationForm({ open: false, draft: null }); setActiveView('automations') }}
-              className={cn(
-                'relative flex-shrink-0 size-[36px] flex items-center justify-center rounded-[10px] transition-colors duration-100 titlebar-no-drag border border-dashed',
-                activeView === 'automations'
-                  ? 'bg-primary/10 text-foreground/70 border-[hsl(var(--dashed-border-hover))]'
-                  : 'bg-primary/5 hover:bg-primary/10 text-foreground/40 hover:text-foreground/60 border-[hsl(var(--dashed-border))] hover:border-[hsl(var(--dashed-border-hover))]',
-              )}
-            >
-              <Clock size={14} />
-              {activeAutomationCount > 0 && (
-                <span className="absolute -top-1.5 -right-1.5 min-w-[16px] h-4 px-1 flex items-center justify-center rounded-full bg-primary text-[10px] font-medium text-primary-foreground">
-                  {activeAutomationCount}
-                </span>
-              )}
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">定时任务</TooltipContent>
-        </Tooltip>
+      </div>
+
+      {/* 自动任务入口：作为任务中心入口放在置顶区上方，不参与置顶列表层级。 */}
+      <div className="px-3 pt-2 pb-0.5">
+        <AutomationSidebarEntry
+          count={automationCount}
+          active={activeView === 'automations'}
+          onClick={handleOpenAutomations}
+        />
       </div>
 
       {/* Chat 模式：导航菜单（置顶区域） */}
       {mode === 'chat' && (
-        <div className="flex flex-col gap-1 pt-3 px-3">
+        <div className="flex flex-col gap-1 pt-1 px-3">
           <SidebarItem
             icon={<Pin size={16} />}
             label="置顶对话"

--- a/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
+++ b/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
@@ -9,13 +9,12 @@
  */
 
 import * as React from 'react'
-import { useAtom, useAtomValue } from 'jotai'
+import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { toast } from 'sonner'
-import { Clock, AlertTriangle, X, CheckCircle2, XCircle, MinusCircle, Pencil, Check } from 'lucide-react'
+import { AlertTriangle, ArrowLeft, Check, Clock, Loader2, Pencil, Play, X } from 'lucide-react'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { Switch } from '@/components/ui/switch'
-import { Button } from '@/components/ui/button'
 import {
   Select,
   SelectTrigger,
@@ -29,12 +28,14 @@ import {
   automationsAtom,
   AUTOMATION_INTERVAL_OPTIONS,
   AUTOMATION_WEEKDAY_OPTIONS,
+  automationToDraft,
   type AutomationDraft,
 } from '@/atoms/automation-atoms'
 import { agentWorkspacesAtom, agentSessionsAtom } from '@/atoms/agent-atoms'
 import { activeSessionIdAtom } from '@/atoms/tab-atoms'
+import { activeViewAtom } from '@/atoms/active-view'
 import { useOpenSession } from '@/hooks/useOpenSession'
-import type { AutomationRun } from '@proma/shared'
+import type { AutomationRun, CreateAutomationInput, UpdateAutomationInput } from '@proma/shared'
 
 const NO_WORKSPACE = '__none__'
 
@@ -43,24 +44,86 @@ function formatTime(ts?: number): string {
   return new Date(ts).toLocaleString('zh-CN', { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' })
 }
 
-function RunStatusIcon({ status }: { status: AutomationRun['status'] }): React.ReactElement {
-  if (status === 'success') return <CheckCircle2 className="size-3 text-emerald-500" />
-  if (status === 'error') return <XCircle className="size-3 text-destructive" />
-  return <MinusCircle className="size-3 text-muted-foreground/50" />
+function formatRunStatus(status: AutomationRun['status']): string {
+  if (status === 'success') return '完成'
+  if (status === 'error') return '失败'
+  return '跳过'
+}
+
+function canPersistDraft(draft: AutomationDraft): boolean {
+  return !!(draft.name.trim() && draft.prompt.trim() && draft.channelId)
+}
+
+function getDraftSignature(draft: AutomationDraft): string {
+  return JSON.stringify({
+    id: draft.id ?? '',
+    name: draft.name.trim(),
+    prompt: draft.prompt.trim(),
+    scheduleType: draft.scheduleType,
+    intervalMinutes: draft.intervalMinutes,
+    timeOfDay: draft.timeOfDay ?? '',
+    dayOfWeek: draft.dayOfWeek ?? '',
+    channelId: draft.channelId,
+    modelId: draft.modelId ?? '',
+    workspaceId: draft.workspaceId ?? '',
+    permissionMode: draft.permissionMode,
+    active: draft.active,
+  })
+}
+
+function draftToCreateInput(draft: AutomationDraft): CreateAutomationInput {
+  return {
+    name: draft.name.trim(),
+    prompt: draft.prompt.trim(),
+    scheduleType: draft.scheduleType,
+    intervalMinutes: draft.intervalMinutes,
+    timeOfDay: draft.timeOfDay,
+    dayOfWeek: draft.dayOfWeek,
+    channelId: draft.channelId,
+    modelId: draft.modelId,
+    workspaceId: draft.workspaceId,
+    permissionMode: draft.permissionMode,
+    sourceSessionId: draft.sourceSessionId,
+    active: draft.active,
+  }
+}
+
+function draftToUpdateInput(draft: AutomationDraft): UpdateAutomationInput {
+  return {
+    id: draft.id ?? '',
+    name: draft.name.trim(),
+    prompt: draft.prompt.trim(),
+    scheduleType: draft.scheduleType,
+    intervalMinutes: draft.intervalMinutes,
+    timeOfDay: draft.timeOfDay,
+    dayOfWeek: draft.dayOfWeek,
+    channelId: draft.channelId,
+    modelId: draft.modelId,
+    workspaceId: draft.workspaceId ?? '',
+    permissionMode: draft.permissionMode,
+    active: draft.active,
+  }
 }
 
 export function AutomationFormView(): React.ReactElement | null {
   const [formState, setFormState] = useAtom(automationFormAtom)
+  const setAutomations = useSetAtom(automationsAtom)
   const workspaces = useAtomValue(agentWorkspacesAtom)
   const automations = useAtomValue(automationsAtom)
-  const agentSessions = useAtomValue(agentSessionsAtom)
+  const [agentSessions, setAgentSessions] = useAtom(agentSessionsAtom)
   const activeSessionId = useAtomValue(activeSessionIdAtom)
+  const setActiveView = useSetAtom(activeViewAtom)
   const openSession = useOpenSession()
 
   const [form, setForm] = React.useState<AutomationDraft | null>(null)
-  const [saving, setSaving] = React.useState(false)
   const [editingName, setEditingName] = React.useState(false)
+  const [runningNow, setRunningNow] = React.useState(false)
   const nameInputRef = React.useRef<HTMLInputElement>(null)
+  const saveTimerRef = React.useRef<number | undefined>(undefined)
+  const lastSavedSignatureRef = React.useRef('')
+  const latestFormRef = React.useRef<AutomationDraft | null>(null)
+  // 串行化保存，避免新建草稿在首次 create 返回前被重复创建。
+  const persistInFlightRef = React.useRef<Promise<string | null> | null>(null)
 
   // 卸载/关闭过程中不再 setState（保存 IPC 是异步的，结束时表单可能已经被关掉了）
   const isMountedRef = React.useRef(true)
@@ -72,8 +135,98 @@ export function AutomationFormView(): React.ReactElement | null {
   React.useEffect(() => {
     if (formState.open && formState.draft) {
       setForm({ ...formState.draft })
+      lastSavedSignatureRef.current = formState.draft.id && canPersistDraft(formState.draft)
+        ? getDraftSignature(formState.draft)
+        : ''
     }
   }, [formState.open, formState.draft])
+
+  React.useEffect(() => {
+    latestFormRef.current = form
+  }, [form])
+
+  React.useEffect(() => {
+    return () => {
+      if (saveTimerRef.current !== undefined) {
+        window.clearTimeout(saveTimerRef.current)
+      }
+    }
+  }, [])
+
+  const refreshAutomations = React.useCallback(async () => {
+    const list = await window.electronAPI.listAutomations()
+    setAutomations(list)
+    return list
+  }, [setAutomations])
+
+  const persistDraft = React.useCallback((draft: AutomationDraft): Promise<string | null> => {
+    if (!canPersistDraft(draft)) return Promise.resolve(draft.id ?? null)
+
+    const previousPersist = persistInFlightRef.current
+    const persistTask = (async (): Promise<string | null> => {
+      const previousId = previousPersist ? await previousPersist.catch(() => null) : null
+      const latestDraft = latestFormRef.current
+      const draftToSave = latestDraft
+        ? { ...latestDraft, id: latestDraft.id ?? previousId ?? draft.id }
+        : { ...draft, id: draft.id ?? previousId ?? undefined }
+
+      if (!canPersistDraft(draftToSave)) return draftToSave.id ?? null
+
+      const signature = getDraftSignature(draftToSave)
+      if (signature === lastSavedSignatureRef.current) return draftToSave.id ?? null
+
+      try {
+        if (draftToSave.id) {
+          const updated = await window.electronAPI.updateAutomation(draftToUpdateInput(draftToSave))
+          if (!updated) throw new Error('定时任务不存在')
+          lastSavedSignatureRef.current = signature
+          setAutomations((prev) => prev.map((a) => (a.id === updated.id ? updated : a)))
+          setForm((prev) => (prev ? { ...prev, id: updated.id, name: updated.name } : prev))
+          return updated.id
+        } else {
+          const created = await window.electronAPI.createAutomation(draftToCreateInput(draftToSave))
+          const createdDraft = automationToDraft(created)
+          lastSavedSignatureRef.current = getDraftSignature(createdDraft)
+          setAutomations((prev) => [created, ...prev.filter((a) => a.id !== created.id)])
+          setForm((prev) => (prev ? { ...prev, id: created.id, name: created.name } : prev))
+          return created.id
+        }
+      } catch (err) {
+        console.error('[定时任务] 自动保存失败:', err)
+        if (isMountedRef.current) toast.error('自动保存失败')
+        return null
+      }
+    })()
+
+    persistInFlightRef.current = persistTask
+    void persistTask.finally(() => {
+      if (persistInFlightRef.current === persistTask) {
+        persistInFlightRef.current = null
+      }
+    })
+    return persistTask
+  }, [setAutomations])
+
+  React.useEffect(() => {
+    if (!formState.open || !form || !canPersistDraft(form)) return
+
+    const signature = getDraftSignature(form)
+    if (signature === lastSavedSignatureRef.current) return
+
+    if (saveTimerRef.current !== undefined) {
+      window.clearTimeout(saveTimerRef.current)
+    }
+    saveTimerRef.current = window.setTimeout(() => {
+      void persistDraft(form)
+    }, 500)
+
+    return () => {
+      if (saveTimerRef.current !== undefined) {
+        window.clearTimeout(saveTimerRef.current)
+        saveTimerRef.current = undefined
+      }
+    }
+  }, [form, formState.open, persistDraft])
 
   // 切换会话/Tab 时自动关闭表单
   const initialSessionRef = React.useRef<string | null | undefined>(undefined)
@@ -87,28 +240,73 @@ export function AutomationFormView(): React.ReactElement | null {
       return
     }
     if (activeSessionId !== initialSessionRef.current) {
+      const latest = latestFormRef.current
+      if (latest) void persistDraft(latest)
       setFormState({ open: false, draft: null })
     }
-  }, [activeSessionId, formState.open, setFormState])
+  }, [activeSessionId, formState.open, persistDraft, setFormState])
 
   if (!formState.open || !form) return null
 
   // 编辑模式下取实时的 automation（用于状态信息 + 运行历史，订阅 changed 后会刷新）
   const live = form.id ? automations.find((a) => a.id === form.id) : undefined
 
-  const close = (): void => setFormState({ open: false, draft: null })
+  const close = (): void => {
+    const latest = latestFormRef.current
+    if (latest) void persistDraft(latest)
+    setFormState({ open: false, draft: null })
+  }
   const update = (patch: Partial<AutomationDraft>): void => {
     setForm((prev) => (prev ? { ...prev, ...patch } : prev))
   }
 
+  const handleRunNow = async (): Promise<void> => {
+    const latest = latestFormRef.current
+    if (!latest || !canPersistDraft(latest)) {
+      toast.error('请先填写任务名称、任务描述并选择模型')
+      return
+    }
+
+    setRunningNow(true)
+    try {
+      const automationId = await persistDraft(latest)
+      if (!automationId) throw new Error('任务尚未创建')
+      await window.electronAPI.runAutomationNow(automationId)
+      await refreshAutomations()
+      const sessions = await window.electronAPI.listAgentSessions()
+      setAgentSessions(sessions)
+      toast.success('已完成一次测试运行')
+    } catch (err) {
+      console.error('[定时任务] 立即运行失败:', err)
+      toast.error('立即运行失败')
+    } finally {
+      if (isMountedRef.current) setRunningNow(false)
+    }
+  }
+
   /** 跳到运行历史中的某次子会话，先关掉表单 overlay 再 openSession */
-  const handleOpenRunSession = (run: AutomationRun): void => {
-    const session = agentSessions.find((s) => s.id === run.sessionId)
+  const handleOpenRunSession = async (run: AutomationRun): Promise<void> => {
+    if (!run.sessionId) {
+      toast.error('这条记录没有可打开的会话')
+      return
+    }
+
+    let session = agentSessions.find((s) => s.id === run.sessionId)
+    if (!session) {
+      const sessions = await window.electronAPI.listAgentSessions()
+      setAgentSessions(sessions)
+      session = sessions.find((s) => s.id === run.sessionId)
+    }
+
     if (!session) {
       toast.error('该会话已不存在')
       return
     }
+
+    const latest = latestFormRef.current
+    if (latest) void persistDraft(latest)
     setFormState({ open: false, draft: null })
+    setActiveView('conversations')
     openSession('agent', session.id, session.title)
   }
 
@@ -116,65 +314,28 @@ export function AutomationFormView(): React.ReactElement | null {
     setEditingName(true)
     requestAnimationFrame(() => nameInputRef.current?.focus())
   }
+  const commitName = async (): Promise<void> => {
+    const name = form.name.trim()
+    if (!name) {
+      toast.error('任务名称不能为空')
+      nameInputRef.current?.focus()
+      return
+    }
+    setEditingName(false)
+    update({ name })
+    void persistDraft({ ...form, name })
+  }
   const handleNameKeyDown = (e: React.KeyboardEvent): void => {
     if (e.key === 'Enter') {
       e.preventDefault()
-      setEditingName(false)
+      void commitName()
     } else if (e.key === 'Escape') {
+      setForm((prev) => (prev ? { ...prev, name: live?.name ?? formState.draft?.name ?? prev.name } : prev))
       setEditingName(false)
     }
   }
 
   const isEdit = !!form.id
-  const canSave = !!(form.name.trim() && form.prompt.trim() && form.channelId)
-
-  const handleSave = async (): Promise<void> => {
-    if (!canSave) return
-    setSaving(true)
-    try {
-      const common = {
-        scheduleType: form.scheduleType,
-        intervalMinutes: form.intervalMinutes,
-        timeOfDay: form.timeOfDay,
-        dayOfWeek: form.dayOfWeek,
-        permissionMode: form.permissionMode,
-      }
-      if (isEdit && form.id) {
-        await window.electronAPI.updateAutomation({
-          id: form.id,
-          name: form.name.trim(),
-          prompt: form.prompt.trim(),
-          ...common,
-          channelId: form.channelId,
-          modelId: form.modelId,
-          workspaceId: form.workspaceId ?? '',
-          active: form.active,
-        })
-        if (isMountedRef.current) toast.success('已保存')
-      } else {
-        const created = await window.electronAPI.createAutomation({
-          name: form.name.trim(),
-          prompt: form.prompt.trim(),
-          ...common,
-          channelId: form.channelId,
-          modelId: form.modelId,
-          workspaceId: form.workspaceId,
-          sourceSessionId: form.sourceSessionId,
-          active: form.active,
-        })
-        // 不关闭页面：转为编辑模式，便于继续调整
-        if (isMountedRef.current && created?.id) {
-          setForm((prev) => (prev ? { ...prev, id: created.id } : prev))
-        }
-        if (isMountedRef.current) toast.success('定时任务已创建')
-      }
-    } catch (err) {
-      console.error('[定时任务] 保存失败:', err)
-      if (isMountedRef.current) toast.error('保存失败')
-    } finally {
-      if (isMountedRef.current) setSaving(false)
-    }
-  }
 
   const selectedModel = form.channelId && form.modelId
     ? { channelId: form.channelId, modelId: form.modelId }
@@ -185,6 +346,15 @@ export function AutomationFormView(): React.ReactElement | null {
       {/* 左栏：自然语言任务描述（主角） */}
       <div className="flex-1 min-w-0 flex flex-col">
         <div className="flex items-center gap-2 px-6 py-4 flex-shrink-0">
+          <button
+            type="button"
+            onClick={close}
+            className="titlebar-no-drag mr-1 flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-foreground/[0.06] hover:text-foreground"
+            aria-label="返回任务列表"
+          >
+            <ArrowLeft className="size-3.5" />
+            <span>自动任务</span>
+          </button>
           <Clock className="size-4 text-primary flex-shrink-0" />
           {editingName ? (
             <div className="flex items-center gap-1.5 flex-1 min-w-0">
@@ -193,7 +363,7 @@ export function AutomationFormView(): React.ReactElement | null {
                 value={form.name}
                 onChange={(e) => update({ name: e.target.value })}
                 onKeyDown={handleNameKeyDown}
-                onBlur={() => setEditingName(false)}
+                onBlur={() => { void commitName() }}
                 placeholder="未命名任务"
                 className="flex-1 bg-transparent text-sm font-semibold text-foreground border-b border-primary/50 outline-none px-0 py-0.5 min-w-0"
                 maxLength={100}
@@ -201,7 +371,7 @@ export function AutomationFormView(): React.ReactElement | null {
               <button
                 type="button"
                 onMouseDown={(e) => e.preventDefault()}
-                onClick={() => setEditingName(false)}
+                onClick={() => { void commitName() }}
                 className="p-1 text-muted-foreground hover:text-foreground transition-colors flex-shrink-0"
               >
                 <Check className="size-3.5" />
@@ -237,14 +407,25 @@ export function AutomationFormView(): React.ReactElement | null {
 
       {/* 右栏：配置 sidebar */}
       <div className="w-[340px] flex-shrink-0 border-l border-border/50 flex flex-col bg-content-area">
-        <div className="flex items-center justify-between px-4 py-4 flex-shrink-0">
+        <div className="flex items-center justify-between gap-2 px-4 py-4 flex-shrink-0">
           <span className="text-sm font-semibold text-foreground">配置</span>
-          <button
-            onClick={close}
-            className="titlebar-no-drag p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-foreground/[0.06] transition-colors"
-          >
-            <X className="size-4" />
-          </button>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={() => { void handleRunNow() }}
+              disabled={runningNow || !canPersistDraft(form)}
+              className="titlebar-no-drag h-7 px-2.5 rounded-md text-xs font-medium bg-primary text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50 transition-colors flex items-center gap-1.5 shadow-sm"
+            >
+              {runningNow ? <Loader2 className="size-3.5 animate-spin" /> : <Play className="size-3.5" />}
+              <span>{runningNow ? '运行中' : '运行一次'}</span>
+            </button>
+            <button
+              onClick={close}
+              className="titlebar-no-drag p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-foreground/[0.06] transition-colors"
+            >
+              <X className="size-4" />
+            </button>
+          </div>
         </div>
 
         <div className="flex-1 overflow-y-auto px-4 pb-4 flex flex-col gap-5">
@@ -414,18 +595,18 @@ export function AutomationFormView(): React.ReactElement | null {
               ) : (
                 <div className="flex flex-col gap-1">
                   {live.runHistory.slice(0, 10).map((run, i) => {
-                    const sessionExists = agentSessions.some((s) => s.id === run.sessionId)
+                    const hasSessionId = !!run.sessionId
                     return (
                       <button
                         key={`${run.runAt}-${i}`}
                         type="button"
-                        onClick={() => handleOpenRunSession(run)}
-                        disabled={!sessionExists}
-                        title={sessionExists ? '查看本次执行的会话' : '该会话已不存在'}
-                        className="flex items-center gap-1.5 px-1.5 py-1 -mx-1.5 rounded-md text-[11px] text-foreground/60 text-left transition-colors enabled:hover:bg-foreground/[0.04] enabled:hover:text-foreground/80 disabled:cursor-not-allowed disabled:opacity-50"
+                        onClick={() => { void handleOpenRunSession(run) }}
+                        disabled={!hasSessionId}
+                        title={hasSessionId ? '查看本次执行的会话' : '这条记录没有可打开的会话'}
+                        className="flex items-center gap-2 px-1.5 py-1 -mx-1.5 rounded-md text-[11px] text-foreground/60 text-left transition-colors enabled:hover:bg-foreground/[0.04] enabled:hover:text-foreground/80 disabled:cursor-not-allowed disabled:opacity-50"
                       >
-                        <RunStatusIcon status={run.status} />
                         <span className="tabular-nums">{formatTime(run.runAt)}</span>
+                        <span className="shrink-0 text-foreground/45">{formatRunStatus(run.status)}</span>
                         <span className="text-foreground/35 truncate">
                           {run.status === 'success' && run.durationMs ? `${(run.durationMs / 1000).toFixed(1)}s` : ''}
                           {run.status === 'error' ? (run.error ?? '失败') : ''}
@@ -438,13 +619,6 @@ export function AutomationFormView(): React.ReactElement | null {
               )}
             </div>
           )}
-        </div>
-
-        <div className="flex justify-end gap-2 px-4 py-4 border-t border-border/50 flex-shrink-0">
-          <Button variant="ghost" onClick={close} disabled={saving}>取消</Button>
-          <Button onClick={handleSave} disabled={!canSave || saving}>
-            {saving ? '保存中…' : isEdit ? '保存' : '创建'}
-          </Button>
         </div>
       </div>
     </div>

--- a/apps/electron/src/renderer/components/automation/AutomationsListView.tsx
+++ b/apps/electron/src/renderer/components/automation/AutomationsListView.tsx
@@ -8,15 +8,16 @@
  * - 内容：分组列表
  *   - Current（启用中）：active=true
  *   - Paused（已暂停 / 草稿）：active=false
- * - 每行：状态点 + 名称 + prompt 摘要 + 调度文案
+ * - 每行：名称 + prompt 摘要 + 调度文案
  * - 点击行 → 通过 automationFormAtom 打开编辑表单 overlay
  */
 
 import * as React from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { toast } from 'sonner'
-import { Clock, Plus, Play, Trash2 } from 'lucide-react'
+import { Clock, Pause, Play, Power, Plus, Trash2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import {
   automationsAtom,
   automationFormAtom,
@@ -75,7 +76,7 @@ export function AutomationsListView(): React.ReactElement {
         <button
           type="button"
           onClick={handleCreate}
-          className="titlebar-no-drag flex items-center gap-1.5 px-3 py-1.5 rounded-md text-[13px] font-medium text-foreground/70 bg-primary/5 hover:bg-primary/10 transition-colors duration-100 border border-dashed border-[hsl(var(--dashed-border))] hover:border-[hsl(var(--dashed-border-hover))]"
+	          className="titlebar-no-drag flex items-center gap-1.5 px-3 py-1.5 rounded-md text-[13px] font-medium bg-primary text-primary-foreground hover:bg-primary/90 transition-colors duration-100 shadow-sm"
         >
           <Plus size={14} />
           <span>新建定时任务</span>
@@ -151,7 +152,7 @@ function Section({ title, automations, onEdit, onRefresh, variant }: SectionProp
       <div className="text-[13px] font-medium text-foreground/55 px-1">{title}</div>
       <div className="rounded-xl border border-border/50 overflow-hidden bg-content-area">
         {automations.map((a, i) => (
-          // 行容器：用 div + role=button，避免与内部 button（立即运行/删除/状态灯）
+          // 行容器：用 div + role=button，避免与内部 button（立即运行/删除/暂停）
           // 形成嵌套 button 的非法 HTML，同时通过 keyDown 维持键盘可达。
           <div
             key={a.id}
@@ -169,10 +170,6 @@ function Section({ title, automations, onEdit, onRefresh, variant }: SectionProp
               i > 0 && 'border-t border-border/40',
             )}
           >
-            <Clock className={cn(
-              'size-4 shrink-0',
-              variant === 'active' ? 'text-emerald-500' : 'text-foreground/30',
-            )} />
             <div className="flex-1 min-w-0">
               <div className="flex items-baseline gap-2">
                 <span className="text-[14px] font-medium text-foreground truncate">{a.name}</span>
@@ -181,49 +178,63 @@ function Section({ title, automations, onEdit, onRefresh, variant }: SectionProp
                 </span>
               </div>
             </div>
-            {/* hover 操作按钮（立即运行 + 删除） */}
-            <div className="hidden group-hover:flex items-center gap-1 shrink-0">
-              <button
-                type="button"
-                aria-label={`立即运行 ${a.name}`}
-                title="立即运行一次"
-                onClick={(e) => { void handleRunNow(e, a) }}
-                className="p-1.5 rounded-md text-foreground/40 hover:text-foreground/80 hover:bg-foreground/[0.06] transition-colors"
-              >
-                <Play className="size-3.5" />
-              </button>
-              <button
-                type="button"
-                aria-label={`删除 ${a.name}`}
-                title="删除"
-                onClick={(e) => { void handleDelete(e, a) }}
-                className="p-1.5 rounded-md text-foreground/40 hover:text-destructive hover:bg-destructive/10 transition-colors"
-              >
-                <Trash2 className="size-3.5" />
-              </button>
-            </div>
-            {/* 非 hover 时显示调度文案 */}
-            <span className={cn(
-              'text-[12px] tabular-nums shrink-0 group-hover:hidden',
-              variant === 'active' ? 'text-foreground/55' : 'text-foreground/35',
-            )}>
-              {variant === 'paused' ? '已暂停' : formatSchedule(a)}
-            </span>
-            {/* 状态灯：常驻显示，绿=启用/红=暂停，点击切换。外层 padding 扩大点击区域 */}
-            <button
-              type="button"
-              aria-label={a.active ? `暂停 ${a.name}` : `启用 ${a.name}`}
-              title={a.active ? '点击暂停' : '点击启用'}
-              onClick={(e) => { void handleToggle(e, a) }}
-              className="p-2 -m-2 shrink-0 flex items-center justify-center"
-            >
+            {/* 右侧槽位固定宽度，只切透明度，避免 hover 时列表行横向跳动。 */}
+            <div className="relative h-7 w-24 shrink-0">
               <span className={cn(
-                'size-2.5 rounded-full transition-colors',
-                a.active
-                  ? 'bg-emerald-500 hover:bg-red-400'
-                  : 'bg-red-400 hover:bg-emerald-500',
-              )} />
-            </button>
+                'absolute right-0 top-1/2 -translate-y-1/2 text-[12px] tabular-nums whitespace-nowrap transition-opacity group-hover:opacity-0',
+                variant === 'active' ? 'text-foreground/55' : 'text-foreground/35',
+              )}>
+                {variant === 'paused' ? '已暂停' : formatSchedule(a)}
+              </span>
+              <div className="pointer-events-none absolute right-0 top-1/2 flex -translate-y-1/2 items-center gap-1 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      aria-label={`立即运行 ${a.name}`}
+                      onClick={(e) => { void handleRunNow(e, a) }}
+                      className="p-1.5 rounded-md text-foreground/40 hover:text-foreground/80 hover:bg-foreground/[0.06] transition-colors"
+                    >
+                      <Play className="size-3.5" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="top">立即运行一次</TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      aria-label={`删除 ${a.name}`}
+                      onClick={(e) => { void handleDelete(e, a) }}
+                      className="p-1.5 rounded-md text-foreground/40 hover:text-destructive hover:bg-destructive/10 transition-colors"
+                    >
+                      <Trash2 className="size-3.5" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="top">删除任务</TooltipContent>
+                </Tooltip>
+              </div>
+            </div>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-label={a.active ? `暂停 ${a.name}` : `启用 ${a.name}`}
+                  onClick={(e) => { void handleToggle(e, a) }}
+                  className={cn(
+                    'p-1.5 -m-1.5 shrink-0 flex items-center justify-center rounded-md transition-colors',
+                    a.active
+                      ? 'text-foreground/35 hover:bg-foreground/[0.06] hover:text-foreground/70'
+                      : 'text-foreground/30 hover:bg-emerald-500/10 hover:text-emerald-500',
+                  )}
+                >
+                  {a.active ? <Pause className="size-3.5" /> : <Power className="size-3.5" />}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top">
+                {a.active ? '暂停任务：从当前开始不再继续后续自动处理' : '启用任务'}
+              </TooltipContent>
+            </Tooltip>
           </div>
         ))}
       </div>
@@ -247,7 +258,7 @@ function EmptyState({ onCreate }: { onCreate: () => void }): React.ReactElement 
       <button
         type="button"
         onClick={onCreate}
-        className="mt-2 flex items-center gap-1.5 px-4 py-2 rounded-md text-[13px] font-medium text-foreground/80 bg-primary/10 hover:bg-primary/20 transition-colors"
+	        className="mt-2 flex items-center gap-1.5 px-4 py-2 rounded-md text-[13px] font-medium bg-primary text-primary-foreground hover:bg-primary/90 transition-colors shadow-sm"
       >
         <Plus size={14} />
         <span>新建定时任务</span>

--- a/apps/electron/src/renderer/components/tabs/MainArea.tsx
+++ b/apps/electron/src/renderer/components/tabs/MainArea.tsx
@@ -152,14 +152,19 @@ export function MainArea(): React.ReactElement {
             className="flex flex-col min-w-0 h-full relative"
             style={leftFlexStyle}
           >
-            {activeView === 'automations' && !automationFormOpen ? (
-              // Automations 列表视图：全屏取代 TabBar + TabContent
-              <AutomationsListView />
+            {activeView === 'automations' ? (
+              automationFormOpen ? (
+                // 定时任务设置页：与列表同层级替换中间区，不经过 TabBar，避免切换时闪出会话 Tab。
+                <AutomationFormView />
+              ) : (
+                // Automations 列表视图：全屏取代 TabBar + TabContent
+                <AutomationsListView />
+              )
             ) : (
               <>
                 <TabBar />
                 {automationFormOpen ? (
-                  // 定时任务编辑表单：替换 TabContent，但保留 TabBar 让用户能点 tab 切走
+                  // 兼容从会话内入口打开任务设置的场景。
                   <AutomationFormView />
                 ) : tabs.length === 0 ? (
                   <WelcomeView />


### PR DESCRIPTION
## Summary
- Move automations into a first-class sidebar/list entry and polish the automation task views.
- Add direct scheduled-run navigation, run-once support, and run history session opening in the automation form.
- Serialize automation draft persistence so a new task cannot be created twice while the first autosave is still pending.
- Bump @proma/electron to 0.11.2.

## Root cause
The new autosave flow could call createAutomation more than once for an id-less draft if a timer save, close save, or run-once save overlapped before the first create returned an id.

## Validation
- bun run --filter='@proma/electron' typecheck\n- git diff --check\n- git diff --check origin/main...HEAD