### PR TITLE
[Reviewed] fix(agent): 优化会话引用提示语，引导大文件智能读取

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -425,7 +425,7 @@ function buildReferencedSessionsPrompt(
 
   if (sessionBlocks.length === 0) return ''
 
-  return `<referenced_sessions>\n用户在消息中明确引用了以下同工作区 Agent 会话。不要假设这些会话的内容；需要上下文时，请先读取对应的 History path，再基于读取结果继续完成任务。\n${sessionBlocks.join('\n\n')}\n</referenced_sessions>`
+  return `<referenced_sessions>\n用户在消息中明确引用了以下同工作区 Agent 会话。不要假设这些会话的内容；需要上下文时，请先读取对应的 History path，再基于读取结果继续完成任务。\n\n重要提示：会话历史文件（.jsonl）可能包含大量消息和 tool results，文件较大。请优先使用 Grep 搜索关键词定位相关消息片段，再局部读取。避免一次性 Read 整个大文件。\n${sessionBlocks.join('\n\n')}\n</referenced_sessions>`
 }
 
 /** 标题生成 Prompt */


### PR DESCRIPTION
## 概述

优化 `buildReferencedSessionsPrompt` 返回的提示语，引导 Claude 在读取会话历史 JSONL 文件时采用更智能的策略（先 Grep 搜索再局部读取），避免一次性读取大文件导致的性能和 token 问题。

## 问题

当用户通过 `&session:` 引用其他 Agent 会话时，Claude 会尝试读取目标会话的 `.jsonl` 历史文件。由于会话历史包含完整的 tool results、文件内容、grep 结果等，文件可能达到数 MB。当前提示语仅要求"先读取对应的 History path"，Claude 可能采用暴力全读策略，导致：

1. 消耗大量 token
2. 响应缓慢
3. 触发上下文长度限制

## 改动

- 修改 `apps/electron/src/main/lib/agent-orchestrator.ts` 第 428 行
- 在 `buildReferencedSessionsPrompt` 返回的提示语中增加一段"大文件智能读取"引导：

> 重要提示：会话历史文件（.jsonl）可能包含大量消息和 tool results，文件较大。请优先使用 Grep 搜索关键词定位相关消息片段，再局部读取。避免一次性 Read 整个大文件。

## 测试

- [x] 代码审查通过，改动范围最小化
- [x] 确认提示语文本正确注入

## 备注

这是一个纯提示词优化，不需要新增任何文件或模块。改动范围最小化，零风险。