### PR TITLE
feat(sidebar): 自动任务按钮 hover 时预览启用中任务清单 【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -83,6 +83,7 @@ import { useOpenSession } from '@/hooks/useOpenSession'
 import { useSyncActiveTabSideEffects } from '@/hooks/useSyncActiveTabSideEffects'
 import { CollapsedWorkspacePopover } from '@/components/agent/CollapsedWorkspacePopover'
 import { MoveSessionDialog } from '@/components/agent/MoveSessionDialog'
+import { AutomationPreviewPopover } from '@/components/automation/AutomationPreviewPopover'
 import {
   SessionMiniMapPopover,
   useSessionMiniMapHover,
@@ -161,35 +162,108 @@ interface AutomationSidebarEntryProps {
 }
 
 function AutomationSidebarEntry({ count, active, onClick }: AutomationSidebarEntryProps): React.ReactElement {
+  const preview = useSessionMiniMapHover()
   return (
-    <button
-      type="button"
-      aria-label={`自动任务，${count} 个任务已创建`}
-      onClick={onClick}
-      className={cn(
-        'group w-full flex items-center justify-between px-3 py-2 rounded-md text-[13px] transition-colors duration-100 titlebar-no-drag',
-        active
-          ? 'bg-primary/10 text-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
-          : 'text-foreground/60 hover:bg-primary/5 hover:text-foreground',
-      )}
-    >
-      <span className="flex items-center gap-3 min-w-0">
-        <span className="flex-shrink-0 w-[18px] h-[18px]">
-          <AlarmClock size={16} className={cn('block', active ? 'text-primary' : 'text-foreground/45')} />
-        </span>
-        <span className="truncate">自动任务</span>
-      </span>
-      <span
+    <>
+      <button
+        ref={preview.setAnchorRef}
+        type="button"
+        aria-label={`自动任务，${count} 个任务已创建`}
+        onClick={onClick}
+        onMouseEnter={preview.handleMouseEnter}
+        onMouseLeave={preview.handleMouseLeave}
         className={cn(
-          'ml-2 flex h-5 min-w-[22px] flex-shrink-0 items-center justify-center rounded-full px-1.5 text-[11px] font-medium tabular-nums',
+          'group w-full flex items-center justify-between px-3 py-2 rounded-md text-[13px] transition-colors duration-100 titlebar-no-drag',
           active
-            ? 'bg-primary/[0.14] text-primary'
-            : 'bg-foreground/[0.045] text-foreground/[0.42] group-hover:text-foreground/65',
+            ? 'bg-primary/10 text-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
+            : 'text-foreground/60 hover:bg-primary/5 hover:text-foreground',
         )}
       >
-        {formatAutomationCount(count)}
-      </span>
-    </button>
+        <span className="flex items-center gap-3 min-w-0">
+          <span className="flex-shrink-0 w-[18px] h-[18px]">
+            <AlarmClock size={16} className={cn('block', active ? 'text-primary' : 'text-foreground/45')} />
+          </span>
+          <span className="truncate">自动任务</span>
+        </span>
+        <span
+          className={cn(
+            'ml-2 flex h-5 min-w-[22px] flex-shrink-0 items-center justify-center rounded-full px-1.5 text-[11px] font-medium tabular-nums',
+            active
+              ? 'bg-primary/[0.14] text-primary'
+              : 'bg-foreground/[0.045] text-foreground/[0.42] group-hover:text-foreground/65',
+          )}
+        >
+          {formatAutomationCount(count)}
+        </span>
+      </button>
+      <AutomationPreviewPopover
+        anchorRef={preview.anchorRef}
+        open={preview.isOpen}
+        isLeaving={preview.isLeaving}
+        onMouseEnter={preview.handlePanelMouseEnter}
+        onMouseLeave={preview.handlePanelMouseLeave}
+      />
+    </>
+  )
+}
+
+interface AutomationRailButtonProps {
+  count: number
+  isActive: boolean
+  onClick: () => void
+}
+
+/**
+ * 折叠态侧边栏的「自动任务」入口：方形按钮 + 数字徽章。
+ * 短 hover（< 600ms）显示原 Tooltip 文本；长 hover 展开 AutomationPreviewPopover。
+ */
+function AutomationRailButton({ count, isActive, onClick }: AutomationRailButtonProps): React.ReactElement {
+  const preview = useSessionMiniMapHover()
+  return (
+    <>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            ref={preview.setAnchorRef}
+            type="button"
+            aria-label={`自动任务，${count} 个任务已创建`}
+            onClick={onClick}
+            onMouseEnter={preview.handleMouseEnter}
+            onMouseLeave={preview.handleMouseLeave}
+            className={cn(
+              'relative size-10 flex items-center justify-center rounded-[12px] transition-colors titlebar-no-drag border',
+              isActive
+                ? 'border-primary/80 bg-primary text-primary-foreground shadow-sm'
+                : 'border-border/45 bg-foreground/[0.025] text-foreground/45 hover:border-border/70 hover:bg-foreground/[0.045] hover:text-primary',
+            )}
+          >
+            <AlarmClock size={16} />
+            {count > 0 && (
+              <span
+                className={cn(
+                  'absolute -top-1 -right-1 flex h-4 min-w-[16px] items-center justify-center rounded-full px-1 text-[10px] font-medium tabular-nums',
+                  isActive
+                    ? 'bg-primary-foreground text-primary'
+                    : 'bg-primary text-primary-foreground',
+                )}
+              >
+                {formatAutomationCount(count)}
+              </span>
+            )}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="right">
+          自动任务（{count} 个任务已创建）
+        </TooltipContent>
+      </Tooltip>
+      <AutomationPreviewPopover
+        anchorRef={preview.anchorRef}
+        open={preview.isOpen}
+        isLeaving={preview.isLeaving}
+        onMouseEnter={preview.handlePanelMouseEnter}
+        onMouseLeave={preview.handlePanelMouseLeave}
+      />
+    </>
   )
 }
 
@@ -1426,38 +1500,11 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
             <TooltipContent side="right">搜索</TooltipContent>
           </Tooltip>
 
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                aria-label={`自动任务，${automationCount} 个任务已创建`}
-                onClick={handleOpenAutomations}
-                className={cn(
-                  'relative size-10 flex items-center justify-center rounded-[12px] transition-colors titlebar-no-drag border',
-                  activeView === 'automations'
-                    ? 'border-primary/80 bg-primary text-primary-foreground shadow-sm'
-                    : 'border-border/45 bg-foreground/[0.025] text-foreground/45 hover:border-border/70 hover:bg-foreground/[0.045] hover:text-primary',
-                )}
-              >
-                <AlarmClock size={16} />
-                {automationCount > 0 && (
-                  <span
-                    className={cn(
-                      'absolute -top-1 -right-1 flex h-4 min-w-[16px] items-center justify-center rounded-full px-1 text-[10px] font-medium tabular-nums',
-                      activeView === 'automations'
-                        ? 'bg-primary-foreground text-primary'
-                        : 'bg-primary text-primary-foreground',
-                    )}
-                  >
-                    {formatAutomationCount(automationCount)}
-                  </span>
-                )}
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="right">
-              自动任务（{automationCount} 个任务已创建）
-            </TooltipContent>
-          </Tooltip>
+          <AutomationRailButton
+            count={automationCount}
+            isActive={activeView === 'automations'}
+            onClick={handleOpenAutomations}
+          />
         </div>
 
         <div className="my-3 h-px w-8 bg-border/70" />

--- a/apps/electron/src/renderer/components/automation/AutomationPreviewPopover.tsx
+++ b/apps/electron/src/renderer/components/automation/AutomationPreviewPopover.tsx
@@ -1,0 +1,135 @@
+/**
+ * AutomationPreviewPopover — 自动任务按钮的悬浮预览
+ *
+ * 在侧边栏「自动任务」按钮 hover 时弹出，列出当前 active=true 的任务清单。
+ * 视觉与交互对齐 SessionMiniMapPopover（createPortal + 600ms 延迟 + 90ms 淡出）。
+ */
+
+import * as React from 'react'
+import { createPortal } from 'react-dom'
+import { useAtomValue } from 'jotai'
+import { AlarmClock } from 'lucide-react'
+import { automationsAtom } from '@/atoms/automation-atoms'
+import { formatNextRunAt, formatSchedule } from '@/components/automation/automation-formatters'
+import { usePopoverPosition } from '@/components/session-preview/SessionMiniMapPopover'
+import { cn } from '@/lib/utils'
+import type { Automation } from '@proma/shared'
+
+const PANEL_WIDTH = 280
+const PANEL_MIN_HEIGHT = 88
+const PANEL_MAX_HEIGHT = 360
+const ROW_HEIGHT = 48
+const HEADER_HEIGHT = 36
+/** 不出现滚动条时最多完整显示几条任务；超过则进入滚动。 */
+const ROWS_BEFORE_SCROLL = 3
+const TICK_INTERVAL_MS = 30_000
+
+interface AutomationPreviewPopoverProps {
+  anchorRef: React.MutableRefObject<HTMLElement | null>
+  open: boolean
+  isLeaving: boolean
+  onMouseEnter: () => void
+  onMouseLeave: () => void
+}
+
+function getPreferredHeight(activeCount: number): number {
+  if (activeCount === 0) return PANEL_MIN_HEIGHT
+  const visibleRows = Math.min(activeCount, ROWS_BEFORE_SCROLL)
+  return Math.min(PANEL_MAX_HEIGHT, Math.max(PANEL_MIN_HEIGHT, HEADER_HEIGHT + visibleRows * ROW_HEIGHT + 12))
+}
+
+/** 仅在浮层打开时每 30 秒刷新一次，让相对时间文案保持新鲜。 */
+function useNowTick(active: boolean): number {
+  const [now, setNow] = React.useState(() => Date.now())
+  React.useEffect(() => {
+    if (!active) return
+    setNow(Date.now())
+    const id = setInterval(() => setNow(Date.now()), TICK_INTERVAL_MS)
+    return () => clearInterval(id)
+  }, [active])
+  return now
+}
+
+export function AutomationPreviewPopover(props: AutomationPreviewPopoverProps): React.ReactElement | null {
+  if (!props.open) return null
+  return <AutomationPreviewPopoverContent {...props} />
+}
+
+function AutomationPreviewPopoverContent({
+  anchorRef,
+  open,
+  isLeaving,
+  onMouseEnter,
+  onMouseLeave,
+}: AutomationPreviewPopoverProps): React.ReactElement | null {
+  const automations = useAtomValue(automationsAtom)
+  const activeAutomations = React.useMemo(
+    () => automations.filter((a) => a.active).sort((a, b) => a.nextRunAt - b.nextRunAt),
+    [automations],
+  )
+  const preferredHeight = getPreferredHeight(activeAutomations.length)
+  const position = usePopoverPosition(anchorRef, open, preferredHeight, PANEL_WIDTH)
+  const now = useNowTick(open)
+
+  if (!open || !position) return null
+
+  return createPortal(
+    <div
+      className="fixed z-[9999] titlebar-no-drag transition-[top,height] duration-150 ease-out"
+      style={{ top: position.top, left: position.left, width: PANEL_WIDTH, height: position.height }}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
+      <div
+        className={cn(
+          'session-minimap-popover h-full rounded-xl bg-popover shadow-xl ring-1 ring-black/[0.05] dark:ring-white/[0.08] flex flex-col overflow-hidden',
+          isLeaving ? 'session-minimap-popover-exit' : 'session-minimap-popover-enter',
+        )}
+      >
+        {/* 头部 */}
+        <div className="flex items-center justify-between gap-2 px-3 py-2 shrink-0 bg-muted/35 border-b border-border/35">
+          <div className="min-w-0 flex items-center gap-1.5">
+            <AlarmClock size={13} className="text-foreground/55 shrink-0" />
+            <span className="truncate text-xs font-medium text-popover-foreground/85">启用中任务</span>
+          </div>
+          <span className="shrink-0 text-[11px] text-muted-foreground tabular-nums">
+            {activeAutomations.length} 个
+          </span>
+        </div>
+
+        {/* 内容 */}
+        <div className="relative flex-1 min-h-0 overflow-hidden bg-popover p-1.5">
+          {activeAutomations.length === 0 ? (
+            <div className="h-full rounded-md bg-muted/30 flex items-center justify-center px-4 text-center text-xs text-muted-foreground">
+              目前没有启用中的任务
+            </div>
+          ) : (
+            <div className="h-full overflow-y-auto space-y-0.5 scrollbar-thin session-minimap-content-enter">
+              {activeAutomations.map((a) => (
+                <AutomationRow key={a.id} automation={a} now={now} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}
+
+function AutomationRow({ automation, now }: { automation: Automation; now: number }): React.ReactElement {
+  const scheduleText = formatSchedule(automation)
+  const nextRunText = formatNextRunAt(automation.nextRunAt, now)
+  return (
+    <div className="w-full px-2 py-1.5 text-left">
+      <div className="truncate text-[12px] leading-4 text-popover-foreground/90 font-medium">
+        {automation.name || '未命名任务'}
+      </div>
+      <div className="mt-0.5 truncate text-[11px] leading-4 text-muted-foreground/70">
+        <span>{scheduleText}</span>
+        <span className="mx-1 text-muted-foreground/40">·</span>
+        <span className="tabular-nums">{nextRunText}</span>
+      </div>
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/automation/AutomationsListView.tsx
+++ b/apps/electron/src/renderer/components/automation/AutomationsListView.tsx
@@ -24,20 +24,8 @@ import {
   automationToDraft,
   createEmptyDraft,
 } from '@/atoms/automation-atoms'
+import { formatSchedule } from '@/components/automation/automation-formatters'
 import type { Automation } from '@proma/shared'
-
-/** 把调度配置格式化为可读文案 */
-function formatSchedule(a: Automation): string {
-  if (a.scheduleType === 'daily') return `每天 ${a.timeOfDay ?? '09:00'}`
-  if (a.scheduleType === 'weekly') {
-    const names = ['周日', '周一', '周二', '周三', '周四', '周五', '周六']
-    return `每${names[a.dayOfWeek ?? 1]} ${a.timeOfDay ?? '09:00'}`
-  }
-  const min = a.intervalMinutes
-  if (min < 60) return `每 ${min} 分钟`
-  if (min < 1440) return `每 ${min / 60} 小时`
-  return `每 ${min / 1440} 天`
-}
 
 export function AutomationsListView(): React.ReactElement {
   const automations = useAtomValue(automationsAtom)

--- a/apps/electron/src/renderer/components/automation/automation-formatters.ts
+++ b/apps/electron/src/renderer/components/automation/automation-formatters.ts
@@ -1,0 +1,55 @@
+/**
+ * 定时任务（Automation）相关的纯展示格式化函数。
+ *
+ * - formatSchedule：把调度配置（interval / daily / weekly）格式化成可读文案
+ * - formatNextRunAt：把下次运行时间格式化为相对/绝对时间（"3 分钟后"、"明天 09:00"）
+ */
+
+import type { Automation } from '@proma/shared'
+
+/** 整数原样输出，非整数保留 1 位小数，避免显示形如 "1.0416666..." 的长串。 */
+function formatDecimal(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1)
+}
+
+/** 把调度配置格式化为可读文案。 */
+export function formatSchedule(a: Automation): string {
+  if (a.scheduleType === 'daily') return `每天 ${a.timeOfDay ?? '09:00'}`
+  if (a.scheduleType === 'weekly') {
+    const names = ['周日', '周一', '周二', '周三', '周四', '周五', '周六']
+    return `每${names[a.dayOfWeek ?? 1]} ${a.timeOfDay ?? '09:00'}`
+  }
+  const min = a.intervalMinutes
+  if (min < 60) return `每 ${min} 分钟`
+  if (min < 1440) return `每 ${formatDecimal(min / 60)} 小时`
+  return `每 ${formatDecimal(min / 1440)} 天`
+}
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : String(n)
+}
+
+/**
+ * 把下次运行时间格式化为人类可读字符串。
+ * - 已过期 / < 1 分钟 → "马上"
+ * - < 1 小时 → "N 分钟后"
+ * - 同一天 → "今天 HH:MM"
+ * - 明天 → "明天 HH:MM"
+ * - 否则 → "MM-DD HH:MM"
+ */
+export function formatNextRunAt(nextRunAt: number, now: number): string {
+  const diff = nextRunAt - now
+  if (diff <= 60_000) return '马上'
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)} 分钟后`
+
+  const target = new Date(nextRunAt)
+  const today = new Date(now)
+  const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate()).getTime()
+  const tomorrowStart = todayStart + 86_400_000
+  const dayAfterStart = tomorrowStart + 86_400_000
+
+  const hhmm = `${pad2(target.getHours())}:${pad2(target.getMinutes())}`
+  if (nextRunAt < tomorrowStart) return `今天 ${hhmm}`
+  if (nextRunAt < dayAfterStart) return `明天 ${hhmm}`
+  return `${pad2(target.getMonth() + 1)}-${pad2(target.getDate())} ${hhmm}`
+}

--- a/apps/electron/src/renderer/components/session-preview/SessionMiniMapPopover.tsx
+++ b/apps/electron/src/renderer/components/session-preview/SessionMiniMapPopover.tsx
@@ -233,10 +233,15 @@ function buildAgentMinimapItems(messages: SDKMessage[], userAvatar?: string): Ta
   return items
 }
 
-function usePopoverPosition(
+/**
+ * 浮层定位计算：右侧优先 / 越界翻左侧 / 垂直居中 / 视口贴边。
+ * panelWidth 可由调用方指定（默认 318，与会话迷你地图保持一致）。
+ */
+export function usePopoverPosition(
   anchorRef: React.MutableRefObject<HTMLElement | null>,
   open: boolean,
   preferredHeight: number,
+  panelWidth: number = PANEL_WIDTH,
 ): { top: number; left: number; height: number } | null {
   const [position, setPosition] = React.useState<{ top: number; left: number; height: number } | null>(null)
 
@@ -255,8 +260,8 @@ function usePopoverPosition(
       const availableHeight = Math.max(120, viewportHeight - VIEWPORT_MARGIN * 2)
       const height = Math.min(preferredHeight, availableHeight)
       let left = rect.right + PANEL_GAP
-      if (left + PANEL_WIDTH > viewportWidth - VIEWPORT_MARGIN) {
-        left = rect.left - PANEL_WIDTH - PANEL_GAP
+      if (left + panelWidth > viewportWidth - VIEWPORT_MARGIN) {
+        left = rect.left - panelWidth - PANEL_GAP
       }
       if (left < VIEWPORT_MARGIN) left = VIEWPORT_MARGIN
 
@@ -273,7 +278,7 @@ function usePopoverPosition(
       window.removeEventListener('resize', update)
       window.removeEventListener('scroll', update, true)
     }
-  }, [anchorRef, open, preferredHeight])
+  }, [anchorRef, open, preferredHeight, panelWidth])
 
   return position
 }


### PR DESCRIPTION
## 概述

侧边栏的「自动任务」按钮目前 hover 时只显示一行 Tooltip 文本（如「自动任务（3 个任务已创建）」），无法快速窥探当前启用的任务清单。本 PR 给该按钮（**展开态 + 折叠态**两处入口）加上 hover 预览浮层，悬浮 600ms 后弹出右侧浮层，列出当前 `active=true` 的任务清单，与已有「会话迷你地图」预览保持一致的视觉与交互。

预览内容：
- 任务名 + 调度文案（如「每 10 分钟」「每天 09:00」「每周一 09:00」）
- 下次运行时间（如「3 分钟后」「今天 18:00」「明天 09:00」「12-25 09:00」）
- 按 `nextRunAt` 升序排序，最快触发的排最上
- 浮层打开时每 30 秒自动刷新一次相对时间文案
- 无启用中任务时显示「目前没有启用中的任务」

## 改动

- `apps/electron/src/renderer/components/automation/AutomationPreviewPopover.tsx` — **新增**：预览浮层组件，复用 `createPortal` + `usePopoverPosition`，1-3 个任务完整显示，≥4 个任务进入滚动
- `apps/electron/src/renderer/components/automation/automation-formatters.ts` — **新增**：抽取 `formatSchedule`（从 AutomationsListView 搬迁）+ 新增 `formatNextRunAt`，对小时/天数显示加 `formatDecimal` 保留 1 位小数避免长串
- `apps/electron/src/renderer/components/automation/AutomationsListView.tsx` — 改用新模块导出的 `formatSchedule`，移除本地副本
- `apps/electron/src/renderer/components/session-preview/SessionMiniMapPopover.tsx` — 导出 `usePopoverPosition` 给自动任务预览复用，hook 加可选 `panelWidth` 参数（默认 318，对原有调用方向后兼容）
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx`：
  - `AutomationSidebarEntry`（展开态）接入 `useSessionMiniMapHover` + `AutomationPreviewPopover`
  - 新增 `AutomationRailButton` 子组件，将折叠态 rail 上的自动任务按钮抽出，Tooltip + 大 Popover 共存（短 hover 显示 Tooltip，长 hover 弹大浮层），模式与已有 `RailRecentButton` 保持一致
- `apps/electron/package.json` — `0.11.10` → `0.11.11`

## 测试方法

1. `bun install && bun run dev` 启动应用
2. **场景一（有启用中任务）**：进入「自动任务」视图新建 1-2 个任务并保持启用，hover 侧边栏「自动任务」按钮 ≥ 0.6 秒，右侧应弹出浮层并列出任务名 + 调度 + 下次运行时间；鼠标移到浮层上时浮层不消失，离开后约 90ms 淡出
3. **场景二（无启用中任务）**：把所有任务暂停（`active=false`），hover 按钮应显示「目前没有启用中的任务」
4. **场景三（折叠态）**：折叠侧边栏，hover 自动任务方形图标，效果同上；短 hover（< 600ms）仍可看到原 Tooltip 文本
5. **场景四（定位翻转）**：把窗口拉到屏幕最右侧，浮层超出视口时自动翻到按钮左侧弹出
6. **场景五（时间自动刷新）**：保持浮层打开，等待 30 秒，「N 分钟后」文案会自动 −1

## 备注

- 类型检查（`bunx tsc --noEmit`）4 个包全部通过
- 已通过独立 code-reviewer 审查（GO 结论）
- 已应用代码审查建议：`formatDecimal` 修复了 `intervalMinutes=1500` 这类值会显示「每 1.0416666... 天」的精度问题；`formatNextRunAt` 的 `<= 60_000` 边界明确覆盖 `diff ≤ 0`（已过期任务）

🤖 Generated with [Claude Code](https://claude.com/claude-code)