### PR TITLE
feat(ui): 新增经典/现代界面风格切换【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -1445,8 +1445,12 @@ export function registerIpcHandlers(): void {
       }
 
       // 主题相关设置变化时，广播给所有窗口（跨窗口同步，如 Quick Task 面板）
-      if (updates.themeMode !== undefined || updates.themeStyle !== undefined) {
-        const payload = { themeMode: result.themeMode, themeStyle: result.themeStyle }
+      if (updates.themeMode !== undefined || updates.themeStyle !== undefined || updates.interfaceVariant !== undefined) {
+        const payload = {
+          themeMode: result.themeMode,
+          themeStyle: result.themeStyle,
+          interfaceVariant: result.interfaceVariant,
+        }
         BrowserWindow.getAllWindows().forEach((win) => {
           // 跳过发起者窗口，避免重复应用
           if (win.webContents.id !== event.sender.id) {

--- a/apps/electron/src/main/lib/settings-service.ts
+++ b/apps/electron/src/main/lib/settings-service.ts
@@ -7,7 +7,7 @@
 
 import { readFileSync, writeFileSync, existsSync } from 'node:fs'
 import { getSettingsPath } from './config-paths'
-import { DEFAULT_THEME_MODE } from '../../types'
+import { DEFAULT_INTERFACE_VARIANT, DEFAULT_THEME_MODE } from '../../types'
 import type { AppSettings } from '../../types'
 
 /**
@@ -21,6 +21,7 @@ export function getSettings(): AppSettings {
   if (!existsSync(filePath)) {
     return {
       themeMode: DEFAULT_THEME_MODE,
+      interfaceVariant: DEFAULT_INTERFACE_VARIANT,
       onboardingCompleted: false,
       environmentCheckSkipped: false,
       notificationsEnabled: true,
@@ -35,6 +36,7 @@ export function getSettings(): AppSettings {
     return {
       ...data,
       themeMode: data.themeMode || DEFAULT_THEME_MODE,
+      interfaceVariant: data.interfaceVariant || DEFAULT_INTERFACE_VARIANT,
       onboardingCompleted: data.onboardingCompleted ?? false,
       environmentCheckSkipped: data.environmentCheckSkipped ?? false,
       notificationsEnabled: data.notificationsEnabled ?? true,
@@ -45,6 +47,7 @@ export function getSettings(): AppSettings {
     console.error('[设置] 读取失败:', error)
     return {
       themeMode: DEFAULT_THEME_MODE,
+      interfaceVariant: DEFAULT_INTERFACE_VARIANT,
       onboardingCompleted: false,
       environmentCheckSkipped: false,
       notificationsEnabled: true,

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -328,7 +328,7 @@ export interface ElectronAPI {
   onSystemThemeChanged: (callback: (isDark: boolean) => void) => () => void
 
   /** 订阅用户手动切换主题事件（跨窗口同步，返回清理函数） */
-  onThemeSettingsChanged: (callback: (payload: { themeMode: string; themeStyle: string }) => void) => () => void
+  onThemeSettingsChanged: (callback: (payload: { themeMode: string; themeStyle: string; interfaceVariant?: string }) => void) => () => void
 
   // ===== Scratch Pad =====
 
@@ -1295,8 +1295,8 @@ const electronAPI: ElectronAPI = {
     return () => { ipcRenderer.removeListener(SETTINGS_IPC_CHANNELS.ON_SYSTEM_THEME_CHANGED, listener) }
   },
 
-  onThemeSettingsChanged: (callback: (payload: { themeMode: string; themeStyle: string }) => void) => {
-    const listener = (_: unknown, payload: { themeMode: string; themeStyle: string }): void => callback(payload)
+  onThemeSettingsChanged: (callback: (payload: { themeMode: string; themeStyle: string; interfaceVariant?: string }) => void) => {
+    const listener = (_: unknown, payload: { themeMode: string; themeStyle: string; interfaceVariant?: string }): void => callback(payload)
     ipcRenderer.on(SETTINGS_IPC_CHANNELS.ON_THEME_SETTINGS_CHANGED, listener)
     return () => { ipcRenderer.removeListener(SETTINGS_IPC_CHANNELS.ON_THEME_SETTINGS_CHANGED, listener) }
   },

--- a/apps/electron/src/renderer/atoms/theme.ts
+++ b/apps/electron/src/renderer/atoms/theme.ts
@@ -11,11 +11,12 @@
  */
 
 import { atom } from 'jotai'
-import { THEME_STYLES, type ThemeMode, type ThemeStyle } from '../../types'
+import { DEFAULT_INTERFACE_VARIANT, THEME_STYLES, type InterfaceVariant, type ThemeMode, type ThemeStyle } from '../../types'
 
 /** localStorage 缓存键 */
 const THEME_CACHE_KEY = 'proma-theme-mode'
 const THEME_STYLE_CACHE_KEY = 'proma-theme-style'
+const INTERFACE_VARIANT_CACHE_KEY = 'proma-interface-variant'
 
 /**
  * 从 localStorage 读取缓存的主题模式
@@ -48,6 +49,21 @@ function getCachedThemeStyle(): ThemeStyle {
 }
 
 /**
+ * 从 localStorage 读取缓存的界面风格
+ */
+function getCachedInterfaceVariant(): InterfaceVariant {
+  try {
+    const cached = localStorage.getItem(INTERFACE_VARIANT_CACHE_KEY)
+    if (cached === 'classic' || cached === 'modern') {
+      return cached
+    }
+  } catch {
+    // localStorage 不可用时忽略
+  }
+  return DEFAULT_INTERFACE_VARIANT
+}
+
+/**
  * 缓存主题模式到 localStorage
  */
 function cacheThemeMode(mode: ThemeMode): void {
@@ -69,11 +85,25 @@ function cacheThemeStyle(style: ThemeStyle): void {
   }
 }
 
+/**
+ * 缓存界面风格到 localStorage
+ */
+function cacheInterfaceVariant(variant: InterfaceVariant): void {
+  try {
+    localStorage.setItem(INTERFACE_VARIANT_CACHE_KEY, variant)
+  } catch {
+    // localStorage 不可用时忽略
+  }
+}
+
 /** 用户选择的主题模式 */
 export const themeModeAtom = atom<ThemeMode>(getCachedThemeMode())
 
 /** 用户选择的特殊风格 */
 export const themeStyleAtom = atom<ThemeStyle>(getCachedThemeStyle())
+
+/** 用户选择的界面风格 */
+export const interfaceVariantAtom = atom<InterfaceVariant>(getCachedInterfaceVariant())
 
 /** 系统当前是否为深色模式 */
 export const systemIsDarkAtom = atom<boolean>(true)
@@ -151,6 +181,28 @@ export function applyThemeToDOM(themeMode: ThemeMode, themeStyle: ThemeStyle = '
 }
 
 /**
+ * 应用界面风格到 DOM
+ */
+export function applyInterfaceVariantToDOM(variant: InterfaceVariant = DEFAULT_INTERFACE_VARIANT): void {
+  const html = document.documentElement
+  const targetClass = variant === 'classic' ? 'ui-classic' : 'ui-modern'
+  const currentClass = html.classList.contains('ui-classic')
+    ? 'ui-classic'
+    : html.classList.contains('ui-modern')
+      ? 'ui-modern'
+      : null
+
+  if (currentClass === targetClass) {
+    return
+  }
+
+  if (currentClass) {
+    html.classList.remove(currentClass)
+  }
+  html.classList.add(targetClass)
+}
+
+/**
  * 初始化主题系统
  *
  * 从主进程加载设置，监听系统主题变化。
@@ -160,6 +212,7 @@ export async function initializeTheme(
   setThemeMode: (mode: ThemeMode) => void,
   setSystemIsDark: (isDark: boolean) => void,
   setThemeStyle?: (style: ThemeStyle) => void,
+  setInterfaceVariant?: (variant: InterfaceVariant) => void,
 ): Promise<() => void> {
   // 从主进程加载持久化设置
   const settings = await window.electronAPI.getSettings()
@@ -171,6 +224,12 @@ export async function initializeTheme(
     setThemeStyle(settings.themeStyle)
     cacheThemeStyle(settings.themeStyle)
   }
+
+  const interfaceVariant = settings.interfaceVariant || DEFAULT_INTERFACE_VARIANT
+  if (setInterfaceVariant) {
+    setInterfaceVariant(interfaceVariant)
+  }
+  cacheInterfaceVariant(interfaceVariant)
 
   // 获取系统主题
   const isDark = await window.electronAPI.getSystemTheme()
@@ -185,11 +244,16 @@ export async function initializeTheme(
   const cleanupThemeSettings = window.electronAPI.onThemeSettingsChanged((payload) => {
     const mode = payload.themeMode as ThemeMode
     const style = (payload.themeStyle || 'default') as ThemeStyle
+    const variant = (payload.interfaceVariant || DEFAULT_INTERFACE_VARIANT) as InterfaceVariant
     setThemeMode(mode)
     cacheThemeMode(mode)
     if (setThemeStyle) {
       setThemeStyle(style)
       cacheThemeStyle(style)
+    }
+    if (setInterfaceVariant) {
+      setInterfaceVariant(variant)
+      cacheInterfaceVariant(variant)
     }
   })
 
@@ -215,4 +279,12 @@ export async function updateThemeMode(mode: ThemeMode): Promise<void> {
 export async function updateThemeStyle(style: ThemeStyle): Promise<void> {
   cacheThemeStyle(style)
   await window.electronAPI.updateSettings({ themeStyle: style })
+}
+
+/**
+ * 更新界面风格并持久化
+ */
+export async function updateInterfaceVariant(variant: InterfaceVariant): Promise<void> {
+  cacheInterfaceVariant(variant)
+  await window.electronAPI.updateSettings({ interfaceVariant: variant })
 }

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -34,6 +34,7 @@ import {
   fileBrowserAutoRevealAtom,
   agentSelectedWorktreeAtom,
 } from '@/atoms/agent-atoms'
+import { interfaceVariantAtom } from '@/atoms/theme'
 import { previewFileMapAtom } from '@/atoms/preview-atoms'
 import { useOpenPreview } from '@/components/diff/preview-opener'
 import { detectIsWindows } from '@/lib/platform'
@@ -393,11 +394,14 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   basePathsRef.current = [sessionPath, workspaceFilesPath, ...fileAccessPathsMemo].filter(Boolean) as string[]
   const hasSessionAttachedItems = attachedDirs.length > 0 || attachedFiles.length > 0
   const hasWorkspaceAttachedItems = wsAttachedDirs.length > 0 || wsAttachedFiles.length > 0
+  const interfaceVariant = useAtomValue(interfaceVariantAtom)
+  const isClassic = interfaceVariant === 'classic'
 
   return (
     <div
       className={cn(
-        'relative z-0 h-full flex-shrink-0 overflow-hidden titlebar-drag-region bg-content-area rounded-2xl shadow-xl dark:shadow-md',
+        'relative z-0 h-full flex-shrink-0 overflow-hidden titlebar-drag-region bg-content-area',
+        isClassic && 'rounded-2xl shadow-xl dark:shadow-md',
         shouldAnimate && 'transition-[width] duration-300 ease-in-out',
         isOpen ? '' : '!w-0',
       )}

--- a/apps/electron/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/electron/src/renderer/components/app-shell/AppShell.tsx
@@ -16,6 +16,7 @@ import { appModeAtom } from '@/atoms/app-mode'
 import { agentSidePanelWidthAtom, currentAgentSessionIdAtom, currentSessionSidePanelOpenAtom } from '@/atoms/agent-atoms'
 import { automationFormAtom } from '@/atoms/automation-atoms'
 import { activeViewAtom } from '@/atoms/active-view'
+import { interfaceVariantAtom } from '@/atoms/theme'
 import { WindowControls } from '@/components/WindowControls'
 import { detectIsWindows } from '@/lib/platform'
 import { cn } from '@/lib/utils'
@@ -37,6 +38,8 @@ export function AppShell({ contextValue }: AppShellProps): React.ReactElement {
   const currentSessionId = useAtomValue(currentAgentSessionIdAtom)
   const isPanelOpen = useAtomValue(currentSessionSidePanelOpenAtom)
   const automationForm = useAtomValue(automationFormAtom)
+  const interfaceVariant = useAtomValue(interfaceVariantAtom)
+  const isClassic = interfaceVariant === 'classic'
   // 定时任务表单打开时隐藏右侧文件面板，让中间区域扩展到全宽（表单内含自己的右栏配置）
   const activeView = useAtomValue(activeViewAtom)
   const showRightPanel = appMode === 'agent' && !!currentSessionId && !automationForm.open && activeView !== 'automations' && activeView !== 'agent-skills'
@@ -99,24 +102,41 @@ export function AppShell({ contextValue }: AppShellProps): React.ReactElement {
       <WindowControls />
 
       <div className="shell-bg h-screen w-screen flex overflow-hidden bg-gradient-to-br from-zinc-50 to-zinc-100 dark:from-zinc-950 dark:to-zinc-900">
-        {/* 左侧边栏：可折叠，带圆角和内边距 */}
-        <div className="p-2 pr-0 relative z-[60] crt-sidebar">
+        {/* 左侧边栏：可折叠 */}
+        <div className={cn(isClassic ? 'p-2 pr-0' : '', 'relative z-[60] crt-sidebar')}>
           <LeftSidebar />
         </div>
+        {!isClassic && (
+          <div aria-hidden="true" className="relative z-[61] w-px flex-shrink-0 bg-border/80 dark:bg-border/70" />
+        )}
 
         {/* 中间容器：relative z-[60] 使其在 z-50 拖动区域之上 */}
-        <div className="flex-1 min-w-0 p-2 relative z-[60]">
+        <div className={cn('flex-1 min-w-0 relative z-[60]', isClassic && 'p-2')}>
           {/* 主内容区域（TabBar + TabContent） */}
           <MainArea />
         </div>
 
-        {/* 右侧边栏：Agent 文件面板，拖拽手柄在间距中间 */}
+        {/* 右侧边栏：Agent 文件面板 */}
         {showRightPanel && (
-          <div className={cn('relative z-[60] flex items-stretch transition-[padding] duration-300 ease-in-out crt-sidebar', isPanelOpen ? 'p-2 pl-0' : 'p-0')}>
-            {/* 拖拽手柄 — 绝对定位，居中于主区域和右侧面板的缝隙 */}
+          <div
+            className={cn(
+              'relative z-[60] flex items-stretch crt-sidebar',
+              isClassic
+                ? 'transition-[padding] duration-300 ease-in-out'
+                : '',
+              isClassic && (isPanelOpen ? 'p-2 pl-0' : 'p-0')
+            )}
+          >
+            {!isClassic && (
+              <div aria-hidden="true" className="pointer-events-none absolute left-0 top-0 bottom-0 z-10 w-px bg-border/80 dark:bg-border/70" />
+            )}
+            {/* 拖拽手柄 */}
             {isPanelOpen && (
               <div
-                className="absolute left-0 top-0 bottom-0 w-[8px] -translate-x-1/2 cursor-col-resize active:bg-primary/50 transition-colors z-10"
+                className={cn(
+                  'absolute left-0 top-0 bottom-0 w-[8px] -translate-x-1/2 cursor-col-resize active:bg-primary/50 transition-colors',
+                  isClassic ? 'z-10' : 'z-20'
+                )}
                 onMouseDown={handleMouseDown}
               />
             )}

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -81,6 +81,7 @@ import { hasUpdateAtom } from '@/atoms/updater'
 import { draftSessionIdsAtom } from '@/atoms/draft-session-atoms'
 import { hasEnvironmentIssuesAtom } from '@/atoms/environment'
 import { promptConfigAtom, selectedPromptIdAtom, conversationPromptIdAtom } from '@/atoms/system-prompt-atoms'
+import { interfaceVariantAtom } from '@/atoms/theme'
 import { useOpenSession } from '@/hooks/useOpenSession'
 import { useSyncActiveTabSideEffects } from '@/hooks/useSyncActiveTabSideEffects'
 import { CollapsedWorkspacePopover } from '@/components/agent/CollapsedWorkspacePopover'
@@ -466,6 +467,8 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   const hasEnvironmentIssues = useAtomValue(hasEnvironmentIssuesAtom)
   const promptConfig = useAtomValue(promptConfigAtom)
   const setSelectedPromptId = useSetAtom(selectedPromptIdAtom)
+  const interfaceVariant = useAtomValue(interfaceVariantAtom)
+  const isClassic = interfaceVariant === 'classic'
 
   // Agent 模式状态
   const [agentSessions, setAgentSessions] = useAtom(agentSessionsAtom)
@@ -1622,7 +1625,12 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   if (sidebarCollapsed) {
     return (
       <div
-        className="relative h-full flex flex-col items-center bg-background rounded-2xl shadow-xl dark:shadow-md transition-[width] duration-300 px-2"
+        className={cn(
+          'relative h-full flex flex-col items-center transition-[width] duration-300 px-2',
+          isClassic
+            ? 'bg-background rounded-2xl shadow-xl dark:shadow-md'
+            : 'bg-[hsl(var(--sidebar-surface))]'
+        )}
         style={{ width: 60, flexShrink: 0 }}
       >
         <SidebarWindowDragStrip
@@ -1833,7 +1841,12 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   // ===== 展开状态：完整侧边栏 =====
   return (
     <div
-      className="relative h-full flex flex-col bg-background rounded-2xl shadow-xl dark:shadow-md transition-[width] duration-300"
+      className={cn(
+        'relative h-full flex flex-col transition-[width] duration-300',
+        isClassic
+          ? 'bg-background rounded-2xl shadow-xl dark:shadow-md'
+          : 'bg-[hsl(var(--sidebar-surface))]'
+      )}
       style={{ width: width ?? 300, minWidth: 200, flexShrink: 1 }}
     >
       <SidebarWindowDragStrip
@@ -1852,7 +1865,12 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
           <TooltipTrigger asChild>
             <button
               onClick={() => setSidebarCollapsed(true)}
-              className="mt-2 size-10 flex-shrink-0 flex items-center justify-center rounded-[10px] bg-muted text-foreground/40 hover:bg-foreground/[0.08] hover:text-foreground/60 transition-colors titlebar-no-drag"
+              className={cn(
+                'sidebar-collapse-button mt-2 size-10 flex-shrink-0 flex items-center justify-center rounded-[10px] text-foreground/40 titlebar-no-drag',
+                isClassic
+                  ? 'bg-muted hover:bg-foreground/[0.08] hover:text-foreground/60 transition-colors'
+                  : 'bg-primary/5 hover:bg-primary/10 hover:text-foreground/60 transition-[background-color,border-color,color] duration-150 border border-border/60 hover:border-border'
+              )}
             >
               <PanelLeftClose size={14} />
             </button>
@@ -2487,6 +2505,8 @@ const ConversationItem = React.memo(function ConversationItem({
   const justStartedEditing = React.useRef(false)
   // 菜单打开时关闭迷你地图预览，避免预览面板盖住菜单项导致点不动
   const preview = useSessionMiniMapHover(600, menuOpen)
+  const interfaceVariant = useAtomValue(interfaceVariantAtom)
+  const isClassic = interfaceVariant === 'classic'
 
   /** 进入编辑模式 */
   const startEdit = (): void => {
@@ -2574,7 +2594,7 @@ const ConversationItem = React.memo(function ConversationItem({
             active && 'bg-foreground/[0.08]',
           )}
         >
-          {(streaming || active) && (
+          {(streaming || (isClassic && active)) && (
             <span
               className={cn(
                 'absolute inset-y-0 left-0 w-[3px] rounded-l-md pointer-events-none',
@@ -2710,6 +2730,8 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
   const justStartedEditing = React.useRef(false)
   // 菜单打开时关闭迷你地图预览，避免预览面板盖住菜单项导致点不动
   const preview = useSessionMiniMapHover(600, disableMiniMap || menuOpen)
+  const interfaceVariant = useAtomValue(interfaceVariantAtom)
+  const isClassic = interfaceVariant === 'classic'
 
   const startEdit = (): void => {
     setEditTitle(session.title)
@@ -2800,7 +2822,7 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
             active && leftAccent !== 'orange' && 'bg-foreground/[0.08]',
           )}
         >
-          {(leftAccent || active) && (
+          {(leftAccent || (isClassic && active)) && (
             <span
               className={cn(
                 'absolute inset-y-0 left-0 w-[3px] rounded-l-md pointer-events-none',

--- a/apps/electron/src/renderer/components/app-shell/ModeSwitcher.tsx
+++ b/apps/electron/src/renderer/components/app-shell/ModeSwitcher.tsx
@@ -14,6 +14,7 @@ import { appModeAtom, type AppMode } from '@/atoms/app-mode'
 import { conversationsAtom, currentConversationIdAtom } from '@/atoms/chat-atoms'
 import { agentSessionsAtom, currentAgentSessionIdAtom } from '@/atoms/agent-atoms'
 import { tabsAtom } from '@/atoms/tab-atoms'
+import { interfaceVariantAtom } from '@/atoms/theme'
 import { useOpenSession } from '@/hooks/useOpenSession'
 import { Bot, MessageSquare } from 'lucide-react'
 import { cn } from '@/lib/utils'
@@ -31,6 +32,8 @@ export function ModeSwitcher(): React.ReactElement {
   const currentConversationId = useAtomValue(currentConversationIdAtom)
   const currentAgentSessionId = useAtomValue(currentAgentSessionIdAtom)
   const tabs = useAtomValue(tabsAtom)
+  const interfaceVariant = useAtomValue(interfaceVariantAtom)
+  const isClassic = interfaceVariant === 'classic'
 
   /** 尝试恢复目标模式下的上一个对话/会话，按优先级 fallback */
   const restoreSession = React.useCallback((targetMode: AppMode) => {
@@ -69,7 +72,12 @@ export function ModeSwitcher(): React.ReactElement {
 
   return (
     <div className="pt-2 titlebar-drag-region select-none">
-      <div className="relative flex rounded-xl bg-muted p-1 titlebar-drag-region mode-switcher-track">
+      <div
+        className={cn(
+          'relative flex rounded-xl p-1 titlebar-drag-region mode-switcher-track',
+          isClassic ? 'bg-muted' : 'bg-primary/5'
+        )}
+      >
         {/* 滑动背景指示器 */}
         <div
           className={cn(

--- a/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
@@ -10,6 +10,7 @@ import { PanelRightClose } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { agentDiffUnseenChangesAtom, currentAgentSessionIdAtom } from '@/atoms/agent-atoms'
+import { interfaceVariantAtom } from '@/atoms/theme'
 
 type DiffPanelTab = 'session' | 'workspace' | 'changes'
 
@@ -28,6 +29,8 @@ export function DiffPanelTabBar({ activeTab, onTabChange, onClose }: DiffPanelTa
   const unseenMap = useAtomValue(agentDiffUnseenChangesAtom)
   const setUnseenMap = useSetAtom(agentDiffUnseenChangesAtom)
   const currentSessionId = useAtomValue(currentAgentSessionIdAtom)
+  const interfaceVariant = useAtomValue(interfaceVariantAtom)
+  const isClassic = interfaceVariant === 'classic'
   const unseenChanges = unseenMap.get(currentSessionId ?? '') ?? false
   const prevTabStateRef = React.useRef<PreviousTabState>({ sessionId: currentSessionId, activeTab })
 
@@ -65,11 +68,16 @@ export function DiffPanelTabBar({ activeTab, onTabChange, onClose }: DiffPanelTa
           type="button"
           onClick={() => onTabChange('session')}
           className={cn(
-            'flex-1 px-3 h-[34px] rounded-t-lg text-xs transition-colors select-none cursor-pointer',
+            'flex-1 px-3 h-[34px] text-xs transition-colors select-none cursor-pointer',
+            isClassic ? 'rounded-t-lg' : 'rounded-none',
             'border-t border-l border-r',
             activeTab === 'session'
-              ? 'bg-content-area text-foreground border-border/50'
-              : 'text-muted-foreground border-transparent hover:text-foreground hover:bg-muted/50',
+              ? isClassic
+                ? 'bg-content-area text-foreground border-border/50'
+                : 'app-tab-active text-foreground border-border/80'
+              : isClassic
+                ? 'text-muted-foreground border-transparent hover:text-foreground hover:bg-muted/50'
+                : 'app-tab-inactive text-muted-foreground border-transparent hover:text-foreground',
           )}
         >
           会话文件
@@ -78,11 +86,16 @@ export function DiffPanelTabBar({ activeTab, onTabChange, onClose }: DiffPanelTa
           type="button"
           onClick={() => onTabChange('workspace')}
           className={cn(
-            'flex-1 px-3 h-[34px] rounded-t-lg text-xs transition-colors select-none cursor-pointer',
+            'flex-1 px-3 h-[34px] text-xs transition-colors select-none cursor-pointer',
+            isClassic ? 'rounded-t-lg' : 'rounded-none',
             'border-t border-l border-r',
             activeTab === 'workspace'
-              ? 'bg-content-area text-foreground border-border/50'
-              : 'text-muted-foreground border-transparent hover:text-foreground hover:bg-muted/50',
+              ? isClassic
+                ? 'bg-content-area text-foreground border-border/50'
+                : 'app-tab-active text-foreground border-border/80'
+              : isClassic
+                ? 'text-muted-foreground border-transparent hover:text-foreground hover:bg-muted/50'
+                : 'app-tab-inactive text-muted-foreground border-transparent hover:text-foreground',
           )}
         >
           工作区文件
@@ -91,11 +104,16 @@ export function DiffPanelTabBar({ activeTab, onTabChange, onClose }: DiffPanelTa
           type="button"
           onClick={handleChangesClick}
           className={cn(
-            'flex-1 px-3 h-[34px] rounded-t-lg text-xs transition-colors select-none cursor-pointer relative',
+            'flex-1 px-3 h-[34px] text-xs transition-colors select-none cursor-pointer relative',
+            isClassic ? 'rounded-t-lg' : 'rounded-none',
             'border-t border-l border-r',
             activeTab === 'changes'
-              ? 'bg-content-area text-foreground border-border/50'
-              : 'text-muted-foreground border-transparent hover:text-foreground hover:bg-muted/50',
+              ? isClassic
+                ? 'bg-content-area text-foreground border-border/50'
+                : 'app-tab-active text-foreground border-border/80'
+              : isClassic
+                ? 'text-muted-foreground border-transparent hover:text-foreground hover:bg-muted/50'
+                : 'app-tab-inactive text-muted-foreground border-transparent hover:text-foreground',
           )}
         >
           <span className="inline-flex items-center gap-1">

--- a/apps/electron/src/renderer/components/settings/AppearanceSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AppearanceSettings.tsx
@@ -18,10 +18,13 @@ import {
 import {
   themeModeAtom,
   themeStyleAtom,
+  interfaceVariantAtom,
   systemIsDarkAtom,
   updateThemeMode,
   updateThemeStyle,
+  updateInterfaceVariant,
   applyThemeToDOM,
+  applyInterfaceVariantToDOM,
 } from '@/atoms/theme'
 import {
   markdownFontSizeAtom,
@@ -30,7 +33,7 @@ import {
 import { previewModePreferenceAtom, type PreviewModePreference } from '@/atoms/preview-atoms'
 import { cn } from '@/lib/utils'
 import { detectIsWindows } from '@/lib/platform'
-import type { ThemeMode, ThemeStyle, MarkdownFontSize } from '../../../types'
+import type { InterfaceVariant, ThemeMode, ThemeStyle, MarkdownFontSize } from '../../../types'
 
 // ===== Logo 资源导入（用于图标选择器） =====
 import promaBlackLogo from '@/assets/bots/proma-logos/proma-black.png'
@@ -62,6 +65,12 @@ const THEME_OPTIONS = [
   { value: 'dark', label: '深色' },
   { value: 'system', label: '跟随系统' },
   { value: 'special', label: '特殊风格' },
+]
+
+/** 界面风格选项 */
+const INTERFACE_VARIANT_OPTIONS: { value: InterfaceVariant; label: string }[] = [
+  { value: 'classic', label: '经典' },
+  { value: 'modern', label: '现代' },
 ]
 
 /** Markdown 字号选项 */
@@ -179,6 +188,7 @@ const ZOOM_HINT = isMac
 export function AppearanceSettings(): React.ReactElement {
   const [themeMode, setThemeMode] = useAtom(themeModeAtom)
   const [themeStyle, setThemeStyle] = useAtom(themeStyleAtom)
+  const [interfaceVariant, setInterfaceVariant] = useAtom(interfaceVariantAtom)
   const systemIsDark = useAtomValue(systemIsDarkAtom)
   const [markdownFontSize, setMarkdownFontSize] = useAtom(markdownFontSizeAtom)
   const [previewModePref, setPreviewModePref] = useAtom(previewModePreferenceAtom)
@@ -206,6 +216,14 @@ export function AppearanceSettings(): React.ReactElement {
     applyThemeToDOM('special', style, systemIsDark)
   }, [setThemeMode, setThemeStyle, systemIsDark])
 
+  /** 切换界面风格 */
+  const handleInterfaceVariantChange = React.useCallback((value: string) => {
+    const variant = value as InterfaceVariant
+    setInterfaceVariant(variant)
+    updateInterfaceVariant(variant)
+    applyInterfaceVariantToDOM(variant)
+  }, [setInterfaceVariant])
+
   /** 切换 Markdown 字号 */
   const handleMarkdownFontSizeChange = React.useCallback((value: string) => {
     const size = value as MarkdownFontSize
@@ -227,6 +245,14 @@ export function AppearanceSettings(): React.ReactElement {
             value={themeMode}
             onValueChange={handleThemeChange}
             options={THEME_OPTIONS}
+          />
+
+          <SettingsSegmentedControl
+            label="界面风格"
+            description="经典风保留旧版视觉；现代风使用更小圆角、更清晰分割线达成更统一干净的质感"
+            value={interfaceVariant}
+            onValueChange={handleInterfaceVariantChange}
+            options={INTERFACE_VARIANT_OPTIONS}
           />
 
           {/* 特殊风格 - 标签在上，卡片在下 */}

--- a/apps/electron/src/renderer/components/tabs/MainArea.tsx
+++ b/apps/electron/src/renderer/components/tabs/MainArea.tsx
@@ -21,6 +21,8 @@ import { AutomationsListView } from '@/components/automation/AutomationsListView
 import { AgentSkillsView } from '@/components/agent-skills/AgentSkillsView'
 import { automationFormAtom } from '@/atoms/automation-atoms'
 import { activeViewAtom } from '@/atoms/active-view'
+import { interfaceVariantAtom } from '@/atoms/theme'
+import { cn } from '@/lib/utils'
 
 export function MainArea(): React.ReactElement {
   // 记录每个会话上次停留的视图（对话 / 预览），供切回时重建预览 Tab
@@ -32,6 +34,8 @@ export function MainArea(): React.ReactElement {
   const activeTab = useAtomValue(activeTabAtom)
   const automationFormOpen = useAtomValue(automationFormAtom).open
   const activeView = useAtomValue(activeViewAtom)
+  const interfaceVariant = useAtomValue(interfaceVariantAtom)
+  const isClassic = interfaceVariant === 'classic'
 
   // Tab 内容渲染降级为非紧急：TabBar 立即高亮新 tab，主区域昂贵渲染（含 PreviewPanel 中
   // DiffTabContent → ProseMirror editor mount + Shiki tokenize）让出主线程，避免点击 tab
@@ -142,7 +146,7 @@ export function MainArea(): React.ReactElement {
     <>
       <Panel
         variant="grow"
-        className="bg-content-area rounded-2xl shadow-xl dark:shadow-sm"
+        className={cn('bg-content-area', isClassic && 'rounded-2xl shadow-xl dark:shadow-sm')}
       >
         <div className="flex flex-1 min-h-0 relative overflow-hidden" data-split-container>
           {/* 左侧：TabBar + TabContent（始终保持在同一 DOM 位置，避免 Tab 切换时 unmount）

--- a/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBarItem.tsx
@@ -14,6 +14,7 @@ import { cn } from '@/lib/utils'
 import type { TabType, TabMinimapItem } from '@/atoms/tab-atoms'
 import type { SessionIndicatorStatus } from '@/atoms/agent-atoms'
 import { tabMinimapCacheAtom } from '@/atoms/tab-atoms'
+import { interfaceVariantAtom } from '@/atoms/theme'
 import { TabPreviewPanel } from './TabPreviewPanel'
 
 export interface TabBarItemProps {
@@ -71,6 +72,8 @@ export function TabBarItem({
   const buttonRef = React.useRef<HTMLButtonElement>(null)
   const [isNarrow, setIsNarrow] = React.useState(false)
   const minimapCache = useAtomValue(tabMinimapCacheAtom)
+  const interfaceVariant = useAtomValue(interfaceVariantAtom)
+  const isClassic = interfaceVariant === 'classic'
 
   React.useEffect(() => {
     const el = buttonRef.current
@@ -124,11 +127,16 @@ export function TabBarItem({
           type="button"
           className={cn(
             'group relative flex items-center justify-center gap-1.5 min-w-[82px] px-3 h-[34px]',
-            'rounded-t-lg text-xs transition-colors select-none cursor-pointer',
+            isClassic ? 'rounded-t-lg' : 'rounded-none',
+            'text-xs transition-colors select-none cursor-pointer',
             'border-t border-l border-r border-transparent',
             isActive
-              ? 'bg-content-area text-foreground border-border/50'
-              : 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
+              ? isClassic
+                ? 'bg-content-area text-foreground border-border/50'
+                : 'app-tab-active text-foreground border-border/80'
+              : isClassic
+                ? 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
+                : 'app-tab-inactive text-muted-foreground hover:text-foreground',
           )}
           onClick={onActivate}
           onMouseDown={handleMouseDown}
@@ -152,11 +160,16 @@ export function TabBarItem({
         type="button"
         className={cn(
           'group relative flex items-center gap-1.5 px-3 h-[34px] w-full',
-          'rounded-t-lg text-xs transition-colors select-none cursor-pointer',
+          isClassic ? 'rounded-t-lg' : 'rounded-none',
+          'text-xs transition-colors select-none cursor-pointer',
           'border-t border-l border-r border-transparent',
           isActive
-            ? 'bg-content-area text-foreground border-border/50'
-            : 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
+            ? isClassic
+              ? 'bg-content-area text-foreground border-border/50'
+              : 'app-tab-active text-foreground border-border/80'
+            : isClassic
+              ? 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
+              : 'app-tab-inactive text-muted-foreground hover:text-foreground',
           isTearingOff && 'ring-2 ring-primary/70 ring-offset-0 bg-primary/10',
         )}
         onClick={onActivate}
@@ -207,7 +220,8 @@ export function TabBarItem({
         {indicatorColor && (
           <span
             className={cn(
-              'absolute inset-0 rounded-t-lg border-t-2 border-l-2 border-r-2 border-b-0 pointer-events-none tab-stream-indicator',
+              'absolute inset-0 border-t-2 border-l-2 border-r-2 border-b-0 pointer-events-none tab-stream-indicator',
+              isClassic ? 'rounded-t-lg' : 'rounded-none',
               indicatorColor,
             )}
             aria-hidden="true"

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -16,9 +16,11 @@ import App from './App'
 import {
   themeModeAtom,
   themeStyleAtom,
+  interfaceVariantAtom,
   systemIsDarkAtom,
   resolvedThemeAtom,
   applyThemeToDOM,
+  applyInterfaceVariantToDOM,
   initializeTheme,
 } from './atoms/theme'
 import {
@@ -91,9 +93,11 @@ const isDetachedPreviewWindow = new URLSearchParams(window.location.search).get(
 function ThemeInitializer(): null {
   const setThemeMode = useSetAtom(themeModeAtom)
   const setThemeStyle = useSetAtom(themeStyleAtom)
+  const setInterfaceVariant = useSetAtom(interfaceVariantAtom)
   const setSystemIsDark = useSetAtom(systemIsDarkAtom)
   const themeMode = useAtomValue(themeModeAtom)
   const themeStyle = useAtomValue(themeStyleAtom)
+  const interfaceVariant = useAtomValue(interfaceVariantAtom)
   const systemIsDark = useAtomValue(systemIsDarkAtom)
 
   // 初始化：从主进程加载设置 + 订阅系统主题变化
@@ -101,7 +105,7 @@ function ThemeInitializer(): null {
     let isMounted = true
     let cleanup: (() => void) | undefined
 
-    initializeTheme(setThemeMode, setSystemIsDark, setThemeStyle).then((fn) => {
+    initializeTheme(setThemeMode, setSystemIsDark, setThemeStyle, setInterfaceVariant).then((fn) => {
       if (isMounted) {
         cleanup = fn
       } else {
@@ -114,7 +118,7 @@ function ThemeInitializer(): null {
       isMounted = false
       cleanup?.()
     }
-  }, [setThemeMode, setSystemIsDark, setThemeStyle])
+  }, [setThemeMode, setSystemIsDark, setThemeStyle, setInterfaceVariant])
 
   // 响应式应用主题到 DOM
   // 用 useMemo 计算"实际会影响 DOM 的状态签名"作为唯一依赖：
@@ -134,6 +138,10 @@ function ThemeInitializer(): null {
     applyThemeToDOM(themeMode, themeStyle, systemIsDark)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [themeSignature])
+
+  useEffect(() => {
+    applyInterfaceVariantToDOM(interfaceVariant)
+  }, [interfaceVariant])
 
   return null
 }

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -72,12 +72,15 @@
 
 @layer base {
   /* ===== 全主题统一的几何与阴影 token =====
-   * --radius 基准 10px，按钮 sm/md/lg/xl 圆角全部由它派生（tailwind.config.js）；
+   * --radius 基准 6px，按钮 sm/md/lg/xl 圆角全部由它派生（tailwind.config.js）；
    * --shadow-* 五档语义阴影，由 :root（亮色）与 .dark（深色）分别定义，
    * 深色态额外加 inset 顶高光来制造"浮起"感（弥补黑底缺乏自然阴影的问题）。
    */
   :root {
-    --radius: 0.625rem;
+    --radius: 0.375rem;
+    --radius-cap: 6px;
+    --radius-xl-extra: 2px;
+    --radius-2xl-extra: 4px;
     --shadow-xs: 0 1px 1px 0 rgb(0 0 0 / 0.04);
     --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05), 0 1px 1px 0 rgb(0 0 0 / 0.04);
     --shadow-md: 0 4px 8px -2px rgb(0 0 0 / 0.08), 0 2px 4px -1px rgb(0 0 0 / 0.05), 0 0 0 1px rgb(0 0 0 / 0.04);
@@ -117,6 +120,10 @@
     --dialog: 0 0% 100%;
     --dialog-foreground: 0 0% 3.9%;
     --content-area: 0 0% 100%;            /* 主内容区域背景 */
+    --sidebar-surface: 60 14.3% 98.6%;    /* 默认浅色侧栏：RGB 252/252/251 */
+    --tabbar-surface: 60 14.3% 98.6%;     /* 默认浅色未选中 Tab 背景：RGB 252/252/251 */
+    --input-surface: 60 14.3% 98.6%;      /* 默认浅色输入框：RGB 252/252/251 */
+    --tab-surface: 0 0% 100%;             /* 与内容区域无缝衔接 */
     /* 毛玻璃 Tooltip：深色半透明背景 + 白色文字 */
     --tooltip: 0 0% 15%;
     --tooltip-foreground: 0 0% 98%;
@@ -154,6 +161,10 @@
     --dialog: 0 0% 12%;                   /* 设置弹窗：比背景更亮，悬浮感 */
     --dialog-foreground: 0 0% 98%;
     --content-area: 0 0% 7%;              /* 主内容区域背景 zinc-900 */
+    --sidebar-surface: 0 0% 7%;
+    --tabbar-surface: 0 0% 7%;
+    --input-surface: 0 0% 7%;
+    --tab-surface: 0 0% 7%;
     /* 毛玻璃 Tooltip：深色半透明背景 + 白色文字 */
     --tooltip: 0 0% 20%;
     --tooltip-foreground: 0 0% 98%;
@@ -189,6 +200,10 @@
     --popover-foreground: 210 30% 15%;    /* #1b2632 弹出前景 */
     --dialog: 0 0% 100%;                  /* #ffffff 弹窗背景 */
     --dialog-foreground: 210 30% 15%;     /* #1b2632 弹窗前景 */
+    --sidebar-surface: 205 35% 94%;
+    --tabbar-surface: 205 35% 94%;
+    --input-surface: 60 14.3% 98.6%;
+    --tab-surface: 205 30% 97%;
     --destructive: 0 84.2% 60.2%;         /* #ef4444 危险色 */
     --destructive-foreground: 0 0% 98%;   /* #fafafa 危险前景 */
     --stop-hover-bg: hsla(0, 80%, 60%, 0.12);
@@ -210,6 +225,9 @@
     --background: 210 12% 13%;            /* 侧边栏：深海玻璃，色相微存 */
     --foreground: 210 14% 92%;
     --content-area: 210 14% 9%;           /* 内容区：最深，专注 */
+    --sidebar-surface: 210 12% 13%;
+    --tabbar-surface: 210 12% 13%;
+    --input-surface: 210 12% 13%;
     --muted: 210 12% 17%;
     --muted-foreground: 210 10% 60%;
     --border: 210 14% 24%;                /* 与背景拉开 11% 亮度，hairline 后可见 */
@@ -264,6 +282,10 @@
     --popover-foreground: 150 25% 15%;    /* #1d3026 弹出前景 */
     --dialog: 140 15% 96%;                /* #f3f6f4 弹窗背景 */
     --dialog-foreground: 150 25% 15%;     /* #1d3026 弹窗前景 */
+    --sidebar-surface: 140 25% 95%;
+    --tabbar-surface: 140 25% 95%;
+    --input-surface: 60 14.3% 98.6%;
+    --tab-surface: 140 20% 97%;
     --destructive: 0 72% 51%;             /* #dc2828 危险色 */
     --destructive-foreground: 0 0% 100%;  /* #ffffff 危险前景 */
     --stop-hover-bg: hsla(0, 70%, 50%, 0.12);
@@ -285,6 +307,9 @@
     --background: 150 8% 14%;             /* 侧边栏：近中性灰 + 微微森绿余韵 */
     --foreground: 140 10% 92%;
     --content-area: 150 10% 9%;           /* 内容区：深林泥土 */
+    --sidebar-surface: 150 8% 14%;
+    --tabbar-surface: 150 8% 14%;
+    --input-surface: 150 8% 14%;
     --muted: 150 10% 17%;
     --muted-foreground: 145 8% 60%;
     --border: 150 12% 25%;
@@ -343,6 +368,10 @@
     --popover-foreground: 40 8% 18%;      /* #312f2a 弹出前景 */
     --dialog: 40 8% 94%;                  /* #f0efec 弹窗背景（主题色） */
     --dialog-foreground: 40 8% 18%;       /* #312f2a 弹窗前景 */
+    --sidebar-surface: 40 6% 88%;
+    --tabbar-surface: 40 6% 88%;
+    --input-surface: 60 14.3% 98.6%;
+    --tab-surface: 40 8% 94%;
     /* 功能色 */
     --destructive: 0 65% 50%;             /* #d43c3c 危险色 */
     --destructive-foreground: 0 0% 100%;  /* #ffffff 危险前景 */
@@ -363,6 +392,9 @@
     --background: 260 6% 12%;             /* #1d1b20 背景（侧边栏） */
     --foreground: 30 10% 90%;             /* #e9e6e3 温暖前景文字 */
     --content-area: 270 8% 9%;            /* #161418 内容区域 */
+    --sidebar-surface: 260 6% 12%;
+    --tabbar-surface: 260 6% 12%;
+    --input-surface: 260 6% 12%;
     /* 次要色 - 淡紫灰调 */
     --muted: 260 6% 16%;                  /* #272429 次要背景 */
     --muted-foreground: 30 8% 60%;        /* #9f9690 次要文字 */
@@ -407,6 +439,9 @@
     --background: 100 6% 5%;              /* #0d0e0c 侧边栏 */
     --foreground: 90 20% 65%;             /* #acb09f 暖黄绿白 */
     --content-area: 100 6% 3%;            /* #080907 内容区：最深 */
+    --sidebar-surface: 100 6% 5%;
+    --tabbar-surface: 100 6% 5%;
+    --input-surface: 100 6% 5%;
     /* 次要色 */
     --muted: 100 5% 10%;                  /* #1a1b19 次要背景 */
     --muted-foreground: 90 12% 38%;       /* #636b5e 次要文字 */
@@ -842,27 +877,110 @@
 /* ===== TabBar 背景 ===== */
 /* 默认背景 */
 .tabbar-bg {
+  position: relative;
+  background-color: hsl(var(--tabbar-surface));
+}
+
+.tabbar-bg::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 1px;
+  background-color: hsl(var(--border) / 0.8);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.app-tab-active {
+  position: relative;
+  z-index: 1;
+  background-color: hsl(var(--content-area));
+}
+
+.app-tab-active::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 1px;
+  background-color: hsl(var(--content-area));
+  pointer-events: none;
+  z-index: 1;
+}
+
+.app-tab-inactive:hover {
+  background-color: hsl(var(--tab-surface) / 0.7);
+}
+
+[data-input-mode] > div:first-child {
+  background-color: hsl(var(--input-surface)) !important;
+}
+
+/* 现代界面：保留 rounded-full 的圆形/胶囊语义，只压低卡片、面板、气泡等大圆角。 */
+:root:not(.ui-classic) [class*="rounded-lg"]:not([class*="rounded-full"]),
+:root:not(.ui-classic) [class*="rounded-xl"]:not([class*="rounded-full"]),
+:root:not(.ui-classic) [class*="rounded-2xl"]:not([class*="rounded-full"]),
+:root:not(.ui-classic) [class*="rounded-3xl"]:not([class*="rounded-full"]),
+:root:not(.ui-classic) [class*="rounded-["]:not([class*="rounded-full"]) {
+  border-radius: var(--radius-cap);
+}
+
+/* 经典界面：视觉规则对齐 upstream。 */
+:root.ui-classic {
+  --radius: 0.625rem;
+  --radius-xl-extra: 4px;
+  --radius-2xl-extra: 8px;
+  --sidebar-surface: 0 0% 98%;
+}
+
+.ui-classic .tabbar-bg {
   background-color: hsl(var(--muted) / 0.5);
 }
 
-/* 远山暮霭：底部浅色阴影勾勒轮廓 */
-.theme-ocean-dark .tabbar-bg {
+.ui-classic.theme-ocean-dark .tabbar-bg {
   box-shadow: inset 0 -1px 0 0 hsl(210 14% 24% / 0.6);
 }
 
-/* 森息夜语：底部浅色阴影勾勒轮廓 */
-.theme-forest-dark .tabbar-bg {
+.ui-classic.theme-forest-dark .tabbar-bg {
   box-shadow: inset 0 -1px 0 0 hsl(150 12% 22% / 0.6);
 }
 
-/* 莫兰迪夜：底部浅色阴影勾勒轮廓 */
-.theme-slate-dark .tabbar-bg {
+.ui-classic.theme-slate-dark .tabbar-bg {
   box-shadow: inset 0 -1px 0 0 hsl(260 10% 18% / 0.6);
 }
 
-/* CRT 终端：TabBar 底部 hairline */
-.theme-terminal-dark .tabbar-bg {
+.ui-classic.theme-terminal-dark .tabbar-bg {
   box-shadow: inset 0 -1px 0 0 hsl(var(--border) / 0.6);
+}
+
+.ui-classic .tabbar-bg::after,
+.ui-classic .app-tab-active::after {
+  display: none;
+}
+
+.ui-classic .app-tab-active {
+  background-color: hsl(var(--tab-surface));
+  border-color: hsl(var(--border) / 0.5) !important;
+}
+
+.ui-classic [data-input-mode] > div:first-child {
+  background-color: hsl(var(--background) / 0.7) !important;
+}
+
+.ui-classic .mode-switcher-track {
+  background-color: hsl(var(--muted)) !important;
+}
+
+.ui-classic .sidebar-collapse-button {
+  background-color: hsl(var(--muted)) !important;
+  border-color: transparent !important;
+}
+
+.ui-classic .sidebar-collapse-button:hover {
+  background-color: hsl(var(--foreground) / 0.08) !important;
 }
 
 /* CRT 终端：Tab 流式指示器 — 保留原色，叠加 CRT 磷光质感 */

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -174,6 +174,12 @@ export const DEFAULT_THEME_MODE: ThemeMode = 'dark'
 /** 默认特殊风格 */
 export const DEFAULT_THEME_STYLE: ThemeStyle = 'default'
 
+/** 界面风格：经典保留旧版视觉，现代使用当前更克制的 UI */
+export type InterfaceVariant = 'classic' | 'modern'
+
+/** 默认界面风格 */
+export const DEFAULT_INTERFACE_VARIANT: InterfaceVariant = 'modern'
+
 /** Markdown 预览字号档位 */
 export type MarkdownFontSize = 'small' | 'medium' | 'large'
 
@@ -186,6 +192,8 @@ export interface AppSettings {
   themeMode: ThemeMode
   /** 特殊风格主题 */
   themeStyle?: ThemeStyle
+  /** 界面风格 */
+  interfaceVariant?: InterfaceVariant
   /** Agent 默认渠道 ID（仅限 Anthropic 渠道） — 当前选中的渠道 */
   agentChannelId?: string
   /** Agent 默认模型 ID */

--- a/apps/electron/tailwind.config.js
+++ b/apps/electron/tailwind.config.js
@@ -73,8 +73,8 @@ export default {
         DEFAULT: 'calc(var(--radius) - 2px)',
         md: 'calc(var(--radius) - 2px)',
         lg: 'var(--radius)',
-        xl: 'calc(var(--radius) + 4px)',
-        '2xl': 'calc(var(--radius) + 8px)',
+        xl: 'calc(var(--radius) + var(--radius-xl-extra, 2px))',
+        '2xl': 'calc(var(--radius) + var(--radius-2xl-extra, 4px))',
       },
       // ===== 阴影：覆写 Tailwind 内置的 sm/md/lg/xl/DEFAULT =====
       // 现有 78 处 shadow-md / shadow-lg 等代码无需改动，自动吃多层柔阴影 + 主题自适应


### PR DESCRIPTION
## 概述

这个 PR 在外观设置中新增「界面风格」切换，提供「经典」和「现代」两种 UI 排版/视觉模式。经典风保留旧版主面板、侧栏、Tab 与圆角阴影规则；现代风使用当前更小圆角、更清晰分割线和更统一干净的表面质感。该设置会持久化到本地 settings，并通过主题广播同步到多个窗口。

## 改动

- `apps/electron/src/types/settings.ts` — 新增 `InterfaceVariant` 类型、默认值 `DEFAULT_INTERFACE_VARIANT`，并扩展 `AppSettings.interfaceVariant`。
- `apps/electron/src/main/lib/settings-service.ts` — 读取设置时补齐界面风格默认值，兼容已有用户的 `settings.json`。
- `apps/electron/src/main/ipc.ts` / `apps/electron/src/preload/index.ts` — 在主题相关设置广播中加入 `interfaceVariant`，支持跨窗口同步经典/现代界面风格。
- `apps/electron/src/renderer/atoms/theme.ts` / `apps/electron/src/renderer/main.tsx` — 新增界面风格 atom、本地缓存、DOM class 应用逻辑，切换 `ui-classic` / `ui-modern`。
- `apps/electron/src/renderer/components/settings/AppearanceSettings.tsx` — 在外观设置中新增「界面风格」分段控件，文案说明经典风与现代风差异。
- `apps/electron/src/renderer/components/app-shell/AppShell.tsx` / `LeftSidebar.tsx` / `ModeSwitcher.tsx` — 根据界面风格切换侧栏贴边/旧版卡片布局、侧栏背景、普通选中竖条和模式切换器表面。
- `apps/electron/src/renderer/components/tabs/MainArea.tsx` / `TabBarItem.tsx` / `apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx` / `apps/electron/src/renderer/components/agent/SidePanel.tsx` — 根据界面风格切换主区域、右侧文件栏、Tab 圆角、边框和阴影规则。
- `apps/electron/src/renderer/styles/globals.css` / `apps/electron/tailwind.config.js` — 增加现代风表面 token、输入框/Tab 背景、清晰分割线、小圆角规则，并为经典风恢复旧版视觉覆盖。
- `apps/electron/package.json` — 按受影响包递增 patch 版本到 `0.13.4`。

## 测试方法

1. 运行 `bun run typecheck`，确认所有 workspace 类型检查通过。
2. 运行 `cd apps/electron && bun run build:renderer`，确认 renderer 构建通过。
3. 打开外观设置，切换「界面风格」为「经典」和「现代」，确认设置可即时生效并持久化。
4. 在浅色/深色主题下分别检查主会话 Tab、右侧文件栏 Tab、左侧侧栏、输入框和主内容分割线的视觉差异。

## 备注

- 现代风是默认值，已有用户未设置该字段时会进入现代风。
- 经典风通过组件分支和 `ui-classic` 覆盖尽量对齐旧版 upstream 视觉规则。
- `build:renderer` 仍会输出已有的大 chunk 警告，本 PR 未改变该问题。
