### PR TITLE
refactor(sidebar): 用图标替代 Agent 状态色码，整体降饱和重做选中态视觉【未完成版本】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.12.23",
+  "version": "0.12.24",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -2422,11 +2422,11 @@ const ConversationItem = React.memo(function ConversationItem({
  */
 function renderSessionStatusIcon(status: SessionIndicatorStatus): React.ReactElement | null {
   if (status === 'running') {
-    return <Spinner className="text-[14px] text-muted-foreground" aria-label="运行中" />
+    return <Spinner className="text-[14px] text-accent-foreground" aria-label="运行中" />
   }
   if (status === 'completed') {
     return (
-      <span className="relative inline-flex items-center justify-center text-muted-foreground" aria-label="已完成">
+      <span className="relative inline-flex items-center justify-center text-accent-foreground" aria-label="已完成">
         <Circle size={17} fill="currentColor" strokeWidth={0} />
         <Check size={11} strokeWidth={4} className="absolute text-background" aria-hidden />
       </span>
@@ -2434,7 +2434,7 @@ function renderSessionStatusIcon(status: SessionIndicatorStatus): React.ReactEle
   }
   if (status === 'blocked') {
     return (
-      <span className="inline-flex items-center justify-center font-bold text-muted-foreground text-[17px] leading-none" aria-label="等待回应">?</span>
+      <span className="inline-flex items-center justify-center font-bold text-accent-foreground text-[17px] leading-none animate-pulse" aria-label="等待回应">?</span>
     )
   }
   return null
@@ -2567,6 +2567,7 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
             'group relative flex items-center gap-1.5 rounded-md py-1 pl-2.5 pr-1.5 mx-1 transition-colors duration-100 titlebar-no-drag text-left',
             active && 'agent-session-item-active',
             'hover:bg-foreground/[0.03]',
+            emphasized && !active && 'bg-foreground/[0.04]',
             emphasized && 'text-foreground font-medium',
             active && 'bg-foreground/[0.08]',
           )}

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -2564,7 +2564,7 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
             startEdit()
           }}
           className={cn(
-            'group relative flex items-center gap-1.5 rounded-md py-1 pl-2.5 pr-1.5 mx-1 transition-colors duration-100 titlebar-no-drag text-left',
+            'group relative w-full flex items-center gap-1.5 rounded-md py-1 pl-4 pr-1.5 mx-1 transition-colors duration-100 titlebar-no-drag text-left',
             active && 'agent-session-item-active',
             emphasized && 'text-foreground font-medium',
           )}

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -2566,13 +2566,18 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
           className={cn(
             'group relative flex items-center gap-1.5 rounded-md py-1 pl-2.5 pr-1.5 mx-1 transition-colors duration-100 titlebar-no-drag text-left',
             active && 'agent-session-item-active',
-            'hover:bg-foreground/[0.03]',
             emphasized && 'text-foreground font-medium',
-            active && 'bg-foreground/[0.08]',
           )}
         >
+          <span
+            className={cn(
+              'absolute inset-y-0 left-1.5 right-0 rounded-md pointer-events-none transition-colors',
+              active ? 'bg-foreground/[0.08]' : 'bg-transparent group-hover:bg-foreground/[0.03]',
+            )}
+            aria-hidden
+          />
           {statusIcon && (
-            <span className="absolute inset-y-0 -left-5 flex items-center justify-center w-5 pointer-events-none">
+            <span className="absolute inset-y-0 -left-3.5 flex items-center justify-center w-5 pointer-events-none">
               {statusIcon}
             </span>
           )}

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -2422,19 +2422,19 @@ const ConversationItem = React.memo(function ConversationItem({
  */
 function renderSessionStatusIcon(status: SessionIndicatorStatus): React.ReactElement | null {
   if (status === 'running') {
-    return <Spinner className="text-[14px] text-accent-foreground" aria-label="运行中" />
+    return <Spinner className="text-[16px] text-primary" aria-label="运行中" />
   }
   if (status === 'completed') {
     return (
-      <span className="relative inline-flex items-center justify-center text-accent-foreground" aria-label="已完成">
-        <Circle size={17} fill="currentColor" strokeWidth={0} />
-        <Check size={11} strokeWidth={4} className="absolute text-background" aria-hidden />
+      <span className="relative inline-flex items-center justify-center text-primary" aria-label="已完成">
+        <Circle size={19} fill="currentColor" strokeWidth={0} />
+        <Check size={13} strokeWidth={4} className="absolute text-background" aria-hidden />
       </span>
     )
   }
   if (status === 'blocked') {
     return (
-      <span className="inline-flex items-center justify-center font-bold text-accent-foreground text-[17px] leading-none animate-pulse" aria-label="等待回应">?</span>
+      <span className="inline-flex items-center justify-center font-bold text-primary text-[19px] leading-none animate-pulse" aria-label="等待回应">?</span>
     )
   }
   return null
@@ -2567,7 +2567,6 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
             'group relative flex items-center gap-1.5 rounded-md py-1 pl-2.5 pr-1.5 mx-1 transition-colors duration-100 titlebar-no-drag text-left',
             active && 'agent-session-item-active',
             'hover:bg-foreground/[0.03]',
-            emphasized && !active && 'bg-foreground/[0.04]',
             emphasized && 'text-foreground font-medium',
             active && 'bg-foreground/[0.08]',
           )}

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -11,7 +11,7 @@
 import * as React from 'react'
 import { useAtom, useSetAtom, useAtomValue, useStore } from 'jotai'
 import { toast } from 'sonner'
-import { Pin, PinOff, Settings, Plus, Trash2, Pencil, Plug, Zap, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, GripVertical, Clock, AlarmClock, ChevronRight, CheckCircle2, MessageCircleQuestion } from 'lucide-react'
+import { Pin, PinOff, Settings, Plus, Trash2, Pencil, Plug, Zap, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, GripVertical, Clock, AlarmClock, ChevronRight, Circle, Check } from 'lucide-react'
 import { Spinner } from '@/components/ui/spinner'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
@@ -2417,18 +2417,25 @@ const ConversationItem = React.memo(function ConversationItem({
 /**
  * 会话行左侧状态图标 — 用图标替代颜色编码
  * - running:   3x3 网格 Spinner（与主界面 Agent Running 一致）
- * - completed: 圆圈对勾
- * - blocked:   带问号的会话气泡（AskUserQuestion 提示）
+ * - completed: 反色填充圆 + 背景色对勾
+ * - blocked:   反色填充会话气泡 + 背景色问号
  */
 function renderSessionStatusIcon(status: SessionIndicatorStatus): React.ReactElement | null {
   if (status === 'running') {
-    return <Spinner className="text-[12px] text-muted-foreground" aria-label="运行中" />
+    return <Spinner className="text-[14px] text-muted-foreground" aria-label="运行中" />
   }
   if (status === 'completed') {
-    return <CheckCircle2 size={15} className="text-muted-foreground" aria-label="已完成" />
+    return (
+      <span className="relative inline-flex items-center justify-center text-muted-foreground" aria-label="已完成">
+        <Circle size={17} fill="currentColor" strokeWidth={0} />
+        <Check size={11} strokeWidth={4} className="absolute text-background" aria-hidden />
+      </span>
+    )
   }
   if (status === 'blocked') {
-    return <MessageCircleQuestion size={15} className="text-muted-foreground" aria-label="等待回应" />
+    return (
+      <span className="inline-flex items-center justify-center font-bold text-muted-foreground text-[17px] leading-none" aria-label="等待回应">?</span>
+    )
   }
   return null
 }
@@ -2508,6 +2515,8 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
 
   const canMove = indicatorStatus === 'idle' || indicatorStatus === 'completed'
   const statusIcon = renderSessionStatusIcon(indicatorStatus)
+  // 加粗 + 全 foreground：选中态、completed、blocked 三种情况下视觉权重提升
+  const emphasized = active || indicatorStatus === 'completed' || indicatorStatus === 'blocked'
 
   const menuItems = (
     MenuItem: typeof ContextMenuItem | typeof DropdownMenuItem,
@@ -2558,7 +2567,8 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
             'group relative flex items-center gap-1.5 rounded-md py-1 pl-2.5 pr-1.5 mx-1 transition-colors duration-100 titlebar-no-drag text-left',
             active && 'agent-session-item-active',
             'hover:bg-foreground/[0.03]',
-            active && 'bg-foreground/[0.08] text-foreground font-medium',
+            emphasized && 'text-foreground font-medium',
+            active && 'bg-foreground/[0.08]',
           )}
         >
           {statusIcon && (
@@ -2581,7 +2591,7 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
             ) : (
               <div className={cn(
                 'truncate text-[13px] leading-[18px] flex items-center gap-1.5',
-                active ? 'text-foreground' : 'text-foreground/80'
+                emphasized ? 'text-foreground' : 'text-foreground/80'
               )}>
                 {showPinIcon && (
                   <Pin size={11} className="flex-shrink-0 text-primary/60" />

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -11,7 +11,8 @@
 import * as React from 'react'
 import { useAtom, useSetAtom, useAtomValue, useStore } from 'jotai'
 import { toast } from 'sonner'
-import { Pin, PinOff, Settings, Plus, Trash2, Pencil, Plug, Zap, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, GripVertical, Clock, AlarmClock, ChevronRight } from 'lucide-react'
+import { Pin, PinOff, Settings, Plus, Trash2, Pencil, Plug, Zap, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, GripVertical, Clock, AlarmClock, ChevronRight, CheckCircle2, MessageCircleQuestion } from 'lucide-react'
+import { Spinner } from '@/components/ui/spinner'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { ModeSwitcher } from './ModeSwitcher'
@@ -1805,7 +1806,6 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                         active={session.id === activeSessionId}
                         indicatorStatus={agentIndicatorMap.get(session.id) ?? 'idle'}
                         showPinIcon={false}
-                        leftAccent={getSessionLeftAccent(agentIndicatorMap.get(session.id) ?? 'idle')}
                         workspaceName={session.workspaceId ? workspaceNameMap.get(session.workspaceId) : undefined}
                         relativeTimeNow={relativeTimeNow}
                         onSelect={handleSelectAgentSession}
@@ -1957,7 +1957,6 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                         active={session.id === activeSessionId}
                         indicatorStatus={agentIndicatorMap.get(session.id) ?? 'idle'}
                         showPinIcon={!!session.pinned}
-                        leftAccent={getSessionLeftAccent(agentIndicatorMap.get(session.id) ?? 'idle')}
                         workspaceName={session.workspaceId ? workspaceNameMap.get(session.workspaceId) : undefined}
                         relativeTimeNow={relativeTimeNow}
                         onSelect={handleSelectAgentSession}
@@ -2415,25 +2414,23 @@ const ConversationItem = React.memo(function ConversationItem({
 
 // ===== Agent 会话列表项 =====
 
-/** 会话行左侧状态条的颜色 — 与 SessionIndicatorStatus 呼应 */
-type SessionLeftAccent = 'orange' | 'blue' | 'green'
-const SESSION_ACCENT_ROW_CLASS: Record<SessionLeftAccent, string> = {
-  orange: 'bg-orange-500/[0.08] text-foreground font-medium',
-  blue: 'text-foreground font-medium hover:bg-foreground/[0.03]',
-  green: 'text-foreground font-medium hover:bg-foreground/[0.03]',
-}
-
-const SESSION_ACCENT_INDICATOR_CLASS: Record<SessionLeftAccent, string> = {
-  orange: 'bg-orange-500',
-  blue: 'bg-blue-500',
-  green: 'bg-green-500',
-}
-
-function getSessionLeftAccent(status: SessionIndicatorStatus): SessionLeftAccent | undefined {
-  if (status === 'blocked') return 'orange'
-  if (status === 'running') return 'blue'
-  if (status === 'completed') return 'green'
-  return undefined
+/**
+ * 会话行左侧状态图标 — 用图标替代颜色编码
+ * - running:   3x3 网格 Spinner（与主界面 Agent Running 一致）
+ * - completed: 圆圈对勾
+ * - blocked:   带问号的会话气泡（AskUserQuestion 提示）
+ */
+function renderSessionStatusIcon(status: SessionIndicatorStatus): React.ReactElement | null {
+  if (status === 'running') {
+    return <Spinner className="text-[12px] text-muted-foreground" aria-label="运行中" />
+  }
+  if (status === 'completed') {
+    return <CheckCircle2 size={15} className="text-muted-foreground" aria-label="已完成" />
+  }
+  if (status === 'blocked') {
+    return <MessageCircleQuestion size={15} className="text-muted-foreground" aria-label="等待回应" />
+  }
+  return null
 }
 
 interface AgentSessionItemProps {
@@ -2441,8 +2438,6 @@ interface AgentSessionItemProps {
   active: boolean
   indicatorStatus: SessionIndicatorStatus
   showPinIcon?: boolean
-  /** 行左侧状态色块；未传则不显示 */
-  leftAccent?: SessionLeftAccent
   /** 是否禁用悬浮 Mini 地图 */
   disableMiniMap?: boolean
   /** 项目名称 Badge（跨项目列表时显示） */
@@ -2462,7 +2457,6 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
   active,
   indicatorStatus,
   showPinIcon,
-  leftAccent,
   disableMiniMap,
   workspaceName,
   relativeTimeNow,
@@ -2513,6 +2507,7 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
   }
 
   const canMove = indicatorStatus === 'idle' || indicatorStatus === 'completed'
+  const statusIcon = renderSessionStatusIcon(indicatorStatus)
 
   const menuItems = (
     MenuItem: typeof ContextMenuItem | typeof DropdownMenuItem,
@@ -2560,23 +2555,16 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
             startEdit()
           }}
           className={cn(
-            'group relative w-full flex items-center gap-1.5 rounded-md py-1 pl-2.5 pr-1.5 transition-colors duration-100 titlebar-no-drag text-left',
+            'group relative flex items-center gap-1.5 rounded-md py-1 pl-2.5 pr-1.5 mx-1 transition-colors duration-100 titlebar-no-drag text-left',
             active && 'agent-session-item-active',
-            leftAccent
-              ? SESSION_ACCENT_ROW_CLASS[leftAccent]
-              : 'hover:bg-foreground/[0.03]',
-            // 选中态背景：浅色叠加深色变深、深色叠加浅色变浅，自动适配主题。
-            // orange accent 自带橙色底色，不再叠加，避免视觉过重。
-            active && leftAccent !== 'orange' && 'bg-foreground/[0.08]',
+            'hover:bg-foreground/[0.03]',
+            active && 'bg-foreground/[0.08] text-foreground font-medium',
           )}
         >
-          {(leftAccent || active) && (
-            <span
-              className={cn(
-                'absolute inset-y-0 left-0 w-[3px] rounded-l-md pointer-events-none',
-                leftAccent ? SESSION_ACCENT_INDICATOR_CLASS[leftAccent] : 'bg-primary',
-              )}
-            />
+          {statusIcon && (
+            <span className="absolute inset-y-0 -left-5 flex items-center justify-center w-5 pointer-events-none">
+              {statusIcon}
+            </span>
           )}
           <div className="flex-1 min-w-0">
             {editing ? (
@@ -2929,7 +2917,6 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
                   active={session.id === activeSessionId}
                   indicatorStatus={agentIndicatorMap.get(session.id) ?? 'idle'}
                   showPinIcon={!!session.pinned}
-                  leftAccent={getSessionLeftAccent(agentIndicatorMap.get(session.id) ?? 'idle')}
                   relativeTimeNow={relativeTimeNow}
                   onSelect={onSelectSession}
                   onRequestDelete={onRequestDelete}

--- a/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
@@ -95,15 +95,6 @@ export function TabBarItem({
   }
 
   const isScratch = type === 'scratch'
-  const indicatorColor = isScratch
-    ? undefined
-    : isStreaming !== 'idle'
-    ? isStreaming === 'completed'
-      ? 'border-green-500'
-      : isStreaming === 'blocked'
-        ? 'border-orange-500'
-        : 'border-blue-500'
-    : undefined
   const previewItems = minimapCache.get(id) ?? []
   // 当前 active Tab 不显示预览面板
   const showPreview = isHovered && !isActive
@@ -197,17 +188,6 @@ export function TabBarItem({
         >
           <X className="size-2.5" />
         </span>
-        )}
-
-        {/* 状态包边 */}
-        {indicatorColor && (
-          <span
-            className={cn(
-              'absolute inset-0 rounded-t-lg border-t-2 border-l-2 border-r-2 border-b-0 pointer-events-none',
-              indicatorColor,
-            )}
-            aria-hidden="true"
-          />
         )}
       </button>
 

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -40,7 +40,7 @@
 .theme-forest-dark ::selection,
 .theme-forest-dark ::-moz-selection {
   background-color: hsl(var(--accent-foreground) / 0.75);
-  color: hsl(var(--primary));
+  color: hsl(var(--foreground));
 }
 
 .theme-slate-dark ::selection,

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -40,7 +40,7 @@
 .theme-forest-dark ::selection,
 .theme-forest-dark ::-moz-selection {
   background-color: hsl(var(--accent-foreground) / 0.75);
-  color: hsl(var(--background));
+  color: hsl(var(--primary));
 }
 
 .theme-slate-dark ::selection,
@@ -66,7 +66,7 @@
     --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05), 0 1px 1px 0 rgb(0 0 0 / 0.04);
     --shadow-md: 0 4px 8px -2px rgb(0 0 0 / 0.08), 0 2px 4px -1px rgb(0 0 0 / 0.05), 0 0 0 1px rgb(0 0 0 / 0.04);
     --shadow-lg: 0 12px 24px -6px rgb(0 0 0 / 0.12), 0 4px 8px -2px rgb(0 0 0 / 0.06), 0 0 0 1px rgb(0 0 0 / 0.04);
-    --shadow-xl: 0 24px 48px -12px rgb(0 0 0 / 0.18), 0 12px 24px -6px rgb(0 0 0 / 0.08), 0 0 0 1px rgb(0 0 0 / 0.05);
+    --shadow-xl: 0 16px 32px -10px rgb(0 0 0 / 0.12), 0 8px 16px -4px rgb(0 0 0 / 0.05), 0 0 0 1px rgb(0 0 0 / 0.04);
   }
 
   .dark {
@@ -74,7 +74,7 @@
     --shadow-sm: 0 1px 3px 0 rgb(0 0 0 / 0.5), inset 0 1px 0 0 hsl(0 0% 100% / 0.03);
     --shadow-md: 0 6px 16px -4px rgb(0 0 0 / 0.55), 0 2px 4px 0 rgb(0 0 0 / 0.35), inset 0 1px 0 0 hsl(0 0% 100% / 0.04);
     --shadow-lg: 0 16px 32px -8px rgb(0 0 0 / 0.6), 0 6px 12px -2px rgb(0 0 0 / 0.4), inset 0 1px 0 0 hsl(0 0% 100% / 0.05);
-    --shadow-xl: 0 32px 64px -16px rgb(0 0 0 / 0.7), 0 16px 32px -8px rgb(0 0 0 / 0.5), inset 0 1px 0 0 hsl(0 0% 100% / 0.06);
+    --shadow-xl: 0 22px 44px -14px rgb(0 0 0 / 0.5), 0 10px 20px -6px rgb(0 0 0 / 0.32), inset 0 1px 0 0 hsl(0 0% 100% / 0.05);
   }
 
   :root {


### PR DESCRIPTION
## 概述

把 LeftSidebar Agent 会话的状态指示从「色块/包边 color code」改成「图标 + 主题色 token」，同时简化选中态视觉、减弱 sidebar 阴影、改善暗色主题下选区文字可读性。

动机：原方案 `running=蓝-500 / completed=绿-500 / blocked=橙-500` + TabBarItem 顶部彩色包边在所有主题下都是 Tailwind 默认饱和度，跟周围低饱和的界面色撞色严重，dark 模式尤其刺眼。本次重构核心思路：

- 状态以图标语义而非颜色编码表达
- 仅采用一种 theme token（`--primary`），不再做与主题色板无关的硬编码
- 选中态保留半透明背景 + 字重，不再用 primary 竖条
- 用对比度更友好的方式恢复暗色主题选区可读性

## 改动

- \`apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx\`
  - 新增 \`renderSessionStatusIcon\` 三状态图标：
    - \`running\` → 复用主界面 \`<Spinner>\` (9 点网格)
    - \`completed\` → 实心 \`<Circle>\` + 背景色 \`<Check>\` 反色填充
    - \`blocked\` → \`?\` 字符，配 \`animate-pulse\` 慢呼吸
  - 三种图标统一用 \`text-primary\`（=`--primary` token，跟 mode-slider / file chip 是同一变量），跨所有主题色对齐主题强调色
  - 移除 \`SESSION_ACCENT_INDICATOR_CLASS\` / \`SESSION_ACCENT_ROW_CLASS\` / \`getSessionLeftAccent\` 等所有色码常量，删掉 \`leftAccent\` prop
  - 图标 absolute 定位在 row 左侧 \`-left-5 w-5\`（外置在 \`ml-4\` gutter 内），不挤标题位置，且视觉上跟项目分组 \`FolderOpen\` icon 同列对齐
  - 引入 \`emphasized = active || completed || blocked\` 变量：三种情况下标题统一 \`text-foreground font-medium\`
  - row 加 \`mx-1\` 让选中态背景左右各内缩 4px；删除原 \`bg-primary\` 3px 选中竖条，仅留半透明背景
- \`apps/electron/src/renderer/components/tabs/TabBarItem.tsx\`
  - 移除 \`indicatorColor\` 计算和顶部彩色包边渲染块，tab 不再做状态着色
- \`apps/electron/src/renderer/styles/globals.css\`
  - \`--shadow-xl\` 强度下调约 30%（light/dark 双向），sidebar 与主内容交界处阴影更轻
  - ocean-dark / forest-dark 主题 \`::selection\` 文字色由 \`hsl(var(--background))\` 改为 \`hsl(var(--foreground))\`，与 \`accent-foreground/0.75\` 选区底色形成足够对比度（之前是深色文字叠在浅色 selection bg 上看不清）
- \`apps/electron/package.json\`
  - patch 版本 bump 至 \`0.12.24\`

## 测试方法

1. \`bun install && bun run dev\`
2. Agent 模式下创建几个会话，分别处于以下状态：
   - 正在运行（运行 \`/help\`）
   - 已完成（运行任意短指令后）
   - 等待回应（触发 AskUserQuestion 工具）
3. 检查左侧 sidebar 三种状态：
   - running 应显示 9 点 Spinner 动画
   - completed 应显示实心圆 + 反色对勾
   - blocked 应显示加粗 \`?\`，伴随慢呼吸
   - 三种图标颜色应与当前主题的 mode-slider / file chip 同色
4. 检查 TabBarItem：tab 顶部不应再有任何蓝/绿/橙色边框
5. 切换主题验证：
   - 莫兰迪夜 (slate-dark)：图标应为杏粉 \`#c9a89e\`
   - 远山暮霭 (ocean-dark) / 森息夜语 (forest-dark)：图标应为各自的主色，且选中正文时选区文字应清晰可读
6. 验证 sidebar 与主内容区交界处的阴影比之前轻

## 备注

- 这是纯 UI 重构，无 IPC / 持久化 / 业务逻辑改动，TypeScript typecheck 通过
- 跨平台：仅 CSS + React 渲染层，Windows 兼容零风险
- 已知细节：\`Spinner\` 组件内部硬编码了 \`aria-label="加载中"\`，外层透传的 \`aria-label="运行中"\` 会被遮盖，不影响视觉，留待后续 a11y 统一时修
- \`emphasized\` 把未选中的 completed/blocked 会话也加粗，这是有意为之；如果觉得视觉权重过重可以再调

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>