### PR TITLE
fix(agent): 后台任务/Monitor 完成时自动唤醒 idle Agent

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -10,7 +10,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "concurrently -k -n vite,electron -c blue,green \"bun run dev:vite\" \"bun run dev:electron\"",
+    "dev": "bun run scripts/dev-kill.ts --vite && concurrently -k -n vite,electron -c blue,green \"bun run dev:vite\" \"bun run dev:electron\"",
     "dev:split": "bash scripts/dev-split.sh",
     "dev:vite": "vite dev",
     "dev:kill": "bun run scripts/dev-kill.ts",

--- a/apps/electron/scripts/dev-kill.ts
+++ b/apps/electron/scripts/dev-kill.ts
@@ -59,8 +59,9 @@ function killStaleVite(port: number): void {
             encoding: 'utf8',
             stdio: ['ignore', 'pipe', 'ignore'],
           })
-          // 仅杀 vite/node 进程，避免误伤偶然占用该端口的其他服务
-          if (/vite|node/.test(cmd)) {
+          // 仅杀命令行包含 vite 的进程（dev server 由 node 运行 vite，命令行必含 vite 脚本路径），
+          // 不匹配裸 node，避免误伤偶然占用该端口的其他 node 服务
+          if (/vite/.test(cmd)) {
             execSync(`kill ${pid} 2>/dev/null`, { stdio: 'ignore' })
           }
         } catch {

--- a/apps/electron/scripts/dev-kill.ts
+++ b/apps/electron/scripts/dev-kill.ts
@@ -1,10 +1,17 @@
 /**
  * 跨平台清理残留的 electronmon / electron 进程
  * 替代 pkill（Windows 不支持）
+ *
+ * 传入 --vite 时，额外清理占用 Vite 端口（5173）的残留进程。
+ * 该清理仅应在 concurrently 拉起 dev:vite 之前跑一次（顶层 dev 脚本），
+ * 不要在与 dev:vite 并发的 dev:electron 内部跑，否则会误杀本次刚启动的 vite。
  */
 import { execSync } from 'child_process'
 
 const isWin = process.platform === 'win32'
+const killVite = process.argv.includes('--vite')
+/** 与 vite.config.ts 的 server.port 保持一致 */
+const VITE_PORT = 5173
 
 function kill(pattern: string): void {
   try {
@@ -20,5 +27,52 @@ function kill(pattern: string): void {
   }
 }
 
+/**
+ * 清理占用 Vite 端口的残留进程。
+ * vite.config.ts 设了 strictPort，端口被占就会直接报错退出，
+ * 残留的孤儿 vite（如已注销 worktree 留下的）会反复阻塞 dev。
+ * 仅当监听进程是 vite/node 时才杀，避免误伤占用同端口的其他服务。
+ */
+function killStaleVite(port: number): void {
+  try {
+    if (isWin) {
+      const out = execSync(`netstat -ano -p tcp | findstr LISTENING | findstr :${port}`, {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      })
+      const pids = new Set<string>()
+      for (const line of out.split('\n')) {
+        const m = line.trim().match(/(\d+)\s*$/)
+        if (m) pids.add(m[1]!)
+      }
+      for (const pid of pids) {
+        try { execSync(`taskkill /F /PID ${pid} 2>nul`, { stdio: 'ignore' }) } catch { /* 已退出 */ }
+      }
+    } else {
+      const out = execSync(`lsof -ti:${port} 2>/dev/null`, {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      })
+      for (const pid of out.split('\n').map((s) => s.trim()).filter(Boolean)) {
+        try {
+          const cmd = execSync(`ps -p ${pid} -o command=`, {
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'ignore'],
+          })
+          // 仅杀 vite/node 进程，避免误伤偶然占用该端口的其他服务
+          if (/vite|node/.test(cmd)) {
+            execSync(`kill ${pid} 2>/dev/null`, { stdio: 'ignore' })
+          }
+        } catch {
+          // 进程已退出或无权限，忽略
+        }
+      }
+    }
+  } catch {
+    // 端口未被占用或命令不可用，忽略
+  }
+}
+
 kill(isWin ? 'electronmon.exe' : 'electronmon \\.')
 kill(isWin ? 'electron.exe' : 'electron.*dist/main')
+if (killVite) killStaleVite(VITE_PORT)

--- a/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
@@ -896,7 +896,12 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
             ;(msg as Record<string, unknown>)._keepChannelOpenForTasks = true
             armIdleTimer()
           } else if (keepForReason) {
-            // 既有"等待用户决策"路径（权限/ExitPlan/AskUser）：保持开启、不加空闲超时。
+            // 既有"可继续"路径（abort/defer/hook，对应权限/ExitPlan/AskUser 等待）：
+            // 保持通道开启。本轮并非真正空闲——SDK 会继续驱动新一轮，故不打
+            // _keepChannelOpenForTasks 注解（不让 UI 进软空闲态，否则会与"继续中"的真实状态冲突）。
+            // 但若此时同时有后台任务在飞行（keepForTasks），仍 arm idle timer 作为安全网：
+            // 任务活动会持续重置计时器，仅在长时间彻底静默时兜底释放子进程，避免叠加场景下子进程泄漏。
+            if (keepForTasks) armIdleTimer()
           } else {
             // result 表示本轮真正结束，关闭消息通道让 SDK 自然调用 endInput() 关闭 stdin。
             // 子进程检测到 stdin EOF 后会退出，readMessages() 结束，iterator 返回 done:true。

--- a/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
@@ -537,6 +537,13 @@ const forceKillTimers = new Map<string, NodeJS.Timeout>()
 const FORCE_KILL_GRACE_MS = 10_000
 
 /**
+ * 后台任务挂起时，无任何活动则释放子进程的空闲上限（1 小时）。
+ * 与 SDK 自动唤醒机制的时限上界对齐：ScheduleWakeup 最长 3600s、非持久 Monitor 最长 3600000ms。
+ * 超过此窗口无任何 task_notification/活动，说明 persistent Monitor 已无事件，安全释放子进程。
+ */
+const BACKGROUND_IDLE_TIMEOUT_MS = 60 * 60 * 1000
+
+/**
  * 平台差异化强制终止：macOS/Linux 用 SIGKILL，Windows 用 taskkill /F /T 级联杀子孙
  *
  * Windows 备注：Node 的 process.kill 对原生 binary 只发 TerminateProcess，且不级联子进程，
@@ -676,9 +683,29 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
     })
     queryReadyPromises.set(options.sessionId, readyPromise)
 
+    // 后台任务等待态：本轮结束时若仍有 background_tasks/session_crons 在飞行，
+    // 保持消息通道开启（不 close），让 SDK 子进程存活、在任务完成时自动 yield
+    // task_notification 驱动新一轮 turn。idleTimer 是兜底：超过空闲上限无任何活动则释放子进程。
+    // 声明在 try 外，使 finally 也能 clearIdleTimer。
+    let backgroundTasksPending = false
+    let idleTimer: NodeJS.Timeout | null = null
+    const clearIdleTimer = (): void => {
+      if (idleTimer) { clearTimeout(idleTimer); idleTimer = null }
+    }
+
     try {
       // 动态导入 SDK
       const sdk = await import('@anthropic-ai/claude-agent-sdk')
+
+      // armIdleTimer 闭包引用下方创建的 channel，故定义在 try 内（channel 在作用域内）。
+      const armIdleTimer = (): void => {
+        clearIdleTimer()
+        idleTimer = setTimeout(() => {
+          console.warn(`[Claude 适配器] 后台任务空闲超时 (${BACKGROUND_IDLE_TIMEOUT_MS}ms)，释放子进程: ${options.sessionId}`)
+          channel.close()
+        }, BACKGROUND_IDLE_TIMEOUT_MS)
+        idleTimer.unref?.()
+      }
 
       // SDK options 构建
       const sdkOptions = {
@@ -729,6 +756,24 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
         // 强制顺序执行工具，防止并发 tool_use 导致 400 错误
         // 根因：多个 tool_use 并发时若结果未完整批量提交会触发 invalid_request_error
         toolUseConcurrency: 1,
+
+        // Stop hook 观察者：读取本轮结束时仍在飞行的后台任务/定时任务集合。
+        // background_tasks（run_in_background bash / Monitor / subagent）与 session_crons
+        // （ScheduleWakeup / CronCreate）是 SDK 权威信息，且 Stop hook 走控制协议、
+        // 在 result 消息发到 host 之前完成，故 result 处理时 backgroundTasksPending 已是最新。
+        // 仅观察、绝不返回 decision:'block'（那会强制模型继续输出）。
+        hooks: {
+          Stop: [{
+            hooks: [async (input: unknown) => {
+              const bt = (input as { background_tasks?: unknown[] }).background_tasks
+              const crons = (input as { session_crons?: unknown[] }).session_crons
+              backgroundTasksPending =
+                (Array.isArray(bt) && bt.length > 0) ||
+                (Array.isArray(crons) && crons.length > 0)
+              return { continue: true }
+            }],
+          }],
+        },
 
         // 自定义 spawn：记录 PID 以供 abort/dispose 做 force-kill 兜底（Issue #357）
         // 注意：一旦提供 spawnClaudeCodeProcess，SDK 会完全绕过 spawnLocalProcess，
@@ -812,6 +857,14 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
           }
         }
 
+        // 后台任务等待期间收到任意 task 活动消息：重置空闲计时器，避免误释放子进程。
+        if (msg.type === 'system' && idleTimer != null) {
+          const sub = msg.subtype
+          if (sub === 'task_started' || sub === 'task_progress' || sub === 'task_notification') {
+            armIdleTimer()
+          }
+        }
+
         // 捕获 result 中的 contextWindow
         if (msg.type === 'result') {
           const resultMsg = msg as {
@@ -831,10 +884,24 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
           // 注意：keep-open 场景本身就是"等待用户决策"（权限审批、Exit Plan、AskUser 等），
           // 不在此处加闲置超时——用户离开再回来继续交互是合法的，强行超时会破坏体验。
           // 若用户关闭 Tab，TabBar/GlobalShortcuts 会主动调 stopAgent → abort() 终止子进程。
-          if (!shouldKeepChannelOpen(resultMsg.terminal_reason)) {
+          const keepForReason = shouldKeepChannelOpen(resultMsg.terminal_reason)
+          // terminal_reason 无法区分"真完成"与"完成但有后台任务挂起"，
+          // 后者由 Stop hook 观察者刷新的 backgroundTasksPending 标识。
+          const keepForTasks = backgroundTasksPending
+
+          if (keepForTasks && !keepForReason) {
+            // 本轮主体结束、但仍有后台任务/定时任务在飞行：保持通道开启，
+            // 子进程存活并在任务完成时自动 yield task_notification 驱动新一轮。
+            // 给消息打注解，让 orchestrator 走"轻量完成"（UI 空闲但保留会话）而非彻底释放。
+            ;(msg as Record<string, unknown>)._keepChannelOpenForTasks = true
+            armIdleTimer()
+          } else if (keepForReason) {
+            // 既有"等待用户决策"路径（权限/ExitPlan/AskUser）：保持开启、不加空闲超时。
+          } else {
             // result 表示本轮真正结束，关闭消息通道让 SDK 自然调用 endInput() 关闭 stdin。
             // 子进程检测到 stdin EOF 后会退出，readMessages() 结束，iterator 返回 done:true。
             // 注意：prompt_suggestion 等尾部消息仍会通过 stdout 正常传递，不受影响。
+            clearIdleTimer()
             channel.close()
           }
         }
@@ -844,6 +911,7 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
     } finally {
       // 注意：pidMap 的清理由 child.on('exit') 触发，不在这里清除
       // 原因：finally 可能先于子进程真正退出执行，此时仍需保留 PID 以便 abort/dispose 兜底
+      clearIdleTimer()
       activeControllers.delete(options.sessionId)
       activeQueries.delete(options.sessionId)
       activeChannels.delete(options.sessionId)

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -68,7 +68,7 @@ export interface SessionCallbacks {
   /** 发送流式错误 */
   onError: (error: string) => void
   /** 发送流式完成（携带已持久化的消息列表） */
-  onComplete: (messages?: AgentMessage[], opts?: { stoppedByUser?: boolean; startedAt?: number; resultSubtype?: string }) => void
+  onComplete: (messages?: AgentMessage[], opts?: { stoppedByUser?: boolean; startedAt?: number; resultSubtype?: string; backgroundTasksPending?: boolean }) => void
   /** 发送标题更新 */
   onTitleUpdated: (title: string) => void
   /** 用户消息已持久化，外部入口可据此通知前端切到实时会话 */
@@ -1044,6 +1044,16 @@ export class AgentOrchestrator {
       releaseActiveRun()
       callbacks.onComplete(messages, opts)
     }
+    // 轻量完成：turn 主体结束但仍有后台任务在飞行。
+    // 关键区别——不调用 releaseActiveRun，保留 activeSessions/activeChannels/sessionPermissionModes，
+    // 以便 ① adapter 保持的通道在任务完成时自动续轮 ② 用户在等待期手动注入消息能复用通道。
+    // UI 侧通过 backgroundTasksPending 进入"空闲可输入"态（spinner 停、输入框启用）。
+    const idleComplete = (
+      messages?: AgentMessage[],
+      opts?: { startedAt?: number; resultSubtype?: string },
+    ): void => {
+      callbacks.onComplete(messages, { ...opts, backgroundTasksPending: true })
+    }
     const failRun = (
       error: string,
       messages?: AgentMessage[],
@@ -1690,6 +1700,9 @@ export class AgentOrchestrator {
           // 此 timeout 仅作安全网，防止极端情况下 iterator 仍未关闭
           let drainTimeoutPromise: Promise<'drain_timeout'> | null = null
           const RESULT_DRAIN_TIMEOUT_MS = 2_000
+          // 后台任务等待态：result 走轻量完成后置 true，下一轮真正开始（收到 assistant/user/task 消息）时
+          // 置回 false 并发 run_resumed，让 UI 从空闲态恢复运行态。
+          let awaitingBackgroundWake = false
 
           while (true) {
             if (!pendingNext) {
@@ -1719,6 +1732,17 @@ export class AgentOrchestrator {
 
             pendingNext = null
             const msg = iterResult.value
+
+            // 后台任务唤醒：轻量完成后处于等待态，收到新一轮的首条实质消息时
+            // 发 run_resumed，让 UI 从"空闲可输入"恢复到"运行中"。
+            // applyAgentEvent 的流式分支不会重置 running，故必须显式通知。
+            if (awaitingBackgroundWake) {
+              const sub = msg.type === 'system' ? (msg as { subtype?: string }).subtype : undefined
+              if (msg.type === 'assistant' || msg.type === 'user' || sub === 'task_started' || sub === 'task_progress') {
+                awaitingBackgroundWake = false
+                this.eventBus.emit(sessionId, { kind: 'proma_event', event: { type: 'run_resumed', sessionId } })
+              }
+            }
 
             // SDK 权限模式可能在 canUseTool 前直接批准工具（如 bypassPermissions）。
             // 因此计划阶段状态要从实际 tool_use 流里同步，不能只依赖权限回调。
@@ -1871,15 +1895,24 @@ export class AgentOrchestrator {
               // 等待队列或后续消息继续 drive Query，此处跳过 drain 超时以免误关闭事件循环。
               // 完整白名单见 adapters/claude-agent-adapter.ts 的 CONTINUABLE_TERMINAL_REASONS。
               const resultTerminalReason = (msg as { terminal_reason?: string }).terminal_reason
-              const keepChannelOpen = shouldKeepChannelOpen(resultTerminalReason)
+              // adapter 在"本轮结束但仍有后台任务/定时任务在飞行"时打的注解：
+              // 走轻量完成（UI 空闲可输入、host 保留会话），等待 task_notification 自动续轮。
+              const keptOpenForTasks = (msg as Record<string, unknown>)._keepChannelOpenForTasks === true
+              const keepChannelOpen = shouldKeepChannelOpen(resultTerminalReason) || keptOpenForTasks
               // 分类打点：跟踪线上哪种 terminal_reason 最常见，配合 deferred_tool_use 回填决策
               const hasDeferredTool = (msg as { deferred_tool_use?: unknown }).deferred_tool_use != null
               console.log(
                 `[Agent 编排] result 到达: sessionId=${sessionId}, subtype=${capturedResultSubtype ?? 'unknown'}, ` +
                 `terminal_reason=${resultTerminalReason ?? 'undefined'}, keepChannelOpen=${keepChannelOpen}` +
+                (keptOpenForTasks ? ', keptOpenForTasks=true' : '') +
                 (hasDeferredTool ? ', hasDeferredTool=true' : ''),
               )
-              if (!keepChannelOpen && !drainTimeoutPromise) {
+              if (keptOpenForTasks) {
+                // 轻量完成：UI 置空闲可输入，但 host 保持运行态（不 releaseActiveRun、不 break、不启动 drain 超时），
+                // while 循环继续 park 在 queryIterator.next()，等待后台任务完成时 SDK 自动 yield 的新一轮消息。
+                awaitingBackgroundWake = true
+                idleComplete(getAgentSessionMessages(sessionId), { startedAt: streamStartedAt, resultSubtype: capturedResultSubtype })
+              } else if (!keepChannelOpen && !drainTimeoutPromise) {
                 // 启动 drain 超时安全网：adapter 层 channel.close() 应让 iterator 自然关闭，
                 // 此处仅在极端情况下（如 SDK 版本不兼容）保护事件循环不无限挂起
                 drainTimeoutPromise = new Promise((resolve) =>

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -142,6 +142,7 @@ export async function runAgent(
             stoppedByUser: opts?.stoppedByUser ?? false,
             startedAt: opts?.startedAt,
             resultSubtype: opts?.resultSubtype,
+            backgroundTasksPending: opts?.backgroundTasksPending,
           })
         }
       },
@@ -226,6 +227,7 @@ export async function runAgentHeadless(
             stoppedByUser: opts?.stoppedByUser ?? false,
             startedAt: opts?.startedAt,
             resultSubtype: opts?.resultSubtype,
+            backgroundTasksPending: opts?.backgroundTasksPending,
           })
         }
       },

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -59,6 +59,11 @@ export function finalizeStreamingActivities(
 /** Agent 会话的流式状态 */
 export interface AgentStreamState {
   running: boolean
+  /**
+   * 后台任务等待态（软空闲）：本轮主体已结束、UI 可输入，但 SDK 通道仍开着等后台任务唤醒。
+   * 此状态下 running 为 false，但服务端 activeSessions 仍保留，新消息必须走注入通道而非新建 run。
+   */
+  backgroundWaiting?: boolean
   content: string
   toolActivities: ToolActivity[]
   model?: string
@@ -687,6 +692,10 @@ export function applyAgentEvent(
         retrying: undefined,
         ...finalizeStreamingActivities(prev.toolActivities),
       }
+
+    case 'run_resumed':
+      // 后台任务完成自动唤醒：从"空闲可输入"恢复到运行态（防御性，监听器已显式处理）。
+      return { ...prev, running: true, backgroundWaiting: false }
 
     case 'typed_error':
       // 处理类型化错误（TypedError）

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -310,6 +310,9 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   // atom 输出引用未变，订阅者跳过通知。
   const streamState = useAtomValue(agentSessionStreamingStateAtomFamily(sessionId))
   const streaming = streamState?.running ?? false
+  // 软空闲态：本轮主体已结束、UI 可输入，但 SDK 通道仍开着等后台任务唤醒。
+  // 此时服务端 activeSessions 仍保留，新消息须走注入通道而非新建 run。
+  const backgroundWaiting = streamState?.backgroundWaiting ?? false
   const stoppedByUserSessions = useAtomValue(stoppedByUserSessionsAtom)
   const sendWithCmdEnter = useAtomValue(sendWithCmdEnterAtom)
   const stoppedByUser = stoppedByUserSessions.has(sessionId)
@@ -667,12 +670,16 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           // 注意：保留 inputTokens/contextWindow 以维持上下文用量圆环显示
           setStreamingStates((prev) => {
             const state = prev.get(sessionId)
-            if (!state || state.running) return prev  // 仍在运行中，不清除
+            // 仍在运行中：不清除
+            if (!state || state.running) return prev
             const map = new Map(prev)
+            // 软空闲态（后台任务等待）：必须保留 backgroundWaiting 标志（否则 handleSend 误走新建 run），
+            // 但展示字段 content/toolActivities 仍要清空——否则上一轮流式文本残留会被兜底气泡渲染成重复消息。
             if (state.inputTokens !== undefined) {
               // 保留 usage 数据，仅清除流式展示字段
               map.set(sessionId, {
                 running: false,
+                backgroundWaiting: state.backgroundWaiting,
                 content: '',
                 toolActivities: [],
                 inputTokens: state.inputTokens,
@@ -681,6 +688,14 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
                 cacheCreationTokens: state.cacheCreationTokens,
                 contextWindow: state.contextWindow,
                 model: state.model,
+              })
+            } else if (state.backgroundWaiting) {
+              // 无 usage 数据但处于软空闲：保留标志，清空展示字段
+              map.set(sessionId, {
+                running: false,
+                backgroundWaiting: true,
+                content: '',
+                toolActivities: [],
               })
             } else {
               map.delete(sessionId)
@@ -1228,8 +1243,11 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       additionalDirectoriesForRun.add(dir)
     }
 
-    // 上一条消息仍在处理中，直接追加发送
-    if (streaming) {
+    // 上一条消息仍在处理中（streaming），或后台任务等待态（backgroundWaiting，通道仍开着）：
+    // 都走注入通道而非新建 run，避免被服务端并发守卫拒绝。
+    // - streaming：本轮真正进行中，注入时需先软中断当前 turn
+    // - backgroundWaiting：软空闲、无活跃 turn，直接注入即可，无需中断
+    if (streaming || backgroundWaiting) {
       // 流式追加时不处理附件（仅支持纯文本）
       if (pendingFilesSnapshot.length > 0) {
         toast.info('Agent 运行中暂不支持追加发送附件', {
@@ -1268,12 +1286,14 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         return map
       })
 
-      // 3. 异步发送到后端（立即软中断当前 turn，再注入消息作为新一轮输入）
+      // 3. 异步发送到后端，注入消息作为新一轮输入。
+      //    - streaming（本轮真正进行中）：先软中断当前 turn 再注入
+      //    - backgroundWaiting（软空闲，无活跃 turn）：直接注入，无需中断
       window.electronAPI.queueAgentMessage({
         sessionId,
         userMessage: effectiveText,
         uuid: localUuid,
-        interrupt: true,
+        interrupt: streaming,
       }).catch((error) => {
         console.error('[AgentView] 追加消息失败:', error)
         toast.error('追加消息失败', { description: String(error) })
@@ -1518,7 +1538,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         return map
       })
     })
-  }, [inputContent, attachedDirs, attachedFileDirectories, sessionId, agentChannelId, agentModelId, currentWorkspaceId, workspaces, streaming, suggestion, hasAvailableModel, store, setStreamingStates, setPendingFiles, setAgentStreamErrors, setPromptSuggestions, setInputContent, setLiveMessagesMap, permissionMode, messagesLoaded])
+  }, [inputContent, attachedDirs, attachedFileDirectories, sessionId, agentChannelId, agentModelId, currentWorkspaceId, workspaces, streaming, backgroundWaiting, suggestion, hasAvailableModel, store, setStreamingStates, setPendingFiles, setAgentStreamErrors, setPromptSuggestions, setInputContent, setLiveMessagesMap, permissionMode, messagesLoaded])
 
   /** 停止生成 */
   const handleStop = React.useCallback((): void => {

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -263,6 +263,11 @@ export interface AssistantTurn {
   model?: string
   /** 创建时间（取首条 assistant 消息的时间） */
   createdAt?: number
+  /**
+   * 该 turn 由后台任务完成通知（task_notification）唤醒后开始。
+   * 用于阻断与前一 turn 的合并，让自动唤醒的新输出独立成块，而不是被追加进上一轮的消息块。
+   */
+  startsAfterWake?: boolean
 }
 
 export type MessageGroup =
@@ -283,6 +288,10 @@ export type MessageGroup =
 export function groupIntoTurns(messages: SDKMessage[], sessionModelId?: string): MessageGroup[] {
   const groups: MessageGroup[] = []
   let currentTurn: AssistantTurn | null = null
+  // 收到后台任务完成通知（task_notification）后，若没有用户输入就直接出现新的 assistant 输出，
+  // 说明这是自动唤醒的新一轮，应另起独立消息块，而不是续接上一轮。
+  // 注意：不能用 result 做信号——正常对话每轮也以 result 结束，会误伤普通回复。
+  let pendingWakeBoundary = false
 
   const flushTurn = (): void => {
     if (currentTurn && currentTurn.assistantMessages.length > 0) {
@@ -298,6 +307,7 @@ export function groupIntoTurns(messages: SDKMessage[], sessionModelId?: string):
         // 真正的用户输入 → 结束当前 turn，开始新段落
         flushTurn()
         groups.push({ type: 'user', message: userMsg })
+        pendingWakeBoundary = false
       } else {
         // tool_result 消息 → 归入当前 turn
         if (currentTurn) {
@@ -318,7 +328,10 @@ export function groupIntoTurns(messages: SDKMessage[], sessionModelId?: string):
           turnMessages: [msg],
           model: aMsg._channelModelId || aMsg.message?.model || sessionModelId,
           createdAt: meta.createdAt,
+          // 紧跟在后台任务唤醒之后的新 turn：阻断与上一轮的合并
+          startsAfterWake: pendingWakeBoundary || undefined,
         }
+        pendingWakeBoundary = false
       } else {
         // 继续当前 turn
         currentTurn.assistantMessages.push(aMsg)
@@ -333,6 +346,12 @@ export function groupIntoTurns(messages: SDKMessage[], sessionModelId?: string):
         groups.push({ type: 'system', message: sysMsg })
       } else if (currentTurn) {
         currentTurn.turnMessages.push(msg)
+        // 后台任务完成通知：标志一次自动唤醒。当前 turn 收尾后，
+        // 后续新出现的 assistant 输出应独立成块。
+        if (sysMsg.subtype === 'task_notification') {
+          flushTurn()
+          pendingWakeBoundary = true
+        }
       }
     } else {
       // result, tool_progress 等 → 归入当前 turn
@@ -364,6 +383,12 @@ function mergeAdjacentSameModelTurns(groups: MessageGroup[]): MessageGroup[] {
 
   for (const group of groups) {
     if (group.type !== 'assistant-turn') {
+      result.push(group)
+      continue
+    }
+
+    // 后台任务唤醒后开始的 turn：独立成块，不向前合并。
+    if (group.startsAfterWake) {
       result.push(group)
       continue
     }

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -149,6 +149,8 @@ function payloadToLegacyEvents(payload: AgentStreamPayload): AgentEvent[] {
         return [{ type: 'model_resolved', model: evt.model }]
       case 'permission_mode_changed':
         return [{ type: 'permission_mode_changed', mode: evt.mode }]
+      case 'run_resumed':
+        return [{ type: 'run_resumed' }]
       case 'retry': {
         const events: AgentEvent[] = []
         if (evt.status === 'starting' && evt.attempt != null && evt.maxAttempts != null) {
@@ -894,6 +896,15 @@ export function useGlobalAgentListeners(): void {
             store.set(agentPlanModeSessionsAtom, (prev: Set<string>) =>
               updatePlanModeSessionSet(prev, sessionId, event.mode === 'plan')
             )
+          } else if (event.type === 'run_resumed') {
+            // 后台任务完成自动唤醒：从"空闲可输入"恢复到"运行中"。
+            store.set(agentStreamingStatesAtom, (prev) => {
+              const current = prev.get(sessionId)
+              if (!current || current.running) return prev
+              const map = new Map(prev)
+              map.set(sessionId, { ...current, running: true })
+              return map
+            })
           }
         }
         }) // unstable_batchedUpdates
@@ -905,22 +916,28 @@ export function useGlobalAgentListeners(): void {
       (data: AgentStreamCompletePayload) => {
         console.log(`[FLASH-DEBUG] STREAM_COMPLETE for session=${data.sessionId.slice(0, 8)}, stoppedByUser=${data.stoppedByUser}, resultSubtype=${data.resultSubtype}`)
         unstable_batchedUpdates(() => {
+        // 后台任务等待态：turn 主体结束但仍有后台任务在飞行，UI 进入"空闲可输入"。
+        // 不发"任务已完成"通知（任务并未真正完成）、不清后台任务列表、不重载消息——
+        // 等后台任务完成时 Agent 会自动唤醒续轮。
+        const backgroundTasksPending = data.backgroundTasksPending === true
         // 发送桌面通知（任务完成，始终播放提示音）
         const enabled = store.get(notificationsEnabledAtom)
         const soundEnabled = store.get(notificationSoundEnabledAtom)
         const sounds = store.get(notificationSoundsAtom)
         const sessionTitle = getSessionTitle(data.sessionId)
-        sendDesktopNotification(
-          'Agent 任务完成',
-          `[${sessionTitle}] 任务已完成`,
-          enabled,
-          {
-            playSound: enabled && soundEnabled,
-            soundType: 'taskComplete',
-            sounds,
-            onNavigate: makeNavigateToSession(data.sessionId, sessionTitle),
-          }
-        )
+        if (!backgroundTasksPending) {
+          sendDesktopNotification(
+            'Agent 任务完成',
+            `[${sessionTitle}] 任务已完成`,
+            enabled,
+            {
+              playSound: enabled && soundEnabled,
+              soundType: 'taskComplete',
+              sounds,
+              onNavigate: makeNavigateToSession(data.sessionId, sessionTitle),
+            }
+          )
+        }
 
         // STREAM_COMPLETE 表示后端已完全结束 — 立即标记 running: false
         // 同时将所有未完成的工具活动标记为已完成，防止 subagent spinner 继续转动
@@ -928,7 +945,10 @@ export function useGlobalAgentListeners(): void {
         // 竞态保护：通过 startedAt 区分新旧流，防止旧流的 complete 事件重置新流的 running 状态
         store.set(agentStreamingStatesAtom, (prev) => {
           const current = prev.get(data.sessionId)
-          if (!current || !current.running) {
+          // 既非运行中、也非软空闲态 → 已彻底结束，忽略重复/陈旧的完成事件。
+          // 软空闲态（running=false 但 backgroundWaiting=true）也要处理：空闲超时/用户停止
+          // 触发的真正完成会带 backgroundTasksPending=false，需借此清除 backgroundWaiting。
+          if (!current || (!current.running && !current.backgroundWaiting)) {
             return prev
           }
           if (current.startedAt != null && (data.startedAt == null || current.startedAt > data.startedAt)) {
@@ -938,6 +958,9 @@ export function useGlobalAgentListeners(): void {
           map.set(data.sessionId, {
             ...current,
             running: false,
+            // backgroundTasksPending=true → 进入/保持软空闲态（通道仍开着，handleSend 走注入路径）；
+            // false → 真正结束，清除软空闲态，新消息回到新建 run 路径。
+            backgroundWaiting: backgroundTasksPending,
             ...finalizeStreamingActivities(current.toolActivities),
           })
           return map
@@ -952,7 +975,7 @@ export function useGlobalAgentListeners(): void {
           sessionId: data.sessionId,
           documentHasFocus: document.hasFocus(),
         })
-        if (completionMarkers.markUnviewedCompleted) {
+        if (completionMarkers.markUnviewedCompleted && !backgroundTasksPending) {
           store.set(unviewedCompletedSessionIdsAtom, (prev: Set<string>) => {
             const next = new Set(prev)
             next.add(data.sessionId)
@@ -1006,6 +1029,10 @@ export function useGlobalAgentListeners(): void {
         const finalize = (): void => {
           // 竞态保护：新流已启动时不要清理状态
           if (isNewStreamRunning()) return
+
+          // 后台任务等待态：保留后台任务列表（面板继续显示在跑任务），不做收尾清理，
+          // 等任务完成 Agent 自动唤醒续轮后再走真正的完成路径。
+          if (backgroundTasksPending) return
 
           // 清理后台任务
           store.set(backgroundTasksAtomFamily(data.sessionId), [])

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -512,6 +512,7 @@ export type AgentEvent =
   | { type: 'tool_use_summary'; summary: string; precedingToolUseIds: string[] }
   // 控制流
   | { type: 'complete'; stopReason?: string; usage?: AgentEventUsage }
+  | { type: 'run_resumed' }
   | { type: 'error'; message: string }
   | { type: 'typed_error'; error: TypedError }
   // 重试机制
@@ -561,6 +562,7 @@ export type PromaEvent =
   | { type: 'permission_mode_changed'; mode: PromaPermissionMode }
   | { type: 'title_updated'; title: string }
   | { type: 'external_run_started'; source: AgentExternalRunSource; sessionId: string; title?: string; workspaceId?: string; modelId?: string; startedAt: number }
+  | { type: 'run_resumed'; sessionId: string }
 
 /** 外部入口触发 Agent 运行的来源 */
 export type AgentExternalRunSource = 'feishu' | 'dingtalk' | 'wechat' | 'bridge'
@@ -974,6 +976,8 @@ export interface AgentStreamCompletePayload {
   startedAt?: number
   /** SDK result 消息的 subtype（success / error_max_turns / error_max_budget_usd / error_during_execution 等） */
   resultSubtype?: string
+  /** 本轮主体结束但仍有后台任务/定时任务在飞行：UI 进入"空闲可输入"态，等待任务完成自动唤醒 */
+  backgroundTasksPending?: boolean
 }
 
 // ===== 文件浏览器 =====


### PR DESCRIPTION
## Summary

修复 Agent 模式下后台任务（`run_in_background`）/ Monitor 完成时无法自动唤醒已结束当前轮次的 Agent 的问题。根因是收到 `result` 后立即 `channel.close()` 导致 SDK 子进程退出，唤醒通知（`task_notification`）无处送达。

## 改动

- **adapter**：用 SDK Stop hook 观察 `background_tasks`/`session_crons`，仍有任务在飞行时保持消息通道开启；加 1 小时空闲超时兜底释放子进程（覆盖 persistent Monitor 场景）
- **orchestrator**：拆出"轻量完成"——UI 置空闲可输入但保留会话（不 `releaseActiveRun`），等任务完成 SDK 自动续轮；唤醒时发 `run_resumed` 事件让 UI 恢复运行态
- **renderer**：软空闲态（`backgroundWaiting`）支持继续注入消息，复用已开启的通道而非新建 run；修复消息加载 effect 误清 `backgroundWaiting` 标志 / 残留 content 导致的重复气泡
- **分组**：以 `task_notification` 为边界，让唤醒后的输出独立成消息块，不续接进上一轮、不被合并
- **dev:kill**：新增 `--vite` 模式清理占用端口的残留 vite 进程，并接入顶层 `dev` 脚本（concurrently 启动前执行一次）

## Test plan

- [ ] 后台任务（如 `sleep 60`）跑着、本轮结束后，输入框可用且后台任务面板持续显示
- [ ] 后台任务完成后 Agent 自动唤醒续跑，无需手动发消息
- [ ] 软空闲期间发消息能正常注入并立即响应，不报"上一条消息仍在处理中"
- [ ] 唤醒输出独立成块，普通连续对话不被误拆成两块（回归）
- [ ] 后台任务等待期间同一条回复只渲染一次（无重复气泡）
- [ ] persistent Monitor 长时间无事件后约 1 小时空闲超时释放子进程
- [ ] 权限审批 / Exit Plan / AskUser 等既有 keep-open 场景行为不变
- [ ] `bun run dev` 端口被残留 vite 占用时能自动清理并正常启动

🤖 Generated with [Claude Code](https://claude.com/claude-code)