### PR TITLE
【已审核】style(theme): 提升深色主题表面层次对比度

### DIFF
--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -90,10 +90,10 @@
 
   .dark {
     --shadow-xs: 0 1px 2px 0 rgb(0 0 0 / 0.4);
-    --shadow-sm: 0 1px 3px 0 rgb(0 0 0 / 0.5), inset 0 1px 0 0 hsl(0 0% 100% / 0.03);
-    --shadow-md: 0 6px 16px -4px rgb(0 0 0 / 0.55), 0 2px 4px 0 rgb(0 0 0 / 0.35), inset 0 1px 0 0 hsl(0 0% 100% / 0.04);
-    --shadow-lg: 0 16px 32px -8px rgb(0 0 0 / 0.6), 0 6px 12px -2px rgb(0 0 0 / 0.4), inset 0 1px 0 0 hsl(0 0% 100% / 0.05);
-    --shadow-xl: 0 32px 64px -16px rgb(0 0 0 / 0.7), 0 16px 32px -8px rgb(0 0 0 / 0.5), inset 0 1px 0 0 hsl(0 0% 100% / 0.06);
+    --shadow-sm: 0 1px 3px 0 rgb(0 0 0 / 0.5), inset 0 1px 0 0 hsl(0 0% 100% / 0.06);
+    --shadow-md: 0 6px 16px -4px rgb(0 0 0 / 0.55), 0 2px 4px 0 rgb(0 0 0 / 0.35), inset 0 1px 0 0 hsl(0 0% 100% / 0.08);
+    --shadow-lg: 0 16px 32px -8px rgb(0 0 0 / 0.6), 0 6px 12px -2px rgb(0 0 0 / 0.4), inset 0 1px 0 0 hsl(0 0% 100% / 0.10);
+    --shadow-xl: 0 32px 64px -16px rgb(0 0 0 / 0.7), 0 16px 32px -8px rgb(0 0 0 / 0.5), inset 0 1px 0 0 hsl(0 0% 100% / 0.12);
   }
 
   :root {
@@ -141,36 +141,36 @@
   }
 
   .dark {
-    --background: 0 0% 7%;                /* 统一背景色 zinc-900 */
+    --background: 0 0% 10%;                /* 侧栏锚点，略亮于内容区 */
     --foreground: 0 0% 98%;
-    --muted: 0 0% 14.9%;
+    --muted: 0 0% 17%;
     --muted-foreground: 0 0% 63.9%;
-    --border: 0 0% 14.9%;
-    --input: 0 0% 14.9%;
+    --border: 0 0% 22%;
+    --input: 0 0% 22%;
     --ring: 0 0% 83.1%;
     --primary: 0 0% 98%;
     --primary-foreground: 0 0% 9%;
-    --secondary: 0 0% 14.9%;
+    --secondary: 0 0% 17%;
     --secondary-foreground: 0 0% 98%;
     --accent: 0 0% 40%;
     --accent-foreground: 0 0% 98%;
     --destructive: 0 55% 45%;
     --destructive-foreground: 0 0% 98%;
     --stop-hover-bg: hsl(0, 40%, 18%);
-    --card: 0 0% 7%;                      /* 卡片背景 = 背景色 */
+    --card: 0 0% 13%;                      /* 卡片：浮起于背景 */
     --card-foreground: 0 0% 98%;
-    --popover: 0 0% 7%;                   /* 弹出层 = 背景色 */
+    --popover: 0 0% 14%;                   /* 弹出层：最高浮起 */
     --popover-foreground: 0 0% 98%;
-    --dialog: 0 0% 12%;                   /* 设置弹窗：比背景更亮，悬浮感 */
+    --dialog: 0 0% 16%;                    /* 弹窗：比弹出层更亮 */
     --dialog-foreground: 0 0% 98%;
-    --content-area: 0 0% 7%;              /* 主内容区域背景 zinc-900 */
-    --sidebar-surface: 0 0% 7%;
-    --tabbar-surface: 0 0% 7%;
-    --sidebar-control-surface: 0 0% 14%;
-    --sidebar-control-surface-hover: 0 0% 18%;
-    --sidebar-control-stroke: 0 0% 100% / 0.08;
-    --input-surface: 0 0% 7%;
-    --tab-surface: 0 0% 7%;
+    --content-area: 0 0% 7%;              /* 主内容区域：最深，专注 */
+    --sidebar-surface: 0 0% 10%;
+    --tabbar-surface: 0 0% 10%;
+    --sidebar-control-surface: 0 0% 17%;
+    --sidebar-control-surface-hover: 0 0% 21%;
+    --sidebar-control-stroke: 0 0% 100% / 0.10;
+    --input-surface: 0 0% 9%;              /* 输入区：介于背景和内容区之间 */
+    --tab-surface: 0 0% 7%;                /* 与内容区域无缝衔接 */
     /* 毛玻璃 Tooltip：深色半透明背景 + 白色文字 */
     --tooltip: 0 0% 20%;
     --tooltip-foreground: 0 0% 98%;


### PR DESCRIPTION
## 概述

默认深色主题（`:root .dark`）中 7 个关键表面（background、content-area、sidebar、card、popover、input、tab）此前全部共享同一个亮度值 `0 0% 7%`，导致视觉层次塌陷——侧边栏与内容区无法区分、卡片/弹出层无浮起感、边框几乎不可见。

本次将 13 个 token 从统一 `7%` 调整为递进分层（7%→10%→13%→14%→16%），匹配已在特殊主题（ocean/forest/slate-dark）中验证过的分层模式。

## 改动

| 文件 | 变更 |
|------|------|
| `apps/electron/src/renderer/styles/globals.css` | 40 行变更（20+, 20-），仅 `.dark` 块内 CSS 变量值 |

具体 token 调整：

| Token | 之前 | 之后 | 说明 |
|-------|------|------|------|
| `--background` | 7% | 10% | 侧栏空间锚点 |
| `--sidebar-surface` | 7% | 10% | 同 background |
| `--tabbar-surface` | 7% | 10% | 同 background |
| `--content-area` | 7% | 7% | 内容区保持最深 |
| `--tab-surface` | 7% | 7% | 与内容区无缝 |
| `--input-surface` | 7% | 9% | 输入区微浮 |
| `--card` | 7% | 13% | 卡片明显浮起 |
| `--popover` | 7% | 14% | 弹出层最高浮起 |
| `--dialog` | 12% | 16% | 弹窗更亮 |
| `--muted` / `--secondary` | 14.9% | 17% | 次要表面 |
| `--border` / `--input` | 14.9% | 22% | 边框可见 |
| `--sidebar-control-*` | 14%/18% | 17%/21% | 侧栏控件 |
| `--shadow-*` inset 高光 | 3-6% | 6-12% | 阴影浮起感 |

## 测试

- [x] `bun run typecheck` 全部通过
- [x] 自审查三轮（code-review / simplify / security-review）零发现
- [x] 用户 `bun run dev` 实时验证深色主题层次效果

## 紧急度

常规

## 备注

- 纯 CSS token 值变更，不改任何 CSS 规则或组件逻辑
- 分层策略参照 ocean-dark / forest-dark / slate-dark 的已有模式
- 不影响亮色主题和特殊主题
