### PR TITLE
fix(agent): input_tokens 已是总量，删除重复加 cache 的错误公式

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -20,7 +20,7 @@ import { join, dirname } from 'node:path'
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { app } from 'electron'
-import type { AgentSendInput, AgentMessage, AgentGenerateTitleInput, AgentProviderAdapter, AgentSessionMeta, TypedError, RetryAttempt, SDKMessage, SDKAssistantMessage, AgentStreamPayload, RewindSessionResult, SdkBeta, ProviderType } from '@proma/shared'
+import type { AgentSendInput, AgentMessage, AgentGenerateTitleInput, AgentProviderAdapter, AgentSessionMeta, TypedError, RetryAttempt, SDKMessage, SDKAssistantMessage, SDKResultMessage, AgentStreamPayload, RewindSessionResult, SdkBeta, ProviderType } from '@proma/shared'
 import {
   PROMA_DEFAULT_PERMISSION_MODE,
   PROMA_PERMISSION_MODE_CONFIG,
@@ -38,6 +38,7 @@ import { AgentEventBus } from './agent-event-bus'
 import { decryptApiKey, getChannelById, listChannels } from './channel-manager'
 import { injectAutomationMcpServer } from './automation-agent-tools'
 import { getAdapter, fetchTitle, normalizeAnthropicBaseUrlForSdk, getPromaUserAgent } from '@proma/core'
+import { normalizeUsage } from '@proma/shared'
 import pkg from '../../../package.json' with { type: 'json' }
 import { getFetchFn } from './proxy-fetch'
 import { getEffectiveProxyUrl } from './proxy-settings-service'
@@ -477,6 +478,32 @@ function collectAttachedDirectories(params: {
   }
 
   return result
+}
+
+/**
+ * 把 SDKMessage 内嵌的 usage 归一化为 Anthropic 语义（原地修改）。
+ *
+ * 仅对 assistant / result 消息生效；其他类型直接返回。
+ * 归一化逻辑见 packages/shared 的 normalizeUsage；此处仅做字段定位。
+ */
+function normalizeSDKMessageUsage(msg: SDKMessage, provider: string | undefined | null): void {
+  if (msg.type === 'assistant') {
+    const inner = (msg as SDKAssistantMessage).message
+    if (inner?.usage) {
+      const normalized = normalizeUsage(inner.usage, provider)
+      if (normalized && normalized !== inner.usage) {
+        inner.usage = normalized
+      }
+    }
+  } else if (msg.type === 'result') {
+    const rMsg = msg as SDKResultMessage
+    if (rMsg.usage) {
+      const normalized = normalizeUsage(rMsg.usage, provider)
+      if (normalized && normalized !== rMsg.usage) {
+        rMsg.usage = normalized
+      }
+    }
+  }
 }
 
 // ===== AgentOrchestrator =====
@@ -1869,6 +1896,12 @@ export class AgentOrchestrator {
                   // 为 assistant 消息注入渠道 modelId，确保持久化后能正确匹配模型显示名
                   if (msg.type === 'assistant' && modelId) {
                     (msg as Record<string, unknown>)._channelModelId = modelId
+                  }
+                  // OpenAI 兼容渠道（zhipu / openai / doubao / qwen / custom）的 usage
+                  // 需要归一化为 Anthropic 语义，避免下游公式 input + cache_read 重复计数。
+                  // 单点处理：持久化和 emit 共用同一引用，故两路都受益。
+                  if (msg.type === 'assistant' || msg.type === 'result') {
+                    normalizeSDKMessageUsage(msg, channel.provider)
                   }
                   accumulatedMessages.push(msg)
                 }

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -693,6 +693,9 @@ export function applyAgentEvent(
       // 同步把 result 里真实的 usage（inputTokens / outputTokens / contextWindow 等）
       // 写入 streamState。SDK 流式过程中 message.usage 一直是 0，只有 result 里才有真实值，
       // 不在这里写入的话上下文指示器分母和分子会永远停留在 0 或上次会话的残留。
+      //
+      // 全字段条件 spread：event.usage 中的 undefined 字段不覆盖 prev 已有值，
+      // 避免流式 usage_update 已写入的真实值被 result 的空字段清零。
       return {
         ...prev,
         ...(event.usage ? {
@@ -702,18 +705,10 @@ export function applyAgentEvent(
           ...(event.usage.cacheCreationTokens != null && { cacheCreationTokens: event.usage.cacheCreationTokens }),
           ...(event.usage.costUsd != null && { costUsd: event.usage.costUsd }),
           ...(event.usage.contextWindow != null && { contextWindow: event.usage.contextWindow }),
+          usageUpdatedAt: Date.now(),
         } : {}),
         retrying: undefined,
         ...finalizeStreamingActivities(prev.toolActivities),
-        ...(event.usage && {
-          inputTokens: event.usage.inputTokens,
-          ...(event.usage.outputTokens != null && { outputTokens: event.usage.outputTokens }),
-          ...(event.usage.cacheReadTokens != null && { cacheReadTokens: event.usage.cacheReadTokens }),
-          ...(event.usage.cacheCreationTokens != null && { cacheCreationTokens: event.usage.cacheCreationTokens }),
-          ...(event.usage.costUsd != null && { costUsd: event.usage.costUsd }),
-          ...(event.usage.contextWindow != null && { contextWindow: event.usage.contextWindow }),
-          usageUpdatedAt: Date.now(),
-        }),
       }
 
     case 'run_resumed':

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -1947,6 +1947,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           usageUpdatedAt={contextStatus.usageUpdatedAt}
           isCompacting={contextStatus.isCompacting}
           isProcessing={streaming}
+          sessionId={sessionId}
           onCompact={handleCompact}
         />
       ),

--- a/apps/electron/src/renderer/components/agent/ContextUsageBadge.tsx
+++ b/apps/electron/src/renderer/components/agent/ContextUsageBadge.tsx
@@ -34,6 +34,11 @@ interface ContextUsageBadgeProps {
   isCompacting: boolean
   isProcessing: boolean
   onCompact: () => void
+  /**
+   * 当前会话 ID，用于在切换会话时清空 stableRef，
+   * 避免新会话尚未发消息时仍显示上一个会话的 token 数。
+   */
+  sessionId?: string
 }
 
 /** 格式化 token 数为可读字符串（如 1234 → "1.2k"） */
@@ -122,6 +127,7 @@ export function ContextUsageBadge({
   isCompacting,
   isProcessing,
   onCompact,
+  sessionId,
 }: ContextUsageBadgeProps): React.ReactElement | null {
   // 保留最近一次有效的 token 值，避免切换会话时闪烁消失
   const stableRef = React.useRef<{
@@ -131,6 +137,14 @@ export function ContextUsageBadge({
     cacheCreationTokens?: number
     contextWindow?: number
   } | null>(null)
+  // 会话切换时清空陈旧值，避免新会话尚未上报 usage 时显示上个会话的数字
+  const lastSessionRef = React.useRef<string | undefined>(sessionId)
+  React.useEffect(() => {
+    if (lastSessionRef.current !== sessionId) {
+      stableRef.current = null
+      lastSessionRef.current = sessionId
+    }
+  }, [sessionId])
   if (inputTokens && inputTokens > 0) {
     stableRef.current = { inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, contextWindow }
   }

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -16,6 +16,11 @@ export {
   inferContextWindow,
 } from './context-window'
 export {
+  normalizeUsage,
+  isOpenAICompatibleProvider,
+  type AnthropicLikeUsage,
+} from './usage-normalizer'
+export {
   THINKING_SIGNATURE_ERROR_CODE,
   THINKING_SIGNATURE_ERROR_TITLE,
   THINKING_SIGNATURE_ERROR_MESSAGE,

--- a/packages/shared/src/utils/usage-normalizer.test.ts
+++ b/packages/shared/src/utils/usage-normalizer.test.ts
@@ -1,0 +1,130 @@
+import { test, expect, describe } from 'bun:test'
+import { normalizeUsage, isOpenAICompatibleProvider } from './usage-normalizer'
+import type { AnthropicLikeUsage } from './usage-normalizer'
+
+describe('normalizeUsage', () => {
+  describe('OpenAI 兼容渠道（zhipu / openai / doubao / qwen / custom）', () => {
+    test('从 input_tokens 中扣减 cache_read，避免下游公式重复计数', () => {
+      // GLM 实际场景：prompt_tokens=100 含 80 命中缓存
+      const usage: AnthropicLikeUsage = {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: 80,
+      }
+      const out = normalizeUsage(usage, 'zhipu')
+      expect(out?.input_tokens).toBe(20)
+      expect(out?.cache_read_input_tokens).toBe(80)
+      expect(out?.output_tokens).toBe(50)
+      // 归一化后：20 + 80 = 100 = 真实总输入
+    })
+
+    test('同时存在 cache_read 与 cache_creation 时一并扣减', () => {
+      const usage: AnthropicLikeUsage = {
+        input_tokens: 200,
+        cache_read_input_tokens: 80,
+        cache_creation_input_tokens: 40,
+      }
+      const out = normalizeUsage(usage, 'openai')
+      expect(out?.input_tokens).toBe(80) // 200 - 80 - 40
+      // 归一化后：80 + 80 + 40 = 200
+    })
+
+    test('端点已按 Anthropic 口径上报（input < cached）时不扣减，尊重端点原值', () => {
+      const usage: AnthropicLikeUsage = {
+        input_tokens: 30,
+        cache_read_input_tokens: 80,
+      }
+      const out = normalizeUsage(usage, 'zhipu')
+      expect(out?.input_tokens).toBe(30)
+    })
+
+    test('无缓存字段时原样返回', () => {
+      const usage: AnthropicLikeUsage = { input_tokens: 100, output_tokens: 50 }
+      const out = normalizeUsage(usage, 'qwen')
+      expect(out).toEqual(usage)
+    })
+
+    test('不修改入参对象', () => {
+      const usage: AnthropicLikeUsage = {
+        input_tokens: 100,
+        cache_read_input_tokens: 80,
+      }
+      const snapshot = { ...usage }
+      normalizeUsage(usage, 'zhipu')
+      expect(usage).toEqual(snapshot)
+    })
+
+    test('所有 OpenAI 兼容 provider 都触发归一化', () => {
+      for (const p of ['openai', 'zhipu', 'doubao', 'qwen', 'custom'] as const) {
+        const out = normalizeUsage({ input_tokens: 100, cache_read_input_tokens: 80 }, p)
+        expect(out?.input_tokens).toBe(20)
+      }
+    })
+  })
+
+  describe('Anthropic 原生 / 兼容渠道（不归一化）', () => {
+    test('anthropic provider 原样返回', () => {
+      const usage: AnthropicLikeUsage = {
+        input_tokens: 20,
+        cache_read_input_tokens: 80,
+        cache_creation_input_tokens: 0,
+      }
+      const out = normalizeUsage(usage, 'anthropic')
+      expect(out).toBe(usage)
+    })
+
+    test('zhipu-coding（走 Anthropic 兼容协议）原样返回', () => {
+      const usage: AnthropicLikeUsage = {
+        input_tokens: 20,
+        cache_read_input_tokens: 80,
+      }
+      const out = normalizeUsage(usage, 'zhipu-coding')
+      expect(out).toBe(usage)
+    })
+
+    test('kimi-coding / minimax / xiaomi 等 Anthropic 兼容渠道原样返回', () => {
+      for (const p of ['kimi-coding', 'minimax', 'xiaomi', 'deepseek', 'anthropic-compatible'] as const) {
+        const usage: AnthropicLikeUsage = { input_tokens: 100, cache_read_input_tokens: 80 }
+        expect(normalizeUsage(usage, p)).toBe(usage)
+      }
+    })
+  })
+
+  describe('边界情况', () => {
+    test('usage 为 undefined 时返回 undefined', () => {
+      expect(normalizeUsage(undefined, 'zhipu')).toBeUndefined()
+    })
+
+    test('usage 为 null 时返回 null', () => {
+      expect(normalizeUsage(null, 'zhipu')).toBeNull()
+    })
+
+    test('provider 为 undefined 时原样返回', () => {
+      const usage: AnthropicLikeUsage = { input_tokens: 100, cache_read_input_tokens: 80 }
+      expect(normalizeUsage(usage, undefined)).toBe(usage)
+    })
+  })
+})
+
+describe('isOpenAICompatibleProvider', () => {
+  test('openai 系列返回 true', () => {
+    expect(isOpenAICompatibleProvider('openai')).toBe(true)
+    expect(isOpenAICompatibleProvider('zhipu')).toBe(true)
+    expect(isOpenAICompatibleProvider('doubao')).toBe(true)
+    expect(isOpenAICompatibleProvider('qwen')).toBe(true)
+    expect(isOpenAICompatibleProvider('custom')).toBe(true)
+  })
+
+  test('Anthropic 兼容系列返回 false', () => {
+    expect(isOpenAICompatibleProvider('anthropic')).toBe(false)
+    expect(isOpenAICompatibleProvider('zhipu-coding')).toBe(false)
+    expect(isOpenAICompatibleProvider('kimi-coding')).toBe(false)
+    expect(isOpenAICompatibleProvider('minimax')).toBe(false)
+  })
+
+  test('空值返回 false', () => {
+    expect(isOpenAICompatibleProvider(undefined)).toBe(false)
+    expect(isOpenAICompatibleProvider(null)).toBe(false)
+    expect(isOpenAICompatibleProvider('')).toBe(false)
+  })
+})

--- a/packages/shared/src/utils/usage-normalizer.ts
+++ b/packages/shared/src/utils/usage-normalizer.ts
@@ -1,0 +1,85 @@
+/**
+ * Usage 归一化 — 把不同协议口径的 token 计数统一为 Anthropic 原生语义。
+ *
+ * 背景：
+ * Anthropic 原生 API 的 usage 字段语义：
+ *   input_tokens              = 本次请求中**未缓存**的输入 token
+ *   cache_read_input_tokens   = 命中缓存的输入 token（独立计数）
+ *   cache_creation_input_tokens = 写入缓存的输入 token（独立计数）
+ *   三者相加 = 真实发送给模型的总输入 token
+ *
+ * OpenAI ChatCompletions 兼容协议（zhipu / doubao / qwen / openai / custom）的 usage 语义：
+ *   prompt_tokens (= SDK 映射后的 input_tokens)        = **总输入**（已含缓存命中部分）
+ *   prompt_tokens_details.cached_tokens (= SDK 映射后
+ *   的 cache_read_input_tokens)                          = 总输入中命中缓存的子集
+ *
+ * 当第三方翻译层把 OpenAI 响应映射到 Anthropic schema 时，若不做扣减，
+ * 会出现：
+ *   input_tokens(=总输入 100) + cache_read_input_tokens(=80) = 180
+ * 即把缓存部分计了两次，导致 UI 上下文指示器显示值显著大于真实值。
+ *
+ * 本工具在 main 进程单点归一化：对 OpenAI 兼容渠道，从 input_tokens 中
+ * 扣除已缓存的子集，使其退化为 Anthropic 的"未缓存"语义。
+ * 归一化后所有下游（renderer 公式、持久化、complete 事件）都按统一口径计算。
+ */
+
+import type { ProviderType } from '../types/channel'
+
+/**
+ * 走 OpenAI ChatCompletions 兼容协议的 provider。
+ * 这些 provider 的 prompt_tokens 已含缓存命中部分，需要归一化。
+ *
+ * 注意：google 走 Gemini 原生协议，语义另算，暂不在此列。
+ */
+const OPENAI_COMPATIBLE_PROVIDERS: ReadonlySet<ProviderType> = new Set<ProviderType>([
+  'openai',
+  'zhipu',
+  'doubao',
+  'qwen',
+  'custom',
+])
+
+/** 是否为 OpenAI 兼容协议 provider（需要 usage 归一化）。 */
+export function isOpenAICompatibleProvider(provider: string | undefined | null): boolean {
+  if (!provider) return false
+  return OPENAI_COMPATIBLE_PROVIDERS.has(provider as ProviderType)
+}
+
+/** Anthropic 风格 usage 结构（与 SDK 上报字段对齐，所有字段可选）。 */
+export interface AnthropicLikeUsage {
+  input_tokens?: number
+  output_tokens?: number
+  cache_read_input_tokens?: number
+  cache_creation_input_tokens?: number
+}
+
+/**
+ * 把 usage 归一化为 Anthropic 原生语义。
+ *
+ * - Anthropic 原生 / Google / 其他：原样返回（无副作用）
+ * - OpenAI 兼容：若 input_tokens > cache_read + cache_creation，
+ *   说明 input_tokens 已含缓存部分，从中扣减；否则原样返回
+ *   （某些端点可能已经按 Anthropic 口径上报，扣减会变负，此时尊重端点原值）
+ *
+ * 返回新对象，不修改入参。
+ */
+export function normalizeUsage<T extends AnthropicLikeUsage>(
+  usage: T | undefined | null,
+  provider: string | undefined | null,
+): T | undefined | null {
+  if (!usage) return usage
+  if (!isOpenAICompatibleProvider(provider)) return usage
+
+  const cacheRead = usage.cache_read_input_tokens ?? 0
+  const cacheCreation = usage.cache_creation_input_tokens ?? 0
+  const cachedTotal = cacheRead + cacheCreation
+  if (cachedTotal === 0) return usage
+  if (usage.input_tokens == null) return usage
+  // 若 input_tokens 已小于等于缓存总量，说明此端点已按 Anthropic 口径上报，不再扣减
+  if (usage.input_tokens <= cachedTotal) return usage
+
+  return {
+    ...usage,
+    input_tokens: usage.input_tokens - cachedTotal,
+  }
+}


### PR DESCRIPTION
## 背景

Agent 输入框底部的上下文指示器显示值显著大于真实占用（典型 1.5~2 倍），**所有渠道都受影响**，包括 Claude 原生和 OpenAI 兼容渠道。

## 根因

代码中有 3 处公式：
```ts
inputTokens = u.input_tokens + (u.cache_read_input_tokens ?? 0) + (u.cache_creation_input_tokens ?? 0)
```

这个公式**基于错误的前提**——以为 `input_tokens` 是"未缓存的部分"，`cache_read` 和 `cache_creation` 是独立增量。

实际上，无论 Anthropic 原生还是 OpenAI 兼容渠道：
- **`input_tokens` 已是总量**（含缓存命中部分）
- `cache_read_input_tokens` 和 `cache_creation_input_tokens` 是 `input_tokens` 的**子集**（用于分档计费）
- 三者相加 = 总量 + 缓存子集 = **重复计数**

对话越长、缓存命中率越高，偏差越明显。

## 改动

### 修正公式（3 处）

| 文件 | 旧 | 新 |
|---|---|---|
| `useGlobalAgentListeners.ts:195` | `input + cache_read + cache_creation` | `input_tokens` |
| `useGlobalAgentListeners.ts:245` | 同上 | `input_tokens` |
| `SDKMessageRenderer.tsx:180` | 同上 | `input_tokens` |

### 清理 PR #807 引入的 normalizeUsage（基于错误前提，不再需要）

- 删除 `packages/shared/src/utils/usage-normalizer.ts` + `.test.ts`
- 删除 `packages/shared/src/utils/index.ts` 中的 re-export
- 删除 `agent-orchestrator.ts` 中的 import、`normalizeSDKMessageUsage` 函数、调用点

### 不需要改的部分（验证后确认正确）

- `ContextUsageBadge.tsx` 的 `pureInput = total - cacheRead - cacheCreation` → 在新语义下正确表示"非缓存输入"
- `AgentMessages.tsx` 的 `buildUsageTooltip` 同理
- PR #807 引入的 `stableRef` 会话切换清空 + `complete` 事件幂等化 → 仍然有效，保留

## 验证

- typecheck：shared / core / ui / electron 四包全过
- 原有单测 11 个全过

## 测试计划

- [ ] Claude 渠道跑一段对话，hover badge 确认 `inputTokens ≤ contextWindow`，数字不再虚高
- [ ] GLM（zhipu 渠道）同样验证
- [ ] Popover 中的"输入"行应显示 `inputTokens - cacheRead - cacheCreation`（非缓存部分），值合理
- [ ] 切换会话后 badge 消失（不显示上个会话残留值）

🤖 Generated with [Claude Code](https://claude.com/claude-code)