### PR TITLE
fix: 外部 MCP 服务器因 mcp.json 缺少 type 字段导致加载失败

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -669,6 +669,8 @@ export class AgentOrchestrator {
           ...(entry.headers && Object.keys(entry.headers).length > 0 && { headers: entry.headers }),
           required: false,
         }
+      } else {
+        console.warn(`[Agent 编排] MCP 服务器 "${name}" 配置不完整，已跳过（type=${entry.type}, command=${entry.command ?? '无'}, url=${entry.url ?? '无'}）`)
       }
     }
 

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -481,7 +481,14 @@ export function getWorkspaceMcpConfig(workspaceSlug: string): WorkspaceMcpConfig
   try {
     const raw = readFileSync(mcpPath, 'utf-8')
     const parsed = JSON.parse(raw) as Partial<WorkspaceMcpConfig>
-    return { servers: parsed.servers ?? {} }
+    const servers = parsed.servers ?? {}
+    for (const [name, entry] of Object.entries(servers)) {
+      if (!entry.type) {
+        entry.type = entry.command ? 'stdio' : entry.url ? 'http' : 'stdio'
+        console.log(`[Agent 工作区] MCP 服务器 "${name}" 缺少 type 字段，已自动推断为 "${entry.type}"`)
+      }
+    }
+    return { servers }
   } catch (error) {
     console.error('[Agent 工作区] 读取 MCP 配置失败:', error)
     return { servers: {} }

--- a/apps/electron/src/renderer/components/settings/AgentSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AgentSettings.tsx
@@ -645,7 +645,7 @@ function McpServerRow({ name, entry, onEdit, onDelete, onToggle }: McpServerRowP
           </span>
         )}
         <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-muted text-muted-foreground font-medium">
-          {TRANSPORT_LABELS[entry.type] ?? entry.type}
+          {TRANSPORT_LABELS[entry.type] ?? entry.type ?? '未知'}
         </span>
         <button onClick={onEdit} className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors opacity-0 group-hover:opacity-100" title="编辑">
           <Pencil size={14} />


### PR DESCRIPTION
## Summary

修复 #802：手动编写的 `mcp.json` 缺少 `type` 字段时，外部 MCP 服务器无法加载，状态显示为 `undefined`，工具不注册。

**根因**：`buildMcpServers()` 中 `entry.type === 'stdio'` 判断失败（因为 `entry.type` 是 `undefined`），服务器被静默跳过。通过 UI 创建的配置总会带 `type`，但手写 JSON 容易遗漏。

**修复**：
- `getWorkspaceMcpConfig()` 读取后自动推断 `type`（有 `command` → `stdio`，有 `url` → `http`），并输出日志
- `buildMcpServers()` 配置不完整被跳过时输出 `console.warn`（原先无任何日志）
- `AgentSettings.tsx` 把 `undefined` type 显示为「未知」而非原始 `undefined` 字符串

## 变更文件

- `apps/electron/src/main/lib/agent-workspace-manager.ts` — type 字段自动推断
- `apps/electron/src/main/lib/agent-orchestrator.ts` — 跳过时输出警告日志
- `apps/electron/src/renderer/components/settings/AgentSettings.tsx` — UI fallback 显示

## Test plan

- [ ] 创建一个不含 `type` 字段的 `mcp.json`（只有 `command`、`args`、`enabled`），确认重启后 MCP 服务器正常加载、工具注册成功
- [ ] 确认控制台输出 `[Agent 工作区] MCP 服务器 "xxx" 缺少 type 字段，已自动推断为 "stdio"` 日志
- [ ] 创建一个 `command` 和 `url` 都缺失的条目，确认控制台输出 `[Agent 编排] MCP 服务器 "xxx" 配置不完整，已跳过` 警告
- [ ] 确认通过 UI 创建的 MCP 服务器行为不受影响（UI 总会写入 type）
- [ ] 确认设置页面不再显示 `undefined` 状态标签

Closes #802

🤖 Generated with [Claude Code](https://claude.com/claude-code)