### PR TITLE
【已审核】feat(agent): 后台任务运行时在输入区域显示视觉反馈

### DIFF
--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -519,7 +519,7 @@ export const agentRunningSessionIdsAtom = atom<Set<string>>((get) => {
   const states = get(agentStreamingStatesAtom)
   const ids = new Set<string>()
   for (const [id, state] of states) {
-    if (state.running) ids.add(id)
+    if (state.running || state.backgroundWaiting) ids.add(id)
   }
   return ids
 })
@@ -566,7 +566,7 @@ export const agentSessionIndicatorMapAtom = atom<Map<string, SessionIndicatorSta
   const map = new Map<string, SessionIndicatorStatus>()
 
   for (const [id, state] of streamStates) {
-    if (!state.running) continue
+    if (!state.running && !state.backgroundWaiting) continue
     const hasBlock = (pendingPerms.get(id)?.length ?? 0) > 0
       || (pendingAskUser.get(id)?.length ?? 0) > 0
       || (pendingExitPlan.get(id)?.length ?? 0) > 0

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -17,7 +17,7 @@ import * as React from 'react'
 import { unstable_batchedUpdates } from 'react-dom'
 import { useAtom, useAtomValue, useSetAtom, useStore } from 'jotai'
 import { toast } from 'sonner'
-import { Bot, CornerDownLeft, Square, Settings, Paperclip, FolderPlus, X, Copy, Check, Brain, Sparkles, Eye } from 'lucide-react'
+import { Bot, CornerDownLeft, Square, Settings, Paperclip, FolderPlus, X, Copy, Check, Brain, Sparkles, Eye, Loader2 } from 'lucide-react'
 import { AgentMessages } from './AgentMessages'
 import { AgentHeader } from './AgentHeader'
 import { ContextUsageBadge } from './ContextUsageBadge'
@@ -89,11 +89,13 @@ import {
   allPendingExitPlanRequestsAtom,
   finalizeStreamingActivities,
   agentProcessGroupsKeepExpandedAtom,
+  backgroundTasksAtomFamily,
 } from '@/atoms/agent-atoms'
 import type { AgentContextStatus } from '@/atoms/agent-atoms'
 import { settingsOpenAtom } from '@/atoms/settings-tab'
 import { channelsAtom, thinkingExpandedAtom } from '@/atoms/chat-atoms'
 import { useOpenSession } from '@/hooks/useOpenSession'
+import { useBackgroundTasks } from '@/hooks/useBackgroundTasks'
 import { AgentSessionProvider } from '@/contexts/session-context'
 import { draftSessionIdsAtom } from '@/atoms/draft-session-atoms'
 import { sendWithCmdEnterAtom } from '@/atoms/shortcut-atoms'
@@ -299,6 +301,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   // 软空闲态：本轮主体已结束、UI 可输入，但 SDK 通道仍开着等后台任务唤醒。
   // 此时服务端 activeSessions 仍保留，新消息须走注入通道而非新建 run。
   const backgroundWaiting = streamState?.backgroundWaiting ?? false
+  const { tasks: backgroundTasks } = useBackgroundTasks(sessionId)
   const stoppedByUserSessions = useAtomValue(stoppedByUserSessionsAtom)
   const sendWithCmdEnter = useAtomValue(sendWithCmdEnterAtom)
   const stoppedByUser = stoppedByUserSessions.has(sessionId)
@@ -1569,22 +1572,28 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     })
   }, [inputContent, attachedDirs, attachedFileDirectories, sessionId, agentChannelId, agentModelId, currentWorkspaceId, workspaces, streaming, backgroundWaiting, suggestion, hasAvailableModel, store, setStreamingStates, setPendingFiles, setAgentStreamErrors, setPromptSuggestions, setInputContent, setLiveMessagesMap, permissionMode, messagesLoaded])
 
-  /** 停止生成 */
+  /** 停止生成（含后台任务等待态） */
   const handleStop = React.useCallback((): void => {
     setStreamingStates((prev) => {
       const current = prev.get(sessionId)
-      if (!current || !current.running) return prev
+      if (!current) return prev
+      // running=false 且非 backgroundWaiting 时才跳过
+      if (!current.running && !current.backgroundWaiting) return prev
       const map = new Map(prev)
       map.set(sessionId, {
         ...current,
         running: false,
-        ...finalizeStreamingActivities(current.toolActivities),
+        backgroundWaiting: false,
+        ...(current.running ? finalizeStreamingActivities(current.toolActivities) : {}),
       })
       return map
     })
 
+    // 同步清除后台任务列表，避免 badge 残留
+    store.set(backgroundTasksAtomFamily(sessionId), [])
+
     window.electronAPI.stopAgent(sessionId).catch(console.error)
-  }, [sessionId, setStreamingStates])
+  }, [sessionId, setStreamingStates, store])
 
   /** 手动发送 /compact 命令 */
   const handleCompact = React.useCallback((): void => {
@@ -2010,8 +2019,25 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     setProcessGroupsKeepExpanded,
   ])
 
-  const inputTrailingNode = streaming && !hasTextInput ? (
-    <Tooltip>
+  const showBadge = backgroundTasks.length > 0 || backgroundWaiting
+  const showStop = (streaming || backgroundWaiting) && !hasTextInput
+
+  const inputTrailingNode = (
+    <div className="flex items-center gap-1">
+      {showBadge && (
+        <div
+          className="flex items-center gap-1.5 h-8 px-2 rounded-full text-xs bg-blue-500/10 text-blue-600 dark:text-blue-400 border border-blue-500/20 animate-in slide-in-from-right-2 fade-in duration-300"
+        >
+          <Loader2 className="size-3 animate-spin" />
+          <span className="whitespace-nowrap">
+            {backgroundTasks.length > 0
+              ? `${backgroundTasks.length} 个后台任务运行中`
+              : '后台任务运行中'}
+          </span>
+        </div>
+      )}
+      {showStop ? (
+        <Tooltip>
       <TooltipTrigger asChild>
         <Button
           type="button"
@@ -2024,7 +2050,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         </Button>
       </TooltipTrigger>
       <TooltipContent side="top">
-        <p>停止 Agent ({getAcceleratorDisplay(getActiveAccelerator('stop-generation'))})</p>
+        <p>停止 Agent{backgroundWaiting ? '（后台任务运行中）' : ''} ({getAcceleratorDisplay(getActiveAccelerator('stop-generation'))})</p>
       </TooltipContent>
     </Tooltip>
   ) : (
@@ -2043,6 +2069,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     >
       <CornerDownLeft className="size-[22px]" />
     </Button>
+      )}
+    </div>
   )
 
   return (


### PR DESCRIPTION
## 概述

Agent 通过 Bash(run_in_background)、Monitor、SubAgent 等机制创建后台任务后，进入 backgroundWaiting 状态（running=false, backgroundWaiting=true），但 UI 与「Agent 彻底完成」完全无法区分：显示 Send 按钮、无 spinner、无任何运行提示。用户误以为 Agent 已完成，切走或重复操作，等后台任务完成后 Agent 自动唤醒时才困惑。

本 PR 在三个层面添加后台任务视觉反馈：输入区域尾部 badge、侧边栏指示点、Tab 栏 spinner。

## 改动

| 文件 | 改动 |
|------|------|
| `apps/electron/src/renderer/components/agent/AgentView.tsx` | +36/-8 |
| `apps/electron/src/renderer/atoms/agent-atoms.ts` | +2/-2 |

具体变更：

**AgentView.tsx**：
- Stop 按钮覆盖 backgroundWaiting：条件从 `streaming && !hasTextInput` 扩展为 `(streaming || backgroundWaiting) && !hasTextInput`
- 蓝色 badge 融合到 Stop 按钮左侧：显示「N 个后台任务运行中」的圆角 chip，带 Loader2 旋转动画，从 Stop 按钮左边弹出
- handleStop 增强：清除 backgroundWaiting 标志 + 清理 backgroundTasksAtomFamily 避免 badge 残留 + 调用 stopAgent 终止 SDK 进程

**agent-atoms.ts**：
- `agentSessionIndicatorMapAtom`：也检查 `state.backgroundWaiting`，侧边栏显示蓝色运行指示点
- `agentRunningSessionIdsAtom`：也检查 `state.backgroundWaiting`，Tab 栏显示蓝色 spinner

## 视觉对比

```
空闲态：    [... toolbar ...]            [Send]    侧边栏: ○ 灰色    Tab: 无 spinner
运行态：    [... toolbar ...]            [Stop]    侧边栏: ● 蓝色    Tab: 蓝色 spinner
后台等待：  [... toolbar ...] [N 个任务] [Stop]    侧边栏: ● 蓝色    Tab: 蓝色 spinner
                                  ↑ 蓝色 badge
```

## 测试

- [x] `bun run typecheck` 全包通过
- [x] `bun run electron:build` 构建通过
- [x] 三轮自审查：code-review → simplify → security-review

## 紧急度

常规

## 备注

- badge 绑定在 inputTrailingNode 容器中，不会被 InputToolbarOverflow 折叠
- handleStop 中 `store.set(backgroundTasksAtomFamily(sessionId), [])` 确保停止后 badge 立即消失
- 后端 stopAgent → adapter.abort() 使用 `taskkill /F /T` (Windows) 级联终止 SDK 进程树
