### PR TITLE
自动任务会话归类到专属虚拟项目组

### DIFF
--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -126,6 +126,16 @@ export async function runAgent(
   try {
     updateAgentSessionMeta(input.sessionId, { completedButUnconfirmed: false })
   } catch { /* 新会话可能尚未写入索引 */ }
+  // 自动任务会话"毕业"：用户手动发消息（非定时触发）即视为接管，标记后该会话回到普通项目列表，
+  // 调度器也不再复用它注入新的定时运行。
+  if (input.triggeredBy !== 'automation') {
+    try {
+      const meta = getAgentSessionMeta(input.sessionId)
+      if (meta?.sourceAutomationId && !meta.automationGraduated) {
+        updateAgentSessionMeta(input.sessionId, { automationGraduated: true })
+      }
+    } catch { /* 新会话可能尚未写入索引 */ }
+  }
   try {
     await orchestrator.sendMessage(input, {
       onError: (error) => {

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -379,7 +379,7 @@ function convertLegacyMessage(legacy: AgentMessage): SDKMessage {
  */
 export function updateAgentSessionMeta(
   id: string,
-  updates: Partial<Pick<AgentSessionMeta, 'title' | 'channelId' | 'modelId' | 'sdkSessionId' | 'workspaceId' | 'pinned' | 'archived' | 'attachedDirectories' | 'attachedFiles' | 'forkSourceDir' | 'forkSourceSdkSessionId' | 'resumeAtMessageUuid' | 'stoppedByUser' | 'permissionMode' | 'completedButUnconfirmed' | 'sourceAutomationId' | 'parentSessionId' | 'rootSessionId' | 'sourceDelegationId' | 'delegationRole' | 'delegationStatus' | 'delegationDepth' | 'delegationGoal'>>,
+  updates: Partial<Pick<AgentSessionMeta, 'title' | 'channelId' | 'modelId' | 'sdkSessionId' | 'workspaceId' | 'pinned' | 'archived' | 'attachedDirectories' | 'attachedFiles' | 'forkSourceDir' | 'forkSourceSdkSessionId' | 'resumeAtMessageUuid' | 'stoppedByUser' | 'permissionMode' | 'completedButUnconfirmed' | 'sourceAutomationId' | 'automationGraduated' | 'parentSessionId' | 'rootSessionId' | 'sourceDelegationId' | 'delegationRole' | 'delegationStatus' | 'delegationDepth' | 'delegationGoal'>>,
 ): AgentSessionMeta {
   const index = readIndex()
   const idx = index.sessions.findIndex((s) => s.id === id)

--- a/apps/electron/src/main/lib/automation-scheduler.ts
+++ b/apps/electron/src/main/lib/automation-scheduler.ts
@@ -119,7 +119,12 @@ export async function runAutomation(automation: Automation, manual = false): Pro
     const sessionMode = automation.sessionMode ?? AUTOMATION_DEFAULT_SESSION_MODE
 
     let reuseSessionId: string | undefined
-    if (automation.lastSessionId && getAgentSessionMeta(automation.lastSessionId)) {
+    const lastSessionMeta = automation.lastSessionId ? getAgentSessionMeta(automation.lastSessionId) : undefined
+    // 已被用户手动接管（毕业）的会话不再复用，强制新建，避免把定时任务消息注入用户的私人会话
+    if (lastSessionMeta?.automationGraduated) {
+      console.log(`[定时任务] ${automation.name} 上次会话已被用户接管，本次自动开新会话`)
+    }
+    if (automation.lastSessionId && lastSessionMeta && !lastSessionMeta.automationGraduated) {
       if (sessionMode === 'reuse') {
         reuseSessionId = automation.lastSessionId
       } else if (

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -205,6 +205,8 @@ export interface AgentPendingPrompt {
 export const agentSessionsAtom = atom<AgentSessionMeta[]>([])
 export const agentWorkspacesAtom = atom<AgentWorkspace[]>([])
 export const currentAgentWorkspaceIdAtom = atom<string | null>(null)
+/** 侧栏「自动任务」合成项目组在项目列表中的位置索引（默认 0 = 最靠前；从 settings.json 加载） */
+export const automationGroupOrderAtom = atom<number>(0)
 /** 全局默认渠道 ID（新会话继承用，从 settings.json 加载） */
 export const agentChannelIdAtom = atom<string | null>(null)
 /** 全局默认模型 ID（新会话继承用，从 settings.json 加载） */

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -60,6 +60,7 @@ import {
   backgroundTasksAtomFamily,
   sessionPersistedPermissionModeAtom,
   sessionExistsAtom,
+  automationGroupOrderAtom,
 } from '@/atoms/agent-atoms'
 import type { SessionIndicatorStatus } from '@/atoms/agent-atoms'
 import { previewPanelOpenMapAtom, previewFileMapAtom } from '@/atoms/preview-atoms'
@@ -450,15 +451,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   /** 项目拖拽排序状态 */
   const [dragProjectId, setDragProjectId] = React.useState<string | null>(null)
   const [projectDropIndicator, setProjectDropIndicator] = React.useState<{ id: string; position: 'before' | 'after' } | null>(null)
-  /** 合成「自动任务」组在项目列表中的位置索引（0 = 最靠前，可拖拽调整并持久化到 settings） */
-  const [automationGroupOrder, setAutomationGroupOrder] = React.useState(0)
-  React.useEffect(() => {
-    window.electronAPI.getSettings()
-      .then((s) => {
-        if (typeof s.agentAutomationGroupOrder === 'number') setAutomationGroupOrder(s.agentAutomationGroupOrder)
-      })
-      .catch(() => { /* 读取失败时保持默认置顶 */ })
-  }, [])
+  const [automationGroupOrder, setAutomationGroupOrder] = useAtom(automationGroupOrderAtom)
   /** 新建项目输入状态 */
   const [creatingProject, setCreatingProject] = React.useState(false)
   const [newProjectName, setNewProjectName] = React.useState('')

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -220,6 +220,12 @@ interface AgentProjectGroup {
   sessions: AgentSessionMeta[]
 }
 
+/** 合成「自动任务」虚拟项目组的工作区 ID（不对应真实 workspace，仅用于聚合自动任务会话） */
+const AUTOMATION_GROUP_ID = '__automations__'
+/** 供合成组复用 AgentProjectGroupItem 时填充无意义的 workspace 专属回调 */
+const noopVoid = (): void => {}
+const noopAsync = async (): Promise<void> => {}
+
 const PROJECT_SESSION_PREVIEW_LIMIT = 5
 const PROJECT_SESSION_RECENT_WINDOW_MS = 3 * 86_400_000
 /** 点击"显示更多"时每次额外展开的会话数量 */
@@ -301,6 +307,15 @@ const SIDEBAR_DRAG_STRIP_HEIGHT = {
 
 function getRailInitial(title: string): string {
   return title.trim().slice(0, 1).toUpperCase() || '·'
+}
+
+/**
+ * 是否为「应从项目会话列表隐藏」的自动任务会话：
+ * 来自定时任务（sourceAutomationId）、尚未被用户接管毕业（automationGraduated）、且未被置顶。
+ * 这类会话的"家"是 Automation 视图；置顶或毕业后回到普通项目列表。
+ */
+function isHiddenAutomationSession(session: AgentSessionMeta): boolean {
+  return !!session.sourceAutomationId && !session.automationGraduated && !session.pinned
 }
 
 interface RailRecentItem {
@@ -435,6 +450,15 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   /** 项目拖拽排序状态 */
   const [dragProjectId, setDragProjectId] = React.useState<string | null>(null)
   const [projectDropIndicator, setProjectDropIndicator] = React.useState<{ id: string; position: 'before' | 'after' } | null>(null)
+  /** 合成「自动任务」组在项目列表中的位置索引（0 = 最靠前，可拖拽调整并持久化到 settings） */
+  const [automationGroupOrder, setAutomationGroupOrder] = React.useState(0)
+  React.useEffect(() => {
+    window.electronAPI.getSettings()
+      .then((s) => {
+        if (typeof s.agentAutomationGroupOrder === 'number') setAutomationGroupOrder(s.agentAutomationGroupOrder)
+      })
+      .catch(() => { /* 读取失败时保持默认置顶 */ })
+  }, [])
   /** 新建项目输入状态 */
   const [creatingProject, setCreatingProject] = React.useState(false)
   const [newProjectName, setNewProjectName] = React.useState('')
@@ -920,6 +944,11 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     window.electronAPI.updateSettings({ agentWorkspaceId: workspaceId }).catch(console.error)
   }, [currentWorkspaceId, setCurrentWorkspaceId, setActiveView])
 
+  /** 合成「自动任务」组头部点击：仅折叠/展开，绝不切换当前项目（它不是真实工作区） */
+  const handleToggleGroupCollapse = React.useCallback((groupId: string): void => {
+    setCollapsedWorkspaceIds((prev) => toggleSetEntry(prev, groupId))
+  }, [])
+
   const canDeleteWorkspace = React.useCallback(
     (workspace: AgentWorkspace): boolean => workspace.slug !== 'default' && workspaces.length > 1,
     [workspaces.length],
@@ -1095,24 +1124,57 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     }
   }, [])
 
-  /** 完成项目排序并持久化 */
+  /**
+   * 合成「自动任务」项目组：聚合所有未毕业的自动任务会话（跨工作区），
+   * 作为这些会话在侧栏的统一归属地。会话为空时返回 null（不渲染空组）。
+   */
+  const automationGroup = React.useMemo<AgentProjectGroup | null>(
+    () => {
+      const sessions = sortAgentSessionsByUpdatedAtDesc(
+        agentSessions.filter((session) =>
+          !session.archived
+          && !session.pinned
+          && !draftSessionIds.has(session.id)
+          && !!session.sourceAutomationId
+          && !session.automationGraduated
+        )
+      )
+      if (sessions.length === 0) return null
+      return {
+        workspace: { id: AUTOMATION_GROUP_ID, name: '自动任务', slug: AUTOMATION_GROUP_ID, createdAt: 0, updatedAt: 0 },
+        sessions,
+      }
+    },
+    [agentSessions, draftSessionIds],
+  )
+
+  /** 完成项目排序并持久化（合成「自动任务」组与真实项目一起排序，二者分别持久化） */
   const handleProjectDrop = React.useCallback((e: React.DragEvent, targetWorkspaceId: string): void => {
     e.preventDefault()
-    if (!dragProjectId || dragProjectId === targetWorkspaceId || !projectDropIndicator || projectDropIndicator.id !== targetWorkspaceId) {
+    const indicator = projectDropIndicator
+    if (!dragProjectId || dragProjectId === targetWorkspaceId || !indicator || indicator.id !== targetWorkspaceId) {
       setDragProjectId(null)
       setProjectDropIndicator(null)
       return
     }
 
-    const fromIndex = workspaces.findIndex((workspace) => workspace.id === dragProjectId)
-    const toIndex = workspaces.findIndex((workspace) => workspace.id === targetWorkspaceId)
+    // 构造当前显示顺序的 id 列表（真实项目 + 按当前索引插入的合成组）
+    const baseIds = workspaces.map((workspace) => workspace.id)
+    const oldAutoIndex = automationGroup
+      ? Math.min(Math.max(automationGroupOrder, 0), baseIds.length)
+      : -1
+    const displayIds = [...baseIds]
+    if (oldAutoIndex >= 0) displayIds.splice(oldAutoIndex, 0, AUTOMATION_GROUP_ID)
+
+    const fromIndex = displayIds.indexOf(dragProjectId)
+    const toIndex = displayIds.indexOf(targetWorkspaceId)
     if (fromIndex === -1 || toIndex === -1) {
       setDragProjectId(null)
       setProjectDropIndicator(null)
       return
     }
 
-    const reordered = [...workspaces]
+    const reordered = [...displayIds]
     const [moved] = reordered.splice(fromIndex, 1)
     if (!moved) {
       setDragProjectId(null)
@@ -1120,21 +1182,37 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       return
     }
     const adjustedToIndex = fromIndex < toIndex ? toIndex - 1 : toIndex
-    const insertIndex = projectDropIndicator.position === 'after' ? adjustedToIndex + 1 : adjustedToIndex
+    const insertIndex = indicator.position === 'after' ? adjustedToIndex + 1 : adjustedToIndex
     reordered.splice(insertIndex, 0, moved)
 
-    setWorkspaces(reordered)
     setDragProjectId(null)
     setProjectDropIndicator(null)
-    window.electronAPI
-      .reorderAgentWorkspaces(reordered.map((workspace) => workspace.id))
-      .then(setWorkspaces)
-      .catch((error) => {
-        console.error('[侧边栏] 项目排序失败:', error)
-        setWorkspaces(workspaces)
-        toast.error('项目排序失败')
-      })
-  }, [dragProjectId, projectDropIndicator, setWorkspaces, workspaces])
+
+    // 拆分：合成组的新索引 → settings；真实项目的新顺序 → 后端
+    const newAutoIndex = reordered.indexOf(AUTOMATION_GROUP_ID)
+    const newWorkspaceIds = reordered.filter((id) => id !== AUTOMATION_GROUP_ID)
+
+    if (oldAutoIndex >= 0 && newAutoIndex !== oldAutoIndex) {
+      setAutomationGroupOrder(newAutoIndex)
+      window.electronAPI.updateSettings({ agentAutomationGroupOrder: newAutoIndex }).catch(console.error)
+    }
+
+    const workspaceOrderChanged = newWorkspaceIds.some((id, i) => id !== baseIds[i])
+    if (workspaceOrderChanged) {
+      const reorderedWorkspaces = newWorkspaceIds
+        .map((id) => workspaces.find((w) => w.id === id))
+        .filter((w): w is AgentWorkspace => !!w)
+      setWorkspaces(reorderedWorkspaces)
+      window.electronAPI
+        .reorderAgentWorkspaces(newWorkspaceIds)
+        .then(setWorkspaces)
+        .catch((error) => {
+          console.error('[侧边栏] 项目排序失败:', error)
+          setWorkspaces(workspaces)
+          toast.error('项目排序失败')
+        })
+    }
+  }, [dragProjectId, projectDropIndicator, automationGroup, automationGroupOrder, setWorkspaces, workspaces])
 
   const handleProjectDragEnd = React.useCallback((): void => {
     setDragProjectId(null)
@@ -1303,6 +1381,8 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
           !session.archived
           && !session.pinned
           && !draftSessionIds.has(session.id)
+          // 未毕业的自动任务会话不进入项目列表，统一归到 Automation 视图
+          && !isHiddenAutomationSession(session)
         )
       )
 
@@ -1321,6 +1401,21 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       }))
     },
     [agentSessions, draftSessionIds, workspaces],
+  )
+
+  /**
+   * 项目组的最终显示顺序：把合成「自动任务」组按持久化的索引插入真实项目组中
+   * （默认索引 0 = 最靠前）。合成组与真实项目一起参与拖拽排序。
+   */
+  const displayProjectGroups = React.useMemo<AgentProjectGroup[]>(
+    () => {
+      if (!automationGroup) return agentProjectGroups
+      const idx = Math.min(Math.max(automationGroupOrder, 0), agentProjectGroups.length)
+      const combined = [...agentProjectGroups]
+      combined.splice(idx, 0, automationGroup)
+      return combined
+    },
+    [agentProjectGroups, automationGroup, automationGroupOrder],
   )
 
   /** Agent 归档会话按日期分组（跨项目） */
@@ -1404,6 +1499,8 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         !session.archived
         && !draftSessionIds.has(session.id)
         && (!currentWorkspaceId || session.workspaceId === currentWorkspaceId)
+        // 未毕业的自动任务会话不出现在收起态 Rail，与项目列表保持一致
+        && !isHiddenAutomationSession(session)
       )
       .sort((a, b) => {
         const statusA = agentIndicatorMap.get(a.id) ?? (unviewedCompletedSessionIds.has(a.id) ? 'completed' : 'idle')
@@ -1957,43 +2054,48 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
             )}
 
             <div className="flex flex-col gap-0.5">
-              {agentProjectGroups.map((group) => (
-                <AgentProjectGroupItem
-                  key={group.workspace.id}
-                  group={group}
-                  currentWorkspaceId={currentWorkspaceId}
-                  expanded={(expandedExtraCountMap.get(group.workspace.id) ?? 0) > 0}
-                  extraCount={expandedExtraCountMap.get(group.workspace.id) ?? 0}
-                  collapsed={collapsedWorkspaceIds.has(group.workspace.id)}
-                  activeSessionId={activeSessionId}
-                  agentIndicatorMap={agentIndicatorMap}
-                  relativeTimeNow={relativeTimeNow}
-                  dragging={dragProjectId === group.workspace.id}
-                  dropPosition={projectDropIndicator?.id === group.workspace.id ? projectDropIndicator.position : null}
-                  onShowMore={handleShowMoreSessions}
-                  onCollapseExtra={handleCollapseExtraSessions}
-                  onSelectProject={handleSelectProject}
-                  onNewSession={createAgentSessionInWorkspace}
-                  onDragStart={handleProjectDragStart}
-                  onDragOver={handleProjectDragOver}
-                  onDragLeave={handleProjectDragLeave}
-                  onDrop={handleProjectDrop}
-                  onDragEnd={handleProjectDragEnd}
-                  onConfigureProject={(workspaceId) => {
-                    handleSelectProject(workspaceId)
-                    handleOpenMcpManagement()
-                  }}
-                  onRenameWorkspace={handleWorkspaceRename}
-                  onRequestDeleteWorkspace={handleRequestDeleteWorkspace}
-                  canDeleteWorkspace={canDeleteWorkspace(group.workspace)}
-                  onSelectSession={handleSelectAgentSession}
-                  onRequestDelete={handleRequestDelete}
-                  onRequestMove={handleRequestMove}
-                  onRename={handleAgentRename}
-                  onTogglePin={handleTogglePinAgent}
-                  onToggleArchive={handleToggleArchiveAgent}
-                />
-              ))}
+              {displayProjectGroups.map((group) => {
+                const isAuto = group.workspace.id === AUTOMATION_GROUP_ID
+                return (
+                  <AgentProjectGroupItem
+                    key={group.workspace.id}
+                    group={group}
+                    isAutomationGroup={isAuto}
+                    workspaceNameMap={isAuto ? workspaceNameMap : undefined}
+                    currentWorkspaceId={currentWorkspaceId}
+                    expanded={(expandedExtraCountMap.get(group.workspace.id) ?? 0) > 0}
+                    extraCount={expandedExtraCountMap.get(group.workspace.id) ?? 0}
+                    collapsed={collapsedWorkspaceIds.has(group.workspace.id)}
+                    activeSessionId={activeSessionId}
+                    agentIndicatorMap={agentIndicatorMap}
+                    relativeTimeNow={relativeTimeNow}
+                    dragging={dragProjectId === group.workspace.id}
+                    dropPosition={projectDropIndicator?.id === group.workspace.id ? projectDropIndicator.position : null}
+                    onShowMore={handleShowMoreSessions}
+                    onCollapseExtra={handleCollapseExtraSessions}
+                    onSelectProject={isAuto ? handleToggleGroupCollapse : handleSelectProject}
+                    onNewSession={isAuto ? noopAsync : createAgentSessionInWorkspace}
+                    onDragStart={handleProjectDragStart}
+                    onDragOver={handleProjectDragOver}
+                    onDragLeave={handleProjectDragLeave}
+                    onDrop={handleProjectDrop}
+                    onDragEnd={handleProjectDragEnd}
+                    onConfigureProject={isAuto ? noopVoid : (workspaceId) => {
+                      handleSelectProject(workspaceId)
+                      handleOpenMcpManagement()
+                    }}
+                    onRenameWorkspace={isAuto ? noopAsync : handleWorkspaceRename}
+                    onRequestDeleteWorkspace={isAuto ? noopVoid : handleRequestDeleteWorkspace}
+                    canDeleteWorkspace={isAuto ? false : canDeleteWorkspace(group.workspace)}
+                    onSelectSession={handleSelectAgentSession}
+                    onRequestDelete={handleRequestDelete}
+                    onRequestMove={handleRequestMove}
+                    onRename={handleAgentRename}
+                    onTogglePin={handleTogglePinAgent}
+                    onToggleArchive={handleToggleArchiveAgent}
+                  />
+                )
+              })}
             </div>
           </div>
         </div>
@@ -2790,6 +2892,10 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
 interface AgentProjectGroupItemProps {
   group: AgentProjectGroup
   currentWorkspaceId: string | null
+  /** 合成「自动任务」只读组：隐藏拖拽 / 新建会话 / 项目菜单等 workspace 专属操作，会话显示来源工作区角标 */
+  isAutomationGroup?: boolean
+  /** 工作区 ID → 名称映射，仅合成组用来给跨工作区会话渲染角标 */
+  workspaceNameMap?: Map<string, string>
   expanded: boolean
   collapsed: boolean
   /** 用户已点击"显示更多"额外展开的会话数量（基于 collapsedSessions 之上累加） */
@@ -2823,6 +2929,8 @@ interface AgentProjectGroupItemProps {
 const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
   group,
   currentWorkspaceId,
+  isAutomationGroup = false,
+  workspaceNameMap,
   expanded,
   collapsed,
   extraCount,
@@ -2990,7 +3098,10 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
                 : 'text-foreground/65 hover:text-foreground/88',
             )}
           >
-            <FolderOpen size={13} className="flex-shrink-0 text-foreground/40" />
+            {isAutomationGroup
+              ? <Clock size={13} className="flex-shrink-0 text-foreground/40" />
+              : <FolderOpen size={13} className="flex-shrink-0 text-foreground/40" />
+            }
             <span className="flex-1 min-w-0 truncate text-[13px] font-medium leading-[18px]">
               {group.workspace.name}
             </span>
@@ -3004,6 +3115,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
           </button>
         )}
 
+        {!isAutomationGroup && (
         <Tooltip>
           <TooltipTrigger asChild>
             <button
@@ -3020,7 +3132,9 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
           </TooltipTrigger>
           <TooltipContent side="top">在此项目中新建会话</TooltipContent>
         </Tooltip>
+        )}
 
+        {!isAutomationGroup && (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <button
@@ -3067,6 +3181,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
+        )}
       </div>
 
       <div id={`project-sessions-${group.workspace.id}`} className="ml-4 mt-px">
@@ -3082,6 +3197,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
                   showPinIcon={!!session.pinned}
                   leftAccent={getSessionLeftAccent(agentIndicatorMap.get(session.id) ?? 'idle')}
                   relativeTimeNow={relativeTimeNow}
+                  workspaceName={isAutomationGroup && session.workspaceId ? workspaceNameMap?.get(session.workspaceId) : undefined}
                   onSelect={onSelectSession}
                   onRequestDelete={onRequestDelete}
                   onRequestMove={onRequestMove}

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -35,6 +35,7 @@ import {
   agentMaxBudgetUsdAtom,
   agentMaxTurnsAtom,
   agentSettingsReadyAtom,
+  automationGroupOrderAtom,
   dockBadgeCountAtom,
   unviewedCompletedSessionIdsAtom,
 } from './atoms/agent-atoms'
@@ -154,6 +155,7 @@ function AgentSettingsInitializer(): null {
   const setEffort = useSetAtom(agentEffortAtom)
   const setMaxBudget = useSetAtom(agentMaxBudgetUsdAtom)
   const setMaxTurns = useSetAtom(agentMaxTurnsAtom)
+  const setAutomationGroupOrder = useSetAtom(automationGroupOrderAtom)
 
   const setAgentSettingsReady = useSetAtom(agentSettingsReadyAtom)
   const setChannels = useSetAtom(channelsAtom)
@@ -238,6 +240,9 @@ function AgentSettingsInitializer(): null {
       if (settings.agentMaxTurns != null) {
         setMaxTurns(settings.agentMaxTurns)
       }
+      if (typeof settings.agentAutomationGroupOrder === 'number') {
+        setAutomationGroupOrder(settings.agentAutomationGroupOrder)
+      }
 
       // 加载工作区列表并恢复上次选中的工作区
       window.electronAPI.listAgentWorkspaces().then((workspaces) => {
@@ -258,7 +263,7 @@ function AgentSettingsInitializer(): null {
       console.error(err)
       setAgentSettingsReady(true) // 即使出错也标记就绪，避免永远阻塞
     })
-  }, [setAgentChannelId, setAgentModelId, setAgentChannelIds, setAgentWorkspaces, setCurrentWorkspaceId, setThinking, setEffort, setMaxBudget, setMaxTurns, setChannels, setChannelsLoaded, setAgentSettingsReady])
+  }, [setAgentChannelId, setAgentModelId, setAgentChannelIds, setAgentWorkspaces, setCurrentWorkspaceId, setThinking, setEffort, setMaxBudget, setMaxTurns, setAutomationGroupOrder, setChannels, setChannelsLoaded, setAgentSettingsReady])
 
   // 工作区切换时重置能力缓存，预加载基线
   useEffect(() => {

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -194,6 +194,8 @@ export interface AppSettings {
   agentChannelIds?: string[]
   /** Agent 当前工作区 ID */
   agentWorkspaceId?: string
+  /** 侧栏「自动任务」合成项目组在项目列表中的位置索引（默认 0 = 最靠前；可拖拽调整） */
+  agentAutomationGroupOrder?: number
   /** 是否已完成 Onboarding 流程 */
   onboardingCompleted?: boolean
   /** 是否跳过了环境检测 */

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -618,6 +618,11 @@ export interface AgentSessionMeta {
   permissionMode?: PromaPermissionMode
   /** 来源定时任务 ID（该会话由定时任务自动创建/复用时标记，用于侧栏显示钟表图标 + 跳转设置） */
   sourceAutomationId?: string
+  /**
+   * 自动任务会话是否已被用户手动接管而"毕业"：true 时该会话回到普通项目会话列表，
+   * 且调度器不再复用它注入新的定时运行（避免污染用户已接管的会话）。默认 undefined/false。
+   */
+  automationGraduated?: boolean
   /** 父 Agent 会话 ID（该会话由父 Agent 委派创建时标记） */
   parentSessionId?: string
   /** 根 Agent 会话 ID（多层委派时用于追溯；当前仅允许一层，预留字段） */


### PR DESCRIPTION
## 背景

定时任务（Automation）数量增多后，每个任务在 `daily`/`reuse` 模式下会持续产出 Agent 会话（daily 模式跨天新建，一个日任务一周约 7 个会话）。这些自动会话当前与用户手动会话平级混在项目会话列表里，挤占正常会话、增加浏览与管理成本，用户被迫频繁手动删除。

本 PR 把自动任务会话归类到侧栏一个专属的合成「自动任务」项目组，正常项目列表回归纯净，并支持用户手动接管后自动「毕业」回普通列表。

## 改动

**数据 / 主进程**
- `AgentSessionMeta` 新增 `automationGraduated` 字段（+ 更新白名单）
- 毕业钩子（`agent-service.ts` `runAgent`）：用户手动发消息（`triggeredBy !== 'automation'`）且会话来自定时任务时，自动标记毕业 → 回到普通项目列表
- 调度器守卫（`automation-scheduler.ts`）：已毕业的会话不再被定时任务复用，强制新建，避免把定时消息注入用户已接管的私人会话

**侧栏（`LeftSidebar.tsx`）**
- 真实项目组与收起态 Rail 不再显示未毕业的自动会话
- 新增合成「自动任务」组（`AUTOMATION_GROUP_ID`）聚合所有未毕业自动会话，每条带来源工作区角标（复用置顶区的 `workspaceName`）
- 复用 `AgentProjectGroupItem`，加 `isAutomationGroup` 只读模式：⏰ 图标、隐藏新建会话/项目菜单（重命名·删除·设为当前项目），头部点击仅折叠不切换当前项目
- 默认置顶且可拖拽排序：位置持久化到 `settings.agentAutomationGroupOrder`；拖放走「统一有序列表 + 拆分持久化」——合成组新索引写 settings，真实项目新顺序（剔除合成 id）调 `reorderAgentWorkspaces`，绝不把合成 id 发给后端

## 效果

- 正常项目会话不再被自动任务挤占
- 所有自动会话集中在一个默认置顶、可拖拽的组里，一眼看出每条来自哪个工作区
- 手动接管某个自动会话后，它毕业回到真实工作区项目组（仍带 ⏰ 可追溯来源），并从自动任务组移除

## 已知边界

- 字段用布尔（与 `pinned`/`archived` 一致）
- 存量「上线前已被手动接管过」的旧自动会话不会回溯标记，会从项目列表移到自动任务组（可接受）

## 验证

- `bun run typecheck` 四个包全绿
- 待实机验证：隐藏 / 毕业 / 调度器守卫 / 置顶 + 拖拽排序持久化

🤖 Generated with [Claude Code](https://claude.com/claude-code)