### PR TITLE
【已审核】fix(sidebar): 折叠列表中选中会话仅在不可见时才置顶

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -3415,21 +3415,22 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
       && item.session.updatedAt >= recentCutoff
     )
     .slice(0, PROJECT_SESSION_PREVIEW_LIMIT)
-  const fillIds = collectTreeSessionIds(fillSessions)
-  // 当前选中会话仅在「既非活跃、又不在自然填充集合中」时才补入折叠列表（紧接活跃区之后），
-  // 确保从搜索结果打开的旧会话（updatedAt 超窗或被上限截断）立即可见；
-  // 若它本就出现在 fillSessions 中，则不再单独前置，避免点击后被强制排到第一位。
-  const currentSession = activeSessionId
-    && !activeIds.has(activeSessionId)
-    && !fillIds.has(activeSessionId)
-    ? treeItems.find((item) => treeContainsSessionId(item, activeSessionId)) ?? null
-    : null
-  const pinnedCurrent = currentSession ? [currentSession] : []
-  const collapsedSessions = [...activeSessions, ...pinnedCurrent, ...fillSessions]
+  // 先拼不含置顶项的可见列表
+  const collapsedSessions = [...activeSessions, ...fillSessions]
   const collapsedIds = new Set(collapsedSessions.map((item) => item.session.id))
   const remainingSessions = treeItems.filter((item) => !collapsedIds.has(item.session.id))
   const extraSessions = remainingSessions.slice(0, extraCount)
-  const sessions = [...collapsedSessions, ...extraSessions]
+  const sessionsWithoutPinned = [...collapsedSessions, ...extraSessions]
+  // 仅当选中会话不在当前可见列表中时才置顶（如搜索结果打开旧会话），
+  // 若会话已在可见区域则保持原位不跳
+  const sessionIds = new Set(sessionsWithoutPinned.map((item) => item.session.id))
+  const currentSession = activeSessionId && !sessionIds.has(activeSessionId)
+    ? treeItems.find((item) => treeContainsSessionId(item, activeSessionId)) ?? null
+    : null
+  const pinnedCurrent = currentSession ? [currentSession] : []
+  const sessions = pinnedCurrent.length > 0
+    ? [...activeSessions, ...pinnedCurrent, ...fillSessions, ...extraSessions]
+    : sessionsWithoutPinned
   const hiddenCount = Math.max(0, treeItems.length - sessions.length)
 
   return (


### PR DESCRIPTION
## 概述

AgentProjectGroupItem 的 pinnedCurrent 置顶逻辑之前只检查 activeIds + fillIds，导致会话在 extra 扩展区可见时仍被强制置顶。改为检查完整可见列表（collapsed + extra），会话已在可见范围内时保持原位。

## 改动

- LeftSidebar.tsx: pinnedCurrent 判断从 !activeIds.has && !fillIds.has 改为 !sessionIds.has（覆盖完整可见列表）

## 测试

- 点击侧边栏已可见的会话 → 不跳位置
- 从搜索打开旧会话（不在可见列表） → 正常置顶

## 紧急度

常规