### PR TITLE
[codex] Move sidebar delegation toggle action

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -3133,36 +3133,6 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
                 {session.sourceDelegationId && !session.sourceAutomationId && (
                   <GitBranch size={11} className={cn('flex-shrink-0', DELEGATION_STATUS_ICON_CLASS[indicatorStatus])} />
                 )}
-                {delegationSummary && (
-                  <button
-                    type="button"
-                    aria-label={`${delegationSummary.expanded ? '收起' : '展开'}子会话`}
-                    onMouseEnter={preview.closeNow}
-                    onFocus={preview.closeNow}
-                    onMouseDown={(event) => {
-                      event.stopPropagation()
-                      preview.closeNow()
-                    }}
-                    onClick={(event) => {
-                      event.stopPropagation()
-                      preview.closeNow()
-                      delegationSummary.onToggle()
-                    }}
-                    onDoubleClick={(event) => {
-                      event.stopPropagation()
-                      preview.closeNow()
-                    }}
-                    className="flex-shrink-0 inline-flex size-6 -my-1 items-center justify-center rounded text-foreground/45 hover:bg-foreground/[0.055] hover:text-foreground/70 transition-colors"
-                  >
-                    <ChevronRight
-                      size={11}
-                      className={cn(
-                        'transition-transform duration-150',
-                        delegationSummary.expanded && 'rotate-90',
-                      )}
-                    />
-                  </button>
-                )}
                 <span
                   className="truncate"
                   onDoubleClick={(event) => {
@@ -3187,16 +3157,48 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
           </div>
 
           {!editing && (
-            <SessionItemActions
-              updatedAt={session.updatedAt}
-              relativeTimeNow={relativeTimeNow}
-              pinned={!!session.pinned}
-              archived={!!session.archived}
-              onTogglePin={() => onTogglePin(session.id)}
-              onToggleArchive={() => onToggleArchive(session.id)}
-              onMenuOpenChange={setMenuOpen}
-              menuItems={menuItems}
-            />
+            <>
+              {delegationSummary && (
+                <button
+                  type="button"
+                  aria-label={`${delegationSummary.expanded ? '收起' : '展开'}子会话`}
+                  onMouseEnter={preview.closeNow}
+                  onFocus={preview.closeNow}
+                  onMouseDown={(event) => {
+                    event.stopPropagation()
+                    preview.closeNow()
+                  }}
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    preview.closeNow()
+                    delegationSummary.onToggle()
+                  }}
+                  onDoubleClick={(event) => {
+                    event.stopPropagation()
+                    preview.closeNow()
+                  }}
+                  className="flex-shrink-0 inline-flex size-6 -my-1 items-center justify-center rounded text-foreground/45 hover:bg-foreground/[0.055] hover:text-foreground/70 transition-colors"
+                >
+                  <ChevronRight
+                    size={11}
+                    className={cn(
+                      'transition-transform duration-150',
+                      delegationSummary.expanded && 'rotate-90',
+                    )}
+                  />
+                </button>
+              )}
+              <SessionItemActions
+                updatedAt={session.updatedAt}
+                relativeTimeNow={relativeTimeNow}
+                pinned={!!session.pinned}
+                archived={!!session.archived}
+                onTogglePin={() => onTogglePin(session.id)}
+                onToggleArchive={() => onToggleArchive(session.id)}
+                onMenuOpenChange={setMenuOpen}
+                menuItems={menuItems}
+              />
+            </>
           )}
         </div>
       </ContextMenuTrigger>


### PR DESCRIPTION
## Summary

Moves the delegated-session expand/collapse control out of the left title content and into the right-side action area before the pin action.

## Why

The previous placement kept the chevron at the far left of rows with child sessions, which made parent session titles visually start at a different x-position from normal rows. Placing the control in the action area keeps the left title area aligned while preserving quick access to expand/collapse.

## Changes

- Removed the delegated-session toggle button from the left title/icon group.
- Rendered the toggle before the existing right-side session actions.
- Preserved the existing minimap suppression and click handling for the toggle.

## Validation

- `bun run --filter='@proma/electron' typecheck`
- `git diff --check -- apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx`
