### PR TITLE
【已审核】fix(diff): 预览面板多项修复——非 git diff、自动换行、视图模式、滚动定位

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -113,7 +113,7 @@ import type {
 } from '@proma/shared'
 import type { UserProfile, AppSettings } from '../types'
 import { getRuntimeStatus, getGitRepoStatus, reinitializeRuntime } from './lib/runtime-init'
-import { getUnstagedChanges, getFileDiff, getUntrackedContent, revertFile, getDiffContents, listWorktrees, getWorktreeChanges, getMainRepoRoot } from './lib/git-diff-service'
+import { getUnstagedChanges, getFileDiff, getUntrackedContent, revertFile, getDiffContents, cacheFileBeforeWrite, listWorktrees, getWorktreeChanges, getMainRepoRoot } from './lib/git-diff-service'
 import { registerPromaFilePath } from './lib/local-file-protocol'
 import { registerUpdaterIpc } from './lib/updater/updater-ipc'
 import {
@@ -826,6 +826,15 @@ export function registerIpcHandlers(): void {
       }
 
       return getGitRepoStatus(dirPath)
+    }
+  )
+
+  // Agent 写入前缓存文件当前内容，供非 git 文件 diff 预览使用
+  ipcMain.handle(
+    IPC_CHANNELS.CACHE_PRE_WRITE_CONTENT,
+    async (_, filePath: string) => {
+      if (!filePath || typeof filePath !== 'string') return
+      cacheFileBeforeWrite(filePath)
     }
   )
 

--- a/apps/electron/src/main/lib/git-diff-service.ts
+++ b/apps/electron/src/main/lib/git-diff-service.ts
@@ -15,6 +15,9 @@ import type { ChangeSource, ChangedFileStatus } from '@proma/shared'
 /** 大文件读取上限：超过则跳过，避免 IPC 序列化撑爆内存 */
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024
 
+/** preWriteContentCache 最大条目数，超出后淘汰最早条目 */
+const MAX_CACHE_SIZE = 200
+
 /**
  * Agent 写入前的文件内容缓存 — keyed by 绝对路径。
  * 非 git 仓库的文件通过此缓存获得"旧版本"，在预览面板中显示 diff 而非纯语法高亮。
@@ -23,7 +26,7 @@ const preWriteContentCache = new Map<string, string>()
 
 /**
  * 在 Agent 写入文件前缓存其当前内容，供后续 getDiffContents 使用。
- * 文件不存在（新文件）时不缓存。
+ * 文件不存在（新文件）时不缓存。缓存超过上限时淘汰最早条目。
  */
 export function cacheFileBeforeWrite(filePath: string): void {
   try {
@@ -31,7 +34,14 @@ export function cacheFileBeforeWrite(filePath: string): void {
       const st = statSync(filePath)
       if (st.size <= MAX_FILE_SIZE_BYTES) {
         const content = readFileSync(filePath, 'utf-8')
+        // 先删再设，把当前路径推到 Map 末尾（最近使用），避免被 LRU 误淘汰
+        preWriteContentCache.delete(filePath)
         preWriteContentCache.set(filePath, normalizeLineEndings(content))
+        // LRU 淘汰：超过上限时删除最早插入的条目
+        if (preWriteContentCache.size > MAX_CACHE_SIZE) {
+          const oldest = preWriteContentCache.keys().next().value
+          if (oldest) preWriteContentCache.delete(oldest)
+        }
       }
     }
   } catch {

--- a/apps/electron/src/main/lib/git-diff-service.ts
+++ b/apps/electron/src/main/lib/git-diff-service.ts
@@ -49,11 +49,6 @@ export function cacheFileBeforeWrite(filePath: string): void {
   }
 }
 
-/** 清除指定文件的内容缓存 */
-export function clearCachedFileContent(filePath: string): void {
-  preWriteContentCache.delete(filePath)
-}
-
 /**
  * 归一化换行符为 LF。
  *

--- a/apps/electron/src/main/lib/git-diff-service.ts
+++ b/apps/electron/src/main/lib/git-diff-service.ts
@@ -16,6 +16,35 @@ import type { ChangeSource, ChangedFileStatus } from '@proma/shared'
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024
 
 /**
+ * Agent 写入前的文件内容缓存 — keyed by 绝对路径。
+ * 非 git 仓库的文件通过此缓存获得"旧版本"，在预览面板中显示 diff 而非纯语法高亮。
+ */
+const preWriteContentCache = new Map<string, string>()
+
+/**
+ * 在 Agent 写入文件前缓存其当前内容，供后续 getDiffContents 使用。
+ * 文件不存在（新文件）时不缓存。
+ */
+export function cacheFileBeforeWrite(filePath: string): void {
+  try {
+    if (existsSync(filePath)) {
+      const st = statSync(filePath)
+      if (st.size <= MAX_FILE_SIZE_BYTES) {
+        const content = readFileSync(filePath, 'utf-8')
+        preWriteContentCache.set(filePath, normalizeLineEndings(content))
+      }
+    }
+  } catch {
+    // 忽略读取失败
+  }
+}
+
+/** 清除指定文件的内容缓存 */
+export function clearCachedFileContent(filePath: string): void {
+  preWriteContentCache.delete(filePath)
+}
+
+/**
  * 归一化换行符为 LF。
  *
  * diff 两侧内容来源不同：旧版本来自 `git show`（读对象库 blob，换行符为 LF），
@@ -462,7 +491,9 @@ export async function getDiffContents(dirPath: string, filePath: string, gitRoot
         // 读取失败保持空字符串
       }
     }
-    return { oldContent: '', newContent: normalizeLineEndings(newContent) }
+    // 无 git root 时从缓存取旧版本，让非 git 文件也能显示 diff 前后对比
+    const cachedOld = fullPath ? preWriteContentCache.get(fullPath) : undefined
+    return { oldContent: cachedOld ?? '', newContent: normalizeLineEndings(newContent) }
   }
 
   const safePath = normalizeSafePath(root, filePath)

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -162,6 +162,8 @@ export interface ElectronAPI {
   revertFile: (input: import('@proma/shared').RevertFileInput) => Promise<void>
   /** 获取文件新旧版本内容 */
   getDiffContents: (input: import('@proma/shared').GetFileDiffInput) => Promise<{ oldContent: string; newContent: string } | null>
+  /** Agent 写入前缓存文件的当前内容（非 git 文件 diff 预览用） */
+  cachePreWriteContent: (filePath: string) => Promise<void>
   /** 列出 Git Worktree */
   listWorktrees: (repoPath: string, sessionId: string) => Promise<import('@proma/shared').WorktreeInfo[]>
   /** 获取 Worktree 相对于基准分支的全量变更 */
@@ -1068,6 +1070,10 @@ const electronAPI: ElectronAPI = {
 
   getDiffContents: (input: import('@proma/shared').GetFileDiffInput) => {
     return ipcRenderer.invoke(IPC_CHANNELS.GET_DIFF_CONTENTS, input)
+  },
+
+  cachePreWriteContent: (filePath: string) => {
+    return ipcRenderer.invoke(IPC_CHANNELS.CACHE_PRE_WRITE_CONTENT, filePath)
   },
 
   listWorktrees: (repoPath: string, sessionId: string) => {

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -297,8 +297,8 @@ export const agentSidePanelOpenMapAtom = atom<Map<string, boolean>>(new Map())
 /** 侧面板当前 Tab：'session' | 'workspace' | 'changes'（per-session Map） */
 export const agentDiffPanelTabAtom = atom<Map<string, 'session' | 'workspace' | 'changes'>>(new Map())
 
-/** Diff 视图模式：'split' | 'unified' */
-export const agentDiffViewModeAtom = atom<'split' | 'unified'>('split')
+/** Diff 视图模式：'split' | 'unified'，持久化 */
+export const agentDiffViewModeAtom = atomWithStorage<'split' | 'unified'>('proma-diff-view-mode', 'split')
 
 /** Diff 刷新版本号 — 按 session 隔离，Agent 写工具完成时递增 */
 export const agentDiffRefreshVersionAtom = atom(new Map<string, number>())

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -297,9 +297,6 @@ export const agentSidePanelOpenMapAtom = atom<Map<string, boolean>>(new Map())
 /** 侧面板当前 Tab：'session' | 'workspace' | 'changes'（per-session Map） */
 export const agentDiffPanelTabAtom = atom<Map<string, 'session' | 'workspace' | 'changes'>>(new Map())
 
-/** Diff 视图模式：'split' | 'unified' */
-export const agentDiffViewModeAtom = atom<'split' | 'unified'>('split')
-
 /** Diff 刷新版本号 — 按 session 隔离，Agent 写工具完成时递增 */
 export const agentDiffRefreshVersionAtom = atom(new Map<string, number>())
 

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -297,8 +297,8 @@ export const agentSidePanelOpenMapAtom = atom<Map<string, boolean>>(new Map())
 /** 侧面板当前 Tab：'session' | 'workspace' | 'changes'（per-session Map） */
 export const agentDiffPanelTabAtom = atom<Map<string, 'session' | 'workspace' | 'changes'>>(new Map())
 
-/** Diff 视图模式：'split' | 'unified'，持久化 */
-export const agentDiffViewModeAtom = atomWithStorage<'split' | 'unified'>('proma-diff-view-mode', 'split')
+/** Diff 视图模式：'split' | 'unified' */
+export const agentDiffViewModeAtom = atom<'split' | 'unified'>('split')
 
 /** Diff 刷新版本号 — 按 session 隔离，Agent 写工具完成时递增 */
 export const agentDiffRefreshVersionAtom = atom(new Map<string, number>())

--- a/apps/electron/src/renderer/components/diff/DetachedPreviewApp.tsx
+++ b/apps/electron/src/renderer/components/diff/DetachedPreviewApp.tsx
@@ -118,6 +118,7 @@ export function DetachedPreviewApp(): React.ReactElement {
           previewOnly={data.previewOnly}
           readOnly={data.readOnly}
           basePaths={data.basePaths}
+          preferredViewMode="split"
         />
       </div>
     </div>

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -12,7 +12,7 @@ import DOMPurify from 'dompurify'
 import { File as PierreFile } from '@pierre/diffs/react'
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
-import { agentDiffViewModeAtom, agentDiffRefreshVersionAtom } from '@/atoms/agent-atoms'
+import { agentDiffRefreshVersionAtom } from '@/atoms/agent-atoms'
 import { resolvedThemeAtom } from '@/atoms/theme'
 import { quotedSelectionMapAtom } from '@/atoms/preview-atoms'
 import { markdownTocOpenAtom } from '@/atoms/markdown-toc'
@@ -195,10 +195,12 @@ interface DiffTabContentProps {
   toolbarActions?: React.ReactNode
   /** 基准 ref（如 "origin/main"），用于 worktree vs main 模式 */
   baseRef?: string
+  /** 视图模式：Tab 预览传 'split'（分栏），侧边预览传 'unified'（统一） */
+  preferredViewMode?: 'split' | 'unified'
 }
 
-export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewOnly, readOnly, basePaths, onEmptyDiff, toolbarActions, baseRef }: DiffTabContentProps): React.ReactElement {
-  const [viewMode, setViewMode] = useAtom(agentDiffViewModeAtom)
+export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewOnly, readOnly, basePaths, onEmptyDiff, toolbarActions, baseRef, preferredViewMode = 'unified' }: DiffTabContentProps): React.ReactElement {
+  const viewMode = preferredViewMode
   const [oldContent, setOldContent] = React.useState('')
   const [newContent, setNewContent] = React.useState('')
   const [markdownEditing, setMarkdownEditing] = React.useState(false)
@@ -974,21 +976,9 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
         </span>
 
         {!previewOnly && (
-          <div
-            className="relative flex rounded-lg bg-muted p-0.5 shrink-0 ml-auto cursor-pointer select-none"
-            onClick={() => setViewMode((v) => v === 'split' ? 'unified' : 'split')}
-          >
-            <div
-              className={cn(
-                'absolute top-0.5 bottom-0.5 w-[calc(50%-2px)] rounded-md bg-background shadow-sm transition-transform duration-200 ease-in-out',
-                viewMode === 'split' ? 'translate-x-full' : 'translate-x-0',
-              )}
-            />
-            <span className={cn('relative z-[1] rounded-md px-2 py-0.5 text-[11px] font-medium transition-colors',
-              viewMode === 'unified' ? 'text-foreground' : 'text-muted-foreground')}>统一</span>
-            <span className={cn('relative z-[1] rounded-md px-2 py-0.5 text-[11px] font-medium transition-colors',
-              viewMode === 'split' ? 'text-foreground' : 'text-muted-foreground')}>分栏</span>
-          </div>
+          <span className="text-[10px] text-muted-foreground/40 ml-auto shrink-0">
+            {viewMode === 'unified' ? '统一视图' : '分栏视图'}
+          </span>
         )}
 
         {previewOnly && isEditableText && !readOnly && (

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -454,7 +454,8 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   const pierreOptions = React.useMemo(() => ({
     theme: { dark: 'one-dark-pro' as const, light: 'one-light' as const },
     disableFileHeader: true,
-    overflow: 'scroll' as const,
+    overflow: 'wrap' as const,
+    preferredHighlighter: 'shiki-wasm' as const,
     themeType: theme as 'light' | 'dark' | 'system',
     unsafeCSS: PIERRE_FILE_CSS,
   }), [theme])
@@ -755,6 +756,28 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     }
   }, [loading, scrollKey])
 
+  // SCROLL to first diff change after content loads in diff mode
+  const scrolledToChangeRef = React.useRef<string | null>(null)
+  React.useEffect(() => {
+    if (previewOnly || loading || !oldContent || !newContent) return
+    if (oldContent === newContent) return
+    // Track by file path + content hash to re-scroll when switching files
+    const contentKey = `${filePath}:${oldContent.length}:${newContent.length}`
+    if (scrolledToChangeRef.current === contentKey) return
+    scrolledToChangeRef.current = contentKey
+    const raf = requestAnimationFrame(() => {
+      const container = scrollContainerRef.current
+      if (!container) return
+      const firstChange = container.querySelector<HTMLElement>(
+        '[data-line-type="change-addition"], [data-line-type="change-deletion"]'
+      )
+      if (firstChange) {
+        firstChange.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+      }
+    })
+    return () => cancelAnimationFrame(raf)
+  }, [previewOnly, loading, oldContent, newContent, filePath])
+
   // SAVE scroll position on scroll (throttled via rAF)
   const scrollRafRef = React.useRef(0)
   const handleScroll = React.useCallback(() => {
@@ -958,13 +981,13 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
             <div
               className={cn(
                 'absolute top-0.5 bottom-0.5 w-[calc(50%-2px)] rounded-md bg-background shadow-sm transition-transform duration-200 ease-in-out',
-                viewMode === 'unified' ? 'translate-x-full' : 'translate-x-0',
+                viewMode === 'split' ? 'translate-x-full' : 'translate-x-0',
               )}
             />
             <span className={cn('relative z-[1] rounded-md px-2 py-0.5 text-[11px] font-medium transition-colors',
-              viewMode === 'split' ? 'text-foreground' : 'text-muted-foreground')}>分栏</span>
-            <span className={cn('relative z-[1] rounded-md px-2 py-0.5 text-[11px] font-medium transition-colors',
               viewMode === 'unified' ? 'text-foreground' : 'text-muted-foreground')}>统一</span>
+            <span className={cn('relative z-[1] rounded-md px-2 py-0.5 text-[11px] font-medium transition-colors',
+              viewMode === 'split' ? 'text-foreground' : 'text-muted-foreground')}>分栏</span>
           </div>
         )}
 

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -753,8 +753,14 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     restoreScrollRef.current = false
     const pos = scrollPositionCache.get(scrollKey)
     if (pos && scrollContainerRef.current) {
-      scrollContainerRef.current.scrollTop = pos.top
-      scrollContainerRef.current.scrollLeft = pos.left
+      // 等待一帧确保 @pierre/diffs Shiki 异步 tokenize 完成，容器高度稳定后再恢复
+      const raf = requestAnimationFrame(() => {
+        if (scrollContainerRef.current) {
+          scrollContainerRef.current.scrollTop = pos.top
+          scrollContainerRef.current.scrollLeft = pos.left
+        }
+      })
+      return () => cancelAnimationFrame(raf)
     }
   }, [loading, scrollKey])
 

--- a/apps/electron/src/renderer/components/diff/DiffView.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffView.tsx
@@ -58,7 +58,8 @@ export const DiffView = React.memo(function DiffView({ oldContent, newContent, f
     diffIndicators: 'bars' as const,
     hunkSeparators: 'line-info' as const,
     lineDiffType: 'none' as const,
-    overflow: 'scroll' as const,
+    overflow: 'wrap' as const,
+    preferredHighlighter: 'shiki-wasm' as const,
     themeType: theme as 'light' | 'dark' | 'system',
     unsafeCSS: `
       :root, :host {

--- a/apps/electron/src/renderer/components/diff/PreviewPanel.tsx
+++ b/apps/electron/src/renderer/components/diff/PreviewPanel.tsx
@@ -187,6 +187,7 @@ export function PreviewPanel({ sessionId }: PreviewPanelProps): React.ReactEleme
             readOnly={currentFile.readOnly}
             basePaths={currentFile.basePaths}
             baseRef={currentFile.baseRef}
+            preferredViewMode="unified"
             onEmptyDiff={handleClosePanel}
           />
         ) : (

--- a/apps/electron/src/renderer/components/diff/PreviewTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/PreviewTabContent.tsx
@@ -121,6 +121,7 @@ export function PreviewTabContent({ sessionId }: PreviewTabContentProps): React.
           readOnly={currentFile.readOnly}
           basePaths={currentFile.basePaths}
           baseRef={currentFile.baseRef}
+          preferredViewMode="split"
           toolbarActions={toolbarActions}
         />
       </div>

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -712,6 +712,8 @@ export function useGlobalAgentListeners(): void {
               if (store.get(autoPreviewEnabledAtom)) {
                 setAutoPreviewFile(sessionId, targetPath, false)
               }
+              // 缓存文件当前内容，供非 git 文件的 diff 预览使用
+              window.electronAPI.cachePreWriteContent(targetPath).catch(() => {})
             }
           }
 

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -504,6 +504,23 @@ export function useGlobalAgentListeners(): void {
         }
       }
 
+      // 回退检测：dirPath 未检测到 git 时，尝试 basePaths 中的路径
+      // 解决 agent session 目录非 git 但托管项目在 git 中时预览不显示 diff 的问题
+      if (previewOnly) {
+        for (const bp of basePaths) {
+          if (!bp) continue
+          try {
+            const status = await window.electronAPI.getGitRepoStatus(bp)
+            if (status?.isRepo === true) {
+              previewOnly = false
+              break
+            }
+          } catch {
+            continue
+          }
+        }
+      }
+
       // 检查文件是否落在当前会话的 diff scope 内（与 getUnstagedChanges 的 candidates 对齐）
       // 注：未纳入 dirPath，因为 DiffChangesList 调用时 dirPath 始终等于 sessionPath
       // 路径分隔符统一为正斜杠，避免 Windows 下 client 与服务端（path.sep='\\'）方向不一致导致反向错配

--- a/packages/shared/src/types/runtime.ts
+++ b/packages/shared/src/types/runtime.ts
@@ -354,6 +354,8 @@ export const IPC_CHANNELS = {
   LIST_WORKTREES: 'git:list-worktrees',
   /** 获取 Worktree 相对于基准分支的全量变更 */
   GET_WORKTREE_CHANGES: 'git:get-worktree-changes',
+  /** 缓存文件在 Agent 写入前的当前内容，供非 git 文件 diff 预览使用 */
+  CACHE_PRE_WRITE_CONTENT: 'git:cache-pre-write-content',
   /** 在系统默认浏览器中打开外部链接 */
   OPEN_EXTERNAL: 'shell:open-external',
   /** 用系统默认应用打开任意文件 */


### PR DESCRIPTION
## 概述

本次 PR 集中修复了 Agent diff 预览面板中的多项问题，覆盖 11 个文件：

**1. 非 git 文件的 diff 预览支持**（核心改进）
之前 Agent 操作非 git 仓库的文件时，预览面板只显示纯语法高亮，无法展示修改前后的对比 diff。原因是 getDiffContents 在无 git root 时仅返回空 oldContent。现引入 preWriteContentCache——在 Agent 写入文件前通过新的 IPC 通道 CACHE_PRE_WRITE_CONTENT 缓存文件当前内容，使非 git 文件的 diff 预览也能展示完整的前后对比。同时增加 git repo 回退检测：当 session 目录非 git 但 basePaths 中存在 git 仓库时，自动启用 diff 模式。

**2. 视图模式自动选择**
移除全局 agentDiffViewModeAtom，改为通过 preferredViewMode prop 传入：Tab 预览页使用 split（分栏），侧边预览面板使用 unified（统一）。移除了切换按钮，改为只读标签。

**3. 自动滚动到首个 diff 变更**
内容加载完成后，使用 requestAnimationFrame 查找第一个 data-line-type 为 change-addition/change-deletion 的 DOM 元素并 scrollIntoView。通过 contentKey（文件路径+内容长度）去重，避免重复滚动。

**4. 自动换行与高亮器优化**
DiffTabContent 和 DiffView 的 overflow 从 scroll 改为 wrap，避免长行代码水平滚动影响可读性。显式指定 preferredHighlighter: shiki-wasm 确保高亮器一致性。

**5. 审查修复（d10b10d）**
- 移除不再使用的 agentDiffViewModeAtom 死代码
- preWriteContentCache 加入 200 条 LRU 上限，超限自动淘汰最早条目
- 滚动位置恢复包 requestAnimationFrame 延迟一帧，等 Shiki 异步 tokenize 完成后再定位

## 改动

- packages/shared/src/types/runtime.ts — 新增 CACHE_PRE_WRITE_CONTENT IPC 通道常量
- apps/electron/src/main/lib/git-diff-service.ts — 新增 preWriteContentCache 缓存（含 LRU 淘汰）+ cacheFileBeforeWrite/clearCachedFileContent
- apps/electron/src/main/ipc.ts — 注册 cachePreWriteContent IPC 处理器
- apps/electron/src/preload/index.ts — contextBridge 暴露 cachePreWriteContent 方法
- apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts — Agent 写入前缓存文件内容 + git repo 回退检测
- apps/electron/src/renderer/atoms/agent-atoms.ts — 移除废弃的 agentDiffViewModeAtom
- apps/electron/src/renderer/components/diff/DiffTabContent.tsx — viewMode 改为 prop + overflow wrap + auto-scroll + 滚动恢复加帧延迟 + 移除切换按钮
- apps/electron/src/renderer/components/diff/DiffView.tsx — overflow wrap + preferredHighlighter
- apps/electron/src/renderer/components/diff/PreviewPanel.tsx — preferredViewMode=unified
- apps/electron/src/renderer/components/diff/PreviewTabContent.tsx — preferredViewMode=split
- apps/electron/src/renderer/components/diff/DetachedPreviewApp.tsx — preferredViewMode=split

## 测试

- 验证 git 仓库文件的 diff 预览：分栏视图正常，滚动自动定位到首个变更行
- 验证非 git 文件修改后预览：展示 old vs new 前后对比 diff
- 验证长代码行自动换行：不再出现水平滚动条
- 验证 Tab 预览和侧边预览视图模式各自正确（Tab分栏/侧边统一）
- 验证 session 目录非 git 但 basePaths 含 git 仓库时，预览自动启用 diff 模式
- 验证切换文件后滚动位置准确恢复

## 紧急度

低

## 备注

关联 PR #867（滚动位置错位修复）。视图模式切换按钮移除后，用户仍可通过侧边 vs Tab 预览间接控制视图布局。