### PR TITLE
【已审核】fix(sidebar): Chat 模式标签行增加占位防跨模式切换跳动

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -2182,8 +2182,10 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
             </div>
           )}
 
-          <div className="px-2 pt-2 pb-1 flex-shrink-0">
+          <div className="px-2 pt-2 pb-1 flex items-center flex-shrink-0">
             <span className="px-1.5 text-[11px] font-medium text-foreground/40 select-none">对话</span>
+            {/* 占位元素：与项目行的 size-6 按钮等高，保证跨模式切换时标签文字垂直位置不变 */}
+            <div className="w-0 h-6" aria-hidden="true" />
           </div>
 
           <div className="flex-1 overflow-y-auto px-2 pb-3 scrollbar-thin min-h-0 titlebar-no-drag">


### PR DESCRIPTION
## 概述

Chat 模式的「对话」标签行增加 `flex items-center` 布局和一个零宽度 `h-6` 占位元素，与 Agent 模式项目行的 `size-6` 按钮等高。保证 Chat/Agent 模式切换时标签文字垂直位置不变，消除视觉跳动。

提取自已关闭的 PR #836，团队在 review 中明确认可了这个交互细节。

## 改动

| 文件 | 改动 |
|------|------|
| `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` | +3/-1 |

- 「对话」标签容器：`flex-shrink-0` → `flex items-center flex-shrink-0`
- 新增 `w-0 h-6` 占位 div（`aria-hidden="true"`），与项目行按钮等高

## 测试

1. Chat 模式 → Agent 模式 → Chat 模式，观察「对话」标签文字垂直位置不变
2. 不同工作区数量下切换，标签位置始终稳定
3. 占位元素不可见、不影响布局宽度（`w-0`）

## 紧急度

常规

## 备注

- 源自 PR #836（@climashscape），根据 ErlichLiu 的反馈剥离为独立 PR
- 原始 PR #885 已 close，现拆分为三个独立 PR 重新提交
