### PR TITLE
fix(agent): 流式指示器回退到用户选择的模型 LOGO

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.12.23",
+  "version": "0.12.24",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -437,7 +437,8 @@ export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persi
 
   // 从 streamState 属性中计算派生值
   const streamingContent = streamState?.content ?? ''
-  const agentStreamingModel = streamState?.model ? resolveModelDisplayName(streamState.model, channels) : undefined
+  const streamingModelId = streamState?.model || sessionModelId
+  const agentStreamingModel = streamingModelId ? resolveModelDisplayName(streamingModelId, channels) : undefined
   const retrying = streamState?.retrying
   const startedAt = streamState?.startedAt
 


### PR DESCRIPTION
## Summary

- 815cf3c fix(agent): 流式指示器回退到用户选择的模型 LOGO

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归