### PR TITLE
fix(ui): 移除文件面板打开按钮的呼吸灯提示【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -26,7 +26,6 @@ import {
   currentAgentSessionIdAtom,
   currentAgentWorkspaceIdAtom,
   unviewedCompletedSessionIdsAtom,
-  workspaceFilesVersionAtom,
 } from '@/atoms/agent-atoms'
 import { appModeAtom } from '@/atoms/app-mode'
 import { automationFormAtom } from '@/atoms/automation-atoms'
@@ -407,7 +406,7 @@ function TabBarInner({
   )
 }
 
-/** 打开 Agent 文件面板按钮：独立订阅 workspaceFilesVersionAtom，避免文件变更时重渲染整个 TabBar。 */
+/** 打开 Agent 文件面板按钮。 */
 function AgentPanelOpenButton({
   isWindows,
   onToggle,
@@ -415,9 +414,6 @@ function AgentPanelOpenButton({
   isWindows: boolean
   onToggle: () => void
 }): React.ReactElement {
-  const filesVersion = useAtomValue(workspaceFilesVersionAtom)
-  const hasFileChanges = filesVersion > 0
-
   return (
     <div
       className={cn(
@@ -435,9 +431,6 @@ function AgentPanelOpenButton({
             onClick={onToggle}
           >
             <PanelRight className="size-3.5" />
-            {hasFileChanges && (
-              <span className="absolute -top-0.5 -right-0.5 size-2 rounded-full bg-primary animate-pulse" />
-            )}
           </Button>
         </TooltipTrigger>
         <TooltipContent side="bottom">


### PR DESCRIPTION
## 概述

移除 TabBar 右上角文件面板打开按钮（PanelRight 图标）的脉冲呼吸灯圆点。之前当工作区文件有变更时，按钮上方会显示一个 `animate-pulse` 的蓝色小圆点，现完全移除该提示。

## 改动

- `apps/electron/src/renderer/components/tabs/TabBar.tsx` — 删除 `AgentPanelOpenButton` 中的呼吸灯 `<span>` 元素（`absolute animate-pulse rounded-full` 圆点），同步清理 `workspaceFilesVersionAtom` 导入和 `hasFileChanges` 变量

## 测试方法

1. 进入 Agent 模式，确认文件面板关闭（右侧无面板）
2. 对工作区文件进行增删改操作
3. 观察 TabBar 右上角的文件面板打开按钮 — 不再显示脉冲圆点
4. 按钮 tooltip 和点击打开面板功能正常

## 备注

- 纯 UI 删除，不影响功能
- `workspaceFilesVersionAtom` 仍在 `FileBrowser.tsx`、`SidePanel.tsx` 等处正常使用