### PR TITLE
fix(agent): 支持已发送附件 chip 预览【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -47,6 +47,8 @@ import { automationsAtom, automationFormAtom, automationToDraft } from '@/atoms/
 import { activeViewAtom } from '@/atoms/active-view'
 import { environmentCheckDialogOpenAtom } from '@/atoms/environment'
 import { settingsOpenAtom, settingsTabAtom } from '@/atoms/settings-tab'
+import { useOpenPreview } from '@/components/diff/preview-opener'
+import { getFileParentPath } from '@/lib/file-utils'
 import type {
   SDKMessage,
   SDKAssistantMessage,
@@ -983,12 +985,34 @@ function AttachedImageThumb({ file, onEditComplete }: { file: AttachedFileRef; o
 function AttachedFileChip({ file }: { file: AttachedFileRef }): React.ReactElement {
   const isImg = isImageFile(file.filename)
   const Icon = isImg ? FileImage : FileText
+  const activeSessionId = useAtomValue(activeSessionIdAtom)
+  const openPreview = useOpenPreview()
+
+  const handleOpenPreview = React.useCallback((): void => {
+    if (!activeSessionId) return
+    const parentPath = getFileParentPath(file.path)
+    openPreview(activeSessionId, {
+      filePath: file.path,
+      previewOnly: true,
+      readOnly: true,
+      basePaths: parentPath ? [parentPath] : undefined,
+    })
+  }, [activeSessionId, file.path, openPreview])
 
   return (
-    <div className="inline-flex items-center gap-1.5 rounded-md bg-muted/60 px-2.5 py-1 text-[12px] text-muted-foreground">
+    <button
+      type="button"
+      onClick={handleOpenPreview}
+      disabled={!activeSessionId}
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-md bg-muted/60 px-2.5 py-1 text-[12px] text-muted-foreground',
+        'transition-colors hover:bg-muted hover:text-foreground disabled:cursor-default disabled:hover:bg-muted/60 disabled:hover:text-muted-foreground'
+      )}
+      title={file.path}
+    >
       <Icon className="size-3.5 shrink-0" />
       <span className="truncate max-w-[200px]">{file.filename}</span>
-    </div>
+    </button>
   )
 }
 


### PR DESCRIPTION
## 概述

这个 PR 修复 Agent 模式中已发送用户消息的非图片附件 chip 点击后无响应的问题。现在用户把长文本粘贴为 `clipboard-*.txt` / `clipboard-*.md` 附件并发送后，历史消息里的附件 chip 可以复用现有文件预览系统打开对应文件，遵循当前预览偏好展示为右侧分屏或预览标签页。

## 改动

- `apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx` — 将已发送消息中的 `AttachedFileChip` 从静态 `div` 改为可点击 `button`，点击后调用 `useOpenPreview` 打开附件真实路径；同时传入父目录作为 `basePaths`，继续复用主进程现有路径解析和权限校验逻辑。预览参数设置为 `previewOnly: true` 与 `readOnly: true`，避免从历史消息入口误改附件内容。
- `apps/electron/package.json` — 按仓库版本管理规则，将 `@proma/electron` patch 版本从 `0.13.0` 递增到 `0.13.1`。

## 测试方法

1. 运行 `bun run typecheck`，确认所有 workspace 类型检查通过。
2. 运行 `bun test apps/electron/src/renderer/lib/clipboard-text-attachment.test.ts`，确认剪贴板长文本附件相关逻辑未回归。
3. 手动验证建议：在 Agent 模式粘贴一段长文本使其生成 `clipboard-*.txt` 或 `clipboard-*.md` 附件，发送后点击历史消息里的附件 chip，应打开现有预览面板或预览标签页。

## 备注

- 已按 Review-Proma-PR 口径审核本次 diff，未发现新增路径白名单扩大、Windows 平台高风险模式或类型安全问题。
- 这次改动只影响 Agent 已发送消息中的非图片附件 chip；图片附件仍保持原有 lightbox 预览行为。
