### PR TITLE
feat(channel): 新增 qwen-anthropic 渠道，适配 Qwen3.7 1M 上下文

### DIFF
--- a/apps/electron/src/main/lib/channel-manager.ts
+++ b/apps/electron/src/main/lib/channel-manager.ts
@@ -276,6 +276,7 @@ export async function testChannel(channelId: string): Promise<ChannelTestResult>
       case 'minimax':
       case 'xiaomi':
       case 'xiaomi-token-plan':
+      case 'qwen-anthropic':
         return await testAnthropicCompatible(channel.baseUrl, apiKey, proxyUrl, channel.provider)
       case 'openai':
       case 'zhipu':
@@ -330,6 +331,9 @@ async function testAnthropicCompatible(
     case 'xiaomi-token-plan':
       testModel = 'mimo-v2.5-pro'
       break
+    case 'qwen-anthropic':
+      testModel = 'qwen3.7-plus'
+      break
     default:
       testModel = 'claude-sonnet-4-6'
   }
@@ -344,7 +348,7 @@ async function testAnthropicCompatible(
   } else if (provider === 'xiaomi-token-plan') {
     headers.Authorization = `Bearer ${apiKey}`
     headers['User-Agent'] = getPromaUserAgent(pkg.version)
-  } else if (provider === 'minimax') {
+  } else if (provider === 'minimax' || provider === 'qwen-anthropic') {
     headers.Authorization = `Bearer ${apiKey}`
   } else {
     headers['x-api-key'] = apiKey
@@ -445,6 +449,7 @@ export async function testChannelDirect(input: FetchModelsInput): Promise<Channe
       case 'minimax':
       case 'xiaomi':
       case 'xiaomi-token-plan':
+      case 'qwen-anthropic':
         return await testAnthropicCompatible(input.baseUrl, input.apiKey, proxyUrl, input.provider)
       case 'openai':
       case 'zhipu':
@@ -485,6 +490,7 @@ export async function fetchModels(input: FetchModelsInput): Promise<FetchModelsR
       case 'minimax':
       case 'xiaomi':
       case 'xiaomi-token-plan':
+      case 'qwen-anthropic':
         return await fetchAnthropicCompatibleModels(input.baseUrl, input.apiKey, proxyUrl, input.provider)
       case 'openai':
       case 'zhipu':
@@ -538,7 +544,7 @@ async function fetchAnthropicCompatibleModels(
   } else if (provider === 'xiaomi-token-plan') {
     headers.Authorization = `Bearer ${apiKey}`
     headers['User-Agent'] = getPromaUserAgent(pkg.version)
-  } else if (provider === 'minimax') {
+  } else if (provider === 'minimax' || provider === 'qwen-anthropic') {
     headers.Authorization = `Bearer ${apiKey}`
   } else {
     headers['x-api-key'] = apiKey

--- a/apps/electron/src/renderer/components/settings/ChannelForm.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelForm.tsx
@@ -72,7 +72,7 @@ interface ChannelFormProps {
 }
 
 /** 所有可选供应商 */
-const PROVIDER_OPTIONS: ProviderType[] = ['anthropic', 'anthropic-compatible', 'openai', 'deepseek', 'google', 'kimi-api', 'kimi-coding', 'zhipu', 'zhipu-coding', 'minimax', 'doubao', 'qwen', 'xiaomi', 'xiaomi-token-plan', 'custom']
+const PROVIDER_OPTIONS: ProviderType[] = ['anthropic', 'anthropic-compatible', 'openai', 'deepseek', 'google', 'kimi-api', 'kimi-coding', 'zhipu', 'zhipu-coding', 'minimax', 'doubao', 'qwen', 'qwen-anthropic', 'xiaomi', 'xiaomi-token-plan', 'custom']
 
 /** 供应商选项（用于 SettingsSelect） */
 const PROVIDER_SELECT_OPTIONS = PROVIDER_OPTIONS.map((p) => ({
@@ -95,6 +95,7 @@ const PROVIDER_CHAT_PATHS: Record<ProviderType, string> = {
   minimax: '/v1/messages',
   doubao: '/chat/completions',
   qwen: '/chat/completions',
+  'qwen-anthropic': '/v1/messages',
   xiaomi: '/v1/messages',
   'xiaomi-token-plan': '/v1/messages',
   custom: '/chat/completions',
@@ -111,6 +112,7 @@ const ANTHROPIC_PROTOCOL_PROVIDERS: ReadonlySet<ProviderType> = new Set<Provider
   'minimax',
   'xiaomi',
   'xiaomi-token-plan',
+  'qwen-anthropic',
 ])
 
 /**
@@ -295,6 +297,11 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
           { id: 'mimo-v2.5', name: 'MiMo V2.5', enabled: true },
           { id: 'mimo-v2-omni', name: 'MiMo V2 Omni', enabled: true },
           { id: 'mimo-v2-flash', name: 'MiMo V2 Flash', enabled: true },
+        ])
+      } else if (p === 'qwen-anthropic') {
+        setModels([
+          { id: 'qwen3.7-max', name: 'Qwen3.7 Max', enabled: true },
+          { id: 'qwen3.7-plus', name: 'Qwen3.7 Plus', enabled: true },
         ])
       }
     }

--- a/apps/electron/src/renderer/lib/model-logo.ts
+++ b/apps/electron/src/renderer/lib/model-logo.ts
@@ -247,6 +247,7 @@ const PROVIDER_LOGO_MAP: Record<ProviderType, string> = {
   minimax: MiniMaxLogo,
   doubao: DoubaoLogo,
   qwen: QwenLogo,
+  'qwen-anthropic': QwenLogo,
   xiaomi: XiaomiLogo,
   'xiaomi-token-plan': XiaomiLogo,
   custom: DefaultLogo,

--- a/packages/core/src/providers/anthropic-adapter.ts
+++ b/packages/core/src/providers/anthropic-adapter.ts
@@ -288,7 +288,7 @@ export class AnthropicAdapter implements ProviderAdapter {
       base['User-Agent'] = getPromaUserAgent()
       return base
     }
-    if (this.providerType === 'minimax') {
+    if (this.providerType === 'minimax' || this.providerType === 'qwen-anthropic') {
       base['Authorization'] = `Bearer ${apiKey}`
       return base
     }

--- a/packages/core/src/providers/index.ts
+++ b/packages/core/src/providers/index.ts
@@ -36,6 +36,7 @@ const adapterRegistry = new Map<ProviderType, ProviderAdapter>([
   ['minimax', new AnthropicAdapter('minimax')], // MiniMax 使用 Anthropic 兼容协议
   ['doubao', new OpenAIAdapter()],        // 豆包使用 OpenAI 兼容协议
   ['qwen', new OpenAIAdapter()],          // 通义千问使用 OpenAI 兼容协议
+  ['qwen-anthropic', new AnthropicAdapter('qwen-anthropic')],       // 通义千问 DashScope Anthropic 兼容协议
   ['xiaomi', new AnthropicAdapter('xiaomi')],                       // 小米 MiMo API 使用 Anthropic 兼容协议
   ['xiaomi-token-plan', new AnthropicAdapter('xiaomi-token-plan')], // 小米 Token Plan 订阅制（强制 User-Agent）
   ['custom', new OpenAIAdapter()],        // 自定义也使用 OpenAI 兼容协议

--- a/packages/core/src/providers/url-utils.ts
+++ b/packages/core/src/providers/url-utils.ts
@@ -89,7 +89,7 @@ export function normalizeBaseUrl(baseUrl: string): string {
  * 根据 Anthropic 协议供应商类型选择对应的 URL 规范化策略。
  *
  * 统一收口 channel-manager 和 AnthropicAdapter 中重复的条件分支逻辑。
- * 仅适用于走 Anthropic 协议的供应商（anthropic / anthropic-compatible / deepseek / kimi-* / minimax / xiaomi-*）。
+ * 仅适用于走 Anthropic 协议的供应商（anthropic / anthropic-compatible / deepseek / kimi-* / minimax / xiaomi-* / qwen-anthropic）。
  */
 export function normalizeAnthropicProviderUrl(baseUrl: string, provider: ProviderType): string {
   if (
@@ -97,6 +97,7 @@ export function normalizeAnthropicProviderUrl(baseUrl: string, provider: Provide
     || provider === 'anthropic-compatible'
     || provider === 'xiaomi'
     || provider === 'xiaomi-token-plan'
+    || provider === 'qwen-anthropic'
     || provider === 'zhipu-coding'
   ) {
     return normalizeVersionedAnthropicBaseUrl(baseUrl)

--- a/packages/shared/src/types/channel.ts
+++ b/packages/shared/src/types/channel.ts
@@ -21,6 +21,7 @@ export type ProviderType =
   | 'minimax'
   | 'doubao'
   | 'qwen'
+  | 'qwen-anthropic'
   | 'xiaomi'
   | 'xiaomi-token-plan'
   | 'custom'
@@ -41,6 +42,7 @@ export const PROVIDER_DEFAULT_URLS: Record<ProviderType, string> = {
   minimax: 'https://api.minimaxi.com/anthropic',
   doubao: 'https://ark.cn-beijing.volces.com/api/v3',
   qwen: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+  'qwen-anthropic': 'https://dashscope.aliyuncs.com/apps/anthropic',
   xiaomi: 'https://api.xiaomimimo.com/anthropic',
   'xiaomi-token-plan': 'https://token-plan-cn.xiaomimimo.com/anthropic',
   custom: '',
@@ -62,6 +64,7 @@ export const PROVIDER_LABELS: Record<ProviderType, string> = {
   minimax: 'MiniMax (API&编程包)',
   doubao: '豆包',
   qwen: '通义千问',
+  'qwen-anthropic': '通义千问 (Anthropic 协议)',
   xiaomi: '小米 MiMo (API)',
   'xiaomi-token-plan': '小米 MiMo Token Plan',
   custom: 'OpenAI 兼容格式',
@@ -83,6 +86,7 @@ export const AGENT_COMPATIBLE_PROVIDERS: ReadonlySet<ProviderType> = new Set<Pro
   'minimax',
   'xiaomi',
   'xiaomi-token-plan',
+  'qwen-anthropic',
 ])
 
 /**

--- a/packages/shared/src/utils/context-window.ts
+++ b/packages/shared/src/utils/context-window.ts
@@ -23,6 +23,7 @@ export const ONE_MILLION_CONTEXT_WINDOW = 1_000_000
  * - 小米 MiMo V2.5 / V2.5 Pro / V2 Pro
  * - 智谱 GLM-5.2、GLM-X-Preview[1m]
  * - MiniMax M3（智谱式兼容端点支持）
+ * - Qwen3.7 Max / Plus（DashScope Anthropic 兼容端点，默认 1M，无需 beta header）
  *
  * 参考：https://docs.anthropic.com/en/docs/build-with-claude/context-windows
  */
@@ -41,6 +42,8 @@ export function supports1MContext(modelId: string): boolean {
   if (m.includes('glm-5.2')) return true
   if (m.includes('glm-x-preview[1m]')) return true
   if (m.includes('minimax-m3')) return true
+  // Qwen3.7 系列（DashScope Anthropic 兼容端点默认 1M，无需 context-1m beta header）
+  if (m.includes('qwen3.7')) return true
   return false
 }
 


### PR DESCRIPTION
## 概述

新增 `qwen-anthropic` provider，让 Qwen3.7-max / Qwen3.7-plus 走 DashScope 的 Anthropic 兼容端点
(`https://dashscope.aliyuncs.com/apps/anthropic`)，作为 Agent 模式 + Claude SDK 生态可用供应商。

参考 MiMo 提交 #698 (f87108fb) 同模板，1:1 套用。

## 改动 (8 files, +28/-5)

- `packages/shared/src/types/channel.ts` — 新增 `qwen-anthropic` provider 类型 / URL / label / AGENT_COMPATIBLE
- `packages/core/src/providers/index.ts` — 注册 `AnthropicAdapter`
- `packages/core/src/providers/url-utils.ts` — versioned URL 规范化分支
- `packages/core/src/providers/anthropic-adapter.ts` — buildHeaders 走 Bearer
- `packages/shared/src/utils/context-window.ts` — `qwen3.7-*` 加 1M 白名单
- `apps/electron/src/main/lib/channel-manager.ts` — 6 处测试/拉取分支
- `apps/electron/src/renderer/components/settings/ChannelForm.tsx` — 4 处 + 预设模型
- `apps/electron/src/renderer/lib/model-logo.ts` — PROVIDER_LOGO_MAP

## 设计选择

- **新增独立 provider**（不是改造现有 `qwen`），保持现有 qwen Chat 模式 OpenAI 协议不受影响
- **认证**：Bearer（curl 验证过，x-api-key 也被 DashScope 接受）
- **URL 规范化**：走 `normalizeVersionedAnthropicBaseUrl`（与 minimax / xiaomi / zhipu-coding 策略一致）
- **1M 上下文**：DashScope 默认即 1M，`anthropic-beta: context-1m-2025-08-07` 被忽略不报错——直接加白名单，未解耦 `supports1MContext` 与 `inferContextWindow`
- **thinking**：默认 `manual-only` 即正确（Qwen3.7 接受 `{type:'enabled', budget_tokens}` 与 `{type:'disabled'}`）

## 验证

- `bun run typecheck`：全过
- `bun run build`：全过
- 本地 Agent 模式实测 qwen3.7-plus 处理自己的任务，30轮对话无问题，进度环显示 1M
- curl **10 项**独立验证全部 200：Bearer / x-api-key / beta header / thinking disabled / enabled (有/无 budget_tokens) / qwen3.7-max / tool_use / tool_result / 空 signature thinking

## 已知限制

- DashScope `/apps/anthropic` 端点在 **多轮 tool_use 场景下偶发 400 错误**（`request_id: d87570de-1620-bcb3-9c88-a39078959626`），不能稳定复现，疑似服务端偶发问题。建议上游加 retry 机制。
- DashScope `/apps/anthropic` 端点的 `usage.input_tokens` 字段估算与 Anthropic 协议 `input_tokens` 字段不一致（多轮对话 token 数估算偏低，12轮，50k，33轮，60k，与之前deepseek v4体感不同），和 GLM-5.2 适配遇到的同样问题，属协议层限制。