### PR TITLE
perf: 移除 overlay 与按钮的 backdrop-blur，修复 UI 卡顿 (#856)

### DIFF
--- a/apps/electron/src/renderer/atoms/theme.ts
+++ b/apps/electron/src/renderer/atoms/theme.ts
@@ -103,7 +103,7 @@ const ALL_THEME_STYLE_CLASSES = THEME_STYLES
  * 在 <html> 元素上切换 dark 类名和特殊风格类名。
  *
  * 幂等实现：先计算目标 class 状态，与当前 DOM 对比，一致时直接 return，
- * 不触发任何 classList mutation。避免与 vibrancy + backdrop-blur 合成层叠加
+ * 不触发任何 classList mutation。避免与 vibrancy 合成层叠加
  * 导致 Chromium 重建合成层造成的全屏闪烁。
  */
 export function applyThemeToDOM(themeMode: ThemeMode, themeStyle: ThemeStyle = 'default', systemIsDark: boolean = true): void {

--- a/apps/electron/src/renderer/components/app-shell/SearchDialog.tsx
+++ b/apps/electron/src/renderer/components/app-shell/SearchDialog.tsx
@@ -470,7 +470,7 @@ export function SearchDialog(): React.ReactElement {
         <DialogPortal>
           <div
             aria-hidden
-            className="fixed inset-0 z-[99] bg-black/40 backdrop-blur-sm pointer-events-none animate-in fade-in-0 duration-150"
+            className="fixed inset-0 z-[99] bg-black/40 pointer-events-none animate-in fade-in-0 duration-150"
           />
         </DialogPortal>
       )}

--- a/apps/electron/src/renderer/components/settings/SettingsDialog.tsx
+++ b/apps/electron/src/renderer/components/settings/SettingsDialog.tsx
@@ -17,9 +17,8 @@ export function SettingsDialog(): React.ReactElement {
   return (
     <DialogPrimitive.Root open={open} onOpenChange={setOpen}>
       <DialogPrimitive.Portal>
-        {/* 轻遮罩 — 与新 Dialog overlay 对齐：bg-black/40 + backdrop-blur-sm */}
         <DialogPrimitive.Overlay
-          className="fixed inset-0 z-[100] bg-black/40 backdrop-blur-sm titlebar-no-drag transition-opacity duration-100 data-[state=open]:opacity-100 data-[state=closed]:opacity-0"
+          className="fixed inset-0 z-[100] bg-black/40 titlebar-no-drag transition-opacity duration-100 data-[state=open]:opacity-100 data-[state=closed]:opacity-0"
         />
         <DialogPrimitive.Content
           className="fixed left-[50%] top-[50%] z-[100] translate-x-[-50%] translate-y-[-50%] w-[85vw] max-w-[992px] h-[85vh] max-h-[752px] bg-dialog text-dialog-foreground shadow-2xl rounded-xl overflow-hidden titlebar-no-drag transition-all duration-100 data-[state=open]:opacity-100 data-[state=open]:scale-100 data-[state=closed]:opacity-0 data-[state=closed]:scale-[0.98]"

--- a/apps/electron/src/renderer/components/tabs/TabSwitcher.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabSwitcher.tsx
@@ -369,9 +369,9 @@ export function TabSwitcher(): ReactElement | null {
 
   return (
     <div className="fixed inset-0 z-[9999] flex items-center justify-center">
-      <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" />
+      <div className="absolute inset-0 bg-black/40" />
 
-      <div className="relative bg-popover/95 backdrop-blur-md border border-border/50 rounded-xl shadow-2xl min-w-[420px] max-w-[540px] overflow-hidden">
+      <div className="relative bg-popover border border-border/50 rounded-xl shadow-2xl min-w-[420px] max-w-[540px] overflow-hidden">
         <div className="flex items-center justify-between gap-3 px-5 py-2.5 border-b border-border/40 bg-muted/30">
           <div className="flex items-center gap-2 min-w-0">
             <span className="text-[13px] font-medium text-foreground">切换会话</span>

--- a/apps/electron/src/renderer/components/ui/alert-dialog.tsx
+++ b/apps/electron/src/renderer/components/ui/alert-dialog.tsx
@@ -18,8 +18,7 @@ const AlertDialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Overlay
     className={cn(
-      // 与 Dialog 同款：blur + 适度深色，制造焦点
-      "fixed inset-0 z-[100] bg-black/40 backdrop-blur-sm titlebar-no-drag",
+      "fixed inset-0 z-[100] bg-black/40 titlebar-no-drag",
       "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}

--- a/apps/electron/src/renderer/components/ui/button.tsx
+++ b/apps/electron/src/renderer/components/ui/button.tsx
@@ -17,7 +17,7 @@ const buttonVariants = cva(
           "bg-destructive text-destructive-foreground shadow-[inset_0_1px_0_0_hsl(0_0%_100%/0.12),0_1px_2px_0_rgb(0_0_0/0.18)] hover:bg-destructive/92 hover:shadow-[inset_0_1px_0_0_hsl(0_0%_100%/0.16),0_2px_4px_-1px_rgb(0_0_0/0.22)]",
         // outline：背景半透明 + hairline 边框 + 极浅阴影，hover 时边框与背景同时加深
         outline:
-          "border border-border/60 bg-background/60 backdrop-blur-[2px] text-foreground shadow-[0_1px_1px_0_rgb(0_0_0/0.04)] hover:bg-accent/60 hover:border-border hover:text-accent-foreground hover:shadow-[0_1px_2px_0_rgb(0_0_0/0.06)]",
+          "border border-border/60 bg-background/80 text-foreground shadow-[0_1px_1px_0_rgb(0_0_0/0.04)] hover:bg-accent/80 hover:border-border hover:text-accent-foreground hover:shadow-[0_1px_2px_0_rgb(0_0_0/0.06)]",
         secondary:
           "bg-secondary text-secondary-foreground shadow-[inset_0_1px_0_0_hsl(0_0%_100%/0.04),0_1px_1px_0_rgb(0_0_0/0.04)] hover:bg-secondary/80 hover:shadow-[inset_0_1px_0_0_hsl(0_0%_100%/0.06),0_1px_2px_0_rgb(0_0_0/0.06)]",
         // ghost：无阴影，hover 仅替换背景，避免和实体按钮抢戏

--- a/apps/electron/src/renderer/components/ui/dialog.tsx
+++ b/apps/electron/src/renderer/components/ui/dialog.tsx
@@ -21,9 +21,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      // overlay：更轻的黑（避免暗主题压得太重）+ backdrop-blur 制造"焦点感"，
-      // 这是飞书/扣子/Linear 等现代 App 弹窗最显著的质感特征
-      "fixed inset-0 z-[100] bg-black/40 backdrop-blur-sm titlebar-no-drag",
+      "fixed inset-0 z-[100] bg-black/40 titlebar-no-drag",
       "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}

--- a/apps/electron/src/renderer/components/ui/image-lightbox.tsx
+++ b/apps/electron/src/renderer/components/ui/image-lightbox.tsx
@@ -42,7 +42,7 @@ export function ImageLightbox({
          */}
         <DialogPrimitive.Overlay
           className={cn(
-            'fixed inset-0 z-[200] bg-black/80 backdrop-blur-md titlebar-no-drag',
+            'fixed inset-0 z-[200] bg-black/90 titlebar-no-drag',
             'data-[state=open]:animate-in data-[state=closed]:animate-out',
             'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0'
           )}

--- a/apps/electron/src/renderer/components/ui/sheet.tsx
+++ b/apps/electron/src/renderer/components/ui/sheet.tsx
@@ -20,8 +20,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      // 与 Dialog 同款：blur + 适度深色。z-[100] 需高于 AppShell 内容区的 z-[60]，否则抽屉被主区盖住
-      "fixed inset-0 z-[100] bg-black/40 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-[100] bg-black/40 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}

--- a/apps/electron/src/renderer/components/ui/tooltip.tsx
+++ b/apps/electron/src/renderer/components/ui/tooltip.tsx
@@ -25,9 +25,8 @@ const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        // 深色毛玻璃效果：主题色调深色背景 + 模糊 + 高对比度文字
         "z-[10050] overflow-hidden rounded-lg px-3 py-2 text-xs",
-        "bg-tooltip/90 text-tooltip-foreground backdrop-blur-md",
+        "bg-tooltip text-tooltip-foreground",
         "shadow-lg shadow-black/25",
         "animate-in fade-in-0 zoom-in-95",
         "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",


### PR DESCRIPTION
## Summary

修复 #856 — 最近两个版本 app 流畅度明显下降，会话切换、设置面板弹出有卡顿（arm mac / windows 均复现，回退 0.12.1 即流畅）。

根因是 commit `27a7a14`（全局质感升级）在全屏 overlay 和按钮上重新引入了 `backdrop-blur`。每个 backdrop-blur 层都会让 GPU 把整个背景渲染为纹理 → 执行模糊着色器 → 合成，在集成显卡或弹窗叠加时（设置面板内再开下拉菜单）开销急剧上升。

**这是项目里反复踩的坑**：v0.9.11（"移除面板 backdrop-blur，GPU 占用显著下降"）和 v0.9.40（"backdrop-blur 回退到 sm"）都曾因同样原因回滚过。

## Changes

- 移除 7 个全屏 overlay 的 `backdrop-blur`（Dialog / Sheet / AlertDialog / SettingsDialog / SearchDialog / TabSwitcher / ImageLightbox），保留纯色半透明遮罩
- 移除 outline 按钮的 `backdrop-blur-[2px]`，bg 透明度 60% → 80% 补偿视觉
- 移除 Tooltip 的 `backdrop-blur-md`，改用不透明 `bg-tooltip`
- 移除 TabSwitcher 内容面板的 `backdrop-blur-md`
- 保留 lightbox 关闭/下载小按钮的 `backdrop-blur-sm`（面积小、触发频率低，开销可接受）

共 10 文件，+11 / -17 行，纯 CSS class 变更，无逻辑改动。

## Test plan

- [ ] 打开/关闭 设置面板，确认弹出流畅无卡顿
- [ ] 快速切换会话，确认无掉帧
- [ ] Dialog / Sheet / AlertDialog 各类弹窗视觉正常（遮罩仍有焦点感）
- [ ] 设置面板内再开下拉菜单，确认叠加场景流畅
- [ ] 图片 lightbox 预览正常，关闭/下载按钮可用
- [ ] Tooltip 文字清晰、背景不透明
- [ ] arm mac 与 windows 平台分别验证

Closes #856

🤖 Generated with [Claude Code](https://claude.com/claude-code)