### PR TITLE
[Reviewed] fix(automation): 优化自动化表单按钮布局

### DIFF
--- a/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
+++ b/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
@@ -12,6 +12,8 @@ import * as React from 'react'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { toast } from 'sonner'
 import { AlertTriangle, ArrowLeft, Bell, Check, Clock, Loader2, Pencil, Play, Settings, X } from 'lucide-react'
+import { detectIsWindows } from '@/lib/platform'
+import { cn } from '@/lib/utils'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import {
@@ -166,6 +168,7 @@ function AutomationPromptEmptyGuide(): React.ReactElement {
 }
 
 export function AutomationFormView(): React.ReactElement | null {
+  const isWindows = React.useMemo(() => detectIsWindows(), [])
   const [formState, setFormState] = useAtom(automationFormAtom)
   const setAutomations = useSetAtom(automationsAtom)
   const workspaces = useAtomValue(agentWorkspacesAtom)
@@ -508,7 +511,10 @@ export function AutomationFormView(): React.ReactElement | null {
 
       {/* 右栏：配置 sidebar */}
       <div className="w-[340px] flex-shrink-0 border-l border-border/50 flex flex-col bg-content-area">
-        <div className="flex items-center justify-between gap-2 px-4 py-4 flex-shrink-0">
+        <div className={cn(
+          "flex items-center justify-between gap-2 px-4 py-4 flex-shrink-0",
+          isWindows && "pr-[140px]"
+        )}>
           <span className="text-sm font-semibold text-foreground">配置</span>
           <div className="flex items-center gap-1">
             <button

--- a/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
+++ b/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
@@ -511,17 +511,16 @@ export function AutomationFormView(): React.ReactElement | null {
 
       {/* 右栏：配置 sidebar */}
       <div className="w-[340px] flex-shrink-0 border-l border-border/50 flex flex-col bg-content-area">
-        <div className={cn(
-          "flex items-center justify-between gap-2 px-4 py-4 flex-shrink-0",
-          isWindows && "pr-[140px]"
-        )}>
+        <div className="flex items-center justify-between gap-2 px-4 py-4 flex-shrink-0">
           <span className="text-sm font-semibold text-foreground">配置</span>
-          <button
-            onClick={close}
-            className="titlebar-no-drag p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-foreground/[0.06] transition-colors"
-          >
-            <X className="size-4" />
-          </button>
+          {!isWindows && (
+            <button
+              onClick={close}
+              className="titlebar-no-drag p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-foreground/[0.06] transition-colors"
+            >
+              <X className="size-4" />
+            </button>
+          )}
         </div>
 
         <div className="flex-1 overflow-y-auto px-4 pb-4 flex flex-col gap-5">

--- a/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
+++ b/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
@@ -516,14 +516,12 @@ export function AutomationFormView(): React.ReactElement | null {
           isWindows && "pr-[140px]"
         )}>
           <span className="text-sm font-semibold text-foreground">配置</span>
-          {!isWindows && (
-            <button
-              onClick={close}
-              className="titlebar-no-drag p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-foreground/[0.06] transition-colors"
-            >
-              <X className="size-4" />
-            </button>
-          )}
+          <button
+            onClick={close}
+            className="titlebar-no-drag p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-foreground/[0.06] transition-colors"
+          >
+            <X className="size-4" />
+          </button>
         </div>
 
         <div className="flex-1 overflow-y-auto px-4 pb-4 flex flex-col gap-5">

--- a/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
+++ b/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
@@ -516,23 +516,14 @@ export function AutomationFormView(): React.ReactElement | null {
           isWindows && "pr-[140px]"
         )}>
           <span className="text-sm font-semibold text-foreground">配置</span>
-          <div className="flex items-center gap-1">
-            <button
-              type="button"
-              onClick={() => { void handleRunNow() }}
-              disabled={runningNow || !canPersistDraft(form)}
-              className="titlebar-no-drag h-7 px-2.5 rounded-md text-xs font-medium bg-primary text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50 transition-colors flex items-center gap-1.5 shadow-sm"
-            >
-              {runningNow ? <Loader2 className="size-3.5 animate-spin" /> : <Play className="size-3.5" />}
-              <span>{runningNow ? '运行中' : '运行一次'}</span>
-            </button>
+          {!isWindows && (
             <button
               onClick={close}
               className="titlebar-no-drag p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-foreground/[0.06] transition-colors"
             >
               <X className="size-4" />
             </button>
-          </div>
+          )}
         </div>
 
         <div className="flex-1 overflow-y-auto px-4 pb-4 flex flex-col gap-5">
@@ -827,6 +818,18 @@ export function AutomationFormView(): React.ReactElement | null {
               )}
             </div>
           )}
+        </div>
+        {/* 底部运行测试按钮 */}
+        <div className="flex-shrink-0 px-4 py-3 border-t border-border/50 bg-content-area">
+          <button
+            type="button"
+            onClick={() => { void handleRunNow() }}
+            disabled={runningNow || !canPersistDraft(form)}
+            className="titlebar-no-drag w-full h-8 rounded-md text-xs font-medium bg-primary text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50 transition-colors flex items-center justify-center gap-1.5 shadow-sm"
+          >
+            {runningNow ? <Loader2 className="size-3.5 animate-spin" /> : <Play className="size-3.5" />}
+            <span>{runningNow ? '运行中' : '运行测试'}</span>
+          </button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 概述

修复 Windows 下自动任务表单右侧面板的关闭按钮与自定义 WindowControls 按钮重叠的问题，并调整表单按钮布局。

## 问题

1. Windows 平台上，`AutomationFormView` 右侧面板的关闭按钮与右上角的 `WindowControls`（最小化/最大化/关闭）自定义按钮位置重叠，导致点击困难。
2. 右栏 header 同时存在"运行一次"和关闭按钮，区域拥挤。

## 改动

- **引入 `detectIsWindows` 检测平台**
- **Windows 下右栏 header 增加 `pr-[140px]` 间距**，避开 `WindowControls` 区域
- **全平台移除右栏 header 的"运行一次"按钮**，统一到底部
- **X 关闭按钮仅在非 Windows 平台显示**（Windows 隐藏避免重叠）
- **底部新增全平台"运行测试"按钮**（全宽主按钮，功能与"运行一次"相同）

## 布局变化

| 按钮 | 之前 | 现在 |
|------|------|------|
| "运行一次"（header） | 全平台显示 | **全平台隐藏** |
| X 关闭按钮（header） | 全平台显示 | **仅非 Windows 显示** |
| "运行测试"（底部） | 无 | **全平台新增** |

## 测试

1. Windows 下打开自动任务表单
2. 确认右侧面板关闭按钮不与 `WindowControls` 重叠
3. 确认底部"运行测试"按钮正常可用
4. macOS/Linux 下 X 按钮正常显示，底部按钮正常

## 备注

- 仅影响 `AutomationFormView.tsx`
- 未改变功能逻辑，仅调整 UI 布局