### PR TITLE
[codex] fix left sidebar action tooltip positioning

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.12.24",
+  "version": "0.12.25",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -2156,6 +2156,14 @@ function SafeTooltip({ children, content, side = 'top' }: SafeTooltipProps): Rea
   const triggerRef = React.useRef<HTMLButtonElement>(null)
   const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
 
+  const getUsableTriggerRect = React.useCallback((): DOMRect | null => {
+    const rect = triggerRef.current?.getBoundingClientRect()
+    if (!rect || rect.width === 0 || rect.height === 0) return null
+    if (rect.right <= 0 || rect.bottom <= 0) return null
+    if (rect.left >= window.innerWidth || rect.top >= window.innerHeight) return null
+    return rect
+  }, [])
+
   React.useEffect(() => {
     return () => {
       if (timerRef.current !== null) {
@@ -2176,26 +2184,28 @@ function SafeTooltip({ children, content, side = 'top' }: SafeTooltipProps): Rea
       return
     }
 
-    // trigger 还没完成布局时不打开
-    const rect = triggerRef.current?.getBoundingClientRect()
-    if (!rect || rect.width === 0 || rect.height === 0) {
-      return
-    }
+    // trigger 还没完成布局或已经离开视口时不打开。
+    if (!getUsableTriggerRect()) return
 
     setOpen(true)
     // 先让 Radix 完成 Popper 定位，再渲染 Content，避免看到 (0,0) 初始位置。
     timerRef.current = setTimeout(() => {
       timerRef.current = null
+      if (!getUsableTriggerRect()) {
+        setOpen(false)
+        setShowContent(false)
+        return
+      }
       setShowContent(true)
     }, 60)
-  }, [])
+  }, [getUsableTriggerRect])
 
   return (
     <Tooltip open={open} onOpenChange={handleOpenChange}>
       <TooltipTrigger asChild ref={triggerRef}>
         {children}
       </TooltipTrigger>
-      {showContent && <TooltipContent side={side}>{content}</TooltipContent>}
+      {showContent && <TooltipContent side={side} hideWhenDetached>{content}</TooltipContent>}
     </Tooltip>
   )
 }
@@ -2215,9 +2225,8 @@ function SessionItemActions({
   onMenuOpenChange,
 }: SessionItemActionsProps): React.ReactElement {
   const [archiveConfirming, setArchiveConfirming] = React.useState(false)
-  // 菜单打开时强制保持按钮组挂载且可见：否则鼠标移开后父级 group:hover 失效，
-  // 外层包装变 display:none，Radix Popper 拿不到 trigger 的位置矩形（getBoundingClientRect 全是 0），
-  // 浮层就漂到视口左上角 (0,0)。
+  // 菜单打开时强制保持按钮组可见：按钮始终保留布局，只切换透明度和 pointer-events。
+  // 这样 Radix Popper 不会在 hover 切换瞬间读到 display:none 的 0 尺寸 trigger。
   const [menuOpen, setMenuOpen] = React.useState(false)
 
   React.useEffect(() => {
@@ -2268,22 +2277,24 @@ function SessionItemActions({
 
   return (
     <div
-      className="flex-shrink-0 flex items-center h-[18px]"
+      className="relative flex-shrink-0 h-[18px] w-[58px]"
       onClick={(e) => e.stopPropagation()}
     >
       <span
         title={`最后更新：${new Date(updatedAt).toLocaleString('zh-CN')}`}
         className={cn(
-          'min-w-[42px] text-right text-[11px] leading-[18px] tabular-nums text-foreground/35',
-          forceVisible ? 'hidden' : 'group-hover:hidden',
+          'absolute inset-y-0 right-0 block w-full text-right text-[11px] leading-[18px] tabular-nums text-foreground/35 transition-opacity duration-100',
+          forceVisible ? 'opacity-0' : 'opacity-100 group-hover:opacity-0',
         )}
       >
         {formatRelativeUpdatedAt(updatedAt, relativeTimeNow)}
       </span>
       <div
         className={cn(
-          'items-center gap-0.5',
-          forceVisible ? 'flex' : 'hidden group-hover:flex',
+          'absolute right-0 top-0 flex items-center gap-0.5 transition-opacity duration-100',
+          forceVisible
+            ? 'opacity-100 pointer-events-auto'
+            : 'opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto',
         )}
       >
         <SafeTooltip content={pinned ? '取消置顶' : '置顶'} side="top">


### PR DESCRIPTION
## Summary

- Keep left-sidebar session action buttons mounted in layout and switch them with opacity/pointer-events instead of `display: none`.
- Harden `SafeTooltip` so it only opens when the trigger has a usable viewport rect, rechecks before showing content, and hides when detached.
- Bump `@proma/electron` from `0.12.24` to `0.12.25`.

## Root Cause

The Pin and Archive action buttons in the left sidebar were hidden with `display: none` until row hover. During fast hover/reflow transitions, Radix Popper could read a zero-sized trigger rect and briefly place the tooltip at the viewport origin.

## Validation

- `bun install`
- `bun run --cwd apps/electron typecheck`
- `git diff --check`