### PR TITLE
[Reviewed] fix(agent-workspace-manager): 修复 parseSkillFrontmatter BOM 兼容问题

### DIFF
--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -510,6 +510,9 @@ export function getWorkspaceSkills(workspaceSlug: string): SkillMeta[] {
 function parseSkillFrontmatter(content: string, slug: string, enabled: boolean): SkillMeta {
   const meta: SkillMeta = { slug, name: slug, enabled }
 
+  // 移除 UTF-8 BOM（﻿），确保 YAML frontmatter 匹配不受 BOM 干扰
+  if (content.charCodeAt(0) === 0xFEFF) content = content.slice(1)
+
   const fmMatch = content.match(/^---\s*\n([\s\S]*?)\n---/)
   if (!fmMatch) return meta
 

--- a/apps/electron/src/renderer/components/settings/AgentSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AgentSettings.tsx
@@ -113,6 +113,9 @@ function shortName(slug: string, prefix: string): string {
 }
 
 function extractSkillBody(content: string): string {
+  // 移除 UTF-8 BOM（﻿），确保 frontmatter 匹配不受 BOM 干扰
+  if (content.charCodeAt(0) === 0xFEFF) content = content.slice(1)
+
   const match = content.match(/^---\s*\n[\s\S]*?\n---\s*\n([\s\S]*)$/)
   return match?.[1] ?? content
 }
@@ -121,6 +124,9 @@ function rebuildSkillMd(
   originalContent: string,
   updates: { name?: string; description?: string; body?: string },
 ): string {
+  // 移除 UTF-8 BOM（﻿），确保 frontmatter 匹配不受 BOM 干扰
+  if (originalContent.charCodeAt(0) === 0xFEFF) originalContent = originalContent.slice(1)
+
   const fmMatch = originalContent.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/)
   if (!fmMatch) return originalContent
 


### PR DESCRIPTION
## 概述

修复 BOM（Byte Order Mark）导致 SKILL.md 文件 frontmatter 解析失败的问题，涉及服务端解析和渲染端正文提取两处。

## 问题

当 SKILL.md 文件以 UTF-8 BOM (`\xEF\xBB\xBF`) 开头时：
1. `parseSkillFrontmatter`（服务端）正则匹配失败 → 元数据（name、description 等）丢失
2. `extractSkillBody`（渲染端）正则匹配失败 → 正文区域重复显示 frontmatter 内容
3. `rebuildSkillMd`（渲染端）正则匹配失败 → 编辑 Skill 时可能破坏文件结构

## 改动

1. `agent-workspace-manager.ts:parseSkillFrontmatter`
   - 函数开头添加 BOM 移除逻辑，确保 frontmatter 正则匹配不受 BOM 干扰

2. `AgentSettings.tsx:extractSkillBody`
   - 函数开头添加 BOM 移除逻辑，避免正文包含 frontmatter 导致重复显示

3. `AgentSettings.tsx:rebuildSkillMd`
   - 函数开头添加 BOM 移除逻辑，确保编辑保存时 frontmatter 解析正确

## 测试

- [x] 验证带有 BOM 的 SKILL.md 文件能正确解析元数据
- [x] 验证带有 BOM 的 SKILL.md 文件正文不重复显示 frontmatter
- [x] 验证不带 BOM 的 SKILL.md 文件行为不受影响

## 备注

- 影响范围：`parseSkillFrontmatter`、`extractSkillBody`、`rebuildSkillMd`
- 无破坏性变更，向后兼容