### PR TITLE
fix(agent): 长任务断连后保留 sdkSessionId，避免上下文丢失重启 (#903)

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -352,9 +352,15 @@ function buildContextPrompt(sessionId: string, currentUserMessage: string, sessi
 
   if (lines.length === 0) return currentUserMessage
 
-  // 注入 session 元信息，便于 Agent 在需要时读取完整历史
+  // 注入 session 元信息 + 强指令：兜底场景（resume 指针丢失）下，仅靠最近
+  // MAX_CONTEXT_MESSAGES 条摘要不足以让长任务无缝接续，必须引导模型先读取完整 JSONL，
+  // 避免「从零重新执行整个任务」（#903）。
   const sessionInfoBlock = sessionHint
-    ? `\n<session_info>\nSession ID: ${sessionId}\nSession CWD: ${sessionHint.agentCwd}\nNote: 上方为近期对话摘要。如需更多上下文，可读取 ~/${getConfigDirName()}/agent-sessions/${sessionId}.jsonl 获取完整历史。\n</session_info>\n`
+    ? `\n<session_info>\nSession ID: ${sessionId}\nSession CWD: ${sessionHint.agentCwd}\n` +
+      `完整历史: ~/${getConfigDirName()}/agent-sessions/${sessionId}.jsonl\n` +
+      `重要：上方仅为最近 ${MAX_CONTEXT_MESSAGES} 条对话摘要，可能不完整。在继续之前，` +
+      `请先读取上述完整历史文件，确认「已经完成了哪些工作、进行到哪一步」，` +
+      `然后从中断处继续，切勿重复执行已完成的步骤。\n</session_info>\n`
     : ''
 
   console.log(`[Agent 编排] buildContextPrompt: 读取 ${allMessages.length} 条消息，注入 ${lines.length} 条历史${sessionHint ? '（含 session 元信息）' : ''}`)
@@ -2062,15 +2068,15 @@ export class AgentOrchestrator {
 
           failRun(userFacingError, getAgentSessionMessages(sessionId), { startedAt: streamStartedAt })
 
-          // 根据错误类型决定是否保留 sdkSessionId
-          const shouldClearSession = !apiError || apiError.statusCode >= 500
-          if (existingSdkSessionId && shouldClearSession) {
-            try {
-              updateAgentSessionMeta(sessionId, { sdkSessionId: undefined })
-              console.log(`[Agent 编排] 已清除失效的 sdkSessionId`)
-            } catch { /* 忽略 */ }
-          } else if (existingSdkSessionId && !shouldClearSession) {
-            console.log(`[Agent 编排] 保留 sdkSessionId (API 错误 ${apiError?.statusCode})`)
+          // 保留 sdkSessionId，确保下一轮能继续 resume（修复 #903）。
+          // 此终止分支只会被「非 session-not-found」的错误命中（session 失效已在上文
+          // isSessionNotFoundError 分支单独处理并切到恢复模式）。网络断连、服务端 5xx、
+          // 未知错误都不代表 SDK 会话本身失效——其完整历史 JSONL 仍保存在
+          // ~/.proma/sdk-config/projects/.../{sdkSessionId}.jsonl 中，依旧可 resume。
+          // 此前这里对 `!apiError`（如普通断连解析不出状态码）一律清除指针，导致下一轮
+          // 退化为「仅回填最近 N 条」的冷启动，上下文从满载骤降（#903）。
+          if (existingSdkSessionId) {
+            console.log(`[Agent 编排] 保留 sdkSessionId 以便下一轮 resume（错误未表明会话失效）`)
           }
 
           return

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -739,10 +739,12 @@ export class AgentOrchestrator {
   }
 
   /**
-   * Session-not-found 恢复：清除失效的 sdkSessionId，切换到上下文回填模式
+   * Session-not-found 恢复：保留磁盘 sdkSessionId，本轮切换到上下文回填模式
    *
-   * 当 resume 的目标 session 已过期/被清理时，SDK 会抛出 "No conversation found" 错误。
-   * 此方法执行恢复的公共逻辑，调用方负责设置 existingSdkSessionId = undefined 和流程控制（break/continue）。
+   * 当 resume 的目标 session 报 "No conversation found" 时触发。注意该错误可能是
+   * listSessions 路径哈希不匹配导致的误检（见步骤 9.6 注释），不代表会话真正失效，
+   * 因此不清除磁盘 meta：本轮以非 resume 模式恢复，若失败下一轮仍可尝试 resume（#903）。
+   * 调用方负责设置本地 existingSdkSessionId = undefined 和流程控制（break/continue）。
    *
    * @returns lastRetryableError 描述字符串
    */
@@ -761,17 +763,22 @@ export class AgentOrchestrator {
       agentCwd,
       accumulatedMessages,
       queryStartedAt,
-      '检测到 session-not-found 错误，清除 sdkSessionId 并切换到上下文回填模式',
-      'Session 已失效，切换到上下文回填模式',
+      '检测到 session-not-found（可能为误检），保留 sdkSessionId 并切换到上下文回填模式',
+      'Session 暂不可 resume，切换到上下文回填模式',
     )
   }
 
   /**
-   * Resume 失败恢复：清除 SDK resume 关系，注入 session 自引用让 Agent 读取完整历史继续工作。
-   *
-   * 适用于 SDK session 过期、thinking signature 跨模型不兼容等场景。
-   * 使用 <session_recovery> 标签指向当前会话的 JSONL 历史文件，Agent 会自动读取并恢复上下文，
+   * Resume 失败恢复：本轮切到「非 resume + 读 JSONL 恢复」模式，注入 session 自引用让 Agent
+   * 读取完整历史继续工作。使用 <session_recovery> 标签指向当前会话的 JSONL 历史文件，
    * 比 buildContextPrompt（仅注入 20 条摘要）提供完整得多的上下文连续性。
+   *
+   * 关于磁盘 meta 的 sdkSessionId（由 clearPersistedSession 控制，默认 false 即保留）：
+   * - 默认保留：本轮恢复只改本地 queryOptions，不动磁盘；若本轮成功，SDK 新会话的 ID 会经
+   *   onSessionId 回调自动覆盖 meta；若本轮失败到终止，下一轮仍可尝试 resume 旧 ID（#903）。
+   *   这是「迷了就别删」的安全默认，适用于 session-not-found（可能为误检）等不确定场景。
+   * - 仅 thinking-signature 跨模型不兼容时传 true：旧 ID 指向的 JSONL 焊死了旧模型思考块，
+   *   当前模型 resume 必然再次失败，此时主动清除可避免下一轮无谓的失败往返。
    */
   private prepareResumeFallbackRecovery(
     sessionId: string,
@@ -782,13 +789,17 @@ export class AgentOrchestrator {
     queryStartedAt: number,
     logMessage: string,
     retryReason: string,
+    clearPersistedSession = false,
   ): string {
     console.log(`[Agent 编排] ${logMessage}`)
     // 先持久化当前已累积的消息，确保 JSONL 文件包含最新内容
     this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
     accumulatedMessages.length = 0
-    // 清除失效的 SDK session，新 SDK 会话产生的 sdkSessionId 会通过 onSessionId 回调自动保存
-    try { updateAgentSessionMeta(sessionId, { sdkSessionId: undefined }) } catch { /* 忽略 */ }
+    // 仅在确定旧会话永久无效时（thinking-signature）才清除磁盘 meta；
+    // 其余场景保留，新 SDK 会话产生的 sdkSessionId 会通过 onSessionId 回调自动覆盖。
+    if (clearPersistedSession) {
+      try { updateAgentSessionMeta(sessionId, { sdkSessionId: undefined }) } catch { /* 忽略 */ }
+    }
     queryOptions.resumeSessionId = undefined
     queryOptions.resumeSessionAt = undefined
     queryOptions.prompt = buildRecoveryPrompt(sessionId, contextualMessage, { agentCwd })
@@ -1733,6 +1744,7 @@ export class AgentOrchestrator {
                     queryStartedAt,
                     '检测到 thinking signature 不兼容，清除 sdkSessionId 并切换到上下文回填模式',
                     '思考签名不兼容，切换到上下文回填模式',
+                    true,  // 跨模型签名不兼容是唯一确定永久无效的场景，清除磁盘 sdkSessionId
                   )
                   stderrChunks.length = 0
                   shouldRetryFromError = true
@@ -1963,6 +1975,7 @@ export class AgentOrchestrator {
               queryStartedAt,
               '检测到 thinking signature 不兼容，清除 sdkSessionId 并切换到上下文回填模式',
               '思考签名不兼容，切换到上下文回填模式',
+              true,  // 跨模型签名不兼容是唯一确定永久无效的场景，清除磁盘 sdkSessionId
             )
             stderrChunks.length = 0
             continue  // 进入下一次 retry 循环

--- a/apps/electron/src/main/lib/error-patterns.test.ts
+++ b/apps/electron/src/main/lib/error-patterns.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'bun:test'
+import { isTransientNetworkError, isMalformedResponseError } from './error-patterns'
+
+describe('isTransientNetworkError', () => {
+  // 原有覆盖：确保扩展正则未回归
+  test.each([
+    'terminated',
+    'socket hang up',
+    'read ECONNRESET',
+    'connect ETIMEDOUT 1.2.3.4:443',
+    'write EPIPE',
+    'getaddrinfo ENOTFOUND api.anthropic.com',
+    'getaddrinfo EAI_AGAIN api.anthropic.com',
+    'connect ECONNREFUSED 127.0.0.1:443',
+    'TypeError: fetch failed',
+    'network error',
+    'stream closed prematurely',
+    'premature close',
+  ])('Given 已知瞬时网络错误 "%s" Then 判定为可重试', (msg) => {
+    expect(isTransientNetworkError(msg)).toBe(true)
+  })
+
+  // #903 新增覆盖：这些断连此前会绕过自动重试、误入终止分支并清除 sdkSessionId
+  test.each([
+    'The operation was aborted',
+    'This operation was aborted',
+    'AbortError: The operation was aborted',
+    'Connection error.',
+    'connection closed',
+    'Connection reset by peer',
+    'other side closed',
+    'request was aborted',
+    'request timed out',
+    'connect ECONNABORTED',
+  ])('Given #903 断连错误 "%s" Then 也判定为可重试', (msg) => {
+    expect(isTransientNetworkError(msg)).toBe(true)
+  })
+
+  test('Given stderr 含瞬时网络错误 Then 判定为可重试', () => {
+    expect(isTransientNetworkError(undefined, 'undici: other side closed')).toBe(true)
+  })
+
+  test('Given 普通业务错误 Then 不判定为瞬时网络错误', () => {
+    expect(isTransientNetworkError('invalid api key')).toBe(false)
+    expect(isTransientNetworkError('400 Bad Request: model not found')).toBe(false)
+    expect(isTransientNetworkError()).toBe(false)
+  })
+})
+
+describe('isMalformedResponseError', () => {
+  test('Given JSON 解析失败 Then 判定为响应体解析失败', () => {
+    expect(isMalformedResponseError('API Error: JSON Parse error: Unable to parse JSON string')).toBe(true)
+    expect(isMalformedResponseError('Unexpected end of JSON input')).toBe(true)
+  })
+
+  test('Given 普通错误 Then 不判定为响应体解析失败', () => {
+    expect(isMalformedResponseError('socket hang up')).toBe(false)
+  })
+})

--- a/apps/electron/src/main/lib/error-patterns.ts
+++ b/apps/electron/src/main/lib/error-patterns.ts
@@ -2,11 +2,13 @@
  * 瞬时网络错误模式
  *
  * 覆盖上游 API 偶发断流/抖动：API SSE 流中途 terminated、TCP 连接被重置、
- * DNS 抖动、fetch 层超时等。这些错误无 HTTP 状态码，SDK HTTP 客户端层
+ * DNS 抖动、fetch 层超时、连接被中止（undici "The operation was aborted" /
+ * AbortError）、对端提前关闭等。这些错误无 HTTP 状态码，SDK HTTP 客户端层
  * 内置的 2 次重试无法完全消化时，会穿透到 Orchestrator 应用层兜底。
+ * 命中此模式的错误会走「保留 resume 的自动重试」，不会清除 sdkSessionId（#903）。
  */
 export const TRANSIENT_NETWORK_PATTERN =
-  /terminated|socket hang up|ECONNRESET|ETIMEDOUT|EPIPE|ENOTFOUND|EAI_AGAIN|ECONNREFUSED|fetch failed|network error|stream (?:closed|ended|disconnected) prematurely|premature close/i
+  /terminated|socket hang up|ECONNRESET|ETIMEDOUT|ECONNABORTED|EPIPE|ENOTFOUND|EAI_AGAIN|ECONNREFUSED|fetch failed|network error|connection (?:error|closed|reset)|other side closed|AbortError|(?:operation|request) was aborted|(?:request )?timed out|stream (?:closed|ended|disconnected) prematurely|premature close/i
 
 /** 判断错误消息/stderr 是否为瞬时网络错误 */
 export function isTransientNetworkError(message?: string, stderr?: string): boolean {


### PR DESCRIPTION
Closes #903

## 问题
长任务运行中发生一次网络断连后，整个上下文丢失（issue 截图中从 **300K 骤降到 50K**），模型从零重新执行任务；"Interrupt + Continue" 也无法恢复，只能新建会话手动救回。

## 根因
断连后，编排层会**主动清除指向 SDK 会话的 resume 指针 `sdkSessionId`**。但 SDK 自身的完整历史 JSONL（`~/.proma/sdk-config/projects/.../{sdkSessionId}.jsonl`，完整 300K）仍在磁盘上、本可 resume。指针一旦丢失，下一轮就走 `buildContextPrompt`（仅回填最近 `MAX_CONTEXT_MESSAGES = 20` 条 ≈ 50K）的冷启动，模型因此"从头再来"。

清除有两条触发路径，都不该清：
1. **终止分支**：`shouldClearSession = !apiError || statusCode >= 500`。普通断连从 stderr **解析不出 HTTP 状态码**（`apiError = null`）→ `!apiError` 命中 → 清除指针。
2. **resume 回退恢复**（`prepareResumeFallbackRecovery`）：session-not-found / thinking-signature 都会无条件清除磁盘 meta。而 session-not-found 可能只是 `listSessions` 路径哈希误检（见步骤 9.6 注释），并非真失效。

此外部分断连错误（`aborted` / `AbortError` / `connection closed` / `timed out` 等）未被 `TRANSIENT_NETWORK_PATTERN` 覆盖，绕过"保留 resume 的自动重试"，直接落入终止分支。

## 修复
核心思路：**"何时清除 sdkSessionId" 收敛到唯一确定永久无效的场景。**

唯一能确定旧会话永久无效的是 **thinking-signature 跨模型不兼容**（旧模型思考块焊死在 JSONL，当前模型 resume 必然再失败）。其余所有场景——断连 / 5xx / unknown / session-not-found——都保留指针：本轮以"非 resume + 读完整 JSONL"模式恢复，本轮成功则新会话 ID 经 `onSessionId` 回调自动覆盖 meta，本轮失败到终止则下一轮仍可 resume 旧 ID。

具体改动：
1. **终止分支不再清除 `sdkSessionId`** — 删除 `shouldClearSession` 判断，保留指针。
2. **`prepareResumeFallbackRecovery` 新增 `clearPersistedSession` 参数（默认 `false`）** — 把"清除磁盘 meta"参数化收敛到唯一一处，由调用方显式决定。仅两处 thinking-signature 调用点传 `true`；session-not-found 不再清除磁盘 meta。
3. **扩展 `TRANSIENT_NETWORK_PATTERN`** — 新增 `ECONNABORTED` / `connection (error|closed|reset)` / `other side closed` / `AbortError` / `(operation|request) was aborted` / `timed out`，让这类断连稳定走自动重试。
4. **冷启动兜底升级** — 万一仍无 `sdkSessionId` 启动，`buildContextPrompt` 的 `<session_info>` 改为强指令：要求模型先读取完整 JSONL 历史、确认进度后从中断处继续，切勿重复已完成的步骤。

结果：磁盘 `sdkSessionId` 的主动清除从"多处条件判断"收敛到"唯一一处、仅 thinking-signature"，彻底消除 #903 的误清风险，并把"何时清除"的心智负担降到最低。

## 测试
- 新增 `error-patterns.test.ts`，覆盖原有 + #903 新增的断连错误模式（**26 通过**）。
- `bun run typecheck` 通过。

## 影响面
仅改动主进程 Agent 编排的错误兜底逻辑，不涉及正常 resume 路径与 UI。

🤖 Generated with [Claude Code](https://claude.com/claude-code)