### PR TITLE
[Reviewed] feat(file-chip): 右键菜单支持在文件管理器中显示文件

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -2769,6 +2769,23 @@ export function registerIpcHandlers(): void {
     }
   )
 
+  // 在系统文件管理器中显示任意路径（无工作区限制，用户主动点击触发）
+  ipcMain.handle(
+    IPC_CHANNELS.SHOW_ITEM_IN_FOLDER,
+    async (_, filePath: string, candidateBasePaths?: string[]): Promise<void> => {
+      const { resolve } = await import('node:path')
+      const { existsSync } = await import('node:fs')
+      const { resolveTargetPath } = await import('./lib/file-preview-service')
+
+      const resolvedPath = resolveTargetPath(filePath, candidateBasePaths?.length ? candidateBasePaths : undefined)
+      if (!existsSync(resolvedPath)) {
+        console.warn('[IPC] shell:show-item-in-folder 路径不存在:', resolvedPath)
+        return
+      }
+      shell.showItemInFolder(resolve(resolvedPath))
+    }
+  )
+
   // 解析文件路径并读取内容（供内联预览使用）
   ipcMain.handle(
     'file:resolve-and-read',

--- a/apps/electron/src/main/lib/file-preview-service.ts
+++ b/apps/electron/src/main/lib/file-preview-service.ts
@@ -95,7 +95,7 @@ function searchFileInDir(dir: string, targetName: string, maxDepth = 8): string 
  * - 绝对路径：直接 resolve，不存在时 fallback 搜索
  * - 相对路径：依次尝试 basePaths，返回第一个存在的；都不存在则 fallback 搜索
  */
-function resolveTargetPath(filePath: string, basePaths?: string[]): string {
+export function resolveTargetPath(filePath: string, basePaths?: string[]): string {
   if (filePath.startsWith('/') || /^[A-Za-z]:[\\/]/.test(filePath)) {
     const direct = resolve(filePath)
     if (existsSync(direct)) return direct

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -699,6 +699,9 @@ export interface ElectronAPI {
   /** 在系统文件管理器中显示文件 */
   showInFolder: (filePath: string) => Promise<void>
 
+  /** 在系统文件管理器中显示文件（无工作区限制，支持候选基础目录） */
+  showItemInFolder: (filePath: string, candidateBasePaths?: string[]) => Promise<void>
+
   /** 解析文件路径并读取内容（供内联预览使用） */
   resolveAndReadFile: (filePath: string, access?: import('@proma/shared').FileAccessOptions) => Promise<{ resolvedPath: string; content: string } | null>
 
@@ -1810,6 +1813,11 @@ const electronAPI: ElectronAPI = {
 
   showInFolder: (filePath: string) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.SHOW_IN_FOLDER, filePath)
+  },
+
+  /** 在系统文件管理器中显示文件（无工作区限制，支持候选基础目录） */
+  showItemInFolder: (filePath: string, candidateBasePaths?: string[]) => {
+    return ipcRenderer.invoke(IPC_CHANNELS.SHOW_ITEM_IN_FOLDER, filePath, candidateBasePaths)
   },
 
   resolveAndReadFile: (filePath: string, access?: import('@proma/shared').FileAccessOptions) => {

--- a/apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx
@@ -13,6 +13,13 @@ import { FileTypeIcon } from '@/components/file-browser/FileTypeIcon'
 import { previewFileMapAtom, previewPanelOpenMapAtom } from '@/atoms/preview-atoms'
 import { currentAgentSessionIdAtom } from '@/atoms/agent-atoms'
 import { activeTabIdAtom, getPreviewTabTitle, openTab, tabsAtom } from '@/atoms/tab-atoms'
+import {
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+} from '@/components/ui/context-menu'
 
 /** 文件存在性缓存（模块级共享，避免重复 IPC）。key = filePath + basePaths */
 const fileExistsCache = new Map<string, boolean>()
@@ -184,25 +191,43 @@ export function FilePathChip({ filePath, basePath, basePaths, className }: FileP
     store.set(activeTabIdAtom, result.activeTabId)
   }, [store, cleanPath, candidateBases])
 
+  const handleShowInFolder = React.useCallback(() => {
+    const bases = candidateBases.length > 0 ? candidateBases : undefined
+    window.electronAPI.showItemInFolder(cleanPath, bases).catch(console.error)
+  }, [cleanPath, candidateBases])
+
   return (
-    <button
-      ref={chipRef}
-      type="button"
-      onClick={handleClick}
-      title={fileStatus === 'broken' ? `文件不存在: ${displayPath}` : displayPath}
-      className={cn(
-        'inline-flex items-center gap-1 rounded px-1.5 py-[2px] text-[12px] font-medium leading-[1.6]',
-        'cursor-pointer transition-colors duration-150',
-        'align-baseline not-prose',
-        fileStatus === 'broken'
-          ? 'opacity-50 border border-dashed border-muted-foreground/30 text-muted-foreground hover:opacity-70 hover:bg-muted/20'
-          : 'bg-primary/10 text-primary hover:bg-primary/20',
-        className
-      )}
-    >
-      <FileTypeIcon name={filename} isDirectory={false} size={14} />
-      <span className="truncate max-w-[240px]">{filename}{lineColSuffix}</span>
-    </button>
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <button
+          ref={chipRef}
+          type="button"
+          onClick={handleClick}
+          title={fileStatus === 'broken' ? `文件不存在: ${displayPath}` : displayPath}
+          className={cn(
+            'inline-flex items-center gap-1 rounded px-1.5 py-[2px] text-[12px] font-medium leading-[1.6]',
+            'cursor-pointer transition-colors duration-150',
+            'align-baseline not-prose',
+            fileStatus === 'broken'
+              ? 'opacity-50 border border-dashed border-muted-foreground/30 text-muted-foreground hover:opacity-70 hover:bg-muted/20'
+              : 'bg-primary/10 text-primary hover:bg-primary/20',
+            className
+          )}
+        >
+          <FileTypeIcon name={filename} isDirectory={false} size={14} />
+          <span className="truncate max-w-[240px]">{filename}{lineColSuffix}</span>
+        </button>
+      </ContextMenuTrigger>
+      <ContextMenuContent className="w-48">
+        <ContextMenuItem onClick={handleClick}>
+          在标签页中打开
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem onClick={handleShowInFolder}>
+          在文件管理器中显示
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   )
 }
 

--- a/packages/shared/src/types/runtime.ts
+++ b/packages/shared/src/types/runtime.ts
@@ -358,6 +358,8 @@ export const IPC_CHANNELS = {
   OPEN_EXTERNAL: 'shell:open-external',
   /** 用系统默认应用打开任意文件 */
   SYSTEM_OPEN_FILE: 'shell:system-open-file',
+  /** 在系统文件管理器（访达/资源管理器）中显示文件 */
+  SHOW_ITEM_IN_FOLDER: 'shell:show-item-in-folder',
   /** 扫描系统中可用的编辑器应用 */
   SCAN_EDITORS: 'shell:scan-editors',
   /** 查询某个文件在本机系统中的默认打开应用信息（带图标） */


### PR DESCRIPTION
## 概述

为会话消息中的路径芯片（`FilePathChip`）添加右键上下文菜单，支持在文件管理器中显示功能。

## 问题

当前点击路径芯片只能打开预览标签页，有时标签页无内容。用户需要另一种快捷操作：直接在系统文件管理器（macOS 访达 / Windows 资源管理器）中定位到该文件。

## 改动

| 文件 | 改动 |
|------|------|
| `file-path-chip.tsx` | 用 Radix UI `ContextMenu` 包裹芯片按钮；左键保持预览打开，右键弹出菜单含在标签页中打开和在文件管理器中显示两项 |
| `runtime.ts` | 新增 `SHOW_ITEM_IN_FOLDER` IPC 通道常量 (`shell:show-item-in-folder`) |
| `ipc.ts` | 新增 handler，通过 `resolveTargetPath` 解析路径 + `shell.showItemInFolder` 打开，无工作区限制 |
| `file-preview-service.ts` | 导出 `resolveTargetPath` 供 IPC 层复用 |
| `preload/index.ts` | 暴露 `showItemInFolder(filePath, candidateBasePaths?)` 给渲染进程 |

## 测试

1. 在 Agent 会话中发送包含绝对路径和相对路径的消息
2. 右键点击路径芯片 → 选择在文件管理器中显示
3. 系统文件管理器应打开并定位到对应文件
4. 左键点击 → 确认预览标签页行为不变

## 备注

- 左键点击行为不变，向后兼容
- `shell:show-item-in-folder` 无工作区路径限制（用户主动点击触发，非自动化操作）