### PR TITLE
【已审核】feat(ui): 添加 Chat/Agent 消息块级截图功能 🔥

### DIFF
--- a/apps/electron/src/main/lib/screenshot-service.ts
+++ b/apps/electron/src/main/lib/screenshot-service.ts
@@ -175,37 +175,29 @@ function sanitizeScreenshotFragment(html: string): string {
 function buildScreenshotHtml(htmlContent: string, isDark: boolean, css: string, themeClass: string): string {
   const bg = isDark ? '#111827' : '#ffffff'
   const safeHtml = sanitizeScreenshotFragment(htmlContent)
-  // 防止 css 字符串中出现 `</style >` 等变体提前终止 style 块。
   const safeCss = css.replace(/<\/style\s*>/gi, '<\\/style>')
   const safeThemeClass = themeClass.replace(/["<>]/g, '')
 
+  // wrapper 不再添加排版样式（padding/max-width/margin 等），
+  // 由渲染端注入的精简 CSS 全权控制排版。此处只做 reset + 安全加固。
   return `<!DOCTYPE html>
 <html class="${safeThemeClass}"><head>
 <meta charset="utf-8">
 <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src 'self' data: blob: proma-file: https: http:; media-src 'self' data: blob: proma-file: https: http:; font-src 'self' data: https: http:; style-src 'unsafe-inline'; script-src 'none'; connect-src 'none'; frame-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'">
+<meta name="color-scheme" content="${isDark ? 'dark' : 'light'}">
 <style>${safeCss}</style>
 <style>
-*{box-sizing:border-box}
 html,body{margin:0;background:${bg};scrollbar-width:none;-ms-overflow-style:none}
 html::-webkit-scrollbar,body::-webkit-scrollbar{display:none}
 body{-webkit-font-smoothing:antialiased;text-rendering:geometricPrecision}
-img,video,canvas,svg{max-width:100%}
-.proma-screenshot-wrapper{padding:${SCREENSHOT_PADDING_TOP}px ${SCREENSHOT_PADDING_X}px;background:${bg};width:max-content;max-width:100%;margin:0 auto}
-.proma-screenshot-sheet{width:max-content;max-width:100%;margin:0 auto;background:${bg}}
-.proma-screenshot-sheet [contenteditable],
-.proma-screenshot-sheet [contenteditable="false"]{outline:none}
-.proma-screenshot-sheet .ProseMirror-selectednode,
-.proma-screenshot-sheet .selectedCell::after{display:none!important}
 </style></head><body class="${safeThemeClass}">
-<div class="proma-screenshot-wrapper">
-<main class="proma-screenshot-sheet">${safeHtml}</main>
-</div>
+${safeHtml}
 </body></html>`
 }
 
 /* ── 核心截图函数 ── */
 
-async function loadScreenshotDocument(win: BrowserWindow, htmlPath: string, width: number): Promise<number> {
+async function loadScreenshotDocument(win: BrowserWindow, htmlPath: string, width: number): Promise<{ width: number; height: number }> {
   win.setSize(width, 100)
   await win.loadURL(pathToFileURL(htmlPath).href)
   await win.webContents.executeJavaScript(`
@@ -227,14 +219,28 @@ async function loadScreenshotDocument(win: BrowserWindow, htmlPath: string, widt
     })()
   `)
   await new Promise((r) => setTimeout(r, 100))
-  const totalHeight: number = await win.webContents.executeJavaScript(`
-      Math.max(document.body.scrollHeight, document.body.offsetHeight,
-               document.documentElement.scrollHeight, document.documentElement.offsetHeight)
+
+  const dims: { width: number; height: number } = await win.webContents.executeJavaScript(`
+    (() => {
+      const article = document.querySelector('.msg');
+      const contentW = article ? article.scrollWidth : document.body.scrollWidth;
+      const finalW = Math.max(contentW, ${SCREENSHOT_LIMITS.MIN_WIDTH}) + ${SCREENSHOT_PADDING_X} * 2;
+      const h = Math.max(document.body.scrollHeight, document.body.offsetHeight,
+               document.documentElement.scrollHeight, document.documentElement.offsetHeight);
+      return { width: Math.ceil(finalW), height: Math.ceil(h) };
+    })()
   `)
-  if (!Number.isFinite(totalHeight) || totalHeight <= 0) {
+
+  if (!Number.isFinite(dims.height) || dims.height <= 0) {
     throw new Error('截图内容高度无效')
   }
-  return Math.ceil(totalHeight)
+  if (!Number.isFinite(dims.width) || dims.width <= 0) {
+    throw new Error('截图内容宽度无效')
+  }
+
+  // 窗口尺寸 = 内容实际宽度 + 左右留白（executeJavaScript 中已计入）
+  win.setSize(dims.width, dims.height)
+  return { width: dims.width, height: dims.height }
 }
 
 async function captureLoadedDocument(win: BrowserWindow, width: number, totalHeight: number, scale: number): Promise<Buffer> {
@@ -275,18 +281,20 @@ async function screenshotCapture(htmlContent: string, width: number): Promise<Bu
 
   try {
     let win = getScreenshotWindow(1)
-    let totalHeight = await loadScreenshotDocument(win, tmpPath, width)
-    const scale = resolveScreenshotScale(width, totalHeight)
+    let { width: actualWidth, height: totalHeight } = await loadScreenshotDocument(win, tmpPath, width)
+    const scale = resolveScreenshotScale(actualWidth, totalHeight)
     if (!scale) {
       throw new Error('文档过长，当前截图会占用过多内存，请缩短内容后重试')
     }
 
     if (scale !== 1) {
       win = getScreenshotWindow(scale)
-      totalHeight = await loadScreenshotDocument(win, tmpPath, width)
+      const dims = await loadScreenshotDocument(win, tmpPath, width)
+      actualWidth = dims.width
+      totalHeight = dims.height
     }
 
-    return captureLoadedDocument(win, width, totalHeight, scale)
+    return captureLoadedDocument(win, actualWidth, totalHeight, scale)
   } finally {
     try { unlinkSync(tmpPath) } catch { /* 清理 */ }
   }

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -7,7 +7,8 @@
 
 import * as React from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
-import { Bot, RotateCw, AlertTriangle, ChevronDown, ChevronRight } from 'lucide-react'
+import { Bot, RotateCw, AlertTriangle, ChevronDown, ChevronRight, Camera, Circle } from 'lucide-react'
+import { toast } from 'sonner'
 import { WelcomeEmptyState } from '@/components/welcome/WelcomeEmptyState'
 import {
   Message,
@@ -34,6 +35,8 @@ import { cn } from '@/lib/utils'
 import { Spinner } from '@/components/ui/spinner'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { groupIntoTurns, MessageGroupRenderer, getGroupId, getGroupPreview, extractUserText, parseAttachedFiles as sdkParseAttachedFiles, isImageFile as sdkIsImageFile, CompactingIndicator, buildHistoricalTaskSubjects, type MessageGroup } from './SDKMessageRenderer'
+import { useMessageSelectionContext } from '@/components/shared/MessageSelectionContext'
+import { captureSelectedMessages } from '@/lib/chat-screenshot'
 import { buildLiveGroupSet } from './live-group-set'
 import { ContentBlock } from './ContentBlock'
 import { parseThinkTagsFromText } from './thinking-tag-parser'
@@ -397,6 +400,7 @@ export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persi
   const userProfile = useAtomValue(userProfileAtom)
   const setMinimapCache = useSetAtom(tabMinimapCacheAtom)
   const channels = useAtomValue(channelsAtom)
+  const sel = useMessageSelectionContext()
   /** 淡入控制：切换会话时先隐藏，等布局完成后再显示。 */
   const [ready, setReady] = React.useState(false)
   // 空会话无需淡入过渡（无消息则无滚动位置问题）
@@ -625,10 +629,15 @@ export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persi
               const isLastAssistantTurn = !streaming && stoppedByUser
                 && group.type === 'assistant-turn'
                 && idx === allGroups.findLastIndex((g) => g.type === 'assistant-turn')
+              const groupId = getGroupId(group)
               return (
-                <MessageGroupRenderer
-                  key={getGroupId(group)}
-                  group={group}
+                <div
+                  key={groupId}
+                  data-message-id={groupId}
+                >
+                  <div className="flex-1 min-w-0">
+                    <MessageGroupRenderer
+                      group={group}
                   allMessages={allSDKMessages}
                   historicalTaskSubjects={historicalTaskSubjects}
                   basePath={sessionPath || undefined}
@@ -641,6 +650,8 @@ export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persi
                   stoppedByUser={isLastAssistantTurn || undefined}
                   sessionModelId={sessionModelId}
                 />
+                  </div>
+                </div>
               )
             })}
 

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -26,6 +26,7 @@ import { PermissionModeSelector } from './PermissionModeSelector'
 import { AskUserBanner } from './AskUserBanner'
 import { ExitPlanModeBanner } from './ExitPlanModeBanner'
 import { PlanModeDashedBorder } from './PlanModeDashedBorder'
+import { MessageSelectionProvider } from '@/components/shared/MessageSelectionContext'
 import { ModelSelector } from '@/components/chat/ModelSelector'
 import { AttachmentPreviewItem } from '@/components/chat/AttachmentPreviewItem'
 import { QuotedSelectionChip } from '@/components/diff/QuotedSelectionChip'
@@ -2028,6 +2029,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         <AgentHeader sessionId={sessionId} />
 
         {/* 消息区域 */}
+        <MessageSelectionProvider>
         <AgentMessages
           sessionId={sessionId}
           sessionModelId={agentModelId || undefined}
@@ -2045,6 +2047,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           onRewind={handleRewindRequest}
           onCompact={handleCompact}
         />
+        </MessageSelectionProvider>
 
         {/* 权限请求横幅 */}
         <PermissionBanner sessionId={sessionId} />

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -760,8 +760,9 @@ export function AssistantTurnRenderer({ turn, allMessages, historicalTaskSubject
             <button
               type="button"
               className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-7 w-7 focus-visible:ring-0 text-muted-foreground/60"
-              onClick={async () => {
-                const ids = sel.selectedIds.size > 0 ? sel.selectedIds : new Set([turnId])
+              onClick={async (e) => {
+                const domId = (e.currentTarget as HTMLElement).closest('[data-message-id]')?.getAttribute('data-message-id') ?? turnId
+                const ids = sel.selectedIds.size > 0 ? sel.selectedIds : new Set([domId])
                 try {
                   const result = await captureSelectedMessages(ids, 'file')
                   if (result.success) toast.success('截图已保存')
@@ -776,8 +777,9 @@ export function AssistantTurnRenderer({ turn, allMessages, historicalTaskSubject
             <button
               type="button"
               className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-7 w-7 focus-visible:ring-0 text-muted-foreground/60"
-              onClick={async () => {
-                const ids = sel.selectedIds.size > 0 ? sel.selectedIds : new Set([turnId])
+              onClick={async (e) => {
+                const domId = (e.currentTarget as HTMLElement).closest('[data-message-id]')?.getAttribute('data-message-id') ?? turnId
+                const ids = sel.selectedIds.size > 0 ? sel.selectedIds : new Set([domId])
                 try {
                   const result = await captureSelectedMessages(ids, 'clipboard')
                   if (result.success) toast.success('已复制到剪贴板')
@@ -1145,8 +1147,9 @@ function UserInputMessage({ message }: { message: SDKUserMessage }): React.React
         <button type="button" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-7 w-7 focus-visible:ring-0 text-muted-foreground/60" onClick={() => sel.toggle(message.uuid || '')}>
           {sel.isSelected(message.uuid || '') ? <Circle className="size-3.5 fill-current" /> : <Circle className="size-3.5" />}
         </button>
-        <button type="button" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-7 w-7 focus-visible:ring-0 text-muted-foreground/60" onClick={async () => {
-          const ids = sel.selectedIds.size > 0 ? sel.selectedIds : new Set([message.uuid || ''])
+        <button type="button" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-7 w-7 focus-visible:ring-0 text-muted-foreground/60" onClick={async (e) => {
+          const domId = (e.currentTarget as HTMLElement).closest('[data-message-id]')?.getAttribute('data-message-id') ?? ''
+          const ids = sel.selectedIds.size > 0 ? sel.selectedIds : new Set([domId])
           try {
             const result = await captureSelectedMessages(ids, 'file')
             if (result.success) toast.success('截图已保存')
@@ -1155,8 +1158,9 @@ function UserInputMessage({ message }: { message: SDKUserMessage }): React.React
         }}>
           <Camera className="size-3.5" />
         </button>
-        <button type="button" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-7 w-7 focus-visible:ring-0 text-muted-foreground/60" onClick={async () => {
-          const ids = sel.selectedIds.size > 0 ? sel.selectedIds : new Set([message.uuid || ''])
+        <button type="button" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-7 w-7 focus-visible:ring-0 text-muted-foreground/60" onClick={async (e) => {
+          const domId = (e.currentTarget as HTMLElement).closest('[data-message-id]')?.getAttribute('data-message-id') ?? ''
+          const ids = sel.selectedIds.size > 0 ? sel.selectedIds : new Set([domId])
           try {
             const result = await captureSelectedMessages(ids, 'clipboard')
             if (result.success) toast.success('已复制到剪贴板')
@@ -1376,8 +1380,9 @@ function ErrorMessage({ message, onRetry, onRetryInNewSession, onCompact }: Erro
             <button
               type="button"
               className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-7 w-7 focus-visible:ring-0 text-muted-foreground/60"
-              onClick={async () => {
-                const ids = sel.selectedIds.size > 0 ? sel.selectedIds : new Set([uid])
+              onClick={async (e) => {
+                const domId = (e.currentTarget as HTMLElement).closest('[data-message-id]')?.getAttribute('data-message-id') ?? uid
+                const ids = sel.selectedIds.size > 0 ? sel.selectedIds : new Set([domId])
                 try {
                   const result = await captureSelectedMessages(ids, 'file')
                   if (result.success) toast.success('截图已保存')
@@ -1392,8 +1397,9 @@ function ErrorMessage({ message, onRetry, onRetryInNewSession, onCompact }: Erro
             <button
               type="button"
               className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-7 w-7 focus-visible:ring-0 text-muted-foreground/60"
-              onClick={async () => {
-                const ids = sel.selectedIds.size > 0 ? sel.selectedIds : new Set([uid])
+              onClick={async (e) => {
+                const domId = (e.currentTarget as HTMLElement).closest('[data-message-id]')?.getAttribute('data-message-id') ?? uid
+                const ids = sel.selectedIds.size > 0 ? sel.selectedIds : new Set([domId])
                 try {
                   const result = await captureSelectedMessages(ids, 'clipboard')
                   if (result.success) toast.success('已复制到剪贴板')

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -12,7 +12,7 @@
  */
 
 import * as React from 'react'
-import { Bot, Loader2, AlertTriangle, FileText, FileImage, Download, Split, Undo2, RotateCw, Plus, Minimize2, Wrench, Settings, ExternalLink, Quote, Clock } from 'lucide-react'
+import { Bot, Loader2, AlertTriangle, FileText, FileImage, Download, Split, Undo2, RotateCw, Plus, Minimize2, Wrench, Settings, ExternalLink, Quote, Clock, Camera, Circle, Copy } from 'lucide-react'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { cn } from '@/lib/utils'
 import { ImageLightbox } from '@/components/ui/image-lightbox'
@@ -34,6 +34,9 @@ import {
 } from '@/components/ai-elements/message'
 import { UserAvatar } from '@/components/chat/UserAvatar'
 import { CopyButton } from '@/components/chat/CopyButton'
+import { captureSelectedMessages } from '@/lib/chat-screenshot'
+import { useMessageSelectionContext } from '@/components/shared/MessageSelectionContext'
+import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { formatMessageTime } from '@/components/chat/ChatMessageItem'
@@ -552,6 +555,8 @@ export interface AssistantTurnRendererProps {
 export function AssistantTurnRenderer({ turn, allMessages, historicalTaskSubjects, basePath, onFork, onRewind, onRetry, onRetryInNewSession, onCompact, isStreaming, stoppedByUser, sessionModelId }: AssistantTurnRendererProps): React.ReactElement | null {
   const channels = useAtomValue(channelsAtom)
   const processGroupsKeepExpanded = useAtomValue(agentProcessGroupsKeepExpandedAtom)
+  const sel = useMessageSelectionContext()
+  const turnId = getGroupId(turn)
   // 收集所有 assistant 消息的内容块，保留 parent_tool_use_id 关联
   interface EnrichedBlock {
     block: SDKContentBlock
@@ -739,12 +744,51 @@ export function AssistantTurnRenderer({ turn, allMessages, historicalTaskSubject
         const lastUuid = mainlineAssistants.length > 0
           ? mainlineAssistants[mainlineAssistants.length - 1]?.uuid
           : undefined
-        const hasActions = !!(textContent || (onFork && lastUuid) || (onRewind && lastUuid))
         const hasDuration = durationMs != null
-        if (!hasDuration && !hasActions && !showStoppedBadge) return null
         return (
           <MessageActions className="pl-[46px] mt-0.5 min-h-[28px] justify-start">
-            {hasDuration && <DurationBadge durationMs={durationMs!} usage={usage} />}
+            <button
+              type="button"
+              className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-7 w-7 focus-visible:ring-0 text-muted-foreground/60"
+              onClick={() => sel.toggle(turnId)}
+            >
+              {sel.isSelected(turnId)
+                ? <Circle className="size-3.5 fill-current" />
+                : <Circle className="size-3.5" />
+              }
+            </button>
+            <button
+              type="button"
+              className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-7 w-7 focus-visible:ring-0 text-muted-foreground/60"
+              onClick={async () => {
+                const ids = sel.selectedIds.size > 0 ? sel.selectedIds : new Set([turnId])
+                try {
+                  const result = await captureSelectedMessages(ids, 'file')
+                  if (result.success) toast.success('截图已保存')
+                  else if (result.error) toast.error(result.error)
+                } catch {
+                  toast.error('截图失败')
+                }
+              }}
+            >
+              <Camera className="size-3.5" />
+            </button>
+            <button
+              type="button"
+              className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-7 w-7 focus-visible:ring-0 text-muted-foreground/60"
+              onClick={async () => {
+                const ids = sel.selectedIds.size > 0 ? sel.selectedIds : new Set([turnId])
+                try {
+                  const result = await captureSelectedMessages(ids, 'clipboard')
+                  if (result.success) toast.success('已复制到剪贴板')
+                  else if (result.error) toast.error(result.error)
+                } catch {
+                  toast.error('截图失败')
+                }
+              }}
+            >
+              <Copy className="size-3.5" />
+            </button>
             {textContent && <CopyButton content={textContent} />}
             {onFork && lastUuid && (
               <MessageAction tooltip="从此处分叉" onClick={() => onFork(lastUuid)}>
@@ -1044,6 +1088,7 @@ function ScheduledRunBadge(): React.ReactElement {
 
 function UserInputMessage({ message }: { message: SDKUserMessage }): React.ReactElement {
   const userProfile = useAtomValue(userProfileAtom)
+  const sel = useMessageSelectionContext()
   const rawText = extractUserText(message) ?? ''
   const isScheduledRun = rawText.includes(SCHEDULED_RUN_MARKER)
   const { files: attachedFiles, quotes, text } = parseAttachedFiles(stripScheduledRunMarker(rawText))
@@ -1096,11 +1141,32 @@ function UserInputMessage({ message }: { message: SDKUserMessage }): React.React
         )}
         {text && <UserMessageContent>{text}</UserMessageContent>}
       </MessageContent>
-      {text && (
-        <MessageActions className="pl-[46px] mt-0.5">
-          <CopyButton content={text} />
-        </MessageActions>
-      )}
+      <MessageActions className="pl-[46px] mt-0.5">
+        <button type="button" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-7 w-7 focus-visible:ring-0 text-muted-foreground/60" onClick={() => sel.toggle(message.uuid || '')}>
+          {sel.isSelected(message.uuid || '') ? <Circle className="size-3.5 fill-current" /> : <Circle className="size-3.5" />}
+        </button>
+        <button type="button" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-7 w-7 focus-visible:ring-0 text-muted-foreground/60" onClick={async () => {
+          const ids = sel.selectedIds.size > 0 ? sel.selectedIds : new Set([message.uuid || ''])
+          try {
+            const result = await captureSelectedMessages(ids, 'file')
+            if (result.success) toast.success('截图已保存')
+            else if (result.error) toast.error(result.error)
+          } catch { toast.error('截图失败') }
+        }}>
+          <Camera className="size-3.5" />
+        </button>
+        <button type="button" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-7 w-7 focus-visible:ring-0 text-muted-foreground/60" onClick={async () => {
+          const ids = sel.selectedIds.size > 0 ? sel.selectedIds : new Set([message.uuid || ''])
+          try {
+            const result = await captureSelectedMessages(ids, 'clipboard')
+            if (result.success) toast.success('已复制到剪贴板')
+            else if (result.error) toast.error(result.error)
+          } catch { toast.error('截图失败') }
+        }}>
+          <Copy className="size-3.5" />
+        </button>
+        {text && <CopyButton content={text} />}
+      </MessageActions>
     </Message>
   )
 }
@@ -1118,6 +1184,7 @@ interface ErrorMessageProps {
 }
 
 function ErrorMessage({ message, onRetry, onRetryInNewSession, onCompact }: ErrorMessageProps): React.ReactElement {
+  const sel = useMessageSelectionContext()
   const meta = extractMeta(message as unknown as SDKMessage)
   const errorText = message.error?.message ?? '未知错误'
 
@@ -1294,6 +1361,52 @@ function ErrorMessage({ message, onRetry, onRetryInNewSession, onCompact }: Erro
         )}
       </MessageContent>
       <MessageActions className="pl-[46px] mt-0.5">
+        {message.uuid && (() => { const uid = message.uuid!; return (
+          <>
+            <button
+              type="button"
+              className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-7 w-7 focus-visible:ring-0 text-muted-foreground/60"
+              onClick={() => sel.toggle(uid)}
+            >
+              {sel.isSelected(uid)
+                ? <Circle className="size-3.5 fill-current" />
+                : <Circle className="size-3.5" />
+              }
+            </button>
+            <button
+              type="button"
+              className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-7 w-7 focus-visible:ring-0 text-muted-foreground/60"
+              onClick={async () => {
+                const ids = sel.selectedIds.size > 0 ? sel.selectedIds : new Set([uid])
+                try {
+                  const result = await captureSelectedMessages(ids, 'file')
+                  if (result.success) toast.success('截图已保存')
+                  else if (result.error) toast.error(result.error)
+                } catch {
+                  toast.error('截图失败')
+                }
+              }}
+            >
+              <Camera className="size-3.5" />
+            </button>
+            <button
+              type="button"
+              className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-7 w-7 focus-visible:ring-0 text-muted-foreground/60"
+              onClick={async () => {
+                const ids = sel.selectedIds.size > 0 ? sel.selectedIds : new Set([uid])
+                try {
+                  const result = await captureSelectedMessages(ids, 'clipboard')
+                  if (result.success) toast.success('已复制到剪贴板')
+                  else if (result.error) toast.error(result.error)
+                } catch {
+                  toast.error('截图失败')
+                }
+              }}
+            >
+              <Copy className="size-3.5" />
+            </button>
+          </>
+        )})()}
         <CopyButton content={displayContentText} />
       </MessageActions>
     </Message>

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -1091,6 +1091,7 @@ function ScheduledRunBadge(): React.ReactElement {
 function UserInputMessage({ message }: { message: SDKUserMessage }): React.ReactElement {
   const userProfile = useAtomValue(userProfileAtom)
   const sel = useMessageSelectionContext()
+  const msgKey = stableUserMsgId(message)
   const rawText = extractUserText(message) ?? ''
   const isScheduledRun = rawText.includes(SCHEDULED_RUN_MARKER)
   const { files: attachedFiles, quotes, text } = parseAttachedFiles(stripScheduledRunMarker(rawText))
@@ -1144,8 +1145,8 @@ function UserInputMessage({ message }: { message: SDKUserMessage }): React.React
         {text && <UserMessageContent>{text}</UserMessageContent>}
       </MessageContent>
       <MessageActions className="pl-[46px] mt-0.5">
-        <button type="button" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-7 w-7 focus-visible:ring-0 text-muted-foreground/60" onClick={() => sel.toggle(message.uuid || '')}>
-          {sel.isSelected(message.uuid || '') ? <Circle className="size-3.5 fill-current" /> : <Circle className="size-3.5" />}
+        <button type="button" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-7 w-7 focus-visible:ring-0 text-muted-foreground/60" onClick={() => sel.toggle(msgKey)}>
+          {sel.isSelected(msgKey) ? <Circle className="size-3.5 fill-current" /> : <Circle className="size-3.5" />}
         </button>
         <button type="button" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-7 w-7 focus-visible:ring-0 text-muted-foreground/60" onClick={async (e) => {
           const domId = (e.currentTarget as HTMLElement).closest('[data-message-id]')?.getAttribute('data-message-id') ?? ''
@@ -1191,6 +1192,7 @@ function ErrorMessage({ message, onRetry, onRetryInNewSession, onCompact }: Erro
   const sel = useMessageSelectionContext()
   const meta = extractMeta(message as unknown as SDKMessage)
   const errorText = message.error?.message ?? '未知错误'
+  const msgKey = stableUserMsgId(message)
 
   const msgAny = message as unknown as Record<string, unknown>
   const errorTitle = typeof msgAny._errorTitle === 'string' ? msgAny._errorTitle : undefined
@@ -1365,14 +1367,14 @@ function ErrorMessage({ message, onRetry, onRetryInNewSession, onCompact }: Erro
         )}
       </MessageContent>
       <MessageActions className="pl-[46px] mt-0.5">
-        {message.uuid && (() => { const uid = message.uuid!; return (
+        {message.uuid && (() => { const msgKeyLocal = msgKey; return (
           <>
             <button
               type="button"
               className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-7 w-7 focus-visible:ring-0 text-muted-foreground/60"
-              onClick={() => sel.toggle(uid)}
+              onClick={() => sel.toggle(msgKeyLocal)}
             >
-              {sel.isSelected(uid)
+              {sel.isSelected(msgKeyLocal)
                 ? <Circle className="size-3.5 fill-current" />
                 : <Circle className="size-3.5" />
               }
@@ -1381,7 +1383,7 @@ function ErrorMessage({ message, onRetry, onRetryInNewSession, onCompact }: Erro
               type="button"
               className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-7 w-7 focus-visible:ring-0 text-muted-foreground/60"
               onClick={async (e) => {
-                const domId = (e.currentTarget as HTMLElement).closest('[data-message-id]')?.getAttribute('data-message-id') ?? uid
+                const domId = (e.currentTarget as HTMLElement).closest('[data-message-id]')?.getAttribute('data-message-id') ?? msgKeyLocal
                 const ids = sel.selectedIds.size > 0 ? sel.selectedIds : new Set([domId])
                 try {
                   const result = await captureSelectedMessages(ids, 'file')
@@ -1398,7 +1400,7 @@ function ErrorMessage({ message, onRetry, onRetryInNewSession, onCompact }: Erro
               type="button"
               className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-7 w-7 focus-visible:ring-0 text-muted-foreground/60"
               onClick={async (e) => {
-                const domId = (e.currentTarget as HTMLElement).closest('[data-message-id]')?.getAttribute('data-message-id') ?? uid
+                const domId = (e.currentTarget as HTMLElement).closest('[data-message-id]')?.getAttribute('data-message-id') ?? msgKeyLocal
                 const ids = sel.selectedIds.size > 0 ? sel.selectedIds : new Set([domId])
                 try {
                   const result = await captureSelectedMessages(ids, 'clipboard')
@@ -1450,6 +1452,18 @@ export interface MessageGroupRendererProps {
  */
 const messageIdCache = new WeakMap<object, string>()
 let fallbackIdCounter = 0
+
+/** 为缺少 uuid 的 UserInput / Error 消息生成稳定 ID，防止空串冲突 */
+const userMsgIdCache = new WeakMap<object, string>()
+let userMsgIdCounter = 0
+
+function stableUserMsgId(msg: { uuid?: string }): string {
+  if (msg.uuid) return msg.uuid
+  if (!userMsgIdCache.has(msg)) {
+    userMsgIdCache.set(msg, `user-msg-${++userMsgIdCounter}`)
+  }
+  return userMsgIdCache.get(msg)!
+}
 
 /**
  * 从 MessageGroup 中提取稳定的 ID，用于 data-message-id 和迷你地图

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -1091,7 +1091,9 @@ function ScheduledRunBadge(): React.ReactElement {
 function UserInputMessage({ message }: { message: SDKUserMessage }): React.ReactElement {
   const userProfile = useAtomValue(userProfileAtom)
   const sel = useMessageSelectionContext()
-  const msgKey = stableUserMsgId(message)
+  // 用 getGroupId 保证与 DOM data-message-id 完全一致
+  const syntheticGroup = React.useMemo<MessageGroup>(() => ({ type: 'user', message }), [message])
+  const msgKey = getGroupId(syntheticGroup)
   const rawText = extractUserText(message) ?? ''
   const isScheduledRun = rawText.includes(SCHEDULED_RUN_MARKER)
   const { files: attachedFiles, quotes, text } = parseAttachedFiles(stripScheduledRunMarker(rawText))
@@ -1149,7 +1151,7 @@ function UserInputMessage({ message }: { message: SDKUserMessage }): React.React
           {sel.isSelected(msgKey) ? <Circle className="size-3.5 fill-current" /> : <Circle className="size-3.5" />}
         </button>
         <button type="button" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-7 w-7 focus-visible:ring-0 text-muted-foreground/60" onClick={async (e) => {
-          const domId = (e.currentTarget as HTMLElement).closest('[data-message-id]')?.getAttribute('data-message-id') ?? ''
+          const domId = (e.currentTarget as HTMLElement).closest('[data-message-id]')?.getAttribute('data-message-id') ?? msgKey
           const ids = sel.selectedIds.size > 0 ? sel.selectedIds : new Set([domId])
           try {
             const result = await captureSelectedMessages(ids, 'file')
@@ -1160,7 +1162,7 @@ function UserInputMessage({ message }: { message: SDKUserMessage }): React.React
           <Camera className="size-3.5" />
         </button>
         <button type="button" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-7 w-7 focus-visible:ring-0 text-muted-foreground/60" onClick={async (e) => {
-          const domId = (e.currentTarget as HTMLElement).closest('[data-message-id]')?.getAttribute('data-message-id') ?? ''
+          const domId = (e.currentTarget as HTMLElement).closest('[data-message-id]')?.getAttribute('data-message-id') ?? msgKey
           const ids = sel.selectedIds.size > 0 ? sel.selectedIds : new Set([domId])
           try {
             const result = await captureSelectedMessages(ids, 'clipboard')

--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -148,6 +148,7 @@ export function MessageActions({
 }: MessageActionsProps): React.ReactElement {
   return (
     <div
+      data-no-screenshot
       className={cn(
         'flex items-center gap-2.5 text-muted-foreground/60 hover:text-muted-foreground/90 transition-colors duration-200',
         className

--- a/apps/electron/src/renderer/components/chat/ChatMessageItem.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessageItem.tsx
@@ -249,12 +249,16 @@ export const ChatMessageItem = React.memo(function ChatMessageItem({
             <button
               type="button"
               className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-7 w-7 focus-visible:ring-0 text-muted-foreground/60"
-              onClick={() => {
-                const ids = sel.selectedIds.size > 0 ? sel.selectedIds : new Set([message.id])
-                void captureSelectedMessages(ids, 'file').then((r) => {
-                  if (r.success) toast.success('截图已保存')
-                  else if (r.error) toast.error(r.error)
-                })
+              onClick={async (e) => {
+                const domId = (e.currentTarget as HTMLElement).closest('[data-message-id]')?.getAttribute('data-message-id') ?? message.id
+                const ids = sel.selectedIds.size > 0 ? sel.selectedIds : new Set([domId])
+                try {
+                  const result = await captureSelectedMessages(ids, 'file')
+                  if (result.success) toast.success('截图已保存')
+                  else if (result.error) toast.error(result.error)
+                } catch {
+                  toast.error('截图失败')
+                }
               }}
             >
               <Camera className="size-3.5" />
@@ -262,8 +266,9 @@ export const ChatMessageItem = React.memo(function ChatMessageItem({
             <button
               type="button"
               className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-7 w-7 focus-visible:ring-0 text-muted-foreground/60"
-              onClick={async () => {
-                const ids = sel.selectedIds.size > 0 ? sel.selectedIds : new Set([message.id])
+              onClick={async (e) => {
+                const domId = (e.currentTarget as HTMLElement).closest('[data-message-id]')?.getAttribute('data-message-id') ?? message.id
+                const ids = sel.selectedIds.size > 0 ? sel.selectedIds : new Set([domId])
                 try {
                   const result = await captureSelectedMessages(ids, 'clipboard')
                   if (result.success) toast.success('已复制到剪贴板')

--- a/apps/electron/src/renderer/components/chat/ChatMessageItem.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessageItem.tsx
@@ -11,7 +11,7 @@
 
 import * as React from 'react'
 import { useAtomValue } from 'jotai'
-import { AlertCircle, Pencil, RotateCcw, Trash2 } from 'lucide-react'
+import { AlertCircle, Pencil, RotateCcw, Trash2, Camera, Circle, Copy } from 'lucide-react'
 import {
   Message,
   MessageHeader,
@@ -35,6 +35,9 @@ import { DeleteMessageDialog } from './DeleteMessageDialog'
 import { InlineEditForm } from './InlineEditForm'
 import { UserAvatar } from './UserAvatar'
 import { getModelLogo, resolveModelDisplayName } from '@/lib/model-logo'
+import { captureSelectedMessages } from '@/lib/chat-screenshot'
+import { useMessageSelectionContext } from '@/components/shared/MessageSelectionContext'
+import { toast } from 'sonner'
 import { userProfileAtom } from '@/atoms/user-profile'
 import { channelsAtom } from '@/atoms/chat-atoms'
 import type { ChatMessage } from '@proma/shared'
@@ -112,6 +115,7 @@ export const ChatMessageItem = React.memo(function ChatMessageItem({
   const [isDeleting, setIsDeleting] = React.useState(false)
   const userProfile = useAtomValue(userProfileAtom)
   const channels = useAtomValue(channelsAtom)
+  const sel = useMessageSelectionContext()
 
   /** 确认删除消息 */
   const handleDeleteConfirm = async (): Promise<void> => {
@@ -232,6 +236,45 @@ export const ChatMessageItem = React.memo(function ChatMessageItem({
         {/* 操作按钮（非 streaming 时显示，hover 时可见） */}
         {(message.content || message.error || (message.attachments && message.attachments.length > 0)) && !isStreaming && !isInlineEditing && (
           <MessageActions className="pl-[46px] mt-0.5 min-h-[28px]">
+            <button
+              type="button"
+              className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-7 w-7 focus-visible:ring-0 text-muted-foreground/60"
+              onClick={() => sel.toggle(message.id)}
+            >
+              {sel.isSelected(message.id)
+                ? <Circle className="size-3.5 fill-current" />
+                : <Circle className="size-3.5" />
+              }
+            </button>
+            <button
+              type="button"
+              className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-7 w-7 focus-visible:ring-0 text-muted-foreground/60"
+              onClick={() => {
+                const ids = sel.selectedIds.size > 0 ? sel.selectedIds : new Set([message.id])
+                void captureSelectedMessages(ids, 'file').then((r) => {
+                  if (r.success) toast.success('截图已保存')
+                  else if (r.error) toast.error(r.error)
+                })
+              }}
+            >
+              <Camera className="size-3.5" />
+            </button>
+            <button
+              type="button"
+              className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-7 w-7 focus-visible:ring-0 text-muted-foreground/60"
+              onClick={async () => {
+                const ids = sel.selectedIds.size > 0 ? sel.selectedIds : new Set([message.id])
+                try {
+                  const result = await captureSelectedMessages(ids, 'clipboard')
+                  if (result.success) toast.success('已复制到剪贴板')
+                  else if (result.error) toast.error(result.error)
+                } catch {
+                  toast.error('截图失败')
+                }
+              }}
+            >
+              <Copy className="size-3.5" />
+            </button>
             <CopyButton content={message.content} />
             {message.role === 'assistant' && conversationId && (
               <MigrateToAgentButton conversationId={conversationId} />

--- a/apps/electron/src/renderer/components/chat/ChatMessages.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessages.tsx
@@ -372,20 +372,22 @@ export function ChatMessages({
             {/* 已有消息 + 分隔线 */}
             {messages.map((msg: ChatMessage) => (
               <React.Fragment key={msg.id}>
-                <div data-message-id={msg.id}>
-                  <ChatMessageItem
-                    message={msg}
-                    conversationId={conversationId}
-                    isStreaming={false}
-                    isLastAssistant={false}
-                    allMessages={messages}
-                    onDeleteMessage={onDeleteMessage}
-                    onResendMessage={onResendMessage}
-                    onStartInlineEdit={onStartInlineEdit}
-                    onSubmitInlineEdit={onSubmitInlineEdit}
-                    onCancelInlineEdit={onCancelInlineEdit}
-                    isInlineEditing={msg.id === inlineEditingMessageId}
-                  />
+                <div>
+                  <div className="flex-1 min-w-0" data-message-id={msg.id}>
+                    <ChatMessageItem
+                      message={msg}
+                      conversationId={conversationId}
+                      isStreaming={false}
+                      isLastAssistant={false}
+                      allMessages={messages}
+                      onDeleteMessage={onDeleteMessage}
+                      onResendMessage={onResendMessage}
+                      onStartInlineEdit={onStartInlineEdit}
+                      onSubmitInlineEdit={onSubmitInlineEdit}
+                      onCancelInlineEdit={onCancelInlineEdit}
+                      isInlineEditing={msg.id === inlineEditingMessageId}
+                    />
+                  </div>
                 </div>
                 {/* 分隔线 */}
                 {dividerSet.has(msg.id) && (

--- a/apps/electron/src/renderer/components/chat/ChatView.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatView.tsx
@@ -21,6 +21,7 @@ import { ChatMessages } from './ChatMessages'
 import { ChatInput } from './ChatInput'
 import { AgentRecommendBanner } from './AgentRecommendBanner'
 import { PromptEditorSidebar } from './PromptEditorSidebar'
+import { MessageSelectionProvider } from '@/components/shared/MessageSelectionContext'
 import type { InlineEditSubmitPayload } from './ChatMessageItem'
 import {
   conversationsAtom,
@@ -574,9 +575,12 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
       {/* 主内容区域 */}
       <div className="flex flex-col h-full flex-1 min-w-0">
         {/* Header 在 max-w 外，按钮可到达最右侧 */}
-        <ChatHeader conversation={conversation} />
+        <ChatHeader
+          conversation={conversation}
+        />
         <div className="flex flex-col flex-1 w-full max-w-[min(72rem,100%)] mx-auto overflow-hidden min-h-0">
           {/* 中间：消息区域 */}
+          <MessageSelectionProvider>
           <ChatMessages
             conversationId={conversationId}
             messages={messages}
@@ -598,6 +602,7 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
             onDeleteDivider={handleDeleteDivider}
             onLoadMore={handleLoadMore}
           />
+          </MessageSelectionProvider>
 
           {/* 错误提示 */}
           {chatError && (

--- a/apps/electron/src/renderer/components/shared/MessageSelectionContext.tsx
+++ b/apps/electron/src/renderer/components/shared/MessageSelectionContext.tsx
@@ -1,0 +1,64 @@
+/**
+ * MessageSelectionContext — 行内消息多选状态
+ *
+ * 供 Chat 和 Agent 模式共享：每条消息操作行有勾选框，
+ * 勾选后点击任意消息的截图按钮导出全部选中消息。
+ */
+
+import * as React from 'react'
+
+interface MessageSelectionState {
+  selectedIds: Set<string>
+  toggle: (id: string) => void
+  isSelected: (id: string) => boolean
+  clearAll: () => void
+}
+
+const MessageSelectionContext = React.createContext<MessageSelectionState | null>(null)
+
+export function MessageSelectionProvider({ children }: { children: React.ReactNode }): React.ReactElement {
+  const [selectedIds, setSelectedIds] = React.useState<Set<string>>(new Set())
+
+  const toggle = React.useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+      return next
+    })
+  }, [])
+
+  const isSelected = React.useCallback(
+    (id: string) => selectedIds.has(id),
+    [selectedIds],
+  )
+
+  const clearAll = React.useCallback(() => {
+    setSelectedIds(new Set())
+  }, [])
+
+  const value = React.useMemo(
+    () => ({ selectedIds, toggle, isSelected, clearAll }),
+    [selectedIds, toggle, isSelected, clearAll],
+  )
+
+  return React.createElement(MessageSelectionContext.Provider, { value }, children)
+}
+
+/** 获取多选上下文；未包裹 Provider 时返回 safe fallback */
+export function useMessageSelectionContext(): MessageSelectionState {
+  const ctx = React.useContext(MessageSelectionContext)
+  if (!ctx) {
+    // fallback: 无 Provider 时不报错，勾选和截图均无效果
+    return {
+      selectedIds: new Set(),
+      toggle: () => {},
+      isSelected: () => false,
+      clearAll: () => {},
+    }
+  }
+  return ctx
+}

--- a/apps/electron/src/renderer/lib/chat-screenshot.ts
+++ b/apps/electron/src/renderer/lib/chat-screenshot.ts
@@ -1,0 +1,174 @@
+/**
+ * chat-screenshot — 基于消息内容生成截图
+ *
+ * 从消息元素中提取内容体（文字/代码/图片），
+ * 嵌入精简排版 CSS 生成清爽的自包含截图。
+ * Shiki 代码高亮通过内联 style 保留，无需外部 CSS。
+ * Chat 和 Agent 模式共享。
+ */
+
+import { SCREENSHOT_LIMITS } from '@proma/shared'
+
+/** 截图精简排版 CSS（自包含，不依赖 Tailwind） */
+const SCREENSHOT_CLEAN_CSS = `
+*{box-sizing:border-box;margin:0;padding:0}
+html{font-size:15px}
+body{font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;line-height:1.65;padding:40px 48px;max-width:800px;margin:0 auto;color:#1f2937;background:#fff}
+body.dark{color:#e5e7eb;background:#111827}
+.msg{margin-bottom:32px}
+.msg-head{font-size:13px;margin-bottom:10px;display:flex;gap:8px;align-items:baseline}
+.msg-role{font-weight:600}
+.msg-time{color:#9ca3af}.dark .msg-time{color:#6b7280}
+.msg-body{word-break:break-word}
+.msg-body p{margin:0 0 12px}.msg-body p:last-child{margin-bottom:0}
+.msg-body p:empty{display:none}
+.msg-body ul,.msg-body ol{padding-left:24px;margin:8px 0}
+.msg-body li{margin:4px 0}
+.msg-body pre{margin:12px 0;padding:14px 16px;border-radius:8px;overflow-x:auto;font-size:13px;line-height:1.5;background:#f3f4f6}
+.dark .msg-body pre{background:#1f2937}
+.msg-body code{font-size:0.9em}
+.msg-body pre code{font-size:13px;background:0;padding:0}
+.msg-body img{max-width:100%;height:auto;border-radius:8px;margin:8px 0}
+.msg-body table{border-collapse:collapse;width:100%;margin:12px 0}
+.msg-body td,.msg-body th{border:1px solid #d1d5db;padding:8px 12px;text-align:left}
+.dark .msg-body td,.dark .msg-body th{border-color:#374151}
+.msg-body th{background:#f9fafb;font-weight:600}.dark .msg-body th{background:#1f2937}
+.msg-body blockquote{border-left:3px solid #e5e7eb;padding-left:16px;margin:12px 0;color:#6b7280}
+.dark .msg-body blockquote{border-color:#374151;color:#9ca3af}
+.msg-body hr{border:none;border-top:1px solid #e5e7eb;margin:16px 0}.dark .msg-body hr{border-color:#374151}
+.msg-body h1,.msg-body h2,.msg-body h3,.msg-body h4{font-weight:600;margin:16px 0 8px;line-height:1.3}
+.msg-body h1{font-size:1.4em}.msg-body h2{font-size:1.2em}.msg-body h3{font-size:1.1em}
+.msg-body [style*="color:"]{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,'Cascadia Code','JetBrains Mono','Fira Code',Consolas,monospace}
+`
+
+/** 消息角色 → 显示名 */
+function roleLabel(role: string): string {
+  if (role === 'user') return 'You'
+  if (role === 'assistant') return 'Assistant'
+  return role
+}
+
+export interface ScreenshotResult {
+  success: boolean
+  error?: string
+}
+
+/**
+ * 从 clone 中提取消息内容体 HTML。
+ * 移除交互元素和 UI 外壳，保留正文 + 代码 + 图片。
+ */
+function extractContentBody(clone: HTMLElement): string {
+  // 1. 移除明确的交互元素和标记
+  clone.querySelectorAll(`
+    button, [role="button"], input, textarea, select,
+    [data-no-screenshot]
+  `).forEach((c) => { (c as HTMLElement).remove() })
+
+  // 2. 移除因按钮被删而变空的容器（如 MessageActions）
+  //    多轮清理：深层容器清空后，外层容器也可能变空
+  for (let i = 0; i < 3; i++) {
+    clone.querySelectorAll('div').forEach((div) => {
+      const el = div as HTMLElement
+      // 有可见子元素（非空白文本）则不删
+      if (el.children.length > 0) return
+      if (el.textContent && el.textContent.trim()) return
+      el.remove()
+    })
+  }
+
+  return clone.innerHTML
+}
+
+/**
+ * 判定消息角色
+ */
+function detectRole(el: HTMLElement): string {
+  const msgRole = el.getAttribute('data-message-role')
+  if (msgRole === 'user' || msgRole === 'assistant') return msgRole
+  if (el.querySelector('.is-user')) return 'user'
+  if (el.querySelector('.is-assistant')) return 'assistant'
+  return 'assistant'
+}
+
+/**
+ * 提取消息时间
+ */
+function extractTime(clone: HTMLElement): string {
+  const timeEl = clone.querySelector('[class*="text-[10px]"], [class*="text-foreground/"] time, time')
+  return timeEl?.textContent?.trim() || ''
+}
+
+/**
+ * 从选中的消息 ID 生成截图
+ *
+ * @param selectedIds - 选中的消息 data-message-id 集合
+ * @param mode - 输出方式：clipboard 复制到剪贴板 / file 保存为文件
+ */
+export async function captureSelectedMessages(
+  selectedIds: Set<string>,
+  mode: 'clipboard' | 'file',
+): Promise<ScreenshotResult> {
+  if (selectedIds.size === 0) {
+    return { success: false, error: '未选择任何消息' }
+  }
+
+  const allMessageEls = Array.from(document.querySelectorAll('[data-message-id]'))
+
+  // 区分 Agent / Chat 模式
+  const isAgentMode = allMessageEls.some((el) => el.hasAttribute('data-message-role'))
+
+  const captureEls = isAgentMode
+    ? allMessageEls.filter((el) => el.hasAttribute('data-message-role'))
+    : allMessageEls
+
+  // 构建内容文章
+  const articles: string[] = []
+  const seen = new Set<string>()
+
+  for (const el of captureEls) {
+    const id = el.getAttribute('data-message-id')
+    if (!id || !selectedIds.has(id) || seen.has(id)) continue
+    seen.add(id)
+
+    const clone = el.cloneNode(true) as HTMLElement
+    const role = detectRole(clone)
+    const time = extractTime(clone)
+    const bodyHtml = extractContentBody(clone)
+
+    if (!bodyHtml.trim()) continue
+
+    articles.push(`<article class="msg">
+  <div class="msg-head"><span class="msg-role">${roleLabel(role)}</span>${time ? ` <span class="msg-time">${time}</span>` : ''}</div>
+  <div class="msg-body">${bodyHtml}</div>
+</article>`)
+  }
+
+  if (articles.length === 0) {
+    return { success: false, error: '未找到选中消息的 DOM 元素' }
+  }
+
+  const isDark = document.documentElement.classList.contains('dark')
+  const html = articles.join('\n')
+
+  const htmlBytes = new TextEncoder().encode(html).length
+  if (htmlBytes > SCREENSHOT_LIMITS.MAX_RAW_HTML_BYTES) {
+    return { success: false, error: '选中内容过多，请减少选择后重试' }
+  }
+
+  try {
+    await window.electronAPI.screenshotCapture({
+      html,
+      isDark,
+      width: 800,
+      mode,
+      css: SCREENSHOT_CLEAN_CSS,
+      themeClass: isDark ? 'dark' : '',
+    })
+    return { success: true }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : '截图失败',
+    }
+  }
+}

--- a/apps/electron/src/renderer/lib/chat-screenshot.ts
+++ b/apps/electron/src/renderer/lib/chat-screenshot.ts
@@ -114,18 +114,15 @@ export async function captureSelectedMessages(
 
   const allMessageEls = Array.from(document.querySelectorAll('[data-message-id]'))
 
-  // 区分 Agent / Chat 模式
-  const isAgentMode = allMessageEls.some((el) => el.hasAttribute('data-message-role'))
-
-  const captureEls = isAgentMode
-    ? allMessageEls.filter((el) => el.hasAttribute('data-message-role'))
-    : allMessageEls
+  if (allMessageEls.length === 0) {
+    return { success: false, error: '页面尚未加载消息，请稍后重试' }
+  }
 
   // 构建内容文章
   const articles: string[] = []
   const seen = new Set<string>()
 
-  for (const el of captureEls) {
+  for (const el of allMessageEls) {
     const id = el.getAttribute('data-message-id')
     if (!id || !selectedIds.has(id) || seen.has(id)) continue
     seen.add(id)

--- a/apps/electron/src/renderer/lib/chat-screenshot.ts
+++ b/apps/electron/src/renderer/lib/chat-screenshot.ts
@@ -121,18 +121,32 @@ export async function captureSelectedMessages(
   // 构建内容文章
   const articles: string[] = []
   const seen = new Set<string>()
+  let matchedCount = 0
+  let emptyCount = 0
+
+  console.log(
+    '[chat-screenshot] DOM 中 %d 个 [data-message-id]，选中 %d 个 ID:',
+    allMessageEls.length, selectedIds.size,
+    [...selectedIds].slice(0, 5),
+    selectedIds.size > 5 ? '…' : '',
+  )
 
   for (const el of allMessageEls) {
     const id = el.getAttribute('data-message-id')
     if (!id || !selectedIds.has(id) || seen.has(id)) continue
     seen.add(id)
+    matchedCount++
 
     const clone = el.cloneNode(true) as HTMLElement
     const role = detectRole(clone)
     const time = extractTime(clone)
     const bodyHtml = extractContentBody(clone)
 
-    if (!bodyHtml.trim()) continue
+    if (!bodyHtml.trim()) {
+      emptyCount++
+      console.log('[chat-screenshot] 消息 %s (%s) bodyHtml 为空，跳过', id, role)
+      continue
+    }
 
     articles.push(`<article class="msg">
   <div class="msg-head"><span class="msg-role">${roleLabel(role)}</span>${time ? ` <span class="msg-time">${time}</span>` : ''}</div>
@@ -140,8 +154,20 @@ export async function captureSelectedMessages(
 </article>`)
   }
 
+  console.log(
+    '[chat-screenshot] 匹配 %d 条，空内容 %d 条，生成 %d 个 article',
+    matchedCount, emptyCount, articles.length,
+  )
+
   if (articles.length === 0) {
-    return { success: false, error: '未找到选中消息的 DOM 元素' }
+    if (matchedCount === 0) {
+      const domIds = allMessageEls.map((el) => el.getAttribute('data-message-id')).filter(Boolean).slice(0, 10)
+      return {
+        success: false,
+        error: `选中 ID 与 DOM 不匹配。选中: [${[...selectedIds].slice(0, 5).join(', ')}]，DOM 前 10: [${domIds.join(', ')}]`,
+      }
+    }
+    return { success: false, error: `选中 ${matchedCount} 条消息内容均为空，无法生成截图` }
   }
 
   const isDark = document.documentElement.classList.contains('dark')

--- a/packages/shared/src/types/runtime.ts
+++ b/packages/shared/src/types/runtime.ts
@@ -396,7 +396,7 @@ export const SCREENSHOT_LIMITS = {
   /** 渲染端预检：编辑器 DOM 元素数上限。超过会导致 inlineComputedStyles 卡顿明显 */
   MAX_ELEMENTS: 3000,
   /** 渲染端预检：原始 outerHTML 字节数上限（不含 inline 样式）。膨胀系数 5-10× 对应主进程 12MB */
-  MAX_RAW_HTML_BYTES: 2 * 1024 * 1024,
+  MAX_RAW_HTML_BYTES: 8 * 1024 * 1024,
   /** 主进程兜底：含 inline 样式的 HTML 字节数上限 */
   MAX_HTML_BYTES: 12 * 1024 * 1024,
   /** 主进程兜底：渲染像素预算（width × height × scale²）。4 字节/像素 ≈ 400MB */

--- a/packages/shared/src/types/runtime.ts
+++ b/packages/shared/src/types/runtime.ts
@@ -396,9 +396,9 @@ export const SCREENSHOT_LIMITS = {
   /** 渲染端预检：编辑器 DOM 元素数上限。超过会导致 inlineComputedStyles 卡顿明显 */
   MAX_ELEMENTS: 3000,
   /** 渲染端预检：原始 outerHTML 字节数上限（不含 inline 样式）。膨胀系数 5-10× 对应主进程 12MB */
-  MAX_RAW_HTML_BYTES: 8 * 1024 * 1024,
+  MAX_RAW_HTML_BYTES: 100 * 1024 * 1024,
   /** 主进程兜底：含 inline 样式的 HTML 字节数上限 */
-  MAX_HTML_BYTES: 12 * 1024 * 1024,
+  MAX_HTML_BYTES: 100 * 1024 * 1024,
   /** 主进程兜底：渲染像素预算（width × height × scale²）。4 字节/像素 ≈ 400MB */
   MAX_PIXELS: 100_000_000,
   /** 输出图片宽度下限 */


### PR DESCRIPTION
## 概述

新增 Chat/Agent 消息块级截图功能。当消息包含代码块、图片等内容时，用户可一键生成清爽的排版截图。新增 `chat-screenshot.ts` 截图引擎，基于消息 DOM 内容提取并嵌入精简 Shiki 内联样式，生成自包含的 HTML 截图，支持浅色/深色主题自适应。同时新增 `MessageSelectionContext` 共享上下文用于消息选择状态管理，并在 ChatMessageItem 和 SDKMessageRenderer 中集成截图入口。

## 改动

- `apps/electron/src/renderer/lib/chat-screenshot.ts`：消息截图引擎，从消息元素提取内容体，嵌入精简排版 CSS 和 Shiki 内联代码高亮样式，生成自包含截图
- `apps/electron/src/renderer/components/shared/MessageSelectionContext.tsx`：新增消息选择状态共享上下文
- `apps/electron/src/renderer/components/chat/ChatMessageItem.tsx`：集成截图入口按钮
- `apps/electron/src/renderer/components/chat/ChatMessages.tsx`：适配消息截图选择逻辑
- `apps/electron/src/renderer/components/chat/ChatView.tsx`：传递截图相关状态
- `apps/electron/src/renderer/components/agent/AgentMessages.tsx`：Agent 消息列表适配截图功能
- `apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx`：Agent SDK 消息渲染器集成截图
- `apps/electron/src/renderer/components/agent/AgentView.tsx`：Agent 视图传递截图状态
- `apps/electron/src/renderer/components/ai-elements/message.tsx`：消息组件适配截图选择
- `apps/electron/src/main/lib/screenshot-service.ts`：截图服务重构，支持块级截图生成
- `packages/shared/src/types/runtime.ts`：新增块级截图相关类型定义

## 测试

- 消息代码块可正常生成截图并保留 Shiki 高亮样式
- 浅色/深色主题截图自动适配
- Chat 和 Agent 模式均可使用截图功能
- 截图内容包含代码、文字、图片等多种元素

## 备注

- Chat 和 Agent 模式共享截图引擎实现
- 截图样式自包含，不依赖外部 Tailwind CSS
