### PR TITLE
fix(channel): normalize provider connection test errors

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/channel-manager.ts
+++ b/apps/electron/src/main/lib/channel-manager.ts
@@ -25,10 +25,27 @@ import { PROVIDER_DEFAULT_URLS } from '@proma/shared'
 import { getFetchFn } from './proxy-fetch'
 import { getEffectiveProxyUrl } from './proxy-settings-service'
 import { normalizeBaseUrl, normalizeAnthropicProviderUrl, getPromaUserAgent } from '@proma/core'
+import {
+  normalizeChannelTestException,
+  normalizeChannelTestResponse,
+} from './channel-test-normalizer'
 import pkg from '../../../package.json' with { type: 'json' }
 
 /** 当前配置版本 */
 const CONFIG_VERSION = 1
+/** 连接测试超时时间 */
+const CHANNEL_TEST_TIMEOUT_MS = 15_000
+
+async function fetchForChannelTest(
+  fetchFn: typeof globalThis.fetch,
+  input: string,
+  init: RequestInit,
+): Promise<Response> {
+  return fetchFn(input, {
+    ...init,
+    signal: AbortSignal.timeout(CHANNEL_TEST_TIMEOUT_MS),
+  })
+}
 
 /**
  * 读取渠道配置文件
@@ -290,8 +307,7 @@ export async function testChannel(channelId: string): Promise<ChannelTestResult>
         return { success: false, message: `不支持的供应商: ${channel.provider}。你可能过去使用的是 Proma 商业版，请重新下载商业版覆盖安装，当前版本为开源版本。` }
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : '未知错误'
-    return { success: false, message: `连接测试失败: ${message}` }
+    return normalizeChannelTestException(error)
   }
 }
 
@@ -355,7 +371,7 @@ async function testAnthropicCompatible(
     headers.Authorization = `Bearer ${apiKey}`
   }
 
-  const response = await fetchFn(`${url}/messages`, {
+  const response = await fetchForChannelTest(fetchFn, `${url}/messages`, {
     method: 'POST',
     headers,
     body: JSON.stringify({
@@ -365,17 +381,7 @@ async function testAnthropicCompatible(
     }),
   })
 
-  if (response.ok) {
-    return { success: true, message: '连接成功' }
-  }
-
-  if (response.status === 401) {
-    const text = await response.text().catch(() => '')
-    return { success: false, message: `API Key 无效${text ? `: ${text.slice(0, 150)}` : ''}` }
-  }
-
-  // 如果能收到 API 的响应（即使是错误），说明连接是通的
-  return { success: true, message: '连接成功' }
+  return normalizeChannelTestResponse(response)
 }
 
 /**
@@ -385,23 +391,14 @@ async function testOpenAICompatible(baseUrl: string, apiKey: string, proxyUrl?: 
   const url = normalizeBaseUrl(baseUrl)
   const fetchFn = getFetchFn(proxyUrl)
 
-  const response = await fetchFn(`${url}/models`, {
+  const response = await fetchForChannelTest(fetchFn, `${url}/models`, {
     method: 'GET',
     headers: {
       Authorization: `Bearer ${apiKey}`,
     },
   })
 
-  if (response.ok) {
-    return { success: true, message: '连接成功' }
-  }
-
-  if (response.status === 401) {
-    return { success: false, message: 'API Key 无效' }
-  }
-
-  const text = await response.text().catch(() => '')
-  return { success: false, message: `请求失败 (${response.status}): ${text.slice(0, 200)}` }
+  return normalizeChannelTestResponse(response)
 }
 
 /**
@@ -411,20 +408,11 @@ async function testGoogle(baseUrl: string, apiKey: string, proxyUrl?: string): P
   const url = normalizeBaseUrl(baseUrl)
   const fetchFn = getFetchFn(proxyUrl)
 
-  const response = await fetchFn(`${url}/v1beta/models?key=${apiKey}`, {
+  const response = await fetchForChannelTest(fetchFn, `${url}/v1beta/models?key=${apiKey}`, {
     method: 'GET',
   })
 
-  if (response.ok) {
-    return { success: true, message: '连接成功' }
-  }
-
-  if (response.status === 400 || response.status === 403) {
-    return { success: false, message: 'API Key 无效' }
-  }
-
-  const text = await response.text().catch(() => '')
-  return { success: false, message: `请求失败 (${response.status}): ${text.slice(0, 200)}` }
+  return normalizeChannelTestResponse(response)
 }
 
 // ===== 直接测试连接 =====
@@ -463,8 +451,7 @@ export async function testChannelDirect(input: FetchModelsInput): Promise<Channe
         return { success: false, message: `不支持的提供商: ${input.provider}` }
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : '未知错误'
-    return { success: false, message: `连接测试失败: ${message}` }
+    return normalizeChannelTestException(error)
   }
 }
 

--- a/apps/electron/src/main/lib/channel-test-normalizer.ts
+++ b/apps/electron/src/main/lib/channel-test-normalizer.ts
@@ -1,0 +1,210 @@
+import type { ChannelTestErrorType, ChannelTestResult } from '@proma/shared'
+
+const MAX_RAW_SUMMARY_LENGTH = 500
+const MAX_ERROR_BODY_BYTES = 16 * 1024
+
+interface ErrorDescriptor {
+  message: string
+  code: string
+}
+
+const ERROR_LABELS: Record<ChannelTestErrorType, string> = {
+  auth: '认证失败',
+  permission: '权限不足',
+  not_found: '资源不存在',
+  rate_limit: '请求频率受限',
+  quota: '额度不足',
+  bad_request: '请求无效',
+  server: '供应商服务异常',
+  network: '网络连接失败',
+  timeout: '连接超时',
+  unknown: '未知错误',
+}
+
+const RETRIABLE_ERROR_TYPES: ReadonlySet<ChannelTestErrorType> = new Set([
+  'rate_limit',
+  'server',
+  'network',
+  'timeout',
+])
+
+const QUOTA_PATTERN = /insufficient[_\s-]?quota|quota|billing|credit|payment[_\s-]?required|余额不足|额度不足|欠费|账户余额|充值/i
+const AUTH_PATTERN = /authentication|unauthorized|invalid[_\s-]?(?:api[_\s-]?)?key|api key not valid|incorrect api key|invalid token|凭证无效|密钥无效|未认证/i
+const PERMISSION_PATTERN = /permission|forbidden|access denied|not allowed|model access|无权限|权限不足|无权|访问受限/i
+const NOT_FOUND_PATTERN = /not found|does not exist|unknown model|model.*不存在|不存在|未找到/i
+const RATE_LIMIT_PATTERN = /rate[_\s-]?limit|too many requests|requests per|限流|请求过于频繁|频率限制/i
+const BAD_REQUEST_PATTERN = /bad request|invalid request|validation|invalid parameter|unsupported|malformed|请求无效|参数错误|协议不兼容/i
+const TIMEOUT_PATTERN = /timeout|timed out|etimedout|超时/i
+const NETWORK_PATTERN = /fetch failed|network|econnreset|econnrefused|enotfound|eai_again|socket|connection|连接失败|网络错误/i
+const INVALID_URL_PATTERN = /invalid url|failed to parse url|unsupported protocol|only absolute urls|invalid protocol|无效的 url/i
+const SENSITIVE_VALUE_PATTERNS: ReadonlyArray<{ pattern: RegExp; replacement: string }> = [
+  { pattern: /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, replacement: 'Bearer [REDACTED]' },
+  { pattern: /\bsk-[A-Za-z0-9_-]{8,}\b/gi, replacement: '[REDACTED]' },
+  {
+    pattern: /(["']?(?:api[_-]?key|x-api-key|access[_-]?token|token|authorization|key)["']?\s*[:=]\s*["']?)[^"',&\s}]+/gi,
+    replacement: '$1[REDACTED]',
+  },
+]
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function readString(record: Record<string, unknown>, key: string): string {
+  const value = record[key]
+  return typeof value === 'string' || typeof value === 'number' ? String(value) : ''
+}
+
+function describeErrorBody(rawBody: string): ErrorDescriptor {
+  const trimmed = rawBody.trim()
+  if (!trimmed) return { message: '', code: '' }
+
+  try {
+    const parsed: unknown = JSON.parse(trimmed)
+    if (!isRecord(parsed)) return { message: trimmed, code: '' }
+
+    const nestedError = isRecord(parsed.error) ? parsed.error : undefined
+    const message = nestedError
+      ? readString(nestedError, 'message')
+      : readString(parsed, 'message')
+    const code = nestedError
+      ? readString(nestedError, 'code') || readString(nestedError, 'type') || readString(nestedError, 'status')
+      : readString(parsed, 'code') || readString(parsed, 'type') || readString(parsed, 'status')
+
+    return {
+      message: message || trimmed,
+      code,
+    }
+  } catch {
+    return { message: trimmed, code: '' }
+  }
+}
+
+async function readErrorBody(response: Response): Promise<string> {
+  const reader = response.body?.getReader()
+  if (!reader) return ''
+
+  const decoder = new TextDecoder()
+  let body = ''
+  let bytesRead = 0
+
+  try {
+    while (bytesRead < MAX_ERROR_BODY_BYTES) {
+      const { done, value } = await reader.read()
+      if (done) break
+
+      const remainingBytes = MAX_ERROR_BODY_BYTES - bytesRead
+      const chunk = value.subarray(0, remainingBytes)
+      body += decoder.decode(chunk, { stream: true })
+      bytesRead += chunk.byteLength
+
+      if (chunk.byteLength < value.byteLength || bytesRead >= MAX_ERROR_BODY_BYTES) {
+        await reader.cancel()
+        break
+      }
+    }
+    return body + decoder.decode()
+  } catch {
+    return body
+  } finally {
+    reader.releaseLock()
+  }
+}
+
+function truncateSummary(value: string): string | undefined {
+  const redacted = SENSITIVE_VALUE_PATTERNS.reduce(
+    (result, { pattern, replacement }) => result.replace(pattern, replacement),
+    value,
+  )
+  const normalized = redacted.replace(/\s+/g, ' ').trim()
+  if (!normalized) return undefined
+  return normalized.length > MAX_RAW_SUMMARY_LENGTH
+    ? `${normalized.slice(0, MAX_RAW_SUMMARY_LENGTH)}...`
+    : normalized
+}
+
+function classifyHttpError(statusCode: number, descriptor: ErrorDescriptor): ChannelTestErrorType {
+  const semanticText = `${descriptor.code} ${descriptor.message}`
+
+  if (statusCode >= 500) return 'server'
+  if (statusCode === 408) return 'timeout'
+  if (statusCode === 402) return 'quota'
+
+  if (QUOTA_PATTERN.test(semanticText)) return 'quota'
+  if (AUTH_PATTERN.test(semanticText)) return 'auth'
+  if (statusCode === 401) return 'auth'
+  if (PERMISSION_PATTERN.test(semanticText)) return 'permission'
+  if (NOT_FOUND_PATTERN.test(semanticText)) return 'not_found'
+  if (RATE_LIMIT_PATTERN.test(semanticText)) return 'rate_limit'
+  if (BAD_REQUEST_PATTERN.test(semanticText)) return 'bad_request'
+
+  if (statusCode === 403) return 'permission'
+  if (statusCode === 404) return 'not_found'
+  if (statusCode === 429) return 'rate_limit'
+  if ([400, 405, 409, 413, 415, 422].includes(statusCode)) return 'bad_request'
+  return 'unknown'
+}
+
+function buildFailureResult(
+  errorType: ChannelTestErrorType,
+  detail: string,
+  statusCode?: number,
+): ChannelTestResult {
+  const rawSummary = truncateSummary(detail)
+  const statusLabel = statusCode == null ? '' : ` (${statusCode})`
+  const detailLabel = rawSummary ? `：${rawSummary}` : ''
+
+  return {
+    success: false,
+    message: `${ERROR_LABELS[errorType]}${statusLabel}${detailLabel}`,
+    errorType,
+    ...(statusCode == null ? {} : { statusCode }),
+    ...(rawSummary ? { rawSummary } : {}),
+    retriable: RETRIABLE_ERROR_TYPES.has(errorType),
+  }
+}
+
+function collectErrorText(error: unknown): string {
+  if (!(error instanceof Error)) return String(error)
+
+  const parts = [error.name, error.message]
+  if (error.cause instanceof Error) {
+    parts.push(error.cause.name, error.cause.message)
+  } else if (error.cause != null) {
+    parts.push(String(error.cause))
+  }
+  return parts.filter(Boolean).join(': ')
+}
+
+export async function normalizeChannelTestResponse(response: Response): Promise<ChannelTestResult> {
+  if (response.ok) {
+    return { success: true, message: '连接成功' }
+  }
+
+  const rawBody = await readErrorBody(response)
+  const descriptor = describeErrorBody(rawBody)
+  const errorType = classifyHttpError(response.status, descriptor)
+  const detail = descriptor.message || response.statusText
+  return buildFailureResult(errorType, detail, response.status)
+}
+
+export function normalizeChannelTestException(error: unknown): ChannelTestResult {
+  const detail = collectErrorText(error)
+
+  if (
+    (error instanceof DOMException && (error.name === 'AbortError' || error.name === 'TimeoutError'))
+    || TIMEOUT_PATTERN.test(detail)
+  ) {
+    return buildFailureResult('timeout', detail)
+  }
+
+  if (INVALID_URL_PATTERN.test(detail)) {
+    return buildFailureResult('bad_request', detail)
+  }
+
+  if (NETWORK_PATTERN.test(detail)) {
+    return buildFailureResult('network', detail)
+  }
+
+  return buildFailureResult('unknown', detail)
+}

--- a/apps/electron/src/renderer/components/settings/ChannelForm.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelForm.tsx
@@ -592,7 +592,7 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
                 testResult.success ? 'text-emerald-600' : 'text-destructive'
               )}>
                 {testResult.success ? <CheckCircle2 size={12} /> : <XCircle size={12} />}
-                <span>{testResult.message}</span>
+                <span className="min-w-0 break-all">{testResult.message}</span>
               </div>
             )}
           </div>

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/shared",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "license": "AGPL-3.0-only",
   "description": "Shared types, configs and utilities for proma",
   "type": "module",

--- a/packages/shared/src/types/channel.ts
+++ b/packages/shared/src/types/channel.ts
@@ -175,11 +175,31 @@ export interface ChannelsConfig {
 /**
  * 连接测试结果
  */
+export type ChannelTestErrorType =
+  | 'auth'
+  | 'permission'
+  | 'not_found'
+  | 'rate_limit'
+  | 'quota'
+  | 'bad_request'
+  | 'server'
+  | 'network'
+  | 'timeout'
+  | 'unknown'
+
 export interface ChannelTestResult {
   /** 是否成功 */
   success: boolean
   /** 结果消息 */
   message: string
+  /** 归一化错误类型，成功时为空 */
+  errorType?: ChannelTestErrorType
+  /** HTTP 状态码，网络或超时异常时为空 */
+  statusCode?: number
+  /** 供应商原始错误摘要，已截断 */
+  rawSummary?: string
+  /** 是否适合稍后重试 */
+  retriable?: boolean
 }
 
 /**


### PR DESCRIPTION
## 背景

修复 #770：模型渠道的“测试连接”在部分 Provider 返回非 2xx 响应时仍可能显示成功。

此前各 Provider 分别解释测试响应，其中 Anthropic 兼容接口只将 `401` 视为失败，`403`、`404`、`429`、额度不足和 `5xx` 等响应均可能被误判为连接成功。不同 Provider 的错误提示和判断标准也不一致。

## 根因

- Provider 请求构造与错误解释耦合在 `channel-manager.ts`。
- Anthropic 兼容测试将“收到 HTTP 响应”等同于“渠道可用”。
- `ChannelTestResult` 只有 `success` 和 `message`，无法表达稳定的错误分类。
- 连接测试没有统一超时、原始摘要截断和凭证脱敏。

## 改动

- 新增无 Electron 依赖的 `channel-test-normalizer`：
  - 仅 HTTP 2xx 判定连接成功。
  - 统一分类 `auth`、`permission`、`not_found`、`rate_limit`、`quota`、`bad_request`、`server`、`network`、`timeout` 和 `unknown`。
  - 支持常见 OpenAI、Anthropic、Google 错误响应结构及纯文本/HTML 错误页。
  - 保留最长 500 字符的供应商错误摘要，并脱敏 Bearer Token、`sk-*` Key 和常见查询参数/字段凭证。
  - 最多读取 16 KB 错误响应体，避免异常端点返回超大内容造成额外内存占用。
- Anthropic、OpenAI 和 Google 连接测试统一使用归一化结果。
- 所有连接测试增加 15 秒超时。
- 非法 Base URL 归类为请求无效，不再误报为网络故障。
- 设置页错误摘要支持长文本换行，避免撑破表单布局。
- 扩展 `ChannelTestResult`，增加 `errorType`、`statusCode`、`rawSummary` 和 `retriable`。
- 递增受影响包版本：
  - `@proma/shared`: `0.1.34` -> `0.1.35`
  - `@proma/electron`: `0.13.4` -> `0.13.5`

## 用户影响

- `403`、`404`、`429`、额度不足和 `5xx` 不再显示“连接成功”。
- 用户可以获得更明确的认证、权限、额度、限流、网络和超时提示。
- Provider 原始错误信息仍可用于排查，但不会无限扩张或直接回显常见凭证。

## 测试

- `bun test`
  - 108 pass，0 fail
- `bun run typecheck`
  - `@proma/shared`
  - `@proma/core`
  - `@proma/ui`
  - `@proma/electron`
- `bun run --filter='@proma/electron' build:main`
- `git diff --check`

## 范围说明

本 PR 只处理配置阶段的连接测试。运行时自动重试、统一错误中间件和熔断器不在本次范围内，后续应作为独立设计和 PR 推进。

Closes #770
