### PR TITLE
style(renderer): 统一主题侧栏与输入区配色【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.13.6",
+  "version": "0.13.10",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.13.10",
+  "version": "0.13.12",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx
@@ -150,7 +150,7 @@ export function StickyUserMessage({ userMessages }: StickyUserMessageProps): Rea
       {/* 复用 ConversationContent(px-8) + Message(px-2.5) 的 padding 链，保证与内容区等宽 */}
       <div className="mx-8 px-2.5 pt-2">
         <div
-          className="sticky-user-banner ml-[46px] rounded-xl bg-card shadow-sm cursor-pointer hover:bg-accent/50 transition-colors"
+          className="sticky-user-banner ml-[46px] rounded-xl bg-[hsl(var(--input-surface))] shadow-sm cursor-pointer hover:bg-accent/50 transition-colors"
           onClick={scrollToOriginal}
         >
           <div className="px-3.5 py-2.5">

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -1707,7 +1707,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                 type="button"
                 aria-label={mode === 'agent' ? '新建 Agent 会话' : '新建 Chat 对话'}
                 onClick={mode === 'agent' ? handleNewAgentSession : handleNewConversation}
-                className="size-10 flex items-center justify-center rounded-[12px] text-foreground/70 bg-primary/5 hover:bg-primary/10 hover:text-foreground transition-[background-color,border-color,color] duration-150 titlebar-no-drag border border-border/60 hover:border-border"
+                className="size-10 flex items-center justify-center rounded-[12px] text-foreground/70 sidebar-control-surface hover:text-foreground transition-[background-color,color] duration-150 titlebar-no-drag"
               >
                 <Plus size={16} />
               </button>
@@ -1723,7 +1723,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                 type="button"
                 aria-label="搜索"
                 onClick={() => setSearchDialogOpen(true)}
-                className="size-10 flex items-center justify-center rounded-[12px] text-foreground/45 bg-primary/5 hover:bg-primary/10 hover:text-foreground/70 transition-[background-color,border-color,color] duration-150 titlebar-no-drag border border-border/60 hover:border-border"
+                className="size-10 flex items-center justify-center rounded-[12px] text-foreground/45 sidebar-control-surface hover:text-foreground/70 transition-[background-color,color] duration-150 titlebar-no-drag"
               >
                 <Search size={16} />
               </button>
@@ -1866,10 +1866,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
             <button
               onClick={() => setSidebarCollapsed(true)}
               className={cn(
-                'sidebar-collapse-button mt-2 size-10 flex-shrink-0 flex items-center justify-center rounded-[10px] text-foreground/40 titlebar-no-drag',
-                isClassic
-                  ? 'bg-muted hover:bg-foreground/[0.08] hover:text-foreground/60 transition-colors'
-                  : 'bg-primary/5 hover:bg-primary/10 hover:text-foreground/60 transition-[background-color,border-color,color] duration-150 border border-border/60 hover:border-border'
+                'sidebar-collapse-button mt-2 size-10 flex-shrink-0 flex items-center justify-center rounded-[10px] text-foreground/40 sidebar-control-surface hover:text-foreground/60 titlebar-no-drag transition-[background-color,color] duration-150'
               )}
             >
               <PanelLeftClose size={14} />
@@ -1883,7 +1880,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       <div className="px-3 pt-2 flex items-center gap-1.5">
         <button
           onClick={mode === 'agent' ? handleNewAgentSession : handleNewConversation}
-          className="flex-1 flex items-center gap-2 px-3 py-2 rounded-[10px] text-[13px] font-medium text-foreground/70 bg-primary/5 hover:bg-primary/10 hover:text-foreground transition-[background-color,border-color,color] duration-150 titlebar-no-drag border border-border/60 hover:border-border"
+          className="flex-1 flex items-center gap-2 px-3 py-2 rounded-[10px] text-[13px] font-medium text-foreground/70 sidebar-control-surface hover:text-foreground transition-[background-color,color] duration-150 titlebar-no-drag"
         >
           <Plus size={14} />
           <span>{mode === 'agent' ? '新会话' : '新对话'}</span>
@@ -1892,7 +1889,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
           <TooltipTrigger asChild>
             <button
               onClick={() => setSearchDialogOpen(true)}
-              className="flex-shrink-0 size-[36px] flex items-center justify-center rounded-[10px] text-foreground/40 bg-primary/5 hover:bg-primary/10 hover:text-foreground/60 transition-[background-color,border-color,color] duration-150 titlebar-no-drag border border-border/60 hover:border-border"
+              className="flex-shrink-0 size-[36px] flex items-center justify-center rounded-[10px] text-foreground/40 sidebar-control-surface hover:text-foreground/60 transition-[background-color,color] duration-150 titlebar-no-drag"
             >
               <Search size={14} />
             </button>

--- a/apps/electron/src/renderer/components/app-shell/ModeSwitcher.tsx
+++ b/apps/electron/src/renderer/components/app-shell/ModeSwitcher.tsx
@@ -14,7 +14,6 @@ import { appModeAtom, type AppMode } from '@/atoms/app-mode'
 import { conversationsAtom, currentConversationIdAtom } from '@/atoms/chat-atoms'
 import { agentSessionsAtom, currentAgentSessionIdAtom } from '@/atoms/agent-atoms'
 import { tabsAtom } from '@/atoms/tab-atoms'
-import { interfaceVariantAtom } from '@/atoms/theme'
 import { useOpenSession } from '@/hooks/useOpenSession'
 import { Bot, MessageSquare } from 'lucide-react'
 import { cn } from '@/lib/utils'
@@ -32,8 +31,6 @@ export function ModeSwitcher(): React.ReactElement {
   const currentConversationId = useAtomValue(currentConversationIdAtom)
   const currentAgentSessionId = useAtomValue(currentAgentSessionIdAtom)
   const tabs = useAtomValue(tabsAtom)
-  const interfaceVariant = useAtomValue(interfaceVariantAtom)
-  const isClassic = interfaceVariant === 'classic'
 
   /** 尝试恢复目标模式下的上一个对话/会话，按优先级 fallback */
   const restoreSession = React.useCallback((targetMode: AppMode) => {
@@ -73,10 +70,7 @@ export function ModeSwitcher(): React.ReactElement {
   return (
     <div className="pt-2 titlebar-drag-region select-none">
       <div
-        className={cn(
-          'relative flex rounded-xl p-1 titlebar-drag-region mode-switcher-track',
-          isClassic ? 'bg-muted' : 'bg-primary/5'
-        )}
+        className="relative flex rounded-xl p-1 titlebar-drag-region mode-switcher-track sidebar-control-surface"
       >
         {/* 滑动背景指示器 */}
         <div

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -124,6 +124,7 @@
     --tabbar-surface: 60 14.3% 98.6%;     /* 默认浅色未选中 Tab 背景：RGB 252/252/251 */
     --sidebar-control-surface: 60 7% 93%;
     --sidebar-control-surface-hover: 60 7% 90%;
+    --sidebar-control-stroke: 0 0% 9% / 0.10;
     --input-surface: 60 14.3% 98.6%;      /* 默认浅色输入框：RGB 252/252/251 */
     --tab-surface: 0 0% 100%;             /* 与内容区域无缝衔接 */
     /* 毛玻璃 Tooltip：深色半透明背景 + 白色文字 */
@@ -167,6 +168,7 @@
     --tabbar-surface: 0 0% 7%;
     --sidebar-control-surface: 0 0% 14%;
     --sidebar-control-surface-hover: 0 0% 18%;
+    --sidebar-control-stroke: 0 0% 100% / 0.08;
     --input-surface: 0 0% 7%;
     --tab-surface: 0 0% 7%;
     /* 毛玻璃 Tooltip：深色半透明背景 + 白色文字 */
@@ -208,6 +210,7 @@
     --tabbar-surface: 205 35% 94%;
     --sidebar-control-surface: 205 32% 90%;
     --sidebar-control-surface-hover: 205 34% 87%;
+    --sidebar-control-stroke: 205 45% 34% / 0.12;
     --input-surface: 205 32% 96%;
     --tab-surface: 205 30% 97%;
     --destructive: 0 84.2% 60.2%;         /* #ef4444 危险色 */
@@ -235,6 +238,7 @@
     --tabbar-surface: 210 12% 13%;
     --sidebar-control-surface: 210 12% 18%;
     --sidebar-control-surface-hover: 210 13% 21%;
+    --sidebar-control-stroke: 210 18% 72% / 0.10;
     --input-surface: 210 12% 13%;
     --muted: 210 12% 17%;
     --muted-foreground: 210 10% 60%;
@@ -294,6 +298,7 @@
     --tabbar-surface: 140 25% 95%;
     --sidebar-control-surface: 140 20% 91%;
     --sidebar-control-surface-hover: 140 20% 88%;
+    --sidebar-control-stroke: 150 28% 34% / 0.12;
     --input-surface: 140 20% 96%;
     --tab-surface: 140 20% 97%;
     --destructive: 0 72% 51%;             /* #dc2828 危险色 */
@@ -319,8 +324,9 @@
     --content-area: 150 10% 9%;           /* 内容区：深林泥土 */
     --sidebar-surface: 150 8% 14%;
     --tabbar-surface: 150 8% 14%;
-    --sidebar-control-surface: 150 9% 19%;
-    --sidebar-control-surface-hover: 150 10% 22%;
+    --sidebar-control-surface: 150 9% 17%;
+    --sidebar-control-surface-hover: 150 10% 20%;
+    --sidebar-control-stroke: 140 14% 72% / 0.10;
     --input-surface: 150 8% 14%;
     --muted: 150 10% 17%;
     --muted-foreground: 145 8% 60%;
@@ -384,6 +390,7 @@
     --tabbar-surface: 40 6% 92%;
     --sidebar-control-surface: 40 6% 88%;
     --sidebar-control-surface-hover: 40 6% 86%;
+    --sidebar-control-stroke: 40 10% 28% / 0.11;
     --input-surface: 40 8% 95%;
     --tab-surface: 40 8% 94%;
     /* 功能色 */
@@ -410,6 +417,7 @@
     --tabbar-surface: 260 6% 12%;
     --sidebar-control-surface: 260 7% 18%;
     --sidebar-control-surface-hover: 260 8% 21%;
+    --sidebar-control-stroke: 30 12% 74% / 0.10;
     --input-surface: 260 6% 12%;
     /* 次要色 - 淡紫灰调 */
     --muted: 260 6% 16%;                  /* #272429 次要背景 */
@@ -459,6 +467,7 @@
     --tabbar-surface: 100 6% 5%;
     --sidebar-control-surface: 100 5% 12%;
     --sidebar-control-surface-hover: 100 6% 16%;
+    --sidebar-control-stroke: 100 20% 55% / 0.12;
     --input-surface: 100 6% 5%;
     /* 次要色 */
     --muted: 100 5% 10%;                  /* #1a1b19 次要背景 */
@@ -526,6 +535,7 @@
 
 .sidebar-control-surface {
   background-color: hsl(var(--sidebar-control-surface));
+  box-shadow: inset 0 0 0 0.5px hsl(var(--sidebar-control-stroke));
 }
 
 .sidebar-control-surface:hover {

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -122,6 +122,8 @@
     --content-area: 0 0% 100%;            /* 主内容区域背景 */
     --sidebar-surface: 60 14.3% 98.6%;    /* 默认浅色侧栏：RGB 252/252/251 */
     --tabbar-surface: 60 14.3% 98.6%;     /* 默认浅色未选中 Tab 背景：RGB 252/252/251 */
+    --sidebar-control-surface: 60 7% 93%;
+    --sidebar-control-surface-hover: 60 7% 90%;
     --input-surface: 60 14.3% 98.6%;      /* 默认浅色输入框：RGB 252/252/251 */
     --tab-surface: 0 0% 100%;             /* 与内容区域无缝衔接 */
     /* 毛玻璃 Tooltip：深色半透明背景 + 白色文字 */
@@ -163,6 +165,8 @@
     --content-area: 0 0% 7%;              /* 主内容区域背景 zinc-900 */
     --sidebar-surface: 0 0% 7%;
     --tabbar-surface: 0 0% 7%;
+    --sidebar-control-surface: 0 0% 14%;
+    --sidebar-control-surface-hover: 0 0% 18%;
     --input-surface: 0 0% 7%;
     --tab-surface: 0 0% 7%;
     /* 毛玻璃 Tooltip：深色半透明背景 + 白色文字 */
@@ -202,6 +206,8 @@
     --dialog-foreground: 210 30% 15%;     /* #1b2632 弹窗前景 */
     --sidebar-surface: 205 35% 94%;
     --tabbar-surface: 205 35% 94%;
+    --sidebar-control-surface: 205 32% 90%;
+    --sidebar-control-surface-hover: 205 34% 87%;
     --input-surface: 205 32% 96%;
     --tab-surface: 205 30% 97%;
     --destructive: 0 84.2% 60.2%;         /* #ef4444 危险色 */
@@ -227,6 +233,8 @@
     --content-area: 210 14% 9%;           /* 内容区：最深，专注 */
     --sidebar-surface: 210 12% 13%;
     --tabbar-surface: 210 12% 13%;
+    --sidebar-control-surface: 210 12% 18%;
+    --sidebar-control-surface-hover: 210 13% 21%;
     --input-surface: 210 12% 13%;
     --muted: 210 12% 17%;
     --muted-foreground: 210 10% 60%;
@@ -284,6 +292,8 @@
     --dialog-foreground: 150 25% 15%;     /* #1d3026 弹窗前景 */
     --sidebar-surface: 140 25% 95%;
     --tabbar-surface: 140 25% 95%;
+    --sidebar-control-surface: 140 20% 91%;
+    --sidebar-control-surface-hover: 140 20% 88%;
     --input-surface: 140 20% 96%;
     --tab-surface: 140 20% 97%;
     --destructive: 0 72% 51%;             /* #dc2828 危险色 */
@@ -309,6 +319,8 @@
     --content-area: 150 10% 9%;           /* 内容区：深林泥土 */
     --sidebar-surface: 150 8% 14%;
     --tabbar-surface: 150 8% 14%;
+    --sidebar-control-surface: 150 9% 19%;
+    --sidebar-control-surface-hover: 150 10% 22%;
     --input-surface: 150 8% 14%;
     --muted: 150 10% 17%;
     --muted-foreground: 145 8% 60%;
@@ -344,7 +356,7 @@
 
   /* 云朵舞者（浅色） - 温暖灰调，柔和舒适 */
   .theme-slate-light {
-    /* 基础色 - sidebar 比主题色深一点 */
+    /* 基础色 - sidebar 比主题色略深，保持轻分层 */
     --background: 40 6% 88%;              /* #e3e1dc 侧边栏背景（比主题色深） */
     --foreground: 40 8% 18%;              /* #312f2a 前景文字 */
     --content-area: 40 8% 94%;            /* #f0efec 内容区域（RGB 240,239,236 主题色） */
@@ -368,8 +380,10 @@
     --popover-foreground: 40 8% 18%;      /* #312f2a 弹出前景 */
     --dialog: 40 8% 94%;                  /* #f0efec 弹窗背景（主题色） */
     --dialog-foreground: 40 8% 18%;       /* #312f2a 弹窗前景 */
-    --sidebar-surface: 40 6% 88%;
-    --tabbar-surface: 40 6% 88%;
+    --sidebar-surface: 40 6% 92%;
+    --tabbar-surface: 40 6% 92%;
+    --sidebar-control-surface: 40 6% 88%;
+    --sidebar-control-surface-hover: 40 6% 86%;
     --input-surface: 40 8% 95%;
     --tab-surface: 40 8% 94%;
     /* 功能色 */
@@ -394,6 +408,8 @@
     --content-area: 270 8% 9%;            /* #161418 内容区域 */
     --sidebar-surface: 260 6% 12%;
     --tabbar-surface: 260 6% 12%;
+    --sidebar-control-surface: 260 7% 18%;
+    --sidebar-control-surface-hover: 260 8% 21%;
     --input-surface: 260 6% 12%;
     /* 次要色 - 淡紫灰调 */
     --muted: 260 6% 16%;                  /* #272429 次要背景 */
@@ -441,6 +457,8 @@
     --content-area: 100 6% 3%;            /* #080907 内容区：最深 */
     --sidebar-surface: 100 6% 5%;
     --tabbar-surface: 100 6% 5%;
+    --sidebar-control-surface: 100 5% 12%;
+    --sidebar-control-surface-hover: 100 6% 16%;
     --input-surface: 100 6% 5%;
     /* 次要色 */
     --muted: 100 5% 10%;                  /* #1a1b19 次要背景 */
@@ -504,6 +522,14 @@
   z-index: 1;
   -webkit-app-region: drag;
   app-region: drag;
+}
+
+.sidebar-control-surface {
+  background-color: hsl(var(--sidebar-control-surface));
+}
+
+.sidebar-control-surface:hover {
+  background-color: hsl(var(--sidebar-control-surface-hover));
 }
 
 /* Windows 自定义窗口控制按钮
@@ -725,11 +751,9 @@
 
 /* 轨道：暗底 + 稀疏未点亮灯珠 */
 .theme-terminal-dark .mode-switcher-track {
-  background-color: hsl(var(--background)) !important;
-  background-image:
-    radial-gradient(circle, hsl(var(--muted-foreground) / 0.20) 0.5px, transparent 0.5px) !important;
-  background-size: 4px 4px !important;
-  border: 1px solid hsl(var(--border)) !important;
+  background-color: hsl(var(--sidebar-control-surface)) !important;
+  background-image: none !important;
+  border: 0 !important;
 }
 
 /* 滑块：点亮灯珠面板 — 密集双层灯珠 + 磷光外溢 + 电磁闪烁
@@ -743,7 +767,7 @@
     radial-gradient(circle at 1px 1px, hsl(var(--primary) / 0.40) 0.5px, transparent 0.5px) !important;
   background-size: 3px 3px, 3px 3px !important;
   background-position: 0 0, 1px 1px !important;
-  border: 1px solid hsl(var(--primary) / 0.30) !important;
+  border: 0 !important;
   border-radius: 2px !important;
   box-shadow:
     0 0 10px hsl(var(--primary) / 0.30),
@@ -971,16 +995,15 @@
 }
 
 .ui-classic .mode-switcher-track {
-  background-color: hsl(var(--muted)) !important;
+  background-color: hsl(var(--sidebar-control-surface)) !important;
 }
 
 .ui-classic .sidebar-collapse-button {
-  background-color: hsl(var(--muted)) !important;
-  border-color: transparent !important;
+  background-color: hsl(var(--sidebar-control-surface)) !important;
 }
 
 .ui-classic .sidebar-collapse-button:hover {
-  background-color: hsl(var(--foreground) / 0.08) !important;
+  background-color: hsl(var(--sidebar-control-surface-hover)) !important;
 }
 
 /* CRT 终端：Tab 流式指示器 — 保留原色，叠加 CRT 磷光质感 */

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -202,7 +202,7 @@
     --dialog-foreground: 210 30% 15%;     /* #1b2632 弹窗前景 */
     --sidebar-surface: 205 35% 94%;
     --tabbar-surface: 205 35% 94%;
-    --input-surface: 60 14.3% 98.6%;
+    --input-surface: 205 32% 96%;
     --tab-surface: 205 30% 97%;
     --destructive: 0 84.2% 60.2%;         /* #ef4444 危险色 */
     --destructive-foreground: 0 0% 98%;   /* #fafafa 危险前景 */
@@ -284,7 +284,7 @@
     --dialog-foreground: 150 25% 15%;     /* #1d3026 弹窗前景 */
     --sidebar-surface: 140 25% 95%;
     --tabbar-surface: 140 25% 95%;
-    --input-surface: 60 14.3% 98.6%;
+    --input-surface: 140 20% 96%;
     --tab-surface: 140 20% 97%;
     --destructive: 0 72% 51%;             /* #dc2828 危险色 */
     --destructive-foreground: 0 0% 100%;  /* #ffffff 危险前景 */
@@ -370,7 +370,7 @@
     --dialog-foreground: 40 8% 18%;       /* #312f2a 弹窗前景 */
     --sidebar-surface: 40 6% 88%;
     --tabbar-surface: 40 6% 88%;
-    --input-surface: 60 14.3% 98.6%;
+    --input-surface: 40 8% 95%;
     --tab-surface: 40 8% 94%;
     /* 功能色 */
     --destructive: 0 65% 50%;             /* #d43c3c 危险色 */

--- a/apps/electron/tailwind.config.js
+++ b/apps/electron/tailwind.config.js
@@ -4,6 +4,17 @@ export default {
   content: [
     './src/renderer/**/*.{js,ts,jsx,tsx}',
   ],
+  // 主题 class 由运行时根据设置拼接到 <html>，Tailwind 无法从 TSX 静态扫描到。
+  // 必须 safelist，否则 @layer base 中对应的 CSS 变量块会在构建时被裁掉。
+  safelist: [
+    'theme-ocean-light',
+    'theme-ocean-dark',
+    'theme-forest-light',
+    'theme-forest-dark',
+    'theme-slate-light',
+    'theme-slate-dark',
+    'theme-terminal-dark',
+  ],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## 概述
这个 PR 修复并统一 Proma 多主题下的实际显示配色。此前部分主题 class 由运行时动态拼接，Tailwind 构建时无法静态扫描到，导致生产构建里主题变量可能被裁掉；同时左上角 mode switcher、收起、新会话、搜索等控制元素在不同主题下背景、边界和层次不一致。本次改动保留动态主题 class，统一侧栏控制元素的主题表面色，并让浅色主题输入框与 sticky prompt bar 更贴合各主题的实际色彩。

## 改动
- `apps/electron/tailwind.config.js` — safelist 运行时动态主题 class，避免 Tailwind 构建裁剪 `@layer base` 中的主题变量块。
- `apps/electron/src/renderer/styles/globals.css` — 为默认主题和各特殊主题补充 `--sidebar-control-surface`、`--sidebar-control-surface-hover`、`--sidebar-control-stroke` 等变量，统一左上角控制区背景、hover 和细边界；同步调整云朵舞者与森息夜语的侧栏/控制区明暗关系。
- `apps/electron/src/renderer/components/app-shell/ModeSwitcher.tsx` — mode switcher 轨道改用统一的 `sidebar-control-surface`，与旁边控制按钮保持一致。
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 新会话、搜索、收起侧栏等按钮改用统一的控制区 surface class，减少每个按钮各自写背景和 border 的重复样式。
- `apps/electron/src/renderer/components/ai-elements/sticky-user-message.tsx` — sticky prompt bar 改用 `--input-surface`，让浅色主题下的悬浮 prompt 条与输入区保持同一主题语义。
- `apps/electron/package.json` — 按仓库约定递增 Electron 包 patch 版本。

## 测试方法
1. 运行 `bun run typecheck`，确认所有 workspace package 类型检查通过。
2. 在 `apps/electron` 下运行 `bun run build:renderer`，确认 Vite renderer 构建通过。
3. 检查构建产物 CSS，确认 `theme-forest-dark`、`theme-slate-light`、`--sidebar-control-stroke` 和新的 control surface 变量未被 Tailwind 裁剪。
4. 按 Review-Proma-PR 流程扫描 Windows 兼容风险，未发现新增 POSIX 路径、Unix-only 命令、平台分支或快捷键问题。

## 备注
- 直接推送 upstream 时当前账号返回 403，因此本 PR 使用 fork 分支 `Andreaseszhang:style/theme-surfaces-202606240042` 提交到 upstream main。
- Vite 构建仍有既有的大 chunk warning，本次没有引入新的构建失败。