### PR TITLE
【已审核】chore(agent): 删除 rewindFilesFromSnapshot 返回值中从未赋值的 insertions/deletions 死字段

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -2250,7 +2250,7 @@ export class AgentOrchestrator {
     console.log(`[Agent 编排] 回退: 解析 user uuid=${userMessageUuid || '未找到'} (assistant uuid=${assistantMessageUuid}, forkSource=${sessionMeta.forkSourceSdkSessionId ?? 'none'})`)
 
     // 1. 文件恢复：直接从 SDK JSONL 的 file-history-snapshot 恢复，无需临时 Query
-    let fileRewindResult: { canRewind: boolean; error?: string; filesChanged?: string[]; insertions?: number; deletions?: number } | undefined
+    let fileRewindResult: { canRewind: boolean; error?: string; filesChanged?: string[] } | undefined
     if (userMessageUuid === '__LAST_TURN__') {
       // 最后一个 turn：当前文件系统已是该 turn 完成后的状态，无需回退文件
       console.log(`[Agent 编排] 回退: 最后一个 turn，跳过文件恢复`)

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -1187,7 +1187,7 @@ export function rewindFilesFromSnapshot(
   projectDir?: string,
   forkSourceSdkSessionId?: string,
   attachedDirectories?: string[],
-): { canRewind: boolean; error?: string; filesChanged?: string[]; insertions?: number; deletions?: number } {
+): { canRewind: boolean; error?: string; filesChanged?: string[] } {
   const sdkConfigDir = getSdkConfigDir()
 
   // 1. 查找 SDK session JSONL（优先当前 session，找不到目标 UUID 时 fallback 到源会话）

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/shared",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "license": "AGPL-3.0-only",
   "description": "Shared types, configs and utilities for proma",
   "type": "module",

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -981,8 +981,6 @@ export interface RewindSessionResult {
     canRewind: boolean
     error?: string
     filesChanged?: string[]
-    insertions?: number
-    deletions?: number
   }
 }
 


### PR DESCRIPTION
## 概述

清理 `rewindFilesFromSnapshot` 返回值中从未被赋值的 `insertions`/`deletions` 死字段。该函数的 7 个 return 语句全部不包含这两个字段，全仓库 grep 确认无任何代码读取。回退是整文件恢复而非逐行 diff，`filesChanged` 已是合适的粒度。

## 改动

| 文件 | 变更 |
|------|------|
| `packages/shared/src/types/agent.ts` | 删除 `RewindSessionResult.fileRewind` 接口中的 `insertions?: number; deletions?: number` |
| `apps/electron/src/main/lib/agent-session-manager.ts` | 删除 `rewindFilesFromSnapshot` 返回类型中的这两个字段 |
| `apps/electron/src/main/lib/agent-orchestrator.ts` | 删除 `rewindSession` 局部变量类型中的这两个字段 |
| `packages/shared/package.json` | bump 0.1.35 → 0.1.36（shared 类型变更） |

## 测试

- TypeCheck 四包全部通过
- 全仓库 grep 确认 `fileRewind.insertions` / `fileRewind.deletions` 零引用
- rewind 功能不受影响（无人读取这两个字段）

## 紧急度

常规

## 备注

- 教科书级别死字段：3 处声明、0 处赋值、0 处读取
