### PR TITLE
【已审核】fix(agent): 修复迁移会话排除分区使用错误工作区 ID

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -550,6 +550,8 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   const [deletingWorkspaceId, setDeletingWorkspaceId] = React.useState<string | null>(null)
   /** 待迁移会话 ID，非空时显示迁移对话框 */
   const [moveTargetId, setMoveTargetId] = React.useState<string | null>(null)
+  /** 待迁移会话所属的工作区 ID（用于对话框排除当前分区） */
+  const [moveSourceWorkspaceId, setMoveSourceWorkspaceId] = React.useState<string | undefined>()
   /** 每个项目额外展开显示的会话数量（每次点击"显示更多" +10），未点击则为 0 或无值 */
   const [expandedExtraCountMap, setExpandedExtraCountMap] = React.useState<Map<string, number>>(new Map())
   /** 记录被用户手动折叠的工作区 ID（点击当前工作区标题时折叠/展开）。刻意不持久化：折叠被视为临时查看行为，刷新/重启后恢复默认展开 */
@@ -1572,7 +1574,10 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   /** 请求迁移会话到其他项目（弹出迁移对话框） */
   const handleRequestMove = React.useCallback((id: string): void => {
     setMoveTargetId(id)
-  }, [])
+    // 查找被迁移会话所属的工作区——排除分区应基于此而非当前 UI 工作区
+    const session = agentSessions.find((s) => s.id === id)
+    setMoveSourceWorkspaceId(session?.workspaceId)
+  }, [agentSessions])
 
   /** 迁移会话到另一个项目后的回调 */
   const handleSessionMoved = (updatedSession: AgentSessionMeta, targetWorkspaceName: string): void => {
@@ -1843,7 +1848,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       open={moveTargetId !== null}
       onOpenChange={(open) => { if (!open) setMoveTargetId(null) }}
       sessionId={moveTargetId ?? ''}
-      currentWorkspaceId={currentWorkspaceId ?? undefined}
+      currentWorkspaceId={moveSourceWorkspaceId ?? undefined}
       workspaces={workspaces}
       onMoved={handleSessionMoved}
     />


### PR DESCRIPTION
## 概述

修复"迁移会话到其他项目"对话框中"排除自己的分区"使用了错误的工作区 ID。

**Bug**：`MoveSessionDialog` 过滤可用目标工作区时，排除的是 `currentAgentWorkspaceIdAtom`（侧栏当前活跃的工作区），而非被迁移会话自身所属的工作区。当用户在侧栏查看工作区 A 的会话列表、但右键迁移一个属于工作区 B 的会话时，对话框错误地排除了工作区 A 而非工作区 B，导致真正的"自己的分区"仍出现在候选列表中。

**修复**：在 `handleRequestMove` 中从 `agentSessions` 查找被迁移会话的 `workspaceId`，传入对话框作为排除依据。

## 改动

- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx`（+7/-2）
  - 新增 `moveSourceWorkspaceId` 状态，记录待迁移会话的所属工作区
  - `handleRequestMove` 回调中查找会话并提取 `workspaceId`
  - `MoveSessionDialog` 的 `currentWorkspaceId` prop 改用 `moveSourceWorkspaceId`

## 测试

- TypeCheck 通过
- 跨工作区场景：在侧栏选中工作区 A，对属于工作区 B 的会话右键 → 迁移 → 对话框应排除工作区 B 而非工作区 A
- 同工作区场景：在当前工作区迁移自己的会话 → 行为不变，排除当前工作区

## 紧急度

常规

## 备注

基于 upstream commit `978c227a`
