### PR TITLE
fix(file-browser): 优化文件树选中高亮样式【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.13.15",
+  "version": "0.13.16",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
@@ -681,15 +681,8 @@ function FileTreeItem({
         ref={rowRef}
         data-sticky-row={isSticky ? 'true' : undefined}
         className={cn(
-          'relative flex h-8 items-center gap-1 pr-2 text-sm cursor-pointer group transition-colors',
+          'relative flex h-8 items-center gap-1 pr-2 text-sm cursor-pointer group',
           isSticky && STICKY_ROW_BASE_CLASS,
-          // sticky 行 hover 用不透明色，避免下方滚动内容透出；普通行保持半透明柔和感
-          isSelected
-            ? 'bg-accent'
-            : isSticky
-              ? 'hover:bg-accent'
-              : 'hover:bg-accent/50',
-          flash && 'file-browser-row-flash',
         )}
         style={{
           paddingLeft,
@@ -698,12 +691,25 @@ function FileTreeItem({
         }}
         onClick={handleClick}
       >
+        <span
+          aria-hidden="true"
+          className={cn(
+            'pointer-events-none absolute inset-y-0 left-2 right-2 z-0 rounded-[17px] transition-colors',
+            // sticky 行 hover 用不透明色，避免下方滚动内容透出；普通行保持半透明柔和感
+            isSelected
+              ? 'bg-accent'
+              : isSticky
+                ? 'group-hover:bg-accent'
+                : 'group-hover:bg-accent/50',
+            flash && 'file-browser-row-flash',
+          )}
+        />
         {/* sticky 行祖先链竖线，逻辑见 tree-row-layout.tsx 的 AncestorGuides */}
         {isSticky && <AncestorGuides depth={depth} isSelected={isSelected} />}
         {recentlyModifiedSet.has(entry.path) && (
           <span
             aria-label="最近被 Agent 修改"
-            className="absolute top-1/2 -translate-y-1/2 w-1.5 h-1.5 rounded-full bg-primary/80"
+            className="absolute top-1/2 z-10 h-1.5 w-1.5 -translate-y-1/2 rounded-full bg-primary/80"
             style={{ left: paddingLeft - 6 }}
           />
         )}
@@ -711,20 +717,25 @@ function FileTreeItem({
         {entry.isDirectory ? (
           <ChevronRight
             className={cn(
-              'size-3.5 text-muted-foreground flex-shrink-0 transition-transform duration-150',
+              'relative z-10 size-3.5 text-muted-foreground flex-shrink-0 transition-transform duration-150',
               expanded && 'rotate-90',
             )}
           />
         ) : (
-          <span className="w-3.5 flex-shrink-0" />
+          <span className="relative z-10 w-3.5 flex-shrink-0" />
         )}
 
         {/* 文件/文件夹图标 */}
-        <FileTypeIcon name={entry.name} isDirectory={entry.isDirectory} isOpen={expanded} />
+        <FileTypeIcon
+          name={entry.name}
+          isDirectory={entry.isDirectory}
+          isOpen={expanded}
+          className="relative z-10"
+        />
 
         {/* 文件名 / 重命名输入框 */}
         {isRenaming ? (
-          <div className="relative flex-1 min-w-0">
+          <div className="relative z-10 flex-1 min-w-0">
             <input
               ref={renameInputRef}
               value={editName}
@@ -745,12 +756,12 @@ function FileTreeItem({
             )}
           </div>
         ) : (
-          <span className="truncate text-xs flex-1">{entry.name}</span>
+          <span className="relative z-10 truncate text-xs flex-1">{entry.name}</span>
         )}
 
         {/* 右侧操作按钮占位（始终占位，避免行宽跳动） */}
         <div
-          className="flex-shrink-0"
+          className="relative z-10 flex-shrink-0"
           onClick={(e) => e.stopPropagation()}
           onMouseDown={(e) => e.stopPropagation()}
         >

--- a/apps/electron/src/renderer/components/file-browser/tree-row-layout.tsx
+++ b/apps/electron/src/renderer/components/file-browser/tree-row-layout.tsx
@@ -69,7 +69,7 @@ export function AncestorGuides({ depth, isSelected }: AncestorGuidesProps): Reac
           key={`ancestor-guide-${i}`}
           aria-hidden="true"
           className={cn(
-            'file-tree-guide pointer-events-none absolute top-0 bottom-0 w-px',
+            'file-tree-guide pointer-events-none absolute top-0 bottom-0 z-10 w-px',
             isSelected ? 'bg-accent-foreground/30' : 'bg-border/70',
           )}
           style={{ left: TREE_ROW_HORIZONTAL_MARGIN + 8 + i * TREE_INDENT_WIDTH + 7 }}

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.13.12",
+      "version": "0.13.16",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.185",
         "@anthropic-ai/sdk": "^0.93.0",


### PR DESCRIPTION
## 概述

这个 PR 优化了 Proma 文件浏览器中文件树条目的选中态和 hover 态视觉。之前会话文件与工作区文件列表的高亮背景直接铺在整行上，导致高亮宽度超过上方搜索框，并且呈现直角矩形。现在将高亮背景收敛到行内独立背景层，使其左右宽度与搜索框一致，并使用与主输入框一致的圆角风格。

## 改动

- `apps/electron/src/renderer/components/file-browser/FileBrowser.tsx` — 将文件树行的选中、hover 与自动定位 flash 背景从整行容器迁移到内部绝对定位背景层，使用 `left-2 right-2` 对齐搜索框横向留白，并使用 `rounded-[17px]` 对齐主输入框圆角；同时为图标、文件名、操作按钮和最近修改标记补充层级，确保它们显示在背景层之上。
- `apps/electron/src/renderer/components/file-browser/tree-row-layout.tsx` — 为 sticky 文件树祖先引导线增加 `z-10`，避免被新的行背景层遮挡。
- `apps/electron/package.json` — 按仓库版本规则将 Electron 包 patch 版本从 `0.13.15` 升级到 `0.13.16`。
- `bun.lock` — 同步更新 `@proma/electron` workspace 版本元数据到 `0.13.16`。

## 测试方法

1. 运行 `git diff --check`，确认补丁没有空白字符或格式问题。
2. 运行 `bun run typecheck`，确认 `@proma/shared`、`@proma/core`、`@proma/ui`、`@proma/electron` 类型检查均通过。
3. 在应用中打开 Agent 文件面板，检查会话文件和工作区文件列表的选中态/hover 态：高亮宽度应与上方搜索框一致，并呈现圆角矩形。

## 备注

- 本次改动只调整文件树行的视觉层级与背景绘制方式，不改变文件选择、展开、预览、重命名、菜单操作或自动定位逻辑。
- 直接推送到 `ErlichLiu/Proma` 时当前账号无权限，因此分支已推送到 fork，并从 fork 创建到 upstream `main` 的 PR。
