### PR TITLE
fix(worktree): 修复文件改动面板找不到 worktree 及选中后报错

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -113,7 +113,7 @@ import type {
 } from '@proma/shared'
 import type { UserProfile, AppSettings } from '../types'
 import { getRuntimeStatus, getGitRepoStatus, reinitializeRuntime } from './lib/runtime-init'
-import { getUnstagedChanges, getFileDiff, getUntrackedContent, revertFile, getDiffContents, listWorktrees, getWorktreeChanges } from './lib/git-diff-service'
+import { getUnstagedChanges, getFileDiff, getUntrackedContent, revertFile, getDiffContents, listWorktrees, getWorktreeChanges, getMainRepoRoot } from './lib/git-diff-service'
 import { registerPromaFilePath } from './lib/local-file-protocol'
 import { registerUpdaterIpc } from './lib/updater/updater-ipc'
 import {
@@ -353,6 +353,21 @@ function getAllowedCandidateBasePaths(options?: FileAccessOptions): string[] | u
 
 function ensurePathAllowed(filePath: string, options?: FileAccessOptions): boolean {
   if (isPathAllowed(filePath, options)) return true
+  console.warn('[IPC] 拒绝越界路径:', filePath)
+  return false
+}
+
+/**
+ * 在 ensurePathAllowed 基础上，额外放行「已授权仓库的 worktree」。
+ *
+ * worktree 常被放在主仓库之外（如 ~/proma-dev/worktrees/xxx），其路径不在任何
+ * 授权根下，会被 ensurePathAllowed 拒绝。但只要它回溯到的主仓库已被授权，就应放行。
+ * 用 git 自身背书（--git-common-dir），避免粗暴跳过安全检查。
+ */
+async function ensurePathAllowedWithWorktree(filePath: string, options?: FileAccessOptions): Promise<boolean> {
+  if (isPathAllowed(filePath, options)) return true
+  const mainRepo = await getMainRepoRoot(filePath)
+  if (mainRepo && isPathAllowed(mainRepo, options)) return true
   console.warn('[IPC] 拒绝越界路径:', filePath)
   return false
 }
@@ -794,7 +809,7 @@ export function registerIpcHandlers(): void {
         return ''
       }
       const access = normalizeFileAccessOptions({ sessionId })
-      if (!ensurePathAllowed(dirPath, access) || (gitRoot && !ensurePathAllowed(gitRoot, access))) return ''
+      if (!(await ensurePathAllowedWithWorktree(dirPath, access)) || (gitRoot && !(await ensurePathAllowedWithWorktree(gitRoot, access)))) return ''
       return getFileDiff(dirPath, filePath, gitRoot)
     }
   )
@@ -809,7 +824,7 @@ export function registerIpcHandlers(): void {
         return ''
       }
       const access = normalizeFileAccessOptions({ sessionId })
-      if (!ensurePathAllowed(dirPath, access) || (gitRoot && !ensurePathAllowed(gitRoot, access))) return ''
+      if (!(await ensurePathAllowedWithWorktree(dirPath, access)) || (gitRoot && !(await ensurePathAllowedWithWorktree(gitRoot, access)))) return ''
       return getUntrackedContent(dirPath, filePath, gitRoot)
     }
   )
@@ -824,7 +839,7 @@ export function registerIpcHandlers(): void {
         return
       }
       const access = normalizeFileAccessOptions({ sessionId })
-      if (!ensurePathAllowed(dirPath, access) || (gitRoot && !ensurePathAllowed(gitRoot, access))) return
+      if (!(await ensurePathAllowedWithWorktree(dirPath, access)) || (gitRoot && !(await ensurePathAllowedWithWorktree(gitRoot, access)))) return
       await revertFile(dirPath, filePath, gitRoot)
     }
   )
@@ -839,7 +854,7 @@ export function registerIpcHandlers(): void {
         return null
       }
       const access = normalizeFileAccessOptions({ sessionId })
-      if (!ensurePathAllowed(dirPath, access) || (gitRoot && !ensurePathAllowed(gitRoot, access))) return null
+      if (!(await ensurePathAllowedWithWorktree(dirPath, access)) || (gitRoot && !(await ensurePathAllowedWithWorktree(gitRoot, access)))) return null
       return getDiffContents(dirPath, filePath, gitRoot, input.baseRef)
     }
   )
@@ -861,7 +876,7 @@ export function registerIpcHandlers(): void {
         return { isGitRepo: false, files: [], untrackedFiles: [], gitRootNames: [] }
       }
       const access = normalizeFileAccessOptions({ sessionId })
-      if (!ensurePathAllowed(worktreePath, access)) {
+      if (!(await ensurePathAllowedWithWorktree(worktreePath, access))) {
         return { isGitRepo: false, files: [], untrackedFiles: [], gitRootNames: [] }
       }
       return getWorktreeChanges(worktreePath, baseBranch)
@@ -2588,7 +2603,7 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(
     AGENT_IPC_CHANNELS.GET_WORKTREE_REPOS,
     async (_, workspaceSlug: string) => {
-      return getWorktreeRepos(workspaceSlug)
+      return await getWorktreeRepos(workspaceSlug)
     }
   )
 

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -20,6 +20,7 @@ import {
   getDefaultSkillsDir,
   parseSkillVersion,
 } from './config-paths'
+import { findAllGitRoots, normalizeGitRoot } from './git-diff-service'
 import type { AgentWorkspace, WorkspaceMcpConfig, SkillMeta, SkillImportSource, OtherWorkspaceSkillsGroup, WorkspaceCapabilities, SkillFileNode, SkillFileContent } from '@proma/shared'
 
 interface AgentWorkspacesIndex {
@@ -1178,10 +1179,50 @@ export function detachWorkspaceFile(workspaceSlug: string, filePath: string): st
 
 // ===== 工作区级 Worktree 仓库管理 =====
 
-export function getWorktreeRepos(workspaceSlug: string): import('@proma/shared').WorkspaceWorktreeRepo[] {
+/**
+ * 获取工作区的 Worktree 仓库列表。
+ *
+ * 优先从工作区的「附加目录」中自动探测 git 仓库根，避免依赖手动维护的
+ * worktreeRepos 配置（其 repoPath 容易因仓库移动而失效，导致 WorktreeSelector
+ * 静默找不到 worktree）。同时保留 config 中仍然存在的手动配置项（如不在附加
+ * 目录内的额外仓库），并自动过滤掉路径已不存在的陈旧条目。
+ */
+export async function getWorktreeRepos(workspaceSlug: string): Promise<import('@proma/shared').WorkspaceWorktreeRepo[]> {
   const config = readWorkspaceConfig(workspaceSlug)
-  const repos = config.worktreeRepos ?? []
-  return repos.sort((a, b) => (a.priority ?? 99) - (b.priority ?? 99))
+
+  // repoPath 归一化后去重
+  const byPath = new Map<string, import('@proma/shared').WorkspaceWorktreeRepo>()
+
+  // 1. 从附加目录自动探测 git 仓库根
+  const attachedDirs = config.attachedDirectories ?? []
+  for (const dir of attachedDirs) {
+    let roots: string[]
+    try {
+      roots = await findAllGitRoots(dir)
+    } catch {
+      continue
+    }
+    for (const root of roots) {
+      if (!byPath.has(root)) {
+        byPath.set(root, {
+          name: basename(root),
+          repoPath: root,
+          worktreesPath: '',
+          priority: 1,
+        })
+      }
+    }
+  }
+
+  // 2. 合并手动配置中仍然存在的仓库（自动过滤失效路径）
+  for (const repo of config.worktreeRepos ?? []) {
+    const normalized = normalizeGitRoot(repo.repoPath)
+    if (!byPath.has(normalized) && existsSync(repo.repoPath)) {
+      byPath.set(normalized, repo)
+    }
+  }
+
+  return Array.from(byPath.values()).sort((a, b) => (a.priority ?? 99) - (b.priority ?? 99))
 }
 
 export function addWorktreeRepo(workspaceSlug: string, repo: import('@proma/shared').WorkspaceWorktreeRepo): import('@proma/shared').WorkspaceWorktreeRepo[] {

--- a/apps/electron/src/main/lib/git-diff-service.ts
+++ b/apps/electron/src/main/lib/git-diff-service.ts
@@ -7,7 +7,7 @@
 
 import { spawn } from 'child_process'
 import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from 'fs'
-import { basename, isAbsolute, join, resolve, sep } from 'path'
+import { basename, dirname, isAbsolute, join, resolve, sep } from 'path'
 import type { ChangedFileEntry, UnstagedChangesResult, UntrackedFileEntry } from '@proma/shared'
 import type { ChangeSource, ChangedFileStatus } from '@proma/shared'
 
@@ -295,7 +295,7 @@ export async function getUnstagedChanges(
  * （`C:/.../repo`），而 Node `path.join` 返回反斜杠（`C:\...\repo`）。统一用 resolve
  * 规范化并转为正斜杠，确保同一仓库的两种写法被识别为同一个根，避免重复跑 git diff。
  */
-function normalizeGitRoot(p: string): string {
+export function normalizeGitRoot(p: string): string {
   return resolve(p).replace(/\\/g, '/')
 }
 
@@ -335,7 +335,7 @@ function findAllGitRootsDown(dirPath: string, maxDepth: number): string[] {
 }
 
 /** 查找 Git 仓库根目录（支持向上搜索子目录内的 repos），返回所有找到的根 */
-async function findAllGitRoots(baseDir: string): Promise<string[]> {
+export async function findAllGitRoots(baseDir: string): Promise<string[]> {
   if (!existsSync(baseDir)) return []
 
   // 1. 向上搜索：git rev-parse --show-toplevel
@@ -484,6 +484,26 @@ export async function revertFile(dirPath: string, filePath: string, gitRoot?: st
   if (result === null) {
     throw new Error(`还原失败: git checkout -- ${safePath}`)
   }
+}
+
+/**
+ * 解析给定路径所属 git 仓库的「主仓库根目录」。
+ *
+ * 对于 worktree，git 的公共目录（--git-common-dir）始终指向主仓库的 .git，
+ * 因此其父目录即主仓库根。普通仓库返回自身根目录。非 git 路径返回 null。
+ *
+ * 用于安全校验：worktree 常被放在主仓库之外（如 ~/proma-dev/worktrees/xxx），
+ * 直接判定其路径会越界；改为校验它回溯到的主仓库是否已授权。
+ */
+export async function getMainRepoRoot(somePath: string): Promise<string | null> {
+  if (!existsSync(somePath)) return null
+  const commonDir = await runGitCommand(
+    ['rev-parse', '--path-format=absolute', '--git-common-dir'],
+    somePath,
+  )
+  if (!commonDir) return null
+  // commonDir 形如 /path/to/main-repo/.git，取其父目录
+  return normalizeGitRoot(dirname(commonDir))
 }
 
 /**

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -109,14 +109,14 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   const selectedWorktreePath = selectedWorktreeMap.get(sessionId) ?? null
 
   const handleWorktreeSelect = React.useCallback((worktree: import('@proma/shared').WorktreeInfo | null) => {
+    // 仅切换 diff 视图，不再自动把 worktree 挂进会话目录。
+    // worktree 的 diff 读取已由主进程的 ensurePathAllowedWithWorktree 凭 git 背书放行，
+    // 无需借「附加目录」绕过安全检查；是否让 Agent 访问该 worktree 交由用户手动决定。
     setSelectedWorktreeMap((prev) => {
       const m = new Map(prev)
       m.set(sessionId, worktree?.path ?? null)
       return m
     })
-    if (worktree) {
-      window.electronAPI.attachDirectory({ sessionId, directoryPath: worktree.path })
-    }
   }, [sessionId, setSelectedWorktreeMap])
 
   const handleDiffFileClick = React.useCallback((filePath: string, _isUntracked: boolean, gitRoot?: string) => {


### PR DESCRIPTION
## 背景

右侧「文件改动」面板的 worktree 选择器有三个连锁问题，导致 worktree 完全不可用。逐层修复。

## 问题与修复

### 1. 下拉为空，找不到任何 worktree
`getWorktreeRepos` 只读工作区 `config.json` 里手动维护的 `worktreeRepos`。一旦主仓库目录移动，`repoPath` 失效，`git worktree list` 直接 fatal 且被 `catch {}` 静默吞掉，下拉永远空。

**修复**：改为从工作区**附加目录自动探测** git 仓库根（复用 `findAllGitRoots`），不再依赖易失效的手动路径；同时合并仍存在的手动配置、自动过滤掉路径已不存在的陈旧条目。`getWorktreeRepos` 改为 async。

### 2. 选中 worktree 后报「不是 git 仓库」
worktree 按设计放在主仓库**之外**（如 `~/proma-dev/worktrees/xxx`），不在任何授权根下，被 `ensurePathAllowed` 拦截，`getWorktreeChanges` 直接返回 `isGitRepo: false`。同样的墙还挡住了 worktree 内文件的 diff。

**修复**：新增 `ensurePathAllowedWithWorktree`——同步检查失败时，用 `git rev-parse --path-format=absolute --git-common-dir` 回溯到该 worktree 的主仓库根，**仅当主仓库本身已被授权才放行**。覆盖全部 5 个相关 handler（`GET_WORKTREE_CHANGES`、`GET_FILE_DIFF`、`GET_UNTRACKED_CONTENT`、`GET_DIFF_CONTENTS`、`REVERT_FILE`）。安全边界不变：越权路径（`/tmp`、home 根等）仍拒绝。

### 3. 选中 worktree 自动污染会话目录
`handleWorktreeSelect` 在选中 worktree 看 diff 时会顺手 `attachDirectory` 把它挂进会话目录。多个 worktree 累积会污染会话状态。这个 attach 原本是早期为绕过路径安全检查的 workaround，问题 2 修复后已多余。

**修复**：移除该副作用。「看 diff」与「授予 Agent 访问权」解耦——选中只切换 diff 视图，要让 Agent 读写某 worktree 由用户手动「附加文件夹」决定。

## 改动文件
- `apps/electron/src/main/lib/git-diff-service.ts` — 导出 `findAllGitRoots`/`normalizeGitRoot`，新增 `getMainRepoRoot`
- `apps/electron/src/main/lib/agent-workspace-manager.ts` — `getWorktreeRepos` 自动探测
- `apps/electron/src/main/ipc.ts` — `ensurePathAllowedWithWorktree` + 5 个 handler 切换
- `apps/electron/src/renderer/components/agent/SidePanel.tsx` — 移除选中 worktree 的自动 attach

## 验证
- `@proma/electron` typecheck 通过
- 用真实 config/worktree 模拟两条核心逻辑：自动探测正确列出全部 worktree、越权路径仍被拒绝

## Test plan
- [ ] 主仓库移动后，文件改动面板仍能列出其 worktree
- [ ] 选中外置 worktree 能正常显示 diff，不再报「不是 git 仓库」
- [ ] 点击 worktree 内文件能查看 diff 内容
- [ ] 选中 worktree 后会话目录不再被自动挂载
- [ ] 越权路径（worktree 外的任意目录）仍被安全拒绝

🤖 Generated with [Claude Code](https://claude.com/claude-code)