### PR TITLE
【已审核】fix(agent): 禁用 x-anthropic-billing-header 避免第三方代理缓存命中率归零 🔥🔥🔥

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -547,6 +547,9 @@ export class AgentOrchestrator {
       CLAUDE_CODE_ENABLE_TASKS: 'true',
       // 禁用实验性 beta 功能，使用稳定模式
       CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: '1',
+      // 禁用 x-anthropic-billing-header：第三方 Anthropic 兼容代理无法处理
+      // 其中每次请求变化的 cch 字段，会导致 prompt cache 前缀变化、命中率归零
+      CLAUDE_CODE_ATTRIBUTION_HEADER: '0',
       // 配置隔离：让 SDK 使用独立的配置目录，不读取用户的 ~/.claude.json
       CLAUDE_CONFIG_DIR: getSdkConfigDir(),
     }


### PR DESCRIPTION
## 概述

第三方 Anthropic 兼容代理（如 one-api / new-api 等）无法正确处理 x-anthropic-billing-header 中每次请求变化的 cch 字段。该字段的随机性导致请求的 HTTP header 发生变化，进而使得下游代理的 prompt cache 前缀每次都不同，缓存命中率直接归零。对于使用第三方代理中转的用户，这意味着每次对话都按完整 prompt 计费，失去了 Anthropic Prompt Caching 带来的成本和延迟优势。

本 PR 通过设置环境变量 CLAUDE_CODE_ATTRIBUTION_HEADER=0 禁用该 billing header 的发送。该环境变量由 Agent SDK 原生支持，仅影响请求头中的 attribution/billing 信息，不影响认证或其他核心功能。

## 改动

- apps/electron/src/main/lib/agent-orchestrator.ts — 在 SDK 子进程环境变量中新增 CLAUDE_CODE_ATTRIBUTION_HEADER: 0，禁用 x-anthropic-billing-header

## 测试

- 在配置了第三方 Anthropic 兼容代理的环境中验证：agent 操作正常，不再发送 x-anthropic-billing-header
- 回归测试：直连 Anthropic API 不受影响，billing header 仅在代理场景中起作用
- 验证 prompt caching 在代理场景下恢复正常命中率

## 备注

关联问题：第三方代理无法处理动态 cch 字段导致的缓存前缀变化。此修复仅影响 Agent SDK 子进程环境，不影响 Chat 模式的直接 API 调用。

Related: https://github.com/anthropics/claude-code/issues/50085
