### PR TITLE
feat(search): 复用 SessionMiniMapPopover 替代搜索弹窗自实现的预览卡片

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/SearchDialog.tsx
+++ b/apps/electron/src/renderer/components/app-shell/SearchDialog.tsx
@@ -31,16 +31,13 @@ import {
 import { activeViewAtom } from '@/atoms/active-view'
 import { useOpenSession } from '@/hooks/useOpenSession'
 import { useCreateSession } from '@/hooks/useCreateSession'
+import {
+  SessionMiniMapPopover,
+  useSessionMiniMapHover,
+} from '@/components/session-preview/SessionMiniMapPopover'
 import type {
-  ChatMessage,
   MessageSearchResult,
   AgentMessageSearchResult,
-  SDKMessage,
-  SDKAssistantMessage,
-  SDKSystemMessage,
-  SDKUserMessage,
-  SDKContentBlock,
-  SDKUserContentBlock,
 } from '@proma/shared'
 
 /** 标题搜索结果项 */
@@ -65,22 +62,6 @@ interface ContentResult {
 }
 
 type SearchResult = TitleResult | ContentResult
-
-interface SearchPreviewTarget {
-  result: SearchResult
-}
-
-interface SessionPreviewItem {
-  id: string
-  role: 'user' | 'assistant' | 'status'
-  preview: string
-  matched: boolean
-}
-
-interface SearchResultSessionPreviewProps {
-  target: SearchPreviewTarget | null
-  committedQuery: string
-}
 
 function isContentResult(result: SearchResult): result is ContentResult {
   return 'snippet' in result
@@ -145,225 +126,87 @@ function SearchResultIcon({ result }: { result: SearchResult }): React.ReactElem
   )
 }
 
-function normalizePreviewText(text: string): string {
-  return text
-    .replace(/<attached_files>[\s\S]*?<\/attached_files>\n*/g, '')
-    .replace(/<quoted_file[^>]*>[\s\S]*?<\/quoted_file>\n*/g, '')
-    .replace(/\s+/g, ' ')
-    .trim()
+interface SearchResultRowProps {
+  result: SearchResult
+  index: number
+  isSelected: boolean
+  committedQuery: string
+  getAgentWorkspaceName: (sessionId: string) => string | undefined
+  onSelect: (result: SearchResult) => void
+  onHover: (index: number) => void
 }
 
-function sdkBlockText(block: SDKContentBlock | SDKUserContentBlock): string {
-  if (block.type === 'text' && 'text' in block && typeof block.text === 'string') {
-    return block.text
-  }
-  if (block.type === 'thinking' && 'thinking' in block && typeof block.thinking === 'string') {
-    return block.thinking
-  }
-  if (block.type === 'tool_use' && 'name' in block && typeof block.name === 'string') {
-    const toolName = block.name || 'tool'
-    return `调用工具 ${toolName}`
-  }
-  if (block.type === 'tool_result') {
-    return block.is_error ? '工具结果出错' : '工具返回结果'
-  }
-  return ''
-}
-
-function buildChatPreviewItems(messages: ChatMessage[], matchMessageId?: string): SessionPreviewItem[] {
-  return messages
-    .map((message) => ({
-      id: message.id,
-      role: message.role === 'user' ? 'user' as const : message.role === 'assistant' ? 'assistant' as const : 'status' as const,
-      preview: normalizePreviewText(message.content).slice(0, 220),
-      matched: message.id === matchMessageId,
-    }))
-    .filter((item) => item.preview.length > 0)
-}
-
-function buildAgentPreviewItems(messages: SDKMessage[], matchMessageId?: string): SessionPreviewItem[] {
-  const items: SessionPreviewItem[] = []
-
-  for (const message of messages) {
-    if (message.type === 'assistant') {
-      const assistant = message as SDKAssistantMessage
-      const blocks = Array.isArray(assistant.message?.content) ? assistant.message.content : []
-      const preview = normalizePreviewText(blocks.map(sdkBlockText).filter(Boolean).join(' ')).slice(0, 220)
-      if (preview) {
-        items.push({
-          id: assistant.uuid ?? `assistant-${items.length}`,
-          role: 'assistant',
-          preview,
-          matched: assistant.uuid === matchMessageId,
-        })
-      }
-      continue
-    }
-
-    if (message.type === 'user') {
-      const user = message as SDKUserMessage
-      const blocks = Array.isArray(user.message?.content) ? user.message.content : []
-      const preview = normalizePreviewText(blocks.map(sdkBlockText).filter(Boolean).join(' ')).slice(0, 220)
-      if (preview) {
-        items.push({
-          id: user.uuid ?? `user-${items.length}`,
-          role: 'user',
-          preview,
-          matched: user.uuid === matchMessageId,
-        })
-      }
-      continue
-    }
-
-    if (message.type === 'system') {
-      const system = message as SDKSystemMessage
-      const preview = system.subtype === 'compact_boundary'
-        ? '上下文已压缩'
-        : system.subtype === 'compacting'
-          ? '正在压缩上下文...'
-          : system.subtype === 'permission_denied'
-            ? '自动审批已拒绝操作'
-            : ''
-      if (preview) {
-        items.push({
-          id: `${system.subtype ?? 'system'}-${items.length}`,
-          role: 'status',
-          preview,
-          matched: false,
-        })
-      }
-    }
-  }
-
-  return items
-}
-
-function SearchResultSessionPreview({ target, committedQuery }: SearchResultSessionPreviewProps): React.ReactElement | null {
-  const [items, setItems] = React.useState<SessionPreviewItem[]>([])
-  const [loading, setLoading] = React.useState(false)
-  const [error, setError] = React.useState<string | null>(null)
-  const cacheRef = React.useRef<Map<string, SessionPreviewItem[]>>(new Map())
-
-  React.useEffect(() => {
-    if (!target) {
-      setItems([])
-      setLoading(false)
-      setError(null)
-      return
-    }
-
-    const key = `${target.result.type}:${target.result.id}:${isContentResult(target.result) ? target.result.messageId : 'title'}`
-    const cached = cacheRef.current.get(key)
-    if (cached) {
-      setItems(cached)
-      setLoading(false)
-      setError(null)
-      return
-    }
-
-    let cancelled = false
-    setLoading(true)
-    setError(null)
-
-    const load = async (): Promise<void> => {
-      try {
-        const matchMessageId = isContentResult(target.result) ? target.result.messageId : undefined
-        const nextItems = target.result.type === 'chat'
-          ? buildChatPreviewItems(await window.electronAPI.getConversationMessages(target.result.id), matchMessageId)
-          : buildAgentPreviewItems(await window.electronAPI.getAgentSessionSDKMessages(target.result.id), matchMessageId)
-        if (cancelled) return
-        cacheRef.current.set(key, nextItems)
-        setItems(nextItems)
-      } catch (loadError) {
-        console.error('[搜索] 会话迷你地图加载失败:', loadError)
-        if (!cancelled) setError('无法加载会话内容')
-      } finally {
-        if (!cancelled) setLoading(false)
-      }
-    }
-
-    void load()
-    return () => {
-      cancelled = true
-    }
-  }, [target])
-
-  if (!target) return null
-
-  const matchedIndex = items.findIndex((item) => item.matched)
+function SearchResultRow({
+  result,
+  index,
+  isSelected,
+  committedQuery,
+  getAgentWorkspaceName,
+  onSelect,
+  onHover,
+}: SearchResultRowProps): React.ReactElement {
+  const preview = useSessionMiniMapHover(400)
+  const isContent = isContentResult(result)
+  const wsName = result.type === 'agent' ? getAgentWorkspaceName(result.id) : undefined
 
   return (
-    <div className="absolute right-2 top-2 bottom-2 z-20 w-[286px] pointer-events-none">
-      <div className="h-full max-h-[380px] rounded-lg border bg-popover shadow-xl overflow-hidden pointer-events-auto animate-in fade-in-0 zoom-in-95 duration-150">
-        <div className="flex items-center justify-between gap-2 px-3 py-2 border-b">
-          <div className="min-w-0 flex items-center gap-2">
-            <SearchResultIcon result={target.result} />
-            <span className="truncate text-xs font-medium text-popover-foreground/75">
-              {target.result.title}
-            </span>
-          </div>
-          <span className="shrink-0 text-[11px] text-muted-foreground tabular-nums">
-            {loading ? '加载中' : `${items.length} 条`}
+    <>
+      <button
+        ref={preview.setAnchorRef}
+        data-index={index}
+        onClick={() => onSelect(result)}
+        onMouseEnter={() => {
+          onHover(index)
+          preview.handleMouseEnter()
+        }}
+        onMouseLeave={preview.handleMouseLeave}
+        className={cn(
+          'w-full px-4 py-2 text-left transition-colors',
+          isContent ? 'flex flex-col gap-0.5' : 'flex items-center gap-2.5',
+          isSelected
+            ? 'bg-primary/10'
+            : 'hover:bg-foreground/[0.04]',
+          result.archived && 'opacity-60'
+        )}
+      >
+        <div className="flex items-center gap-2.5">
+          <SearchResultIcon result={result} />
+          <span className="flex-1 min-w-0 truncate text-[13px] text-foreground/80">
+            {isContent ? result.title : <HighlightText text={result.title} query={committedQuery} />}
           </span>
-        </div>
-
-        <div className="max-h-[336px] overflow-y-auto scrollbar-thin p-2">
-          {loading && (
-            <div className="py-8 flex items-center justify-center gap-2 text-xs text-muted-foreground">
-              <Loader2 size={13} className="animate-spin" />
-              <span>正在读取会话...</span>
-            </div>
+          {wsName && (
+            <span className="flex-shrink-0 px-1.5 py-0 rounded-full bg-foreground/[0.06] text-[10px] leading-4 text-foreground/40 font-medium truncate max-w-[80px]">
+              {wsName}
+            </span>
           )}
-
-          {!loading && error && (
-            <div className="py-8 text-center text-xs text-muted-foreground">{error}</div>
-          )}
-
-          {!loading && !error && items.length === 0 && (
-            <div className="py-8 text-center text-xs text-muted-foreground">暂无可预览内容</div>
-          )}
-
-          {!loading && !error && items.length > 0 && (
-            <div className="space-y-1">
-              {items.map((item, index) => (
-                <div
-                  key={`${item.id}-${index}`}
-                  className={cn(
-                    'flex items-start gap-2 rounded-md px-1.5 py-1.5',
-                    item.matched && 'bg-primary/10'
-                  )}
-                >
-                  <div className="relative mt-1 w-7 shrink-0">
-                    <div
-                      className={cn(
-                        'h-[3px] rounded-full',
-                        item.matched
-                          ? 'bg-primary'
-                          : item.role === 'user'
-                            ? 'bg-primary/35'
-                            : item.role === 'assistant'
-                              ? 'bg-blue-500/35'
-                              : 'bg-foreground/20'
-                      )}
-                    />
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <div className="line-clamp-2 text-[11px] leading-4 text-popover-foreground/70">
-                      <HighlightText text={item.preview} query={committedQuery} />
-                    </div>
-                  </div>
-                </div>
-              ))}
-              {matchedIndex >= 0 && (
-                <div className="pt-1 text-center text-[10px] text-muted-foreground">
-                  已定位到第 {matchedIndex + 1} 条匹配消息
-                </div>
-              )}
-            </div>
+          {result.archived && (
+            <Archive size={12} className="flex-shrink-0 text-foreground/30" />
           )}
         </div>
-      </div>
-    </div>
+        {isContent && (
+          <div className="pl-[22px] text-[12px] text-foreground/50 truncate">
+            <HighlightSnippet
+              snippet={result.snippet}
+              matchStart={result.matchStart}
+              matchLength={result.matchLength}
+            />
+          </div>
+        )}
+      </button>
+      <SessionMiniMapPopover
+        target={{
+          type: result.type,
+          sessionId: result.id,
+          title: result.title,
+          workspaceName: wsName,
+        }}
+        anchorRef={preview.anchorRef}
+        open={preview.isOpen}
+        isLeaving={preview.isLeaving}
+        onMouseEnter={preview.handlePanelMouseEnter}
+        onMouseLeave={preview.handlePanelMouseLeave}
+      />
+    </>
   )
 }
 
@@ -400,7 +243,6 @@ export function SearchDialog(): React.ReactElement {
   const [selectedIndex, setSelectedIndex] = React.useState(0)
   const [loading, setLoading] = React.useState(false)
   const [hasSearched, setHasSearched] = React.useState(false)
-  const [previewTarget, setPreviewTarget] = React.useState<SearchPreviewTarget | null>(null)
   const inputRef = React.useRef<HTMLInputElement>(null)
   const listRef = React.useRef<HTMLDivElement>(null)
   const isComposingRef = React.useRef(false)
@@ -426,7 +268,6 @@ export function SearchDialog(): React.ReactElement {
     setContentResults([])
     setHasSearched(false)
     setSelectedIndex(0)
-    setPreviewTarget(null)
     searchTokenRef.current += 1
     setLoading(false)
     inputRef.current?.focus()
@@ -444,7 +285,6 @@ export function SearchDialog(): React.ReactElement {
       setContentResults([])
       setHasSearched(false)
       setCommittedQuery('')
-      setPreviewTarget(null)
       return
     }
 
@@ -453,7 +293,6 @@ export function SearchDialog(): React.ReactElement {
     setHasSearched(true)
     setLoading(true)
     setSelectedIndex(0)
-    setPreviewTarget(null)
 
     const qLower = q.toLowerCase()
     const titles: TitleResult[] = [
@@ -610,7 +449,6 @@ export function SearchDialog(): React.ReactElement {
       setContentResults([])
       setHasSearched(false)
       setSelectedIndex(0)
-      setPreviewTarget(null)
       setLoading(false)
       setTimeout(() => inputRef.current?.focus(), 50)
     }
@@ -621,7 +459,7 @@ export function SearchDialog(): React.ReactElement {
   const isQueryDirty = trimmedQuery !== committedQuery
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={setOpen} modal={false}>
       <DialogContent
         hideClose
         className="sm:max-w-[520px] p-0 gap-0 overflow-hidden"
@@ -680,10 +518,7 @@ export function SearchDialog(): React.ReactElement {
         </div>
 
         {/* 搜索结果 */}
-        <div
-          className="relative"
-          onMouseLeave={() => setPreviewTarget(null)}
-        >
+        <div className="relative">
           <div ref={listRef} className="max-h-[400px] overflow-y-auto scrollbar-thin">
           {!hasSearched && (
             <div className="py-12 text-center text-[13px] text-foreground/40">
@@ -722,38 +557,16 @@ export function SearchDialog(): React.ReactElement {
                 标题匹配
               </div>
               {titleResults.map((result, idx) => (
-                <button
+                <SearchResultRow
                   key={`title-${result.id}`}
-                  data-index={idx}
-                  onClick={() => navigateToResult(result)}
-                  onMouseEnter={() => {
-                    setSelectedIndex(idx)
-                    setPreviewTarget({ result })
-                  }}
-                  className={cn(
-                    'w-full flex items-center gap-2.5 px-4 py-2 text-left transition-colors',
-                    selectedIndex === idx
-                      ? 'bg-primary/10'
-                      : 'hover:bg-foreground/[0.04]',
-                    result.archived && 'opacity-60'
-                  )}
-                >
-                  <SearchResultIcon result={result} />
-                  <span className="flex-1 min-w-0 truncate text-[13px] text-foreground/80">
-                    <HighlightText text={result.title} query={committedQuery} />
-                  </span>
-                  {result.type === 'agent' && (() => {
-                    const wsName = getAgentWorkspaceName(result.id)
-                    return wsName ? (
-                      <span className="flex-shrink-0 px-1.5 py-0 rounded-full bg-foreground/[0.06] text-[10px] leading-4 text-foreground/40 font-medium truncate max-w-[80px]">
-                        {wsName}
-                      </span>
-                    ) : null
-                  })()}
-                  {result.archived && (
-                    <Archive size={12} className="flex-shrink-0 text-foreground/30" />
-                  )}
-                </button>
+                  result={result}
+                  index={idx}
+                  isSelected={selectedIndex === idx}
+                  committedQuery={committedQuery}
+                  getAgentWorkspaceName={getAgentWorkspaceName}
+                  onSelect={navigateToResult}
+                  onHover={setSelectedIndex}
+                />
               ))}
             </div>
           )}
@@ -765,60 +578,21 @@ export function SearchDialog(): React.ReactElement {
                 <span>消息内容匹配</span>
                 {loading && <Loader2 size={12} className="animate-spin text-foreground/30" />}
               </div>
-              {contentResults.map((result, i) => {
-                const globalIdx = titleResults.length + i
-                return (
-                  <button
-                    key={`content-${result.id}-${result.messageId}`}
-                    data-index={globalIdx}
-                    onClick={() => navigateToResult(result)}
-                    onMouseEnter={() => {
-                      setSelectedIndex(globalIdx)
-                      setPreviewTarget({ result })
-                    }}
-                    className={cn(
-                      'w-full flex flex-col gap-0.5 px-4 py-2 text-left transition-colors',
-                      selectedIndex === globalIdx
-                        ? 'bg-primary/10'
-                        : 'hover:bg-foreground/[0.04]',
-                      result.archived && 'opacity-60'
-                    )}
-                  >
-                    <div className="flex items-center gap-2.5">
-                      <SearchResultIcon result={result} />
-                      <span className="flex-1 min-w-0 truncate text-[13px] text-foreground/80">
-                        {result.title}
-                      </span>
-                      {result.type === 'agent' && (() => {
-                        const wsName = getAgentWorkspaceName(result.id)
-                        return wsName ? (
-                          <span className="flex-shrink-0 px-1.5 py-0 rounded-full bg-foreground/[0.06] text-[10px] leading-4 text-foreground/40 font-medium truncate max-w-[80px]">
-                            {wsName}
-                          </span>
-                        ) : null
-                      })()}
-                      {result.archived && (
-                        <Archive size={12} className="flex-shrink-0 text-foreground/30" />
-                      )}
-                    </div>
-                    <div className="pl-[22px] text-[12px] text-foreground/50 truncate">
-                      <HighlightSnippet
-                        snippet={result.snippet}
-                        matchStart={result.matchStart}
-                        matchLength={result.matchLength}
-                      />
-                    </div>
-                  </button>
-                )
-              })}
+              {contentResults.map((result, i) => (
+                <SearchResultRow
+                  key={`content-${result.id}-${result.messageId}`}
+                  result={result}
+                  index={titleResults.length + i}
+                  isSelected={selectedIndex === titleResults.length + i}
+                  committedQuery={committedQuery}
+                  getAgentWorkspaceName={getAgentWorkspaceName}
+                  onSelect={navigateToResult}
+                  onHover={setSelectedIndex}
+                />
+              ))}
             </div>
           )}
           </div>
-
-          <SearchResultSessionPreview
-            target={previewTarget}
-            committedQuery={committedQuery}
-          />
         </div>
 
         {/* 底部快捷键提示 */}

--- a/apps/electron/src/renderer/components/session-preview/SessionMiniMapPopover.tsx
+++ b/apps/electron/src/renderer/components/session-preview/SessionMiniMapPopover.tsx
@@ -407,7 +407,7 @@ function SessionMiniMapPopoverContent({
 
   return createPortal(
     <div
-      className="fixed z-[9999] titlebar-no-drag transition-[top,height] duration-150 ease-out"
+      className="fixed z-[9999] titlebar-no-drag transition-[top,height] duration-150 ease-out pointer-events-auto"
       style={{ top: position.top, left: position.left, width: PANEL_WIDTH, height: position.height }}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}


### PR DESCRIPTION
## Summary

- 搜索弹窗的 SearchResultSessionPreview 与左栏 SessionMiniMapPopover 是两套独立实现，前者在 Dialog 内 absolute 定位会被 `overflow-hidden` 裁剪、被滚动列表项遮盖；后者用 `createPortal` + `z-[9999]` 抗遮盖
- 直接复用 SessionMiniMapPopover：抽出 `SearchResultRow`，每项挂 `useSessionMiniMapHover(400)` + `<SessionMiniMapPopover>`，删除自实现的预览组件、build\*PreviewItems、sdkBlockText、各类 Preview 接口（净减约 226 行）
- 去掉搜索专有的"匹配消息高亮"逻辑，与左栏体验一致
- 走 `tabMinimapCacheAtom` 缓存，与左栏共享已打开会话的预读结果

## 兼容性修复

- `SessionMiniMapPopover` 根 div 显式 `pointer-events-auto`，让 portal 内容在 Radix Dialog modal 模式（body `pointer-events: none`）下也能接收鼠标事件
- `SearchDialog` 改 `modal={false}`，避免 `react-remove-scroll` 在 document capture 阶段拦截 wheel 事件，导致 popover 内的会话列表无法用滚轮滚动

## Test plan

- [x] 类型检查通过（`bunx tsc --noEmit`）
- [ ] 打开搜索弹窗（Cmd/Ctrl+K 或搜索按钮）
- [ ] hover 标题匹配结果 → mini map 在右侧弹出
- [ ] hover 内容匹配结果 → mini map 同样弹出
- [ ] 鼠标移到 mini map 上 → 不消失，可点击内部
- [ ] 在 mini map 内用鼠标滚轮 → 消息列表正常滚动
- [ ] ESC / 点击外部 → 弹窗正常关闭（modal=false 仍由 DismissableLayer 处理）
- [ ] 左栏会话项 hover → mini map 仍然正常工作（pointer-events-auto 对非 Dialog 场景无副作用）

🤖 Generated with [Claude Code](https://claude.com/claude-code)