### PR TITLE
feat(collaboration): blocked event bubbling + continue delegation

### DIFF
--- a/apps/electron/src/main/lib/agent-collaboration-tools.ts
+++ b/apps/electron/src/main/lib/agent-collaboration-tools.ts
@@ -11,6 +11,9 @@ import type {
   AgentDelegationStatus,
   AgentMessage,
   AgentSessionMeta,
+  AgentStreamPayload,
+  AskUserRequest,
+  PermissionRequest,
   PromaPermissionMode,
   SDKMessage,
 } from '@proma/shared'
@@ -72,6 +75,114 @@ const DELEGATION_GOAL_CHAR_LIMIT = 1_000
 const MAX_RETAINED_FINISHED_DELEGATIONS = 200
 
 const delegations = new Map<string, DelegationRecord>()
+
+// ===== 阻塞事件追踪（Level 1: Blocked Event Bubbling） =====
+
+interface BlockedEvent {
+  id: string
+  delegationId: string
+  childSessionId: string
+  type: 'ask_user' | 'permission'
+  askUserRequestId?: string
+  askUserQuestions?: Array<{ question: string; header?: string; options: Array<{ label: string; description?: string }> }>
+  permissionRequestId?: string
+  permissionToolName?: string
+  resolved: boolean
+  createdAt: number
+}
+
+const blockedEvents = new Map<string, BlockedEvent>()
+
+let _eventBusRegistered = false
+let _eventBusRef: import('./agent-event-bus').AgentEventBus | null = null
+
+export function registerCollaborationEventBus(eventBus: import('./agent-event-bus').AgentEventBus): void {
+  if (_eventBusRegistered) return
+  _eventBusRegistered = true
+  _eventBusRef = eventBus
+
+  eventBus.on((sessionId: string, payload: AgentStreamPayload) => {
+    const record = Array.from(delegations.values()).find((d) => d.childSessionId === sessionId)
+    if (!record || record.status !== 'running') return
+    if (payload.kind !== 'proma_event') return
+
+    const event = payload.event
+    if (event.type === 'ask_user_request') {
+      const req = event.request as AskUserRequest
+      const blocked: BlockedEvent = {
+        id: randomUUID(),
+        delegationId: record.delegationId,
+        childSessionId: sessionId,
+        type: 'ask_user',
+        askUserRequestId: req.requestId,
+        askUserQuestions: req.questions.map((q) => ({
+          question: q.question,
+          header: q.header,
+          options: q.options.map((o) => ({ label: o.label, description: o.description })),
+        })),
+        resolved: false,
+        createdAt: Date.now(),
+      }
+      blockedEvents.set(blocked.id, blocked)
+
+      eventBus.emit(record.parentSessionId, {
+        kind: 'proma_event',
+        event: {
+          type: 'delegation_blocked' as const,
+          delegationId: record.delegationId,
+          blockedEvent: blocked,
+        } as import('@proma/shared').PromaEvent,
+      })
+    }
+
+    if (event.type === 'permission_request') {
+      const req = event.request as PermissionRequest
+      const blocked: BlockedEvent = {
+        id: randomUUID(),
+        delegationId: record.delegationId,
+        childSessionId: sessionId,
+        type: 'permission',
+        permissionRequestId: req.requestId,
+        permissionToolName: req.toolName,
+        resolved: false,
+        createdAt: Date.now(),
+      }
+      blockedEvents.set(blocked.id, blocked)
+
+      eventBus.emit(record.parentSessionId, {
+        kind: 'proma_event',
+        event: {
+          type: 'delegation_blocked' as const,
+          delegationId: record.delegationId,
+          blockedEvent: blocked,
+        } as import('@proma/shared').PromaEvent,
+      })
+    }
+
+    if (event.type === 'ask_user_resolved' || event.type === 'permission_resolved') {
+      const requestId = 'requestId' in event ? (event as { requestId: string }).requestId : undefined
+      if (requestId) {
+        for (const be of blockedEvents.values()) {
+          if (be.resolved) continue
+          if (be.askUserRequestId === requestId || be.permissionRequestId === requestId) {
+            be.resolved = true
+            break
+          }
+        }
+      }
+    }
+  })
+
+  console.log('[协作工具] EventBus 阻塞事件监听已注册')
+}
+
+function getPendingBlockedEvents(delegationId: string): BlockedEvent[] {
+  return Array.from(blockedEvents.values()).filter((be) => be.delegationId === delegationId && !be.resolved)
+}
+
+function getBlockedEventById(blockedEventId: string): BlockedEvent | undefined {
+  return blockedEvents.get(blockedEventId)
+}
 
 /**
  * 清理内存中过多的已结束委派，避免 live Map 无界增长。
@@ -229,6 +340,7 @@ function getDelegationSummary(record: DelegationRecord): Record<string, unknown>
     completedAt: record.completedAt,
     error: record.error,
     resultSummary: record.resultSummary,
+    pendingBlockedEvents: getPendingBlockedEvents(record.delegationId),
   }
 }
 
@@ -523,6 +635,16 @@ function buildCollaborationSchemas(z: ZodModule['z']) {
     stopBatch: {
       delegationIds: z.array(z.string()).min(1).max(MAX_RUNNING_DELEGATIONS_PER_PARENT).describe('要停止的委派 ID 列表'),
     },
+    answer: {
+      delegationId: nonBlankString.describe('子会话所属的委派 ID'),
+      blockedEventId: nonBlankString.describe('要回答的阻塞事件 ID（从 delegation 的 pendingBlockedEvents 中获取）'),
+      answers: z.record(z.string(), z.string()).optional().describe('AskUserQuestion 的回答（问题文本 → 答案文本）'),
+      permissionBehavior: z.enum(['allow', 'deny']).optional().describe('Permission 请求的回复行为，默认 allow'),
+    },
+    continueD: {
+      delegationId: nonBlankString.describe('要继续操作的委派 ID（必须是已完成/已失败/已取消状态）'),
+      message: nonBlankString.describe('追加给子 Agent 的后续指令'),
+    },
   }
 }
 
@@ -678,6 +800,114 @@ export async function injectAgentCollaborationMcpServer(
         async (args) => {
           return jsonResult({
             results: args.delegationIds.map((delegationId) => stopDelegation(ctx.sessionId, delegationId)),
+          })
+        },
+      ),
+      sdk.tool(
+        'answer_delegation_question',
+        '代答协作子会话的阻塞问题（AskUserQuestion）或审批权限请求（Permission）。当子会话被阻塞时，父 Agent 可通过此工具代替用户回答，让子会话继续执行。从 delegation 的 pendingBlockedEvents 获取 blockedEventId。',
+        schemas.answer,
+        async (args) => {
+          const blocked = getBlockedEventById(args.blockedEventId)
+          if (!blocked) throw new Error(`阻塞事件不存在: ${args.blockedEventId}`)
+          if (blocked.resolved) return jsonResult({ answered: false, note: '该阻塞事件已被解决' })
+
+          const record = delegations.get(blocked.delegationId)
+          if (record && record.parentSessionId !== ctx.sessionId) {
+            throw new Error(`委派不属于当前父会话: ${blocked.delegationId}`)
+          }
+
+          if (blocked.type === 'ask_user' && blocked.askUserRequestId) {
+            const { askUserService } = await import('./agent-ask-user-service')
+            const answers = args.answers ?? {}
+            const sessionId = askUserService.respondToAskUser(blocked.askUserRequestId, answers)
+            blocked.resolved = !!sessionId
+            if (blocked.resolved && _eventBusRef) {
+              _eventBusRef.emit(blocked.childSessionId, {
+                kind: 'proma_event',
+                event: { type: 'ask_user_resolved', requestId: blocked.askUserRequestId },
+              })
+            }
+            return jsonResult({ answered: blocked.resolved, type: 'ask_user' })
+          }
+
+          if (blocked.type === 'permission' && blocked.permissionRequestId) {
+            const { permissionService } = await import('./agent-permission-service')
+            const behavior = args.permissionBehavior ?? 'allow'
+            const sessionId = permissionService.respondToPermission(blocked.permissionRequestId, behavior, false)
+            blocked.resolved = !!sessionId
+            if (blocked.resolved && _eventBusRef) {
+              _eventBusRef.emit(blocked.childSessionId, {
+                kind: 'proma_event',
+                event: { type: 'permission_resolved', requestId: blocked.permissionRequestId, behavior },
+              })
+            }
+            return jsonResult({ answered: blocked.resolved, type: 'permission', behavior })
+          }
+
+          return jsonResult({ answered: false, note: '无法匹配阻塞事件类型' })
+        },
+      ),
+      sdk.tool(
+        'continue_delegation',
+        '向已完成、已失败或已取消的协作子会话追加后续指令。子会话保留完整上下文继续执行。适合多轮协作场景：先让子 Agent 完成第一步，审查结果后继续下一步。',
+        schemas.continueD,
+        async (args) => {
+          const record = delegations.get(args.delegationId)
+          if (!record) throw new Error(`未找到当前会话下的委派: ${args.delegationId}`)
+          if (record.parentSessionId !== ctx.sessionId) {
+            throw new Error(`委派不属于当前父会话: ${args.delegationId}`)
+          }
+          if (record.status === 'running') {
+            throw new Error(`委派正在运行中，无法追加指令。请先等待完成或停止后再继续: ${args.delegationId}`)
+          }
+
+          record.status = 'running'
+          record.error = undefined
+          record.resultSummary = undefined
+          record.completedAt = undefined
+          let resolveCompletion: () => void = () => {}
+          const completion = new Promise<void>((resolve) => { resolveCompletion = resolve })
+          record.completion = completion
+          record.resolveCompletion = resolveCompletion
+
+          updateAgentSessionMeta(record.childSessionId, { delegationStatus: 'running' })
+
+          runRegisteredHeadlessAgent(
+            {
+              sessionId: record.childSessionId,
+              userMessage: args.message,
+              channelId: ctx.channelId,
+              modelId: ctx.modelId,
+              workspaceId: ctx.workspaceId,
+              permissionModeOverride: record.permissionMode,
+              triggeredBy: 'delegation',
+              startedAt: Date.now(),
+            },
+            {
+              source: 'delegation',
+              onError: (error) => {
+                markDelegationFinished(record, 'failed', { error })
+              },
+              onComplete: (messages) => {
+                if (record.status !== 'running') return
+                const resultSummary = summarizeChildResult(record.childSessionId, messages)
+                markDelegationFinished(record, 'completed', { resultSummary })
+              },
+              onTitleUpdated: () => {},
+            },
+          ).catch((error: unknown) => {
+            markDelegationFinished(record, 'failed', {
+              error: error instanceof Error ? error.message : '未知错误',
+            })
+          })
+
+          const timeout = new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), DEFAULT_WAIT_SECONDS * 1000))
+          await Promise.race([completion, timeout])
+
+          return jsonResult({
+            delegation: getDelegationSummary(record),
+            note: record.status === 'running' ? '子会话仍在运行中（等待超时），可稍后用 wait_for_delegations 等待结果。' : undefined,
           })
         },
       ),

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -44,6 +44,11 @@ const orchestrator = new AgentOrchestrator(adapter, eventBus)
 /** 导出 EventBus 供飞书 Bridge 等外部服务订阅事件 */
 export { eventBus as agentEventBus }
 
+// 注册协作子会话 EventBus 阻塞事件监听
+import('./agent-collaboration-tools').then(({ registerCollaborationEventBus }) => {
+  registerCollaborationEventBus(eventBus)
+}).catch(() => { /* collaboration 模块可能未加载 */ })
+
 /**
  * 会话 → webContents 映射
  *

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -11,7 +11,7 @@
 import * as React from 'react'
 import { useAtom, useSetAtom, useAtomValue, useStore } from 'jotai'
 import { toast } from 'sonner'
-import { Pin, PinOff, Settings, Plus, Trash2, Pencil, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, GripVertical, Clock, AlarmClock, ChevronRight, Blocks } from 'lucide-react'
+import { Pin, PinOff, Settings, Plus, Trash2, Pencil, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, GripVertical, Clock, AlarmClock, ChevronRight, Blocks, GitBranch } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { ModeSwitcher } from './ModeSwitcher'
@@ -368,7 +368,7 @@ function RailRecentButton({
             {item.isAutomation
               ? <Clock size={14} className="text-foreground/40" />
               : item.isDelegation
-                ? <Blocks size={14} className="text-foreground/40" />
+                ? <GitBranch size={14} className="text-foreground/40" />
                 : <span className="text-[13px] font-semibold leading-none">{item.initial}</span>
             }
           </button>
@@ -2832,7 +2832,7 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
                   <Clock size={11} className="flex-shrink-0 text-foreground/40" />
                 )}
                 {session.sourceDelegationId && !session.sourceAutomationId && (
-                  <Blocks size={11} className="flex-shrink-0 text-foreground/40" />
+                  <GitBranch size={11} className="flex-shrink-0 text-foreground/40" />
                 )}
                 <span className="truncate">{session.title}</span>
                 {workspaceName && (

--- a/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
@@ -9,7 +9,7 @@
 import * as React from 'react'
 import { createPortal } from 'react-dom'
 import { useAtomValue } from 'jotai'
-import { FileText, StickyNote, X, Clock, Blocks } from 'lucide-react'
+import { FileText, StickyNote, X, Clock, GitBranch } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import type { TabType, TabMinimapItem } from '@/atoms/tab-atoms'
 import type { SessionIndicatorStatus } from '@/atoms/agent-atoms'
@@ -173,7 +173,7 @@ export function TabBarItem({
         ) : (
           <span className="flex-1 min-w-0 truncate text-left flex items-center gap-1">
             {isAutomation && <Clock className="size-3 shrink-0 text-foreground/40" />}
-            {isDelegation && !isAutomation && <Blocks className="size-3 shrink-0 text-foreground/40" />}
+            {isDelegation && !isAutomation && <GitBranch className="size-3 shrink-0 text-foreground/40" />}
             {title}
           </span>
         )}

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -564,6 +564,8 @@ export type PromaEvent =
   | { type: 'title_updated'; title: string }
   | { type: 'external_run_started'; source: AgentExternalRunSource; sessionId: string; title?: string; workspaceId?: string; modelId?: string; startedAt: number }
   | { type: 'run_resumed'; sessionId: string }
+  // 协作子会话阻塞事件上浮
+  | { type: 'delegation_blocked'; delegationId: string; blockedEvent: unknown }
 
 /** 外部入口触发 Agent 运行的来源 */
 export type AgentExternalRunSource = 'feishu' | 'dingtalk' | 'wechat' | 'bridge' | 'delegation'


### PR DESCRIPTION
## Summary

增强协作子会话系统，新增两个核心能力：

- **Level 1: 阻塞事件上浮 + 代答** — 子会话遇到 AskUserQuestion/Permission 阻塞时，EventBus 自动捕获并通知父会话。父 Agent 可通过 `answer_delegation_question` 工具代答，子会话继续执行，前端 UI 同步关闭阻塞提示
- **Level 2: 追加指令** — 父 Agent 可通过 `continue_delegation` 工具向已完成/已失败的子会话发送后续指令，子会话保留完整上下文继续执行（SDK resume）
- **UI**: delegation 会话图标从 Blocks 改为 GitBranch

### 新增工具

| 工具 | 描述 |
|------|------|
| `answer_delegation_question` | 代答子会话的 AskUser/Permission，含 EventBus resolved 事件通知前端 |
| `continue_delegation` | 向已完成子会话追加指令，阻塞等待完成后返回结果 |

### 改动文件

- `agent-collaboration-tools.ts` — BlockedEvent 追踪、EventBus 注册、2 个新工具
- `agent-service.ts` — 模块加载时注册 EventBus 监听
- `agent.ts` — PromaEvent 新增 `delegation_blocked` 事件类型
- `LeftSidebar.tsx` / `TabBarItem.tsx` — delegation 图标 Blocks → GitBranch

## Test plan

- [ ] 父 Agent 调用 `delegate_agent` 创建子会话 → 子会话触发 AskUserQuestion → 父 Agent 通过 `wait_for_delegations` 看到 pendingBlockedEvents → 调用 `answer_delegation_question` 代答 → 子会话继续执行 → 前端 AskUser UI 消失
- [ ] 父 Agent 创建子会话完成首轮 → 调用 `continue_delegation` 追加指令 → 子会话保留上下文继续执行
- [ ] 子会话被阻塞时，用户在子会话 UI 手动答 → 父 Agent 后续代答返回 `answered: false`（竞争安全）
- [ ] delegation 会话在侧边栏和 TabBar 显示 GitBranch 图标

🤖 Generated with [Claude Code](https://claude.com/claude-code)