### PR TITLE
【已审核】fix(agent): stableStringify 增加循环引用防护防止栈溢出

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -40,11 +40,19 @@ import { parseThinkTagsFromText } from './thinking-tag-parser'
 import type { AgentEventUsage, RetryAttempt, SDKMessage } from '@proma/shared'
 import type { AgentStreamState } from '@/atoms/agent-atoms'
 
+const stableStringifySeen = new WeakSet<object>()
+
 function stableStringify(value: unknown): string {
   if (value == null || typeof value !== 'object') return JSON.stringify(value) ?? String(value)
-  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`
-  const record = value as Record<string, unknown>
-  return `{${Object.keys(record).sort().map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`).join(',')}}`
+  if (stableStringifySeen.has(value)) return '"[Circular]"'
+  stableStringifySeen.add(value)
+  try {
+    if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`
+    const record = value as Record<string, unknown>
+    return `{${Object.keys(record).sort().map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`).join(',')}}`
+  } finally {
+    stableStringifySeen.delete(value)
+  }
 }
 
 /** 消息对象引用 → 稳定 key 缓存，避免内容相同的消息产生重复 key */


### PR DESCRIPTION
## 概述

`stableStringify` 递归序列化对象时无循环引用检测，遇到循环引用（如对象属性指向自身）会导致栈溢出。本次修改增加 `WeakSet` 循环检测，6 行零风险修复。

## 改动

| 文件 | 改动 |
|------|------|
| `apps/electron/src/renderer/components/agent/AgentMessages.tsx` | +11 / -3 |

**具体修改：**
- 模块级声明 `const stableStringifySeen = new WeakSet<object>()`（不阻止 GC）
- 进入对象分支后先检查 `seen.has(value)`，命中返回 `'"[Circular]"'`
- `seen.add(value)` 后进入原有逻辑
- 用 `try/finally` 包裹，`finally` 中 `seen.delete(value)`——即使属性 getter 抛异常也不残留
- 不需要改任何调用方，WeakSet 每次调用结束后为空

## 测试

- TypeCheck 通过
- /code-review /simplify /security-review 三轮自审零发现问题
- 正常路径不变：SDK 消息数据天然无循环引用，序列化结果不变
- 循环引用路径不崩溃：返回含 `[Circular]` 的字符串

## 紧急度

低

## 备注

- 调用方仅 `getSDKMessageStableKey`（同一文件内），输出用于 React key 拼接，不受 `[Circular]` 返回值影响
- `WeakSet` 的 `delete` 清理确保共享引用（DAG 结构）不会误报为循环引用