### PR TITLE
fix(agent): 防止 ModelSelector 在瞬态 null 时显示「选择模型」

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -1245,10 +1245,15 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   }, [sessionId, setSessionChannelMap, setSessionModelMap, setDefaultChannelId, setDefaultModelId, agentChannelIds, setAgentChannelIds])
 
   /** 构建 externalSelectedModel 给 ModelSelector */
-  const externalSelectedModel = React.useMemo(() => {
+  const computedSelectedModel = React.useMemo(() => {
     if (!agentChannelId || !agentModelId) return null
     return { channelId: agentChannelId, modelId: agentModelId }
   }, [agentChannelId, agentModelId])
+
+  // 防止瞬态 null 传递给 ModelSelector（防御 overflow remount 时 stableModelInfoRef 丢失）
+  const stableSelectedModelRef = React.useRef(computedSelectedModel)
+  if (computedSelectedModel) stableSelectedModelRef.current = computedSelectedModel
+  const externalSelectedModel = computedSelectedModel ?? stableSelectedModelRef.current
 
   /** 发送消息 */
   const handleSend = React.useCallback(async (): Promise<void> => {
@@ -1974,7 +1979,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     },
   ], [
     agentChannelIds,
-    externalSelectedModel,
+    agentChannelId,
+    agentModelId,
     handleModelSelect,
     sessionId,
     agentThinking,


### PR DESCRIPTION
## 问题

正常使用 Agent 会话时，输入框底部的模型选择器偶尔突然显示「选择模型」（空白），需要用户手动重选。

## 根因

`AgentView` 构建 `externalSelectedModel` 传给 `ModelSelector` 时，若 `agentChannelId` 或 `agentModelId` 暂时为 falsy 就会传入 null。`ModelSelector` 内部虽有 `stableModelInfoRef` 保护显示，但该 ref 绑定在组件实例上——如果 `InputToolbarOverflow` 因容器宽度变化（如流式 token badge 宽度增长）导致 `visibleCount` 跨越边界，ModelSelector 会被 unmount/remount。新实例的 ref 初始化为 null，无法恢复之前的有效模型。

触发条件：
1. 后台任务（automation/external run）完成 → 状态更新 → 短暂竞态使 `agentModelId` 为 null
2. 恰好此时 `InputToolbarOverflow` 因 token badge 宽度变化重新计算溢出 → ModelSelector remount
3. 新实例 `stableModelInfoRef` 从 null 开始 → 显示「选择模型」

## 修复

在 `AgentView` 层面添加 `stableSelectedModelRef`，确保 `externalSelectedModel` 一旦有过有效值，就不会因瞬态 null 而丢失：

```tsx
const stableSelectedModelRef = React.useRef(computedSelectedModel)
if (computedSelectedModel) stableSelectedModelRef.current = computedSelectedModel
const externalSelectedModel = computedSelectedModel ?? stableSelectedModelRef.current
```

同时将 `inputToolbarItems` useMemo 的依赖从对象引用（`externalSelectedModel`）改为 primitive 值（`agentChannelId`, `agentModelId`），减少不必要的 memo 重算。

## Test plan

- [ ] 正常使用会话，运行 automation 后观察模型选择器是否保持稳定
- [ ] 调整窗口宽度使 toolbar overflow 触发，确认模型选择器不闪「选择模型」
- [ ] 启动时快速切换到已有 Agent Tab，确认无短暂「选择模型」闪烁

🤖 Generated with [Claude Code](https://claude.com/claude-code)