### PR TITLE
feat(memory): Chat 工具新增 Nowledge Mem 本地记忆卡片【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.12.31",
+  "version": "0.12.32",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.12.32",
+  "version": "0.12.33",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.12.33",
+  "version": "0.12.34",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.12.34",
+  "version": "0.12.35",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/settings/MemorySettings.tsx
+++ b/apps/electron/src/renderer/components/settings/MemorySettings.tsx
@@ -302,7 +302,7 @@ function NowledgeMemSection(): React.ReactElement {
               💡 平台支持：macOS、Linux 主流支持；Windows 用户需在 Git Bash + uv 环境中尝试（实验性，未经 Nowledge 官方验证）
             </p>
             <p className="text-xs text-muted-foreground">
-              配置过程遇到问题？查看{' '}
+              📖 配置过程遇到问题？查看{' '}
               <a
                 href="https://mem.nowledge.co/zh/docs/integrations/proma"
                 target="_blank"

--- a/apps/electron/src/renderer/components/settings/MemorySettings.tsx
+++ b/apps/electron/src/renderer/components/settings/MemorySettings.tsx
@@ -191,7 +191,8 @@ function NowledgeMemSection(): React.ReactElement {
           try {
             const caps = await window.electronAPI.getWorkspaceCapabilities(ws.slug)
             return caps.mcpServers.some((m) => m.name === 'nowledge-mem') ? ws.slug : null
-          } catch {
+          } catch (err) {
+            console.error('[Nowledge Mem] 检查工作区能力失败:', ws.slug, err)
             return null
           }
         }),

--- a/apps/electron/src/renderer/components/settings/MemorySettings.tsx
+++ b/apps/electron/src/renderer/components/settings/MemorySettings.tsx
@@ -1,20 +1,23 @@
 /**
  * MemorySettings - 记忆设置页
  *
- * 独立的顶级设置 tab，管理全局跨会话记忆功能的配置。
- * Chat 和 Agent 模式共享同一份记忆配置。
+ * Chat 工具 tab 下的记忆区，提供两种记忆方案：
+ *  - MemOS Cloud：官方云端记忆（含 Switch 开关，作为 chat-tools 的一项）
+ *  - Nowledge Mem：本地优先记忆 + Agent 集成（仅展示配置提示词，不持久化任何凭证）
  */
 
 import * as React from 'react'
-import { useSetAtom } from 'jotai'
+import { useAtomValue, useSetAtom } from 'jotai'
 import { toast } from 'sonner'
-import { ExternalLink, Eye, EyeOff, Loader2, CheckCircle2, XCircle } from 'lucide-react'
+import { ExternalLink, Eye, EyeOff, Loader2, CheckCircle2, XCircle, Copy } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
 import { Input } from '@/components/ui/input'
 import type { MemoryConfig } from '@proma/shared'
 import { SettingsSection, SettingsCard } from './primitives'
 import { chatToolsAtom } from '@/atoms/chat-tool-atoms'
+import { agentWorkspacesAtom } from '@/atoms/agent-atoms'
+import nowledgeMemPrompt from './nowledge-mem-prompt.md?raw'
 
 /** 刷新全局工具列表 atom */
 async function refreshChatTools(setter: (tools: Awaited<ReturnType<typeof window.electronAPI.getChatTools>>) => void): Promise<void> {
@@ -26,21 +29,19 @@ async function refreshChatTools(setter: (tools: Awaited<ReturnType<typeof window
   }
 }
 
-export function MemorySettings(): React.ReactElement {
+/** MemOS Cloud · 云端记忆（原有实现） */
+function MemOSSection(): React.ReactElement {
   const [config, setConfig] = React.useState<MemoryConfig>({ enabled: false, apiKey: '', userId: 'proma-user' })
   const [saving, setSaving] = React.useState(false)
   const [loading, setLoading] = React.useState(true)
   const setChatTools = useSetAtom(chatToolsAtom)
 
-  // 本地编辑状态
   const [apiKey, setApiKey] = React.useState('')
   const [showApiKey, setShowApiKey] = React.useState(false)
 
-  // 连接测试状态
   const [testing, setTesting] = React.useState(false)
   const [testResult, setTestResult] = React.useState<{ success: boolean; message: string } | null>(null)
 
-  // 加载全局配置
   React.useEffect(() => {
     window.electronAPI.getMemoryConfig()
       .then((c) => {
@@ -59,7 +60,6 @@ export function MemorySettings(): React.ReactElement {
       await window.electronAPI.updateChatToolState('memory', { enabled: updated.enabled })
       setConfig(updated)
       setApiKey(updated.apiKey)
-      // 刷新全局工具列表（available/enabled 可能变化）
       await refreshChatTools(setChatTools)
       toast.success('记忆设置已保存')
     } catch (error) {
@@ -76,7 +76,6 @@ export function MemorySettings(): React.ReactElement {
   }, [apiKey, config])
 
   const handleTest = async (): Promise<void> => {
-    // 如果有未保存的 API Key，先保存再测试
     if (apiKey !== config.apiKey) {
       await handleSave({ ...config, apiKey })
     }
@@ -97,84 +96,235 @@ export function MemorySettings(): React.ReactElement {
   }
 
   return (
-    <div className="space-y-8">
-      <SettingsSection
-        title="记忆"
-        description="启用后 Chat 和 Agent 模式都可跨会话记住重要信息"
-        action={
-          <Switch
-            checked={config.enabled}
-            onCheckedChange={(checked) => handleSave({ ...config, apiKey, enabled: checked })}
-            disabled={saving}
-          />
-        }
-      >
-        <SettingsCard divided={false}>
-          <div className="space-y-4 p-4">
-            {/* 引导说明 */}
-            <div className="rounded-lg bg-muted/50 p-3 space-y-2 text-sm text-muted-foreground">
-              <p>记忆功能由 <span className="font-medium text-foreground">MemOS Cloud</span> 提供，启用后能跨会话记住你的偏好、决策和项目上下文。免费用户每月提供 5 万次添加记忆，2 万次查询记忆，对于绝大部分用户均足够。</p>
-              <p className="text-xs">配置步骤：</p>
-              <ol className="text-xs list-decimal list-inside space-y-1">
-                <li>
-                  访问{' '}
-                  <a
-                    href="https://memos-dashboard.openmem.net"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-primary hover:underline inline-flex items-center gap-0.5"
-                  >
-                    MemOS Cloud 控制台
-                    <ExternalLink size={10} />
-                  </a>
-                  {' '}注册账号
-                </li>
-                <li>在控制台的 API Keys 页面生成一个 API Key</li>
-                <li>将 API Key 填入下方，然后开启开关</li>
-              </ol>
-            </div>
-
-            <div className="space-y-1.5">
-              <div className="flex items-center justify-between">
-                <label className="text-sm font-medium">API Key</label>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  disabled={testing || !apiKey}
-                  onClick={handleTest}
+    <SettingsSection
+      title="MemOS Cloud · 云端记忆"
+      description="免费云端服务，启用后 Chat 与 Agent 都可跨会话记住偏好、决策和项目上下文"
+      action={
+        <Switch
+          checked={config.enabled}
+          onCheckedChange={(checked) => handleSave({ ...config, apiKey, enabled: checked })}
+          disabled={saving}
+        />
+      }
+    >
+      <SettingsCard divided={false}>
+        <div className="space-y-4 p-4">
+          {/* 引导说明 */}
+          <div className="rounded-lg bg-muted/50 p-3 space-y-2 text-sm text-muted-foreground">
+            <p>记忆功能由 <span className="font-medium text-foreground">MemOS Cloud</span> 提供。免费用户每月提供 5 万次添加记忆，2 万次查询记忆，对于绝大部分用户均足够。</p>
+            <p className="text-xs">配置步骤：</p>
+            <ol className="text-xs list-decimal list-inside space-y-1">
+              <li>
+                访问{' '}
+                <a
+                  href="https://memos-dashboard.openmem.net"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary hover:underline inline-flex items-center gap-0.5"
                 >
-                  {testing ? <><Loader2 size={14} className="animate-spin mr-1.5" />测试中...</> : '测试连接'}
-                </Button>
-              </div>
-              <div className="relative">
-                <Input
-                  type={showApiKey ? 'text' : 'password'}
-                  placeholder="memos API Key"
-                  value={apiKey}
-                  onChange={(e) => setApiKey(e.target.value)}
-                  onBlur={handleBlurSave}
-                  className="pr-10"
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowApiKey(!showApiKey)}
-                  className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-muted-foreground hover:text-foreground transition-colors"
-                  tabIndex={-1}
-                >
-                  {showApiKey ? <EyeOff size={16} /> : <Eye size={16} />}
-                </button>
-              </div>
-            </div>
-
-            {testResult && (
-              <div className={`flex items-start gap-2 rounded-lg p-3 text-sm ${testResult.success ? 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' : 'bg-destructive/10 text-destructive'}`}>
-                {testResult.success ? <CheckCircle2 size={16} className="mt-0.5 shrink-0" /> : <XCircle size={16} className="mt-0.5 shrink-0" />}
-                <span>{testResult.message}</span>
-              </div>
-            )}
+                  MemOS Cloud 控制台
+                  <ExternalLink size={10} />
+                </a>
+                {' '}注册账号
+              </li>
+              <li>在控制台的 API Keys 页面生成一个 API Key</li>
+              <li>将 API Key 填入下方，然后开启开关</li>
+            </ol>
           </div>
-        </SettingsCard>
-      </SettingsSection>
+
+          <div className="space-y-1.5">
+            <div className="flex items-center justify-between">
+              <label className="text-sm font-medium">API Key</label>
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={testing || !apiKey}
+                onClick={handleTest}
+              >
+                {testing ? <><Loader2 size={14} className="animate-spin mr-1.5" />测试中...</> : '测试连接'}
+              </Button>
+            </div>
+            <div className="relative">
+              <Input
+                type={showApiKey ? 'text' : 'password'}
+                placeholder="memos API Key"
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                onBlur={handleBlurSave}
+                className="pr-10"
+              />
+              <button
+                type="button"
+                onClick={() => setShowApiKey(!showApiKey)}
+                className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-muted-foreground hover:text-foreground transition-colors"
+                tabIndex={-1}
+              >
+                {showApiKey ? <EyeOff size={16} /> : <Eye size={16} />}
+              </button>
+            </div>
+          </div>
+
+          {testResult && (
+            <div className={`flex items-start gap-2 rounded-lg p-3 text-sm ${testResult.success ? 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' : 'bg-destructive/10 text-destructive'}`}>
+              {testResult.success ? <CheckCircle2 size={16} className="mt-0.5 shrink-0" /> : <XCircle size={16} className="mt-0.5 shrink-0" />}
+              <span>{testResult.message}</span>
+            </div>
+          )}
+        </div>
+      </SettingsCard>
+    </SettingsSection>
+  )
+}
+
+/** Nowledge Mem · 本地优先记忆 + Agent 集成 */
+function NowledgeMemSection(): React.ReactElement {
+  const workspaces = useAtomValue(agentWorkspacesAtom)
+  const [configuredSlugs, setConfiguredSlugs] = React.useState<string[]>([])
+  const [copying, setCopying] = React.useState(false)
+
+  // 检测哪些工作区的 mcp.json 里已经写入了 nowledge-mem 条目
+  React.useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      const results = await Promise.all(
+        workspaces.map(async (ws) => {
+          try {
+            const caps = await window.electronAPI.getWorkspaceCapabilities(ws.slug)
+            return caps.mcpServers.some((m) => m.name === 'nowledge-mem') ? ws.slug : null
+          } catch {
+            return null
+          }
+        }),
+      )
+      if (!cancelled) {
+        setConfiguredSlugs(results.filter((s): s is string => s !== null))
+      }
+    })()
+    return () => { cancelled = true }
+  }, [workspaces])
+
+  const handleCopy = async (): Promise<void> => {
+    setCopying(true)
+    try {
+      await navigator.clipboard.writeText(nowledgeMemPrompt)
+      toast.success('已复制配置提示词，请粘贴到 Agent 模式输入框执行')
+    } catch (error) {
+      console.error('[Nowledge Mem] 复制失败:', error)
+      toast.error('复制失败，请检查剪贴板权限')
+    } finally {
+      setCopying(false)
+    }
+  }
+
+  const badge = configuredSlugs.length > 0 ? (
+    <span
+      className="inline-flex items-center gap-1 text-xs font-normal text-emerald-600 dark:text-emerald-400"
+      title={`已配置工作区：${configuredSlugs.join('、')}`}
+    >
+      <span className="w-1.5 h-1.5 rounded-full bg-emerald-500" />
+      已在 {configuredSlugs.length} 个工作区配置
+    </span>
+  ) : (
+    <span className="inline-flex items-center gap-1 text-xs font-normal text-muted-foreground">
+      <span className="w-1.5 h-1.5 rounded-full bg-muted-foreground/50" />
+      未配置
+    </span>
+  )
+
+  return (
+    <SettingsSection
+      title={
+        <span className="inline-flex items-center gap-2 flex-wrap">
+          Nowledge Mem · 本地优先记忆
+          {badge}
+        </span>
+      }
+      description="本地客户端 + Agent 集成方案，记忆完全留在你自己机器上，跨会话自动注入与回写"
+    >
+      <SettingsCard divided={false}>
+        <div className="space-y-4 p-4">
+          {/* 第 1 步：下载 */}
+          <div className="space-y-2">
+            <p className="text-xs font-medium text-foreground">第 1 步：下载并安装 Nowledge Mem 桌面客户端</p>
+            <a
+              href="https://mem.nowledge.co/zh"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 rounded-md border border-border bg-muted/30 px-2.5 py-1 text-xs text-foreground hover:bg-muted transition-colors"
+            >
+              mem.nowledge.co/zh
+              <ExternalLink size={10} />
+            </a>
+          </div>
+
+          {/* 第 2 步：执行前 Set Up 清单 */}
+          <div className="space-y-2">
+            <p className="text-xs font-medium text-foreground">第 2 步：执行第三步的配置提示词前请确认</p>
+            <ul className="text-xs text-muted-foreground list-disc list-inside space-y-1">
+              <li>已下载并安装 Nowledge Mem 桌面客户端</li>
+              <li>已启动 Nowledge Mem，托盘 / Dock 中能看到运行图标</li>
+              <li>Proma 已切换到 <span className="font-medium text-foreground">Agent 模式</span>（此提示词只能在 Agent 中执行）</li>
+            </ul>
+          </div>
+
+          {/* 第 3 步：复制 */}
+          <div className="space-y-2">
+            <p className="text-xs font-medium text-foreground">第 3 步：复制配置提示词，粘贴到 Agent 输入框执行</p>
+            <div className="flex items-center gap-3">
+              <Button onClick={handleCopy} disabled={copying} size="sm">
+                <Copy size={14} className="mr-1.5" />
+                {copying ? '复制中...' : '复制配置提示词'}
+              </Button>
+              <p className="text-xs text-muted-foreground">
+                <span className="font-medium text-foreground">一键让 Agent 完成所有配置</span>，提示词包含 nmem CLI 安装、插件下载、MCP 与 Hooks 配置全流程
+              </p>
+            </div>
+            <p className="text-xs text-muted-foreground pt-1">
+              ⚠️ 提示词执行完成后需要 <span className="font-medium text-foreground">完全退出并重启 Proma</span>，MCP 与 Hooks 才会生效
+            </p>
+          </div>
+
+          {/* 第 4 步：验证记忆闭环 */}
+          <div className="space-y-2">
+            <p className="text-xs font-medium text-foreground">第 4 步：重启后验证记忆是否打通</p>
+            <p className="text-xs text-muted-foreground">
+              在 Agent 模式中先用{' '}
+              <code className="rounded bg-muted px-1 py-0.5 font-mono text-[11px]">/skill:distill-memory</code>{' '}
+              让 Agent 记住一段对话内容，再开一个新会话用{' '}
+              <code className="rounded bg-muted px-1 py-0.5 font-mono text-[11px]">/skill:search-memory</code>{' '}
+              把它搜出来。能搜到即代表记忆系统已完整生效。
+            </p>
+          </div>
+
+          {/* 平台支持说明 + 帮助链接 */}
+          <div className="space-y-1">
+            <p className="text-xs text-muted-foreground">
+              💡 平台支持：macOS、Linux 主流支持；Windows 用户需在 Git Bash + uv 环境中尝试（实验性，未经 Nowledge 官方验证）
+            </p>
+            <p className="text-xs text-muted-foreground">
+              配置过程遇到问题？查看{' '}
+              <a
+                href="https://mem.nowledge.co/zh/docs/integrations/proma"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline inline-flex items-center gap-0.5"
+              >
+                Nowledge Mem · Proma 集成文档
+                <ExternalLink size={10} />
+              </a>
+            </p>
+          </div>
+        </div>
+      </SettingsCard>
+    </SettingsSection>
+  )
+}
+
+export function MemorySettings(): React.ReactElement {
+  return (
+    <div className="space-y-8">
+      <NowledgeMemSection />
+      <MemOSSection />
     </div>
   )
 }

--- a/apps/electron/src/renderer/components/settings/MemorySettings.tsx
+++ b/apps/electron/src/renderer/components/settings/MemorySettings.tsx
@@ -261,7 +261,7 @@ function NowledgeMemSection(): React.ReactElement {
           <div className="space-y-2">
             <p className="text-xs font-medium text-foreground">第 2 步：执行第三步的配置提示词前请确认</p>
             <ul className="text-xs text-muted-foreground list-disc list-inside space-y-1">
-              <li>已下载并安装 Nowledge Mem 桌面客户端</li>
+              <li>已下载并安装 Nowledge Mem 桌面客户端（配置时无需登录或注册账号）</li>
               <li>已启动 Nowledge Mem，托盘 / Dock 中能看到运行图标</li>
               <li>Proma 已切换到 <span className="font-medium text-foreground">Agent 模式</span>（此提示词只能在 Agent 中执行）</li>
             </ul>

--- a/apps/electron/src/renderer/components/settings/nowledge-mem-prompt.md
+++ b/apps/electron/src/renderer/components/settings/nowledge-mem-prompt.md
@@ -1,0 +1,228 @@
+请帮我从零完成 Nowledge Mem 接入 Proma 的完整配置。严格按以下步骤操作。
+
+---
+
+## Step 0：确认 Nowledge Mem 客户端已安装并运行（必须）
+
+本地模式下**不需要登录或注册账号**——Nowledge Mem 是本地优先的，App 装好并启动之后，后台服务就在 `127.0.0.1:14242` 运行，Proma 通过 MCP 直连，全程不出本地。
+
+先检查 App 是否已安装：
+
+```bash
+ls -d "/Applications/Nowledge Mem.app" 2>/dev/null && echo "已安装" || echo "未安装"
+```
+
+再检查后台服务是否在运行：
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:14242/mcp/ 2>/dev/null || echo "服务不可达"
+```
+
+返回 `200` 或非空即表示服务在运行。如果 App 已安装但服务不可达，打开 Nowledge Mem 桌面应用即可（它会在后台自动启动服务）。
+
+**如果未安装**，去 https://mem.nowledge.co/zh 下载桌面应用。装好并启动后再继续下面的步骤，否则一切无法工作。
+
+---
+
+## Step 0.5：与用户确认目标工作区（必须）
+
+MCP、Skills、Hooks 都是按工作区生效的，所以**必须先问清楚用户希望装到哪个工作区**。
+
+先列出当前所有工作区：
+
+```bash
+ls ~/.proma/agent-workspaces/
+```
+
+然后**必须调用 `AskUserQuestion` 工具**向用户提问，不要用纯文本问，否则用户无法在选项中点选。具体参数：
+
+- `question`: "你希望把 Nowledge Mem 装到哪个工作区？"
+- `header`: "目标工作区"
+- `multiSelect`: `false`
+- `options`: 上一步扫描到的每个工作区名作为一个 option，`label` 直接写工作区名（如 `default`、`dev-pma`），`description` 留空或填工作区简介。`mcp.json` 中已存在 `nowledge-mem` 条目的工作区可以在 `description` 标注 "已配置"，方便用户避免重复装。
+
+**记下用户选中的工作区名**（下文统一用 `<工作区名>` 表示）。后续 Step 2 / 3 / 4 中所有 `<工作区名>` 占位都要替换成用户的选择。
+
+---
+
+## Step 1：确保 nmem 命令行可用
+
+**首先检测 nmem 是否已在 PATH 中**：
+
+```bash
+command -v nmem && nmem status
+```
+
+如果显示 `status: ok, mode: local, database connected, agent running`，跳过本步骤直接进入 Step 2。
+
+否则按以下方式之一引导用户安装 nmem CLI（按推荐顺序）：
+
+### 方式 A · 推荐 · macOS
+
+让用户打开 **Nowledge Mem 桌面应用 → 设置 → 开发者工具 → 点击「安装 CLI」**。完成后跑：
+
+```bash
+nmem status
+```
+
+### 方式 B · 跨平台兜底 · macOS / Linux / Windows
+
+如果方式 A 不可行（或用户在 Linux / Windows 上），用 **uv**（Astral.sh 的跨平台 Python 工具运行器）：
+
+安装 uv（一次性）：
+
+```bash
+# macOS / Linux
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Windows（PowerShell，注意：当前提示词其他步骤需要 bash 环境，Windows 用户建议在 Git Bash 中执行）
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+
+之后用 `uvx nmem-cli` 代替 `nmem` 调用，无需全局安装：
+
+```bash
+uvx nmem-cli status
+```
+
+如果走方式 B，**记下"用户的 nmem 实际命令是 `uvx nmem-cli`"**——这个信息当前 Step 4 的 hooks 不直接用到（hooks 是调用 `~/.proma/scripts/` 下的 Python 脚本，跟 nmem CLI 无关），但用户排错或自己用 nmem 时需要知道。
+
+### 方式 C · 最后兜底 · 仅 macOS
+
+只在方式 A、B 都不可行时使用，手动 wrap App Bundle 内置的 nmem：
+
+```bash
+mkdir -p ~/.local/bin
+cat > ~/.local/bin/nmem << 'EOF'
+#!/bin/bash
+exec "/Applications/Nowledge Mem.app/Contents/Resources/_up_/python-standalone/python/bin/python3" "/Applications/Nowledge Mem.app/Contents/Resources/_up_/python-standalone/python/lib/python3.13/site-packages/bin/nmem" "$@"
+EOF
+chmod +x ~/.local/bin/nmem
+export PATH="$HOME/.local/bin:$PATH"
+nmem status
+```
+
+注意：这条路径绕过 Nowledge 官方推荐方式，依赖 App 内部实现，未来 App 升级可能失效。
+
+## Step 2：下载插件文件并安装到目标工作区
+```bash
+rm -rf /tmp/nowledge-community
+git clone https://github.com/nowledge-co/community.git /tmp/nowledge-community
+
+mkdir -p ~/.proma/scripts ~/.proma/agent-workspaces/<工作区名>/skills
+cp /tmp/nowledge-community/nowledge-mem-proma-plugin/hooks/save-to-nmem.py ~/.proma/scripts/
+cp /tmp/nowledge-community/nowledge-mem-proma-plugin/hooks/read-working-memory.py ~/.proma/scripts/
+chmod +x ~/.proma/scripts/save-to-nmem.py ~/.proma/scripts/read-working-memory.py
+cp -R /tmp/nowledge-community/nowledge-mem-proma-plugin/skills/{read-working-memory,search-memory,distill-memory,save-thread,status} ~/.proma/agent-workspaces/<工作区名>/skills/
+```
+
+## Step 3：配置目标工作区的 MCP
+在 `~/.proma/agent-workspaces/<工作区名>/mcp.json` 中创建或编辑（顶层 key 必须是 `servers`）：
+
+```json
+{
+  "servers": {
+    "nowledge-mem": {
+      "url": "http://127.0.0.1:14242/mcp/",
+      "type": "streamableHttp",
+      "headers": {
+        "APP": "Proma"
+      }
+    }
+  }
+}
+```
+
+如果文件已存在，把 `nowledge-mem` 合并进已有 `servers`，**不要覆盖其他条目**。
+
+## Step 4：配置 Hooks
+编辑 `~/.proma/sdk-config/.claude/settings.json`，添加以下 hooks。如果文件已有内容则合并，不要覆盖。
+
+**先把下面所有 `<工作区名>` 替换成 Step 0.5 中用户选择的工作区**：
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "PROMA_WORKSPACE_DIR=\"${PROMA_HOME}/agent-workspaces/<工作区名>\" python \"${PROMA_HOME}/scripts/read-working-memory.py\"",
+            "timeout": 15000
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"${PROMA_HOME}/scripts/save-to-nmem.py\" --event user-prompt-submit",
+            "timeout": 30000
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"${PROMA_HOME}/scripts/save-to-nmem.py\" --event stop",
+            "timeout": 30000
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "PROMA_WORKSPACE_DIR=\"${PROMA_HOME}/agent-workspaces/<工作区名>\" python \"${PROMA_HOME}/scripts/read-working-memory.py\" --rewake",
+            "timeout": 15000,
+            "async": true,
+            "asyncRewake": true,
+            "rewakeMessage": "Nowledge Mem context refreshed"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Step 5：验证
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+nmem status
+python3 ~/.proma/scripts/read-working-memory.py
+grep 'nowledge-mem:start' ~/.proma/agent-workspaces/<工作区名>/CLAUDE.md && echo "Block 已注入" || echo "Block 缺失"
+
+# 检查 5 个 skill 是否都已安装到目标工作区
+for s in read-working-memory search-memory distill-memory save-thread status; do
+  if [ -d ~/.proma/agent-workspaces/<工作区名>/skills/$s ]; then
+    echo "✅ skill: $s"
+  else
+    echo "❌ skill: $s 缺失"
+  fi
+done
+```
+预期：
+- `nmem status` 全绿
+- `read-working-memory.py` 返回 `{"status": "updated"}`
+- CLAUDE.md 中存在 nowledge-mem block
+- 5 个 skill 全部显示 ✅
+
+如有任何一项失败，回到对应 Step 重新执行。
+
+---
+
+## ⚠️ 以上步骤完成后，必须完全退出并重启 Proma，配置才会生效。
+
+MCP 和 Hooks 只在 Proma 启动时加载，不重启等于没有配置。
+
+重启后在新会话里验证：
+1. `cat ~/.proma/logs/nm-hooks.log` — 确认有新的 SessionStart 记录
+2. 用自然语言说「帮我记住：<想存的内容>」存第一条记忆


### PR DESCRIPTION
## 概述

在「设置 → Chat 工具 → 记忆」区新增 **Nowledge Mem · 本地优先记忆** 卡片，置于 MemOS Cloud 之上。Nowledge Mem 是本地优先的记忆方案（MCP + Hooks + Skills 集成），记忆完全留在用户本机。卡片提供一键复制的 Agent 配置提示词，引导用户在 Agent 模式中自动完成 nmem CLI 安装、插件下载、MCP 与 Hooks 配置全流程。

## 改动

- `apps/electron/src/renderer/components/settings/MemorySettings.tsx`
  - 拆为 `NowledgeMemSection` / `MemOSSection` 两张并列卡片，Nowledge Mem 在上
  - Nowledge Mem 卡片含：官网下载链接、执行前 Set Up 清单、复制配置提示词按钮、记忆闭环验证步骤、平台支持说明、Proma 集成文档帮助链接
  - 「当前已配置工作区」徽章：通过 `getWorkspaceCapabilities` 检测各工作区 `mcp.json` 是否含 `nowledge-mem` 条目（语义仅代表配置文件已写入，不代表已生效）
- `apps/electron/src/renderer/components/settings/nowledge-mem-prompt.md`（新增）
  - 完整配置提示词，以 Vite `?raw` 形式导入
  - Step 0 客户端检查 / Step 0.5 强制 AskUserQuestion 选目标工作区 / Step 1 三档 nmem 安装方式（App 开发者工具 → uvx 跨平台兜底 → wrapper 仅 Mac 兜底）/ Step 2~4 插件、MCP、Hooks 配置 / Step 5 含 5 个 skill 安装校验
- `apps/electron/package.json`：版本 0.12.31 → 0.12.32

## 测试方法

1. 启动应用，进入 设置 → Chat 工具
2. 确认「记忆」区顶部为 Nowledge Mem 卡片，下方为 MemOS Cloud
3. 点击「复制配置提示词」，确认 toast 提示出现、剪贴板内容完整
4. 确认徽章正确反映当前工作区 mcp.json 是否含 nowledge-mem 条目
5. （端到端，未验证）在 Agent 模式粘贴提示词执行，重启后用 /skill:distill-memory + /skill:search-memory 验证记忆闭环

## 备注

- **平台支持**：macOS / Linux 主流支持；Windows 为实验性（需 Git Bash + uv，未经 Nowledge 官方验证）。Nowledge 官方集成文档目前也无 Windows 章节。
- 端到端安装流程（Step 0~5 在真实 Agent 会话中跑通 + 重启生效）尚未完整验证，故标记为未完成草稿。
- 徽章状态在卡片打开期间不会随安装实时刷新，需重开设置 tab，属已知小限制。

🤖 Generated with [Claude Code](https://claude.com/claude-code)