### PR TITLE
[codex] Add Feishu notifications for automations

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -4095,7 +4095,27 @@ export function registerIpcHandlers(): void {
     v === 'interval' || v === 'daily' || v === 'weekly'
   const validPermissionMode = (v: unknown): v is 'auto' | 'bypassPermissions' =>
     v === 'auto' || v === 'bypassPermissions'
+  const validAutomationNotificationTrigger = (v: unknown): v is 'always' | 'success' | 'error' =>
+    v === 'always' || v === 'success' || v === 'error'
   const validTimeOfDay = (v: unknown): boolean => typeof v === 'string' && /^([01]\d|2[0-3]):[0-5]\d$/.test(v)
+
+  const validateAutomationNotificationTargets = (targets: unknown): void => {
+    if (targets === undefined) return
+    if (!Array.isArray(targets)) throw new Error('notificationTargets 必须是数组')
+    if (targets.length > 5) throw new Error('notificationTargets 最多 5 个')
+
+    for (const target of targets) {
+      if (!target || typeof target !== 'object') throw new Error('notificationTargets 包含非法目标')
+      const t = target as Record<string, unknown>
+      if (t.type !== 'feishu') throw new Error(`不支持的通知目标: ${String(t.type)}`)
+      if (typeof t.enabled !== 'boolean') throw new Error('notificationTargets.enabled 必须是 boolean')
+      if (!validAutomationNotificationTrigger(t.trigger)) {
+        throw new Error(`非法的 notificationTargets.trigger: ${String(t.trigger)}`)
+      }
+      if (!isNonEmptyString(t.botId)) throw new Error('notificationTargets.botId 必填')
+      if (!isNonEmptyString(t.chatId)) throw new Error('notificationTargets.chatId 必填')
+    }
+  }
 
   const validateAutomationFields = (i: Partial<CreateAutomationInput | UpdateAutomationInput>): void => {
     if (i.scheduleType !== undefined && !validScheduleType(i.scheduleType)) {
@@ -4113,6 +4133,7 @@ export function registerIpcHandlers(): void {
     if (i.permissionMode !== undefined && !validPermissionMode(i.permissionMode)) {
       throw new Error(`非法的 permissionMode: ${String(i.permissionMode)}`)
     }
+    validateAutomationNotificationTargets(i.notificationTargets)
   }
 
   ipcMain.handle(

--- a/apps/electron/src/main/lib/automation-manager.ts
+++ b/apps/electron/src/main/lib/automation-manager.ts
@@ -151,6 +151,7 @@ export function createAutomation(input: CreateAutomationInput): Automation {
     modelId: input.modelId,
     workspaceId: input.workspaceId,
     permissionMode: input.permissionMode ?? AUTOMATION_DEFAULT_PERMISSION_MODE,
+    notificationTargets: input.notificationTargets,
     sourceSessionId: input.sourceSessionId,
     createdAt: now,
     updatedAt: now,
@@ -180,6 +181,7 @@ export function updateAutomation(input: UpdateAutomationInput): Automation | und
     target.workspaceId = input.workspaceId || undefined
   }
   if (input.permissionMode !== undefined) target.permissionMode = input.permissionMode
+  if (input.notificationTargets !== undefined) target.notificationTargets = input.notificationTargets
 
   // 调度参数变化：重算下次运行时间（从现在起算，避免旧时间戳立即触发）
   const scheduleChanged =

--- a/apps/electron/src/main/lib/automation-notification-format.ts
+++ b/apps/electron/src/main/lib/automation-notification-format.ts
@@ -1,0 +1,86 @@
+/**
+ * 定时任务通知的纯格式化逻辑。
+ */
+
+import type {
+  Automation,
+  AutomationNotificationTarget,
+  AutomationRun,
+  SDKAssistantMessage,
+  SDKMessage,
+} from '@proma/shared'
+
+interface AutomationNotificationCardPayload {
+  automation: Automation
+  run: AutomationRun
+  summary: string
+}
+
+export function shouldNotifyAutomationTarget(
+  target: AutomationNotificationTarget,
+  status: AutomationRun['status'],
+): boolean {
+  if (!target.enabled) return false
+  if (status === 'skipped') return false
+  if (target.trigger === 'always') return true
+  return target.trigger === status
+}
+
+export function extractAssistantText(messages: SDKMessage[]): string {
+  const chunks: string[] = []
+
+  for (const msg of messages) {
+    if (msg.type !== 'assistant') continue
+    const assistant = msg as SDKAssistantMessage
+    for (const block of assistant.message.content) {
+      if (block.type === 'text' && typeof block.text === 'string') {
+        chunks.push(block.text)
+      }
+    }
+  }
+
+  return chunks.join('\n\n').trim()
+}
+
+function formatDuration(ms?: number): string {
+  if (!ms || ms < 0) return '未知'
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)} 秒`
+  return `${Math.round(ms / 60_000)} 分钟`
+}
+
+function truncate(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text
+  return `${text.slice(0, maxLength)}\n\n... [内容过长，请在 Proma 中查看完整会话]`
+}
+
+export function buildAutomationFeishuCard(payload: AutomationNotificationCardPayload): Record<string, unknown> {
+  const { automation, run } = payload
+  const success = run.status === 'success'
+  const title = success ? '定时任务已完成' : '定时任务失败'
+  const template = success ? 'green' : 'red'
+  const statusLine = success ? '完成' : '失败'
+  const fallback = success ? 'Agent 已完成（无文本输出）' : '没有错误详情'
+
+  const lines = [
+    `**任务**: ${automation.name}`,
+    `**状态**: ${statusLine}`,
+    `**耗时**: ${formatDuration(run.durationMs)}`,
+    run.sessionId ? `**会话 ID**: ${run.sessionId}` : '',
+    '',
+    truncate(payload.summary.trim() || fallback, 12000),
+  ].filter(Boolean)
+
+  return {
+    config: { wide_screen_mode: true },
+    header: {
+      title: { tag: 'plain_text', content: title },
+      template,
+    },
+    elements: [
+      {
+        tag: 'markdown',
+        content: lines.join('\n'),
+      },
+    ],
+  }
+}

--- a/apps/electron/src/main/lib/automation-notification-service.ts
+++ b/apps/electron/src/main/lib/automation-notification-service.ts
@@ -1,0 +1,46 @@
+/**
+ * 定时任务完成通知投递服务。
+ *
+ * 当前仅实现飞书目标；钉钉/微信后续接入时复用同一入口。
+ */
+
+import type {
+  Automation,
+  AutomationRun,
+} from '@proma/shared'
+import { getAgentSessionSDKMessages } from './agent-session-manager'
+import { feishuBridgeManager } from './feishu-bridge-manager'
+import {
+  buildAutomationFeishuCard,
+  extractAssistantText,
+  shouldNotifyAutomationTarget,
+} from './automation-notification-format'
+
+interface AutomationNotificationPayload {
+  automation: Automation
+  run: AutomationRun
+}
+
+export async function notifyAutomationRunFinished(payload: AutomationNotificationPayload): Promise<void> {
+  const targets = payload.automation.notificationTargets ?? []
+  if (targets.length === 0) return
+
+  for (const target of targets) {
+    if (!shouldNotifyAutomationTarget(target, payload.run.status)) continue
+
+    if (target.type === 'feishu') {
+      try {
+        const summary = payload.run.status === 'success'
+          ? extractAssistantText(getAgentSessionSDKMessages(payload.run.sessionId))
+          : (payload.run.error ?? '未知错误')
+        await feishuBridgeManager.sendCardToChat(
+          target.botId,
+          target.chatId,
+          buildAutomationFeishuCard({ ...payload, summary }),
+        )
+      } catch (error) {
+        console.error(`[定时任务] 飞书通知发送失败: automation=${payload.automation.id}, chat=${target.chatId}`, error)
+      }
+    }
+  }
+}

--- a/apps/electron/src/main/lib/automation-scheduler.ts
+++ b/apps/electron/src/main/lib/automation-scheduler.ts
@@ -15,6 +15,7 @@ import {
   AUTOMATION_MAX_CONSECUTIVE_FAILURES,
   AUTOMATION_IPC_CHANNELS,
   type Automation,
+  type AutomationRun,
 } from '@proma/shared'
 import {
   listAutomations,
@@ -27,6 +28,7 @@ import {
 } from './automation-manager'
 import { createAgentSession, updateAgentSessionMeta } from './agent-session-manager'
 import { runAgentHeadless, isAgentSessionActive } from './agent-service'
+import { notifyAutomationRunFinished } from './automation-notification-service'
 
 /** tick 周期：每 30s 检查一次到期任务（短轮询，抗休眠漂移） */
 const TICK_INTERVAL_MS = 30_000
@@ -95,14 +97,18 @@ export async function runAutomation(automation: Automation, manual = false): Pro
         if (settled) return
         settled = true
         if (timeoutTimer) clearTimeout(timeoutTimer)
-        appendRun(automation.id, {
+        const run: AutomationRun = {
           runAt,
           sessionId: targetSessionId,
           status,
           durationMs: Date.now() - runAt,
           error,
-        })
+        }
+        appendRun(automation.id, run)
         broadcastChanged()
+        void notifyAutomationRunFinished({ automation, run }).catch((err) => {
+          console.error(`[定时任务] 发送完成通知失败: ${automation.name}`, err)
+        })
         // 失败退避：连续失败达上限自动暂停
         const latest = getAutomation(automation.id)
         if (
@@ -147,14 +153,18 @@ export async function runAutomation(automation: Automation, manual = false): Pro
     })
   } catch (err) {
     console.error(`[定时任务] ${automation.name} 执行异常:`, err)
-    appendRun(automation.id, {
+    const run: AutomationRun = {
       runAt,
       sessionId: '',
       status: 'error',
       durationMs: Date.now() - runAt,
       error: err instanceof Error ? err.message : '未知错误',
-    })
+    }
+    appendRun(automation.id, run)
     broadcastChanged()
+    void notifyAutomationRunFinished({ automation, run }).catch((notifyError) => {
+      console.error(`[定时任务] 发送异常通知失败: ${automation.name}`, notifyError)
+    })
   } finally {
     runningAutomations.delete(automation.id)
   }

--- a/apps/electron/src/main/lib/feishu-bridge-manager.ts
+++ b/apps/electron/src/main/lib/feishu-bridge-manager.ts
@@ -184,6 +184,18 @@ class FeishuBridgeManager {
     return undefined
   }
 
+  /** 直接向指定飞书聊天发送卡片（用于定时任务完成通知等主动推送场景） */
+  async sendCardToChat(botId: string, chatId: string, card: Record<string, unknown>): Promise<void> {
+    const bridge = this.bridges.get(botId) ?? this.findBridgeByChatId(chatId)
+    if (!bridge) {
+      throw new Error(`飞书 Bot 未连接或未找到聊天绑定: bot=${botId}, chat=${chatId}`)
+    }
+    if (bridge.getStatus().status !== 'connected') {
+      throw new Error(`飞书 Bot 未连接: bot=${botId}`)
+    }
+    await bridge.sendCardToChat(chatId, card)
+  }
+
   // ===== 连接测试（静态，不影响运行中的 Bridge） =====
 
   async testConnection(appId: string, appSecret: string): Promise<FeishuTestResult> {

--- a/apps/electron/src/main/lib/feishu-bridge.ts
+++ b/apps/electron/src/main/lib/feishu-bridge.ts
@@ -2451,6 +2451,11 @@ class FeishuBridge {
     }
   }
 
+  /** 主动向指定飞书聊天发送卡片，不绑定上一条用户消息线程。 */
+  async sendCardToChat(chatId: string, card: Record<string, unknown>): Promise<void> {
+    await this.sendCard(chatId, card)
+  }
+
   // ===== 群聊 Thread Reply =====
 
   /** 回复指定消息（文本，群聊线程回复） */

--- a/apps/electron/src/renderer/atoms/automation-atoms.ts
+++ b/apps/electron/src/renderer/atoms/automation-atoms.ts
@@ -6,7 +6,12 @@
  */
 
 import { atom } from 'jotai'
-import type { Automation, AutomationScheduleType, AutomationPermissionMode } from '@proma/shared'
+import type {
+  Automation,
+  AutomationNotificationTarget,
+  AutomationScheduleType,
+  AutomationPermissionMode,
+} from '@proma/shared'
 import { AUTOMATION_DEFAULT_PERMISSION_MODE } from '@proma/shared'
 
 /** 全部定时任务列表 */
@@ -30,6 +35,7 @@ export interface AutomationDraft {
   modelId?: string
   workspaceId?: string
   permissionMode: AutomationPermissionMode
+  notificationTargets?: AutomationNotificationTarget[]
   sourceSessionId?: string
   active: boolean
 }
@@ -77,6 +83,7 @@ export function automationToDraft(a: Automation): AutomationDraft {
     modelId: a.modelId,
     workspaceId: a.workspaceId,
     permissionMode: a.permissionMode ?? AUTOMATION_DEFAULT_PERMISSION_MODE,
+    notificationTargets: a.notificationTargets,
     sourceSessionId: a.sourceSessionId,
     active: a.active,
   }
@@ -103,5 +110,4 @@ export const AUTOMATION_WEEKDAY_OPTIONS = [
   { label: '周六', value: 6 },
   { label: '周日', value: 0 },
 ] as const
-
 

--- a/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
+++ b/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
@@ -11,7 +11,7 @@
 import * as React from 'react'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { toast } from 'sonner'
-import { AlertTriangle, ArrowLeft, Check, Clock, Loader2, Pencil, Play, X } from 'lucide-react'
+import { AlertTriangle, ArrowLeft, Bell, Check, Clock, Loader2, Pencil, Play, X } from 'lucide-react'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { Switch } from '@/components/ui/switch'
@@ -35,9 +35,17 @@ import { agentWorkspacesAtom, agentSessionsAtom } from '@/atoms/agent-atoms'
 import { activeSessionIdAtom } from '@/atoms/tab-atoms'
 import { activeViewAtom } from '@/atoms/active-view'
 import { useOpenSession } from '@/hooks/useOpenSession'
-import type { AutomationRun, CreateAutomationInput, UpdateAutomationInput } from '@proma/shared'
+import type {
+  AutomationFeishuNotificationTarget,
+  AutomationNotificationTarget,
+  AutomationRun,
+  CreateAutomationInput,
+  FeishuChatBinding,
+  UpdateAutomationInput,
+} from '@proma/shared'
 
 const NO_WORKSPACE = '__none__'
+const NO_FEISHU_BINDING = '__none__'
 
 function formatTime(ts?: number): string {
   if (!ts) return '—'
@@ -67,6 +75,7 @@ function getDraftSignature(draft: AutomationDraft): string {
     modelId: draft.modelId ?? '',
     workspaceId: draft.workspaceId ?? '',
     permissionMode: draft.permissionMode,
+    notificationTargets: draft.notificationTargets ?? [],
     active: draft.active,
   })
 }
@@ -83,6 +92,7 @@ function draftToCreateInput(draft: AutomationDraft): CreateAutomationInput {
     modelId: draft.modelId,
     workspaceId: draft.workspaceId,
     permissionMode: draft.permissionMode,
+    notificationTargets: draft.notificationTargets,
     sourceSessionId: draft.sourceSessionId,
     active: draft.active,
   }
@@ -101,7 +111,33 @@ function draftToUpdateInput(draft: AutomationDraft): UpdateAutomationInput {
     modelId: draft.modelId,
     workspaceId: draft.workspaceId ?? '',
     permissionMode: draft.permissionMode,
+    notificationTargets: draft.notificationTargets ?? [],
     active: draft.active,
+  }
+}
+
+function getFeishuTarget(targets?: AutomationNotificationTarget[]): AutomationFeishuNotificationTarget | undefined {
+  return targets?.find((target): target is AutomationFeishuNotificationTarget => target.type === 'feishu')
+}
+
+function getFeishuBindingValue(binding: FeishuChatBinding): string {
+  return `${binding.botId}::${binding.chatId}`
+}
+
+function formatFeishuBinding(binding: FeishuChatBinding): string {
+  const name = binding.chatType === 'group'
+    ? binding.groupName || '未命名群聊'
+    : '飞书单聊'
+  return `${name} · ${binding.botId.slice(0, 8)}`
+}
+
+function createFeishuTarget(binding: FeishuChatBinding): AutomationFeishuNotificationTarget {
+  return {
+    type: 'feishu',
+    enabled: true,
+    trigger: 'always',
+    botId: binding.botId,
+    chatId: binding.chatId,
   }
 }
 
@@ -118,6 +154,7 @@ export function AutomationFormView(): React.ReactElement | null {
   const [form, setForm] = React.useState<AutomationDraft | null>(null)
   const [editingName, setEditingName] = React.useState(false)
   const [runningNow, setRunningNow] = React.useState(false)
+  const [feishuBindings, setFeishuBindings] = React.useState<FeishuChatBinding[]>([])
   const nameInputRef = React.useRef<HTMLInputElement>(null)
   const saveTimerRef = React.useRef<number | undefined>(undefined)
   const lastSavedSignatureRef = React.useRef('')
@@ -140,6 +177,15 @@ export function AutomationFormView(): React.ReactElement | null {
         : ''
     }
   }, [formState.open, formState.draft])
+
+  React.useEffect(() => {
+    if (!formState.open) return
+    window.electronAPI.listFeishuBindings()
+      .then(setFeishuBindings)
+      .catch((err: unknown) => {
+        console.error('[定时任务] 获取飞书绑定失败:', err)
+      })
+  }, [formState.open])
 
   React.useEffect(() => {
     latestFormRef.current = form
@@ -260,6 +306,10 @@ export function AutomationFormView(): React.ReactElement | null {
     setForm((prev) => (prev ? { ...prev, ...patch } : prev))
   }
 
+  const updateFeishuNotification = (target: AutomationFeishuNotificationTarget | null): void => {
+    update({ notificationTargets: target ? [target] : [] })
+  }
+
   const handleRunNow = async (): Promise<void> => {
     const latest = latestFormRef.current
     if (!latest || !canPersistDraft(latest)) {
@@ -342,6 +392,13 @@ export function AutomationFormView(): React.ReactElement | null {
   const selectedModel = form.channelId && form.modelId
     ? { channelId: form.channelId, modelId: form.modelId }
     : null
+  const feishuTarget = getFeishuTarget(form.notificationTargets)
+  const selectedFeishuBinding = feishuTarget
+    ? feishuBindings.find((binding) => binding.botId === feishuTarget.botId && binding.chatId === feishuTarget.chatId)
+    : undefined
+  const selectedFeishuBindingValue = selectedFeishuBinding
+    ? getFeishuBindingValue(selectedFeishuBinding)
+    : NO_FEISHU_BINDING
 
   return (
     <div className="titlebar-no-drag absolute inset-0 z-10 bg-content-area flex animate-in fade-in duration-200">
@@ -559,6 +616,83 @@ export function AutomationFormView(): React.ReactElement | null {
                 ))}
               </SelectContent>
             </Select>
+          </div>
+
+          {/* 飞书通知 */}
+          <div className="flex flex-col gap-2 rounded-lg bg-foreground/[0.03] p-3">
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-start gap-2">
+                <Bell className="size-4 shrink-0 mt-0.5 text-primary" />
+                <div className="flex flex-col gap-0.5">
+                  <Label htmlFor="auto-feishu-notify">飞书通知</Label>
+                  <span className="text-xs text-muted-foreground leading-relaxed">
+                    任务结束后把结果推送到已有飞书绑定
+                  </span>
+                </div>
+              </div>
+              <Switch
+                id="auto-feishu-notify"
+                checked={feishuTarget?.enabled === true}
+                onCheckedChange={(checked) => {
+                  if (!checked) {
+                    updateFeishuNotification(null)
+                    return
+                  }
+                  const target = selectedFeishuBinding ?? feishuBindings[0]
+                  if (!target) {
+                    toast.error('暂无飞书绑定，请先在飞书里向 Bot 发送一条消息')
+                    return
+                  }
+                  updateFeishuNotification(feishuTarget
+                    ? { ...feishuTarget, enabled: true }
+                    : createFeishuTarget(target))
+                }}
+              />
+            </div>
+
+            {feishuTarget?.enabled === true && (
+              <div className="flex flex-col gap-2 pt-1">
+                <Select
+                  value={selectedFeishuBindingValue}
+                  onValueChange={(value) => {
+                    const binding = feishuBindings.find((item) => getFeishuBindingValue(item) === value)
+                    if (!binding) return
+                    updateFeishuNotification({
+                      ...createFeishuTarget(binding),
+                      trigger: feishuTarget.trigger,
+                    })
+                  }}
+                >
+                  <SelectTrigger><SelectValue placeholder="选择飞书聊天" /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={NO_FEISHU_BINDING} disabled>
+                      {feishuBindings.length === 0 ? '暂无飞书绑定' : '选择飞书聊天'}
+                    </SelectItem>
+                    {feishuBindings.map((binding) => (
+                      <SelectItem key={getFeishuBindingValue(binding)} value={getFeishuBindingValue(binding)}>
+                        {formatFeishuBinding(binding)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <Select
+                  value={feishuTarget.trigger}
+                  onValueChange={(value) => {
+                    updateFeishuNotification({
+                      ...feishuTarget,
+                      trigger: value as AutomationFeishuNotificationTarget['trigger'],
+                    })
+                  }}
+                >
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="always">成功或失败都通知</SelectItem>
+                    <SelectItem value="success">仅成功时通知</SelectItem>
+                    <SelectItem value="error">仅失败时通知</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
           </div>
 
           {/* 权限模式 */}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/shared",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "license": "AGPL-3.0-only",
   "description": "Shared types, configs and utilities for proma",
   "type": "module",

--- a/packages/shared/src/types/automation.ts
+++ b/packages/shared/src/types/automation.ts
@@ -35,6 +35,24 @@ export type AutomationPermissionMode = 'auto' | 'bypassPermissions'
 /** 定时任务默认权限模式（向后兼容：旧任务无此字段时按此值运行） */
 export const AUTOMATION_DEFAULT_PERMISSION_MODE: AutomationPermissionMode = 'bypassPermissions'
 
+/** 定时任务通知触发条件 */
+export type AutomationNotificationTrigger = 'always' | 'success' | 'error'
+
+/** 飞书通知目标 */
+export interface AutomationFeishuNotificationTarget {
+  type: 'feishu'
+  enabled: boolean
+  /** 通知触发条件：默认 always */
+  trigger: AutomationNotificationTrigger
+  /** 负责发送通知的飞书 Bot ID */
+  botId: string
+  /** 飞书 chat_id（来自已有绑定） */
+  chatId: string
+}
+
+/** 定时任务通知目标（钉钉/微信后续扩展） */
+export type AutomationNotificationTarget = AutomationFeishuNotificationTarget
+
 /** 定时任务定义 */
 export interface Automation {
   id: string
@@ -60,6 +78,8 @@ export interface Automation {
   workspaceId?: string
   /** 权限模式（无人值守运行时的工具审批策略，默认 bypassPermissions） */
   permissionMode?: AutomationPermissionMode
+  /** 运行完成后的外部通知目标 */
+  notificationTargets?: AutomationNotificationTarget[]
   /** 创建来源会话 ID（作为模板，运行时不复用而是新建子会话） */
   sourceSessionId?: string
   /** 创建时间 */
@@ -96,6 +116,7 @@ export interface CreateAutomationInput {
   modelId?: string
   workspaceId?: string
   permissionMode?: AutomationPermissionMode
+  notificationTargets?: AutomationNotificationTarget[]
   sourceSessionId?: string
   /** 创建后是否立即启用（默认 true） */
   active?: boolean
@@ -115,6 +136,7 @@ export interface UpdateAutomationInput {
   /** 工作区（用户可在创建后调整子会话归属的工作区） */
   workspaceId?: string
   permissionMode?: AutomationPermissionMode
+  notificationTargets?: AutomationNotificationTarget[]
   active?: boolean
 }
 


### PR DESCRIPTION
## Summary
- Add Feishu notification targets to Automation create/update data and validation.
- Send a Feishu card when an automation run succeeds or fails, using existing Feishu chat bindings.
- Add Automation form controls for enabling Feishu notifications, selecting a target chat, and choosing success/error notification behavior.

## Validation
- bun run --filter='@proma/shared' typecheck
- bun run --filter='@proma/electron' typecheck
- bun run --filter='@proma/electron' build:main
- bun run --filter='@proma/electron' build:preload
- bun run --filter='@proma/electron' build:renderer
- bun test
