### PR TITLE
feat(sidebar): 点击工作区标题可折叠/展开会话列表

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -365,6 +365,8 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   const [moveTargetId, setMoveTargetId] = React.useState<string | null>(null)
   /** 每个项目额外展开显示的会话数量（每次点击"显示更多" +10），未点击则为 0 或无值 */
   const [expandedExtraCountMap, setExpandedExtraCountMap] = React.useState<Map<string, number>>(new Map())
+  /** 记录被用户手动折叠的工作区 ID（点击当前工作区标题时折叠/展开） */
+  const [collapsedWorkspaceIds, setCollapsedWorkspaceIds] = React.useState<Set<string>>(new Set())
   /** 项目拖拽排序状态 */
   const [dragProjectId, setDragProjectId] = React.useState<string | null>(null)
   const [projectDropIndicator, setProjectDropIndicator] = React.useState<{ id: string; position: 'before' | 'after' } | null>(null)
@@ -828,12 +830,34 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     await createAgentSessionInWorkspace()
   }, [createAgentSessionInWorkspace, setActiveView])
 
-  /** 切换当前项目 */
+  /** 切换当前项目 - 使用 ref 确保获取最新的 currentWorkspaceId */
+  const currentWorkspaceIdRef = React.useRef(currentWorkspaceId)
+  currentWorkspaceIdRef.current = currentWorkspaceId
+
   const handleSelectProject = React.useCallback((workspaceId: string): void => {
-    if (workspaceId === currentWorkspaceId) return
+    const currentId = currentWorkspaceIdRef.current
+    if (workspaceId === currentId) {
+      // 点击当前工作区 → 折叠/展开会话列表
+      setCollapsedWorkspaceIds((prev) => {
+        const next = new Set(prev)
+        if (next.has(workspaceId)) {
+          next.delete(workspaceId)
+        } else {
+          next.add(workspaceId)
+        }
+        return next
+      })
+      return
+    }
     setCurrentWorkspaceId(workspaceId)
+    // 切换到新工作区时，自动展开该工作区
+    setCollapsedWorkspaceIds((prev) => {
+      const next = new Set(prev)
+      next.delete(workspaceId)
+      return next
+    })
     window.electronAPI.updateSettings({ agentWorkspaceId: workspaceId }).catch(console.error)
-  }, [currentWorkspaceId, setCurrentWorkspaceId])
+  }, [setCurrentWorkspaceId])
 
   const canDeleteWorkspace = React.useCallback(
     (workspace: AgentWorkspace): boolean => workspace.slug !== 'default' && workspaces.length > 1,
@@ -1840,6 +1864,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                   currentWorkspaceId={currentWorkspaceId}
                   expanded={(expandedExtraCountMap.get(group.workspace.id) ?? 0) > 0}
                   extraCount={expandedExtraCountMap.get(group.workspace.id) ?? 0}
+                  collapsed={collapsedWorkspaceIds.has(group.workspace.id)}
                   activeSessionId={activeSessionId}
                   agentIndicatorMap={agentIndicatorMap}
                   relativeTimeNow={relativeTimeNow}
@@ -2623,6 +2648,7 @@ interface AgentProjectGroupItemProps {
   group: AgentProjectGroup
   currentWorkspaceId: string | null
   expanded: boolean
+  collapsed: boolean
   /** 用户已点击"显示更多"额外展开的会话数量（基于 collapsedSessions 之上累加） */
   extraCount: number
   activeSessionId: string | null
@@ -2655,6 +2681,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
   group,
   currentWorkspaceId,
   expanded,
+  collapsed,
   extraCount,
   activeSessionId,
   agentIndicatorMap,
@@ -2794,7 +2821,10 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
         ) : (
           <button
             type="button"
-            onClick={() => onSelectProject(group.workspace.id)}
+            onClick={(e) => {
+              e.stopPropagation()
+              onSelectProject(group.workspace.id)
+            }}
             className={cn(
               'relative flex-1 min-w-0 flex items-center gap-1 px-1 py-1 rounded-md text-left transition-[padding,color,background-color] titlebar-no-drag group-hover/project:pl-4 group-hover/project:pr-11 hover:bg-foreground/[0.025]',
               isCurrent
@@ -2875,51 +2905,53 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
       </div>
 
       <div className="ml-4 mt-px">
-        {group.sessions.length > 0 ? (
-          <div className="flex flex-col gap-0.5">
-            {sessions.map((session) => (
-              <AgentSessionItem
-                key={session.id}
-                session={session}
-                active={session.id === activeSessionId}
-                indicatorStatus={agentIndicatorMap.get(session.id) ?? 'idle'}
-                showPinIcon={!!session.pinned}
-                leftAccent={getSessionLeftAccent(agentIndicatorMap.get(session.id) ?? 'idle')}
-                relativeTimeNow={relativeTimeNow}
-                onSelect={onSelectSession}
-                onRequestDelete={onRequestDelete}
-                onRequestMove={onRequestMove}
-                onRename={onRename}
-                onTogglePin={onTogglePin}
-                onToggleArchive={onToggleArchive}
-              />
-            ))}
+        {!collapsed ? (
+          group.sessions.length > 0 ? (
+            <div className="flex flex-col gap-0.5">
+              {sessions.map((session) => (
+                <AgentSessionItem
+                  key={session.id}
+                  session={session}
+                  active={session.id === activeSessionId}
+                  indicatorStatus={agentIndicatorMap.get(session.id) ?? 'idle'}
+                  showPinIcon={!!session.pinned}
+                  leftAccent={getSessionLeftAccent(agentIndicatorMap.get(session.id) ?? 'idle')}
+                  relativeTimeNow={relativeTimeNow}
+                  onSelect={onSelectSession}
+                  onRequestDelete={onRequestDelete}
+                  onRequestMove={onRequestMove}
+                  onRename={onRename}
+                  onTogglePin={onTogglePin}
+                  onToggleArchive={onToggleArchive}
+                />
+              ))}
 
-            {hiddenCount > 0 && (
-              <button
-                type="button"
-                onClick={() => onShowMore(group.workspace.id)}
-                className="w-full text-left px-1.5 py-1 rounded-md text-[12px] text-foreground/35 hover:bg-foreground/[0.03] hover:text-foreground/60 transition-colors titlebar-no-drag"
-              >
-                显示更多
-              </button>
-            )}
+              {hiddenCount > 0 && (
+                <button
+                  type="button"
+                  onClick={() => onShowMore(group.workspace.id)}
+                  className="w-full text-left px-1.5 py-1 rounded-md text-[12px] text-foreground/35 hover:bg-foreground/[0.03] hover:text-foreground/60 transition-colors titlebar-no-drag"
+                >
+                  显示更多
+                </button>
+              )}
 
-            {expanded && (
-              <button
-                type="button"
-                onClick={() => onCollapseExtra(group.workspace.id)}
-                className="w-full text-left px-1.5 py-1 rounded-md text-[12px] text-foreground/35 hover:bg-foreground/[0.03] hover:text-foreground/60 transition-colors titlebar-no-drag"
-              >
-                收起
-              </button>
-            )}
-          </div>
-        ) : (
-          <div className="px-1.5 py-0.5 text-[12px] text-foreground/22 select-none">
-            暂无会话
-          </div>
-        )}
+              {expanded && (
+                <button
+                  type="button"
+                  onClick={() => onCollapseExtra(group.workspace.id)}
+                  className="w-full text-left px-1.5 py-1 rounded-md text-[12px] text-foreground/35 hover:bg-foreground/[0.03] hover:text-foreground/60 transition-colors titlebar-no-drag"
+                >
+                  收起
+                </button>
+              )}
+            </div>
+          ) : (
+            <div className="px-1.5 py-0.5 text-[12px] text-foreground/22 select-none">
+              暂无会话
+            </div>
+          )
+        ) : null}
       </div>
       {dropPosition === 'after' && (
         <div className="absolute -bottom-0.5 left-3 right-3 h-0.5 rounded-full bg-primary z-10" />

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -11,7 +11,7 @@
 import * as React from 'react'
 import { useAtom, useSetAtom, useAtomValue, useStore } from 'jotai'
 import { toast } from 'sonner'
-import { Pin, PinOff, Settings, Plus, Trash2, Pencil, Plug, Zap, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, GripVertical, Clock, AlarmClock } from 'lucide-react'
+import { Pin, PinOff, Settings, Plus, Trash2, Pencil, Plug, Zap, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, GripVertical, Clock, AlarmClock, ChevronRight } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { ModeSwitcher } from './ModeSwitcher'
@@ -342,6 +342,25 @@ function SidebarWindowDragStrip({ height }: { height: number }): React.ReactElem
   )
 }
 
+/** 不可变地切换 Set 中某个成员的存在状态（存在则删除，不存在则添加），返回新 Set */
+function toggleSetEntry<T>(prev: Set<T>, value: T): Set<T> {
+  const next = new Set(prev)
+  if (next.has(value)) {
+    next.delete(value)
+  } else {
+    next.add(value)
+  }
+  return next
+}
+
+/** 不可变地从 Set 中移除某个成员，若不存在则原样返回 */
+function deleteSetEntry<T>(prev: Set<T>, value: T): Set<T> {
+  if (!prev.has(value)) return prev
+  const next = new Set(prev)
+  next.delete(value)
+  return next
+}
+
 export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   const [activeView, setActiveView] = useAtom(activeViewAtom)
   const setAutomationForm = useSetAtom(automationFormAtom)
@@ -365,7 +384,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   const [moveTargetId, setMoveTargetId] = React.useState<string | null>(null)
   /** 每个项目额外展开显示的会话数量（每次点击"显示更多" +10），未点击则为 0 或无值 */
   const [expandedExtraCountMap, setExpandedExtraCountMap] = React.useState<Map<string, number>>(new Map())
-  /** 记录被用户手动折叠的工作区 ID（点击当前工作区标题时折叠/展开） */
+  /** 记录被用户手动折叠的工作区 ID（点击当前工作区标题时折叠/展开）。刻意不持久化：折叠被视为临时查看行为，刷新/重启后恢复默认展开 */
   const [collapsedWorkspaceIds, setCollapsedWorkspaceIds] = React.useState<Set<string>>(new Set())
   /** 项目拖拽排序状态 */
   const [dragProjectId, setDragProjectId] = React.useState<string | null>(null)
@@ -830,34 +849,18 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     await createAgentSessionInWorkspace()
   }, [createAgentSessionInWorkspace, setActiveView])
 
-  /** 切换当前项目 - 使用 ref 确保获取最新的 currentWorkspaceId */
-  const currentWorkspaceIdRef = React.useRef(currentWorkspaceId)
-  currentWorkspaceIdRef.current = currentWorkspaceId
-
+  /** 切换当前项目；点击当前已选中工作区标题时则折叠/展开其会话列表 */
   const handleSelectProject = React.useCallback((workspaceId: string): void => {
-    const currentId = currentWorkspaceIdRef.current
-    if (workspaceId === currentId) {
+    if (workspaceId === currentWorkspaceId) {
       // 点击当前工作区 → 折叠/展开会话列表
-      setCollapsedWorkspaceIds((prev) => {
-        const next = new Set(prev)
-        if (next.has(workspaceId)) {
-          next.delete(workspaceId)
-        } else {
-          next.add(workspaceId)
-        }
-        return next
-      })
+      setCollapsedWorkspaceIds((prev) => toggleSetEntry(prev, workspaceId))
       return
     }
     setCurrentWorkspaceId(workspaceId)
     // 切换到新工作区时，自动展开该工作区
-    setCollapsedWorkspaceIds((prev) => {
-      const next = new Set(prev)
-      next.delete(workspaceId)
-      return next
-    })
+    setCollapsedWorkspaceIds((prev) => deleteSetEntry(prev, workspaceId))
     window.electronAPI.updateSettings({ agentWorkspaceId: workspaceId }).catch(console.error)
-  }, [setCurrentWorkspaceId])
+  }, [currentWorkspaceId, setCurrentWorkspaceId])
 
   const canDeleteWorkspace = React.useCallback(
     (workspace: AgentWorkspace): boolean => workspace.slug !== 'default' && workspaces.length > 1,
@@ -942,6 +945,8 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         next.delete(workspaceId)
         return next
       })
+
+      setCollapsedWorkspaceIds((prev) => deleteSetEntry(prev, workspaceId))
 
       if (workspaceId === currentWorkspaceId) {
         const fallback = remainingWorkspaces.find((item) => item.slug === 'default') ?? remainingWorkspaces[0] ?? null
@@ -2821,6 +2826,8 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
         ) : (
           <button
             type="button"
+            aria-expanded={!collapsed}
+            aria-controls={`project-sessions-${group.workspace.id}`}
             onClick={(e) => {
               e.stopPropagation()
               onSelectProject(group.workspace.id)
@@ -2836,6 +2843,13 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
             <span className="flex-1 min-w-0 truncate text-[13px] font-medium leading-[18px]">
               {group.workspace.name}
             </span>
+            <ChevronRight
+              size={12}
+              className={cn(
+                'flex-shrink-0 text-foreground/30 transition-transform duration-150',
+                collapsed ? '-rotate-90' : 'rotate-90',
+              )}
+            />
           </button>
         )}
 
@@ -2904,7 +2918,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
         </DropdownMenu>
       </div>
 
-      <div className="ml-4 mt-px">
+      <div id={`project-sessions-${group.workspace.id}`} className="ml-4 mt-px">
         {!collapsed ? (
           group.sessions.length > 0 ? (
             <div className="flex flex-col gap-0.5">


### PR DESCRIPTION
## 背景

基于 #774（@climashscape 原始实现），测试与代码审查后合并功能本体并补齐若干改进。

## 功能

- 点击**当前工作区**标题 → 折叠/展开其下会话列表
- 切换到新工作区时自动展开
- 折叠状态用 ChevronRight 图标旋转 + `aria-expanded` 做视觉/语义提示

## 审查改进（已合入）

- **状态泄漏修复**：删除工作区时同步清理 `collapsedWorkspaceIds`
- **无障碍**：标题按钮补 `aria-expanded` / `aria-controls`，会话容器补对应 `id`
- **移除反模式**：不再在渲染期写 `ref.current`，`handleSelectProject` 直接依赖 `currentWorkspaceId`
- **工具函数**：抽取 `toggleSetEntry` / `deleteSetEntry` 减少样板代码
- **决策注释**：明确折叠状态刻意不持久化（视为临时查看行为）

## Test plan

- [ ] 点击当前工作区标题，会话列表折叠/展开，Chevron 图标旋转
- [ ] 切换到其他工作区，目标工作区自动展开
- [ ] 折叠某工作区后删除该工作区，无异常
- [ ] 刷新应用后折叠状态重置为展开
- [ ] 屏幕阅读器能正确识别折叠控件