### PR TITLE
[codex] fix agent worktree diff panel

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.12.24",
+  "version": "0.12.25",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -9,7 +9,7 @@ import { join, resolve, sep, dirname } from 'node:path'
 import { existsSync, realpathSync, rmSync, readFileSync, writeFileSync, mkdirSync, statSync } from 'node:fs'
 import { writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, INSTALLER_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, MEMORY_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS, DINGTALK_IPC_CHANNELS, WECHAT_IPC_CHANNELS, AUTOMATION_IPC_CHANNELS, isPromaPermissionMode } from '@proma/shared'
+import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, INSTALLER_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, MEMORY_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS, DINGTALK_IPC_CHANNELS, WECHAT_IPC_CHANNELS, AUTOMATION_IPC_CHANNELS, isPromaPermissionMode, normalizePathForCompare } from '@proma/shared'
 import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS, SCRATCH_PAD_IPC_CHANNELS, QUICK_TASK_IPC_CHANNELS, VOICE_DICTATION_IPC_CHANNELS, APP_ICON_IPC_CHANNELS, DOCK_BADGE_IPC_CHANNELS, STORAGE_IPC_CHANNELS } from '../types'
 import type {
   QuickTaskSubmitInput,
@@ -396,11 +396,11 @@ async function ensurePathAllowedWithWorktree(filePath: string, options?: FileAcc
   const mainRepo = await getMainRepoRoot(filePath)
   if (mainRepo && isPathAllowed(mainRepo, options)) return true
   if (mainRepo) {
-    const targetMainRepo = realpathOrResolve(mainRepo).replace(/\\/g, '/').replace(/\/+$/, '')
+    const targetMainRepo = normalizePathForCompare(realpathOrResolve(mainRepo))
     for (const root of getAuthorizedRoots(options)) {
       const authorizedMainRepo = await getAccessRootMainRepo(root)
       if (!authorizedMainRepo) continue
-      const authorizedRoot = realpathOrResolve(authorizedMainRepo).replace(/\\/g, '/').replace(/\/+$/, '')
+      const authorizedRoot = normalizePathForCompare(realpathOrResolve(authorizedMainRepo))
       if (authorizedRoot === targetMainRepo) return true
     }
     for (const workspaceSlug of getWorkspaceSlugsForAccess(options)) {
@@ -412,7 +412,7 @@ async function ensurePathAllowedWithWorktree(filePath: string, options?: FileAcc
       }
       for (const repo of repos) {
         const repoMain = await getMainRepoRoot(repo.repoPath)
-        const repoRoot = realpathOrResolve(repoMain ?? repo.repoPath).replace(/\\/g, '/').replace(/\/+$/, '')
+        const repoRoot = normalizePathForCompare(realpathOrResolve(repoMain ?? repo.repoPath))
         if (repoRoot === targetMainRepo) return true
       }
     }

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -6,7 +6,7 @@
 
 import { ipcMain, nativeTheme, shell, dialog, BrowserWindow, app } from 'electron'
 import { join, resolve, sep, dirname } from 'node:path'
-import { existsSync, realpathSync, rmSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { existsSync, realpathSync, rmSync, readFileSync, writeFileSync, mkdirSync, statSync } from 'node:fs'
 import { writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, INSTALLER_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, MEMORY_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS, DINGTALK_IPC_CHANNELS, WECHAT_IPC_CHANNELS, AUTOMATION_IPC_CHANNELS, isPromaPermissionMode } from '@proma/shared'
@@ -346,9 +346,36 @@ function normalizeFileAccessOptions(value?: FileAccessOptions | string[]): FileA
   }
 }
 
+function getWorkspaceSlugsForAccess(options?: FileAccessOptions): string[] {
+  const workspaceSlugs = new Set<string>()
+  if (options?.sessionId) {
+    const meta = getAgentSessionMeta(options.sessionId)
+    if (meta?.workspaceId) {
+      const workspace = getAgentWorkspace(meta.workspaceId)
+      if (workspace?.slug) workspaceSlugs.add(workspace.slug)
+    }
+  }
+  if (options?.workspaceSlug) {
+    workspaceSlugs.add(options.workspaceSlug)
+  }
+  return Array.from(workspaceSlugs)
+}
+
 function getAllowedCandidateBasePaths(options?: FileAccessOptions): string[] | undefined {
   const allowed = options?.candidateBasePaths?.filter((p) => isPathAllowed(p, options)) ?? []
   return allowed.length > 0 ? allowed : undefined
+}
+
+async function getAccessRootMainRepo(root: string): Promise<string | null> {
+  if (!existsSync(root)) return null
+  let probePath = root
+  try {
+    const stats = statSync(probePath)
+    if (stats.isFile()) probePath = dirname(probePath)
+  } catch {
+    return null
+  }
+  return getMainRepoRoot(probePath)
 }
 
 function ensurePathAllowed(filePath: string, options?: FileAccessOptions): boolean {
@@ -368,6 +395,28 @@ async function ensurePathAllowedWithWorktree(filePath: string, options?: FileAcc
   if (isPathAllowed(filePath, options)) return true
   const mainRepo = await getMainRepoRoot(filePath)
   if (mainRepo && isPathAllowed(mainRepo, options)) return true
+  if (mainRepo) {
+    const targetMainRepo = realpathOrResolve(mainRepo).replace(/\\/g, '/').replace(/\/+$/, '')
+    for (const root of getAuthorizedRoots(options)) {
+      const authorizedMainRepo = await getAccessRootMainRepo(root)
+      if (!authorizedMainRepo) continue
+      const authorizedRoot = realpathOrResolve(authorizedMainRepo).replace(/\\/g, '/').replace(/\/+$/, '')
+      if (authorizedRoot === targetMainRepo) return true
+    }
+    for (const workspaceSlug of getWorkspaceSlugsForAccess(options)) {
+      let repos: import('@proma/shared').WorkspaceWorktreeRepo[]
+      try {
+        repos = await getWorktreeRepos(workspaceSlug)
+      } catch {
+        continue
+      }
+      for (const repo of repos) {
+        const repoMain = await getMainRepoRoot(repo.repoPath)
+        const repoRoot = realpathOrResolve(repoMain ?? repo.repoPath).replace(/\\/g, '/').replace(/\/+$/, '')
+        if (repoRoot === targetMainRepo) return true
+      }
+    }
+  }
   console.warn('[IPC] 拒绝越界路径:', filePath)
   return false
 }

--- a/apps/electron/src/main/lib/git-diff-service.ts
+++ b/apps/electron/src/main/lib/git-diff-service.ts
@@ -9,6 +9,7 @@ import { spawn } from 'child_process'
 import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from 'fs'
 import { basename, dirname, isAbsolute, join, resolve, sep } from 'path'
 import type { ChangedFileEntry, UnstagedChangesResult, UntrackedFileEntry } from '@proma/shared'
+import { normalizePathForCompare } from '@proma/shared'
 import type { ChangeSource, ChangedFileStatus } from '@proma/shared'
 
 /** 大文件读取上限：超过则跳过，避免 IPC 序列化撑爆内存 */
@@ -27,7 +28,7 @@ function normalizeLineEndings(content: string): string {
 }
 
 function normalizeComparablePath(filePath: string): string {
-  return resolve(filePath).replace(/\\/g, '/').replace(/\/+$/, '')
+  return normalizePathForCompare(resolve(filePath))
 }
 
 interface ChangeCandidate {

--- a/apps/electron/src/main/lib/git-diff-service.ts
+++ b/apps/electron/src/main/lib/git-diff-service.ts
@@ -26,6 +26,49 @@ function normalizeLineEndings(content: string): string {
   return content.replace(/\r\n/g, '\n')
 }
 
+function normalizeComparablePath(filePath: string): string {
+  return resolve(filePath).replace(/\\/g, '/').replace(/\/+$/, '')
+}
+
+interface ChangeCandidate {
+  /** 原始候选路径，保留给 git root 搜索 */
+  searchPath: string
+  /** 用于过滤变更文件的规范化路径 */
+  matchPath: string
+  /** true 表示只匹配这个文件，false 表示匹配目录下所有文件 */
+  fileOnly: boolean
+}
+
+function toChangeCandidate(input: string): ChangeCandidate | null {
+  if (!input || typeof input !== 'string') return null
+  const resolved = resolve(input)
+  try {
+    const stats = statSync(resolved)
+    if (stats.isFile()) {
+      return {
+        searchPath: dirname(resolved),
+        matchPath: normalizeComparablePath(resolved),
+        fileOnly: true,
+      }
+    }
+    if (stats.isDirectory()) {
+      return {
+        searchPath: resolved,
+        matchPath: normalizeComparablePath(resolved),
+        fileOnly: false,
+      }
+    }
+  } catch {
+    // 附加文件被删除后仍可能需要展示 git 删除记录；此时用父目录找仓库、按文件精确匹配。
+    return {
+      searchPath: dirname(resolved),
+      matchPath: normalizeComparablePath(resolved),
+      fileOnly: true,
+    }
+  }
+  return null
+}
+
 /**
  * 校验并规范化 filePath，确保其位于 root 目录内。
  * 支持相对路径和绝对路径。绝对路径会被自动转为相对路径。
@@ -34,7 +77,12 @@ function normalizeLineEndings(content: string): string {
  */
 function normalizeSafePath(root: string, filePath: string): string | null {
   if (!filePath || typeof filePath !== 'string') return null
-  const resolvedRoot = resolve(root)
+  let resolvedRoot: string
+  try {
+    resolvedRoot = realpathSync(resolve(root))
+  } catch {
+    resolvedRoot = resolve(root)
+  }
   const rootWithSep = resolvedRoot.endsWith(sep) ? resolvedRoot : resolvedRoot + sep
 
   if (isAbsolute(filePath)) {
@@ -67,7 +115,7 @@ function normalizeSafePath(root: string, filePath: string): string | null {
  * @param cwd - 工作目录
  * @returns 命令输出，如果失败返回 null
  */
-function runGitCommand(args: string[], cwd: string): Promise<string | null> {
+function runGitCommand(args: string[], cwd: string, options?: { quiet?: boolean }): Promise<string | null> {
   return new Promise((resolve) => {
     try {
       // -c core.quotePath=false：禁用 git 对非 ASCII 路径的八进制转义（如中文文件名
@@ -109,14 +157,18 @@ function runGitCommand(args: string[], cwd: string): Promise<string | null> {
         if (code === 0) {
           resolve(stdout.trim())
         } else {
-          console.error('[git-diff-service] git 命令失败:', args.join(' '), stderr.trim())
+          if (!options?.quiet) {
+            console.error('[git-diff-service] git 命令失败:', args.join(' '), stderr.trim())
+          }
           resolve(null)
         }
       })
 
       child.on('error', (err) => {
         clearTimeout(timeout)
-        console.error('[git-diff-service] git 命令错误:', err)
+        if (!options?.quiet) {
+          console.error('[git-diff-service] git 命令错误:', err)
+        }
         resolve(null)
       })
     } catch {
@@ -188,7 +240,9 @@ function parseNumstat(numStat: string | null): Map<string, { additions: number; 
 }
 
 /**
- * 获取未暂存的文件变更列表（支持多 Git 仓库）
+ * 获取当前工作树相对 HEAD 的文件变更列表（支持多 Git 仓库）
+ *
+ * 包含 staged + unstaged 改动；函数名保留为 getUnstagedChanges 以兼容现有 IPC。
  */
 export async function getUnstagedChanges(
   dirPath: string,
@@ -197,12 +251,16 @@ export async function getUnstagedChanges(
   extraPaths?: string[],
 ): Promise<UnstagedChangesResult> {
   // 收集所有候选目录中的不重复 Git 仓库根
-  const candidates = [dirPath, sessionPath, workspaceFilesPath, ...(extraPaths || [])].filter(
+  const rawCandidates = [dirPath, sessionPath, workspaceFilesPath, ...(extraPaths || [])].filter(
     (p): p is string => typeof p === 'string' && p.length > 0
   )
+  const candidates = rawCandidates
+    .map(toChangeCandidate)
+    .filter((candidate): candidate is ChangeCandidate => candidate !== null)
+
   const gitRoots: string[] = []
   for (const cand of candidates) {
-    const roots = await findAllGitRoots(cand)
+    const roots = await findAllGitRoots(cand.searchPath)
     for (const root of roots) {
       if (!gitRoots.includes(root)) gitRoots.push(root)
     }
@@ -215,19 +273,19 @@ export async function getUnstagedChanges(
   const allFiles: ChangedFileEntry[] = []
   const allUntracked: UntrackedFileEntry[] = []
 
-  // 候选目录绝对路径（用于过滤：只显示落在某个候选目录内的文件）
-  const candidateRoots = candidates.map((c) => {
-    const r = c.replace(/[/\\]+$/, '')
-    return r + sep
-  })
+  // 候选路径用于过滤：目录匹配子树，附加文件只匹配自身，避免显示同级无关改动。
   const isUnderAnyCandidate = (absPath: string): boolean => {
-    return candidateRoots.some((root) => absPath === root.slice(0, -1) || absPath.startsWith(root))
+    const normalized = normalizeComparablePath(absPath)
+    return candidates.some((candidate) => {
+      if (candidate.fileOnly) return normalized === candidate.matchPath
+      return normalized === candidate.matchPath || normalized.startsWith(candidate.matchPath + '/')
+    })
   }
 
   for (const gitRoot of gitRoots) {
-    // 获取变更文件列表 (M=modified, D=deleted, A=added, R=renamed, C=copied, T=type)
-    const nameStatus = await runGitCommand(['diff', '--name-status'], gitRoot)
-    const numStat = await runGitCommand(['diff', '--numstat'], gitRoot)
+    // 获取当前工作树相对 HEAD 的变更文件列表，覆盖 staged + unstaged。
+    const nameStatus = await runGitCommand(['diff', 'HEAD', '--name-status'], gitRoot)
+    const numStat = await runGitCommand(['diff', 'HEAD', '--numstat'], gitRoot)
     const numStatMap = parseNumstat(numStat)
 
     if (nameStatus) {
@@ -339,7 +397,7 @@ export async function findAllGitRoots(baseDir: string): Promise<string[]> {
   if (!existsSync(baseDir)) return []
 
   // 1. 向上搜索：git rev-parse --show-toplevel
-  const toplevel = await runGitCommand(['rev-parse', '--show-toplevel'], baseDir)
+  const toplevel = await runGitCommand(['rev-parse', '--show-toplevel'], baseDir, { quiet: true })
   const roots: string[] = []
   if (toplevel && existsSync(toplevel)) {
     const normalized = normalizeGitRoot(toplevel)
@@ -471,7 +529,7 @@ export async function getUntrackedContent(dirPath: string, filePath: string, git
 }
 
 /**
- * 还原文件的未暂存变更
+ * 还原文件相对 HEAD 的所有改动（index + working tree）。
  */
 export async function revertFile(dirPath: string, filePath: string, gitRoot?: string): Promise<void> {
   const root = gitRoot || await findGitRoot(dirPath)
@@ -480,9 +538,9 @@ export async function revertFile(dirPath: string, filePath: string, gitRoot?: st
   if (!safePath) {
     throw new Error(`不安全的路径: ${filePath}`)
   }
-  const result = await runGitCommand(['checkout', '--', safePath], root)
+  const result = await runGitCommand(['restore', '--staged', '--worktree', '--', safePath], root)
   if (result === null) {
-    throw new Error(`还原失败: git checkout -- ${safePath}`)
+    throw new Error(`还原失败: git restore --staged --worktree -- ${safePath}`)
   }
 }
 
@@ -500,6 +558,7 @@ export async function getMainRepoRoot(somePath: string): Promise<string | null> 
   const commonDir = await runGitCommand(
     ['rev-parse', '--path-format=absolute', '--git-common-dir'],
     somePath,
+    { quiet: true },
   )
   if (!commonDir) return null
   // commonDir 形如 /path/to/main-repo/.git，取其父目录
@@ -510,8 +569,12 @@ export async function getMainRepoRoot(somePath: string): Promise<string | null> 
  * 列出指定仓库的所有 Git Worktree
  */
 export async function listWorktrees(repoPath: string): Promise<import('@proma/shared').WorktreeInfo[]> {
-  const output = await runGitCommand(['worktree', 'list', '--porcelain'], repoPath)
+  const root = await findGitRoot(repoPath)
+  if (!root) return []
+  const output = await runGitCommand(['worktree', 'list', '--porcelain'], root, { quiet: true })
   if (!output) return []
+  const mainRepoRoot = await getMainRepoRoot(root)
+  const normalizedMainRoot = mainRepoRoot ? normalizeGitRoot(mainRepoRoot) : normalizeGitRoot(root)
 
   const worktrees: import('@proma/shared').WorktreeInfo[] = []
   const blocks = output.split('\n\n').filter(Boolean)
@@ -521,6 +584,7 @@ export async function listWorktrees(repoPath: string): Promise<import('@proma/sh
     let path = ''
     let head = ''
     let branch = ''
+    let prunable = false
 
     for (const line of lines) {
       if (line.startsWith('worktree ')) {
@@ -531,11 +595,13 @@ export async function listWorktrees(repoPath: string): Promise<import('@proma/sh
         branch = line.slice('branch refs/heads/'.length)
       } else if (line === 'detached') {
         branch = '(detached)'
+      } else if (line.startsWith('prunable')) {
+        prunable = true
       }
     }
 
-    if (path) {
-      const isMain = path === repoPath
+    if (path && !prunable && existsSync(path)) {
+      const isMain = normalizeGitRoot(path) === normalizedMainRoot
       worktrees.push({
         path,
         branch: branch || 'unknown',
@@ -610,9 +676,9 @@ export async function getWorktreeChanges(
     }
   }
 
-  // 2. 未提交的改动: git diff (working tree vs HEAD)
-  const uncommittedStatus = await runGitCommand(['diff', '--name-status'], gitRoot)
-  const uncommittedNumstat = await runGitCommand(['diff', '--numstat'], gitRoot)
+  // 2. 未提交的改动：当前工作树相对 HEAD，覆盖 staged + unstaged。
+  const uncommittedStatus = await runGitCommand(['diff', 'HEAD', '--name-status'], gitRoot)
+  const uncommittedNumstat = await runGitCommand(['diff', 'HEAD', '--numstat'], gitRoot)
   const uncommittedStats = parseNumstat(uncommittedNumstat)
 
   if (uncommittedStatus) {

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -358,6 +358,11 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
     window.electronAPI.getWorkspaceFilesPath(workspaceSlug).then(setWorkspaceFilesPath).catch(() => setWorkspaceFilesPath(null))
   }, [workspaceSlug])
 
+  const worktreeRepoPathsMemo = React.useMemo(
+    () => [sessionPath, workspaceFilesPath, ...extraPathsMemo].filter(Boolean) as string[],
+    [sessionPath, workspaceFilesPath, extraPathsMemo]
+  )
+
   // Agent 写文件触发自动定位时，把 Tab 切到该文件所在的面板（session / workspace），
   // 让"最近修改"高亮落在用户当前可见的 Tab 上。仅响应 Agent 写入（select 未置位）的 reveal，
   // 用户搜索点击（select=true）不抢占 Tab；ts 去重确保用户手动切回后不会被重新抢占。
@@ -417,11 +422,12 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
                 sessionId={sessionId}
                 sessionPath={sessionPath}
                 workspaceFilesPath={workspaceFilesPath || undefined}
-                extraPaths={extraPathsMemo}
+                extraPaths={fileAccessPathsMemo}
                 refreshVersion={diffRefreshVersion}
                 selectedFilePath={selectedFilePath}
                 onFileClick={handleDiffFileClick}
                 workspaceSlug={workspaceSlug || undefined}
+                worktreeRepoPaths={worktreeRepoPathsMemo}
               />
             ) : (
               <div className="flex-1 flex items-center justify-center text-muted-foreground text-xs">等待会话初始化...</div>

--- a/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
@@ -100,6 +100,7 @@ export const DiffChangesList = React.memo(function DiffChangesList({
   /** 单调递增的 fetch 序号，用于丢弃乱序到达的旧响应 */
   const fetchSeqRef = React.useRef(0)
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- only reset state on cache key switch, not on every diffDataMap update
   React.useEffect(() => {
     fetchSeqRef.current += 1
     const nextCached = diffDataMap.get(diffCacheKey)

--- a/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
@@ -1,7 +1,7 @@
 /**
  * DiffChangesList — 代码改动文件列表
  *
- * 显示所有未暂存文件，按目录分组，支持 hover 操作按钮。
+ * 显示当前工作树相对 HEAD 的代码改动，按目录分组，支持 hover 操作按钮。
  */
 
 import * as React from 'react'
@@ -45,6 +45,8 @@ interface DiffChangesListProps {
   extraPaths?: string[]
   /** 工作区 slug，用于 WorktreeSelector 拉取 worktree 列表 */
   workspaceSlug?: string
+  /** 用于自动发现 worktree 的仓库候选路径 */
+  worktreeRepoPaths?: string[]
 }
 
 /** 文件来源 badge 的颜色和文案 */
@@ -65,25 +67,13 @@ export const DiffChangesList = React.memo(function DiffChangesList({
   selectedFilePath,
   extraPaths,
   workspaceSlug,
+  worktreeRepoPaths,
 }: DiffChangesListProps): React.ReactElement {
-  // Diff 数据缓存：mount 时若已有上次结果，立即用作初值，避免空数组闪 1s "没有代码改动"
-  const diffDataMap = useAtomValue(agentDiffDataAtom)
-  const setDiffDataMap = useSetAtom(agentDiffDataAtom)
-  const cached = diffDataMap.get(sessionId)
-  const [files, setFiles] = React.useState<ChangedFileEntry[]>(() => cached?.files ?? [])
-  const [untrackedFiles, setUntrackedFiles] = React.useState<UntrackedFileEntry[]>(() => cached?.untrackedFiles ?? [])
-  const [isGitRepo, setIsGitRepo] = React.useState(() => cached?.isGitRepo ?? true)
-  /** 首次 fetch 是否已返回——区分 loading 与真·空，避免 "没有代码改动" 误闪 */
-  const [hasFetched, setHasFetched] = React.useState<boolean>(() => cached !== undefined)
-  const [collapsedDirs, setCollapsedDirs] = React.useState<Set<string>>(new Set())
-  const [searchQuery, setSearchQuery] = React.useState('')
-  /** 单调递增的 fetch 序号，用于丢弃乱序到达的旧响应 */
-  const fetchSeqRef = React.useRef(0)
-
   // Worktree 选择状态（内联 WorktreeSelector）
   const selectedWorktreeMap = useAtomValue(agentSelectedWorktreeAtom)
   const setSelectedWorktreeMap = useSetAtom(agentSelectedWorktreeAtom)
   const selectedWorktreePath = selectedWorktreeMap.get(sessionId) ?? null
+  const diffCacheKey = selectedWorktreePath ? `${sessionId}:worktree:${selectedWorktreePath}` : `${sessionId}:session`
   const worktreeMode = React.useMemo(
     () => selectedWorktreePath ? { path: selectedWorktreePath, baseBranch: 'origin/main' } : undefined,
     [selectedWorktreePath],
@@ -95,6 +85,29 @@ export const DiffChangesList = React.memo(function DiffChangesList({
       return m
     })
   }, [sessionId, setSelectedWorktreeMap])
+
+  // Diff 数据缓存：mount 时若已有上次结果，立即用作初值，避免空数组闪 1s "没有代码改动"
+  const diffDataMap = useAtomValue(agentDiffDataAtom)
+  const setDiffDataMap = useSetAtom(agentDiffDataAtom)
+  const cached = diffDataMap.get(diffCacheKey)
+  const [files, setFiles] = React.useState<ChangedFileEntry[]>(() => cached?.files ?? [])
+  const [untrackedFiles, setUntrackedFiles] = React.useState<UntrackedFileEntry[]>(() => cached?.untrackedFiles ?? [])
+  const [isGitRepo, setIsGitRepo] = React.useState(() => cached?.isGitRepo ?? true)
+  /** 首次 fetch 是否已返回——区分 loading 与真·空，避免 "没有代码改动" 误闪 */
+  const [hasFetched, setHasFetched] = React.useState<boolean>(() => cached !== undefined)
+  const [collapsedDirs, setCollapsedDirs] = React.useState<Set<string>>(new Set())
+  const [searchQuery, setSearchQuery] = React.useState('')
+  /** 单调递增的 fetch 序号，用于丢弃乱序到达的旧响应 */
+  const fetchSeqRef = React.useRef(0)
+
+  React.useEffect(() => {
+    fetchSeqRef.current += 1
+    const nextCached = diffDataMap.get(diffCacheKey)
+    setFiles(nextCached?.files ?? [])
+    setUntrackedFiles(nextCached?.untrackedFiles ?? [])
+    setIsGitRepo(nextCached?.isGitRepo ?? true)
+    setHasFetched(nextCached !== undefined)
+  }, [diffCacheKey])
 
   // Agent 本轮刚修改但尚未查看的文件
   const unseenFilesMap = useAtomValue(agentDiffUnseenFilesAtom)
@@ -127,7 +140,7 @@ export const DiffChangesList = React.memo(function DiffChangesList({
       setHasFetched(true)
       setDiffDataMap((prev) => {
         const next = new Map(prev)
-        next.set(sessionId, result)
+        next.set(diffCacheKey, result)
         return next
       })
     } catch {
@@ -135,7 +148,7 @@ export const DiffChangesList = React.memo(function DiffChangesList({
       setIsGitRepo(true)
       setHasFetched(true)
     }
-  }, [dirPath, sessionPath, workspaceFilesPath, extraPaths, sessionId, setDiffDataMap, worktreeMode])
+  }, [dirPath, sessionPath, workspaceFilesPath, extraPaths, sessionId, setDiffDataMap, worktreeMode, diffCacheKey])
 
   React.useEffect(() => {
     fetchChanges()
@@ -198,73 +211,71 @@ export const DiffChangesList = React.memo(function DiffChangesList({
   }, [untrackedFiles, searchQuery])
 
   const isEmpty = fileGroups.length === 0 && filteredUntrackedFiles.length === 0
-
-  // 非 Git 仓库
-  if (!isGitRepo) {
-    return (
-      <div className="flex flex-col items-center justify-center h-full text-muted-foreground p-4">
-        <p className="text-[12px] text-center">当前目录不是 Git 仓库或暂无改动</p>
-      </div>
-    )
-  }
-
-  // 空状态：首次 fetch 未完成时显示加载占位，避免误显示 "没有代码改动"
-  if (files.length === 0 && untrackedFiles.length === 0) {
-    return (
-      <div className="flex flex-col items-center justify-center h-full text-muted-foreground p-4">
-        <p className="text-[12px] text-center">{hasFetched ? '没有代码改动' : '加载中…'}</p>
-      </div>
-    )
-  }
+  const hasAnyChanges = files.length > 0 || untrackedFiles.length > 0
+  const shouldShowSearch = isGitRepo && (hasAnyChanges || searchQuery.length > 0)
+  const shouldShowWorktreeSelector = Boolean(workspaceSlug || (worktreeRepoPaths?.length ?? 0) > 0)
 
   return (
     <div className="flex flex-col h-full overflow-y-auto">
-      {/* 搜索框 — 有改动文件时才显示 */}
-      <div className="flex-shrink-0 sticky top-0 z-10 bg-content-area px-2 pt-1.5 pb-1">
-        <div className="flex items-center gap-1.5 px-2 h-7 rounded-md bg-muted/50 border border-transparent focus-within:border-primary/40 focus-within:bg-muted/70 transition-colors">
-          <Search className="size-3 text-muted-foreground flex-shrink-0" />
-          <input
-            type="text"
-            aria-label="搜索改动文件"
-            className="flex-1 bg-transparent text-[11px] outline-none placeholder:text-muted-foreground/40"
-            placeholder="搜索改动文件..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-          />
-          {searchQuery && (
-            <>
-              <span className="text-[10px] text-muted-foreground/50 flex-shrink-0 tabular-nums">
-                {matchedFilesCount + filteredUntrackedFiles.length}
-              </span>
-              <button
-                type="button"
-                aria-label="清除搜索"
-                className="flex-shrink-0 p-0.5 rounded-sm hover:bg-foreground/[0.08] text-muted-foreground/50 hover:text-muted-foreground transition-colors"
-                onClick={() => setSearchQuery('')}
-              >
-                <X className="size-3" />
-              </button>
-            </>
-          )}
-        </div>
-      </div>
-
-      {/* Worktree 分支选择器 — 仅当有 worktree 时显示（组件内部自动隐藏） */}
-      {workspaceSlug && (
+      {/* Worktree 分支选择器 — 空 diff / 非 Git 空态也保留，避免无法切到会话 worktree */}
+      {shouldShowWorktreeSelector && (
         <WorktreeSelector
           sessionId={sessionId}
           workspaceSlug={workspaceSlug}
+          repoPaths={worktreeRepoPaths}
           selectedPath={selectedWorktreePath}
           onSelect={handleWorktreeSelect}
         />
       )}
 
-      {isEmpty && (
+      {/* 搜索框 — 有改动文件时才显示 */}
+      {shouldShowSearch && (
+        <div className="flex-shrink-0 sticky top-0 z-10 bg-content-area px-2 pt-1.5 pb-1">
+          <div className="flex items-center gap-1.5 px-2 h-7 rounded-md bg-muted/50 border border-transparent focus-within:border-primary/40 focus-within:bg-muted/70 transition-colors">
+            <Search className="size-3 text-muted-foreground flex-shrink-0" />
+            <input
+              type="text"
+              aria-label="搜索改动文件"
+              className="flex-1 bg-transparent text-[11px] outline-none placeholder:text-muted-foreground/40"
+              placeholder="搜索改动文件..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
+            {searchQuery && (
+              <>
+                <span className="text-[10px] text-muted-foreground/50 flex-shrink-0 tabular-nums">
+                  {matchedFilesCount + filteredUntrackedFiles.length}
+                </span>
+                <button
+                  type="button"
+                  aria-label="清除搜索"
+                  className="flex-shrink-0 p-0.5 rounded-sm hover:bg-foreground/[0.08] text-muted-foreground/50 hover:text-muted-foreground transition-colors"
+                  onClick={() => setSearchQuery('')}
+                >
+                  <X className="size-3" />
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+
+      {!isGitRepo && (
+        <div className="flex flex-col items-center justify-center h-full text-muted-foreground p-4">
+          <p className="text-[12px] text-center">当前目录不是 Git 仓库</p>
+        </div>
+      )}
+      {isGitRepo && !hasAnyChanges && (
+        <div className="flex flex-col items-center justify-center h-full text-muted-foreground p-4">
+          <p className="text-[12px] text-center">{hasFetched ? '没有代码改动' : '加载中…'}</p>
+        </div>
+      )}
+      {isGitRepo && hasAnyChanges && isEmpty && (
         <div className="flex flex-col items-center justify-center h-full text-muted-foreground p-4">
           <p className="text-[12px] text-center">没有匹配的文件</p>
         </div>
       )}
-      {!isEmpty && (
+      {isGitRepo && hasAnyChanges && !isEmpty && (
         <>
           {fileGroups.map((group) => {
             const isCollapsed = collapsedDirs.has(group.gitRoot)

--- a/apps/electron/src/renderer/components/diff/WorktreeSelector.tsx
+++ b/apps/electron/src/renderer/components/diff/WorktreeSelector.tsx
@@ -5,7 +5,8 @@ import type { WorktreeInfo, WorkspaceWorktreeRepo } from '@proma/shared'
 
 interface WorktreeSelectorProps {
   sessionId: string
-  workspaceSlug: string
+  workspaceSlug?: string
+  repoPaths?: string[]
   selectedPath: string | null
   onSelect: (worktree: WorktreeInfo | null) => void
 }
@@ -15,9 +16,18 @@ interface RepoWorktrees {
   worktrees: WorktreeInfo[]
 }
 
+function normalizePathKey(filePath: string): string {
+  return filePath.replace(/\\/g, '/').replace(/\/+$/, '')
+}
+
+function getPathBasename(filePath: string): string {
+  return normalizePathKey(filePath).split('/').filter(Boolean).pop() || filePath
+}
+
 export function WorktreeSelector({
   sessionId,
   workspaceSlug,
+  repoPaths,
   selectedPath,
   onSelect,
 }: WorktreeSelectorProps): React.ReactElement {
@@ -29,7 +39,28 @@ export function WorktreeSelector({
   const fetchWorktrees = React.useCallback(async () => {
     setIsLoading(true)
     try {
-      const repos = await window.electronAPI.getWorktreeRepos(workspaceSlug)
+      const repoMap = new Map<string, WorkspaceWorktreeRepo>()
+
+      if (workspaceSlug) {
+        const repos = await window.electronAPI.getWorktreeRepos(workspaceSlug)
+        for (const repo of repos) {
+          repoMap.set(normalizePathKey(repo.repoPath), repo)
+        }
+      }
+
+      for (const repoPath of repoPaths ?? []) {
+        if (!repoPath) continue
+        const key = normalizePathKey(repoPath)
+        if (repoMap.has(key)) continue
+        repoMap.set(key, {
+          name: getPathBasename(repoPath),
+          repoPath,
+          worktreesPath: '',
+          priority: 0,
+        })
+      }
+
+      const repos = Array.from(repoMap.values())
       if (repos.length === 0) {
         setRepoWorktrees([])
         return
@@ -53,7 +84,7 @@ export function WorktreeSelector({
     } finally {
       setIsLoading(false)
     }
-  }, [workspaceSlug, sessionId])
+  }, [workspaceSlug, repoPaths, sessionId])
 
   React.useEffect(() => {
     fetchWorktrees()

--- a/apps/electron/src/renderer/components/diff/WorktreeSelector.tsx
+++ b/apps/electron/src/renderer/components/diff/WorktreeSelector.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { GitBranch, ChevronDown, RefreshCw } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import type { WorktreeInfo, WorkspaceWorktreeRepo } from '@proma/shared'
+import { normalizePathForCompare } from '@proma/shared'
 
 interface WorktreeSelectorProps {
   sessionId: string
@@ -17,7 +18,7 @@ interface RepoWorktrees {
 }
 
 function normalizePathKey(filePath: string): string {
-  return filePath.replace(/\\/g, '/').replace(/\/+$/, '')
+  return normalizePathForCompare(filePath)
 }
 
 function getPathBasename(filePath: string): string {

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.12.5",
+      "version": "0.12.25",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.153",
         "@anthropic-ai/sdk": "^0.93.0",

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -24,3 +24,4 @@ export {
   formatThinkingSignatureError,
   normalizeThinkingSignatureError,
 } from './thinking-signature-error'
+export { normalizePathForCompare } from './normalize-path'

--- a/packages/shared/src/utils/normalize-path.ts
+++ b/packages/shared/src/utils/normalize-path.ts
@@ -1,0 +1,7 @@
+/**
+ * Normalize a file path for cross-platform comparison:
+ * backslashes → forward slashes, trailing slashes stripped.
+ */
+export function normalizePathForCompare(filePath: string): string {
+  return filePath.replace(/\\/g, '/').replace(/\/+$/, '')
+}


### PR DESCRIPTION
## Summary

Fixes the Agent right-side changes panel so it reflects the Git repositories and worktrees that the current session can actually access.

## What changed

- Discover worktree repositories from the session path, workspace files path, and attached directories instead of relying only on manually configured repos.
- Keep the worktree selector available even when the current session diff is empty, so users can switch to a session worktree.
- Filter stale/prunable worktrees and missing paths returned by Git metadata.
- Allow sibling worktrees when they belong to the same authorized main repository.
- Include attached files in diff scanning while keeping single-file attachments scoped to that file.
- Treat the changes list as `HEAD` to current worktree, covering staged and unstaged changes; revert now restores both index and worktree.
- Bump `@proma/electron` to `0.12.25`.

## Root cause

The panel was centered on `sessionPath` and manual workspace worktree config. That missed attached/session/workspace Git roots, hid worktree selection in empty states, and trusted stale worktree metadata returned by Git after directories were deleted.

## Validation

- `bun run --filter='@proma/electron' typecheck`
- `git diff --check`

Note: the temporary test file used during development was removed before this PR, per request.
