### PR TITLE
【已审核】style(sidebar): 定时任务与 AI 技能入口移至 Agent 底部并统一按钮风格 🔥

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -138,7 +138,7 @@ function AutomationSidebarEntry({ count, active, onClick }: AutomationSidebarEnt
       aria-label={`自动任务，${count} 个任务已创建`}
       onClick={onClick}
       className={cn(
-        'group w-full flex items-center justify-between px-3 py-2 rounded-md text-[13px] transition-colors duration-100 titlebar-no-drag automation-entry',
+        'group w-full flex items-center justify-between px-3 py-2 rounded-[10px] text-[13px] transition-colors duration-100 titlebar-no-drag automation-entry',
         active
           ? 'automation-entry-selected bg-accent-foreground/[0.10] text-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
           : 'text-foreground/60 hover:bg-accent-foreground/[0.08] hover:text-foreground',
@@ -1752,7 +1752,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
           <TooltipTrigger asChild>
             <button
               onClick={() => setSidebarCollapsed(true)}
-              className="mt-2 size-10 flex-shrink-0 flex items-center justify-center rounded-[10px] bg-muted text-foreground/40 hover:bg-foreground/[0.08] hover:text-foreground/60 transition-colors titlebar-no-drag"
+              className="mt-2 size-[36px] flex-shrink-0 flex items-center justify-center rounded-[10px] text-foreground/40 bg-primary/5 hover:bg-primary/10 hover:text-foreground/60 transition-[background-color,border-color,color] duration-150 titlebar-no-drag border border-border/60 hover:border-border"
             >
               <PanelLeftClose size={14} />
             </button>

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -1811,8 +1811,10 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
             </div>
           )}
 
-          <div className="px-2 pt-2 pb-1 flex flex-shrink-0">
+          <div className="px-2 pt-2 pb-1 flex items-center flex-shrink-0">
             <span className="px-1.5 text-[11px] font-medium text-foreground/40 select-none">对话</span>
+            {/* 占位元素：与项目行的 size-6 按钮等高，保证跨模式切换时标签文字垂直位置不变 */}
+            <div className="w-0 h-6" aria-hidden="true" />
           </div>
 
           <div className="flex-1 overflow-y-auto px-2 pb-3 scrollbar-thin min-h-0 titlebar-no-drag">

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -135,30 +135,19 @@ function AutomationSidebarEntry({ count, active, onClick }: AutomationSidebarEnt
   return (
     <button
       type="button"
-      aria-label={`自动任务，${count} 个任务已创建`}
+      aria-label={`定时任务，${count} 个任务已创建`}
       onClick={onClick}
       className={cn(
-        'group w-full flex items-center justify-between px-3 py-2 rounded-[10px] text-[13px] transition-colors duration-100 titlebar-no-drag automation-entry',
+        'w-full flex items-center justify-center px-3 py-2 rounded-[10px] text-[12px] transition-colors titlebar-no-drag whitespace-nowrap',
         active
-          ? 'automation-entry-selected bg-accent-foreground/[0.10] text-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
-          : 'text-foreground/60 hover:bg-accent-foreground/[0.08] hover:text-foreground',
+          ? 'bg-primary/10 text-foreground'
+          : 'text-foreground/50 hover:bg-foreground/[0.04] hover:text-foreground/70',
       )}
     >
-      <span className="flex items-center gap-3 min-w-0">
-        <span className={cn('flex-shrink-0 w-[18px] h-[18px] automation-entry-icon', active ? 'text-accent-foreground' : 'text-foreground/45')}>
-          <AlarmClock size={16} className="block" />
-        </span>
-        <span className="truncate">自动任务</span>
-      </span>
-      <span
-        className={cn(
-          'ml-2 flex h-5 min-w-[22px] flex-shrink-0 items-center justify-center rounded-full px-1.5 text-[11px] font-medium tabular-nums automation-entry-badge',
-          active
-            ? 'bg-accent-foreground/[0.26] text-primary-foreground'
-            : 'bg-foreground/[0.045] text-foreground/[0.42] group-hover:text-foreground/65',
-        )}
-      >
-        {formatAutomationCount(count)}
+      <span className="flex items-center gap-1">
+        <AlarmClock size={13} className={active ? 'text-primary' : 'text-foreground/40'} />
+        <span className="tabular-nums">{formatAutomationCount(count)}</span>
+        <span className={active ? 'text-foreground/50' : 'text-foreground/30'}>定时任务</span>
       </span>
     </button>
   )
@@ -665,11 +654,15 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     return () => window.removeEventListener('focus', handleFocus)
   }, [setConversations, setAgentSessions])
 
-  /** 打开自动任务列表 */
+  /** 打开/关闭定时任务列表 */
   const handleOpenAutomations = React.useCallback((): void => {
+    if (activeView === 'automations') {
+      setActiveView('conversations')
+      return
+    }
     setAutomationForm({ open: false, draft: null })
     setActiveView('automations')
-  }, [setAutomationForm, setActiveView])
+  }, [activeView, setAutomationForm, setActiveView])
 
   /** 打开 Agent 技能视图 */
   const handleOpenSkills = React.useCallback((): void => {
@@ -1489,7 +1482,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         <AlertDialogHeader>
           <AlertDialogTitle>确认删除项目</AlertDialogTitle>
           <AlertDialogDescription>
-            将删除「{pendingDeleteWorkspace?.name ?? '该项目'}」及其绑定的所有会话、自动任务、MCP、Skills、工作区文件和本地项目目录。附加目录和附加文件只会移除引用，不会删除原始文件。删除后无法恢复。
+            将删除「{pendingDeleteWorkspace?.name ?? '该项目'}」及其绑定的所有会话、定时任务、MCP、Skills、工作区文件和本地项目目录。附加目录和附加文件只会移除引用，不会删除原始文件。删除后无法恢复。
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
@@ -1627,7 +1620,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
             <TooltipTrigger asChild>
               <button
                 type="button"
-                aria-label={`自动任务，${automationCount} 个任务已创建`}
+                aria-label={`定时任务，${automationCount} 个任务已创建`}
                 onClick={handleOpenAutomations}
                 className={cn(
                   'relative size-10 flex items-center justify-center rounded-[12px] transition-colors titlebar-no-drag border',
@@ -1652,7 +1645,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
               </button>
             </TooltipTrigger>
             <TooltipContent side="right">
-              自动任务（{automationCount} 个任务已创建）
+              定时任务（{automationCount} 个任务已创建）
             </TooltipContent>
           </Tooltip>
 
@@ -1818,7 +1811,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
             </div>
           )}
 
-          <div className="px-2 pt-2 pb-1 flex-shrink-0">
+          <div className="px-2 pt-2 pb-1 flex flex-shrink-0">
             <span className="px-1.5 text-[11px] font-medium text-foreground/40 select-none">对话</span>
           </div>
 
@@ -2074,10 +2067,10 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         )}
       </div>
 
-      {/* Agent 模式：自动任务 + 项目能力指示器 */}
+      {/* Agent 模式：定时任务 + 项目能力指示器 */}
       {mode === 'agent' && (
         <div className="px-3 pb-1 flex items-center gap-1.5">
-          <div className="flex-1 min-w-0">
+          <div className="flex-1">
             <AutomationSidebarEntry
               count={automationCount}
               active={activeView === 'automations'}
@@ -2089,7 +2082,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
               <TooltipTrigger asChild>
                 <button
                   onClick={() => { setSettingsTab('agent'); setSettingsOpen(true) }}
-                  className="flex-1 flex items-center justify-center gap-2.5 px-3 py-2 rounded-[10px] text-[12px] text-foreground/50 hover:bg-foreground/[0.04] hover:text-foreground/70 transition-colors titlebar-no-drag"
+                  className="flex-1 flex items-center justify-center gap-2.5 px-3 py-2 rounded-[10px] text-[12px] text-foreground/50 hover:bg-foreground/[0.04] hover:text-foreground/70 transition-colors titlebar-no-drag whitespace-nowrap"
                 >
                   <span className="flex items-center gap-1">
                     <Plug size={13} className="text-foreground/40" />

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -1635,7 +1635,33 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
             </TooltipTrigger>
             <TooltipContent side="right">搜索</TooltipContent>
           </Tooltip>
+        </div>
 
+        <div className="my-3 h-px w-8 bg-border/70" />
+
+        {/* 最近/关键会话入口 */}
+        <div className="flex-1 min-h-0 w-full overflow-y-auto scrollbar-thin">
+          <div className="flex flex-col items-center gap-1.5 pb-2">
+            {railRecentItems.map((item) => (
+              <RailRecentButton
+                key={`${item.type}-${item.id}`}
+                item={item}
+                onSelect={(selected) => {
+                  if (selected.type === 'agent') {
+                    handleSelectAgentSession(selected.id, selected.title)
+                  } else {
+                    handleSelectConversation(selected.id, selected.title)
+                  }
+                }}
+              />
+            ))}
+          </div>
+        </div>
+
+        <div className="my-3 h-px w-8 bg-border/70" />
+
+        {/* 定时任务 + Agent 技能 */}
+        <div className="flex flex-col items-center gap-1.5">
           <Tooltip>
             <TooltipTrigger asChild>
               <button
@@ -1643,10 +1669,10 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                 aria-label={`定时任务，${automationCount} 个任务已创建`}
                 onClick={handleOpenAutomations}
                 className={cn(
-                  'relative size-10 flex items-center justify-center rounded-[12px] transition-colors titlebar-no-drag border',
+                  'relative size-10 flex items-center justify-center rounded-[12px] transition-[background-color,border-color,color] duration-150 titlebar-no-drag border',
                   activeView === 'automations'
                     ? 'border-primary/80 bg-primary text-primary-foreground shadow-sm'
-                    : 'border-border/45 bg-foreground/[0.025] text-foreground/45 hover:border-border/70 hover:bg-foreground/[0.045] hover:text-primary',
+                    : 'border-border/60 bg-primary/5 text-foreground/45 hover:border-border hover:bg-primary/10 hover:text-primary',
                 )}
               >
                 <AlarmClock size={16} />
@@ -1677,10 +1703,10 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                   aria-label="Agent 技能"
                   onClick={handleOpenSkills}
                   className={cn(
-                    'relative size-10 flex items-center justify-center rounded-[12px] transition-colors titlebar-no-drag border',
+                    'relative size-10 flex items-center justify-center rounded-[12px] transition-[background-color,border-color,color] duration-150 titlebar-no-drag border',
                     activeView === 'agent-skills'
                       ? 'border-primary/80 bg-primary text-primary-foreground shadow-sm'
-                      : 'border-border/45 bg-foreground/[0.025] text-foreground/45 hover:border-border/70 hover:bg-foreground/[0.045] hover:text-primary',
+                      : 'border-border/60 bg-primary/5 text-foreground/45 hover:border-border hover:bg-primary/10 hover:text-primary',
                   )}
                 >
                   <Blocks size={16} />
@@ -1692,27 +1718,6 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
               <TooltipContent side="right">Agent 技能</TooltipContent>
             </Tooltip>
           )}
-        </div>
-
-        <div className="my-3 h-px w-8 bg-border/70" />
-
-        {/* 最近/关键会话入口 */}
-        <div className="flex-1 min-h-0 w-full overflow-y-auto scrollbar-thin">
-          <div className="flex flex-col items-center gap-1.5 pb-2">
-            {railRecentItems.map((item) => (
-              <RailRecentButton
-                key={`${item.type}-${item.id}`}
-                item={item}
-                onSelect={(selected) => {
-                  if (selected.type === 'agent') {
-                    handleSelectAgentSession(selected.id, selected.title)
-                  } else {
-                    handleSelectConversation(selected.id, selected.title)
-                  }
-                }}
-              />
-            ))}
-          </div>
         </div>
 
         {/* 用户头像（点击打开设置） */}

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -680,10 +680,14 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     setActiveView('automations')
   }, [activeView, setAutomationForm, setActiveView, store])
 
-  /** 打开 Agent 技能视图 */
+  /** 打开/关闭 Agent 技能视图 */
   const handleOpenSkills = React.useCallback((): void => {
+    if (activeView === 'agent-skills') {
+      setActiveView('conversations')
+      return
+    }
     setActiveView('agent-skills')
-  }, [setActiveView])
+  }, [activeView, setActiveView])
 
   // 切换模式时重置归档视图
   React.useEffect(() => {

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -11,7 +11,7 @@
 import * as React from 'react'
 import { useAtom, useSetAtom, useAtomValue, useStore } from 'jotai'
 import { toast } from 'sonner'
-import { Pin, PinOff, Settings, Plus, Trash2, Pencil, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, GripVertical, Clock, AlarmClock, ChevronRight, Blocks } from 'lucide-react'
+import { Pin, PinOff, Settings, Plus, Trash2, Pencil, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, GripVertical, Clock, AlarmClock, ChevronRight, Blocks, Plug, Zap } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { ModeSwitcher } from './ModeSwitcher'
@@ -1783,27 +1783,6 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         </Tooltip>
       </div>
 
-      {/* 自动任务入口：作为任务中心入口放在置顶区上方，不参与置顶列表层级。 */}
-      <div className="px-3 pt-2 pb-0.5">
-        <AutomationSidebarEntry
-          count={automationCount}
-          active={activeView === 'automations'}
-          onClick={handleOpenAutomations}
-        />
-      </div>
-
-      {/* Agent 技能入口：Skills / MCP 能力中心，仅 Agent 模式可见 */}
-      {mode === 'agent' && (
-        <div className="px-3 pb-0.5">
-          <SkillsSidebarEntry
-            count={capabilities?.skills.length ?? 0}
-            updateCount={capabilities?.skills.filter((s) => s.hasUpdate).length ?? 0}
-            active={activeView === 'agent-skills'}
-            onClick={handleOpenSkills}
-          />
-        </div>
-      )}
-
       {/* Chat 模式 active 视图：置顶 + 对话历史，结构与 Agent active 视图保持一致 */}
       {mode === 'chat' && viewMode === 'active' ? (
         <div className="flex-1 flex flex-col min-h-0">
@@ -2094,6 +2073,42 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
           </button>
         )}
       </div>
+
+      {/* Agent 模式：自动任务 + 项目能力指示器 */}
+      {mode === 'agent' && (
+        <div className="px-3 pb-1 flex items-center gap-1.5">
+          <div className="flex-1 min-w-0">
+            <AutomationSidebarEntry
+              count={automationCount}
+              active={activeView === 'automations'}
+              onClick={handleOpenAutomations}
+            />
+          </div>
+          {capabilities && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => { setSettingsTab('agent'); setSettingsOpen(true) }}
+                  className="flex-1 flex items-center justify-center gap-2.5 px-3 py-2 rounded-[10px] text-[12px] text-foreground/50 hover:bg-foreground/[0.04] hover:text-foreground/70 transition-colors titlebar-no-drag"
+                >
+                  <span className="flex items-center gap-1">
+                    <Plug size={13} className="text-foreground/40" />
+                    <span className="tabular-nums">{capabilities.mcpServers.filter((s) => s.enabled).length}</span>
+                    <span className="text-foreground/30">MCP</span>
+                  </span>
+                  <span className="text-foreground/20">·</span>
+                  <span className="flex items-center gap-1">
+                    <Zap size={13} className="text-foreground/40" />
+                    <span className="tabular-nums">{capabilities.skills.length}</span>
+                    <span className="text-foreground/30">Skills</span>
+                  </span>
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top">点击配置 MCP 与 Skills</TooltipContent>
+            </Tooltip>
+          )}
+        </div>
+      )}
 
       {/* 底部：用户资料 + 设置入口 */}
       <div className="px-3 pb-3">

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -11,7 +11,7 @@
 import * as React from 'react'
 import { useAtom, useSetAtom, useAtomValue, useStore } from 'jotai'
 import { toast } from 'sonner'
-import { Pin, PinOff, Settings, Plus, Trash2, Pencil, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, GripVertical, Clock, AlarmClock, ChevronRight, Blocks, Plug, Zap } from 'lucide-react'
+import { Pin, PinOff, Settings, Plus, Trash2, Pencil, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, GripVertical, Clock, AlarmClock, ChevronRight, Blocks } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { ModeSwitcher } from './ModeSwitcher'
@@ -138,16 +138,27 @@ function AutomationSidebarEntry({ count, active, onClick }: AutomationSidebarEnt
       aria-label={`定时任务，${count} 个任务已创建`}
       onClick={onClick}
       className={cn(
-        'w-full flex items-center justify-center px-3 py-2 rounded-[10px] text-[12px] transition-colors titlebar-no-drag whitespace-nowrap',
+        'group w-full flex items-center justify-between px-3 py-2 rounded-[10px] text-[13px] transition-colors duration-100 titlebar-no-drag',
         active
-          ? 'bg-primary/10 text-foreground'
-          : 'text-foreground/50 hover:bg-foreground/[0.04] hover:text-foreground/70',
+          ? 'bg-accent-foreground/[0.10] text-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
+          : 'text-foreground/60 hover:bg-accent-foreground/[0.08] hover:text-foreground',
       )}
     >
-      <span className="flex items-center gap-1">
-        <AlarmClock size={13} className={active ? 'text-primary' : 'text-foreground/40'} />
-        <span className="tabular-nums">{formatAutomationCount(count)}</span>
-        <span className={active ? 'text-foreground/50' : 'text-foreground/30'}>定时任务</span>
+      <span className="flex items-center gap-3 min-w-0">
+        <span className={cn('flex-shrink-0 w-[18px] h-[18px]', active ? 'text-accent-foreground' : 'text-foreground/45')}>
+          <AlarmClock size={16} className="block" />
+        </span>
+        <span className="truncate">定时任务</span>
+      </span>
+      <span
+        className={cn(
+          'ml-2 flex h-5 min-w-[22px] flex-shrink-0 items-center justify-center rounded-full px-1.5 text-[11px] font-medium tabular-nums',
+          active
+            ? 'bg-accent-foreground/[0.26] text-primary-foreground'
+            : 'bg-foreground/[0.045] text-foreground/[0.42] group-hover:text-foreground/65',
+        )}
+      >
+        {formatAutomationCount(count)}
       </span>
     </button>
   )
@@ -168,7 +179,7 @@ function SkillsSidebarEntry({ count, updateCount, active, onClick }: SkillsSideb
       aria-label={`Agent 技能，${count} 个能力${hasUpdate ? `，${updateCount} 个可更新` : ''}`}
       onClick={onClick}
       className={cn(
-        'group w-full flex items-center justify-between px-3 py-2 rounded-md text-[13px] transition-colors duration-100 titlebar-no-drag',
+        'group w-full flex items-center justify-between px-3 py-2 rounded-[10px] text-[13px] transition-colors duration-100 titlebar-no-drag',
         active
           ? 'bg-accent-foreground/[0.10] text-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
           : 'text-foreground/60 hover:bg-accent-foreground/[0.08] hover:text-foreground',
@@ -657,12 +668,17 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   /** 打开/关闭定时任务列表 */
   const handleOpenAutomations = React.useCallback((): void => {
     if (activeView === 'automations') {
+      // 编辑页 → 关表单回列表；列表页 → 退出到对话
+      if (store.get(automationFormAtom).open) {
+        setAutomationForm({ open: false, draft: null })
+        return
+      }
       setActiveView('conversations')
       return
     }
     setAutomationForm({ open: false, draft: null })
     setActiveView('automations')
-  }, [activeView, setAutomationForm, setActiveView])
+  }, [activeView, setAutomationForm, setActiveView, store])
 
   /** 打开 Agent 技能视图 */
   const handleOpenSkills = React.useCallback((): void => {
@@ -2069,39 +2085,20 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         )}
       </div>
 
-      {/* Agent 模式：定时任务 + 项目能力指示器 */}
+      {/* Agent 模式：定时任务 + Agent 技能 */}
       {mode === 'agent' && (
-        <div className="px-3 pb-1 flex items-center gap-1.5">
-          <div className="flex-1">
-            <AutomationSidebarEntry
-              count={automationCount}
-              active={activeView === 'automations'}
-              onClick={handleOpenAutomations}
-            />
-          </div>
-          {capabilities && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  onClick={() => { setSettingsTab('agent'); setSettingsOpen(true) }}
-                  className="flex-1 flex items-center justify-center gap-2.5 px-3 py-2 rounded-[10px] text-[12px] text-foreground/50 hover:bg-foreground/[0.04] hover:text-foreground/70 transition-colors titlebar-no-drag whitespace-nowrap"
-                >
-                  <span className="flex items-center gap-1">
-                    <Plug size={13} className="text-foreground/40" />
-                    <span className="tabular-nums">{capabilities.mcpServers.filter((s) => s.enabled).length}</span>
-                    <span className="text-foreground/30">MCP</span>
-                  </span>
-                  <span className="text-foreground/20">·</span>
-                  <span className="flex items-center gap-1">
-                    <Zap size={13} className="text-foreground/40" />
-                    <span className="tabular-nums">{capabilities.skills.length}</span>
-                    <span className="text-foreground/30">Skills</span>
-                  </span>
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="top">点击配置 MCP 与 Skills</TooltipContent>
-            </Tooltip>
-          )}
+        <div className="px-3 pb-1 flex flex-col gap-0.5">
+          <AutomationSidebarEntry
+            count={automationCount}
+            active={activeView === 'automations'}
+            onClick={handleOpenAutomations}
+          />
+          <SkillsSidebarEntry
+            count={capabilities?.skills.length ?? 0}
+            updateCount={capabilities?.skills.filter((s) => s.hasUpdate).length ?? 0}
+            active={activeView === 'agent-skills'}
+            onClick={handleOpenSkills}
+          />
         </div>
       )}
 

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -1658,67 +1658,69 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
           </div>
         </div>
 
-        <div className="my-3 h-px w-8 bg-border/70" />
+        {mode === 'agent' && (
+          <>
+            <div className="my-3 h-px w-8 bg-border/70" />
 
-        {/* 定时任务 + Agent 技能 */}
-        <div className="flex flex-col items-center gap-1.5">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                aria-label={`定时任务，${automationCount} 个任务已创建`}
-                onClick={handleOpenAutomations}
-                className={cn(
-                  'relative size-10 flex items-center justify-center rounded-[12px] transition-[background-color,border-color,color] duration-150 titlebar-no-drag border',
-                  activeView === 'automations'
-                    ? 'border-primary/80 bg-primary text-primary-foreground shadow-sm'
-                    : 'border-border/60 bg-primary/5 text-foreground/45 hover:border-border hover:bg-primary/10 hover:text-primary',
-                )}
-              >
-                <AlarmClock size={16} />
-                {automationCount > 0 && (
-                  <span
+            {/* 定时任务 + Agent 技能 */}
+            <div className="flex flex-col items-center gap-1.5">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label={`定时任务，${automationCount} 个任务已创建`}
+                    onClick={handleOpenAutomations}
                     className={cn(
-                      'absolute -top-1 -right-1 flex h-4 min-w-[16px] items-center justify-center rounded-full px-1 text-[10px] font-medium tabular-nums',
+                      'relative size-10 flex items-center justify-center rounded-[12px] transition-[background-color,border-color,color] duration-150 titlebar-no-drag border',
                       activeView === 'automations'
-                        ? 'bg-primary-foreground text-primary'
-                        : 'bg-primary text-primary-foreground',
+                        ? 'border-primary/80 bg-primary text-primary-foreground shadow-sm'
+                        : 'border-border/60 bg-primary/5 text-foreground/45 hover:border-border hover:bg-primary/10 hover:text-primary',
                     )}
                   >
-                    {formatAutomationCount(automationCount)}
-                  </span>
-                )}
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="right">
-              定时任务（{automationCount} 个任务已创建）
-            </TooltipContent>
-          </Tooltip>
+                    <AlarmClock size={16} />
+                    {automationCount > 0 && (
+                      <span
+                        className={cn(
+                          'absolute -top-1 -right-1 flex h-4 min-w-[16px] items-center justify-center rounded-full px-1 text-[10px] font-medium tabular-nums',
+                          activeView === 'automations'
+                            ? 'bg-primary-foreground text-primary'
+                            : 'bg-primary text-primary-foreground',
+                        )}
+                      >
+                        {formatAutomationCount(automationCount)}
+                      </span>
+                    )}
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="right">
+                  定时任务（{automationCount} 个任务已创建）
+                </TooltipContent>
+              </Tooltip>
 
-          {mode === 'agent' && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  aria-label="Agent 技能"
-                  onClick={handleOpenSkills}
-                  className={cn(
-                    'relative size-10 flex items-center justify-center rounded-[12px] transition-[background-color,border-color,color] duration-150 titlebar-no-drag border',
-                    activeView === 'agent-skills'
-                      ? 'border-primary/80 bg-primary text-primary-foreground shadow-sm'
-                      : 'border-border/60 bg-primary/5 text-foreground/45 hover:border-border hover:bg-primary/10 hover:text-primary',
-                  )}
-                >
-                  <Blocks size={16} />
-                  {(capabilities?.skills.filter((s) => s.hasUpdate).length ?? 0) > 0 && (
-                    <span className="absolute -top-1 -right-1 size-2.5 rounded-full bg-blue-500" />
-                  )}
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="right">Agent 技能</TooltipContent>
-            </Tooltip>
-          )}
-        </div>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label="Agent 技能"
+                    onClick={handleOpenSkills}
+                    className={cn(
+                      'relative size-10 flex items-center justify-center rounded-[12px] transition-[background-color,border-color,color] duration-150 titlebar-no-drag border',
+                      activeView === 'agent-skills'
+                        ? 'border-primary/80 bg-primary text-primary-foreground shadow-sm'
+                        : 'border-border/60 bg-primary/5 text-foreground/45 hover:border-border hover:bg-primary/10 hover:text-primary',
+                    )}
+                  >
+                    <Blocks size={16} />
+                    {(capabilities?.skills.filter((s) => s.hasUpdate).length ?? 0) > 0 && (
+                      <span className="absolute -top-1 -right-1 size-2.5 rounded-full bg-blue-500" />
+                    )}
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="right">Agent 技能</TooltipContent>
+              </Tooltip>
+            </div>
+          </>
+        )}
 
         {/* 用户头像（点击打开设置） */}
         <div className="pt-3 pb-3">

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -621,18 +621,6 @@
   color: inherit !important;
 }
 
-/* 远山暮霭：自动化入口选中状态 */
-.theme-ocean-dark .automation-entry-selected.automation-entry-selected {
-  background-color: hsl(210 14% 22%) !important;
-}
-.theme-ocean-dark .automation-entry-selected .automation-entry-icon {
-  color: hsl(210 35% 70%) !important;
-}
-.theme-ocean-dark .automation-entry-selected .automation-entry-badge {
-  background-color: hsl(210 35% 70% / 0.20) !important;
-  color: hsl(210 35% 70%) !important;
-}
-
 /* ===== 森系主题：会话/工作区选中状态 ===== */
 /* 森息晨光：浅绿背景 + 深绿文字 */
 .theme-forest-light .session-item-selected,
@@ -658,18 +646,6 @@
 .theme-forest-dark .workspace-item-selected *,
 .theme-forest-dark .tab-item-selected * {
   color: inherit !important;
-}
-
-/* 森息夜语：自动化入口选中状态 */
-.theme-forest-dark .automation-entry-selected.automation-entry-selected {
-  background-color: hsl(150 12% 22%) !important;
-}
-.theme-forest-dark .automation-entry-selected .automation-entry-icon {
-  color: hsl(145 35% 65%) !important;
-}
-.theme-forest-dark .automation-entry-selected .automation-entry-badge {
-  background-color: hsl(145 35% 65% / 0.20) !important;
-  color: hsl(145 35% 65%) !important;
 }
 
 /* ===== 莫兰迪主题：模式切换器选中状态 ===== */
@@ -754,18 +730,6 @@
   color: inherit !important;
 }
 
-/* 莫兰迪夜：自动化入口选中状态 */
-.theme-slate-dark .automation-entry-selected.automation-entry-selected {
-  background-color: hsl(260 10% 22%) !important;
-}
-.theme-slate-dark .automation-entry-selected .automation-entry-icon {
-  color: hsl(15 30% 75%) !important;
-}
-.theme-slate-dark .automation-entry-selected .automation-entry-badge {
-  background-color: hsl(15 30% 75% / 0.20) !important;
-  color: hsl(15 30% 75%) !important;
-}
-
 /* ===== CRT 终端：会话/工作区选中态 ===== */
 .theme-terminal-dark .session-item-selected.session-item-selected,
 .theme-terminal-dark .workspace-item-selected.workspace-item-selected,
@@ -777,18 +741,6 @@
 .theme-terminal-dark .workspace-item-selected *,
 .theme-terminal-dark .tab-item-selected * {
   color: inherit !important;
-}
-
-/* CRT 终端：自动化入口选中态 */
-.theme-terminal-dark .automation-entry-selected.automation-entry-selected {
-  background-color: hsl(100 10% 16%) !important;
-}
-.theme-terminal-dark .automation-entry-selected .automation-entry-icon {
-  color: hsl(var(--primary)) !important;
-}
-.theme-terminal-dark .automation-entry-selected .automation-entry-badge {
-  background-color: hsl(var(--primary) / 0.20) !important;
-  color: hsl(var(--primary)) !important;
 }
 
 /* ===== 云朵舞者主题：会话/工作区选中状态 ===== */


### PR DESCRIPTION
## 概述

本次重构统一了侧边栏展开态与收缩态（rail）中定时任务和 AI 技能入口的布局与样式。展开态中，原位于顶部独立行的「自动任务」和「Agent 技能」入口被移至 Agent 模式下底部（项目列表下方、用户头像上方），上下排列；收缩 rail 模式中同样移至底部最近会话下方，且与展开态一致——仅在 Agent 模式显示。同时统一了折叠按钮与搜索按钮的视觉风格（36px 尺寸、边框、primary/5 背景），并将「自动任务」统一改称「定时任务」。

样式层面去除了 4 个主题（远山暮霭/森息夜语/莫兰迪夜/CRT 终端）中全局 CSS 的 `.automation-entry-*` 废弃样式，全部改用内联 Tailwind class，降低主题 CSS 维护成本。新增点击已激活入口可再次点击关闭的导航行为（编辑页→回列表，列表页→退出），并在「对话」标签行增加占位元素保证跨模式切换时文字不跳动。

## 改动

- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx`（+110/-92）：整体布局调整——展开态定时任务/AI 技能从顶部移至 Agent 底部上下排列；收缩 rail 模式同样移至底部，仅 Agent 模式可见；折叠按钮统一为 36px + 边框 + primary/5 背景；「自动任务」统一为「定时任务」；新增点击已激活入口可关闭返回；对话标签行增加占位元素防跳动
- `apps/electron/src/renderer/styles/globals.css`（-48）：删除 4 个主题的 `.automation-entry-*` 废弃 CSS 样式

## 测试

1. 展开侧边栏：折叠按钮尺寸与搜索按钮一致（36px），同底色同边框
2. Agent 模式下底部显示定时任务 + Agent 技能上下排列
3. Chat 模式下展开/收缩侧边栏均不显示定时任务/Agent 技能入口
4. 切换 Chat/Agent 模式，对话/项目标签文字不跳动
5. 定时任务有计数时数字徽章正常显示
6. 点击已激活的定时任务按钮可关闭返回上一视图
7. 收缩 rail 模式底部正确显示定时任务 + Agent 技能图标

## 备注

无