### PR TITLE
【已审核】fix(automation): 自动任务会话始终留在自动任务区，毕业时 toast 提示

### DIFF
--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -138,6 +138,11 @@ export async function runAgent(
       const meta = getAgentSessionMeta(input.sessionId)
       if (meta?.sourceAutomationId && !meta.automationGraduated) {
         updateAgentSessionMeta(input.sessionId, { automationGraduated: true })
+        // 向渲染进程发送毕业事件，触发 toast 提示
+        eventBus.emit(input.sessionId, {
+          kind: 'proma_event',
+          event: { type: 'automation_graduated' },
+        })
       }
     } catch { /* 新会话可能尚未写入索引 */ }
   }

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -313,11 +313,11 @@ function getRailInitial(title: string): string {
 
 /**
  * 是否为「应从项目会话列表隐藏」的自动任务会话：
- * 来自定时任务（sourceAutomationId）、尚未被用户接管毕业（automationGraduated）、且未被置顶。
- * 这类会话的"家"是 Automation 视图；置顶或毕业后回到普通项目列表。
+ * 来自定时任务（sourceAutomationId）且未被置顶。
+ * 这类会话的"家"是「自动任务」视图，始终不出现在普通项目列表。
  */
 function isHiddenAutomationSession(session: AgentSessionMeta): boolean {
-  return !!session.sourceAutomationId && !session.automationGraduated && !session.pinned
+  return !!session.sourceAutomationId && !session.pinned
 }
 
 interface RailRecentItem {
@@ -1121,7 +1121,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   }, [])
 
   /**
-   * 合成「自动任务」项目组：聚合所有未毕业的自动任务会话（跨工作区），
+   * 合成「自动任务」项目组：聚合所有自动任务会话（跨工作区），
    * 作为这些会话在侧栏的统一归属地。会话为空时返回 null（不渲染空组）。
    */
   const automationGroup = React.useMemo<AgentProjectGroup | null>(
@@ -1132,7 +1132,6 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
           && !session.pinned
           && !draftSessionIds.has(session.id)
           && !!session.sourceAutomationId
-          && !session.automationGraduated
         )
       )
       if (sessions.length === 0) return null
@@ -1377,7 +1376,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
           !session.archived
           && !session.pinned
           && !draftSessionIds.has(session.id)
-          // 未毕业的自动任务会话不进入项目列表，统一归到 Automation 视图
+          // 自动任务会话不进入项目列表，统一归到「自动任务」视图
           && !isHiddenAutomationSession(session)
         )
       )
@@ -1495,7 +1494,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         !session.archived
         && !draftSessionIds.has(session.id)
         && (!currentWorkspaceId || session.workspaceId === currentWorkspaceId)
-        // 未毕业的自动任务会话不出现在收起态 Rail，与项目列表保持一致
+        // 自动任务会话不出现在收起态 Rail，与展开态列表保持一致
         && !isHiddenAutomationSession(session)
       )
       .sort((a, b) => {

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -565,6 +565,15 @@ export function useGlobalAgentListeners(): void {
           activateExternalAgentRun(payload.event)
         }
 
+        // 自动任务会话被用户接管（毕业）：向用户提示，触发会话列表刷新
+        if (payload.kind === 'proma_event' && payload.event.type === 'automation_graduated') {
+          toast('已接管自动任务会话，会话已移至项目列表。后续定时任务将新建独立会话。', { duration: 4000 })
+          // 立即刷新会话列表，让侧边栏自动任务组即时更新
+          window.electronAPI.listAgentSessions()
+            .then((sessions) => store.set(agentSessionsAtom, sessions))
+            .catch(console.error)
+        }
+
         // 如果收到未知会话的事件（跨工作区场景），立即刷新会话列表
         const knownSessions = store.get(agentSessionsAtom)
         if (!knownSessions.some((s) => s.id === sessionId)) {

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -565,10 +565,9 @@ export function useGlobalAgentListeners(): void {
           activateExternalAgentRun(payload.event)
         }
 
-        // 自动任务会话被用户接管（毕业）：向用户提示，触发会话列表刷新
+        // 自动任务会话被用户接管（毕业）：向用户提示，后续定时运行将新建独立会话
         if (payload.kind === 'proma_event' && payload.event.type === 'automation_graduated') {
-          toast('已接管自动任务会话，会话已移至项目列表。后续定时任务将新建独立会话。', { duration: 4000 })
-          // 立即刷新会话列表，让侧边栏自动任务组即时更新
+          toast('已接管自动任务会话，后续定时运行将创建新会话。', { duration: 3000 })
           window.electronAPI.listAgentSessions()
             .then((sessions) => store.set(agentSessionsAtom, sessions))
             .catch(console.error)

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -28,6 +28,7 @@ import {
   agentModelIdAtom,
   agentChannelIdsAtom,
   agentWorkspacesAtom,
+  agentSessionsAtom,
   currentAgentWorkspaceIdAtom,
   currentAgentSessionIdAtom,
   workspaceCapabilitiesVersionAtom,
@@ -349,15 +350,17 @@ function UpdaterInitializer(): null {
  */
 function AutomationInitializer(): null {
   const setAutomations = useSetAtom(automationsAtom)
+  const setAgentSessions = useSetAtom(agentSessionsAtom)
 
   useEffect(() => {
     const load = (): void => {
       window.electronAPI.listAutomations().then(setAutomations).catch(console.error)
+      window.electronAPI.listAgentSessions().then(setAgentSessions).catch(console.error)
     }
     load()
     const unsub = window.electronAPI.onAutomationChanged(load)
     return unsub
-  }, [setAutomations])
+  }, [setAutomations, setAgentSessions])
 
   return null
 }

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -566,6 +566,8 @@ export type PromaEvent =
   | { type: 'run_resumed'; sessionId: string }
   // 协作子会话阻塞事件上浮
   | { type: 'delegation_blocked'; delegationId: string; blockedEvent: unknown }
+  // 自动任务会话被用户接管（毕业）
+  | { type: 'automation_graduated' }
 
 /** 外部入口触发 Agent 运行的来源 */
 export type AgentExternalRunSource = 'feishu' | 'dingtalk' | 'wechat' | 'bridge' | 'delegation'


### PR DESCRIPTION
## 概述

自动任务会话之前有"毕业"机制：用户发消息后 `automationGraduated=true`，会话从「自动任务」组静默移到普通工作区项目列表——用户困惑"自动任务去哪了"。

本 PR 修复两个问题：

1. **自动任务会话永远留在「自动任务」组** — 移除 `isHiddenAutomationSession` 和 `automationGroup` 中对 `automationGraduated` 的过滤，自动任务会话无论是否被用户互动过，始终归属自动任务区
2. **新增 toast 提示** — 用户首次向自动任务会话发消息时，toast 提示"已接管自动任务会话，后续定时运行将创建新会话"
3. **`broadcastChanged` 刷新会话列表** — 自动任务运行完成时同步刷新侧边栏会话列表，确保新会话及时出现

`automationGraduated` 字段保留且仍由 `agent-service.ts` 设置，调度器用它阻止向已被用户接管的会话注入新的定时运行。

## 改动

- `packages/shared/src/types/agent.ts` (+2) — PromaEvent 新增 `automation_graduated` 类型
- `apps/electron/src/main/lib/agent-service.ts` (+5) — 毕业时通过 eventBus 发送 proma_event
- `apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts` (+6) — 处理毕业事件显示 toast
- `apps/electron/src/renderer/main.tsx` (+5/-1) — AutomationInitializer 同步刷新会话列表
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` (+5/-8) — 移除 `automationGraduated` 过滤，会话始终留在自动任务组

## 测试

- [x] TypeCheck 通过 (`bun run typecheck`)

## 紧急度

低 — UX 改进。
