### PR TITLE
fix(automation): 列表为空时隐藏右上角「新建定时任务」按钮，避免与空状态按钮重复【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/automation/AutomationsListView.tsx
+++ b/apps/electron/src/renderer/components/automation/AutomationsListView.tsx
@@ -71,16 +71,19 @@ export function AutomationsListView(): React.ReactElement {
   return (
     <div className="h-full flex flex-col overflow-hidden">
       {/* 标题栏 */}
+      {/* 空列表时隐藏右上角「新建」按钮，避免与空状态中心按钮重复 */}
       <div className="titlebar-drag-region flex items-center justify-between max-w-5xl w-full mx-auto px-8 pt-8 pb-6 flex-shrink-0">
         <h1 className="text-2xl font-semibold text-foreground">定时任务</h1>
-        <button
-          type="button"
-          onClick={handleCreate}
-	          className="titlebar-no-drag flex items-center gap-1.5 px-3 py-1.5 rounded-md text-[13px] font-medium bg-primary text-primary-foreground hover:bg-primary/90 transition-colors duration-100 shadow-sm"
-        >
-          <Plus size={14} />
-          <span>新建定时任务</span>
-        </button>
+        {automations.length > 0 && (
+          <button
+            type="button"
+            onClick={handleCreate}
+            className="titlebar-no-drag flex items-center gap-1.5 px-3 py-1.5 rounded-md text-[13px] font-medium bg-primary text-primary-foreground hover:bg-primary/90 transition-colors duration-100 shadow-sm"
+          >
+            <Plus size={14} />
+            <span>新建定时任务</span>
+          </button>
+        )}
       </div>
 
       {/* 列表内容 */}


### PR DESCRIPTION
## 概述

定时任务页面在空状态下，空状态中心已有一个「+ 新建定时任务」主按钮（带引导文案），但标题栏右上角也有一个相同功能的按钮，两个按钮同时出现造成视觉重复、引导割裂。

本 PR 让标题栏右上角的「新建」按钮仅在 `automations.length > 0`（即列表非空）时才渲染。空列表 → 只保留中心引导按钮；有任务 → 恢复右上角快捷入口。

## 改动

- `apps/electron/src/renderer/components/automation/AutomationsListView.tsx`
  - 标题栏右上角的「+ 新建定时任务」按钮外层加 `{automations.length > 0 && (...)}` 条件渲染
  - 同步加一行 why 注释说明「空列表时隐藏右上角按钮，避免与空状态中心按钮重复」
  - 同时修掉原有 className 行首多余的 tab 缩进
- `apps/electron/package.json`
  - 版本 `0.11.10 → 0.11.11`（按 CLAUDE.md 版本契约递增 patch）

## 测试方法

1. 启动应用 `bun run dev`，从左侧侧栏入口进入「定时任务」页
2. **空列表场景：** 在没有任何定时任务时，确认标题栏右上角不再显示「+ 新建定时任务」按钮；仅空状态中心保留一个引导按钮
3. **非空列表场景：** 点击中心按钮创建一个任务后，确认标题栏右上角的「+ 新建定时任务」按钮自动出现，可正常打开创建表单
4. **回落场景：** 将所有任务删除后，确认 UI 自动从「列表态」回落到「空状态」，标题栏按钮同时消失，只剩中心按钮
5. **快捷创建链路：** 标题栏按钮、空状态中心按钮均调用同一个 `handleCreate`，应自动按「定时任务 N」格式命名草稿

## 备注

- 改动纯前端 React 条件渲染，无 IPC / 持久化 / 平台分支变化，Windows 行为一致
- 类型检查 `bunx tsc --noEmit -p apps/electron/tsconfig.json` 通过