### PR TITLE
fix: 修复超长上下文 400 错误识别及 Agent 消息全量加载卡顿

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -1668,8 +1668,8 @@ export function registerIpcHandlers(): void {
   // 获取 Agent 会话 SDKMessage（Phase 4 新格式）
   ipcMain.handle(
     AGENT_IPC_CHANNELS.GET_SDK_MESSAGES,
-    async (_, id: string, limit?: number): Promise<SDKMessage[]> => {
-      return getAgentSessionSDKMessages(id, limit)
+    async (_, id: string, limit?: number, offset?: number): Promise<SDKMessage[]> => {
+      return getAgentSessionSDKMessages(id, limit, offset)
     }
   )
 

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -1668,8 +1668,8 @@ export function registerIpcHandlers(): void {
   // 获取 Agent 会话 SDKMessage（Phase 4 新格式）
   ipcMain.handle(
     AGENT_IPC_CHANNELS.GET_SDK_MESSAGES,
-    async (_, id: string): Promise<SDKMessage[]> => {
-      return getAgentSessionSDKMessages(id)
+    async (_, id: string, limit?: number): Promise<SDKMessage[]> => {
+      return getAgentSessionSDKMessages(id, limit)
     }
   )
 

--- a/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
@@ -258,6 +258,7 @@ const PROMPT_TOO_LONG_PATTERNS = [
   'maximum context length',
   'token limit',
   'exceeds the model',
+  'range of input length',
 ] as const
 
 /** 检测错误消息是否为 prompt too long 类型 */

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -288,7 +288,7 @@ function sanitizeOversizedMessage(msg: SDKMessage, originalLength: number): SDKM
  * 旧格式（有 `role` 字段）会被转换为近似的 SDKMessage。
  * 新格式（有 `type` 字段）直接返回。
  */
-export function getAgentSessionSDKMessages(id: string): SDKMessage[] {
+export function getAgentSessionSDKMessages(id: string, limit?: number): SDKMessage[] {
   const filePath = getAgentSessionMessagesPath(id)
 
   if (!existsSync(filePath)) {
@@ -297,7 +297,10 @@ export function getAgentSessionSDKMessages(id: string): SDKMessage[] {
 
   try {
     const raw = readFileSync(filePath, 'utf-8')
-    const lines = raw.split('\n').filter((line) => line.trim())
+    let lines = raw.split('\n').filter((line) => line.trim())
+    if (limit !== undefined && lines.length > limit) {
+      lines = lines.slice(-limit)
+    }
     return lines.map((line) => {
       const parsed = JSON.parse(line)
       // 旧格式检测：AgentMessage 有 `role` 字段，SDKMessage 有 `type` 字段

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -288,7 +288,7 @@ function sanitizeOversizedMessage(msg: SDKMessage, originalLength: number): SDKM
  * 旧格式（有 `role` 字段）会被转换为近似的 SDKMessage。
  * 新格式（有 `type` 字段）直接返回。
  */
-export function getAgentSessionSDKMessages(id: string, limit?: number): SDKMessage[] {
+export function getAgentSessionSDKMessages(id: string, limit?: number, offset?: number): SDKMessage[] {
   const filePath = getAgentSessionMessagesPath(id)
 
   if (!existsSync(filePath)) {
@@ -298,8 +298,10 @@ export function getAgentSessionSDKMessages(id: string, limit?: number): SDKMessa
   try {
     const raw = readFileSync(filePath, 'utf-8')
     let lines = raw.split('\n').filter((line) => line.trim())
-    if (limit !== undefined && lines.length > limit) {
-      lines = lines.slice(-limit)
+    if (limit !== undefined) {
+      const end = offset !== undefined ? lines.length - offset : lines.length
+      const start = Math.max(0, end - limit)
+      lines = lines.slice(start, end)
     }
     return lines.map((line) => {
       const parsed = JSON.parse(line)

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -416,7 +416,7 @@ export interface ElectronAPI {
   createAgentSession: (title?: string, channelId?: string, workspaceId?: string) => Promise<AgentSessionMeta>
 
   /** 获取 Agent 会话 SDKMessage（Phase 4 新格式） */
-  getAgentSessionSDKMessages: (id: string) => Promise<SDKMessage[]>
+  getAgentSessionSDKMessages: (id: string, limit?: number) => Promise<SDKMessage[]>
 
   /** 更新 Agent 会话标题 */
   updateAgentSessionTitle: (id: string, title: string) => Promise<AgentSessionMeta>
@@ -1403,8 +1403,8 @@ const electronAPI: ElectronAPI = {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.CREATE_SESSION, title, channelId, workspaceId)
   },
 
-  getAgentSessionSDKMessages: (id: string) => {
-    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.GET_SDK_MESSAGES, id)
+  getAgentSessionSDKMessages: (id: string, limit?: number) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.GET_SDK_MESSAGES, id, limit)
   },
 
   updateAgentSessionTitle: (id: string, title: string) => {

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -416,7 +416,7 @@ export interface ElectronAPI {
   createAgentSession: (title?: string, channelId?: string, workspaceId?: string) => Promise<AgentSessionMeta>
 
   /** 获取 Agent 会话 SDKMessage（Phase 4 新格式） */
-  getAgentSessionSDKMessages: (id: string, limit?: number) => Promise<SDKMessage[]>
+  getAgentSessionSDKMessages: (id: string, limit?: number, offset?: number) => Promise<SDKMessage[]>
 
   /** 更新 Agent 会话标题 */
   updateAgentSessionTitle: (id: string, title: string) => Promise<AgentSessionMeta>
@@ -1403,8 +1403,8 @@ const electronAPI: ElectronAPI = {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.CREATE_SESSION, title, channelId, workspaceId)
   },
 
-  getAgentSessionSDKMessages: (id: string, limit?: number) => {
-    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.GET_SDK_MESSAGES, id, limit)
+  getAgentSessionSDKMessages: (id: string, limit?: number, offset?: number) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.GET_SDK_MESSAGES, id, limit, offset)
   },
 
   updateAgentSessionTitle: (id: string, title: string) => {

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -110,11 +110,29 @@ interface AgentMessagesProps {
   onFork?: (upToMessageUuid: string) => void
   onRewind?: (assistantMessageUuid: string) => void
   onCompact?: () => void
+  hasMore?: boolean
+  loadingMore?: boolean
+  onLoadMore?: () => void
 }
 
 /** 空状态引导 — 使用 WelcomeEmptyState */
 function EmptyState(): React.ReactElement {
   return <WelcomeEmptyState />
+}
+
+/** 滚动到顶部时触发加载更多 */
+function LoadMoreTrigger({ onLoadMore, loadingMore }: { onLoadMore: () => void; loadingMore?: boolean }): null {
+  const { scrollRef } = useStickToBottomContext()
+  React.useEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+    const handle = (): void => {
+      if (el.scrollTop < 80 && !loadingMore) onLoadMore()
+    }
+    el.addEventListener('scroll', handle, { passive: true })
+    return () => el.removeEventListener('scroll', handle)
+  }, [scrollRef, onLoadMore, loadingMore])
+  return null
 }
 
 function AssistantLogo({ model }: { model?: string }): React.ReactElement {
@@ -393,7 +411,7 @@ function AgentRunningIndicator({ startedAt }: { startedAt?: number }): React.Rea
   )
 }
 
-export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persistedSDKMessages, streaming, streamState, liveMessages, sessionPath, attachedDirs, stoppedByUser, onRetry, onRetryInNewSession, onFork, onRewind, onCompact }: AgentMessagesProps): React.ReactElement {
+export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persistedSDKMessages, streaming, streamState, liveMessages, sessionPath, attachedDirs, stoppedByUser, onRetry, onRetryInNewSession, onFork, onRewind, onCompact, hasMore, loadingMore, onLoadMore }: AgentMessagesProps): React.ReactElement {
   const userProfile = useAtomValue(userProfileAtom)
   const setMinimapCache = useSetAtom(tabMinimapCacheAtom)
   const channels = useAtomValue(channelsAtom)
@@ -610,7 +628,11 @@ export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persi
     <BasePathsProvider basePaths={attachedDirs}>
     <Conversation resize={ready && !transitioning ? 'smooth' : 'instant'} className={ready ? (skipFadeIn ? 'opacity-100' : 'opacity-100 transition-opacity duration-200') : 'opacity-0'}>
       <ScrollPositionManager id={sessionId} ready={ready} />
+      {hasMore && onLoadMore && <LoadMoreTrigger onLoadMore={onLoadMore} loadingMore={loadingMore} />}
       <ConversationContent>
+        {hasMore && loadingMore && (
+          <div className="flex justify-center py-2 text-xs text-muted-foreground">加载更多...</div>
+        )}
         {!hasContent && !streaming ? (
           <EmptyState />
         ) : (

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -123,15 +123,17 @@ function EmptyState(): React.ReactElement {
 /** 滚动到顶部时触发加载更多 */
 function LoadMoreTrigger({ onLoadMore, loadingMore }: { onLoadMore: () => void; loadingMore?: boolean }): null {
   const { scrollRef } = useStickToBottomContext()
+  const stateRef = React.useRef({ onLoadMore, loadingMore })
+  stateRef.current = { onLoadMore, loadingMore }
   React.useEffect(() => {
     const el = scrollRef.current
     if (!el) return
     const handle = (): void => {
-      if (el.scrollTop < 80 && !loadingMore) onLoadMore()
+      if (el.scrollTop < 80 && !stateRef.current.loadingMore) stateRef.current.onLoadMore()
     }
     el.addEventListener('scroll', handle, { passive: true })
     return () => el.removeEventListener('scroll', handle)
-  }, [scrollRef, onLoadMore, loadingMore])
+  }, [scrollRef])
   return null
 }
 

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -633,6 +633,10 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   // 消息是否已完成首次加载（用于 auto-send 等待）
   const [messagesLoaded, setMessagesLoaded] = React.useState(false)
   const loadingSessionIdRef = React.useRef<string | null>(null)
+  const PAGE_SIZE = 500
+  const [loadedCount, setLoadedCount] = React.useState(PAGE_SIZE)
+  const [hasMore, setHasMore] = React.useState(false)
+  const [loadingMore, setLoadingMore] = React.useState(false)
 
   // 加载当前会话消息
   React.useEffect(() => {
@@ -641,6 +645,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     const isSessionSwitch = loadingSessionIdRef.current !== sessionId
     if (isSessionSwitch) {
       loadingSessionIdRef.current = sessionId
+      setLoadedCount(PAGE_SIZE)
+      setHasMore(false)
       // 命中缓存则立即填充，消除「先清空 → 等 IPC 全量读盘」的可见空窗；
       // IPC 返回后仍会以最新数据覆盖。未命中才回退到清空 + loading 态。
       // 注意：refreshVersion bump（流结束/出错/rewind）不是会话切换，
@@ -655,10 +661,10 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       }
     }
     let cancelled = false
-    window.electronAPI.getAgentSessionSDKMessages(sessionId, 500)
+    window.electronAPI.getAgentSessionSDKMessages(sessionId, PAGE_SIZE)
       .then((sdkMsgs) => {
         if (cancelled) return
-        // 写入缓存（含 LRU 淘汰，防止会话数增长导致内存无限膨胀）
+        setHasMore(sdkMsgs.length === PAGE_SIZE)
         setMessagesCache((prev) => setSessionMessagesCache(prev, sessionId, sdkMsgs))
         unstable_batchedUpdates(() => {
           setPersistedSDKMessages(sdkMsgs)
@@ -720,6 +726,22 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       })
     return () => { cancelled = true }
   }, [sessionId, refreshVersion, setStreamingStates, setLiveMessagesMap, setMessagesCache, store])
+
+  const loadMore = React.useCallback(async () => {
+    if (loadingMore || !hasMore) return
+    setLoadingMore(true)
+    const nextOffset = loadedCount
+    const nextCount = loadedCount + PAGE_SIZE
+    try {
+      const older = await window.electronAPI.getAgentSessionSDKMessages(sessionId, PAGE_SIZE, nextOffset)
+      setLoadedCount(nextCount)
+      setHasMore(older.length === PAGE_SIZE)
+      setPersistedSDKMessages((prev) => [...older, ...prev])
+      setMessagesCache((c) => setSessionMessagesCache(c, sessionId, [...older, ...persistedSDKMessagesRef.current]))
+    } finally {
+      setLoadingMore(false)
+    }
+  }, [loadingMore, hasMore, loadedCount, sessionId, setMessagesCache])
 
   // 从会话元数据初始化附加目录（仅冷启动水合，后续由 handleAttachFolder/handleDetachDirectory 实时写入）
   React.useEffect(() => {
@@ -2033,6 +2055,9 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           onFork={handleFork}
           onRewind={handleRewindRequest}
           onCompact={handleCompact}
+          hasMore={hasMore}
+          loadingMore={loadingMore}
+          onLoadMore={loadMore}
         />
 
         {/* 权限请求横幅 */}

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -655,7 +655,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       }
     }
     let cancelled = false
-    window.electronAPI.getAgentSessionSDKMessages(sessionId)
+    window.electronAPI.getAgentSessionSDKMessages(sessionId, 500)
       .then((sdkMsgs) => {
         if (cancelled) return
         // 写入缓存（含 LRU 淘汰，防止会话数增长导致内存无限膨胀）


### PR DESCRIPTION
## 问题

修复两个用户反馈的性能/可用性 bug（#777、#779）。

**#777**：用户使用国内 provider（豆包/字节等）时，context 超限会返回 `InternalError.Algo.InvalidParameter: Range of input length should be [1, 202752]`，但 `PROMPT_TOO_LONG_PATTERNS` 未覆盖该格式，导致 Proma 不识别错误类型，用户看到的是一个无法理解的原始错误。

**#779**：单个会话积累 3000+ 条消息（~73MB jsonl）时，每次打开卡顿数秒、打字有延迟。根因是 `getAgentSessionSDKMessages` 全量 `readFileSync` + 全量 IPC 传输 + 全量 `setState`，3000 条消息一次性进入 React state，触发 `groupIntoTurns` 等多个 `useMemo` 全量重算。

## 修改

**`claude-agent-adapter.ts`**：`PROMPT_TOO_LONG_PATTERNS` 新增 `'range of input length'`，覆盖国内 provider 的错误格式。

**`agent-session-manager.ts`**：`getAgentSessionSDKMessages` 加 `limit?: number` 可选参数，超出时只返回尾部 N 条（`slice(-limit)`）。

**`ipc.ts` / `preload/index.ts`**：IPC 层透传 `limit` 参数。

**`AgentView.tsx`**：UI 加载时传 `limit: 500`，只渲染最近 500 条。搜索（`SearchDialog`）和 minimap（`SessionMiniMapPopover`）场景不传 limit，继续读全量。

## 测试

- TypeScript 类型检查：零错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)