### PR TITLE
【已审核】fix(automation): 自动任务委托子会话继承归属ID

### DIFF
--- a/apps/electron/src/main/lib/agent-collaboration-tools.ts
+++ b/apps/electron/src/main/lib/agent-collaboration-tools.ts
@@ -643,6 +643,7 @@ function startDelegation(
     parentSessionId: ctx.sessionId,
     rootSessionId,
     sourceDelegationId: delegationId,
+    sourceAutomationId: parent?.sourceAutomationId,
     delegationRole: role,
     delegationStatus: 'running',
     delegationDepth: (parent?.delegationDepth ?? 0) + 1,


### PR DESCRIPTION
## 概述

修复自动任务运行期间通过 `delegate_agent` 创建的委托子会话不显示在侧栏「自动任务」组下的问题。

根因：`startDelegation()` 创建子会话时未传播父会话的 `sourceAutomationId`，导致侧栏过滤 `!!session.sourceAutomationId` 时子会话被排除。

## 改动

| 文件 | 改动 |
|---|---|
| `apps/electron/src/main/lib/agent-collaboration-tools.ts` | +1 行：新增 `sourceAutomationId: parent?.sourceAutomationId` |

## 测试

- `bun run typecheck` 全部通过 ✓
- 委托子会话创建时继承父会话的 `sourceAutomationId`
- 父会话非自动化时 `parent?.sourceAutomationId` 为 `undefined`，无影响

## 紧急度

常规

## 备注

- `sourceAutomationId` 已在 `updateAgentSessionMeta` 的允许字段列表中，无需额外类型变更
