### PR TITLE
fix(chat): 归档会话发送消息时立即取消归档显示【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/chat/ChatView.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatView.tsx
@@ -82,6 +82,7 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
 
   // ===== 全局 atoms（Map 结构，按 conversationId 读取） =====
   const conversations = useAtomValue(conversationsAtom)
+  const setConversations = useSetAtom(conversationsAtom)
   const setDraftSessionIds = useSetAtom(draftSessionIdsAtom)
   const streamingStates = useAtomValue(streamingStatesAtom)
   const setStreamingStates = useSetAtom(streamingStatesAtom)
@@ -295,6 +296,19 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
       return map
     })
 
+    // 乐观更新：发送瞬间若会话已归档，立即取消归档，
+    // 让侧边栏立即把它移到未归档列表，无需等待 STREAM_COMPLETE。
+    // 后端 appendMessage 已会做同样的取消归档，STREAM_COMPLETE 时会再用 listConversations 对齐
+    setConversations((prev) => {
+      const idx = prev.findIndex((c) => c.id === conversationId)
+      if (idx === -1) return prev
+      const conv = prev[idx]!
+      if (!conv.archived) return prev
+      const next = [...prev]
+      next[idx] = { ...conv, archived: false, updatedAt: Date.now() }
+      return next
+    })
+
     const input: ChatSendInput = {
       conversationId,
       userMessage: content,
@@ -344,6 +358,7 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
     activeToolIds,
     setChatStreamErrors,
     setStreamingStates,
+    setConversations,
   ])
 
   // ===== 自动发送快速任务消息 =====


### PR DESCRIPTION
## 概述

修复 Chat 模式下一个体验问题：对一个已归档（archived）的会话发送消息后，会话要等 LLM 流式输出**完全结束**才会出现在「未归档」列表里——在流式输出过程中，它仍然停留在「已归档」分组下。期望行为是发送消息的那一刻就立即取消归档显示。

## 根因

- 主进程 `conversation-manager.ts:186` 的 `appendMessage` 在写入用户消息时已经无条件执行 `if (conv.archived) conv.archived = false`，**后端状态从一开始就是对的**。
- 但前端 `useGlobalChatListeners.ts:110-114` 只在 `STREAM_COMPLETE` 事件触发时才调用 `listConversations()` 同步 `conversationsAtom`。
- 所以归档状态的 UI 反映被整段流式时长延迟了。

## 改动

- `apps/electron/src/renderer/components/chat/ChatView.tsx`
  - 在 `handleSend` 中新增一段乐观更新：发送瞬间若当前 `conversationsAtom` 中该会话 `archived === true`，立即把它改成 `archived: false` 并刷新 `updatedAt`。
  - 与该文件已有的「乐观渲染用户消息」（line 313-322）保持同一种模式，不引入新 IPC 通道，不动主进程逻辑。
  - 仅在 `conv.archived === true` 时更新，避免对未归档会话的位置造成抖动。
  - `STREAM_COMPLETE` 时已有的 `listConversations()` 会用后端真相做最终对齐，不存在双源真相风险。
  - 同步把 `setConversations` 加入 `useCallback` 依赖数组。
- `apps/electron/package.json`：版本 \`0.12.5\` → \`0.12.6\`，按 CLAUDE.md 约定 patch +1。

## 测试方法

1. 在 Chat 模式下打开任意一个会话，归档它（侧边栏右键 → 归档），切到「已归档」列表确认它在那里。
2. 打开这个归档会话，在输入框发送一条消息。
3. **观察侧边栏**：消息发出的那一刻（不需要等 LLM 流式响应结束），会话应当立即从「已归档」列表消失、出现在「未归档」分组的顶部。
4. 等流式响应结束后，再次确认会话仍在未归档列表里，不会跳回归档。
5. 反向回归：对一个**未归档**的会话发送消息，确认它在列表中的位置不发生意外抖动（因为乐观更新只在 archived=true 时触发）。

## 备注

- 不动主进程逻辑，无新增 IPC 通道，最小侵入。
- Type check 已跑过，无新增错误（仅有上游预存在的 `automation-manager.test.ts` 类型错误，与本 PR 无关）。
- Windows 兼容性：改动全是 React state + Jotai atom，无路径、shell、平台分支。