### PR TITLE
fix(channel): normalize provider connection test errors (status-first)

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.13.16",
+  "version": "0.13.17",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/channel-manager.ts
+++ b/apps/electron/src/main/lib/channel-manager.ts
@@ -25,10 +25,21 @@ import { PROVIDER_DEFAULT_URLS } from '@proma/shared'
 import { getFetchFn } from './proxy-fetch'
 import { getEffectiveProxyUrl } from './proxy-settings-service'
 import { normalizeBaseUrl, normalizeAnthropicProviderUrl, getPromaUserAgent } from '@proma/core'
+import { normalizeHttpResponse, normalizeRequestError } from './channel-test-error'
 import pkg from '../../../package.json' with { type: 'json' }
 
 /** 当前配置版本 */
 const CONFIG_VERSION = 1
+/** 连接测试 / 模型拉取的统一超时时间 */
+const CHANNEL_TEST_TIMEOUT_MS = 15_000
+
+/**
+ * 为连接测试 / 模型拉取请求统一附加超时信号。
+ * 避免供应商不响应时请求无限挂起。
+ */
+function withTimeout(init: RequestInit): RequestInit {
+  return { ...init, signal: AbortSignal.timeout(CHANNEL_TEST_TIMEOUT_MS) }
+}
 
 /**
  * 读取渠道配置文件
@@ -290,8 +301,7 @@ export async function testChannel(channelId: string): Promise<ChannelTestResult>
         return { success: false, message: `不支持的供应商: ${channel.provider}。你可能过去使用的是 Proma 商业版，请重新下载商业版覆盖安装，当前版本为开源版本。` }
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : '未知错误'
-    return { success: false, message: `连接测试失败: ${message}` }
+    return normalizeRequestError(error)
   }
 }
 
@@ -356,7 +366,7 @@ async function testAnthropicCompatible(
     headers.Authorization = `Bearer ${apiKey}`
   }
 
-  const response = await fetchFn(`${url}/messages`, {
+  const response = await fetchFn(`${url}/messages`, withTimeout({
     method: 'POST',
     headers,
     body: JSON.stringify({
@@ -364,19 +374,9 @@ async function testAnthropicCompatible(
       max_tokens: 1,
       messages: [{ role: 'user', content: 'hi' }],
     }),
-  })
+  }))
 
-  if (response.ok) {
-    return { success: true, message: '连接成功' }
-  }
-
-  if (response.status === 401) {
-    const text = await response.text().catch(() => '')
-    return { success: false, message: `API Key 无效${text ? `: ${text.slice(0, 150)}` : ''}` }
-  }
-
-  // 如果能收到 API 的响应（即使是错误），说明连接是通的
-  return { success: true, message: '连接成功' }
+  return normalizeHttpResponse(response)
 }
 
 /**
@@ -386,23 +386,14 @@ async function testOpenAICompatible(baseUrl: string, apiKey: string, proxyUrl?: 
   const url = normalizeBaseUrl(baseUrl)
   const fetchFn = getFetchFn(proxyUrl)
 
-  const response = await fetchFn(`${url}/models`, {
+  const response = await fetchFn(`${url}/models`, withTimeout({
     method: 'GET',
     headers: {
       Authorization: `Bearer ${apiKey}`,
     },
-  })
+  }))
 
-  if (response.ok) {
-    return { success: true, message: '连接成功' }
-  }
-
-  if (response.status === 401) {
-    return { success: false, message: 'API Key 无效' }
-  }
-
-  const text = await response.text().catch(() => '')
-  return { success: false, message: `请求失败 (${response.status}): ${text.slice(0, 200)}` }
+  return normalizeHttpResponse(response)
 }
 
 /**
@@ -412,20 +403,11 @@ async function testGoogle(baseUrl: string, apiKey: string, proxyUrl?: string): P
   const url = normalizeBaseUrl(baseUrl)
   const fetchFn = getFetchFn(proxyUrl)
 
-  const response = await fetchFn(`${url}/v1beta/models?key=${apiKey}`, {
+  const response = await fetchFn(`${url}/v1beta/models?key=${apiKey}`, withTimeout({
     method: 'GET',
-  })
+  }))
 
-  if (response.ok) {
-    return { success: true, message: '连接成功' }
-  }
-
-  if (response.status === 400 || response.status === 403) {
-    return { success: false, message: 'API Key 无效' }
-  }
-
-  const text = await response.text().catch(() => '')
-  return { success: false, message: `请求失败 (${response.status}): ${text.slice(0, 200)}` }
+  return normalizeHttpResponse(response)
 }
 
 // ===== 直接测试连接 =====
@@ -464,8 +446,7 @@ export async function testChannelDirect(input: FetchModelsInput): Promise<Channe
         return { success: false, message: `不支持的提供商: ${input.provider}` }
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : '未知错误'
-    return { success: false, message: `连接测试失败: ${message}` }
+    return normalizeRequestError(error)
   }
 }
 
@@ -505,9 +486,9 @@ export async function fetchModels(input: FetchModelsInput): Promise<FetchModelsR
         return { success: false, message: `不支持的供应商: ${input.provider}`, models: [] }
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : '未知错误'
     console.error('[渠道管理] 拉取模型列表失败:', error)
-    return { success: false, message: `拉取模型失败: ${message}`, models: [] }
+    const result = normalizeRequestError(error)
+    return { success: false, message: result.message, models: [] }
   }
 }
 
@@ -553,19 +534,14 @@ async function fetchAnthropicCompatibleModels(
     headers.Authorization = `Bearer ${apiKey}`
   }
 
-  const response = await fetchFn(`${url}/models`, {
+  const response = await fetchFn(`${url}/models`, withTimeout({
     method: 'GET',
     headers,
-  })
-
-  if (response.status === 401) {
-    const text = await response.text().catch(() => '')
-    return { success: false, message: `API Key 无效${text ? `: ${text.slice(0, 150)}` : ''}`, models: [] }
-  }
+  }))
 
   if (!response.ok) {
-    const text = await response.text().catch(() => '')
-    return { success: false, message: `请求失败 (${response.status}): ${text.slice(0, 200)}`, models: [] }
+    const result = await normalizeHttpResponse(response)
+    return { success: false, message: result.message, models: [] }
   }
 
   const data = await response.json() as { data?: AnthropicModelItem[] }
@@ -602,20 +578,16 @@ async function fetchOpenAICompatibleModels(baseUrl: string, apiKey: string, prox
   const url = normalizeBaseUrl(baseUrl)
   const fetchFn = getFetchFn(proxyUrl)
 
-  const response = await fetchFn(`${url}/models`, {
+  const response = await fetchFn(`${url}/models`, withTimeout({
     method: 'GET',
     headers: {
       Authorization: `Bearer ${apiKey}`,
     },
-  })
-
-  if (response.status === 401) {
-    return { success: false, message: 'API Key 无效', models: [] }
-  }
+  }))
 
   if (!response.ok) {
-    const text = await response.text().catch(() => '')
-    return { success: false, message: `请求失败 (${response.status}): ${text.slice(0, 200)}`, models: [] }
+    const result = await normalizeHttpResponse(response)
+    return { success: false, message: result.message, models: [] }
   }
 
   const data = await response.json() as { data?: OpenAIModelItem[] }
@@ -657,17 +629,13 @@ async function fetchGoogleModels(baseUrl: string, apiKey: string, proxyUrl?: str
   const url = normalizeBaseUrl(baseUrl)
   const fetchFn = getFetchFn(proxyUrl)
 
-  const response = await fetchFn(`${url}/v1beta/models?key=${apiKey}`, {
+  const response = await fetchFn(`${url}/v1beta/models?key=${apiKey}`, withTimeout({
     method: 'GET',
-  })
-
-  if (response.status === 400 || response.status === 403) {
-    return { success: false, message: 'API Key 无效', models: [] }
-  }
+  }))
 
   if (!response.ok) {
-    const text = await response.text().catch(() => '')
-    return { success: false, message: `请求失败 (${response.status}): ${text.slice(0, 200)}`, models: [] }
+    const result = await normalizeHttpResponse(response)
+    return { success: false, message: result.message, models: [] }
   }
 
   const data = await response.json() as { models?: GoogleModelItem[] }

--- a/apps/electron/src/main/lib/channel-test-error.test.ts
+++ b/apps/electron/src/main/lib/channel-test-error.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  classifyHttpStatus,
+  extractErrorMessage,
+  summarizeDetail,
+  normalizeHttpResponse,
+  normalizeRequestError,
+} from './channel-test-error'
+
+describe('classifyHttpStatus - 状态码主轴', () => {
+  test.each([
+    [401, 'auth'],
+    [402, 'quota'],
+    [404, 'not_found'],
+    [408, 'timeout'],
+    [405, 'bad_request'],
+    [409, 'bad_request'],
+    [413, 'bad_request'],
+    [415, 'bad_request'],
+    [422, 'bad_request'],
+    [500, 'server'],
+    [502, 'server'],
+    [503, 'server'],
+    [418, 'unknown'],
+  ] as const)('Given %i（无歧义文本）Then 归类为 %s', (status, expected) => {
+    expect(classifyHttpStatus(status, '')).toBe(expected)
+  })
+
+  test('Given 5xx 即便响应体含 quota 字样 Then 仍归类为 server', () => {
+    expect(classifyHttpStatus(503, 'insufficient_quota')).toBe('server')
+  })
+})
+
+describe('classifyHttpStatus - 歧义状态借文本消解', () => {
+  // 403：默认 permission；含 auth 特征 → auth（Google 风格）
+  test('Given 403 普通禁止 Then permission', () => {
+    expect(classifyHttpStatus(403, 'forbidden')).toBe('permission')
+  })
+  test('Given 403 且文本为 API key not valid Then auth', () => {
+    expect(classifyHttpStatus(403, 'API key not valid. Please pass a valid API key.')).toBe('auth')
+  })
+
+  // 400：默认 bad_request；含 auth 特征 → auth（Google 用 400 表达 Key 无效）
+  test('Given 400 普通参数错误 Then bad_request', () => {
+    expect(classifyHttpStatus(400, 'invalid request: missing field')).toBe('bad_request')
+  })
+  test('Given 400 且文本为 API_KEY_INVALID Then auth', () => {
+    expect(classifyHttpStatus(400, '{"error":{"status":"INVALID_ARGUMENT","message":"API key not valid"}}')).toBe('auth')
+  })
+
+  // 429：默认 rate_limit；含 quota 特征 → quota（OpenAI 的 insufficient_quota）
+  test('Given 429 普通限流 Then rate_limit', () => {
+    expect(classifyHttpStatus(429, 'Rate limit reached for requests')).toBe('rate_limit')
+  })
+  test('Given 429 且文本为 insufficient_quota Then quota', () => {
+    expect(classifyHttpStatus(429, 'You exceeded your current quota, insufficient_quota')).toBe('quota')
+  })
+})
+
+describe('extractErrorMessage - 兼容多家结构', () => {
+  test('OpenAI / Anthropic 嵌套 error.message', () => {
+    expect(extractErrorMessage('{"error":{"message":"Incorrect API key provided","type":"invalid_request_error"}}'))
+      .toBe('Incorrect API key provided')
+  })
+  test('顶层 message', () => {
+    expect(extractErrorMessage('{"message":"boom"}')).toBe('boom')
+  })
+  test('无 message 时回退到 code/type/status', () => {
+    expect(extractErrorMessage('{"error":{"code":"model_not_found"}}')).toBe('model_not_found')
+  })
+  test('纯文本 / HTML 原样返回', () => {
+    expect(extractErrorMessage('<html>404 Not Found</html>')).toBe('<html>404 Not Found</html>')
+  })
+  test('空体返回空串', () => {
+    expect(extractErrorMessage('   ')).toBe('')
+  })
+})
+
+describe('summarizeDetail - 脱敏与截断', () => {
+  test('脱敏 Bearer Token', () => {
+    expect(summarizeDetail('header Authorization: Bearer sk-ant-abc123def456'))
+      .not.toContain('sk-ant-abc123def456')
+  })
+  test('脱敏 sk- 开头的 Key', () => {
+    const out = summarizeDetail('key leaked: sk-proj-ABCDEFGH12345678') ?? ''
+    expect(out).toContain('[REDACTED]')
+    expect(out).not.toContain('ABCDEFGH12345678')
+  })
+  test('脱敏 URL 查询参数中的 key=（Google 风格）', () => {
+    const out = summarizeDetail('failed to fetch https://x/v1beta/models?key=AIzaSyVERYSECRET') ?? ''
+    expect(out).not.toContain('AIzaSyVERYSECRET')
+  })
+  test('脱敏 json 字段 api_key', () => {
+    const out = summarizeDetail('{"api_key":"super-secret-value"}') ?? ''
+    expect(out).not.toContain('super-secret-value')
+  })
+  test('压缩空白', () => {
+    expect(summarizeDetail('a   \n  b')).toBe('a b')
+  })
+  test('超长截断到 500 字符并加省略号', () => {
+    const out = summarizeDetail('x'.repeat(1000)) ?? ''
+    expect(out.length).toBe(501) // 500 + 省略号
+    expect(out.endsWith('…')).toBe(true)
+  })
+  test('空内容返回 undefined', () => {
+    expect(summarizeDetail('   ')).toBeUndefined()
+  })
+})
+
+describe('normalizeHttpResponse - 端到端（仅 2xx 成功）', () => {
+  test('200 → 成功', async () => {
+    const result = await normalizeHttpResponse(new Response('{}', { status: 200 }))
+    expect(result.success).toBe(true)
+    expect(result.message).toBe('连接成功')
+  })
+
+  // 核心回归：#770 —— 403/404/429/5xx 不再被误判为成功
+  test.each([403, 404, 429, 500, 503] as const)('%i → 失败（修复 #770）', async (status) => {
+    const result = await normalizeHttpResponse(new Response('err', { status }))
+    expect(result.success).toBe(false)
+    expect(result.statusCode).toBe(status)
+  })
+
+  test('401 → auth，且携带脱敏后的供应商摘要', async () => {
+    const body = JSON.stringify({ error: { message: 'Incorrect API key provided: sk-abcdEFGH1234' } })
+    const result = await normalizeHttpResponse(new Response(body, { status: 401 }))
+    expect(result.success).toBe(false)
+    expect(result.errorType).toBe('auth')
+    expect(result.statusCode).toBe(401)
+    expect(result.detail).toBeDefined()
+    expect(result.message).not.toContain('sk-abcdEFGH1234')
+  })
+
+  test('Google 400 API key not valid → auth（不再误报 bad_request）', async () => {
+    const body = JSON.stringify({ error: { status: 'INVALID_ARGUMENT', message: 'API key not valid' } })
+    const result = await normalizeHttpResponse(new Response(body, { status: 400 }))
+    expect(result.errorType).toBe('auth')
+  })
+
+  test('OpenAI 429 insufficient_quota → quota（不再误报 rate_limit）', async () => {
+    const body = JSON.stringify({ error: { message: 'You exceeded your current quota', type: 'insufficient_quota' } })
+    const result = await normalizeHttpResponse(new Response(body, { status: 429 }))
+    expect(result.errorType).toBe('quota')
+  })
+
+  test('无响应体时回退到 statusText', async () => {
+    const result = await normalizeHttpResponse(new Response(null, { status: 404, statusText: 'Not Found' }))
+    expect(result.errorType).toBe('not_found')
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('normalizeRequestError - 异常分类', () => {
+  test('AbortSignal.timeout 触发的 TimeoutError → timeout', () => {
+    const err = new DOMException('The operation timed out', 'TimeoutError')
+    expect(normalizeRequestError(err).errorType).toBe('timeout')
+  })
+  test('AbortError → timeout', () => {
+    const err = new DOMException('The operation was aborted', 'AbortError')
+    expect(normalizeRequestError(err).errorType).toBe('timeout')
+  })
+  test('非法 URL → bad_request（不再误报 network）', () => {
+    expect(normalizeRequestError(new TypeError('Failed to parse URL from xxx')).errorType).toBe('bad_request')
+  })
+  test('fetch failed → network', () => {
+    expect(normalizeRequestError(new TypeError('fetch failed')).errorType).toBe('network')
+  })
+  test('携带 cause 的网络错误 → network', () => {
+    const err = new TypeError('fetch failed')
+    ;(err as { cause?: unknown }).cause = new Error('getaddrinfo ENOTFOUND api.example.com')
+    expect(normalizeRequestError(err).errorType).toBe('network')
+  })
+  test('异常摘要也会脱敏', () => {
+    const err = new Error('connect failed for https://x?key=AIzaSECRETLEAK')
+    const result = normalizeRequestError(err)
+    expect(result.message).not.toContain('AIzaSECRETLEAK')
+  })
+})

--- a/apps/electron/src/main/lib/channel-test-error.ts
+++ b/apps/electron/src/main/lib/channel-test-error.ts
@@ -1,0 +1,258 @@
+/**
+ * 渠道连接测试错误归一化
+ *
+ * 设计原则：
+ * - HTTP 语义是标准化的，分类以「状态码」为主轴；文本匹配只用于消解三个
+ *   真正存在歧义的状态（400 / 403 / 429），而不是作为主判据。这样新增
+ *   Provider 时不需要再堆叠正则，长期可维护性远好于「文本优先」方案。
+ * - 纯函数、无 Electron 依赖，可独立单元测试。
+ * - 安全与资源边界：限制错误响应体读取大小、截断摘要、脱敏凭证。
+ *
+ * 修复 #770：此前部分 Provider 把「收到任何 HTTP 响应」等同于「连接成功」，
+ * 导致 403 / 404 / 429 / 额度不足 / 5xx 被误判为成功。这里统一约定：
+ * 仅 HTTP 2xx 才算连接成功。
+ */
+
+import type { ChannelTestErrorType, ChannelTestResult } from '@proma/shared'
+
+/** 脱敏后原始错误摘要的最大长度 */
+const MAX_DETAIL_LENGTH = 500
+/** 错误响应体最多读取的字节数，避免异常端点返回超大内容造成额外内存占用 */
+const MAX_ERROR_BODY_BYTES = 16 * 1024
+
+/** 各分类对应的用户可读提示（已带处置建议） */
+const ERROR_LABELS: Record<ChannelTestErrorType, string> = {
+  auth: '认证失败，请检查 API Key',
+  permission: '权限不足，当前 Key 无访问权限',
+  not_found: '资源不存在，请检查 Base URL 或模型',
+  rate_limit: '请求频率受限，请稍后重试',
+  quota: '额度不足，请检查账户余额',
+  bad_request: '请求无效，请检查渠道配置',
+  server: '供应商服务异常，请稍后重试',
+  network: '网络连接失败，请检查网络或代理',
+  timeout: '连接超时，请检查网络或代理',
+  unknown: '连接测试失败',
+}
+
+/**
+ * 仅用于消解「歧义状态」的两个文本特征：
+ * - 400 / 403 可能表达「Key 无效」而非「请求错误 / 无权限」（如 Google）。
+ * - 429 可能表达「额度不足」而非「限流」（如 OpenAI 的 insufficient_quota）。
+ * 除此之外的状态全部由状态码直接决定，无需文本。
+ */
+const AUTH_TEXT =
+  /invalid[_\s-]?(?:api[_\s-]?)?key|api[_\s-]?key[_\s-]?(?:not[_\s-]?valid|invalid)|incorrect api key|unauthorized|authentication|invalid token|密钥无效|凭证无效|未认证/i
+const QUOTA_TEXT =
+  /insufficient[_\s-]?quota|exceeded your current quota|out of credit|billing|payment[_\s-]?required|余额不足|额度不足|欠费|充值/i
+
+/** 异常（无 HTTP 响应）阶段使用的文本特征 */
+const TIMEOUT_TEXT = /timeout|timed out|etimedout|超时/i
+const INVALID_URL_TEXT =
+  /invalid url|failed to parse url|unsupported protocol|only absolute urls|invalid protocol|无效的 url/i
+
+/** 凭证脱敏规则：Bearer Token、sk-* Key、常见 key=/token: 字段与查询参数 */
+const SENSITIVE_PATTERNS: ReadonlyArray<{ pattern: RegExp; replacement: string }> = [
+  { pattern: /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, replacement: 'Bearer [REDACTED]' },
+  { pattern: /\bsk-[A-Za-z0-9_-]{8,}\b/gi, replacement: '[REDACTED]' },
+  {
+    pattern:
+      /(["']?(?:api[_-]?key|x-api-key|access[_-]?token|token|authorization|key)["']?\s*[:=]\s*["']?)[^"',&\s}]+/gi,
+    replacement: '$1[REDACTED]',
+  },
+]
+
+/**
+ * 按 HTTP 状态码分类。文本仅用于消解 400 / 403 / 429 三个歧义状态。
+ *
+ * @param status   HTTP 状态码
+ * @param bodyText 错误响应体文本（仅用于歧义消解，可为空）
+ */
+export function classifyHttpStatus(status: number, bodyText = ''): ChannelTestErrorType {
+  // 5xx：无论响应体如何，都是供应商侧故障
+  if (status >= 500) return 'server'
+
+  switch (status) {
+    case 401:
+      return 'auth'
+    case 402:
+      return 'quota'
+    case 403:
+      // 多数 Provider 用 403 表示「禁止 / 无权限」；
+      // 但 Google 等会用 403 表达 Key 无效 —— 借文本消解。
+      return AUTH_TEXT.test(bodyText) ? 'auth' : 'permission'
+    case 404:
+      return 'not_found'
+    case 408:
+      return 'timeout'
+    case 429:
+      // OpenAI 用 429 表达 insufficient_quota —— 借文本区分「欠费」与「限流」。
+      return QUOTA_TEXT.test(bodyText) ? 'quota' : 'rate_limit'
+    case 400:
+      // Google 用 400「API key not valid」表达 Key 无效 —— 借文本消解。
+      return AUTH_TEXT.test(bodyText) ? 'auth' : 'bad_request'
+    case 405:
+    case 409:
+    case 413:
+    case 415:
+    case 422:
+      return 'bad_request'
+    default:
+      return 'unknown'
+  }
+}
+
+/** 判断对象（排除数组与 null） */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function readString(record: Record<string, unknown>, key: string): string {
+  const value = record[key]
+  return typeof value === 'string' || typeof value === 'number' ? String(value) : ''
+}
+
+/**
+ * 从错误响应体中提取可读消息。
+ * 兼容 OpenAI / Anthropic / Google 的 `{ error: { message } }` 结构，
+ * 也兼容顶层 `{ message }`；非 JSON（纯文本 / HTML）原样返回。
+ */
+export function extractErrorMessage(bodyText: string): string {
+  const trimmed = bodyText.trim()
+  if (!trimmed) return ''
+
+  try {
+    const parsed: unknown = JSON.parse(trimmed)
+    if (!isRecord(parsed)) return trimmed
+
+    const target = isRecord(parsed.error) ? parsed.error : parsed
+    const message = readString(target, 'message')
+    if (message) return message
+
+    const code =
+      readString(target, 'code') || readString(target, 'type') || readString(target, 'status')
+    return code || trimmed
+  } catch {
+    return trimmed
+  }
+}
+
+/**
+ * 对错误摘要脱敏、压缩空白并截断到上限。
+ */
+export function summarizeDetail(text: string): string | undefined {
+  const redacted = SENSITIVE_PATTERNS.reduce(
+    (acc, { pattern, replacement }) => acc.replace(pattern, replacement),
+    text,
+  )
+  const normalized = redacted.replace(/\s+/g, ' ').trim()
+  if (!normalized) return undefined
+  return normalized.length > MAX_DETAIL_LENGTH
+    ? `${normalized.slice(0, MAX_DETAIL_LENGTH)}…`
+    : normalized
+}
+
+function buildFailure(
+  errorType: ChannelTestErrorType,
+  detail: string,
+  statusCode?: number,
+): ChannelTestResult {
+  const summary = summarizeDetail(detail)
+  const statusPart = statusCode == null ? '' : ` (${statusCode})`
+  const detailPart = summary ? `：${summary}` : ''
+
+  return {
+    success: false,
+    message: `${ERROR_LABELS[errorType]}${statusPart}${detailPart}`,
+    errorType,
+    ...(statusCode == null ? {} : { statusCode }),
+    ...(summary ? { detail: summary } : {}),
+  }
+}
+
+/**
+ * 在字节上限内读取错误响应体，避免把超大错误页全部读进内存。
+ */
+async function readBoundedText(response: Response): Promise<string> {
+  const body = response.body
+  if (!body) {
+    try {
+      return (await response.text()).slice(0, MAX_ERROR_BODY_BYTES)
+    } catch {
+      return ''
+    }
+  }
+
+  const reader = body.getReader()
+  const decoder = new TextDecoder()
+  let out = ''
+  let bytes = 0
+
+  try {
+    while (bytes < MAX_ERROR_BODY_BYTES) {
+      const { done, value } = await reader.read()
+      if (done) break
+
+      const remaining = MAX_ERROR_BODY_BYTES - bytes
+      const chunk = value.byteLength > remaining ? value.subarray(0, remaining) : value
+      out += decoder.decode(chunk, { stream: true })
+      bytes += chunk.byteLength
+
+      if (chunk.byteLength < value.byteLength) break
+    }
+    out += decoder.decode()
+  } catch {
+    // 读取中断：返回已读部分
+  } finally {
+    await reader.cancel().catch(() => {})
+  }
+
+  return out
+}
+
+function collectErrorText(error: unknown): string {
+  if (!(error instanceof Error)) return String(error)
+
+  const parts = [error.name, error.message]
+  if (error.cause instanceof Error) {
+    parts.push(error.cause.name, error.cause.message)
+  } else if (error.cause != null) {
+    parts.push(String(error.cause))
+  }
+  return parts.filter(Boolean).join(': ')
+}
+
+/**
+ * 归一化一个 HTTP 响应：仅 2xx 视为成功，其余按状态码分类并附脱敏摘要。
+ */
+export async function normalizeHttpResponse(response: Response): Promise<ChannelTestResult> {
+  if (response.ok) {
+    return { success: true, message: '连接成功' }
+  }
+
+  const bodyText = await readBoundedText(response)
+  const errorType = classifyHttpStatus(response.status, bodyText)
+  const detail = extractErrorMessage(bodyText) || response.statusText
+  return buildFailure(errorType, detail, response.status)
+}
+
+/**
+ * 归一化一个请求异常（无 HTTP 响应）：超时 / 非法 URL / 网络。
+ * fetch 抛出但非以上两类时，绝大多数是连通性问题，归类为 network。
+ */
+export function normalizeRequestError(error: unknown): ChannelTestResult {
+  const detail = collectErrorText(error)
+
+  if (
+    (error instanceof DOMException &&
+      (error.name === 'TimeoutError' || error.name === 'AbortError')) ||
+    TIMEOUT_TEXT.test(detail)
+  ) {
+    return buildFailure('timeout', detail)
+  }
+
+  if (INVALID_URL_TEXT.test(detail)) {
+    return buildFailure('bad_request', detail)
+  }
+
+  return buildFailure('network', detail)
+}

--- a/apps/electron/src/renderer/components/settings/ChannelForm.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelForm.tsx
@@ -588,11 +588,13 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
             </div>
             {testResult && (
               <div className={cn(
-                'flex items-center gap-1.5 text-xs',
+                'flex items-start gap-1.5 text-xs',
                 testResult.success ? 'text-emerald-600' : 'text-destructive'
               )}>
-                {testResult.success ? <CheckCircle2 size={12} /> : <XCircle size={12} />}
-                <span>{testResult.message}</span>
+                {testResult.success
+                  ? <CheckCircle2 size={12} className="mt-0.5 shrink-0" />
+                  : <XCircle size={12} className="mt-0.5 shrink-0" />}
+                <span className="min-w-0 break-all">{testResult.message}</span>
               </div>
             )}
           </div>

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/shared",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "license": "AGPL-3.0-only",
   "description": "Shared types, configs and utilities for proma",
   "type": "module",

--- a/packages/shared/src/types/channel.ts
+++ b/packages/shared/src/types/channel.ts
@@ -173,13 +173,37 @@ export interface ChannelsConfig {
 }
 
 /**
+ * 连接测试失败的归一化分类
+ *
+ * 以 HTTP 状态码为主轴判定；UI 可据此渲染不同提示 / 图标，
+ * 而无需解析 message 字符串。
+ */
+export type ChannelTestErrorType =
+  | 'auth'
+  | 'permission'
+  | 'not_found'
+  | 'rate_limit'
+  | 'quota'
+  | 'bad_request'
+  | 'server'
+  | 'network'
+  | 'timeout'
+  | 'unknown'
+
+/**
  * 连接测试结果
  */
 export interface ChannelTestResult {
   /** 是否成功 */
   success: boolean
-  /** 结果消息 */
+  /** 结果消息（含分类提示与脱敏后的供应商摘要） */
   message: string
+  /** 归一化错误分类，成功时为空 */
+  errorType?: ChannelTestErrorType
+  /** HTTP 状态码，网络 / 超时等无响应异常时为空 */
+  statusCode?: number
+  /** 供应商原始错误摘要，已脱敏并截断 */
+  detail?: string
 }
 
 /**


### PR DESCRIPTION
## 背景

修复 #770:模型渠道"测试连接"在部分 Provider 返回非 2xx(403/404/429/额度不足/5xx)时仍显示"连接成功"。

> 注:这是对 #935 所解决问题的一个**替代实现**,从设计角度做了重构。两者解决同一问题,可择优合并。

## 根因

- Provider 请求构造与错误解释耦合在 `channel-manager.ts`,每个 Provider 各写一套 if/else,标准不一致。
- Anthropic 兼容测试把"收到任何 HTTP 响应"等同于"渠道可用"。
- 同样的散弹式错误解释逻辑在 `fetchModels` 三个函数里**再次重复**,且直接回显原始文本、未脱敏。
- `ChannelTestResult` 只有 `success` / `message`,无稳定的机器可读分类。
- 连接测试没有统一超时。

## 设计思路(与 #935 的关键差异)

**分类以 HTTP 状态码为主轴,文本只用于消解歧义。** HTTP 语义是标准化的(401/403/404/429/5xx 含义明确),应优先信任状态码;只有 3 个状态真正有歧义需要文本辅助:

| 状态 | 默认分类 | 文本消解的特例 |
|------|---------|---------------|
| 400 | bad_request | "API key not valid" → auth(Google) |
| 403 | permission | 含 auth 特征 → auth |
| 429 | rate_limit | "insufficient_quota" → quota(OpenAI) |

这样把分类正则从约 10 条压缩到 **2 条**(`AUTH_TEXT` / `QUOTA_TEXT`),新增 Provider 时几乎不需要再动正则,长期可维护性显著更好。

## 改动

- 新增纯函数、无 Electron 依赖的 `channel-test-error.ts`:
  - 仅 HTTP 2xx 判定成功。
  - 状态码主轴分类:`auth` / `permission` / `not_found` / `rate_limit` / `quota` / `bad_request` / `server` / `network` / `timeout` / `unknown`。
  - 兼容 OpenAI / Anthropic / Google 的 `{error:{message}}` 结构及纯文本/HTML。
  - 脱敏 Bearer Token、`sk-*` Key、`key=`/`token:` 字段;限读 16KB;摘要截断 500 字符。
- **`testChannel` 与 `fetchModels` 两条路径统一走分类器**,消除重复;`fetchModels` 的原始错误回显此前未脱敏,现一并脱敏。
- 所有连接测试 / 模型拉取统一加 **15s 超时**(`AbortSignal.timeout`)。
- 扩展 `ChannelTestResult`:`errorType` / `statusCode` / `detail`(均可选,向后兼容)。未引入无消费方的投机字段(如 `retriable`),留待运行时重试真正落地时在使用点派生。
- 设置页错误摘要支持长文本换行,图标 `shrink-0` 不被挤压。
- **新增 48 个单元测试**覆盖:各状态码分类、三个歧义状态的文本消解、脱敏、限长、异常(timeout/invalid-url/network)分类。

## 用户影响

- `403` / `404` / `429` / 额度不足 / `5xx` 不再显示"连接成功"。
- 错误提示带处置建议(检查 Key / 检查 Base URL / 充值 / 稍后重试 / 检查网络等)。
- Provider 原始错误仍可用于排查,但不会无限扩张或回显常见凭证。

## 测试

- `bun test` — 189 pass / 0 fail(含新增 48 个)
- `bun run --filter='@proma/shared' typecheck` ✅
- `bun run --filter='@proma/electron' typecheck` ✅
- `bun run --filter='@proma/electron' build:main` ✅
- `git diff --check` ✅

## 范围说明

本 PR 只处理配置阶段的连接测试与模型拉取。运行时自动重试、统一错误中间件、熔断器不在本次范围。

Closes #770

🤖 Generated with [Claude Code](https://claude.com/claude-code)