### PR TITLE
fix(agent): 调整子会话展开按钮位置【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.13.15",
+  "version": "0.13.16",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -3047,6 +3047,37 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
 
   const canMove = indicatorStatus === 'idle' || indicatorStatus === 'completed'
 
+  const delegationToggleButton = !editing && delegationSummary ? (
+    <button
+      type="button"
+      aria-label={`${delegationSummary.expanded ? '收起' : '展开'}子会话`}
+      onMouseEnter={preview.closeNow}
+      onFocus={preview.closeNow}
+      onMouseDown={(event) => {
+        event.stopPropagation()
+        preview.closeNow()
+      }}
+      onClick={(event) => {
+        event.stopPropagation()
+        preview.closeNow()
+        delegationSummary.onToggle()
+      }}
+      onDoubleClick={(event) => {
+        event.stopPropagation()
+        preview.closeNow()
+      }}
+      className="flex-shrink-0 inline-flex size-5 -my-1 -ml-[5px] items-center justify-center rounded text-foreground/45 hover:bg-foreground/[0.055] hover:text-foreground/70 transition-colors"
+    >
+      <ChevronRight
+        size={11}
+        className={cn(
+          'transition-transform duration-150',
+          delegationSummary.expanded && 'rotate-90',
+        )}
+      />
+    </button>
+  ) : null
+
   const menuItems = (
     MenuItem: typeof ContextMenuItem | typeof DropdownMenuItem,
     MenuSeparator: typeof ContextMenuSeparator | typeof DropdownMenuSeparator,
@@ -3107,6 +3138,7 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
               )}
             />
           )}
+          {delegationToggleButton}
           <div className="flex-1 min-w-0">
             {editing ? (
               <input
@@ -3158,36 +3190,6 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
 
           {!editing && (
             <>
-              {delegationSummary && (
-                <button
-                  type="button"
-                  aria-label={`${delegationSummary.expanded ? '收起' : '展开'}子会话`}
-                  onMouseEnter={preview.closeNow}
-                  onFocus={preview.closeNow}
-                  onMouseDown={(event) => {
-                    event.stopPropagation()
-                    preview.closeNow()
-                  }}
-                  onClick={(event) => {
-                    event.stopPropagation()
-                    preview.closeNow()
-                    delegationSummary.onToggle()
-                  }}
-                  onDoubleClick={(event) => {
-                    event.stopPropagation()
-                    preview.closeNow()
-                  }}
-                  className="flex-shrink-0 inline-flex size-6 -my-1 items-center justify-center rounded text-foreground/45 hover:bg-foreground/[0.055] hover:text-foreground/70 transition-colors"
-                >
-                  <ChevronRight
-                    size={11}
-                    className={cn(
-                      'transition-transform duration-150',
-                      delegationSummary.expanded && 'rotate-90',
-                    )}
-                  />
-                </button>
-              )}
               <SessionItemActions
                 updatedAt={session.updatedAt}
                 relativeTimeNow={relativeTimeNow}


### PR DESCRIPTION
## 概述
这个 PR 调整 Agent 侧边栏中委派母会话的子会话展开/收起按钮位置。此前 toggle 三角位于母会话标题右侧，视觉上容易和更新时间、操作区混在一起；现在将它移动到母会话标题左侧，并保持在选中态背景条内部，让父子会话层级关系更清晰。

## 改动
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 将委派母会话的展开/收起按钮抽成 `delegationToggleButton`，从标题右侧移动到行内容左侧、标题之前；保留原有点击拦截、双击拦截、mini map 关闭和展开旋转逻辑，并通过 `-ml-[5px]` 让按钮与标题整体更贴近左侧。
- `apps/electron/package.json` — 按仓库版本规则将 `@proma/electron` patch 版本从 `0.13.15` 递增到 `0.13.16`。

## 测试方法
1. 运行 `bun run typecheck`。
2. 打开 Agent 侧边栏，找到包含子会话的委派母会话。
3. 确认展开/收起三角位于母会话 title 左侧，并且仍在选中态背景条内部。
4. 点击三角确认子会话展开/收起行为正常，点击行其他区域仍能选中会话。

## 备注
- 已执行 PR 前 review：类型检查通过，未发现 Windows 兼容性风险。
- upstream 直接推送因权限返回 403，因此本分支推送到 fork 后创建跨仓库 PR。