### PR TITLE
fix(renderer): 优化输入框光标可见性【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.13.17",
+  "version": "0.13.18",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -14,6 +14,7 @@
  */
 
 import { useState, useEffect, useRef, useMemo } from 'react'
+import { Extension } from '@tiptap/core'
 import { useEditor, EditorContent } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import Placeholder from '@tiptap/extension-placeholder'
@@ -21,6 +22,8 @@ import Underline from '@tiptap/extension-underline'
 import Link from '@tiptap/extension-link'
 import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
 import Mention from '@tiptap/extension-mention'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
+import { Decoration, DecorationSet } from '@tiptap/pm/view'
 import { ChevronsDownUp, ChevronsUpDown } from 'lucide-react'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
@@ -35,6 +38,63 @@ import {
 } from '@/lib/voice-input-focus'
 
 // ===== 行数计算 =====
+
+const thickCaretPluginKey = new PluginKey<boolean>('promaThickInputCaret')
+
+const ThickInputCaret = Extension.create({
+  name: 'thickInputCaret',
+
+  addProseMirrorPlugins() {
+    const editor = this.editor
+
+    return [
+      new Plugin<boolean>({
+        key: thickCaretPluginKey,
+        state: {
+          init: () => false,
+          apply: (tr, focused) => {
+            const nextFocused = tr.getMeta(thickCaretPluginKey)
+            return typeof nextFocused === 'boolean' ? nextFocused : focused
+          },
+        },
+        props: {
+          handleDOMEvents: {
+            focus: (view) => {
+              view.dispatch(view.state.tr.setMeta(thickCaretPluginKey, true))
+              return false
+            },
+            blur: (view) => {
+              view.dispatch(view.state.tr.setMeta(thickCaretPluginKey, false))
+              return false
+            },
+          },
+          decorations: (state) => {
+            const focused = thickCaretPluginKey.getState(state)
+            if (!focused || !editor.isEditable || !state.selection.empty) {
+              return DecorationSet.empty
+            }
+
+            return DecorationSet.create(state.doc, [
+              Decoration.widget(
+                state.selection.from,
+                () => {
+                  const caret = document.createElement('span')
+                  caret.className = 'proma-input-caret'
+                  caret.setAttribute('aria-hidden', 'true')
+                  return caret
+                },
+                {
+                  key: 'proma-input-caret',
+                  side: 1,
+                },
+              ),
+            ])
+          },
+        },
+      }),
+    ]
+  },
+})
 
 /** 计算编辑器内容的行数 */
 function countEditorLines(editor: ReturnType<typeof useEditor>): number {
@@ -233,6 +293,7 @@ export function RichTextInput({
         link: false,
         underline: false,
       }),
+      ThickInputCaret,
       Underline,
       Link.configure({
         openOnClick: false,
@@ -646,6 +707,37 @@ export function RichTextInput({
           outline: none;
           padding: 9px 15px 0px;
           font-style: normal;
+        }
+        .rich-text-input .ProseMirror:focus {
+          caret-color: transparent;
+        }
+        .rich-text-input .proma-input-caret {
+          display: inline-block;
+          width: 0;
+          height: 1em;
+          position: relative;
+          vertical-align: baseline;
+          pointer-events: none;
+        }
+        .rich-text-input .proma-input-caret::after {
+          content: '';
+          position: absolute;
+          left: 0;
+          top: 50%;
+          width: 2px;
+          height: calc(1.45em - 2px);
+          border-radius: 999px;
+          background: hsl(var(--foreground));
+          transform: translateY(calc(-50% + 2px));
+          animation: proma-input-caret-blink 1s steps(1, end) infinite;
+        }
+        @keyframes proma-input-caret-blink {
+          0%, 49% {
+            opacity: 1;
+          }
+          50%, 100% {
+            opacity: 0;
+          }
         }
         .ProseMirror p {
           font-style: normal;


### PR DESCRIPTION
## 概述
这个 PR 优化了 Proma 富文本输入框的打字光标显示。之前输入框里的原生光标太细，在浅色背景和部分字体/缩放组合下不容易看清，长时间输入时比较费眼睛；新版通过自定义 2px 光标提升可见性，并微调高度和垂直位置，让输入体验更清楚、更舒服。

## 改动
- `apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx` — 新增 TipTap/ProseMirror 自定义光标扩展，在输入框聚焦且选区折叠时渲染更清晰的自定义 caret；隐藏原生细 caret，避免双光标；限制作用域在 `.rich-text-input`，不影响其他编辑器。
- `apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx` — 将光标设置为 2px 宽，并按当前前景色渲染，保留闪烁动画，同时微调高度和基线对齐，避免光标过高或底部过长。
- `apps/electron/package.json` — 按项目提交规范递增 `@proma/electron` patch 版本到 `0.13.16`。

## 测试方法
1. 运行 `bun run typecheck`，确认所有 workspace 类型检查通过。
2. 打开 Proma Chat/Agent 输入框，聚焦输入区域。
3. 输入中文或英文文本，确认打字光标比原来更清楚，位置与文字视觉对齐更自然。
4. 选中文本时确认不会显示自定义插入光标，避免和选区状态冲突。

## 备注
- 这是纯 renderer 视觉优化，不涉及 IPC、持久化、主进程或打包配置。
- 该改动的目标是减少输入时寻找光标的视觉负担，让长时间输入更舒适。