### PR TITLE
fix(agent): 删除自动预览修改中文件开关【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/atoms/preview-atoms.ts
+++ b/apps/electron/src/renderer/atoms/preview-atoms.ts
@@ -38,9 +38,6 @@ export const previewFileMapAtom = atom<Map<string, PreviewFile | null>>(new Map(
 /** 分栏比例（对话占比），持久化 */
 export const previewSplitRatioAtom = atomWithStorage<number>('proma-preview-split-ratio', 0.5, undefined, { getOnInit: true })
 
-/** 自动预览开关，持久化（默认关闭以减轻设备性能负担，老用户保留已设置的偏好） */
-export const autoPreviewEnabledAtom = atomWithStorage<boolean>('proma-auto-preview-enabled', false, undefined, { getOnInit: true })
-
 /**
  * 预览默认展开方式，持久化。
  * - 'tab'   = 以预览标签页形式打开（旧版默认）

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -49,7 +49,7 @@ import {
 import { cn } from '@/lib/utils'
 import { getActiveAccelerator, getAcceleratorDisplay } from '@/lib/shortcut-registry'
 import { registerShortcut } from '@/lib/shortcut-registry'
-import { previewPanelOpenMapAtom, autoPreviewEnabledAtom, quotedSelectionMapAtom, currentQuotedSelectionAtom } from '@/atoms/preview-atoms'
+import { previewPanelOpenMapAtom, quotedSelectionMapAtom, currentQuotedSelectionAtom } from '@/atoms/preview-atoms'
 import {
   agentStreamingStatesAtom,
   agentSessionStreamingStateAtomFamily,
@@ -218,20 +218,15 @@ function AgentThinkingPopover({ agentThinking, onToggle }: AgentThinkingPopoverP
 }
 
 interface DisplayOptionsPopoverProps {
-  autoPreviewEnabled: boolean
   processGroupsKeepExpanded: boolean
-  onAutoPreviewChange: (enabled: boolean) => void
   onProcessGroupsKeepExpandedChange: (expanded: boolean) => void
 }
 
 function DisplayOptionsPopover({
-  autoPreviewEnabled,
   processGroupsKeepExpanded,
-  onAutoPreviewChange,
   onProcessGroupsKeepExpandedChange,
 }: DisplayOptionsPopoverProps): React.ReactElement {
   const [open, setOpen] = React.useState(false)
-  const hasEnabledOption = autoPreviewEnabled || processGroupsKeepExpanded
   const hoverTimeout = React.useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const handleMouseEnter = React.useCallback(() => {
@@ -258,13 +253,13 @@ function DisplayOptionsPopover({
           size="icon"
           className={cn(
             'size-[36px] rounded-full',
-            hasEnabledOption ? 'text-green-500' : 'text-foreground/60 hover:text-foreground'
+            processGroupsKeepExpanded ? 'text-green-500' : 'text-foreground/60 hover:text-foreground'
           )}
           aria-label="显示选项"
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
         >
-          <Eye className="size-5" />
+          <Eye className={cn('size-5', processGroupsKeepExpanded && 'text-green-500')} />
         </Button>
       </PopoverTrigger>
       <PopoverContent
@@ -277,15 +272,6 @@ function DisplayOptionsPopover({
         onMouseLeave={handleMouseLeave}
       >
         <div className="flex flex-col gap-1.5">
-          <div className="flex items-center justify-between gap-4">
-            <span className="text-xs text-foreground/70">自动预览修改中文件</span>
-            <Switch
-              checked={autoPreviewEnabled}
-              onCheckedChange={onAutoPreviewChange}
-              className="h-4 w-7 [&>span]:size-3 [&>span]:data-[state=checked]:translate-x-3"
-            />
-          </div>
-          <div className="h-px bg-border" />
           <div className="flex items-center justify-between gap-4">
             <span className="text-xs text-foreground/70">输出完保持展开</span>
             <Switch
@@ -1868,9 +1854,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     (allAskUserRequests.get(sessionId)?.length ?? 0) > 0 ||
     (allExitPlanRequests.get(sessionId)?.length ?? 0) > 0
 
-  // ===== 预览面板状态（toggle 快捷键 + auto-preview 设置，分屏布局在 MainArea） =====
+  // ===== 预览面板状态（toggle 快捷键，分屏布局在 MainArea） =====
   const setPreviewOpenMap = useSetAtom(previewPanelOpenMapAtom)
-  const [autoPreviewEnabled, setAutoPreviewEnabled] = useAtom(autoPreviewEnabledAtom)
   const [processGroupsKeepExpanded, setProcessGroupsKeepExpanded] = useAtom(agentProcessGroupsKeepExpandedAtom)
 
   const togglePreviewPanel = React.useCallback(() => {
@@ -1977,12 +1962,10 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       ),
     },
     {
-      key: 'auto-preview',
+      key: 'display-options',
       node: (
         <DisplayOptionsPopover
-          autoPreviewEnabled={autoPreviewEnabled}
           processGroupsKeepExpanded={processGroupsKeepExpanded}
-          onAutoPreviewChange={setAutoPreviewEnabled}
           onProcessGroupsKeepExpandedChange={setProcessGroupsKeepExpanded}
         />
       ),
@@ -2005,9 +1988,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     contextStatus.isCompacting,
     streaming,
     handleCompact,
-    autoPreviewEnabled,
     processGroupsKeepExpanded,
-    setAutoPreviewEnabled,
     setProcessGroupsKeepExpanded,
   ])
 

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -51,8 +51,8 @@ import {
 import { appModeAtom } from '@/atoms/app-mode'
 import { tabsAtom, activeTabIdAtom, openTab, updateTabTitle } from '@/atoms/tab-atoms'
 import type { AgentStreamState } from '@/atoms/agent-atoms'
-import { agentDiffUnseenChangesAtom, agentDiffUnseenFilesAtom, agentDiffPanelTabAtom, agentSidePanelOpenAtom } from '@/atoms/agent-atoms'
-import { autoPreviewEnabledAtom, previewPanelOpenMapAtom, previewFileMapAtom } from '@/atoms/preview-atoms'
+import { agentDiffUnseenChangesAtom, agentDiffUnseenFilesAtom } from '@/atoms/agent-atoms'
+import { previewFileMapAtom } from '@/atoms/preview-atoms'
 import type { NotificationSoundType } from '@/types/settings'
 import { toast } from 'sonner'
 import type { AgentStreamEvent, AgentStreamCompletePayload, AgentEvent, AgentStreamPayload, SDKAssistantMessage, SDKUserMessage, SDKSystemMessage, SDKContentBlock, SDKUserContentBlock, PromaEvent, AgentSessionMeta } from '@proma/shared'
@@ -443,7 +443,6 @@ export function useGlobalAgentListeners(): void {
     }
 
     const workspaceFilesPathCache = new Map<string, string>()
-    const autoPreviewSeq = new Map<string, number>()
 
     const getWorkspaceIdForSession = (sid: string): string | null => {
       const session = store.get(agentSessionsAtom).find((s) => s.id === sid)
@@ -470,7 +469,7 @@ export function useGlobalAgentListeners(): void {
       }
     }
 
-    const buildAutoPreviewFile = async (sid: string, targetPath: string) => {
+    const buildWrittenFilePreviewInfo = async (sid: string, targetPath: string) => {
       const sessionPath = store.get(agentSessionPathMapAtom).get(sid) ?? ''
       const parentDir = getParentDir(targetPath)
       const dirPath = isAbsolutePath(targetPath) ? parentDir : (sessionPath || parentDir)
@@ -531,28 +530,6 @@ export function useGlobalAgentListeners(): void {
         inDiffScope,
         basePaths: basePaths.length > 0 ? basePaths : undefined,
       }
-    }
-
-    const setAutoPreviewFile = (sid: string, targetPath: string, openPanel: boolean) => {
-      const seq = (autoPreviewSeq.get(sid) ?? 0) + 1
-      autoPreviewSeq.set(sid, seq)
-      return buildAutoPreviewFile(sid, targetPath)
-        .then((previewFile) => {
-          if (autoPreviewSeq.get(sid) !== seq) return null
-          store.set(previewFileMapAtom, (prev) => {
-            const m = new Map(prev)
-            m.set(sid, previewFile)
-            return m
-          })
-          if (openPanel) {
-            store.set(previewPanelOpenMapAtom, (prev) => {
-              if (prev.get(sid)) return prev
-              const m = new Map(prev); m.set(sid, true); return m
-            })
-          }
-          return previewFile
-        })
-        .catch(() => null)
     }
 
     // ===== 0. 初始化：从持久化 meta 恢复 stoppedByUser 状态 =====
@@ -691,10 +668,6 @@ export function useGlobalAgentListeners(): void {
                 map.set(sessionId, inner)
                 return map
               })
-              // Agent 开始改文件时，自动切换预览面板到该文件
-              if (store.get(autoPreviewEnabledAtom)) {
-                setAutoPreviewFile(sessionId, targetPath, false)
-              }
             }
           }
 
@@ -745,7 +718,7 @@ export function useGlobalAgentListeners(): void {
             store.set(backgroundTasksAtomFamily(sessionId), (prev) =>
               prev.filter((t) => t.toolUseId !== event.toolUseId)
             )
-            // Agent 写类工具完成时，递增 diff 刷新版本号并切换预览文件
+            // Agent 写类工具完成时，递增 diff 刷新版本号并标记未查看改动
             if (pendingWriteTools.has(event.toolUseId)) {
               const entry = pendingWriteTools.get(event.toolUseId)!
               const writtenPath = entry.path
@@ -754,12 +727,7 @@ export function useGlobalAgentListeners(): void {
                 const m = new Map(prev); m.set(sessionId, (prev.get(sessionId) ?? 0) + 1); return m
               })
               if (writtenPath) {
-                const autoPreviewEnabled = store.get(autoPreviewEnabledAtom)
-                const previewPromise = autoPreviewEnabled
-                  ? setAutoPreviewFile(sessionId, writtenPath, true)
-                  : buildAutoPreviewFile(sessionId, writtenPath)
-
-                previewPromise.then((previewFile) => {
+                buildWrittenFilePreviewInfo(sessionId, writtenPath).then((previewFile) => {
                   if (!previewFile || previewFile.previewOnly || !previewFile.inDiffScope) return
 
                   store.set(agentDiffUnseenChangesAtom, (prev) => {
@@ -773,27 +741,7 @@ export function useGlobalAgentListeners(): void {
                     return m
                   })
 
-                  // 只有当前文件确实能显示 git diff 时，才切到「文件改动」。
-                  if (autoPreviewEnabled && store.get(agentSidePanelOpenAtom)) {
-                    store.set(agentDiffPanelTabAtom, (prev) => {
-                      if (prev.get(sessionId) === 'changes') return prev
-                      const m = new Map(prev); m.set(sessionId, 'changes'); return m
-                    })
-                  }
-
-                  // auto-preview 已展示该文件，标记为已查看
-                  if (autoPreviewEnabled) {
-                    store.set(agentDiffUnseenFilesAtom, (prev) => {
-                      const s = prev.get(sessionId)
-                      if (!s?.has(writtenPath)) return prev
-                      const m = new Map(prev)
-                      const next = new Set(s)
-                      next.delete(writtenPath)
-                      m.set(sessionId, next)
-                      return m
-                    })
-                  }
-                }).catch(() => { /* auto preview should never break streaming */ })
+                }).catch(() => { /* 改动提示不应影响流式输出 */ })
               }
             }
             // Bash git 突变命令完成时，仅刷新 diff 列表（不标记 unseen，避免红点）


### PR DESCRIPTION
## 概述
删除 Agent 输入框显示选项中的「自动预览修改中文件」开关，并移除 Agent 写文件时自动切换/打开预览面板的行为。这样预览面板完全回到用户手动控制，避免 Agent 修改文件时打断当前输入和查看上下文。

## 改动
- `apps/electron/src/renderer/atoms/preview-atoms.ts` — 删除 `autoPreviewEnabledAtom` 及其 `proma-auto-preview-enabled` 持久化开关。
- `apps/electron/src/renderer/components/agent/AgentView.tsx` — 从输入框显示选项 Popover 中移除「自动预览修改中文件」开关，保留「输出完保持展开」选项。
- `apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts` — 移除写文件工具开始/完成时自动设置预览文件、打开预览面板、切换 diff tab、自动标记已查看的逻辑；保留文件自动定位、diff 刷新和未查看改动提示。
- `apps/electron/package.json` — 按仓库提交规范将 `@proma/electron` patch 版本从 `0.13.0` 递增到 `0.13.1`。

## 测试方法
1. 运行 `bun run typecheck`，确认所有 workspace 类型检查通过。
2. 运行 `git diff --check`，确认没有空白格式问题。
3. 全仓库搜索 `autoPreviewEnabled`、`autoPreviewEnabledAtom`、`setAutoPreviewFile`、`自动预览修改中文件`、`proma-auto-preview-enabled`，确认功能代码和文案均无残留。

## 备注
- 本 PR 保留手动文件预览、右侧预览面板、diff 刷新、文件浏览器自动定位和未查看改动提示能力。
- 已按 Review-Proma-PR 流程审查当前 diff，未发现代码质量、类型安全或 Windows 兼容性问题。