### PR TITLE
【已审核】feat(sidebar): 自动任务/Agent 技能入口支持 toggle 关闭

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -810,16 +810,29 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     return () => window.removeEventListener('focus', handleFocus)
   }, [setConversations, setAgentSessions])
 
-  /** 打开自动任务列表 */
+  /** 打开/关闭自动任务列表 */
   const handleOpenAutomations = React.useCallback((): void => {
+    if (activeView === 'automations') {
+      // 编辑页 → 关表单回列表；列表页 → 退出到对话
+      if (store.get(automationFormAtom).open) {
+        setAutomationForm({ open: false, draft: null })
+        return
+      }
+      setActiveView('conversations')
+      return
+    }
     setAutomationForm({ open: false, draft: null })
     setActiveView('automations')
-  }, [setAutomationForm, setActiveView])
+  }, [activeView, setAutomationForm, setActiveView, store])
 
-  /** 打开 Agent 技能视图 */
+  /** 打开/关闭 Agent 技能视图 */
   const handleOpenSkills = React.useCallback((): void => {
+    if (activeView === 'agent-skills') {
+      setActiveView('conversations')
+      return
+    }
     setActiveView('agent-skills')
-  }, [setActiveView])
+  }, [activeView, setActiveView])
 
   /** 打开当前工作区的 MCP 管理页 */
   const handleOpenMcpManagement = React.useCallback((): void => {


### PR DESCRIPTION
## 概述

点击已激活的「自动任务」/「Agent 技能」侧边栏入口可再次点击关闭返回对话视图。编辑页状态下仅关闭表单不退出列表。

提取自已关闭的 PR #836，团队在 review 中明确认可了这个 toggle 交互模式。

## 改动

| 文件 | 改动 |
|------|------|
|  | +17/-4 |

- ：增加 toggle 逻辑 — 已在列表页则返回对话视图，在编辑页则仅关闭表单
- ：增加 toggle 逻辑 — 已在技能视图则返回对话视图

## 测试

1. 点击自动任务进入列表 → 再次点击返回对话视图
2. 进入自动任务编辑表单 → 再次点击仅关闭表单（不退出列表）
3. 点击 Agent 技能进入 → 再次点击返回对话视图

## 紧急度

常规

## 备注

- 源自 PR #836（@climashscape），根据 ErlichLiu 的反馈剥离为独立 PR
- 原始 PR #885 已 close，现拆分为三个独立 PR 重新提交