### PR TITLE
[Reviewed] fix(side-panel): WorktreeSelector 下沉至 DiffChangesList，消除加载闪现

### DIFF
--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -20,7 +20,6 @@ import { cn } from '@/lib/utils'
 import { FileBrowser, FileDropZone, FileTypeIcon, FileSearchBar, computeRevealAncestors, isPathUnderRoot, computeTreeRowLayout, AncestorGuides, STICKY_ROW_BASE_CLASS, canBeSticky } from '@/components/file-browser'
 import { DiffPanelTabBar } from '@/components/diff/DiffPanelTabBar'
 import { DiffChangesList } from '@/components/diff/DiffChangesList'
-import { WorktreeSelector } from '@/components/diff/WorktreeSelector'
 import {
   agentSidePanelOpenAtom,
   workspaceFilesVersionAtom,
@@ -104,20 +103,9 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
     })
   }, [openPreviewTabForFile])
 
-  // Worktree 选择状态
-  const [selectedWorktreeMap, setSelectedWorktreeMap] = useAtom(agentSelectedWorktreeAtom)
+  // Worktree 选择状态（仅用于 diff 文件点击时传递 baseRef，选取逻辑已下沉至 DiffChangesList）
+  const selectedWorktreeMap = useAtomValue(agentSelectedWorktreeAtom)
   const selectedWorktreePath = selectedWorktreeMap.get(sessionId) ?? null
-
-  const handleWorktreeSelect = React.useCallback((worktree: import('@proma/shared').WorktreeInfo | null) => {
-    // 仅切换 diff 视图，不再自动把 worktree 挂进会话目录。
-    // worktree 的 diff 读取已由主进程的 ensurePathAllowedWithWorktree 凭 git 背书放行，
-    // 无需借「附加目录」绕过安全检查；是否让 Agent 访问该 worktree 交由用户手动决定。
-    setSelectedWorktreeMap((prev) => {
-      const m = new Map(prev)
-      m.set(sessionId, worktree?.path ?? null)
-      return m
-    })
-  }, [sessionId, setSelectedWorktreeMap])
 
   const handleDiffFileClick = React.useCallback((filePath: string, _isUntracked: boolean, gitRoot?: string) => {
     openPreviewTabForFile({
@@ -442,13 +430,6 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
 
           {activeTab === 'changes' ? (
             sessionPath ? (
-            <>
-              <WorktreeSelector
-                sessionId={sessionId}
-                workspaceSlug={workspaceSlug || ''}
-                selectedPath={selectedWorktreePath}
-                onSelect={handleWorktreeSelect}
-              />
               <DiffChangesList
                 key={sessionId}
                 dirPath={sessionPath}
@@ -459,9 +440,8 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
                 refreshVersion={diffRefreshVersion}
                 selectedFilePath={selectedFilePath}
                 onFileClick={handleDiffFileClick}
-                worktreeMode={selectedWorktreePath ? { path: selectedWorktreePath, baseBranch: 'origin/main' } : undefined}
+                workspaceSlug={workspaceSlug || undefined}
               />
-            </>
             ) : (
               <div className="flex-1 flex items-center justify-center text-muted-foreground text-xs">等待会话初始化...</div>
             )

--- a/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
@@ -10,8 +10,9 @@ import { useAtomValue, useSetAtom } from 'jotai'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { FileTypeIcon } from '@/components/file-browser/FileTypeIcon'
-import { agentDiffUnseenFilesAtom, agentDiffDataAtom } from '@/atoms/agent-atoms'
-import type { ChangedFileEntry, ChangeSource, UntrackedFileEntry } from '@proma/shared'
+import { agentDiffUnseenFilesAtom, agentDiffDataAtom, agentSelectedWorktreeAtom } from '@/atoms/agent-atoms'
+import type { ChangedFileEntry, ChangeSource, UntrackedFileEntry, WorktreeInfo } from '@proma/shared'
+import { WorktreeSelector } from './WorktreeSelector'
 
 /** 按目录分组后的数据结构 */
 interface FileGroup {
@@ -42,8 +43,8 @@ interface DiffChangesListProps {
   selectedFilePath?: string
   /** 额外的候选目录（附加目录等） */
   extraPaths?: string[]
-  /** Worktree 模式：显示 worktree vs baseBranch 的全量 diff */
-  worktreeMode?: { path: string; baseBranch: string }
+  /** 工作区 slug，用于 WorktreeSelector 拉取 worktree 列表 */
+  workspaceSlug?: string
 }
 
 /** 文件来源 badge 的颜色和文案 */
@@ -63,7 +64,7 @@ export const DiffChangesList = React.memo(function DiffChangesList({
   refreshVersion,
   selectedFilePath,
   extraPaths,
-  worktreeMode,
+  workspaceSlug,
 }: DiffChangesListProps): React.ReactElement {
   // Diff 数据缓存：mount 时若已有上次结果，立即用作初值，避免空数组闪 1s "没有代码改动"
   const diffDataMap = useAtomValue(agentDiffDataAtom)
@@ -78,6 +79,22 @@ export const DiffChangesList = React.memo(function DiffChangesList({
   const [searchQuery, setSearchQuery] = React.useState('')
   /** 单调递增的 fetch 序号，用于丢弃乱序到达的旧响应 */
   const fetchSeqRef = React.useRef(0)
+
+  // Worktree 选择状态（内联 WorktreeSelector）
+  const selectedWorktreeMap = useAtomValue(agentSelectedWorktreeAtom)
+  const setSelectedWorktreeMap = useSetAtom(agentSelectedWorktreeAtom)
+  const selectedWorktreePath = selectedWorktreeMap.get(sessionId) ?? null
+  const worktreeMode = React.useMemo(
+    () => selectedWorktreePath ? { path: selectedWorktreePath, baseBranch: 'origin/main' } : undefined,
+    [selectedWorktreePath],
+  )
+  const handleWorktreeSelect = React.useCallback((worktree: WorktreeInfo | null) => {
+    setSelectedWorktreeMap((prev) => {
+      const m = new Map(prev)
+      m.set(sessionId, worktree?.path ?? null)
+      return m
+    })
+  }, [sessionId, setSelectedWorktreeMap])
 
   // Agent 本轮刚修改但尚未查看的文件
   const unseenFilesMap = useAtomValue(agentDiffUnseenFilesAtom)
@@ -231,6 +248,16 @@ export const DiffChangesList = React.memo(function DiffChangesList({
           )}
         </div>
       </div>
+
+      {/* Worktree 分支选择器 — 仅当有 worktree 时显示（组件内部自动隐藏） */}
+      {workspaceSlug && (
+        <WorktreeSelector
+          sessionId={sessionId}
+          workspaceSlug={workspaceSlug}
+          selectedPath={selectedWorktreePath}
+          onSelect={handleWorktreeSelect}
+        />
+      )}
 
       {isEmpty && (
         <div className="flex flex-col items-center justify-center h-full text-muted-foreground p-4">

--- a/apps/electron/src/renderer/components/diff/WorktreeSelector.tsx
+++ b/apps/electron/src/renderer/components/diff/WorktreeSelector.tsx
@@ -76,7 +76,7 @@ export function WorktreeSelector({
   const displayLabel = selectedWorktree ? selectedWorktree.branch : '会话改动'
   const hasMultipleRepos = repoWorktrees.length > 1
 
-  if (allWorktrees.length === 0 && !isLoading) return <></>
+  if (allWorktrees.length === 0) return <></>
 
   return (
     <div ref={dropdownRef} className="relative px-3 py-1.5 border-b border-border/50">


### PR DESCRIPTION
@
## 概述

将 WorktreeSelector 从 SidePanel 独立行下沉至 DiffChangesList 内部，消除切换到文件改动tab时的会话改动文字闪现问题。

## 问题

切换到文件改动tab时，WorktreeSelector 在 fetch worktree 列表期间短暂渲染会话改动标签，随后因无 worktree 数据而隐藏，造成视觉闪现。

## 改动

- WorktreeSelector: 加载期间不再渲染，仅在有 worktree 数据时才显示
- DiffChangesList: 内联 WorktreeSelector 于搜索栏与文件列表之间，自行管理 worktree 选取状态
- SidePanel: 移除独立 WorktreeSelector 渲染行和 worktreeMode prop 透传，改为传递 workspaceSlug

## 测试

- 切换到文件改动tab，确认不再有文字闪现
- 有 worktree 的会话中，确认 WorktreeSelector 正常显示在搜索栏下方
- 选取不同 worktree 分支，确认 diff 列表正确切换
@