### PR TITLE
fix(agent): 恢复 input_tokens + cache 的正确上下文公式（回退 #813）

### DIFF
--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -177,7 +177,7 @@ function extractTurnUsage(turnMessages: SDKMessage[]): { durationMs?: number; us
     return {
       durationMs,
       usage: {
-        inputTokens: u.input_tokens,
+        inputTokens: u.input_tokens + (u.cache_read_input_tokens ?? 0) + (u.cache_creation_input_tokens ?? 0),
         outputTokens: u.output_tokens,
         cacheReadTokens: u.cache_read_input_tokens,
         cacheCreationTokens: u.cache_creation_input_tokens,

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -192,7 +192,7 @@ function payloadToLegacyEvents(payload: AgentStreamPayload): AgentEvent[] {
       // Usage（保留完整字段用于详细展示）
       if (!aMsg.parent_tool_use_id && aMsg.message.usage) {
         const u = aMsg.message.usage
-        const inputTokens = u.input_tokens
+        const inputTokens = u.input_tokens + (u.cache_read_input_tokens ?? 0) + (u.cache_creation_input_tokens ?? 0)
         // 流式过程中 SDK 不返回 contextWindow，按模型名推断一个默认值作为 fallback。
         // 注意：必须优先用 _channelModelId（用户在 UI 上选择的原始模型 ID），
         // 因为部分端点（如智谱）会在 message.model 里剥掉 [1m] 等规格后缀，
@@ -242,7 +242,7 @@ function payloadToLegacyEvents(payload: AgentStreamPayload): AgentEvent[] {
         type: 'complete',
         stopReason: rMsg.subtype === 'success' ? 'end_turn' : 'error',
         usage: usage ? {
-          inputTokens: usage.input_tokens,
+          inputTokens: usage.input_tokens + (usage.cache_read_input_tokens ?? 0) + (usage.cache_creation_input_tokens ?? 0),
           outputTokens: usage.output_tokens,
           cacheReadTokens: usage.cache_read_input_tokens,
           cacheCreationTokens: usage.cache_creation_input_tokens,


### PR DESCRIPTION
## 问题

PR #813 把上下文 token 公式从 `input_tokens + cache_read + cache_creation` 改成只取 `input_tokens`，导致 **Claude 等启用 prompt caching 的渠道上下文显示严重偏小**——只显示了缓存断点之后的非缓存部分。

#813 的依据是一个二手搜索摘要，结论是错的。

## 官方文档依据

[Anthropic prompt-caching 文档](https://platform.claude.com/docs/en/build-with-claude/prompt-caching)「Tracking cache performance」明确：

| 字段 | 含义 |
|---|---|
| `input_tokens` | **仅**缓存断点之后的非缓存 token |
| `cache_read_input_tokens` | 命中缓存的 token |
| `cache_creation_input_tokens` | 写入缓存的 token |

三者**分立、可加**，`total = input_tokens + cache_read + cache_creation`。

官方示例：`cache_read=100000, cache_creation=0, input=50` → **total=100050**。

#813 只取 `input_tokens` 在这个例子里就只显示 50，而非 100050。

## 改动

恢复 #807 之前的正确公式：
- `useGlobalAgentListeners.ts` (2 处)
- `SDKMessageRenderer.tsx` (1 处)

`normalizeUsage` 已在 #813 删除，保持删除（它本就基于错误前提，对原始公式是多余的扣减）。

## 验证

- 我改动的 3 处所在文件 typecheck 干净
- （`automation-manager.test.ts` 的类型报错为 main 上预先存在，与本 PR 无关）

## 测试计划

- [ ] Claude 渠道跑长对话，确认上下文随历史增长，接近真实总量（input + 缓存）
- [ ] hover badge，确认「上下文」≈「输入 + 缓存读 + 缓存写」三者之和

🤖 Generated with [Claude Code](https://claude.com/claude-code)