### PR TITLE
fix(agent): 禁用 attribution block 避免第三方代理 prompt 缓存命中率骤降

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -546,6 +546,11 @@ export class AgentOrchestrator {
       CLAUDE_CODE_ENABLE_TASKS: 'true',
       // 禁用实验性 beta 功能，使用稳定模式
       CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: '1',
+      // 禁用 attribution block：SDK 默认会在 system prompt 最前面注入一段
+      // 文本（含客户端版本号与基于会话内容计算的指纹），且每次请求都变化。
+      // 经第三方 Anthropic 兼容代理/网关中转时，会导致缓存前缀变化、命中率骤降。
+      // 官方文档确认直连 Anthropic API 不受此设置影响，故对所有 provider 无条件禁用。
+      CLAUDE_CODE_ATTRIBUTION_HEADER: '0',
       // 配置隔离：让 SDK 使用独立的配置目录，不读取用户的 ~/.claude.json
       CLAUDE_CONFIG_DIR: getSdkConfigDir(),
     }


### PR DESCRIPTION
## 概述

Claude Agent SDK 默认会在 system prompt **最前面**注入一段 attribution block —— 一段名为 `x-anthropic-billing-header` 的**文本块**（注意：不是 HTTP 请求头），内容形如：

```text
x-anthropic-billing-header: cc_version=2.1.xxx.abc; cc_entrypoint=cli; cch=xxxxx;
```

其中 `cc_version` 后缀与 `cch` 都是**基于本次会话内容计算、每次请求都变化的指纹**。

prompt caching 依赖请求前缀逐字节匹配。由于这段文本位于 system prompt 最前面且每次都变，**经第三方 Anthropic 兼容代理 / LLM 网关（one-api、new-api、claude-code-router 等）中转时，缓存前缀每次都不同，命中率骤降甚至归零** —— 对使用第三方代理的用户意味着每轮对话都按完整 prompt 计费，失去 Prompt Caching 的成本与延迟优势。

Anthropic 第一方 API 会在处理前剥离这段文本，因此**直连 Anthropic 不受影响**；只有不做归一化的第三方代理会受害。

## 改动

`apps/electron/src/main/lib/agent-orchestrator.ts` —— 在 SDK 子进程环境变量中新增 `CLAUDE_CODE_ATTRIBUTION_HEADER='0'`，关闭 attribution block 注入。

该环境变量由 SDK 内部判断 `disabledByEnv(process.env.CLAUDE_CODE_ATTRIBUTION_HEADER)` 读取，CLI 与 SDK 场景均生效。

## 为什么对所有 provider 无条件禁用

[官方 env-vars 文档](https://code.claude.com/docs/en/env-vars)明确：

> Set to `0` to omit the attribution block (client version and prompt fingerprint) from the start of the system prompt. Disabling it improves prompt-cache hit rates when routing through an LLM gateway. **Anthropic API caching is unaffected.**

即直连用户无任何副作用，因此无需按 provider 分支，统一禁用最简洁。

## 测试

- 第三方代理场景：agent 操作正常，prompt cache 命中率恢复
- 回归：直连 Anthropic API 不受影响

## 备注

替代并取代 #869（该 PR 把这段文本误述为「HTTP header」，且只归因到 `cch` 字段，描述不够准确；本 PR 修正描述并补充技术细节）。

Related: https://github.com/anthropics/claude-code/issues/50085