### PR TITLE
[Reviewed] fix(agent): 修复上下文占用量显示不准的问题

### DIFF
--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -691,6 +691,14 @@ export function applyAgentEvent(
         ...prev,
         retrying: undefined,
         ...finalizeStreamingActivities(prev.toolActivities),
+        ...(event.usage && {
+          inputTokens: event.usage.inputTokens,
+          ...(event.usage.outputTokens != null && { outputTokens: event.usage.outputTokens }),
+          ...(event.usage.cacheReadTokens != null && { cacheReadTokens: event.usage.cacheReadTokens }),
+          ...(event.usage.cacheCreationTokens != null && { cacheCreationTokens: event.usage.cacheCreationTokens }),
+          ...(event.usage.costUsd != null && { costUsd: event.usage.costUsd }),
+          ...(event.usage.contextWindow != null && { contextWindow: event.usage.contextWindow }),
+        }),
       }
 
     case 'run_resumed':
@@ -715,7 +723,9 @@ export function applyAgentEvent(
         ...(event.usage.cacheReadTokens != null && { cacheReadTokens: event.usage.cacheReadTokens }),
         ...(event.usage.cacheCreationTokens != null && { cacheCreationTokens: event.usage.cacheCreationTokens }),
         ...(event.usage.costUsd != null && { costUsd: event.usage.costUsd }),
-        ...(event.usage.contextWindow && { contextWindow: event.usage.contextWindow }),
+        // 流式中 assistant 消息的 usage_update 可能携带推断的 contextWindow，
+        // 若已有 result 消息提供的真实值，则不再覆盖
+        ...(event.usage.contextWindow && !prev.contextWindow && { contextWindow: event.usage.contextWindow }),
       }
 
     case 'compacting':

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -81,6 +81,8 @@ export interface AgentStreamState {
   contextWindow?: number
   /** 当前 thinking block 的 token 估算值（SDK 实时估算，非计费值） */
   thinkingEstimatedTokens?: number
+  /** usage 数据最后更新时间戳（毫秒），用于 UI 提示数据时效 */
+  usageUpdatedAt?: number
   /** 是否正在压缩上下文 */
   isCompacting?: boolean
   /**
@@ -698,6 +700,7 @@ export function applyAgentEvent(
           ...(event.usage.cacheCreationTokens != null && { cacheCreationTokens: event.usage.cacheCreationTokens }),
           ...(event.usage.costUsd != null && { costUsd: event.usage.costUsd }),
           ...(event.usage.contextWindow != null && { contextWindow: event.usage.contextWindow }),
+          usageUpdatedAt: Date.now(),
         }),
       }
 
@@ -726,6 +729,7 @@ export function applyAgentEvent(
         // 流式中 assistant 消息的 usage_update 可能携带推断的 contextWindow，
         // 若已有 result 消息提供的真实值，则不再覆盖
         ...(event.usage.contextWindow && !prev.contextWindow && { contextWindow: event.usage.contextWindow }),
+        usageUpdatedAt: Date.now(),
       }
 
     case 'compacting':
@@ -818,6 +822,8 @@ export interface AgentContextStatus {
   cacheCreationTokens?: number
   costUsd?: number
   contextWindow?: number
+  /** usage 数据最后更新时间戳（毫秒） */
+  usageUpdatedAt?: number
 }
 
 /** 当前会话的上下文使用量派生 atom */
@@ -833,6 +839,7 @@ export const agentContextStatusAtom = atom<AgentContextStatus>((get) => {
     cacheCreationTokens: state?.cacheCreationTokens,
     costUsd: state?.costUsd,
     contextWindow: state?.contextWindow,
+    usageUpdatedAt: state?.usageUpdatedAt,
   }
 })
 

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -1205,6 +1205,15 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       return map
     })
 
+    // 模型切换时：清除旧的 contextWindow，让 result 重新提供真实值
+    setStreamingStates((prev) => {
+      const state = prev.get(sessionId)
+      if (!state) return prev
+      const map = new Map(prev)
+      map.set(sessionId, { ...state, contextWindow: undefined })
+      return map
+    })
+
     // 自动将选中的渠道加入 Agent 可用渠道白名单
     const updatedChannelIds = agentChannelIds.includes(option.channelId)
       ? agentChannelIds

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -377,6 +377,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     isCompacting: streamState?.isCompacting ?? false,
     inputTokens: streamState?.inputTokens,
     contextWindow: streamState?.contextWindow,
+    usageUpdatedAt: streamState?.usageUpdatedAt,
   }
   const setAgentStreamErrors = useSetAtom(agentStreamErrorsAtom)
   const streamErrors = useAtomValue(agentStreamErrorsAtom)
@@ -1943,6 +1944,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           cacheReadTokens={contextStatus.cacheReadTokens}
           cacheCreationTokens={contextStatus.cacheCreationTokens}
           contextWindow={contextStatus.contextWindow}
+          usageUpdatedAt={contextStatus.usageUpdatedAt}
           isCompacting={contextStatus.isCompacting}
           isProcessing={streaming}
           onCompact={handleCompact}

--- a/apps/electron/src/renderer/components/agent/ContextUsageBadge.tsx
+++ b/apps/electron/src/renderer/components/agent/ContextUsageBadge.tsx
@@ -29,6 +29,8 @@ interface ContextUsageBadgeProps {
   cacheCreationTokens?: number
   costUsd?: number
   contextWindow?: number
+  /** usage 数据最后更新时间戳（毫秒），用于显示数据时效 */
+  usageUpdatedAt?: number
   isCompacting: boolean
   isProcessing: boolean
   onCompact: () => void
@@ -116,6 +118,7 @@ export function ContextUsageBadge({
   cacheReadTokens,
   cacheCreationTokens,
   contextWindow,
+  usageUpdatedAt,
   isCompacting,
   isProcessing,
   onCompact,
@@ -193,6 +196,17 @@ export function ContextUsageBadge({
     ? Math.round((displayTokens / displayWindow) * 100)
     : undefined
 
+  /** 计算数据时效提示（普通变量，非 useMemo — 避免在 isCompacting early return 后 hook 数不一致） */
+  let ageText: string | undefined
+  if (usageUpdatedAt) {
+    const ageMs = Date.now() - usageUpdatedAt
+    if (ageMs >= 5_000 && ageMs < 60_000) {
+      ageText = `${Math.round(ageMs / 1000)}秒前更新`
+    } else if (ageMs >= 60_000) {
+      ageText = `${Math.round(ageMs / 60_000)}分钟前更新`
+    }
+  }
+
   const handleCompactClick = (): void => {
     if (isProcessing) return
     onCompact()
@@ -249,6 +263,12 @@ export function ContextUsageBadge({
                   emphasized={isWarning}
                 />
               )}
+              {ageText ? (
+                <DetailRow
+                  label=""
+                  value={`数据${ageText}`}
+                />
+              ) : null}
             </>
           ) : null}
 

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -101,9 +101,10 @@ function uniqueTruthyPaths(paths: Array<string | null | undefined>): string[] {
 // ============================================================================
 
 /**
- * 按模型名推断 contextWindow。SDK 流式过程中不返回此字段，
- * 只有 result 消息的 modelUsage 才带（且部分渠道不返回）。
- * 这里提供一个按模型家族的 fallback，保证进度环永远有分母可用。
+ * 按模型名推断 contextWindow。
+ *
+ * @deprecated 仅作为 fallback 在 SDK 未返回 contextWindow 时启用。
+ * result 消息中的 modelUsage.contextWindow 是权威来源，优先使用。
  */
 function inferContextWindow(model?: string): number | undefined {
   if (!model) return undefined


### PR DESCRIPTION
## 概述

修复 Proma Agent 模式下上下文占用量（ContextUsageBadge）显示不准确的问题。

## 问题

1. **result 消息中的真实 `contextWindow` 被忽略** — `complete` 事件（result 消息）原本不写入 usage 信息，导致 SDK 返回的真实上下文窗口大小无法使用
2. **推断值覆盖真实值** — 流式中 `usage_update` 会用模型名推断的 `contextWindow` 覆盖一切，即使 result 已经提供了真实值
3. **模型切换后 `contextWindow` 过期** — 从 200K 模型切到 1M 模型后，圆环仍在 155K 就显示满（按旧窗口的 77.5% 计算）
4. **用户不知道数据何时更新** — Agent 执行多轮工具期间圆环完全不动，用户不知道是 bug 还是数据真的没变

## 改动

### 核心修复

1. `complete` 事件现在正确写入 usage 信息（`inputTokens`、`outputTokens`、`cacheReadTokens`、`cacheCreationTokens`、`costUsd`、`contextWindow`）
2. `usage_update` 不再覆盖已有的 `contextWindow`，确保 result 提供的真实值优先于推断值
3. 模型切换时清空旧 `contextWindow`，等待新 result 提供正确值
4. `inferContextWindow` 标记为 deprecated fallback，明确 `result.modelUsage.contextWindow` 是权威来源

### 新增：数据时效提示

5. ContextUsageBadge Popover 中显示"数据 X 秒/分钟前更新"提示，帮助用户理解圆环在 Agent 执行期间不会变化的原因

## 测试

- [x] result 消息到达后，`contextWindow` 正确更新为 SDK 返回的真实值
- [x] 流式中推断的 fallback 值不会覆盖 result 提供的真实值
- [x] 模型切换后旧 `contextWindow` 被清空
- [x] Popover 中正确显示数据时效提示

## 备注

未修复的已知限制：
- 缓存 token 在不同渠道下的语义差异（Anthropic vs OpenAI 兼容）
  - 需要主进程传递 provider 类型到渲染进程才能区分处理