### PR TITLE
[codex] Align agent file chips with inline code

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.13.18",
+  "version": "0.13.19",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx
@@ -189,7 +189,7 @@ export function FilePathChip({ filePath, basePath, basePaths, className }: FileP
           onClick={handleClick}
           title={fileStatus === 'broken' ? `文件不存在: ${displayPath}` : displayPath}
           className={cn(
-            'inline-flex items-center gap-1 rounded px-1.5 py-[2px] text-[12px] font-medium leading-[1.6]',
+            'inline-flex items-center gap-[0.25em] rounded px-[0.35em] py-[0.15em] text-[0.875em] font-medium leading-none',
             'cursor-pointer transition-colors duration-150',
             'align-baseline not-prose',
             fileStatus === 'broken'
@@ -198,8 +198,8 @@ export function FilePathChip({ filePath, basePath, basePaths, className }: FileP
             className
           )}
         >
-          <FileTypeIcon name={filename} isDirectory={false} size={14} />
-          <span className="truncate max-w-[240px]">{filename}{lineColSuffix}</span>
+          <FileTypeIcon name={filename} isDirectory={false} size={12} />
+          <span className="truncate max-w-[240px] leading-none">{filename}{lineColSuffix}</span>
         </button>
       </ContextMenuTrigger>
       <ContextMenuContent className="w-48">


### PR DESCRIPTION
## Summary

- Align Agent history file path chips with markdown inline code sizing.
- Reduce chip icon size and line height so file chips do not sit taller than normal inline code.
- Bump `@proma/electron` patch version from `0.13.18` to `0.13.19` per repository release rules.

## Why

Agent replies frequently render file paths as clickable chips. The previous chip styling used fixed 12px text, 14px icons, and `leading-[1.6]`, which made the chip visually taller than adjacent markdown inline code.

## Validation

- `bun run typecheck`
- `git diff --check`
