### PR TITLE
fix(mention): 中文 IME 下 / 输入正文 8 字以上时隐藏 Skill 面板【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.12.23",
+  "version": "0.12.24",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/agent/mention-suggestions.tsx
+++ b/apps/electron/src/renderer/components/agent/mention-suggestions.tsx
@@ -29,6 +29,12 @@ interface MentionSuggestionConfig<T> {
   renderItem: (item: T) => React.ReactNode
   /** 选中后传给 command 的 id 和 label */
   toCommand: (item: T) => { id: string; label: string }
+  /**
+   * 可选：根据当前 items 和 query 决定是否隐藏 popup。
+   * 返回 true 时 popup 仅 display:none，不销毁；query 变化后会重新评估，可恢复显示。
+   * 同时 mentionActiveRef/mentionItemCountRef 会被置 0，避免 Enter 键被 Mention 拦截。
+   */
+  shouldHidePopup?: (items: T[], query: string) => boolean
 }
 
 function createMentionSuggestion<T>(
@@ -72,14 +78,27 @@ function createMentionSuggestion<T>(
         renderer = null
       }
 
+      // 根据 shouldHidePopup 切换 popup 可见性，不销毁；同步 active/count ref 让 Enter 键路由正确
+      function applyVisibility(items: T[], query: string) {
+        if (!popup) return
+        const hide = config.shouldHidePopup?.(items, query) ?? false
+        if (hide) {
+          popup.style.display = 'none'
+          mentionActiveRef.current = false
+          mentionItemCountRef.current = 0
+        } else {
+          popup.style.display = ''
+          mentionActiveRef.current = true
+          mentionItemCountRef.current = items.length
+        }
+      }
+
       return {
         onStart(props) {
           if (popup || renderer) {
             cleanup()
           }
 
-          mentionActiveRef.current = true
-          mentionItemCountRef.current = props.items.length
           editorDom = props.editor.view.dom
           renderer = new ReactRenderer(MentionList, {
             props: {
@@ -96,6 +115,7 @@ function createMentionSuggestion<T>(
           })
           popup = createMentionPopup(renderer.element)
           positionPopup(popup, props.clientRect?.())
+          applyVisibility(props.items, props.query ?? '')
 
           blurHandler = () => {
             setTimeout(() => {
@@ -108,7 +128,6 @@ function createMentionSuggestion<T>(
         },
 
         onUpdate(props) {
-          mentionItemCountRef.current = props.items.length
           renderer?.updateProps({
             items: props.items,
             onSelect: (item: T) => {
@@ -117,9 +136,12 @@ function createMentionSuggestion<T>(
             },
           })
           positionPopup(popup, props.clientRect?.())
+          applyVisibility(props.items, props.query ?? '')
         },
 
         onKeyDown(props) {
+          // popup 被隐藏时让按键透传给编辑器（用户其实在打字而非选命令）
+          if (popup?.style.display === 'none') return false
           return renderer?.ref?.onKeyDown({ event: props.event }) ?? false
         },
 
@@ -138,6 +160,11 @@ export interface SkillMentionItem {
   name: string
   description?: string
 }
+
+/** Skill query 中 CJK 字符数超过此值就隐藏 popup（≤ 此值仍显示，没匹配时显示「无匹配 Skill」占位）。 */
+const SKILL_QUERY_CJK_VISIBLE_LIMIT = 8
+/** CJK：汉字（中日韩统一表意） + 日文平假名/片假名。韩文谚文暂不算（实际场景少且 skill 名通常英文）。 */
+const CJK_RANGE_REGEX = /[一-鿿぀-ゟ゠-ヿ]/g
 
 export function createSkillMentionSuggestion(
   workspaceSlugRef: React.RefObject<string | null>,
@@ -166,6 +193,12 @@ export function createSkillMentionSuggestion(
         </>
       ),
       toCommand: (item) => ({ id: item.id, label: item.name }),
+      // 中文 IME 输入正文时不应一直挡着：query 里 CJK 字符数 > 阈值 就隐藏 popup。
+      // ≤ 阈值时保持原行为（有匹配显示列表，无匹配显示"无匹配 Skill"占位）。
+      shouldHidePopup: (_items, query) => {
+        const cjkCount = query.match(CJK_RANGE_REGEX)?.length ?? 0
+        return cjkCount > SKILL_QUERY_CJK_VISIBLE_LIMIT
+      },
     },
     workspaceSlugRef,
     mentionActiveRef,


### PR DESCRIPTION
## 概述

修复中文输入法状态下，在富文本输入框打 `/` 想输入符号本身时，Skill 命令面板一直挡着的问题。

之前 TipTap Mention 扩展按字面字符触发 popup，没区分用户意图是"搜 skill"还是"在写中文正文"。当用户打 `/` 后继续输入中文正文时，弹窗会一直跟随 query 显示，必须打空格才会消失，严重干扰输入体验。

本次改动按"query 里 CJK 字符数"判断是否在写正文：超过 8 字就隐藏 popup（用户已经在写句子，不是在搜命令）；≤ 8 字保持原行为（短中文 query 仍能搜 skill 或显示「无匹配 Skill」占位）。删字符回到 ≤ 8 字时 popup 自动恢复。

只对 Skill（`/`）应用此规则。MCP（`#`）和 Session（`&`）触发的行为完全不变。

## 改动

- `apps/electron/src/renderer/components/agent/mention-suggestions.tsx`
  - 给 `MentionSuggestionConfig<T>` 加可选 `shouldHidePopup?: (items, query) => boolean` 配置项
  - 在通用工厂 `createMentionSuggestion` 的 `render()` 闭包里加 `applyVisibility()` 辅助函数：通过 `popup.style.display` 切换可见性（**不销毁 renderer**，保证删字符后能自然恢复显示），同时同步置 `mentionActiveRef` / `mentionItemCountRef`，让隐藏状态下 Enter 键走"发送消息"而非"选 mention"
  - `onStart` / `onUpdate` 在更新完 props 后调用 `applyVisibility`
  - `onKeyDown` 加守卫：popup 处于 `display:none` 时键盘事件透传给编辑器
  - `createSkillMentionSuggestion` 传入 `shouldHidePopup`：CJK 字符数 > 阈值（默认 8）则隐藏。CJK 范围包含汉字（U+4E00-U+9FFF）+ 日文平假名（U+3040-U+309F）+ 片假名（U+30A0-U+30FF）。阈值提取为命名常量 `SKILL_QUERY_CJK_VISIBLE_LIMIT`
- `apps/electron/package.json` — 版本递增 `0.12.23` → `0.12.24`

## 测试方法

1. 切换到中文输入法
2. 在 Agent / Chat 输入框打 `/`，应弹出 Skill 命令面板
3. 继续输入 ≤ 8 个汉字：
   - 有匹配 → 显示匹配列表
   - 无匹配 → 显示「无匹配 Skill」占位
4. 继续输入 ≥ 9 个汉字 → 弹窗自动隐藏；按 Enter 应直接发送消息（而非误选 skill）
5. 删除字符回到 ≤ 8 字 → 弹窗自动恢复显示
6. 切回英文输入法打 `/khazix-writer-something` 等长英文 query，弹窗行为不受影响（不数英文字符）
7. 验证 `#`（MCP）和 `&`（会话引用）行为与改动前完全一致

## 备注

- 选择"隐藏而非销毁"是关键设计决策：TipTap Suggestion 一旦走 `onExit` cleanup 销毁 popup，需要重新触发 `char` 才会再次 `onStart`，无法做到"删字符后恢复"。用 `display:none` 让 popup 保留在 DOM、状态可恢复
- CJK 范围暂不算韩文谚文（实际场景少，且 skill 名通常英文）；如有需要可后续在 `CJK_RANGE_REGEX` 中扩展
- 阈值 `SKILL_QUERY_CJK_VISIBLE_LIMIT = 8` 为命名常量，体验调整方便
- 已本地通过 `tsc --noEmit` 类型检查