### PR TITLE
fix(chat-input): 修复斜杠命令补全弹出后按 Enter 误发送消息

### DIFF
--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -408,8 +408,13 @@ export function RichTextInput({
             return false
           }
 
-          // Mention 列表打开且有可选项时，让 TipTap Mention 处理 Enter
-          if (mentionActiveRef.current && mentionItemCountRef.current > 0) {
+          // Suggestion（@ 文件 / / Skill / # MCP / & 会话）弹窗激活时，让 TipTap Suggestion
+          // 插件处理 Enter（选中高亮项 / 关闭）。这里用实时 decoration 判定，而非 onStart 里
+          // 异步设置的 mentionActiveRef/mentionItemCountRef——后者要等 items() 异步加载
+          // （IPC 拉取工作区能力）resolve 后才置位，存在竞态窗口：插件已 active、补全列表
+          // 正在加载时按 Enter，旧逻辑会误判为无 mention 激活而把消息直接发送出去。
+          // data-decoration-id 由 @tiptap/suggestion 在 active 时同步渲染，与插件状态严格一致。
+          if (view.dom.querySelector('[data-decoration-id]')) {
             return false
           }
 


### PR DESCRIPTION
## 问题

在 Agent 输入框输入 `/` 弹出 Skill 补全列表后，按 Enter 不会选中高亮项填入输入框，反而把消息直接发送出去（`@` 文件 / `#` MCP / `&` 会话补全同理）。

## 根因

补全基于 `@tiptap/suggestion`，按 Enter 的链路是：编辑器 `handleKeyDown` 先跑 → 判断"补全弹窗激活"则 `return false` 放行 → 优先级 101 的 suggestion 插件接管 Enter → 选中。

放行判断原本依赖 suggestion `onStart` 里设置的 `mentionActiveRef`/`mentionItemCountRef`，而 `onStart` 要等 `items()` 这次**异步 IPC**（`getWorkspaceCapabilities`）resolve 后才执行。但 TipTap 插件的 `active` 状态与其 decoration 在事务 `apply` 时已**同步**生效。二者之间存在竞态窗口：**补全列表刚弹出、items 仍在加载时按 Enter，ref 还是 false**，编辑器误判无 mention 激活 → 走 `isSend` 把消息发出去。

## 修复

把放行判断从异步 ref 改为实时 `data-decoration-id` 检测——该属性由 `@tiptap/suggestion` 在 active 时同步渲染，与插件状态严格一致，彻底消除竞态窗口。未激活时返回 null、正常发送，不影响普通输入。

共用 `RichTextInput` 的 ChatInput / ScratchPad 也一并受益且无回归。

## 测试

- [x] `tsc --noEmit` 通过
- [ ] 手动：输入 `/` 弹出列表后立即按 Enter，应填入选中 Skill 而非发送消息
- [ ] 手动：`@` / `#` / `&` 补全 Enter 选中正常
- [ ] 手动：无补全时 Enter 正常发送、Shift+Enter 正常换行