### PR TITLE
fix: 修复预览面板滚动位置在切换后向下错位

### DIFF
--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -731,27 +731,61 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   // content changes (refreshVersion bump) → delete stored position;
   // cached mount → restore; scroll → save.
   const prevRefreshVersionRef = React.useRef(refreshVersion)
+  const restoreScrollRef = React.useRef(false)
+  const restoreRafRef = React.useRef(0)
 
   // WHEN content version changes (refreshVersion bump): delete stored scroll position
   // 只在内容变化时清除，切换文件时保留位置以支持返回导航
   React.useEffect(() => {
     if (loading) return // still loading, don't clear yet
     if (prevRefreshVersionRef.current !== refreshVersion) {
-      // refreshVersion changed for current file → content updated, clear position
       scrollPositionCache.delete(scrollKey)
+      restoreScrollRef.current = false
       prevRefreshVersionRef.current = refreshVersion
     }
   }, [scrollKey, refreshVersion, loading])
 
-  // RESTORE scroll position after cached content renders
-  const restoreScrollRef = React.useRef(false)
+  // RESTORE scroll position after cached content renders.
+  // 等待滚动容器内容高度连续 3 帧稳定后再恢复，避免异步渲染
+  // （Shiki tokenize、ProseMirror mount）导致高度变化引起滚动偏移。
   React.useEffect(() => {
     if (loading || !restoreScrollRef.current) return
-    restoreScrollRef.current = false
+
     const pos = scrollPositionCache.get(scrollKey)
-    if (pos && scrollContainerRef.current) {
-      scrollContainerRef.current.scrollTop = pos.top
-      scrollContainerRef.current.scrollLeft = pos.left
+    if (!pos || !scrollContainerRef.current) {
+      restoreScrollRef.current = false
+      return
+    }
+
+    const el = scrollContainerRef.current
+    let prevHeight = el.scrollHeight
+    let stableFrames = 0
+
+    const check = () => {
+      const curHeight = el.scrollHeight
+      if (curHeight === prevHeight) {
+        stableFrames++
+      } else {
+        stableFrames = 0
+        prevHeight = curHeight
+      }
+      if (stableFrames >= 3) {
+        restoreScrollRef.current = false
+        el.scrollTop = pos.top
+        el.scrollLeft = pos.left
+        restoreRafRef.current = 0
+        return
+      }
+      restoreRafRef.current = requestAnimationFrame(check)
+    }
+
+    restoreRafRef.current = requestAnimationFrame(check)
+
+    return () => {
+      if (restoreRafRef.current) {
+        cancelAnimationFrame(restoreRafRef.current)
+        restoreRafRef.current = 0
+      }
     }
   }, [loading, scrollKey])
 
@@ -772,6 +806,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   React.useEffect(() => {
     return () => {
       if (scrollRafRef.current) cancelAnimationFrame(scrollRafRef.current)
+      if (restoreRafRef.current) cancelAnimationFrame(restoreRafRef.current)
     }
   }, [])
 


### PR DESCRIPTION
## Summary

- 修复 Agent 模式下预览面板在切换回来后滚动位置向下错位的 bug
- 根因是 `DiffTabContent` remount 后两个 `useEffect` 竞争 + Shiki/ProseMirror 异步渲染导致容器高度延迟确定
- 在 refreshVersion 变化清除缓存时同步阻止恢复 effect 的错误触发
- 恢复 effect 改为 rAF 轮询等待 `scrollHeight` 连续 3 帧稳定后再设置 `scrollTop`

## Test plan

- [ ] 打开 Agent 会话，点击文件预览并滚动到中间位置
- [ ] 切回 Agent 对话界面，再切回预览，确认滚动位置精确恢复
- [ ] Agent 后台修改文件期间切换，确认回来后不会出现偏移（refreshVersion 竞争场景）
- [ ] 大文件（>1000 行代码）预览的滚动恢复精度
- [ ] Markdown 文件预览的滚动恢复精度（ProseMirror 异步 mount）
- [ ] Split 分屏模式和 Tab 标签页模式分别验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)