### PR TITLE
fix(channel): DeepSeek/Kimi 等 Anthropic 协议渠道 Chat 模式补全 /v1

### DIFF
--- a/apps/electron/src/main/lib/channel-manager.ts
+++ b/apps/electron/src/main/lib/channel-manager.ts
@@ -298,7 +298,8 @@ export async function testChannel(channelId: string): Promise<ChannelTestResult>
 /**
  * 测试 Anthropic 兼容 API 连接（Anthropic / DeepSeek / Kimi API / Kimi Coding Plan / MiniMax）
  *
- * DeepSeek / Kimi 的 Anthropic API 端点无需 /v1 前缀。
+ * DeepSeek / Kimi 等以 /anthropic 为协议根路径的供应商，实际端点位于 /anthropic/v1/messages，
+ * 由 normalizeAnthropicProviderUrl 统一按需补 /v1。
  * Kimi Coding Plan 必须发送 Proma User-Agent，否则返回 403。
  */
 async function testAnthropicCompatible(
@@ -522,7 +523,8 @@ interface AnthropicModelItem {
 /**
  * 从 Anthropic 兼容 API 拉取模型列表（Anthropic / DeepSeek / Kimi API / Kimi Coding Plan / MiniMax）
  *
- * DeepSeek / Kimi 的 Anthropic API 端点无需 /v1 前缀。
+ * DeepSeek / Kimi 等以 /anthropic 为协议根路径的供应商，实际端点位于 /anthropic/v1/messages，
+ * 由 normalizeAnthropicProviderUrl 统一按需补 /v1。
  * Kimi Coding Plan 必须发送 Proma User-Agent。
  * 文档: https://docs.anthropic.com/en/api/models-list
  */

--- a/packages/core/src/providers/url-utils.test.ts
+++ b/packages/core/src/providers/url-utils.test.ts
@@ -1,0 +1,152 @@
+import { test, expect, describe } from 'bun:test'
+import {
+  normalizeAnthropicBaseUrl,
+  normalizeVersionedAnthropicBaseUrl,
+  normalizeAnthropicBaseUrlForSdk,
+  normalizeBaseUrl,
+  normalizeAnthropicProviderUrl,
+} from './url-utils.ts'
+
+describe('normalizeAnthropicBaseUrl', () => {
+  test('纯域名追加 /v1', () => {
+    expect(normalizeAnthropicBaseUrl('https://api.anthropic.com')).toBe('https://api.anthropic.com/v1')
+  })
+
+  test('已有 /v1 保持不变', () => {
+    expect(normalizeAnthropicBaseUrl('https://api.anthropic.com/v1')).toBe('https://api.anthropic.com/v1')
+  })
+
+  test('去除尾部斜杠并保留版本号', () => {
+    expect(normalizeAnthropicBaseUrl('https://proxy.example.com/v2/')).toBe('https://proxy.example.com/v2')
+  })
+
+  test('去除误填的 /messages 后缀', () => {
+    expect(normalizeAnthropicBaseUrl('https://proxy.example.com/v1/messages')).toBe('https://proxy.example.com/v1')
+    expect(normalizeAnthropicBaseUrl('https://proxy.example.com/v1/messages/')).toBe('https://proxy.example.com/v1')
+  })
+
+  test('已有非版本路径保持原样（不追加 /v1）', () => {
+    expect(normalizeAnthropicBaseUrl('https://api.deepseek.com/anthropic')).toBe('https://api.deepseek.com/anthropic')
+  })
+})
+
+describe('normalizeVersionedAnthropicBaseUrl', () => {
+  test('协议根路径追加 /v1', () => {
+    expect(normalizeVersionedAnthropicBaseUrl('https://api.minimaxi.com/anthropic')).toBe(
+      'https://api.minimaxi.com/anthropic/v1',
+    )
+  })
+
+  test('已含 /v1 的路径不重复追加', () => {
+    expect(normalizeVersionedAnthropicBaseUrl('https://api.kimi.com/coding/v1')).toBe('https://api.kimi.com/coding/v1')
+  })
+
+  test('去除误填的 /messages 后缀并保留版本号', () => {
+    expect(normalizeVersionedAnthropicBaseUrl('https://api.minimaxi.com/anthropic/v1/messages')).toBe(
+      'https://api.minimaxi.com/anthropic/v1',
+    )
+  })
+
+  test('纯域名追加 /v1', () => {
+    expect(normalizeVersionedAnthropicBaseUrl('https://api.anthropic.com')).toBe('https://api.anthropic.com/v1')
+  })
+})
+
+describe('normalizeAnthropicBaseUrlForSdk', () => {
+  test('纯域名保持不变', () => {
+    expect(normalizeAnthropicBaseUrlForSdk('https://api.anthropic.com')).toBe('https://api.anthropic.com')
+  })
+
+  test('去除 /v1 后缀', () => {
+    expect(normalizeAnthropicBaseUrlForSdk('https://api.anthropic.com/v1')).toBe('https://api.anthropic.com')
+  })
+
+  test('去除 /v1/messages 后缀', () => {
+    expect(normalizeAnthropicBaseUrlForSdk('https://api.anthropic.com/v1/messages')).toBe('https://api.anthropic.com')
+  })
+
+  test('保留 /anthropic 协议根路径', () => {
+    expect(normalizeAnthropicBaseUrlForSdk('https://gateway.example.com/anthropic/v1/messages')).toBe(
+      'https://gateway.example.com/anthropic',
+    )
+    expect(normalizeAnthropicBaseUrlForSdk('https://gateway.example.com/anthropic/')).toBe(
+      'https://gateway.example.com/anthropic',
+    )
+  })
+})
+
+describe('normalizeBaseUrl', () => {
+  test('仅去除尾部斜杠', () => {
+    expect(normalizeBaseUrl('https://api.openai.com/v1/')).toBe('https://api.openai.com/v1')
+    expect(normalizeBaseUrl('https://api.openai.com/v1')).toBe('https://api.openai.com/v1')
+  })
+})
+
+describe('normalizeAnthropicProviderUrl', () => {
+  // 回归测试：deepseek / kimi-api 的默认 /anthropic 端点必须补 /v1，
+  // 否则 Chat 模式拼出 .../anthropic/messages 会 404。
+  test('deepseek 默认端点补全 /v1', () => {
+    const url = normalizeAnthropicProviderUrl('https://api.deepseek.com/anthropic', 'deepseek')
+    expect(url).toBe('https://api.deepseek.com/anthropic/v1')
+    // 拼接 /messages 后得到正确的完整端点
+    expect(`${url}/messages`).toBe('https://api.deepseek.com/anthropic/v1/messages')
+  })
+
+  test('kimi-api 默认端点补全 /v1', () => {
+    const url = normalizeAnthropicProviderUrl('https://api.moonshot.cn/anthropic', 'kimi-api')
+    expect(url).toBe('https://api.moonshot.cn/anthropic/v1')
+    expect(`${url}/messages`).toBe('https://api.moonshot.cn/anthropic/v1/messages')
+  })
+
+  test('kimi-coding 默认端点已含 /v1，不重复追加', () => {
+    const url = normalizeAnthropicProviderUrl('https://api.kimi.com/coding/v1', 'kimi-coding')
+    expect(url).toBe('https://api.kimi.com/coding/v1')
+    expect(`${url}/messages`).toBe('https://api.kimi.com/coding/v1/messages')
+  })
+
+  test('用户手动填写不带 /v1 的 kimi-coding 地址也会补全', () => {
+    const url = normalizeAnthropicProviderUrl('https://api.kimi.com/coding', 'kimi-coding')
+    expect(url).toBe('https://api.kimi.com/coding/v1')
+  })
+
+  test('minimax 协议根路径补全 /v1', () => {
+    expect(normalizeAnthropicProviderUrl('https://api.minimaxi.com/anthropic', 'minimax')).toBe(
+      'https://api.minimaxi.com/anthropic/v1',
+    )
+  })
+
+  test('anthropic-compatible 协议根路径补全 /v1', () => {
+    expect(normalizeAnthropicProviderUrl('https://gateway.example.com/anthropic', 'anthropic-compatible')).toBe(
+      'https://gateway.example.com/anthropic/v1',
+    )
+  })
+
+  test('qwen-anthropic 补全 /v1', () => {
+    expect(normalizeAnthropicProviderUrl('https://dashscope.aliyuncs.com/apps/anthropic', 'qwen-anthropic')).toBe(
+      'https://dashscope.aliyuncs.com/apps/anthropic/v1',
+    )
+  })
+
+  test('xiaomi / xiaomi-token-plan 补全 /v1', () => {
+    expect(normalizeAnthropicProviderUrl('https://api.xiaomimimo.com/anthropic', 'xiaomi')).toBe(
+      'https://api.xiaomimimo.com/anthropic/v1',
+    )
+    expect(
+      normalizeAnthropicProviderUrl('https://token-plan-cn.xiaomimimo.com/anthropic', 'xiaomi-token-plan'),
+    ).toBe('https://token-plan-cn.xiaomimimo.com/anthropic/v1')
+  })
+
+  test('zhipu-coding 补全 /v1', () => {
+    expect(normalizeAnthropicProviderUrl('https://open.bigmodel.cn/api/anthropic', 'zhipu-coding')).toBe(
+      'https://open.bigmodel.cn/api/anthropic/v1',
+    )
+  })
+
+  test('原生 anthropic 纯域名补全 /v1', () => {
+    expect(normalizeAnthropicProviderUrl('https://api.anthropic.com', 'anthropic')).toBe('https://api.anthropic.com/v1')
+  })
+
+  test('原生 anthropic 已含 /v1 保持不变', () => {
+    expect(normalizeAnthropicProviderUrl('https://api.anthropic.com/v1', 'anthropic')).toBe('https://api.anthropic.com/v1')
+  })
+})

--- a/packages/core/src/providers/url-utils.ts
+++ b/packages/core/src/providers/url-utils.ts
@@ -42,9 +42,12 @@ export function normalizeAnthropicBaseUrl(baseUrl: string): string {
  * 规范化带版本路径的 Anthropic 兼容 Base URL。
  *
  * 某些网关以 `/anthropic` 作为协议根路径，但实际 API 仍位于 `/v1/messages`。
+ * 没有版本路径时追加 `/v1`，已有版本路径（如 `/coding/v1`）则保持不变。
  * 例如：
  * - "https://api.minimaxi.com/anthropic" → "https://api.minimaxi.com/anthropic/v1"
  * - "https://api.minimaxi.com/anthropic/v1/messages" → "https://api.minimaxi.com/anthropic/v1"
+ * - "https://api.deepseek.com/anthropic" → "https://api.deepseek.com/anthropic/v1"
+ * - "https://api.kimi.com/coding/v1" → 不变（已有版本路径）
  */
 export function normalizeVersionedAnthropicBaseUrl(baseUrl: string): string {
   let url = baseUrl.trim().replace(/\/+$/, '')
@@ -90,6 +93,10 @@ export function normalizeBaseUrl(baseUrl: string): string {
  *
  * 统一收口 channel-manager 和 AnthropicAdapter 中重复的条件分支逻辑。
  * 仅适用于走 Anthropic 协议的供应商（anthropic / anthropic-compatible / deepseek / kimi-* / minimax / xiaomi-* / qwen-anthropic）。
+ *
+ * DeepSeek / Kimi 等以 `/anthropic` 为协议根路径的供应商，实际端点仍位于
+ * `/anthropic/v1/messages`，因此统一走 normalizeVersionedAnthropicBaseUrl 按需补 `/v1`
+ * （已含版本路径如 `/coding/v1` 的不会重复追加），与 Agent SDK 自动拼接 /v1/messages 的行为保持一致。
  */
 export function normalizeAnthropicProviderUrl(baseUrl: string, provider: ProviderType): string {
   if (
@@ -99,11 +106,11 @@ export function normalizeAnthropicProviderUrl(baseUrl: string, provider: Provide
     || provider === 'xiaomi-token-plan'
     || provider === 'qwen-anthropic'
     || provider === 'zhipu-coding'
+    || provider === 'deepseek'
+    || provider === 'kimi-api'
+    || provider === 'kimi-coding'
   ) {
     return normalizeVersionedAnthropicBaseUrl(baseUrl)
-  }
-  if (provider === 'deepseek' || provider === 'kimi-api' || provider === 'kimi-coding') {
-    return normalizeBaseUrl(baseUrl)
   }
   return normalizeAnthropicBaseUrl(baseUrl)
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -9,7 +9,7 @@
     "resolveJsonModule": true,
     "allowImportingTsExtensions": true,
     "noEmit": true,
-    "types": []
+    "types": ["bun"]
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
## 问题

在设置中选择 **DeepSeek** 或 **Kimi API（Anthropic 协议）** 等渠道时，Chat 模式拼接出的请求地址缺少 `/v1`，得到 `.../anthropic/messages`，而正确端点应为 `.../anthropic/v1/messages`，导致连接测试 / 拉取模型 / Chat 请求失败（404）。

同一渠道在 **Agent 模式**下却正常——因为 Agent 走 Claude Agent SDK，由 SDK 内部自动拼接 `/v1/messages`，造成「Agent 能跑、Chat 报错」的不一致表现。

## 根因

`packages/core/src/providers/url-utils.ts` 的 `normalizeAnthropicProviderUrl` 此前把 `deepseek` / `kimi-api` / `kimi-coding` 单独路由到 `normalizeBaseUrl`（仅去尾部斜杠、**从不补 `/v1`**），依据是一条错误的注释「DeepSeek / Kimi 的 Anthropic API 端点无需 /v1 前缀」。

实际上 DeepSeek 官方文档（https://api-docs.deepseek.com/guides/anthropic_api ）明确：Anthropic 兼容端点 base_url 为 `https://api.deepseek.com/anthropic`，配合标准 Anthropic SDK 调用时实际命中 `.../anthropic/v1/messages`，`/v1` 必不可少。

这是 Issue #647 / PR #659 / PR #670 当时统一 URL 规范化逻辑时遗留的一半——只修了 `provider: anthropic` 配 `/anthropic` 后缀的场景，把 deepseek/kimi 显式留在了「不补 /v1」分支。

## 改动

- **核心修复**：将 `deepseek` / `kimi-api` / `kimi-coding` 改为统一走 `normalizeVersionedAnthropicBaseUrl`，按需补 `/v1`（已含版本路径如 `/coding/v1` 的不会重复追加），与 Agent SDK 行为保持一致。删除已无 provider 使用的「从不补 /v1」分支。
- **修正注释**：更新 `channel-manager.ts` 中两处错误注释。
- **补充单测**：新增 `packages/core/src/providers/url-utils.test.ts`，覆盖各 provider 的 URL 拼接（含 deepseek/kimi 回归用例）。这是该文件首个测试，故 `packages/core/tsconfig.json` 的 `types` 加入 `bun` 以解析 `bun:test`。

附带收益：设置页 `ChannelForm.tsx` 的预览 URL（`buildPreviewUrl`）调用同一函数，预览地址会自动跟随修复。

### 各 provider 规范化结果

| Provider | 默认 baseUrl | 修复前拼接 | 修复后拼接 |
|---|---|---|---|
| deepseek | `.../anthropic` | `.../anthropic/messages` ❌ | `.../anthropic/v1/messages` ✅ |
| kimi-api | `.../anthropic` | `.../anthropic/messages` ❌ | `.../anthropic/v1/messages` ✅ |
| kimi-coding | `.../coding/v1` | `.../coding/v1/messages` ✅ | `.../coding/v1/messages` ✅（不重复加） |

## 验证

- `bun run --filter='@proma/core' typecheck` 通过
- `bun test` 全量 137 个测试通过（含新增 25 个 url-utils 用例）

## 关联

- 关联 Issue #647，补全当时未覆盖的 deepseek/kimi 场景