### PR TITLE
fix(default-skills): 修复 5 个 SKILL.md 重复 frontmatter

### DIFF
--- a/apps/electron/default-skills/brainstorming/SKILL.md
+++ b/apps/electron/default-skills/brainstorming/SKILL.md
@@ -1,9 +1,7 @@
 ---
 name: brainstorming
 description: "You MUST use this before any creative work - creating features, building components, adding functionality, or modifying behavior. Explores user intent, requirements and design before implementation."
-version: "1.0.0"
----
-version: "1.0.0"
+version: "1.0.1"
 ---
 # Brainstorming Ideas Into Designs
 

--- a/apps/electron/default-skills/executing-plans/SKILL.md
+++ b/apps/electron/default-skills/executing-plans/SKILL.md
@@ -1,9 +1,7 @@
 ---
 name: executing-plans
 description: Use when you have a written implementation plan to execute in a separate session with review checkpoints
-version: "1.0.0"
----
-version: "1.0.0"
+version: "1.0.1"
 ---
 # Executing Plans
 

--- a/apps/electron/default-skills/find-skills/SKILL.md
+++ b/apps/electron/default-skills/find-skills/SKILL.md
@@ -1,9 +1,7 @@
 ---
 name: find-skills
 description: Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express interest in extending capabilities. This skill should be used when the user is looking for functionality that might exist as an installable skill.
-version: "1.0.0"
----
-version: "1.0.0"
+version: "1.0.1"
 ---
 # Find Skills
 

--- a/apps/electron/default-skills/tool-builder/SKILL.md
+++ b/apps/electron/default-skills/tool-builder/SKILL.md
@@ -1,9 +1,7 @@
 ---
 name: tool-builder
 description: 交互式创建和管理 Chat 模式的自定义 HTTP 工具。当用户想要创建新的 API 工具、配置 Chat 工具、添加自定义工具、管理自定义工具、或说"帮我创建一个 XX 工具"时使用此 Skill。也适用于调试、修复或删除已有的自定义工具。
-version: "1.0.0"
----
-version: "1.0.0"
+version: "1.0.1"
 ---
 # Tool Builder
 

--- a/apps/electron/default-skills/writing-plans/SKILL.md
+++ b/apps/electron/default-skills/writing-plans/SKILL.md
@@ -1,9 +1,7 @@
 ---
 name: writing-plans
 description: Use when you have a spec or requirements for a multi-step task, before touching code
-version: "1.0.0"
----
-version: "1.0.0"
+version: "1.0.1"
 ---
 # Writing Plans
 


### PR DESCRIPTION
## 概述

`brainstorming`、`executing-plans`、`find-skills`、`tool-builder`、`writing-plans` 这 5 个 Skill 的 frontmatter 存在 YAML 格式错误——重复的 `version` 字段和双份 `---` 分隔符，导致 frontmatter 解析异常。

本 PR 将其去重为单块合法 frontmatter，`version` 从 `1.0.0` bump 到 `1.0.1`，**description 保持原样不变**。

## 背景

本 PR 拆取自 #866 中**正确且无争议**的部分。#866 同时还把 13 个 Skill 的 description 改写为以 "IMMEDIATELY invoke this skill" 开头、并塞入大段执行指引——经审核认为该改法是反模式（把"如何执行"塞进常驻上下文的"何时触发"字段、降低触发区分度、拼接处语法破碎、改动官方精调文案），故 #866 已关闭，仅保留此处的 frontmatter 修复。

#868（markdown 预览渲染 frontmatter）是独立的正确改动，不在本 PR 范围内，保持独立。

## 改动

- `apps/electron/default-skills/brainstorming/SKILL.md` — 去重 frontmatter + version bump
- `apps/electron/default-skills/executing-plans/SKILL.md` — 去重 frontmatter + version bump
- `apps/electron/default-skills/find-skills/SKILL.md` — 去重 frontmatter + version bump
- `apps/electron/default-skills/tool-builder/SKILL.md` — 去重 frontmatter + version bump
- `apps/electron/default-skills/writing-plans/SKILL.md` — 去重 frontmatter + version bump

## 测试

- 5 个文件的 frontmatter 均验证可作为单块合法 YAML 解析（keys 仅含 name/description/version，version 出现 1 次，块内无残留 `---`）
- 无功能性变更，description 内容零改动

🤖 Generated with [Claude Code](https://claude.com/claude-code)