### PR TITLE
【已审核】fix(ui): 统一文件路径解析 basePaths 构建，修复 Windows C:/ 绝对路径识别

### DIFF
--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -962,6 +962,14 @@ export const workspaceAttachedDirectoriesMapAtom = atom<Map<string, string[]>>(n
  */
 export const workspaceAttachedFilesMapAtom = atom<Map<string, string[]>>(new Map())
 
+/**
+ * 工作区共享文件目录路径缓存（按 workspace slug 存储）
+ *
+ * 由 AgentView 在挂载时通过 IPC 获取，供 MarkdownInlineCode / buildAutoPreviewFile
+ * 同步读取，避免 FilePathChip 初次渲染因异步时序缺失 workspaceFilesPath。
+ */
+export const agentWorkspaceFilesPathMapAtom = atom<Map<string, string>>(new Map())
+
 /** 当前 Agent 会话的草稿内容（派生读写原子） */
 export const currentAgentSessionDraftAtom = atom(
   (get) => {

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -29,6 +29,7 @@ import { getModelLogo, resolveModelDisplayName, resolveModelProvider } from '@/l
 import { userProfileAtom } from '@/atoms/user-profile'
 import { tabMinimapCacheAtom } from '@/atoms/tab-atoms'
 import { channelsAtom } from '@/atoms/chat-atoms'
+import { agentSessionsAtom, agentWorkspacesAtom, agentWorkspaceFilesPathMapAtom } from '@/atoms/agent-atoms'
 import { ScrollPositionManager } from '@/hooks/useScrollPositionMemory'
 import { cn } from '@/lib/utils'
 import { Spinner } from '@/components/ui/spinner'
@@ -398,6 +399,25 @@ export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persi
   const userProfile = useAtomValue(userProfileAtom)
   const setMinimapCache = useSetAtom(tabMinimapCacheAtom)
   const channels = useAtomValue(channelsAtom)
+  const agentSessions = useAtomValue(agentSessionsAtom)
+  const agentWorkspaces = useAtomValue(agentWorkspacesAtom)
+  const workspaceFilesPathMap = useAtomValue(agentWorkspaceFilesPathMapAtom)
+
+  // 补全 basePaths：将 workspaceFilesPath 从 atom 缓存补入，消除 IPC 异步时序缺口
+  const enrichedAttachedDirs = React.useMemo(() => {
+    const dirs = [...(attachedDirs ?? [])]
+    const session = agentSessions.find((s) => s.id === sessionId)
+    if (session?.workspaceId) {
+      const ws = agentWorkspaces.find((w) => w.id === session.workspaceId)
+      if (ws?.slug) {
+        const wfp = workspaceFilesPathMap.get(ws.slug)
+        if (wfp && !dirs.includes(wfp)) {
+          dirs.push(wfp)
+        }
+      }
+    }
+    return dirs
+  }, [attachedDirs, sessionId, agentSessions, agentWorkspaces, workspaceFilesPathMap])
   /** 淡入控制：切换会话时先隐藏，等布局完成后再显示。 */
   const [ready, setReady] = React.useState(false)
   // 空会话无需淡入过渡（无消息则无滚动位置问题）
@@ -609,7 +629,7 @@ export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persi
     : (liveMessages != null && liveMessages.some((m) => (m as { type: string }).type === 'assistant'))
 
   return (
-    <BasePathsProvider basePaths={attachedDirs}>
+    <BasePathsProvider basePaths={enrichedAttachedDirs}>
     <Conversation resize={ready && !transitioning ? 'smooth' : 'instant'} className={ready ? (skipFadeIn ? 'opacity-100' : 'opacity-100 transition-opacity duration-200') : 'opacity-0'}>
       <ScrollPositionManager id={sessionId} ready={ready} />
       <ConversationContent>
@@ -676,7 +696,7 @@ export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persi
                             block={block}
                             allMessages={allSDKMessages}
                             basePath={sessionPath || undefined}
-                            basePaths={attachedDirs}
+                            basePaths={enrichedAttachedDirs}
                             index={index}
                             dimmed={hasSmoothTextContent && block.type !== 'text'}
                             isStreaming={streaming}

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -77,6 +77,7 @@ import {
   agentAttachedFilesMapAtom,
   workspaceAttachedDirectoriesMapAtom,
   workspaceAttachedFilesMapAtom,
+  agentWorkspaceFilesPathMapAtom,
   liveMessagesMapAtom,
   agentThinkingAtom,
   stoppedByUserSessionsAtom,
@@ -461,6 +462,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const setSessionPathMap = useSetAtom(agentSessionPathMapAtom)
   const sessionPath = sessionPathMap.get(sessionId) ?? null
   const [workspaceFilesPath, setWorkspaceFilesPath] = React.useState<string | null>(null)
+  const setWorkspaceFilesPathMap = useSetAtom(agentWorkspaceFilesPathMapAtom)
   const [isDragOver, setIsDragOver] = React.useState(false)
   const [errorCopied, setErrorCopied] = React.useState(false)
 
@@ -548,18 +550,34 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       })
   }, [sessionId, currentWorkspaceId, setSessionPathMap])
 
-  // 获取工作区共享文件目录路径（@ 引用时需要搜索）
+  // 获取工作区共享文件目录路径（@ 引用时需要搜索），同步写入 atom 供其他组件读取
   const workspaceSlug = workspaces.find((w) => w.id === currentWorkspaceId)?.slug ?? null
   React.useEffect(() => {
     if (!workspaceSlug) {
       setWorkspaceFilesPath(null)
+      setWorkspaceFilesPathMap(new Map())
       return
     }
     window.electronAPI
       .getWorkspaceFilesPath(workspaceSlug)
-      .then(setWorkspaceFilesPath)
-      .catch(() => setWorkspaceFilesPath(null))
-  }, [workspaceSlug])
+      .then((path) => {
+        setWorkspaceFilesPath(path)
+        setWorkspaceFilesPathMap((prev) => {
+          const next = new Map(prev)
+          if (path) next.set(workspaceSlug, path)
+          else next.delete(workspaceSlug)
+          return next
+        })
+      })
+      .catch(() => {
+        setWorkspaceFilesPath(null)
+        setWorkspaceFilesPathMap((prev) => {
+          const next = new Map(prev)
+          next.delete(workspaceSlug)
+          return next
+        })
+      })
+  }, [workspaceSlug, setWorkspaceFilesPathMap])
 
   // 获取工作区级附加文件（@ 引用和路径解析都需要）
   React.useEffect(() => {

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -555,7 +555,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   React.useEffect(() => {
     if (!workspaceSlug) {
       setWorkspaceFilesPath(null)
-      setWorkspaceFilesPathMap(new Map())
       return
     }
     window.electronAPI

--- a/apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx
@@ -12,6 +12,8 @@ import { cn } from '@/lib/utils'
 import { FileTypeIcon } from '@/components/file-browser/FileTypeIcon'
 import { useOpenPreview } from '@/components/diff/preview-opener'
 import { currentAgentSessionIdAtom } from '@/atoms/agent-atoms'
+import { buildOrderedBasePaths } from '@/lib/session-base-paths'
+import { getFileParentPath } from '@/lib/file-utils'
 import {
   ContextMenu,
   ContextMenuTrigger,
@@ -97,7 +99,7 @@ export function FilePathChip({ filePath, basePath, basePaths, className }: FileP
 
   const filename = getFileName(cleanPath)
 
-  const isAbsolute = cleanPath.startsWith('/') || /^[A-Z]:\\/.test(cleanPath)
+  const isAbsolute = cleanPath.startsWith('/') || /^[A-Za-z]:[\\/]/.test(cleanPath)
 
   const chipRef = React.useRef<HTMLButtonElement>(null)
   const [fileStatus, setFileStatus] = React.useState<'idle' | 'resolved' | 'broken'>('idle')
@@ -168,12 +170,20 @@ export function FilePathChip({ filePath, basePath, basePaths, className }: FileP
     const sessionId = store.get(currentAgentSessionIdAtom)
     if (!sessionId) return
 
+    // 统一构建 basePaths，包含 dirPath（目标文件父目录）提升解析优先级
+    const dirPath = isAbsolute ? getFileParentPath(cleanPath) : null
+    const previewBasePaths = buildOrderedBasePaths({
+      dirPath,
+      sessionPath: candidateBases[0] ?? undefined,
+      sessionAttachedDirs: candidateBases,
+    })
+
     openPreview(sessionId, {
       filePath: cleanPath,
       previewOnly: true,
-      basePaths: candidateBases.length > 0 ? candidateBases : undefined,
+      basePaths: previewBasePaths.length > 0 ? previewBasePaths : undefined,
     })
-  }, [store, openPreview, cleanPath, candidateBases])
+  }, [store, openPreview, cleanPath, candidateBases, isAbsolute])
 
   const handleShowInFolder = React.useCallback(() => {
     const bases = candidateBases.length > 0 ? candidateBases : undefined
@@ -236,8 +246,8 @@ export function isAbsoluteFilePath(text: string): boolean {
     return true
   }
 
-  // Windows 绝对路径
-  if (/^[A-Z]:\\/.test(clean)) return true
+  // Windows 绝对路径（兼容 C:\foo 和 C:/foo）
+  if (/^[A-Za-z]:[\\/]/.test(clean)) return true
 
   return false
 }

--- a/apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx
@@ -171,6 +171,7 @@ export function FilePathChip({ filePath, basePath, basePaths, className }: FileP
     if (!sessionId) return
 
     // 统一构建 basePaths，包含 dirPath（目标文件父目录）提升解析优先级
+    // candidateBases 由 MarkdownInlineCode 按 sessionPath 置首的顺序构建，首元素即为 sessionPath
     const dirPath = isAbsolute ? getFileParentPath(cleanPath) : null
     const previewBasePaths = buildOrderedBasePaths({
       dirPath,

--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -38,6 +38,7 @@ import { LoadingIndicator } from '@/components/ui/loading-indicator'
 import { CodeBlock, MermaidBlock } from '@proma/ui'
 import { detectLanguage } from '@proma/core'
 import { FilePathChip, isAbsoluteFilePath, isRelativeFilePath } from './file-path-chip'
+import { buildOrderedBasePaths } from '@/lib/session-base-paths'
 import type { HTMLAttributes, ComponentProps, ReactNode } from 'react'
 import type { FileAttachment } from '@proma/shared'
 
@@ -505,15 +506,12 @@ const MarkdownInlineCode = React.memo(function MarkdownInlineCode({
   const text = typeof codeChildren === 'string' ? codeChildren : ''
 
   if (text) {
-    // 合并 basePath（主 cwd）+ basePaths（props 或 context 提供的附加目录）作为候选
-    const merged: string[] = []
-    if (basePath) merged.push(basePath)
+    // 使用统一函数构建 basePaths，保证与 buildAutoPreviewFile 等消费者顺序一致
     const allExtra = basePaths || ctxBasePaths
-    if (allExtra) {
-      for (const p of allExtra) {
-        if (p && !merged.includes(p)) merged.push(p)
-      }
-    }
+    const merged = buildOrderedBasePaths({
+      sessionPath: basePath,
+      sessionAttachedDirs: allExtra,
+    })
     if (isAbsoluteFilePath(text)) {
       return <FilePathChip filePath={text.trim()} basePaths={merged.length > 0 ? merged : undefined} />
     }

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -40,6 +40,7 @@ import {
   workspaceAttachedFilesMapAtom,
   unviewedCompletedSessionIdsAtom,
   agentSessionPathMapAtom,
+  agentWorkspaceFilesPathMapAtom,
   agentDiffRefreshVersionAtom,
 } from '@/atoms/agent-atoms'
 import {
@@ -462,6 +463,9 @@ export function useGlobalAgentListeners(): void {
       if (!slug) return null
       const cached = workspaceFilesPathCache.get(slug)
       if (cached) return cached
+      // 优先从 atom 缓存读取，避免冗余 IPC
+      const atomCached = store.get(agentWorkspaceFilesPathMapAtom).get(slug)
+      if (atomCached) return atomCached
       try {
         const path = await window.electronAPI.getWorkspaceFilesPath(slug)
         workspaceFilesPathCache.set(slug, path)

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -60,6 +60,7 @@ import { inferContextWindow } from '@proma/shared'
 import { buildExternalAgentRunActivation } from '@/lib/external-agent-run'
 import { getAgentCompletionMarkers } from '@/lib/agent-completion-presence'
 import { getPlanModeChangeFromToolName, updatePlanModeSessionSet } from '@/lib/agent-plan-mode'
+import { buildOrderedBasePaths } from '@/lib/session-base-paths'
 
 /** 触发右侧文件浏览器自动定位的写入类工具集合 */
 const WRITE_TOOLS = new Set(['Write', 'Edit', 'MultiEdit', 'NotebookEdit', 'Update'])
@@ -484,15 +485,15 @@ export function useGlobalAgentListeners(): void {
       const workspaceAttachedFiles = workspaceId
         ? (store.get(workspaceAttachedFilesMapAtom).get(workspaceId) ?? [])
         : []
-      const basePaths = uniqueTruthyPaths([
+      const basePaths = buildOrderedBasePaths({
         sessionPath,
         workspaceFilesPath,
         dirPath,
-        ...sessionAttachedDirs,
-        ...sessionAttachedFiles,
-        ...workspaceAttachedDirs,
-        ...workspaceAttachedFiles,
-      ])
+        sessionAttachedDirs,
+        sessionAttachedFiles,
+        workspaceAttachedDirs,
+        workspaceAttachedFiles,
+      })
 
       let previewOnly = true
       if (dirPath) {

--- a/apps/electron/src/renderer/lib/session-base-paths.ts
+++ b/apps/electron/src/renderer/lib/session-base-paths.ts
@@ -41,7 +41,7 @@ export function buildOrderedBasePaths(input: BasePathsInput): string[] {
   const result: string[] = []
 
   function add(path: string | null | undefined): void {
-    if (!path) return
+    if (path == null || path === '') return
     // 标准化：去除尾部分隔符
     const normalized = path.replace(/[/\\]+$/, '')
     if (normalized && !result.includes(normalized)) {

--- a/apps/electron/src/renderer/lib/session-base-paths.ts
+++ b/apps/electron/src/renderer/lib/session-base-paths.ts
@@ -1,0 +1,74 @@
+/**
+ * 统一的会话 basePaths 构建工具
+ *
+ * 用于在 FilePathChip 渲染、自动预览、手动预览间保持一致的文件路径解析候选集。
+ * 优先级：dirPath > sessionPath > workspaceFilesPath > 附加目录 > 附加文件父目录
+ * 去重保留首次出现顺序，避免 resolveTargetPath 因顺序敏感产生不一致。
+ */
+
+import { getFileParentPath } from './file-utils'
+
+export interface BasePathsInput {
+  /** 会话工作目录（CWD） */
+  sessionPath?: string | null
+  /** 工作区共享文件目录（~/.proma/agent-workspaces/{slug}/workspace-files） */
+  workspaceFilesPath?: string | null
+  /** 目标文件所在目录（最精确的 hint） */
+  dirPath?: string | null
+  /** 会话级附加目录 */
+  sessionAttachedDirs?: string[]
+  /** 会话级附加文件 */
+  sessionAttachedFiles?: string[]
+  /** 工作区级附加目录 */
+  workspaceAttachedDirs?: string[]
+  /** 工作区级附加文件 */
+  workspaceAttachedFiles?: string[]
+}
+
+/**
+ * 按优先级排序、去重的 basePaths 列表
+ *
+ * 优先级（降序）：
+ * 1. dirPath — 目标文件的直接父目录
+ * 2. sessionPath — 当前会话 CWD
+ * 3. workspaceFilesPath — 工作区共享文件
+ * 4. 会话级附加目录
+ * 5. 工作区级附加目录
+ * 6. 会话级附加文件（父目录）
+ * 7. 工作区级附加文件（父目录）
+ */
+export function buildOrderedBasePaths(input: BasePathsInput): string[] {
+  const result: string[] = []
+
+  function add(path: string | null | undefined): void {
+    if (!path) return
+    // 标准化：去除尾部分隔符
+    const normalized = path.replace(/[/\\]+$/, '')
+    if (normalized && !result.includes(normalized)) {
+      result.push(normalized)
+    }
+  }
+
+  // 1. 最精确 hint：目标文件所在目录
+  add(input.dirPath)
+
+  // 2. 会话工作目录
+  add(input.sessionPath)
+
+  // 3. 工作区共享文件目录
+  add(input.workspaceFilesPath)
+
+  // 4. 会话级附加目录
+  for (const d of input.sessionAttachedDirs ?? []) add(d)
+
+  // 5. 工作区级附加目录
+  for (const d of input.workspaceAttachedDirs ?? []) add(d)
+
+  // 6. 会话级附加文件（取其父目录）
+  for (const f of input.sessionAttachedFiles ?? []) add(getFileParentPath(f))
+
+  // 7. 工作区级附加文件（取其父目录）
+  for (const f of input.workspaceAttachedFiles ?? []) add(getFileParentPath(f))
+
+  return result
+}


### PR DESCRIPTION
## 概述

修复 FilePathChip 路径解析在不同来源间 basePaths 不统一的问题。PR #830 的 review 指出三类来源的相对路径解析依赖的 basePath 集合不统一，导致「打开预览」可能失败。

- 新建 `buildOrderedBasePaths()` 统一函数，按优先级排序去重
- 三个消费者（MarkdownInlineCode / handleClick / buildAutoPreviewFile）全部迁移
- 修复 Windows 绝对路径正则 `C:\` → `C:[/\]`，兼容 `C:/` 正斜杠
- workspaceFilesPath 通过 atom 跨组件同步 + AgentMessages 补全，消除异步时序缺口
- 安全策略（isPathAllowed 白名单）按设计不变，仅影响工作区范围文件

## 改动

- **新建** `lib/session-base-paths.ts` — `buildOrderedBasePaths()` 统一 basePaths 构建
- **修复** `file-path-chip.tsx` — Windows 正斜杠正则 + handleClick 统一 basePaths + dirPath
- **统一** `message.tsx` — MarkdownInlineCode 改用统一函数
- **统一** `useGlobalAgentListeners.ts` — buildAutoPreviewFile 改用统一函数
- **新增** `agent-atoms.ts` `agentWorkspaceFilesPathMapAtom`
- **同步** `AgentView.tsx` — workspaceFilesPath 获取时写入 atom
- **补全** `AgentMessages.tsx` — 读 atom 补 workspaceFilesPath 到 BasePathsContext

## 测试

- TypeScript 检查通过
- 编译 + Windows 打包通过
- `C:/` 正斜杠路径可识别为 chip（与 #830 合并后实测）
- `C:\ ` 反斜杠不受影响
- 三种来源（会话 CWD / workspace-files / 附加目录）统一 basePaths
- workspaceFilesPath 异步时序缺口已关闭

## 紧急度

低

## 备注

- Related: #830（解决 review 指出的上游路径解析稳定性问题）
- 安全策略按设计保持：`file:resolve-path` 仅放行工作区范围文件（与 `shell:show-item-in-folder` 职责分离）