### PR TITLE
【已审核】fix(agent): 点击推荐条发送建议后保留输入栏草稿

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -1310,9 +1310,11 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         return map
       })
 
-      // 2. 清空输入框
-      setInputContent('')
-      setInputHtmlContent('')
+      // 2. 清空输入框（仅当发送的是用户自己输入的内容，而非推荐建议时）
+      if (!overrideText) {
+        setInputContent('')
+        setInputHtmlContent('')
+      }
       setPromptSuggestions((prev) => {
         if (!prev.has(sessionId)) return prev
         const map = new Map(prev)
@@ -1559,8 +1561,11 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       })(),
     }
 
-    setInputContent('')
-    setInputHtmlContent('')
+    // 清空输入框（仅当发送的是用户自己输入的内容，而非推荐建议时）
+    if (!overrideText) {
+      setInputContent('')
+      setInputHtmlContent('')
+    }
 
     window.electronAPI.sendAgentMessage(input).catch((error) => {
       console.error('[AgentView] 发送消息失败:', error)

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -1311,7 +1311,9 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       })
 
       // 2. 清空输入框（仅当发送的是用户自己输入的内容，而非推荐建议时）
-      if (!overrideText) {
+      // 用 === undefined 与上方 `overrideText ?? inputContent` 的取值语义保持一致，
+      // 避免未来出现 handleSend('') 时两条路径行为割裂
+      if (overrideText === undefined) {
         setInputContent('')
         setInputHtmlContent('')
       }
@@ -1562,7 +1564,9 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     }
 
     // 清空输入框（仅当发送的是用户自己输入的内容，而非推荐建议时）
-    if (!overrideText) {
+    // 用 === undefined 与上方 `overrideText ?? inputContent` 的取值语义保持一致，
+    // 避免未来出现 handleSend('') 时两条路径行为割裂
+    if (overrideText === undefined) {
       setInputContent('')
       setInputHtmlContent('')
     }


### PR DESCRIPTION
## 概述

修复 Agent 模式下点击推荐条（prompt suggestion）发送建议后，输入栏中用户正在编辑的草稿被意外清除的问题。

此前已有 PR 修复了"点击推荐条会发送草稿而非建议内容"的问题 — 通过 `handleSend(overrideText)` 正确区分了用户输入和建议。但 `setInputContent('')` 在两条发送路径中仍然无条件执行，导致即使用户只是点击推荐条，草稿也被清空。

## 改动

| 文件 | 说明 |
|------|------|
| `apps/electron/src/renderer/components/agent/AgentView.tsx` | `handleSend` 中两处 `setInputContent('')` + `setInputHtmlContent('')` 加 `if (!overrideText)` 守卫 |

- **流式/后台等待分支**：`overrideText` 存在时跳过清除
- **新建 turn 分支**：同上

共 +10/-5 行。

## 测试

- [x] TypeCheck 全通过
- [x] SubAgent 自审通过（三类审查全部 CLEAN）
- [x] 手动验证：输入草稿 → 等待推荐 → 点击推荐条 → 确认草稿保留

## 紧急度

中 — 影响 Agent 核心交互体验，用户编辑中的草稿丢失。

## 备注

- 推荐条的 UI 渲染逻辑（`suggestion && !streaming`）和相关 atoms 未改动