### PR TITLE
fix(automation): computeNextRunAt 调度字段改为可选，修复 tsc 报错

### DIFF
--- a/apps/electron/src/main/lib/automation-manager.ts
+++ b/apps/electron/src/main/lib/automation-manager.ts
@@ -77,7 +77,9 @@ function writeIndex(index: AutomationsIndex): void {
  * 返回值保证为有限正整数。输入非法时回退到 from + 10min 并打印警告。
  */
 export function computeNextRunAt(
-  a: Pick<Automation, 'scheduleType' | 'intervalMinutes' | 'timeOfDay' | 'dayOfWeek' | 'dayOfMonth'>,
+  a: { scheduleType: Automation['scheduleType'] } & Partial<
+    Pick<Automation, 'intervalMinutes' | 'timeOfDay' | 'dayOfWeek' | 'dayOfMonth'>
+  >,
   from: number = Date.now(),
 ): number {
   const FALLBACK_INTERVAL_MS = 10 * 60_000


### PR DESCRIPTION
## Summary
- `automation-manager.test.ts` 在 `bunx tsc --noEmit` 下报 6 处 TS2345：测试只传 `scheduleType/timeOfDay/dayOfMonth`，而 `computeNextRunAt` 的参数签名把 `intervalMinutes/dayOfWeek/dayOfMonth` 全标成必填。
- 但 monthly/daily/weekly 场景下这几个字段本就无意义，函数实现内部也按可选字段处理（`?? 默认值` + `Number.isFinite`）。
- 把签名改为 `{ scheduleType } & Partial<Pick<...>>`，与实现一致，测试代码无需修改。

## Test plan
- [x] `bunx tsc --noEmit` 无 automation 相关报错
- [x] `bun test apps/electron/src/main/lib/automation-manager.test.ts` 6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)