### PR TITLE
fix(renderer): 修复浅色主题代码块选区可读性（rebase #907）

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -1081,6 +1081,32 @@
   padding: 0;
 }
 
+/* 浅色主题代码块是深底，用偏浅的蓝灰选区承托白字，避免 Shiki token 内联色在选中后变黑。 */
+:root:not(.dark) :is(
+  .code-block-wrapper pre.shiki,
+  .tiptap pre
+)::selection,
+:root:not(.dark) :is(
+  .code-block-wrapper pre.shiki,
+  .tiptap pre
+) ::selection {
+  background-color: hsl(210 80% 62% / 0.32);
+  color: hsl(0 0% 98%) !important;
+  -webkit-text-fill-color: hsl(0 0% 98%);
+}
+
+:root:not(.dark) :is(
+  .code-block-wrapper pre.shiki,
+  .tiptap pre
+)::-moz-selection,
+:root:not(.dark) :is(
+  .code-block-wrapper pre.shiki,
+  .tiptap pre
+) ::-moz-selection {
+  background-color: hsl(210 80% 62% / 0.32);
+  color: hsl(0 0% 98%) !important;
+}
+
 /* 代码行：限制重排范围，GPU 合成优化 */
 .code-block-wrapper .line {
   display: inline;

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.13.1",
+      "version": "0.13.2",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.185",
         "@anthropic-ai/sdk": "^0.93.0",


### PR DESCRIPTION
将 #907 rebase 到最新 main 后重新提交（原 PR 来自 fork，分支无法直接更新）。

## 概述
为浅色主题下深底代码块新增专用 `::selection` / `::-moz-selection` 样式，避免 Shiki token 内联色在选中后变黑，统一浅蓝灰选区背景 + 高对比浅色文字。

## 与 #907 的差异
- 仅解决版本号冲突：`@proma/electron` 版本顺延为 **0.13.2**（main 已被 #908/#909 推到 0.13.1），`bun.lock` 同步。
- `globals.css` 功能改动与原 #907 完全一致，无逻辑变化。

Closes #907