### PR TITLE
修复图片编辑预览高分屏模糊 + Agent 附件支持编辑

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -1037,6 +1037,32 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     })
   }, [setPendingFiles])
 
+  /** 图片附件编辑完成：用编辑后的图替换该附件（统一转为内存图片走 __pendingAgentFileData） */
+  const handleAttachmentEditComplete = React.useCallback((fileId: string, editedDataUrl: string): void => {
+    const base64 = editedDataUrl.split(',')[1]
+    if (!base64) return
+    if (!window.__pendingAgentFileData) {
+      window.__pendingAgentFileData = new Map<string, string>()
+    }
+    window.__pendingAgentFileData.set(fileId, base64)
+    setPendingFiles((prev) => prev.map((f) => {
+      if (f.id !== fileId) return f
+      if (f.previewUrl?.startsWith('blob:')) {
+        URL.revokeObjectURL(f.previewUrl)
+      }
+      return {
+        ...f,
+        previewUrl: editedDataUrl,
+        filename: f.filename.replace(/(\.[^.]+)?$/, '') + '_edited.png',
+        mediaType: 'image/png',
+        size: Math.round(base64.length * 0.75),
+        // 编辑后统一当作内存图片：清除文件引用，发送时从 __pendingAgentFileData 读取最新数据
+        sourcePath: undefined,
+        isClipboardDraft: undefined,
+      }
+    }))
+  }, [setPendingFiles])
+
   const openClipboardPreviewFile = React.useCallback((filePath: string): void => {
     const parentPath = getFileParentPath(filePath)
     openPreview(sessionId, {
@@ -2096,6 +2122,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
                     previewUrl={file.previewUrl}
                     onRemove={() => handleRemoveFile(file.id)}
                     onClick={file.filename.startsWith('clipboard-') ? () => handleClipboardPreview(file) : undefined}
+                    onEditComplete={(editedDataUrl) => handleAttachmentEditComplete(file.id, editedDataUrl)}
                   />
                 ))}
                 {currentQuotedSelection && (

--- a/apps/electron/src/renderer/components/ui/image-editor.tsx
+++ b/apps/electron/src/renderer/components/ui/image-editor.tsx
@@ -116,24 +116,28 @@ export function ImageEditor({ src, onSave, onCancel }: ImageEditorProps): React.
     const srcW = rotated ? sh : sw
     const srcH = rotated ? sw : sh
 
+    const dpr = window.devicePixelRatio || 1
     const scale = Math.min(maxW / srcW, maxH / srcH, 1)
     scaleRef.current = scale
     const dw = Math.floor(srcW * scale)
     const dh = Math.floor(srcH * scale)
     displayDimRef.current = { w: dw, h: dh }
-    display.width = dw
-    display.height = dh
+    // 缓冲区按物理像素分配（× dpr），CSS 尺寸保持逻辑像素，避免高分屏下被浏览器放大而模糊
+    display.width = Math.floor(dw * dpr)
+    display.height = Math.floor(dh * dpr)
     display.style.width = `${dw}px`
     display.style.height = `${dh}px`
 
     const dCtx = display.getContext('2d')
     if (!dCtx) return
-    dCtx.clearRect(0, 0, display.width, display.height)
+    // 绘制坐标系统一到 CSS 逻辑像素：dpr 由 transform 吸收，后续绘制与坐标换算无需感知 dpr
+    dCtx.setTransform(dpr, 0, 0, dpr, 0, 0)
+    dCtx.clearRect(0, 0, dw, dh)
 
     // 填充棋盘格背景（透明区域可见）
     const tileSize = 8
-    for (let y = 0; y < display.height; y += tileSize) {
-      for (let x = 0; x < display.width; x += tileSize) {
+    for (let y = 0; y < dh; y += tileSize) {
+      for (let x = 0; x < dw; x += tileSize) {
         dCtx.fillStyle = (Math.floor(x / tileSize) + Math.floor(y / tileSize)) % 2 === 0 ? '#e0e0e0' : '#ffffff'
         dCtx.fillRect(x, y, tileSize, tileSize)
       }
@@ -660,7 +664,7 @@ export function ImageEditor({ src, onSave, onCancel }: ImageEditorProps): React.
           <X className="size-5" />
         </button>
 
-        {/* 发送到对话 */}
+        {/* 保存 */}
         <button
           type="button"
           onClick={handleExport}
@@ -671,7 +675,7 @@ export function ImageEditor({ src, onSave, onCancel }: ImageEditorProps): React.
             'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring/40'
           )}
         >
-          发送到对话
+          保存
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- 11247f5 fix(image-editor): 修复编辑预览高分屏模糊 + Agent 附件支持编辑 + 导出文案调整

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归