### PR TITLE
feat(mention): 为 / # & 补全面板补齐标题栏并统一快捷键提示【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.12.31",
+  "version": "0.12.32",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/agent/MentionList.tsx
+++ b/apps/electron/src/renderer/components/agent/MentionList.tsx
@@ -18,6 +18,18 @@ export interface MentionListProps<T> {
   keyExtractor: (item: T) => string
   /** 自定义每项渲染 */
   renderItem: (item: T) => React.ReactNode
+  /** 标题栏左侧标签（如 Skill / MCP 服务 / 会话），不传则只显示快捷键提示 */
+  headerLabel?: string
+}
+
+/** 标题栏：左侧面板类型标签，右侧快捷键提示 */
+function MentionHeader({ label }: { label?: string }): React.ReactElement {
+  return (
+    <div className="flex items-center justify-between gap-2 px-2.5 py-1.5 text-[11px] font-medium bg-primary/10 text-primary border-b border-border/50">
+      <span>{label}</span>
+      <span className="font-normal text-muted-foreground">Esc 关闭 · Enter 选中</span>
+    </div>
+  )
 }
 
 export interface MentionListRef {
@@ -25,7 +37,7 @@ export interface MentionListRef {
 }
 
 function MentionListInner<T>(
-  { items, onSelect, emptyText, keyExtractor, renderItem }: MentionListProps<T>,
+  { items, onSelect, emptyText, keyExtractor, renderItem, headerLabel }: MentionListProps<T>,
   ref: React.ForwardedRef<MentionListRef>,
 ): React.ReactElement {
   const [localIndex, setLocalIndex] = React.useState(0)
@@ -67,36 +79,38 @@ function MentionListInner<T>(
 
   if (items.length === 0) {
     return (
-      <div className="rounded-lg border bg-popover p-2 shadow-lg text-[11px] text-muted-foreground w-[280px]">
-        {emptyText}
+      <div className="rounded-lg border bg-popover shadow-lg overflow-hidden w-[280px]">
+        <MentionHeader label={headerLabel} />
+        <div className="p-2 text-[11px] text-muted-foreground">{emptyText}</div>
       </div>
     )
   }
 
   return (
-    <div
-      ref={containerRef}
-      className="rounded-lg border bg-popover shadow-lg overflow-y-auto max-h-[240px] w-[280px]"
-    >
-      {items.map((item, index) => (
-        <button
-          key={keyExtractor(item)}
-          type="button"
-          className={cn(
-            'w-full flex items-center gap-2 px-2.5 py-1.5 text-left text-xs hover:bg-accent transition-colors',
-            index === localIndex && 'bg-accent text-accent-foreground',
-          )}
-          // 用 mousedown 而非 click：异步 items 重渲染会替换 button 节点，
-          // 导致 mousedown/mouseup 不在同一节点、click 不派发而漏选；
-          // preventDefault 阻止按钮抢焦点，避免编辑器 blur 触发弹窗关闭竞态。
-          onMouseDown={(e) => {
-            e.preventDefault()
-            onSelect(item)
-          }}
-        >
-          {renderItem(item)}
-        </button>
-      ))}
+    <div className="rounded-lg border bg-popover shadow-lg overflow-hidden w-[280px]">
+      <MentionHeader label={headerLabel} />
+      {/* containerRef 只包裹列表项，键盘导航靠 children[index] 定位，head 须置于其外 */}
+      <div ref={containerRef} className="overflow-y-auto max-h-[240px]">
+        {items.map((item, index) => (
+          <button
+            key={keyExtractor(item)}
+            type="button"
+            className={cn(
+              'w-full flex items-center gap-2 px-2.5 py-1.5 text-left text-xs hover:bg-accent transition-colors',
+              index === localIndex && 'bg-accent text-accent-foreground',
+            )}
+            // 用 mousedown 而非 click：异步 items 重渲染会替换 button 节点，
+            // 导致 mousedown/mouseup 不在同一节点、click 不派发而漏选；
+            // preventDefault 阻止按钮抢焦点，避免编辑器 blur 触发弹窗关闭竞态。
+            onMouseDown={(e) => {
+              e.preventDefault()
+              onSelect(item)
+            }}
+          >
+            {renderItem(item)}
+          </button>
+        ))}
+      </div>
     </div>
   )
 }

--- a/apps/electron/src/renderer/components/agent/mention-suggestions.tsx
+++ b/apps/electron/src/renderer/components/agent/mention-suggestions.tsx
@@ -19,6 +19,8 @@ import type { AgentSessionReferenceSearchResult } from '@proma/shared'
 interface MentionSuggestionConfig<T> {
   /** 触发字符 */
   char: string
+  /** 标题栏左侧标签（面板类型） */
+  headerLabel: string
   /** 空列表占位文字 */
   emptyText: string
   /** 异步获取列表项 */
@@ -85,6 +87,7 @@ function createMentionSuggestion<T>(
             props: {
               items: props.items,
               emptyText: config.emptyText,
+              headerLabel: config.headerLabel,
               keyExtractor: config.keyExtractor,
               renderItem: config.renderItem,
               onSelect: (item: T) => {
@@ -147,6 +150,7 @@ export function createSkillMentionSuggestion(
   return createMentionSuggestion<SkillMentionItem>(
     {
       char: '/',
+      headerLabel: '调用 skill',
       emptyText: '无匹配 Skill',
       fetchItems: async (slug, q) => {
         const caps = await window.electronAPI.getWorkspaceCapabilities(slug)
@@ -189,6 +193,7 @@ export function createMcpMentionSuggestion(
   return createMentionSuggestion<McpMentionItem>(
     {
       char: '#',
+      headerLabel: 'MCP 服务',
       emptyText: '无匹配 MCP 服务',
       fetchItems: async (slug, q) => {
         const caps = await window.electronAPI.getWorkspaceCapabilities(slug)
@@ -226,6 +231,7 @@ export function createSessionMentionSuggestion(
   return createMentionSuggestion<SessionMentionItem>(
     {
       char: '&',
+      headerLabel: '引用会话',
       emptyText: '无匹配会话',
       fetchItems: async (_slug, q) => {
         const workspaceId = workspaceIdRef.current

--- a/apps/electron/src/renderer/components/file-browser/FileMentionList.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileMentionList.tsx
@@ -300,8 +300,12 @@ export const FileMentionList = React.forwardRef<FileMentionRef, FileMentionListP
     // 无匹配结果
     if (!hasResults) {
       return (
-        <div className="rounded-lg border bg-popover p-2 shadow-lg text-[11px] text-muted-foreground">
-          无匹配文件
+        <div className="rounded-lg border bg-popover shadow-lg overflow-hidden min-w-[260px]">
+          <div className="flex items-center justify-between gap-2 px-2.5 py-1.5 text-[11px] font-medium bg-primary/10 text-primary border-b border-border/50">
+            <span>文件</span>
+            <span className="font-normal text-muted-foreground">Esc 关闭 · Enter 选中</span>
+          </div>
+          <div className="p-2 text-[11px] text-muted-foreground">无匹配文件</div>
         </div>
       )
     }
@@ -323,6 +327,7 @@ export const FileMentionList = React.forwardRef<FileMentionRef, FileMentionListP
             onSelect={handleSelect}
             onToggle={toggleExpand}
             setSelectedIndex={handleSetIndex}
+            showHint
           />
         )}
 
@@ -336,6 +341,7 @@ export const FileMentionList = React.forwardRef<FileMentionRef, FileMentionListP
             onSelect={handleSelect}
             onToggle={toggleExpand}
             setSelectedIndex={handleSetIndex}
+            showHint={!hasSession}
           />
         )}
       </div>
@@ -356,6 +362,7 @@ function FileSection({
   onSelect,
   onToggle,
   setSelectedIndex,
+  showHint,
 }: {
   label: string
   tree: FileTreeNode[]
@@ -364,12 +371,17 @@ function FileSection({
   onSelect: (node: FileTreeNode) => void
   onToggle: (path: string) => void
   setSelectedIndex: (index: number) => void
+  /** 在标题栏右侧显示快捷键提示 */
+  showHint?: boolean
 }) {
   return (
     <div>
       <div className="flex items-center gap-1.5 px-2.5 py-1.5 text-[11px] font-medium bg-primary/10 text-primary border-b border-border/50">
         <Folder className="size-3" />
         <span>{label}</span>
+        {showHint && (
+          <span className="ml-auto font-normal text-muted-foreground">Esc 关闭 · Enter 选中</span>
+        )}
       </div>
       <TreeNodeList
         nodes={tree}


### PR DESCRIPTION
## 概述

输入框里 `@` 文件面板有「会话文件」等标题栏（head），而 `/`（Skill）、`#`（MCP）、`&`（会话）三个补全面板没有 head。本 PR 为这三个面板补齐 head，并在所有补全面板（含 `@`）的 head 上统一显示 `Esc 关闭 · Enter 选中` 快捷键提示，覆盖有结果与空结果两种状态，让交互提示一致、可发现。

## 改动

- `apps/electron/src/renderer/components/agent/MentionList.tsx` — 新增 `MentionHeader` 子组件（左侧面板类型标签 + 右侧快捷键提示）与可选 `headerLabel` prop；重构渲染结构，把 head 放在滚动容器（`containerRef`）**外层**——键盘上下导航依赖 `containerRef.children[index]` 定位，head 留在容器内会打乱索引；空结果状态也改为「head + 占位文字」。
- `apps/electron/src/renderer/components/agent/mention-suggestions.tsx` — 泛型工厂配置新增 `headerLabel` 并透传给 `MentionList`；三个面板分别设置标签：`/` → `调用 skill`、`#` → `MCP 服务`、`&` → `引用会话`。
- `apps/electron/src/renderer/components/file-browser/FileMentionList.tsx` — `FileSection` 新增 `showHint`，在第一个可见分组（会话文件优先）的标题栏右侧显示快捷键提示，避免两个分组重复；`@` 空结果状态补一条 head。
- `apps/electron/package.json` — 版本号 0.12.31 → 0.12.32。

## 测试方法

1. 启动应用（`bun run dev`），进入 Agent 模式输入框。
2. 分别输入 `/`、`#`、`&`，确认各自弹出面板顶部出现 head：左侧为「调用 skill / MCP 服务 / 引用会话」，右侧为「Esc 关闭 · Enter 选中」。
3. 输入 `@`，确认「会话文件」/「工作区文件」分组标题栏右侧出现快捷键提示（仅第一个分组显示一次）。
4. 输入一个不匹配任何项的查询（如 `#zzzzzz`），确认空结果面板也带 head。
5. 验证键盘交互未受影响：↑↓ 切换高亮、Enter 选中、Esc 关闭均正常。

## 备注

- 纯前端 UI 改动，不触碰 IPC、存储或 agent 逻辑。
- 已通过全仓库类型检查（`bun run typecheck`，4 个包全部通过）。
- `#` 面板标签保留名词「MCP 服务」（未与 `/`、`&` 的动词短语对齐），为产品方有意选择。
- `@` 面板的提示嵌在分组标题栏内、随列表滚动；`/ # &` 的 head 固定在顶部不滚动——两者视觉样式一致，滚动行为略有差异。