### PR TITLE
fix(sidebar): 当前选中会话强制在项目折叠列表中显示【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -2720,6 +2720,8 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
   // 不受 PROJECT_SESSION_PREVIEW_LIMIT 与 3 天窗口限制；活跃部分内部按
   // blocked > running > completed 优先级排序（与 railRecentItems 对齐），
   // 同优先级保留 group.sessions 的 updatedAt 倒序。
+  // 当前选中的会话（activeSessionId）也必须出现在折叠列表中，无论 updatedAt 多旧、
+  // 状态如何，确保从搜索结果打开旧会话时左侧栏立即可见，不必等待 agent 完成。
   // 非活跃部分仍保留原"最近 3 天 + 至多 5 条"预览策略，作为额外补充展示。
   // 用户点击"显示更多"会在折叠基线之上每次再额外展开 PROJECT_SESSION_EXPAND_STEP 条。
   const getStatus = (sessionId: string): SessionIndicatorStatus =>
@@ -2734,10 +2736,21 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
       return b.updatedAt - a.updatedAt
     })
   const activeIds = new Set(activeSessions.map((s) => s.id))
+  // 当前选中的会话若属于本 group 且未被 activeSessions 捕获，则补入折叠列表顶部
+  const currentSession = activeSessionId
+    && !activeIds.has(activeSessionId)
+    ? group.sessions.find((s) => s.id === activeSessionId) ?? null
+    : null
+  const pinnedCurrent = currentSession ? [currentSession] : []
+  const pinnedCurrentIds = new Set(pinnedCurrent.map((s) => s.id))
   const fillSessions = group.sessions
-    .filter((session) => !activeIds.has(session.id) && session.updatedAt >= recentCutoff)
+    .filter((session) =>
+      !activeIds.has(session.id)
+      && !pinnedCurrentIds.has(session.id)
+      && session.updatedAt >= recentCutoff
+    )
     .slice(0, PROJECT_SESSION_PREVIEW_LIMIT)
-  const collapsedSessions = [...activeSessions, ...fillSessions]
+  const collapsedSessions = [...activeSessions, ...pinnedCurrent, ...fillSessions]
   const collapsedIds = new Set(collapsedSessions.map((s) => s.id))
   const remainingSessions = group.sessions.filter((s) => !collapsedIds.has(s.id))
   const extraSessions = remainingSessions.slice(0, extraCount)


### PR DESCRIPTION
## 概述

从搜索结果打开一个较旧的 agent session（updatedAt 超过 3 天）后，左侧栏不会立即把它显示出来，必须等当前 agent 跑完一轮（触发 `STREAM_COMPLETE` → `listAgentSessions()` 刷新后端 `updatedAt`）才会出现。本 PR 通过在 `LeftSidebar` 折叠视图的过滤逻辑里增加一条不变式——"当前选中的会话必须出现在所属项目的折叠列表中"——从源头根治该问题。

## 根因

`AgentProjectGroupItem` 在折叠态只保留两类会话：

1. **活跃会话**：`agentIndicatorMap` 中状态为 `running` / `blocked` / `completed` 的会话
2. **填充会话（fillSessions）**：`updatedAt` 在最近 3 天内、最多 5 条

旧会话从搜索结果打开的瞬间：

- `updatedAt` 不在 3 天窗口 → 不进 fillSessions
- 还没触发 agent / agent 状态尚未传播到 `agentIndicatorMap` → 不进 activeSessions

结果就是该会话被完全过滤掉，要等到 agent 跑完后端持久化新的 `updatedAt`、前端调用 `listAgentSessions()` 全量刷新后才进入 fillSessions。

## 改动

- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx`
  - 在 `AgentProjectGroupItem` 计算 `collapsedSessions` 的位置增加一条不变式：若 `activeSessionId` 对应的 session 属于本 group、且未被 `activeSessions` 捕获，则将其补入折叠列表（位置在活跃区之后、最近会话区之前）。
  - 同时让 `fillSessions` 排除这条 pinned current 项，避免在折叠列表中重复出现。
  - 在原本的中文注释块里追加了一段说明，解释新增不变式的意图。

## 测试方法

1. 在工作区里打开任意一个 agent 项目，挑一个 `updatedAt` 早于 3 天前的旧 session（可以在搜索框搜旧关键词找到）。
2. 从搜索结果点击进入该旧 session。
3. **预期（修复后）**：左侧栏所属项目的折叠列表里立即出现该 session，无需发消息或等待 agent 完成。
4. **回归对比（修复前）**：同一操作下侧边栏列表中找不到该 session，要等向它发完消息且 agent 跑完后才显示。
5. 额外验证：
   - 切换到另一个 session 后，原 session 若仍在最近 3 天 / 活跃区内则继续显示；若不再满足条件且不再是 active，则按原逻辑被折叠隐藏（不会永久占位）。
   - 当 active session 本身就处于 `running` / `blocked` 状态时，仅在活跃区出现一次，不会重复。
   - 当 active session 在最近 3 天 fillSessions 范围内时，仅以 pinned current 形式出现一次，fillSessions 不再重复列出。

## 备注

- 修复纯粹是 renderer 层的过滤逻辑调整，不涉及 IPC、主进程、持久化或类型变更。
- `bun run typecheck` 通过。
- 跨平台无副作用：diff 全部为 TS 数据结构操作（Array / Set / spread），无路径、shell、`process.platform` 分支，Windows / macOS / Linux 行为一致。
- 归档会话（archived）和草稿（draft）不在 `agentProjectGroups` 的 `group.sessions` 范围内（上游已过滤），因此本修复对它们不生效，这两类会话各自有独立显示路径，符合既有产品逻辑。