### PR TITLE
fix(preview): atomWithStorage 加 getOnInit 修复重启后分屏偏好失效【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/atoms/preview-atoms.ts
+++ b/apps/electron/src/renderer/atoms/preview-atoms.ts
@@ -36,10 +36,10 @@ export const previewPanelOpenMapAtom = atom<Map<string, boolean>>(new Map())
 export const previewFileMapAtom = atom<Map<string, PreviewFile | null>>(new Map())
 
 /** 分栏比例（对话占比），持久化 */
-export const previewSplitRatioAtom = atomWithStorage<number>('proma-preview-split-ratio', 0.5)
+export const previewSplitRatioAtom = atomWithStorage<number>('proma-preview-split-ratio', 0.5, undefined, { getOnInit: true })
 
 /** 自动预览开关，持久化（默认关闭以减轻设备性能负担，老用户保留已设置的偏好） */
-export const autoPreviewEnabledAtom = atomWithStorage<boolean>('proma-auto-preview-enabled', false)
+export const autoPreviewEnabledAtom = atomWithStorage<boolean>('proma-auto-preview-enabled', false, undefined, { getOnInit: true })
 
 /**
  * 预览默认展开方式，持久化。
@@ -52,6 +52,8 @@ export type PreviewModePreference = 'tab' | 'split'
 export const previewModePreferenceAtom = atomWithStorage<PreviewModePreference>(
   'proma-preview-mode-pref',
   'tab',
+  undefined,
+  { getOnInit: true },
 )
 
 /** 当前会话的预览面板是否打开（derived） */


### PR DESCRIPTION
## 概述

修复 Agent 预览展开方式（侧边分屏/标签页）在重启 Proma 后失效的 bug：虽然设置 UI 显示正确，但实际行为退回到默认值 `tab`，必须重新切换设置才能生效。

**根因：** Jotai `atomWithStorage` 默认采用懒初始化策略——原子创建时使用默认值，`onMount`（首次被 React 组件通过 `useAtom`/`useAtomValue` 订阅）时才从 localStorage 读取真实值。但 `useOpenPreview()` 和 `useGlobalAgentListeners` 通过 `store.get()` 读取偏好值，不触发 `onMount`。而唯一订阅 `previewModePreferenceAtom` 的 `AppearanceSettings` 组件位于设置面板的「外观」标签页，仅在用户主动导航到外观设置时才挂载。因此 App 启动后到用户打开外观设置之间，原子始终返回默认值 `'tab'`。

**修复：** 给 `preview-atoms.ts` 中三个 `atomWithStorage` 调用统一加上 `{ getOnInit: true }`（Jotai 2.1.0+ 支持），使原子在创建时立即从 localStorage 读取，无需等待组件订阅。

## 改动

- `apps/electron/src/renderer/atoms/preview-atoms.ts` — `previewSplitRatioAtom`、`autoPreviewEnabledAtom`、`previewModePreferenceAtom` 三个 `atomWithStorage` 调用加上 `{ getOnInit: true }`

## 测试方法

1. 在 Proma 外观设置中将「Agent 预览展开方式」设为「侧边分屏」
2. 完全退出并重启 Proma
3. 在 Agent 会话中点击任意文件路径 chip 或工具结果的「预览」按钮
4. 预期：预览在右侧分屏打开（而非标签页）
5. 验证：无需打开外观设置，偏好直接生效

## 备注

- `getOnInit` 在 Jotai 2.1.0 引入，当前依赖 `jotai@^2.17.1` 完全兼容
- 同时修复了 `autoPreviewEnabledAtom` 的同理问题（在 `useGlobalAgentListeners` 中通过 `store.get()` 读取，始终不触发 `onMount`）
- `previewSplitRatioAtom` 当前仅通过 `useAtom` 读取，加 `getOnInit` 为防御性加固