### PR TITLE
[Reviewed] feat(skills): 默认折叠分组并添加搜索功能

### DIFF
--- a/apps/electron/src/renderer/components/settings/AgentSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AgentSettings.tsx
@@ -670,9 +670,9 @@ interface SkillListPanelProps {
 
 function SkillListPanel({ skills, defaultSkillSlugs, selectedSlug, onSelect, onDelete, onToggle, onUpdate, skillsDir }: SkillListPanelProps): React.ReactElement {
   const groups = React.useMemo(() => groupSkillsByPrefix(skills, defaultSkillSlugs), [skills, defaultSkillSlugs])
-  const [expandedGroups, setExpandedGroups] = React.useState<Set<string>>(() =>
-    new Set(groups.filter((g) => g.prefix).map((g) => g.prefix)),
-  )
+  // 默认折叠所有分组
+  const [expandedGroups, setExpandedGroups] = React.useState<Set<string>>(() => new Set())
+  const [searchQuery, setSearchQuery] = React.useState('')
 
   const toggleGroup = (prefix: string): void => {
     setExpandedGroups((prev) => {
@@ -687,65 +687,100 @@ function SkillListPanel({ skills, defaultSkillSlugs, selectedSlug, onSelect, onD
     if (skillsDir) window.electronAPI.openFile(`${skillsDir}/${slug}`)
   }
 
-  return (
-    <div className="w-56 flex-shrink-0 border-r border-border overflow-y-auto bg-muted/20">
-      {groups.map((group) =>
-        group.prefix ? (
-          <div key={group.prefix}>
-            <button
-              onClick={() => toggleGroup(group.prefix)}
-              className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-muted/40 transition-colors"
-            >
-              {expandedGroups.has(group.prefix)
-                ? <ChevronDown size={12} className="text-muted-foreground flex-shrink-0" />
-                : <ChevronRight size={12} className="text-muted-foreground flex-shrink-0" />}
-              <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider truncate flex-1">
-                {group.isBuiltin ? 'built-in' : group.prefix}
-              </span>
-              {group.isBuiltin && (
-                <span className="text-[10px] px-1.5 py-0.5 rounded-md bg-blue-500/10 text-blue-600 dark:text-blue-400 font-medium flex-shrink-0">
-                  PROMA
-                </span>
-              )}
-              <span className="text-[10px] tabular-nums text-muted-foreground flex-shrink-0">{group.skills.length}</span>
-            </button>
-            {expandedGroups.has(group.prefix) && (
-              <div className="relative">
-                <div className="absolute left-3 top-0 bottom-0 w-px bg-border/60 pointer-events-none z-10" />
-                {group.skills.map((skill) => (
-                  <SkillCompactItem
-                    key={skill.slug}
-                    skill={skill}
-                    displayName={shortName(skill.slug, group.prefix)}
-                    selected={selectedSlug === skill.slug}
-                    onSelect={() => onSelect(skill.slug)}
-                    onDelete={() => onDelete(skill.slug, skill.name)}
-                    onToggle={(enabled) => onToggle(skill.slug, enabled)}
-                    onOpenFolder={() => openSkillFolder(skill.slug)}
-                    onUpdate={skill.hasUpdate ? () => onUpdate(skill.slug) : undefined}
-                    isBuiltin={group.isBuiltin}
-                    indented
-                  />
-                ))}
-              </div>
-            )}
-          </div>
-        ) : (
-          group.skills.map((skill) => (
-            <SkillCompactItem
-              key={skill.slug}
-              skill={skill}
-              displayName={skill.name}
-              selected={selectedSlug === skill.slug}
-              onSelect={() => onSelect(skill.slug)}
-              onDelete={() => onDelete(skill.slug, skill.name)}
-              onToggle={(enabled) => onToggle(skill.slug, enabled)}
-              onOpenFolder={() => openSkillFolder(skill.slug)}
-              onUpdate={skill.hasUpdate ? () => onUpdate(skill.slug) : undefined}
-            />
-          ))
+  const filteredGroups = React.useMemo(() => {
+    if (!searchQuery.trim()) return groups
+    const query = searchQuery.toLowerCase()
+    return groups
+      .map((group) => ({
+        ...group,
+        skills: group.skills.filter(
+          (skill) =>
+            skill.name.toLowerCase().includes(query) ||
+            skill.slug.toLowerCase().includes(query) ||
+            (skill.description?.toLowerCase().includes(query) ?? false),
         ),
-      )}
+      }))
+      .filter((group) => group.skills.length > 0)
+  }, [groups, searchQuery])
+
+  const isGroupExpanded = (prefix: string): boolean => {
+    if (searchQuery.trim()) return true
+    return expandedGroups.has(prefix)
+  }
+
+  return (
+    <div className="w-56 flex-shrink-0 border-r border-border overflow-y-auto bg-muted/20 flex flex-col">
+      <div className="p-2 border-b border-border">
+        <div className="relative">
+          <Search size={14} className="absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground" />
+          <input
+            type="text"
+            placeholder="搜索 Skills..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="w-full pl-7 pr-2 py-1.5 text-sm rounded-md border border-border bg-background focus:outline-none focus:ring-1 focus:ring-ring"
+          />
+        </div>
+      </div>
+      <div className="flex-1 overflow-y-auto">
+        {filteredGroups.map((group) =>
+          group.prefix ? (
+            <div key={group.prefix}>
+              <button
+                onClick={() => toggleGroup(group.prefix)}
+                className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-muted/40 transition-colors"
+              >
+                {isGroupExpanded(group.prefix)
+                  ? <ChevronDown size={12} className="text-muted-foreground flex-shrink-0" />
+                  : <ChevronRight size={12} className="text-muted-foreground flex-shrink-0" />}
+                <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider truncate flex-1">
+                  {group.isBuiltin ? 'built-in' : group.prefix}
+                </span>
+                {group.isBuiltin && (
+                  <span className="text-[10px] px-1.5 py-0.5 rounded-md bg-blue-500/10 text-blue-600 dark:text-blue-400 font-medium flex-shrink-0">
+                    PROMA
+                  </span>
+                )}
+                <span className="text-[10px] tabular-nums text-muted-foreground flex-shrink-0">{group.skills.length}</span>
+              </button>
+              {isGroupExpanded(group.prefix) && (
+                <div className="relative">
+                  <div className="absolute left-3 top-0 bottom-0 w-px bg-border/60 pointer-events-none z-10" />
+                  {group.skills.map((skill) => (
+                    <SkillCompactItem
+                      key={skill.slug}
+                      skill={skill}
+                      displayName={shortName(skill.slug, group.prefix)}
+                      selected={selectedSlug === skill.slug}
+                      onSelect={() => onSelect(skill.slug)}
+                      onDelete={() => onDelete(skill.slug, skill.name)}
+                      onToggle={(enabled) => onToggle(skill.slug, enabled)}
+                      onOpenFolder={() => openSkillFolder(skill.slug)}
+                      onUpdate={skill.hasUpdate ? () => onUpdate(skill.slug) : undefined}
+                      isBuiltin={group.isBuiltin}
+                      indented
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          ) : (
+            group.skills.map((skill) => (
+              <SkillCompactItem
+                key={skill.slug}
+                skill={skill}
+                displayName={skill.name}
+                selected={selectedSlug === skill.slug}
+                onSelect={() => onSelect(skill.slug)}
+                onDelete={() => onDelete(skill.slug, skill.name)}
+                onToggle={(enabled) => onToggle(skill.slug, enabled)}
+                onOpenFolder={() => openSkillFolder(skill.slug)}
+                onUpdate={skill.hasUpdate ? () => onUpdate(skill.slug) : undefined}
+              />
+            ))
+          ),
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## 概述

优化 Agent 设置页 Skills 面板的左侧分组展示体验，减少视觉拥挤并提升 Skill 定位效率。

## 问题

- Skills 分组默认全部展开，分组较多时列表过长，视觉拥挤
- 缺乏搜索过滤能力，难以快速定位特定 Skill

## 改动

**`SkillListPanel` 组件 (`AgentSettings.tsx`)：**

1. **默认折叠所有分组**：`expandedGroups` 初始值从 `new Set(所有前缀)` 改为 `new Set()`，进入页面时所有分组默认折叠
2. **添加搜索框**：顶部新增输入框，支持按 `name` / `slug` / `description` 实时过滤 Skills
3. **搜索时自动展开**：`isGroupExpanded` 在搜索状态下返回 `true`，匹配分组自动展开
4. **面板布局调整**：外层容器改为 `flex flex-col`，搜索框固定在顶部，列表区域 `flex-1` 自适应滚动

## 测试

1. 打开 Agent 设置 → Skills Tab
2. 确认所有分组默认折叠（只显示分组标题）
3. 点击分组标题可展开/折叠
4. 在搜索框输入关键词，确认匹配的 Skills 被过滤并自动展开所在分组
5. 清空搜索框，确认分组恢复折叠状态

## 备注

- 基于 upstream/main (`09a1a44`) 创建分支
- 改动范围：`apps/electron/src/renderer/components/settings/AgentSettings.tsx`，仅涉及 `SkillListPanel` 组件内部
- 未引入新依赖（`Search` 图标已在 `lucide-react` import 中）
- 无类型变更，无 API 接口改动