### PR TITLE
[codex] Remove scroll button border

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.12.30",
+  "version": "0.12.31",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/ai-elements/conversation.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/conversation.tsx
@@ -106,12 +106,12 @@ export function ConversationScrollButton({
     <Button
       className={cn(
         'absolute bottom-[26px] left-1/2 -translate-x-1/2 rounded-[17px] size-9',
-        'border-2 border-primary/25',
+        'bg-card shadow-sm hover:bg-accent/80',
         className
       )}
       onClick={handleScrollToBottom}
       type="button"
-      variant="outline"
+      variant="ghost"
       {...props}
     >
       <ArrowDownIcon className="size-4" />


### PR DESCRIPTION
## Summary
- remove the visible border from the centered scroll-to-bottom button
- keep the card background, subtle shadow, and hover feedback consistent with the borderless sticky user message treatment
- bump @proma/electron patch version to 0.12.31

## Why
PR #895 removed the sticky user message banner border, but the same conversation surface still had a framed scroll-to-bottom arrow. The button used both an explicit primary border class and the `outline` button variant, so both sources needed to be removed.

## Validation
- `git diff --check -- apps/electron/src/renderer/components/ai-elements/conversation.tsx apps/electron/package.json`
- `bun install --frozen-lockfile`
- `cd apps/electron && bun run typecheck`
