### PR TITLE
[codex] Support Streamable HTTP MCP aliases

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -28,6 +28,7 @@ import {
   THINKING_SIGNATURE_ERROR_CODE,
   THINKING_SIGNATURE_ERROR_MESSAGE,
   THINKING_SIGNATURE_ERROR_TITLE,
+  normalizeMcpTransportType,
   supports1MContext,
 } from '@proma/shared'
 import type { PermissionRequest, PromaPermissionMode, AskUserRequest, ExitPlanModeRequest } from '@proma/shared'
@@ -633,8 +634,9 @@ export class AgentOrchestrator {
     for (const [name, entry] of Object.entries(mcpConfig.servers ?? {})) {
       if (!entry.enabled) continue
       if (name === 'memos-cloud') continue
+      const type = normalizeMcpTransportType((entry as { type?: unknown }).type)
 
-      if (entry.type === 'stdio' && entry.command) {
+      if (type === 'stdio' && entry.command) {
         const mergedEnv: Record<string, string> = {
           ...(process.env.PATH && { PATH: process.env.PATH }),
           ...entry.env,
@@ -647,9 +649,9 @@ export class AgentOrchestrator {
           required: false,
           startup_timeout_sec: entry.timeout ?? 30,
         }
-      } else if ((entry.type === 'http' || entry.type === 'sse') && entry.url) {
+      } else if ((type === 'http' || type === 'sse') && entry.url) {
         mcpServers[name] = {
-          type: entry.type,
+          type,
           url: entry.url,
           ...(entry.headers && Object.keys(entry.headers).length > 0 && { headers: entry.headers }),
           required: false,

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -22,6 +22,7 @@ import {
 } from './config-paths'
 import { findAllGitRoots, normalizeGitRoot } from './git-diff-service'
 import { listBuiltinMcpServers } from './builtin-mcp/catalog'
+import { inferMcpTransportType, normalizeMcpTransportType } from '@proma/shared'
 import type { AgentWorkspace, WorkspaceMcpConfig, SkillMeta, SkillImportSource, OtherWorkspaceSkillsGroup, WorkspaceCapabilities, SkillFileNode, SkillFileContent } from '@proma/shared'
 
 interface AgentWorkspacesIndex {
@@ -472,6 +473,33 @@ export function ensurePluginManifest(workspaceSlug: string, workspaceName: strin
 
 // ===== MCP 配置管理 =====
 
+function normalizeWorkspaceMcpConfig(config: Partial<WorkspaceMcpConfig>): WorkspaceMcpConfig {
+  const servers: WorkspaceMcpConfig['servers'] = {}
+  const rawServers = config.servers ?? {}
+
+  for (const [name, rawEntry] of Object.entries(rawServers)) {
+    if (!rawEntry || typeof rawEntry !== 'object') continue
+
+    const entryRecord = { ...(rawEntry as unknown as Record<string, unknown>) }
+    const entry = entryRecord as unknown as WorkspaceMcpConfig['servers'][string] & { type?: unknown }
+    const normalizedType = normalizeMcpTransportType(entry.type)
+
+    if (normalizedType) {
+      if (entry.type !== normalizedType) {
+        console.log(`[Agent 工作区] MCP 服务器 "${name}" 的 type "${String(entry.type)}" 已规范化为 "${normalizedType}"`)
+      }
+      entry.type = normalizedType
+    } else if (!entry.type) {
+      entry.type = inferMcpTransportType(entry)
+      console.log(`[Agent 工作区] MCP 服务器 "${name}" 缺少 type 字段，已自动推断为 "${entry.type}"`)
+    }
+
+    servers[name] = entry as WorkspaceMcpConfig['servers'][string]
+  }
+
+  return { servers }
+}
+
 export function getWorkspaceMcpConfig(workspaceSlug: string): WorkspaceMcpConfig {
   const mcpPath = getWorkspaceMcpPath(workspaceSlug)
 
@@ -482,14 +510,7 @@ export function getWorkspaceMcpConfig(workspaceSlug: string): WorkspaceMcpConfig
   try {
     const raw = readFileSync(mcpPath, 'utf-8')
     const parsed = JSON.parse(raw) as Partial<WorkspaceMcpConfig>
-    const servers = parsed.servers ?? {}
-    for (const [name, entry] of Object.entries(servers)) {
-      if (!entry.type) {
-        entry.type = entry.command ? 'stdio' : entry.url ? 'http' : 'stdio'
-        console.log(`[Agent 工作区] MCP 服务器 "${name}" 缺少 type 字段，已自动推断为 "${entry.type}"`)
-      }
-    }
-    return { servers }
+    return normalizeWorkspaceMcpConfig(parsed)
   } catch (error) {
     console.error('[Agent 工作区] 读取 MCP 配置失败:', error)
     return { servers: {} }
@@ -500,7 +521,7 @@ export function saveWorkspaceMcpConfig(workspaceSlug: string, config: WorkspaceM
   const mcpPath = getWorkspaceMcpPath(workspaceSlug)
 
   try {
-    writeFileSync(mcpPath, JSON.stringify(config, null, 2), 'utf-8')
+    writeFileSync(mcpPath, JSON.stringify(normalizeWorkspaceMcpConfig(config), null, 2), 'utf-8')
     console.log(`[Agent 工作区] 已保存 MCP 配置: ${workspaceSlug}`)
   } catch (error) {
     console.error('[Agent 工作区] 保存 MCP 配置失败:', error)

--- a/apps/electron/src/main/lib/mcp-validator.ts
+++ b/apps/electron/src/main/lib/mcp-validator.ts
@@ -10,6 +10,7 @@
 
 import { existsSync } from 'node:fs'
 import { execSync } from 'node:child_process'
+import { normalizeMcpTransportType } from '@proma/shared'
 import type { McpServerEntry } from '@proma/shared'
 
 /**
@@ -35,8 +36,18 @@ export async function validateMcpServer(
   name: string,
   entry: McpServerEntry,
 ): Promise<McpValidationResult> {
+  const type = normalizeMcpTransportType((entry as { type?: unknown }).type)
+
+  if (!type) {
+    return {
+      name,
+      valid: false,
+      reason: `未知的传输类型: ${String((entry as { type?: unknown }).type)}`,
+    }
+  }
+
   // stdio 类型：检查命令是否存在
-  if (entry.type === 'stdio') {
+  if (type === 'stdio') {
     if (!entry.command) {
       return {
         name,
@@ -59,7 +70,7 @@ export async function validateMcpServer(
   }
 
   // http/sse 类型：检查 URL 格式
-  if (entry.type === 'http' || entry.type === 'sse') {
+  if (type === 'http' || type === 'sse') {
     if (!entry.url) {
       return {
         name,
@@ -85,11 +96,10 @@ export async function validateMcpServer(
 
     return { name, valid: true }
   }
-
   return {
     name,
     valid: false,
-    reason: `未知的传输类型: ${entry.type}`,
+    reason: `未知的传输类型: ${type}`,
   }
 }
 

--- a/apps/electron/src/renderer/components/settings/nowledge-mem-prompt.md
+++ b/apps/electron/src/renderer/components/settings/nowledge-mem-prompt.md
@@ -124,7 +124,7 @@ cp -R /tmp/nowledge-community/nowledge-mem-proma-plugin/skills/{read-working-mem
   "servers": {
     "nowledge-mem": {
       "url": "http://127.0.0.1:14242/mcp/",
-      "type": "streamableHttp",
+      "type": "http",
       "headers": {
         "APP": "Proma"
       }

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -757,8 +757,14 @@ export interface AgentGenerateTitleInput {
 
 // ===== MCP 服务器配置 =====
 
-/** MCP 传输类型 */
+/** MCP 传输类型；Proma 将 Streamable HTTP 规范化存储为 http */
 export type McpTransportType = 'stdio' | 'http' | 'sse'
+
+/** 外部配置中常见的 Streamable HTTP 别名 */
+export type McpTransportTypeAlias = 'streamableHttp' | 'streamable-http' | 'streamable_http'
+
+/** MCP 传输类型输入；保存和运行前会规范化为 McpTransportType */
+export type McpTransportTypeInput = McpTransportType | McpTransportTypeAlias
 
 /** MCP 服务器条目 */
 export interface McpServerEntry {

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -17,6 +17,10 @@ export {
 } from './context-window'
 export { calculateContextUsageRatio } from './context-usage'
 export {
+  inferMcpTransportType,
+  normalizeMcpTransportType,
+} from './mcp-transport'
+export {
   THINKING_SIGNATURE_ERROR_CODE,
   THINKING_SIGNATURE_ERROR_TITLE,
   THINKING_SIGNATURE_ERROR_MESSAGE,

--- a/packages/shared/src/utils/mcp-transport.test.ts
+++ b/packages/shared/src/utils/mcp-transport.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'bun:test'
+import { inferMcpTransportType, normalizeMcpTransportType } from './mcp-transport'
+
+describe('MCP transport normalization', () => {
+  test('keeps canonical transport types unchanged', () => {
+    expect(normalizeMcpTransportType('stdio')).toBe('stdio')
+    expect(normalizeMcpTransportType('http')).toBe('http')
+    expect(normalizeMcpTransportType('sse')).toBe('sse')
+  })
+
+  test('maps Streamable HTTP aliases to canonical http', () => {
+    expect(normalizeMcpTransportType('streamableHttp')).toBe('http')
+    expect(normalizeMcpTransportType('streamable-http')).toBe('http')
+    expect(normalizeMcpTransportType('streamable_http')).toBe('http')
+  })
+
+  test('rejects unknown transport types', () => {
+    expect(normalizeMcpTransportType('websocket')).toBeNull()
+    expect(normalizeMcpTransportType(undefined)).toBeNull()
+  })
+
+  test('infers legacy entries without type', () => {
+    expect(inferMcpTransportType({ command: 'npx' })).toBe('stdio')
+    expect(inferMcpTransportType({ url: 'http://127.0.0.1:14242/mcp/' })).toBe('http')
+    expect(inferMcpTransportType({})).toBe('stdio')
+  })
+})

--- a/packages/shared/src/utils/mcp-transport.ts
+++ b/packages/shared/src/utils/mcp-transport.ts
@@ -1,0 +1,34 @@
+import type { McpTransportType } from '../types/agent'
+
+const STREAMABLE_HTTP_ALIASES = new Set([
+  'streamableHttp',
+  'streamable-http',
+  'streamable_http',
+])
+
+export function normalizeMcpTransportType(type: unknown): McpTransportType | null {
+  if (type === 'stdio' || type === 'http' || type === 'sse') {
+    return type
+  }
+
+  if (typeof type === 'string' && STREAMABLE_HTTP_ALIASES.has(type)) {
+    return 'http'
+  }
+
+  return null
+}
+
+export function inferMcpTransportType(entry: {
+  command?: unknown
+  url?: unknown
+}): McpTransportType {
+  if (typeof entry.command === 'string' && entry.command.trim()) {
+    return 'stdio'
+  }
+
+  if (typeof entry.url === 'string' && entry.url.trim()) {
+    return 'http'
+  }
+
+  return 'stdio'
+}


### PR DESCRIPTION
## Summary

- normalize common Streamable HTTP MCP transport aliases (`streamableHttp`, `streamable-http`, `streamable_http`) to Proma's canonical `http` transport
- apply normalization when reading/saving workspace `mcp.json`, validating server configs, and building Agent SDK MCP server config
- update the Nowledge memory MCP setup prompt to use Proma's canonical `http` type
- add focused shared utility tests for MCP transport normalization and legacy type inference

## Why

Proma already labels `http` as Streamable HTTP in the UI and passes `type: 'http'` to the Claude Agent SDK, which is the SDK's current Streamable HTTP discriminant. However, external MCP examples commonly use `type: 'streamableHttp'`, and our own Nowledge prompt used that spelling. Those configs could fail validation or be skipped at runtime because Proma only accepted `http` and `sse` for URL-based MCP servers.

## Validation

- `bun test packages/shared/src/utils/mcp-transport.test.ts`
- `bun run --filter='@proma/shared' typecheck`
- `bun run --cwd apps/electron typecheck`
- `git diff --check`
