### PR TITLE
fix(agent): task_notification 在对话中途不再截断分组

### DIFF
--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -348,14 +348,16 @@ export function groupIntoTurns(messages: SDKMessage[], sessionModelId?: string):
       if (sysMsg.subtype === 'compact_boundary' || sysMsg.subtype === 'compacting' || sysMsg.subtype === 'permission_denied') {
         flushTurn()
         groups.push({ type: 'system', message: sysMsg })
-      } else if (currentTurn) {
-        currentTurn.turnMessages.push(msg)
-        // 后台任务完成通知：标志一次自动唤醒。当前 turn 收尾后，
-        // 后续新出现的 assistant 输出应独立成块。
-        if (sysMsg.subtype === 'task_notification') {
-          flushTurn()
+      } else if (sysMsg.subtype === 'task_notification') {
+        // 后台任务完成通知：仅在没有进行中的 turn 时标记唤醒边界（真正的唤醒场景）。
+        // 若当前有 turn 正在进行，归入当前 turn 不截断。
+        if (currentTurn) {
+          currentTurn.turnMessages.push(msg)
+        } else {
           pendingWakeBoundary = true
         }
+      } else if (currentTurn) {
+        currentTurn.turnMessages.push(msg)
       }
     } else {
       // result, tool_progress 等 → 归入当前 turn


### PR DESCRIPTION
## 问题

为了支持监控状态和后台任务唤醒功能，`task_notification` 系统消息被用来标记自动唤醒边界。但原来的实现在收到 `task_notification` 时，无论 Agent 是否正在回复，都会调用 `flushTurn()` 截断当前 turn，导致一次正常对话被渲染成多个独立气泡。

## 原因

`task_notification` 只应在"后台任务完成唤醒新一轮对话"时生效，即 `currentTurn` 为空时。而原来的代码是在 `else if (currentTurn)` 分支内处理的，反而只在有进行中 turn 时触发截断，逻辑相反。

## 修复

将 `task_notification` 提取为独立分支：
- **有 `currentTurn`**（Agent 正在回复中途）→ 归入当前 turn，不截断
- **无 `currentTurn`**（真正的唤醒场景）→ 设置 `pendingWakeBoundary = true`

## 测试

- [ ] 正常对话中 Agent 回复不再被分成多个气泡
- [ ] 后台任务完成唤醒后，新一轮回复仍然独立成块

🤖 Generated with [Claude Code](https://claude.com/claude-code)