### PR TITLE
[codex] Add bridge self healing

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -92,7 +92,13 @@ import { initAutoUpdater, cleanupUpdater } from './lib/updater/auto-updater'
 import { startWorkspaceWatcher, stopWorkspaceWatcher } from './lib/workspace-watcher'
 import { startChatToolsWatcher, stopChatToolsWatcher } from './lib/chat-tools-watcher'
 import { getIsQuitting, setQuitting } from './lib/app-lifecycle'
-import { registerBridge, startAllBridges, stopAllBridges } from './lib/bridge-registry'
+import {
+  registerBridge,
+  startAllBridges,
+  startBridgeSelfHealing,
+  stopAllBridges,
+  stopBridgeSelfHealing,
+} from './lib/bridge-registry'
 import { startScheduler, stopScheduler } from './lib/automation-scheduler'
 import { feishuBridgeManager } from './lib/feishu-bridge-manager'
 import { getFeishuMultiBotConfig } from './lib/feishu-config'
@@ -129,8 +135,19 @@ registerBridge({
     const config = getFeishuMultiBotConfig()
     return config.bots.some((b) => b.enabled && b.appId && b.appSecret)
   },
+  needsRecovery: () => {
+    const config = getFeishuMultiBotConfig()
+    const states = feishuBridgeManager.getStates()
+    return config.bots.some((bot) => (
+      bot.enabled &&
+      !!bot.appId &&
+      !!bot.appSecret &&
+      states.bots[bot.id]?.status === 'error'
+    ))
+  },
   start: () => feishuBridgeManager.startAll(),
   stop: () => feishuBridgeManager.stopAll(),
+  recover: () => recoverEnabledFeishuBots(),
 })
 
 registerBridge({
@@ -139,8 +156,19 @@ registerBridge({
     const config = getDingTalkMultiBotConfig()
     return config.bots.some((b) => b.enabled && b.clientId && b.clientSecret)
   },
+  needsRecovery: () => {
+    const config = getDingTalkMultiBotConfig()
+    const states = dingtalkBridgeManager.getStates()
+    return config.bots.some((bot) => (
+      bot.enabled &&
+      !!bot.clientId &&
+      !!bot.clientSecret &&
+      states.bots[bot.id]?.status === 'error'
+    ))
+  },
   start: () => dingtalkBridgeManager.startAll(),
   stop: () => dingtalkBridgeManager.stopAll(),
+  recover: () => recoverEnabledDingTalkBots(),
 })
 
 registerBridge({
@@ -149,9 +177,44 @@ registerBridge({
     const config = getWeChatConfig()
     return !!(config.enabled && config.credentials)
   },
+  needsRecovery: () => wechatBridge.getStatus().status === 'error',
   start: () => wechatBridge.start(),
   stop: () => wechatBridge.stop(),
 })
+
+async function recoverEnabledFeishuBots(): Promise<void> {
+  const config = getFeishuMultiBotConfig()
+  let failedCount = 0
+  for (const bot of config.bots) {
+    if (!bot.enabled || !bot.appId || !bot.appSecret) continue
+    try {
+      await feishuBridgeManager.restartBot(bot.id)
+    } catch (error) {
+      failedCount++
+      console.error(`[飞书 BridgeManager] Bot "${bot.name}" 自愈恢复失败:`, error)
+    }
+  }
+  if (failedCount > 0) {
+    throw new Error(`${failedCount} 个飞书 Bot 自愈恢复失败`)
+  }
+}
+
+async function recoverEnabledDingTalkBots(): Promise<void> {
+  const config = getDingTalkMultiBotConfig()
+  let failedCount = 0
+  for (const bot of config.bots) {
+    if (!bot.enabled || !bot.clientId || !bot.clientSecret) continue
+    try {
+      await dingtalkBridgeManager.restartBot(bot.id)
+    } catch (error) {
+      failedCount++
+      console.error(`[钉钉 BridgeManager] Bot "${bot.name}" 自愈恢复失败:`, error)
+    }
+  }
+  if (failedCount > 0) {
+    throw new Error(`${failedCount} 个钉钉 Bot 自愈恢复失败`)
+  }
+}
 
 let mainWindow: BrowserWindow | null = null
 
@@ -504,6 +567,7 @@ async function bootstrap(): Promise<void> {
 
   // 启动所有已注册的 Bridge（飞书/钉钉/微信等）
   await safeAwait('startAllBridges', () => startAllBridges())
+  safeRun('startBridgeSelfHealing', startBridgeSelfHealing)
 
   // 启动定时任务调度器（恢复持久化的 active 任务）
   safeRun('startScheduler', startScheduler)
@@ -598,6 +662,7 @@ app.on('before-quit', () => {
   // 停止 Chat 工具配置文件监听
   stopChatToolsWatcher()
   // 停止所有 Bridge
+  stopBridgeSelfHealing()
   stopAllBridges()
   // 停止定时任务调度器
   stopScheduler()

--- a/apps/electron/src/main/lib/bridge-registry.ts
+++ b/apps/electron/src/main/lib/bridge-registry.ts
@@ -1,3 +1,5 @@
+import { powerMonitor } from 'electron'
+
 /**
  * Bridge Registry — 统一管理 IM Bridge 生命周期
  *
@@ -19,13 +21,29 @@ export interface BridgeRegistration {
   name: string
   /** 判断是否应在启动时自动连接（检查配置是否完整/启用） */
   shouldAutoStart: () => boolean
+  /** 判断当前 Bridge 是否需要自愈恢复；通常只在 error 状态返回 true */
+  needsRecovery?: () => boolean
   /** 启动连接 */
   start: () => Promise<void>
   /** 停止连接并释放资源 */
   stop: () => void
+  /** 自愈恢复；未提供时默认 stop 后 start */
+  recover?: () => Promise<void>
 }
 
+export interface BridgeSelfHealingOptions {
+  /** 定时健康检查间隔；传 0 可关闭定时检查 */
+  healthCheckIntervalMs?: number
+}
+
+const DEFAULT_HEALTH_CHECK_INTERVAL_MS = 60_000
+const POWER_RECOVERY_DELAYS_MS = [1_500, 10_000] as const
+
 const bridges: BridgeRegistration[] = []
+let recoveryInFlight = false
+let selfHealingStarted = false
+let healthCheckTimer: ReturnType<typeof setInterval> | null = null
+const scheduledRecoveryTimers = new Set<ReturnType<typeof setTimeout>>()
 
 /** 注册一个 Bridge（通常在模块顶层调用） */
 export function registerBridge(bridge: BridgeRegistration): void {
@@ -45,6 +63,100 @@ export async function startAllBridges(): Promise<void> {
         console.error(`[Bridge Registry] ${bridge.name} 自动启动失败:`, err)
       })
     }
+  }
+}
+
+/** 启动 Bridge 自愈守护：系统恢复/解锁后重建长连接，定时恢复 error 状态。 */
+export function startBridgeSelfHealing(options: BridgeSelfHealingOptions = {}): void {
+  if (selfHealingStarted) return
+  selfHealingStarted = true
+
+  powerMonitor.on('resume', handlePowerResume)
+  powerMonitor.on('unlock-screen', handlePowerUnlock)
+
+  const intervalMs = options.healthCheckIntervalMs ?? DEFAULT_HEALTH_CHECK_INTERVAL_MS
+  if (intervalMs > 0) {
+    healthCheckTimer = setInterval(() => {
+      void recoverAllBridges('定时健康检查', { force: false })
+    }, intervalMs)
+    healthCheckTimer.unref?.()
+  }
+
+  console.log('[Bridge Registry] 自愈守护已启动')
+}
+
+/** 停止 Bridge 自愈守护（应用退出时调用）。 */
+export function stopBridgeSelfHealing(): void {
+  if (!selfHealingStarted) return
+  selfHealingStarted = false
+
+  powerMonitor.off('resume', handlePowerResume)
+  powerMonitor.off('unlock-screen', handlePowerUnlock)
+
+  if (healthCheckTimer) {
+    clearInterval(healthCheckTimer)
+    healthCheckTimer = null
+  }
+
+  for (const timer of scheduledRecoveryTimers) {
+    clearTimeout(timer)
+  }
+  scheduledRecoveryTimers.clear()
+
+  console.log('[Bridge Registry] 自愈守护已停止')
+}
+
+/** 立即恢复需要自愈的 Bridge。force=true 时会重启所有自动启用的 Bridge。 */
+export async function recoverAllBridges(
+  reason: string,
+  options: { force?: boolean } = {},
+): Promise<void> {
+  if (recoveryInFlight) return
+
+  recoveryInFlight = true
+  try {
+    for (const bridge of bridges) {
+      if (!bridge.shouldAutoStart()) continue
+      if (!options.force && bridge.needsRecovery?.() !== true) continue
+
+      console.log(`[Bridge Registry] 自愈恢复 ${bridge.name}，原因：${reason}`)
+      try {
+        if (bridge.recover) {
+          await bridge.recover()
+        } else {
+          try {
+            bridge.stop()
+          } catch (err) {
+            console.error(`[Bridge Registry] ${bridge.name} 自愈停止失败:`, err)
+          }
+          await bridge.start()
+        }
+        console.log(`[Bridge Registry] ${bridge.name} 自愈恢复完成`)
+      } catch (err) {
+        console.error(`[Bridge Registry] ${bridge.name} 自愈恢复失败:`, err)
+      }
+    }
+  } finally {
+    recoveryInFlight = false
+  }
+}
+
+function handlePowerResume(): void {
+  schedulePowerRecovery('系统恢复')
+}
+
+function handlePowerUnlock(): void {
+  schedulePowerRecovery('系统解锁')
+}
+
+function schedulePowerRecovery(reason: string): void {
+  for (const delayMs of POWER_RECOVERY_DELAYS_MS) {
+    const timer = setTimeout(() => {
+      scheduledRecoveryTimers.delete(timer)
+      void recoverAllBridges(reason, { force: true })
+    }, delayMs)
+    timer.unref?.()
+    scheduledRecoveryTimers.add(timer)
   }
 }
 


### PR DESCRIPTION
## Summary
- Add Bridge Registry self-healing for power resume, unlock, and periodic error-state recovery.
- Register Feishu, DingTalk, and WeChat recovery checks in the main process.
- Bump @proma/electron to 0.11.11.

## Why
When macOS briefly changes networking during lid-close or wake flows, Bridge long connections can get stuck in an error state. The registry now restarts enabled bridges after system resume/unlock and periodically recovers bridges marked as unhealthy.

## Validation
- bun build apps/electron/src/main/lib/bridge-registry.ts --target=node --external electron --outdir .context/bridge-registry-check
- git diff --check

Note: full typecheck/build were not runnable in this workspace because tsc and esbuild are missing from the local install.