### PR TITLE
feat(input): 新增「输入框 Markdown 渲染」开关【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.12.26",
+  "version": "0.12.27",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/atoms/ui-preferences.ts
+++ b/apps/electron/src/renderer/atoms/ui-preferences.ts
@@ -1,7 +1,7 @@
 /**
  * UI 偏好设置状态管理
  *
- * 管理用户界面相关的显示偏好，如悬浮置顶条等。
+ * 管理用户界面相关的显示偏好，如悬浮置顶条、输入框 Markdown 渲染等。
  */
 
 import { atom } from 'jotai'
@@ -11,17 +11,22 @@ import { atom } from 'jotai'
 /** 是否显示用户消息悬浮置顶条 */
 export const stickyUserMessageEnabledAtom = atom<boolean>(true)
 
+/** 输入框是否渲染 Markdown（关闭后粘贴保留纯文本、禁用输入快捷格式） */
+export const richTextInputRenderingEnabledAtom = atom<boolean>(true)
+
 // ===== 初始化 =====
 
 /**
  * 从主进程加载 UI 偏好设置
  */
 export async function initializeUiPreferences(
-  setStickyUserMessageEnabled: (enabled: boolean) => void
+  setStickyUserMessageEnabled: (enabled: boolean) => void,
+  setRichTextInputRenderingEnabled: (enabled: boolean) => void,
 ): Promise<void> {
   try {
     const settings = await window.electronAPI.getSettings()
     setStickyUserMessageEnabled(settings.stickyUserMessageEnabled ?? true)
+    setRichTextInputRenderingEnabled(settings.richTextInputRenderingEnabled ?? true)
   } catch (error) {
     console.error('[UI偏好] 初始化失败:', error)
   }
@@ -37,5 +42,16 @@ export async function updateStickyUserMessageEnabled(enabled: boolean): Promise<
     await window.electronAPI.updateSettings({ stickyUserMessageEnabled: enabled })
   } catch (error) {
     console.error('[UI偏好] 更新悬浮置顶条设置失败:', error)
+  }
+}
+
+/**
+ * 更新输入框 Markdown 渲染开关并持久化
+ */
+export async function updateRichTextInputRenderingEnabled(enabled: boolean): Promise<void> {
+  try {
+    await window.electronAPI.updateSettings({ richTextInputRenderingEnabled: enabled })
+  } catch (error) {
+    console.error('[UI偏好] 更新输入框 Markdown 渲染设置失败:', error)
   }
 }

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -14,6 +14,7 @@
  */
 
 import { useState, useEffect, useRef, useMemo } from 'react'
+import { useAtomValue } from 'jotai'
 import { useEditor, EditorContent } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import Placeholder from '@tiptap/extension-placeholder'
@@ -26,6 +27,7 @@ import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip
 import { cn } from '@/lib/utils'
 import { lowlight } from '@/lib/lowlight'
 import { htmlToMarkdown } from '@/lib/markdown-rich-text'
+import { richTextInputRenderingEnabledAtom } from '@/atoms/ui-preferences'
 import { createFileMentionSuggestion } from '@/components/file-browser/file-mention-suggestion'
 import { createSkillMentionSuggestion, createMcpMentionSuggestion, createSessionMentionSuggestion } from '@/components/agent/mention-suggestions'
 import {
@@ -174,6 +176,10 @@ export function RichTextInput({
   // 发送模式引用
   const sendWithCmdEnterRef = useRef(sendWithCmdEnter)
   sendWithCmdEnterRef.current = sendWithCmdEnter
+  // 输入框 Markdown 渲染开关（用户偏好）：关闭后粘贴保留纯文本、禁用 TipTap input/paste rules
+  const markdownRenderingEnabled = useAtomValue(richTextInputRenderingEnabledAtom)
+  const markdownRenderingEnabledRef = useRef(markdownRenderingEnabled)
+  markdownRenderingEnabledRef.current = markdownRenderingEnabled
   // Mention 活跃状态（阻止 Enter 发送消息）
   const mentionActiveRef = useRef(false)
   // Mention 弹窗中的可选项数量（0 时 Enter 不阻塞发送）
@@ -225,6 +231,9 @@ export function RichTextInput({
   )
 
   const editor = useEditor({
+    // 关闭 Markdown 渲染时，禁用输入/粘贴的格式自动识别规则
+    enableInputRules: markdownRenderingEnabled,
+    enablePasteRules: markdownRenderingEnabled,
     extensions: [
       StarterKit.configure({
         codeBlock: false, // 使用 CodeBlockLowlight 替代
@@ -351,6 +360,33 @@ export function RichTextInput({
 
         const threshold = longTextPasteThresholdRef.current
         const plainText = event.clipboardData?.getData('text/plain') ?? ''
+
+        // 关闭 Markdown 渲染：直接插入原始纯文本，不做 HTML → Markdown 转换
+        if (!markdownRenderingEnabledRef.current) {
+          // 超长文本附件路径仍然生效（按纯文本长度判断）
+          if (
+            threshold &&
+            threshold > 0 &&
+            plainText.length >= threshold &&
+            onPasteLongTextRef.current
+          ) {
+            event.preventDefault()
+            onPasteLongTextRef.current(plainText)
+            return true
+          }
+          event.preventDefault()
+          // 按行拆分为多个 paragraph 节点（JSON 形式直接构造，绕开 HTML 解析的空白规范化）。
+          // 空行 → 空 paragraph，连续空格、缩进、空行全部保留。
+          const lines = plainText.replace(/\r\n?/g, '\n').split('\n')
+          const paragraphs = lines.map((line) => (
+            line.length > 0
+              ? { type: 'paragraph', content: [{ type: 'text', text: line }] }
+              : { type: 'paragraph' }
+          ))
+          editor?.chain().focus().insertContent(paragraphs).run()
+          return true
+        }
+
         const html = event.clipboardData?.getData('text/html') ?? ''
         // 预处理 HTML：将 <div> 替换为 <p>，避免 htmlToMarkdown 对 <div> 不分段导致换行丢失
         const text = html
@@ -502,7 +538,7 @@ export function RichTextInput({
         })
       }
     },
-  })
+  }, [markdownRenderingEnabled])
 
   // 卸载时取消未触发的 rAF 行数检查，避免泄漏 / 在卸载组件上 setState
   useEffect(() => {

--- a/apps/electron/src/renderer/components/settings/GeneralSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/GeneralSettings.tsx
@@ -40,6 +40,8 @@ import {
 import {
   stickyUserMessageEnabledAtom,
   updateStickyUserMessageEnabled,
+  richTextInputRenderingEnabledAtom,
+  updateRichTextInputRenderingEnabled,
 } from '@/atoms/ui-preferences'
 import { cn } from '@/lib/utils'
 import { Button } from '../ui/button'
@@ -61,6 +63,7 @@ export function GeneralSettings(): React.ReactElement {
   const [notificationSoundEnabled, setNotificationSoundEnabled] = useAtom(notificationSoundEnabledAtom)
   const [notificationSounds, setNotificationSounds] = useAtom(notificationSoundsAtom)
   const [stickyUserMessageEnabled, setStickyUserMessageEnabled] = useAtom(stickyUserMessageEnabledAtom)
+  const [richTextInputRenderingEnabled, setRichTextInputRenderingEnabled] = useAtom(richTextInputRenderingEnabledAtom)
   const [isEditingName, setIsEditingName] = React.useState(false)
   const [nameInput, setNameInput] = React.useState(userProfile.userName)
   const [showEmojiPicker, setShowEmojiPicker] = React.useState(false)
@@ -317,6 +320,15 @@ export function GeneralSettings(): React.ReactElement {
             onCheckedChange={(checked) => {
               setStickyUserMessageEnabled(checked)
               updateStickyUserMessageEnabled(checked)
+            }}
+          />
+          <SettingsToggle
+            label="输入框 Markdown 渲染"
+            description="关闭后，粘贴文本保留原始 Markdown 字符（如 **、# 等），不再实时渲染为富文本"
+            checked={richTextInputRenderingEnabled}
+            onCheckedChange={(checked) => {
+              setRichTextInputRenderingEnabled(checked)
+              updateRichTextInputRenderingEnabled(checked)
             }}
           />
         </SettingsCard>

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -48,6 +48,7 @@ import {
 } from './atoms/notifications'
 import {
   stickyUserMessageEnabledAtom,
+  richTextInputRenderingEnabledAtom,
   initializeUiPreferences,
 } from './atoms/ui-preferences'
 import {
@@ -410,14 +411,15 @@ function DockBadgeInitializer(): null {
 /**
  * UI 偏好初始化组件
  *
- * 从主进程加载 UI 偏好设置（悬浮置顶条等）。
+ * 从主进程加载 UI 偏好设置（悬浮置顶条、输入框 Markdown 渲染等）。
  */
 function UiPreferencesInitializer(): null {
   const setStickyUserMessageEnabled = useSetAtom(stickyUserMessageEnabledAtom)
+  const setRichTextInputRenderingEnabled = useSetAtom(richTextInputRenderingEnabledAtom)
 
   useEffect(() => {
-    initializeUiPreferences(setStickyUserMessageEnabled)
-  }, [setStickyUserMessageEnabled])
+    initializeUiPreferences(setStickyUserMessageEnabled, setRichTextInputRenderingEnabled)
+  }, [setStickyUserMessageEnabled, setRichTextInputRenderingEnabled])
 
   return null
 }

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -226,6 +226,8 @@ export interface AppSettings {
   shortcutOverrides?: ShortcutOverrides
   /** 是否显示用户消息悬浮置顶条（默认 true） */
   stickyUserMessageEnabled?: boolean
+  /** 输入框是否渲染 Markdown（默认 true；关闭后粘贴保留纯文本、禁用输入快捷格式） */
+  richTextInputRenderingEnabled?: boolean
   /** Markdown 预览字号档位（默认 'medium'，对应 15px） */
   markdownFontSize?: MarkdownFontSize
   /** 上次是否在 Scratch Pad 页（用于重启恢复） */


### PR DESCRIPTION
## 背景

有用户反馈：当他们复制一段 Markdown 文本粘贴到 Proma 的输入框，TipTap 会立刻把 `**bold**`、`# 标题`、`- 列表` 等渲染成对应的富文本节点——粘贴进来的是「看起来已经排好版的样子」而不是原始 Markdown 字符，**无法二次编辑这些 Markdown 标记本身**。

很多场景下用户希望先在输入框里**逐字面修改**原始 Markdown 文本（修标题层级、调整列表项、改某个加粗位置），再发送出去；现有的实时渲染让这件事变得很困难。

本 PR 提供一个全局开关，关闭后输入框退回到「纯文本编辑」语义：粘贴保留原始字符、手打的 Markdown 快捷格式也不再被自动识别，把「输入框作为 Markdown 编辑器」的能力交还给用户。
## 概述

在「设置 → 通用设置」新增一个开关「输入框 Markdown 渲染」（默认开启，保持现状）。关闭后，输入框（基于 TipTap 富文本编辑器的 `RichTextInput`）将不再实时渲染粘贴的 Markdown 富文本，也不再把手打的 `**bold**`、`# 标题`、`- 列表` 等实时转格式，让用户能看到字面字符并直接编辑——解决"从外部复制粘贴 Markdown 文本进输入框后无法二次编辑"的痛点。

开关持久化到 `~/.proma/settings.json`，作用于全部三处 `RichTextInput` 调用点（ChatInput、AgentView、ScratchPad），通过组件内 `useAtomValue` 自动同步，调用点零改动。

## 改动

- `apps/electron/src/types/settings.ts` — `AppSettings` 新增 `richTextInputRenderingEnabled?: boolean` 字段，默认 `true`，注释清晰
- `apps/electron/src/renderer/atoms/ui-preferences.ts` — 新增 `richTextInputRenderingEnabledAtom` 与 `updateRichTextInputRenderingEnabled()`；扩展 `initializeUiPreferences` 签名接收第二个 setter
- `apps/electron/src/renderer/main.tsx` — `UiPreferencesInitializer` 注入第二个 setter，挂载位置不动
- `apps/electron/src/renderer/components/settings/GeneralSettings.tsx` — 在「消息悬浮置顶条」`SettingsToggle` 下方新增「输入框 Markdown 渲染」`SettingsToggle`，文案明确说明"关闭后粘贴文本保留原始 Markdown 字符"
- `apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx` —
  - 顶部 `useAtomValue(richTextInputRenderingEnabledAtom)` + ref，与现有 ref pattern 一致
  - `useEditor` 加 `enableInputRules` / `enablePasteRules` 顶层选项（值 = `markdownRenderingEnabled`），第二参数传 `[markdownRenderingEnabled]` 让 editor 在开关切换时重建
  - `handlePaste` 新增分支：关闭渲染时跳过 `htmlToMarkdown` 转换，按 `\n` 拆分构造 ProseMirror JSON paragraph 节点数组传给 `editor.insertContent()`——**关键设计：绕开 HTML 字符串解析路径**，避免浏览器对 `\n` / 连续空格做空白规范化，从而完整保留空行、缩进、连续空格
  - 文件粘贴（图片）与超长文本附件化路径继续生效，不受开关影响
- `apps/electron/package.json` — `0.12.26 → 0.12.27`

## 测试方法

1. 进入「设置 → 通用设置」，确认「输入框 Markdown 渲染」开关存在，默认开启
2. **开启状态（保持现状）**：
   - Chat 输入框粘贴一段 markdown（含 `**粗体**`、`# 标题`、`- 列表`） → 渲染为富文本
   - 直接键入 `**hello**` 后空格 → 自动变粗体
3. **关闭状态**：
   - 粘贴同样内容 → 输入框里看到原始 `**粗体**`、`# 标题`、`- 列表` 字面字符
   - 粘贴一段含**空行 + 缩进 + 行内连续空格 + 注释对齐**的 markdown → 空行、缩进、对齐全部保留
   - 键入 `**hello**` → 保持字面字符，不变粗体
   - 按 Enter 发送 → 聊天气泡里 Agent 收到正确 markdown
4. **跨实例**：Agent 输入框 + ScratchPad 同样验证开关生效
5. **持久化**：关闭开关 → 重启应用 → 仍为关闭状态（`~/.proma/settings.json` 含 `"richTextInputRenderingEnabled": false`）
6. **粘贴文件**：粘贴图片仍走文件附件路径，不受开关影响
7. **超长文本附件**：粘贴超过 `longTextPasteThreshold` 的文本仍触发附件化
8. `bun run typecheck` 通过

## 备注

- 实现完全镜像现有 `stickyUserMessageEnabled` 偏好的持久化与初始化模式，没有引入新模式
- TipTap v3 的 `enableInputRules` / `enablePasteRules` 是顶层 EditorOptions，传 `false` 时禁用全部扩展的 input/paste rules；Mention（@/、#、&）、Link、CodeBlockLowlight 等扩展的 schema 仍然存在，只是输入触发的格式转换被关闭——不影响已有富文本节点的渲染与 chip 触发
- 粘贴分支使用 ProseMirror JSON 节点而非 HTML 字符串，**这是关键设计**：HTML 字符串经 `innerHTML` 解析时浏览器会规范化空白（空行被吞、连续空格合并），而 JSON 节点直接构造节点树，完全跳过这个阶段
- 开关切换时 editor 会重建，现有 `useEffect(() => syncValue, [editor, value])` 自动用 markdown 字符串回填新 editor，草稿不会丢失