### PR TITLE
feat(ui): 消息截图（单条 + 多选 + 大图片修复，合并 #877/#878/#879）

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -30,6 +30,7 @@ import { userProfileAtom } from '@/atoms/user-profile'
 import { tabMinimapCacheAtom } from '@/atoms/tab-atoms'
 import { channelsAtom } from '@/atoms/chat-atoms'
 import { ScrollPositionManager } from '@/hooks/useScrollPositionMemory'
+import { useMessageSelection } from '@/contexts/MessageSelectionContext'
 import { cn } from '@/lib/utils'
 import { Spinner } from '@/components/ui/spinner'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -398,6 +399,13 @@ export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persi
   const userProfile = useAtomValue(userProfileAtom)
   const setMinimapCache = useSetAtom(tabMinimapCacheAtom)
   const channels = useAtomValue(channelsAtom)
+  const { toggleSelect, isSelected } = useMessageSelection()
+  const handleGroupClick = React.useCallback((e: React.MouseEvent, groupId: string) => {
+    if (e.metaKey || e.ctrlKey) {
+      e.preventDefault()
+      toggleSelect(groupId)
+    }
+  }, [toggleSelect])
   /** 淡入控制：切换会话时先隐藏，等布局完成后再显示。 */
   const [ready, setReady] = React.useState(false)
   // 空会话无需淡入过渡（无消息则无滚动位置问题）
@@ -628,8 +636,11 @@ export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persi
                 && group.type === 'assistant-turn'
                 && idx === allGroups.findLastIndex((g) => g.type === 'assistant-turn')
               return (
+                <div key={getGroupId(group)} data-message-id={getGroupId(group)}
+                  onClick={(e) => handleGroupClick(e, getGroupId(group))}
+                  className={cn(isSelected(getGroupId(group)) && 'ring-2 ring-primary/40 bg-primary/[0.03] rounded-[10px]')}
+                >
                 <MessageGroupRenderer
-                  key={getGroupId(group)}
                   group={group}
                   allMessages={allSDKMessages}
                   historicalTaskSubjects={historicalTaskSubjects}
@@ -643,6 +654,7 @@ export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persi
                   stoppedByUser={isLastAssistantTurn || undefined}
                   sessionModelId={sessionModelId}
                 />
+                </div>
               )
             })}
 

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -28,6 +28,8 @@ import { ExitPlanModeBanner } from './ExitPlanModeBanner'
 import { PlanModeDashedBorder } from './PlanModeDashedBorder'
 import { ModelSelector } from '@/components/chat/ModelSelector'
 import { AttachmentPreviewItem } from '@/components/chat/AttachmentPreviewItem'
+import { MessageSelectionBar } from '@/components/chat/MessageSelectionBar'
+import { MessageSelectionProvider } from '@/contexts/MessageSelectionContext'
 import { QuotedSelectionChip } from '@/components/diff/QuotedSelectionChip'
 import { RichTextInput } from '@/components/ai-elements/rich-text-input'
 import { SpeechButton } from '@/components/ai-elements/speech-button'
@@ -2047,30 +2049,34 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   )
 
   return (
+    <MessageSelectionProvider>
     <>
     <AgentSessionProvider sessionId={sessionId}>
       <div className="flex flex-col h-full flex-1 min-w-0 max-w-[min(72rem,100%)] mx-auto">
         {/* Agent Header */}
         <AgentHeader sessionId={sessionId} />
 
-        {/* 消息区域 */}
-        <AgentMessages
-          sessionId={sessionId}
-          sessionModelId={agentModelId || undefined}
-          messagesLoaded={messagesLoaded}
-          persistedSDKMessages={persistedSDKMessages}
-          streaming={streaming}
-          streamState={streamState}
-          liveMessages={liveMessages}
-          sessionPath={sessionPath}
-          attachedDirs={allAttachedDirs}
-          stoppedByUser={stoppedByUser}
-          onRetry={handleRetry}
-          onRetryInNewSession={handleRetryInNewSession}
-          onFork={handleFork}
-          onRewind={handleRewindRequest}
-          onCompact={handleCompact}
-        />
+        {/* 消息区域 + 浮动操作栏 */}
+        <div className="relative flex-1 overflow-hidden">
+          <AgentMessages
+            sessionId={sessionId}
+            sessionModelId={agentModelId || undefined}
+            messagesLoaded={messagesLoaded}
+            persistedSDKMessages={persistedSDKMessages}
+            streaming={streaming}
+            streamState={streamState}
+            liveMessages={liveMessages}
+            sessionPath={sessionPath}
+            attachedDirs={allAttachedDirs}
+            stoppedByUser={stoppedByUser}
+            onRetry={handleRetry}
+            onRetryInNewSession={handleRetryInNewSession}
+            onFork={handleFork}
+            onRewind={handleRewindRequest}
+            onCompact={handleCompact}
+          />
+          <MessageSelectionBar />
+        </div>
 
         {/* 权限请求横幅 */}
         <PermissionBanner sessionId={sessionId} />
@@ -2224,5 +2230,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       </AlertDialogContent>
     </AlertDialog>
     </>
+    </MessageSelectionProvider>
   )
 }

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -12,7 +12,7 @@
  */
 
 import * as React from 'react'
-import { Bot, Loader2, AlertTriangle, FileText, FileImage, Download, Split, Undo2, RotateCw, Plus, Minimize2, Wrench, Settings, ExternalLink, Quote, Clock } from 'lucide-react'
+import { Bot, Loader2, AlertTriangle, Camera, FileText, FileImage, Download, Split, Undo2, RotateCw, Plus, Minimize2, Wrench, Settings, ExternalLink, Quote, Clock } from 'lucide-react'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { cn } from '@/lib/utils'
 import { ImageLightbox } from '@/components/ui/image-lightbox'
@@ -37,6 +37,7 @@ import { CopyButton } from '@/components/chat/CopyButton'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { formatMessageTime } from '@/components/chat/ChatMessageItem'
+import { captureMessageScreenshot } from '@/lib/message-screenshot'
 import { getModelLogo, resolveModelDisplayName, resolveModelProvider } from '@/lib/model-logo'
 import { userProfileAtom } from '@/atoms/user-profile'
 import { channelsAtom } from '@/atoms/chat-atoms'
@@ -554,6 +555,13 @@ export interface AssistantTurnRendererProps {
 export function AssistantTurnRenderer({ turn, allMessages, historicalTaskSubjects, basePath, onFork, onRewind, onRetry, onRetryInNewSession, onCompact, isStreaming, stoppedByUser, sessionModelId }: AssistantTurnRendererProps): React.ReactElement | null {
   const channels = useAtomValue(channelsAtom)
   const processGroupsKeepExpanded = useAtomValue(agentProcessGroupsKeepExpandedAtom)
+  const assistantRef = React.useRef<HTMLDivElement>(null)
+
+  const handleAssistantScreenshot = React.useCallback((): void => {
+    if (assistantRef.current) {
+      void captureMessageScreenshot(assistantRef.current)
+    }
+  }, [])
   // 收集所有 assistant 消息的内容块，保留 parent_tool_use_id 关联
   interface EnrichedBlock {
     block: SDKContentBlock
@@ -687,7 +695,7 @@ export function AssistantTurnRenderer({ turn, allMessages, historicalTaskSubject
   }
 
   return (
-    <Message from="assistant">
+    <Message ref={assistantRef} from="assistant">
       <MessageHeader
         model={turn.model ? resolveModelDisplayName(turn.model, channels) : undefined}
         time={turn.createdAt ? formatMessageTime(turn.createdAt) : undefined}
@@ -746,6 +754,9 @@ export function AssistantTurnRenderer({ turn, allMessages, historicalTaskSubject
         if (!hasDuration && !hasActions && !showStoppedBadge) return null
         return (
           <MessageActions className="pl-[46px] mt-0.5 min-h-[28px] justify-start">
+            <MessageAction tooltip="截图" onClick={handleAssistantScreenshot}>
+              <Camera className="size-3.5" />
+            </MessageAction>
             {hasDuration && <DurationBadge durationMs={durationMs!} usage={usage} />}
             {textContent && <CopyButton content={textContent} />}
             {onFork && lastUuid && (
@@ -1047,6 +1058,13 @@ function ScheduledRunBadge(): React.ReactElement {
 
 function UserInputMessage({ message }: { message: SDKUserMessage }): React.ReactElement {
   const userProfile = useAtomValue(userProfileAtom)
+  const userMsgRef = React.useRef<HTMLDivElement>(null)
+
+  const handleUserScreenshot = React.useCallback((): void => {
+    if (userMsgRef.current) {
+      void captureMessageScreenshot(userMsgRef.current)
+    }
+  }, [])
   const rawText = extractUserText(message) ?? ''
   const isScheduledRun = rawText.includes(SCHEDULED_RUN_MARKER)
   const { files: attachedFiles, quotes, text } = parseAttachedFiles(stripScheduledRunMarker(rawText))
@@ -1083,7 +1101,7 @@ function UserInputMessage({ message }: { message: SDKUserMessage }): React.React
   }, [activeSessionId, setSessionPendingFiles])
 
   return (
-    <Message from="user">
+    <Message ref={userMsgRef} from="user">
       <div className="flex items-start gap-2.5 mb-2.5">
         <UserAvatar avatar={userProfile.avatar} size={35} />
         <div className="flex flex-col justify-between h-[35px]">
@@ -1129,6 +1147,9 @@ function UserInputMessage({ message }: { message: SDKUserMessage }): React.React
       </MessageContent>
       {text && (
         <MessageActions className="pl-[46px] mt-0.5">
+          <MessageAction tooltip="截图" onClick={handleUserScreenshot}>
+            <Camera className="size-3.5" />
+          </MessageAction>
           <CopyButton content={text} />
         </MessageActions>
       )}
@@ -1149,6 +1170,13 @@ interface ErrorMessageProps {
 }
 
 function ErrorMessage({ message, onRetry, onRetryInNewSession, onCompact }: ErrorMessageProps): React.ReactElement {
+  const errorMsgRef = React.useRef<HTMLDivElement>(null)
+
+  const handleErrorScreenshot = React.useCallback((): void => {
+    if (errorMsgRef.current) {
+      void captureMessageScreenshot(errorMsgRef.current)
+    }
+  }, [])
   const meta = extractMeta(message as unknown as SDKMessage)
   const errorText = message.error?.message ?? '未知错误'
 
@@ -1239,7 +1267,7 @@ function ErrorMessage({ message, onRetry, onRetryInNewSession, onCompact }: Erro
   const hasActions = hasStructuredActions || hasLegacyActions
 
   return (
-    <Message from="assistant">
+    <Message ref={errorMsgRef} from="assistant">
       <MessageHeader
         model={undefined}
         time={meta.createdAt ? formatMessageTime(meta.createdAt) : undefined}
@@ -1325,6 +1353,9 @@ function ErrorMessage({ message, onRetry, onRetryInNewSession, onCompact }: Erro
         )}
       </MessageContent>
       <MessageActions className="pl-[46px] mt-0.5">
+        <MessageAction tooltip="截图" onClick={handleErrorScreenshot}>
+          <Camera className="size-3.5" />
+        </MessageAction>
         <CopyButton content={displayContentText} />
       </MessageActions>
     </Message>

--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -51,18 +51,21 @@ interface MessageProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 /** 消息根容器，user 自动右对齐 */
-export function Message({ className, from, ...props }: MessageProps): React.ReactElement {
-  return (
-    <div
-      className={cn(
-        'message-item group flex w-full flex-col gap-0.5 rounded-[10px] px-2.5 py-2.5',
-        from === 'user' ? 'is-user' : 'is-assistant',
-        className
-      )}
-      {...props}
-    />
-  )
-}
+export const Message = React.forwardRef<HTMLDivElement, MessageProps>(
+  function Message({ className, from, ...props }, ref): React.ReactElement {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'message-item group flex w-full flex-col gap-0.5 rounded-[10px] px-2.5 py-2.5',
+          from === 'user' ? 'is-user' : 'is-assistant',
+          className
+        )}
+        {...props}
+      />
+    )
+  }
+)
 
 // ===== MessageHeader 头像 + 模型名 =====
 

--- a/apps/electron/src/renderer/components/chat/ChatMessageItem.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessageItem.tsx
@@ -11,7 +11,10 @@
 
 import * as React from 'react'
 import { useAtomValue } from 'jotai'
-import { AlertCircle, Pencil, RotateCcw, Trash2 } from 'lucide-react'
+import { AlertCircle, Camera, Pencil, RotateCcw, Trash2 } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { captureMessageScreenshot } from '@/lib/message-screenshot'
+import { useMessageSelection } from '@/contexts/MessageSelectionContext'
 import {
   Message,
   MessageHeader,
@@ -113,8 +116,11 @@ export const ChatMessageItem = React.memo(function ChatMessageItem({
 }: ChatMessageItemProps): React.ReactElement {
   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false)
   const [isDeleting, setIsDeleting] = React.useState(false)
+  const messageRef = React.useRef<HTMLDivElement>(null)
   const userProfile = useAtomValue(userProfileAtom)
   const channels = useAtomValue(channelsAtom)
+  const { toggleSelect, isSelected } = useMessageSelection()
+  const selected = isSelected(message.id)
 
   /** 确认删除消息 */
   const handleDeleteConfirm = async (): Promise<void> => {
@@ -137,9 +143,30 @@ export const ChatMessageItem = React.memo(function ChatMessageItem({
   // 并排模式下，user 消息不使用 from="user" 以避免右对齐
   const messageFrom = isParallelMode ? 'assistant' : message.role
 
+  /** 截取消息为图片并复制到剪贴板 */
+  const handleScreenshot = React.useCallback((): void => {
+    if (messageRef.current) {
+      void captureMessageScreenshot(messageRef.current)
+    }
+  }, [])
+
+  /** Ctrl/Cmd+Click 切换多选 */
+  const handleMessageClick = React.useCallback((e: React.MouseEvent): void => {
+    if (e.metaKey || e.ctrlKey) {
+      e.preventDefault()
+      toggleSelect(message.id)
+    }
+  }, [message.id, toggleSelect])
+
   return (
     <>
-      <Message from={messageFrom}>
+      <Message
+        ref={messageRef}
+        data-message-id={message.id}
+        from={messageFrom}
+        onClick={handleMessageClick}
+        className={cn(selected && 'ring-2 ring-primary/40 bg-primary/[0.03]')}
+      >
         {/* assistant 头像 + 模型名 + 时间 */}
         {message.role === 'assistant' && (
           <MessageHeader
@@ -235,6 +262,9 @@ export const ChatMessageItem = React.memo(function ChatMessageItem({
         {/* 操作按钮（非 streaming 时显示，hover 时可见） */}
         {(message.content || message.error || (message.attachments && message.attachments.length > 0)) && !isStreaming && !isInlineEditing && (
           <MessageActions className="pl-[46px] mt-0.5 min-h-[28px]">
+            <MessageAction tooltip="截图" onClick={handleScreenshot}>
+              <Camera className="size-3.5" />
+            </MessageAction>
             <CopyButton content={message.content} />
             {message.role === 'assistant' && conversationId && (
               <MigrateToAgentButton conversationId={conversationId} />

--- a/apps/electron/src/renderer/components/chat/ChatView.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatView.tsx
@@ -21,6 +21,8 @@ import { ChatMessages } from './ChatMessages'
 import { ChatInput } from './ChatInput'
 import { AgentRecommendBanner } from './AgentRecommendBanner'
 import { PromptEditorSidebar } from './PromptEditorSidebar'
+import { MessageSelectionBar } from './MessageSelectionBar'
+import { MessageSelectionProvider } from '@/contexts/MessageSelectionContext'
 import type { InlineEditSubmitPayload } from './ChatMessageItem'
 import {
   conversationsAtom,
@@ -600,13 +602,15 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
   }, [setPendingAttachments])
 
   return (
+    <MessageSelectionProvider>
     <div className="flex h-full overflow-hidden">
       {/* 主内容区域 */}
       <div className="flex flex-col h-full flex-1 min-w-0">
         {/* Header 在 max-w 外，按钮可到达最右侧 */}
         <ChatHeader conversation={conversation} />
         <div className="flex flex-col flex-1 w-full max-w-[min(72rem,100%)] mx-auto overflow-hidden min-h-0">
-          {/* 中间：消息区域 */}
+          {/* 中间：消息区域 + 浮动操作栏 */}
+          <div className="relative flex flex-col flex-1 overflow-hidden min-h-0">
           <ChatMessages
             conversationId={conversationId}
             messages={messages}
@@ -629,6 +633,8 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
             onLoadMore={handleLoadMore}
             onImageEditComplete={handleImageEditComplete}
           />
+          <MessageSelectionBar />
+          </div>
 
           {/* 错误提示 */}
           {chatError && (
@@ -680,5 +686,6 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
         </div>
       </div>
     </div>
+    </MessageSelectionProvider>
   )
 }

--- a/apps/electron/src/renderer/components/chat/MessageSelectionBar.tsx
+++ b/apps/electron/src/renderer/components/chat/MessageSelectionBar.tsx
@@ -1,0 +1,65 @@
+/**
+ * MessageSelectionBar — 底部浮动多选操作栏
+ *
+ * 显示"已选 N 条" + 截图按钮 + 清除按钮。
+ * Chat 和 Agent 模式共用。通过 data-message-id 属性定位 DOM。
+ */
+
+import { Camera, X } from 'lucide-react'
+import { useMessageSelection } from '@/contexts/MessageSelectionContext'
+import { captureMultiMessageScreenshot } from '@/lib/message-screenshot'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+export function MessageSelectionBar(): React.ReactElement | null {
+  const { selectedIds, clearSelection, selectedCount } = useMessageSelection()
+
+  if (selectedCount === 0) return null
+
+  const handleScreenshot = () => {
+    // 按文档顺序收集（而非点击顺序）：遍历 DOM 中所有带 data-message-id 的元素，
+    // 过滤出已选中的，保证拼接截图自上而下与界面一致。
+    const els = Array.from(
+      document.querySelectorAll<HTMLElement>('[data-message-id]'),
+    ).filter((el) => {
+      const id = el.dataset.messageId
+      return id != null && selectedIds.has(id)
+    })
+    if (els.length === 0) return
+    void captureMultiMessageScreenshot(els)
+  }
+
+  return (
+    <div className="absolute left-0 right-0 bottom-0 flex items-center justify-center pb-3 z-10 pointer-events-none">
+      <div
+        className={cn(
+          'pointer-events-auto flex items-center gap-3 rounded-full border px-4 py-2',
+          'bg-white/80 dark:bg-zinc-800/80 backdrop-blur-md shadow-lg border-border/60',
+        )}
+      >
+        <span className="text-sm text-muted-foreground whitespace-nowrap">
+          已选 {selectedCount} 条
+        </span>
+
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-8 gap-1.5 rounded-full"
+          onClick={handleScreenshot}
+        >
+          <Camera className="size-3.5" />
+          截图
+        </Button>
+
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          className="h-8 w-8 rounded-full"
+          onClick={clearSelection}
+        >
+          <X className="size-3.5" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/contexts/MessageSelectionContext.tsx
+++ b/apps/electron/src/renderer/contexts/MessageSelectionContext.tsx
@@ -1,0 +1,79 @@
+/**
+ * MessageSelectionContext — 消息多选状态共享 Context
+ *
+ * 极简实现：只有选中状态，没有 DOM ref 注册。
+ * 截图时使用 data-message-id 属性 + querySelector 定位 DOM 元素。
+ */
+
+import * as React from 'react'
+
+interface MessageSelectionContextValue {
+  /** 当前选中的消息/Group ID 集合 */
+  selectedIds: Set<string>
+  /** 是否处于多选模式 */
+  isSelectMode: boolean
+  /** 切换选中状态 */
+  toggleSelect: (id: string) => void
+  /** 清除所有选中 */
+  clearSelection: () => void
+  /** 检查是否已选中 */
+  isSelected: (id: string) => boolean
+  /** 选中数量 */
+  selectedCount: number
+}
+
+const MessageSelectionContext = React.createContext<MessageSelectionContextValue | null>(null)
+
+export function useMessageSelection(): MessageSelectionContextValue {
+  const ctx = React.useContext(MessageSelectionContext)
+  if (!ctx) {
+    throw new Error('useMessageSelection must be used within MessageSelectionProvider')
+  }
+  return ctx
+}
+
+interface MessageSelectionProviderProps {
+  children: React.ReactNode
+}
+
+export function MessageSelectionProvider({ children }: MessageSelectionProviderProps): React.ReactElement {
+  const [selectedIds, setSelectedIds] = React.useState<Set<string>>(new Set())
+
+  const isSelectMode = selectedIds.size > 0
+
+  const toggleSelect = React.useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+      return next
+    })
+  }, [])
+
+  const clearSelection = React.useCallback(() => {
+    setSelectedIds(new Set())
+  }, [])
+
+  const isSelected = React.useCallback((id: string) => selectedIds.has(id), [selectedIds])
+
+  const value = React.useMemo<MessageSelectionContextValue>(
+    () => ({
+      selectedIds,
+      isSelectMode,
+      toggleSelect,
+      clearSelection,
+      isSelected,
+      selectedCount: selectedIds.size,
+    }),
+    [selectedIds, isSelectMode, toggleSelect, clearSelection, isSelected],
+  )
+
+  return (
+    <MessageSelectionContext.Provider value={value}>
+      {children}
+    </MessageSelectionContext.Provider>
+  )
+}

--- a/apps/electron/src/renderer/lib/message-screenshot.ts
+++ b/apps/electron/src/renderer/lib/message-screenshot.ts
@@ -1,0 +1,159 @@
+/**
+ * message-screenshot — 消息截图载荷构建工具
+ *
+ * 复刻自 MarkdownEditorToolbar 的 buildScreenshotPayload 模式：
+ * 克隆消息 DOM + 收集运行时 CSS → 走现有 IPC 截图管线。
+ *
+ * 避免了自建截图引擎的并行渲染路径维护问题——截图侧用的就是
+ * 渲染侧的真实 CSS（含 Tailwind 编译输出 + globals.css 变量），
+ * 与页面样式 100% 一致。
+ */
+
+import { SCREENSHOT_LIMITS } from '@proma/shared'
+import { toast } from 'sonner'
+
+export interface MessageScreenshotPayload {
+  html: string
+  width: number
+  css: string
+  themeClass: string
+}
+
+/**
+ * 收集渲染端已编译的运行时 CSS（含 Tailwind 输出 + globals.css）。
+ * 跨域 sheet 读 cssRules 会抛，捕获后跳过。
+ */
+function collectRuntimeStyles(): string {
+  const chunks: string[] = []
+  for (const sheet of Array.from(document.styleSheets)) {
+    try {
+      const rules = sheet.cssRules
+      if (!rules) continue
+      for (const rule of Array.from(rules)) {
+        chunks.push(rule.cssText)
+      }
+    } catch {
+      // 跨域 sheet 跳过
+    }
+  }
+  return chunks.join('\n')
+}
+
+/**
+ * 从消息 DOM 元素构建截图载荷。
+ * 遵循与 MarkdownEditorToolbar 相同的预检→克隆→收集流程。
+ *
+ * @param messageEl - 消息根元素的 HTMLElement（<Message> 容器）
+ * @param contentWidth - 可选的内容宽度覆盖，默认从元素测量
+ * @returns 适用于 window.electronAPI.screenshotCapture 的载荷
+ */
+export function buildMessageScreenshotPayload(
+  messageEl: HTMLElement,
+  contentWidth?: number,
+): MessageScreenshotPayload {
+  // 预检：早失败
+  const elementCount = messageEl.querySelectorAll('*').length
+  if (elementCount > SCREENSHOT_LIMITS.MAX_ELEMENTS) {
+    throw new Error('消息结构过于复杂，请简化后重试')
+  }
+
+  // outerHTML 字节预检：剔除 base64 data URI 后再算长度（图片的 base64 会大幅
+  // 膨胀 HTML 尺寸但不影响渲染复杂度，主进程 12MB MAX_HTML_BYTES 兜底）。
+  const htmlForSizeCheck = messageEl.outerHTML.replace(
+    /src\s*=\s*"data:[^"]{100,}"/gi,
+    'src="data:image/placeholder"',
+  )
+  if (htmlForSizeCheck.length > SCREENSHOT_LIMITS.MAX_RAW_HTML_BYTES) {
+    throw new Error('消息过大，请缩短后重试')
+  }
+
+  // 克隆 DOM
+  const clone = messageEl.cloneNode(true) as HTMLElement
+  clone.querySelectorAll('[contenteditable]').forEach((el) => {
+    el.removeAttribute('contenteditable')
+  })
+
+  const rect = messageEl.getBoundingClientRect()
+  const width = Math.max(
+    SCREENSHOT_LIMITS.MIN_WIDTH,
+    Math.min(
+      SCREENSHOT_LIMITS.MAX_WIDTH,
+      Math.ceil(contentWidth ?? (rect.width || 680)),
+    ),
+  )
+  clone.style.width = `${width}px`
+
+  return {
+    html: clone.outerHTML,
+    width,
+    css: collectRuntimeStyles(),
+    themeClass: document.documentElement.className,
+  }
+}
+
+/**
+ * 截图消息元素并复制到剪贴板。
+ * 封装了 IPC 调用 + toast 反馈，组件中只需一行调用。
+ *
+ * @param el - 消息根元素
+ * @returns 是否成功
+ */
+export async function captureMessageScreenshot(el: HTMLElement): Promise<boolean> {
+  try {
+    const payload = buildMessageScreenshotPayload(el)
+    const result = await window.electronAPI.screenshotCapture({
+      ...payload,
+      isDark: document.documentElement.classList.contains('dark'),
+      mode: 'clipboard',
+    })
+    if (result.success) {
+      toast.success(result.message || '截图已复制到剪贴板')
+    } else {
+      toast.error(result.message || '截图失败')
+    }
+    return result.success
+  } catch (error) {
+    toast.error(error instanceof Error ? error.message : '截图失败')
+    return false
+  }
+}
+
+/**
+ * 多消息截图：选中 N 条消息，拼接 HTML 后一次 IPC 渲染。
+ *
+ * 复用 buildMessageScreenshotPayload 逐条构建（因此自动享受 base64 预检修复，
+ * 含大图片的多选也能正常截图）。分隔线使用中性半透明灰，明暗主题均适配。
+ *
+ * @param els - 选中的消息 DOM 元素列表，应按文档顺序传入
+ * @returns 是否成功
+ */
+export async function captureMultiMessageScreenshot(els: HTMLElement[]): Promise<boolean> {
+  if (els.length === 0) return false
+
+  try {
+    const payloads = els.map((el) => buildMessageScreenshotPayload(el))
+    const maxWidth = Math.max(...payloads.map((p) => p.width))
+    const combinedHtml = payloads
+      .map((p) => p.html)
+      .join('\n<hr style="margin:0;border:none;border-top:1px solid rgba(127,127,127,0.25)" />\n')
+
+    const first = payloads[0]!
+    const result = await window.electronAPI.screenshotCapture({
+      html: combinedHtml,
+      isDark: document.documentElement.classList.contains('dark'),
+      width: maxWidth,
+      mode: 'clipboard',
+      css: first.css,
+      themeClass: first.themeClass,
+    })
+    if (result.success) {
+      toast.success(`已截图 ${els.length} 条消息`)
+    } else {
+      toast.error(result.message || '截图失败')
+    }
+    return result.success
+  } catch (error) {
+    toast.error(error instanceof Error ? error.message : '截图失败')
+    return false
+  }
+}


### PR DESCRIPTION
## 概述

将三个截图相关 PR 合并为一个完整、基于最新 main 的功能，并修复了它们各自独立分支、合并时会**静默丢功能**的结构性问题。

- **#877** 单条消息截图（基础）
- **#878** Ctrl/Cmd+Click 多选拼接截图
- **#879** 大 base64 图片导致截图失败的修复

原三个 PR 都各自 `new file` 创建同一个 `message-screenshot.ts` 且内容互不包含，按序 merge 会 add/add 冲突且丢失彼此改动。本 PR 一次性给出三者合一的正确状态。

## 功能

- 单条消息截图：Chat 消息、Agent 的 assistant turn / user / error 消息均可一键截图复制到剪贴板
- 多选截图：Ctrl/Cmd+Click 选中多条（Chat 按单条、Agent 按 turn），底部浮动栏「截图 N 条」拼接为一张图
- 复用已审核的 `screenshot-service.ts` 离屏渲染管线，截图样式与页面 100% 一致，零自建引擎、零新依赖

## 改动

| 文件 | 改动 |
|------|------|
| `lib/message-screenshot.ts` | **新增** — `captureMessageScreenshot` / `captureMultiMessageScreenshot` / `buildMessageScreenshotPayload`（含 base64 预检修复） |
| `contexts/MessageSelectionContext.tsx` | **新增** — 极简多选状态 Context |
| `components/chat/MessageSelectionBar.tsx` | **新增** — 底部浮动操作栏 |
| `components/ai-elements/message.tsx` | `Message` 改为 `forwardRef` |
| `components/chat/ChatMessageItem.tsx` | ref + 截图按钮 + 多选（含 `data-message-id`） |
| `components/agent/SDKMessageRenderer.tsx` | assistant / user / error 三处截图按钮 |
| `components/chat/ChatView.tsx` | 包裹 Provider + 浮动栏 + relative 容器 |
| `components/agent/AgentView.tsx` | 同上（Agent 模式） |
| `components/agent/AgentMessages.tsx` | group 多选 wrapper + `data-message-id` |

## 相比原三个 PR 的合并修复

- **多选大图片可截图**：多选路径复用同一 `buildMessageScreenshotPayload`，自动享受 #879 的 base64 预检修复（原 #878 的版本不含该修复，多选含大图片仍会失败）
- **截图按文档顺序**：浮动栏遍历 DOM 中所有 `data-message-id` 元素过滤选中项，保证拼接自上而下与界面一致（原实现按点击顺序）
- **Chat 多选定位修复**：Chat 的 `<Message>` 补 `data-message-id`，否则浮动栏 `querySelector` 找不到元素（原 #878 遗漏）
- **分隔线主题适配**：拼接分隔线改用中性半透明灰 `rgba(127,127,127,0.25)`，明暗主题均正常（原写死浅灰，深色模式是亮线）

## 测试

- [x] TypeScript 类型检查通过（`tsc --noEmit`，0 错误）
- [ ] Chat 模式：hover 消息 → 相机图标 → 截图复制 → toast
- [ ] Agent 模式：assistant / user / error 三种消息可截图
- [ ] Ctrl/Cmd+Click 多选 → 浮动栏「截图 N 条」→ 拼接图
- [ ] 含大 base64 图片的消息，单条与多选均能截图
- [ ] 乱序点选时，截图仍按界面自上而下顺序
- [ ] 深色 / 浅色主题截图与分隔线均正常

## 备注

- 基于最新 `origin/main`（aa4b0b5）
- Closes #877, #878, #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)