### PR TITLE
[Reviewed] fix(file-chip): 移除 ContextMenuTrigger 的 asChild 修复右键菜单不响应

### DIFF
--- a/apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx
@@ -198,7 +198,7 @@ export function FilePathChip({ filePath, basePath, basePaths, className }: FileP
 
   return (
     <ContextMenu>
-      <ContextMenuTrigger asChild>
+      <ContextMenuTrigger>
         <button
           ref={chipRef}
           type="button"


### PR DESCRIPTION
## 概述

移除 FilePathChip 中 ContextMenuTrigger 的 `asChild` 属性，改用默认 span 包装 button，修复右键菜单在 Electron 生产环境下不响应的问题。

## 问题

#820 新增的右键菜单（"在文件管理器中显示"）在 Electron 生产构建中不工作。右键点击文件路径 chip 没有任何反应。

## 原因

`ContextMenuTrigger asChild` 通过 `React.cloneElement` 将右键事件处理器注入 `<button>` 元素。但 chip 的 button 同时绑定了 `chipRef`（IntersectionObserver）和 `onClick`，`asChild` 合并这些 prop 时可能导致右键事件绑定在特定环境下不生效。

## 改动

`apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx`
- 第 201 行：`<ContextMenuTrigger asChild>` → `<ContextMenuTrigger>`
- Trigger 现在渲染 `<span>` 包裹 button，span 自然承接右键事件，button 的 ref 和 onClick 不受干烧

## 测试

1. 在 Agent 消息中找到文件路径 chip（如 `src/main/index.ts`）
2. 左键点击应正常打开预览
3. 右键点击应弹出菜单：["在标签页中打开", "在文件管理器中显示"]
4. 点击"在文件管理器中显示"应打开系统文件管理器定位到文件

## 备注

基于 upstream/main `41878f3`