### PR TITLE
fix(agent): 运行中切换模型对追加消息生效

### DIFF
--- a/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
@@ -1009,6 +1009,22 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
     )
     console.log(`[Claude 适配器] 权限模式已切换: sessionId=${sessionId}, mode=${mode}`)
   }
+
+  /**
+   * 动态切换活跃查询的模型
+   *
+   * 通过 SDK Query.setModel() 在查询进行中切换模型。
+   * 典型场景：用户在 Agent 运行中（streaming / backgroundWaiting）通过 ModelSelector 切换模型后追加消息。
+   */
+  async setModel(sessionId: string, model: string): Promise<void> {
+    const query = activeQueries.get(sessionId)
+    if (!query) {
+      console.warn(`[Claude 适配器] 无活跃查询，跳过模型切换: ${sessionId}`)
+      return
+    }
+    await (query as ReturnType<typeof import('@anthropic-ai/claude-agent-sdk').query>).setModel(model)
+    console.log(`[Claude 适配器] 模型已切换: sessionId=${sessionId}, model=${model}`)
+  }
 }
 
 /**

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -497,6 +497,9 @@ export class AgentOrchestrator {
   /** 运行中会话的当前权限模式（支持运行时动态切换） */
   private sessionPermissionModes = new Map<string, PromaPermissionMode>()
 
+  /** 运行中会话的当前模型 ID（注入消息时对比，变化则调 adapter.setModel 切 SDK 侧模型） */
+  private sessionRunningModels = new Map<string, string>()
+
   constructor(adapter: AgentProviderAdapter, eventBus: AgentEventBus) {
     this.adapter = adapter
     this.eventBus = eventBus
@@ -1013,6 +1016,8 @@ export class AgentOrchestrator {
     // 否则用本地 runGeneration 作为回退（headless 模式等无渲染进程场景）
     const streamStartedAt = input.startedAt ?? runGeneration
     this.activeSessions.set(sessionId, runGeneration)
+    // 记录本轮运行的模型，供注入通道（queueMessage）对比是否需要 setModel 切换
+    this.sessionRunningModels.set(sessionId, modelId || DEFAULT_MODEL_ID)
 
     const releaseActiveRun = (): void => {
       // 在发送 STREAM_COMPLETE 前释放 active slot，避免渲染进程已进入空闲态、
@@ -1020,6 +1025,7 @@ export class AgentOrchestrator {
       if (this.activeSessions.get(sessionId) !== runGeneration) return
       this.activeSessions.delete(sessionId)
       this.sessionPermissionModes.delete(sessionId)
+      this.sessionRunningModels.delete(sessionId)
       this.queuedMessageUuids.delete(sessionId)
     }
     const completeRun = (
@@ -2325,7 +2331,7 @@ export class AgentOrchestrator {
     text: string,
     _priority?: string,
     presetUuid?: string,
-    opts?: { interrupt?: boolean },
+    opts?: { interrupt?: boolean; modelId?: string },
   ): Promise<string> {
     if (!this.activeSessions.has(sessionId)) {
       throw new Error(`[Agent 编排] 会话未运行，无法追加消息: ${sessionId}`)
@@ -2341,6 +2347,20 @@ export class AgentOrchestrator {
     const uuids = this.queuedMessageUuids.get(sessionId) ?? new Set<string>()
     uuids.add(uuid)
     this.queuedMessageUuids.set(sessionId, uuids)
+
+    // 模型切换：用户在 Agent 运行中（streaming / backgroundWaiting）切了模型后追加消息，
+    // 注入前先把 SDK 侧模型切到新模型，否则本轮注入仍用启动时的旧模型。
+    if (opts?.modelId && this.adapter.setModel) {
+      const currentModel = this.sessionRunningModels.get(sessionId)
+      if (currentModel !== opts.modelId) {
+        try {
+          await this.adapter.setModel(sessionId, opts.modelId)
+          this.sessionRunningModels.set(sessionId, opts.modelId)
+        } catch (error) {
+          console.warn(`[Agent 编排] 注入前切换模型失败（将沿用旧模型继续）:`, error)
+        }
+      }
+    }
 
     // 构造 SDKUserMessage 并注入（强制 'now' 优先级）
     const sdkMessage = {

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -348,7 +348,7 @@ export async function queueAgentMessage(
     input.userMessage,
     undefined,
     input.uuid,
-    { interrupt: input.interrupt },
+    { interrupt: input.interrupt, modelId: input.modelId },
   )
 }
 

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -1301,6 +1301,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         sessionId,
         userMessage: effectiveText,
         uuid: localUuid,
+        modelId: agentModelId || undefined,
         interrupt: streaming,
       }).catch((error) => {
         console.error('[AgentView] 追加消息失败:', error)

--- a/packages/shared/src/types/agent-provider.ts
+++ b/packages/shared/src/types/agent-provider.ts
@@ -61,4 +61,6 @@ export interface AgentProviderAdapter {
   cancelQueuedMessage?(sessionId: string, messageUuid: string): Promise<void>
   /** 动态切换活跃查询的权限模式（可选，仅支持 SDK 原生 setPermissionMode 的 Provider） */
   setPermissionMode?(sessionId: string, mode: string): Promise<void>
+  /** 动态切换活跃查询的模型（可选，仅支持 SDK 原生 setModel 的 Provider） */
+  setModel?(sessionId: string, model: string): Promise<void>
 }

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -876,6 +876,12 @@ export interface AgentQueueMessageInput {
   /** 前端预生成的 UUID（用于乐观更新去重） */
   uuid?: string
   /**
+   * 当前会话选中的模型 ID。
+   * 用户在 Agent 运行中（streaming / backgroundWaiting）切换模型后追加消息时传入，
+   * 后端在注入前调用 SDK setModel 切换；与本轮启动时的模型相同则后端跳过切换。
+   */
+  modelId?: string
+  /**
    * 软中断当前 Agent turn 后再追加消息。
    * true：先调用 SDK query.interrupt() 立即打断正在输出的 turn，再注入消息。
    * false / undefined：排队追加（默认行为，turn 结束后才会被消费）。


### PR DESCRIPTION
## 问题

Agent 模式下切换模型对正在运行的会话不生效。

**根因**：Agent 运行中（streaming / backgroundWaiting）切换模型后，追加消息走 `queueAgentMessage` 注入通道，但该路径全程未传递 `modelId`——`renderer → service → orchestrator.queueMessage → adapter` 各层都没有 model 参数，消息被塞进以旧模型启动的 `query()`，导致切换不生效。

## 修复

利用 SDK 的 `query.setModel()`，注入消息前对比会话当前运行模型，变化则先切 SDK 侧模型再注入：

- `AgentProviderAdapter` 接口新增可选 `setModel(sessionId, model)`
- `ClaudeAgentAdapter` 实现 `setModel`，调 SDK `query.setModel()`（仿照已有 `setPermissionMode`）
- `AgentQueueMessageInput` 新增 `modelId` 字段
- `orchestrator` 用 `sessionRunningModels` map 记录本轮运行模型，`queueMessage` 注入前对比、变化才切（幂等避免无谓控制请求），`releaseActiveRun` 一并清理
- `service` 透传 `modelId`，`renderer` 注入路径传当前 `agentModelId`

## 测试计划

- [ ] Agent 运行中（流式输出途中）切换模型，追加消息，确认新模型生效（主进程日志 `[Claude 适配器] 模型已切换`）
- [ ] backgroundWaiting 软空闲态下切换模型，追加消息，确认新模型生效
- [ ] 不切模型连续追加消息，确认不触发无谓的 setModel（日志无重复切换）
- [ ] setModel 失败时消息仍能注入（兜底沿用旧模型）

## 待跟进（不在本 PR 范围）

会话**完全空闲后**发新消息走 `sendMessage` + `resume` 路径，不经过本次改动的注入通道。若 SDK 在 resume 时以会话头记录的模型为准、忽略 `model` 选项，那条路径仍需补 setModel——需先观察日志 \`[Agent 编排] SDK 确认模型\` 验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)