### PR TITLE
【自审中】feat(artifact): 新增 Artifacts 基础设施 — 沙箱、契约、Agent 工具、流跟踪、持久化

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -37,6 +37,8 @@ import { isTransientNetworkError, isMalformedResponseError } from './error-patte
 import { AgentEventBus } from './agent-event-bus'
 import { decryptApiKey, getChannelById, listChannels } from './channel-manager'
 import { injectAutomationMcpServer } from './automation-agent-tools'
+import { injectArtifactMcpServer, getArtifactAllowedToolNames, buildArtifactRunPrompt } from './artifact-agent-tools'
+import { ArtifactPartialStreamTracker } from './artifact-partial-stream'
 import { getAdapter, fetchTitle, normalizeAnthropicBaseUrlForSdk, getPromaUserAgent } from '@proma/core'
 import pkg from '../../../package.json' with { type: 'json' }
 import { getFetchFn } from './proxy-fetch'
@@ -731,6 +733,23 @@ export class AgentOrchestrator {
   }
 
   /**
+   * 注入 Artifact 工具（create_artifact / edit_artifact）
+   */
+  private async injectArtifactTools(
+    sdk: typeof import('@anthropic-ai/claude-agent-sdk'),
+    mcpServers: Record<string, Record<string, unknown>>,
+    sessionId: string,
+    workspaceId?: string,
+  ): Promise<void> {
+    try {
+      await injectArtifactMcpServer(sdk, mcpServers, { sessionId, workspaceId })
+      console.log(`[Agent 编排] 已注入 Artifact 工具 (artifact)`)
+    } catch (err) {
+      console.error(`[Agent 编排] 注入 Artifact 工具失败:`, err)
+    }
+  }
+
+  /**
    * 生成 Agent 会话标题
    *
    * 使用 Provider 适配器系统，支持所有渠道。任何错误返回 null。
@@ -1227,6 +1246,11 @@ export class AgentOrchestrator {
         triggeredBy: input.triggeredBy,
       })
 
+      // 注入 Artifact 工具（需用户显式启用）
+      if (input.artifactsEnabled) {
+        await this.injectArtifactTools(sdk, mcpServers, sessionId, workspaceId)
+      }
+
       // 合并外部注入的自定义 MCP 服务器（如飞书群聊工具）
       if (customMcpServers) {
         Object.assign(mcpServers, customMcpServers)
@@ -1525,7 +1549,7 @@ export class AgentOrchestrator {
         // 从实际 tool_use 流里同步，避免 UI 停留在计划阶段。
         allowDangerouslySkipPermissions: !canUseTool,
         canUseTool,
-        ...(sdkPermissionModeForPromaMode(initialPermissionMode) === 'auto' && { allowedTools: [...SAFE_TOOLS] }),
+        ...(sdkPermissionModeForPromaMode(initialPermissionMode) === 'auto' && { allowedTools: [...SAFE_TOOLS, ...(input.artifactsEnabled ? getArtifactAllowedToolNames(true) : [])] }),
         // claude_code preset 提供基础环境信息（platform/shell/OS/git/model/知识截止日期等）
         // buildSystemPrompt 追加 Proma 特有指令（角色定义、SubAgent 策略、工作区信息等）
         systemPrompt: {
@@ -1539,7 +1563,7 @@ export class AgentOrchestrator {
             memoryEnabled: (() => { const mc = getMemoryConfig(); return mc.enabled && !!mc.apiKey })(),
             claudeAvailable,
             deepSeekSubagentModel: modelRouting.subagentModel,
-          }) + (automationContext ? `\n\n## 定时任务执行上下文\n\n${automationContext}` : ''),
+          }) + (automationContext ? `\n\n## 定时任务执行上下文\n\n${automationContext}` : '') + (input.artifactsEnabled ? `\n\n${buildArtifactRunPrompt()}` : ''),
         },
         resumeSessionId: existingSdkSessionId,
         // 回退后 resume：从指定消息处继续（SDK 在同一 JSONL 内创建分支）
@@ -1697,6 +1721,9 @@ export class AgentOrchestrator {
           // 后台任务等待态：result 走轻量完成后置 true，下一轮真正开始（收到 assistant/user/task 消息）时
           // 置回 false 并发 run_resumed，让 UI 从空闲态恢复运行态。
           let awaitingBackgroundWake = false
+
+          // Artifact 部分流跟踪器（渐进式 artifact 内容预览）
+          const artifactTracker = input.artifactsEnabled ? new ArtifactPartialStreamTracker() : null
 
           while (true) {
             if (!pendingNext) {
@@ -1931,6 +1958,19 @@ export class AgentOrchestrator {
               // 跳过 SDK 内部 user 消息的前端推送
             } else {
               this.eventBus.emit(sessionId, { kind: 'sdk_message', message: msg })
+
+              // Artifact 部分流事件分发
+              if (artifactTracker) {
+                for (const event of artifactTracker.handleMessage(msg)) {
+                  this.eventBus.emit(sessionId, { kind: 'proma_event', event })
+                }
+                // assistant 消息完成时发送 artifact_stream_end
+                if (msg.type === 'assistant') {
+                  for (const event of artifactTracker.buildFinalEvents(msg)) {
+                    this.eventBus.emit(sessionId, { kind: 'proma_event', event })
+                  }
+                }
+              }
             }
           }
 

--- a/apps/electron/src/main/lib/artifact-agent-tools.test.ts
+++ b/apps/electron/src/main/lib/artifact-agent-tools.test.ts
@@ -1,0 +1,78 @@
+import { describe, test, expect } from 'bun:test'
+import {
+  ARTIFACT_SERVER_NAME,
+  ARTIFACT_CREATE_TOOL,
+  ARTIFACT_EDIT_TOOL,
+  isArtifactToolName,
+  isArtifactGuidelineToolName,
+  isArtifactsEnabled,
+  getArtifactAllowedToolNames,
+} from './artifact-agent-tools'
+
+describe('artifact-agent-tools', () => {
+  describe('isArtifactsEnabled', () => {
+    test('returns true when enabled', () => {
+      expect(isArtifactsEnabled({ enabled: true })).toBe(true)
+    })
+
+    test('returns false when disabled', () => {
+      expect(isArtifactsEnabled({ enabled: false })).toBe(false)
+    })
+
+    test('returns false when undefined', () => {
+      expect(isArtifactsEnabled(undefined)).toBe(false)
+    })
+  })
+
+  describe('getArtifactAllowedToolNames', () => {
+    test('returns tool names when enabled', () => {
+      const names = getArtifactAllowedToolNames(true)
+      expect(names).toContain(ARTIFACT_CREATE_TOOL)
+      expect(names).toContain(ARTIFACT_EDIT_TOOL)
+      expect(names).toContain('load_artifact_guidelines')
+    })
+
+    test('includes MCP-qualified names', () => {
+      const names = getArtifactAllowedToolNames(true)
+      expect(names).toContain(`mcp__${ARTIFACT_SERVER_NAME}__${ARTIFACT_CREATE_TOOL}`)
+      expect(names).toContain(`mcp__${ARTIFACT_SERVER_NAME}__${ARTIFACT_EDIT_TOOL}`)
+    })
+
+    test('returns empty when disabled', () => {
+      expect(getArtifactAllowedToolNames(false)).toEqual([])
+    })
+  })
+
+  describe('isArtifactToolName', () => {
+    test('recognizes create_artifact', () => {
+      expect(isArtifactToolName(ARTIFACT_CREATE_TOOL)).toBe(true)
+    })
+
+    test('recognizes edit_artifact', () => {
+      expect(isArtifactToolName(ARTIFACT_EDIT_TOOL)).toBe(true)
+    })
+
+    test('recognizes MCP-qualified create_artifact', () => {
+      expect(isArtifactToolName(`mcp__artifact__${ARTIFACT_CREATE_TOOL}`)).toBe(true)
+    })
+
+    test('recognizes MCP-qualified edit_artifact', () => {
+      expect(isArtifactToolName(`mcp__artifact__${ARTIFACT_EDIT_TOOL}`)).toBe(true)
+    })
+
+    test('rejects unrelated tool names', () => {
+      expect(isArtifactToolName('read')).toBe(false)
+      expect(isArtifactToolName('write')).toBe(false)
+    })
+  })
+
+  describe('isArtifactGuidelineToolName', () => {
+    test('recognizes load_artifact_guidelines', () => {
+      expect(isArtifactGuidelineToolName('load_artifact_guidelines')).toBe(true)
+    })
+
+    test('recognizes MCP-qualified name', () => {
+      expect(isArtifactGuidelineToolName('mcp__artifact__load_artifact_guidelines')).toBe(true)
+    })
+  })
+})

--- a/apps/electron/src/main/lib/artifact-agent-tools.ts
+++ b/apps/electron/src/main/lib/artifact-agent-tools.ts
@@ -10,11 +10,27 @@ interface ArtifactToolResult extends Record<string, unknown> {
 
 type ZodNamespace = typeof import('zod')['z']
 
+import type { Artifact } from '@proma/shared'
+import {
+  ARTIFACT_CREATE_TOOL,
+  ARTIFACT_EDIT_TOOL,
+  ARTIFACT_LOAD_GUIDELINES_TOOL,
+  MAX_ARTIFACT_CONTENT_CHARS,
+  isArtifactToolName,
+  isArtifactGuidelineToolName,
+} from '@proma/shared'
+import { saveArtifact } from './artifact-service'
+
+export {
+  ARTIFACT_CREATE_TOOL,
+  ARTIFACT_EDIT_TOOL,
+  ARTIFACT_LOAD_GUIDELINES_TOOL,
+  MAX_ARTIFACT_CONTENT_CHARS,
+  isArtifactToolName,
+  isArtifactGuidelineToolName,
+}
+
 export const ARTIFACT_SERVER_NAME = 'artifact'
-export const ARTIFACT_CREATE_TOOL = 'create_artifact'
-export const ARTIFACT_EDIT_TOOL = 'edit_artifact'
-export const ARTIFACT_LOAD_GUIDELINES_TOOL = 'load_artifact_guidelines'
-export const MAX_ARTIFACT_CONTENT_CHARS = 120_000
 
 export function isArtifactsEnabled(config: { enabled?: boolean } | undefined): boolean {
   return config?.enabled === true
@@ -32,19 +48,6 @@ export function getArtifactAllowedToolNames(enabled: boolean): string[] {
     ARTIFACT_CREATE_TOOL,
     ARTIFACT_EDIT_TOOL,
   ]
-}
-
-export function isArtifactToolName(toolName: string): boolean {
-  return (
-    toolName === ARTIFACT_CREATE_TOOL ||
-    toolName === ARTIFACT_EDIT_TOOL ||
-    toolName.endsWith(`__${ARTIFACT_CREATE_TOOL}`) ||
-    toolName.endsWith(`__${ARTIFACT_EDIT_TOOL}`)
-  )
-}
-
-export function isArtifactGuidelineToolName(toolName: string): boolean {
-  return toolName === ARTIFACT_LOAD_GUIDELINES_TOOL || toolName.endsWith(`__${ARTIFACT_LOAD_GUIDELINES_TOOL}`)
 }
 
 function jsonResult(payload: Record<string, unknown>): ArtifactToolResult {
@@ -164,20 +167,26 @@ export async function injectArtifactMcpServer(
         schemas.createArtifact,
         async (args) => {
           const artifactId = `art-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+          const now = Date.now()
+          const artifact: Artifact = {
+            id: artifactId,
+            title: args.title,
+            type: args.type,
+            language: args.language,
+            content: args.content,
+            description: args.description,
+            version: 1,
+            sessionId: ctx.sessionId,
+            workspaceId: ctx.workspaceId,
+            createdAt: now,
+            updatedAt: now,
+          }
+          saveArtifact(artifact)
           return jsonResult({
             type: 'artifact_created',
             ok: true,
             artifact: {
-              id: artifactId,
-              title: args.title,
-              type: args.type,
-              language: args.language,
-              content: args.content,
-              description: args.description,
-              version: 1,
-              sessionId: ctx.sessionId,
-              workspaceId: ctx.workspaceId,
-              runId: ctx.runId,
+              ...artifact,
               contentLength: args.content.length,
             },
           })

--- a/apps/electron/src/main/lib/artifact-agent-tools.ts
+++ b/apps/electron/src/main/lib/artifact-agent-tools.ts
@@ -1,0 +1,205 @@
+interface ArtifactToolContext {
+  sessionId: string
+  workspaceId?: string
+  runId?: string
+}
+
+interface ArtifactToolResult extends Record<string, unknown> {
+  content: Array<{ type: 'text'; text: string }>
+}
+
+type ZodNamespace = typeof import('zod')['z']
+
+export const ARTIFACT_SERVER_NAME = 'artifact'
+export const ARTIFACT_CREATE_TOOL = 'create_artifact'
+export const ARTIFACT_EDIT_TOOL = 'edit_artifact'
+export const ARTIFACT_LOAD_GUIDELINES_TOOL = 'load_artifact_guidelines'
+export const MAX_ARTIFACT_CONTENT_CHARS = 120_000
+
+export function isArtifactsEnabled(config: { enabled?: boolean } | undefined): boolean {
+  return config?.enabled === true
+}
+
+const ARTIFACT_MCP_TOOL_PREFIX = 'artifact'
+
+export function getArtifactAllowedToolNames(enabled: boolean): string[] {
+  if (!enabled) return []
+  return [
+    `mcp__${ARTIFACT_MCP_TOOL_PREFIX}__${ARTIFACT_LOAD_GUIDELINES_TOOL}`,
+    `mcp__${ARTIFACT_MCP_TOOL_PREFIX}__${ARTIFACT_CREATE_TOOL}`,
+    `mcp__${ARTIFACT_MCP_TOOL_PREFIX}__${ARTIFACT_EDIT_TOOL}`,
+    ARTIFACT_LOAD_GUIDELINES_TOOL,
+    ARTIFACT_CREATE_TOOL,
+    ARTIFACT_EDIT_TOOL,
+  ]
+}
+
+export function isArtifactToolName(toolName: string): boolean {
+  return (
+    toolName === ARTIFACT_CREATE_TOOL ||
+    toolName === ARTIFACT_EDIT_TOOL ||
+    toolName.endsWith(`__${ARTIFACT_CREATE_TOOL}`) ||
+    toolName.endsWith(`__${ARTIFACT_EDIT_TOOL}`)
+  )
+}
+
+export function isArtifactGuidelineToolName(toolName: string): boolean {
+  return toolName === ARTIFACT_LOAD_GUIDELINES_TOOL || toolName.endsWith(`__${ARTIFACT_LOAD_GUIDELINES_TOOL}`)
+}
+
+function jsonResult(payload: Record<string, unknown>): ArtifactToolResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(payload) }],
+  }
+}
+
+function buildSchemas(z: ZodNamespace) {
+  return {
+    loadGuidelines: {
+      focus: z.enum(['general', 'chart', 'diagram', 'interactive', 'dashboard']).optional()
+        .describe('Optional guideline focus for the artifact you are about to build.'),
+    },
+    createArtifact: {
+      title: z.string().min(1).max(120).describe('Short human-readable artifact title.'),
+      type: z.enum(['code', 'html', 'svg', 'mermaid', 'markdown'])
+        .describe('Artifact content type: code (source code), html (interactive widget), svg (vector graphic), mermaid (diagram), markdown (document).'),
+      content: z.string().min(1).max(MAX_ARTIFACT_CONTENT_CHARS)
+        .describe('Artifact content. For html type: HTML/SVG/CSS/JS fragment (no doctype/html/head/body). For code type: source code. For markdown: markdown text.'),
+      language: z.string().max(40).optional()
+        .describe('Programming language identifier for code type artifacts (e.g. typescript, python, go).'),
+      description: z.string().max(500).optional()
+        .describe('One short sentence describing what the artifact shows.'),
+    },
+    editArtifact: {
+      artifact_id: z.string().min(1).describe('ID of the artifact to edit.'),
+      title: z.string().min(1).max(120).optional()
+        .describe('Updated artifact title.'),
+      content: z.string().min(1).max(MAX_ARTIFACT_CONTENT_CHARS).optional()
+        .describe('Updated artifact content (full replacement, not diff).'),
+      language: z.string().max(40).optional()
+        .describe('Updated programming language for code type artifacts.'),
+    },
+  }
+}
+
+export function buildArtifactRunPrompt(): string {
+  return [
+    '## Artifact authorization for this run',
+    '',
+    'The user has enabled Artifacts for this run. You may use `create_artifact` and `edit_artifact` tools to create and iterate on persistent, named content pieces that appear in a dedicated side panel.',
+    '',
+    'Rules:',
+    '- Before your first artifact in this run, call `load_artifact_guidelines` with the closest focus.',
+    '- Use `create_artifact` to produce a new named artifact. Use `edit_artifact` to update an existing one.',
+    '- For html type: do not include doctype, html, head, body, iframe, object, embed, form, or base tags.',
+    '- html type artifacts run in a sandboxed iframe. Do not use inline event handlers such as onclick/onerror.',
+    '- Do not fetch live data from inside an artifact. Use data already present in the conversation.',
+    '- Default visual style: light surfaces, warm neutral cards, flat solid fills, 8-12px radii, restrained accents.',
+    '- For charts and dashboards, data marks must be visibly encoded with contrasting fills, borders, labels, and legends.',
+    '- Prefer responsive SVG/CSS/vanilla JS. Keep text legible, dimensions stable.',
+  ].join('\n')
+}
+
+export function getArtifactGuidelines(focus: string = 'general'): string {
+  const common = [
+    'Build polished, self-contained content for the artifact side panel.',
+    'For html artifacts: use inline CSS scoped to one root element. Do not style html or body.',
+    'Use app-friendly CSS variables: --background, --foreground, --muted, --muted-foreground, --border, --primary, --card.',
+    'Default aesthetic: flat, native, calm, readable. Prefer light/transparent outer surfaces with warm neutral cards.',
+    'Do not paint with pure black (#000, #050505) unless the user explicitly requests a dark theme.',
+    'For streaming safety, place scripts at the end of html artifacts.',
+    'Never use iframe/object/embed/form/base/meta/link. Never use javascript:, data:, vbscript:, or file: URLs.',
+  ]
+
+  const focused: Record<string, string[]> = {
+    chart: [
+      'For charts, provide labeled axes, units, legends, and useful empty states.',
+      'Prefer SVG or lightweight canvas.',
+      'Every data mark must be visible before interaction.',
+    ],
+    diagram: [
+      'For diagrams, prioritize readable hierarchy, alignment, connectors, labels.',
+      'Use SVG viewBox with width="100%" and avoid tiny labels.',
+    ],
+    interactive: [
+      'For interactive artifacts, keep state local to the iframe.',
+      'Controls should have immediate visual feedback and sane defaults.',
+    ],
+    dashboard: [
+      'For dashboards, lead with the most important state, use dense but readable cards.',
+      'Avoid decorative hero layouts.',
+    ],
+    general: [],
+  }
+
+  return [...common, ...(focused[focus] ?? [])].join('\n')
+}
+
+export async function injectArtifactMcpServer(
+  sdk: typeof import('@anthropic-ai/claude-agent-sdk'),
+  mcpServers: Record<string, Record<string, unknown>>,
+  ctx: ArtifactToolContext,
+): Promise<void> {
+  const { z } = await import('zod')
+  const schemas = buildSchemas(z)
+
+  const server = sdk.createSdkMcpServer({
+    name: ARTIFACT_SERVER_NAME,
+    version: '1.0.0',
+    tools: [
+      sdk.tool(
+        ARTIFACT_LOAD_GUIDELINES_TOOL,
+        'Load concise Artifact design and safety guidelines before creating an artifact.',
+        schemas.loadGuidelines,
+        async (args) => jsonResult({
+          type: 'artifact_guidelines',
+          focus: args.focus ?? 'general',
+          guidelines: getArtifactGuidelines(args.focus ?? 'general'),
+        }),
+        { annotations: { readOnlyHint: true } },
+      ),
+      sdk.tool(
+        ARTIFACT_CREATE_TOOL,
+        'Create a new named artifact that appears in the side panel. Use for code, HTML widgets, SVG graphics, Mermaid diagrams, or Markdown documents.',
+        schemas.createArtifact,
+        async (args) => {
+          const artifactId = `art-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+          return jsonResult({
+            type: 'artifact_created',
+            ok: true,
+            artifact: {
+              id: artifactId,
+              title: args.title,
+              type: args.type,
+              language: args.language,
+              content: args.content,
+              description: args.description,
+              version: 1,
+              sessionId: ctx.sessionId,
+              workspaceId: ctx.workspaceId,
+              runId: ctx.runId,
+              contentLength: args.content.length,
+            },
+          })
+        },
+      ),
+      sdk.tool(
+        ARTIFACT_EDIT_TOOL,
+        'Edit an existing artifact by ID. Updates title, content, and/or language. The new content replaces the old content entirely.',
+        schemas.editArtifact,
+        async (args) => jsonResult({
+          type: 'artifact_edited',
+          ok: true,
+          artifact_id: args.artifact_id,
+          updates: {
+            ...(args.title !== undefined && { title: args.title }),
+            ...(args.content !== undefined && { content: args.content }),
+            ...(args.language !== undefined && { language: args.language }),
+          },
+        }),
+      ),
+    ],
+  })
+
+  mcpServers[ARTIFACT_SERVER_NAME] = server as unknown as Record<string, unknown>
+}

--- a/apps/electron/src/main/lib/artifact-partial-stream.test.ts
+++ b/apps/electron/src/main/lib/artifact-partial-stream.test.ts
@@ -1,0 +1,193 @@
+import { describe, test, expect } from 'bun:test'
+import { ArtifactPartialStreamTracker } from './artifact-partial-stream'
+import type { SDKMessage, PromaEvent } from '@proma/shared'
+
+type ArtifactStreamEvent = Extract<PromaEvent, { type: 'artifact_stream' }>
+type ArtifactStreamEndEvent = Extract<PromaEvent, { type: 'artifact_stream_end' }>
+
+function asStreamEvent(e: PromaEvent): ArtifactStreamEvent {
+  return e as ArtifactStreamEvent
+}
+function asStreamEndEvent(e: PromaEvent): ArtifactStreamEndEvent {
+  return e as ArtifactStreamEndEvent
+}
+
+function makeStreamEvent(event: Record<string, unknown>, parentToolUseId?: string | null): SDKMessage {
+  return {
+    type: 'stream_event',
+    event,
+    parent_tool_use_id: parentToolUseId ?? null,
+  } as unknown as SDKMessage
+}
+
+function makeAssistantMessage(blocks: Record<string, unknown>[]): SDKMessage {
+  return {
+    type: 'assistant',
+    message: { content: blocks },
+  } as unknown as SDKMessage
+}
+
+describe('ArtifactPartialStreamTracker', () => {
+  test('ignores non-stream_event messages', () => {
+    const tracker = new ArtifactPartialStreamTracker()
+    const events = tracker.handleMessage({ type: 'user', message: {} } as unknown as SDKMessage)
+    expect(events).toEqual([])
+  })
+
+  test('tracks create_artifact content_block_start and deltas', () => {
+    const tracker = new ArtifactPartialStreamTracker()
+
+    const start = makeStreamEvent({
+      type: 'content_block_start',
+      index: 0,
+      content_block: {
+        type: 'tool_use',
+        id: 'toolu_001',
+        name: 'create_artifact',
+      },
+    })
+    expect(tracker.handleMessage(start)).toEqual([])
+
+    const delta = makeStreamEvent({
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'input_json_delta', partial_json: '{"title":' },
+    })
+    const events = tracker.handleMessage(delta)
+    expect(events).toHaveLength(1)
+    expect(events[0]!.type).toBe('artifact_stream')
+    expect(asStreamEvent(events[0]!).toolUseId).toBe('toolu_001')
+    expect(asStreamEvent(events[0]!).partialJson).toBe('{"title":')
+  })
+
+  test('tracks edit_artifact blocks', () => {
+    const tracker = new ArtifactPartialStreamTracker()
+
+    const start = makeStreamEvent({
+      type: 'content_block_start',
+      index: 0,
+      content_block: {
+        type: 'tool_use',
+        id: 'toolu_002',
+        name: 'edit_artifact',
+      },
+    })
+    expect(tracker.handleMessage(start)).toEqual([])
+
+    const delta = makeStreamEvent({
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'input_json_delta', partial_json: '{"artifact_id":"art-001"}' },
+    })
+    const events = tracker.handleMessage(delta)
+    expect(events).toHaveLength(1)
+    expect(asStreamEvent(events[0]!).toolName).toBe('edit_artifact')
+  })
+
+  test('recognizes MCP-qualified artifact tool names', () => {
+    const tracker = new ArtifactPartialStreamTracker()
+
+    const start = makeStreamEvent({
+      type: 'content_block_start',
+      index: 0,
+      content_block: {
+        type: 'mcp_tool_use',
+        id: 'toolu_003',
+        name: 'create_artifact',
+        server_name: 'artifact',
+      },
+    })
+    expect(tracker.handleMessage(start)).toEqual([])
+
+    const delta = makeStreamEvent({
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'input_json_delta', partial_json: '{"type":"html"}' },
+    })
+    const events = tracker.handleMessage(delta)
+    expect(events).toHaveLength(1)
+  })
+
+  test('ignores non-artifact tool blocks', () => {
+    const tracker = new ArtifactPartialStreamTracker()
+
+    const start = makeStreamEvent({
+      type: 'content_block_start',
+      index: 0,
+      content_block: {
+        type: 'tool_use',
+        id: 'toolu_004',
+        name: 'read',
+      },
+    })
+    expect(tracker.handleMessage(start)).toEqual([])
+  })
+
+  test('clears block on content_block_stop', () => {
+    const tracker = new ArtifactPartialStreamTracker()
+
+    const start = makeStreamEvent({
+      type: 'content_block_start',
+      index: 0,
+      content_block: {
+        type: 'tool_use',
+        id: 'toolu_005',
+        name: 'create_artifact',
+      },
+    })
+    tracker.handleMessage(start)
+
+    const stop = makeStreamEvent({ type: 'content_block_stop', index: 0 })
+    tracker.handleMessage(stop)
+
+    // After stop, deltas should not be tracked
+    const delta = makeStreamEvent({
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'input_json_delta', partial_json: 'should not appear' },
+    })
+    expect(tracker.handleMessage(delta)).toEqual([])
+  })
+
+  test('builds final events from assistant message', () => {
+    const tracker = new ArtifactPartialStreamTracker()
+
+    const events = tracker.buildFinalEvents(makeAssistantMessage([
+      { type: 'tool_use', id: 'toolu_010', name: 'create_artifact', input: { title: 'Chart', type: 'html', content: '<svg/>' } },
+      { type: 'text', text: 'Here is your chart:' },
+    ]))
+
+    expect(events).toHaveLength(1)
+    expect(events[0]!.type).toBe('artifact_stream_end')
+    expect(asStreamEndEvent(events[0]!).toolUseId).toBe('toolu_010')
+    expect(asStreamEndEvent(events[0]!).input).toEqual({ title: 'Chart', type: 'html', content: '<svg/>' })
+  })
+
+  test('accumulates partial JSON across deltas', () => {
+    const tracker = new ArtifactPartialStreamTracker()
+
+    tracker.handleMessage(makeStreamEvent({
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'tool_use', id: 'toolu_020', name: 'create_artifact' },
+    }))
+
+    tracker.handleMessage(makeStreamEvent({
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'input_json_delta', partial_json: '{"title":"He' },
+    }))
+    tracker.handleMessage(makeStreamEvent({
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'input_json_delta', partial_json: 'llo"}' },
+    }))
+
+    // buildFinalEvents captures the completed input
+    const events = tracker.buildFinalEvents(makeAssistantMessage([
+      { type: 'tool_use', id: 'toolu_020', name: 'create_artifact', input: { title: 'Hello' } },
+    ]))
+    expect(events).toHaveLength(1)
+    expect(asStreamEndEvent(events[0]!).input).toEqual({ title: 'Hello' })
+  })
+})

--- a/apps/electron/src/main/lib/artifact-partial-stream.ts
+++ b/apps/electron/src/main/lib/artifact-partial-stream.ts
@@ -1,0 +1,126 @@
+import type { PromaEvent, SDKAssistantMessage, SDKMessage } from '@proma/shared'
+import { isArtifactToolName } from './artifact-agent-tools'
+
+interface TrackedArtifactBlock {
+  toolUseId: string
+  toolName: string
+  partialJson: string
+  parentToolUseId?: string | null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function getEventIndex(event: Record<string, unknown>): number | undefined {
+  return numberValue(event.index)
+}
+
+function getParentToolUseId(message: SDKMessage): string | null | undefined {
+  const value = (message as Record<string, unknown>).parent_tool_use_id
+  return value === null || typeof value === 'string' ? value : undefined
+}
+
+function getToolUseName(block: Record<string, unknown>): string | undefined {
+  const name = stringValue(block.name)
+  if (!name) return undefined
+  const serverName = stringValue(block.server_name)
+  if (serverName === 'artifact') return name
+  if (isArtifactToolName(name)) return name
+  return undefined
+}
+
+function isArtifactBlock(block: unknown): block is Record<string, unknown> {
+  if (!isRecord(block)) return false
+  const type = stringValue(block.type)
+  if (type !== 'tool_use' && type !== 'mcp_tool_use') return false
+  const name = getToolUseName(block)
+  return typeof name === 'string' && isArtifactToolName(name)
+}
+
+function createStreamEvent(block: TrackedArtifactBlock): PromaEvent {
+  return {
+    type: 'artifact_stream',
+    toolUseId: block.toolUseId,
+    toolName: block.toolName,
+    partialJson: block.partialJson,
+    parentToolUseId: block.parentToolUseId,
+    updatedAt: Date.now(),
+  }
+}
+
+export class ArtifactPartialStreamTracker {
+  private readonly blocks = new Map<number, TrackedArtifactBlock>()
+
+  handleMessage(message: SDKMessage): PromaEvent[] {
+    if ((message as Record<string, unknown>).type !== 'stream_event') return []
+
+    const event = (message as { event?: unknown }).event
+    if (!isRecord(event)) return []
+
+    const eventType = stringValue(event.type)
+    const index = getEventIndex(event)
+    if (index == null) return []
+
+    if (eventType === 'content_block_start') {
+      const block = event.content_block
+      if (!isArtifactBlock(block)) return []
+      const toolUseId = stringValue(block.id)
+      const toolName = getToolUseName(block)
+      if (!toolUseId || !toolName) return []
+      this.blocks.set(index, {
+        toolUseId,
+        toolName,
+        partialJson: '',
+        parentToolUseId: getParentToolUseId(message),
+      })
+      return []
+    }
+
+    if (eventType === 'content_block_delta') {
+      const tracked = this.blocks.get(index)
+      if (!tracked) return []
+      const delta = event.delta
+      if (!isRecord(delta) || stringValue(delta.type) !== 'input_json_delta') return []
+      const partial = stringValue(delta.partial_json)
+      if (!partial) return []
+      tracked.partialJson += partial
+      return [createStreamEvent(tracked)]
+    }
+
+    if (eventType === 'content_block_stop') {
+      this.blocks.delete(index)
+    }
+
+    return []
+  }
+
+  buildFinalEvents(message: SDKMessage): PromaEvent[] {
+    if (message.type !== 'assistant') return []
+    const assistant = message as SDKAssistantMessage
+    const events: PromaEvent[] = []
+    for (const block of assistant.message.content) {
+      if (!isArtifactBlock(block)) continue
+      const toolUseId = stringValue(block.id)
+      const toolName = getToolUseName(block)
+      if (!toolUseId || !toolName) continue
+      events.push({
+        type: 'artifact_stream_end',
+        toolUseId,
+        toolName,
+        input: isRecord(block.input) ? block.input : undefined,
+        parentToolUseId: getParentToolUseId(message),
+        updatedAt: Date.now(),
+      })
+    }
+    return events
+  }
+}

--- a/apps/electron/src/main/lib/artifact-service.ts
+++ b/apps/electron/src/main/lib/artifact-service.ts
@@ -1,0 +1,60 @@
+import { join } from 'node:path'
+import { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync, unlinkSync } from 'node:fs'
+import { getConfigDir } from './config-paths'
+import type { Artifact } from '@proma/shared'
+
+const ARTIFACTS_DIR = join(getConfigDir(), 'artifacts')
+
+function ensureDir(): void {
+  if (!existsSync(ARTIFACTS_DIR)) {
+    mkdirSync(ARTIFACTS_DIR, { recursive: true })
+  }
+}
+
+function artifactPath(id: string): string {
+  return join(ARTIFACTS_DIR, `${id}.json`)
+}
+
+export function listArtifacts(sessionId: string): Artifact[] {
+  ensureDir()
+  const artifacts: Artifact[] = []
+  try {
+    for (const entry of readdirSync(ARTIFACTS_DIR)) {
+      if (!entry.endsWith('.json')) continue
+      try {
+        const raw = readFileSync(join(ARTIFACTS_DIR, entry), 'utf-8')
+        const artifact = JSON.parse(raw) as Artifact
+        if (artifact.sessionId === sessionId) {
+          artifacts.push(artifact)
+        }
+      } catch {
+        // skip corrupted files
+      }
+    }
+  } catch {
+    // directory may not exist yet
+  }
+  return artifacts.sort((a, b) => b.updatedAt - a.updatedAt)
+}
+
+export function getArtifact(id: string): Artifact | null {
+  const path = artifactPath(id)
+  if (!existsSync(path)) return null
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as Artifact
+  } catch {
+    return null
+  }
+}
+
+export function saveArtifact(artifact: Artifact): void {
+  ensureDir()
+  writeFileSync(artifactPath(artifact.id), JSON.stringify(artifact, null, 2), 'utf-8')
+}
+
+export function deleteArtifact(id: string): void {
+  const path = artifactPath(id)
+  if (existsSync(path)) {
+    unlinkSync(path)
+  }
+}

--- a/apps/electron/src/renderer/lib/artifact-contract.test.ts
+++ b/apps/electron/src/renderer/lib/artifact-contract.test.ts
@@ -1,0 +1,145 @@
+import { describe, test, expect } from 'bun:test'
+import {
+  parsePartialArtifactInputJson,
+  parseArtifactCreateInput,
+  parseArtifactEditInput,
+  isArtifactToolName,
+  isArtifactGuidelineToolName,
+  ARTIFACT_CREATE_TOOL,
+  ARTIFACT_EDIT_TOOL,
+} from './artifact-contract'
+
+describe('artifact-contract', () => {
+  describe('isArtifactToolName', () => {
+    test('recognizes create_artifact', () => {
+      expect(isArtifactToolName(ARTIFACT_CREATE_TOOL)).toBe(true)
+    })
+
+    test('recognizes edit_artifact', () => {
+      expect(isArtifactToolName(ARTIFACT_EDIT_TOOL)).toBe(true)
+    })
+
+    test('recognizes MCP-qualified names', () => {
+      expect(isArtifactToolName(`mcp__artifact__${ARTIFACT_CREATE_TOOL}`)).toBe(true)
+    })
+
+    test('rejects unknown tool names', () => {
+      expect(isArtifactToolName('read')).toBe(false)
+    })
+  })
+
+  describe('isArtifactGuidelineToolName', () => {
+    test('recognizes load_artifact_guidelines', () => {
+      expect(isArtifactGuidelineToolName('load_artifact_guidelines')).toBe(true)
+    })
+  })
+
+  describe('parsePartialArtifactInputJson', () => {
+    test('parses valid JSON', () => {
+      const result = parsePartialArtifactInputJson('{"title":"Hello","type":"code"}')
+      expect(result).toEqual({ title: 'Hello', type: 'code' })
+    })
+
+    test('extracts title from partial JSON', () => {
+      const result = parsePartialArtifactInputJson('"title":"My Chart","cont')
+      expect(result?.title).toBe('My Chart')
+    })
+
+    test('extracts content from snake_case key', () => {
+      const result = parsePartialArtifactInputJson('"content":"<svg><","type":"html"')
+      expect(result?.content).toBe('<svg><')
+    })
+
+    test('returns undefined for empty input', () => {
+      expect(parsePartialArtifactInputJson('')).toBeUndefined()
+    })
+
+    test('returns undefined for whitespace-only input', () => {
+      expect(parsePartialArtifactInputJson('   ')).toBeUndefined()
+    })
+  })
+
+  describe('parseArtifactCreateInput', () => {
+    test('parses valid create_artifact input', () => {
+      const result = parseArtifactCreateInput({
+        title: 'My Chart',
+        type: 'html',
+        content: '<svg></svg>',
+      })
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.title).toBe('My Chart')
+        expect(result.type).toBe('html')
+        expect(result.content).toBe('<svg></svg>')
+      }
+    })
+
+    test('accepts widget_code as alias for content', () => {
+      const result = parseArtifactCreateInput({
+        title: 'Widget',
+        widget_code: '<div/>',
+      })
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.content).toBe('<div/>')
+      }
+    })
+
+    test('defaults type to code', () => {
+      const result = parseArtifactCreateInput({
+        title: 'Code',
+        content: 'console.log("hi")',
+      })
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.type).toBe('code')
+      }
+    })
+
+    test('fails on missing content', () => {
+      const result = parseArtifactCreateInput({ title: 'Empty' })
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.reason).toContain('missing content')
+      }
+    })
+
+    test('fails on oversized content', () => {
+      const result = parseArtifactCreateInput({
+        title: 'Huge',
+        content: 'x'.repeat(200_000),
+      })
+      expect(result.ok).toBe(false)
+    })
+  })
+
+  describe('parseArtifactEditInput', () => {
+    test('parses valid edit_artifact input', () => {
+      const result = parseArtifactEditInput({
+        artifact_id: 'art-001',
+        title: 'Updated Title',
+      })
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.artifactId).toBe('art-001')
+        expect(result.title).toBe('Updated Title')
+      }
+    })
+
+    test('accepts artifactId as alias', () => {
+      const result = parseArtifactEditInput({
+        artifactId: 'art-002',
+        content: 'new content',
+      })
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.artifactId).toBe('art-002')
+      }
+    })
+
+    test('fails on missing artifact_id', () => {
+      const result = parseArtifactEditInput({ title: 'No ID' })
+      expect(result.ok).toBe(false)
+    })
+  })
+})

--- a/apps/electron/src/renderer/lib/artifact-contract.ts
+++ b/apps/electron/src/renderer/lib/artifact-contract.ts
@@ -1,24 +1,24 @@
 import type { SDKToolUseBlock, ArtifactType } from '@proma/shared'
+import {
+  ARTIFACT_CREATE_TOOL,
+  ARTIFACT_EDIT_TOOL,
+  ARTIFACT_LOAD_GUIDELINES_TOOL,
+  MAX_ARTIFACT_CONTENT_CHARS,
+  isArtifactToolName,
+  isArtifactGuidelineToolName,
+} from '@proma/shared'
+
+export {
+  ARTIFACT_CREATE_TOOL,
+  ARTIFACT_EDIT_TOOL,
+  ARTIFACT_LOAD_GUIDELINES_TOOL,
+  MAX_ARTIFACT_CONTENT_CHARS,
+  isArtifactToolName,
+  isArtifactGuidelineToolName,
+}
 
 export const ARTIFACT_TOOL_SERVER = 'artifact'
-export const ARTIFACT_CREATE_TOOL = 'create_artifact'
-export const ARTIFACT_EDIT_TOOL = 'edit_artifact'
-export const ARTIFACT_LOAD_GUIDELINES_TOOL = 'load_artifact_guidelines'
-export const MAX_ARTIFACT_CONTENT_CHARS = 120_000
 export const DEFAULT_ARTIFACT_TITLE = 'Artifact'
-
-export function isArtifactToolName(name: string): boolean {
-  return (
-    name === ARTIFACT_CREATE_TOOL ||
-    name === ARTIFACT_EDIT_TOOL ||
-    name.endsWith(`__${ARTIFACT_CREATE_TOOL}`) ||
-    name.endsWith(`__${ARTIFACT_EDIT_TOOL}`)
-  )
-}
-
-export function isArtifactGuidelineToolName(name: string): boolean {
-  return name === ARTIFACT_LOAD_GUIDELINES_TOOL || name.endsWith(`__${ARTIFACT_LOAD_GUIDELINES_TOOL}`)
-}
 
 function normalizeString(value: unknown): string | undefined {
   return typeof value === 'string' ? value.trim() : undefined

--- a/apps/electron/src/renderer/lib/artifact-contract.ts
+++ b/apps/electron/src/renderer/lib/artifact-contract.ts
@@ -1,0 +1,183 @@
+import type { SDKToolUseBlock, ArtifactType } from '@proma/shared'
+
+export const ARTIFACT_TOOL_SERVER = 'artifact'
+export const ARTIFACT_CREATE_TOOL = 'create_artifact'
+export const ARTIFACT_EDIT_TOOL = 'edit_artifact'
+export const ARTIFACT_LOAD_GUIDELINES_TOOL = 'load_artifact_guidelines'
+export const MAX_ARTIFACT_CONTENT_CHARS = 120_000
+export const DEFAULT_ARTIFACT_TITLE = 'Artifact'
+
+export function isArtifactToolName(name: string): boolean {
+  return (
+    name === ARTIFACT_CREATE_TOOL ||
+    name === ARTIFACT_EDIT_TOOL ||
+    name.endsWith(`__${ARTIFACT_CREATE_TOOL}`) ||
+    name.endsWith(`__${ARTIFACT_EDIT_TOOL}`)
+  )
+}
+
+export function isArtifactGuidelineToolName(name: string): boolean {
+  return name === ARTIFACT_LOAD_GUIDELINES_TOOL || name.endsWith(`__${ARTIFACT_LOAD_GUIDELINES_TOOL}`)
+}
+
+function normalizeString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value.trim() : undefined
+}
+
+function normalizeArtifactType(value: unknown): ArtifactType {
+  const valid: ArtifactType[] = ['code', 'html', 'svg', 'mermaid', 'markdown']
+  return typeof value === 'string' && valid.includes(value as ArtifactType)
+    ? (value as ArtifactType)
+    : 'code'
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function readPartialJsonStringValue(source: string, key: string): string | undefined {
+  const pattern = new RegExp(`"${escapeRegExp(key)}"\\s*:\\s*"`, 'g')
+  const match = pattern.exec(source)
+  if (!match) return undefined
+
+  let value = ''
+  let escaped = false
+  const start = match.index + match[0].length
+  for (let i = start; i < source.length; i += 1) {
+    const char = source[i]
+    if (escaped) {
+      escaped = false
+      if (char === 'n') value += '\n'
+      else if (char === 'r') value += '\r'
+      else if (char === 't') value += '\t'
+      else if (char === 'b') value += '\b'
+      else if (char === 'f') value += '\f'
+      else if (char === '/') value += '/'
+      else if (char === 'u' && i + 4 < source.length) {
+        const hex = source.slice(i + 1, i + 5)
+        if (/^[0-9a-f]{4}$/i.test(hex)) {
+          value += String.fromCharCode(Number.parseInt(hex, 16))
+          i += 4
+        } else {
+          value += char
+        }
+      } else {
+        value += char
+      }
+      continue
+    }
+    if (char === '\\') {
+      escaped = true
+      continue
+    }
+    if (char === '"') return value
+    value += char
+  }
+  return value.length > 0 ? value : undefined
+}
+
+function assignPartialString(
+  target: Record<string, unknown>,
+  outputKey: string,
+  source: string,
+  keys: string[],
+): void {
+  for (const key of keys) {
+    const value = readPartialJsonStringValue(source, key)
+    if (value !== undefined) {
+      target[outputKey] = value
+      return
+    }
+  }
+}
+
+export function parsePartialArtifactInputJson(partialJson: string): Record<string, unknown> | undefined {
+  if (!partialJson.trim()) return undefined
+
+  try {
+    const parsed = JSON.parse(partialJson) as unknown
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>
+    }
+  } catch {
+    // Fall through to tolerant field extraction
+  }
+
+  const extracted: Record<string, unknown> = {}
+  assignPartialString(extracted, 'title', partialJson, ['title'])
+  assignPartialString(extracted, 'content', partialJson, ['content', 'widget_code'])
+  assignPartialString(extracted, 'type', partialJson, ['type'])
+  assignPartialString(extracted, 'language', partialJson, ['language'])
+  assignPartialString(extracted, 'artifact_id', partialJson, ['artifact_id', 'artifactId'])
+
+  return Object.keys(extracted).length > 0 ? extracted : undefined
+}
+
+export type ArtifactCreateParseResult =
+  | { ok: true; title: string; type: ArtifactType; content: string; language?: string; description?: string }
+  | { ok: false; reason: string; title?: string }
+
+export function parseArtifactCreateInput(
+  input: Record<string, unknown> | undefined,
+): ArtifactCreateParseResult {
+  if (!input || typeof input !== 'object') {
+    return { ok: false, reason: 'create_artifact input must be an object' }
+  }
+
+  const content = normalizeString(input.content ?? input.widget_code)
+  const title = normalizeString(input.title) ?? DEFAULT_ARTIFACT_TITLE
+  if (!content) {
+    return { ok: false, reason: 'create_artifact input is missing content', title }
+  }
+  if (content.length > MAX_ARTIFACT_CONTENT_CHARS) {
+    return { ok: false, reason: `content exceeds ${MAX_ARTIFACT_CONTENT_CHARS} characters`, title }
+  }
+
+  return {
+    ok: true,
+    title,
+    type: normalizeArtifactType(input.type),
+    content,
+    language: normalizeString(input.language),
+    description: normalizeString(input.description),
+  }
+}
+
+export type ArtifactEditParseResult =
+  | { ok: true; artifactId: string; title?: string; content?: string; language?: string }
+  | { ok: false; reason: string }
+
+export function parseArtifactEditInput(
+  input: Record<string, unknown> | undefined,
+): ArtifactEditParseResult {
+  if (!input || typeof input !== 'object') {
+    return { ok: false, reason: 'edit_artifact input must be an object' }
+  }
+
+  const artifactId = normalizeString(input.artifact_id ?? input.artifactId)
+  if (!artifactId) {
+    return { ok: false, reason: 'edit_artifact input is missing artifact_id' }
+  }
+
+  const content = normalizeString(input.content)
+  if (content && content.length > MAX_ARTIFACT_CONTENT_CHARS) {
+    return { ok: false, reason: `content exceeds ${MAX_ARTIFACT_CONTENT_CHARS} characters` }
+  }
+
+  return {
+    ok: true,
+    artifactId,
+    title: normalizeString(input.title),
+    content,
+    language: normalizeString(input.language),
+  }
+}
+
+export function parseArtifactToolBlock(
+  block: SDKToolUseBlock,
+): { toolName: string; input: Record<string, unknown> } | null {
+  if (block.type !== 'tool_use') return null
+  const name = typeof block.name === 'string' ? block.name : ''
+  if (!isArtifactToolName(name)) return null
+  return { toolName: name, input: (block.input as Record<string, unknown>) ?? {} }
+}

--- a/apps/electron/src/renderer/lib/artifact-sandbox.test.ts
+++ b/apps/electron/src/renderer/lib/artifact-sandbox.test.ts
@@ -1,0 +1,95 @@
+import { describe, test, expect } from 'bun:test'
+import {
+  sanitizeArtifactForStreaming,
+  sanitizeArtifactForIframe,
+  buildArtifactSrcdoc,
+  ARTIFACT_CDN_HOSTS,
+  ARTIFACT_IFRAME_SANDBOX,
+} from './artifact-sandbox'
+
+describe('artifact-sandbox', () => {
+  describe('sanitizeArtifactForStreaming', () => {
+    test('strips script tags', () => {
+      const html = '<div>Hello</div><script>alert("xss")</script>'
+      const result = sanitizeArtifactForStreaming(html)
+      expect(result).not.toContain('<script')
+      expect(result).toContain('<div>Hello</div>')
+    })
+
+    test('strips event handlers', () => {
+      const html = '<div onclick="alert(1)">Click</div>'
+      const result = sanitizeArtifactForStreaming(html)
+      expect(result).not.toContain('onclick')
+    })
+
+    test('strips dangerous URLs', () => {
+      const html = '<a href="javascript:alert(1)">link</a>'
+      const result = sanitizeArtifactForStreaming(html)
+      expect(result).not.toContain('javascript:')
+    })
+
+    test('strips dangerous container tags', () => {
+      const html = '<iframe src="https://evil.com"></iframe>'
+      const result = sanitizeArtifactForStreaming(html)
+      expect(result).not.toContain('iframe')
+    })
+
+    test('strips unclosed script at end', () => {
+      const html = '<div>partial</div><script>var x='
+      const result = sanitizeArtifactForStreaming(html)
+      expect(result).not.toContain('<script')
+      expect(result).toContain('<div>partial</div>')
+    })
+  })
+
+  describe('sanitizeArtifactForIframe', () => {
+    test('allows CDN scripts from whitelisted hosts', () => {
+      const html = '<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>'
+      const result = sanitizeArtifactForIframe(html)
+      expect(result).toContain('cdn.jsdelivr.net')
+    })
+
+    test('blocks non-CDN scripts', () => {
+      const html = '<script src="https://evil.com/steal.js"></script>'
+      const result = sanitizeArtifactForIframe(html)
+      expect(result).not.toContain('evil.com')
+    })
+
+    test('allows inline scripts', () => {
+      const html = '<script>console.log("ok")</script>'
+      const result = sanitizeArtifactForIframe(html)
+      expect(result).toContain('console.log')
+    })
+  })
+
+  describe('buildArtifactSrcdoc', () => {
+    test('returns valid HTML with CSP meta tag', () => {
+      const result = buildArtifactSrcdoc()
+      expect(result).toContain('<!DOCTYPE html>')
+      expect(result).toContain('Content-Security-Policy')
+      expect(result).toContain('<div id="__root"></div>')
+    })
+
+    test('includes custom style block', () => {
+      const style = '.my-class{color:red;}'
+      const result = buildArtifactSrcdoc(style)
+      expect(result).toContain(style)
+    })
+
+    test('uses dark class when isDark is true', () => {
+      const result = buildArtifactSrcdoc('', true)
+      expect(result).toContain('<html class="dark">')
+    })
+  })
+
+  describe('constants', () => {
+    test('ARTIFACT_CDN_HOSTS contains expected hosts', () => {
+      expect(ARTIFACT_CDN_HOSTS).toContain('cdn.jsdelivr.net')
+      expect(ARTIFACT_CDN_HOSTS).toContain('unpkg.com')
+    })
+
+    test('ARTIFACT_IFRAME_SANDBOX allows scripts', () => {
+      expect(ARTIFACT_IFRAME_SANDBOX).toBe('allow-scripts')
+    })
+  })
+})

--- a/apps/electron/src/renderer/lib/artifact-sandbox.ts
+++ b/apps/electron/src/renderer/lib/artifact-sandbox.ts
@@ -1,0 +1,250 @@
+export const ARTIFACT_CDN_HOSTS = [
+  'cdnjs.cloudflare.com',
+  'cdn.jsdelivr.net',
+  'unpkg.com',
+  'esm.sh',
+] as const
+
+export const ARTIFACT_IFRAME_SANDBOX = 'allow-scripts'
+
+const DANGEROUS_CONTAINER_TAGS = [
+  'iframe',
+  'object',
+  'embed',
+  'meta',
+  'link',
+  'base',
+  'form',
+  'frame',
+  'frameset',
+  'portal',
+]
+
+const DANGEROUS_CONTAINER_RE = new RegExp(`<(${DANGEROUS_CONTAINER_TAGS.join('|')})\\b[^>]*>[\\s\\S]*?<\\/\\1>`, 'gi')
+const DANGEROUS_VOID_RE = new RegExp(`<(${DANGEROUS_CONTAINER_TAGS.join('|')})\\b[^>]*\\/?>`, 'gi')
+
+function stripDangerousContainers(html: string): string {
+  return html.replace(DANGEROUS_CONTAINER_RE, '').replace(DANGEROUS_VOID_RE, '')
+}
+
+function stripEventHandlers(html: string): string {
+  return html.replace(/\s+on[a-z]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>"']*)/gi, '')
+}
+
+function stripDangerousUrls(html: string): string {
+  return html.replace(
+    /\s+(href|src|action|formaction|xlink:href)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>"']*))/gi,
+    (match, _attr: string, dq?: string, sq?: string, uq?: string) => {
+      const value = (dq ?? sq ?? uq ?? '').trim()
+      if (/^(javascript|data|vbscript|file)\s*:/i.test(value)) return ''
+      return match
+    },
+  )
+}
+
+function stripStyleJavascriptUrls(html: string): string {
+  return html.replace(/url\(\s*(['"]?)\s*(javascript|data|vbscript|file)\s*:[^)]+\)/gi, 'url()')
+}
+
+function stripScripts(html: string): string {
+  return html
+    .replace(/<script\b[\s\S]*?<\/script>/gi, '')
+    .replace(/<script\b[^>]*\/?>/gi, '')
+}
+
+function stripUnclosedScript(html: string): string {
+  const lower = html.toLowerCase()
+  const start = lower.lastIndexOf('<script')
+  if (start === -1) return html
+  const end = lower.indexOf('</script>', start)
+  return end === -1 ? html.slice(0, start) : html
+}
+
+function isAllowedCdnScript(src: string): boolean {
+  try {
+    const url = new URL(src)
+    return url.protocol === 'https:' && ARTIFACT_CDN_HOSTS.includes(url.hostname as typeof ARTIFACT_CDN_HOSTS[number])
+  } catch {
+    return false
+  }
+}
+
+function stripDisallowedScriptSources(html: string): string {
+  return html.replace(/<script\b([^>]*)>([\s\S]*?)<\/script>/gi, (match, attrs: string) => {
+    const srcMatch = attrs.match(/\ssrc\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>"']*))/i)
+    if (!srcMatch) return match
+    const src = (srcMatch[1] ?? srcMatch[2] ?? srcMatch[3] ?? '').trim()
+    return isAllowedCdnScript(src) ? match : ''
+  })
+}
+
+export function sanitizeArtifactForStreaming(html: string): string {
+  return stripStyleJavascriptUrls(
+    stripDangerousUrls(
+      stripScripts(
+        stripEventHandlers(
+          stripDangerousContainers(stripUnclosedScript(html)),
+        ),
+      ),
+    ),
+  )
+}
+
+export function sanitizeArtifactForIframe(html: string): string {
+  return stripStyleJavascriptUrls(
+    stripDangerousUrls(
+      stripEventHandlers(
+        stripDisallowedScriptSources(
+          stripDangerousContainers(html),
+        ),
+      ),
+    ),
+  )
+}
+
+export function buildArtifactSrcdoc(styleBlock = '', isDark = false): string {
+  const scriptHosts = ARTIFACT_CDN_HOSTS.map((host) => `https://${host}`).join(' ')
+  const csp = [
+    "default-src 'none'",
+    `script-src 'unsafe-inline' ${scriptHosts}`,
+    "style-src 'unsafe-inline'",
+    "img-src data: blob:",
+    "font-src data:",
+    "media-src data: blob:",
+    "connect-src 'none'",
+    "frame-src 'none'",
+    "object-src 'none'",
+    "base-uri 'none'",
+    "form-action 'none'",
+  ].join('; ')
+
+  const receiverScript = `(function(){
+var root=document.getElementById('__root');
+var lastHeight=0;
+var first=true;
+var timer=null;
+function reportRuntimeError(reason){
+var message='Artifact runtime error';
+if(typeof reason==='string')message=reason;
+else if(reason&&typeof reason.message==='string')message=reason.message;
+try{parent.postMessage({type:'artifact:error',message:String(message).slice(0,500)},'*');}catch(_err){}
+}
+function postHeight(){
+if(timer)clearTimeout(timer);
+timer=setTimeout(function(){
+var rect=root.getBoundingClientRect();
+var height=Math.ceil(Math.max(rect.height, document.body.scrollHeight, document.documentElement.scrollHeight));
+if(height>0&&height!==lastHeight){lastHeight=height;parent.postMessage({type:'artifact:resize',height:height,first:first},'*');}
+first=false;
+},60);
+}
+function applyHtml(html){
+root.innerHTML=html||'';
+postHeight();
+}
+function finalizeHtml(html){
+var tmp=document.createElement('div');
+tmp.innerHTML=html||'';
+var nodes=tmp.querySelectorAll('script');
+var scripts=[];
+for(var i=0;i<nodes.length;i++){
+var node=nodes[i];
+scripts.push({src:node.getAttribute('src')||'',text:node.textContent||'',attrs:Array.prototype.slice.call(node.attributes).map(function(a){return{name:a.name,value:a.value};})});
+node.remove();
+}
+var visual=tmp.innerHTML;
+if(root.innerHTML!==visual)root.innerHTML=visual;
+var cdn=scripts.filter(function(s){return !!s.src});
+var inline=scripts.filter(function(s){return !s.src&&s.text});
+function runInline(){
+for(var k=0;k<inline.length;k++){
+var el=document.createElement('script');
+for(var j=0;j<inline[k].attrs.length;j++){if(inline[k].attrs[j].name!=='src')el.setAttribute(inline[k].attrs[j].name,inline[k].attrs[j].value);}
+el.textContent=inline[k].text;
+root.appendChild(el);
+}
+postHeight();
+setTimeout(function(){parent.postMessage({type:'artifact:scriptsReady'},'*');postHeight();},50);
+}
+if(cdn.length===0){runInline();return;}
+var pending=cdn.length;
+function done(){pending-=1;if(pending<=0)runInline();}
+for(var c=0;c<cdn.length;c++){
+var s=document.createElement('script');
+s.src=cdn[c].src;
+s.onload=done;
+s.onerror=done;
+for(var a=0;a<cdn[c].attrs.length;a++){var attr=cdn[c].attrs[a];if(attr.name!=='src'&&attr.name!=='onload'&&attr.name!=='onerror')s.setAttribute(attr.name,attr.value);}
+root.appendChild(s);
+}
+}
+window.addEventListener('message',function(event){
+if(!event.data||typeof event.data.type!=='string')return;
+if(event.data.type==='artifact:update')applyHtml(event.data.html);
+if(event.data.type==='artifact:finalize')finalizeHtml(event.data.html);
+if(event.data.type==='artifact:theme'&&event.data.vars){
+var r=document.documentElement;
+Object.keys(event.data.vars).forEach(function(k){r.style.setProperty(k,event.data.vars[k]);});
+if(typeof event.data.isDark==='boolean')r.className=event.data.isDark?'dark':'';
+postHeight();
+}
+});
+window.addEventListener('error',function(event){reportRuntimeError(event.error||event.message);});
+window.addEventListener('unhandledrejection',function(event){reportRuntimeError(event.reason);});
+document.addEventListener('click',function(event){
+var target=event.target;
+var link=target&&target.closest?target.closest('a[href]'):null;
+if(!link)return;
+var href=link.getAttribute('href')||'';
+if(!href||href.charAt(0)==='#')return;
+event.preventDefault();
+parent.postMessage({type:'artifact:link',href:href},'*');
+});
+window.__artifactSendMessage=function(text){
+if(typeof text==='string'&&text.length<=500)parent.postMessage({type:'artifact:sendMessage',text:text},'*');
+};
+new ResizeObserver(postHeight).observe(root);
+parent.postMessage({type:'artifact:ready'},'*');
+})();`
+
+  return `<!DOCTYPE html>
+<html class="${isDark ? 'dark' : ''}">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta http-equiv="Content-Security-Policy" content="${csp}">
+<style>
+html,body{margin:0;padding:0;background:transparent;color:CanvasText;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;}
+*,*::before,*::after{box-sizing:border-box;}
+:root{
+color-scheme:light dark;
+--artifact-bg:transparent;
+--artifact-fg:CanvasText;
+--artifact-muted:#737373;
+--artifact-border:rgba(127,127,127,.25);
+--artifact-accent:#2563eb;
+--color-background-primary:var(--card,#fff);
+--color-background-secondary:var(--muted,#f5f4ef);
+--color-background-tertiary:var(--background,#faf9f5);
+--color-text-primary:var(--foreground,#1f2937);
+--color-text-secondary:var(--muted-foreground,#6b7280);
+--color-text-tertiary:color-mix(in srgb,var(--muted-foreground,#6b7280) 72%,transparent);
+--color-border-tertiary:var(--border,rgba(31,41,55,.16));
+--color-border-secondary:color-mix(in srgb,var(--border,rgba(31,41,55,.16)) 70%,var(--foreground,#1f2937));
+--font-sans:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+--font-mono:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;
+--border-radius-md:8px;
+--border-radius-lg:12px;
+--border-radius-xl:16px;
+}
+${styleBlock}
+#__root{width:100%;min-height:1px;overflow:hidden;}
+a{color:var(--artifact-accent);}
+</style>
+</head>
+<body>
+<div id="__root"></div>
+<script>${receiverScript}</script>
+</body>
+</html>`
+}

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -842,6 +842,7 @@ export interface Artifact {
   title: string
   type: ArtifactType
   language?: string
+  description?: string
   content: string
   version: number
   sessionId: string
@@ -857,6 +858,7 @@ export interface ArtifactCreateInput {
   type: ArtifactType
   content: string
   language?: string
+  description?: string
 }
 
 /** edit_artifact 工具入参 */
@@ -865,6 +867,26 @@ export interface ArtifactEditInput {
   title?: string
   content?: string
   language?: string
+}
+
+// ===== Artifact 共享常量与工具函数 =====
+
+export const ARTIFACT_CREATE_TOOL = 'create_artifact'
+export const ARTIFACT_EDIT_TOOL = 'edit_artifact'
+export const ARTIFACT_LOAD_GUIDELINES_TOOL = 'load_artifact_guidelines'
+export const MAX_ARTIFACT_CONTENT_CHARS = 120_000
+
+export function isArtifactToolName(toolName: string): boolean {
+  return (
+    toolName === ARTIFACT_CREATE_TOOL ||
+    toolName === ARTIFACT_EDIT_TOOL ||
+    toolName.endsWith(`__${ARTIFACT_CREATE_TOOL}`) ||
+    toolName.endsWith(`__${ARTIFACT_EDIT_TOOL}`)
+  )
+}
+
+export function isArtifactGuidelineToolName(toolName: string): boolean {
+  return toolName === ARTIFACT_LOAD_GUIDELINES_TOOL || toolName.endsWith(`__${ARTIFACT_LOAD_GUIDELINES_TOOL}`)
 }
 
 // ===== Agent 发送输入 =====

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -564,6 +564,8 @@ export type PromaEvent =
   | { type: 'title_updated'; title: string }
   | { type: 'external_run_started'; source: AgentExternalRunSource; sessionId: string; title?: string; workspaceId?: string; modelId?: string; startedAt: number }
   | { type: 'run_resumed'; sessionId: string }
+  | { type: 'artifact_stream'; toolUseId: string; toolName: string; partialJson: string; parentToolUseId?: string | null; updatedAt: number }
+  | { type: 'artifact_stream_end'; toolUseId: string; toolName: string; input?: Record<string, unknown>; parentToolUseId?: string | null; updatedAt: number }
 
 /** 外部入口触发 Agent 运行的来源 */
 export type AgentExternalRunSource = 'feishu' | 'dingtalk' | 'wechat' | 'bridge'
@@ -829,6 +831,42 @@ export interface WorkspaceCapabilities {
   skills: SkillMeta[]
 }
 
+// ===== Artifacts =====
+
+/** Artifact 内容类型 */
+export type ArtifactType = 'code' | 'html' | 'svg' | 'mermaid' | 'markdown'
+
+/** Artifact 持久化实体 */
+export interface Artifact {
+  id: string
+  title: string
+  type: ArtifactType
+  language?: string
+  content: string
+  version: number
+  sessionId: string
+  workspaceId?: string
+  parentId?: string
+  createdAt: number
+  updatedAt: number
+}
+
+/** create_artifact 工具入参 */
+export interface ArtifactCreateInput {
+  title: string
+  type: ArtifactType
+  content: string
+  language?: string
+}
+
+/** edit_artifact 工具入参 */
+export interface ArtifactEditInput {
+  artifactId: string
+  title?: string
+  content?: string
+  language?: string
+}
+
 // ===== Agent 发送输入 =====
 
 /**
@@ -863,6 +901,8 @@ export interface AgentSendInput {
   triggeredBy?: 'user' | 'automation'
   /** 定时任务执行上下文（注入到系统提示词，用户不可见） */
   automationContext?: string
+  /** 是否启用 Artifacts 功能（Agent 可用 create_artifact/edit_artifact 工具） */
+  artifactsEnabled?: boolean
 }
 
 // ===== Agent 队列消息 =====


### PR DESCRIPTION
## 概述

为 Artifacts 功能提供完整的基础设施层。Agent 可通过 create_artifact / edit_artifact 工具创建和迭代持久化产物，产物经 HTML 沙箱安全消毒，支持渐进式流预览。不改变任何 UI——artifact 工具结果以普通 tool result 形式显示在对话中，侧面板渲染推迟到后续 PR。

## 改动

| 文件 | 行数 | 说明 |
|---|---|---|
| packages/shared/src/types/agent.ts | +40 | Artifact 类型、ArtifactCreateInput/EditInput、PromaEvent 扩展、AgentSendInput.artifactsEnabled |
| renderer/lib/artifact-sandbox.ts | +250 | 双轨 HTML 消毒器（流式/iframe）+ CSP 白名单 + srcdoc 构建 |
| renderer/lib/artifact-sandbox.test.ts | +95 | 沙箱安全测试 |
| renderer/lib/artifact-contract.ts | +183 | 工具输入解析、部分 JSON 容错提取、create/edit 参数校验 |
| renderer/lib/artifact-contract.test.ts | +145 | 契约解析测试 |
| main/lib/artifact-agent-tools.ts | +205 | create_artifact / edit_artifact / load_artifact_guidelines MCP 工具（zod schema） |
| main/lib/artifact-agent-tools.test.ts | +78 | 工具定义测试 |
| main/lib/artifact-partial-stream.ts | +126 | 渐进式 artifact 流跟踪器（旁路消费 SDK stream_event） |
| main/lib/artifact-partial-stream.test.ts | +193 | 流跟踪生命周期测试 |
| main/lib/artifact-service.ts | +60 | 文件系统持久化 CRUD（~/.proma/artifacts/） |
| main/lib/agent-orchestrator.ts | +44 | 注入 artifact MCP server、allowedTools、system prompt、流跟踪器 |

## 测试

- TypeCheck: 4/4 包通过
- 单元测试: 52 pass / 0 fail

## 紧急度

常规

## 备注

- 基于原 Generative UI Runtime（PR #804）的基础设施层重构
- 原 PR 被认可的安全沙箱、CSP 白名单、partial stream 旁路消费、contract 设计全部保留
- 原 PR 被否定的 widget-in-chat UI 形态全部移除
- Artifacts 侧面板 UI 推迟到后续 PR