### PR TITLE
fix(preview): 修复预览文件切换界面后滚动位置回到顶部

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.12.26",
+  "version": "0.12.27",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -23,6 +23,11 @@ import { MarkdownRichEditor } from './MarkdownRichEditor'
 import { PreviewFindBar } from './PreviewFindBar'
 import { MarkdownToc } from './MarkdownToc'
 import { PIERRE_FILE_CSS } from '@/components/agent/tool-result-renderers/pierre-styles'
+import {
+  clearPreviewScrollPositionsForSession,
+  getPreviewScrollPosition,
+  savePreviewScrollFromElement,
+} from '@/lib/preview-scroll-memory'
 
 const MD_EXTS = new Set(['.md', '.markdown'])
 const PLAIN_TEXT_EDIT_EXTS = new Set(['.txt', '.text', '.log'])
@@ -61,26 +66,12 @@ const MAX_PREVIEW_CHARS = 500_000
 /** 选中文本最大字符数（与 Bozeman DOM 模式一致） */
 const MAX_QUOTED_CHARS = 2000
 
-/** 滚动位置持久化：key = `${sessionId}:${filePath}` */
-const scrollPositionCache = new Map<string, { top: number; left: number }>()
-
-function scrollCacheKey(sessionId: string, filePath: string): string {
-  return `${sessionId}:${filePath}`
-}
-
-/** 获取缓存的滚动位置 */
-export function getPreviewScrollPosition(sessionId: string, filePath: string): { top: number; left: number } | undefined {
-  return scrollPositionCache.get(scrollCacheKey(sessionId, filePath))
-}
-
 /**
  * 清除指定 session 的预览缓存，供 useCloseTab 调用。
  */
 export function clearPreviewCacheForSession(sessionId: string): void {
+  clearPreviewScrollPositionsForSession(sessionId)
   const prefix = `${sessionId}:`
-  for (const key of scrollPositionCache.keys()) {
-    if (key.startsWith(prefix)) scrollPositionCache.delete(key)
-  }
   for (const key of contentCache.keys()) {
     if (key.startsWith(prefix)) contentCache.delete(key)
   }
@@ -519,8 +510,6 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
 
   // 滚动位置持久化 key（sessionId:filePath）。主加载 effect 在缓存未命中时
   // 也会读它判断是否需要恢复滚动，故声明须早于该 effect。
-  const scrollKey = scrollCacheKey(sessionId, filePath)
-
   // 主加载 effect：上下文变化（filePath/dirPath/gitRoot/previewOnly）时触发；
   // 纯预览模式也跟随 refreshVersion 失效，保证同一文件二次写入后重新读盘。
   // 命中缓存时跳过 loading 闪烁直接渲染；未命中走 IPC 拉取
@@ -568,7 +557,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
       lastOldContentRef.current = ''
       // 内容缓存被 LRU 淘汰但滚动位置仍在时（如切走会话后预览 Tab 重建），
       // 也标记需要恢复，待 load() 重新拉取渲染后回到上次滚动位置。
-      if (scrollPositionCache.has(scrollKey)) {
+      if (getPreviewScrollPosition(sessionId, filePath)) {
         restoreScrollRef.current = true
       }
     }
@@ -727,33 +716,18 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     }
   }, [previewOnly, loading, filePath, ext, isLegacyOffice, isPdf, pdfSrc, isDocx, docxHtml, isOfficePreview, officeHtml, isImage, imageDataUrl])
 
-  // scrollPosition persistent: module-level Map keyed by sessionId:filePath
-  // content changes (refreshVersion bump) → delete stored position;
-  // cached mount → restore; scroll → save.
-  const prevRefreshVersionRef = React.useRef(refreshVersion)
-
-  // WHEN content version changes (refreshVersion bump): delete stored scroll position
-  // 只在内容变化时清除，切换文件时保留位置以支持返回导航
-  React.useEffect(() => {
-    if (loading) return // still loading, don't clear yet
-    if (prevRefreshVersionRef.current !== refreshVersion) {
-      // refreshVersion changed for current file → content updated, clear position
-      scrollPositionCache.delete(scrollKey)
-      prevRefreshVersionRef.current = refreshVersion
-    }
-  }, [scrollKey, refreshVersion, loading])
-
-  // RESTORE scroll position after cached content renders
+  // 预览滚动位置持久化：同一 session/file 的刷新、自动保存、外部写入都应尽量保留上下文，
+  // 否则“编辑中切走再回来跳回顶部”的体验会很割裂。
   const restoreScrollRef = React.useRef(false)
   React.useEffect(() => {
     if (loading || !restoreScrollRef.current) return
     restoreScrollRef.current = false
-    const pos = scrollPositionCache.get(scrollKey)
+    const pos = getPreviewScrollPosition(sessionId, filePath)
     if (pos && scrollContainerRef.current) {
       scrollContainerRef.current.scrollTop = pos.top
       scrollContainerRef.current.scrollLeft = pos.left
     }
-  }, [loading, scrollKey])
+  }, [filePath, loading, sessionId])
 
   // SAVE scroll position on scroll (throttled via rAF)
   const scrollRafRef = React.useRef(0)
@@ -762,18 +736,18 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     scrollRafRef.current = requestAnimationFrame(() => {
       scrollRafRef.current = 0
       const el = scrollContainerRef.current
-      if (el) {
-        scrollPositionCache.set(scrollKey, { top: el.scrollTop, left: el.scrollLeft })
-      }
+      if (el) savePreviewScrollFromElement(sessionId, filePath, el)
     })
-  }, [scrollKey])
+  }, [filePath, sessionId])
 
-  // Cleanup rAF on unmount to prevent stale writes
+  // Cleanup rAF on unmount to prevent stale writes，同时同步落一次当前位置，避免刚滚完就切页时丢最后一帧。
   React.useEffect(() => {
     return () => {
+      const el = scrollContainerRef.current
+      if (el) savePreviewScrollFromElement(sessionId, filePath, el)
       if (scrollRafRef.current) cancelAnimationFrame(scrollRafRef.current)
     }
-  }, [])
+  }, [filePath, sessionId])
 
   const handleCopy = React.useCallback(async () => {
     try {

--- a/apps/electron/src/renderer/lib/preview-scroll-memory.test.ts
+++ b/apps/electron/src/renderer/lib/preview-scroll-memory.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  clearPreviewScrollPositionsForSession,
+  getPreviewScrollPosition,
+  savePreviewScrollPosition,
+} from './preview-scroll-memory'
+
+describe('preview scroll memory', () => {
+  test('given saved position when reading same session and file then returns that position', () => {
+    clearPreviewScrollPositionsForSession('session-a')
+
+    savePreviewScrollPosition('session-a', '/tmp/demo.md', { top: 320, left: 12 })
+
+    expect(getPreviewScrollPosition('session-a', '/tmp/demo.md')).toEqual({ top: 320, left: 12 })
+  })
+
+  test('given same file keeps being updated when saving new positions then latest position wins', () => {
+    clearPreviewScrollPositionsForSession('session-b')
+
+    savePreviewScrollPosition('session-b', '/tmp/demo.md', { top: 480, left: 0 })
+    savePreviewScrollPosition('session-b', '/tmp/demo.md', { top: 512, left: 8 })
+
+    expect(getPreviewScrollPosition('session-b', '/tmp/demo.md')).toEqual({ top: 512, left: 8 })
+  })
+
+  test('given multiple files in one session when clearing that session then other sessions stay intact', () => {
+    clearPreviewScrollPositionsForSession('session-c')
+    clearPreviewScrollPositionsForSession('session-d')
+
+    savePreviewScrollPosition('session-c', '/tmp/a.md', { top: 10, left: 0 })
+    savePreviewScrollPosition('session-c', '/tmp/b.md', { top: 20, left: 1 })
+    savePreviewScrollPosition('session-d', '/tmp/a.md', { top: 30, left: 2 })
+
+    clearPreviewScrollPositionsForSession('session-c')
+
+    expect(getPreviewScrollPosition('session-c', '/tmp/a.md')).toBeUndefined()
+    expect(getPreviewScrollPosition('session-c', '/tmp/b.md')).toBeUndefined()
+    expect(getPreviewScrollPosition('session-d', '/tmp/a.md')).toEqual({ top: 30, left: 2 })
+  })
+})

--- a/apps/electron/src/renderer/lib/preview-scroll-memory.ts
+++ b/apps/electron/src/renderer/lib/preview-scroll-memory.ts
@@ -1,0 +1,36 @@
+export interface PreviewScrollPosition {
+  top: number
+  left: number
+}
+
+const scrollPositionCache = new Map<string, PreviewScrollPosition>()
+
+function scrollCacheKey(sessionId: string, filePath: string): string {
+  return `${sessionId}:${filePath}`
+}
+
+export function getPreviewScrollPosition(sessionId: string, filePath: string): PreviewScrollPosition | undefined {
+  return scrollPositionCache.get(scrollCacheKey(sessionId, filePath))
+}
+
+export function savePreviewScrollPosition(sessionId: string, filePath: string, position: PreviewScrollPosition): void {
+  scrollPositionCache.set(scrollCacheKey(sessionId, filePath), position)
+}
+
+export function savePreviewScrollFromElement(
+  sessionId: string,
+  filePath: string,
+  element: Pick<HTMLElement, 'scrollTop' | 'scrollLeft'>,
+): void {
+  savePreviewScrollPosition(sessionId, filePath, {
+    top: element.scrollTop,
+    left: element.scrollLeft,
+  })
+}
+
+export function clearPreviewScrollPositionsForSession(sessionId: string): void {
+  const prefix = `${sessionId}:`
+  for (const key of scrollPositionCache.keys()) {
+    if (key.startsWith(prefix)) scrollPositionCache.delete(key)
+  }
+}


### PR DESCRIPTION
## 概述

修复预览文件编辑场景下一个很容易打断阅读和修改节奏的体验问题：

- 当用户在预览面板中打开一个 Markdown / 文本文件，滚动到中下部开始查看或编辑
- 中途切到别的界面或别的 Tab，再回到这个文件预览
- 预览会重新回到顶部，而不是停留在用户刚才的位置

这个问题在长文档预览和边看边改的场景里尤其明显，会反复打断上下文。

## 根因

当前预览组件 `DiffTabContent` 本来已经有一层按 `sessionId:filePath` 保存滚动位置的缓存，但同一文件一旦触发 `refreshVersion` 更新（例如预览编辑保存、文件刷新），旧逻辑会主动清掉这个文件的滚动缓存。

结果就是：

- 用户切走前即使已经保存过滚动位置
- 只要这期间文件刷新过一次
- 再回来时就拿不到原来的滚动位置，只能从顶部重新开始

另外，原实现只在滚动事件的 `requestAnimationFrame` 回调里异步写缓存；如果用户刚滚动完就立刻切走，最后一帧位置也有机会来不及落盘。

## 改动

- `apps/electron/src/renderer/lib/preview-scroll-memory.ts`
  - 抽出独立的预览滚动位置 helper，统一管理读取、写入和按 session 清理
- `apps/electron/src/renderer/components/diff/DiffTabContent.tsx`
  - 删除“内容 refresh 时清空当前文件滚动缓存”的逻辑
  - 改为在预览重新渲染后优先恢复已有滚动位置
  - 滚动时继续按 `sessionId + filePath` 保存位置
  - 组件卸载时额外同步保存一次当前位置，避免最后一帧丢失
- `apps/electron/src/renderer/lib/preview-scroll-memory.test.ts`
  - 新增 focused regression test，覆盖：
    - 同文件位置保存/读取
    - 同文件多次更新后保留最新位置
    - 清理某个 session 时不误伤其他 session
- `apps/electron/package.json`
  - `@proma/electron` patch 版本从 `0.12.26` 升到 `0.12.27`

## 测试方法

1. 打开任意可编辑预览文件（如 Markdown 草稿）
2. 滚动到中下部位置
3. 切到其他界面或其他 Tab，再切回该文件预览
   - 预期：仍停留在原来的滚动位置，不回到顶部
4. 在预览里修改同一文件并触发保存/刷新，再重复切走/切回
   - 预期：滚动位置仍然保留
5. 关闭该会话后重新进入其它会话
   - 预期：只清理当前 session 的预览缓存，不影响别的 session
6. 自动测试：
   - `bun test apps/electron/src/renderer/lib/preview-scroll-memory.test.ts`

## 备注

- 这次修复的是“切走再回来后滚动位置丢失”这一条链路
- 当前还发现一个相关但未并入本 PR 的问题：当 Agent 持续重复写入同一文档、且预览正打开时，预览会在每次刷新后跳回顶部。这个症状相似，但触发路径不同，建议单独排查后再决定是否做第二个 PR
- 当前 checkout 里完整 Electron typecheck 仍有一批与本改动无关的既有环境 / 类型解析噪声，因此这次以 focused regression test + 本地交互验证为主
