### PR TITLE
fix(agent-skills): 移除 Skill/MCP 抽屉关闭按钮并统一导航，新增 Tooltip 与删除确认弹窗，MCP 编辑支持自动保存

### DIFF
--- a/apps/electron/src/renderer/components/agent-skills/AgentSkillsView.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/AgentSkillsView.tsx
@@ -20,16 +20,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover'
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { workspaceCapabilitiesVersionAtom } from '@/atoms/agent-atoms'
 import { useProjectActions } from '@/hooks/useProjectActions'
 import type { McpServerEntry, SkillMeta } from '@proma/shared'
@@ -281,63 +272,41 @@ export function AgentSkillsView(): React.ReactElement {
       />
 
       {/* Skill 删除确认 */}
-      <AlertDialog
+      <ConfirmDialog
         open={pendingDeleteSkill !== null}
-        onOpenChange={(open) => { if (!open && !isDeletingSkill) setPendingDeleteSkill(null) }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>确认删除 Skill「{pendingDeleteSkill?.name}」？</AlertDialogTitle>
-            <AlertDialogDescription>删除后将无法恢复，确定要卸载这个 Skill 吗？</AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isDeletingSkill}>取消</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={async () => {
-                if (!pendingDeleteSkill || isDeletingSkill) return
-                setIsDeletingSkill(true)
-                const ok = await data.deleteSkill(pendingDeleteSkill.slug, pendingDeleteSkill.name)
-                setIsDeletingSkill(false)
-                setPendingDeleteSkill(null)
-                if (ok) setSelectedSkillSlug(null)
-              }}
-              disabled={isDeletingSkill}
-              className="bg-destructive text-white hover:bg-destructive/90"
-            >
-              {isDeletingSkill ? '删除中...' : '删除'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        onOpenChange={(open) => { if (!open) setPendingDeleteSkill(null) }}
+        title={`确认删除 Skill「${pendingDeleteSkill?.name}」？`}
+        description="删除后将无法恢复，确定要卸载这个 Skill 吗？"
+        confirmLabel="删除"
+        loadingLabel="删除中..."
+        loading={isDeletingSkill}
+        onConfirm={async () => {
+          if (!pendingDeleteSkill || isDeletingSkill) return
+          setIsDeletingSkill(true)
+          const ok = await data.deleteSkill(pendingDeleteSkill.slug, pendingDeleteSkill.name)
+          setIsDeletingSkill(false)
+          setPendingDeleteSkill(null)
+          if (ok) setSelectedSkillSlug(null)
+        }}
+      />
 
       {/* MCP 删除确认 */}
-      <AlertDialog
+      <ConfirmDialog
         open={pendingDeleteMcpName !== null}
-        onOpenChange={(open) => { if (!open && !isDeletingMcp) setPendingDeleteMcpName(null) }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>确认删除 MCP 服务器「{pendingDeleteMcpName}」？</AlertDialogTitle>
-            <AlertDialogDescription>删除后将无法恢复，确定要删除这个 MCP 服务器吗？</AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isDeletingMcp}>取消</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={async () => {
-                if (!pendingDeleteMcpName || isDeletingMcp) return
-                setIsDeletingMcp(true)
-                await data.deleteMcp(pendingDeleteMcpName)
-                setIsDeletingMcp(false)
-                setPendingDeleteMcpName(null)
-              }}
-              disabled={isDeletingMcp}
-              className="bg-destructive text-white hover:bg-destructive/90"
-            >
-              {isDeletingMcp ? '删除中...' : '删除'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        onOpenChange={(open) => { if (!open) setPendingDeleteMcpName(null) }}
+        title={`确认删除 MCP 服务器「${pendingDeleteMcpName}」？`}
+        description="删除后将无法恢复，确定要删除这个 MCP 服务器吗？"
+        confirmLabel="删除"
+        loadingLabel="删除中..."
+        loading={isDeletingMcp}
+        onConfirm={async () => {
+          if (!pendingDeleteMcpName || isDeletingMcp) return
+          setIsDeletingMcp(true)
+          await data.deleteMcp(pendingDeleteMcpName)
+          setIsDeletingMcp(false)
+          setPendingDeleteMcpName(null)
+        }}
+      />
 
       <McpDetailSheet
         open={mcpSheetOpen}

--- a/apps/electron/src/renderer/components/agent-skills/AgentSkillsView.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/AgentSkillsView.tsx
@@ -20,6 +20,16 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import { workspaceCapabilitiesVersionAtom } from '@/atoms/agent-atoms'
 import { useProjectActions } from '@/hooks/useProjectActions'
 import type { McpServerEntry, SkillMeta } from '@proma/shared'
@@ -44,6 +54,10 @@ export function AgentSkillsView(): React.ReactElement {
   const [editingMcp, setEditingMcp] = React.useState<{ name: string; entry: McpServerEntry } | null>(null)
   const [showImport, setShowImport] = React.useState(false)
   const [wsPopoverOpen, setWsPopoverOpen] = React.useState(false)
+  const [pendingDeleteSkill, setPendingDeleteSkill] = React.useState<SkillMeta | null>(null)
+  const [pendingDeleteMcpName, setPendingDeleteMcpName] = React.useState<string | null>(null)
+  const [isDeletingSkill, setIsDeletingSkill] = React.useState(false)
+  const [isDeletingMcp, setIsDeletingMcp] = React.useState(false)
 
   const q = search.trim().toLowerCase()
 
@@ -245,7 +259,7 @@ export function AgentSkillsView(): React.ReactElement {
               total={mcpCount}
               onOpen={(name, entry) => { setEditingMcp({ name, entry }); setMcpSheetOpen(true) }}
               onToggle={data.toggleMcp}
-              onDelete={data.deleteMcp}
+              onRequestDelete={setPendingDeleteMcpName}
               onAdd={() => { setEditingMcp(null); setMcpSheetOpen(true) }}
             />
           )}
@@ -261,21 +275,76 @@ export function AgentSkillsView(): React.ReactElement {
         onOpenChange={(open) => { if (!open) setSelectedSkillSlug(null) }}
         onToggle={(enabled) => selectedSkill && data.toggleSkill(selectedSkill.slug, enabled)}
         onUpdate={() => selectedSkill && data.updateSkill(selectedSkill.slug)}
-        onDelete={async () => {
-          if (!selectedSkill) return
-          const ok = await data.deleteSkill(selectedSkill.slug, selectedSkill.name)
-          if (ok) setSelectedSkillSlug(null)
-        }}
+        onRequestDelete={() => selectedSkill && setPendingDeleteSkill(selectedSkill)}
         onOpenFolder={() => selectedSkill && openSkillFolder(selectedSkill.slug)}
         onChanged={() => bumpCapabilities((v) => v + 1)}
       />
+
+      {/* Skill 删除确认 */}
+      <AlertDialog
+        open={pendingDeleteSkill !== null}
+        onOpenChange={(open) => { if (!open && !isDeletingSkill) setPendingDeleteSkill(null) }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>确认删除 Skill「{pendingDeleteSkill?.name}」？</AlertDialogTitle>
+            <AlertDialogDescription>删除后将无法恢复，确定要卸载这个 Skill 吗？</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeletingSkill}>取消</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={async () => {
+                if (!pendingDeleteSkill || isDeletingSkill) return
+                setIsDeletingSkill(true)
+                const ok = await data.deleteSkill(pendingDeleteSkill.slug, pendingDeleteSkill.name)
+                setIsDeletingSkill(false)
+                setPendingDeleteSkill(null)
+                if (ok) setSelectedSkillSlug(null)
+              }}
+              disabled={isDeletingSkill}
+              className="bg-destructive text-white hover:bg-destructive/90"
+            >
+              {isDeletingSkill ? '删除中...' : '删除'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* MCP 删除确认 */}
+      <AlertDialog
+        open={pendingDeleteMcpName !== null}
+        onOpenChange={(open) => { if (!open && !isDeletingMcp) setPendingDeleteMcpName(null) }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>确认删除 MCP 服务器「{pendingDeleteMcpName}」？</AlertDialogTitle>
+            <AlertDialogDescription>删除后将无法恢复，确定要删除这个 MCP 服务器吗？</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeletingMcp}>取消</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={async () => {
+                if (!pendingDeleteMcpName || isDeletingMcp) return
+                setIsDeletingMcp(true)
+                await data.deleteMcp(pendingDeleteMcpName)
+                setIsDeletingMcp(false)
+                setPendingDeleteMcpName(null)
+              }}
+              disabled={isDeletingMcp}
+              className="bg-destructive text-white hover:bg-destructive/90"
+            >
+              {isDeletingMcp ? '删除中...' : '删除'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       <McpDetailSheet
         open={mcpSheetOpen}
         server={editingMcp}
         workspaceSlug={data.workspaceSlug}
-        onOpenChange={setMcpSheetOpen}
-        onSaved={() => { setMcpSheetOpen(false); bumpCapabilities((v) => v + 1) }}
+        onOpenChange={(open) => { setMcpSheetOpen(open); if (!open) bumpCapabilities((v) => v + 1) }}
+        onSaved={() => setMcpSheetOpen(false)}
       />
 
       <ImportSkillDialog
@@ -369,11 +438,11 @@ interface McpTabProps {
   total: number
   onOpen: (name: string, entry: McpServerEntry) => void
   onToggle: (name: string, enabled: boolean) => void
-  onDelete: (name: string) => void
+  onRequestDelete: (name: string) => void
   onAdd: () => void
 }
 
-function McpTab({ entries, total, onOpen, onToggle, onDelete, onAdd }: McpTabProps): React.ReactElement {
+function McpTab({ entries, total, onOpen, onToggle, onRequestDelete, onAdd }: McpTabProps): React.ReactElement {
   if (total === 0) {
     return (
       <EmptyState
@@ -406,7 +475,7 @@ function McpTab({ entries, total, onOpen, onToggle, onDelete, onAdd }: McpTabPro
           entry={entry}
           onOpen={() => onOpen(name, entry)}
           onToggle={(enabled) => onToggle(name, enabled)}
-          onDelete={() => onDelete(name)}
+          onRequestDelete={() => onRequestDelete(name)}
         />
       ))}
     </div>

--- a/apps/electron/src/renderer/components/agent-skills/McpCard.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/McpCard.tsx
@@ -7,6 +7,7 @@
 import * as React from 'react'
 import { Plug, ShieldCheck, CheckCircle2, XCircle, Trash2 } from 'lucide-react'
 import { Switch } from '@/components/ui/switch'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import type { McpServerEntry } from '@proma/shared'
 
@@ -17,10 +18,10 @@ interface McpCardProps {
   entry: McpServerEntry
   onOpen: () => void
   onToggle: (enabled: boolean) => void
-  onDelete: () => void
+  onRequestDelete: () => void
 }
 
-export function McpCard({ name, entry, onOpen, onToggle, onDelete }: McpCardProps): React.ReactElement {
+export function McpCard({ name, entry, onOpen, onToggle, onRequestDelete }: McpCardProps): React.ReactElement {
   const isBuiltin = entry.isBuiltin === true
   const target = entry.type === 'stdio' ? entry.command : entry.url
   const test = entry.lastTestResult
@@ -83,14 +84,18 @@ export function McpCard({ name, entry, onOpen, onToggle, onDelete }: McpCardProp
           </span>
         )}
         {!isBuiltin && (
-          <button
-            type="button"
-            onClick={(e) => { e.stopPropagation(); onDelete() }}
-            title="删除"
-            className="ml-auto rounded p-1 text-muted-foreground/50 opacity-0 transition-opacity hover:text-destructive group-hover:opacity-100"
-          >
-            <Trash2 size={14} />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={(e) => { e.stopPropagation(); onRequestDelete() }}
+                className="ml-auto rounded p-1 text-muted-foreground/50 opacity-0 transition-opacity hover:text-destructive group-hover:opacity-100"
+              >
+                <Trash2 size={14} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top">删除</TooltipContent>
+          </Tooltip>
         )}
       </div>
     </div>

--- a/apps/electron/src/renderer/components/agent-skills/McpDetailSheet.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/McpDetailSheet.tsx
@@ -20,7 +20,7 @@ interface McpDetailSheetProps {
 export function McpDetailSheet({ open, server, workspaceSlug, onOpenChange, onSaved }: McpDetailSheetProps): React.ReactElement {
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="right" className="w-[560px] sm:max-w-[560px] overflow-y-auto scrollbar-thin pt-12" aria-describedby={undefined}>
+      <SheetContent hideClose side="right" className="w-[560px] sm:max-w-[560px] overflow-y-auto scrollbar-thin pt-5" aria-describedby={undefined}>
         <SheetTitle className="sr-only">{server ? `编辑 MCP 服务器 ${server.name}` : '添加 MCP 服务器'}</SheetTitle>
         {open && (
           <McpServerForm

--- a/apps/electron/src/renderer/components/agent-skills/SkillDetailSheet.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/SkillDetailSheet.tsx
@@ -9,11 +9,12 @@ import * as React from 'react'
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { toast } from 'sonner'
-import { Sparkles, Pencil, Save, X, FolderOpen, RefreshCw, Trash2 } from 'lucide-react'
-import { Sheet, SheetContent, SheetTitle, SheetDescription } from '@/components/ui/sheet'
+import { Sparkles, Pencil, Save, X, FolderOpen, RefreshCw, Trash2, ArrowLeft } from 'lucide-react'
+import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
 import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { SettingsCard } from '@/components/settings/primitives'
 import { SkillFilesPanel } from '@/components/settings/SkillFilesPanel'
 import { cn } from '@/lib/utils'
@@ -28,7 +29,7 @@ interface SkillDetailSheetProps {
   onOpenChange: (open: boolean) => void
   onToggle: (enabled: boolean) => void
   onUpdate: () => void
-  onDelete: () => void
+  onRequestDelete: () => void
   onOpenFolder: () => void
   onChanged: () => void
 }
@@ -37,7 +38,7 @@ export function SkillDetailSheet(props: SkillDetailSheetProps): React.ReactEleme
   const { skill, onOpenChange } = props
   return (
     <Sheet open={!!skill} onOpenChange={onOpenChange}>
-      <SheetContent side="right" className="w-[62vw] min-w-[680px] max-w-[1100px] sm:max-w-[1100px] p-0 flex flex-col gap-0" aria-describedby={undefined}>
+      <SheetContent hideClose side="right" className="w-[62vw] min-w-[680px] max-w-[1100px] sm:max-w-[1100px] p-0 flex flex-col gap-0" aria-describedby={undefined}>
         <SheetTitle className="sr-only">Skill 详情</SheetTitle>
         {skill && <SkillDetailBody key={skill.slug} {...props} skill={skill} />}
       </SheetContent>
@@ -50,9 +51,10 @@ function SkillDetailBody({
   workspaceSlug,
   isBuiltin,
   updating,
+  onOpenChange,
   onToggle,
   onUpdate,
-  onDelete,
+  onRequestDelete,
   onOpenFolder,
   onChanged,
 }: SkillDetailSheetProps & { skill: SkillMeta }): React.ReactElement {
@@ -133,8 +135,15 @@ function SkillDetailBody({
   return (
     <div className="flex h-full flex-col min-h-0">
       {/* 头部 */}
-      <div className="shrink-0 border-b border-border/60 px-5 pb-4 pt-5 pr-12">
-        <div className="flex items-start gap-3">
+      <div className="shrink-0 border-b border-border/60 px-5 pb-4 pt-5">
+        <div className="flex items-center gap-3">
+          <Button variant="ghost" size="icon" className="h-8 w-8" type="button" onClick={() => onOpenChange(false)}>
+            <ArrowLeft size={18} />
+          </Button>
+          <h3 className="text-lg font-medium text-foreground">Skill 详情</h3>
+        </div>
+
+        <div className="mt-4 flex items-start gap-3">
           <div className="rounded-xl bg-amber-500/12 p-2 text-amber-500 shadow-sm shrink-0">
             <Sparkles size={18} />
           </div>
@@ -163,13 +172,28 @@ function SkillDetailBody({
               {updating ? '更新中' : '更新'}
             </Button>
           )}
-          <Button size="sm" variant="ghost" onClick={onOpenFolder} title="打开目录">
-            <FolderOpen size={14} />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button size="sm" variant="ghost" onClick={onOpenFolder}>
+                <FolderOpen size={14} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="top">打开目录</TooltipContent>
+          </Tooltip>
           {!isBuiltin && (
-            <Button size="sm" variant="ghost" onClick={onDelete} className="text-muted-foreground hover:text-destructive" title="卸载">
-              <Trash2 size={14} />
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={onRequestDelete}
+                  className="text-muted-foreground hover:text-destructive"
+                >
+                  <Trash2 size={14} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top">卸载</TooltipContent>
+            </Tooltip>
           )}
         </div>
       </div>
@@ -184,9 +208,18 @@ function SkillDetailBody({
             <div className="flex items-center justify-between">
               <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">元数据</h4>
               {!isEditingMeta ? (
-                <button onClick={startEditMeta} className="flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground">
-                  <Pencil size={12} /> 编辑
-                </button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={startEditMeta}
+                      className="flex items-center rounded p-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                    >
+                      <Pencil size={12} />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="top">编辑</TooltipContent>
+                </Tooltip>
               ) : (
                 <div className="flex items-center gap-2">
                   <Button size="sm" variant="ghost" onClick={() => setIsEditingMeta(false)} disabled={saving}>
@@ -234,14 +267,18 @@ function SkillDetailBody({
                 <div className="flex min-h-[28px] shrink-0 items-center justify-between px-1 pb-2">
                   <div className="font-mono text-xs text-muted-foreground">SKILL.md</div>
                   {!isEditingBody ? (
-                    <button
-                      type="button"
-                      title="编辑"
-                      onClick={() => { setEditBody(body); setIsEditingBody(true) }}
-                      className="flex items-center gap-1 rounded p-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-                    >
-                      <Pencil size={14} />
-                    </button>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          onClick={() => { setEditBody(body); setIsEditingBody(true) }}
+                          className="flex items-center gap-1 rounded p-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                        >
+                          <Pencil size={14} />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="top">编辑</TooltipContent>
+                    </Tooltip>
                   ) : (
                     <div className="flex items-center gap-1">
                       <Button size="sm" variant="ghost" onClick={() => setIsEditingBody(false)} disabled={saving}>

--- a/apps/electron/src/renderer/components/agent-skills/useAgentSkillsData.ts
+++ b/apps/electron/src/renderer/components/agent-skills/useAgentSkillsData.ts
@@ -93,7 +93,6 @@ export function useAgentSkillsData(): AgentSkillsData {
   }, [workspaceSlug, bumpCapabilitiesVersion])
 
   const deleteSkill = React.useCallback(async (slug: string, name: string): Promise<boolean> => {
-    if (!confirm(`确定删除 Skill「${name}」？此操作不可恢复。`)) return false
     try {
       await window.electronAPI.deleteWorkspaceSkill(workspaceSlug, slug)
       setSkills((prev) => prev.filter((s) => s.slug !== slug))
@@ -143,7 +142,6 @@ export function useAgentSkillsData(): AgentSkillsData {
   const deleteMcp = React.useCallback(async (name: string) => {
     const entry = mcpConfig.servers[name]
     if (entry?.isBuiltin) return
-    if (!confirm(`确定删除 MCP 服务器「${name}」？此操作不可恢复。`)) return
     try {
       const newServers = { ...mcpConfig.servers }
       delete newServers[name]

--- a/apps/electron/src/renderer/components/settings/McpServerForm.tsx
+++ b/apps/electron/src/renderer/components/settings/McpServerForm.tsx
@@ -150,7 +150,8 @@ export function McpServerForm({ server, workspaceSlug, onSaved, onCancel }: McpS
   // 自动保存状态（仅编辑模式）
   const AUTO_SAVE_DELAY = 600
   const autoSaveTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
-  const initializedRef = React.useRef(false)
+  const isFirstRenderRef = React.useRef(true)
+  const mountedRef = React.useRef(true)
   const [saveStatus, setSaveStatus] = React.useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
 
   // 保留最新表单值，供 unmount 时 flush 待保存变更
@@ -213,17 +214,17 @@ export function McpServerForm({ server, workspaceSlug, onSaved, onCancel }: McpS
         servers: { ...config.servers, [serverName]: entry },
       }
       await window.electronAPI.saveWorkspaceMcpConfig(workspaceSlug, newConfig)
-      if (generation === saveGenerationRef.current) {
+      if (generation === saveGenerationRef.current && mountedRef.current) {
         setSaveStatus('saved')
         setTimeout(() => {
-          if (generation === saveGenerationRef.current) {
+          if (generation === saveGenerationRef.current && mountedRef.current) {
             setSaveStatus('idle')
           }
         }, 2000)
       }
     } catch (error) {
       console.error('[MCP 表单] 自动保存失败:', error)
-      if (generation === saveGenerationRef.current) {
+      if (generation === saveGenerationRef.current && mountedRef.current) {
         toast.error('自动保存失败')
         setSaveStatus('error')
       }
@@ -233,20 +234,18 @@ export function McpServerForm({ server, workspaceSlug, onSaved, onCancel }: McpS
   const doSaveEntryRef = React.useRef(doSaveEntry)
   React.useEffect(() => { doSaveEntryRef.current = doSaveEntry }, [doSaveEntry])
 
-  // 编辑模式初始化完成后标记，避免加载时触发 auto-save
-  React.useEffect(() => {
-    if (!isEdit) {
-      initializedRef.current = true
-      return
-    }
-    const t = setTimeout(() => { initializedRef.current = true }, 100)
-    return () => clearTimeout(t)
-  }, [isEdit])
-
   // 编辑模式下监听字段变化，防抖自动保存
   React.useEffect(() => {
-    if (!isEdit || !initializedRef.current) return
-    if (!canSubmit()) return
+    if (!isEdit) return
+    // 首次渲染跳过，避免加载时触发 auto-save
+    if (isFirstRenderRef.current) {
+      isFirstRenderRef.current = false
+      return
+    }
+    const serverName = name.trim()
+    if (!serverName) return
+    if (transportType === 'stdio' && !command.trim()) return
+    if (transportType !== 'stdio' && !url.trim()) return
     setSaveStatus('idle')
     autoSaveTimerRef.current = setTimeout(() => {
       const vals = latestValuesRef.current
@@ -273,9 +272,10 @@ export function McpServerForm({ server, workspaceSlug, onSaved, onCancel }: McpS
     testResult,
   ])
 
-  // 组件卸载时 flush 待保存的变更
+  // 组件卸载时 flush 待保存的变更，并标记 unmounted
   React.useEffect(() => {
     return () => {
+      mountedRef.current = false
       if (autoSaveTimerRef.current) {
         clearTimeout(autoSaveTimerRef.current)
         autoSaveTimerRef.current = null

--- a/apps/electron/src/renderer/components/settings/McpServerForm.tsx
+++ b/apps/electron/src/renderer/components/settings/McpServerForm.tsx
@@ -7,6 +7,7 @@
 
 import * as React from 'react'
 import { ArrowLeft, Loader2, CheckCircle2, XCircle, AlertCircle } from 'lucide-react'
+import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import type { McpServerEntry, McpTransportType, WorkspaceMcpConfig } from '@proma/shared'
@@ -71,6 +72,53 @@ function serializeKeyValueText(record: Record<string, string> | undefined, separ
     .join('\n')
 }
 
+interface McpFormValues {
+  transportType: McpTransportType
+  enabled: boolean
+  testResult: { success: boolean; message: string; timestamp?: number } | null
+  isBuiltin: boolean
+  command: string
+  argsText: string
+  envText: string
+  timeoutStr: string
+  url: string
+  headersText: string
+}
+
+/** 根据当前表单值构建 McpServerEntry */
+function buildEntryFromValues(values: McpFormValues, includeTestResult = false): McpServerEntry {
+  const base: McpServerEntry = {
+    type: values.transportType,
+    enabled: values.enabled && values.testResult?.success === true,
+    ...(values.isBuiltin && { isBuiltin: true }),
+    ...(includeTestResult && values.testResult && {
+      lastTestResult: {
+        ...values.testResult,
+        timestamp: values.testResult.timestamp ?? Date.now(),
+      },
+    }),
+  }
+
+  if (values.transportType === 'stdio') {
+    base.command = values.command.trim()
+    const args = values.argsText
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+    if (args.length > 0) base.args = args
+    const env = parseKeyValueText(values.envText, '=')
+    if (Object.keys(env).length > 0) base.env = env
+    const timeout = parseInt(values.timeoutStr, 10)
+    if (!isNaN(timeout) && timeout > 0) base.timeout = timeout
+  } else {
+    base.url = values.url.trim()
+    const headers = parseKeyValueText(values.headersText, ':')
+    if (Object.keys(headers).length > 0) base.headers = headers
+  }
+
+  return base
+}
+
 export function McpServerForm({ server, workspaceSlug, onSaved, onCancel }: McpServerFormProps): React.ReactElement {
   const isEdit = server !== null
   const isBuiltin = server?.entry.isBuiltin === true
@@ -95,9 +143,25 @@ export function McpServerForm({ server, workspaceSlug, onSaved, onCancel }: McpS
   // UI 状态
   const [saving, setSaving] = React.useState(false)
   const [testing, setTesting] = React.useState(false)
-  const [testResult, setTestResult] = React.useState<{ success: boolean; message: string } | null>(
+  const [testResult, setTestResult] = React.useState<{ success: boolean; message: string; timestamp?: number } | null>(
     server?.entry.lastTestResult ?? null
   )
+
+  // 自动保存状态（仅编辑模式）
+  const AUTO_SAVE_DELAY = 600
+  const autoSaveTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+  const initializedRef = React.useRef(false)
+  const [saveStatus, setSaveStatus] = React.useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
+
+  // 保留最新表单值，供 unmount 时 flush 待保存变更
+  const latestValuesRef = React.useRef({
+    name, transportType, command, url, argsText, envText, headersText, timeoutStr, enabled, testResult, isBuiltin,
+  })
+  React.useEffect(() => {
+    latestValuesRef.current = {
+      name, transportType, command, url, argsText, envText, headersText, timeoutStr, enabled, testResult, isBuiltin,
+    }
+  }, [name, transportType, command, url, argsText, envText, headersText, timeoutStr, enabled, testResult, isBuiltin])
 
   // 监听配置改变，清空测试结果（避免使用过期的测试结果）
   React.useEffect(() => {
@@ -120,42 +184,111 @@ export function McpServerForm({ server, workspaceSlug, onSaved, onCancel }: McpS
 
   /** 构建 McpServerEntry */
   const buildEntry = (includeTestResult = false): McpServerEntry => {
-    const base: McpServerEntry = {
-      type: transportType,
-      // 关键保护：只有测试成功才能启用
-      enabled: enabled && testResult?.success === true,
-      // 保留内置标记
-      ...(isBuiltin && { isBuiltin: true }),
-      // 保存测试结果
-      ...(includeTestResult && testResult && {
-        lastTestResult: {
-          ...testResult,
-          timestamp: Date.now(),
-        },
-      }),
-    }
-
-    if (transportType === 'stdio') {
-      base.command = command.trim()
-      const args = argsText
-        .split(',')
-        .map((s) => s.trim())
-        .filter(Boolean)
-      if (args.length > 0) base.args = args
-      const env = parseKeyValueText(envText, '=')
-      if (Object.keys(env).length > 0) base.env = env
-      const timeout = parseInt(timeoutStr, 10)
-      if (!isNaN(timeout) && timeout > 0) base.timeout = timeout
-    } else {
-      base.url = url.trim()
-      const headers = parseKeyValueText(headersText, ':')
-      if (Object.keys(headers).length > 0) base.headers = headers
-    }
-
-    return base
+    return buildEntryFromValues(
+      {
+        transportType,
+        enabled,
+        testResult,
+        isBuiltin,
+        command,
+        argsText,
+        envText,
+        timeoutStr,
+        url,
+        headersText,
+      },
+      includeTestResult,
+    )
   }
 
-  /** 测试连接 */
+  const saveGenerationRef = React.useRef(0)
+
+  /** 执行自动保存 */
+  const doSaveEntry = React.useCallback(async (serverName: string, entry: McpServerEntry) => {
+    const generation = ++saveGenerationRef.current
+    setSaveStatus('saving')
+    try {
+      const config = await window.electronAPI.getWorkspaceMcpConfig(workspaceSlug)
+      const newConfig: WorkspaceMcpConfig = {
+        servers: { ...config.servers, [serverName]: entry },
+      }
+      await window.electronAPI.saveWorkspaceMcpConfig(workspaceSlug, newConfig)
+      if (generation === saveGenerationRef.current) {
+        setSaveStatus('saved')
+        setTimeout(() => {
+          if (generation === saveGenerationRef.current) {
+            setSaveStatus('idle')
+          }
+        }, 2000)
+      }
+    } catch (error) {
+      console.error('[MCP 表单] 自动保存失败:', error)
+      if (generation === saveGenerationRef.current) {
+        toast.error('自动保存失败')
+        setSaveStatus('error')
+      }
+    }
+  }, [workspaceSlug])
+
+  const doSaveEntryRef = React.useRef(doSaveEntry)
+  React.useEffect(() => { doSaveEntryRef.current = doSaveEntry }, [doSaveEntry])
+
+  // 编辑模式初始化完成后标记，避免加载时触发 auto-save
+  React.useEffect(() => {
+    if (!isEdit) {
+      initializedRef.current = true
+      return
+    }
+    const t = setTimeout(() => { initializedRef.current = true }, 100)
+    return () => clearTimeout(t)
+  }, [isEdit])
+
+  // 编辑模式下监听字段变化，防抖自动保存
+  React.useEffect(() => {
+    if (!isEdit || !initializedRef.current) return
+    if (!canSubmit()) return
+    setSaveStatus('idle')
+    autoSaveTimerRef.current = setTimeout(() => {
+      const vals = latestValuesRef.current
+      const entry = buildEntryFromValues(vals, true)
+      void doSaveEntryRef.current(vals.name.trim(), entry)
+    }, AUTO_SAVE_DELAY)
+    return () => {
+      if (autoSaveTimerRef.current) {
+        clearTimeout(autoSaveTimerRef.current)
+        autoSaveTimerRef.current = null
+      }
+    }
+  }, [
+    isEdit,
+    name,
+    transportType,
+    command,
+    url,
+    argsText,
+    envText,
+    headersText,
+    timeoutStr,
+    enabled,
+    testResult,
+  ])
+
+  // 组件卸载时 flush 待保存的变更
+  React.useEffect(() => {
+    return () => {
+      if (autoSaveTimerRef.current) {
+        clearTimeout(autoSaveTimerRef.current)
+        autoSaveTimerRef.current = null
+        const vals = latestValuesRef.current
+        const serverName = vals.name.trim()
+        if (!serverName) return
+        if (vals.transportType === 'stdio' && !vals.command.trim()) return
+        if (vals.transportType !== 'stdio' && !vals.url.trim()) return
+        const entry = buildEntryFromValues(vals, true)
+        void doSaveEntryRef.current(serverName, entry)
+      }
+    }
+  }, [])
   const handleTest = async (): Promise<void> => {
     const serverName = name.trim()
     if (!serverName) return
@@ -173,20 +306,23 @@ export function McpServerForm({ server, workspaceSlug, onSaved, onCancel }: McpS
       setTestResult({
         success: result.success,
         message: result.message,
+        timestamp: Date.now(),
       })
     } catch (error) {
       setTestResult({
         success: false,
         message: error instanceof Error ? error.message : '测试失败',
+        timestamp: Date.now(),
       })
     } finally {
       setTesting(false)
     }
   }
 
-  /** 提交表单 */
+  /** 提交表单（仅创建模式） */
   const handleSubmit = async (e: React.FormEvent): Promise<void> => {
     e.preventDefault()
+    if (isEdit) return
 
     const serverName = name.trim()
     if (!serverName) return
@@ -247,15 +383,27 @@ export function McpServerForm({ server, workspaceSlug, onSaved, onCancel }: McpS
         <h3 className="text-lg font-medium text-foreground flex-1">
           {isEdit ? '编辑 MCP 服务器' : '添加 MCP 服务器'}
         </h3>
-        <div className="flex items-center gap-2">
-          <Button variant="ghost" size="sm" type="button" onClick={onCancel}>
-            取消
-          </Button>
+        {isEdit && saveStatus !== 'idle' && (
+          <div className={cn(
+            'flex items-center gap-1.5 text-xs',
+            saveStatus === 'error' ? 'text-destructive' : 'text-muted-foreground',
+          )}>
+            {saveStatus === 'saving' && <Loader2 size={12} className="animate-spin" />}
+            {saveStatus === 'saved' && <CheckCircle2 size={12} className="text-emerald-600" />}
+            {saveStatus === 'error' && <XCircle size={12} />}
+            <span>
+              {saveStatus === 'saving' && '保存中...'}
+              {saveStatus === 'saved' && '已保存'}
+              {saveStatus === 'error' && '保存失败'}
+            </span>
+          </div>
+        )}
+        {!isEdit && (
           <Button size="sm" type="submit" disabled={saving || !canSubmit()}>
             {saving && <Loader2 size={14} className="animate-spin" />}
-            <span>{isEdit ? '保存修改' : '创建服务器'}</span>
+            <span>创建服务器</span>
           </Button>
-        </div>
+        )}
       </div>
 
       {/* 基本信息 */}

--- a/apps/electron/src/renderer/components/ui/confirm-dialog.tsx
+++ b/apps/electron/src/renderer/components/ui/confirm-dialog.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+
+interface ConfirmDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  title: string
+  description?: string
+  confirmLabel?: string
+  cancelLabel?: string
+  loadingLabel?: string
+  onConfirm: () => void | Promise<void>
+  loading?: boolean
+  variant?: 'destructive' | 'default'
+  children?: React.ReactNode
+}
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = '确认',
+  cancelLabel = '取消',
+  loadingLabel,
+  onConfirm,
+  loading = false,
+  variant = 'destructive',
+  children,
+}: ConfirmDialogProps): React.ReactElement {
+  return (
+    <AlertDialog open={open} onOpenChange={(v) => { if (!v && !loading) onOpenChange(v) }}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          {(description || children) && (
+            <AlertDialogDescription asChild={!!children}>
+              {children ?? description}
+            </AlertDialogDescription>
+          )}
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={loading}>{cancelLabel}</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            disabled={loading}
+            className={variant === 'destructive' ? 'bg-destructive text-white hover:bg-destructive/90' : undefined}
+          >
+            {loading ? (loadingLabel ?? confirmLabel) : confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/apps/electron/src/renderer/components/ui/sheet.tsx
+++ b/apps/electron/src/renderer/components/ui/sheet.tsx
@@ -52,16 +52,19 @@ const sheetVariants = cva(
 
 interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
-    VariantProps<typeof sheetVariants> {}
+    VariantProps<typeof sheetVariants> {
+  hideClose?: boolean
+}
 
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = "right", className, children, ...props }, ref) => {
+>(({ side = "right", className, children, hideClose, ...props }, ref) => {
   // Windows 下右侧抽屉的关闭按钮（right-4 top-4）会与窗口控制按钮重叠，隐藏它；
   // 用户可点击遮罩空白处或按 Esc 关闭。其他方向的抽屉不在窗口边缘，不受影响。
+  // 业务组件也可通过 hideClose 显式移除关闭按钮。
   const isWindows = React.useMemo(() => detectIsWindows(), [])
-  const hideClose = side === "right" && isWindows
+  const shouldHideClose = hideClose || (side === "right" && isWindows)
   return (
     <SheetPortal>
       <SheetOverlay />
@@ -70,7 +73,7 @@ const SheetContent = React.forwardRef<
         className={cn(sheetVariants({ side }), className)}
         {...props}
       >
-        {!hideClose && (
+        {!shouldHideClose && (
           <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
             <X className="h-4 w-4" />
             <span className="sr-only">Close</span>


### PR DESCRIPTION
## Summary

- 8e71060 fix(agent-skills): 移除 Skill/MCP 抽屉关闭按钮并统一导航，新增 Tooltip 与删除确认弹窗，MCP 编辑支持自动保存

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归