### PR TITLE
上游响应解析失败错误自动重试

### DIFF
--- a/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
@@ -25,7 +25,7 @@ import {
   isThinkingSignatureError as matchesThinkingSignatureError,
 } from '@proma/shared'
 import type { CanUseToolOptions, PermissionResult } from '../agent-permission-service'
-import { TRANSIENT_NETWORK_PATTERN } from '../error-patterns'
+import { TRANSIENT_NETWORK_PATTERN, isMalformedResponseError } from '../error-patterns'
 import { spawn as spawnChild, execFileSync } from 'node:child_process'
 
 /** SDK Query 对象类型（从动态导入中推断） */
@@ -402,6 +402,27 @@ export function mapSDKErrorToTypedError(
       code: 'network_error',
       title: '网络异常',
       message: detailedMessage || '上游 API 连接中断',
+      actions: [
+        { key: 's', label: '设置', action: 'settings' },
+        { key: 'r', label: '重试', action: 'retry' },
+      ],
+      canRetry: true,
+      retryDelayMs: 1000,
+      originalError,
+    }
+  }
+
+  // 上游响应体解析失败（JSON Parse error: Unable to parse JSON string 等）：
+  // 网关返回 HTML 错误页 / SSE 流截断 / 代理注入脏数据导致 SDK 解析非 JSON 体失败，
+  // SDK 常标记为 errorType='unknown'。归类为可重试的 service_error（已在重试白名单内）。
+  const looksLikeMalformedResponse =
+    (!errorMap[errorCode]) &&
+    isMalformedResponseError(detailedMessage, originalError)
+  if (looksLikeMalformedResponse) {
+    return {
+      code: 'service_error',
+      title: '响应解析失败',
+      message: '上游返回了无法解析的响应，通常为网关瞬时异常，正在重试',
       actions: [
         { key: 's', label: '设置', action: 'settings' },
         { key: 'r', label: '重试', action: 'retry' },

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -33,7 +33,7 @@ import {
 import type { PermissionRequest, PromaPermissionMode, AskUserRequest, ExitPlanModeRequest } from '@proma/shared'
 import type { ClaudeAgentQueryOptions } from './adapters/claude-agent-adapter'
 import { isPromptTooLongError, isThinkingSignatureError, friendlyErrorMessage, mapSDKErrorToTypedError, extractErrorDetails, shouldKeepChannelOpen } from './adapters/claude-agent-adapter'
-import { isTransientNetworkError } from './error-patterns'
+import { isTransientNetworkError, isMalformedResponseError } from './error-patterns'
 import { AgentEventBus } from './agent-event-bus'
 import { decryptApiKey, getChannelById, listChannels } from './channel-manager'
 import { injectAutomationMcpServer } from './automation-agent-tools'
@@ -168,6 +168,8 @@ function isAutoRetryableCatchError(
   if (/\b502\b|\b529\b|overloaded/i.test(text)) return true
   // 瞬时网络错误（terminated / ECONNRESET / socket hang up 等）
   if (isTransientNetworkError(rawErrorMessage, stderr)) return true
+  // 上游响应体解析失败（JSON Parse error 等）：网关瞬时异常返回非 JSON 体，重试通常即可恢复
+  if (isMalformedResponseError(rawErrorMessage, stderr)) return true
   return false
 }
 

--- a/apps/electron/src/main/lib/error-patterns.ts
+++ b/apps/electron/src/main/lib/error-patterns.ts
@@ -16,3 +16,24 @@ export function isTransientNetworkError(message?: string, stderr?: string): bool
     (!!stderr && TRANSIENT_NETWORK_PATTERN.test(stderr))
   )
 }
+
+/**
+ * 上游响应体解析失败模式
+ *
+ * SDK native CLI（Bun/JavaScriptCore）将上游响应解析为 JSON 失败时抛出，
+ * 典型形如 "API Error: JSON Parse error: Unable to parse JSON string"。
+ * 成因多为网关返回 HTML 错误页、SSE 流被截断、代理注入脏数据等瞬时异常，
+ * 与瞬时网络错误同属上游抖动，重试通常即可恢复。
+ * 同时覆盖 V8 引擎措辞（Unexpected end of JSON input / is not valid JSON）。
+ */
+export const MALFORMED_RESPONSE_PATTERN =
+  /JSON Parse error|Unable to parse JSON|Unexpected end of JSON input|Unexpected token.*JSON|is not valid JSON/i
+
+/** 判断错误消息/stderr 是否为上游响应体解析失败 */
+export function isMalformedResponseError(message?: string, stderr?: string): boolean {
+  if (!message && !stderr) return false
+  return (
+    (!!message && MALFORMED_RESPONSE_PATTERN.test(message)) ||
+    (!!stderr && MALFORMED_RESPONSE_PATTERN.test(stderr))
+  )
+}


### PR DESCRIPTION
## Summary

- 034f87f feat(agent): 上游响应解析失败错误自动重试

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归