### PR TITLE
fix(agent): 修复有序列表 Shift+Enter 续项【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -427,7 +427,7 @@ export function RichTextInput({
             return true
           }
 
-          // 换行：Shift+Enter 插入硬换行 <br>，普通 Enter 拆分段落或列表项
+          // 换行：普通段落中 Shift+Enter 插入硬换行；列表项内使用拆分列表项生成下一条。
           event.preventDefault()
           // 检查是否在列表项内（遍历祖先节点）
           let isInList = false
@@ -443,10 +443,8 @@ export function RichTextInput({
             // 空列表项再次按 Enter：退出列表，回到普通输入
             if (listItemNode && listItemNode.textContent === '') {
               editor.chain().focus().liftListItem('listItem').run()
-            } else if (hasShift) {
-              // Shift+Enter：在列表项内硬换行
-              editor.chain().focus().setHardBreak().run()
             } else {
+              // 发送模式下 Enter 会提交消息，因此 Shift+Enter 也应作为列表续项键。
               editor.chain().focus().splitListItem('listItem').run()
             }
           } else if (editor) {

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.12.27",
+      "version": "0.13.1",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.185",
         "@anthropic-ai/sdk": "^0.93.0",


### PR DESCRIPTION
## 概述
修复 Agent 模式输入框中有序列表续行异常的问题。此前在列表项内按 Shift+Enter 会插入硬换行，导致新行作为同一列表项的续行出现缩进，并让 Backspace 表现为回到上一行尾部。现在列表项内的换行会拆分为新的列表项，使 `1. 内容` 后按 Shift+Enter 正常生成 `2. `。

## 改动
- `apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx` — 调整 TipTap 输入框在列表项内的换行处理：列表项内不再插入 `HardBreak`，而是调用 `splitListItem('listItem')` 生成下一条列表项；普通段落、代码块、Mention/Suggestion 弹窗逻辑保持不变。
- `apps/electron/package.json` — 按仓库版本规则将 `@proma/electron` patch 版本递增到 `0.13.1`。
- `bun.lock` — 同步 workspace 版本元数据。

## 测试方法
1. 运行 `bun run typecheck`，确认所有 workspace 类型检查通过。
2. 在 Agent 输入框中输入 `1. 第一行内容`。
3. 按 `Shift+Enter`，确认下一行生成 `2. `，而不是缩进到上一条列表项内部。
4. 确认 `/@#&` 的补全面板触发与选择逻辑不受影响。

## 备注
- 已执行 Proma PR review 流程，未发现代码质量、类型安全或 Windows 兼容性问题。
- 本次修复只影响共享富文本输入框中“列表项内换行”的按键分支，不修改 Markdown 渲染转换逻辑。