### PR TITLE
【已审核】fix(sidebar): 修复委托子会话彩色注视灯、级联清除完成标记、归档级联与树层级

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -1411,15 +1411,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   /** 选择 Agent 会话（打开或聚焦标签页） */
   const handleSelectAgentSession = React.useCallback((id: string, title: string): void => {
     openSession('agent', id, title)
-    setActiveView('conversations')
-    // 清除该会话的"已完成未查看"标记
-    setUnviewedCompleted((prev: Set<string>) => {
-      if (!prev.has(id)) return prev
-      const next = new Set(prev)
-      next.delete(id)
-      return next
-    })
-  }, [openSession, setActiveView, setUnviewedCompleted])
+  }, [openSession])
 
   /** 重命名工作区（项目）名称 */
   const handleWorkspaceRename = React.useCallback(async (workspaceId: string, newName: string): Promise<void> => {
@@ -1524,7 +1516,11 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       const targetArchived = !!updated.archived
       const delegatedChildren = targetArchived
         ? getSyncableDelegatedChildren(sessions, id, draftSessionIds)
-        : []
+        : getDirectDelegatedChildren(sessions, id).filter((child) => (
+          !!child.archived
+          && !draftSessionIds.has(child.id)
+          && !isHiddenAutomationSession(child)
+        ))
       cascaded = delegatedChildren.length > 0
       for (const child of delegatedChildren) {
         if (!!child.archived !== targetArchived) {
@@ -1642,11 +1638,17 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     [agentProjectGroups, automationGroup, automationGroupOrder],
   )
 
-  /** Agent 归档会话按日期分组（跨项目） */
-  const agentSessionGroups = React.useMemo(
-    () => groupByDate(sortAgentSessionsByUpdatedAtDesc(
-      agentSessions.filter((session) => session.archived && !draftSessionIds.has(session.id))
-    )),
+  /** Agent 归档会话：构建树后按根会话日期分组（跨项目） */
+  const agentArchivedTreeGroups = React.useMemo(
+    () => {
+      const archived = agentSessions.filter((s) => s.archived && !draftSessionIds.has(s.id))
+      if (archived.length === 0) return []
+      const trees = buildAgentSessionTrees(archived)
+      // 按根会话 updatedAt 降序排列
+      const sorted = [...trees].sort((a, b) => b.session.updatedAt - a.session.updatedAt)
+      // groupByDate 需要 { updatedAt } 形状，用根 session 的日期代表整棵树
+      return groupByDate(sorted.map((t) => ({ updatedAt: t.session.updatedAt, tree: t })))
+    },
     [agentSessions, draftSessionIds]
   )
 
@@ -2417,31 +2419,70 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                 </div>
               ))
             ) : (
-              /* Agent 模式归档：Agent 会话按日期分组 */
-              agentSessionGroups.map((group) => (
+              /* Agent 模式归档：Agent 会话树按日期分组 */
+              agentArchivedTreeGroups.map((group) => (
                 <div key={group.label} className="mb-1">
                   <div className="px-3 pt-2 pb-1 text-[11px] font-medium text-foreground/40 select-none">
                     {group.label}
                   </div>
                   <div className="flex flex-col gap-0.5">
-                    {group.items.map((session) => (
-                      <AgentSessionItem
-                        key={session.id}
-                        session={session}
-                        active={session.id === activeSessionId}
-                        indicatorStatus={agentIndicatorMap.get(session.id) ?? 'idle'}
-                        showPinIcon={!!session.pinned}
-                        leftAccent={getSessionLeftAccent(agentIndicatorMap.get(session.id) ?? 'idle')}
-                        workspaceName={session.workspaceId ? workspaceNameMap.get(session.workspaceId) : undefined}
-                        relativeTimeNow={relativeTimeNow}
-                        onSelect={handleSelectAgentSession}
-                        onRequestDelete={handleRequestDelete}
-                        onRequestMove={handleRequestMove}
-                        onRename={handleAgentRename}
-                        onTogglePin={handleTogglePinAgent}
-                        onToggleArchive={handleToggleArchiveAgent}
-                      />
-                    ))}
+                    {group.items.map(({ tree: item }) => {
+                      const childCount = item.childSessions.length
+                      const rowStatus = getSessionTreeStatus(item, agentIndicatorMap)
+                      const treeActive = treeContainsSessionId(item, activeSessionId)
+                      const activeChildVisible = item.childSessions.some((child) => child.id === activeSessionId)
+                      const expandedChildren = expandedDelegationParentIds.has(item.session.id)
+                        || (activeChildVisible && !collapsedDelegationParentIds.has(item.session.id))
+
+                      return (
+                        <div key={item.session.id} className="flex flex-col gap-0.5">
+                          <AgentSessionItem
+                            session={item.session}
+                            active={treeActive}
+                            indicatorStatus={rowStatus}
+                            showPinIcon={!!item.session.pinned}
+                            delegationSummary={childCount > 0
+                              ? {
+                                total: childCount,
+                                completed: countCompletedDelegatedChildren(item.childSessions),
+                                expanded: expandedChildren,
+                                onToggle: () => handleToggleDelegationParent(item.session.id, expandedChildren),
+                              }
+                              : undefined}
+                            leftAccent={getSessionLeftAccent(rowStatus)}
+                            workspaceName={item.session.workspaceId ? workspaceNameMap.get(item.session.workspaceId) : undefined}
+                            relativeTimeNow={relativeTimeNow}
+                            onSelect={handleSelectAgentSession}
+                            onRequestDelete={handleRequestDelete}
+                            onRequestMove={handleRequestMove}
+                            onRename={handleAgentRename}
+                            onTogglePin={handleTogglePinAgent}
+                            onToggleArchive={handleToggleArchiveAgent}
+                          />
+
+                          {childCount > 0 && expandedChildren && (
+                            <div className="ml-3 border-l border-foreground/10 pl-2 flex flex-col gap-0.5">
+                              {item.childSessions.map((childSession) => (
+                                <DelegatedChildSessionItem
+                                  key={childSession.id}
+                                  session={childSession}
+                                  activeSessionId={activeSessionId}
+                                  agentIndicatorMap={agentIndicatorMap}
+                                  relativeTimeNow={relativeTimeNow}
+                                  workspaceName={childSession.workspaceId ? workspaceNameMap.get(childSession.workspaceId) : undefined}
+                                  onSelect={handleSelectAgentSession}
+                                  onRequestDelete={handleRequestDelete}
+                                  onRequestMove={handleRequestMove}
+                                  onRename={handleAgentRename}
+                                  onTogglePin={handleTogglePinAgent}
+                                  onToggleArchive={handleToggleArchiveAgent}
+                                />
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                      )
+                    })}
                   </div>
                 </div>
               ))
@@ -3258,6 +3299,7 @@ const DelegatedChildSessionItem = React.memo(function DelegatedChildSessionItem(
       session={session}
       active={session.id === activeSessionId}
       indicatorStatus={status}
+      leftAccent={getSessionLeftAccent(status)}
       relativeTimeNow={relativeTimeNow}
       workspaceName={workspaceName}
       onSelect={onSelect}

--- a/apps/electron/src/renderer/hooks/useOpenSession.ts
+++ b/apps/electron/src/renderer/hooks/useOpenSession.ts
@@ -66,10 +66,16 @@ export function useOpenSession(): OpenSessionFn {
         setCurrentAgentSessionId(sessionId)
 
         // 用户打开查看后只清除未读角标；是否完成由用户通过对勾确认。
+        // 同时级联清除所有委托子会话的完成标记，避免子会话的
+        // unviewedCompleted 使母会话树状态持续显示 green accent。
         setUnviewedCompleted((prev) => {
-          if (!prev.has(sessionId)) return prev
+          const childIds = agentSessions
+            .filter((s) => s.parentSessionId === sessionId && !!s.sourceDelegationId)
+            .map((s) => s.id)
+          const allIds = [sessionId, ...childIds]
+          if (!allIds.some((rid) => prev.has(rid))) return prev
           const next = new Set(prev)
-          next.delete(sessionId)
+          for (const rid of allIds) next.delete(rid)
           return next
         })
 

--- a/apps/electron/src/renderer/hooks/useSyncActiveTabSideEffects.ts
+++ b/apps/electron/src/renderer/hooks/useSyncActiveTabSideEffects.ts
@@ -62,11 +62,17 @@ export function useSyncActiveTabSideEffects(): SyncActiveTabSideEffects {
       setCurrentAgentSessionId(newActiveTab.sessionId)
       setCurrentConversationId(null)
 
-      // 清除该会话的"已完成未查看"标记
+      // 清除该会话及其所有委托子会话的"已完成未查看"标记
+      // 若不级联清除子会话，母会话的树状态会因子会话的 unviewedCompleted
+      // 而持续显示 green accent，导致点击/切换后绿色不消失。
+      const childIds = agentSessions
+        .filter((s) => s.parentSessionId === newActiveTab.sessionId && !!s.sourceDelegationId)
+        .map((s) => s.id)
       setUnviewedCompleted((prev) => {
-        if (!prev.has(newActiveTab.sessionId)) return prev
+        const allIds = [newActiveTab.sessionId, ...childIds]
+        if (!allIds.some((rid) => prev.has(rid))) return prev
         const next = new Set(prev)
-        next.delete(newActiveTab.sessionId)
+        for (const rid of allIds) next.delete(rid)
         return next
       })
 


### PR DESCRIPTION
## 概述

修复委托子会话在侧边栏中的四个问题：

1. **子会话缺失彩色注视灯**：DelegatedChildSessionItem 未传入 leftAccent，子会话行无 blue/orange/green 状态指示条
2. **completed 标记不清除**：点击带委托子会话的父会话时，不清除子会话的 unviewedCompleted 标记，导致父会话树状态常绿
3. **取消归档不级联**：取消归档父会话时，已归档的子会话不被同步取消归档（只有归档操作做了级联）
4. **归档视图展平**：Agent 归档视图以扁平列表渲染，未按父子树结构展示

## 改动

| 文件 | 说明 |
|------|------|
| `LeftSidebar.tsx` | DelegatedChildSessionItem 添加 leftAccent；归档视图改用 agentArchivedTreeGroups 树结构；取消归档路径增加级联子会话 |
| `useOpenSession.ts` | 打开父会话时级联清除委托子会话的 unviewedCompleted 标记 |
| `useSyncActiveTabSideEffects.ts` | Tab 切换时同步级联清除标记 |

## 测试

- TypeCheck 通过
- 子会话行正确显示彩色状态指示条
- 点击父会话后 completed 标记正确清除
- 取消归档父会话后子会话同步取消归档

## 紧急度

常规

## 备注

Related: #970