### PR TITLE
【已审核】fix(agent): 修复 Windows 上跨工作区迁移会话时的 EBUSY 错误

### DIFF
--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -8,7 +8,7 @@
  * 照搬 conversation-manager.ts 的模式。
  */
 
-import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync, unlinkSync, rmSync, renameSync, readdirSync, createReadStream, createWriteStream, type WriteStream } from 'node:fs'
+import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync, unlinkSync, rmSync, renameSync, readdirSync, cpSync, createReadStream, createWriteStream, type WriteStream } from 'node:fs'
 import { createInterface } from 'node:readline'
 import { writeJsonFileAtomic, readJsonFileSafe } from './safe-file'
 import { randomUUID } from 'node:crypto'
@@ -540,8 +540,28 @@ export function moveSessionToWorkspace(sessionId: string, targetWorkspaceId: str
             console.warn(`[Agent 会话] 清理目标目录失败，跳过目录迁移:`, cleanupError)
           }
         }
-        renameSync(srcDir, destDir)
-        console.log(`[Agent 会话] 已移动工作目录: ${srcDir} → ${destDir}`)
+        try {
+          renameSync(srcDir, destDir)
+          console.log(`[Agent 会话] 已移动工作目录: ${srcDir} → ${destDir}`)
+        } catch (renameError) {
+          // Windows: 文件监听器(chokidar)或子进程持有目录句柄时 rename 会抛 EBUSY，
+          // 降级为 先复制再删除 策略，cpSync 不需要独占访问源目录
+          const errnoErr = renameError as NodeJS.ErrnoException
+          if (errnoErr?.code === 'EBUSY') {
+            console.log(`[Agent 会话] rename 被锁定(EBUSY)，降级为复制+删除: ${srcDir} → ${destDir}`)
+            cpSync(srcDir, destDir, { recursive: true })
+            try {
+              rmSync(srcDir, { recursive: true })
+              console.log(`[Agent 会话] 已复制并删除源目录: ${srcDir} → ${destDir}`)
+            } catch (rmError) {
+              // Windows: 源目录可能仍被 chokidar/子进程占用无法立即删除，
+              // 但数据已完整复制到目标位置，迁移实际已生效，仅记录警告
+              console.warn(`[Agent 会话] 源目录删除失败（可能仍被占用），数据已复制到目标: ${srcDir}`, (rmError as NodeJS.ErrnoException)?.message)
+            }
+          } else {
+            throw renameError
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
## 概述

修复 Windows 上 Agent 会话跨工作区迁移时 `EBUSY: resource busy or locked` 错误。

**根因**：Proma 的 `workspace-watcher.ts` 用 chokidar `recursive: true` 监听整个 `~/.proma/agent-workspaces/` 目录树。Windows 上 chokidar 对监听目录持有文件句柄，当 `moveSessionToWorkspace` 调用 `renameSync()` 时，Windows 要求独占访问源目录 → `EBUSY`。Linux/macOS 不受影响（POSIX 允许有句柄持有时 rename）。

**修复**：`renameSync` 失败时捕获 `EBUSY` 错误码，降级为 `cpSync` + `rmSync`（先复制再删除）。`cpSync` 不需要独占访问源目录。若 `rmSync` 也失败（源目录仍被占用），不阻断迁移——数据已完整复制，仅记录警告。

## 改动

| 文件 | 改动 |
|------|------|
| `apps/electron/src/main/lib/agent-session-manager.ts` | +23 −3：`moveSessionToWorkspace` 中 `renameSync` 增加 EBUSY 容错降级 |

## 测试

- [x] `bun run typecheck` — 四个包全部通过
- [x] `bun run electron:build` — esbuild 打包成功（main.cjs 24.4MB）
- [x] `/code-review` — 审查中发现 rmSync 容错问题已当场修复
- [x] `/simplify` — 无优化项
- [x] `/security-review` — 无安全发现

## 紧急度

中 — 阻塞 Windows 用户跨工作区迁移会话

## 备注

- `cpSync` 是 Node.js 16.7.0+ 标准库函数，已在项目 Electron 39.x 中可用
- 降级路径仅在 `EBUSY` 时触发，POSIX 平台仍走原子 `renameSync`，无性能影响
