### PR TITLE
refactor(settings): built-in 分组哨兵改为 proma-built-in 避免前缀碰撞

### DIFF
--- a/apps/electron/src/renderer/components/settings/AgentSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AgentSettings.tsx
@@ -99,16 +99,16 @@ function groupSkillsByPrefix(skills: SkillMeta[], defaultSlugs: Set<string>): Sk
     groups.push({ prefix: '', skills: standalone })
   }
 
-  // built-in 分组放在最前面
+  // built-in 分组放在最前面（用 proma-built-in 作为内部哨兵，避免与用户 skill 的 slug 前缀碰撞）
   if (builtinSkills.length > 0) {
-    groups.unshift({ prefix: 'built-in', skills: builtinSkills, isBuiltin: true })
+    groups.unshift({ prefix: 'proma-built-in', skills: builtinSkills, isBuiltin: true })
   }
 
   return groups
 }
 
 function shortName(slug: string, prefix: string): string {
-  if (!prefix || prefix === 'built-in') return slug
+  if (!prefix || prefix === 'proma-built-in') return slug
   return slug.startsWith(prefix + '-') ? slug.slice(prefix.length + 1) : slug
 }
 
@@ -700,7 +700,7 @@ function SkillListPanel({ skills, defaultSkillSlugs, selectedSlug, onSelect, onD
                 ? <ChevronDown size={12} className="text-muted-foreground flex-shrink-0" />
                 : <ChevronRight size={12} className="text-muted-foreground flex-shrink-0" />}
               <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider truncate flex-1">
-                {group.prefix === 'built-in' ? 'built-in' : group.prefix}
+                {group.isBuiltin ? 'built-in' : group.prefix}
               </span>
               {group.isBuiltin && (
                 <span className="text-[10px] px-1.5 py-0.5 rounded-md bg-blue-500/10 text-blue-600 dark:text-blue-400 font-medium flex-shrink-0">


### PR DESCRIPTION
## Summary
跟进 #723 的两处优化：

- **哨兵改名**：内部分组哨兵从 `'built-in'` 改为 `'proma-built-in'`，避免与用户安装的、slug 前缀恰好是 `built-in` 的第三方 skill 产生分组 key 碰撞（会导致 React `key` 冲突与重复分组）。
- **消除冗余三元**：分组标签判断从 `group.prefix === 'built-in' ? 'built-in' : group.prefix`（两分支结果相同的无意义三元）改为基于 `group.isBuiltin` 标志，逻辑更清晰。UI 显示的标签仍是 `built-in`，对用户无变化。

## Test plan
- [x] `bun run --filter='@proma/electron' typecheck` 通过
- [ ] 设置页 Skills 列表：Proma 自带 skill 仍归在置顶的 built-in 分组、带 PROMA 标签、无删除按钮
- [ ] 安装一个 slug 形如 `built-in-xxx` 的 skill，确认不再与内置分组冲突

🤖 Generated with [Claude Code](https://claude.com/claude-code)