### PR TITLE
【已审核】style(sidebar): 统一折叠按钮样式、添加 toggle 开关与跨模式防跳动

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -665,16 +665,29 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     return () => window.removeEventListener('focus', handleFocus)
   }, [setConversations, setAgentSessions])
 
-  /** 打开自动任务列表 */
+  /** 打开/关闭自动任务列表 */
   const handleOpenAutomations = React.useCallback((): void => {
+    if (activeView === 'automations') {
+      // 编辑页 → 关表单回列表；列表页 → 退出到对话
+      if (store.get(automationFormAtom).open) {
+        setAutomationForm({ open: false, draft: null })
+        return
+      }
+      setActiveView('conversations')
+      return
+    }
     setAutomationForm({ open: false, draft: null })
     setActiveView('automations')
-  }, [setAutomationForm, setActiveView])
+  }, [activeView, setAutomationForm, setActiveView, store])
 
-  /** 打开 Agent 技能视图 */
+  /** 打开/关闭 Agent 技能视图 */
   const handleOpenSkills = React.useCallback((): void => {
+    if (activeView === 'agent-skills') {
+      setActiveView('conversations')
+      return
+    }
     setActiveView('agent-skills')
-  }, [setActiveView])
+  }, [activeView, setActiveView])
 
   // 切换模式时重置归档视图
   React.useEffect(() => {
@@ -1752,7 +1765,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
           <TooltipTrigger asChild>
             <button
               onClick={() => setSidebarCollapsed(true)}
-              className="mt-2 size-10 flex-shrink-0 flex items-center justify-center rounded-[10px] bg-muted text-foreground/40 hover:bg-foreground/[0.08] hover:text-foreground/60 transition-colors titlebar-no-drag"
+              className="mt-2 size-[36px] flex-shrink-0 flex items-center justify-center rounded-[10px] text-foreground/40 bg-primary/5 hover:bg-primary/10 hover:text-foreground/60 transition-[background-color,border-color,color] duration-150 titlebar-no-drag border border-border/60 hover:border-border"
             >
               <PanelLeftClose size={14} />
             </button>
@@ -1839,8 +1852,10 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
             </div>
           )}
 
-          <div className="px-2 pt-2 pb-1 flex-shrink-0">
+          <div className="px-2 pt-2 pb-1 flex items-center flex-shrink-0">
             <span className="px-1.5 text-[11px] font-medium text-foreground/40 select-none">对话</span>
+            {/* 占位元素：与项目行的 size-6 按钮等高，保证跨模式切换时标签文字垂直位置不变 */}
+            <div className="w-0 h-6" aria-hidden="true" />
           </div>
 
           <div className="flex-1 overflow-y-auto px-2 pb-3 scrollbar-thin min-h-0 titlebar-no-drag">


### PR DESCRIPTION
## 概述

从已关闭的 PR #836 中提取 ErlichLiu 认可的三个交互优化点，独立提交。原 PR 因入口位置和命名分歧被 close，但这三个交互细节被明确认可为会单独吸收。

### 三项改动

1. **Toggle 关闭行为**：点击已激活的「自动任务」/「Agent 技能」入口可再次点击关闭返回上一视图。编辑页状态下仅关闭表单不退出列表
2. **跨模式切换防跳动**：Chat 模式的「对话」标签行增加与项目行 size-6 按钮等高的占位元素，保证 Chat/Agent 模式切换时标签文字垂直位置不变
3. **折叠按钮视觉统一**：展开态左上角折叠按钮从 `size-10 bg-muted` 改为 `size-[36px] bg-primary/5 border`，与旁边的搜索按钮视觉一致

## 改动

```
apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx  | 27 +++++++++++++++++-----
```

- `LeftSidebar.tsx`（+21/-6）：`handleOpenAutomations` 和 `handleOpenSkills` 增加 toggle 逻辑；折叠按钮样式对齐搜索按钮；对话标签行加占位防跳动

## 测试

1. 点击自动任务进入列表 → 再次点击返回对话视图
2. 进入自动任务编辑表单 → 再次点击仅关闭表单（不退出列表）
3. Chat/Agent 模式切换，对话标签文字垂直位置不跳动
4. 折叠按钮尺寸（36px）和样式与搜索按钮一致

## 紧急度

常规

## 备注

- 源自 PR #836（@climashscape），已根据 ErlichLiu 的反馈剥离了入口位置移动和重命名的分歧项
- 这三个优化点来自 ErlichLiu 在 #836 的评论中的明确认可："尤其是「点击已激活入口可再次点击关闭」的 toggle 行为、跨模式切换时「对话」标签的防跳动占位、以及折叠按钮与搜索按钮的视觉统一，这些点我们都很认可，会单独吸收进后续迭代。"