### PR TITLE
feat(preview): 预览支持侧边分屏，新增 Tab 拖出转分屏与展开方式偏好

### DIFF
--- a/apps/electron/src/renderer/atoms/preview-atoms.ts
+++ b/apps/electron/src/renderer/atoms/preview-atoms.ts
@@ -41,6 +41,19 @@ export const previewSplitRatioAtom = atomWithStorage<number>('proma-preview-spli
 /** 自动预览开关，持久化（默认关闭以减轻设备性能负担，老用户保留已设置的偏好） */
 export const autoPreviewEnabledAtom = atomWithStorage<boolean>('proma-auto-preview-enabled', false)
 
+/**
+ * 预览默认展开方式，持久化。
+ * - 'tab'   = 以预览标签页形式打开（旧版默认）
+ * - 'split' = 在主区域右侧分屏展开（可同时看到 Agent 输出与文件内容）
+ *
+ * 用户仍可通过拖拽 Tab 出区域、PreviewPanel 顶栏按钮等即时切换。
+ */
+export type PreviewModePreference = 'tab' | 'split'
+export const previewModePreferenceAtom = atomWithStorage<PreviewModePreference>(
+  'proma-preview-mode-pref',
+  'tab',
+)
+
 /** 当前会话的预览面板是否打开（derived） */
 export const currentSessionPreviewOpenAtom = atom<boolean>((get) => {
   const sessionId = get(currentAgentSessionIdAtom)

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -49,7 +49,7 @@ import {
 import { cn } from '@/lib/utils'
 import { getActiveAccelerator, getAcceleratorDisplay } from '@/lib/shortcut-registry'
 import { registerShortcut } from '@/lib/shortcut-registry'
-import { previewPanelOpenMapAtom, previewFileMapAtom, autoPreviewEnabledAtom, quotedSelectionMapAtom, currentQuotedSelectionAtom } from '@/atoms/preview-atoms'
+import { previewPanelOpenMapAtom, autoPreviewEnabledAtom, quotedSelectionMapAtom, currentQuotedSelectionAtom } from '@/atoms/preview-atoms'
 import {
   agentStreamingStatesAtom,
   agentSessionStreamingStateAtomFamily,
@@ -97,7 +97,7 @@ import { useOpenSession } from '@/hooks/useOpenSession'
 import { AgentSessionProvider } from '@/contexts/session-context'
 import { draftSessionIdsAtom } from '@/atoms/draft-session-atoms'
 import { sendWithCmdEnterAtom } from '@/atoms/shortcut-atoms'
-import { activeTabIdAtom, getPreviewTabTitle, openTab, tabsAtom } from '@/atoms/tab-atoms'
+import { useOpenPreview } from '@/components/diff/preview-opener'
 import type { AgentSendInput, AgentPendingFile, FileDialogLargeFile, ModelOption, SDKMessage } from '@proma/shared'
 import { MAX_ATTACHMENT_SIZE } from '@proma/shared'
 import { fileToBase64, formatFileNames, getFileParentPath } from '@/lib/file-utils'
@@ -401,6 +401,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const store = useStore()
   const currentQuotedSelection = useAtomValue(currentQuotedSelectionAtom)
   const setQuotedSelectionMap = useSetAtom(quotedSelectionMapAtom)
+  const openPreview = useOpenPreview()
 
   /** 移除当前引用选中文本 */
   const handleRemoveQuotedSelection = React.useCallback(() => {
@@ -411,7 +412,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     })
   }, [sessionId, setQuotedSelectionMap])
 
-  const setPreviewFileMap = useSetAtom(previewFileMapAtom)
   const suggestionsMap = useAtomValue(agentPromptSuggestionsAtom)
   const suggestion = suggestionsMap.get(sessionId) ?? null
   const setPromptSuggestions = useSetAtom(agentPromptSuggestionsAtom)
@@ -1039,29 +1039,13 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
 
   const openClipboardPreviewFile = React.useCallback((filePath: string): void => {
     const parentPath = getFileParentPath(filePath)
-    setPreviewFileMap((prev) => {
-      const m = new Map(prev)
-      m.set(sessionId, {
-        filePath,
-        previewOnly: true,
-        readOnly: false,
-        basePaths: parentPath ? [parentPath] : undefined,
-      })
-      return m
+    openPreview(sessionId, {
+      filePath,
+      previewOnly: true,
+      readOnly: false,
+      basePaths: parentPath ? [parentPath] : undefined,
     })
-    store.set(previewPanelOpenMapAtom, (prev) => {
-      const m = new Map(prev)
-      m.set(sessionId, false)
-      return m
-    })
-    const result = openTab(store.get(tabsAtom), {
-      type: 'preview',
-      sessionId,
-      title: getPreviewTabTitle(filePath),
-    })
-    store.set(tabsAtom, result.tabs)
-    store.set(activeTabIdAtom, result.activeTabId)
-  }, [sessionId, setPreviewFileMap, store])
+  }, [sessionId, openPreview])
 
   /** 点击 clipboard 附件时，在当前会话的临时预览标签页中显示内容 */
   const handleClipboardPreview = React.useCallback(async (file: AgentPendingFile) => {

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -6,7 +6,7 @@
  */
 
 import * as React from 'react'
-import { useAtom, useAtomValue, useSetAtom, useStore } from 'jotai'
+import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { X, FolderOpen, ExternalLink, ChevronRight, MoreHorizontal, FolderSearch, Pencil, FolderInput, Info, FolderHeart, MessageSquarePlus } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -35,8 +35,8 @@ import {
   fileBrowserAutoRevealAtom,
   agentSelectedWorktreeAtom,
 } from '@/atoms/agent-atoms'
-import { previewPanelOpenMapAtom, previewFileMapAtom, type PreviewFile } from '@/atoms/preview-atoms'
-import { activeTabIdAtom, getPreviewTabTitle, openTab, tabsAtom } from '@/atoms/tab-atoms'
+import { previewFileMapAtom } from '@/atoms/preview-atoms'
+import { useOpenPreview } from '@/components/diff/preview-opener'
 import { detectIsWindows } from '@/lib/platform'
 import type { FileEntry, AgentPendingFile } from '@proma/shared'
 
@@ -70,39 +70,20 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   // Tab 系统
   const previewFileMap = useAtomValue(previewFileMapAtom)
   const selectedFilePath = previewFileMap.get(sessionId)?.filePath
-  const store = useStore()
 
-  // 预览面板 atoms
-  const setPreviewFileMap = useSetAtom(previewFileMapAtom)
-  const setPreviewOpenMap = useSetAtom(previewPanelOpenMapAtom)
+  const openPreview = useOpenPreview()
 
   // 用 ref 存 basePaths 相关值，避免声明顺序问题
   const basePathsRef = React.useRef<string[]>([])
 
-  const openPreviewTabForFile = React.useCallback((file: PreviewFile) => {
-    setPreviewFileMap((prev) => {
-      const m = new Map(prev)
-      m.set(sessionId, file)
-      return m
-    })
-    setPreviewOpenMap((prev) => { const m = new Map(prev); m.set(sessionId, false); return m })
-    const result = openTab(store.get(tabsAtom), {
-      type: 'preview',
-      sessionId,
-      title: getPreviewTabTitle(file.filePath),
-    })
-    store.set(tabsAtom, result.tabs)
-    store.set(activeTabIdAtom, result.activeTabId)
-  }, [sessionId, setPreviewFileMap, setPreviewOpenMap, store])
-
   const handleFilePreview = React.useCallback((filePath: string) => {
     const bp = basePathsRef.current
-    openPreviewTabForFile({
+    openPreview(sessionId, {
       filePath,
       previewOnly: true,
       basePaths: bp.length > 0 ? bp : undefined,
     })
-  }, [openPreviewTabForFile])
+  }, [sessionId, openPreview])
 
   // Worktree 选择状态
   const [selectedWorktreeMap, setSelectedWorktreeMap] = useAtom(agentSelectedWorktreeAtom)
@@ -120,13 +101,13 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   }, [sessionId, setSelectedWorktreeMap])
 
   const handleDiffFileClick = React.useCallback((filePath: string, _isUntracked: boolean, gitRoot?: string) => {
-    openPreviewTabForFile({
+    openPreview(sessionId, {
       filePath,
       dirPath: sessionPath || undefined,
       gitRoot,
       baseRef: selectedWorktreePath ? 'origin/main' : undefined,
     })
-  }, [openPreviewTabForFile, sessionPath, selectedWorktreePath])
+  }, [openPreview, sessionId, sessionPath, selectedWorktreePath])
 
   // 动画标志：isOpen 变化时启用过渡动画，切换会话时即时显示
   const prevIsOpenRef = React.useRef(isOpen)

--- a/apps/electron/src/renderer/components/agent/tool-result-renderers/preview-open-button.tsx
+++ b/apps/electron/src/renderer/components/agent/tool-result-renderers/preview-open-button.tsx
@@ -3,14 +3,13 @@
  *
  * 显示在工具结果预览区域（Read/Edit/Write）的 chevron 旁边，
  * 使用 span 避免嵌套 button 的 HTML 问题，
- * 点击后将文件内容在当前会话的临时预览标签页中打开。
+ * 点击后按用户偏好（标签页 / 右侧分屏）打开文件预览。
  */
 
 import * as React from 'react'
-import { useAtomValue, useSetAtom, useStore } from 'jotai'
-import { previewFileMapAtom, previewPanelOpenMapAtom } from '@/atoms/preview-atoms'
+import { useAtomValue } from 'jotai'
 import { currentAgentSessionIdAtom } from '@/atoms/agent-atoms'
-import { activeTabIdAtom, getPreviewTabTitle, openTab, tabsAtom } from '@/atoms/tab-atoms'
+import { useOpenPreview } from '@/components/diff/preview-opener'
 import { cn } from '@/lib/utils'
 
 interface PreviewOpenButtonProps {
@@ -20,30 +19,12 @@ interface PreviewOpenButtonProps {
 
 export function PreviewOpenButton({ filePath, className }: PreviewOpenButtonProps): React.ReactElement | null {
   const sessionId = useAtomValue(currentAgentSessionIdAtom)
-  const store = useStore()
-  const setPreviewFile = useSetAtom(previewFileMapAtom)
-  const setPreviewOpen = useSetAtom(previewPanelOpenMapAtom)
+  const openPreview = useOpenPreview()
 
   if (!sessionId || !filePath) return null
 
   const handleOpen = () => {
-    setPreviewFile((prev) => {
-      const next = new Map(prev)
-      next.set(sessionId, { filePath, previewOnly: true, readOnly: true })
-      return next
-    })
-    setPreviewOpen((prev) => {
-      const next = new Map(prev)
-      next.set(sessionId, false)
-      return next
-    })
-    const result = openTab(store.get(tabsAtom), {
-      type: 'preview',
-      sessionId,
-      title: getPreviewTabTitle(filePath),
-    })
-    store.set(tabsAtom, result.tabs)
-    store.set(activeTabIdAtom, result.activeTabId)
+    openPreview(sessionId, { filePath, previewOnly: true, readOnly: true })
   }
 
   return (
@@ -68,7 +49,7 @@ export function PreviewOpenButton({ filePath, className }: PreviewOpenButtonProp
           handleOpen()
         }
       }}
-      title="在预览标签页中打开"
+      title="预览文件"
     >
       预览
     </span>

--- a/apps/electron/src/renderer/components/diff/PreviewPanel.tsx
+++ b/apps/electron/src/renderer/components/diff/PreviewPanel.tsx
@@ -6,12 +6,13 @@
  */
 
 import * as React from 'react'
-import { useAtomValue, useSetAtom } from 'jotai'
-import { Maximize2, X } from 'lucide-react'
+import { useAtom, useAtomValue, useSetAtom } from 'jotai'
+import { Maximize2, PanelRight, X } from 'lucide-react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import {
   previewPanelOpenMapAtom,
   previewFileMapAtom,
+  previewModePreferenceAtom,
 } from '@/atoms/preview-atoms'
 import {
   agentSessionPathMapAtom,
@@ -43,6 +44,7 @@ export function PreviewPanel({ sessionId }: PreviewPanelProps): React.ReactEleme
   const setTabs = useSetAtom(tabsAtom)
   const setActiveTabId = useSetAtom(activeTabIdAtom)
   const isSidePanelOpen = useAtomValue(currentSessionSidePanelOpenAtom)
+  const [previewModePref, setPreviewModePref] = useAtom(previewModePreferenceAtom)
 
   const currentFile = fileMap.get(sessionId) ?? null
 
@@ -82,6 +84,32 @@ export function PreviewPanel({ sessionId }: PreviewPanelProps): React.ReactEleme
           filePath={defaultAppTargetPath}
           access={defaultAppAccess}
         />
+      )}
+      {currentFile && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={() => setPreviewModePref((p) => (p === 'split' ? 'tab' : 'split'))}
+              className={cn(
+                'flex items-center justify-center size-6 shrink-0 rounded transition-colors',
+                previewModePref === 'split'
+                  ? 'text-primary bg-primary/10'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
+              )}
+              aria-label={previewModePref === 'split' ? '默认侧边分屏（已启用）' : '默认侧边分屏'}
+            >
+              <PanelRight className="size-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            <p>
+              {previewModePref === 'split'
+                ? '默认预览方式：侧边分屏（点击切回标签页）'
+                : '默认预览方式：标签页（点击切为侧边分屏）'}
+            </p>
+          </TooltipContent>
+        </Tooltip>
       )}
       {currentFile && (
         <Tooltip>

--- a/apps/electron/src/renderer/components/diff/PreviewPanel.tsx
+++ b/apps/electron/src/renderer/components/diff/PreviewPanel.tsx
@@ -97,7 +97,7 @@ export function PreviewPanel({ sessionId }: PreviewPanelProps): React.ReactEleme
                   ? 'text-primary bg-primary/10'
                   : 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
               )}
-              aria-label={previewModePref === 'split' ? '默认侧边分屏（已启用）' : '默认侧边分屏'}
+              aria-label={previewModePref === 'split' ? '默认展开方式：侧边分屏，点击改为标签页' : '默认展开方式：标签页，点击改为侧边分屏'}
             >
               <PanelRight className="size-3.5" />
             </button>
@@ -105,8 +105,8 @@ export function PreviewPanel({ sessionId }: PreviewPanelProps): React.ReactEleme
           <TooltipContent side="bottom">
             <p>
               {previewModePref === 'split'
-                ? '默认预览方式：侧边分屏（点击切回标签页）'
-                : '默认预览方式：标签页（点击切为侧边分屏）'}
+                ? '默认展开方式：侧边分屏 · 点击改为「标签页」（仅影响下次打开，不改变当前预览）'
+                : '默认展开方式：标签页 · 点击改为「侧边分屏」（仅影响下次打开，不改变当前预览）'}
             </p>
           </TooltipContent>
         </Tooltip>

--- a/apps/electron/src/renderer/components/diff/PreviewTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/PreviewTabContent.tsx
@@ -5,7 +5,9 @@
  */
 
 import * as React from 'react'
-import { useAtomValue, useSetAtom } from 'jotai'
+import { useAtomValue, useSetAtom, useStore } from 'jotai'
+import { PanelRight } from 'lucide-react'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import {
   agentSessionPathMapAtom,
 } from '@/atoms/agent-atoms'
@@ -16,9 +18,35 @@ import {
   tabsAtom,
 } from '@/atoms/tab-atoms'
 import { previewFileMapAtom } from '@/atoms/preview-atoms'
+import { tearOffPreviewToSplit } from './preview-opener'
 import { DefaultAppOpenButton } from './DefaultAppOpenButton'
 import { DiffTabContent } from './DiffTabContent'
 import { getDefaultAppTargetPath, getPreviewFileAccess } from './preview-open-path'
+
+/** 切换为侧边分屏的小按钮 — 与拖拽 Tab 出 TabBar 触发的 tear-off 等价 */
+function TearOffButton({ sessionId }: { sessionId: string }): React.ReactElement {
+  const store = useStore()
+  const onClick = React.useCallback(() => {
+    tearOffPreviewToSplit(store, createPreviewTabId(sessionId))
+  }, [store, sessionId])
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onClick={onClick}
+          className="flex items-center justify-center size-7 shrink-0 text-muted-foreground hover:text-foreground hover:bg-muted/50 rounded transition-colors"
+          aria-label="切换为侧边分屏"
+        >
+          <PanelRight className="size-3.5" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">
+        <p>切换为侧边分屏（保留会话 Tab，文件预览移到右侧）</p>
+      </TooltipContent>
+    </Tooltip>
+  )
+}
 
 interface PreviewTabContentProps {
   sessionId: string
@@ -76,6 +104,7 @@ export function PreviewTabContent({ sessionId }: PreviewTabContentProps): React.
         filePath={defaultAppTargetPath}
         access={defaultAppAccess}
       />
+      <TearOffButton sessionId={sessionId} />
     </>
   )
 

--- a/apps/electron/src/renderer/components/diff/preview-opener.ts
+++ b/apps/electron/src/renderer/components/diff/preview-opener.ts
@@ -1,0 +1,131 @@
+/**
+ * useOpenPreview — 统一的预览入口 Hook
+ *
+ * 把分散在 SidePanel / PreviewOpenButton / AgentView 等处的「打开预览」逻辑收敛到一处，
+ * 按用户偏好（previewModePreferenceAtom）路由到 Tab 或右侧分屏。
+ *
+ * 用户仍可通过：
+ *   - 拖拽 preview Tab 出 TabBar（即时切换为分屏）
+ *   - PreviewPanel 顶栏 Maximize2（即时切换为 Tab）
+ *   - PreviewTabContent 顶栏「切换为侧边分屏」按钮（即时切换为分屏）
+ * 在两种模式间即时切换，本 hook 仅控制默认行为。
+ */
+
+import * as React from 'react'
+import { useStore } from 'jotai'
+import {
+  previewFileMapAtom,
+  previewPanelOpenMapAtom,
+  previewModePreferenceAtom,
+  type PreviewFile,
+} from '@/atoms/preview-atoms'
+import {
+  activeTabIdAtom,
+  closeTab,
+  createPreviewTabId,
+  getPreviewTabTitle,
+  isPreviewTab,
+  openTab,
+  sessionViewStateMapAtom,
+  tabsAtom,
+} from '@/atoms/tab-atoms'
+
+/** Jotai store 类型（从 useStore 推导，避免直接 import 内部 Store 类型） */
+type JotaiStore = ReturnType<typeof useStore>
+
+interface OpenPreviewOptions {
+  /** 跳过偏好读取，强制以 Tab 方式打开（用于 PreviewPanel 的 Maximize2 等显式入口） */
+  forceTab?: boolean
+  /** 跳过偏好读取，强制以分屏方式打开（用于拖拽 Tab 出区域转分屏） */
+  forceSplit?: boolean
+}
+
+export function useOpenPreview() {
+  const store = useStore()
+
+  return React.useCallback(
+    (sessionId: string, file: PreviewFile, opts: OpenPreviewOptions = {}) => {
+      // 1. 文件状态两种模式都需要，先写入
+      store.set(previewFileMapAtom, (prev) => {
+        const m = new Map(prev)
+        m.set(sessionId, file)
+        return m
+      })
+
+      const preferSplit = opts.forceSplit
+        ? true
+        : opts.forceTab
+          ? false
+          : store.get(previewModePreferenceAtom) === 'split'
+
+      if (preferSplit) {
+        // 分屏：开启预览面板，不创建 Tab
+        store.set(previewPanelOpenMapAtom, (prev) => {
+          const m = new Map(prev)
+          m.set(sessionId, true)
+          return m
+        })
+        return
+      }
+
+      // Tab：保持旧行为（关闭分屏 + 创建/复用 preview Tab）
+      store.set(previewPanelOpenMapAtom, (prev) => {
+        const m = new Map(prev)
+        m.set(sessionId, false)
+        return m
+      })
+      const result = openTab(store.get(tabsAtom), {
+        type: 'preview',
+        sessionId,
+        title: getPreviewTabTitle(file.filePath),
+      })
+      store.set(tabsAtom, result.tabs)
+      store.set(activeTabIdAtom, result.activeTabId)
+    },
+    [store],
+  )
+}
+
+/**
+ * tearOffPreviewToSplit — 把 preview Tab 即时切换为右侧分屏。
+ *
+ * 用于「拖拽 preview Tab 出 TabBar」与「PreviewTabContent 顶栏切换按钮」两条入口共用。
+ * 流程：关闭 preview Tab → 激活对应会话的 agent Tab → 开启右侧分屏。
+ * previewFileMap 中保留的文件就是分屏要显示的内容，无需重新打开。
+ *
+ * 若传入的 tabId 不是 preview Tab（或已找不到），不做任何事。
+ */
+export function tearOffPreviewToSplit(store: JotaiStore, tabId: string): void {
+  const tabs = store.get(tabsAtom)
+  const tab = tabs.find((t) => t.id === tabId)
+  if (!tab || !isPreviewTab(tab)) return
+
+  const sessionId = tab.sessionId
+
+  // 关闭 preview Tab，激活相邻 Tab（通常是会话 Tab）
+  const closed = closeTab(store.get(tabsAtom), store.get(activeTabIdAtom), tabId)
+  store.set(tabsAtom, closed.tabs)
+  // 优先激活该会话的 agent Tab，让右侧分屏可见
+  const agentTab = closed.tabs.find((t) => t.type === 'agent' && t.sessionId === sessionId)
+  store.set(activeTabIdAtom, agentTab?.id ?? closed.activeTabId)
+
+  // 标记会话视图为 session，避免切走再切回时重建 preview Tab
+  store.set(sessionViewStateMapAtom, (prev) => {
+    const m = new Map(prev)
+    m.set(sessionId, { previewTabOpen: false, lastView: 'session' })
+    return m
+  })
+
+  // 开启右侧分屏
+  store.set(previewPanelOpenMapAtom, (prev) => {
+    const m = new Map(prev)
+    m.set(sessionId, true)
+    return m
+  })
+}
+
+/** 根据会话 ID 派生对应的 preview Tab ID */
+export function getPreviewTabIdForSession(sessionId: string): string {
+  return createPreviewTabId(sessionId)
+}
+

--- a/apps/electron/src/renderer/components/diff/preview-opener.ts
+++ b/apps/electron/src/renderer/components/diff/preview-opener.ts
@@ -22,7 +22,6 @@ import {
 import {
   activeTabIdAtom,
   closeTab,
-  createPreviewTabId,
   getPreviewTabTitle,
   isPreviewTab,
   openTab,
@@ -33,18 +32,11 @@ import {
 /** Jotai store 类型（从 useStore 推导，避免直接 import 内部 Store 类型） */
 type JotaiStore = ReturnType<typeof useStore>
 
-interface OpenPreviewOptions {
-  /** 跳过偏好读取，强制以 Tab 方式打开（用于 PreviewPanel 的 Maximize2 等显式入口） */
-  forceTab?: boolean
-  /** 跳过偏好读取，强制以分屏方式打开（用于拖拽 Tab 出区域转分屏） */
-  forceSplit?: boolean
-}
-
 export function useOpenPreview() {
   const store = useStore()
 
   return React.useCallback(
-    (sessionId: string, file: PreviewFile, opts: OpenPreviewOptions = {}) => {
+    (sessionId: string, file: PreviewFile) => {
       // 1. 文件状态两种模式都需要，先写入
       store.set(previewFileMapAtom, (prev) => {
         const m = new Map(prev)
@@ -52,11 +44,7 @@ export function useOpenPreview() {
         return m
       })
 
-      const preferSplit = opts.forceSplit
-        ? true
-        : opts.forceTab
-          ? false
-          : store.get(previewModePreferenceAtom) === 'split'
+      const preferSplit = store.get(previewModePreferenceAtom) === 'split'
 
       if (preferSplit) {
         // 分屏：开启预览面板，不创建 Tab
@@ -93,7 +81,7 @@ export function useOpenPreview() {
  * 流程：关闭 preview Tab → 激活对应会话的 agent Tab → 开启右侧分屏。
  * previewFileMap 中保留的文件就是分屏要显示的内容，无需重新打开。
  *
- * 若传入的 tabId 不是 preview Tab（或已找不到），不做任何事。
+ * 若传入的 tabId 不是 preview Tab、已找不到，或该会话没有可承载分屏的 agent Tab，则不做任何事。
  */
 export function tearOffPreviewToSplit(store: JotaiStore, tabId: string): void {
   const tabs = store.get(tabsAtom)
@@ -102,12 +90,14 @@ export function tearOffPreviewToSplit(store: JotaiStore, tabId: string): void {
 
   const sessionId = tab.sessionId
 
-  // 关闭 preview Tab，激活相邻 Tab（通常是会话 Tab）
+  // 分屏渲染在该会话的 agent 视图内，若没有对应 agent Tab 则无处承载，保持 Tab 模式不动
+  const agentTab = tabs.find((t) => t.type === 'agent' && t.sessionId === sessionId)
+  if (!agentTab) return
+
+  // 关闭 preview Tab，并激活该会话的 agent Tab，让右侧分屏可见
   const closed = closeTab(store.get(tabsAtom), store.get(activeTabIdAtom), tabId)
   store.set(tabsAtom, closed.tabs)
-  // 优先激活该会话的 agent Tab，让右侧分屏可见
-  const agentTab = closed.tabs.find((t) => t.type === 'agent' && t.sessionId === sessionId)
-  store.set(activeTabIdAtom, agentTab?.id ?? closed.activeTabId)
+  store.set(activeTabIdAtom, agentTab.id)
 
   // 标记会话视图为 session，避免切走再切回时重建 preview Tab
   store.set(sessionViewStateMapAtom, (prev) => {
@@ -122,10 +112,5 @@ export function tearOffPreviewToSplit(store: JotaiStore, tabId: string): void {
     m.set(sessionId, true)
     return m
   })
-}
-
-/** 根据会话 ID 派生对应的 preview Tab ID */
-export function getPreviewTabIdForSession(sessionId: string): string {
-  return createPreviewTabId(sessionId)
 }
 

--- a/apps/electron/src/renderer/components/settings/AppearanceSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AppearanceSettings.tsx
@@ -27,6 +27,7 @@ import {
   markdownFontSizeAtom,
   updateMarkdownFontSize,
 } from '@/atoms/markdown-font-size'
+import { previewModePreferenceAtom, type PreviewModePreference } from '@/atoms/preview-atoms'
 import { cn } from '@/lib/utils'
 import { detectIsWindows } from '@/lib/platform'
 import type { ThemeMode, ThemeStyle, MarkdownFontSize } from '../../../types'
@@ -67,6 +68,12 @@ const MARKDOWN_FONT_SIZE_OPTIONS = [
   { value: 'small', label: '小' },
   { value: 'medium', label: '中' },
   { value: 'large', label: '大' },
+]
+
+/** 预览默认展开方式 */
+const PREVIEW_MODE_OPTIONS: { value: PreviewModePreference; label: string }[] = [
+  { value: 'tab', label: '标签页' },
+  { value: 'split', label: '侧边分屏' },
 ]
 
 /** 特殊风格 ID（排除 default） */
@@ -174,6 +181,7 @@ export function AppearanceSettings(): React.ReactElement {
   const [themeStyle, setThemeStyle] = useAtom(themeStyleAtom)
   const systemIsDark = useAtomValue(systemIsDarkAtom)
   const [markdownFontSize, setMarkdownFontSize] = useAtom(markdownFontSizeAtom)
+  const [previewModePref, setPreviewModePref] = useAtom(previewModePreferenceAtom)
 
   /** 切换主题模式 */
   const handleThemeChange = React.useCallback((value: string) => {
@@ -247,6 +255,14 @@ export function AppearanceSettings(): React.ReactElement {
             value={markdownFontSize}
             onValueChange={handleMarkdownFontSizeChange}
             options={MARKDOWN_FONT_SIZE_OPTIONS}
+          />
+
+          <SettingsSegmentedControl
+            label="Agent 预览展开方式"
+            description="点击文件、工具结果「预览」按钮时的默认展开位置；拖拽预览 Tab 出标签栏可即时切换为侧边分屏"
+            value={previewModePref}
+            onValueChange={(v) => setPreviewModePref(v as PreviewModePreference)}
+            options={PREVIEW_MODE_OPTIONS}
           />
         </SettingsCard>
       </SettingsSection>

--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -222,15 +222,18 @@ function TabBarInner({
 
     if (e.button !== 0) return
     const startX = e.clientX
-    const startY = e.clientY
     let torn = false
     let sorting = false
+
+    // 拖出 TabBar 上下边界后还需再越过这段缓冲距离才触发 tear-off，
+    // 避免在水平排序过程中轻微的垂直抖动误触发转分屏。
+    const TEAR_OFF_MARGIN = 24
 
     const handleMove = (me: PointerEvent): void => {
       if (torn) return
       const rect = barRef.current?.getBoundingClientRect()
-      // 拖出 TabBar 上下边界即视为 tear-off
-      const outOfBar = !!rect && (me.clientY < rect.top || me.clientY > rect.bottom)
+      // 拖出 TabBar 上/下边界并越过缓冲距离才视为 tear-off
+      const outOfBar = !!rect && (me.clientY < rect.top - TEAR_OFF_MARGIN || me.clientY > rect.bottom + TEAR_OFF_MARGIN)
       if (outOfBar) {
         torn = true
         setTearingOff(tabId)
@@ -258,7 +261,6 @@ function TabBarInner({
 
     document.addEventListener('pointermove', handleMove)
     document.addEventListener('pointerup', handleUp)
-    void startY
   }, [tabs, onDragStart, onTearOff])
 
   // 鼠标滚轮横向滚动（使用原生事件监听器以支持 preventDefault）

--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -9,7 +9,7 @@
  */
 
 import * as React from 'react'
-import { useAtom, useAtomValue, useSetAtom } from 'jotai'
+import { useAtom, useAtomValue, useSetAtom, useStore } from 'jotai'
 import {
   tabsAtom,
   activeTabIdAtom,
@@ -27,6 +27,7 @@ import {
 } from '@/atoms/agent-atoms'
 import { appModeAtom } from '@/atoms/app-mode'
 import { automationFormAtom } from '@/atoms/automation-atoms'
+import { tearOffPreviewToSplit } from '@/components/diff/preview-opener'
 import { TabBarItem } from './TabBarItem'
 import { useCloseTab } from '@/hooks/useCloseTab'
 import { detectIsWindows } from '@/lib/platform'
@@ -50,6 +51,15 @@ export function TabBar(): React.ReactElement {
 
   // 统一关闭逻辑：关闭当前会话入口并回到 Scratch Pad，不停止后台 Agent
   const { requestClose } = useCloseTab()
+  const store = useStore()
+
+  /**
+   * Tear-off：把 preview Tab 拖出 TabBar 时，转成右侧分屏预览。
+   * 公共实现在 preview-opener.ts，PreviewTabContent 顶栏切换按钮共用同一份逻辑。
+   */
+  const handleTearOff = React.useCallback((tabId: string) => {
+    tearOffPreviewToSplit(store, tabId)
+  }, [store])
 
   const workspaceNameBySessionId = React.useMemo(() => {
     const workspaceNameMap = new Map(agentWorkspaces.map((workspace) => [workspace.id, workspace.name]))
@@ -157,6 +167,7 @@ export function TabBar(): React.ReactElement {
         onActivate={handleActivate}
         onClose={requestClose}
         onDragStart={handleDragStart}
+        onTearOff={handleTearOff}
       />
     </>
   )
@@ -172,6 +183,7 @@ function TabBarInner({
   onActivate,
   onClose,
   onDragStart,
+  onTearOff,
 }: {
   tabs: TabItem[]
   activeTabId: string | null
@@ -181,6 +193,7 @@ function TabBarInner({
   onActivate: (tabId: string) => void
   onClose: (tabId: string) => void
   onDragStart: (tabId: string, e: React.PointerEvent) => void
+  onTearOff: (tabId: string) => void
 }): React.ReactElement {
   const [hoveredTabId, setHoveredTabId] = React.useState<string | null>(null)
   const [isLeaving, setIsLeaving] = React.useState(false)
@@ -191,6 +204,62 @@ function TabBarInner({
 
   // 滚动容器 ref
   const scrollRef = React.useRef<HTMLDivElement>(null)
+
+  // 整条 TabBar 容器 ref，用于拖拽 tear-off 时检测鼠标是否离开 TabBar 区域
+  const barRef = React.useRef<HTMLDivElement>(null)
+
+  // 拖出 TabBar 区域时给出视觉提示（仅 preview Tab 可 tear-off）
+  const [tearingOff, setTearingOff] = React.useState<string | null>(null)
+
+  // 拦截外层 handleDragStart：若拖出 TabBar 区域且是 preview Tab，触发 tear-off
+  const handleDragStartWithTearOff = React.useCallback((tabId: string, e: React.PointerEvent) => {
+    const tab = tabs.find((t) => t.id === tabId)
+    // 仅 preview Tab 支持拖出转分屏
+    if (!tab || tab.type !== 'preview') {
+      onDragStart(tabId, e)
+      return
+    }
+
+    if (e.button !== 0) return
+    const startX = e.clientX
+    const startY = e.clientY
+    let torn = false
+    let sorting = false
+
+    const handleMove = (me: PointerEvent): void => {
+      if (torn) return
+      const rect = barRef.current?.getBoundingClientRect()
+      // 拖出 TabBar 上下边界即视为 tear-off
+      const outOfBar = !!rect && (me.clientY < rect.top || me.clientY > rect.bottom)
+      if (outOfBar) {
+        torn = true
+        setTearingOff(tabId)
+        // 仅停止 move 监听，保留 pointerup 让浏览器自然结束按住状态
+        document.removeEventListener('pointermove', handleMove)
+        // 等下一帧再触发，避免在事件回调中同步重渲染导致 React 警告
+        requestAnimationFrame(() => {
+          onTearOff(tabId)
+          setTearingOff(null)
+        })
+        return
+      }
+      // 在 TabBar 内水平移动 → 交给原有排序逻辑
+      const dx = Math.abs(me.clientX - startX)
+      if (!sorting && dx > 5) {
+        sorting = true
+        onDragStart(tabId, e)
+      }
+    }
+
+    const handleUp = (): void => {
+      document.removeEventListener('pointermove', handleMove)
+      document.removeEventListener('pointerup', handleUp)
+    }
+
+    document.addEventListener('pointermove', handleMove)
+    document.addEventListener('pointerup', handleUp)
+    void startY
+  }, [tabs, onDragStart, onTearOff])
 
   // 鼠标滚轮横向滚动（使用原生事件监听器以支持 preventDefault）
   React.useEffect(() => {
@@ -257,12 +326,17 @@ function TabBarInner({
   }, [])
 
   return (
-    <div className="flex items-end h-[34px] tabbar-bg relative">
+    <div ref={barRef} className="flex items-end h-[34px] tabbar-bg relative">
       {/* 顶部 TabBar 的空白区域必须保持可拖拽，尤其是 macOS/Windows 自定义标题栏。
           注意：不要把 titlebar-no-drag 加到下面的整条 flex 容器上，否则标签右侧空白会再次失去拖拽能力。
           Windows 上背景拖拽层避开右上角 WindowControls 区域（126px），防止 hitmask 重叠。
           需要交互的单个 Tab 会在 TabBarItem 内部自己声明 titlebar-no-drag。 */}
       <div className={cn("absolute inset-0 titlebar-drag-region", isWindows && "right-[126px]")} />
+
+      {/* Tear-off 提示遮罩：拖出 TabBar 区域时，让 TabBar 下方出现一条高亮分割线 */}
+      {tearingOff && (
+        <div className="pointer-events-none absolute -bottom-px left-0 right-0 h-px bg-primary/60 shadow-[0_0_8px_rgba(0,0,0,0.2)]" />
+      )}
 
       <div
         ref={scrollRef}
@@ -280,10 +354,11 @@ function TabBarInner({
             isStreaming={streamingMap.get(tab.id) ?? 'idle'}
             isHovered={hoveredTabId === tab.id}
             isLeaving={hoveredTabId === tab.id && isLeaving}
+            isTearingOff={tearingOff === tab.id}
             onActivate={() => onActivate(tab.id)}
             onClose={() => onClose(tab.id)}
             onMiddleClick={() => onClose(tab.id)}
-            onDragStart={(e) => onDragStart(tab.id, e)}
+            onDragStart={(e) => handleDragStartWithTearOff(tab.id, e)}
             onHoverEnter={() => handleTabHoverEnter(tab.id)}
             onHoverLeave={handleTabHoverLeave}
             onPanelHoverEnter={handlePanelHoverEnter}

--- a/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
@@ -27,6 +27,8 @@ export interface TabBarItemProps {
   isHovered: boolean
   /** 预览面板是否正在退出动画 */
   isLeaving: boolean
+  /** 该 Tab 正在被拖出 TabBar 转分屏（tear-off 触发瞬间） */
+  isTearingOff?: boolean
   onActivate: () => void
   onClose: () => void
   onMiddleClick: () => void
@@ -52,6 +54,7 @@ export function TabBarItem({
   isStreaming,
   isHovered,
   isLeaving,
+  isTearingOff,
   onActivate,
   onClose,
   onMiddleClick,
@@ -151,6 +154,7 @@ export function TabBarItem({
           isActive
             ? 'bg-content-area text-foreground border-border/50'
             : 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
+          isTearingOff && 'ring-2 ring-primary/70 ring-offset-0 bg-primary/10',
         )}
         onClick={onActivate}
         onMouseDown={handleMouseDown}


### PR DESCRIPTION
- 新增持久化偏好 previewModePreferenceAtom（'tab' | 'split'），默认 'tab'
- 抽 useOpenPreview hook 收敛 SidePanel / PreviewOpenButton / AgentView clipboard 等 4 处入口，按偏好路由
- 新增 tearOffPreviewToSplit 公共函数：关 preview Tab → 激活 agent Tab → 开右侧分屏
- TabBar 支持拖拽 preview Tab 出上下边界转分屏，含高亮提示
- PreviewTabContent 顶栏加 PanelRight 按钮，与拖拽手势等价的显式入口
- PreviewPanel 顶栏加偏好切换按钮；AppearanceSettings 加 segment