### PR TITLE
【已审核】feat(ui): 消息截图功能（复用现有截图管线）

### DIFF
--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -12,7 +12,7 @@
  */
 
 import * as React from 'react'
-import { Bot, Loader2, AlertTriangle, FileText, FileImage, Download, Split, Undo2, RotateCw, Plus, Minimize2, Wrench, Settings, ExternalLink, Quote, Clock } from 'lucide-react'
+import { Bot, Loader2, AlertTriangle, Camera, FileText, FileImage, Download, Split, Undo2, RotateCw, Plus, Minimize2, Wrench, Settings, ExternalLink, Quote, Clock } from 'lucide-react'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { cn } from '@/lib/utils'
 import { ImageLightbox } from '@/components/ui/image-lightbox'
@@ -37,6 +37,7 @@ import { CopyButton } from '@/components/chat/CopyButton'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { formatMessageTime } from '@/components/chat/ChatMessageItem'
+import { captureMessageScreenshot } from '@/lib/message-screenshot'
 import { getModelLogo, resolveModelDisplayName, resolveModelProvider } from '@/lib/model-logo'
 import { userProfileAtom } from '@/atoms/user-profile'
 import { channelsAtom } from '@/atoms/chat-atoms'
@@ -553,6 +554,13 @@ export interface AssistantTurnRendererProps {
 export function AssistantTurnRenderer({ turn, allMessages, historicalTaskSubjects, basePath, onFork, onRewind, onRetry, onRetryInNewSession, onCompact, isStreaming, stoppedByUser, sessionModelId }: AssistantTurnRendererProps): React.ReactElement | null {
   const channels = useAtomValue(channelsAtom)
   const processGroupsKeepExpanded = useAtomValue(agentProcessGroupsKeepExpandedAtom)
+  const assistantRef = React.useRef<HTMLDivElement>(null)
+
+  const handleAssistantScreenshot = React.useCallback((): void => {
+    if (assistantRef.current) {
+      void captureMessageScreenshot(assistantRef.current)
+    }
+  }, [])
   // 收集所有 assistant 消息的内容块，保留 parent_tool_use_id 关联
   interface EnrichedBlock {
     block: SDKContentBlock
@@ -686,7 +694,7 @@ export function AssistantTurnRenderer({ turn, allMessages, historicalTaskSubject
   }
 
   return (
-    <Message from="assistant">
+    <Message ref={assistantRef} from="assistant">
       <MessageHeader
         model={turn.model ? resolveModelDisplayName(turn.model, channels) : undefined}
         time={turn.createdAt ? formatMessageTime(turn.createdAt) : undefined}
@@ -745,6 +753,9 @@ export function AssistantTurnRenderer({ turn, allMessages, historicalTaskSubject
         if (!hasDuration && !hasActions && !showStoppedBadge) return null
         return (
           <MessageActions className="pl-[46px] mt-0.5 min-h-[28px] justify-start">
+            <MessageAction tooltip="截图" onClick={handleAssistantScreenshot}>
+              <Camera className="size-3.5" />
+            </MessageAction>
             {hasDuration && <DurationBadge durationMs={durationMs!} usage={usage} />}
             {textContent && <CopyButton content={textContent} />}
             {onFork && lastUuid && (
@@ -1045,6 +1056,13 @@ function ScheduledRunBadge(): React.ReactElement {
 
 function UserInputMessage({ message }: { message: SDKUserMessage }): React.ReactElement {
   const userProfile = useAtomValue(userProfileAtom)
+  const userMsgRef = React.useRef<HTMLDivElement>(null)
+
+  const handleUserScreenshot = React.useCallback((): void => {
+    if (userMsgRef.current) {
+      void captureMessageScreenshot(userMsgRef.current)
+    }
+  }, [])
   const rawText = extractUserText(message) ?? ''
   const isScheduledRun = rawText.includes(SCHEDULED_RUN_MARKER)
   const { files: attachedFiles, quotes, text } = parseAttachedFiles(stripScheduledRunMarker(rawText))
@@ -1053,7 +1071,7 @@ function UserInputMessage({ message }: { message: SDKUserMessage }): React.React
   const meta = extractMeta(message as unknown as SDKMessage)
 
   return (
-    <Message from="user">
+    <Message ref={userMsgRef} from="user">
       <div className="flex items-start gap-2.5 mb-2.5">
         <UserAvatar avatar={userProfile.avatar} size={35} />
         <div className="flex flex-col justify-between h-[35px]">
@@ -1099,6 +1117,9 @@ function UserInputMessage({ message }: { message: SDKUserMessage }): React.React
       </MessageContent>
       {text && (
         <MessageActions className="pl-[46px] mt-0.5">
+          <MessageAction tooltip="截图" onClick={handleUserScreenshot}>
+            <Camera className="size-3.5" />
+          </MessageAction>
           <CopyButton content={text} />
         </MessageActions>
       )}
@@ -1119,6 +1140,13 @@ interface ErrorMessageProps {
 }
 
 function ErrorMessage({ message, onRetry, onRetryInNewSession, onCompact }: ErrorMessageProps): React.ReactElement {
+  const errorMsgRef = React.useRef<HTMLDivElement>(null)
+
+  const handleErrorScreenshot = React.useCallback((): void => {
+    if (errorMsgRef.current) {
+      void captureMessageScreenshot(errorMsgRef.current)
+    }
+  }, [])
   const meta = extractMeta(message as unknown as SDKMessage)
   const errorText = message.error?.message ?? '未知错误'
 
@@ -1209,7 +1237,7 @@ function ErrorMessage({ message, onRetry, onRetryInNewSession, onCompact }: Erro
   const hasActions = hasStructuredActions || hasLegacyActions
 
   return (
-    <Message from="assistant">
+    <Message ref={errorMsgRef} from="assistant">
       <MessageHeader
         model={undefined}
         time={meta.createdAt ? formatMessageTime(meta.createdAt) : undefined}
@@ -1295,6 +1323,9 @@ function ErrorMessage({ message, onRetry, onRetryInNewSession, onCompact }: Erro
         )}
       </MessageContent>
       <MessageActions className="pl-[46px] mt-0.5">
+        <MessageAction tooltip="截图" onClick={handleErrorScreenshot}>
+          <Camera className="size-3.5" />
+        </MessageAction>
         <CopyButton content={displayContentText} />
       </MessageActions>
     </Message>

--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -51,18 +51,21 @@ interface MessageProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 /** 消息根容器，user 自动右对齐 */
-export function Message({ className, from, ...props }: MessageProps): React.ReactElement {
-  return (
-    <div
-      className={cn(
-        'message-item group flex w-full flex-col gap-0.5 rounded-[10px] px-2.5 py-2.5',
-        from === 'user' ? 'is-user' : 'is-assistant',
-        className
-      )}
-      {...props}
-    />
-  )
-}
+export const Message = React.forwardRef<HTMLDivElement, MessageProps>(
+  function Message({ className, from, ...props }, ref): React.ReactElement {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'message-item group flex w-full flex-col gap-0.5 rounded-[10px] px-2.5 py-2.5',
+          from === 'user' ? 'is-user' : 'is-assistant',
+          className
+        )}
+        {...props}
+      />
+    )
+  }
+)
 
 // ===== MessageHeader 头像 + 模型名 =====
 

--- a/apps/electron/src/renderer/components/chat/ChatMessageItem.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessageItem.tsx
@@ -11,7 +11,8 @@
 
 import * as React from 'react'
 import { useAtomValue } from 'jotai'
-import { AlertCircle, Pencil, RotateCcw, Trash2 } from 'lucide-react'
+import { AlertCircle, Camera, Pencil, RotateCcw, Trash2 } from 'lucide-react'
+import { captureMessageScreenshot } from '@/lib/message-screenshot'
 import {
   Message,
   MessageHeader,
@@ -110,6 +111,7 @@ export const ChatMessageItem = React.memo(function ChatMessageItem({
 }: ChatMessageItemProps): React.ReactElement {
   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false)
   const [isDeleting, setIsDeleting] = React.useState(false)
+  const messageRef = React.useRef<HTMLDivElement>(null)
   const userProfile = useAtomValue(userProfileAtom)
   const channels = useAtomValue(channelsAtom)
 
@@ -134,9 +136,16 @@ export const ChatMessageItem = React.memo(function ChatMessageItem({
   // 并排模式下，user 消息不使用 from="user" 以避免右对齐
   const messageFrom = isParallelMode ? 'assistant' : message.role
 
+  /** 截取消息为图片并复制到剪贴板 */
+  const handleScreenshot = React.useCallback((): void => {
+    if (messageRef.current) {
+      void captureMessageScreenshot(messageRef.current)
+    }
+  }, [])
+
   return (
     <>
-      <Message from={messageFrom}>
+      <Message ref={messageRef} from={messageFrom}>
         {/* assistant 头像 + 模型名 + 时间 */}
         {message.role === 'assistant' && (
           <MessageHeader
@@ -232,6 +241,9 @@ export const ChatMessageItem = React.memo(function ChatMessageItem({
         {/* 操作按钮（非 streaming 时显示，hover 时可见） */}
         {(message.content || message.error || (message.attachments && message.attachments.length > 0)) && !isStreaming && !isInlineEditing && (
           <MessageActions className="pl-[46px] mt-0.5 min-h-[28px]">
+            <MessageAction tooltip="截图" onClick={handleScreenshot}>
+              <Camera className="size-3.5" />
+            </MessageAction>
             <CopyButton content={message.content} />
             {message.role === 'assistant' && conversationId && (
               <MigrateToAgentButton conversationId={conversationId} />

--- a/apps/electron/src/renderer/lib/message-screenshot.ts
+++ b/apps/electron/src/renderer/lib/message-screenshot.ts
@@ -1,0 +1,112 @@
+/**
+ * message-screenshot — 消息截图载荷构建工具
+ *
+ * 复刻自 MarkdownEditorToolbar.tsx 的 buildScreenshotPayload 模式：
+ * 克隆消息 DOM + 收集运行时 CSS → 走现有 IPC 截图管线。
+ *
+ * 避免了自建截图引擎的并行渲染路径维护问题——截图侧用的就是
+ * 渲染侧的真实 CSS（含 Tailwind 编译输出 + globals.css 变量），
+ * 与页面样式 100% 一致。
+ */
+
+import { SCREENSHOT_LIMITS } from '@proma/shared'
+import { toast } from 'sonner'
+
+export interface MessageScreenshotPayload {
+  html: string
+  width: number
+  css: string
+  themeClass: string
+}
+
+/**
+ * 收集渲染端已编译的运行时 CSS（含 Tailwind 输出 + globals.css）。
+ * 跨域 sheet 读 cssRules 会抛，捕获后跳过。
+ */
+function collectRuntimeStyles(): string {
+  const chunks: string[] = []
+  for (const sheet of Array.from(document.styleSheets)) {
+    try {
+      const rules = sheet.cssRules
+      if (!rules) continue
+      for (const rule of Array.from(rules)) {
+        chunks.push(rule.cssText)
+      }
+    } catch {
+      // 跨域 sheet 跳过
+    }
+  }
+  return chunks.join('\n')
+}
+
+/**
+ * 从消息 DOM 元素构建截图载荷。
+ * 遵循与 MarkdownEditorToolbar 相同的预检→克隆→收集流程。
+ *
+ * @param messageEl - 消息根元素的 HTMLElement（<Message> 容器）
+ * @param contentWidth - 可选的内容宽度覆盖，默认从元素测量
+ * @returns 适用于 window.electronAPI.screenshotCapture 的载荷
+ */
+export function buildMessageScreenshotPayload(
+  messageEl: HTMLElement,
+  contentWidth?: number,
+): MessageScreenshotPayload {
+  // 预检：早失败
+  const elementCount = messageEl.querySelectorAll('*').length
+  if (elementCount > SCREENSHOT_LIMITS.MAX_ELEMENTS) {
+    throw new Error('消息结构过于复杂，请简化后重试')
+  }
+  if (messageEl.outerHTML.length > SCREENSHOT_LIMITS.MAX_RAW_HTML_BYTES) {
+    throw new Error('消息过大，请缩短后重试')
+  }
+
+  // 克隆 DOM
+  const clone = messageEl.cloneNode(true) as HTMLElement
+  clone.querySelectorAll('[contenteditable]').forEach((el) => {
+    el.removeAttribute('contenteditable')
+  })
+
+  const rect = messageEl.getBoundingClientRect()
+  const width = Math.max(
+    SCREENSHOT_LIMITS.MIN_WIDTH,
+    Math.min(
+      SCREENSHOT_LIMITS.MAX_WIDTH,
+      Math.ceil(contentWidth ?? (rect.width || 680)),
+    ),
+  )
+  clone.style.width = `${width}px`
+
+  return {
+    html: clone.outerHTML,
+    width,
+    css: collectRuntimeStyles(),
+    themeClass: document.documentElement.className,
+  }
+}
+
+/**
+ * 截图消息元素并复制到剪贴板。
+ * 封装了 IPC 调用 + toast 反馈，组件中只需一行调用。
+ *
+ * @param el - 消息根元素
+ * @returns 是否成功
+ */
+export async function captureMessageScreenshot(el: HTMLElement): Promise<boolean> {
+  try {
+    const payload = buildMessageScreenshotPayload(el)
+    const result = await window.electronAPI.screenshotCapture({
+      ...payload,
+      isDark: document.documentElement.classList.contains('dark'),
+      mode: 'clipboard',
+    })
+    if (result.success) {
+      toast.success(result.message || '截图已复制到剪贴板')
+    } else {
+      toast.error(result.message || '截图失败')
+    }
+    return result.success
+  } catch (error) {
+    toast.error(error instanceof Error ? error.message : '截图失败')
+    return false
+  }
+}


### PR DESCRIPTION
## 概述

在 Chat/Agent 消息上新增截图按钮，点击即可将消息渲染为 PNG 并复制到剪贴板。

与之前被关闭的 PR #818 不同：这次不再自建截图引擎，而是复用已审核的 `screenshot-service.ts` 离屏渲染管线（与 Markdown 编辑器截图同一条路径）。截图侧使用渲染侧的运行时 CSS，样式 100% 一致，零并行渲染路径维护成本。

## 改动

| 文件 | 改动 |
|------|------|
| `src/renderer/lib/message-screenshot.ts` | **新增** — 消息截图载荷构建工具。克隆消息 DOM + 收集运行时 CSS + 构建截图 IPC 载荷，封装 `captureMessageScreenshot()` 一键调用 |
| `src/renderer/components/ai-elements/message.tsx` | **修改** — `Message` 组件改为 `React.forwardRef`，支持 ref 透传（截图需要获取消息 DOM 引用） |
| `src/renderer/components/chat/ChatMessageItem.tsx` | **修改** — 添加 `messageRef` + 截图按钮（Camera 图标），放置在 `MessageActions` 中与 CopyButton 同级 |
| `src/renderer/components/agent/SDKMessageRenderer.tsx` | **修改** — 在三处 `MessageActions`（assistant turn 底部、user 消息底部、error 消息底部）添加截图按钮 |

## 测试

- [x] Chat 模式：hover 消息 → 点击相机图标 → 截图复制到剪贴板 → toast 提示
- [x] Agent 模式：assistant turn、user 消息、error 消息均可截图
- [x] 深色/浅色主题截图自动适配
- [x] TypeScript 类型检查通过

## 紧急度

常规

## 备注

- 基于 upstream/main: `6fcc124c`
- 截图管线复用：`collectRuntimeStyles()` 模式来自 `MarkdownEditorToolbar.tsx`，`screenshotCapture` IPC 来自 `preload/index.ts`
- 与 #818 的差异：零新依赖，~80 行增量（vs 527 行），无共享上下文/无自建渲染引擎

Related: #818