### PR TITLE
fix(theme): 修复 Terminal 主题下 Read 行号叠影与长消息折叠按钮压字【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/agent/tool-result-renderers/pierre-styles.ts
+++ b/apps/electron/src/renderer/components/agent/tool-result-renderers/pierre-styles.ts
@@ -126,8 +126,12 @@ export function createPierreFileCSS(lineNumberStart: number, maxLineNumber: numb
     [data-gutter] {
       counter-reset: proma-read-line ${safeStart - 1};
     }
+    /* color: transparent 隐藏 Pierre 自带的相对行号；
+     * text-shadow: none 阻断 Terminal 主题的 CRT 辉光继承——否则
+     * transparent 文字会被 text-shadow 画出模糊轮廓，与 ::before 真实行号叠加。 */
     [data-line-number-content] {
       color: transparent !important;
+      text-shadow: none !important;
     }
     [data-line-number-content]::before {
       counter-increment: proma-read-line;

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -1982,6 +1982,15 @@
   background: transparent !important;
 }
 
+/* 折叠态长消息的"展开全部"按钮：默认 absolute + 渐变遮罩在 Terminal 主题下失效
+ * （父容器 padding:0 撤掉了为按钮预留的 pb-6，渐变也被透明化），
+ * 会让按钮文字直接压在正文最后一行上。改为流式布局，让按钮自然落到正文下方。 */
+.theme-terminal-dark .is-user button[class*="bg-gradient-to-t"] {
+  position: static !important;
+  padding: 0 !important;
+  margin-top: 0.25rem !important;
+}
+
 /* AI 消息前缀 — 已移除 */
 
 /* 终端格式时间戳 — [MM/DD HH:MM] 方括号包裹 */


### PR DESCRIPTION
## 概述

修复 Terminal 主题（CRT 终端风格）下两个 UI 显示问题：

1. **代码行号叠影**：Agent 用 Read 工具读文件、且为 partial read（如从第 221 行开始）时，每个真实行号后面叠加一个模糊的相对行号（如 `221` 后面叠了一个模糊 `1`，看起来像 `2211`）。
2. **长消息折叠按钮压字**：用户发送的长消息折叠后，"展开全部" 按钮直接覆盖在正文最后一行上，与正文文字重叠。

两个问题都只出现在 Terminal 主题，其它主题（默认 light/dark、ocean、slate、forest 等）无影响。

## 根因分析

### 问题 1：行号叠影

`@pierre/diffs` 的 File 组件在 Shadow DOM 内把行号渲染为 `<span data-line-number-content>1</span>`（基于 contents 的相对行号）。Proma 用 `color: transparent` 隐藏它，再用 `::before` + CSS counter 显示真实文件行号（如 `221`）。

但 Terminal 主题给 `.text-foreground` / `[class*="text-foreground"]` 应用了 CRT 辉光 `text-shadow`，而 **`text-shadow` 是可继承 CSS 属性**，跨 Shadow Boundary 也会继承到 `[data-line-number-content]`。`color: transparent` 让文字本身不可见，但 `text-shadow` 仍把文字的"模糊轮廓"画了出来——于是真实行号 `221` 后面就叠了一个模糊的 `1`、`222` 后面叠 `2`，依此类推。

### 问题 2：折叠按钮压字

折叠态下 `UserMessageContent` 组件的设计是：

- 父容器加 `pb-6` 给按钮腾位
- 按钮 `absolute bottom-0` + `bg-gradient-to-t from-primary/10 to-transparent` 渐变遮罩浮在底部

Terminal 主题为去气泡化加了规则：
```css
.theme-terminal-dark .is-user [class*="bg-primary/10"] {
  padding: 0 !important;
}
.theme-terminal-dark .is-user [class*="bg-gradient-to-t"] {
  background: transparent !important;
}
```

这两条规则的副作用是：父容器的 `pb-6` 被清空 + 按钮渐变遮罩透明化。按钮 `absolute bottom-0` 失去视觉缓冲，文字直接压在正文最后一行上。

## 改动

- `apps/electron/src/renderer/components/agent/tool-result-renderers/pierre-styles.ts` — `createPierreFileCSS()` 中给 `[data-line-number-content]` 追加 `text-shadow: none !important`，阻断 Terminal CRT 辉光跨 Shadow DOM 继承。仅在 partial read（safeStart > 1）路径注入；safeStart === 1 时本来就不隐藏原始行号，无需修复。
- `apps/electron/src/renderer/styles/globals.css` — Terminal 主题用户消息样式块新增一条规则，把 `.is-user button[class*="bg-gradient-to-t"]` 从 `absolute` 改为 `static`，配合 `padding: 0` + `margin-top: 0.25rem` 让按钮在 flow 布局里自然落到正文下方，避免叠字。保留了既有"去气泡化"的 Terminal 视觉风格。

合计 +13 行 CSS（含注释），无业务逻辑变更，类型检查全部 PASS。

## 测试方法

1. 切换到 **Terminal Dark** 主题（设置 → 外观 → 特殊风格 → 旧屏微光）。
2. **验证行号修复**：让 Agent 用 Read 工具读取一个文件的 partial 段（例如 `Read file_path offset=140`），观察行号区。
   - **预期**：左侧行号只显示真实行号（140、141、142…），不再有模糊的相对行号 1、2、3 叠加在后面。
3. **验证折叠按钮修复**：在 Agent 模式下发送一条很长的多行消息（超过 4 行），等消息发送后被折叠。
   - **预期**："展开全部 (xxx 字符, N 行)" 按钮出现在正文下方，与正文之间有清晰间隔，不与正文文字重叠。
   - 点击展开后按钮变成"收起"，仍在正文下方。
4. 切回默认 Dark 主题，重复上述步骤，确认其它主题表现不变。

## 备注

- 修复不引入新依赖，纯 CSS 调整。
- 未 bump `apps/electron/package.json` 的 patch 版本，按需由维护者决定是否在合入时一并升版本和补 release notes。
- 已通过 `bun run typecheck`，4 个 workspace 包全部 Exited with code 0。