### PR TITLE
【已审核】fix(agent): 补全 applyAgentEvent switch 中缺失的 5 个 case 分支

### DIFF
--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -844,7 +844,32 @@ export function applyAgentEvent(
       // 提示建议由全局监听器处理，不影响流式状态
       return prev
 
+    case 'exit_plan_mode_request':
+      // ExitPlanMode 请求由全局监听器处理，不影响流式状态
+      return prev
+
+    case 'exit_plan_mode_resolved':
+      // ExitPlanMode 解决由全局监听器处理，不影响流式状态
+      return prev
+
+    case 'enter_plan_mode':
+      // 进入计划模式由全局监听器处理，不影响流式状态
+      return prev
+
+    case 'plan_mode_changed':
+      // 计划模式变更由全局监听器处理，不影响流式状态
+      return prev
+
+    case 'permission_mode_changed':
+      // 权限模式变更由全局监听器处理，不影响流式状态
+      return prev
+
     default:
+      if (import.meta.env.DEV) {
+        console.warn(
+          `[applyAgentEvent] 未处理的 AgentEvent 类型: ${(event as { type: string }).type}`,
+        )
+      }
       return prev
   }
 }


### PR DESCRIPTION
## 概述

`applyAgentEvent` 的 switch 语句处理 `AgentEvent` 联合类型（34 个成员），实际覆盖 29 个，5 个事件落入 `default` 静默返回 `prev`。功能上正确（这 5 个事件都不应改变 `AgentStreamState`），但可维护性有缺陷——已有 10 个 no-op case 都有注释说明，而这 5 个连 case 都没有，破坏一致性。此外 `exit_plan_mode_resolved` 在全局监听器主事件循环中也无消费者，是额外的死代码隐患。

## 改动

| 文件 | 改动 |
|---|---|
| `apps/electron/src/renderer/atoms/agent-atoms.ts` | +25 行 |

- 在 `default` 分支前插入 5 个 case（`exit_plan_mode_request`、`exit_plan_mode_resolved`、`enter_plan_mode`、`plan_mode_changed`、`permission_mode_changed`），每个带注释说明不影响流式状态的原因，风格与已有 no-op case 一致
- `default` 分支加 `console.warn`，仅在 dev 模式输出未处理的 `event.type`。Vite 构建时 `import.meta.env.DEV` 替换为字面量 `false`，生产环境 dead-code elimination 零开销

## 测试

- `bun run typecheck` 全部通过
- 代码审查三轮（/code-review → /simplify → /security-review）均无发现

## 紧急度

常规

## 备注

- 不影响任何运行时行为，纯可维护性改进
- 34 个 `AgentEvent` 类型现在在 switch 中全部有显式 case
