### PR TITLE
fix(automation): 「无工作区」视为草稿态，禁止启用和立即运行【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -4202,7 +4202,7 @@ export function registerIpcHandlers(): void {
       if (!input || typeof input !== 'object') throw new Error('input 必须是对象')
       if (!isNonEmptyString(input.name)) throw new Error('name 必填')
       if (!isNonEmptyString(input.prompt)) throw new Error('prompt 必填')
-      if (!isNonEmptyString(input.channelId)) throw new Error('channelId 必填')
+      // channelId / workspaceId 允许为空（草稿态），但此时任务不能被启用
       validateAutomationFields(input)
       if (input.scheduleType === 'interval' && !isFiniteInt(input.intervalMinutes)) throw new Error('scheduleType=interval 时 intervalMinutes 必填')
       if ((input.scheduleType === 'daily' || input.scheduleType === 'weekly' || input.scheduleType === 'monthly') && !validTimeOfDay(input.timeOfDay)) throw new Error('scheduleType=daily/weekly/monthly 时 timeOfDay 必填')

--- a/apps/electron/src/main/lib/automation-manager.ts
+++ b/apps/electron/src/main/lib/automation-manager.ts
@@ -148,11 +148,18 @@ export function getAutomation(id: string): Automation | undefined {
   return readIndex().automations.find((a) => a.id === id)
 }
 
+/** 任务是否具备运行所需的最小完整度（channelId + workspaceId） */
+function isAutomationRunnable(a: Pick<Automation, 'channelId' | 'workspaceId'>): boolean {
+  return !!a.channelId && !!a.workspaceId
+}
+
 /** 创建定时任务 */
 export function createAutomation(input: CreateAutomationInput): Automation {
   const index = readIndex()
   const now = Date.now()
-  const active = input.active ?? true
+  // 草稿态（缺 channelId / workspaceId）强制不启用，避免空配置任务进入调度
+  const requestedActive = input.active ?? true
+  const active = requestedActive && isAutomationRunnable(input)
 
   const automation: Automation = {
     id: randomUUID(),
@@ -220,12 +227,21 @@ export function updateAutomation(input: UpdateAutomationInput): Automation | und
 
   // 启用状态变化
   if (input.active !== undefined && input.active !== target.active) {
+    // 启用要求 channelId + workspaceId 齐全，否则拒绝（兜底前端校验，避免空配置任务进入调度）
+    if (input.active && !isAutomationRunnable(target)) {
+      throw new Error('启用定时任务前必须配置模型与工作区')
+    }
     target.active = input.active
     if (input.active) {
       // 重新启用：从现在起算下一次触发，清空连续失败计数
       target.nextRunAt = computeNextRunAt(target, now)
       target.consecutiveFailures = 0
     }
+  }
+
+  // 调度配置被改成不完整时自动暂停：防止用户清空工作区 / 渠道后任务仍处于 active 进入 tick
+  if (target.active && !isAutomationRunnable(target)) {
+    target.active = false
   }
 
   target.updatedAt = now

--- a/apps/electron/src/main/lib/automation-scheduler.ts
+++ b/apps/electron/src/main/lib/automation-scheduler.ts
@@ -185,6 +185,10 @@ export async function runAutomation(automation: Automation, manual = false): Pro
 export async function runAutomationNow(id: string): Promise<void> {
   const automation = getAutomation(id)
   if (!automation) throw new Error(`定时任务不存在: ${id}`)
+  // 草稿态（缺 channelId / workspaceId）拒绝运行，兜底前端 disabled 防止 IPC 绕过
+  if (!automation.channelId || !automation.workspaceId) {
+    throw new Error('请先为该任务配置模型与工作区')
+  }
   await runAutomation(automation, true)
 }
 
@@ -193,6 +197,8 @@ function tick(): void {
   const now = Date.now()
   for (const automation of listAutomations()) {
     if (!automation.active) continue
+    // 完整度兜底：老用户可能存在「active=true 但缺工作区 / 渠道」的历史数据，跳过避免运行时崩溃
+    if (!automation.channelId || !automation.workspaceId) continue
     if (now < automation.nextRunAt) continue
     if (runningAutomations.has(automation.id)) continue
     // 来源会话忙时跳过（极端情况下的额外保险，主要靠新建子会话规避）

--- a/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
+++ b/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
@@ -591,7 +591,7 @@ export function AutomationFormView(): React.ReactElement | null {
             <div className="flex flex-col gap-0.5">
               <Label htmlFor="auto-active">启用</Label>
               <span className="text-xs text-muted-foreground">
-                {isReadyToRun(form) ? '关闭后任务暂停调度' : '补全模型与工作区后方可启用'}
+                {isReadyToRun(form) ? '关闭后任务暂停调度' : `补全${listMissingFields(form).join('、')}后方可启用`}
               </span>
             </div>
             <Switch

--- a/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
+++ b/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
@@ -64,7 +64,23 @@ function formatRunStatus(status: AutomationRun['status']): string {
 }
 
 function canPersistDraft(draft: AutomationDraft): boolean {
-  return !!(draft.name.trim() && draft.prompt.trim() && draft.channelId)
+  // 草稿保存门槛：只要有任务名和任务描述就保存为草稿（缺 channelId / workspaceId 会被强制不启用）
+  return !!(draft.name.trim() && draft.prompt.trim())
+}
+
+/** 任务是否具备运行 / 启用所需的最小完整度（模型 + 工作区） */
+function isReadyToRun(draft: AutomationDraft): boolean {
+  return canPersistDraft(draft) && !!draft.channelId && !!draft.workspaceId
+}
+
+/** 列出当前还缺哪些必填项（用于"运行一次" Tooltip 与关闭时的 toast 提示） */
+function listMissingFields(draft: AutomationDraft): string[] {
+  const missing: string[] = []
+  if (!draft.name.trim()) missing.push('任务名称')
+  if (!draft.prompt.trim()) missing.push('任务描述')
+  if (!draft.channelId) missing.push('模型')
+  if (!draft.workspaceId) missing.push('工作区')
+  return missing
 }
 
 function getDraftSignature(draft: AutomationDraft): string {
@@ -248,9 +264,14 @@ export function AutomationFormView(): React.ReactElement | null {
     const persistTask = (async (): Promise<string | null> => {
       const previousId = previousPersist ? await previousPersist.catch(() => null) : null
       const latestDraft = latestFormRef.current
-      const draftToSave = latestDraft
+      const baseDraft = latestDraft
         ? { ...latestDraft, id: latestDraft.id ?? previousId ?? draft.id }
         : { ...draft, id: draft.id ?? previousId ?? undefined }
+
+      // 不完整任务（缺模型 / 工作区）强制不启用：避免无配置任务出现在「启用中」分组
+      const draftToSave: AutomationDraft = isReadyToRun(baseDraft)
+        ? baseDraft
+        : { ...baseDraft, active: false }
 
       if (!canPersistDraft(draftToSave)) return draftToSave.id ?? null
 
@@ -350,8 +371,9 @@ export function AutomationFormView(): React.ReactElement | null {
 
   const handleRunNow = async (): Promise<void> => {
     const latest = latestFormRef.current
-    if (!latest || !canPersistDraft(latest)) {
-      toast.error('请先填写任务名称、任务描述并选择模型')
+    if (!latest || !isReadyToRun(latest)) {
+      const missing = latest ? listMissingFields(latest) : ['任务名称', '任务描述', '模型', '工作区']
+      toast.error(`请先补全：${missing.join('、')}`)
       return
     }
 
@@ -522,15 +544,26 @@ export function AutomationFormView(): React.ReactElement | null {
         <div className="flex items-center justify-between gap-2 px-4 py-4 flex-shrink-0">
           <span className="text-sm font-semibold text-foreground">配置</span>
           <div className="flex items-center gap-1">
-            <button
-              type="button"
-              onClick={() => { void handleRunNow() }}
-              disabled={runningNow || !canPersistDraft(form)}
-              className="titlebar-no-drag h-7 px-2.5 rounded-md text-xs font-medium bg-primary text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50 transition-colors flex items-center gap-1.5 shadow-sm"
-            >
-              {runningNow ? <Loader2 className="size-3.5 animate-spin" /> : <Play className="size-3.5" />}
-              <span>{runningNow ? '运行中' : '运行一次'}</span>
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span>
+                  <button
+                    type="button"
+                    onClick={() => { void handleRunNow() }}
+                    disabled={runningNow || !isReadyToRun(form)}
+                    className="titlebar-no-drag h-7 px-2.5 rounded-md text-xs font-medium bg-primary text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50 transition-colors flex items-center gap-1.5 shadow-sm"
+                  >
+                    {runningNow ? <Loader2 className="size-3.5 animate-spin" /> : <Play className="size-3.5" />}
+                    <span>{runningNow ? '运行中' : '运行一次'}</span>
+                  </button>
+                </span>
+              </TooltipTrigger>
+              {!isReadyToRun(form) && !runningNow && (
+                <TooltipContent side="bottom">
+                  请先补全：{listMissingFields(form).join('、')}
+                </TooltipContent>
+              )}
+            </Tooltip>
             <button
               onClick={close}
               className="titlebar-no-drag p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-foreground/[0.06] transition-colors"
@@ -541,15 +574,18 @@ export function AutomationFormView(): React.ReactElement | null {
         </div>
 
         <div className="flex-1 overflow-y-auto px-4 pb-4 flex flex-col gap-5">
-          {/* 启用开关（最上） */}
+          {/* 启用开关（最上）：模型 / 工作区缺失时禁用，避免 UI 状态与持久化结果不一致 */}
           <div className="flex items-center justify-between">
             <div className="flex flex-col gap-0.5">
               <Label htmlFor="auto-active">启用</Label>
-              <span className="text-xs text-muted-foreground">关闭后任务暂停调度</span>
+              <span className="text-xs text-muted-foreground">
+                {isReadyToRun(form) ? '关闭后任务暂停调度' : '补全模型与工作区后方可启用'}
+              </span>
             </div>
             <Switch
               id="auto-active"
-              checked={form.active}
+              checked={form.active && isReadyToRun(form)}
+              disabled={!isReadyToRun(form)}
               onCheckedChange={(checked) => update({ active: checked })}
             />
           </div>

--- a/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
+++ b/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
@@ -33,7 +33,7 @@ import {
   automationToDraft,
   type AutomationDraft,
 } from '@/atoms/automation-atoms'
-import { agentWorkspacesAtom, agentSessionsAtom, agentChannelIdsAtom } from '@/atoms/agent-atoms'
+import { agentWorkspacesAtom, agentSessionsAtom, agentChannelIdsAtom, currentAgentWorkspaceIdAtom } from '@/atoms/agent-atoms'
 import { activeSessionIdAtom } from '@/atoms/tab-atoms'
 import { activeViewAtom } from '@/atoms/active-view'
 import { settingsOpenAtom, settingsTabAtom } from '@/atoms/settings-tab'
@@ -49,7 +49,6 @@ import type {
   UpdateAutomationInput,
 } from '@proma/shared'
 
-const NO_WORKSPACE = '__none__'
 const NO_FEISHU_BINDING = '__none__'
 
 function formatTime(ts?: number): string {
@@ -198,6 +197,7 @@ export function AutomationFormView(): React.ReactElement | null {
   const agentChannelIds = useAtomValue(agentChannelIdsAtom)
   const [agentSessions, setAgentSessions] = useAtom(agentSessionsAtom)
   const activeSessionId = useAtomValue(activeSessionIdAtom)
+  const currentAgentWorkspaceId = useAtomValue(currentAgentWorkspaceIdAtom)
   const setActiveView = useSetAtom(activeViewAtom)
   const setSettingsOpen = useSetAtom(settingsOpenAtom)
   const setSettingsTab = useSetAtom(settingsTabAtom)
@@ -229,6 +229,18 @@ export function AutomationFormView(): React.ReactElement | null {
         : ''
     }
   }, [formState.open, formState.draft])
+
+  // 新建模式下若 workspaceId 为空，按优先级填入默认值：
+  // 1. 当前 Agent 模式选中的工作区（≈ 当前会话所在工作区）
+  // 2. 第一个工作区（fallback）
+  // 编辑模式不动；用户已显式选过的也不覆盖。
+  React.useEffect(() => {
+    if (!formState.open || !form || form.id || form.workspaceId) return
+    const fallback = currentAgentWorkspaceId ?? workspaces[0]?.id
+    if (fallback) {
+      setForm((prev) => (prev && !prev.id && !prev.workspaceId ? { ...prev, workspaceId: fallback } : prev))
+    }
+  }, [formState.open, form?.id, form?.workspaceId, currentAgentWorkspaceId, workspaces])
 
   React.useEffect(() => {
     if (!formState.open) return
@@ -767,21 +779,37 @@ export function AutomationFormView(): React.ReactElement | null {
             )}
           </div>
 
-          {/* 工作区 */}
+          {/* 工作区（必选，默认填入当前会话所在工作区） */}
           <div className="flex flex-col gap-2">
             <Label>工作区</Label>
-            <Select
-              value={form.workspaceId ?? NO_WORKSPACE}
-              onValueChange={(v) => update({ workspaceId: v === NO_WORKSPACE ? undefined : v })}
-            >
-              <SelectTrigger><SelectValue placeholder="选择工作区" /></SelectTrigger>
-              <SelectContent>
-                <SelectItem value={NO_WORKSPACE}>无工作区</SelectItem>
-                {workspaces.map((ws) => (
-                  <SelectItem key={ws.id} value={ws.id}>{ws.name}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            {workspaces.length === 0 ? (
+              <div className="flex items-center gap-2 rounded-md border border-amber-200 dark:border-amber-900/50 bg-amber-50 dark:bg-amber-950/30 px-3 py-2 text-sm text-amber-700 dark:text-amber-400">
+                <Settings size={14} className="shrink-0" />
+                <span>尚未创建任何工作区</span>
+                <button
+                  type="button"
+                  className="ml-auto text-xs underline underline-offset-2 hover:text-foreground transition-colors"
+                  onClick={() => {
+                    setSettingsTab('agent')
+                    setSettingsOpen(true)
+                  }}
+                >
+                  前往 Agent 设置
+                </button>
+              </div>
+            ) : (
+              <Select
+                value={form.workspaceId ?? ''}
+                onValueChange={(v) => update({ workspaceId: v })}
+              >
+                <SelectTrigger><SelectValue placeholder="选择工作区" /></SelectTrigger>
+                <SelectContent>
+                  {workspaces.map((ws) => (
+                    <SelectItem key={ws.id} value={ws.id}>{ws.name}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
           </div>
 
           {/* 飞书通知 */}

--- a/apps/electron/src/renderer/components/automation/AutomationsListView.tsx
+++ b/apps/electron/src/renderer/components/automation/AutomationsListView.tsx
@@ -120,8 +120,16 @@ interface SectionProps {
 }
 
 function Section({ title, automations, onEdit, onRefresh, variant }: SectionProps): React.ReactElement {
+  /** 列表上的任务是否具备运行 / 启用所需的最小完整度 */
+  const isRunnable = (a: Automation): boolean => !!a.channelId && !!a.workspaceId
+
   const handleRunNow = async (e: React.MouseEvent, a: Automation): Promise<void> => {
     e.stopPropagation()
+    if (!isRunnable(a)) {
+      toast.error('请先为该任务配置模型与工作区')
+      onEdit(a)
+      return
+    }
     toast.success(`已开始运行「${a.name}」`, {
       description: '本次任务会创建新的 Agent 会话，可在左侧会话列表查看',
     })
@@ -135,6 +143,12 @@ function Section({ title, automations, onEdit, onRefresh, variant }: SectionProp
 
   const handleToggle = async (e: React.MouseEvent, a: Automation): Promise<void> => {
     e.stopPropagation()
+    // 启用前必须配齐模型与工作区，否则打开编辑面板让用户补全
+    if (!a.active && !isRunnable(a)) {
+      toast.error('请先为该任务配置模型与工作区')
+      onEdit(a)
+      return
+    }
     try {
       await window.electronAPI.toggleAutomation(a.id, !a.active)
       await onRefresh()


### PR DESCRIPTION
## 概述

修复定时任务里「无工作区」选项的语义问题——原本它只是个 placeholder，但 UI 上允许用户保存并启用一个无工作区的任务，启用按钮亮、能点「运行一次」、列表里还会显示在「启用中」分组里，但实际运行时缺少 cwd 会有未定义行为。

本 PR 把「无工作区」/「无模型」明确建模为**草稿态**：UI 层用 disabled + Tooltip 引导用户补全；持久化层和调度层兜底防止任何不完整任务进入运行流程。

顺带把「关闭表单时静默丢失未保存内容」也修了——以前用户填了 name + prompt 但还没选模型 / 工作区就关掉，会直接丢失；现在会作为未启用草稿落到「已暂停」分组里，方便后续继续编辑。

## 改动

### 后端

- `apps/electron/src/main/ipc.ts` — CREATE 移除 `channelId` 必填校验，允许保存为草稿；prompt + name 仍是必填
- `apps/electron/src/main/lib/automation-manager.ts`
  - 新增 `isAutomationRunnable()` 工具：`channelId && workspaceId` 才视为可运行
  - `createAutomation`：缺配置时强制 `active = false`，避免空配置任务进入调度
  - `updateAutomation`：启用前校验 + 用后兜底——若 update 把配置改成不完整，自动 `active = false`
- `apps/electron/src/main/lib/automation-scheduler.ts`
  - `runAutomationNow`：缺配置时 throw 拒绝
  - `tick()`：跳过缺配置任务（兼容老用户的历史 `active=true` 数据）

### 前端

- `apps/electron/src/renderer/components/automation/AutomationFormView.tsx`
  - `canPersistDraft` 从 `name + prompt + channelId` 降到 `name + prompt`
  - 新增 `isReadyToRun(draft)` = `canPersistDraft + channelId + workspaceId`，作为运行 / 启用门槛
  - 新增 `listMissingFields(draft)`，用于 Tooltip / toast 列出缺失项
  - 「运行一次」按钮 disabled 改用 `isReadyToRun`，配 Tooltip 「请先补全：模型、工作区」
  - 「启用」开关在缺配置时 disabled，副文案改成「补全模型与工作区后方可启用」；UI 上 checked 用 `form.active && isReadyToRun(form)`，避免和持久化结果不一致
  - `persistDraft` 落库前若 `!isReadyToRun` 强制 `active = false`
- `apps/electron/src/renderer/components/automation/AutomationsListView.tsx`
  - 列表里「启用」/「立即运行」按钮在不完整时弹 toast 拒绝，并自动调 `onEdit(a)` 打开编辑面板让用户补全

### 版本

- `@proma/electron` 0.12.5 → 0.12.6

## 测试方法

1. 新建定时任务 → 不选工作区 → 「运行一次」按钮应为 disabled，悬停显示 Tooltip 「请先补全：工作区」
2. 同上 → 启用开关应为 disabled，副文案显示「补全模型与工作区后方可启用」
3. 新建任务 → 只填 name + prompt 后关闭表单 → 任务应保存到「已暂停」分组（未启用草稿）
4. 在「已暂停」分组里点草稿任务的 Power 按钮 → 应弹 toast「请先为该任务配置模型与工作区」并自动打开编辑面板
5. 同上情况点 Play 按钮 → 行为同上
6. 已启用的任务 → 编辑里把工作区改成「无工作区」→ 任务应立即落到「已暂停」分组
7. 重启 Proma 后老数据若存在 `active = true` 但缺工作区的历史任务，调度器应跳过不触发（不再尝试运行）

## 备注

- 三层防御：UI（按钮 disabled / Tooltip）→ 持久化（归一化 active）→ 运行时（scheduler 跳过 / IPC throw），任何一层被绕过都不会让空配置任务真正运行
- 类型检查通过；`automation-manager.test.ts` 里既有 6 处 TS2345 错误是上游 main 已存在的，与本 PR 无关
- 无任何 OS 相关 / 路径 / shell / 平台分支改动，Windows 兼容性 SAFE
- 对外的 IPC 接口签名（`CreateAutomationInput` 等）保持不变，前端传 `channelId: ''` 表示草稿