### PR TITLE
fix(automation): 子会话持久化 modelId，避免输入框模型选择被清空

### DIFF
--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -100,6 +100,7 @@ export function createAgentSession(
   title?: string,
   channelId?: string,
   workspaceId?: string,
+  modelId?: string,
 ): AgentSessionMeta {
   const index = readIndex()
   const now = Date.now()
@@ -108,6 +109,7 @@ export function createAgentSession(
     id: randomUUID(),
     title: title || '新 Agent 会话',
     channelId,
+    modelId,
     workspaceId,
     createdAt: now,
     updatedAt: now,
@@ -377,7 +379,7 @@ function convertLegacyMessage(legacy: AgentMessage): SDKMessage {
  */
 export function updateAgentSessionMeta(
   id: string,
-  updates: Partial<Pick<AgentSessionMeta, 'title' | 'channelId' | 'sdkSessionId' | 'workspaceId' | 'pinned' | 'archived' | 'attachedDirectories' | 'attachedFiles' | 'forkSourceDir' | 'forkSourceSdkSessionId' | 'resumeAtMessageUuid' | 'stoppedByUser' | 'permissionMode' | 'completedButUnconfirmed' | 'sourceAutomationId'>>,
+  updates: Partial<Pick<AgentSessionMeta, 'title' | 'channelId' | 'modelId' | 'sdkSessionId' | 'workspaceId' | 'pinned' | 'archived' | 'attachedDirectories' | 'attachedFiles' | 'forkSourceDir' | 'forkSourceSdkSessionId' | 'resumeAtMessageUuid' | 'stoppedByUser' | 'permissionMode' | 'completedButUnconfirmed' | 'sourceAutomationId'>>,
 ): AgentSessionMeta {
   const index = readIndex()
   const idx = index.sessions.findIndex((s) => s.id === id)

--- a/apps/electron/src/main/lib/automation-scheduler.ts
+++ b/apps/electron/src/main/lib/automation-scheduler.ts
@@ -96,7 +96,7 @@ export async function runAutomation(automation: Automation, manual = false): Pro
     if (reuseSessionId) {
       targetSessionId = reuseSessionId
     } else {
-      const created = createAgentSession(automation.name, automation.channelId, automation.workspaceId)
+      const created = createAgentSession(automation.name, automation.channelId, automation.workspaceId, automation.modelId)
       updateAgentSessionMeta(created.id, { sourceAutomationId: automation.id })
       targetSessionId = created.id
       setLastSessionId(automation.id, created.id)

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -353,25 +353,34 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   // 已有会话首次打开时，从全局默认值初始化 per-session map。
   // setter 内的 `prev.has(sessionId)` 守卫保证幂等，外层不再订阅 Map atom，
   // 避免 setter 写入 → atom 引用变化 → effect 重跑的自循环（React #185）。
+  // 优先使用会话元数据上的 channelId/modelId（如自动任务子会话），回退到全局默认。
+  const sessionMeta = React.useMemo(
+    () => sessions.find((s) => s.id === sessionId),
+    [sessions, sessionId],
+  )
+  const sessionMetaChannelId = sessionMeta?.channelId
+  const sessionMetaModelId = sessionMeta?.modelId
   React.useEffect(() => {
     if (!sessionId) return
-    if (defaultChannelId) {
+    const initialChannelId = sessionMetaChannelId ?? defaultChannelId
+    const initialModelId = sessionMetaModelId ?? defaultModelId
+    if (initialChannelId) {
       setSessionChannelMap((prev) => {
         if (prev.has(sessionId)) return prev
         const map = new Map(prev)
-        map.set(sessionId, defaultChannelId)
+        map.set(sessionId, initialChannelId)
         return map
       })
     }
-    if (defaultModelId) {
+    if (initialModelId) {
       setSessionModelMap((prev) => {
         if (prev.has(sessionId)) return prev
         const map = new Map(prev)
-        map.set(sessionId, defaultModelId)
+        map.set(sessionId, initialModelId)
         return map
       })
     }
-  }, [sessionId, defaultChannelId, defaultModelId, setSessionChannelMap, setSessionModelMap])
+  }, [sessionId, sessionMetaChannelId, sessionMetaModelId, defaultChannelId, defaultModelId, setSessionChannelMap, setSessionModelMap])
 
   const contextStatus: AgentContextStatus = {
     isCompacting: streamState?.isCompacting ?? false,

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -588,6 +588,8 @@ export interface AgentSessionMeta {
   title: string
   /** 使用的渠道 ID */
   channelId?: string
+  /** 使用的模型 ID（自动任务子会话恢复输入框模型选择时使用） */
+  modelId?: string
   /** SDK 内部会话 ID（用于 resume 衔接上下文） */
   sdkSessionId?: string
   /** 所属工作区 ID */


### PR DESCRIPTION
## 问题

自动任务每轮执行会新建一个 Agent 子会话（`createAgentSession(automation.name, automation.channelId, automation.workspaceId)`），但 `createAgentSession` 不接收 `modelId`，所以 automation 配置的 `modelId` 没有被写入子会话元数据；同时 `AgentView` 初始化 per-session 模型 Map 时只读全局默认（`defaultChannelId` / `defaultModelId`），完全忽略会话元数据上的 `channelId` / `modelId`。

最终用户打开自动任务触发的子会话时，输入框的模型选择回退到全局默认；如果全局默认 modelId 不在该会话渠道允许的模型里，`ModelSelector` 就显示「选择模型」。

## 修复

- `AgentSessionMeta` 新增可选 `modelId` 字段
- `createAgentSession` 增加可选 `modelId` 参数并写入元数据
- `updateAgentSessionMeta` 允许更新 `modelId`
- `automation-scheduler` 在新建子会话时传入 `automation.modelId`
- `AgentView` 初始化 per-session 模型 Map 时优先使用会话元数据上的 `channelId` / `modelId`，回退到全局默认

为兼容旧的调用方，`modelId` 参数全程可选，其它 `createAgentSession` 调用点行为不变。

## Test plan

- [ ] 创建一个自动任务并配置非全局默认渠道+模型，触发执行后打开子会话，输入框应显示 automation 配置的模型而非「选择模型」
- [ ] 既有 Agent 会话（非 automation 来源）打开后，输入框仍显示全局默认模型，无回归
- [ ] 删除/归档 automation 子会话流程无回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)