### PR TITLE
[WIP] feat(sidebar): 工作区双形态选择器 + 置顶标签常驻（每工作区单约束）+ 项目排序 + 排版统一

### DIFF
--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -1005,4 +1005,4 @@ export const stoppedByUserSessionsAtom = atom<Set<string>>(new Set<string>())
 export const agentSettingsReadyAtom = atom(false)
 
 /** AgentSettings 内部激活的 Tab（skills / workspaces / mcp / tools） */
-export const agentSettingsTabAtom = atom<string>('skills')
+export const agentSettingsTabAtom = atom<string>('workspaces')

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -1003,3 +1003,6 @@ export const stoppedByUserSessionsAtom = atom<Set<string>>(new Set<string>())
 
 /** AgentSettingsInitializer 是否已完成加载（渠道/工作区/设置全部就绪） */
 export const agentSettingsReadyAtom = atom(false)
+
+/** AgentSettings 内部激活的 Tab（skills / workspaces / mcp / tools） */
+export const agentSettingsTabAtom = atom<string>('skills')

--- a/apps/electron/src/renderer/atoms/sidebar-atoms.ts
+++ b/apps/electron/src/renderer/atoms/sidebar-atoms.ts
@@ -5,16 +5,9 @@
  */
 
 import { atom } from 'jotai'
-import { atomWithStorage } from 'jotai/utils'
 
 /** 侧边栏视图模式 */
 export type SidebarViewMode = 'active' | 'archived'
 
 /** 侧边栏视图模式（active = 显示活跃对话，archived = 显示已归档对话） */
 export const sidebarViewModeAtom = atom<SidebarViewMode>('active')
-
-/** 项目列表高度（px），用户可拖拽调整，持久化到 localStorage */
-export const projectListHeightAtom = atomWithStorage<number>(
-  'proma-workspace-list-height',
-  120,
-)

--- a/apps/electron/src/renderer/atoms/sidebar-atoms.ts
+++ b/apps/electron/src/renderer/atoms/sidebar-atoms.ts
@@ -1,13 +1,29 @@
 /**
  * 侧边栏状态 Atoms
  *
- * 管理侧边栏视图模式（活跃 / 已归档）。
+ * 管理侧边栏视图模式（活跃 / 已归档）、项目列表展示形态、项目列表高度。
  */
 
 import { atom } from 'jotai'
+import { atomWithStorage } from 'jotai/utils'
 
 /** 侧边栏视图模式 */
 export type SidebarViewMode = 'active' | 'archived'
 
 /** 侧边栏视图模式（active = 显示活跃对话，archived = 显示已归档对话） */
 export const sidebarViewModeAtom = atom<SidebarViewMode>('active')
+
+/** 项目列表展示形态：下拉选择器 / 垂直列表 */
+export type WorkspaceListMode = 'dropdown' | 'list'
+
+/** 项目列表展示形态（持久化到 localStorage） */
+export const workspaceListModeAtom = atomWithStorage<WorkspaceListMode>(
+  'proma-workspace-list-mode',
+  'dropdown',
+)
+
+/** 项目垂直列表高度（仅 list 形态使用，持久化到 localStorage） */
+export const projectListHeightAtom = atomWithStorage<number>(
+  'proma-workspace-list-height',
+  120,
+)

--- a/apps/electron/src/renderer/atoms/tab-atoms.ts
+++ b/apps/electron/src/renderer/atoms/tab-atoms.ts
@@ -174,7 +174,7 @@ export const tabIndicatorMapAtom = atom<Map<string, SessionIndicatorStatus>>((ge
 
 // ===== 操作函数 =====
 
-function createScratchPadTab(): TabItem {
+export function createScratchPadTab(): TabItem {
   return {
     id: SCRATCH_PAD_ID,
     type: 'scratch',
@@ -250,7 +250,6 @@ export function openTab(
 
   if (item.type === 'preview') {
     const ownerAgentTab = tabs.find((t) => t.type === 'agent' && t.sessionId === item.sessionId)
-      ?? pinnedTabs.find((t) => t.type === 'agent' && t.sessionId === item.sessionId)
       ?? {
           id: item.sessionId,
           type: 'agent' as const,
@@ -387,9 +386,5 @@ export function ensureScratchPadTab(tabs: TabItem[]): TabItem[] {
   const scratchTab = tabs.find((t) => t.id === SCRATCH_PAD_ID) ?? createScratchPadTab()
   const pinnedTabs = tabs.filter((t) => t.pinned)
   const sessionTab = tabs.filter((t) => !t.pinned && t.id !== SCRATCH_PAD_ID && !isPreviewTab(t)).at(-1)
-  if (scratchTab) {
-    return sessionTab ? [scratchTab, ...pinnedTabs, sessionTab] : [scratchTab, ...pinnedTabs]
-  }
-  const newTab = createScratchPadTab()
-  return sessionTab ? [newTab, ...pinnedTabs, sessionTab] : [newTab, ...pinnedTabs]
+  return sessionTab ? [scratchTab, ...pinnedTabs, sessionTab] : [scratchTab, ...pinnedTabs]
 }

--- a/apps/electron/src/renderer/atoms/tab-atoms.ts
+++ b/apps/electron/src/renderer/atoms/tab-atoms.ts
@@ -234,7 +234,7 @@ export function getPersistableTabState(
  *  restore 提示存在时，切回带预览的会话会一并重建其预览 Tab 并回到上次视图。 */
 export function openTab(
   tabs: TabItem[],
-  item: { type: TabType; sessionId: string; title: string },
+  item: { type: TabType; sessionId: string; title: string; workspaceId?: string },
   restore?: OpenTabRestore,
 ): { tabs: TabItem[]; activeTabId: string } {
   const scratchTab = tabs.find((t) => t.id === SCRATCH_PAD_ID) ?? createScratchPadTab()
@@ -260,6 +260,7 @@ export function openTab(
           type: 'agent' as const,
           sessionId: item.sessionId,
           title: 'Agent 会话',
+          workspaceId: item.workspaceId,
         }
     const previewTab: TabItem = {
       id: createPreviewTabId(item.sessionId),
@@ -280,6 +281,7 @@ export function openTab(
     type: item.type,
     sessionId: item.sessionId,
     title: item.title,
+    workspaceId: item.workspaceId,
   }
 
   // 切回带预览的会话：重建该会话的预览 Tab，并按 lastView 决定激活哪个。

--- a/apps/electron/src/renderer/atoms/tab-atoms.ts
+++ b/apps/electron/src/renderer/atoms/tab-atoms.ts
@@ -43,6 +43,8 @@ export interface TabItem {
   sessionId: string
   /** 标签页显示标题 */
   title: string
+  /** 置顶标签：常驻显示，不可手动关闭，只能取消置顶移除 */
+  pinned?: boolean
 }
 
 /** Tab 持久化数据（保存到 settings.json） */
@@ -223,7 +225,7 @@ export function getPersistableTabState(
   }
 }
 
-/** 打开或聚焦会话入口：始终用目标会话替换当前会话，避免顶部累积多个 Tab。
+/** 打开或聚焦会话入口：置顶标签常驻，非置顶会话标签替换。
  *  restore 提示存在时，切回带预览的会话会一并重建其预览 Tab 并回到上次视图。 */
 export function openTab(
   tabs: TabItem[],
@@ -231,21 +233,30 @@ export function openTab(
   restore?: OpenTabRestore,
 ): { tabs: TabItem[]; activeTabId: string } {
   const scratchTab = tabs.find((t) => t.id === SCRATCH_PAD_ID) ?? createScratchPadTab()
+  const pinnedTabs = tabs.filter((t) => t.pinned && t.id !== SCRATCH_PAD_ID)
 
   if (item.type === 'scratch') {
     return {
-      tabs: [scratchTab],
+      tabs: [scratchTab, ...pinnedTabs],
       activeTabId: SCRATCH_PAD_ID,
     }
   }
 
+  // 如果目标会话已有置顶标签，直接激活它
+  const existingPinned = pinnedTabs.find((t) => t.sessionId === item.sessionId)
+  if (existingPinned) {
+    return { tabs, activeTabId: existingPinned.id }
+  }
+
   if (item.type === 'preview') {
-    const ownerAgentTab = tabs.find((t) => t.type === 'agent' && t.sessionId === item.sessionId) ?? {
-      id: item.sessionId,
-      type: 'agent' as const,
-      sessionId: item.sessionId,
-      title: 'Agent 会话',
-    }
+    const ownerAgentTab = tabs.find((t) => t.type === 'agent' && t.sessionId === item.sessionId)
+      ?? pinnedTabs.find((t) => t.type === 'agent' && t.sessionId === item.sessionId)
+      ?? {
+          id: item.sessionId,
+          type: 'agent' as const,
+          sessionId: item.sessionId,
+          title: 'Agent 会话',
+        }
     const previewTab: TabItem = {
       id: createPreviewTabId(item.sessionId),
       type: 'preview',
@@ -254,12 +265,12 @@ export function openTab(
     }
 
     return {
-      tabs: [scratchTab, ownerAgentTab, previewTab],
+      tabs: [scratchTab, ...pinnedTabs, ownerAgentTab, previewTab],
       activeTabId: previewTab.id,
     }
   }
 
-  const existingTab = tabs.find((t) => t.sessionId === item.sessionId && t.type === item.type)
+  const existingTab = tabs.find((t) => t.sessionId === item.sessionId && t.type === item.type && !t.pinned)
   const sessionTab: TabItem = existingTab ?? {
     id: item.sessionId,
     type: item.type,
@@ -276,13 +287,13 @@ export function openTab(
       title: restore.previewTitle,
     }
     return {
-      tabs: [scratchTab, sessionTab, previewTab],
+      tabs: [scratchTab, ...pinnedTabs, sessionTab, previewTab],
       activeTabId: restore.lastView === 'preview' ? previewTab.id : sessionTab.id,
     }
   }
 
   return {
-    tabs: [scratchTab, sessionTab],
+    tabs: [scratchTab, ...pinnedTabs, sessionTab],
     activeTabId: sessionTab.id,
   }
 }
@@ -307,7 +318,7 @@ export function buildOpenTabRestore(
   }
 }
 
-/** 关闭标签页（scratch tab 不可关闭） */
+/** 关闭标签页（scratch tab 和置顶标签不可关闭） */
 export function closeTab(
   tabs: TabItem[],
   activeTabId: string | null,
@@ -315,6 +326,10 @@ export function closeTab(
 ): { tabs: TabItem[]; activeTabId: string | null } {
   // Scratch Pad 不可关闭
   if (tabId === SCRATCH_PAD_ID) return { tabs, activeTabId }
+
+  // 置顶标签不可关闭
+  const target = tabs.find((t) => t.id === tabId)
+  if (target?.pinned) return { tabs, activeTabId }
 
   const tabIndex = tabs.findIndex((t) => t.id === tabId)
   if (tabIndex === -1) return { tabs, activeTabId }
@@ -337,7 +352,7 @@ export function closeTab(
   return { tabs: newTabs, activeTabId: newActiveTabId }
 }
 
-/** 重排标签顺序（当前只保留 Scratch + 当前会话，保留函数用于兼容旧调用） */
+/** 重排标签顺序（Scratch 不可移出第 0 位，置顶标签不可拖拽） */
 export function reorderTabs(
   tabs: TabItem[],
   fromIndex: number,
@@ -346,6 +361,10 @@ export function reorderTabs(
   if (fromIndex === toIndex) return tabs
   // Scratch 不可移出第 0 位
   if (tabs[0]?.id === SCRATCH_PAD_ID && (fromIndex === 0 || toIndex === 0)) return tabs
+  // 置顶标签不可移动
+  const movingTab = tabs[fromIndex]
+  const targetTab = tabs[toIndex]
+  if (movingTab?.pinned || targetTab?.pinned) return tabs
   const newTabs = [...tabs]
   const [moved] = newTabs.splice(fromIndex, 1)
   newTabs.splice(toIndex, 0, moved!)
@@ -363,13 +382,14 @@ export function updateTabTitle(
   )
 }
 
-/** 确保 Scratch Pad 标签存在并位于首位，同时只保留一个会话入口 */
+/** 确保 Scratch Pad 标签存在并位于首位，同时保留置顶标签和唯一非置顶会话入口 */
 export function ensureScratchPadTab(tabs: TabItem[]): TabItem[] {
-  const scratchTab = tabs.find((t) => t.id === SCRATCH_PAD_ID)
-  const sessionTab = tabs.filter((t) => t.id !== SCRATCH_PAD_ID && !isPreviewTab(t)).at(-1)
+  const scratchTab = tabs.find((t) => t.id === SCRATCH_PAD_ID) ?? createScratchPadTab()
+  const pinnedTabs = tabs.filter((t) => t.pinned)
+  const sessionTab = tabs.filter((t) => !t.pinned && t.id !== SCRATCH_PAD_ID && !isPreviewTab(t)).at(-1)
   if (scratchTab) {
-    return sessionTab ? [scratchTab, sessionTab] : [scratchTab]
+    return sessionTab ? [scratchTab, ...pinnedTabs, sessionTab] : [scratchTab, ...pinnedTabs]
   }
   const newTab = createScratchPadTab()
-  return sessionTab ? [newTab, sessionTab] : [newTab]
+  return sessionTab ? [newTab, ...pinnedTabs, sessionTab] : [newTab, ...pinnedTabs]
 }

--- a/apps/electron/src/renderer/atoms/tab-atoms.ts
+++ b/apps/electron/src/renderer/atoms/tab-atoms.ts
@@ -351,7 +351,7 @@ export function closeTab(
   return { tabs: newTabs, activeTabId: newActiveTabId }
 }
 
-/** 重排标签顺序（Scratch 不可移出第 0 位，置顶标签不可拖拽） */
+/** 重排标签顺序（Scratch 不可移出第 0 位，置顶标签只能在置顶区域内移动） */
 export function reorderTabs(
   tabs: TabItem[],
   fromIndex: number,
@@ -360,10 +360,15 @@ export function reorderTabs(
   if (fromIndex === toIndex) return tabs
   // Scratch 不可移出第 0 位
   if (tabs[0]?.id === SCRATCH_PAD_ID && (fromIndex === 0 || toIndex === 0)) return tabs
-  // 置顶标签不可移动
   const movingTab = tabs[fromIndex]
   const targetTab = tabs[toIndex]
-  if (movingTab?.pinned || targetTab?.pinned) return tabs
+  if (!movingTab) return tabs
+  // 置顶标签只能在置顶区域内互相移动
+  if (movingTab.pinned) {
+    if (!targetTab?.pinned) return tabs // 不能拖到非置顶区域
+  } else if (targetTab?.pinned) {
+    return tabs // 非置顶标签不能拖到置顶区域
+  }
   const newTabs = [...tabs]
   const [moved] = newTabs.splice(fromIndex, 1)
   newTabs.splice(toIndex, 0, moved!)

--- a/apps/electron/src/renderer/atoms/tab-atoms.ts
+++ b/apps/electron/src/renderer/atoms/tab-atoms.ts
@@ -27,6 +27,9 @@ export type TabType = 'chat' | 'agent' | 'scratch' | 'preview'
 /** Scratch Pad 专用的固定 sessionId */
 export const SCRATCH_PAD_ID = '__scratch-pad__'
 
+/** Chat 置顶标签的 workspaceId 标识（Chat 无工作区概念，用此常量统一处理单置顶约束） */
+export const CHAT_WORKSPACE_ID = '__chat__'
+
 /** 会话预览 Tab 的 ID 前缀：运行时临时入口，不参与持久化 */
 const PREVIEW_TAB_PREFIX = '__preview__:'
 
@@ -45,6 +48,8 @@ export interface TabItem {
   title: string
   /** 置顶标签：常驻显示，不可手动关闭，只能取消置顶移除 */
   pinned?: boolean
+  /** 置顶标签所属工作区 ID（agent 类型），或 '__chat__'（chat 类型）。用于每工作区单置顶约束 */
+  workspaceId?: string
 }
 
 /** Tab 持久化数据（保存到 settings.json） */

--- a/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
@@ -1,13 +1,13 @@
 /**
- * WorkspaceSelector — Agent 项目切换器
+ * WorkspaceSelector — Agent 项目下拉选择器
  *
- * 垂直列表展示所有项目，支持新建、重命名、删除、切换和拖拽排序。
- * 切换项目后持久化到底层 workspace 设置。
+ * 使用 DropdownMenu 展示所有项目，支持切换、新建、重命名、删除。
+ * 排序功能将在设置页中提供。
  */
 
 import * as React from 'react'
 import { useAtom } from 'jotai'
-import { FolderOpen, Plus, Pencil, Trash2, GripVertical } from 'lucide-react'
+import { Check, FolderOpen, MoreHorizontal, Pencil, Plus, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
 import {
@@ -20,136 +20,91 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
-import { projectListHeightAtom } from '@/atoms/sidebar-atoms'
-import { useProjectActions } from '@/hooks/useProjectActions'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import { agentSessionsAtom, agentWorkspacesAtom } from '@/atoms/agent-atoms'
+import { useProjectActions } from '@/hooks/useProjectActions'
 import type { AgentWorkspace } from '@proma/shared'
 
 export function WorkspaceSelector(): React.ReactElement {
   const { workspaces, currentWorkspaceId, selectProject, createProject } = useProjectActions()
   const [, setWorkspaces] = useAtom(agentWorkspacesAtom)
   const [, setAgentSessions] = useAtom(agentSessionsAtom)
-  const [listHeight, setListHeight] = useAtom(projectListHeightAtom)
 
-  // 高度拖拽调整
-  const listRef = React.useRef<HTMLDivElement>(null)
-  const resizing = React.useRef(false)
-  const startY = React.useRef(0)
-  const startH = React.useRef(0)
-  const cleanupResizeRef = React.useRef<(() => void) | null>(null)
+  const currentWorkspace = workspaces.find((w) => w.id === currentWorkspaceId)
 
-  React.useEffect(() => {
-    return () => { cleanupResizeRef.current?.() }
-  }, [])
-
-  const handleResizeStart = React.useCallback(
-    (e: React.MouseEvent) => {
-      e.preventDefault()
-      resizing.current = true
-      startY.current = e.clientY
-      // 用实际渲染高度作为起点，避免 maxHeight > 实际高度时不跟手
-      startH.current = listRef.current?.getBoundingClientRect().height ?? 120
-
-      const onMove = (ev: MouseEvent): void => {
-        if (!resizing.current) return
-        const delta = ev.clientY - startY.current
-        const next = Math.min(400, Math.max(80, startH.current + delta))
-        setListHeight(next)
-      }
-      const onUp = (): void => {
-        resizing.current = false
-        document.removeEventListener('mousemove', onMove)
-        document.removeEventListener('mouseup', onUp)
-        document.body.style.cursor = ''
-        document.body.style.userSelect = ''
-        cleanupResizeRef.current = null
-      }
-      document.addEventListener('mousemove', onMove)
-      document.addEventListener('mouseup', onUp)
-      document.body.style.cursor = 'row-resize'
-      document.body.style.userSelect = 'none'
-      cleanupResizeRef.current = onUp
-    },
-    [setListHeight],
-  )
-
-  // 新建状态
-  const [creating, setCreating] = React.useState(false)
-  const [newName, setNewName] = React.useState('')
+  // 新建项目 Dialog
+  const [createOpen, setCreateOpen] = React.useState(false)
+  const [createName, setCreateName] = React.useState('')
   const createInputRef = React.useRef<HTMLInputElement>(null)
 
-  // 重命名状态
-  const [editingId, setEditingId] = React.useState<string | null>(null)
-  const [editName, setEditName] = React.useState('')
-  const editInputRef = React.useRef<HTMLInputElement>(null)
+  // 重命名项目 Dialog
+  const [renameTarget, setRenameTarget] = React.useState<AgentWorkspace | null>(null)
+  const [renameName, setRenameName] = React.useState('')
+  const renameInputRef = React.useRef<HTMLInputElement>(null)
 
-  // 删除确认状态
+  // 删除确认
   const [deleteTargetId, setDeleteTargetId] = React.useState<string | null>(null)
-
-  // 拖拽状态
-  const [dragId, setDragId] = React.useState<string | null>(null)
-  const [dropIndicator, setDropIndicator] = React.useState<{ id: string; position: 'before' | 'after' } | null>(null)
-
-  /** 切换项目 */
-  const handleSelect = (workspace: AgentWorkspace): void => {
-    if (editingId) return
-    selectProject(workspace.id)
-  }
 
   // ===== 新建 =====
 
-  const handleStartCreate = (): void => {
-    setCreating(true)
-    setNewName('')
-    requestAnimationFrame(() => {
-      createInputRef.current?.focus()
-    })
-  }
-
   const handleCreate = async (): Promise<void> => {
-    await createProject(newName)
-    setCreating(false)
+    const result = await createProject(createName)
+    if (result) {
+      setCreateOpen(false)
+      setCreateName('')
+    }
   }
 
   const handleCreateKeyDown = (e: React.KeyboardEvent): void => {
     if (e.key === 'Enter') {
       if (e.nativeEvent.isComposing) return
       e.preventDefault()
-      handleCreate()
+      void handleCreate()
     } else if (e.key === 'Escape') {
-      setCreating(false)
+      setCreateOpen(false)
     }
   }
 
   // ===== 重命名 =====
 
-  const handleStartRename = (e: React.MouseEvent, ws: AgentWorkspace): void => {
-    e.stopPropagation()
-    setEditingId(ws.id)
-    setEditName(ws.name)
+  const handleStartRename = (ws: AgentWorkspace): void => {
+    setRenameTarget(ws)
+    setRenameName(ws.name)
     requestAnimationFrame(() => {
-      editInputRef.current?.focus()
-      editInputRef.current?.select()
+      renameInputRef.current?.focus()
+      renameInputRef.current?.select()
     })
   }
 
   const handleRename = async (): Promise<void> => {
-    if (!editingId) return
-    const trimmed = editName.trim()
-
-    if (!trimmed) {
-      setEditingId(null)
+    if (!renameTarget) return
+    const trimmed = renameName.trim()
+    if (!trimmed || trimmed === renameTarget.name) {
+      setRenameTarget(null)
       return
     }
 
     try {
-      const updated = await window.electronAPI.updateAgentWorkspace(editingId, { name: trimmed })
+      const updated = await window.electronAPI.updateAgentWorkspace(renameTarget.id, { name: trimmed })
       setWorkspaces((prev) => prev.map((w) => (w.id === updated.id ? updated : w)))
     } catch (error) {
       const msg = error instanceof Error ? error.message : '重命名失败'
       toast.error(msg)
     } finally {
-      setEditingId(null)
+      setRenameTarget(null)
     }
   }
 
@@ -157,18 +112,13 @@ export function WorkspaceSelector(): React.ReactElement {
     if (e.key === 'Enter') {
       if (e.nativeEvent.isComposing) return
       e.preventDefault()
-      handleRename()
+      void handleRename()
     } else if (e.key === 'Escape') {
-      setEditingId(null)
+      setRenameTarget(null)
     }
   }
 
   // ===== 删除 =====
-
-  const handleStartDelete = (e: React.MouseEvent, wsId: string): void => {
-    e.stopPropagation()
-    setDeleteTargetId(wsId)
-  }
 
   const handleConfirmDelete = async (): Promise<void> => {
     if (!deleteTargetId) return
@@ -197,196 +147,141 @@ export function WorkspaceSelector(): React.ReactElement {
     return ws.slug !== 'default' && workspaces.length > 1
   }
 
-  // ===== 拖拽排序 =====
-
-  const handleDragStart = (e: React.DragEvent, wsId: string): void => {
-    setDragId(wsId)
-    e.dataTransfer.effectAllowed = 'move'
-    e.dataTransfer.setData('text/plain', wsId)
-  }
-
-  const handleDragOver = (e: React.DragEvent, wsId: string): void => {
-    e.preventDefault()
-    e.dataTransfer.dropEffect = 'move'
-    if (!dragId || wsId === dragId) {
-      setDropIndicator(null)
-      return
-    }
-    // 根据鼠标在目标元素的上半/下半部分决定插入位置
-    // 中线附近 30% 区域为死区，避免鼠标抖动导致横线闪烁
-    const rect = e.currentTarget.getBoundingClientRect()
-    const ratio = (e.clientY - rect.top) / rect.height
-    let position: 'before' | 'after'
-    if (ratio < 0.35) {
-      position = 'before'
-    } else if (ratio > 0.65) {
-      position = 'after'
-    } else {
-      // 死区内保持当前方向不变
-      if (dropIndicator?.id === wsId) return
-      position = ratio < 0.5 ? 'before' : 'after'
-    }
-    // 仅在状态变化时更新，减少不必要的重渲染
-    if (dropIndicator?.id === wsId && dropIndicator.position === position) return
-    setDropIndicator({ id: wsId, position })
-  }
-
-  const handleDragLeave = (e: React.DragEvent): void => {
-    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-      setDropIndicator(null)
-    }
-  }
-
-  const handleDrop = (e: React.DragEvent, targetId: string): void => {
-    e.preventDefault()
-    if (!dragId || dragId === targetId || !dropIndicator || dropIndicator.id !== targetId) {
-      setDragId(null)
-      setDropIndicator(null)
-      return
-    }
-
-    const fromIdx = workspaces.findIndex((w) => w.id === dragId)
-    const toIdx = workspaces.findIndex((w) => w.id === targetId)
-    if (fromIdx === -1 || toIdx === -1) return
-
-    const reordered = [...workspaces]
-    const [moved] = reordered.splice(fromIdx, 1)
-    // 从原数组中移除后，目标索引需要调整
-    const adjustedToIdx = fromIdx < toIdx ? toIdx - 1 : toIdx
-    const insertIdx = dropIndicator.position === 'after' ? adjustedToIdx + 1 : adjustedToIdx
-    reordered.splice(insertIdx, 0, moved!)
-
-    setWorkspaces(reordered)
-    setDragId(null)
-    setDropIndicator(null)
-
-    window.electronAPI.reorderAgentWorkspaces(reordered.map((w) => w.id)).catch(console.error)
-  }
-
-  const handleDragEnd = (): void => {
-    setDragId(null)
-    setDropIndicator(null)
-  }
-
   return (
     <>
-      <div className="rounded-lg border border-border/60 overflow-hidden">
-        {/* 头部 */}
-        <div className="flex items-center justify-between px-2.5 py-1.5 border-b border-border/40">
-          <span className="text-[11px] font-medium text-foreground/50 uppercase tracking-wide">项目</span>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
           <button
-            onClick={handleStartCreate}
-            className="p-1 rounded hover:bg-foreground/[0.06] text-foreground/35 hover:text-foreground/60 transition-colors titlebar-no-drag"
-            title="新建项目"
+            type="button"
+            className="w-full flex items-center gap-2 px-3 py-1.5 rounded-md text-[13px] font-medium text-foreground/70 hover:bg-foreground/[0.04] transition-colors titlebar-no-drag"
           >
-            <Plus size={13} />
+            <FolderOpen size={14} className="flex-shrink-0 text-foreground/40" />
+            <span className="flex-1 min-w-0 truncate text-left">{currentWorkspace?.name ?? '项目'}</span>
+            <span className="text-foreground/25 text-[10px]">▼</span>
           </button>
-        </div>
-
-        {/* 项目列表 */}
-        <div
-          ref={listRef}
-          className="overflow-y-auto scrollbar-thin flex flex-col p-1"
-          style={{ maxHeight: listHeight }}
-        >
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-56 z-[9999] min-w-0 p-0.5">
           {workspaces.map((ws) => (
-            <div key={ws.id} className="relative">
-              {/* 上方插入指示线 */}
-              {dropIndicator?.id === ws.id && dropIndicator.position === 'before' && (
-                <div className="absolute top-0 left-1 right-1 h-0.5 bg-primary rounded-full z-10" />
+            <DropdownMenuItem
+              key={ws.id}
+              className={cn(
+                'text-xs py-1.5 [&>svg]:size-3.5 gap-2',
+                ws.id === currentWorkspaceId && 'font-medium',
               )}
-
-              <div
-                draggable={editingId !== ws.id}
-                onDragStart={(e) => handleDragStart(e, ws.id)}
-                onDragOver={(e) => handleDragOver(e, ws.id)}
-                onDragLeave={handleDragLeave}
-                onDrop={(e) => handleDrop(e, ws.id)}
-                onDragEnd={handleDragEnd}
-                onClick={() => handleSelect(ws)}
-                className={cn(
-                  'group w-full flex items-center gap-1 px-1 py-[5px] rounded-md text-[13px] transition-colors duration-100 cursor-pointer titlebar-no-drag',
-                  ws.id === currentWorkspaceId
-                    ? 'workspace-item-selected bg-foreground/[0.08] text-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
-                    : 'text-foreground/70 hover:bg-foreground/[0.04]',
-                  dragId === ws.id && 'opacity-40',
-                )}
-              >
-              {/* 拖拽手柄 */}
-              <GripVertical size={12} className="flex-shrink-0 text-foreground/20 opacity-0 group-hover:opacity-100 transition-opacity cursor-grab active:cursor-grabbing" />
-
-              <FolderOpen size={13} className="flex-shrink-0 text-foreground/40" />
-
-              {editingId === ws.id ? (
-                <input
-                  ref={editInputRef}
-                  value={editName}
-                  onChange={(e) => setEditName(e.target.value)}
-                  onKeyDown={handleRenameKeyDown}
-                  onBlur={handleRename}
-                  onClick={(e) => e.stopPropagation()}
-                  className="flex-1 min-w-0 bg-transparent text-[13px] text-foreground border-b border-primary/50 outline-none px-0.5"
-                  maxLength={50}
-                />
-              ) : (
-                <>
-                  <span className="flex-1 min-w-0 truncate">{ws.name}</span>
-
-                  <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0">
-                    <button
-                      onClick={(e) => handleStartRename(e, ws)}
-                      className="p-0.5 rounded hover:bg-foreground/[0.08] text-foreground/30 hover:text-foreground/60 transition-colors"
-                      title="重命名"
-                    >
-                      <Pencil size={12} />
-                    </button>
-                    {canDelete(ws) && (
-                      <button
-                        onClick={(e) => handleStartDelete(e, ws.id)}
-                        className="p-0.5 rounded hover:bg-destructive/10 text-foreground/30 hover:text-destructive transition-colors"
-                        title="删除"
-                      >
-                        <Trash2 size={12} />
-                      </button>
-                    )}
-                  </div>
-                </>
+              onSelect={() => selectProject(ws.id)}
+            >
+              {ws.id === currentWorkspaceId
+                ? <Check size={14} className="text-primary" />
+                : <span className="w-[14px]" />
+              }
+              <span className="flex-1 min-w-0 truncate">{ws.name}</span>
+              {canDelete(ws) && (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setDeleteTargetId(ws.id)
+                  }}
+                  className="p-0.5 rounded text-foreground/30 hover:bg-destructive/10 hover:text-destructive transition-colors"
+                  aria-label="删除项目"
+                >
+                  <Trash2 size={12} />
+                </button>
               )}
-              </div>
-
-              {/* 下方插入指示线 */}
-              {dropIndicator?.id === ws.id && dropIndicator.position === 'after' && (
-                <div className="absolute bottom-0 left-1 right-1 h-0.5 bg-primary rounded-full z-10" />
-              )}
-            </div>
+            </DropdownMenuItem>
           ))}
+          <DropdownMenuSeparator className="my-0.5" />
+          <DropdownMenuItem
+            className="text-xs py-1.5 [&>svg]:size-3.5"
+            onSelect={() => handleStartRename(currentWorkspace!)}
+            disabled={!currentWorkspace}
+          >
+            <Pencil size={14} />
+            重命名当前项目
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="text-xs py-1.5 [&>svg]:size-3.5"
+            onSelect={() => {
+              setCreateName('')
+              setCreateOpen(true)
+              requestAnimationFrame(() => createInputRef.current?.focus())
+            }}
+          >
+            <Plus size={14} />
+            新建项目...
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
 
-          {/* 新建项目输入框 */}
-          {creating && (
-            <div className="flex items-center gap-2 px-2 py-[5px]">
-              <FolderOpen size={13} className="flex-shrink-0 text-foreground/40" />
-              <input
-                ref={createInputRef}
-                value={newName}
-                onChange={(e) => setNewName(e.target.value)}
-                onKeyDown={handleCreateKeyDown}
-                onBlur={() => setCreating(false)}
-                placeholder="项目名称..."
-                className="flex-1 min-w-0 bg-transparent text-[13px] text-foreground border-b border-primary/50 outline-none px-0.5"
-                maxLength={50}
-              />
-            </div>
-          )}
-        </div>
+      {/* 新建项目 Dialog */}
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent className="sm:max-w-[360px]">
+          <DialogHeader>
+            <DialogTitle>新建项目</DialogTitle>
+          </DialogHeader>
+          <input
+            ref={createInputRef}
+            value={createName}
+            onChange={(e) => setCreateName(e.target.value)}
+            onKeyDown={handleCreateKeyDown}
+            placeholder="项目名称..."
+            className="w-full bg-transparent text-sm text-foreground border-b border-primary/50 outline-none px-0.5 py-1"
+            maxLength={50}
+            autoFocus
+          />
+          <DialogFooter>
+            <button
+              type="button"
+              onClick={() => setCreateOpen(false)}
+              className="px-3 py-1.5 rounded-md text-sm text-foreground/60 hover:bg-foreground/[0.04] transition-colors"
+            >
+              取消
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleCreate()}
+              disabled={!createName.trim()}
+              className="px-3 py-1.5 rounded-md text-sm bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-40"
+            >
+              创建
+            </button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
-        {/* 拖拽调整高度的 handle */}
-        <div
-          onMouseDown={handleResizeStart}
-          className="h-1 cursor-row-resize group/resize flex items-center justify-center hover:bg-foreground/[0.06] transition-colors titlebar-no-drag"
-        >
-          <div className="w-8 h-[2px] rounded-full bg-foreground/0 group-hover/resize:bg-foreground/20 transition-colors" />
-        </div>
-      </div>
+      {/* 重命名项目 Dialog */}
+      <Dialog open={renameTarget !== null} onOpenChange={(v) => { if (!v) setRenameTarget(null) }}>
+        <DialogContent className="sm:max-w-[360px]">
+          <DialogHeader>
+            <DialogTitle>重命名项目</DialogTitle>
+          </DialogHeader>
+          <input
+            ref={renameInputRef}
+            value={renameName}
+            onChange={(e) => setRenameName(e.target.value)}
+            onKeyDown={handleRenameKeyDown}
+            className="w-full bg-transparent text-sm text-foreground border-b border-primary/50 outline-none px-0.5 py-1"
+            maxLength={50}
+          />
+          <DialogFooter>
+            <button
+              type="button"
+              onClick={() => setRenameTarget(null)}
+              className="px-3 py-1.5 rounded-md text-sm text-foreground/60 hover:bg-foreground/[0.04] transition-colors"
+            >
+              取消
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleRename()}
+              disabled={!renameName.trim() || renameName.trim() === renameTarget?.name}
+              className="px-3 py-1.5 rounded-md text-sm bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-40"
+            >
+              保存
+            </button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* 删除确认弹窗 */}
       <AlertDialog

--- a/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
@@ -7,7 +7,7 @@
 
 import * as React from 'react'
 import { useAtom } from 'jotai'
-import { Check, ChevronDown, FolderOpen, MoreHorizontal, Pencil, Plus, Trash2 } from 'lucide-react'
+import { Check, ChevronDown, FolderOpen, Pencil, Plus, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
 import {
@@ -160,7 +160,7 @@ export function WorkspaceSelector(): React.ReactElement {
             <ChevronDown size={12} className="flex-shrink-0 text-foreground/30" />
           </button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="w-56 z-[9999] min-w-0 p-0.5">
+        <DropdownMenuContent align="start" className="w-56 min-w-0 p-0.5">
           {workspaces.map((ws) => (
             <DropdownMenuItem
               key={ws.id}
@@ -180,6 +180,7 @@ export function WorkspaceSelector(): React.ReactElement {
                   type="button"
                   onClick={(e) => {
                     e.stopPropagation()
+                    e.preventDefault()
                     setDeleteTargetId(ws.id)
                   }}
                   className="p-0.5 rounded text-foreground/30 hover:bg-destructive/10 hover:text-destructive transition-colors"

--- a/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
@@ -40,6 +40,7 @@ import {
 import { agentSessionsAtom, agentWorkspacesAtom, agentSettingsTabAtom } from '@/atoms/agent-atoms'
 import { settingsTabAtom, settingsOpenAtom, type SettingsTab } from '@/atoms/settings-tab'
 import { workspaceListModeAtom, projectListHeightAtom } from '@/atoms/sidebar-atoms'
+import { tabsAtom } from '@/atoms/tab-atoms'
 import { useProjectActions } from '@/hooks/useProjectActions'
 import type { AgentWorkspace, AgentSessionMeta } from '@proma/shared'
 
@@ -47,6 +48,7 @@ export function WorkspaceSelector(): React.ReactElement {
   const { workspaces, currentWorkspaceId, selectProject, createProject } = useProjectActions()
   const [, setWorkspaces] = useAtom(agentWorkspacesAtom)
   const [, setAgentSessions] = useAtom(agentSessionsAtom)
+  const setTabs = useSetAtom(tabsAtom)
   const setSettingsTab = useSetAtom(settingsTabAtom)
   const setSettingsOpen = useSetAtom(settingsOpenAtom)
   const setAgentSettingsTab = useSetAtom(agentSettingsTabAtom)
@@ -54,10 +56,10 @@ export function WorkspaceSelector(): React.ReactElement {
   const [workspaceListMode] = useAtom(workspaceListModeAtom)
 
   if (workspaceListMode === 'list') {
-    return <WorkspaceListMode workspaces={workspaces} currentWorkspaceId={currentWorkspaceId} selectProject={selectProject} createProject={createProject} setWorkspaces={setWorkspaces} setAgentSessions={setAgentSessions} setSettingsTab={setSettingsTab} setSettingsOpen={setSettingsOpen} setAgentSettingsTab={setAgentSettingsTab} />
+    return <WorkspaceListMode workspaces={workspaces} currentWorkspaceId={currentWorkspaceId} selectProject={selectProject} createProject={createProject} setWorkspaces={setWorkspaces} setAgentSessions={setAgentSessions} setSettingsTab={setSettingsTab} setSettingsOpen={setSettingsOpen} setAgentSettingsTab={setAgentSettingsTab} setTabs={setTabs} />
   }
 
-  return <WorkspaceDropdownMode workspaces={workspaces} currentWorkspaceId={currentWorkspaceId} selectProject={selectProject} createProject={createProject} setWorkspaces={setWorkspaces} setAgentSessions={setAgentSessions} setSettingsTab={setSettingsTab} setSettingsOpen={setSettingsOpen} setAgentSettingsTab={setAgentSettingsTab} />
+  return <WorkspaceDropdownMode workspaces={workspaces} currentWorkspaceId={currentWorkspaceId} selectProject={selectProject} createProject={createProject} setWorkspaces={setWorkspaces} setAgentSessions={setAgentSessions} setSettingsTab={setSettingsTab} setSettingsOpen={setSettingsOpen} setAgentSettingsTab={setAgentSettingsTab} setTabs={setTabs} />
 }
 
 // ===== 共享状态与逻辑 =====
@@ -72,13 +74,14 @@ interface WorkspaceModeProps {
   setSettingsTab: (tab: SettingsTab) => void
   setSettingsOpen: (open: boolean) => void
   setAgentSettingsTab: (tab: string) => void
+  setTabs: React.Dispatch<React.SetStateAction<import('@/atoms/tab-atoms').TabItem[]>>
 }
 
 const canDelete = (ws: AgentWorkspace, total: number): boolean => {
   return ws.slug !== 'default' && total > 1
 }
 
-const useDeleteConfirm = (setWorkspaces: WorkspaceModeProps['setWorkspaces'], setAgentSessions: WorkspaceModeProps['setAgentSessions'], currentWorkspaceId: string | null, selectProject: WorkspaceModeProps['selectProject'], workspaces: AgentWorkspace[]) => {
+const useDeleteConfirm = (setWorkspaces: WorkspaceModeProps['setWorkspaces'], setAgentSessions: WorkspaceModeProps['setAgentSessions'], setTabs: WorkspaceModeProps['setTabs'], currentWorkspaceId: string | null, selectProject: WorkspaceModeProps['selectProject'], workspaces: AgentWorkspace[]) => {
   const [deleteTargetId, setDeleteTargetId] = React.useState<string | null>(null)
 
   const handleConfirmDelete = async (): Promise<void> => {
@@ -92,6 +95,7 @@ const useDeleteConfirm = (setWorkspaces: WorkspaceModeProps['setWorkspaces'], se
       ])
       setWorkspaces(remaining)
       setAgentSessions(sessions)
+      setTabs((prev) => prev.filter((t) => !t.pinned || t.workspaceId !== deleteTargetId))
 
       if (deleteTargetId === currentWorkspaceId && remaining.length > 0) {
         const defaultWorkspace = remaining.find((workspace) => workspace.slug === 'default')
@@ -144,7 +148,7 @@ function WorkspaceDropdownMode(props: WorkspaceModeProps): React.ReactElement {
   const [renameName, setRenameName] = React.useState('')
   const renameInputRef = React.useRef<HTMLInputElement>(null)
 
-  const { deleteTargetId, setDeleteTargetId, handleConfirmDelete } = useDeleteConfirm(props.setWorkspaces, props.setAgentSessions, currentWorkspaceId, selectProject, workspaces)
+  const { deleteTargetId, setDeleteTargetId, handleConfirmDelete } = useDeleteConfirm(props.setWorkspaces, props.setAgentSessions, props.setTabs, currentWorkspaceId, selectProject, workspaces)
 
   const handleCreate = async (): Promise<void> => {
     const result = await createProject(createName)
@@ -383,7 +387,7 @@ function WorkspaceListMode(props: WorkspaceModeProps): React.ReactElement {
   const [editName, setEditName] = React.useState('')
   const editInputRef = React.useRef<HTMLInputElement>(null)
 
-  const { deleteTargetId, setDeleteTargetId, handleConfirmDelete } = useDeleteConfirm(props.setWorkspaces, props.setAgentSessions, currentWorkspaceId, selectProject, workspaces)
+  const { deleteTargetId, setDeleteTargetId, handleConfirmDelete } = useDeleteConfirm(props.setWorkspaces, props.setAgentSessions, props.setTabs, currentWorkspaceId, selectProject, workspaces)
 
   // 拖拽排序
   const [dragId, setDragId] = React.useState<string | null>(null)
@@ -485,7 +489,7 @@ function WorkspaceListMode(props: WorkspaceModeProps): React.ReactElement {
     }
     const fromIdx = workspaces.findIndex((w) => w.id === dragId)
     const toIdx = workspaces.findIndex((w) => w.id === targetId)
-    if (fromIdx === -1 || toIdx === -1) return
+    if (fromIdx === -1 || toIdx === -1) { setDragId(null); setDropIndicator(null); return }
     const reordered = [...workspaces]
     const [moved] = reordered.splice(fromIdx, 1)
     const adjustedToIdx = fromIdx < toIdx ? toIdx - 1 : toIdx

--- a/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
@@ -7,7 +7,7 @@
 
 import * as React from 'react'
 import { useAtom } from 'jotai'
-import { Check, FolderOpen, MoreHorizontal, Pencil, Plus, Trash2 } from 'lucide-react'
+import { Check, ChevronDown, FolderOpen, MoreHorizontal, Pencil, Plus, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
 import {
@@ -153,11 +153,11 @@ export function WorkspaceSelector(): React.ReactElement {
         <DropdownMenuTrigger asChild>
           <button
             type="button"
-            className="w-full flex items-center gap-2 px-3 py-1.5 rounded-md text-[13px] font-medium text-foreground/70 hover:bg-foreground/[0.04] transition-colors titlebar-no-drag"
+            className="w-full flex items-center gap-2 px-3 py-2 rounded-[10px] text-[13px] font-medium text-foreground/70 bg-primary/5 hover:bg-primary/10 transition-colors duration-100 titlebar-no-drag border border-dashed border-[hsl(var(--dashed-border))] hover:border-[hsl(var(--dashed-border-hover))]"
           >
             <FolderOpen size={14} className="flex-shrink-0 text-foreground/40" />
             <span className="flex-1 min-w-0 truncate text-left">{currentWorkspace?.name ?? '项目'}</span>
-            <span className="text-foreground/25 text-[10px]">▼</span>
+            <ChevronDown size={12} className="flex-shrink-0 text-foreground/30" />
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" className="w-56 z-[9999] min-w-0 p-0.5">

--- a/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
@@ -1,13 +1,16 @@
 /**
- * WorkspaceSelector — Agent 项目下拉选择器
+ * WorkspaceSelector — Agent 项目切换器
  *
- * 使用 DropdownMenu 展示所有项目，支持切换、新建、重命名、删除。
- * 排序功能将在设置页中提供。
+ * 支持两种展示形态：
+ * - dropdown（默认）：DropdownMenu 下拉选择器，节省侧边栏空间
+ * - list：垂直列表，项目并排展示，支持内联重命名和拖拽排序
+ *
+ * 形态切换通过 workspaceListModeAtom 控制，在 AgentSettings 项目 Tab 中切换。
  */
 
 import * as React from 'react'
 import { useAtom, useSetAtom } from 'jotai'
-import { Check, ChevronDown, FolderOpen, Pencil, Plus, Trash2, ArrowRight } from 'lucide-react'
+import { Check, ChevronDown, FolderOpen, GripVertical, Pencil, Plus, Trash2, ArrowRight } from 'lucide-react'
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
 import {
@@ -35,9 +38,10 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { agentSessionsAtom, agentWorkspacesAtom, agentSettingsTabAtom } from '@/atoms/agent-atoms'
-import { settingsTabAtom, settingsOpenAtom } from '@/atoms/settings-tab'
+import { settingsTabAtom, settingsOpenAtom, type SettingsTab } from '@/atoms/settings-tab'
+import { workspaceListModeAtom, projectListHeightAtom } from '@/atoms/sidebar-atoms'
 import { useProjectActions } from '@/hooks/useProjectActions'
-import type { AgentWorkspace } from '@proma/shared'
+import type { AgentWorkspace, AgentSessionMeta } from '@proma/shared'
 
 export function WorkspaceSelector(): React.ReactElement {
   const { workspaces, currentWorkspaceId, selectProject, createProject } = useProjectActions()
@@ -47,82 +51,35 @@ export function WorkspaceSelector(): React.ReactElement {
   const setSettingsOpen = useSetAtom(settingsOpenAtom)
   const setAgentSettingsTab = useSetAtom(agentSettingsTabAtom)
 
-  const currentWorkspace = workspaces.find((w) => w.id === currentWorkspaceId)
+  const [workspaceListMode] = useAtom(workspaceListModeAtom)
 
-  // 新建项目 Dialog
-  const [createOpen, setCreateOpen] = React.useState(false)
-  const [createName, setCreateName] = React.useState('')
-  const createInputRef = React.useRef<HTMLInputElement>(null)
+  if (workspaceListMode === 'list') {
+    return <WorkspaceListMode workspaces={workspaces} currentWorkspaceId={currentWorkspaceId} selectProject={selectProject} createProject={createProject} setWorkspaces={setWorkspaces} setAgentSessions={setAgentSessions} setSettingsTab={setSettingsTab} setSettingsOpen={setSettingsOpen} setAgentSettingsTab={setAgentSettingsTab} />
+  }
 
-  // 重命名项目 Dialog
-  const [renameTarget, setRenameTarget] = React.useState<AgentWorkspace | null>(null)
-  const [renameName, setRenameName] = React.useState('')
-  const renameInputRef = React.useRef<HTMLInputElement>(null)
+  return <WorkspaceDropdownMode workspaces={workspaces} currentWorkspaceId={currentWorkspaceId} selectProject={selectProject} createProject={createProject} setWorkspaces={setWorkspaces} setAgentSessions={setAgentSessions} setSettingsTab={setSettingsTab} setSettingsOpen={setSettingsOpen} setAgentSettingsTab={setAgentSettingsTab} />
+}
 
-  // 删除确认
+// ===== 共享状态与逻辑 =====
+
+interface WorkspaceModeProps {
+  workspaces: AgentWorkspace[]
+  currentWorkspaceId: string | null
+  selectProject: (id: string) => void
+  createProject: (name: string) => Promise<AgentWorkspace | null>
+  setWorkspaces: React.Dispatch<React.SetStateAction<AgentWorkspace[]>>
+  setAgentSessions: React.Dispatch<React.SetStateAction<AgentSessionMeta[]>>
+  setSettingsTab: (tab: SettingsTab) => void
+  setSettingsOpen: (open: boolean) => void
+  setAgentSettingsTab: (tab: string) => void
+}
+
+const canDelete = (ws: AgentWorkspace, total: number): boolean => {
+  return ws.slug !== 'default' && total > 1
+}
+
+const useDeleteConfirm = (setWorkspaces: WorkspaceModeProps['setWorkspaces'], setAgentSessions: WorkspaceModeProps['setAgentSessions'], currentWorkspaceId: string | null, selectProject: WorkspaceModeProps['selectProject'], workspaces: AgentWorkspace[]) => {
   const [deleteTargetId, setDeleteTargetId] = React.useState<string | null>(null)
-
-  // ===== 新建 =====
-
-  const handleCreate = async (): Promise<void> => {
-    const result = await createProject(createName)
-    if (result) {
-      setCreateOpen(false)
-      setCreateName('')
-    }
-  }
-
-  const handleCreateKeyDown = (e: React.KeyboardEvent): void => {
-    if (e.key === 'Enter') {
-      if (e.nativeEvent.isComposing) return
-      e.preventDefault()
-      void handleCreate()
-    } else if (e.key === 'Escape') {
-      setCreateOpen(false)
-    }
-  }
-
-  // ===== 重命名 =====
-
-  const handleStartRename = (ws: AgentWorkspace): void => {
-    setRenameTarget(ws)
-    setRenameName(ws.name)
-    requestAnimationFrame(() => {
-      renameInputRef.current?.focus()
-      renameInputRef.current?.select()
-    })
-  }
-
-  const handleRename = async (): Promise<void> => {
-    if (!renameTarget) return
-    const trimmed = renameName.trim()
-    if (!trimmed || trimmed === renameTarget.name) {
-      setRenameTarget(null)
-      return
-    }
-
-    try {
-      const updated = await window.electronAPI.updateAgentWorkspace(renameTarget.id, { name: trimmed })
-      setWorkspaces((prev) => prev.map((w) => (w.id === updated.id ? updated : w)))
-    } catch (error) {
-      const msg = error instanceof Error ? error.message : '重命名失败'
-      toast.error(msg)
-    } finally {
-      setRenameTarget(null)
-    }
-  }
-
-  const handleRenameKeyDown = (e: React.KeyboardEvent): void => {
-    if (e.key === 'Enter') {
-      if (e.nativeEvent.isComposing) return
-      e.preventDefault()
-      void handleRename()
-    } else if (e.key === 'Escape') {
-      setRenameTarget(null)
-    }
-  }
-
-  // ===== 删除 =====
 
   const handleConfirmDelete = async (): Promise<void> => {
     if (!deleteTargetId) return
@@ -147,8 +104,101 @@ export function WorkspaceSelector(): React.ReactElement {
     }
   }
 
-  const canDelete = (ws: AgentWorkspace): boolean => {
-    return ws.slug !== 'default' && workspaces.length > 1
+  return { deleteTargetId, setDeleteTargetId, handleConfirmDelete }
+}
+
+const DeleteConfirmDialog = ({ deleteTargetId, setDeleteTargetId, handleConfirmDelete }: {
+  deleteTargetId: string | null
+  setDeleteTargetId: (id: string | null) => void
+  handleConfirmDelete: () => Promise<void>
+}) => (
+  <AlertDialog open={deleteTargetId !== null} onOpenChange={(v) => { if (!v) setDeleteTargetId(null) }}>
+    <AlertDialogContent>
+      <AlertDialogHeader>
+        <AlertDialogTitle>确认删除项目</AlertDialogTitle>
+        <AlertDialogDescription>
+          删除后项目配置将被移除，但目录文件会保留。确定要删除吗？
+        </AlertDialogDescription>
+      </AlertDialogHeader>
+      <AlertDialogFooter>
+        <AlertDialogCancel>取消</AlertDialogCancel>
+        <AlertDialogAction onClick={handleConfirmDelete} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
+          删除
+        </AlertDialogAction>
+      </AlertDialogFooter>
+    </AlertDialogContent>
+  </AlertDialog>
+)
+
+// ===== 下拉选择器形态 =====
+
+function WorkspaceDropdownMode(props: WorkspaceModeProps): React.ReactElement {
+  const { workspaces, currentWorkspaceId, selectProject, createProject, setWorkspaces, setSettingsTab, setSettingsOpen, setAgentSettingsTab } = props
+  const currentWorkspace = workspaces.find((w) => w.id === currentWorkspaceId)
+
+  const [createOpen, setCreateOpen] = React.useState(false)
+  const [createName, setCreateName] = React.useState('')
+  const createInputRef = React.useRef<HTMLInputElement>(null)
+
+  const [renameTarget, setRenameTarget] = React.useState<AgentWorkspace | null>(null)
+  const [renameName, setRenameName] = React.useState('')
+  const renameInputRef = React.useRef<HTMLInputElement>(null)
+
+  const { deleteTargetId, setDeleteTargetId, handleConfirmDelete } = useDeleteConfirm(props.setWorkspaces, props.setAgentSessions, currentWorkspaceId, selectProject, workspaces)
+
+  const handleCreate = async (): Promise<void> => {
+    const result = await createProject(createName)
+    if (result) {
+      setCreateOpen(false)
+      setCreateName('')
+    }
+  }
+
+  const handleCreateKeyDown = (e: React.KeyboardEvent): void => {
+    if (e.key === 'Enter') {
+      if (e.nativeEvent.isComposing) return
+      e.preventDefault()
+      void handleCreate()
+    } else if (e.key === 'Escape') {
+      setCreateOpen(false)
+    }
+  }
+
+  const handleStartRename = (ws: AgentWorkspace): void => {
+    setRenameTarget(ws)
+    setRenameName(ws.name)
+    requestAnimationFrame(() => {
+      renameInputRef.current?.focus()
+      renameInputRef.current?.select()
+    })
+  }
+
+  const handleRename = async (): Promise<void> => {
+    if (!renameTarget) return
+    const trimmed = renameName.trim()
+    if (!trimmed || trimmed === renameTarget.name) {
+      setRenameTarget(null)
+      return
+    }
+    try {
+      const updated = await window.electronAPI.updateAgentWorkspace(renameTarget.id, { name: trimmed })
+      setWorkspaces((prev) => prev.map((w) => (w.id === updated.id ? updated : w)))
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : '重命名失败'
+      toast.error(msg)
+    } finally {
+      setRenameTarget(null)
+    }
+  }
+
+  const handleRenameKeyDown = (e: React.KeyboardEvent): void => {
+    if (e.key === 'Enter') {
+      if (e.nativeEvent.isComposing) return
+      e.preventDefault()
+      void handleRename()
+    } else if (e.key === 'Escape') {
+      setRenameTarget(null)
+    }
   }
 
   return (
@@ -179,7 +229,7 @@ export function WorkspaceSelector(): React.ReactElement {
                 : <span className="w-[14px]" />
               }
               <span className="flex-1 min-w-0 truncate">{ws.name}</span>
-              {canDelete(ws) && (
+              {canDelete(ws, workspaces.length) && (
                 <button
                   type="button"
                   onClick={(e) => {
@@ -229,7 +279,6 @@ export function WorkspaceSelector(): React.ReactElement {
         </DropdownMenuContent>
       </DropdownMenu>
 
-      {/* 新建项目 Dialog */}
       <Dialog open={createOpen} onOpenChange={setCreateOpen}>
         <DialogContent className="sm:max-w-[360px]">
           <DialogHeader>
@@ -246,26 +295,12 @@ export function WorkspaceSelector(): React.ReactElement {
             autoFocus
           />
           <DialogFooter>
-            <button
-              type="button"
-              onClick={() => setCreateOpen(false)}
-              className="px-3 py-1.5 rounded-md text-sm text-foreground/60 hover:bg-foreground/[0.04] transition-colors"
-            >
-              取消
-            </button>
-            <button
-              type="button"
-              onClick={() => void handleCreate()}
-              disabled={!createName.trim()}
-              className="px-3 py-1.5 rounded-md text-sm bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-40"
-            >
-              创建
-            </button>
+            <button type="button" onClick={() => setCreateOpen(false)} className="px-3 py-1.5 rounded-md text-sm text-foreground/60 hover:bg-foreground/[0.04] transition-colors">取消</button>
+            <button type="button" onClick={() => void handleCreate()} disabled={!createName.trim()} className="px-3 py-1.5 rounded-md text-sm bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-40">创建</button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
 
-      {/* 重命名项目 Dialog */}
       <Dialog open={renameTarget !== null} onOpenChange={(v) => { if (!v) setRenameTarget(null) }}>
         <DialogContent className="sm:max-w-[360px]">
           <DialogHeader>
@@ -280,48 +315,301 @@ export function WorkspaceSelector(): React.ReactElement {
             maxLength={50}
           />
           <DialogFooter>
-            <button
-              type="button"
-              onClick={() => setRenameTarget(null)}
-              className="px-3 py-1.5 rounded-md text-sm text-foreground/60 hover:bg-foreground/[0.04] transition-colors"
-            >
-              取消
-            </button>
-            <button
-              type="button"
-              onClick={() => void handleRename()}
-              disabled={!renameName.trim() || renameName.trim() === renameTarget?.name}
-              className="px-3 py-1.5 rounded-md text-sm bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-40"
-            >
-              保存
-            </button>
+            <button type="button" onClick={() => setRenameTarget(null)} className="px-3 py-1.5 rounded-md text-sm text-foreground/60 hover:bg-foreground/[0.04] transition-colors">取消</button>
+            <button type="button" onClick={() => void handleRename()} disabled={!renameName.trim() || renameName.trim() === renameTarget?.name} className="px-3 py-1.5 rounded-md text-sm bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-40">保存</button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
 
-      {/* 删除确认弹窗 */}
-      <AlertDialog
-        open={deleteTargetId !== null}
-        onOpenChange={(v) => { if (!v) setDeleteTargetId(null) }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>确认删除项目</AlertDialogTitle>
-            <AlertDialogDescription>
-              删除后项目配置将被移除，但目录文件会保留。确定要删除吗？
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>取消</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleConfirmDelete}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              删除
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <DeleteConfirmDialog deleteTargetId={deleteTargetId} setDeleteTargetId={setDeleteTargetId} handleConfirmDelete={handleConfirmDelete} />
+    </>
+  )
+}
+
+// ===== 垂直列表形态 =====
+
+function WorkspaceListMode(props: WorkspaceModeProps): React.ReactElement {
+  const { workspaces, currentWorkspaceId, selectProject, createProject, setWorkspaces } = props
+  const [listHeight, setListHeight] = useAtom(projectListHeightAtom)
+
+  // 高度拖拽调整
+  const listRef = React.useRef<HTMLDivElement>(null)
+  const resizing = React.useRef(false)
+  const startY = React.useRef(0)
+  const startH = React.useRef(0)
+  const cleanupResizeRef = React.useRef<(() => void) | null>(null)
+
+  React.useEffect(() => {
+    return () => { cleanupResizeRef.current?.() }
+  }, [])
+
+  const handleResizeStart = React.useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault()
+      resizing.current = true
+      startY.current = e.clientY
+      startH.current = listRef.current?.getBoundingClientRect().height ?? 120
+
+      const onMove = (ev: MouseEvent): void => {
+        if (!resizing.current) return
+        const delta = ev.clientY - startY.current
+        const next = Math.min(400, Math.max(80, startH.current + delta))
+        setListHeight(next)
+      }
+      const onUp = (): void => {
+        resizing.current = false
+        document.removeEventListener('mousemove', onMove)
+        document.removeEventListener('mouseup', onUp)
+        document.body.style.cursor = ''
+        document.body.style.userSelect = ''
+        cleanupResizeRef.current = null
+      }
+      document.addEventListener('mousemove', onMove)
+      document.addEventListener('mouseup', onUp)
+      document.body.style.cursor = 'row-resize'
+      document.body.style.userSelect = 'none'
+      cleanupResizeRef.current = onUp
+    },
+    [setListHeight],
+  )
+
+  // 新建状态
+  const [creating, setCreating] = React.useState(false)
+  const [newName, setNewName] = React.useState('')
+  const createInputRef = React.useRef<HTMLInputElement>(null)
+
+  // 重命名状态
+  const [editingId, setEditingId] = React.useState<string | null>(null)
+  const [editName, setEditName] = React.useState('')
+  const editInputRef = React.useRef<HTMLInputElement>(null)
+
+  const { deleteTargetId, setDeleteTargetId, handleConfirmDelete } = useDeleteConfirm(props.setWorkspaces, props.setAgentSessions, currentWorkspaceId, selectProject, workspaces)
+
+  // 拖拽排序
+  const [dragId, setDragId] = React.useState<string | null>(null)
+  const [dropIndicator, setDropIndicator] = React.useState<{ id: string; position: 'before' | 'after' } | null>(null)
+
+  const handleSelect = (workspace: AgentWorkspace): void => {
+    if (editingId) return
+    selectProject(workspace.id)
+  }
+
+  const handleStartCreate = (): void => {
+    setCreating(true)
+    setNewName('')
+    requestAnimationFrame(() => createInputRef.current?.focus())
+  }
+
+  const handleCreate = async (): Promise<void> => {
+    const result = await createProject(newName)
+    if (result) setCreating(false)
+  }
+
+  const handleCreateKeyDown = (e: React.KeyboardEvent): void => {
+    if (e.key === 'Enter') {
+      if (e.nativeEvent.isComposing) return
+      e.preventDefault()
+      void handleCreate()
+    } else if (e.key === 'Escape') {
+      setCreating(false)
+    }
+  }
+
+  const handleStartRename = (e: React.MouseEvent, ws: AgentWorkspace): void => {
+    e.stopPropagation()
+    setEditingId(ws.id)
+    setEditName(ws.name)
+    requestAnimationFrame(() => {
+      editInputRef.current?.focus()
+      editInputRef.current?.select()
+    })
+  }
+
+  const handleRename = async (): Promise<void> => {
+    if (!editingId) return
+    const trimmed = editName.trim()
+    if (!trimmed) { setEditingId(null); return }
+    try {
+      const updated = await window.electronAPI.updateAgentWorkspace(editingId, { name: trimmed })
+      setWorkspaces((prev) => prev.map((w) => (w.id === updated.id ? updated : w)))
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : '重命名失败'
+      toast.error(msg)
+    } finally {
+      setEditingId(null)
+    }
+  }
+
+  const handleRenameKeyDown = (e: React.KeyboardEvent): void => {
+    if (e.key === 'Enter') {
+      if (e.nativeEvent.isComposing) return
+      e.preventDefault()
+      void handleRename()
+    } else if (e.key === 'Escape') {
+      setEditingId(null)
+    }
+  }
+
+  // 拖拽排序
+  const handleDragStart = (e: React.DragEvent, wsId: string): void => {
+    setDragId(wsId)
+    e.dataTransfer.effectAllowed = 'move'
+    e.dataTransfer.setData('text/plain', wsId)
+  }
+
+  const handleDragOver = (e: React.DragEvent, wsId: string): void => {
+    e.preventDefault()
+    e.dataTransfer.dropEffect = 'move'
+    if (!dragId || wsId === dragId) { setDropIndicator(null); return }
+    const rect = e.currentTarget.getBoundingClientRect()
+    const ratio = (e.clientY - rect.top) / rect.height
+    let position: 'before' | 'after'
+    if (ratio < 0.35) position = 'before'
+    else if (ratio > 0.65) position = 'after'
+    else {
+      if (dropIndicator?.id === wsId) return
+      position = ratio < 0.5 ? 'before' : 'after'
+    }
+    if (dropIndicator?.id === wsId && dropIndicator.position === position) return
+    setDropIndicator({ id: wsId, position })
+  }
+
+  const handleDragLeave = (e: React.DragEvent): void => {
+    if (!e.currentTarget.contains(e.relatedTarget as Node)) setDropIndicator(null)
+  }
+
+  const handleDrop = (e: React.DragEvent, targetId: string): void => {
+    e.preventDefault()
+    if (!dragId || dragId === targetId || !dropIndicator || dropIndicator.id !== targetId) {
+      setDragId(null); setDropIndicator(null); return
+    }
+    const fromIdx = workspaces.findIndex((w) => w.id === dragId)
+    const toIdx = workspaces.findIndex((w) => w.id === targetId)
+    if (fromIdx === -1 || toIdx === -1) return
+    const reordered = [...workspaces]
+    const [moved] = reordered.splice(fromIdx, 1)
+    const adjustedToIdx = fromIdx < toIdx ? toIdx - 1 : toIdx
+    const insertIdx = dropIndicator.position === 'after' ? adjustedToIdx + 1 : adjustedToIdx
+    reordered.splice(insertIdx, 0, moved!)
+    setWorkspaces(reordered)
+    setDragId(null)
+    setDropIndicator(null)
+    window.electronAPI.reorderAgentWorkspaces(reordered.map((w) => w.id)).catch(console.error)
+  }
+
+  const handleDragEnd = (): void => { setDragId(null); setDropIndicator(null) }
+
+  return (
+    <>
+      <div className="rounded-lg border border-border/60 overflow-hidden">
+        {/* 头部 */}
+        <div className="flex items-center justify-between px-2.5 py-1.5 border-b border-border/40">
+          <span className="text-[11px] font-medium text-foreground/50 uppercase tracking-wide">项目</span>
+          <button
+            onClick={handleStartCreate}
+            className="p-1 rounded hover:bg-foreground/[0.06] text-foreground/35 hover:text-foreground/60 transition-colors titlebar-no-drag"
+            title="新建项目"
+          >
+            <Plus size={13} />
+          </button>
+        </div>
+
+        {/* 项目列表 */}
+        <div
+          ref={listRef}
+          className="overflow-y-auto scrollbar-thin flex flex-col p-1"
+          style={{ maxHeight: listHeight }}
+        >
+          {workspaces.map((ws) => (
+            <div key={ws.id} className="relative">
+              {dropIndicator?.id === ws.id && dropIndicator.position === 'before' && (
+                <div className="absolute top-0 left-1 right-1 h-0.5 bg-primary rounded-full z-10" />
+              )}
+              <div
+                draggable={editingId !== ws.id}
+                onDragStart={(e) => handleDragStart(e, ws.id)}
+                onDragOver={(e) => handleDragOver(e, ws.id)}
+                onDragLeave={handleDragLeave}
+                onDrop={(e) => handleDrop(e, ws.id)}
+                onDragEnd={handleDragEnd}
+                onClick={() => handleSelect(ws)}
+                className={cn(
+                  'group w-full flex items-center gap-1 px-1 py-[5px] rounded-md text-[13px] transition-colors duration-100 cursor-pointer titlebar-no-drag',
+                  ws.id === currentWorkspaceId
+                    ? 'workspace-item-selected bg-foreground/[0.08] text-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
+                    : 'text-foreground/70 hover:bg-foreground/[0.04]',
+                  dragId === ws.id && 'opacity-40',
+                )}
+              >
+                <GripVertical size={12} className="flex-shrink-0 text-foreground/20 opacity-0 group-hover:opacity-100 transition-opacity cursor-grab active:cursor-grabbing" />
+                <FolderOpen size={13} className="flex-shrink-0 text-foreground/40" />
+                {editingId === ws.id ? (
+                  <input
+                    ref={editInputRef}
+                    value={editName}
+                    onChange={(e) => setEditName(e.target.value)}
+                    onKeyDown={handleRenameKeyDown}
+                    onBlur={() => void handleRename()}
+                    onClick={(e) => e.stopPropagation()}
+                    className="flex-1 min-w-0 bg-transparent text-[13px] text-foreground border-b border-primary/50 outline-none px-0.5"
+                    maxLength={50}
+                  />
+                ) : (
+                  <>
+                    <span className="flex-1 min-w-0 truncate">{ws.name}</span>
+                    <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0">
+                      <button
+                        onClick={(e) => handleStartRename(e, ws)}
+                        className="p-0.5 rounded hover:bg-foreground/[0.08] text-foreground/30 hover:text-foreground/60 transition-colors"
+                        title="重命名"
+                      >
+                        <Pencil size={12} />
+                      </button>
+                      {canDelete(ws, workspaces.length) && (
+                        <button
+                          onClick={(e) => { e.stopPropagation(); setDeleteTargetId(ws.id) }}
+                          className="p-0.5 rounded hover:bg-destructive/10 text-foreground/30 hover:text-destructive transition-colors"
+                          title="删除"
+                        >
+                          <Trash2 size={12} />
+                        </button>
+                      )}
+                    </div>
+                  </>
+                )}
+              </div>
+              {dropIndicator?.id === ws.id && dropIndicator.position === 'after' && (
+                <div className="absolute bottom-0 left-1 right-1 h-0.5 bg-primary rounded-full z-10" />
+              )}
+            </div>
+          ))}
+          {creating && (
+            <div className="flex items-center gap-2 px-2 py-[5px]">
+              <FolderOpen size={13} className="flex-shrink-0 text-foreground/40" />
+              <input
+                ref={createInputRef}
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                onKeyDown={handleCreateKeyDown}
+                onBlur={() => { if (newName.trim()) void handleCreate(); else setCreating(false) }}
+                placeholder="项目名称..."
+                className="flex-1 min-w-0 bg-transparent text-[13px] text-foreground border-b border-primary/50 outline-none px-0.5"
+                maxLength={50}
+              />
+            </div>
+          )}
+        </div>
+
+        {/* 拖拽调整高度的 handle */}
+        <div
+          onMouseDown={handleResizeStart}
+          className="h-1 cursor-row-resize group/resize flex items-center justify-center hover:bg-foreground/[0.06] transition-colors titlebar-no-drag"
+        >
+          <div className="w-8 h-[2px] rounded-full bg-foreground/0 group-hover/resize:bg-foreground/20 transition-colors" />
+        </div>
+      </div>
+
+      <DeleteConfirmDialog deleteTargetId={deleteTargetId} setDeleteTargetId={setDeleteTargetId} handleConfirmDelete={handleConfirmDelete} />
     </>
   )
 }

--- a/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
@@ -6,8 +6,8 @@
  */
 
 import * as React from 'react'
-import { useAtom } from 'jotai'
-import { Check, ChevronDown, FolderOpen, Pencil, Plus, Trash2 } from 'lucide-react'
+import { useAtom, useSetAtom } from 'jotai'
+import { Check, ChevronDown, FolderOpen, Pencil, Plus, Trash2, ArrowRight } from 'lucide-react'
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
 import {
@@ -34,7 +34,8 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { agentSessionsAtom, agentWorkspacesAtom } from '@/atoms/agent-atoms'
+import { agentSessionsAtom, agentWorkspacesAtom, agentSettingsTabAtom } from '@/atoms/agent-atoms'
+import { settingsTabAtom, settingsOpenAtom } from '@/atoms/settings-tab'
 import { useProjectActions } from '@/hooks/useProjectActions'
 import type { AgentWorkspace } from '@proma/shared'
 
@@ -42,6 +43,9 @@ export function WorkspaceSelector(): React.ReactElement {
   const { workspaces, currentWorkspaceId, selectProject, createProject } = useProjectActions()
   const [, setWorkspaces] = useAtom(agentWorkspacesAtom)
   const [, setAgentSessions] = useAtom(agentSessionsAtom)
+  const setSettingsTab = useSetAtom(settingsTabAtom)
+  const setSettingsOpen = useSetAtom(settingsOpenAtom)
+  const setAgentSettingsTab = useSetAtom(agentSettingsTabAtom)
 
   const currentWorkspace = workspaces.find((w) => w.id === currentWorkspaceId)
 
@@ -199,6 +203,17 @@ export function WorkspaceSelector(): React.ReactElement {
           >
             <Pencil size={14} />
             重命名当前项目
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="text-xs py-1.5 [&>svg]:size-3.5"
+            onSelect={() => {
+              setAgentSettingsTab('workspaces')
+              setSettingsTab('agent')
+              setSettingsOpen(true)
+            }}
+          >
+            <ArrowRight size={14} />
+            项目排序设置...
           </DropdownMenuItem>
           <DropdownMenuItem
             className="text-xs py-1.5 [&>svg]:size-3.5"

--- a/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
@@ -160,7 +160,7 @@ export function WorkspaceSelector(): React.ReactElement {
             <ChevronDown size={12} className="flex-shrink-0 text-foreground/30" />
           </button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="w-56 min-w-0 p-0.5">
+        <DropdownMenuContent align="start" className="w-56 z-[200] min-w-0 p-0.5">
           {workspaces.map((ws) => (
             <DropdownMenuItem
               key={ws.id}

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -11,7 +11,7 @@
 import * as React from 'react'
 import { useAtom, useSetAtom, useAtomValue, useStore } from 'jotai'
 import { toast } from 'sonner'
-import { Pin, PinOff, Settings, Plus, Trash2, Pencil, ChevronDown, ChevronRight, Plug, Zap, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, Clock, AlarmClock } from 'lucide-react'
+import { Pin, PinOff, Settings, Plus, Trash2, Pencil, Plug, Zap, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, Clock, AlarmClock } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { ModeSwitcher } from './ModeSwitcher'
@@ -72,6 +72,7 @@ import {
   updateTabTitle,
   sessionViewStateMapAtom,
   SCRATCH_PAD_ID,
+  createScratchPadTab,
   type TabItem,
 } from '@/atoms/tab-atoms'
 import { userProfileAtom } from '@/atoms/user-profile'
@@ -529,7 +530,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
 
   /** 置顶对话列表（仅活跃模式显示，排除 draft） */
   const pinnedConversations = React.useMemo(
-    () => viewMode === 'active' ? conversations.filter((c) => c.pinned && !draftSessionIds.has(c.id)) : [],
+    () => viewMode === 'active' ? conversations.filter((c) => c.pinned && !c.archived && !draftSessionIds.has(c.id)) : [],
     [conversations, viewMode, draftSessionIds]
   )
 
@@ -585,10 +586,10 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     [conversations]
   )
 
-  /** 已归档 Agent 会话数量（跨项目） */
+  /** 已归档 Agent 会话数量（当前项目） */
   const archivedAgentSessionCount = React.useMemo(
-    () => agentSessions.filter((s) => s.archived && !draftSessionIds.has(s.id)).length,
-    [agentSessions, draftSessionIds]
+    () => agentSessions.filter((s) => s.archived && !draftSessionIds.has(s.id) && s.workspaceId === currentWorkspaceId).length,
+    [agentSessions, draftSessionIds, currentWorkspaceId]
   )
 
   // 初始加载对话列表 + 用户档案 + Agent 会话
@@ -702,25 +703,16 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       )
 
       if (updated.pinned) {
-        // 置顶时：创建或标记置顶标签
+        // 置顶时：创建或标记置顶标签，确保顺序 [scratch, ...pinned, ...nonPinned]
         setTabs((prev) => {
+          const scratchTab = prev.find((t) => t.id === SCRATCH_PAD_ID) ?? createScratchPadTab()
           const existing = prev.find((t) => t.sessionId === id && t.type === 'chat')
-          if (existing) {
-            return prev.map((t) => t.id === existing.id ? { ...t, pinned: true } : t)
-          }
-          const scratchTab = prev.find((t) => t.id === SCRATCH_PAD_ID)
-          const pinnedTabs = prev.filter((t) => t.pinned)
-          const nonPinnedTabs = prev.filter((t) => !t.pinned && t.id !== SCRATCH_PAD_ID && t.type !== 'preview')
-          const newTab: TabItem = {
-            id: id,
-            type: 'chat',
-            sessionId: id,
-            title: updated.title,
-            pinned: true,
-          }
-          return scratchTab
-            ? [scratchTab, ...pinnedTabs, newTab, ...nonPinnedTabs]
-            : [newTab, ...pinnedTabs, ...nonPinnedTabs]
+          const updatedTabs = existing
+            ? prev.map((t) => t.id === existing.id ? { ...t, pinned: true } : t)
+            : [...prev, { id: id, type: 'chat' as const, sessionId: id, title: updated.title, pinned: true }]
+          const pinnedTabs = updatedTabs.filter((t) => t.pinned && t.id !== SCRATCH_PAD_ID)
+          const nonPinnedTabs = updatedTabs.filter((t) => !t.pinned && t.id !== SCRATCH_PAD_ID && t.type !== 'preview')
+          return [scratchTab, ...pinnedTabs, ...nonPinnedTabs]
         })
         if (original?.archived && !updated.archived) {
           toast.success('已置顶', { description: '已自动取消归档' })
@@ -728,7 +720,8 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
           toast.success('已置顶')
         }
       } else {
-        // 取消置顶时：移除置顶标签
+        // 取消置顶时：移除置顶标签（纯函数计算，副作用在外部调用）
+        let newActiveId: string | null = null
         setTabs((prev) => {
           const tab = prev.find((t) => t.sessionId === id && t.pinned)
           if (!tab) return prev
@@ -736,11 +729,11 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
           if (currentActive === tab.id) {
             const otherPinned = prev.filter((t) => t.pinned && t.id !== tab.id)
             const nonPinned = prev.filter((t) => !t.pinned && t.id !== SCRATCH_PAD_ID && t.type !== 'preview')
-            const newActive = otherPinned.at(-1)?.id ?? nonPinned.at(0)?.id ?? SCRATCH_PAD_ID
-            setActiveTabId(newActive)
+            newActiveId = otherPinned.at(-1)?.id ?? nonPinned.at(0)?.id ?? SCRATCH_PAD_ID
           }
           return prev.filter((t) => t.id !== tab.id)
         })
+        if (newActiveId) setActiveTabId(newActiveId)
         toast.success('已取消置顶')
       }
     } catch (error) {
@@ -759,6 +752,12 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       // （appMode、currentXxxId 等），避免文件面板/工具栏等 per-tab
       // 状态被遗留为旧值或被错误地置 null。
       if (updated.archived) {
+        // 归档时：先取消置顶标记（closeTab 会拒绝关闭置顶标签），再关闭标签页
+        setTabs((prev) => {
+          const tab = prev.find((t) => t.sessionId === id && t.pinned)
+          if (tab) return prev.map((t) => t.id === tab.id ? { ...t, pinned: false } : t)
+          return prev
+        })
         const currentTabs = store.get(tabsAtom)
         const currentActiveTabId = store.get(activeTabIdAtom)
         const wasActive = currentActiveTabId === id
@@ -953,26 +952,16 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       setAgentSessions((prev) => replaceAgentSessionInFreshnessOrder(prev, updated))
 
       if (updated.pinned) {
-        // 置顶时：创建或标记置顶标签
+        // 置顶时：创建或标记置顶标签，确保顺序 [scratch, ...pinned, ...nonPinned]
         setTabs((prev) => {
+          const scratchTab = prev.find((t) => t.id === SCRATCH_PAD_ID) ?? createScratchPadTab()
           const existing = prev.find((t) => t.sessionId === id && t.type === 'agent')
-          if (existing) {
-            return prev.map((t) => t.id === existing.id ? { ...t, pinned: true } : t)
-          }
-          // 创建新置顶标签
-          const scratchTab = prev.find((t) => t.id === SCRATCH_PAD_ID)
-          const pinnedTabs = prev.filter((t) => t.pinned)
-          const nonPinnedTabs = prev.filter((t) => !t.pinned && t.id !== SCRATCH_PAD_ID && t.type !== 'preview')
-          const newTab: TabItem = {
-            id: id,
-            type: 'agent',
-            sessionId: id,
-            title: updated.title,
-            pinned: true,
-          }
-          return scratchTab
-            ? [scratchTab, ...pinnedTabs, newTab, ...nonPinnedTabs]
-            : [newTab, ...pinnedTabs, ...nonPinnedTabs]
+          const updatedTabs = existing
+            ? prev.map((t) => t.id === existing.id ? { ...t, pinned: true } : t)
+            : [...prev, { id: id, type: 'agent' as const, sessionId: id, title: updated.title, pinned: true }]
+          const pinnedTabs = updatedTabs.filter((t) => t.pinned && t.id !== SCRATCH_PAD_ID)
+          const nonPinnedTabs = updatedTabs.filter((t) => !t.pinned && t.id !== SCRATCH_PAD_ID && t.type !== 'preview')
+          return [scratchTab, ...pinnedTabs, ...nonPinnedTabs]
         })
         if (original?.archived && !updated.archived) {
           toast.success('已置顶', { description: '已自动取消归档' })
@@ -980,20 +969,20 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
           toast.success('已置顶')
         }
       } else {
-        // 取消置顶时：移除置顶标签
+        // 取消置顶时：移除置顶标签（纯函数计算，副作用在外部调用）
+        let newActiveId: string | null = null
         setTabs((prev) => {
           const tab = prev.find((t) => t.sessionId === id && t.pinned)
           if (!tab) return prev
-          // 如果当前激活的是这个标签，切换到最近的置顶标签或 Scratch Pad
           const currentActive = store.get(activeTabIdAtom)
           if (currentActive === tab.id) {
             const otherPinned = prev.filter((t) => t.pinned && t.id !== tab.id)
             const nonPinned = prev.filter((t) => !t.pinned && t.id !== SCRATCH_PAD_ID && t.type !== 'preview')
-            const newActive = otherPinned.at(-1)?.id ?? nonPinned.at(0)?.id ?? SCRATCH_PAD_ID
-            setActiveTabId(newActive)
+            newActiveId = otherPinned.at(-1)?.id ?? nonPinned.at(0)?.id ?? SCRATCH_PAD_ID
           }
           return prev.filter((t) => t.id !== tab.id)
         })
+        if (newActiveId) setActiveTabId(newActiveId)
         toast.success('已取消置顶')
       }
     } catch (error) {
@@ -1010,6 +999,12 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       // 否则 RightSidePanel（依赖 currentAgentSessionIdAtom）会因为
       // 指针被错误置 null 而消失。
       if (updated.archived) {
+        // 归档时：先取消置顶标记（closeTab 会拒绝关闭置顶标签），再关闭标签页
+        setTabs((prev) => {
+          const tab = prev.find((t) => t.sessionId === id && t.pinned)
+          if (tab) return prev.map((t) => t.id === tab.id ? { ...t, pinned: false } : t)
+          return prev
+        })
         const currentTabs = store.get(tabsAtom)
         const currentActiveTabId = store.get(activeTabIdAtom)
         const wasActive = currentActiveTabId === id

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -11,7 +11,7 @@
 import * as React from 'react'
 import { useAtom, useSetAtom, useAtomValue, useStore } from 'jotai'
 import { toast } from 'sonner'
-import { Pin, PinOff, Settings, Plus, Trash2, Pencil, ChevronDown, ChevronRight, Plug, Zap, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, GripVertical, Clock, AlarmClock } from 'lucide-react'
+import { Pin, PinOff, Settings, Plus, Trash2, Pencil, ChevronDown, ChevronRight, Plug, Zap, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, Clock, AlarmClock } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { ModeSwitcher } from './ModeSwitcher'
@@ -83,6 +83,7 @@ import { useOpenSession } from '@/hooks/useOpenSession'
 import { useSyncActiveTabSideEffects } from '@/hooks/useSyncActiveTabSideEffects'
 import { CollapsedWorkspacePopover } from '@/components/agent/CollapsedWorkspacePopover'
 import { MoveSessionDialog } from '@/components/agent/MoveSessionDialog'
+import { WorkspaceSelector } from '@/components/agent/WorkspaceSelector'
 import {
   SessionMiniMapPopover,
   useSessionMiniMapHover,
@@ -210,28 +211,6 @@ const ITEM_TO_VIEW: Record<SidebarItemId, ActiveView> = {
 /** 日期分组标签 */
 type DateGroup = '今天' | '昨天' | '更早'
 
-interface AgentProjectGroup {
-  workspace: AgentWorkspace
-  sessions: AgentSessionMeta[]
-}
-
-const PROJECT_SESSION_PREVIEW_LIMIT = 5
-const PROJECT_SESSION_RECENT_WINDOW_MS = 3 * 86_400_000
-/** 点击"显示更多"时每次额外展开的会话数量 */
-const PROJECT_SESSION_EXPAND_STEP = 10
-
-const ACTIVE_SESSION_STATUSES: ReadonlySet<SessionIndicatorStatus> = new Set([
-  'blocked',
-  'running',
-  'completed',
-])
-
-const ACTIVE_SESSION_STATUS_PRIORITY: Record<SessionIndicatorStatus, number> = {
-  blocked: 0,
-  running: 1,
-  completed: 2,
-  idle: 3,
-}
 
 function formatRelativeUpdatedAt(updatedAt: number, now: number): string {
   const diff = Math.max(0, now - updatedAt)
@@ -396,15 +375,6 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   const [moveTargetId, setMoveTargetId] = React.useState<string | null>(null)
   /** 置顶区域展开/收起 */
   const [pinnedExpanded, setPinnedExpanded] = React.useState(true)
-  /** 每个项目额外展开显示的会话数量（每次点击"显示更多" +10），未点击则为 0 或无值 */
-  const [expandedExtraCountMap, setExpandedExtraCountMap] = React.useState<Map<string, number>>(new Map())
-  /** 项目拖拽排序状态 */
-  const [dragProjectId, setDragProjectId] = React.useState<string | null>(null)
-  const [projectDropIndicator, setProjectDropIndicator] = React.useState<{ id: string; position: 'before' | 'after' } | null>(null)
-  /** 新建项目输入状态 */
-  const [creatingProject, setCreatingProject] = React.useState(false)
-  const [newProjectName, setNewProjectName] = React.useState('')
-  const newProjectInputRef = React.useRef<HTMLInputElement>(null)
   const [relativeTimeNow, setRelativeTimeNow] = React.useState(() => Date.now())
   const [userProfile, setUserProfile] = useAtom(userProfileAtom)
   const selectedModel = useAtomValue(selectedModelAtom)
@@ -561,17 +531,39 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     [conversations, viewMode, draftSessionIds]
   )
 
-  /** 置顶 Agent 会话列表（仅活跃模式显示，跨项目展示，排除 draft） */
+  /** 置顶 Agent 会话列表（仅活跃模式显示，按当前项目过滤，排除 draft） */
   const pinnedAgentSessions = React.useMemo(
     () => {
       if (viewMode !== 'active') return []
       const filtered = agentSessions.filter((s) =>
         s.pinned
+        && !s.archived
         && !draftSessionIds.has(s.id)
+        && s.workspaceId === currentWorkspaceId
       )
       return sortAgentSessionsByUpdatedAtDesc(filtered)
     },
-    [agentSessions, viewMode, draftSessionIds]
+    [agentSessions, viewMode, draftSessionIds, currentWorkspaceId]
+  )
+
+  /** 当前项目的非置顶 Agent 会话（根据 viewMode 过滤归档状态，排除 draft） */
+  const filteredAgentSessions = React.useMemo(
+    () => {
+      const byWorkspace = agentSessions.filter(
+        (s) => s.workspaceId === currentWorkspaceId && !draftSessionIds.has(s.id)
+      )
+      const filtered = viewMode === 'archived'
+        ? byWorkspace.filter((s) => s.archived)
+        : byWorkspace.filter((s) => !s.archived && !s.pinned)
+      return sortAgentSessionsByUpdatedAtDesc(filtered)
+    },
+    [agentSessions, currentWorkspaceId, viewMode, draftSessionIds]
+  )
+
+  /** 当前项目的非置顶会话按日期分组 */
+  const agentSessionGroups = React.useMemo(
+    () => groupByDate(filteredAgentSessions),
+    [filteredAgentSessions]
   )
 
   /** 对话按日期分组（根据 viewMode 过滤归档状态，排除 draft） */
@@ -874,145 +866,6 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     window.electronAPI.updateSettings({ agentWorkspaceId: workspaceId }).catch(console.error)
   }, [currentWorkspaceId, setCurrentWorkspaceId])
 
-  /** 展开某个项目时每次额外显示的会话数量 */
-  const handleShowMoreSessions = React.useCallback((workspaceId: string): void => {
-    setExpandedExtraCountMap((prev) => {
-      const next = new Map(prev)
-      next.set(workspaceId, (prev.get(workspaceId) ?? 0) + PROJECT_SESSION_EXPAND_STEP)
-      return next
-    })
-  }, [])
-
-  /** 收起某个项目额外展开的会话 */
-  const handleCollapseExtraSessions = React.useCallback((workspaceId: string): void => {
-    setExpandedExtraCountMap((prev) => {
-      if (!prev.has(workspaceId)) return prev
-      const next = new Map(prev)
-      next.delete(workspaceId)
-      return next
-    })
-  }, [])
-
-  /** 开始拖拽项目排序 */
-  const handleProjectDragStart = React.useCallback((e: React.DragEvent, workspaceId: string): void => {
-    setDragProjectId(workspaceId)
-    e.dataTransfer.effectAllowed = 'move'
-    e.dataTransfer.setData('text/plain', workspaceId)
-  }, [])
-
-  /** 根据鼠标位置计算项目插入点 */
-  const handleProjectDragOver = React.useCallback((e: React.DragEvent, workspaceId: string): void => {
-    e.preventDefault()
-    e.dataTransfer.dropEffect = 'move'
-    if (!dragProjectId || dragProjectId === workspaceId) {
-      setProjectDropIndicator(null)
-      return
-    }
-
-    const rect = e.currentTarget.getBoundingClientRect()
-    const ratio = (e.clientY - rect.top) / rect.height
-    const position: 'before' | 'after' = ratio < 0.5 ? 'before' : 'after'
-    setProjectDropIndicator((prev) => (
-      prev?.id === workspaceId && prev.position === position
-        ? prev
-        : { id: workspaceId, position }
-    ))
-  }, [dragProjectId])
-
-  const handleProjectDragLeave = React.useCallback((e: React.DragEvent): void => {
-    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-      setProjectDropIndicator(null)
-    }
-  }, [])
-
-  /** 完成项目排序并持久化 */
-  const handleProjectDrop = React.useCallback((e: React.DragEvent, targetWorkspaceId: string): void => {
-    e.preventDefault()
-    if (!dragProjectId || dragProjectId === targetWorkspaceId || !projectDropIndicator || projectDropIndicator.id !== targetWorkspaceId) {
-      setDragProjectId(null)
-      setProjectDropIndicator(null)
-      return
-    }
-
-    const fromIndex = workspaces.findIndex((workspace) => workspace.id === dragProjectId)
-    const toIndex = workspaces.findIndex((workspace) => workspace.id === targetWorkspaceId)
-    if (fromIndex === -1 || toIndex === -1) {
-      setDragProjectId(null)
-      setProjectDropIndicator(null)
-      return
-    }
-
-    const reordered = [...workspaces]
-    const [moved] = reordered.splice(fromIndex, 1)
-    if (!moved) {
-      setDragProjectId(null)
-      setProjectDropIndicator(null)
-      return
-    }
-    const adjustedToIndex = fromIndex < toIndex ? toIndex - 1 : toIndex
-    const insertIndex = projectDropIndicator.position === 'after' ? adjustedToIndex + 1 : adjustedToIndex
-    reordered.splice(insertIndex, 0, moved)
-
-    setWorkspaces(reordered)
-    setDragProjectId(null)
-    setProjectDropIndicator(null)
-    window.electronAPI
-      .reorderAgentWorkspaces(reordered.map((workspace) => workspace.id))
-      .then(setWorkspaces)
-      .catch((error) => {
-        console.error('[侧边栏] 项目排序失败:', error)
-        setWorkspaces(workspaces)
-        toast.error('项目排序失败')
-      })
-  }, [dragProjectId, projectDropIndicator, setWorkspaces, workspaces])
-
-  const handleProjectDragEnd = React.useCallback((): void => {
-    setDragProjectId(null)
-    setProjectDropIndicator(null)
-  }, [])
-
-  /** 开始创建新项目 */
-  const handleStartCreateProject = React.useCallback((): void => {
-    setCreatingProject(true)
-    setNewProjectName('')
-    requestAnimationFrame(() => {
-      newProjectInputRef.current?.focus()
-    })
-  }, [])
-
-  /** 创建新项目，并设为当前项目 */
-  const handleCreateProject = React.useCallback(async (): Promise<void> => {
-    const trimmed = newProjectName.trim()
-    if (!trimmed) {
-      setCreatingProject(false)
-      return
-    }
-
-    try {
-      const workspace = await window.electronAPI.createAgentWorkspace(trimmed)
-      setWorkspaces((prev) => [workspace, ...prev])
-      setCurrentWorkspaceId(workspace.id)
-      window.electronAPI.updateSettings({ agentWorkspaceId: workspace.id }).catch(console.error)
-      setCreatingProject(false)
-      setNewProjectName('')
-    } catch (error) {
-      const msg = error instanceof Error ? error.message : '创建项目失败'
-      toast.error(msg)
-    }
-  }, [newProjectName, setCurrentWorkspaceId, setWorkspaces])
-
-  const handleCreateProjectKeyDown = React.useCallback((e: React.KeyboardEvent): void => {
-    if (e.key === 'Enter') {
-      if (e.nativeEvent.isComposing) return
-      e.preventDefault()
-      void handleCreateProject()
-    } else if (e.key === 'Escape') {
-      e.preventDefault()
-      setCreatingProject(false)
-      setNewProjectName('')
-    }
-  }, [handleCreateProject])
-
   /** 选择 Agent 会话（打开或聚焦标签页） */
   const handleSelectAgentSession = React.useCallback((id: string, title: string): void => {
     openSession('agent', id, title)
@@ -1121,45 +974,16 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     })
   }
 
-  /** Agent 普通历史按项目分组（排除置顶 / 归档 / draft） */
-  const agentProjectGroups = React.useMemo<AgentProjectGroup[]>(
-    () => {
-      const sessionsByWorkspaceId = new Map<string, AgentSessionMeta[]>()
-      for (const workspace of workspaces) {
-        sessionsByWorkspaceId.set(workspace.id, [])
-      }
-
-      const visibleHistory = sortAgentSessionsByUpdatedAtDesc(
-        agentSessions.filter((session) =>
-          !session.archived
-          && !session.pinned
-          && !draftSessionIds.has(session.id)
-        )
-      )
-
-      const defaultWsId = workspaces.find((ws) => ws.slug === 'default')?.id ?? workspaces[0]?.id
-      for (const session of visibleHistory) {
-        const targetId = session.workspaceId && sessionsByWorkspaceId.has(session.workspaceId)
-          ? session.workspaceId
-          : defaultWsId
-        if (!targetId) continue
-        sessionsByWorkspaceId.get(targetId)!.push(session)
-      }
-
-      return workspaces.map((workspace) => ({
-        workspace,
-        sessions: sessionsByWorkspaceId.get(workspace.id) ?? [],
-      }))
-    },
-    [agentSessions, draftSessionIds, workspaces],
-  )
-
-  /** Agent 归档会话按日期分组（跨项目） */
-  const agentSessionGroups = React.useMemo(
+  /** Agent 归档会话按日期分组（按当前项目过滤） */
+  const archivedAgentSessionGroups = React.useMemo(
     () => groupByDate(sortAgentSessionsByUpdatedAtDesc(
-      agentSessions.filter((session) => session.archived && !draftSessionIds.has(session.id))
+      agentSessions.filter((session) =>
+        session.archived
+        && !draftSessionIds.has(session.id)
+        && session.workspaceId === currentWorkspaceId
+      )
     )),
-    [agentSessions, draftSessionIds]
+    [agentSessions, draftSessionIds, currentWorkspaceId]
   )
 
   const handleRailModeSwitch = React.useCallback((targetMode: AppMode) => {
@@ -1611,9 +1435,14 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         </div>
       )}
 
-      {/* Agent 模式 active 视图：置顶 + 项目历史 */}
+      {/* Agent 模式 active 视图：项目选择器 + 置顶 + 日期分组 */}
       {mode === 'agent' && viewMode === 'active' ? (
         <div className="flex-1 flex flex-col min-h-0">
+          {/* 项目选择器 */}
+          <div className="px-3 pt-1 flex-shrink-0 titlebar-no-drag">
+            <WorkspaceSelector />
+          </div>
+
           {pinnedAgentSessions.length > 0 && (
             <div className="px-2 pt-2 pb-1 flex-shrink-0 titlebar-no-drag">
               <div className="px-1.5 pb-1 text-[11px] font-medium text-foreground/40 select-none">
@@ -1628,7 +1457,6 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                     indicatorStatus={agentIndicatorMap.get(session.id) ?? 'idle'}
                     showPinIcon={false}
                     leftAccent={getSessionLeftAccent(agentIndicatorMap.get(session.id) ?? 'idle')}
-                    workspaceName={session.workspaceId ? workspaceNameMap.get(session.workspaceId) : undefined}
                     relativeTimeNow={relativeTimeNow}
                     onSelect={handleSelectAgentSession}
                     onRequestDelete={handleRequestDelete}
@@ -1642,80 +1470,34 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
             </div>
           )}
 
-          {/* 下区标题：项目历史 */}
-          <div className="px-2 pt-2 pb-1 flex items-center justify-between flex-shrink-0">
-            <span className="px-1.5 text-[11px] font-medium text-foreground/40 select-none">项目</span>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  onClick={handleStartCreateProject}
-                  className="size-6 flex items-center justify-center rounded-md text-foreground/35 hover:bg-foreground/[0.06] hover:text-foreground/60 transition-colors titlebar-no-drag"
-                  aria-label="新建项目"
-                >
-                  <Plus size={13} />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="top">新建项目</TooltipContent>
-            </Tooltip>
-          </div>
-
-          {/* 下区：项目分组历史 */}
+          {/* 日期分组会话列表 */}
           <div className="flex-1 overflow-y-auto px-2 pb-3 scrollbar-thin min-h-0 titlebar-no-drag">
-            {creatingProject && (
-              <div className="flex items-center gap-2 px-2 py-1.5 mb-1 rounded-md bg-foreground/[0.04]">
-                <FolderOpen size={14} className="flex-shrink-0 text-foreground/40" />
-                <input
-                  ref={newProjectInputRef}
-                  value={newProjectName}
-                  onChange={(e) => setNewProjectName(e.target.value)}
-                  onKeyDown={handleCreateProjectKeyDown}
-                  onBlur={() => {
-                    setCreatingProject(false)
-                    setNewProjectName('')
-                  }}
-                  placeholder="项目名称..."
-                  className="flex-1 min-w-0 bg-transparent text-[13px] text-foreground border-b border-primary/50 outline-none px-0.5"
-                  maxLength={50}
-                />
-              </div>
-            )}
-
             <div className="flex flex-col gap-0.5">
-              {agentProjectGroups.map((group) => (
-                <AgentProjectGroupItem
-                  key={group.workspace.id}
-                  group={group}
-                  currentWorkspaceId={currentWorkspaceId}
-                  expanded={(expandedExtraCountMap.get(group.workspace.id) ?? 0) > 0}
-                  extraCount={expandedExtraCountMap.get(group.workspace.id) ?? 0}
-                  activeSessionId={activeSessionId}
-                  agentIndicatorMap={agentIndicatorMap}
-                  relativeTimeNow={relativeTimeNow}
-                  dragging={dragProjectId === group.workspace.id}
-                  dropPosition={projectDropIndicator?.id === group.workspace.id ? projectDropIndicator.position : null}
-                  onShowMore={handleShowMoreSessions}
-                  onCollapseExtra={handleCollapseExtraSessions}
-                  onSelectProject={handleSelectProject}
-                  onNewSession={createAgentSessionInWorkspace}
-                  onDragStart={handleProjectDragStart}
-                  onDragOver={handleProjectDragOver}
-                  onDragLeave={handleProjectDragLeave}
-                  onDrop={handleProjectDrop}
-                  onDragEnd={handleProjectDragEnd}
-                  onConfigureProject={(workspaceId) => {
-                    handleSelectProject(workspaceId)
-                    setSettingsTab('agent')
-                    setSettingsOpen(true)
-                  }}
-                  onRenameWorkspace={handleWorkspaceRename}
-                  onSelectSession={handleSelectAgentSession}
-                  onRequestDelete={handleRequestDelete}
-                  onRequestMove={handleRequestMove}
-                  onRename={handleAgentRename}
-                  onTogglePin={handleTogglePinAgent}
-                  onToggleArchive={handleToggleArchiveAgent}
-                />
+              {agentSessionGroups.map((group) => (
+                <div key={group.label} className="mb-1">
+                  <div className="px-1.5 pt-2 pb-1 text-[11px] font-medium text-foreground/40 select-none">
+                    {group.label}
+                  </div>
+                  <div className="flex flex-col gap-0.5">
+                    {group.items.map((session) => (
+                      <AgentSessionItem
+                        key={session.id}
+                        session={session}
+                        active={session.id === activeSessionId}
+                        indicatorStatus={agentIndicatorMap.get(session.id) ?? 'idle'}
+                        showPinIcon={!!session.pinned}
+                        leftAccent={getSessionLeftAccent(agentIndicatorMap.get(session.id) ?? 'idle')}
+                        relativeTimeNow={relativeTimeNow}
+                        onSelect={handleSelectAgentSession}
+                        onRequestDelete={handleRequestDelete}
+                        onRequestMove={handleRequestMove}
+                        onRename={handleAgentRename}
+                        onTogglePin={handleTogglePinAgent}
+                        onToggleArchive={handleToggleArchiveAgent}
+                      />
+                    ))}
+                  </div>
+                </div>
               ))}
             </div>
           </div>
@@ -1761,7 +1543,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
               ))
             ) : (
               /* Agent 模式归档：Agent 会话按日期分组 */
-              agentSessionGroups.map((group) => (
+              archivedAgentSessionGroups.map((group) => (
                 <div key={group.label} className="mb-1">
                   <div className="px-3 pt-2 pb-1 text-[11px] font-medium text-foreground/40 select-none">
                     {group.label}
@@ -2456,297 +2238,3 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
   )
 })
 
-// ===== 项目分组历史 =====
-
-interface AgentProjectGroupItemProps {
-  group: AgentProjectGroup
-  currentWorkspaceId: string | null
-  expanded: boolean
-  /** 用户已点击"显示更多"额外展开的会话数量（基于 collapsedSessions 之上累加） */
-  extraCount: number
-  activeSessionId: string | null
-  agentIndicatorMap: Map<string, SessionIndicatorStatus>
-  relativeTimeNow: number
-  dragging: boolean
-  dropPosition: 'before' | 'after' | null
-  onShowMore: (workspaceId: string) => void
-  onCollapseExtra: (workspaceId: string) => void
-  onSelectProject: (workspaceId: string) => void
-  onNewSession: (workspaceId: string) => Promise<void>
-  onDragStart: (e: React.DragEvent, workspaceId: string) => void
-  onDragOver: (e: React.DragEvent, workspaceId: string) => void
-  onDragLeave: (e: React.DragEvent) => void
-  onDrop: (e: React.DragEvent, workspaceId: string) => void
-  onDragEnd: () => void
-  onConfigureProject: (workspaceId: string) => void
-  onRenameWorkspace: (workspaceId: string, newName: string) => Promise<void>
-  onSelectSession: (id: string, title: string) => void
-  onRequestDelete: (id: string) => void
-  onRequestMove: (id: string) => void
-  onRename: (id: string, newTitle: string) => Promise<void>
-  onTogglePin: (id: string) => Promise<void>
-  onToggleArchive: (id: string) => Promise<void>
-}
-
-const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
-  group,
-  currentWorkspaceId,
-  expanded,
-  extraCount,
-  activeSessionId,
-  agentIndicatorMap,
-  relativeTimeNow,
-  dragging,
-  dropPosition,
-  onShowMore,
-  onCollapseExtra,
-  onSelectProject,
-  onNewSession,
-  onDragStart,
-  onDragOver,
-  onDragLeave,
-  onDrop,
-  onDragEnd,
-  onConfigureProject,
-  onRenameWorkspace,
-  onSelectSession,
-  onRequestDelete,
-  onRequestMove,
-  onRename,
-  onTogglePin,
-  onToggleArchive,
-}: AgentProjectGroupItemProps): React.ReactElement {
-  const isCurrent = group.workspace.id === currentWorkspaceId
-
-  const [renamingWorkspace, setRenamingWorkspace] = React.useState(false)
-  const [workspaceEditName, setWorkspaceEditName] = React.useState('')
-  const workspaceEditRef = React.useRef<HTMLInputElement>(null)
-  const justStartedRenamingRef = React.useRef(false)
-
-  const handleStartWorkspaceRename = (): void => {
-    setWorkspaceEditName(group.workspace.name)
-    setRenamingWorkspace(true)
-    justStartedRenamingRef.current = true
-    setTimeout(() => {
-      justStartedRenamingRef.current = false
-      workspaceEditRef.current?.focus()
-      workspaceEditRef.current?.select()
-    }, 300)
-  }
-
-  const handleWorkspaceRenameCommit = async (): Promise<void> => {
-    if (justStartedRenamingRef.current) return
-    const trimmed = workspaceEditName.trim()
-    if (!trimmed || trimmed === group.workspace.name) {
-      setRenamingWorkspace(false)
-      return
-    }
-    await onRenameWorkspace(group.workspace.id, trimmed)
-    setRenamingWorkspace(false)
-  }
-
-  const handleWorkspaceRenameKeyDown = (e: React.KeyboardEvent): void => {
-    if (e.key === 'Enter') {
-      if (e.nativeEvent.isComposing) return
-      e.preventDefault()
-      void handleWorkspaceRenameCommit()
-    } else if (e.key === 'Escape') {
-      setRenamingWorkspace(false)
-    }
-  }
-  const recentCutoff = relativeTimeNow - PROJECT_SESSION_RECENT_WINDOW_MS
-  // 折叠时：所有"活跃"会话（运行中 / 阻塞 / 未查看的已完成）必须展示，
-  // 不受 PROJECT_SESSION_PREVIEW_LIMIT 与 3 天窗口限制；活跃部分内部按
-  // blocked > running > completed 优先级排序（与 railRecentItems 对齐），
-  // 同优先级保留 group.sessions 的 updatedAt 倒序。
-  // 非活跃部分仍保留原"最近 3 天 + 至多 5 条"预览策略，作为额外补充展示。
-  // 用户点击"显示更多"会在折叠基线之上每次再额外展开 PROJECT_SESSION_EXPAND_STEP 条。
-  const getStatus = (sessionId: string): SessionIndicatorStatus =>
-    agentIndicatorMap.get(sessionId) ?? 'idle'
-  const activeSessions = group.sessions
-    .filter((session) => ACTIVE_SESSION_STATUSES.has(getStatus(session.id)))
-    .slice()
-    .sort((a, b) => {
-      const delta = ACTIVE_SESSION_STATUS_PRIORITY[getStatus(a.id)]
-        - ACTIVE_SESSION_STATUS_PRIORITY[getStatus(b.id)]
-      if (delta !== 0) return delta
-      return b.updatedAt - a.updatedAt
-    })
-  const activeIds = new Set(activeSessions.map((s) => s.id))
-  const fillSessions = group.sessions
-    .filter((session) => !activeIds.has(session.id) && session.updatedAt >= recentCutoff)
-    .slice(0, PROJECT_SESSION_PREVIEW_LIMIT)
-  const collapsedSessions = [...activeSessions, ...fillSessions]
-  const collapsedIds = new Set(collapsedSessions.map((s) => s.id))
-  const remainingSessions = group.sessions.filter((s) => !collapsedIds.has(s.id))
-  const extraSessions = remainingSessions.slice(0, extraCount)
-  const sessions = [...collapsedSessions, ...extraSessions]
-  const hiddenCount = Math.max(0, group.sessions.length - sessions.length)
-
-  return (
-    <section
-      onDragOver={(e) => onDragOver(e, group.workspace.id)}
-      onDragLeave={onDragLeave}
-      onDrop={(e) => onDrop(e, group.workspace.id)}
-      onDragEnd={onDragEnd}
-      className={cn('relative py-0.5 rounded-md transition-opacity', dragging && 'opacity-45')}
-    >
-      {dropPosition === 'before' && (
-        <div className="absolute -top-0.5 left-3 right-3 h-0.5 rounded-full bg-primary z-10" />
-      )}
-
-      <div className="group/project relative flex items-center">
-        <span
-          draggable
-          onDragStart={(e) => onDragStart(e, group.workspace.id)}
-          title="拖拽排序"
-          className="absolute -left-0.5 top-1/2 z-10 flex size-[18px] -translate-y-1/2 cursor-grab items-center justify-center text-foreground/20 opacity-0 transition-opacity group-hover/project:opacity-100 active:cursor-grabbing"
-          aria-hidden="true"
-        >
-          <GripVertical size={12} />
-        </span>
-
-        {renamingWorkspace ? (
-          <div
-            className={cn(
-              'relative flex-1 min-w-0 flex items-center gap-1 px-1 py-1 rounded-md text-left titlebar-no-drag group-hover/project:pl-4 group-hover/project:pr-11',
-              isCurrent
-                ? 'agent-project-item-current text-foreground'
-                : 'text-foreground/65',
-            )}
-          >
-            <FolderOpen size={13} className="flex-shrink-0 text-foreground/40" />
-            <input
-              ref={workspaceEditRef}
-              value={workspaceEditName}
-              onChange={(e) => setWorkspaceEditName(e.target.value)}
-              onKeyDown={handleWorkspaceRenameKeyDown}
-              onBlur={() => void handleWorkspaceRenameCommit()}
-              className="flex-1 min-w-0 bg-transparent text-[13px] font-medium text-foreground border-b border-primary/50 outline-none px-0.5 leading-[18px]"
-              maxLength={50}
-            />
-          </div>
-        ) : (
-          <button
-            type="button"
-            onClick={() => onSelectProject(group.workspace.id)}
-            className={cn(
-              'relative flex-1 min-w-0 flex items-center gap-1 px-1 py-1 rounded-md text-left transition-[padding,color,background-color] titlebar-no-drag group-hover/project:pl-4 group-hover/project:pr-11 hover:bg-foreground/[0.025]',
-              isCurrent
-                ? 'agent-project-item-current text-foreground'
-                : 'text-foreground/65 hover:text-foreground/88',
-            )}
-          >
-            <FolderOpen size={13} className="flex-shrink-0 text-foreground/40" />
-            <span className="flex-1 min-w-0 truncate text-[13px] font-medium leading-[18px]">
-              {group.workspace.name}
-            </span>
-          </button>
-        )}
-
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              aria-label={`在「${group.workspace.name}」中新建会话`}
-              onClick={(e) => {
-                e.stopPropagation()
-                void onNewSession(group.workspace.id)
-              }}
-              className="absolute right-5 top-1/2 flex size-5 -translate-y-1/2 items-center justify-center rounded-md text-foreground/30 opacity-0 transition-colors hover:bg-foreground/[0.055] hover:text-foreground/65 group-hover/project:opacity-100 titlebar-no-drag"
-            >
-              <Plus size={13} />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="top">在此项目中新建会话</TooltipContent>
-        </Tooltip>
-
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button
-              type="button"
-              aria-label="项目菜单"
-              className="absolute right-0 top-1/2 flex size-5 -translate-y-1/2 items-center justify-center rounded-md text-foreground/30 opacity-0 transition-colors hover:bg-foreground/[0.055] hover:text-foreground/60 group-hover/project:opacity-100 data-[state=open]:opacity-100 titlebar-no-drag"
-            >
-              <MoreHorizontal size={13} />
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="start" className="w-44 z-[9999] min-w-0 p-0.5">
-            <DropdownMenuItem
-              className="text-xs py-1 [&>svg]:size-3.5"
-              onSelect={() => onSelectProject(group.workspace.id)}
-            >
-              <FolderOpen size={14} />
-              设为当前项目
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              className="text-xs py-1 [&>svg]:size-3.5"
-              onSelect={handleStartWorkspaceRename}
-            >
-              <Pencil size={14} />
-              重命名
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              className="text-xs py-1 [&>svg]:size-3.5"
-              onSelect={() => onConfigureProject(group.workspace.id)}
-            >
-              <Settings size={14} />
-              配置 MCP 与 Skills
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
-
-      <div className="ml-4 mt-px">
-        {group.sessions.length > 0 ? (
-          <div className="flex flex-col gap-0.5">
-            {sessions.map((session) => (
-              <AgentSessionItem
-                key={session.id}
-                session={session}
-                active={session.id === activeSessionId}
-                indicatorStatus={agentIndicatorMap.get(session.id) ?? 'idle'}
-                showPinIcon={!!session.pinned}
-                leftAccent={getSessionLeftAccent(agentIndicatorMap.get(session.id) ?? 'idle')}
-                relativeTimeNow={relativeTimeNow}
-                onSelect={onSelectSession}
-                onRequestDelete={onRequestDelete}
-                onRequestMove={onRequestMove}
-                onRename={onRename}
-                onTogglePin={onTogglePin}
-                onToggleArchive={onToggleArchive}
-              />
-            ))}
-
-            {hiddenCount > 0 && (
-              <button
-                type="button"
-                onClick={() => onShowMore(group.workspace.id)}
-                className="w-full text-left px-1.5 py-1 rounded-md text-[12px] text-foreground/35 hover:bg-foreground/[0.03] hover:text-foreground/60 transition-colors titlebar-no-drag"
-              >
-                显示更多
-              </button>
-            )}
-
-            {expanded && (
-              <button
-                type="button"
-                onClick={() => onCollapseExtra(group.workspace.id)}
-                className="w-full text-left px-1.5 py-1 rounded-md text-[12px] text-foreground/35 hover:bg-foreground/[0.03] hover:text-foreground/60 transition-colors titlebar-no-drag"
-              >
-                收起
-              </button>
-            )}
-          </div>
-        ) : (
-          <div className="px-1.5 py-0.5 text-[12px] text-foreground/22 select-none">
-            暂无会话
-          </div>
-        )}
-      </div>
-      {dropPosition === 'after' && (
-        <div className="absolute -bottom-0.5 left-3 right-3 h-0.5 rounded-full bg-primary z-10" />
-      )}
-    </section>
-  )
-})

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -553,7 +553,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   const filteredAgentSessions = React.useMemo(
     () => {
       const byWorkspace = agentSessions.filter(
-        (s) => s.workspaceId === currentWorkspaceId && !draftSessionIds.has(s.id)
+        (s) => (s.workspaceId ?? currentWorkspaceId) === currentWorkspaceId && !draftSessionIds.has(s.id)
       )
       const filtered = viewMode === 'archived'
         ? byWorkspace.filter((s) => s.archived)
@@ -588,7 +588,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
 
   /** 已归档 Agent 会话数量（当前项目） */
   const archivedAgentSessionCount = React.useMemo(
-    () => agentSessions.filter((s) => s.archived && !draftSessionIds.has(s.id) && s.workspaceId === currentWorkspaceId).length,
+    () => agentSessions.filter((s) => s.archived && !draftSessionIds.has(s.id) && (s.workspaceId ?? currentWorkspaceId) === currentWorkspaceId).length,
     [agentSessions, draftSessionIds, currentWorkspaceId]
   )
 
@@ -703,18 +703,15 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       )
 
       if (updated.pinned) {
-        // 置顶时：创建或标记置顶标签，确保顺序 [scratch, ...pinned, ...nonPinned]
-        // Chat 单置顶约束：已有 Chat 置顶标签时先自动取消旧置顶
-        let oldChatPinnedSessionId: string | null = null
+        // Chat 单置顶约束：先从当前 tabs 计算旧置顶信息，再在 updater 中纯计算
+        const currentTabs = store.get(tabsAtom)
+        const existingChatPinned = currentTabs.find((t) => t.pinned && t.type === 'chat' && t.sessionId !== id)
+        const oldChatPinnedSessionId = existingChatPinned?.sessionId ?? null
+
         setTabs((prev) => {
           const scratchTab = prev.find((t) => t.id === SCRATCH_PAD_ID) ?? createScratchPadTab()
-          // 检查是否已有 Chat 置顶标签
-          const existingChatPinned = prev.find((t) => t.pinned && t.type === 'chat' && t.sessionId !== id)
-          if (existingChatPinned) {
-            oldChatPinnedSessionId = existingChatPinned.sessionId
-          }
-          // 移除旧 Chat 置顶标签
-          let tabsWithoutOldPinned = existingChatPinned
+          // 移除旧 Chat 置顶标签（用 sessionId 匹配，因为 prev 可能已变化）
+          const tabsWithoutOldPinned = existingChatPinned
             ? prev.filter((t) => t.id !== existingChatPinned.id)
             : prev
           const existing = tabsWithoutOldPinned.find((t) => t.sessionId === id && t.type === 'chat')
@@ -762,20 +759,20 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
           toast.success('已置顶')
         }
       } else {
-        // 取消置顶时：移除置顶标签（纯函数计算，副作用在外部调用）
-        let newActiveId: string | null = null
-        setTabs((prev) => {
-          const tab = prev.find((t) => t.sessionId === id && t.pinned)
-          if (!tab) return prev
+        // 取消置顶时：先计算新 activeId，再在 updater 中纯计算
+        const currentTabs = store.get(tabsAtom)
+        const tab = currentTabs.find((t) => t.sessionId === id && t.pinned && t.type === 'chat')
+        if (tab) {
           const currentActive = store.get(activeTabIdAtom)
+          let newActiveId: string | null = null
           if (currentActive === tab.id) {
-            const otherPinned = prev.filter((t) => t.pinned && t.id !== tab.id)
-            const nonPinned = prev.filter((t) => !t.pinned && t.id !== SCRATCH_PAD_ID && t.type !== 'preview')
+            const otherPinned = currentTabs.filter((t) => t.pinned && t.id !== tab.id)
+            const nonPinned = currentTabs.filter((t) => !t.pinned && t.id !== SCRATCH_PAD_ID && t.type !== 'preview')
             newActiveId = otherPinned.at(-1)?.id ?? nonPinned.at(0)?.id ?? SCRATCH_PAD_ID
           }
-          return prev.filter((t) => t.id !== tab.id)
-        })
-        if (newActiveId) setActiveTabId(newActiveId)
+          setTabs((prev) => prev.filter((t) => t.id !== tab.id))
+          if (newActiveId) setActiveTabId(newActiveId)
+        }
         toast.success('已取消置顶')
       }
     } catch (error) {
@@ -992,23 +989,20 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       const original = store.get(agentSessionsAtom).find((s) => s.id === id)
       const updated = await window.electronAPI.togglePinAgentSession(id)
       setAgentSessions((prev) => replaceAgentSessionInFreshnessOrder(prev, updated))
-      const workspaceId = updated.workspaceId
+      const workspaceId = updated.workspaceId ?? store.get(agentSessionsAtom).find((s) => s.id === id)?.workspaceId
 
       if (updated.pinned) {
-        // 置顶时：创建或标记置顶标签，确保顺序 [scratch, ...pinned, ...nonPinned]
-        // 每工作区单置顶约束：同工作区已有置顶标签时先自动取消旧置顶
-        let oldPinnedSessionId: string | null = null
+        // 每工作区单置顶约束：先从当前 tabs 计算旧置顶信息，再在 updater 中纯计算
+        const currentTabs = store.get(tabsAtom)
+        const existingWorkspacePinned = workspaceId
+          ? currentTabs.find((t) => t.pinned && t.type === 'agent' && t.workspaceId === workspaceId && t.sessionId !== id)
+          : undefined
+        const oldPinnedSessionId = existingWorkspacePinned?.sessionId ?? null
+
         setTabs((prev) => {
           const scratchTab = prev.find((t) => t.id === SCRATCH_PAD_ID) ?? createScratchPadTab()
-          // 检查是否已有同工作区的置顶标签（workspaceId 为空时跳过约束，无法确定工作区归属）
-          const existingWorkspacePinned = workspaceId
-            ? prev.find((t) => t.pinned && t.type === 'agent' && t.workspaceId === workspaceId && t.sessionId !== id)
-            : undefined
-          if (existingWorkspacePinned) {
-            oldPinnedSessionId = existingWorkspacePinned.sessionId
-          }
           // 移除旧置顶标签
-          let tabsWithoutOldPinned = existingWorkspacePinned
+          const tabsWithoutOldPinned = existingWorkspacePinned
             ? prev.filter((t) => t.id !== existingWorkspacePinned.id)
             : prev
           const existing = tabsWithoutOldPinned.find((t) => t.sessionId === id && t.type === 'agent')
@@ -1026,7 +1020,6 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
           }).catch((err) => {
             console.error('[侧边栏] 取消旧置顶失败，回滚前端标签:', err)
             const rollbackId = oldPinnedSessionId
-            if (!rollbackId) return
             // 回滚：将旧置顶标签重新添加回 tabs
             setTabs((prev) => {
               const scratchTab = prev.find((t) => t.id === SCRATCH_PAD_ID) ?? createScratchPadTab()
@@ -1056,20 +1049,20 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
           toast.success('已置顶')
         }
       } else {
-        // 取消置顶时：移除置顶标签（纯函数计算，副作用在外部调用）
-        let newActiveId: string | null = null
-        setTabs((prev) => {
-          const tab = prev.find((t) => t.sessionId === id && t.pinned)
-          if (!tab) return prev
+        // 取消置顶时：先计算新 activeId，再在 updater 中纯计算
+        const currentTabs = store.get(tabsAtom)
+        const tab = currentTabs.find((t) => t.sessionId === id && t.pinned && t.type === 'agent')
+        if (tab) {
           const currentActive = store.get(activeTabIdAtom)
+          let newActiveId: string | null = null
           if (currentActive === tab.id) {
-            const otherPinned = prev.filter((t) => t.pinned && t.id !== tab.id)
-            const nonPinned = prev.filter((t) => !t.pinned && t.id !== SCRATCH_PAD_ID && t.type !== 'preview')
+            const otherPinned = currentTabs.filter((t) => t.pinned && t.id !== tab.id)
+            const nonPinned = currentTabs.filter((t) => !t.pinned && t.id !== SCRATCH_PAD_ID && t.type !== 'preview')
             newActiveId = otherPinned.at(-1)?.id ?? nonPinned.at(0)?.id ?? SCRATCH_PAD_ID
           }
-          return prev.filter((t) => t.id !== tab.id)
-        })
-        if (newActiveId) setActiveTabId(newActiveId)
+          setTabs((prev) => prev.filter((t) => t.id !== tab.id))
+          if (newActiveId) setActiveTabId(newActiveId)
+        }
         toast.success('已取消置顶')
       }
     } catch (error) {
@@ -1145,14 +1138,21 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         const existingPinned = updatedSession.workspaceId
           ? prev.find((t) => t.pinned && t.type === 'agent' && t.workspaceId === updatedSession.workspaceId && t.id !== tab.id)
           : undefined
+        let result: TabItem[]
         if (existingPinned) {
           oldPinnedSessionId = existingPinned.sessionId
           // 取消旧置顶标签，更新迁移标签的 workspaceId
-          return prev
+          result = prev
             .map((t) => t.id === existingPinned.id ? { ...t, pinned: false } : t)
             .map((t) => t.id === tab.id ? { ...t, workspaceId: updatedSession.workspaceId } : t)
+        } else {
+          result = prev.map((t) => t.id === tab.id ? { ...t, workspaceId: updatedSession.workspaceId } : t)
         }
-        return prev.map((t) => t.id === tab.id ? { ...t, workspaceId: updatedSession.workspaceId } : t)
+        // 重排标签顺序：scratch → pinned → non-pinned
+        const scratchTab = result.find((t) => t.id === SCRATCH_PAD_ID) ?? createScratchPadTab()
+        const pinnedTabs = result.filter((t) => t.pinned && t.id !== SCRATCH_PAD_ID)
+        const nonPinnedTabs = result.filter((t) => !t.pinned && t.id !== SCRATCH_PAD_ID && t.type !== 'preview')
+        return [scratchTab, ...pinnedTabs, ...nonPinnedTabs]
       })
       // 同步取消旧置顶的后端状态
       if (oldPinnedSessionId) {
@@ -1173,7 +1173,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       agentSessions.filter((session) =>
         session.archived
         && !draftSessionIds.has(session.id)
-        && session.workspaceId === currentWorkspaceId
+        && (session.workspaceId ?? currentWorkspaceId) === currentWorkspaceId
       )
     )),
     [agentSessions, draftSessionIds, currentWorkspaceId]

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -71,6 +71,8 @@ import {
   closeTab,
   updateTabTitle,
   sessionViewStateMapAtom,
+  SCRATCH_PAD_ID,
+  type TabItem,
 } from '@/atoms/tab-atoms'
 import { userProfileAtom } from '@/atoms/user-profile'
 import { sidebarViewModeAtom } from '@/atoms/sidebar-atoms'
@@ -904,25 +906,61 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     }
   }, [setAgentSessions, setTabs])
 
-  /** 切换 Agent 会话置顶状态 */
+  /** 切换 Agent 会话置顶状态（同步标签页常驻） */
   const handleTogglePinAgent = React.useCallback(async (id: string): Promise<void> => {
     try {
       const original = store.get(agentSessionsAtom).find((s) => s.id === id)
       const updated = await window.electronAPI.togglePinAgentSession(id)
       setAgentSessions((prev) => replaceAgentSessionInFreshnessOrder(prev, updated))
+
       if (updated.pinned) {
+        // 置顶时：创建或标记置顶标签
+        setTabs((prev) => {
+          const existing = prev.find((t) => t.sessionId === id && t.type === 'agent')
+          if (existing) {
+            return prev.map((t) => t.id === existing.id ? { ...t, pinned: true } : t)
+          }
+          // 创建新置顶标签
+          const scratchTab = prev.find((t) => t.id === SCRATCH_PAD_ID)
+          const pinnedTabs = prev.filter((t) => t.pinned)
+          const nonPinnedTabs = prev.filter((t) => !t.pinned && t.id !== SCRATCH_PAD_ID && t.type !== 'preview')
+          const newTab: TabItem = {
+            id: id,
+            type: 'agent',
+            sessionId: id,
+            title: updated.title,
+            pinned: true,
+          }
+          return scratchTab
+            ? [scratchTab, ...pinnedTabs, newTab, ...nonPinnedTabs]
+            : [newTab, ...pinnedTabs, ...nonPinnedTabs]
+        })
         if (original?.archived && !updated.archived) {
           toast.success('已置顶', { description: '已自动取消归档' })
         } else {
           toast.success('已置顶')
         }
       } else {
+        // 取消置顶时：移除置顶标签
+        setTabs((prev) => {
+          const tab = prev.find((t) => t.sessionId === id && t.pinned)
+          if (!tab) return prev
+          // 如果当前激活的是这个标签，切换到最近的置顶标签或 Scratch Pad
+          const currentActive = store.get(activeTabIdAtom)
+          if (currentActive === tab.id) {
+            const otherPinned = prev.filter((t) => t.pinned && t.id !== tab.id)
+            const nonPinned = prev.filter((t) => !t.pinned && t.id !== SCRATCH_PAD_ID && t.type !== 'preview')
+            const newActive = otherPinned.at(-1)?.id ?? nonPinned.at(0)?.id ?? SCRATCH_PAD_ID
+            setActiveTabId(newActive)
+          }
+          return prev.filter((t) => t.id !== tab.id)
+        })
         toast.success('已取消置顶')
       }
     } catch (error) {
       console.error('[侧边栏] 切换 Agent 会话置顶失败:', error)
     }
-  }, [store, setAgentSessions])
+  }, [store, setAgentSessions, setTabs, setActiveTabId])
 
   /** 切换 Agent 会话归档状态 */
   const handleToggleArchiveAgent = React.useCallback(async (id: string): Promise<void> => {

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -692,7 +692,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     }
   }, [setConversations, setTabs])
 
-  /** 切换对话置顶状态 */
+  /** 切换对话置顶状态（同步标签页常驻） */
   const handleTogglePin = React.useCallback(async (id: string): Promise<void> => {
     try {
       const original = store.get(conversationsAtom).find((c) => c.id === id)
@@ -700,14 +700,53 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       setConversations((prev) =>
         prev.map((c) => (c.id === updated.id ? updated : c))
       )
-      // 归档会话被置顶时会自动取消归档
-      if (original?.archived && updated.pinned && !updated.archived) {
-        toast.success('已取消归档并置顶')
+
+      if (updated.pinned) {
+        // 置顶时：创建或标记置顶标签
+        setTabs((prev) => {
+          const existing = prev.find((t) => t.sessionId === id && t.type === 'chat')
+          if (existing) {
+            return prev.map((t) => t.id === existing.id ? { ...t, pinned: true } : t)
+          }
+          const scratchTab = prev.find((t) => t.id === SCRATCH_PAD_ID)
+          const pinnedTabs = prev.filter((t) => t.pinned)
+          const nonPinnedTabs = prev.filter((t) => !t.pinned && t.id !== SCRATCH_PAD_ID && t.type !== 'preview')
+          const newTab: TabItem = {
+            id: id,
+            type: 'chat',
+            sessionId: id,
+            title: updated.title,
+            pinned: true,
+          }
+          return scratchTab
+            ? [scratchTab, ...pinnedTabs, newTab, ...nonPinnedTabs]
+            : [newTab, ...pinnedTabs, ...nonPinnedTabs]
+        })
+        if (original?.archived && !updated.archived) {
+          toast.success('已置顶', { description: '已自动取消归档' })
+        } else {
+          toast.success('已置顶')
+        }
+      } else {
+        // 取消置顶时：移除置顶标签
+        setTabs((prev) => {
+          const tab = prev.find((t) => t.sessionId === id && t.pinned)
+          if (!tab) return prev
+          const currentActive = store.get(activeTabIdAtom)
+          if (currentActive === tab.id) {
+            const otherPinned = prev.filter((t) => t.pinned && t.id !== tab.id)
+            const nonPinned = prev.filter((t) => !t.pinned && t.id !== SCRATCH_PAD_ID && t.type !== 'preview')
+            const newActive = otherPinned.at(-1)?.id ?? nonPinned.at(0)?.id ?? SCRATCH_PAD_ID
+            setActiveTabId(newActive)
+          }
+          return prev.filter((t) => t.id !== tab.id)
+        })
+        toast.success('已取消置顶')
       }
     } catch (error) {
       console.error('[侧边栏] 切换置顶失败:', error)
     }
-  }, [store, setConversations])
+  }, [store, setConversations, setTabs, setActiveTabId])
 
   /** 切换对话归档状态 */
   const handleToggleArchive = React.useCallback(async (id: string): Promise<void> => {

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -1440,11 +1440,14 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         </Tooltip>
       </div>
 
-      {/* 新对话/新会话按钮 + 搜索按钮 */}
+      {/* 新对话/新会话按钮 + 搜索按钮 + 工作区选择器（Agent 模式） */}
       <div className="px-3 pt-2 flex items-center gap-1.5">
         <button
           onClick={mode === 'agent' ? handleNewAgentSession : handleNewConversation}
-          className="flex-1 flex items-center gap-2 px-3 py-2 rounded-[10px] text-[13px] font-medium text-foreground/70 bg-primary/5 hover:bg-primary/10 transition-colors duration-100 titlebar-no-drag border border-dashed border-[hsl(var(--dashed-border))] hover:border-[hsl(var(--dashed-border-hover))]"
+          className={cn(
+            'flex items-center gap-2 px-3 py-2 rounded-[10px] text-[13px] font-medium text-foreground/70 bg-primary/5 hover:bg-primary/10 transition-colors duration-100 titlebar-no-drag border border-dashed border-[hsl(var(--dashed-border))] hover:border-[hsl(var(--dashed-border-hover))]',
+            mode === 'agent' ? 'flex-shrink-0' : 'flex-1',
+          )}
         >
           <Plus size={14} />
           <span>{mode === 'agent' ? '新会话' : '新对话'}</span>
@@ -1460,6 +1463,11 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
           </TooltipTrigger>
           <TooltipContent side="bottom">搜索 ({getAcceleratorDisplay(getActiveAccelerator('global-search'))})</TooltipContent>
         </Tooltip>
+        {mode === 'agent' && (
+          <div className="flex-1 min-w-0 titlebar-no-drag">
+            <WorkspaceSelector />
+          </div>
+        )}
       </div>
 
       {/* 自动任务入口：作为任务中心入口放在置顶区上方，不参与置顶列表层级。 */}
@@ -1471,55 +1479,69 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         />
       </div>
 
-      {/* Chat 模式：导航菜单（置顶区域） */}
-      {mode === 'chat' && (
-        <div className="flex flex-col gap-1 pt-1 px-3">
-          <SidebarItem
-            icon={<Pin size={16} />}
-            label="置顶对话"
-            suffix={
-              pinnedConversations.length > 0 ? (
-                pinnedExpanded
-                  ? <ChevronDown size={14} className="text-foreground/40" />
-                  : <ChevronRight size={14} className="text-foreground/40" />
-              ) : undefined
-            }
-            onClick={() => handleItemClick('pinned')}
-          />
-        </div>
-      )}
-
-      {/* Chat 模式：置顶对话区域 */}
-      {mode === 'chat' && pinnedExpanded && pinnedConversations.length > 0 && (
-        <div className="px-3 pt-1 pb-1">
-          <div className="flex flex-col gap-0.5 pl-1 border-l-2 border-primary/20 ml-2">
-            {pinnedConversations.map((conv) => (
-              <ConversationItem
-                key={`pinned-${conv.id}`}
-                conversation={conv}
-                active={conv.id === activeSessionId}
-                streaming={streamingIds.has(conv.id)}
-                showPinIcon={false}
-                relativeTimeNow={relativeTimeNow}
-                onSelect={handleSelectConversation}
-                onRequestDelete={handleRequestDelete}
-                onRename={handleRename}
-                onTogglePin={handleTogglePin}
-                onToggleArchive={handleToggleArchive}
-              />
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* Agent 模式 active 视图：项目选择器 + 置顶 + 日期分组 */}
-      {mode === 'agent' && viewMode === 'active' ? (
+      {/* Chat 模式 active 视图：置顶 + 日期分组 */}
+      {mode === 'chat' && viewMode === 'active' && (
         <div className="flex-1 flex flex-col min-h-0">
-          {/* 项目选择器 */}
-          <div className="px-3 pt-1 flex-shrink-0 titlebar-no-drag">
-            <WorkspaceSelector />
-          </div>
+          {pinnedConversations.length > 0 && (
+            <div className="px-2 pt-2 pb-1 flex-shrink-0 titlebar-no-drag">
+              <div className="px-1.5 pb-1 text-[11px] font-medium text-foreground/40 select-none">
+                置顶
+              </div>
+              <div className="flex flex-col gap-0.5">
+                {pinnedConversations.map((conv) => (
+                  <ConversationItem
+                    key={`pinned-${conv.id}`}
+                    conversation={conv}
+                    active={conv.id === activeSessionId}
+                    streaming={streamingIds.has(conv.id)}
+                    showPinIcon={false}
+                    relativeTimeNow={relativeTimeNow}
+                    onSelect={handleSelectConversation}
+                    onRequestDelete={handleRequestDelete}
+                    onRename={handleRename}
+                    onTogglePin={handleTogglePin}
+                    onToggleArchive={handleToggleArchive}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
 
+          {/* 日期分组对话列表 */}
+          <div className="flex-1 overflow-y-auto px-2 pb-3 scrollbar-thin min-h-0 titlebar-no-drag">
+            <div className="flex flex-col gap-0.5">
+              {conversationGroups.map((group) => (
+                <div key={group.label} className="mb-1">
+                  <div className="px-1.5 pt-2 pb-1 text-[11px] font-medium text-foreground/40 select-none">
+                    {group.label}
+                  </div>
+                  <div className="flex flex-col gap-0.5">
+                    {group.items.map((conv) => (
+                      <ConversationItem
+                        key={conv.id}
+                        conversation={conv}
+                        active={conv.id === activeSessionId}
+                        streaming={streamingIds.has(conv.id)}
+                        showPinIcon={!!conv.pinned}
+                        relativeTimeNow={relativeTimeNow}
+                        onSelect={handleSelectConversation}
+                        onRequestDelete={handleRequestDelete}
+                        onRename={handleRename}
+                        onTogglePin={handleTogglePin}
+                        onToggleArchive={handleToggleArchive}
+                      />
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Agent 模式 active 视图：置顶 + 日期分组 */}
+      {mode === 'agent' && viewMode === 'active' && (
+        <div className="flex-1 flex flex-col min-h-0">
           {pinnedAgentSessions.length > 0 && (
             <div className="px-2 pt-2 pb-1 flex-shrink-0 titlebar-no-drag">
               <div className="px-1.5 pb-1 text-[11px] font-medium text-foreground/40 select-none">
@@ -1579,18 +1601,19 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
             </div>
           </div>
         </div>
-      ) : (
+      )}
+
+      {/* 归档视图 */}
+      {viewMode === 'archived' && (
         <>
           {/* 归档视图标题栏 */}
-          {viewMode === 'archived' && (
-            <div className="px-6 pt-3 pb-1">
-              <div className="text-[12px] font-medium text-foreground/40">
-                已归档{mode === 'agent' ? '会话' : '对话'}
-              </div>
+          <div className="px-6 pt-3 pb-1">
+            <div className="text-[12px] font-medium text-foreground/40">
+              已归档{mode === 'agent' ? '会话' : '对话'}
             </div>
-          )}
+          </div>
 
-          {/* Chat 模式 / 归档视图：单列表布局 */}
+          {/* Chat 模式 / Agent 模式归档：单列表布局 */}
           <div className="flex-1 overflow-y-auto px-3 pt-2 pb-3 scrollbar-thin titlebar-no-drag">
             {mode === 'chat' ? (
               /* Chat 模式：对话按日期分组 */

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -1435,8 +1435,13 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         </Tooltip>
       </div>
 
-      {/* 新对话/新会话按钮 + 搜索按钮 + 工作区选择器（Agent 模式） */}
+      {/* 工作区选择器（Agent 模式，放在最前）/ 新对话/新会话按钮 + 搜索按钮 */}
       <div className="px-3 pt-2 flex items-center gap-1.5">
+        {mode === 'agent' && (
+          <div className="flex-1 min-w-0 titlebar-no-drag">
+            <WorkspaceSelector />
+          </div>
+        )}
         <button
           onClick={mode === 'agent' ? handleNewAgentSession : handleNewConversation}
           className={cn(
@@ -1458,11 +1463,6 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
           </TooltipTrigger>
           <TooltipContent side="bottom">搜索 ({getAcceleratorDisplay(getActiveAccelerator('global-search'))})</TooltipContent>
         </Tooltip>
-        {mode === 'agent' && (
-          <div className="flex-1 min-w-0 titlebar-no-drag">
-            <WorkspaceSelector />
-          </div>
-        )}
       </div>
 
       {/* 自动任务入口：作为任务中心入口放在置顶区上方，不参与置顶列表层级。 */}
@@ -2249,7 +2249,7 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
             startEdit()
           }}
           className={cn(
-            'group relative w-full flex items-center gap-1.5 rounded-md py-1 pl-2.5 pr-1.5 transition-colors duration-100 titlebar-no-drag text-left',
+            'group relative w-full flex items-center gap-2 px-2 py-1.5 rounded-md transition-colors duration-100 titlebar-no-drag text-left',
             active && 'agent-session-item-active',
             leftAccent
               ? SESSION_ACCENT_ROW_CLASS[leftAccent]

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -72,6 +72,7 @@ import {
   updateTabTitle,
   sessionViewStateMapAtom,
   SCRATCH_PAD_ID,
+  CHAT_WORKSPACE_ID,
   createScratchPadTab,
   type TabItem,
 } from '@/atoms/tab-atoms'
@@ -534,7 +535,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     [conversations, viewMode, draftSessionIds]
   )
 
-  /** 置顶 Agent 会话列表（仅活跃模式显示，按当前项目过滤，排除 draft） */
+  /** 置顶 Agent 会话列表（仅活跃模式显示，显示所有工作区，排除 draft） */
   const pinnedAgentSessions = React.useMemo(
     () => {
       if (viewMode !== 'active') return []
@@ -542,11 +543,10 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         s.pinned
         && !s.archived
         && !draftSessionIds.has(s.id)
-        && s.workspaceId === currentWorkspaceId
       )
       return sortAgentSessionsByUpdatedAtDesc(filtered)
     },
-    [agentSessions, viewMode, draftSessionIds, currentWorkspaceId]
+    [agentSessions, viewMode, draftSessionIds]
   )
 
   /** 当前项目的非置顶 Agent 会话（根据 viewMode 过滤归档状态，排除 draft） */
@@ -693,7 +693,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     }
   }, [setConversations, setTabs])
 
-  /** 切换对话置顶状态（同步标签页常驻） */
+  /** 切换对话置顶状态（同步标签页常驻，Chat 同时只允许一个置顶标签） */
   const handleTogglePin = React.useCallback(async (id: string): Promise<void> => {
     try {
       const original = store.get(conversationsAtom).find((c) => c.id === id)
@@ -704,18 +704,60 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
 
       if (updated.pinned) {
         // 置顶时：创建或标记置顶标签，确保顺序 [scratch, ...pinned, ...nonPinned]
+        // Chat 单置顶约束：已有 Chat 置顶标签时先自动取消旧置顶
+        let oldChatPinnedSessionId: string | null = null
         setTabs((prev) => {
           const scratchTab = prev.find((t) => t.id === SCRATCH_PAD_ID) ?? createScratchPadTab()
-          const existing = prev.find((t) => t.sessionId === id && t.type === 'chat')
+          // 检查是否已有 Chat 置顶标签
+          const existingChatPinned = prev.find((t) => t.pinned && t.type === 'chat' && t.sessionId !== id)
+          if (existingChatPinned) {
+            oldChatPinnedSessionId = existingChatPinned.sessionId
+          }
+          // 移除旧 Chat 置顶标签
+          let tabsWithoutOldPinned = existingChatPinned
+            ? prev.filter((t) => t.id !== existingChatPinned.id)
+            : prev
+          const existing = tabsWithoutOldPinned.find((t) => t.sessionId === id && t.type === 'chat')
           const updatedTabs = existing
-            ? prev.map((t) => t.id === existing.id ? { ...t, pinned: true } : t)
-            : [...prev, { id: id, type: 'chat' as const, sessionId: id, title: updated.title, pinned: true }]
+            ? tabsWithoutOldPinned.map((t) => t.id === existing.id ? { ...t, pinned: true, workspaceId: CHAT_WORKSPACE_ID } : t)
+            : [...tabsWithoutOldPinned, { id: id, type: 'chat' as const, sessionId: id, title: updated.title, pinned: true, workspaceId: CHAT_WORKSPACE_ID }]
           const pinnedTabs = updatedTabs.filter((t) => t.pinned && t.id !== SCRATCH_PAD_ID)
           const nonPinnedTabs = updatedTabs.filter((t) => !t.pinned && t.id !== SCRATCH_PAD_ID && t.type !== 'preview')
           return [scratchTab, ...pinnedTabs, ...nonPinnedTabs]
         })
+        // 同步取消旧 Chat 置顶的后端状态（失败时回滚前端标签）
+        if (oldChatPinnedSessionId) {
+          window.electronAPI.togglePinConversation(oldChatPinnedSessionId).then((oldUpdated) => {
+            setConversations((prev) => prev.map((c) => (c.id === oldUpdated.id ? oldUpdated : c)))
+          }).catch((err) => {
+            console.error('[侧边栏] 取消旧 Chat 置顶失败，回滚前端标签:', err)
+            const rollbackId = oldChatPinnedSessionId
+            if (!rollbackId) return
+            // 回滚：将旧置顶标签重新添加回 tabs
+            setTabs((prev) => {
+              const scratchTab = prev.find((t) => t.id === SCRATCH_PAD_ID) ?? createScratchPadTab()
+              const oldConversation = store.get(conversationsAtom).find((c) => c.id === rollbackId)
+              const restoredTab: TabItem = {
+                id: rollbackId,
+                type: 'chat',
+                sessionId: rollbackId,
+                title: oldConversation?.title ?? '对话',
+                pinned: true,
+                workspaceId: CHAT_WORKSPACE_ID,
+              }
+              const pinnedTabs = prev.filter((t) => t.pinned && t.id !== SCRATCH_PAD_ID)
+              const hasRestored = pinnedTabs.some((t) => t.id === rollbackId)
+              const allPinned = hasRestored ? pinnedTabs : [...pinnedTabs, restoredTab]
+              const nonPinnedTabs = prev.filter((t) => !t.pinned && t.id !== SCRATCH_PAD_ID && t.type !== 'preview')
+              return [scratchTab, ...allPinned, ...nonPinnedTabs]
+            })
+            toast.error('替换置顶失败', { description: '旧置顶状态未同步，请重试' })
+          })
+        }
         if (original?.archived && !updated.archived) {
-          toast.success('已置顶', { description: '已自动取消归档' })
+          toast.success('已置顶', { description: oldChatPinnedSessionId ? '已替换之前的置顶' : '已自动取消归档' })
+        } else if (oldChatPinnedSessionId) {
+          toast.success('已置顶', { description: '已替换之前的置顶' })
         } else {
           toast.success('已置顶')
         }
@@ -944,27 +986,72 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     }
   }, [setAgentSessions, setTabs])
 
-  /** 切换 Agent 会话置顶状态（同步标签页常驻） */
+  /** 切换 Agent 会话置顶状态（同步标签页常驻，每工作区只允许一个置顶标签） */
   const handleTogglePinAgent = React.useCallback(async (id: string): Promise<void> => {
     try {
       const original = store.get(agentSessionsAtom).find((s) => s.id === id)
       const updated = await window.electronAPI.togglePinAgentSession(id)
       setAgentSessions((prev) => replaceAgentSessionInFreshnessOrder(prev, updated))
+      const workspaceId = updated.workspaceId
 
       if (updated.pinned) {
         // 置顶时：创建或标记置顶标签，确保顺序 [scratch, ...pinned, ...nonPinned]
+        // 每工作区单置顶约束：同工作区已有置顶标签时先自动取消旧置顶
+        let oldPinnedSessionId: string | null = null
         setTabs((prev) => {
           const scratchTab = prev.find((t) => t.id === SCRATCH_PAD_ID) ?? createScratchPadTab()
-          const existing = prev.find((t) => t.sessionId === id && t.type === 'agent')
+          // 检查是否已有同工作区的置顶标签（workspaceId 为空时跳过约束，无法确定工作区归属）
+          const existingWorkspacePinned = workspaceId
+            ? prev.find((t) => t.pinned && t.type === 'agent' && t.workspaceId === workspaceId && t.sessionId !== id)
+            : undefined
+          if (existingWorkspacePinned) {
+            oldPinnedSessionId = existingWorkspacePinned.sessionId
+          }
+          // 移除旧置顶标签
+          let tabsWithoutOldPinned = existingWorkspacePinned
+            ? prev.filter((t) => t.id !== existingWorkspacePinned.id)
+            : prev
+          const existing = tabsWithoutOldPinned.find((t) => t.sessionId === id && t.type === 'agent')
           const updatedTabs = existing
-            ? prev.map((t) => t.id === existing.id ? { ...t, pinned: true } : t)
-            : [...prev, { id: id, type: 'agent' as const, sessionId: id, title: updated.title, pinned: true }]
+            ? tabsWithoutOldPinned.map((t) => t.id === existing.id ? { ...t, pinned: true, workspaceId } : t)
+            : [...tabsWithoutOldPinned, { id: id, type: 'agent' as const, sessionId: id, title: updated.title, pinned: true, workspaceId }]
           const pinnedTabs = updatedTabs.filter((t) => t.pinned && t.id !== SCRATCH_PAD_ID)
           const nonPinnedTabs = updatedTabs.filter((t) => !t.pinned && t.id !== SCRATCH_PAD_ID && t.type !== 'preview')
           return [scratchTab, ...pinnedTabs, ...nonPinnedTabs]
         })
+        // 同步取消旧置顶的后端状态（失败时回滚前端标签）
+        if (oldPinnedSessionId) {
+          window.electronAPI.togglePinAgentSession(oldPinnedSessionId).then((oldUpdated) => {
+            setAgentSessions((prev) => prev.map((s) => (s.id === oldUpdated.id ? oldUpdated : s)))
+          }).catch((err) => {
+            console.error('[侧边栏] 取消旧置顶失败，回滚前端标签:', err)
+            const rollbackId = oldPinnedSessionId
+            if (!rollbackId) return
+            // 回滚：将旧置顶标签重新添加回 tabs
+            setTabs((prev) => {
+              const scratchTab = prev.find((t) => t.id === SCRATCH_PAD_ID) ?? createScratchPadTab()
+              const oldSession = store.get(agentSessionsAtom).find((s) => s.id === rollbackId)
+              const restoredTab: TabItem = {
+                id: rollbackId,
+                type: 'agent',
+                sessionId: rollbackId,
+                title: oldSession?.title ?? 'Agent 会话',
+                pinned: true,
+                workspaceId: oldSession?.workspaceId,
+              }
+              const pinnedTabs = prev.filter((t) => t.pinned && t.id !== SCRATCH_PAD_ID)
+              const hasRestored = pinnedTabs.some((t) => t.id === rollbackId)
+              const allPinned = hasRestored ? pinnedTabs : [...pinnedTabs, restoredTab]
+              const nonPinnedTabs = prev.filter((t) => !t.pinned && t.id !== SCRATCH_PAD_ID && t.type !== 'preview')
+              return [scratchTab, ...allPinned, ...nonPinnedTabs]
+            })
+            toast.error('替换置顶失败', { description: '旧置顶状态未同步，请重试' })
+          })
+        }
         if (original?.archived && !updated.archived) {
-          toast.success('已置顶', { description: '已自动取消归档' })
+          toast.success('已置顶', { description: oldPinnedSessionId ? '已替换之前的置顶' : '已自动取消归档' })
+        } else if (oldPinnedSessionId) {
+          toast.success('已置顶', { description: '已替换之前的置顶' })
         } else {
           toast.success('已置顶')
         }
@@ -1035,10 +1122,44 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     setAgentSessions((prev) => replaceAgentSessionInFreshnessOrder(prev, updatedSession))
     // 如果迁移的是当前选中的会话，取消选中并关闭标签页
     if (currentAgentSessionId === updatedSession.id) {
-      const tabResult = closeTab(tabs, activeTabId, updatedSession.id)
+      // 置顶标签不可关闭，先取消置顶标记再关闭
+      setTabs((prev) => {
+        const tab = prev.find((t) => t.sessionId === updatedSession.id && t.pinned)
+        if (tab) return prev.map((t) => t.id === tab.id ? { ...t, pinned: false } : t)
+        return prev
+      })
+      const currentTabs = store.get(tabsAtom)
+      const currentActiveTabId = store.get(activeTabIdAtom)
+      const tabResult = closeTab(currentTabs, currentActiveTabId, updatedSession.id)
       setTabs(tabResult.tabs)
       setActiveTabId(tabResult.activeTabId)
       setCurrentAgentSessionId(null)
+    } else {
+      // 非当前会话：如果是置顶标签，更新 workspaceId（会话已迁移到新工作区）
+      // 同时检查目标工作区是否已有置顶标签，如有则取消旧置顶以保持单约束
+      let oldPinnedSessionId: string | null = null
+      setTabs((prev) => {
+        const tab = prev.find((t) => t.sessionId === updatedSession.id && t.pinned)
+        if (!tab || tab.workspaceId === updatedSession.workspaceId) return prev
+        // 检查目标工作区是否已有置顶标签
+        const existingPinned = updatedSession.workspaceId
+          ? prev.find((t) => t.pinned && t.type === 'agent' && t.workspaceId === updatedSession.workspaceId && t.id !== tab.id)
+          : undefined
+        if (existingPinned) {
+          oldPinnedSessionId = existingPinned.sessionId
+          // 取消旧置顶标签，更新迁移标签的 workspaceId
+          return prev
+            .map((t) => t.id === existingPinned.id ? { ...t, pinned: false } : t)
+            .map((t) => t.id === tab.id ? { ...t, workspaceId: updatedSession.workspaceId } : t)
+        }
+        return prev.map((t) => t.id === tab.id ? { ...t, workspaceId: updatedSession.workspaceId } : t)
+      })
+      // 同步取消旧置顶的后端状态
+      if (oldPinnedSessionId) {
+        window.electronAPI.togglePinAgentSession(oldPinnedSessionId).then((oldUpdated) => {
+          setAgentSessions((prev) => prev.map((s) => (s.id === oldUpdated.id ? oldUpdated : s)))
+        }).catch(console.error)
+      }
     }
     setMoveTargetId(null)
     toast.success('会话已迁移', {
@@ -1551,6 +1672,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                     indicatorStatus={agentIndicatorMap.get(session.id) ?? 'idle'}
                     showPinIcon={false}
                     leftAccent={getSessionLeftAccent(agentIndicatorMap.get(session.id) ?? 'idle')}
+                    workspaceName={workspaces.find((w) => w.id === session.workspaceId)?.name}
                     relativeTimeNow={relativeTimeNow}
                     onSelect={handleSelectAgentSession}
                     onRequestDelete={handleRequestDelete}

--- a/apps/electron/src/renderer/components/settings/AgentSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AgentSettings.tsx
@@ -143,7 +143,6 @@ export function AgentSettings(): React.ReactElement {
   const workspaceSlug = currentWorkspace?.slug ?? ''
 
   // 项目排序
-  const { selectProject } = useProjectActions()
   const [dragId, setDragId] = React.useState<string | null>(null)
   const [dropIndicator, setDropIndicator] = React.useState<{ id: string; position: 'before' | 'after' } | null>(null)
 

--- a/apps/electron/src/renderer/components/settings/AgentSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AgentSettings.tsx
@@ -182,7 +182,13 @@ export function AgentSettings(): React.ReactElement {
     setWorkspaces(reordered)
     setDragId(null)
     setDropIndicator(null)
-    window.electronAPI.reorderAgentWorkspaces(reordered.map((w) => w.id)).catch(console.error)
+    const previous = workspaces
+    setWorkspaces(reordered)
+    window.electronAPI.reorderAgentWorkspaces(reordered.map((w) => w.id)).catch((error) => {
+      console.error('[AgentSettings] 项目排序失败:', error)
+      setWorkspaces(previous)
+      toast.error('项目排序失败')
+    })
   }
 
   const handleDragEnd = (): void => { setDragId(null); setDropIndicator(null) }

--- a/apps/electron/src/renderer/components/settings/AgentSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AgentSettings.tsx
@@ -181,11 +181,9 @@ export function AgentSettings(): React.ReactElement {
     const adjustedToIdx = fromIdx < toIdx ? toIdx - 1 : toIdx
     const insertIdx = dropIndicator.position === 'after' ? adjustedToIdx + 1 : adjustedToIdx
     reordered.splice(insertIdx, 0, moved!)
-    setWorkspaces(reordered)
+    const previous = workspaces
     setDragId(null)
     setDropIndicator(null)
-    const previous = workspaces
-    setWorkspaces(reordered)
     window.electronAPI.reorderAgentWorkspaces(reordered.map((w) => w.id)).catch((error) => {
       console.error('[AgentSettings] 项目排序失败:', error)
       setWorkspaces(previous)

--- a/apps/electron/src/renderer/components/settings/AgentSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AgentSettings.tsx
@@ -8,8 +8,8 @@
  */
 
 import * as React from 'react'
-import { useAtomValue, useSetAtom } from 'jotai'
-import { Plus, Plug, Pencil, Trash2, Sparkles, FolderOpen, MessageSquare, ShieldCheck, ChevronDown, ChevronRight, Brain, ImagePlus, Search, RefreshCw, Save, X } from 'lucide-react'
+import { useAtomValue, useSetAtom, useAtom } from 'jotai'
+import { Plus, Plug, Pencil, Trash2, Sparkles, FolderOpen, MessageSquare, ShieldCheck, ChevronDown, ChevronRight, Brain, ImagePlus, Search, RefreshCw, Save, X, GripVertical } from 'lucide-react'
 import { toast } from 'sonner'
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -29,6 +29,7 @@ import {
   agentPendingPromptAtom,
   workspaceCapabilitiesVersionAtom,
 } from '@/atoms/agent-atoms'
+import { useProjectActions } from '@/hooks/useProjectActions'
 import { settingsTabAtom, settingsOpenAtom } from '@/atoms/settings-tab'
 import { appModeAtom } from '@/atoms/app-mode'
 import { chatToolsAtom } from '@/atoms/chat-tool-atoms'
@@ -128,7 +129,7 @@ function rebuildSkillMd(
 // ===== Main Component =====
 
 export function AgentSettings(): React.ReactElement {
-  const workspaces = useAtomValue(agentWorkspacesAtom)
+  const [workspaces, setWorkspaces] = useAtom(agentWorkspacesAtom)
   const currentWorkspaceId = useAtomValue(currentAgentWorkspaceIdAtom)
   const agentChannelId = useAtomValue(agentChannelIdAtom)
   const setAgentSessions = useSetAtom(agentSessionsAtom)
@@ -140,6 +141,52 @@ export function AgentSettings(): React.ReactElement {
 
   const currentWorkspace = workspaces.find((w) => w.id === currentWorkspaceId)
   const workspaceSlug = currentWorkspace?.slug ?? ''
+
+  // 项目排序
+  const { selectProject } = useProjectActions()
+  const [dragId, setDragId] = React.useState<string | null>(null)
+  const [dropIndicator, setDropIndicator] = React.useState<{ id: string; position: 'before' | 'after' } | null>(null)
+
+  const handleDragStart = (e: React.DragEvent, wsId: string): void => {
+    setDragId(wsId)
+    e.dataTransfer.effectAllowed = 'move'
+    e.dataTransfer.setData('text/plain', wsId)
+  }
+
+  const handleDragOver = (e: React.DragEvent, wsId: string): void => {
+    e.preventDefault()
+    e.dataTransfer.dropEffect = 'move'
+    if (!dragId || wsId === dragId) { setDropIndicator(null); return }
+    const rect = e.currentTarget.getBoundingClientRect()
+    const ratio = (e.clientY - rect.top) / rect.height
+    const position: 'before' | 'after' = ratio < 0.5 ? 'before' : 'after'
+    setDropIndicator((prev) => prev?.id === wsId && prev.position === position ? prev : { id: wsId, position })
+  }
+
+  const handleDragLeave = (e: React.DragEvent): void => {
+    if (!e.currentTarget.contains(e.relatedTarget as Node)) setDropIndicator(null)
+  }
+
+  const handleDrop = (e: React.DragEvent, targetId: string): void => {
+    e.preventDefault()
+    if (!dragId || dragId === targetId || !dropIndicator || dropIndicator.id !== targetId) {
+      setDragId(null); setDropIndicator(null); return
+    }
+    const fromIdx = workspaces.findIndex((w) => w.id === dragId)
+    const toIdx = workspaces.findIndex((w) => w.id === targetId)
+    if (fromIdx === -1 || toIdx === -1) { setDragId(null); setDropIndicator(null); return }
+    const reordered = [...workspaces]
+    const [moved] = reordered.splice(fromIdx, 1)
+    const adjustedToIdx = fromIdx < toIdx ? toIdx - 1 : toIdx
+    const insertIdx = dropIndicator.position === 'after' ? adjustedToIdx + 1 : adjustedToIdx
+    reordered.splice(insertIdx, 0, moved!)
+    setWorkspaces(reordered)
+    setDragId(null)
+    setDropIndicator(null)
+    window.electronAPI.reorderAgentWorkspaces(reordered.map((w) => w.id)).catch(console.error)
+  }
+
+  const handleDragEnd = (): void => { setDragId(null); setDropIndicator(null) }
 
   // Tab & view state
   const [activeTab, setActiveTab] = React.useState('skills')
@@ -418,6 +465,42 @@ ${skillList}
 
   return (
     <div className="space-y-4">
+      {/* 项目排序 */}
+      <SettingsSection title="项目排序" description="拖拽调整项目在侧边栏下拉选择器中的显示顺序">
+        <SettingsCard>
+          {workspaces.map((ws) => (
+            <div key={ws.id} className="relative">
+              {dropIndicator?.id === ws.id && dropIndicator.position === 'before' && (
+                <div className="absolute top-0 left-4 right-4 h-0.5 bg-primary rounded-full z-10" />
+              )}
+              <div
+                draggable
+                onDragStart={(e) => handleDragStart(e, ws.id)}
+                onDragOver={(e) => handleDragOver(e, ws.id)}
+                onDragLeave={handleDragLeave}
+                onDrop={(e) => handleDrop(e, ws.id)}
+                onDragEnd={handleDragEnd}
+                className={cn(
+                  'group w-full flex items-center gap-2 px-4 py-2.5 transition-colors cursor-grab active:cursor-grabbing',
+                  dragId === ws.id ? 'opacity-40' : 'hover:bg-muted/50',
+                  ws.id === currentWorkspaceId && 'font-medium',
+                )}
+              >
+                <GripVertical size={14} className="flex-shrink-0 text-muted-foreground/40 group-hover:text-muted-foreground" />
+                <FolderOpen size={16} className="flex-shrink-0 text-muted-foreground" />
+                <span className="flex-1 min-w-0 truncate text-sm">{ws.name}</span>
+                {ws.id === currentWorkspaceId && (
+                  <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-primary/10 text-primary font-medium">当前</span>
+                )}
+              </div>
+              {dropIndicator?.id === ws.id && dropIndicator.position === 'after' && (
+                <div className="absolute bottom-0 left-4 right-4 h-0.5 bg-primary rounded-full z-10" />
+              )}
+            </div>
+          ))}
+        </SettingsCard>
+      </SettingsSection>
+
       <Tabs value={activeTab} onValueChange={setActiveTab}>
         <div className="relative flex rounded-xl bg-muted p-1">
           <div

--- a/apps/electron/src/renderer/components/settings/AgentSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AgentSettings.tsx
@@ -28,6 +28,7 @@ import {
   currentAgentSessionIdAtom,
   agentPendingPromptAtom,
   workspaceCapabilitiesVersionAtom,
+  agentSettingsTabAtom,
 } from '@/atoms/agent-atoms'
 import { useProjectActions } from '@/hooks/useProjectActions'
 import { settingsTabAtom, settingsOpenAtom } from '@/atoms/settings-tab'
@@ -194,7 +195,7 @@ export function AgentSettings(): React.ReactElement {
   const handleDragEnd = (): void => { setDragId(null); setDropIndicator(null) }
 
   // Tab & view state
-  const [activeTab, setActiveTab] = React.useState('skills')
+  const [activeTab, setActiveTab] = useAtom(agentSettingsTabAtom)
   const [viewMode, setViewMode] = React.useState<ViewMode>('list')
   const [editingServer, setEditingServer] = React.useState<EditingServer | null>(null)
 

--- a/apps/electron/src/renderer/components/settings/AgentSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AgentSettings.tsx
@@ -33,6 +33,7 @@ import {
 import { useProjectActions } from '@/hooks/useProjectActions'
 import { settingsTabAtom, settingsOpenAtom } from '@/atoms/settings-tab'
 import { appModeAtom } from '@/atoms/app-mode'
+import { workspaceListModeAtom } from '@/atoms/sidebar-atoms'
 import { chatToolsAtom } from '@/atoms/chat-tool-atoms'
 import type { McpServerEntry, SkillMeta, OtherWorkspaceSkillsGroup, WorkspaceMcpConfig } from '@proma/shared'
 import { SettingsSection, SettingsCard, SettingsRow } from './primitives'
@@ -196,6 +197,7 @@ export function AgentSettings(): React.ReactElement {
 
   // Tab & view state
   const [activeTab, setActiveTab] = useAtom(agentSettingsTabAtom)
+  const [workspaceListMode, setWorkspaceListMode] = useAtom(workspaceListModeAtom)
   const [viewMode, setViewMode] = React.useState<ViewMode>('list')
   const [editingServer, setEditingServer] = React.useState<EditingServer | null>(null)
 
@@ -483,7 +485,7 @@ ${skillList}
             )}
           />
           {[
-            { value: 'workspaces', label: '项目排序' },
+            { value: 'workspaces', label: '项目' },
             { value: 'skills', label: 'Skills' },
             { value: 'mcp', label: 'MCP' },
             { value: 'tools', label: '内置工具' },
@@ -503,10 +505,49 @@ ${skillList}
           ))}
         </div>
 
-        {/* ===== 项目排序 Tab ===== */}
+        {/* ===== 项目 Tab ===== */}
         <TabsContent value="workspaces" className="mt-4 space-y-4">
-          <SettingsSection title="项目排序" description="拖拽调整项目在侧边栏下拉选择器中的显示顺序">
+          <SettingsSection
+            title="项目"
+            description={workspaceListMode === 'dropdown' ? '下拉选择器模式：项目切换压缩为一行按钮，释放侧边栏空间' : '垂直列表模式：项目并排展示，支持内联重命名和拖拽排序'}
+          >
             <SettingsCard>
+              {/* 形态切换开关 */}
+              <div className="flex items-center justify-between px-4 py-3 border-b border-border/40">
+                <div className="space-y-0.5">
+                  <div className="text-sm font-medium">侧边栏展示方式</div>
+                  <div className="text-xs text-muted-foreground">
+                    {workspaceListMode === 'dropdown' ? '当前：下拉选择器' : '当前：垂直列表'}
+                  </div>
+                </div>
+                <div className="flex items-center gap-1 rounded-lg bg-muted p-0.5">
+                  <button
+                    type="button"
+                    onClick={() => setWorkspaceListMode('dropdown')}
+                    className={cn(
+                      'px-3 py-1 text-xs rounded-md transition-colors',
+                      workspaceListMode === 'dropdown'
+                        ? 'bg-background text-foreground shadow-sm font-medium'
+                        : 'text-muted-foreground hover:text-foreground',
+                    )}
+                  >
+                    下拉选择器
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setWorkspaceListMode('list')}
+                    className={cn(
+                      'px-3 py-1 text-xs rounded-md transition-colors',
+                      workspaceListMode === 'list'
+                        ? 'bg-background text-foreground shadow-sm font-medium'
+                        : 'text-muted-foreground hover:text-foreground',
+                    )}
+                  >
+                    垂直列表
+                  </button>
+                </div>
+              </div>
+              {/* 项目排序列表（两种形态共用） */}
               {workspaces.map((ws) => (
                 <div key={ws.id} className="relative">
                   {dropIndicator?.id === ws.id && dropIndicator.position === 'before' && (

--- a/apps/electron/src/renderer/components/settings/AgentSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AgentSettings.tsx
@@ -470,53 +470,19 @@ ${skillList}
 
   return (
     <div className="space-y-4">
-      {/* 项目排序 */}
-      <SettingsSection title="项目排序" description="拖拽调整项目在侧边栏下拉选择器中的显示顺序">
-        <SettingsCard>
-          {workspaces.map((ws) => (
-            <div key={ws.id} className="relative">
-              {dropIndicator?.id === ws.id && dropIndicator.position === 'before' && (
-                <div className="absolute top-0 left-4 right-4 h-0.5 bg-primary rounded-full z-10" />
-              )}
-              <div
-                draggable
-                onDragStart={(e) => handleDragStart(e, ws.id)}
-                onDragOver={(e) => handleDragOver(e, ws.id)}
-                onDragLeave={handleDragLeave}
-                onDrop={(e) => handleDrop(e, ws.id)}
-                onDragEnd={handleDragEnd}
-                className={cn(
-                  'group w-full flex items-center gap-2 px-4 py-2.5 transition-colors cursor-grab active:cursor-grabbing',
-                  dragId === ws.id ? 'opacity-40' : 'hover:bg-muted/50',
-                  ws.id === currentWorkspaceId && 'font-medium',
-                )}
-              >
-                <GripVertical size={14} className="flex-shrink-0 text-muted-foreground/40 group-hover:text-muted-foreground" />
-                <FolderOpen size={16} className="flex-shrink-0 text-muted-foreground" />
-                <span className="flex-1 min-w-0 truncate text-sm">{ws.name}</span>
-                {ws.id === currentWorkspaceId && (
-                  <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-primary/10 text-primary font-medium">当前</span>
-                )}
-              </div>
-              {dropIndicator?.id === ws.id && dropIndicator.position === 'after' && (
-                <div className="absolute bottom-0 left-4 right-4 h-0.5 bg-primary rounded-full z-10" />
-              )}
-            </div>
-          ))}
-        </SettingsCard>
-      </SettingsSection>
-
       <Tabs value={activeTab} onValueChange={setActiveTab}>
         <div className="relative flex rounded-xl bg-muted p-1">
           <div
             className={cn(
-              'mode-slider absolute top-1 bottom-1 w-[calc(33.333%-3px)] rounded-lg bg-background shadow-sm transition-transform duration-300 ease-in-out',
-              activeTab === 'skills' && 'translate-x-0',
-              activeTab === 'mcp' && 'translate-x-[100%]',
-              activeTab === 'tools' && 'translate-x-[200%]',
+              'mode-slider absolute top-1 bottom-1 w-[calc(25%-3px)] rounded-lg bg-background shadow-sm transition-transform duration-300 ease-in-out',
+              activeTab === 'workspaces' && 'translate-x-0',
+              activeTab === 'skills' && 'translate-x-[100%]',
+              activeTab === 'mcp' && 'translate-x-[200%]',
+              activeTab === 'tools' && 'translate-x-[300%]',
             )}
           />
           {[
+            { value: 'workspaces', label: '项目排序' },
             { value: 'skills', label: 'Skills' },
             { value: 'mcp', label: 'MCP' },
             { value: 'tools', label: '内置工具' },
@@ -535,6 +501,44 @@ ${skillList}
             </button>
           ))}
         </div>
+
+        {/* ===== 项目排序 Tab ===== */}
+        <TabsContent value="workspaces" className="mt-4 space-y-4">
+          <SettingsSection title="项目排序" description="拖拽调整项目在侧边栏下拉选择器中的显示顺序">
+            <SettingsCard>
+              {workspaces.map((ws) => (
+                <div key={ws.id} className="relative">
+                  {dropIndicator?.id === ws.id && dropIndicator.position === 'before' && (
+                    <div className="absolute top-0 left-4 right-4 h-0.5 bg-primary rounded-full z-10" />
+                  )}
+                  <div
+                    draggable
+                    onDragStart={(e) => handleDragStart(e, ws.id)}
+                    onDragOver={(e) => handleDragOver(e, ws.id)}
+                    onDragLeave={handleDragLeave}
+                    onDrop={(e) => handleDrop(e, ws.id)}
+                    onDragEnd={handleDragEnd}
+                    className={cn(
+                      'group w-full flex items-center gap-2 px-4 py-2.5 transition-colors cursor-grab active:cursor-grabbing',
+                      dragId === ws.id ? 'opacity-40' : 'hover:bg-muted/50',
+                      ws.id === currentWorkspaceId && 'font-medium',
+                    )}
+                  >
+                    <GripVertical size={14} className="flex-shrink-0 text-muted-foreground/40 group-hover:text-muted-foreground" />
+                    <FolderOpen size={16} className="flex-shrink-0 text-muted-foreground" />
+                    <span className="flex-1 min-w-0 truncate text-sm">{ws.name}</span>
+                    {ws.id === currentWorkspaceId && (
+                      <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-primary/10 text-primary font-medium">当前</span>
+                    )}
+                  </div>
+                  {dropIndicator?.id === ws.id && dropIndicator.position === 'after' && (
+                    <div className="absolute bottom-0 left-4 right-4 h-0.5 bg-primary rounded-full z-10" />
+                  )}
+                </div>
+              ))}
+            </SettingsCard>
+          </SettingsSection>
+        </TabsContent>
 
         {/* ===== Skills Tab ===== */}
         <TabsContent value="skills" className="mt-4 space-y-4">

--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -58,14 +58,14 @@ export function TabBar(): React.ReactElement {
   const { requestClose } = useCloseTab()
 
   const workspaceNameBySessionId = React.useMemo(() => {
-    const workspaceNameMap = new Map(agentWorkspaces.map((workspace) => [workspace.id, workspace.name]))
+    const workspaceNameByIdMap = new Map(agentWorkspaces.map((workspace) => [workspace.id, workspace.name]))
     const sessionWorkspaceNameMap = new Map<string, string>()
     for (const session of agentSessions) {
       if (!session.workspaceId) continue
-      const workspaceName = workspaceNameMap.get(session.workspaceId)
+      const workspaceName = workspaceNameByIdMap.get(session.workspaceId)
       if (workspaceName) sessionWorkspaceNameMap.set(session.id, workspaceName)
     }
-    return sessionWorkspaceNameMap
+    return { sessionIdMap: sessionWorkspaceNameMap, workspaceIdMap: workspaceNameByIdMap }
   }, [agentSessions, agentWorkspaces])
 
   const automationSessionIds = React.useMemo(() => {
@@ -131,22 +131,20 @@ export function TabBar(): React.ReactElement {
 
   /** 取消置顶标签（同步更新 session/conversation 元数据并移除标签） */
   const handleUnpinTab = React.useCallback((tabId: string) => {
-    const tab = tabs.find((t) => t.id === tabId)
+    // 用 store.get 获取最新 tabs，避免闭包过期
+    const currentTabs = store.get(tabsAtom)
+    const tab = currentTabs.find((t) => t.id === tabId)
     if (!tab?.pinned) return
 
-    // 从 tabs 数组中移除该标签，激活切换到其他标签
+    // 先计算新 activeId，再在 updater 中纯计算
+    const currentActive = store.get(activeTabIdAtom)
     let newActiveId: string | null = null
-    setTabs((prev) => {
-      const target = prev.find((t) => t.id === tabId)
-      if (!target?.pinned) return prev
-      const currentActive = store.get(activeTabIdAtom)
-      if (currentActive === tabId) {
-        const otherPinned = prev.filter((t) => t.pinned && t.id !== tabId)
-        const nonPinned = prev.filter((t) => !t.pinned && t.id !== SCRATCH_PAD_ID && t.type !== 'preview')
-        newActiveId = otherPinned.at(-1)?.id ?? nonPinned.at(0)?.id ?? SCRATCH_PAD_ID
-      }
-      return prev.filter((t) => t.id !== tabId)
-    })
+    if (currentActive === tabId) {
+      const otherPinned = currentTabs.filter((t) => t.pinned && t.id !== tabId)
+      const nonPinned = currentTabs.filter((t) => !t.pinned && t.id !== SCRATCH_PAD_ID && t.type !== 'preview')
+      newActiveId = otherPinned.at(-1)?.id ?? nonPinned.at(0)?.id ?? SCRATCH_PAD_ID
+    }
+    setTabs((prev) => prev.filter((t) => t.id !== tabId))
     if (newActiveId) setActiveTabId(newActiveId)
 
     // 同步更新 session/conversation 元数据并更新 atom
@@ -159,7 +157,7 @@ export function TabBar(): React.ReactElement {
         setConversations((prev) => prev.map((c) => c.id === updated.id ? updated : c))
       }).catch(console.error)
     }
-  }, [tabs, setTabs, setActiveTabId, store, setAgentSessions, setConversations])
+  }, [setTabs, setActiveTabId, store, setAgentSessions, setConversations])
 
   const handleDragStart = React.useCallback((tabId: string, e: React.PointerEvent) => {
     if (e.button !== 0) return
@@ -246,7 +244,8 @@ export function TabBar(): React.ReactElement {
         tabs={tabs}
         activeTabId={activeTabId}
         streamingMap={indicatorMap}
-        workspaceNameBySessionId={workspaceNameBySessionId}
+        workspaceNameBySessionId={workspaceNameBySessionId.sessionIdMap}
+        workspaceNameByIdMap={workspaceNameBySessionId.workspaceIdMap}
         automationSessionIds={automationSessionIds}
         draggingTabId={draggingTabId}
         dragLeft={dragLeft}
@@ -266,6 +265,7 @@ function TabBarInner({
   activeTabId,
   streamingMap,
   workspaceNameBySessionId,
+  workspaceNameByIdMap,
   automationSessionIds,
   draggingTabId,
   dragLeft,
@@ -279,6 +279,7 @@ function TabBarInner({
   activeTabId: string | null
   streamingMap: Map<string, SessionIndicatorStatus>
   workspaceNameBySessionId: Map<string, string>
+  workspaceNameByIdMap: Map<string, string>
   automationSessionIds: Set<string>
   draggingTabId: string | null
   dragLeft: number
@@ -444,7 +445,7 @@ function TabBarInner({
               title={tab.title}
               workspaceName={
                 tab.workspaceId === CHAT_WORKSPACE_ID ? 'Chat'
-                : tab.workspaceId ? workspaceNameBySessionId.get(tab.sessionId)
+                : tab.workspaceId ? workspaceNameByIdMap.get(tab.workspaceId)
                 : undefined
               }
               isAutomation={tab.type === 'agent' && automationSessionIds.has(tab.sessionId)}

--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -81,7 +81,14 @@ export function TabBar(): React.ReactElement {
     tabId: string
     startX: number
     startIndex: number
+    offsetX: number
+    pointerOffsetInTab: number
   } | null>(null)
+  const [draggingTabId, setDraggingTabId] = React.useState<string | null>(null)
+  const [dragOffsetX, setDragOffsetX] = React.useState(0)
+  // 保持 tabs 的最新值供拖拽事件处理器使用
+  const tabsRef = React.useRef(tabs)
+  tabsRef.current = tabs
 
   const handleActivate = React.useCallback((tabId: string) => {
     setActiveTabId(tabId)
@@ -159,44 +166,88 @@ export function TabBar(): React.ReactElement {
     const idx = tabs.findIndex((t) => t.id === tabId)
     if (idx === -1) return
 
+    // 记录鼠标按下时在 tab 内部的偏移量
+    const tabEl = document.querySelector(`[data-tab-id="${tabId}"]`) as HTMLElement | null
+    if (!tabEl) return
+    const tabRect = tabEl.getBoundingClientRect()
+    const pointerOffsetInTab = e.clientX - tabRect.left
+
     dragState.current = {
       dragging: false,
       tabId,
       startX: e.clientX,
       startIndex: idx,
+      offsetX: 0,
+      pointerOffsetInTab,
     }
 
     const handleMove = (me: PointerEvent): void => {
       if (!dragState.current) return
-      const dx = Math.abs(me.clientX - dragState.current.startX)
-      if (dx > 5) dragState.current.dragging = true
+      const dx = me.clientX - dragState.current.startX
+      if (!dragState.current.dragging && Math.abs(dx) > 5) {
+        dragState.current.dragging = true
+        setDraggingTabId(tabId)
+      }
+      if (!dragState.current.dragging) return
+
+      // 计算被拖 tab 的视觉中心位置
+      const currentTabs = tabsRef.current
+      const currentIdx = currentTabs.findIndex((t) => t.id === tabId)
+      if (currentIdx === -1) return
+
+      // 使用所有 tab 元素的当前位置计算拖拽中心
+      const allTabEls = document.querySelectorAll('[data-tab-id]')
+      const draggedEl = allTabEls[currentIdx] as HTMLElement | null
+      if (!draggedEl) return
+      const draggedRect = draggedEl.getBoundingClientRect()
+      const dragCenterX = draggedRect.left + dragState.current.pointerOffsetInTab + dx
+
+      // 确定 dragCenterX 落在哪个 tab 的范围内
+      let targetIndex = currentIdx
+      for (let i = 0; i < allTabEls.length; i++) {
+        const el = allTabEls[i] as HTMLElement
+        const rect = el.getBoundingClientRect()
+        if (dragCenterX < rect.left + rect.width / 2) {
+          targetIndex = i
+          break
+        }
+        targetIndex = i
+      }
+
+      // 更新 transform 偏移量
+      dragState.current.offsetX = dx
+      setDragOffsetX(dx)
+
+      // 实时交换
+      if (targetIndex !== currentIdx) {
+        const reordered = reorderTabs(currentTabs, currentIdx, targetIndex)
+        if (reordered !== currentTabs) {
+          // 记录交换前被拖 tab 的视觉位置
+          const visualLeftBefore = draggedRect.left + dx
+          setTabs(reordered)
+          // 交换后 React 会重渲染，tab 在 DOM 中的位置变了
+          // 需要修正 offset 使 tab 视觉位置不变
+          // 在 requestAnimationFrame 中（React 已渲染）读取新 DOM 位置并修正
+          requestAnimationFrame(() => {
+            const newEl = document.querySelector(`[data-tab-id="${tabId}"]`) as HTMLElement | null
+            if (newEl && dragState.current) {
+              const newRect = newEl.getBoundingClientRect()
+              const newDx = visualLeftBefore - newRect.left
+              dragState.current.startX = me.clientX - newDx
+              dragState.current.offsetX = newDx
+              setDragOffsetX(newDx)
+            }
+          })
+        }
+      }
     }
 
     const handleUp = (): void => {
       document.removeEventListener('pointermove', handleMove)
       document.removeEventListener('pointerup', handleUp)
-      if (!dragState.current) return
-      const { dragging, startIndex, tabId: dragTabId } = dragState.current
       dragState.current = null
-      if (!dragging) return // 未实际拖拽，只是点击
-
-      // 计算释放位置对应的 tab 索引
-      const tabElements = document.querySelectorAll('[data-tab-id]')
-      let dropIndex = startIndex
-      for (let i = 0; i < tabElements.length; i++) {
-        const el = tabElements[i] as HTMLElement
-        const rect = el.getBoundingClientRect()
-        if (e.clientX < rect.right) {
-          dropIndex = i
-          break
-        }
-        dropIndex = i
-      }
-
-      if (dropIndex !== startIndex) {
-        const reordered = reorderTabs(tabs, startIndex, dropIndex)
-        if (reordered !== tabs) setTabs(reordered)
-      }
+      setDraggingTabId(null)
+      setDragOffsetX(0)
     }
 
     document.addEventListener('pointermove', handleMove)
@@ -213,6 +264,8 @@ export function TabBar(): React.ReactElement {
         streamingMap={indicatorMap}
         workspaceNameBySessionId={workspaceNameBySessionId}
         automationSessionIds={automationSessionIds}
+        draggingTabId={draggingTabId}
+        dragOffsetX={dragOffsetX}
         onActivate={handleActivate}
         onClose={requestClose}
         onDragStart={handleDragStart}
@@ -229,6 +282,8 @@ function TabBarInner({
   streamingMap,
   workspaceNameBySessionId,
   automationSessionIds,
+  draggingTabId,
+  dragOffsetX,
   onActivate,
   onClose,
   onDragStart,
@@ -239,6 +294,8 @@ function TabBarInner({
   streamingMap: Map<string, SessionIndicatorStatus>
   workspaceNameBySessionId: Map<string, string>
   automationSessionIds: Set<string>
+  draggingTabId: string | null
+  dragOffsetX: number
   onActivate: (tabId: string) => void
   onClose: (tabId: string) => void
   onDragStart: (tabId: string, e: React.PointerEvent) => void
@@ -354,10 +411,10 @@ function TabBarInner({
   }, [])
 
   return (
-    <div className="flex items-end h-[34px] tabbar-bg relative">
+    <div className={cn("flex items-end h-[34px] tabbar-bg relative", isWindows && "pr-[126px]")}>
       {/* 顶部 TabBar 的空白区域必须保持可拖拽，尤其是 macOS/Windows 自定义标题栏。
-          注意：不要把 titlebar-no-drag 加到下面的整条 flex 容器上，否则标签右侧空白会再次失去拖拽能力。
-          Windows 上背景拖拽层避开右上角 WindowControls 区域（126px），防止 hitmask 重叠。
+          Windows 上外层 pr-[126px] 让 TabBar 背景（tabbar-bg）不延伸到 WindowControls 区域，
+          同时拖拽层也用 right-[126px] 避开按钮区，防止 hitmask 重叠。
           需要交互的单个 Tab 会在 TabBarItem 内部自己声明 titlebar-no-drag。 */}
       <div className={cn("absolute inset-0 titlebar-drag-region", isWindows && "right-[126px]")} />
 
@@ -375,7 +432,7 @@ function TabBarInner({
 
       <div
         ref={scrollRef}
-        className={cn("relative flex items-end flex-1 min-w-0 overflow-x-auto scrollbar-none", canScrollLeft && "pl-5", canScrollRight && "pr-5", isWindows && "pr-[126px]")}
+        className={cn("relative flex items-end flex-1 min-w-0 overflow-x-auto scrollbar-none", canScrollLeft && "pl-5", canScrollRight && "pr-5")}
       >
         {tabs.map((tab) => (
           <TabBarItem
@@ -394,6 +451,8 @@ function TabBarInner({
             isStreaming={streamingMap.get(tab.id) ?? 'idle'}
             isHovered={hoveredTabId === tab.id}
             isLeaving={hoveredTabId === tab.id && isLeaving}
+            isDragging={draggingTabId === tab.id}
+            dragOffsetX={draggingTabId === tab.id ? dragOffsetX : 0}
             onActivate={() => onActivate(tab.id)}
             onClose={() => onClose(tab.id)}
             onMiddleClick={() => onClose(tab.id)}

--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -119,11 +119,12 @@ export function TabBar(): React.ReactElement {
 
   /** 取消置顶标签 */
   const handleUnpinTab = React.useCallback((tabId: string) => {
-    const tab = tabs.find((t) => t.id === tabId)
-    if (!tab?.pinned) return
-    // 移除置顶标记，该标签变为可关闭的普通标签
-    setTabs(tabs.map((t) => t.id === tabId ? { ...t, pinned: false } : t))
-  }, [tabs, setTabs])
+    setTabs((prev) => {
+      const tab = prev.find((t) => t.id === tabId)
+      if (!tab?.pinned) return prev
+      return prev.map((t) => t.id === tabId ? { ...t, pinned: false } : t)
+    })
+  }, [setTabs])
 
   const handleDragStart = React.useCallback((tabId: string, e: React.PointerEvent) => {
     if (e.button !== 0) return // 只处理左键

--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -33,7 +33,7 @@ import { detectIsWindows } from '@/lib/platform'
 import { cn } from '@/lib/utils'
 
 export function TabBar(): React.ReactElement {
-  const tabs = useAtomValue(tabsAtom)
+  const [tabs, setTabs] = useAtom(tabsAtom)
   const [activeTabId, setActiveTabId] = useAtom(activeTabIdAtom)
   const indicatorMap = useAtomValue(tabIndicatorMapAtom)
 
@@ -117,6 +117,14 @@ export function TabBar(): React.ReactElement {
     }
   }, [setActiveTabId, setAutomationForm, tabs, agentSessions, appMode, setAppMode, setCurrentConversationId, setCurrentAgentSessionId, setCurrentAgentWorkspaceId, setUnviewedCompleted])
 
+  /** 取消置顶标签 */
+  const handleUnpinTab = React.useCallback((tabId: string) => {
+    const tab = tabs.find((t) => t.id === tabId)
+    if (!tab?.pinned) return
+    // 移除置顶标记，该标签变为可关闭的普通标签
+    setTabs(tabs.map((t) => t.id === tabId ? { ...t, pinned: false } : t))
+  }, [tabs, setTabs])
+
   const handleDragStart = React.useCallback((tabId: string, e: React.PointerEvent) => {
     if (e.button !== 0) return // 只处理左键
     const idx = tabs.findIndex((t) => t.id === tabId)
@@ -158,6 +166,7 @@ export function TabBar(): React.ReactElement {
         onActivate={handleActivate}
         onClose={requestClose}
         onDragStart={handleDragStart}
+        onUnpin={handleUnpinTab}
       />
     </>
   )
@@ -173,6 +182,7 @@ function TabBarInner({
   onActivate,
   onClose,
   onDragStart,
+  onUnpin,
 }: {
   tabs: TabItem[]
   activeTabId: string | null
@@ -182,6 +192,7 @@ function TabBarInner({
   onActivate: (tabId: string) => void
   onClose: (tabId: string) => void
   onDragStart: (tabId: string, e: React.PointerEvent) => void
+  onUnpin?: (tabId: string) => void
 }): React.ReactElement {
   const [hoveredTabId, setHoveredTabId] = React.useState<string | null>(null)
   const [isLeaving, setIsLeaving] = React.useState(false)
@@ -277,6 +288,7 @@ function TabBarInner({
             title={tab.title}
             workspaceName={tab.type === 'agent' ? workspaceNameBySessionId.get(tab.sessionId) : undefined}
             isAutomation={tab.type === 'agent' && automationSessionIds.has(tab.sessionId)}
+            isPinned={!!tab.pinned}
             isActive={tab.id === activeTabId}
             isStreaming={streamingMap.get(tab.id) ?? 'idle'}
             isHovered={hoveredTabId === tab.id}
@@ -285,6 +297,7 @@ function TabBarInner({
             onClose={() => onClose(tab.id)}
             onMiddleClick={() => onClose(tab.id)}
             onDragStart={(e) => onDragStart(tab.id, e)}
+            onUnpin={onUnpin ? () => onUnpin(tab.id) : undefined}
             onHoverEnter={() => handleTabHoverEnter(tab.id)}
             onHoverLeave={handleTabHoverLeave}
             onPanelHoverEnter={handlePanelHoverEnter}

--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -15,6 +15,7 @@ import {
   activeTabIdAtom,
   tabIndicatorMapAtom,
   SCRATCH_PAD_ID,
+  reorderTabs,
 } from '@/atoms/tab-atoms'
 import type { TabItem } from '@/atoms/tab-atoms'
 import type { SessionIndicatorStatus } from '@/atoms/agent-atoms'
@@ -168,12 +169,33 @@ export function TabBar(): React.ReactElement {
     const handleUp = (): void => {
       document.removeEventListener('pointermove', handleMove)
       document.removeEventListener('pointerup', handleUp)
+      if (!dragState.current) return
+      const { dragging, startIndex, tabId: dragTabId } = dragState.current
       dragState.current = null
+      if (!dragging) return // 未实际拖拽，只是点击
+
+      // 计算释放位置对应的 tab 索引
+      const tabElements = document.querySelectorAll('[data-tab-id]')
+      let dropIndex = startIndex
+      for (let i = 0; i < tabElements.length; i++) {
+        const el = tabElements[i] as HTMLElement
+        const rect = el.getBoundingClientRect()
+        if (e.clientX < rect.right) {
+          dropIndex = i
+          break
+        }
+        dropIndex = i
+      }
+
+      if (dropIndex !== startIndex) {
+        const reordered = reorderTabs(tabs, startIndex, dropIndex)
+        if (reordered !== tabs) setTabs(reordered)
+      }
     }
 
     document.addEventListener('pointermove', handleMove)
     document.addEventListener('pointerup', handleUp)
-  }, [tabs])
+  }, [tabs, setTabs])
 
   if (tabs.length === 0) return <div className="h-[34px] titlebar-drag-region" />
 
@@ -290,6 +312,41 @@ function TabBarInner({
     setIsLeaving(false)
   }, [])
 
+  // 溢出检测：左右滚动指示器
+  const [canScrollLeft, setCanScrollLeft] = React.useState(false)
+  const [canScrollRight, setCanScrollRight] = React.useState(false)
+
+  const updateScrollState = React.useCallback(() => {
+    const el = scrollRef.current
+    if (!el) return
+    setCanScrollLeft(el.scrollLeft > 2)
+    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 2)
+  }, [])
+
+  React.useEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+    updateScrollState()
+    el.addEventListener('scroll', updateScrollState)
+    const ro = new ResizeObserver(updateScrollState)
+    ro.observe(el)
+    return () => {
+      el.removeEventListener('scroll', updateScrollState)
+      ro.disconnect()
+    }
+  }, [updateScrollState, tabs])
+
+  // tabs 变化时更新溢出状态
+  React.useEffect(() => {
+    updateScrollState()
+  }, [tabs, updateScrollState])
+
+  const scrollByTab = React.useCallback((direction: 'left' | 'right') => {
+    const el = scrollRef.current
+    if (!el) return
+    el.scrollBy({ left: direction === 'left' ? -150 : 150, behavior: 'smooth' })
+  }, [])
+
   return (
     <div className="flex items-end h-[34px] tabbar-bg relative">
       {/* 顶部 TabBar 的空白区域必须保持可拖拽，尤其是 macOS/Windows 自定义标题栏。
@@ -298,9 +355,21 @@ function TabBarInner({
           需要交互的单个 Tab 会在 TabBarItem 内部自己声明 titlebar-no-drag。 */}
       <div className={cn("absolute inset-0 titlebar-drag-region", isWindows && "right-[126px]")} />
 
+      {/* 左侧滚动指示器 */}
+      {canScrollLeft && (
+        <button
+          type="button"
+          onClick={() => scrollByTab('left')}
+          className="absolute left-0 top-0 bottom-0 w-6 z-10 flex items-center justify-center bg-gradient-to-r from-tabbar-bg to-transparent titlebar-no-drag text-foreground/40 hover:text-foreground/70 transition-colors"
+          aria-label="向左滚动标签栏"
+        >
+          ‹
+        </button>
+      )}
+
       <div
         ref={scrollRef}
-        className={cn("relative flex items-end flex-1 min-w-0 overflow-x-auto scrollbar-none", isWindows && "pr-[126px]")}
+        className={cn("relative flex items-end flex-1 min-w-0 overflow-x-auto scrollbar-none", canScrollLeft && "pl-5", canScrollRight && "pr-5", isWindows && "pr-[126px]")}
       >
         {tabs.map((tab) => (
           <TabBarItem
@@ -331,6 +400,21 @@ function TabBarInner({
           />
         ))}
       </div>
+
+      {/* 右侧滚动指示器 */}
+      {canScrollRight && (
+        <button
+          type="button"
+          onClick={() => scrollByTab('right')}
+          className={cn(
+            "absolute top-0 bottom-0 w-6 z-10 flex items-center justify-center bg-gradient-to-l from-tabbar-bg to-transparent titlebar-no-drag text-foreground/40 hover:text-foreground/70 transition-colors",
+            isWindows ? "right-[126px]" : "right-0",
+          )}
+          aria-label="向右滚动标签栏"
+        >
+          ›
+        </button>
+      )}
     </div>
   )
 }

--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -9,11 +9,12 @@
  */
 
 import * as React from 'react'
-import { useAtom, useAtomValue, useSetAtom } from 'jotai'
+import { useAtom, useAtomValue, useSetAtom, useStore } from 'jotai'
 import {
   tabsAtom,
   activeTabIdAtom,
   tabIndicatorMapAtom,
+  SCRATCH_PAD_ID,
 } from '@/atoms/tab-atoms'
 import type { TabItem } from '@/atoms/tab-atoms'
 import type { SessionIndicatorStatus } from '@/atoms/agent-atoms'
@@ -36,6 +37,7 @@ export function TabBar(): React.ReactElement {
   const [tabs, setTabs] = useAtom(tabsAtom)
   const [activeTabId, setActiveTabId] = useAtom(activeTabIdAtom)
   const indicatorMap = useAtomValue(tabIndicatorMapAtom)
+  const store = useStore()
 
   // Tab 切换时同步 sidebar 状态
   const appMode = useAtomValue(appModeAtom)
@@ -117,14 +119,33 @@ export function TabBar(): React.ReactElement {
     }
   }, [setActiveTabId, setAutomationForm, tabs, agentSessions, appMode, setAppMode, setCurrentConversationId, setCurrentAgentSessionId, setCurrentAgentWorkspaceId, setUnviewedCompleted])
 
-  /** 取消置顶标签 */
+  /** 取消置顶标签（同步更新 session/conversation 元数据并移除标签） */
   const handleUnpinTab = React.useCallback((tabId: string) => {
+    const tab = tabs.find((t) => t.id === tabId)
+    if (!tab?.pinned) return
+
+    // 从 tabs 数组中移除该标签，激活切换到其他标签
+    let newActiveId: string | null = null
     setTabs((prev) => {
-      const tab = prev.find((t) => t.id === tabId)
-      if (!tab?.pinned) return prev
-      return prev.map((t) => t.id === tabId ? { ...t, pinned: false } : t)
+      const target = prev.find((t) => t.id === tabId)
+      if (!target?.pinned) return prev
+      const currentActive = store.get(activeTabIdAtom)
+      if (currentActive === tabId) {
+        const otherPinned = prev.filter((t) => t.pinned && t.id !== tabId)
+        const nonPinned = prev.filter((t) => !t.pinned && t.id !== SCRATCH_PAD_ID && t.type !== 'preview')
+        newActiveId = otherPinned.at(-1)?.id ?? nonPinned.at(0)?.id ?? SCRATCH_PAD_ID
+      }
+      return prev.filter((t) => t.id !== tabId)
     })
-  }, [setTabs])
+    if (newActiveId) setActiveTabId(newActiveId)
+
+    // 同步更新 session/conversation 元数据
+    if (tab.type === 'agent') {
+      window.electronAPI.togglePinAgentSession(tab.sessionId).catch(console.error)
+    } else if (tab.type === 'chat') {
+      window.electronAPI.togglePinConversation(tab.sessionId).catch(console.error)
+    }
+  }, [tabs, setTabs, setActiveTabId, store])
 
   const handleDragStart = React.useCallback((tabId: string, e: React.PointerEvent) => {
     if (e.button !== 0) return // 只处理左键

--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -75,18 +75,17 @@ export function TabBar(): React.ReactElement {
     return ids
   }, [agentSessions])
 
-  // 拖拽状态
+  // 拖拽状态（浏览器风格：被拖 tab 绝对定位跟随鼠标，占位符在 flex 流中标记空位）
   const dragState = React.useRef<{
     dragging: boolean
     tabId: string
     startX: number
-    startIndex: number
-    offsetX: number
     pointerOffsetInTab: number
+    placeholderIndex: number
   } | null>(null)
   const [draggingTabId, setDraggingTabId] = React.useState<string | null>(null)
-  const [dragOffsetX, setDragOffsetX] = React.useState(0)
-  // 保持 tabs 的最新值供拖拽事件处理器使用
+  const [dragLeft, setDragLeft] = React.useState(0)
+  const [placeholderIndex, setPlaceholderIndex] = React.useState(-1)
   const tabsRef = React.useRef(tabs)
   tabsRef.current = tabs
 
@@ -162,92 +161,76 @@ export function TabBar(): React.ReactElement {
   }, [tabs, setTabs, setActiveTabId, store, setAgentSessions, setConversations])
 
   const handleDragStart = React.useCallback((tabId: string, e: React.PointerEvent) => {
-    if (e.button !== 0) return // 只处理左键
+    if (e.button !== 0) return
     const idx = tabs.findIndex((t) => t.id === tabId)
     if (idx === -1) return
 
-    // 记录鼠标按下时在 tab 内部的偏移量
     const tabEl = document.querySelector(`[data-tab-id="${tabId}"]`) as HTMLElement | null
     if (!tabEl) return
     const tabRect = tabEl.getBoundingClientRect()
-    const pointerOffsetInTab = e.clientX - tabRect.left
 
     dragState.current = {
       dragging: false,
       tabId,
       startX: e.clientX,
-      startIndex: idx,
-      offsetX: 0,
-      pointerOffsetInTab,
+      pointerOffsetInTab: e.clientX - tabRect.left,
+      placeholderIndex: idx,
     }
 
     const handleMove = (me: PointerEvent): void => {
       if (!dragState.current) return
       const dx = me.clientX - dragState.current.startX
-      if (!dragState.current.dragging && Math.abs(dx) > 5) {
+      if (!dragState.current.dragging && Math.abs(dx) > 4) {
         dragState.current.dragging = true
         setDraggingTabId(tabId)
+        setPlaceholderIndex(dragState.current.placeholderIndex)
       }
       if (!dragState.current.dragging) return
 
-      // 计算被拖 tab 的视觉中心位置
-      const currentTabs = tabsRef.current
-      const currentIdx = currentTabs.findIndex((t) => t.id === tabId)
-      if (currentIdx === -1) return
+      // 被拖 tab 跟随鼠标
+      const container = document.querySelector('[data-tabbar-scroll]') as HTMLElement | null
+      if (!container) return
+      const containerRect = container.getBoundingClientRect()
+      const left = me.clientX - containerRect.left - dragState.current.pointerOffsetInTab + container.scrollLeft
+      setDragLeft(left)
 
-      // 使用所有 tab 元素的当前位置计算拖拽中心
-      const allTabEls = document.querySelectorAll('[data-tab-id]')
-      const draggedEl = allTabEls[currentIdx] as HTMLElement | null
-      if (!draggedEl) return
-      const draggedRect = draggedEl.getBoundingClientRect()
-      const dragCenterX = draggedRect.left + dragState.current.pointerOffsetInTab + dx
-
-      // 确定 dragCenterX 落在哪个 tab 的范围内
-      let targetIndex = currentIdx
+      // 计算被拖 tab 视觉中心应该落在哪个 slot
+      const dragCenterX = me.clientX - containerRect.left + container.scrollLeft
+      const allTabEls = container.querySelectorAll('[data-tab-id]')
+      let newPlaceholder = dragState.current.placeholderIndex
       for (let i = 0; i < allTabEls.length; i++) {
         const el = allTabEls[i] as HTMLElement
         const rect = el.getBoundingClientRect()
-        if (dragCenterX < rect.left + rect.width / 2) {
-          targetIndex = i
+        const center = rect.left + rect.width / 2 - containerRect.left + container.scrollLeft
+        if (dragCenterX < center) {
+          newPlaceholder = i
           break
         }
-        targetIndex = i
+        newPlaceholder = i
       }
 
-      // 更新 transform 偏移量
-      dragState.current.offsetX = dx
-      setDragOffsetX(dx)
-
-      // 实时交换
-      if (targetIndex !== currentIdx) {
-        const reordered = reorderTabs(currentTabs, currentIdx, targetIndex)
-        if (reordered !== currentTabs) {
-          // 记录交换前被拖 tab 的视觉位置
-          const visualLeftBefore = draggedRect.left + dx
-          setTabs(reordered)
-          // 交换后 React 会重渲染，tab 在 DOM 中的位置变了
-          // 需要修正 offset 使 tab 视觉位置不变
-          // 在 requestAnimationFrame 中（React 已渲染）读取新 DOM 位置并修正
-          requestAnimationFrame(() => {
-            const newEl = document.querySelector(`[data-tab-id="${tabId}"]`) as HTMLElement | null
-            if (newEl && dragState.current) {
-              const newRect = newEl.getBoundingClientRect()
-              const newDx = visualLeftBefore - newRect.left
-              dragState.current.startX = me.clientX - newDx
-              dragState.current.offsetX = newDx
-              setDragOffsetX(newDx)
-            }
-          })
-        }
+      if (newPlaceholder !== dragState.current.placeholderIndex) {
+        dragState.current.placeholderIndex = newPlaceholder
+        setPlaceholderIndex(newPlaceholder)
       }
     }
 
     const handleUp = (): void => {
       document.removeEventListener('pointermove', handleMove)
       document.removeEventListener('pointerup', handleUp)
+      if (dragState.current?.dragging) {
+        // 把被拖 tab 移到 placeholderIndex 位置
+        const currentTabs = tabsRef.current
+        const fromIdx = currentTabs.findIndex((t) => t.id === tabId)
+        const toIdx = dragState.current.placeholderIndex
+        if (fromIdx !== -1 && toIdx !== fromIdx) {
+          const reordered = reorderTabs(currentTabs, fromIdx, toIdx)
+          if (reordered !== currentTabs) setTabs(reordered)
+        }
+      }
       dragState.current = null
       setDraggingTabId(null)
-      setDragOffsetX(0)
+      setPlaceholderIndex(-1)
     }
 
     document.addEventListener('pointermove', handleMove)
@@ -265,7 +248,8 @@ export function TabBar(): React.ReactElement {
         workspaceNameBySessionId={workspaceNameBySessionId}
         automationSessionIds={automationSessionIds}
         draggingTabId={draggingTabId}
-        dragOffsetX={dragOffsetX}
+        dragLeft={dragLeft}
+        placeholderIndex={placeholderIndex}
         onActivate={handleActivate}
         onClose={requestClose}
         onDragStart={handleDragStart}
@@ -283,7 +267,8 @@ function TabBarInner({
   workspaceNameBySessionId,
   automationSessionIds,
   draggingTabId,
-  dragOffsetX,
+  dragLeft,
+  placeholderIndex,
   onActivate,
   onClose,
   onDragStart,
@@ -295,7 +280,8 @@ function TabBarInner({
   workspaceNameBySessionId: Map<string, string>
   automationSessionIds: Set<string>
   draggingTabId: string | null
-  dragOffsetX: number
+  dragLeft: number
+  placeholderIndex: number
   onActivate: (tabId: string) => void
   onClose: (tabId: string) => void
   onDragStart: (tabId: string, e: React.PointerEvent) => void
@@ -411,10 +397,9 @@ function TabBarInner({
   }, [])
 
   return (
-    <div className={cn("flex items-end h-[34px] tabbar-bg relative", isWindows && "pr-[126px]")}>
+    <div className="flex items-end h-[34px] tabbar-bg relative">
       {/* 顶部 TabBar 的空白区域必须保持可拖拽，尤其是 macOS/Windows 自定义标题栏。
-          Windows 上外层 pr-[126px] 让 TabBar 背景（tabbar-bg）不延伸到 WindowControls 区域，
-          同时拖拽层也用 right-[126px] 避开按钮区，防止 hitmask 重叠。
+          Windows 上背景拖拽层避开右上角 WindowControls 区域（126px），防止 hitmask 重叠。
           需要交互的单个 Tab 会在 TabBarItem 内部自己声明 titlebar-no-drag。 */}
       <div className={cn("absolute inset-0 titlebar-drag-region", isWindows && "right-[126px]")} />
 
@@ -432,38 +417,56 @@ function TabBarInner({
 
       <div
         ref={scrollRef}
-        className={cn("relative flex items-end flex-1 min-w-0 overflow-x-auto scrollbar-none", canScrollLeft && "pl-5", canScrollRight && "pr-5")}
+        data-tabbar-scroll
+        className={cn("relative flex items-end flex-1 min-w-0 overflow-x-auto scrollbar-none", canScrollLeft && "pl-5", canScrollRight && "pr-5", isWindows && "pr-[126px]")}
       >
-        {tabs.map((tab) => (
-          <TabBarItem
-            key={tab.id}
-            id={tab.id}
-            type={tab.type}
-            title={tab.title}
-            workspaceName={
-              tab.type === 'agent' ? workspaceNameBySessionId.get(tab.sessionId)
-              : tab.type === 'chat' && tab.pinned ? 'Chat'
-              : undefined
-            }
-            isAutomation={tab.type === 'agent' && automationSessionIds.has(tab.sessionId)}
-            isPinned={!!tab.pinned}
-            isActive={tab.id === activeTabId}
-            isStreaming={streamingMap.get(tab.id) ?? 'idle'}
-            isHovered={hoveredTabId === tab.id}
-            isLeaving={hoveredTabId === tab.id && isLeaving}
-            isDragging={draggingTabId === tab.id}
-            dragOffsetX={draggingTabId === tab.id ? dragOffsetX : 0}
-            onActivate={() => onActivate(tab.id)}
-            onClose={() => onClose(tab.id)}
-            onMiddleClick={() => onClose(tab.id)}
-            onDragStart={(e) => onDragStart(tab.id, e)}
-            onUnpin={onUnpin ? () => onUnpin(tab.id) : undefined}
-            onHoverEnter={() => handleTabHoverEnter(tab.id)}
-            onHoverLeave={handleTabHoverLeave}
-            onPanelHoverEnter={handlePanelHoverEnter}
-            onPanelHoverLeave={handleTabHoverLeave}
-          />
-        ))}
+        {tabs.map((tab) => {
+          const isDragged = draggingTabId === tab.id
+          return (
+            <React.Fragment key={tab.id}>
+              {/* 被拖 tab 脱离 flex 流时，占位符保持原宽度 */}
+              {isDragged && (
+                <div
+                  className="flex-shrink-0 h-[34px]"
+                  ref={(el) => {
+                    if (el) {
+                      const draggedEl = document.querySelector(`[data-tab-id="${tab.id}"]`) as HTMLElement | null
+                      if (draggedEl) el.style.width = `${draggedEl.offsetWidth}px`
+                    }
+                  }}
+                />
+              )}
+              <TabBarItem
+              key={tab.id}
+              id={tab.id}
+              type={tab.type}
+              title={tab.title}
+              workspaceName={
+                tab.type === 'agent' ? workspaceNameBySessionId.get(tab.sessionId)
+                : tab.type === 'chat' && tab.pinned ? 'Chat'
+                : undefined
+              }
+              isAutomation={tab.type === 'agent' && automationSessionIds.has(tab.sessionId)}
+              isPinned={!!tab.pinned}
+              isActive={tab.id === activeTabId}
+              isStreaming={streamingMap.get(tab.id) ?? 'idle'}
+              isHovered={isDragged ? false : hoveredTabId === tab.id}
+              isLeaving={isDragged ? false : hoveredTabId === tab.id && isLeaving}
+              isDragging={isDragged}
+              dragLeft={isDragged ? dragLeft : undefined}
+              onActivate={isDragged ? () => {} : () => onActivate(tab.id)}
+              onClose={isDragged ? () => {} : () => onClose(tab.id)}
+              onMiddleClick={isDragged ? () => {} : () => onClose(tab.id)}
+              onDragStart={isDragged ? () => {} : (e) => onDragStart(tab.id, e)}
+              onUnpin={isDragged ? undefined : onUnpin ? () => onUnpin(tab.id) : undefined}
+              onHoverEnter={isDragged ? () => {} : () => handleTabHoverEnter(tab.id)}
+              onHoverLeave={isDragged ? () => {} : handleTabHoverLeave}
+              onPanelHoverEnter={isDragged ? () => {} : handlePanelHoverEnter}
+              onPanelHoverLeave={isDragged ? () => {} : handleTabHoverLeave}
+            />
+            </React.Fragment>
+          )
+        })}
       </div>
 
       {/* 右侧滚动指示器 */}

--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -15,6 +15,7 @@ import {
   activeTabIdAtom,
   tabIndicatorMapAtom,
   SCRATCH_PAD_ID,
+  CHAT_WORKSPACE_ID,
   reorderTabs,
 } from '@/atoms/tab-atoms'
 import type { TabItem } from '@/atoms/tab-atoms'
@@ -442,8 +443,8 @@ function TabBarInner({
               type={tab.type}
               title={tab.title}
               workspaceName={
-                tab.type === 'agent' ? workspaceNameBySessionId.get(tab.sessionId)
-                : tab.type === 'chat' && tab.pinned ? 'Chat'
+                tab.workspaceId === CHAT_WORKSPACE_ID ? 'Chat'
+                : tab.workspaceId ? workspaceNameBySessionId.get(tab.sessionId)
                 : undefined
               }
               isAutomation={tab.type === 'agent' && automationSessionIds.has(tab.sessionId)}

--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -19,7 +19,7 @@ import {
 } from '@/atoms/tab-atoms'
 import type { TabItem } from '@/atoms/tab-atoms'
 import type { SessionIndicatorStatus } from '@/atoms/agent-atoms'
-import { currentConversationIdAtom } from '@/atoms/chat-atoms'
+import { conversationsAtom, currentConversationIdAtom } from '@/atoms/chat-atoms'
 import {
   agentSessionsAtom,
   agentWorkspacesAtom,
@@ -46,6 +46,8 @@ export function TabBar(): React.ReactElement {
   const setCurrentConversationId = useSetAtom(currentConversationIdAtom)
   const setCurrentAgentSessionId = useSetAtom(currentAgentSessionIdAtom)
   const agentSessions = useAtomValue(agentSessionsAtom)
+  const setAgentSessions = useSetAtom(agentSessionsAtom)
+  const setConversations = useSetAtom(conversationsAtom)
   const agentWorkspaces = useAtomValue(agentWorkspacesAtom)
   const setCurrentAgentWorkspaceId = useSetAtom(currentAgentWorkspaceIdAtom)
   const setUnviewedCompleted = useSetAtom(unviewedCompletedSessionIdsAtom)
@@ -140,13 +142,17 @@ export function TabBar(): React.ReactElement {
     })
     if (newActiveId) setActiveTabId(newActiveId)
 
-    // 同步更新 session/conversation 元数据
+    // 同步更新 session/conversation 元数据并更新 atom
     if (tab.type === 'agent') {
-      window.electronAPI.togglePinAgentSession(tab.sessionId).catch(console.error)
+      window.electronAPI.togglePinAgentSession(tab.sessionId).then((updated) => {
+        setAgentSessions((prev) => prev.map((s) => s.id === updated.id ? updated : s))
+      }).catch(console.error)
     } else if (tab.type === 'chat') {
-      window.electronAPI.togglePinConversation(tab.sessionId).catch(console.error)
+      window.electronAPI.togglePinConversation(tab.sessionId).then((updated) => {
+        setConversations((prev) => prev.map((c) => c.id === updated.id ? updated : c))
+      }).catch(console.error)
     }
-  }, [tabs, setTabs, setActiveTabId, store])
+  }, [tabs, setTabs, setActiveTabId, store, setAgentSessions, setConversations])
 
   const handleDragStart = React.useCallback((tabId: string, e: React.PointerEvent) => {
     if (e.button !== 0) return // 只处理左键

--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -286,7 +286,11 @@ function TabBarInner({
             id={tab.id}
             type={tab.type}
             title={tab.title}
-            workspaceName={tab.type === 'agent' ? workspaceNameBySessionId.get(tab.sessionId) : undefined}
+            workspaceName={
+              tab.type === 'agent' ? workspaceNameBySessionId.get(tab.sessionId)
+              : tab.type === 'chat' && tab.pinned ? 'Chat'
+              : undefined
+            }
             isAutomation={tab.type === 'agent' && automationSessionIds.has(tab.sessionId)}
             isPinned={!!tab.pinned}
             isActive={tab.id === activeTabId}

--- a/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
@@ -144,6 +144,7 @@ export function TabBarItem({
 
   return (
     <div
+      data-tab-id={id}
       className="relative min-w-[120px] max-w-[200px] flex-[1_0_120px] titlebar-no-drag"
       onMouseEnter={onHoverEnter}
       onMouseLeave={onHoverLeave}

--- a/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
@@ -9,8 +9,9 @@
 import * as React from 'react'
 import { createPortal } from 'react-dom'
 import { useAtomValue } from 'jotai'
-import { FileText, StickyNote, X, Clock } from 'lucide-react'
+import { FileText, StickyNote, X, Clock, PinOff, Pin } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import type { TabType, TabMinimapItem } from '@/atoms/tab-atoms'
 import type { SessionIndicatorStatus } from '@/atoms/agent-atoms'
 import { tabMinimapCacheAtom } from '@/atoms/tab-atoms'
@@ -33,6 +34,10 @@ export interface TabBarItemProps {
   onDragStart: (e: React.PointerEvent) => void
   /** 该 Tab 对应的会话是否由定时任务创建 */
   isAutomation?: boolean
+  /** 是否置顶标签（常驻，不可关闭） */
+  isPinned?: boolean
+  /** 取消置顶回调 */
+  onUnpin?: () => void
   /** hover 进入 Tab */
   onHoverEnter: () => void
   /** hover 离开 Tab */
@@ -57,6 +62,8 @@ export function TabBarItem({
   onMiddleClick,
   onDragStart,
   isAutomation,
+  isPinned,
+  onUnpin,
   onHoverEnter,
   onHoverLeave,
   onPanelHoverEnter,
@@ -165,6 +172,7 @@ export function TabBarItem({
           <span className="flex-1" />
         ) : (
           <span className="flex-1 min-w-0 truncate text-left flex items-center gap-1">
+            {isPinned && <Pin size={10} className="shrink-0 text-primary/50" />}
             {isAutomation && <Clock className="size-3 shrink-0 text-foreground/40" />}
             {title}
           </span>
@@ -176,23 +184,49 @@ export function TabBarItem({
           </span>
         )}
 
-        {/* 关闭按钮（scratch 类型不显示） */}
+        {/* 关闭按钮 / 取消置顶按钮（scratch 类型不显示） */}
         {!isScratch && (
-        <span
-          role="button"
-          tabIndex={-1}
-          className={cn(
-            'size-4 rounded-sm flex items-center justify-center shrink-0',
-            'opacity-0 group-hover:opacity-100 hover:bg-muted-foreground/20 transition-opacity',
-            isActive && 'opacity-60',
-          )}
-          onClick={handleCloseClick}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' || e.key === ' ') handleCloseClick(e as unknown as React.MouseEvent)
-          }}
-        >
-          <X className="size-2.5" />
-        </span>
+          isPinned ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span
+                  role="button"
+                  tabIndex={-1}
+                  className={cn(
+                    'size-4 rounded-sm flex items-center justify-center shrink-0',
+                    'opacity-0 group-hover:opacity-100 hover:bg-muted-foreground/20 transition-opacity',
+                    isActive && 'opacity-60',
+                  )}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onUnpin?.()
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') onUnpin?.()
+                  }}
+                >
+                  <PinOff className="size-2.5 text-primary/60" />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">取消置顶</TooltipContent>
+            </Tooltip>
+          ) : (
+            <span
+              role="button"
+              tabIndex={-1}
+              className={cn(
+                'size-4 rounded-sm flex items-center justify-center shrink-0',
+                'opacity-0 group-hover:opacity-100 hover:bg-muted-foreground/20 transition-opacity',
+                isActive && 'opacity-60',
+              )}
+              onClick={handleCloseClick}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') handleCloseClick(e as unknown as React.MouseEvent)
+              }}
+            >
+              <X className="size-2.5" />
+            </span>
+          )
         )}
 
         {/* 状态包边 */}

--- a/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
@@ -201,7 +201,11 @@ export function TabBarItem({
                     onUnpin?.()
                   }}
                   onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') onUnpin?.()
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.stopPropagation()
+                      e.preventDefault()
+                      onUnpin?.()
+                    }
                   }}
                 >
                   <PinOff className="size-2.5 text-primary/60" />

--- a/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
@@ -28,6 +28,10 @@ export interface TabBarItemProps {
   isHovered: boolean
   /** 预览面板是否正在退出动画 */
   isLeaving: boolean
+  /** 是否正在被拖拽 */
+  isDragging?: boolean
+  /** 拖拽时水平偏移量 */
+  dragOffsetX?: number
   onActivate: () => void
   onClose: () => void
   onMiddleClick: () => void
@@ -57,6 +61,8 @@ export function TabBarItem({
   isStreaming,
   isHovered,
   isLeaving,
+  isDragging,
+  dragOffsetX,
   onActivate,
   onClose,
   onMiddleClick,
@@ -145,7 +151,15 @@ export function TabBarItem({
   return (
     <div
       data-tab-id={id}
-      className="relative min-w-[120px] max-w-[200px] flex-[1_0_120px] titlebar-no-drag"
+      className={cn(
+        "relative min-w-[120px] max-w-[200px] flex-[1_0_120px] titlebar-no-drag",
+        isDragging ? "z-20" : "",
+      )}
+      style={isDragging ? {
+        transform: `translateX(${dragOffsetX ?? 0}px)`,
+        transition: 'none',
+        opacity: 0.85,
+      } : undefined}
       onMouseEnter={onHoverEnter}
       onMouseLeave={onHoverLeave}
     >

--- a/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
@@ -9,7 +9,7 @@
 import * as React from 'react'
 import { createPortal } from 'react-dom'
 import { useAtomValue } from 'jotai'
-import { FileText, StickyNote, X, Clock, PinOff, Pin } from 'lucide-react'
+import { FileText, StickyNote, X, Clock, PinOff } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import type { TabType, TabMinimapItem } from '@/atoms/tab-atoms'
@@ -172,7 +172,6 @@ export function TabBarItem({
           <span className="flex-1" />
         ) : (
           <span className="flex-1 min-w-0 truncate text-left flex items-center gap-1">
-            {isPinned && <Pin size={10} className="shrink-0 text-primary/50" />}
             {isAutomation && <Clock className="size-3 shrink-0 text-foreground/40" />}
             {title}
           </span>

--- a/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
@@ -30,8 +30,8 @@ export interface TabBarItemProps {
   isLeaving: boolean
   /** 是否正在被拖拽 */
   isDragging?: boolean
-  /** 拖拽时水平偏移量 */
-  dragOffsetX?: number
+  /** 拖拽时绝对 left 位置（浏览器风格：被拖 tab 脱离 flex 流跟随鼠标） */
+  dragLeft?: number
   onActivate: () => void
   onClose: () => void
   onMiddleClick: () => void
@@ -62,7 +62,7 @@ export function TabBarItem({
   isHovered,
   isLeaving,
   isDragging,
-  dragOffsetX,
+  dragLeft,
   onActivate,
   onClose,
   onMiddleClick,
@@ -156,9 +156,9 @@ export function TabBarItem({
         isDragging ? "z-20" : "",
       )}
       style={isDragging ? {
-        transform: `translateX(${dragOffsetX ?? 0}px)`,
-        transition: 'none',
-        opacity: 0.85,
+        position: 'absolute',
+        left: dragLeft ?? 0,
+        pointerEvents: 'none',
       } : undefined}
       onMouseEnter={onHoverEnter}
       onMouseLeave={onHoverLeave}

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -674,7 +674,7 @@ function TabStatePersistenceInitializer(): null {
       }
 
       const activeTab = validTabs.find((t) => t.id === restoredActiveTabId) ?? validTabs[0] ?? null
-      store.set(tabsAtom, ensureScratchPadTab(activeTab ? [activeTab] : []))
+      store.set(tabsAtom, ensureScratchPadTab(validTabs))
       store.set(activeTabIdAtom, restoredActiveTabId)
 
       // 同步 appMode 和 currentSessionId

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -51,7 +51,7 @@ import {
 } from './atoms/markdown-font-size'
 import { useGlobalAgentListeners } from './hooks/useGlobalAgentListeners'
 import { useGlobalChatListeners } from './hooks/useGlobalChatListeners'
-import { tabsAtom, activeTabIdAtom, ensureScratchPadTab, getPersistableTabState, scratchPadContentAtom, scratchPadLoadedAtom, SCRATCH_PAD_ID } from './atoms/tab-atoms'
+import { tabsAtom, activeTabIdAtom, ensureScratchPadTab, getPersistableTabState, scratchPadContentAtom, scratchPadLoadedAtom, SCRATCH_PAD_ID, CHAT_WORKSPACE_ID } from './atoms/tab-atoms'
 import type { TabItem } from './atoms/tab-atoms'
 import { chatToolsAtom } from './atoms/chat-tool-atoms'
 import { feishuBotStatesAtom } from './atoms/feishu-atoms'
@@ -640,6 +640,11 @@ function TabStatePersistenceInitializer(): null {
         ...agentSessions.map((s) => s.id),
       ])
 
+      // 构建 sessionId → workspaceId 映射（用于旧标签补充 workspaceId）
+      const agentSessionWorkspaceMap = new Map(
+        agentSessions.map((s) => [s.id, s.workspaceId]),
+      )
+
       // 过滤 diff 类型 Tab（不持久化），同时过滤掉已被删除的会话
       const validTabs = tabState.tabs.filter(
         (t): t is TabItem =>
@@ -651,7 +656,15 @@ function TabStatePersistenceInitializer(): null {
           'title' in t &&
           (t.type === 'chat' || t.type === 'agent') &&
           validSessionIds.has(t.sessionId),
-      )
+      // 补充 workspaceId：标签如果缺少 workspaceId，从 session 数据回填
+      ).map((t) => {
+        if (!t.workspaceId) {
+          if (t.type === 'chat') return { ...t, workspaceId: CHAT_WORKSPACE_ID }
+          const wsId = agentSessionWorkspaceMap.get(t.sessionId)
+          if (wsId) return { ...t, workspaceId: wsId }
+        }
+        return t
+      })
       if (validTabs.length === 0) {
         restoredRef.current = true
         return


### PR DESCRIPTION
## 概述

侧边栏项目选择器支持「下拉选择器/垂直列表」双形态切换 + 置顶会话标签页常驻显示（每工作区/Chat 单约束）+ Chat/Agent 排版统一 + 设置页项目拖拽排序 + 置顶标签拖拽重排 + 标签栏溢出滚动优化。

---

## 为什么需要这些改动

### 1. 项目列表 → 双形态选择器

**问题**：原项目列表占据侧边栏大量垂直空间，项目多时挤压会话列表。项目切换是低频操作，却占据了和高频操作（切换会话）同等甚至更多的空间，信息密度不合理。但部分用户偏好原垂直列表形态——所有项目并排可见、内联操作更直接。

**方案**：支持「下拉选择器」和「垂直列表」两种形态，用户可在 AgentSettings 项目 Tab 中切换。下拉选择器将项目切换压缩为一行按钮，释放垂直空间；垂直列表保留原有内联重命名/删除/拖拽排序/可调高度的完整交互。形态通过 `workspaceListModeAtom` 持久化到 localStorage。

### 2. 置顶会话标签页常驻（每工作区/Chat 单约束）

**问题**：用户在多个会话间频繁切换时，每次都要回到侧边栏重新定位目标会话。对于正在进行中的关键会话（如长任务 Agent、重要对话），缺乏"钉住"机制导致操作路径过长。多个工作区各有一个置顶会话时，切换工作区后旧置顶消失，无法跨工作区快速定位。

**方案**：
- 置顶会话以标签页形式常驻顶部标签栏，一键切换、始终可见
- **每工作区单约束**：同一工作区同时只允许一个 Agent 置顶标签，Chat 也只允许一个。置顶新会话时自动替换同工作区旧置顶，无需手动取消
- **跨工作区可见**：Agent 侧边栏置顶区显示所有工作区的置顶会话，带工作区名称标识
- `TabItem` 新增 `workspaceId` 字段，agent 类型存工作区 ID，chat 类型用 `CHAT_WORKSPACE_ID` 常量标识

### 3. Chat/Agent 排版统一

**问题**：Chat 和 Agent 两种模式的侧边栏布局不一致——Chat 用旧的展开/收起模式，Agent 用置顶区+日期分组。切换模式时视觉跳跃明显。

**方案**：Chat active 视图改为和 Agent 一样的「置顶区 + 日期分组」布局，移除旧的 SidebarItem 展开/收起模式。

### 4. 设置页项目拖拽排序

**问题**：项目在选择器中的显示顺序无法调整，项目多了之后找目标项目效率低。

**方案**：AgentSettings 项目 Tab 支持拖拽调整顺序，排序持久化到后端，失败时回滚并 toast 提示。

### 5. 标签栏溢出滚动优化

**问题**：置顶标签过多时，标签栏没有横向滚动机制，标签被压缩到不可用或直接溢出。

**方案**：溢出时显示左右滚动指示箭头，点击平滑滚动。右侧指示器在 Windows 上避开 WindowControls 区域。

---

## 改动内容

### WorkspaceSelector → 双形态选择器

- 新增 `workspaceListModeAtom`（`'dropdown' | 'list'`）+ `projectListHeightAtom` 持久化
- **下拉选择器形态**：DropdownMenu，支持切换/新建/重命名/删除，"项目排序设置..."快捷入口
- **垂直列表形态**：还原 main 分支原有交互——内联重命名/删除、拖拽排序、可调高度
- 两种形态共享 `useDeleteConfirm` / `DeleteConfirmDialog` / `canDelete` 逻辑

### 置顶会话标签页常驻（每工作区/Chat 单约束）

- `TabItem` 新增 `pinned?: boolean` + `workspaceId?: string`
- 新增 `CHAT_WORKSPACE_ID = '__chat__'` 常量标识 Chat 置顶标签
- `openTab`：置顶标签保留，非置顶替换；已有置顶标签直接激活
- `closeTab`：置顶标签不可关闭
- `reorderTabs`：置顶标签可在置顶区域内互相拖拽
- **单约束逻辑**：`handleTogglePin` / `handleTogglePinAgent` 置顶时检查同工作区已有置顶标签，自动取消旧置顶（前端移标签 + 后端同步取消）
- `handleUnpinTab`：同步调用后端 API + 更新 atom
- **跨工作区可见**：`pinnedAgentSessions` 移除 `workspaceId === currentWorkspaceId` 过滤，置顶区显示所有工作区的置顶会话，每个带 `workspaceName` 标识
- TabBarItem：置顶标签显示 PinOff 图标替代关闭按钮

### Chat/Agent 排版统一

- Chat active 视图改为「置顶区 + 日期分组」布局
- 移除旧的 SidebarItem 展开/收起模式
- Agent 模式排列顺序：工作区选择器 → 新会话 → 搜索

### 设置页项目 Tab（原"项目排序"）

- Tab 名从"项目排序"改为"项目"
- 顶部加入「下拉选择器 / 垂直列表」二选一开关，描述文字根据当前模式动态切换
- 保留拖拽排序功能（两种形态共用）

### 标签栏溢出滚动优化

- 溢出时显示左右滚动指示箭头（‹ / ›）
- scroll 事件 + ResizeObserver 实时检测溢出
- Windows 上避开 WindowControls 区域

---

## 改动文件

| 文件 | 变化 |
|------|------|
| `WorkspaceSelector.tsx` | 416→488 行（双形态：DropdownMenu + 垂直列表） |
| `LeftSidebar.tsx` | -857→+150 行（置顶单约束 + 跨工作区可见 + 排版统一 + 迁移修复） |
| `tab-atoms.ts` | +71→+76 行（TabItem.pinned + workspaceId + CHAT_WORKSPACE_ID + 单约束相关逻辑） |
| `sidebar-atoms.ts` | -7→+13 行（workspaceListModeAtom + projectListHeightAtom） |
| `TabBar.tsx` | +260 行（isPinned + onUnpin + workspaceId 判断 + 拖拽重排 + 溢出滚动） |
| `TabBarItem.tsx` | +88 行（PinOff 按钮 + pinned UI + data-tab-id） |
| `AgentSettings.tsx` | +150 行（项目 Tab + 形态开关 + 拖拽排序） |
| `agent-atoms.ts` | +12 行（agentSettingsTabAtom） |
| `main.tsx` | +17→+19 行（恢复时保留置顶标签 + workspaceId 回填） |

---

## 健壮性保障

- **单约束替换**：置顶新会话时自动取消同工作区旧置顶，异步取消失败时回滚前端标签 + toast 提示
- **workspaceId 安全**：`workspaceId` 为 `undefined` 时跳过单约束检查，避免误删其他工作区置顶标签
- **迁移安全**：置顶会话迁移到新工作区时，检查目标工作区是否已有置顶标签，有则取消旧置顶
- **归档联动**：归档置顶会话前先取消 pinned 标记（closeTab 会拒绝关闭置顶标签）
- **React 纯函数**：setTabs updater 内不调用 setActiveTabId 副作用
- **闭包竞态**：handleUnpinTab 使用函数式更新消除闭包竞态
- **标签顺序**：置顶后重排 tabs，确保 `[scratch, ...pinned, ...nonPinned]` 顺序
- **恢复回填**：所有缺少 `workspaceId` 的标签在恢复时统一从 session 数据回填
- **DropdownMenu z-index**：`z-[200]` 解决下拉弹窗被 Dialog 遮挡
- **PinOff 按钮**：`onKeyDown` 加 `stopPropagation` + `preventDefault`
- **创建失败**：WorkspaceListMode 创建项目失败时不关闭输入框，与 DropdownMode 行为一致
- **拖拽排序**：AgentSettings 排序失败时回滚到旧顺序并 toast 提示

## 测试

- [x] TypeScript 编译零错误
- [x] 每工作区单约束：同工作区置顶第二个会话时自动取消旧置顶
- [x] Chat 单约束：置顶第二个 Chat 对话时自动取消旧 Chat 置顶
- [x] workspaceId undefined 跳过约束
- [x] 异步取消旧置顶失败时回滚
- [x] 置顶会话迁移检查目标工作区冲突
- [x] 项目列表双形态切换持久化