### PR TITLE
fix(markdown): 编辑器工具条改为固定行+独立滚动，滚动时稳定不动

### DIFF
--- a/apps/electron/src/renderer/components/diff/MarkdownEditorToolbar.tsx
+++ b/apps/electron/src/renderer/components/diff/MarkdownEditorToolbar.tsx
@@ -338,7 +338,7 @@ export function MarkdownEditorToolbar({ editor }: MarkdownEditorToolbarProps): R
   }, [handleScreenshot])
 
   return (
-    <div className="sticky top-0 z-10 flex items-center gap-0.5 border-b border-border/50 bg-background px-2 py-1">
+    <div className="z-10 flex shrink-0 items-center gap-0.5 border-b border-border/50 bg-background px-2 py-1">
       {/* 行内格式 */}
       <ToolbarButton icon={Bold} label="加粗" shortcut={`${mod}B`} active={activeState.bold} onClick={() => editor.chain().focus().toggleBold().run()} />
       <ToolbarButton icon={Italic} label="斜体" shortcut={`${mod}I`} active={activeState.italic} onClick={() => editor.chain().focus().toggleItalic().run()} />

--- a/apps/electron/src/renderer/components/diff/MarkdownRichEditor.tsx
+++ b/apps/electron/src/renderer/components/diff/MarkdownRichEditor.tsx
@@ -192,7 +192,7 @@ export function MarkdownRichEditor({
   }, [editor, isEditable])
 
   return (
-    <div className="flex h-full min-h-full flex-col">
+    <div className="flex min-h-full flex-col">
       {editing && editor && <MarkdownEditorToolbar editor={editor} />}
       <EditorContent
         editor={editor}

--- a/apps/electron/src/renderer/components/diff/MarkdownRichEditor.tsx
+++ b/apps/electron/src/renderer/components/diff/MarkdownRichEditor.tsx
@@ -192,13 +192,16 @@ export function MarkdownRichEditor({
   }, [editor, isEditable])
 
   return (
-    <div className="flex min-h-full flex-col">
+    // 编辑态：固定高度容器，工具条为固定行、编辑区独立滚动（toolbar 物理上在滚动区之外，
+    // 不依赖 position:sticky，彻底避免被内容滚走）。
+    // 预览态：内容驱动高度，由外层容器滚动（保持 TOC / 查找栏对外层滚动容器的依赖）。
+    <div className={cn('flex flex-col', editing ? 'h-full' : 'min-h-full')}>
       {editing && editor && <MarkdownEditorToolbar editor={editor} />}
       <EditorContent
         editor={editor}
         onMouseDown={focusEditorFromBlankArea}
         className={cn(
-          'h-full min-h-full flex-1',
+          editing ? 'min-h-0 flex-1 overflow-auto scrollbar-thin' : 'h-full min-h-full flex-1',
           isEditable
             ? '[&_.proma-mermaid-preview]:hidden [&_.proma-code-source-body]:block'
             : [


### PR DESCRIPTION
## 问题

Markdown 富文本编辑器的顶部工具条（加粗、标题、列表等格式化按钮）在编辑长文档向下滚动时会被滚走 / 收起，无法持续访问。用户期望工具条在滚动时**稳定固定**在顶部，方便随时切换格式化工具。

## 演进过程

**第一版**：工具条早已声明 `sticky top-0`，但因外层 wrapper 的 `h-full` 把包含块高度锁死成一屏高，滚过一屏后 wrapper 整体被带出视口。先尝试去掉 `h-full`。

**第二版（当前）**：实测发现 `sticky` 方案仍不够稳——工具条会随部分元素的滚动被收起。根因是 `position: sticky` 在「外层 `overflow-auto` 容器 + flex 列 + ProseMirror 深层嵌套」结构里**本质脆弱**：它要求工具条始终留在滚动流里、靠包含块粘住，长内容下高度解析存在边界情况，容易部分失效。

## 最终方案：固定头 + 独立滚动体

放弃 `sticky`，改为确定性布局——让工具条**彻底脱离滚动流**：

- **编辑态**：容器固定高度（`h-full`），工具条作为 `shrink-0` 固定行，`EditorContent` 自身 `overflow-auto` 独立内部滚动。工具条物理上位于滚动区之外，**任何内容都无法把它滚走**，不再依赖任何祖先链假设。
- **预览态**：保持 `min-h-full` 由内容驱动、外层容器滚动的原有行为，不触碰 TOC / 查找栏对外层滚动容器的依赖。

## 改动

- `MarkdownRichEditor.tsx`：按 `editing` 区分两种布局。编辑态 `h-full` + 内层 `EditorContent` 独立滚动；预览态保持原样。
- `MarkdownEditorToolbar.tsx`：移除 `sticky top-0`（新布局下已无意义），加 `shrink-0` 防止 flex 列压缩。

## 影响面

三处使用点的父容器在编辑态均有确定高度，`h-full` 正确填充：
- `DiffTabContent`（`scrollContainerRef` 是 `h-full flex-1`，在 `flex + min-h-0` 父级内）
- `AutomationFormView`（父级 `min-h-0 flex-1 overflow-y-auto`）
- `TabContent`（教程，`editing={false}`，走预览态，**完全不变**）

源码编辑模式走独立 textarea 路径，不受影响。

## 测试

- [ ] 编辑长 Markdown 文档，向下滚动，工具条**始终固定**在顶部不动
- [ ] 各种内容（长代码块、表格、图片）滚动时工具条都不被收起
- [ ] 空文档时编辑区仍占满高度、点击空白处可聚焦
- [ ] 只读预览模式的 TOC、Cmd+F 查找功能正常