### PR TITLE
fix(ui): 恢复主面板与右侧面板阴影，统一左右缝隙立体感【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.12.31",
+  "version": "0.12.32",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -397,7 +397,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   return (
     <div
       className={cn(
-        'relative z-0 h-full flex-shrink-0 overflow-hidden titlebar-drag-region bg-content-area rounded-2xl',
+        'relative z-0 h-full flex-shrink-0 overflow-hidden titlebar-drag-region bg-content-area rounded-2xl shadow-xl dark:shadow-md',
         shouldAnimate && 'transition-[width] duration-300 ease-in-out',
         isOpen ? '' : '!w-0',
       )}

--- a/apps/electron/src/renderer/components/tabs/MainArea.tsx
+++ b/apps/electron/src/renderer/components/tabs/MainArea.tsx
@@ -142,7 +142,7 @@ export function MainArea(): React.ReactElement {
     <>
       <Panel
         variant="grow"
-        className="bg-content-area rounded-2xl"
+        className="bg-content-area rounded-2xl shadow-xl dark:shadow-sm"
       >
         <div className="flex flex-1 min-h-0 relative overflow-hidden" data-split-container>
           {/* 左侧：TabBar + TabContent（始终保持在同一 DOM 位置，避免 Tab 切换时 unmount）


### PR DESCRIPTION
## 概述

当前左右两侧面板缝隙的阴影质感不一致，观感割裂：左侧边栏（LeftSidebar）仍保留 `shadow-xl` 的立体投影，而 commit #859「移除主面板阴影」把**中间主面板（MainArea）**和**右侧面板（SidePanel）**的阴影一并删掉了。结果是右侧缝隙变得扁平、缺乏层次，与左侧立体的缝隙形成明显反差，整体观感较差。

本 PR 恢复 #859 之前主面板与右侧面板的阴影，使三个面板之间的缝隙立体感一致，对齐商业版上线版本的视觉效果。

## 改动

- `apps/electron/src/renderer/components/tabs/MainArea.tsx` — 中间主面板 Panel 恢复 `shadow-xl dark:shadow-sm`。立体感主要来源是中间主面板向左右两侧缝隙的投影，恢复后左右缝隙同时获得阴影。
- `apps/electron/src/renderer/components/agent/SidePanel.tsx` — 右侧面板容器加上 `shadow-xl dark:shadow-md`，与左侧边栏 LeftSidebar 的阴影类保持一致，左右对称。
- `apps/electron/package.json` — 版本号 `0.12.31` → `0.12.32`。

## 测试方法

1. `bun run dev` 启动应用。
2. 打开 Agent 模式并展开右侧文件面板。
3. 亮色主题下观察左侧边栏、中间主面板、右侧面板之间的缝隙——三处阴影立体感应一致，无扁平割裂。
4. 切换深色主题，确认阴影减弱但仍保持左右对称、不过度干扰（MainArea 用 `dark:shadow-sm`，SidePanel/LeftSidebar 用 `dark:shadow-md`）。

## 备注

- 纯样式改动（仅 Tailwind class），typecheck 全部通过，无路径/shell/平台相关代码，Windows 兼容性 SAFE。
- 深色模式下 MainArea 恢复的是较弱的 `shadow-sm`（#859 当初移除是为减少深色干扰）；如需深色完全无阴影可改为 `dark:shadow-none`，本 PR 选择保留弱阴影以维持立体一致性。