### PR TITLE
feat(automation): 定时任务模型选择仅展示 Agent 兼容渠道【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
+++ b/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
@@ -11,7 +11,7 @@
 import * as React from 'react'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { toast } from 'sonner'
-import { AlertTriangle, ArrowLeft, Bell, Check, Clock, Loader2, Pencil, Play, X } from 'lucide-react'
+import { AlertTriangle, ArrowLeft, Bell, Check, Clock, Loader2, Pencil, Play, Settings, X } from 'lucide-react'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import {
@@ -31,9 +31,10 @@ import {
   automationToDraft,
   type AutomationDraft,
 } from '@/atoms/automation-atoms'
-import { agentWorkspacesAtom, agentSessionsAtom } from '@/atoms/agent-atoms'
+import { agentWorkspacesAtom, agentSessionsAtom, agentChannelIdsAtom } from '@/atoms/agent-atoms'
 import { activeSessionIdAtom } from '@/atoms/tab-atoms'
 import { activeViewAtom } from '@/atoms/active-view'
+import { settingsOpenAtom, settingsTabAtom } from '@/atoms/settings-tab'
 import { useOpenSession } from '@/hooks/useOpenSession'
 import { MarkdownRichEditor } from '@/components/diff/MarkdownRichEditor'
 import type {
@@ -169,9 +170,12 @@ export function AutomationFormView(): React.ReactElement | null {
   const setAutomations = useSetAtom(automationsAtom)
   const workspaces = useAtomValue(agentWorkspacesAtom)
   const automations = useAtomValue(automationsAtom)
+  const agentChannelIds = useAtomValue(agentChannelIdsAtom)
   const [agentSessions, setAgentSessions] = useAtom(agentSessionsAtom)
   const activeSessionId = useAtomValue(activeSessionIdAtom)
   const setActiveView = useSetAtom(activeViewAtom)
+  const setSettingsOpen = useSetAtom(settingsOpenAtom)
+  const setSettingsTab = useSetAtom(settingsTabAtom)
   const openSession = useOpenSession()
 
   const [form, setForm] = React.useState<AutomationDraft | null>(null)
@@ -629,14 +633,32 @@ export function AutomationFormView(): React.ReactElement | null {
             </div>
           )}
 
-          {/* 选择模型 */}
+          {/* 选择模型（定时任务只能跑 Agent，因此只显示已勾选为 Agent 兼容的渠道模型） */}
           <div className="flex flex-col gap-2">
             <Label>选择模型</Label>
-            <ModelSelector
-              externalSelectedModel={selectedModel}
-              showChannelInTrigger
-              onModelSelect={(opt) => update({ channelId: opt.channelId, modelId: opt.modelId })}
-            />
+            {agentChannelIds.length === 0 ? (
+              <div className="flex items-center gap-2 rounded-md border border-amber-200 dark:border-amber-900/50 bg-amber-50 dark:bg-amber-950/30 px-3 py-2 text-sm text-amber-700 dark:text-amber-400">
+                <Settings size={14} className="shrink-0" />
+                <span>尚未启用任何 Agent 兼容渠道</span>
+                <button
+                  type="button"
+                  className="ml-auto text-xs underline underline-offset-2 hover:text-foreground transition-colors"
+                  onClick={() => {
+                    setSettingsTab('channels')
+                    setSettingsOpen(true)
+                  }}
+                >
+                  前往渠道设置
+                </button>
+              </div>
+            ) : (
+              <ModelSelector
+                filterChannelIds={agentChannelIds}
+                externalSelectedModel={selectedModel}
+                showChannelInTrigger
+                onModelSelect={(opt) => update({ channelId: opt.channelId, modelId: opt.modelId })}
+              />
+            )}
           </div>
 
           {/* 工作区 */}


### PR DESCRIPTION
## 概述

定时任务（automation）的执行路径完全走 `agent-orchestrator.ts`，因此只有走 Anthropic Messages API 协议的渠道（即用户在「设置 → 渠道」中显式勾选了 Agent 开关的那些）才能被定时任务真正使用。但当前定时任务表单的「选择模型」下拉里展示的是所有 enabled 模型——包括 OpenAI / Gemini / 豆包 / 通义千问 / Custom 等纯 Chat Completions 协议的渠道，用户选了之后跑起来必然失败。

本 PR 让定时任务的模型选择和 Agent 模式保持一致，复用现有的 `agentChannelIdsAtom` 白名单做过滤，并补一个空状态保护。

## 改动

- `apps/electron/src/renderer/components/automation/AutomationFormView.tsx`
  - 引入 `agentChannelIdsAtom`，读出用户在渠道设置里勾选的 Agent 兼容渠道白名单
  - 给 `ModelSelector` 加 `filterChannelIds={agentChannelIds}`——这是 `ModelSelector` 原生支持的 prop，AgentView 已经在用同一套机制（`AgentView.tsx:1863`），不引入新概念
  - 增加空状态分支：当 `agentChannelIds.length === 0` 时不渲染 ModelSelector，改显示 amber 提示卡片 + 「前往渠道设置」按钮直接跳到 `settings → channels` tab。这是为了规避 `ModelSelector` 内部 `filterChannelIds.length > 0` 守卫的语义陷阱——空数组会被当作「不过滤」而展示全部模型，与本次意图相反
  - 空状态样式与 AgentView 既有的「无可用模型」提示（`AgentView.tsx:2063-2075`）视觉一致，保证多入口体验统一

- `apps/electron/package.json`
  - `@proma/electron` patch 版本 `0.12.0 → 0.12.1`（遵循项目「修改即递增 patch」的版本契约）

## 测试方法

1. 启动 `bun run dev`
2. 进入「设置 → 渠道」，确认至少一个渠道的 Agent 开关已打开（例如 Anthropic / DeepSeek / Kimi）
3. 打开「定时任务」面板，新建或编辑一个任务，查看「选择模型」下拉
   - 预期：只看到上一步开启了 Agent 的那些渠道下的模型，OpenAI / Gemini / Custom 等不会出现
4. 回到「设置 → 渠道」，把所有 Agent 开关都关掉
5. 回到定时任务表单
   - 预期：原本的模型下拉变成 amber 提示卡片，文案「尚未启用任何 Agent 兼容渠道」，右侧「前往渠道设置」按钮可点
6. 点击「前往渠道设置」
   - 预期：直接打开设置面板，定位在「渠道」tab
7. 在渠道设置里重新启用一个 Agent 渠道，返回定时任务表单
   - 预期：amber 提示消失，ModelSelector 恢复，可选模型即时更新

## 备注

- 复用 `agentChannelIdsAtom` 而非新增 `agentOnly?: boolean` prop，是为了让定时任务和 Agent 模式共用同一份「用户授权用于 Agent 的渠道」的真源，避免出现「Agent 里能选但定时任务里看不到」这类不一致
- `bun run typecheck` 全部 4 个包 PASS
- 未引入新依赖、未改 IPC 通道、未触碰 Windows-specific 代码路径
- `proma-official` 商业渠道的特殊处理沿用 AgentView 既有行为（`hasAvailableModel` 里有 fallback 但 ModelSelector 下拉不展示），本 PR 不动这块语义