### PR TITLE
【已审核】feat(ui): 多选截图

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -30,6 +30,7 @@ import { userProfileAtom } from '@/atoms/user-profile'
 import { tabMinimapCacheAtom } from '@/atoms/tab-atoms'
 import { channelsAtom } from '@/atoms/chat-atoms'
 import { ScrollPositionManager } from '@/hooks/useScrollPositionMemory'
+import { useMessageSelection } from '@/contexts/MessageSelectionContext'
 import { cn } from '@/lib/utils'
 import { Spinner } from '@/components/ui/spinner'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -398,6 +399,13 @@ export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persi
   const userProfile = useAtomValue(userProfileAtom)
   const setMinimapCache = useSetAtom(tabMinimapCacheAtom)
   const channels = useAtomValue(channelsAtom)
+  const { toggleSelect, isSelected } = useMessageSelection()
+  const handleGroupClick = React.useCallback((e: React.MouseEvent, groupId: string) => {
+    if (e.metaKey || e.ctrlKey) {
+      e.preventDefault()
+      toggleSelect(groupId)
+    }
+  }, [toggleSelect])
   /** 淡入控制：切换会话时先隐藏，等布局完成后再显示。 */
   const [ready, setReady] = React.useState(false)
   // 空会话无需淡入过渡（无消息则无滚动位置问题）
@@ -628,8 +636,11 @@ export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persi
                 && group.type === 'assistant-turn'
                 && idx === allGroups.findLastIndex((g) => g.type === 'assistant-turn')
               return (
+                <div key={getGroupId(group)} data-message-id={getGroupId(group)}
+                  onClick={(e) => handleGroupClick(e, getGroupId(group))}
+                  className={cn(isSelected(getGroupId(group)) && 'ring-2 ring-primary/40 bg-primary/[0.03] rounded-[10px]')}
+                >
                 <MessageGroupRenderer
-                  key={getGroupId(group)}
                   group={group}
                   allMessages={allSDKMessages}
                   historicalTaskSubjects={historicalTaskSubjects}
@@ -643,6 +654,7 @@ export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persi
                   stoppedByUser={isLastAssistantTurn || undefined}
                   sessionModelId={sessionModelId}
                 />
+                </div>
               )
             })}
 

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -26,6 +26,8 @@ import { PermissionModeSelector } from './PermissionModeSelector'
 import { AskUserBanner } from './AskUserBanner'
 import { ExitPlanModeBanner } from './ExitPlanModeBanner'
 import { PlanModeDashedBorder } from './PlanModeDashedBorder'
+import { MessageSelectionBar } from '@/components/chat/MessageSelectionBar'
+import { MessageSelectionProvider } from '@/contexts/MessageSelectionContext'
 import { ModelSelector } from '@/components/chat/ModelSelector'
 import { AttachmentPreviewItem } from '@/components/chat/AttachmentPreviewItem'
 import { QuotedSelectionChip } from '@/components/diff/QuotedSelectionChip'
@@ -2021,30 +2023,34 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   )
 
   return (
+    <MessageSelectionProvider>
     <>
     <AgentSessionProvider sessionId={sessionId}>
       <div className="flex flex-col h-full flex-1 min-w-0 max-w-[min(72rem,100%)] mx-auto">
         {/* Agent Header */}
         <AgentHeader sessionId={sessionId} />
 
-        {/* 消息区域 */}
-        <AgentMessages
-          sessionId={sessionId}
-          sessionModelId={agentModelId || undefined}
-          messagesLoaded={messagesLoaded}
-          persistedSDKMessages={persistedSDKMessages}
-          streaming={streaming}
-          streamState={streamState}
-          liveMessages={liveMessages}
-          sessionPath={sessionPath}
-          attachedDirs={allAttachedDirs}
-          stoppedByUser={stoppedByUser}
-          onRetry={handleRetry}
-          onRetryInNewSession={handleRetryInNewSession}
-          onFork={handleFork}
-          onRewind={handleRewindRequest}
-          onCompact={handleCompact}
-        />
+        {/* 消息区域 + 浮动操作栏 */}
+        <div className="relative flex-1 overflow-hidden">
+          <AgentMessages
+            sessionId={sessionId}
+            sessionModelId={agentModelId || undefined}
+            messagesLoaded={messagesLoaded}
+            persistedSDKMessages={persistedSDKMessages}
+            streaming={streaming}
+            streamState={streamState}
+            liveMessages={liveMessages}
+            sessionPath={sessionPath}
+            attachedDirs={allAttachedDirs}
+            stoppedByUser={stoppedByUser}
+            onRetry={handleRetry}
+            onRetryInNewSession={handleRetryInNewSession}
+            onFork={handleFork}
+            onRewind={handleRewindRequest}
+            onCompact={handleCompact}
+          />
+          <MessageSelectionBar />
+        </div>
 
         {/* 权限请求横幅 */}
         <PermissionBanner sessionId={sessionId} />
@@ -2197,5 +2203,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       </AlertDialogContent>
     </AlertDialog>
     </>
+  </MessageSelectionProvider>
   )
 }

--- a/apps/electron/src/renderer/components/chat/ChatMessageItem.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessageItem.tsx
@@ -11,7 +11,7 @@
 
 import * as React from 'react'
 import { useAtomValue } from 'jotai'
-import { AlertCircle, Check, Pencil, RotateCcw, Trash2 } from 'lucide-react'
+import { AlertCircle, Pencil, RotateCcw, Trash2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useMessageSelection } from '@/contexts/MessageSelectionContext'
 import {
@@ -114,7 +114,7 @@ export const ChatMessageItem = React.memo(function ChatMessageItem({
   const [isDeleting, setIsDeleting] = React.useState(false)
   const userProfile = useAtomValue(userProfileAtom)
   const channels = useAtomValue(channelsAtom)
-  const { toggleSelect, isSelected, selectedCount } = useMessageSelection()
+  const { toggleSelect, isSelected } = useMessageSelection()
   const selected = isSelected(message.id)
 
   /** 确认删除消息 */

--- a/apps/electron/src/renderer/components/chat/ChatMessageItem.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessageItem.tsx
@@ -11,7 +11,9 @@
 
 import * as React from 'react'
 import { useAtomValue } from 'jotai'
-import { AlertCircle, Pencil, RotateCcw, Trash2 } from 'lucide-react'
+import { AlertCircle, Check, Pencil, RotateCcw, Trash2 } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useMessageSelection } from '@/contexts/MessageSelectionContext'
 import {
   Message,
   MessageHeader,
@@ -112,6 +114,8 @@ export const ChatMessageItem = React.memo(function ChatMessageItem({
   const [isDeleting, setIsDeleting] = React.useState(false)
   const userProfile = useAtomValue(userProfileAtom)
   const channels = useAtomValue(channelsAtom)
+  const { toggleSelect, isSelected, selectedCount } = useMessageSelection()
+  const selected = isSelected(message.id)
 
   /** 确认删除消息 */
   const handleDeleteConfirm = async (): Promise<void> => {
@@ -134,9 +138,20 @@ export const ChatMessageItem = React.memo(function ChatMessageItem({
   // 并排模式下，user 消息不使用 from="user" 以避免右对齐
   const messageFrom = isParallelMode ? 'assistant' : message.role
 
+  const handleMessageClick = React.useCallback((e: React.MouseEvent) => {
+    if (e.metaKey || e.ctrlKey) {
+      e.preventDefault()
+      toggleSelect(message.id)
+    }
+  }, [message.id, toggleSelect])
+
   return (
     <>
-      <Message from={messageFrom}>
+      <Message
+        from={messageFrom}
+        onClick={handleMessageClick}
+        className={cn(selected && 'ring-2 ring-primary/40 bg-primary/[0.03]')}
+      >
         {/* assistant 头像 + 模型名 + 时间 */}
         {message.role === 'assistant' && (
           <MessageHeader

--- a/apps/electron/src/renderer/components/chat/ChatView.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatView.tsx
@@ -581,29 +581,27 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
           <div className="flex flex-col flex-1 w-full max-w-[min(72rem,100%)] mx-auto overflow-hidden min-h-0">
             {/* 中间：消息区域 + 浮动操作栏 */}
             <div className="relative flex flex-col flex-1 overflow-hidden min-h-0">
-              <div className="flex-1 overflow-y-auto min-h-0">
-                <ChatMessages
-                  conversationId={conversationId}
-                  messages={messages}
-                  messagesLoaded={messagesLoaded}
-                  streaming={isStreaming}
-                  streamingContent={streamingContent}
-                  streamingReasoning={streamingReasoning}
-                  streamingModel={streamingModel}
-                  startedAt={streamState?.startedAt}
-                  toolActivities={toolActivities}
-                  contextDividers={contextDividers}
-                  hasMore={hasMoreMessages}
-                  onDeleteMessage={handleDeleteMessage}
-                  onResendMessage={handleResendMessage}
-                  onStartInlineEdit={handleStartInlineEdit}
-                  onSubmitInlineEdit={handleSubmitInlineEdit}
-                  onCancelInlineEdit={handleCancelInlineEdit}
-                  inlineEditingMessageId={inlineEditingMessageId}
-                  onDeleteDivider={handleDeleteDivider}
-                  onLoadMore={handleLoadMore}
-                />
-              </div>
+              <ChatMessages
+                conversationId={conversationId}
+                messages={messages}
+                messagesLoaded={messagesLoaded}
+                streaming={isStreaming}
+                streamingContent={streamingContent}
+                streamingReasoning={streamingReasoning}
+                streamingModel={streamingModel}
+                startedAt={streamState?.startedAt}
+                toolActivities={toolActivities}
+                contextDividers={contextDividers}
+                hasMore={hasMoreMessages}
+                onDeleteMessage={handleDeleteMessage}
+                onResendMessage={handleResendMessage}
+                onStartInlineEdit={handleStartInlineEdit}
+                onSubmitInlineEdit={handleSubmitInlineEdit}
+                onCancelInlineEdit={handleCancelInlineEdit}
+                inlineEditingMessageId={inlineEditingMessageId}
+                onDeleteDivider={handleDeleteDivider}
+                onLoadMore={handleLoadMore}
+              />
               <MessageSelectionBar />
             </div>
 

--- a/apps/electron/src/renderer/components/chat/ChatView.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatView.tsx
@@ -21,6 +21,8 @@ import { ChatMessages } from './ChatMessages'
 import { ChatInput } from './ChatInput'
 import { AgentRecommendBanner } from './AgentRecommendBanner'
 import { PromptEditorSidebar } from './PromptEditorSidebar'
+import { MessageSelectionBar } from './MessageSelectionBar'
+import { MessageSelectionProvider } from '@/contexts/MessageSelectionContext'
 import type { InlineEditSubmitPayload } from './ChatMessageItem'
 import {
   conversationsAtom,
@@ -570,38 +572,44 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
   }, [conversationId])
 
   return (
-    <div className="flex h-full overflow-hidden">
-      {/* 主内容区域 */}
-      <div className="flex flex-col h-full flex-1 min-w-0">
-        {/* Header 在 max-w 外，按钮可到达最右侧 */}
-        <ChatHeader conversation={conversation} />
-        <div className="flex flex-col flex-1 w-full max-w-[min(72rem,100%)] mx-auto overflow-hidden min-h-0">
-          {/* 中间：消息区域 */}
-          <ChatMessages
-            conversationId={conversationId}
-            messages={messages}
-            messagesLoaded={messagesLoaded}
-            streaming={isStreaming}
-            streamingContent={streamingContent}
-            streamingReasoning={streamingReasoning}
-            streamingModel={streamingModel}
-            startedAt={streamState?.startedAt}
-            toolActivities={toolActivities}
-            contextDividers={contextDividers}
-            hasMore={hasMoreMessages}
-            onDeleteMessage={handleDeleteMessage}
-            onResendMessage={handleResendMessage}
-            onStartInlineEdit={handleStartInlineEdit}
-            onSubmitInlineEdit={handleSubmitInlineEdit}
-            onCancelInlineEdit={handleCancelInlineEdit}
-            inlineEditingMessageId={inlineEditingMessageId}
-            onDeleteDivider={handleDeleteDivider}
-            onLoadMore={handleLoadMore}
-          />
+    <MessageSelectionProvider>
+      <div className="flex h-full overflow-hidden">
+        {/* 主内容区域 */}
+        <div className="flex flex-col h-full flex-1 min-w-0">
+          {/* Header 在 max-w 外，按钮可到达最右侧 */}
+          <ChatHeader conversation={conversation} />
+          <div className="flex flex-col flex-1 w-full max-w-[min(72rem,100%)] mx-auto overflow-hidden min-h-0">
+            {/* 中间：消息区域 + 浮动操作栏 */}
+            <div className="relative flex flex-col flex-1 overflow-hidden min-h-0">
+              <div className="flex-1 overflow-y-auto min-h-0">
+                <ChatMessages
+                  conversationId={conversationId}
+                  messages={messages}
+                  messagesLoaded={messagesLoaded}
+                  streaming={isStreaming}
+                  streamingContent={streamingContent}
+                  streamingReasoning={streamingReasoning}
+                  streamingModel={streamingModel}
+                  startedAt={streamState?.startedAt}
+                  toolActivities={toolActivities}
+                  contextDividers={contextDividers}
+                  hasMore={hasMoreMessages}
+                  onDeleteMessage={handleDeleteMessage}
+                  onResendMessage={handleResendMessage}
+                  onStartInlineEdit={handleStartInlineEdit}
+                  onSubmitInlineEdit={handleSubmitInlineEdit}
+                  onCancelInlineEdit={handleCancelInlineEdit}
+                  inlineEditingMessageId={inlineEditingMessageId}
+                  onDeleteDivider={handleDeleteDivider}
+                  onLoadMore={handleLoadMore}
+                />
+              </div>
+              <MessageSelectionBar />
+            </div>
 
-          {/* 错误提示 */}
-          {chatError && (
-            <div className="mx-4 mb-2 px-4 py-2.5 rounded-lg bg-destructive/10 text-destructive text-sm flex items-center gap-2">
+            {/* 错误提示 */}
+            {chatError && (
+              <div className="mx-4 mb-2 px-4 py-2.5 rounded-lg bg-destructive/10 text-destructive text-sm flex items-center gap-2">
               <AlertCircle className="size-4 shrink-0" />
               <span className="flex-1 break-all">{chatError}</span>
               <button
@@ -649,5 +657,6 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
         </div>
       </div>
     </div>
-  )
+  </MessageSelectionProvider>
+)
 }

--- a/apps/electron/src/renderer/components/chat/MessageSelectionBar.tsx
+++ b/apps/electron/src/renderer/components/chat/MessageSelectionBar.tsx
@@ -1,0 +1,62 @@
+/**
+ * MessageSelectionBar — 底部浮动多选操作栏
+ *
+ * 显示"已选 N 条" + 截图按钮 + 清除按钮。
+ * Chat 和 Agent 模式共用。通过 data-message-id 属性定位 DOM。
+ */
+
+import { Camera, X } from 'lucide-react'
+import { useMessageSelection } from '@/contexts/MessageSelectionContext'
+import { captureMultiMessageScreenshot } from '@/lib/message-screenshot'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+export function MessageSelectionBar(): React.ReactElement | null {
+  const { selectedIds, clearSelection, selectedCount } = useMessageSelection()
+
+  if (selectedCount === 0) return null
+
+  const handleScreenshot = () => {
+    const els: HTMLElement[] = []
+    for (const id of selectedIds) {
+      const el = document.querySelector<HTMLElement>(`[data-message-id="${id}"]`)
+      if (el) els.push(el)
+    }
+    if (els.length === 0) return
+    void captureMultiMessageScreenshot(els)
+  }
+
+  return (
+    <div className="absolute left-0 right-0 bottom-0 flex items-center justify-center pb-3 z-10 pointer-events-none">
+      <div
+        className={cn(
+          'pointer-events-auto flex items-center gap-3 rounded-full border px-4 py-2',
+          'bg-white/80 dark:bg-zinc-800/80 backdrop-blur-md shadow-lg border-border/60',
+        )}
+      >
+        <span className="text-sm text-muted-foreground whitespace-nowrap">
+          已选 {selectedCount} 条
+        </span>
+
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-8 gap-1.5 rounded-full"
+          onClick={handleScreenshot}
+        >
+          <Camera className="size-3.5" />
+          截图
+        </Button>
+
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          className="h-8 w-8 rounded-full"
+          onClick={clearSelection}
+        >
+          <X className="size-3.5" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/contexts/MessageSelectionContext.tsx
+++ b/apps/electron/src/renderer/contexts/MessageSelectionContext.tsx
@@ -1,0 +1,79 @@
+/**
+ * MessageSelectionContext — 消息多选状态共享 Context
+ *
+ * 极简实现：只有选中状态,没有 DOM ref 注册。
+ * 截图中使用 data-message-id 属性 + querySelector 定位 DOM 元素。
+ */
+
+import * as React from 'react'
+
+interface MessageSelectionContextValue {
+  /** 当前选中的消息/Group ID 集合 */
+  selectedIds: Set<string>
+  /** 是否处于多选模式 */
+  isSelectMode: boolean
+  /** 切换选中状态 */
+  toggleSelect: (id: string) => void
+  /** 清除所有选中 */
+  clearSelection: () => void
+  /** 检查是否已选中 */
+  isSelected: (id: string) => boolean
+  /** 选中数量 */
+  selectedCount: number
+}
+
+const MessageSelectionContext = React.createContext<MessageSelectionContextValue | null>(null)
+
+export function useMessageSelection(): MessageSelectionContextValue {
+  const ctx = React.useContext(MessageSelectionContext)
+  if (!ctx) {
+    throw new Error('useMessageSelection must be used within MessageSelectionProvider')
+  }
+  return ctx
+}
+
+interface MessageSelectionProviderProps {
+  children: React.ReactNode
+}
+
+export function MessageSelectionProvider({ children }: MessageSelectionProviderProps): React.ReactElement {
+  const [selectedIds, setSelectedIds] = React.useState<Set<string>>(new Set())
+
+  const isSelectMode = selectedIds.size > 0
+
+  const toggleSelect = React.useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+      return next
+    })
+  }, [])
+
+  const clearSelection = React.useCallback(() => {
+    setSelectedIds(new Set())
+  }, [])
+
+  const isSelected = React.useCallback((id: string) => selectedIds.has(id), [selectedIds])
+
+  const value = React.useMemo<MessageSelectionContextValue>(
+    () => ({
+      selectedIds,
+      isSelectMode,
+      toggleSelect,
+      clearSelection,
+      isSelected,
+      selectedCount: selectedIds.size,
+    }),
+    [selectedIds, isSelectMode, toggleSelect, clearSelection, isSelected],
+  )
+
+  return (
+    <MessageSelectionContext.Provider value={value}>
+      {children}
+    </MessageSelectionContext.Provider>
+  )
+}

--- a/apps/electron/src/renderer/lib/message-screenshot.ts
+++ b/apps/electron/src/renderer/lib/message-screenshot.ts
@@ -1,0 +1,147 @@
+/**
+ * message-screenshot — 消息截图载荷构建工具
+ *
+ * 复刻自 MarkdownEditorToolbar.tsx 的 buildScreenshotPayload 模式：
+ * 克隆消息 DOM + 收集运行时 CSS → 走现有 IPC 截图管线。
+ *
+ * 避免了自建截图引擎的并行渲染路径维护问题——截图侧用的就是
+ * 渲染侧的真实 CSS（含 Tailwind 编译输出 + globals.css 变量），
+ * 与页面样式 100% 一致。
+ */
+
+import { SCREENSHOT_LIMITS } from '@proma/shared'
+import { toast } from 'sonner'
+
+export interface MessageScreenshotPayload {
+  html: string
+  width: number
+  css: string
+  themeClass: string
+}
+
+/**
+ * 收集渲染端已编译的运行时 CSS（含 Tailwind 输出 + globals.css）。
+ * 跨域 sheet 读 cssRules 会抛，捕获后跳过。
+ */
+function collectRuntimeStyles(): string {
+  const chunks: string[] = []
+  for (const sheet of Array.from(document.styleSheets)) {
+    try {
+      const rules = sheet.cssRules
+      if (!rules) continue
+      for (const rule of Array.from(rules)) {
+        chunks.push(rule.cssText)
+      }
+    } catch {
+      // 跨域 sheet 跳过
+    }
+  }
+  return chunks.join('\n')
+}
+
+/**
+ * 从消息 DOM 元素构建截图载荷。
+ * 遵循与 MarkdownEditorToolbar 相同的预检→克隆→收集流程。
+ *
+ * @param messageEl - 消息根元素的 HTMLElement（<Message> 容器）
+ * @param contentWidth - 可选的内容宽度覆盖，默认从元素测量
+ * @returns 适用于 window.electronAPI.screenshotCapture 的载荷
+ */
+export function buildMessageScreenshotPayload(
+  messageEl: HTMLElement,
+  contentWidth?: number,
+): MessageScreenshotPayload {
+  // 预检：早失败
+  const elementCount = messageEl.querySelectorAll('*').length
+  if (elementCount > SCREENSHOT_LIMITS.MAX_ELEMENTS) {
+    throw new Error('消息结构过于复杂，请简化后重试')
+  }
+  if (messageEl.outerHTML.length > SCREENSHOT_LIMITS.MAX_RAW_HTML_BYTES) {
+    throw new Error('消息过大，请缩短后重试')
+  }
+
+  // 克隆 DOM
+  const clone = messageEl.cloneNode(true) as HTMLElement
+  clone.querySelectorAll('[contenteditable]').forEach((el) => {
+    el.removeAttribute('contenteditable')
+  })
+
+  const rect = messageEl.getBoundingClientRect()
+  const width = Math.max(
+    SCREENSHOT_LIMITS.MIN_WIDTH,
+    Math.min(
+      SCREENSHOT_LIMITS.MAX_WIDTH,
+      Math.ceil(contentWidth ?? (rect.width || 680)),
+    ),
+  )
+  clone.style.width = `${width}px`
+
+  return {
+    html: clone.outerHTML,
+    width,
+    css: collectRuntimeStyles(),
+    themeClass: document.documentElement.className,
+  }
+}
+
+/**
+ * 截图消息元素并复制到剪贴板。
+ * 封装了 IPC 调用 + toast 反馈，组件中只需一行调用。
+ *
+ * @param el - 消息根元素
+ * @returns 是否成功
+ */
+export async function captureMessageScreenshot(el: HTMLElement): Promise<boolean> {
+  try {
+    const payload = buildMessageScreenshotPayload(el)
+    const result = await window.electronAPI.screenshotCapture({
+      ...payload,
+      isDark: document.documentElement.classList.contains('dark'),
+      mode: 'clipboard',
+    })
+    if (result.success) {
+      toast.success(result.message || '截图已复制到剪贴板')
+    } else {
+      toast.error(result.message || '截图失败')
+    }
+    return result.success
+  } catch (error) {
+    toast.error(error instanceof Error ? error.message : '截图失败')
+    return false
+  }
+}
+
+/**
+ * 多消息截图：选中 N 条消息，拼接 HTML 后一次 IPC 渲染。
+ *
+ * @param els - 选中的消息 DOM 元素列表
+ * @returns 是否成功
+ */
+export async function captureMultiMessageScreenshot(els: HTMLElement[]): Promise<boolean> {
+  if (els.length === 0) return false
+
+  try {
+    const payloads = els.map((el) => buildMessageScreenshotPayload(el))
+    const maxWidth = Math.max(...payloads.map((p) => p.width))
+    const combinedHtml = payloads.map((p) => p.html).join('\n<hr style="margin:0;border:none;border-top:1px solid #e5e7eb" />\n')
+
+    const first = payloads[0]!
+    const result = await window.electronAPI.screenshotCapture({
+      html: combinedHtml,
+      isDark: document.documentElement.classList.contains('dark'),
+      width: maxWidth,
+      mode: 'clipboard',
+      css: first.css,
+      themeClass: first.themeClass,
+    })
+    if (result.success) {
+      toast.success(`已截图 ${els.length} 条消息`)
+    } else {
+      toast.error(result.message || '截图失败')
+    }
+    return result.success
+  } catch (error) {
+    toast.error(error instanceof Error ? error.message : '截图失败')
+    return false
+  }
+}


### PR DESCRIPTION
## 概述

在单条消息截图（#877）基础上，新增多选截图功能。Ctrl/Cmd+Click 选中多条消息，底部浮动栏出现"截图 N 条"按钮，一键生成拼接截图。

## 改动

| 文件 | 改动 |
|------|------|
| `renderer/contexts/MessageSelectionContext.tsx` | **新增** — 选中状态 React Context（极简实现，仅 `Set<string>` + toggle/clear/isSelected） |
| `renderer/components/chat/MessageSelectionBar.tsx` | **新增** — 底部浮动操作栏，显示"已选 N 条" + 截图按钮 + 清除按钮 |
| `renderer/lib/message-screenshot.ts` | **新增** — 截图工具。`captureMultiMessageScreenshot()` 拼接多条 HTML 后一次 IPC 渲染 |
| `renderer/components/chat/ChatMessageItem.tsx` | **修改** — Ctrl/Cmd+Click 选中 + ring 高亮，`Check` 和 `selectedCount` 已清理 |
| `renderer/components/chat/ChatView.tsx` | **修改** — 包裹 `MessageSelectionProvider` + `MessageSelectionBar`，ChatMessages 直接作为 relative 子元素（其内部 Conversation/StickToBottom 自行管理滚动） |
| `renderer/components/agent/AgentView.tsx` | **修改** — Agent 模式多选支持 |
| `renderer/components/agent/AgentMessages.tsx` | **修改** — `data-message-id` wrapper + Ctrl/Cmd+Click 选中 |

## 测试

- [x] Chat/Agent 模式：Ctrl/Cmd+Click 选中/取消 → 浮动栏 → 截图按钮
- [x] 浮动栏定位在消息区底部，不遮挡内容
- [x] TypeScript 类型检查通过
- [x] 自审查修复：移除 ChatView 多余 overflow-y-auto wrapper（避免嵌套双滚动），清理死 import/变量

## 紧急度

常规

## 备注

- 选中粒度：Chat 按单条消息，Agent 按整个 turn
- 不引入新依赖，截图管线复用 `screenshot-service.ts`
- 合并需在 #877 之后

Related: #877