### PR TITLE
【已审核】fix(mainarea): 侧边分屏时切换到技能页或自动任务页的预览面板隐藏

### DIFF
--- a/apps/electron/src/renderer/components/tabs/MainArea.tsx
+++ b/apps/electron/src/renderer/components/tabs/MainArea.tsx
@@ -72,7 +72,7 @@ export function MainArea(): React.ReactElement {
     prevPreviewStateRef.current = { open: previewOpen, sessionId: previewSessionId }
   }, [previewOpen, previewSessionId])
 
-  const showPreview = (previewOpen || closing) && previewSessionId
+  const showPreview = (previewOpen || closing) && previewSessionId && activeView === 'conversations'
 
   const handlePreviewDragStart = React.useCallback((e: React.MouseEvent) => {
     e.preventDefault()
@@ -138,7 +138,7 @@ export function MainArea(): React.ReactElement {
 
   // 左侧容器宽度：预览打开时固定占 splitRatio；其他情况（含 closing 动画期间）
   // 直接 1 1 auto 占满——closing 时右侧 absolute 脱离 flex 流，所以左侧自然占 100%。
-  const leftFlexStyle: React.CSSProperties = (previewOpen && previewSessionId)
+  const leftFlexStyle: React.CSSProperties = (previewOpen && previewSessionId && activeView === 'conversations')
     ? { flex: `0 0 calc(${splitRatio * 100}% - 4px)` }
     : { flex: '1 1 auto' }
 


### PR DESCRIPTION
## 概述

侧边栏切换到 Agent 技能页（AgentSkillsView）或自动任务页（AutomationsListView）时，MainArea 的预览分屏面板（PreviewPanel）仍然显示在右侧并与全屏视图争夺空间，导致技能页/自动任务页被挤入左侧分栏区域而非占据 100% 宽度。

根因：`showPreview` 和 `leftFlexStyle` 仅检查了 `activeTab` 和 `previewPanelOpenMap`，但未考虑 `activeView`。当活跃 Tab 是 agent session 且 `previewPanelOpenMap` 残留 `open=true` 条目时，预览面板持续占据分栏空间。

修复：在 `showPreview` 和 `leftFlexStyle` 条件中增加 `activeView === 'conversations'` 守卫。预览状态（`previewPanelOpenMapAtom`）保持不变，切回对话视图后自动恢复。

## 改动

| 文件 | 改动 |
|------|------|
| `apps/electron/src/renderer/components/tabs/MainArea.tsx` | `showPreview` 增加 `activeView === 'conversations'` 条件（第 75 行） |
| 同上 | `leftFlexStyle` 增加 `activeView === 'conversations'` 条件（第 141 行） |

共 2 行修改。

## 测试

- [x] 切换到 Agent 技能 / 自动任务视图 — 预览面板应隐藏。`showPreview` 中 `activeView === 'conversations'` 为 false，面板不渲染；`leftFlexStyle` fallback 到 `flex: 1 1 auto`，左侧全宽。
- [x] 回到对话视图 — 预览面板应恢复。`openSession()` 内部设 `setActiveView('conversations')`，`activeTab` 和 `previewPanelOpenMapAtom` 均未变，`previewOpen` 保持原值，`showPreview` 回到 true，分栏比例不变。

`bun run typecheck` 通过 ✅

## 紧急度

低
