### PR TITLE
【已审核】fix(diff): 修复文件面板折叠时标签文字竖排

### DIFF
--- a/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
@@ -68,7 +68,7 @@ export function DiffPanelTabBar({ activeTab, onTabChange, onClose }: DiffPanelTa
           type="button"
           onClick={() => onTabChange('session')}
           className={cn(
-            'flex-1 px-3 h-[34px] text-xs transition-colors select-none cursor-pointer',
+            'flex-1 px-3 h-[34px] text-xs transition-colors select-none cursor-pointer whitespace-nowrap overflow-hidden',
             isClassic ? 'rounded-t-lg' : 'rounded-none',
             'border-t border-l border-r',
             activeTab === 'session'
@@ -86,7 +86,7 @@ export function DiffPanelTabBar({ activeTab, onTabChange, onClose }: DiffPanelTa
           type="button"
           onClick={() => onTabChange('workspace')}
           className={cn(
-            'flex-1 px-3 h-[34px] text-xs transition-colors select-none cursor-pointer',
+            'flex-1 px-3 h-[34px] text-xs transition-colors select-none cursor-pointer whitespace-nowrap overflow-hidden',
             isClassic ? 'rounded-t-lg' : 'rounded-none',
             'border-t border-l border-r',
             activeTab === 'workspace'
@@ -104,7 +104,7 @@ export function DiffPanelTabBar({ activeTab, onTabChange, onClose }: DiffPanelTa
           type="button"
           onClick={handleChangesClick}
           className={cn(
-            'flex-1 px-3 h-[34px] text-xs transition-colors select-none cursor-pointer relative',
+            'flex-1 px-3 h-[34px] text-xs transition-colors select-none cursor-pointer relative whitespace-nowrap overflow-hidden',
             isClassic ? 'rounded-t-lg' : 'rounded-none',
             'border-t border-l border-r',
             activeTab === 'changes'


### PR DESCRIPTION
## 概述

右侧文件面板的 DiffPanelTabBar 在折叠动画中，三个中文标签按钮的宽度随面板收缩至极窄，"会话文件""工作区文件""文件改动"的中文字符被迫逐字竖向换行，产生奇怪的竖排文字效果。

给三个标签按钮添加 `whitespace-nowrap overflow-hidden`，文字固定单行不换行，超出部分裁剪。

## 改动

| 文件 | 说明 |
|------|------|
| `DiffPanelTabBar.tsx` | 三个标签按钮各加 `whitespace-nowrap overflow-hidden`，阻止折叠动画中竖向换行 |

## 测试

- TypeCheck 全部通过
- 折叠文件面板时标签文字不再竖向排列

## 紧急度

常规