### PR TITLE
feat(agent): AskUserBanner 新增"暂时隐藏 / 展开"提问卡片【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.11.10",
+  "version": "0.11.14",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/agent/AskUserBanner.tsx
+++ b/apps/electron/src/renderer/components/agent/AskUserBanner.tsx
@@ -7,10 +7,11 @@
 
 import * as React from 'react'
 import { useAtom, useSetAtom } from 'jotai'
-import { Send, X } from 'lucide-react'
+import { Eye, EyeOff, Send, X } from 'lucide-react'
 import Markdown, { defaultUrlTransform } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { allPendingAskUserRequestsAtom, agentStreamingStatesAtom, finalizeStreamingActivities } from '@/atoms/agent-atoms'
 import type { AskUserQuestion } from '@proma/shared'
 
@@ -42,6 +43,8 @@ export function AskUserBanner({ sessionId }: AskUserBannerProps): React.ReactEle
   const [submitting, setSubmitting] = React.useState(false)
   const [activeTab, setActiveTab] = React.useState(0)
   const [focusedOptIdx, setFocusedOptIdx] = React.useState(-1)
+  // 临时隐藏卡片：方便用户先回看 AI 内容再决策；不持久化
+  const [isHidden, setIsHidden] = React.useState(false)
 
   const request = requests[0] ?? null
   const questions = request?.questions ?? []
@@ -54,6 +57,8 @@ export function AskUserBanner({ sessionId }: AskUserBannerProps): React.ReactEle
   questionsRef.current = questions
   const focusedOptIdxRef = React.useRef(focusedOptIdx)
   focusedOptIdxRef.current = focusedOptIdx
+  const isHiddenRef = React.useRef(isHidden)
+  isHiddenRef.current = isHidden
   const submitRef = React.useRef<(() => void) | null>(null)
   const autoAdvanceTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -71,6 +76,7 @@ export function AskUserBanner({ sessionId }: AskUserBannerProps): React.ReactEle
     clearAutoAdvanceTimer()
     setActiveTab(0)
     setFocusedOptIdx(-1)
+    setIsHidden(false)
     const firstOpt = questions[0]?.options[0]
     setAnswers(firstOpt
       ? new Map([[0, { ...EMPTY_ANSWER, selected: [firstOpt.label] }]])
@@ -95,6 +101,8 @@ export function AskUserBanner({ sessionId }: AskUserBannerProps): React.ReactEle
     if (!request || questions.length === 0) return
 
     const handleKeyDown = (e: KeyboardEvent): void => {
+      // 卡片被临时隐藏时，禁用所有键盘导航，避免用户回看 AI 内容时误触提交
+      if (isHiddenRef.current) return
       const curTab = activeTabRef.current
       const qs = questionsRef.current
       const curFocusIdx = focusedOptIdxRef.current
@@ -236,27 +244,53 @@ export function AskUserBanner({ sessionId }: AskUserBannerProps): React.ReactEle
 
   return (
     <div className="mx-4 mb-3 rounded-xl bg-card shadow-lg overflow-hidden animate-in slide-in-from-bottom-2 duration-200">
-      {/* 头部 + Tab 栏 */}
-      <div className="px-4 pt-3 pb-2">
-        <div className="flex items-center justify-between mb-2">
+      {/* 头部按钮行 —— 显示/隐藏态共用同一行 DOM，避免切换时位移 */}
+      <div className={`px-4 pt-3 ${isHidden ? 'pb-3' : 'pb-2'}`}>
+        <div className={`flex items-center justify-between ${!isHidden && questions.length > 1 ? 'mb-2' : ''}`}>
           <span className="text-sm font-medium text-foreground">Proma Agent 需要你的输入</span>
           <div className="flex items-center gap-1.5">
             {requests.length > 1 && (
               <span className="text-xs text-muted-foreground">(+{requests.length - 1})</span>
             )}
-            <button
-              type="button"
-              className="size-5 flex items-center justify-center rounded-md text-muted-foreground/50 hover:text-foreground hover:bg-muted/60 transition-colors"
-              onClick={handleDismiss}
-              title="关闭并终止 Agent"
-            >
-              <X className="size-3.5" />
-            </button>
+            <Tooltip delayDuration={0}>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  className="size-5 flex items-center justify-center rounded-md text-muted-foreground/50 hover:text-foreground hover:bg-muted/60 transition-colors"
+                  // 点击后主动 blur：避免 Radix Tooltip 因 trigger 仍 focused 而抑制下次 hover 弹出
+                  onClick={(e) => {
+                    setIsHidden((v) => !v)
+                    e.currentTarget.blur()
+                  }}
+                  aria-label={isHidden ? '展开提问卡片' : '暂时隐藏提问卡片'}
+                >
+                  {isHidden ? <Eye className="size-3.5" /> : <EyeOff className="size-3.5" />}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                <p>{isHidden ? '展开提问卡片' : '暂时隐藏提问卡片'}</p>
+              </TooltipContent>
+            </Tooltip>
+            {!isHidden && (
+              <Tooltip delayDuration={0}>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    className="size-5 flex items-center justify-center rounded-md text-muted-foreground/50 hover:text-foreground hover:bg-muted/60 transition-colors"
+                    onClick={handleDismiss}
+                    aria-label="关闭并终止 Agent"
+                  >
+                    <X className="size-3.5" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom"><p>关闭并终止 Agent</p></TooltipContent>
+              </Tooltip>
+            )}
           </div>
         </div>
 
-        {/* Tab 栏（多问题时显示） */}
-        {questions.length > 1 && (
+        {/* Tab 栏（多问题时显示，隐藏态折叠） */}
+        {!isHidden && questions.length > 1 && (
           <div className="flex gap-1">
             {questions.map((q, idx) => {
               const isActive = idx === activeTab
@@ -285,6 +319,9 @@ export function AskUserBanner({ sessionId }: AskUserBannerProps): React.ReactEle
         )}
       </div>
 
+      {/* 隐藏态：折叠以下全部内容，仅保留头部按钮行 */}
+      {!isHidden && (
+      <>
       {/* 当前问题内容 */}
       <div className="px-4 pb-2">
         <QuestionCard
@@ -332,6 +369,8 @@ export function AskUserBanner({ sessionId }: AskUserBannerProps): React.ReactEle
           </Button>
         )}
       </div>
+      </>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## 概述

AskUserQuestion 提问卡片在选项较多、Markdown preview 较长时会占据屏幕大量纵向空间，挡住下方 AI 之前生成的内容。用户的真实使用场景是：**想先回看 AI 内容确认细节再做选择，但不能关闭卡片（关闭会终止 Agent）**。

本 PR 给卡片头部加一个 Eye / EyeOff 图标按钮，可以把卡片折叠成一行 header（标题 + 切换按钮），露出下方 AI 内容；看完后再点 Eye 展开继续答题。新问题到达时自动恢复展开，避免用户漏看后续提问。

同时顺手修复了三个 Radix Tooltip 相关的 UX 体验问题。

## 改动

- `apps/electron/src/renderer/components/agent/AskUserBanner.tsx`
  - **新增 `isHidden` 本地 state** + `isHiddenRef`（同步给键盘 handler 使用）
  - **头部按钮区改造**：在 X 关闭按钮左侧插入 Eye/EyeOff 切换按钮；X 按钮在隐藏态下不渲染（要终止 Agent 先得展开看清楚再操作）
  - **统一 DOM 结构**：把"显示态"和"隐藏态"合并到同一棵 DOM——外卡 `<div>` 和头部按钮行始终是同一个节点，下方 Tab / QuestionCard / 底部确认条用 `{!isHidden && ...}` 折叠掉。这样切换时标题行像素不动、`animate-in slide-in-from-bottom-2` 入场动画也不会被重放
  - **键盘事件守卫**：`handleKeyDown` 顶部加 `if (isHiddenRef.current) return`，禁用隐藏态下的 ↑↓/Enter 导航，避免用户回看内容时误触提交
  - **新 request 自动恢复**：`useEffect(() => { ..., setIsHidden(false) }, [request?.requestId])` 让新问题到达时强制展开
  - **Tooltip 三处修复**：
    1. 给 hide/show 切换按钮、关闭按钮的 `<Tooltip>` 加 `delayDuration={0}`，绕过 `TooltipProvider` 200ms 默认延迟带来的"冷启动"假死（第一次 hover 不出、第二次秒出）
    2. 切换按钮 `onClick` 末尾 `e.currentTarget.blur()`，避免 Radix Tooltip 因 trigger 仍 focused 而抑制下一次 hover 重开（"点完隐藏后再 hover 展开按钮 tooltip 不出"）
    3. 把原本用 `title` 原生属性的 X 按钮也升级为 `<Tooltip>`，与新按钮风格统一
  - 新增 `Eye`、`EyeOff` 从 `lucide-react` 引入；新增 `Tooltip` / `TooltipTrigger` / `TooltipContent` 从 `@/components/ui/tooltip` 引入

- `apps/electron/package.json`
  - `@proma/electron` 版本 `0.11.10 → 0.11.14`（按 `CLAUDE.md` 约定递增 patch）

## 测试方法

1. 在 Agent 模式打开一个会话，触发一个 `AskUserQuestion`（多选 + 至少 1 个选项带较长 `preview` Markdown）
2. 验证卡片右上角顺序：`(+N)` → 👁️‍🗨️ EyeOff → ✕ 关闭，三个按钮 hover 第一次就应有 tooltip
3. 点击 EyeOff：卡片下方内容应"折叠收起"，外壳和标题行**像素不动**、不重新滑入动画，X 关闭按钮消失，按钮图标变成 Eye
4. 隐藏态下按 ↑↓ / Enter：**应无任何反应**（键盘导航被禁用）
5. 点击 Eye：卡片重新展开下方内容
6. Hover Eye 按钮：第一次就应弹 tooltip"展开提问卡片"
7. 触发第二个 `AskUserQuestion` request：卡片应自动展开（即使之前被隐藏过）
8. 隐藏 → 移开鼠标 → 再次 hover Eye：第一次 hover 就应弹 tooltip（验证 focus blur 修复）

## 备注

- 隐藏态是**本地、不持久化**的瞬时 UI 状态，因此用 `useState` 而非 Jotai。其他跨组件状态仍然走 atoms
- 隐藏态藏掉了 X 关闭按钮，是有意为之——终止 Agent 是不可逆操作，应当先看到完整 UI 再决定，避免用户在"折叠"状态下误关
- 改动仅涉及 React 组件渲染逻辑 + Tailwind class + lucide 图标 + Radix Tooltip 配置，无 path / shell / fs / platform 分支，Windows 兼容性零风险