### PR TITLE
fix(agent): 适配 SDK 0.3.185 iterator 终止语义，消除每会话 2s drain timeout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ proma-v2/
 #### @proma/electron (v0.9.5)
 - **职责**：Electron 桌面应用主体，集成所有包
 - **关键依赖**：
-  - `@anthropic-ai/claude-agent-sdk@0.3.143` - Agent SDK
+  - `@anthropic-ai/claude-agent-sdk@0.3.185` - Agent SDK
   - `@larksuiteoapi/node-sdk` - 飞书集成
   - Radix UI、TipTap、Tailwind CSS
   - 文件解析：`pdf-parse`、`officeparser`、`word-extractor`
@@ -135,7 +135,7 @@ bun run generate:icons    # 生成应用图标
 | **构建工具** | Vite | 6.0.3 |
 | **打包工具** | esbuild | 0.24.0+ |
 | **分发工具** | Electron Builder | 25.1.8 |
-| **Agent SDK** | @anthropic-ai/claude-agent-sdk | 0.3.143 |
+| **Agent SDK** | @anthropic-ai/claude-agent-sdk | 0.3.185 |
 | **飞书 SDK** | @larksuiteoapi/node-sdk | 最新 |
 
 ## 核心架构
@@ -390,7 +390,7 @@ bun run generate:icons    # 生成应用图标
 
 ## Agent SDK 集成架构
 
-基于 `@anthropic-ai/claude-agent-sdk@0.3.143` 实现 Agent 模式，与 Chat 模式并行。
+基于 `@anthropic-ai/claude-agent-sdk@0.3.185` 实现 Agent 模式，与 Chat 模式并行。
 
 ### 核心流程
 
@@ -461,6 +461,10 @@ React UI 更新
 - `0.2.120`: `query()` 省略 `settingSources` 时默认加载所有来源（Proma 已显式传 `['user', 'project']`，不受影响）
 - `0.3.142`: SDK/headless 默认使用 Task 工具（`TaskCreate` / `TaskUpdate` / `TaskGet` / `TaskList`）替代已废弃的 `TodoWrite`；MCP server 默认后台连接，慢连接会在 `init` 中呈现 `pending`
 - `0.3.143`: `@anthropic-ai/sdk` 与 `@modelcontextprotocol/sdk` 改为 peerDependencies；bun/npm/pnpm 会自动安装
+- `0.3.185`: **会话终止语义改变（重要）**。旧版链路「收到 result → `channel.close()` → SDK `endInput()` 关 stdin → 子进程 EOF 退出 → 输出流自然 yield done」已废弃（`Transport.close` 注释明确 "eliminating need for endInput"）。新版把终止逻辑全部挪进 `Query.cleanup()`，而 `cleanup()` **只在 `iterator.return()` 被调用时触发**（`next()` 仅透传，不会因输入关闭而自动 yield done）。
+  - **症状**：若 adapter 收到 terminal result 后只调 `channel.close()` 而不主动终止 iterator，输出流不会结束，消费循环挂在 `next()` 上，最终只能靠 orchestrator 的 2s drain timeout 兜底——表现为**每个会话结束都白等 2 秒**并打印 `drain timeout` 日志。
+  - **正确做法**：adapter（`claude-agent-adapter.ts`）收到非 keep-open 的 terminal result 后，在 yield 该消息后主动 `break` for-await 循环，触发 SDK `iterator.return()` → `cleanup()`（内部 `Promise.race([waitForExit(), 2s])` 有界等待子进程退出）。配合关闭 `promptSuggestions`（该消息在 result 之后到达，否则 break 会丢它）。
+  - orchestrator 的 `RESULT_DRAIN_TIMEOUT_MS` drain timeout 应退化为永不触发的兜底；若日志频繁出现 `drain timeout`，说明 adapter 主动终止路径失效，需排查。
 
 ### 共享类型（`@proma/shared`）
 

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
@@ -738,7 +738,11 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
         allowDangerouslySkipPermissions: options.allowDangerouslySkipPermissions,
         // 关键：false 获取完整消息，与 v2 stream() 返回格式一致
         includePartialMessages: false,
-        promptSuggestions: true,
+        // 关闭 SDK 自动 prompt_suggestion：它在每轮 result 之后才到达，是旧版「收到 result 后
+        // 仍需等 2s 尾部消息」约束的根源。关闭后 result 即本轮最后一条消息，adapter 可在 result
+        // 后立即主动终止 iterator（见下方终止分支）。Plan 模式的「请执行该计划」建议由
+        // orchestrator 自行注入，不依赖此选项，故功能不受影响。
+        promptSuggestions: false,
         cwd: options.cwd,
         abortController: controller,
         env: options.env,
@@ -861,6 +865,15 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
         queryReadyResolvers.delete(options.sessionId)
       }
 
+      // 终止标记：收到非 keep-open 的 terminal result 后置 true，yield 该 result 后主动 break。
+      // SDK 0.3.185 把会话终止逻辑挪进了 cleanup()，而 cleanup() 只在 iterator.return() 被调用时
+      // 触发（旧版「关 stdin → 子进程 EOF 退出 → 输出流自然 done」的链路已废弃，见 Transport.close
+      // 注释 "eliminating need for endInput"）。for-await 的 break 会自动对 SDK iterator 调
+      // .return()，进而触发 cleanup（内部 Promise.race([waitForExit(), 2s]) 有界），让子进程退出、
+      // 输出流结束。这样 orchestrator 的 next() 立即拿到 done:true 走自然退出路径，无需再依赖其
+      // 2s drain timeout 兜底。promptSuggestions 已关闭，result 即本轮最后一条消息，break 不会丢消息。
+      let terminateAfterTerminalResult = false
+
       for await (const sdkMessage of queryIterator) {
         if (controller.signal.aborted) break
 
@@ -924,15 +937,23 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
             // 任务活动会持续重置计时器，仅在长时间彻底静默时兜底释放子进程，避免叠加场景下子进程泄漏。
             if (keepForTasks) armIdleTimer()
           } else {
-            // result 表示本轮真正结束，关闭消息通道让 SDK 自然调用 endInput() 关闭 stdin。
-            // 子进程检测到 stdin EOF 后会退出，readMessages() 结束，iterator 返回 done:true。
-            // 注意：prompt_suggestion 等尾部消息仍会通过 stdout 正常传递，不受影响。
+            // result 表示本轮真正结束。先关闭消息通道（让 SDK 不再读取新输入），
+            // 再标记 terminateAfterTerminalResult，在 yield 本条 result 后主动 break 出循环。
+            // break 会对 SDK iterator 调 .return() → 触发 SDK cleanup（关闭 in-process MCP 传输 +
+            // 有界等待子进程退出），输出流随即结束。SDK 0.3.185 已不再走「stdin EOF → 自然 done」
+            // 链路（见 Transport.close 注释），必须由 .return() 驱动终止，否则会挂在 next() 上、
+            // 只能靠 orchestrator 的 2s drain timeout 兜底。promptSuggestions 已关闭，result 即
+            // 本轮最后一条消息，break 不会丢失尾部消息。
             clearIdleTimer()
             channel.close()
+            terminateAfterTerminalResult = true
           }
         }
 
         yield sdkMessage as SDKMessage
+
+        // terminal result 已 yield，主动结束循环触发 SDK iterator 的优雅清理
+        if (terminateAfterTerminalResult) break
       }
     } finally {
       // 注意：pidMap 的清理由 child.on('exit') 触发，不在这里清除

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -1647,8 +1647,11 @@ export class AgentOrchestrator {
           let pendingNext: Promise<IteratorResult<SDKMessage>> | null = null
           // 捕获 result.subtype 以传递给前端（用于区分 success/error_max_turns/error_max_budget_usd）
           let capturedResultSubtype: string | undefined
-          // result 收到后的安全超时：adapter 层 channel.close() 应让 iterator 自然关闭，
-          // 此 timeout 仅作安全网，防止极端情况下 iterator 仍未关闭
+          // result 收到后的安全超时：正常情况下 adapter 收到 terminal result 后会主动 break 自己的
+          // for-await 循环（触发 SDK iterator.return → cleanup），让此处的 next() 立即拿到 done。
+          // 此 timeout 仅作真正的兜底安全网，防止极端情况（SDK 行为再次变化等）下 iterator 不关闭、
+          // 事件循环无限挂起。正常运行下不应触发——若日志频繁出现 drain timeout，说明 adapter 主动
+          // 终止路径失效，需排查。
           let drainTimeoutPromise: Promise<'drain_timeout'> | null = null
           const RESULT_DRAIN_TIMEOUT_MS = 2_000
           // 后台任务等待态：result 走轻量完成后置 true，下一轮真正开始（收到 assistant/user/task 消息）时
@@ -1865,8 +1868,9 @@ export class AgentOrchestrator {
                 awaitingBackgroundWake = true
                 idleComplete(getAgentSessionMessages(sessionId), { startedAt: streamStartedAt, resultSubtype: capturedResultSubtype })
               } else if (!keepChannelOpen && !drainTimeoutPromise) {
-                // 启动 drain 超时安全网：adapter 层 channel.close() 应让 iterator 自然关闭，
-                // 此处仅在极端情况下（如 SDK 版本不兼容）保护事件循环不无限挂起
+                // 启动 drain 超时安全网：正常情况下 adapter 收到 terminal result 会主动 break
+                // 触发 iterator.return → 下一次 next() 立即返回 done，此 timeout 不会触发。
+                // 仅在极端情况下（adapter 主动终止失效、SDK 行为再次变化）保护事件循环不无限挂起。
                 drainTimeoutPromise = new Promise((resolve) =>
                   setTimeout(() => resolve('drain_timeout'), RESULT_DRAIN_TIMEOUT_MS),
                 )


### PR DESCRIPTION
## Summary

- 43eaeed fix(agent): 适配 SDK 0.3.185 iterator 终止语义，消除每会话 2s drain timeout

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归