### PR TITLE
fix: 优化自动任务入口在深色主题下的选中态可见性【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -167,21 +167,21 @@ function AutomationSidebarEntry({ count, active, onClick }: AutomationSidebarEnt
       aria-label={`自动任务，${count} 个任务已创建`}
       onClick={onClick}
       className={cn(
-        'group w-full flex items-center justify-between px-3 py-2 rounded-md text-[13px] transition-colors duration-100 titlebar-no-drag',
+        'group w-full flex items-center justify-between px-3 py-2 rounded-md text-[13px] transition-colors duration-100 titlebar-no-drag automation-entry',
         active
-          ? 'bg-accent-foreground/[0.10] text-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
+          ? 'automation-entry-selected bg-accent-foreground/[0.10] text-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
           : 'text-foreground/60 hover:bg-accent-foreground/[0.08] hover:text-foreground',
       )}
     >
       <span className="flex items-center gap-3 min-w-0">
-        <span className="flex-shrink-0 w-[18px] h-[18px]">
-          <AlarmClock size={16} className={cn('block', active ? 'text-accent-foreground' : 'text-foreground/45')} />
+        <span className={cn('flex-shrink-0 w-[18px] h-[18px] automation-entry-icon', active ? 'text-accent-foreground' : 'text-foreground/45')}>
+          <AlarmClock size={16} className="block" />
         </span>
         <span className="truncate">自动任务</span>
       </span>
       <span
         className={cn(
-          'ml-2 flex h-5 min-w-[22px] flex-shrink-0 items-center justify-center rounded-full px-1.5 text-[11px] font-medium tabular-nums',
+          'ml-2 flex h-5 min-w-[22px] flex-shrink-0 items-center justify-center rounded-full px-1.5 text-[11px] font-medium tabular-nums automation-entry-badge',
           active
             ? 'bg-accent-foreground/[0.26] text-primary-foreground'
             : 'bg-foreground/[0.045] text-foreground/[0.42] group-hover:text-foreground/65',

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -169,13 +169,13 @@ function AutomationSidebarEntry({ count, active, onClick }: AutomationSidebarEnt
       className={cn(
         'group w-full flex items-center justify-between px-3 py-2 rounded-md text-[13px] transition-colors duration-100 titlebar-no-drag',
         active
-          ? 'bg-primary/10 text-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
-          : 'text-foreground/60 hover:bg-primary/5 hover:text-foreground',
+          ? 'bg-accent-foreground/[0.10] text-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
+          : 'text-foreground/60 hover:bg-accent-foreground/[0.08] hover:text-foreground',
       )}
     >
       <span className="flex items-center gap-3 min-w-0">
         <span className="flex-shrink-0 w-[18px] h-[18px]">
-          <AlarmClock size={16} className={cn('block', active ? 'text-primary' : 'text-foreground/45')} />
+          <AlarmClock size={16} className={cn('block', active ? 'text-accent-foreground' : 'text-foreground/45')} />
         </span>
         <span className="truncate">自动任务</span>
       </span>
@@ -183,7 +183,7 @@ function AutomationSidebarEntry({ count, active, onClick }: AutomationSidebarEnt
         className={cn(
           'ml-2 flex h-5 min-w-[22px] flex-shrink-0 items-center justify-center rounded-full px-1.5 text-[11px] font-medium tabular-nums',
           active
-            ? 'bg-primary/[0.14] text-primary'
+            ? 'bg-accent-foreground/[0.26] text-primary-foreground'
             : 'bg-foreground/[0.045] text-foreground/[0.42] group-hover:text-foreground/65',
         )}
       >

--- a/apps/electron/src/renderer/components/automation/AutomationsListView.tsx
+++ b/apps/electron/src/renderer/components/automation/AutomationsListView.tsx
@@ -166,7 +166,7 @@ function Section({ title, automations, onEdit, onRefresh, variant }: SectionProp
               }
             }}
             className={cn(
-              'group w-full flex items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-foreground/[0.03] cursor-pointer focus:outline-none focus-visible:bg-foreground/[0.05]',
+              'group w-full flex items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-foreground/[0.15] cursor-pointer focus:outline-none focus-visible:bg-foreground/[0.18]',
               i > 0 && 'border-t border-border/40',
             )}
           >
@@ -193,7 +193,7 @@ function Section({ title, automations, onEdit, onRefresh, variant }: SectionProp
                       type="button"
                       aria-label={`立即运行 ${a.name}`}
                       onClick={(e) => { void handleRunNow(e, a) }}
-                      className="p-1.5 rounded-md text-foreground/40 hover:text-foreground/80 hover:bg-foreground/[0.06] transition-colors"
+                      className="p-1.5 rounded-md text-foreground/50 hover:text-foreground/85 hover:bg-foreground/[0.08] transition-colors"
                     >
                       <Play className="size-3.5" />
                     </button>
@@ -206,7 +206,7 @@ function Section({ title, automations, onEdit, onRefresh, variant }: SectionProp
                       type="button"
                       aria-label={`删除 ${a.name}`}
                       onClick={(e) => { void handleDelete(e, a) }}
-                      className="p-1.5 rounded-md text-foreground/40 hover:text-destructive hover:bg-destructive/10 transition-colors"
+                      className="p-1.5 rounded-md text-foreground/50 hover:text-destructive hover:bg-destructive/10 transition-colors"
                     >
                       <Trash2 className="size-3.5" />
                     </button>
@@ -224,8 +224,8 @@ function Section({ title, automations, onEdit, onRefresh, variant }: SectionProp
                   className={cn(
                     'p-1.5 -m-1.5 shrink-0 flex items-center justify-center rounded-md transition-colors',
                     a.active
-                      ? 'text-foreground/35 hover:bg-foreground/[0.06] hover:text-foreground/70'
-                      : 'text-foreground/30 hover:bg-emerald-500/10 hover:text-emerald-500',
+                      ? 'text-foreground/35 hover:bg-foreground/[0.06] hover:text-foreground/70 group-hover:text-foreground/55'
+                      : 'text-foreground/30 hover:bg-emerald-500/10 hover:text-emerald-500 group-hover:text-foreground/45',
                   )}
                 >
                   {a.active ? <Pause className="size-3.5" /> : <Power className="size-3.5" />}

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -469,6 +469,18 @@
   color: inherit !important;
 }
 
+/* 苍穹暮色：自动化入口选中状态 */
+.theme-ocean-dark .automation-entry-selected.automation-entry-selected {
+  background-color: hsl(210 40% 18%) !important;
+}
+.theme-ocean-dark .automation-entry-selected .automation-entry-icon {
+  color: hsl(205 70% 75%) !important;
+}
+.theme-ocean-dark .automation-entry-selected .automation-entry-badge {
+  background-color: hsl(205 70% 75% / 0.20) !important;
+  color: #fff !important;
+}
+
 /* ===== 森系主题：会话/工作区选中状态 ===== */
 /* 森息晨光：浅绿背景 + 深绿文字 */
 .theme-forest-light .session-item-selected,
@@ -496,6 +508,18 @@
   color: inherit !important;
 }
 
+/* 森息夜语：自动化入口选中状态 */
+.theme-forest-dark .automation-entry-selected.automation-entry-selected {
+  background-color: hsl(150 25% 18%) !important;
+}
+.theme-forest-dark .automation-entry-selected .automation-entry-icon {
+  color: hsl(150 40% 70%) !important;
+}
+.theme-forest-dark .automation-entry-selected .automation-entry-badge {
+  background-color: hsl(150 40% 70% / 0.20) !important;
+  color: #fff !important;
+}
+
 /* ===== 莫兰迪主题：模式切换器选中状态 ===== */
 /* 莫兰迪夜：淡杏粉滑块 + 深色文字 */
 .theme-slate-dark .mode-slider {
@@ -518,6 +542,18 @@
 .theme-slate-dark .workspace-item-selected *,
 .theme-slate-dark .tab-item-selected * {
   color: inherit !important;
+}
+
+/* 莫兰迪夜：自动化入口选中状态 */
+.theme-slate-dark .automation-entry-selected.automation-entry-selected {
+  background-color: hsl(260 10% 22%) !important;
+}
+.theme-slate-dark .automation-entry-selected .automation-entry-icon {
+  color: hsl(15 30% 75%) !important;
+}
+.theme-slate-dark .automation-entry-selected .automation-entry-badge {
+  background-color: hsl(15 30% 75% / 0.20) !important;
+  color: hsl(15 30% 75%) !important;
 }
 
 /* ===== 云朵舞者主题：会话/工作区选中状态 ===== */

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -478,7 +478,7 @@
 }
 .theme-ocean-dark .automation-entry-selected .automation-entry-badge {
   background-color: hsl(205 70% 75% / 0.20) !important;
-  color: #fff !important;
+  color: hsl(205 70% 75%) !important;
 }
 
 /* ===== 森系主题：会话/工作区选中状态 ===== */
@@ -517,7 +517,7 @@
 }
 .theme-forest-dark .automation-entry-selected .automation-entry-badge {
   background-color: hsl(150 40% 70% / 0.20) !important;
-  color: #fff !important;
+  color: hsl(150 40% 70%) !important;
 }
 
 /* ===== 莫兰迪主题：模式切换器选中状态 ===== */


### PR DESCRIPTION
## 概述

自动任务侧边栏入口（AutomationSidebarEntry）在苍穹暮色、森息夜语、莫兰迪夜等深色主题下选中态几乎不可见。根因是组件使用了 `--primary` 变量做选中态颜色，而这些主题的 `--primary` 是深色。同时自动任务列表项 hover 态在深色主题下也偏淡。

## 改动

- `LeftSidebar.tsx` — AutomationSidebarEntry 组件选中态改用 `--accent-foreground` 做基础色，并为苍穹暮色/森息夜语/莫兰迪夜添加 `automation-entry-selected` CSS 覆盖规则，对齐 session-item-selected 的同款配色。图标颜色从 AlarmClock 上移到 span 包裹层，确保 CSS 覆盖生效
- `AutomationsListView.tsx` — 列表项 hover/focus 背景透明度从 3%/5% 提升至 15%/18%，toggle 按钮增加 `group-hover` 提亮，操作按钮基础可见度从 40% 提升至 50%
- `globals.css` — 新增三个深色主题的 `automation-entry-selected` / `automation-entry-icon` / `automation-entry-badge` 规则

## 测试方法

1. 切换到苍穹暮色 / 森息夜语 / 莫兰迪夜主题
2. 点击侧边栏「自动任务」入口
3. 确认图标（闹钟）和数字徽章均以对应主题色（亮蓝/亮绿/暖杏粉）显示
4. 确认选中态背景色与同主题下置顶会话的选中态一致
5. hover 自动任务列表项，确认背景变化明显

## 备注

- 默认深色/浅色主题不受影响，Tailwind 类作为兜底
- CSS 规则模式与现有 `session-item-selected` / `workspace-item-selected` 一致