### PR TITLE
[codex] Remove sticky user message border

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.12.29",
+  "version": "0.12.30",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx
@@ -150,7 +150,7 @@ export function StickyUserMessage({ userMessages }: StickyUserMessageProps): Rea
       {/* 复用 ConversationContent(px-8) + Message(px-2.5) 的 padding 链，保证与内容区等宽 */}
       <div className="mx-8 px-2.5 pt-2">
         <div
-          className="sticky-user-banner ml-[46px] rounded-xl bg-card border-2 border-primary/25 shadow-sm cursor-pointer hover:bg-accent/50 transition-colors"
+          className="sticky-user-banner ml-[46px] rounded-xl bg-card shadow-sm cursor-pointer hover:bg-accent/50 transition-colors"
           onClick={scrollToOriginal}
         >
           <div className="px-3.5 py-2.5">


### PR DESCRIPTION
## Summary
- remove the newly added primary border from the sticky user message banner
- bump @proma/electron patch version to 0.12.30

## Why
PR #859 made the Agent/Chat sticky user message banner show a prominent 2px primary border. This patch keeps the card background and shadow but removes that extra frame.

## Validation
- git diff --check -- apps/electron/package.json apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx