### PR TITLE
feat(sidebar): 把委派出去的子会话收进父会话下面，置顶/归档一起联动【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -222,6 +222,11 @@ interface AgentProjectGroup {
   sessions: AgentSessionMeta[]
 }
 
+interface AgentSessionTreeItem {
+  session: AgentSessionMeta
+  childSessions: AgentSessionMeta[]
+}
+
 /** 合成「自动任务」虚拟项目组的工作区 ID（不对应真实 workspace，仅用于聚合自动任务会话） */
 const AUTOMATION_GROUP_ID = '__automations__'
 /** 供合成组复用 AgentProjectGroupItem 时填充无意义的 workspace 专属回调 */
@@ -318,6 +323,106 @@ function getRailInitial(title: string): string {
  */
 function isHiddenAutomationSession(session: AgentSessionMeta): boolean {
   return !!session.sourceAutomationId && !session.pinned
+}
+
+function isDelegatedChildSession(session: AgentSessionMeta): boolean {
+  return !!session.parentSessionId && !!session.sourceDelegationId
+}
+
+function buildAgentSessionTrees(sessions: AgentSessionMeta[]): AgentSessionTreeItem[] {
+  const sessionIds = new Set(sessions.map((session) => session.id))
+  const childrenByParentId = new Map<string, AgentSessionMeta[]>()
+  const roots: AgentSessionMeta[] = []
+
+  for (const session of sessions) {
+    if (
+      isDelegatedChildSession(session)
+      && session.parentSessionId
+      && sessionIds.has(session.parentSessionId)
+    ) {
+      const children = childrenByParentId.get(session.parentSessionId) ?? []
+      children.push(session)
+      childrenByParentId.set(session.parentSessionId, children)
+      continue
+    }
+
+    roots.push(session)
+  }
+
+  return roots.map((session) => ({
+    session,
+    childSessions: childrenByParentId.get(session.id) ?? [],
+  }))
+}
+
+function getDelegatedChildStatus(
+  session: AgentSessionMeta,
+  agentIndicatorMap: Map<string, SessionIndicatorStatus>,
+): SessionIndicatorStatus {
+  const status = agentIndicatorMap.get(session.id)
+  if (status) return status
+  return session.delegationStatus === 'running' ? 'running' : 'idle'
+}
+
+function getSessionTreeStatus(
+  item: AgentSessionTreeItem,
+  agentIndicatorMap: Map<string, SessionIndicatorStatus>,
+): SessionIndicatorStatus {
+  const statuses = [
+    agentIndicatorMap.get(item.session.id) ?? 'idle',
+    ...item.childSessions.map((session) => getDelegatedChildStatus(session, agentIndicatorMap)),
+  ]
+
+  if (statuses.includes('blocked')) return 'blocked'
+  if (statuses.includes('running')) return 'running'
+  if (statuses.includes('completed')) return 'completed'
+  return 'idle'
+}
+
+function countCompletedDelegatedChildren(childSessions: AgentSessionMeta[]): number {
+  return childSessions.filter((session) => session.delegationStatus === 'completed').length
+}
+
+function treeContainsSessionId(item: AgentSessionTreeItem, sessionId: string | null): boolean {
+  if (!sessionId) return false
+  return item.session.id === sessionId || item.childSessions.some((session) => session.id === sessionId)
+}
+
+function collectTreeSessionIds(items: AgentSessionTreeItem[]): Set<string> {
+  const ids = new Set<string>()
+  for (const item of items) {
+    ids.add(item.session.id)
+    for (const child of item.childSessions) ids.add(child.id)
+  }
+  return ids
+}
+
+function getDirectDelegatedChildren(
+  sessions: AgentSessionMeta[],
+  parentSessionId: string,
+): AgentSessionMeta[] {
+  return sessions.filter((session) => (
+    session.parentSessionId === parentSessionId
+    && !!session.sourceDelegationId
+  ))
+}
+
+function hasPinnedVisibleParent(session: AgentSessionMeta, sessions: AgentSessionMeta[]): boolean {
+  if (!isDelegatedChildSession(session) || !session.parentSessionId) return false
+  const parent = sessions.find((item) => item.id === session.parentSessionId)
+  return !!parent?.pinned && !parent.archived
+}
+
+function getSyncableDelegatedChildren(
+  sessions: AgentSessionMeta[],
+  parentSessionId: string,
+  draftSessionIds: Set<string>,
+): AgentSessionMeta[] {
+  return getDirectDelegatedChildren(sessions, parentSessionId).filter((child) => (
+    !child.archived
+    && !draftSessionIds.has(child.id)
+    && !isHiddenAutomationSession(child)
+  ))
 }
 
 interface RailRecentItem {
@@ -449,6 +554,8 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   const [expandedExtraCountMap, setExpandedExtraCountMap] = React.useState<Map<string, number>>(new Map())
   /** 记录被用户手动折叠的工作区 ID（点击当前工作区标题时折叠/展开）。刻意不持久化：折叠被视为临时查看行为，刷新/重启后恢复默认展开 */
   const [collapsedWorkspaceIds, setCollapsedWorkspaceIds] = React.useState<Set<string>>(new Set())
+  /** 记录已展开的委派母会话；默认收起，避免批量派遣后撑满侧栏 */
+  const [expandedDelegationParentIds, setExpandedDelegationParentIds] = React.useState<Set<string>>(new Set())
   /** 项目拖拽排序状态 */
   const [dragProjectId, setDragProjectId] = React.useState<string | null>(null)
   const [projectDropIndicator, setProjectDropIndicator] = React.useState<{ id: string; position: 'before' | 'after' } | null>(null)
@@ -630,10 +737,23 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       const filtered = agentSessions.filter((s) =>
         s.pinned
         && !draftSessionIds.has(s.id)
+        && !hasPinnedVisibleParent(s, agentSessions)
       )
       return sortAgentSessionsByUpdatedAtDesc(filtered)
     },
     [agentSessions, viewMode, draftSessionIds]
+  )
+
+  const pinnedAgentSessionTrees = React.useMemo<AgentSessionTreeItem[]>(
+    () => pinnedAgentSessions.map((session) => ({
+      session,
+      childSessions: getDirectDelegatedChildren(agentSessions, session.id).filter((child) => (
+        !child.archived
+        && !draftSessionIds.has(child.id)
+        && !isHiddenAutomationSession(child)
+      )),
+    })),
+    [agentSessions, draftSessionIds, pinnedAgentSessions],
   )
 
   /** 对话按日期分组（根据 viewMode 过滤归档状态，排除 draft） */
@@ -839,6 +959,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
 
     // 清理 per-conversation/session Map atoms 条目
     cleanupMapAtoms(pendingDeleteId)
+    setExpandedDelegationParentIds((prev) => deleteSetEntry(prev, pendingDeleteId))
 
     if (mode === 'agent') {
       // Agent 模式：删除 Agent 会话
@@ -945,6 +1066,10 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     setCollapsedWorkspaceIds((prev) => toggleSetEntry(prev, groupId))
   }, [])
 
+  const handleToggleDelegationParent = React.useCallback((sessionId: string): void => {
+    setExpandedDelegationParentIds((prev) => toggleSetEntry(prev, sessionId))
+  }, [])
+
   const canDeleteWorkspace = React.useCallback(
     (workspace: AgentWorkspace): boolean => workspace.slug !== 'default' && workspaces.length > 1,
     [workspaces.length],
@@ -1030,6 +1155,14 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       })
 
       setCollapsedWorkspaceIds((prev) => deleteSetEntry(prev, workspaceId))
+      setExpandedDelegationParentIds((prev) => {
+        let changed = false
+        const next = new Set(prev)
+        for (const sessionId of deletedSessionIds) {
+          if (next.delete(sessionId)) changed = true
+        }
+        return changed ? next : prev
+      })
 
       if (workspaceId === currentWorkspaceId) {
         const fallback = remainingWorkspaces.find((item) => item.slug === 'default') ?? remainingWorkspaces[0] ?? null
@@ -1293,54 +1426,129 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     }
   }, [setAgentSessions, setTabs])
 
+  const closeArchivedAgentTabs = React.useCallback((sessionIds: string[]): void => {
+    const ids = new Set(sessionIds)
+    const currentTabs = store.get(tabsAtom)
+    const currentActiveTabId = store.get(activeTabIdAtom)
+    const nextTabs = currentTabs.filter((tab) => (
+      (tab.type !== 'agent' && tab.type !== 'preview') || !ids.has(tab.sessionId)
+    ))
+    const nextActiveTabId = currentActiveTabId && nextTabs.some((tab) => tab.id === currentActiveTabId)
+      ? currentActiveTabId
+      : nextTabs[0]?.id ?? null
+
+    setTabs(nextTabs)
+    setActiveTabId(nextActiveTabId)
+    for (const sessionId of ids) cleanupMapAtoms(sessionId)
+    syncActiveTabSideEffects(nextActiveTabId ? nextTabs.find((tab) => tab.id === nextActiveTabId) ?? null : null)
+  }, [cleanupMapAtoms, setActiveTabId, setTabs, store, syncActiveTabSideEffects])
+
   /** 切换 Agent 会话置顶状态 */
   const handleTogglePinAgent = React.useCallback(async (id: string): Promise<void> => {
+    const sessions = store.get(agentSessionsAtom)
+    const original = sessions.find((s) => s.id === id)
+    const delegatedChildren = getSyncableDelegatedChildren(sessions, id, draftSessionIds)
     try {
-      const original = store.get(agentSessionsAtom).find((s) => s.id === id)
       const updated = await window.electronAPI.togglePinAgentSession(id)
-      setAgentSessions((prev) => replaceAgentSessionInFreshnessOrder(prev, updated))
+      const targetPinned = !!updated.pinned
+      for (const child of delegatedChildren) {
+        if (!!child.pinned !== targetPinned) {
+          await window.electronAPI.togglePinAgentSession(child.id)
+        }
+      }
+      const refreshedSessions = delegatedChildren.length > 0
+        ? await window.electronAPI.listAgentSessions()
+        : null
+      if (refreshedSessions) {
+        setAgentSessions(refreshedSessions)
+      } else {
+        setAgentSessions((prev) => replaceAgentSessionInFreshnessOrder(prev, updated))
+      }
       if (updated.pinned) {
         if (original?.archived && !updated.archived) {
           toast.success('已置顶', { description: '已自动取消归档' })
+        } else if (delegatedChildren.length > 0) {
+          toast.success('已置顶', { description: `已同步 ${delegatedChildren.length} 个子会话` })
         } else {
           toast.success('已置顶')
         }
       } else {
-        toast.success('已取消置顶')
+        toast.success(
+          '已取消置顶',
+          delegatedChildren.length > 0
+            ? { description: `已同步 ${delegatedChildren.length} 个子会话` }
+            : undefined,
+        )
       }
     } catch (error) {
       console.error('[侧边栏] 切换 Agent 会话置顶失败:', error)
+      // 级联可能在中途失败，导致部分子会话已切换、部分未切换。
+      // 重新拉取磁盘真实状态，避免侧边栏与磁盘不一致直到下次重载。
+      if (delegatedChildren.length > 0) {
+        try {
+          setAgentSessions(await window.electronAPI.listAgentSessions())
+        } catch (refreshError) {
+          console.error('[侧边栏] 置顶失败后刷新会话列表失败:', refreshError)
+        }
+      }
     }
-  }, [store, setAgentSessions])
+  }, [draftSessionIds, store, setAgentSessions])
 
   /** 切换 Agent 会话归档状态 */
   const handleToggleArchiveAgent = React.useCallback(async (id: string): Promise<void> => {
+    const sessions = store.get(agentSessionsAtom)
+    // 在 try 外追踪级联状态，便于失败时重新同步与关闭已归档子会话的标签页。
+    let cascaded = false
+    const changedChildIds: string[] = []
     try {
       const updated = await window.electronAPI.toggleArchiveAgentSession(id)
-      setAgentSessions((prev) => replaceAgentSessionInFreshnessOrder(prev, updated))
+      const targetArchived = !!updated.archived
+      const delegatedChildren = targetArchived
+        ? getSyncableDelegatedChildren(sessions, id, draftSessionIds)
+        : []
+      cascaded = delegatedChildren.length > 0
+      for (const child of delegatedChildren) {
+        if (!!child.archived !== targetArchived) {
+          const childUpdated = await window.electronAPI.toggleArchiveAgentSession(child.id)
+          changedChildIds.push(childUpdated.id)
+        }
+      }
+      const refreshedSessions = delegatedChildren.length > 0
+        ? await window.electronAPI.listAgentSessions()
+        : null
+      if (refreshedSessions) {
+        setAgentSessions(refreshedSessions)
+      } else {
+        setAgentSessions((prev) => replaceAgentSessionInFreshnessOrder(prev, updated))
+      }
       // 归档时自动关闭该会话的标签页，并同步新激活标签的副作用，
       // 否则 RightSidePanel（依赖 currentAgentSessionIdAtom）会因为
       // 指针被错误置 null 而消失。
       if (updated.archived) {
-        const currentTabs = store.get(tabsAtom)
-        const currentActiveTabId = store.get(activeTabIdAtom)
-        const wasActive = currentActiveTabId === id
-        const tabResult = closeTab(currentTabs, currentActiveTabId, id)
-        setTabs(tabResult.tabs)
-        setActiveTabId(tabResult.activeTabId)
-        cleanupMapAtoms(id)
-        if (wasActive) {
-          const newActiveTab = tabResult.activeTabId
-            ? tabResult.tabs.find((t) => t.id === tabResult.activeTabId) ?? null
-            : null
-          syncActiveTabSideEffects(newActiveTab)
-        }
+        closeArchivedAgentTabs([updated.id, ...changedChildIds])
       }
-      toast.success(updated.archived ? '已归档' : '已取消归档')
+      toast.success(
+        updated.archived ? '已归档' : '已取消归档',
+        delegatedChildren.length > 0
+          ? { description: `已同步 ${delegatedChildren.length} 个子会话` }
+          : undefined,
+      )
     } catch (error) {
       console.error('[侧边栏] 切换 Agent 会话归档失败:', error)
+      // 级联可能在中途失败，导致部分子会话已归档、部分未归档。
+      // 关闭已确认归档的子会话标签页，并重新拉取磁盘真实状态以避免不一致。
+      if (cascaded) {
+        if (changedChildIds.length > 0) {
+          closeArchivedAgentTabs(changedChildIds)
+        }
+        try {
+          setAgentSessions(await window.electronAPI.listAgentSessions())
+        } catch (refreshError) {
+          console.error('[侧边栏] 归档失败后刷新会话列表失败:', refreshError)
+        }
+      }
     }
-  }, [store, setAgentSessions, setTabs, setActiveTabId, cleanupMapAtoms, syncActiveTabSideEffects])
+  }, [closeArchivedAgentTabs, draftSessionIds, store, setAgentSessions])
 
   /** 请求迁移会话到其他项目（弹出迁移对话框） */
   const handleRequestMove = React.useCallback((id: string): void => {
@@ -1378,6 +1586,8 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
           && !draftSessionIds.has(session.id)
           // 自动任务会话不进入项目列表，统一归到「自动任务」视图
           && !isHiddenAutomationSession(session)
+          // 已被置顶母会话收纳的子会话留在置顶区的母会话下面，避免重复显示为项目根会话
+          && !hasPinnedVisibleParent(session, agentSessions)
         )
       )
 
@@ -1997,24 +2207,62 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
               >
                 <div className="px-2">
                   <div className="ml-4 flex flex-col gap-0.5">
-                    {pinnedAgentSessions.map((session) => (
-                      <AgentSessionItem
-                        key={`pinned-${session.id}`}
-                        session={session}
-                        active={session.id === activeSessionId}
-                        indicatorStatus={agentIndicatorMap.get(session.id) ?? 'idle'}
-                        showPinIcon={false}
-                        leftAccent={getSessionLeftAccent(agentIndicatorMap.get(session.id) ?? 'idle')}
-                        workspaceName={session.workspaceId ? workspaceNameMap.get(session.workspaceId) : undefined}
-                        relativeTimeNow={relativeTimeNow}
-                        onSelect={handleSelectAgentSession}
-                        onRequestDelete={handleRequestDelete}
-                        onRequestMove={handleRequestMove}
-                        onRename={handleAgentRename}
-                        onTogglePin={handleTogglePinAgent}
-                        onToggleArchive={handleToggleArchiveAgent}
-                      />
-                    ))}
+                    {pinnedAgentSessionTrees.map((item) => {
+                      const childCount = item.childSessions.length
+                      const rowStatus = getSessionTreeStatus(item, agentIndicatorMap)
+                      const treeActive = treeContainsSessionId(item, activeSessionId)
+                      const activeChildVisible = item.childSessions.some((child) => child.id === activeSessionId)
+                      const expandedChildren = expandedDelegationParentIds.has(item.session.id) || activeChildVisible
+
+                      return (
+                        <div key={`pinned-${item.session.id}`} className="flex flex-col gap-0.5">
+                          <AgentSessionItem
+                            session={item.session}
+                            active={treeActive}
+                            indicatorStatus={rowStatus}
+                            showPinIcon={false}
+                            delegationSummary={childCount > 0
+                              ? {
+                                total: childCount,
+                                completed: countCompletedDelegatedChildren(item.childSessions),
+                                expanded: expandedChildren,
+                                onToggle: () => handleToggleDelegationParent(item.session.id),
+                              }
+                              : undefined}
+                            leftAccent={getSessionLeftAccent(rowStatus)}
+                            workspaceName={item.session.workspaceId ? workspaceNameMap.get(item.session.workspaceId) : undefined}
+                            relativeTimeNow={relativeTimeNow}
+                            onSelect={handleSelectAgentSession}
+                            onRequestDelete={handleRequestDelete}
+                            onRequestMove={handleRequestMove}
+                            onRename={handleAgentRename}
+                            onTogglePin={handleTogglePinAgent}
+                            onToggleArchive={handleToggleArchiveAgent}
+                          />
+
+                          {childCount > 0 && expandedChildren && (
+                            <div className="ml-3 border-l border-foreground/10 pl-2 flex flex-col gap-0.5">
+                              {item.childSessions.map((childSession) => (
+                                <DelegatedChildSessionItem
+                                  key={childSession.id}
+                                  session={childSession}
+                                  activeSessionId={activeSessionId}
+                                  agentIndicatorMap={agentIndicatorMap}
+                                  relativeTimeNow={relativeTimeNow}
+                                  workspaceName={childSession.workspaceId ? workspaceNameMap.get(childSession.workspaceId) : undefined}
+                                  onSelect={handleSelectAgentSession}
+                                  onRequestDelete={handleRequestDelete}
+                                  onRequestMove={handleRequestMove}
+                                  onRename={handleAgentRename}
+                                  onTogglePin={handleTogglePinAgent}
+                                  onToggleArchive={handleToggleArchiveAgent}
+                                />
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                      )
+                    })}
                   </div>
                 </div>
               </div>
@@ -2075,6 +2323,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                     collapsed={collapsedWorkspaceIds.has(group.workspace.id)}
                     activeSessionId={activeSessionId}
                     agentIndicatorMap={agentIndicatorMap}
+                    expandedDelegationParentIds={expandedDelegationParentIds}
                     relativeTimeNow={relativeTimeNow}
                     dragging={dragProjectId === group.workspace.id}
                     dropPosition={projectDropIndicator?.id === group.workspace.id ? projectDropIndicator.position : null}
@@ -2100,6 +2349,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                     onRename={handleAgentRename}
                     onTogglePin={handleTogglePinAgent}
                     onToggleArchive={handleToggleArchiveAgent}
+                    onToggleDelegationParent={handleToggleDelegationParent}
                   />
                 )
               })}
@@ -2675,6 +2925,13 @@ const SESSION_ACCENT_INDICATOR_CLASS: Record<SessionLeftAccent, string> = {
   green: 'bg-green-500',
 }
 
+const DELEGATION_STATUS_ICON_CLASS: Record<SessionIndicatorStatus, string> = {
+  idle: 'text-foreground/40',
+  running: 'text-blue-500',
+  blocked: 'text-orange-500',
+  completed: 'text-green-500',
+}
+
 function getSessionLeftAccent(status: SessionIndicatorStatus): SessionLeftAccent | undefined {
   if (status === 'blocked') return 'orange'
   if (status === 'running') return 'blue'
@@ -2687,6 +2944,12 @@ interface AgentSessionItemProps {
   active: boolean
   indicatorStatus: SessionIndicatorStatus
   showPinIcon?: boolean
+  delegationSummary?: {
+    total: number
+    completed: number
+    expanded: boolean
+    onToggle: () => void
+  }
   /** 行左侧状态色块；未传则不显示 */
   leftAccent?: SessionLeftAccent
   /** 是否禁用悬浮 Mini 地图 */
@@ -2708,6 +2971,7 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
   active,
   indicatorStatus,
   showPinIcon,
+  delegationSummary,
   leftAccent,
   disableMiniMap,
   workspaceName,
@@ -2850,12 +3114,36 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
                   <Clock size={11} className="flex-shrink-0 text-foreground/40" />
                 )}
                 {session.sourceDelegationId && !session.sourceAutomationId && (
-                  <GitBranch size={11} className="flex-shrink-0 text-foreground/40" />
+                  <GitBranch size={11} className={cn('flex-shrink-0', DELEGATION_STATUS_ICON_CLASS[indicatorStatus])} />
+                )}
+                {delegationSummary && (
+                  <button
+                    type="button"
+                    aria-label={`${delegationSummary.expanded ? '收起' : '展开'}子会话`}
+                    onClick={(event) => {
+                      event.stopPropagation()
+                      delegationSummary.onToggle()
+                    }}
+                    className="flex-shrink-0 inline-flex size-4 items-center justify-center rounded text-foreground/45 hover:bg-foreground/[0.055] hover:text-foreground/70 transition-colors"
+                  >
+                    <ChevronRight
+                      size={11}
+                      className={cn(
+                        'transition-transform duration-150',
+                        delegationSummary.expanded && 'rotate-90',
+                      )}
+                    />
+                  </button>
                 )}
                 <span className="truncate">{session.title}</span>
                 {workspaceName && (
                   <span className="flex-shrink-0 px-1.5 py-0 rounded-full bg-primary/10 text-[10px] leading-4 workspace-badge font-medium truncate max-w-[80px]">
                     {workspaceName}
+                  </span>
+                )}
+                {delegationSummary && (
+                  <span className="flex-shrink-0 text-[11px] leading-4 text-foreground/45">
+                    {delegationSummary.completed}/{delegationSummary.total} 子会话
                   </span>
                 )}
               </div>
@@ -2898,6 +3186,52 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
   )
 })
 
+interface DelegatedChildSessionItemProps {
+  session: AgentSessionMeta
+  activeSessionId: string | null
+  agentIndicatorMap: Map<string, SessionIndicatorStatus>
+  relativeTimeNow: number
+  workspaceName?: string
+  onSelect: (id: string, title: string) => void
+  onRequestDelete: (id: string) => void
+  onRequestMove: (id: string) => void
+  onRename: (id: string, newTitle: string) => Promise<void>
+  onTogglePin: (id: string) => Promise<void>
+  onToggleArchive: (id: string) => Promise<void>
+}
+
+const DelegatedChildSessionItem = React.memo(function DelegatedChildSessionItem({
+  session,
+  activeSessionId,
+  agentIndicatorMap,
+  relativeTimeNow,
+  workspaceName,
+  onSelect,
+  onRequestDelete,
+  onRequestMove,
+  onRename,
+  onTogglePin,
+  onToggleArchive,
+}: DelegatedChildSessionItemProps): React.ReactElement {
+  const status = getDelegatedChildStatus(session, agentIndicatorMap)
+
+  return (
+    <AgentSessionItem
+      session={session}
+      active={session.id === activeSessionId}
+      indicatorStatus={status}
+      relativeTimeNow={relativeTimeNow}
+      workspaceName={workspaceName}
+      onSelect={onSelect}
+      onRequestDelete={onRequestDelete}
+      onRequestMove={onRequestMove}
+      onRename={onRename}
+      onTogglePin={onTogglePin}
+      onToggleArchive={onToggleArchive}
+    />
+  )
+})
+
 // ===== 项目分组历史 =====
 
 interface AgentProjectGroupItemProps {
@@ -2913,6 +3247,7 @@ interface AgentProjectGroupItemProps {
   extraCount: number
   activeSessionId: string | null
   agentIndicatorMap: Map<string, SessionIndicatorStatus>
+  expandedDelegationParentIds: Set<string>
   relativeTimeNow: number
   dragging: boolean
   dropPosition: 'before' | 'after' | null
@@ -2935,6 +3270,7 @@ interface AgentProjectGroupItemProps {
   onRename: (id: string, newTitle: string) => Promise<void>
   onTogglePin: (id: string) => Promise<void>
   onToggleArchive: (id: string) => Promise<void>
+  onToggleDelegationParent: (id: string) => void
 }
 
 const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
@@ -2947,6 +3283,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
   extraCount,
   activeSessionId,
   agentIndicatorMap,
+  expandedDelegationParentIds,
   relativeTimeNow,
   dragging,
   dropPosition,
@@ -2969,6 +3306,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
   onRename,
   onTogglePin,
   onToggleArchive,
+  onToggleDelegationParent,
 }: AgentProjectGroupItemProps): React.ReactElement {
   const isCurrent = group.workspace.id === currentWorkspaceId
 
@@ -3017,43 +3355,42 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
   // 状态如何，确保从搜索结果打开旧会话时左侧栏立即可见，不必等待 agent 完成。
   // 非活跃部分仍保留原"最近 3 天 + 至多 5 条"预览策略，作为额外补充展示。
   // 用户点击"显示更多"会在折叠基线之上每次再额外展开 PROJECT_SESSION_EXPAND_STEP 条。
-  const getStatus = (sessionId: string): SessionIndicatorStatus =>
-    agentIndicatorMap.get(sessionId) ?? 'idle'
-  const activeSessions = group.sessions
-    .filter((session) => ACTIVE_SESSION_STATUSES.has(getStatus(session.id)))
+  const treeItems = buildAgentSessionTrees(group.sessions)
+  const activeSessions = treeItems
+    .filter((item) => ACTIVE_SESSION_STATUSES.has(getSessionTreeStatus(item, agentIndicatorMap)))
     .slice()
     .sort((a, b) => {
-      const delta = ACTIVE_SESSION_STATUS_PRIORITY[getStatus(a.id)]
-        - ACTIVE_SESSION_STATUS_PRIORITY[getStatus(b.id)]
+      const delta = ACTIVE_SESSION_STATUS_PRIORITY[getSessionTreeStatus(a, agentIndicatorMap)]
+        - ACTIVE_SESSION_STATUS_PRIORITY[getSessionTreeStatus(b, agentIndicatorMap)]
       if (delta !== 0) return delta
-      return b.updatedAt - a.updatedAt
+      return b.session.updatedAt - a.session.updatedAt
     })
-  const activeIds = new Set(activeSessions.map((s) => s.id))
+  const activeIds = collectTreeSessionIds(activeSessions)
   // 非活跃部分按自然策略（最近 3 天窗口 + 预览上限）计算，且不依赖当前选中态，
   // 保持 group.sessions 的 updatedAt 倒序——这样点击已可见会话时顺序保持稳定，
   // 不会因为它变成 activeSessionId 而被提到顶部。
-  const fillSessions = group.sessions
-    .filter((session) =>
-      !activeIds.has(session.id)
-      && session.updatedAt >= recentCutoff
+  const fillSessions = treeItems
+    .filter((item) =>
+      !activeIds.has(item.session.id)
+      && item.session.updatedAt >= recentCutoff
     )
     .slice(0, PROJECT_SESSION_PREVIEW_LIMIT)
-  const fillIds = new Set(fillSessions.map((s) => s.id))
+  const fillIds = collectTreeSessionIds(fillSessions)
   // 当前选中会话仅在「既非活跃、又不在自然填充集合中」时才补入折叠列表（紧接活跃区之后），
   // 确保从搜索结果打开的旧会话（updatedAt 超窗或被上限截断）立即可见；
   // 若它本就出现在 fillSessions 中，则不再单独前置，避免点击后被强制排到第一位。
   const currentSession = activeSessionId
     && !activeIds.has(activeSessionId)
     && !fillIds.has(activeSessionId)
-    ? group.sessions.find((s) => s.id === activeSessionId) ?? null
+    ? treeItems.find((item) => treeContainsSessionId(item, activeSessionId)) ?? null
     : null
   const pinnedCurrent = currentSession ? [currentSession] : []
   const collapsedSessions = [...activeSessions, ...pinnedCurrent, ...fillSessions]
-  const collapsedIds = new Set(collapsedSessions.map((s) => s.id))
-  const remainingSessions = group.sessions.filter((s) => !collapsedIds.has(s.id))
+  const collapsedIds = new Set(collapsedSessions.map((item) => item.session.id))
+  const remainingSessions = treeItems.filter((item) => !collapsedIds.has(item.session.id))
   const extraSessions = remainingSessions.slice(0, extraCount)
   const sessions = [...collapsedSessions, ...extraSessions]
-  const hiddenCount = Math.max(0, group.sessions.length - sessions.length)
+  const hiddenCount = Math.max(0, treeItems.length - sessions.length)
 
   return (
     <section
@@ -3202,26 +3539,64 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
 
       <div id={`project-sessions-${group.workspace.id}`} className="ml-4 mt-px">
         {!collapsed ? (
-          group.sessions.length > 0 ? (
+          treeItems.length > 0 ? (
             <div className="flex flex-col gap-0.5">
-              {sessions.map((session) => (
-                <AgentSessionItem
-                  key={session.id}
-                  session={session}
-                  active={session.id === activeSessionId}
-                  indicatorStatus={agentIndicatorMap.get(session.id) ?? 'idle'}
-                  showPinIcon={!!session.pinned}
-                  leftAccent={getSessionLeftAccent(agentIndicatorMap.get(session.id) ?? 'idle')}
-                  relativeTimeNow={relativeTimeNow}
-                  workspaceName={isAutomationGroup && session.workspaceId ? workspaceNameMap?.get(session.workspaceId) : undefined}
-                  onSelect={onSelectSession}
-                  onRequestDelete={onRequestDelete}
-                  onRequestMove={onRequestMove}
-                  onRename={onRename}
-                  onTogglePin={onTogglePin}
-                  onToggleArchive={onToggleArchive}
-                />
-              ))}
+              {sessions.map((item) => {
+                const childCount = item.childSessions.length
+                const rowStatus = getSessionTreeStatus(item, agentIndicatorMap)
+                const treeActive = treeContainsSessionId(item, activeSessionId)
+                const activeChildVisible = item.childSessions.some((child) => child.id === activeSessionId)
+                const expandedChildren = expandedDelegationParentIds.has(item.session.id) || activeChildVisible
+
+                return (
+                  <div key={item.session.id} className="flex flex-col gap-0.5">
+                    <AgentSessionItem
+                      session={item.session}
+                      active={treeActive}
+                      indicatorStatus={rowStatus}
+                      showPinIcon={!!item.session.pinned}
+                      delegationSummary={childCount > 0
+                        ? {
+                          total: childCount,
+                          completed: countCompletedDelegatedChildren(item.childSessions),
+                          expanded: expandedChildren,
+                          onToggle: () => onToggleDelegationParent(item.session.id),
+                        }
+                        : undefined}
+                      leftAccent={getSessionLeftAccent(rowStatus)}
+                      relativeTimeNow={relativeTimeNow}
+                      workspaceName={isAutomationGroup && item.session.workspaceId ? workspaceNameMap?.get(item.session.workspaceId) : undefined}
+                      onSelect={onSelectSession}
+                      onRequestDelete={onRequestDelete}
+                      onRequestMove={onRequestMove}
+                      onRename={onRename}
+                      onTogglePin={onTogglePin}
+                      onToggleArchive={onToggleArchive}
+                    />
+
+                    {childCount > 0 && expandedChildren && (
+                      <div className="ml-3 border-l border-foreground/10 pl-2 flex flex-col gap-0.5">
+                        {item.childSessions.map((childSession) => (
+                          <DelegatedChildSessionItem
+                            key={childSession.id}
+                            session={childSession}
+                            activeSessionId={activeSessionId}
+                            agentIndicatorMap={agentIndicatorMap}
+                            relativeTimeNow={relativeTimeNow}
+                            workspaceName={isAutomationGroup && childSession.workspaceId ? workspaceNameMap?.get(childSession.workspaceId) : undefined}
+                            onSelect={onSelectSession}
+                            onRequestDelete={onRequestDelete}
+                            onRequestMove={onRequestMove}
+                            onRename={onRename}
+                            onTogglePin={onTogglePin}
+                            onToggleArchive={onToggleArchive}
+                          />
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
 
               {hiddenCount > 0 && (
                 <button


### PR DESCRIPTION
## 这个 PR 做了啥

以前在协作里委派出去的子会话，会和普通会话平铺在侧边栏里，多了之后很难看出谁是谁的子任务。这个 PR 把它们收进各自的父会话下面，变成一棵能折叠的小树：父会话那一行会显示子任务跑得怎么样（聚合状态灯 + 「完成数/总数」的计数），点一下就能展开看具体子会话。

顺手还做了两件事：

1. **置顶 / 归档父会话时，子会话跟着一起动。** 置顶父会话，它名下的子会话也一起置顶；归档父会话，子会话一起归档、对应的标签页也一起关掉。操作完会有「已同步 N 个子会话」的提示。
2. **修了一个状态对不上的坑。** 之前级联同步子会话时，如果中途某一步失败，代码只在控制台报个错就结束了，导致一部分子会话已经切换、一部分没切换，侧边栏显示的状态和磁盘里实际存的对不上，得重开应用才能恢复。现在失败后会重新从磁盘拉一遍真实状态盖回去，保证看到的就是真实的。

## 具体改了哪些文件

- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx`
  - 新增委派会话树的构建和渲染：子会话嵌套在父会话下、可折叠；父行显示聚合状态（优先级 blocked > running > completed > idle）和完成计数
  - 在置顶区、项目分组、自动任务三个视图里做了去重，避免子会话又作为根会话重复出现一遍
  - `handleTogglePinAgent` / `handleToggleArchiveAgent`：实现置顶/归档的级联同步，并修复级联中途失败导致的状态不一致（catch 里重新拉取磁盘状态，归档路径还会补关掉已归档子会话的标签页）
  - 会话删除 / 工作区删除时，顺便清掉残留的展开状态
- `apps/electron/package.json` — 版本号从 0.13.4 升到 0.13.5

## 怎么测

1. 建个父会话，通过协作委派几个子会话，看子会话是不是收在父会话下面、能折叠展开
2. 看父行的状态灯和「完成数/总数」是不是和子会话实际状态对得上
3. 给有子会话的父会话点置顶 / 取消置顶，确认子会话跟着动，提示「已同步 N 个子会话」
4. 归档父会话，确认子会话一起归档、标签页也关掉了
5. 删会话 / 删工作区之后，确认没有残留的展开状态导致显示异常

## 备注

- 纯前端（renderer）改动 + 版本号 bump，没碰主进程 IPC、路径处理或任何平台相关代码，Windows 这边是安全的
- \`bun run typecheck\` 四个包全过，0 报错
- 经 Review-Proma-PR 双子会话交叉审核，审核发现的「级联失败状态不一致」Warning 已在本 PR 一并修掉