### PR TITLE
Add long text paste attachment toggle

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.13.21",
+  "version": "0.13.22",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/settings-service.ts
+++ b/apps/electron/src/main/lib/settings-service.ts
@@ -25,6 +25,7 @@ export function getSettings(): AppSettings {
       onboardingCompleted: false,
       environmentCheckSkipped: false,
       notificationsEnabled: true,
+      longTextPasteAsAttachmentEnabled: false,
       feishuSessionMirror: { mode: 'off' },
       builtinMcpDisabledIds: [],
     }
@@ -40,6 +41,7 @@ export function getSettings(): AppSettings {
       onboardingCompleted: data.onboardingCompleted ?? false,
       environmentCheckSkipped: data.environmentCheckSkipped ?? false,
       notificationsEnabled: data.notificationsEnabled ?? true,
+      longTextPasteAsAttachmentEnabled: data.longTextPasteAsAttachmentEnabled ?? false,
       feishuSessionMirror: data.feishuSessionMirror ?? { mode: 'off' },
       builtinMcpDisabledIds: data.builtinMcpDisabledIds ?? [],
     }
@@ -51,6 +53,7 @@ export function getSettings(): AppSettings {
       onboardingCompleted: false,
       environmentCheckSkipped: false,
       notificationsEnabled: true,
+      longTextPasteAsAttachmentEnabled: false,
       feishuSessionMirror: { mode: 'off' },
       builtinMcpDisabledIds: [],
     }

--- a/apps/electron/src/renderer/atoms/ui-preferences.ts
+++ b/apps/electron/src/renderer/atoms/ui-preferences.ts
@@ -11,17 +11,22 @@ import { atom } from 'jotai'
 /** 是否显示用户消息悬浮置顶条 */
 export const stickyUserMessageEnabledAtom = atom<boolean>(true)
 
+/** 粘贴长文本时是否自动转为附件 */
+export const longTextPasteAsAttachmentEnabledAtom = atom<boolean>(false)
+
 // ===== 初始化 =====
 
 /**
  * 从主进程加载 UI 偏好设置
  */
 export async function initializeUiPreferences(
-  setStickyUserMessageEnabled: (enabled: boolean) => void
+  setStickyUserMessageEnabled: (enabled: boolean) => void,
+  setLongTextPasteAsAttachmentEnabled?: (enabled: boolean) => void
 ): Promise<void> {
   try {
     const settings = await window.electronAPI.getSettings()
     setStickyUserMessageEnabled(settings.stickyUserMessageEnabled ?? true)
+    setLongTextPasteAsAttachmentEnabled?.(settings.longTextPasteAsAttachmentEnabled ?? false)
   } catch (error) {
     console.error('[UI偏好] 初始化失败:', error)
   }
@@ -37,5 +42,16 @@ export async function updateStickyUserMessageEnabled(enabled: boolean): Promise<
     await window.electronAPI.updateSettings({ stickyUserMessageEnabled: enabled })
   } catch (error) {
     console.error('[UI偏好] 更新悬浮置顶条设置失败:', error)
+  }
+}
+
+/**
+ * 更新长文本粘贴转附件开关并持久化
+ */
+export async function updateLongTextPasteAsAttachmentEnabled(enabled: boolean): Promise<void> {
+  try {
+    await window.electronAPI.updateSettings({ longTextPasteAsAttachmentEnabled: enabled })
+  } catch (error) {
+    console.error('[UI偏好] 更新长文本粘贴附件设置失败:', error)
   }
 }

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -92,6 +92,7 @@ import {
 } from '@/atoms/agent-atoms'
 import type { AgentContextStatus } from '@/atoms/agent-atoms'
 import { settingsOpenAtom } from '@/atoms/settings-tab'
+import { longTextPasteAsAttachmentEnabledAtom } from '@/atoms/ui-preferences'
 import { channelsAtom, thinkingExpandedAtom } from '@/atoms/chat-atoms'
 import { useOpenSession } from '@/hooks/useOpenSession'
 import { AgentSessionProvider } from '@/contexts/session-context'
@@ -301,6 +302,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const backgroundWaiting = streamState?.backgroundWaiting ?? false
   const stoppedByUserSessions = useAtomValue(stoppedByUserSessionsAtom)
   const sendWithCmdEnter = useAtomValue(sendWithCmdEnterAtom)
+  const longTextPasteAsAttachmentEnabled = useAtomValue(longTextPasteAsAttachmentEnabledAtom)
   const stoppedByUser = stoppedByUserSessions.has(sessionId)
   const liveMessagesMap = useAtomValue(liveMessagesMapAtom)
   const setLiveMessagesMap = useSetAtom(liveMessagesMapAtom)
@@ -2166,7 +2168,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
               onSubmit={handleSend}
               onPasteFiles={handlePasteFiles}
               onPasteLongText={handlePasteLongText}
-              longTextPasteThreshold={LONG_TEXT_ATTACHMENT_THRESHOLD}
+              longTextPasteThreshold={longTextPasteAsAttachmentEnabled ? LONG_TEXT_ATTACHMENT_THRESHOLD : undefined}
               placeholder={
                 agentChannelId && hasAvailableModel
                   ? sendWithCmdEnter

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -31,6 +31,7 @@ import { lowlight } from '@/lib/lowlight'
 import { htmlToMarkdown } from '@/lib/markdown-rich-text'
 import { createFileMentionSuggestion } from '@/components/file-browser/file-mention-suggestion'
 import { createSkillMentionSuggestion, createMcpMentionSuggestion, createSessionMentionSuggestion } from '@/components/agent/mention-suggestions'
+import { shouldConvertClipboardTextToAttachment } from '@/lib/clipboard-text-attachment'
 import {
   VOICE_DICTATION_INSERT_EVENT,
   getLastFocusedVoiceInputId,
@@ -422,9 +423,12 @@ export function RichTextInput({
             ).trim() || plainText)
           : plainText
         if (
-          threshold &&
-          threshold > 0 &&
-          (plainText.length >= threshold || text.length >= threshold) &&
+          shouldConvertClipboardTextToAttachment({
+            enabled: Boolean(threshold && onPasteLongTextRef.current),
+            plainText,
+            normalizedText: text,
+            threshold: threshold ?? 0,
+          }) &&
           onPasteLongTextRef.current
         ) {
           event.preventDefault()

--- a/apps/electron/src/renderer/components/settings/GeneralSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/GeneralSettings.tsx
@@ -38,7 +38,9 @@ import {
   DEFAULT_NOTIFICATION_SOUNDS,
 } from '@/atoms/notifications'
 import {
+  longTextPasteAsAttachmentEnabledAtom,
   stickyUserMessageEnabledAtom,
+  updateLongTextPasteAsAttachmentEnabled,
   updateStickyUserMessageEnabled,
 } from '@/atoms/ui-preferences'
 import { cn } from '@/lib/utils'
@@ -61,6 +63,7 @@ export function GeneralSettings(): React.ReactElement {
   const [notificationSoundEnabled, setNotificationSoundEnabled] = useAtom(notificationSoundEnabledAtom)
   const [notificationSounds, setNotificationSounds] = useAtom(notificationSoundsAtom)
   const [stickyUserMessageEnabled, setStickyUserMessageEnabled] = useAtom(stickyUserMessageEnabledAtom)
+  const [longTextPasteAsAttachmentEnabled, setLongTextPasteAsAttachmentEnabled] = useAtom(longTextPasteAsAttachmentEnabledAtom)
   const [isEditingName, setIsEditingName] = React.useState(false)
   const [nameInput, setNameInput] = React.useState(userProfile.userName)
   const [showEmojiPicker, setShowEmojiPicker] = React.useState(false)
@@ -317,6 +320,15 @@ export function GeneralSettings(): React.ReactElement {
             onCheckedChange={(checked) => {
               setStickyUserMessageEnabled(checked)
               updateStickyUserMessageEnabled(checked)
+            }}
+          />
+          <SettingsToggle
+            label="长文本粘贴转附件"
+            description="开启后，输入框粘贴超过 2000 字的文本会自动生成可预览编辑的附件"
+            checked={longTextPasteAsAttachmentEnabled}
+            onCheckedChange={(checked) => {
+              setLongTextPasteAsAttachmentEnabled(checked)
+              updateLongTextPasteAsAttachmentEnabled(checked)
             }}
           />
         </SettingsCard>

--- a/apps/electron/src/renderer/lib/clipboard-text-attachment.ts
+++ b/apps/electron/src/renderer/lib/clipboard-text-attachment.ts
@@ -6,6 +6,18 @@ export interface ClipboardTextDraft {
   size: number
 }
 
+export interface ShouldConvertClipboardTextInput {
+  enabled: boolean
+  plainText: string
+  normalizedText: string
+  threshold: number
+}
+
+export function shouldConvertClipboardTextToAttachment(input: ShouldConvertClipboardTextInput): boolean {
+  if (!input.enabled || input.threshold <= 0) return false
+  return input.plainText.length >= input.threshold || input.normalizedText.length >= input.threshold
+}
+
 export function makeUniqueAttachmentName(originalName: string, existingNames: string[]): string {
   if (!existingNames.includes(originalName)) return originalName
   const dotIdx = originalName.lastIndexOf('.')

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -52,6 +52,7 @@ import {
 } from './atoms/notifications'
 import {
   stickyUserMessageEnabledAtom,
+  longTextPasteAsAttachmentEnabledAtom,
   initializeUiPreferences,
 } from './atoms/ui-preferences'
 import {
@@ -430,10 +431,11 @@ function DockBadgeInitializer(): null {
  */
 function UiPreferencesInitializer(): null {
   const setStickyUserMessageEnabled = useSetAtom(stickyUserMessageEnabledAtom)
+  const setLongTextPasteAsAttachmentEnabled = useSetAtom(longTextPasteAsAttachmentEnabledAtom)
 
   useEffect(() => {
-    initializeUiPreferences(setStickyUserMessageEnabled)
-  }, [setStickyUserMessageEnabled])
+    initializeUiPreferences(setStickyUserMessageEnabled, setLongTextPasteAsAttachmentEnabled)
+  }, [setStickyUserMessageEnabled, setLongTextPasteAsAttachmentEnabled])
 
   return null
 }

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -236,6 +236,8 @@ export interface AppSettings {
   shortcutOverrides?: ShortcutOverrides
   /** 是否显示用户消息悬浮置顶条（默认 true） */
   stickyUserMessageEnabled?: boolean
+  /** 粘贴超过阈值的长文本时是否自动转为附件（默认 false） */
+  longTextPasteAsAttachmentEnabled?: boolean
   /** Markdown 预览字号档位（默认 'medium'，对应 15px） */
   markdownFontSize?: MarkdownFontSize
   /** 上次是否在 Scratch Pad 页（用于重启恢复） */

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.13.21",
+      "version": "0.13.22",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.185",
         "@anthropic-ai/sdk": "^0.93.0",
@@ -100,6 +100,7 @@
         "electron-updater": "^6.7.3",
         "electronmon": "^2.0.4",
         "esbuild": "^0.24.0",
+        "jszip": "^3.10.1",
         "katex": "^0.16",
         "lowlight": "^3.3.0",
         "lucide-react": "^0.460.0",
@@ -156,7 +157,7 @@
     },
     "packages/shared": {
       "name": "@proma/shared",
-      "version": "0.1.31",
+      "version": "0.1.35",
       "devDependencies": {
         "typescript": "^5.0.0",
       },


### PR DESCRIPTION
## Summary
- Add a persisted general setting for long text paste attachment conversion, defaulting to off for existing and new users.
- Wire the Agent input to only convert pasted text over 2000 characters when the setting is enabled.
- Keep the existing attachment preview/edit flow and bump @proma/electron to 0.13.22 with bun.lock synced.

## Checks
- bun run --filter='@proma/electron' typecheck
- git diff --check