### PR TITLE
【已审核】feat(skill): /skill:name 支持临时激活 skills-inactive 中的禁用 Skill

### DIFF
--- a/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
@@ -175,6 +175,8 @@ export interface ClaudeAgentQueryOptions extends AgentQueryInput {
   outputFormat?: JsonSchemaOutputFormat
   /** Beta 特性（如 1M context window） */
   betas?: SdkBeta[]
+  /** Skill 白名单：仅列出的 skill 对模型可见，未列出者不占上下文。'all' 启用全部已发现 skill */
+  skills?: string[] | 'all'
   /** 是否持久化会话到磁盘（默认 true） */
   persistSession?: boolean
   /** resume 时是否 fork 为新会话 */
@@ -772,6 +774,7 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
         ...(options.maxBudgetUsd != null && { maxBudgetUsd: options.maxBudgetUsd }),
         ...(options.outputFormat && { outputFormat: options.outputFormat }),
         ...(options.betas && { betas: options.betas }),
+        ...(options.skills && { skills: options.skills }),
         ...(options.persistSession != null && { persistSession: options.persistSession }),
         ...(options.forkSession != null && { forkSession: options.forkSession }),
         ...(options.sdkSessionId && { sessionId: options.sdkSessionId }),

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -41,8 +41,8 @@ import pkg from '../../../package.json' with { type: 'json' }
 import { getFetchFn } from './proxy-fetch'
 import { getEffectiveProxyUrl } from './proxy-settings-service'
 import { appendSDKMessages, updateAgentSessionMeta, getAgentSessionMeta, getAgentSessionMessages, getAgentSessionSDKMessages, truncateSDKMessages, resolveUserUuidFromSDK, rewindFilesFromSnapshot } from './agent-session-manager'
-import { getAgentWorkspace, getWorkspaceMcpConfig, ensurePluginManifest } from './agent-workspace-manager'
-import { getAgentWorkspacePath, getAgentSessionWorkspacePath, getSdkConfigDir, getWorkspaceFilesDir, getConfigDirName } from './config-paths'
+import { getAgentWorkspace, getWorkspaceMcpConfig, ensurePluginManifest, getWorkspaceSkills } from './agent-workspace-manager'
+import { getAgentWorkspacePath, getAgentSessionWorkspacePath, getSdkConfigDir, getWorkspaceFilesDir, getConfigDirName, getInactiveSkillsDir } from './config-paths'
 import { getWorkspaceAttachedDirectories, getWorkspaceAttachedFiles } from './agent-workspace-manager'
 import { getRuntimeStatus } from './runtime-init'
 import { getSettings } from './settings-service'
@@ -1185,6 +1185,21 @@ export class AgentOrchestrator {
         console.log(`[Agent 编排] 已合并 ${Object.keys(customMcpServers).length} 个自定义 MCP 服务器`)
       }
 
+      // 11.2 Skills 白名单：仅活跃 skill 占上下文，inactive skill 仅 /skill:name 时临时可见
+      const activeSkills = workspaceSlug ? getWorkspaceSkills(workspaceSlug) : []
+      const activeSkillSlugs = new Set(activeSkills.map((s) => s.slug))
+      const extraSkillSlugs: string[] = []
+      for (const slug of mentionedSkills ?? []) {
+        if (!activeSkillSlugs.has(slug) && workspaceSlug) {
+          const inactiveMd = join(getInactiveSkillsDir(workspaceSlug), slug, 'SKILL.md')
+          if (existsSync(inactiveMd)) {
+            extraSkillSlugs.push(slug)
+            console.log(`[Agent 编排] 临时启用 inactive skill: ${slug}`)
+          }
+        }
+      }
+      const skillsWhitelist: string[] = [...activeSkillSlugs, ...extraSkillSlugs]
+
       // 11. 构建动态上下文和最终 prompt
       const dynamicCtx = buildDynamicContext({
         workspaceName: workspace?.name,
@@ -1497,6 +1512,8 @@ export class AgentOrchestrator {
         resumeSessionId: existingSdkSessionId,
         // 回退后 resume：从指定消息处继续（SDK 在同一 JSONL 内创建分支）
         ...(rewindResumeAt && { resumeSessionAt: rewindResumeAt }),
+        // Skills 白名单：仅活跃 skill + 显式 /skill:name 的 inactive skill 对模型可见
+        skills: skillsWhitelist,
         ...(Object.keys(mcpServers).length > 0 && { mcpServers }),
         ...(workspaceSlug && { plugins: [{ type: 'local' as const, path: getAgentWorkspacePath(workspaceSlug) }] }),
         // 合并附加目录：用户当次输入 + 会话级 + 工作区级（详见 collectAttachedDirectories）

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -449,25 +449,35 @@ function compareSemver(a: string, b: string): number {
 
 // ===== Plugin Manifest（SDK 插件发现） =====
 
-/** 确保工作区包含 .claude-plugin/plugin.json，SDK 需要此文件发现 skills */
+/** 确保工作区包含 .claude-plugin/plugin.json，SDK 需要此文件发现 skills。
+ *  同时注册 skills-inactive 作为额外发现路径，使禁用 Skill 仍可被 SDK 感知、
+ *  由 skills 白名单精确控制上下文可见性。 */
 export function ensurePluginManifest(workspaceSlug: string, workspaceName: string): void {
   const wsPath = getAgentWorkspacePath(workspaceSlug)
   const pluginDir = join(wsPath, '.claude-plugin')
   const manifestPath = join(pluginDir, 'plugin.json')
 
-  if (existsSync(manifestPath)) return
-
   if (!existsSync(pluginDir)) {
     mkdirSync(pluginDir, { recursive: true })
   }
 
-  const manifest = {
-    name: `proma-workspace-${workspaceSlug}`,
-    version: '1.0.0',
+  let manifest: { name: string; version: string; skills?: string }
+  if (existsSync(manifestPath)) {
+    try {
+      manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'))
+    } catch {
+      manifest = { name: `proma-workspace-${workspaceSlug}`, version: '1.0.0' }
+    }
+  } else {
+    manifest = { name: `proma-workspace-${workspaceSlug}`, version: '1.0.0' }
   }
 
-  writeFileSync(manifestPath, JSON.stringify(manifest, null, 2), 'utf-8')
-  console.log(`[Agent 工作区] 已创建 plugin manifest: ${workspaceSlug}`)
+  // 确保 SDK 同时扫描 skills-inactive 目录，配合 skills 白名单实现按需可见
+  if (manifest.skills !== 'skills-inactive') {
+    manifest.skills = 'skills-inactive'
+    writeFileSync(manifestPath, JSON.stringify(manifest, null, 2), 'utf-8')
+    console.log(`[Agent 工作区] 已更新 plugin manifest (skills-inactive): ${workspaceSlug}`)
+  }
 }
 
 // ===== MCP 配置管理 =====


### PR DESCRIPTION
## 概述

实现 `skills-inactive/` 下禁用 Skill 的按需激活：平时不占上下文预算，用户通过 `/skill:name` 显式引用时临时对本次会话可见。

**动机**：当前工作区 23 个活跃 Skill 的元数据合计 ~10,000 字符，远超 SDK 默认 1% 上下文预算（200K → ~2,000 字符），导致多数 Skill description 被截断。将低频 Skill 移到 `skills-inactive/` 后，只有显式 `/skill:name` 时才临时加入白名单，大幅降低常驻上下文开销。

## 机制

```
plugin.json skills: "skills-inactive"
  → SDK 发现 skills/ + skills-inactive/ 全部 skill
  → skills 白名单过滤: [pdf, docx, skill-audit, ...]
  → 只有白名单内 skill 注入上下文
  → /skill:dev-flutter → 临时加入白名单，本次会话可见
```

## 改动

| 文件 | 改动 |
|------|------|
| `agent-workspace-manager.ts` | `ensurePluginManifest` 始终确保 plugin.json 包含 `skills: "skills-inactive"`，让 SDK 同时扫描两个目录 |
| `claude-agent-adapter.ts` | 新增 `skills` 查询选项并透传到 SDK |
| `agent-orchestrator.ts` | 每次发消息时构建 skills 白名单：活跃 skill + 显式 /skill:name 的 inactive skill |

## 测试

- [x] `bun run typecheck` 全部通过
- [x] `bun run electron:build` 构建成功

## 紧急度

常规

## 备注

- SDK 的 `skills` 白名单是「上下文过滤器」而非沙箱：未列出的 skill 描述不注入上下文，但文件仍在磁盘、SDK Skill 工具会拒绝调用
- 已存在的 plugin.json 会在首次启动时自动升级（添加 `skills` 字段）
- 不影响 resume 会话：每次 sendMessage 都重建白名单