### PR TITLE
fix(agent): 删除 Agent 会话后右侧文件面板不再报 ENOENT

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -2622,7 +2622,7 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(
     AGENT_IPC_CHANNELS.LIST_DIRECTORY,
     async (_, dirPath: string): Promise<FileEntry[]> => {
-      const { readdirSync, statSync } = await import('node:fs')
+      const { existsSync, readdirSync, statSync } = await import('node:fs')
       const { resolve } = await import('node:path')
 
       // 安全校验：路径必须在 agent-workspaces 目录下
@@ -2630,6 +2630,11 @@ export function registerIpcHandlers(): void {
       const workspacesRoot = resolve(getAgentWorkspacesDir())
       if (!safePath.startsWith(workspacesRoot)) {
         throw new Error('访问路径超出 Agent 工作区范围')
+      }
+
+      // 目录可能已被删除（如删除 Agent 会话后面板仍持有旧路径），优雅返回空列表
+      if (!existsSync(safePath)) {
+        return []
       }
 
       const entries: FileEntry[] = []

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -41,6 +41,7 @@ import {
   agentModelIdAtom,
   agentSessionChannelMapAtom,
   agentSessionModelMapAtom,
+  agentSessionPathMapAtom,
   currentAgentWorkspaceIdAtom,
   agentWorkspacesAtom,
   workspaceCapabilitiesVersionAtom,
@@ -392,6 +393,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   const agentModelId = useAtomValue(agentModelIdAtom)
   const setSessionChannelMap = useSetAtom(agentSessionChannelMapAtom)
   const setSessionModelMap = useSetAtom(agentSessionModelMapAtom)
+  const setSessionPathMap = useSetAtom(agentSessionPathMapAtom)
   const [currentWorkspaceId, setCurrentWorkspaceId] = useAtom(currentAgentWorkspaceIdAtom)
   const [workspaces, setWorkspaces] = useAtom(agentWorkspacesAtom)
   const setMode = useSetAtom(appModeAtom)
@@ -468,6 +470,8 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     setDiffData(deleteKey)
     setSessionChannelMap(deleteKey)
     setSessionModelMap(deleteKey)
+    // 会话工作目录路径：不清理会导致右侧文件面板继续用已删除目录请求 list-directory
+    setSessionPathMap(deleteKey)
     // 视图状态（预览开关 + 上次视图）：删除/归档是终态，统一清理避免孤立条目
     setSessionViewStateMap(deleteKey)
 
@@ -497,7 +501,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     sessionExistsAtom.remove(id)
 
     clearPreviewCacheForSession(id)
-  }, [setConvModels, setConvContextLength, setConvThinking, setConvParallel, setConvPromptId, setPreviewPanelOpen, setPreviewFile, setDiffPanelTab, setDiffRefreshVersion, setDiffUnseen, setDiffUnseenFiles, setDiffData, setSessionChannelMap, setSessionModelMap, setSessionViewStateMap, setStreamingStates, setLiveMessagesMap, setSessionPendingFiles, store])
+  }, [setConvModels, setConvContextLength, setConvThinking, setConvParallel, setConvPromptId, setPreviewPanelOpen, setPreviewFile, setDiffPanelTab, setDiffRefreshVersion, setDiffUnseen, setDiffUnseenFiles, setDiffData, setSessionChannelMap, setSessionModelMap, setSessionPathMap, setSessionViewStateMap, setStreamingStates, setLiveMessagesMap, setSessionPendingFiles, store])
 
   const currentWorkspaceSlug = React.useMemo(() => {
     if (!currentWorkspaceId) return null


### PR DESCRIPTION
## Summary
- 删除 Agent 会话后右侧文件面板不再抛 `Error invoking remote method 'agent:list-directory': ENOENT`
- 主进程 `list-directory` handler 增加目录存在性检查，目录不存在时优雅返回空列表，吸收竞态
- `LeftSidebar.tsx` 的 `cleanupMapAtoms` 补充清理 `agentSessionPathMapAtom`，删除会话时同步清掉已失效的路径，面板正确回到无会话状态

## 根因
两层叠加：
1. 渲染端状态滞留——`cleanupMapAtoms` 漏掉 `agentSessionPathMapAtom`，删除会话后已删目录路径仍留在 map 中，`RightSidePanel` 继续用它渲染 `FileBrowser`
2. 主进程不容错——`ipc.ts` 的 `agent:list-directory` 对不存在目录直接 `readdirSync` 抛 ENOENT，原样透传到面板

## 修复策略（双层防御）
- **主进程容错**（兜底，吸收所有竞态）：`apps/electron/src/main/ipc.ts` 安全校验后增加 `existsSync`，目录不存在返回 `[]`
- **渲染端清理**（根因修复）：`cleanupMapAtoms` 补 `setSessionPathMap(deleteKey)`

## Test plan
- [x] 类型检查通过（`bun run typecheck` 四个包全部 exit 0）
- [ ] 手动验证：Agent 模式下删除当前活跃会话，右侧文件面板不再显示 ENOENT 错误
- [ ] 手动验证：删除非当前会话，列表与面板表现正常
- [ ] 手动验证：切换到其他会话后文件面板正常加载