### PR TITLE
fix(agent): task_notification 不再截断活跃的 assistant turn

### DIFF
--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -348,14 +348,16 @@ export function groupIntoTurns(messages: SDKMessage[], sessionModelId?: string):
       if (sysMsg.subtype === 'compact_boundary' || sysMsg.subtype === 'compacting' || sysMsg.subtype === 'permission_denied') {
         flushTurn()
         groups.push({ type: 'system', message: sysMsg })
-      } else if (currentTurn) {
-        currentTurn.turnMessages.push(msg)
-        // 后台任务完成通知：标志一次自动唤醒。当前 turn 收尾后，
-        // 后续新出现的 assistant 输出应独立成块。
-        if (sysMsg.subtype === 'task_notification') {
-          flushTurn()
+      } else if (sysMsg.subtype === 'task_notification') {
+        // 后台任务完成通知：仅在没有进行中的 turn 时标记唤醒边界（真正的唤醒场景）。
+        // 若当前有 turn 正在进行，归入当前 turn 不截断。
+        if (currentTurn) {
+          currentTurn.turnMessages.push(msg)
+        } else {
           pendingWakeBoundary = true
         }
+      } else if (currentTurn) {
+        currentTurn.turnMessages.push(msg)
       }
     } else {
       // result, tool_progress 等 → 归入当前 turn


### PR DESCRIPTION
## Summary

- 修复 `groupIntoTurns` 中 task_notification 错误截断活跃 assistant turn 的问题
- Agent 思考/输出过程中收到后台任务完成通知时，回复会被切成两块并打上"自动唤醒边界"标记
- 调整分支优先级：当前已有 turn 时归入当前 turn，仅在没有 turn（真正唤醒场景）才设 `pendingWakeBoundary`

## 复现场景

Agent 正在回复用户 → 后台任务（如自动化任务）完成 → SDK 推送 `task_notification` → 原逻辑触发 `flushTurn()` → 同一次回复被切成两块，且后续块标记为 `startsAfterWake`，视觉上像两次独立回复。

## Test plan

- [x] 类型检查通过
- [ ] 触发 Agent 回复过程中收到 task_notification → 验证回复仍是单块
- [ ] Agent 空闲时收到 task_notification → 验证后续回复仍标记为自动唤醒

🤖 Generated with [Claude Code](https://claude.com/claude-code)