### PR TITLE
[WIP] fix(agent): 修复流式期间 bash 工具执行后 turn 分裂为多个折叠块的问题

### DIFF
--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -391,9 +391,30 @@ function mergeAdjacentSameModelTurns(groups: MessageGroup[]): MessageGroup[] {
       continue
     }
 
-    // 后台任务唤醒后开始的 turn：独立成块，不向前合并。
+    // 后台任务唤醒后开始的 turn：原则上独立成块，不向前合并。
+    // 但如果前一个 turn 也是同模型的 assistant-turn（中间无用户输入），
+    // 说明这是同一轮对话的延续（如 bash 工具执行后的续接），应合并。
     if (group.startsAfterWake) {
-      result.push(group)
+      let canMerge = false
+      for (let i = result.length - 1; i >= 0; i--) {
+        const prev = result[i]!
+        if (prev.type === 'user') break
+        if (prev.type === 'system' && ['compact_boundary', 'permission_denied'].includes((prev.message as SDKSystemMessage).subtype ?? '')) break
+        if (prev.type === 'assistant-turn') {
+          const sameModel = prev.model === group.model
+          const eitherFalsy = !prev.model || !group.model
+          if (sameModel || eitherFalsy) {
+            canMerge = true
+            // 合并到前一个 turn
+            prev.assistantMessages.push(...group.assistantMessages)
+            prev.turnMessages.push(...group.turnMessages)
+          }
+          break
+        }
+      }
+      if (!canMerge) {
+        result.push(group)
+      }
       continue
     }
 
@@ -404,7 +425,10 @@ function mergeAdjacentSameModelTurns(groups: MessageGroup[]): MessageGroup[] {
       if (prev.type === 'user') break // 真正的用户输入阻断合并
       if (prev.type === 'system' && ['compact_boundary', 'permission_denied'].includes((prev.message as SDKSystemMessage).subtype ?? '')) break
       if (prev.type === 'assistant-turn') {
-        if (prev.model === group.model) {
+        // 模型相同 → 可合并；任意一方 model 为 falsy（流式期间 modelId 注入不一致）→ 也视为同模型
+        const sameModel = prev.model === group.model
+        const eitherFalsy = !prev.model || !group.model
+        if (sameModel || eitherFalsy) {
           mergeTargetIdx = i
         }
         break // 遇到第一个 assistant-turn 就停止（不跨越不同模型的 turn）


### PR DESCRIPTION
## 概述

修复 Agent 模式下 bash 工具执行后，UI 出现多个"执行过程"折叠块的问题。

## 问题

#745 引入的 `startsAfterWake` 逻辑本意是防止后台任务唤醒的输出被合并进上一轮，但误伤了正常场景（如 bash 工具执行后的续接），导致 `mergeAdjacentSameModelTurns` 无法合并，UI 出现多个折叠块。

## 改动

- `SDKMessageRenderer.tsx`：当 `startsAfterWake` 的 turn 前一个也是同模型的 assistant-turn（中间无用户输入）时，允许合并。

## 测试

- [x] 本地复现：多 Bash 工具调用后出现多个折叠块
- [x] 修复后：相邻 turn 正确合并为一个折叠块

## 备注

- 问题引入于 #745（2026-06-07），该 PR 引入了后台任务/Monitor 完成时自动唤醒 idle Agent 的功能