### PR TITLE
fix(renderer): 修复浅色主题代码块选区可读性【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.13.0",
+  "version": "0.13.3",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -1081,6 +1081,32 @@
   padding: 0;
 }
 
+/* 浅色主题代码块是深底，用偏浅的蓝灰选区承托白字，避免 Shiki token 内联色在选中后变黑。 */
+:root:not(.dark) :is(
+  .code-block-wrapper pre.shiki,
+  .tiptap pre
+)::selection,
+:root:not(.dark) :is(
+  .code-block-wrapper pre.shiki,
+  .tiptap pre
+) ::selection {
+  background-color: hsl(210 80% 62% / 0.32);
+  color: hsl(0 0% 98%) !important;
+  -webkit-text-fill-color: hsl(0 0% 98%);
+}
+
+:root:not(.dark) :is(
+  .code-block-wrapper pre.shiki,
+  .tiptap pre
+)::-moz-selection,
+:root:not(.dark) :is(
+  .code-block-wrapper pre.shiki,
+  .tiptap pre
+) ::-moz-selection {
+  background-color: hsl(210 80% 62% / 0.32);
+  color: hsl(0 0% 98%) !important;
+}
+
 /* 代码行：限制重排范围，GPU 合成优化 */
 .code-block-wrapper .line {
   display: inline;

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.12.27",
+      "version": "0.13.3",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.185",
         "@anthropic-ai/sdk": "^0.93.0",


### PR DESCRIPTION
## 概述

这个 PR 修复浅色主题下深色代码块选中文本后可读性变差的问题。此前 Shiki token 使用内联颜色，浏览器选区可能保留接近黑色的 token 前景色，导致选中的代码在深色代码块背景上看不清。本次为浅色主题下的深底代码块增加专用选区样式，统一使用浅蓝灰选区背景和高对比浅色文字。

## 改动

- `apps/electron/src/renderer/styles/globals.css` — 为浅色主题下的 `.code-block-wrapper pre.shiki` 和 `.tiptap pre` 增加专用 `::selection` / `::-moz-selection` 样式，避免 Shiki token 内联色在选中时变黑；同时将选区背景调整为更浅的蓝灰色，减少黑色选区带来的视觉突兀。
- `apps/electron/package.json` — 按项目版本规则将 `@proma/electron` patch 版本递增到 `0.13.3`。
- `bun.lock` — 同步 Electron app workspace 版本号，保证 lockfile 与 package metadata 一致。

## 测试方法

1. 运行 `bun install --frozen-lockfile`，确认 lockfile 状态有效。
2. 运行 `bun run --filter='@proma/electron' build:renderer`，确认 renderer CSS 能通过 Vite/Tailwind 构建。
3. 运行 `bun run --filter='@proma/electron' typecheck`，确认 Electron 包类型检查通过。
4. 运行 `git diff --check`，确认 diff 没有空白格式问题。
5. 代码审核中已检查 Windows 兼容性，本次改动不涉及路径、shell、平台分支或原生依赖。

## 备注

- 选区规则刻意只覆盖深底代码块路径，不覆盖浅底的 `.ProseMirror pre.markdown-code-block`，避免浅底代码块被强制白字造成新的可读性问题。
- 当前环境内置浏览器后端不可用，因此未附加实际 Electron 截图；建议合并前在浅色主题下手动选中一段代码块文本做最终视觉确认。