### PR TITLE
refactor(session): 抽取 @proma/session-core 作为会话处理唯一真源

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -58,6 +58,7 @@
     "@emoji-mart/react": "^1.1.1",
     "@larksuiteoapi/node-sdk": "^1.65.0",
     "@proma/core": "workspace:*",
+    "@proma/session-core": "workspace:*",
     "@proma/shared": "workspace:*",
     "@proma/ui": "workspace:*",
     "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -38,6 +38,8 @@ import type {
   AgentSessionReferenceSearchResult,
 } from '@proma/shared'
 import { getConversationMessages } from './conversation-manager'
+// 旧格式 → SDKMessage 的转换逻辑下沉到 @proma/session-core 作为唯一真源，避免主进程与渲染层各存一份。
+import { convertLegacyMessage } from '@proma/session-core'
 import { clearNanoBananaAgentHistory } from './chat-tools/nano-banana-mcp'
 import { assertEnabledModelForChannel } from './agent-model-selection'
 import { copyForkWorkspaceFiles } from './agent-fork-workspace-copy'
@@ -310,64 +312,8 @@ export function getAgentSessionSDKMessages(id: string): SDKMessage[] {
 }
 
 /**
- * 将旧的 AgentMessage 转换为近似的 SDKMessage（向后兼容）
- *
- * 不需要完美还原，只需在 UI 中可读即可。
+ * convertLegacyMessage 已迁移至 @proma/session-core（本文件从该包 import 使用）。
  */
-function convertLegacyMessage(legacy: AgentMessage): SDKMessage {
-  if (legacy.role === 'user') {
-    return {
-      type: 'user',
-      message: {
-        content: [{ type: 'text', text: legacy.content }],
-      },
-      parent_tool_use_id: null,
-      // 附加元数据供渲染器使用
-      _legacy: true,
-      _createdAt: legacy.createdAt,
-    } as unknown as SDKMessage
-  }
-
-  if (legacy.role === 'assistant') {
-    return {
-      type: 'assistant',
-      message: {
-        content: [{ type: 'text', text: legacy.content }],
-        model: legacy.model,
-      },
-      parent_tool_use_id: null,
-      _legacy: true,
-      _createdAt: legacy.createdAt,
-    } as unknown as SDKMessage
-  }
-
-  if (legacy.role === 'status') {
-    // 错误消息转换为 assistant error 格式
-    return {
-      type: 'assistant',
-      message: {
-        content: [{ type: 'text', text: legacy.content }],
-      },
-      parent_tool_use_id: null,
-      error: { message: legacy.content, errorType: legacy.errorCode },
-      _legacy: true,
-      _createdAt: legacy.createdAt,
-      _errorCode: legacy.errorCode,
-      _errorTitle: legacy.errorTitle,
-      _errorDetails: legacy.errorDetails,
-      _errorCanRetry: legacy.errorCanRetry,
-      _errorActions: legacy.errorActions,
-    } as unknown as SDKMessage
-  }
-
-  // 其他类型，作为 system 消息返回
-  return {
-    type: 'system',
-    subtype: 'init',
-    _legacy: true,
-    _createdAt: legacy.createdAt,
-  } as unknown as SDKMessage
-}
 
 /**
  * 更新会话元数据

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -22,6 +22,20 @@ import { TurnFileChangesSummary } from './TurnFileChangesSummary'
 import { ProcessBlockGroup, buildAssistantTurnRenderItems, buildCompletedToolResultIds } from './ProcessBlockGroup'
 import { extractToolResultText, parseTaskCreateResult, TASK_TOOL_NAMES } from './task-progress'
 import { normalizeThinkTagsInContentBlocks } from './thinking-tag-parser'
+// 会话转录的纯逻辑(Turn 分组 / 快照去重 / 预览)已下沉到 @proma/session-core 作为唯一真源。
+// 这里 import 供本文件内部使用，并 re-export 以保持既有 `from './SDKMessageRenderer'` 导入方零改动。
+import {
+  groupIntoTurns,
+  getGroupPreview,
+  extractUserText,
+  extractMeta,
+  isUserInputMessage,
+  stripScheduledRunMarker,
+  type MessageGroup,
+  type AssistantTurn,
+} from '@proma/session-core'
+export { groupIntoTurns, getGroupPreview, extractUserText } from '@proma/session-core'
+export type { MessageGroup, AssistantTurn } from '@proma/session-core'
 import { DurationBadge } from './AgentMessages'
 import {
   Message,
@@ -152,18 +166,7 @@ export function CompactingIndicator(): React.ReactElement {
   )
 }
 
-// ===== 辅助：从 SDKMessage 提取元数据 =====
-
-interface MessageMeta {
-  createdAt?: number
-}
-
-function extractMeta(message: SDKMessage): MessageMeta {
-  const msg = message as Record<string, unknown>
-  return {
-    createdAt: typeof msg._createdAt === 'number' ? msg._createdAt : undefined,
-  }
-}
+// extractMeta / MessageMeta 已迁移至 @proma/session-core
 
 /** 从 turn 消息列表中提取 result 消息的耗时和用量数据 */
 function extractTurnUsage(turnMessages: SDKMessage[]): { durationMs?: number; usage?: AgentEventUsage } {
@@ -192,21 +195,7 @@ function extractTurnUsage(turnMessages: SDKMessage[]): { durationMs?: number; us
   return {}
 }
 
-// ===== 辅助：从 user 消息中提取纯文本内容 =====
-
-export function extractUserText(message: SDKUserMessage): string | null {
-  const content = message.message?.content
-  if (!Array.isArray(content)) return null
-
-  const texts: string[] = []
-  for (const block of content) {
-    if (block.type === 'text' && 'text' in block) {
-      texts.push((block as { text: string }).text)
-    }
-  }
-
-  return texts.length > 0 ? texts.join('\n') : null
-}
+// extractUserText 已迁移至 @proma/session-core
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
@@ -227,17 +216,7 @@ function extractToolResultForTask(message: SDKUserMessage, resultBlock: SDKToolR
   return extractStructuredToolResultText(message) ?? extractToolResultText(resultBlock.content)
 }
 
-// ===== 辅助：判断 user 消息是否为真正的人类用户输入（非工具结果/子代理提示） =====
-
-function isUserInputMessage(message: SDKUserMessage): boolean {
-  if (message.parent_tool_use_id) return false
-  // SDK 合成消息（如 Skill 展开 prompt）不是用户输入
-  if (message.isSynthetic) return false
-  // 包含 tool_result 块的消息是工具结果，不是用户输入
-  const content = message.message?.content
-  if (Array.isArray(content) && content.some((b) => b.type === 'tool_result')) return false
-  return extractUserText(message) !== null
-}
+// isUserInputMessage 已迁移至 @proma/session-core
 
 // ===== 助手头像 =====
 
@@ -259,176 +238,9 @@ function AssistantLogo({ model }: { model?: string }): React.ReactElement {
   )
 }
 
-// ===== Turn 分组类型 =====
+// AssistantTurn / MessageGroup 类型已迁移至 @proma/session-core
 
-export interface AssistantTurn {
-  type: 'assistant-turn'
-  /** 当前 turn 内所有 assistant 消息 */
-  assistantMessages: SDKAssistantMessage[]
-  /** 当前 turn 内所有消息（含 tool_result user 消息，供工具结果查找） */
-  turnMessages: SDKMessage[]
-  /** 模型名称（取首条 assistant 消息的 model） */
-  model?: string
-  /** 创建时间（取首条 assistant 消息的时间） */
-  createdAt?: number
-  /**
-   * 该 turn 由后台任务完成通知（task_notification）唤醒后开始。
-   * 用于阻断与前一 turn 的合并，让自动唤醒的新输出独立成块，而不是被追加进上一轮的消息块。
-   */
-  startsAfterWake?: boolean
-}
-
-export type MessageGroup =
-  | { type: 'user'; message: SDKUserMessage }
-  | { type: 'system'; message: SDKSystemMessage }
-  | AssistantTurn
-
-/**
- * 将 SDKMessage 列表分组为可渲染的 Turn
- *
- * 规则：
- * 1. user（真正用户输入）→ 单独的 user group
- * 2. assistant + user(tool_result) + assistant... → 合并为一个 assistant-turn
- * 3. system（compact_boundary / compacting / permission_denied）→ 独立渲染，其他归入当前 turn
- * 4. 其他类型（result, tool_progress 等）→ 归入当前 assistant-turn
- * 5. 后处理：合并相邻同模型的 assistant-turn（处理子代理切换模型导致的碎片化）
- */
-export function groupIntoTurns(messages: SDKMessage[], sessionModelId?: string): MessageGroup[] {
-  const groups: MessageGroup[] = []
-  let currentTurn: AssistantTurn | null = null
-  // 收到后台任务完成通知（task_notification）后，若没有用户输入就直接出现新的 assistant 输出，
-  // 说明这是自动唤醒的新一轮，应另起独立消息块，而不是续接上一轮。
-  // 注意：不能用 result 做信号——正常对话每轮也以 result 结束，会误伤普通回复。
-  let pendingWakeBoundary = false
-
-  const flushTurn = (): void => {
-    if (currentTurn && currentTurn.assistantMessages.length > 0) {
-      groups.push(currentTurn)
-    }
-    currentTurn = null
-  }
-
-  for (const msg of messages) {
-    if (msg.type === 'user') {
-      const userMsg = msg as SDKUserMessage
-      if (isUserInputMessage(userMsg)) {
-        // 真正的用户输入 → 结束当前 turn，开始新段落
-        flushTurn()
-        groups.push({ type: 'user', message: userMsg })
-        pendingWakeBoundary = false
-      } else {
-        // tool_result 消息 → 归入当前 turn
-        if (currentTurn) {
-          currentTurn.turnMessages.push(msg)
-        }
-      }
-    } else if (msg.type === 'assistant') {
-      const aMsg = msg as SDKAssistantMessage
-      // 跳过重放消息
-      if (aMsg.isReplay) continue
-
-      if (!currentTurn) {
-        // 开始新 turn
-        const meta = extractMeta(msg)
-        currentTurn = {
-          type: 'assistant-turn',
-          assistantMessages: [aMsg],
-          turnMessages: [msg],
-          model: aMsg._channelModelId || aMsg.message?.model || sessionModelId,
-          createdAt: meta.createdAt,
-          // 紧跟在后台任务唤醒之后的新 turn：阻断与上一轮的合并
-          startsAfterWake: pendingWakeBoundary || undefined,
-        }
-        pendingWakeBoundary = false
-      } else {
-        // 继续当前 turn
-        currentTurn.assistantMessages.push(aMsg)
-        currentTurn.turnMessages.push(msg)
-      }
-    } else if (msg.type === 'system') {
-      const sysMsg = msg as SDKSystemMessage
-      // 仅需要独立渲染的 system 消息才中断 turn（compact_boundary / compacting / permission_denied）
-      // 其他 system 消息（如 init、task_started、task_progress）归入当前 turn，不中断分组
-      if (sysMsg.subtype === 'compact_boundary' || sysMsg.subtype === 'compacting' || sysMsg.subtype === 'permission_denied') {
-        flushTurn()
-        groups.push({ type: 'system', message: sysMsg })
-      } else if (sysMsg.subtype === 'task_notification') {
-        // 后台任务完成通知：仅在没有进行中的 turn 时标记唤醒边界（真正的唤醒场景）。
-        // 若当前有 turn 正在进行，归入当前 turn 不截断。
-        if (currentTurn) {
-          currentTurn.turnMessages.push(msg)
-        } else {
-          pendingWakeBoundary = true
-        }
-      } else if (currentTurn) {
-        currentTurn.turnMessages.push(msg)
-      }
-    } else {
-      // result, tool_progress 等 → 归入当前 turn
-      // prompt_suggestion 不属于对话转录，不入 turn，避免被当作文本附加到助手消息末尾
-      if ((msg as { type: string }).type === 'prompt_suggestion') {
-        continue
-      }
-      if (currentTurn) {
-        currentTurn.turnMessages.push(msg)
-      }
-    }
-  }
-
-  flushTurn()
-  return mergeAdjacentSameModelTurns(groups)
-}
-
-/**
- * 后处理：合并相邻同模型的 assistant-turn
- *
- * 当子代理（如 haiku）执行多个工具调用时，中间的 user(tool_result) 消息
- * 可能导致 turn 被拆分为多个碎片。此函数将同模型的相邻 assistant-turn 合并，
- * 同时吸收它们之间的非用户输入 group（如被误判为用户输入的子代理内部消息）。
- */
-function mergeAdjacentSameModelTurns(groups: MessageGroup[]): MessageGroup[] {
-  if (groups.length <= 1) return groups
-
-  const result: MessageGroup[] = []
-
-  for (const group of groups) {
-    if (group.type !== 'assistant-turn') {
-      result.push(group)
-      continue
-    }
-
-    // 后台任务唤醒后开始的 turn：独立成块，不向前合并。
-    if (group.startsAfterWake) {
-      result.push(group)
-      continue
-    }
-
-    // 向前查找可合并的同模型 assistant-turn（跳过非 user-input 的中间 group）
-    let mergeTargetIdx = -1
-    for (let i = result.length - 1; i >= 0; i--) {
-      const prev = result[i]!
-      if (prev.type === 'user') break // 真正的用户输入阻断合并
-      if (prev.type === 'system' && ['compact_boundary', 'permission_denied'].includes((prev.message as SDKSystemMessage).subtype ?? '')) break
-      if (prev.type === 'assistant-turn') {
-        if (prev.model === group.model) {
-          mergeTargetIdx = i
-        }
-        break // 遇到第一个 assistant-turn 就停止（不跨越不同模型的 turn）
-      }
-      // system 或其他 group：继续向前查找
-    }
-
-    if (mergeTargetIdx >= 0) {
-      const target = result[mergeTargetIdx] as AssistantTurn
-      target.assistantMessages.push(...group.assistantMessages)
-      target.turnMessages.push(...group.turnMessages)
-    } else {
-      result.push(group)
-    }
-  }
-
-  return result
-}
+// groupIntoTurns / mergeAdjacentSameModelTurns 已迁移至 @proma/session-core
 
 function buildTaskProgressData(
   topLevelBlocks: SDKContentBlock[],
@@ -1031,9 +843,7 @@ function QuoteChip({ quote }: { quote: QuotedFileRef }): React.ReactElement {
 
 const SCHEDULED_RUN_MARKER = '<!--PROMA_SCHEDULED_RUN-->'
 
-function stripScheduledRunMarker(text: string): string {
-  return text.replaceAll(SCHEDULED_RUN_MARKER, '').trim()
-}
+// stripScheduledRunMarker 已迁移至 @proma/session-core（本文件从该包 import 使用）
 
 function ScheduledRunBadge(): React.ReactElement {
   const activeSessionId = useAtomValue(activeSessionIdAtom)
@@ -1423,35 +1233,7 @@ export function getGroupId(group: MessageGroup): string {
   return `turn-empty-${++fallbackIdCounter}`
 }
 
-/**
- * 从 MessageGroup 中提取纯文本预览，供迷你地图使用
- */
-export function getGroupPreview(group: MessageGroup): string {
-  if (group.type === 'user') {
-    return stripScheduledRunMarker(extractUserText(group.message) ?? '')
-      .replace(/<attached_files>[\s\S]*?<\/attached_files>\n*/, '')
-      .replace(/<quoted_file[^>]*>[\s\S]*?<\/quoted_file>\n*/g, '')
-      .slice(0, 200)
-  }
-  if (group.type === 'system') {
-    if (group.message.subtype === 'compact_boundary') return '上下文已压缩'
-    if (group.message.subtype === 'compacting') return '正在压缩上下文...'
-    if (group.message.subtype === 'permission_denied') return '自动审批已拒绝操作'
-    return ''
-  }
-  // assistant-turn：收集所有 text 块
-  const texts: string[] = []
-  for (const aMsg of group.assistantMessages) {
-    const rawBlocks = aMsg.message?.content
-    if (!Array.isArray(rawBlocks)) continue
-    for (const block of normalizeThinkTagsInContentBlocks(rawBlocks)) {
-      if (block.type === 'text' && 'text' in block) {
-        texts.push((block as { text: string }).text)
-      }
-    }
-  }
-  return texts.join(' ').slice(0, 200)
-}
+// getGroupPreview 已迁移至 @proma/session-core（本文件从该包 import 并 re-export）
 
 export function MessageGroupRenderer({ group, allMessages, historicalTaskSubjects, basePath, onFork, onRewind, onRetry, onRetryInNewSession, onCompact, isStreaming, stoppedByUser, sessionModelId }: MessageGroupRendererProps): React.ReactElement | null {
   const groupId = getGroupId(group)

--- a/apps/electron/src/renderer/components/agent/thinking-tag-parser.ts
+++ b/apps/electron/src/renderer/components/agent/thinking-tag-parser.ts
@@ -1,64 +1,9 @@
-import type { SDKContentBlock, SDKTextBlock } from '@proma/shared'
-
-const THINK_OPEN_TAG = '<think>'
-const THINK_CLOSE_TAG = '</think>'
-
-function appendTextBlock(blocks: SDKContentBlock[], text: string): void {
-  if (!text.trim()) return
-  blocks.push({ type: 'text', text })
-}
-
-function appendThinkingBlock(blocks: SDKContentBlock[], thinking: string): void {
-  const content = thinking.trim()
-  if (!content) return
-  blocks.push({ type: 'thinking', thinking: content })
-}
-
 /**
- * 兼容部分模型把思考内容包在 <think> 标签里的返回格式。
- * 未闭合的 <think> 在流式阶段按思考块处理，等闭合标签到达后会自然拆出后续正文。
+ * 该模块实现已迁移至 @proma/session-core（headless 核心，纯函数）。
+ * 保留此文件为 re-export shim，使既有 `from './thinking-tag-parser'` 导入方零改动。
  */
-export function parseThinkTagsFromText(text: string): SDKContentBlock[] {
-  const lowerText = text.toLowerCase()
-  const blocks: SDKContentBlock[] = []
-  let cursor = 0
-
-  while (cursor < text.length) {
-    const openIndex = lowerText.indexOf(THINK_OPEN_TAG, cursor)
-    if (openIndex === -1) {
-      appendTextBlock(blocks, text.slice(cursor))
-      break
-    }
-
-    appendTextBlock(blocks, text.slice(cursor, openIndex))
-
-    const contentStart = openIndex + THINK_OPEN_TAG.length
-    const closeIndex = lowerText.indexOf(THINK_CLOSE_TAG, contentStart)
-    if (closeIndex === -1) {
-      appendThinkingBlock(blocks, text.slice(contentStart))
-      break
-    }
-
-    appendThinkingBlock(blocks, text.slice(contentStart, closeIndex))
-    cursor = closeIndex + THINK_CLOSE_TAG.length
-  }
-
-  return blocks
-}
-
-export function splitThinkTagsInTextBlock(block: SDKTextBlock): SDKContentBlock[] {
-  if (!block.text.toLowerCase().includes(THINK_OPEN_TAG)) return [block]
-  return parseThinkTagsFromText(block.text)
-}
-
-export function normalizeThinkTagsInContentBlocks(blocks: SDKContentBlock[]): SDKContentBlock[] {
-  const normalized: SDKContentBlock[] = []
-  for (const block of blocks) {
-    if (block.type === 'text' && 'text' in block && typeof block.text === 'string') {
-      normalized.push(...splitThinkTagsInTextBlock(block as SDKTextBlock))
-    } else {
-      normalized.push(block)
-    }
-  }
-  return normalized
-}
+export {
+  normalizeThinkTagsInContentBlocks,
+  parseThinkTagsFromText,
+  splitThinkTagsInTextBlock,
+} from '@proma/session-core'

--- a/bun.lock
+++ b/bun.lock
@@ -41,6 +41,7 @@
         "@emoji-mart/react": "^1.1.1",
         "@larksuiteoapi/node-sdk": "^1.65.0",
         "@proma/core": "workspace:*",
+        "@proma/session-core": "workspace:*",
         "@proma/shared": "workspace:*",
         "@proma/ui": "workspace:*",
         "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -100,6 +101,7 @@
         "electron-updater": "^6.7.3",
         "electronmon": "^2.0.4",
         "esbuild": "^0.24.0",
+        "jszip": "^3.10.1",
         "katex": "^0.16",
         "lowlight": "^3.3.0",
         "lucide-react": "^0.460.0",
@@ -154,9 +156,19 @@
         "@modelcontextprotocol/sdk": ">=1.0.0",
       },
     },
+    "packages/session-core": {
+      "name": "@proma/session-core",
+      "version": "0.1.0",
+      "dependencies": {
+        "@proma/shared": "workspace:*",
+      },
+      "devDependencies": {
+        "typescript": "^5.0.0",
+      },
+    },
     "packages/shared": {
       "name": "@proma/shared",
-      "version": "0.1.31",
+      "version": "0.1.35",
       "devDependencies": {
         "typescript": "^5.0.0",
       },
@@ -416,6 +428,8 @@
     "@proma/core": ["@proma/core@workspace:packages/core"],
 
     "@proma/electron": ["@proma/electron@workspace:apps/electron"],
+
+    "@proma/session-core": ["@proma/session-core@workspace:packages/session-core"],
 
     "@proma/shared": ["@proma/shared@workspace:packages/shared"],
 

--- a/packages/session-core/package.json
+++ b/packages/session-core/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@proma/session-core",
+  "version": "0.1.0",
+  "license": "AGPL-3.0-only",
+  "description": "Headless core for reading, grouping, searching and rendering Proma agent sessions. Single source of truth shared by the Electron app, the proma CLI and future query surfaces.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@proma/shared": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/session-core/package.json
+++ b/packages/session-core/package.json
@@ -7,7 +7,8 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./node": "./src/node.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/session-core/src/group.ts
+++ b/packages/session-core/src/group.ts
@@ -1,0 +1,266 @@
+/**
+ * Turn 分组 — 将流式产生的 SDKMessage 列表(含同一回合的多行快照碎片)
+ * 合并为可渲染/可导出的 Turn 分组。
+ *
+ * 这是 Proma 会话「快照去重」的唯一真源：Electron 渲染层、proma CLI 以及
+ * 未来的 query 型接口都复用本模块，避免各处重抄一份会随存储格式漂移的解析器。
+ *
+ * 逻辑逐字迁移自 apps/electron 渲染层 SDKMessageRenderer.tsx，保持行为一致。
+ */
+import type {
+  SDKMessage,
+  SDKAssistantMessage,
+  SDKUserMessage,
+  SDKSystemMessage,
+} from '@proma/shared'
+import { normalizeThinkTagsInContentBlocks } from './thinking-tags'
+
+// ===== 辅助：从 SDKMessage 提取元数据 =====
+
+export interface MessageMeta {
+  createdAt?: number
+}
+
+export function extractMeta(message: SDKMessage): MessageMeta {
+  const msg = message as Record<string, unknown>
+  return {
+    createdAt: typeof msg._createdAt === 'number' ? msg._createdAt : undefined,
+  }
+}
+
+// ===== 辅助：从 user 消息中提取纯文本内容 =====
+
+export function extractUserText(message: SDKUserMessage): string | null {
+  const content = message.message?.content
+  if (!Array.isArray(content)) return null
+
+  const texts: string[] = []
+  for (const block of content) {
+    if (block.type === 'text' && 'text' in block) {
+      texts.push((block as { text: string }).text)
+    }
+  }
+
+  return texts.length > 0 ? texts.join('\n') : null
+}
+
+// ===== 辅助：判断 user 消息是否为真正的人类用户输入（非工具结果/子代理提示） =====
+
+export function isUserInputMessage(message: SDKUserMessage): boolean {
+  if (message.parent_tool_use_id) return false
+  // SDK 合成消息（如 Skill 展开 prompt）不是用户输入
+  if (message.isSynthetic) return false
+  // 包含 tool_result 块的消息是工具结果，不是用户输入
+  const content = message.message?.content
+  if (Array.isArray(content) && content.some((b) => b.type === 'tool_result')) return false
+  return extractUserText(message) !== null
+}
+
+// ===== Turn 分组类型 =====
+
+export interface AssistantTurn {
+  type: 'assistant-turn'
+  /** 当前 turn 内所有 assistant 消息 */
+  assistantMessages: SDKAssistantMessage[]
+  /** 当前 turn 内所有消息（含 tool_result user 消息，供工具结果查找） */
+  turnMessages: SDKMessage[]
+  /** 模型名称（取首条 assistant 消息的 model） */
+  model?: string
+  /** 创建时间（取首条 assistant 消息的时间） */
+  createdAt?: number
+  /**
+   * 该 turn 由后台任务完成通知（task_notification）唤醒后开始。
+   * 用于阻断与前一 turn 的合并，让自动唤醒的新输出独立成块，而不是被追加进上一轮的消息块。
+   */
+  startsAfterWake?: boolean
+}
+
+export type MessageGroup =
+  | { type: 'user'; message: SDKUserMessage }
+  | { type: 'system'; message: SDKSystemMessage }
+  | AssistantTurn
+
+/**
+ * 将 SDKMessage 列表分组为可渲染的 Turn
+ *
+ * 规则：
+ * 1. user（真正用户输入）→ 单独的 user group
+ * 2. assistant + user(tool_result) + assistant... → 合并为一个 assistant-turn
+ * 3. system（compact_boundary / compacting / permission_denied）→ 独立渲染，其他归入当前 turn
+ * 4. 其他类型（result, tool_progress 等）→ 归入当前 assistant-turn
+ * 5. 后处理：合并相邻同模型的 assistant-turn（处理子代理切换模型导致的碎片化）
+ */
+export function groupIntoTurns(messages: SDKMessage[], sessionModelId?: string): MessageGroup[] {
+  const groups: MessageGroup[] = []
+  let currentTurn: AssistantTurn | null = null
+  // 收到后台任务完成通知（task_notification）后，若没有用户输入就直接出现新的 assistant 输出，
+  // 说明这是自动唤醒的新一轮，应另起独立消息块，而不是续接上一轮。
+  // 注意：不能用 result 做信号——正常对话每轮也以 result 结束，会误伤普通回复。
+  let pendingWakeBoundary = false
+
+  const flushTurn = (): void => {
+    if (currentTurn && currentTurn.assistantMessages.length > 0) {
+      groups.push(currentTurn)
+    }
+    currentTurn = null
+  }
+
+  for (const msg of messages) {
+    if (msg.type === 'user') {
+      const userMsg = msg as SDKUserMessage
+      if (isUserInputMessage(userMsg)) {
+        // 真正的用户输入 → 结束当前 turn，开始新段落
+        flushTurn()
+        groups.push({ type: 'user', message: userMsg })
+        pendingWakeBoundary = false
+      } else {
+        // tool_result 消息 → 归入当前 turn
+        if (currentTurn) {
+          currentTurn.turnMessages.push(msg)
+        }
+      }
+    } else if (msg.type === 'assistant') {
+      const aMsg = msg as SDKAssistantMessage
+      // 跳过重放消息
+      if (aMsg.isReplay) continue
+
+      if (!currentTurn) {
+        // 开始新 turn
+        const meta = extractMeta(msg)
+        currentTurn = {
+          type: 'assistant-turn',
+          assistantMessages: [aMsg],
+          turnMessages: [msg],
+          model: aMsg._channelModelId || aMsg.message?.model || sessionModelId,
+          createdAt: meta.createdAt,
+          // 紧跟在后台任务唤醒之后的新 turn：阻断与上一轮的合并
+          startsAfterWake: pendingWakeBoundary || undefined,
+        }
+        pendingWakeBoundary = false
+      } else {
+        // 继续当前 turn
+        currentTurn.assistantMessages.push(aMsg)
+        currentTurn.turnMessages.push(msg)
+      }
+    } else if (msg.type === 'system') {
+      const sysMsg = msg as SDKSystemMessage
+      // 仅需要独立渲染的 system 消息才中断 turn（compact_boundary / compacting / permission_denied）
+      // 其他 system 消息（如 init、task_started、task_progress）归入当前 turn，不中断分组
+      if (sysMsg.subtype === 'compact_boundary' || sysMsg.subtype === 'compacting' || sysMsg.subtype === 'permission_denied') {
+        flushTurn()
+        groups.push({ type: 'system', message: sysMsg })
+      } else if (sysMsg.subtype === 'task_notification') {
+        // 后台任务完成通知：仅在没有进行中的 turn 时标记唤醒边界（真正的唤醒场景）。
+        // 若当前有 turn 正在进行，归入当前 turn 不截断。
+        if (currentTurn) {
+          currentTurn.turnMessages.push(msg)
+        } else {
+          pendingWakeBoundary = true
+        }
+      } else if (currentTurn) {
+        currentTurn.turnMessages.push(msg)
+      }
+    } else {
+      // result, tool_progress 等 → 归入当前 turn
+      // prompt_suggestion 不属于对话转录，不入 turn，避免被当作文本附加到助手消息末尾
+      if ((msg as { type: string }).type === 'prompt_suggestion') {
+        continue
+      }
+      if (currentTurn) {
+        currentTurn.turnMessages.push(msg)
+      }
+    }
+  }
+
+  flushTurn()
+  return mergeAdjacentSameModelTurns(groups)
+}
+
+/**
+ * 后处理：合并相邻同模型的 assistant-turn
+ *
+ * 当子代理（如 haiku）执行多个工具调用时，中间的 user(tool_result) 消息
+ * 可能导致 turn 被拆分为多个碎片。此函数将同模型的相邻 assistant-turn 合并，
+ * 同时吸收它们之间的非用户输入 group（如被误判为用户输入的子代理内部消息）。
+ */
+function mergeAdjacentSameModelTurns(groups: MessageGroup[]): MessageGroup[] {
+  if (groups.length <= 1) return groups
+
+  const result: MessageGroup[] = []
+
+  for (const group of groups) {
+    if (group.type !== 'assistant-turn') {
+      result.push(group)
+      continue
+    }
+
+    // 后台任务唤醒后开始的 turn：独立成块，不向前合并。
+    if (group.startsAfterWake) {
+      result.push(group)
+      continue
+    }
+
+    // 向前查找可合并的同模型 assistant-turn（跳过非 user-input 的中间 group）
+    let mergeTargetIdx = -1
+    for (let i = result.length - 1; i >= 0; i--) {
+      const prev = result[i]!
+      if (prev.type === 'user') break // 真正的用户输入阻断合并
+      if (prev.type === 'system' && ['compact_boundary', 'permission_denied'].includes((prev.message as SDKSystemMessage).subtype ?? '')) break
+      if (prev.type === 'assistant-turn') {
+        if (prev.model === group.model) {
+          mergeTargetIdx = i
+        }
+        break // 遇到第一个 assistant-turn 就停止（不跨越不同模型的 turn）
+      }
+      // system 或其他 group：继续向前查找
+    }
+
+    if (mergeTargetIdx >= 0) {
+      const target = result[mergeTargetIdx] as AssistantTurn
+      target.assistantMessages.push(...group.assistantMessages)
+      target.turnMessages.push(...group.turnMessages)
+    } else {
+      result.push(group)
+    }
+  }
+
+  return result
+}
+
+// ===== 预览/摘要 =====
+
+const SCHEDULED_RUN_MARKER = '<!--PROMA_SCHEDULED_RUN-->'
+
+export function stripScheduledRunMarker(text: string): string {
+  return text.replaceAll(SCHEDULED_RUN_MARKER, '').trim()
+}
+
+/**
+ * 从 MessageGroup 中提取纯文本预览，供迷你地图 / outline 使用
+ */
+export function getGroupPreview(group: MessageGroup): string {
+  if (group.type === 'user') {
+    return stripScheduledRunMarker(extractUserText(group.message) ?? '')
+      .replace(/<attached_files>[\s\S]*?<\/attached_files>\n*/, '')
+      .replace(/<quoted_file[^>]*>[\s\S]*?<\/quoted_file>\n*/g, '')
+      .slice(0, 200)
+  }
+  if (group.type === 'system') {
+    if (group.message.subtype === 'compact_boundary') return '上下文已压缩'
+    if (group.message.subtype === 'compacting') return '正在压缩上下文...'
+    if (group.message.subtype === 'permission_denied') return '自动审批已拒绝操作'
+    return ''
+  }
+  // assistant-turn：收集所有 text 块
+  const texts: string[] = []
+  for (const aMsg of group.assistantMessages) {
+    const rawBlocks = aMsg.message?.content
+    if (!Array.isArray(rawBlocks)) continue
+    for (const block of normalizeThinkTagsInContentBlocks(rawBlocks)) {
+      if (block.type === 'text' && 'text' in block) {
+        texts.push((block as { text: string }).text)
+      }
+    }
+  }
+  return texts.join(' ').slice(0, 200)
+}

--- a/packages/session-core/src/index.ts
+++ b/packages/session-core/src/index.ts
@@ -2,12 +2,15 @@
  * @proma/session-core — Proma 会话读取 / 快照去重 / 转录 / 渲染的 headless 核心。
  *
  * 唯一真源：Electron 主进程、proma CLI、未来的 query 型接口共用本包，
- * 避免在仓库外侧重抄一份会随存储格式漂移的解析器。全部为纯函数（除 read 的文件 IO）。
+ * 避免在仓库外侧重抄一份会随存储格式漂移的解析器。
+ *
+ * 本主入口（'.'）**全部为纯函数，浏览器安全**，可被 Electron 渲染层直接 import。
+ * 涉及文件 IO（node:fs）的 readSessionMessages 在子入口 '@proma/session-core/node'，
+ * 仅供 Node 侧（proma CLI / 主进程）使用，避免 Vite 把 node:fs 打进渲染层 bundle。
  */
 
-// 读取与格式归一
+// 解析与格式归一（纯函数，无文件 IO）
 export {
-  readSessionMessages,
   readSessionMessagesFromString,
   convertLegacyMessage,
 } from './read'

--- a/packages/session-core/src/index.ts
+++ b/packages/session-core/src/index.ts
@@ -1,0 +1,49 @@
+/**
+ * @proma/session-core — Proma 会话读取 / 快照去重 / 转录 / 渲染的 headless 核心。
+ *
+ * 唯一真源：Electron 主进程、proma CLI、未来的 query 型接口共用本包，
+ * 避免在仓库外侧重抄一份会随存储格式漂移的解析器。全部为纯函数（除 read 的文件 IO）。
+ */
+
+// 读取与格式归一
+export {
+  readSessionMessages,
+  readSessionMessagesFromString,
+  convertLegacyMessage,
+} from './read'
+
+// Turn 分组（快照合并去重的唯一真源）
+export {
+  groupIntoTurns,
+  getGroupPreview,
+  extractUserText,
+  extractMeta,
+  isUserInputMessage,
+  stripScheduledRunMarker,
+  type MessageGroup,
+  type AssistantTurn,
+  type MessageMeta,
+} from './group'
+
+// <think> 标签归一
+export {
+  normalizeThinkTagsInContentBlocks,
+  parseThinkTagsFromText,
+  splitThinkTagsInTextBlock,
+} from './thinking-tags'
+
+// 转录（稳定下标 + assistant 多快照去重 + 工具摘要折叠）
+export {
+  toTranscript,
+  summarizeToolInput,
+  collapseToolSummaries,
+  type TranscriptTurn,
+  type TurnRole,
+} from './transcript'
+
+// 渐进式读取原语
+export { outline, formatOutlineLine, type OutlineEntry } from './outline'
+export { searchTurns, type SearchHit, type SearchOptions } from './search'
+export { selectTurns, type SelectOptions } from './select'
+export { renderTranscriptMarkdown, type RenderMarkdownOptions } from './render-markdown'
+export { estimateTokens } from './tokens'

--- a/packages/session-core/src/node.ts
+++ b/packages/session-core/src/node.ts
@@ -1,0 +1,8 @@
+/**
+ * @proma/session-core/node — Node 侧子入口（含文件 IO，import 'node:fs'）。
+ *
+ * 仅供 proma CLI 与 Electron 主进程使用。**不要**从浏览器/渲染层 import 本入口，
+ * 否则 Vite 会把 node:fs 打进 bundle 导致运行时报错。浏览器侧请用主入口
+ * '@proma/session-core'（纯函数）。
+ */
+export { readSessionMessages } from './read-fs'

--- a/packages/session-core/src/outline.ts
+++ b/packages/session-core/src/outline.ts
@@ -1,0 +1,43 @@
+import type { TranscriptTurn, TurnRole } from './transcript'
+
+export interface OutlineEntry {
+  index: number
+  role: TurnRole
+  preview: string
+  /** assistant 回合的工具摘要计数概览，如 "Read ×3, Bash ×1"。 */
+  tools?: string
+  tokens: number
+}
+
+/** 生成 turn 级地图：每 turn 一行的结构概览，便于 Agent 决定读哪段。 */
+export function outline(turns: TranscriptTurn[]): OutlineEntry[] {
+  return turns.map((t) => ({
+    index: t.index,
+    role: t.role,
+    preview: t.preview,
+    tools: t.toolSummaries.length ? summarizeToolCounts(t.toolSummaries) : undefined,
+    tokens: t.tokens,
+  }))
+}
+
+/** 把工具摘要列表收敛成 "ToolName ×N" 概览（取工具名首词）。 */
+function summarizeToolCounts(toolSummaries: string[]): string {
+  const counts = new Map<string, number>()
+  for (const s of toolSummaries) {
+    const m = /^(\S+)(?:.*?×(\d+))?$/.exec(s)
+    const name = m?.[1] ?? 'tool'
+    const n = m?.[2] ? Number(m[2]) : 1
+    counts.set(name, (counts.get(name) ?? 0) + n)
+  }
+  return [...counts.entries()].map(([name, n]) => `${name} ×${n}`).join(', ')
+}
+
+const ROLE_LABEL: Record<TurnRole, string> = { user: '用户', assistant: '助手', system: '系统' }
+
+/** 单行渲染一个 outline 条目。 */
+export function formatOutlineLine(e: OutlineEntry): string {
+  const head = `#${e.index} ${ROLE_LABEL[e.role]}`
+  const body = e.preview ? ` · ${e.preview.replace(/\s+/g, ' ').slice(0, 80)}` : ''
+  const tools = e.tools ? ` · [${e.tools}]` : ''
+  return `${head}${body}${tools} (~${e.tokens}t)`
+}

--- a/packages/session-core/src/read-fs.ts
+++ b/packages/session-core/src/read-fs.ts
@@ -1,0 +1,17 @@
+/**
+ * 文件 IO 层 — 仅供 Node 侧（proma CLI / Electron 主进程）使用。
+ *
+ * 本文件 import 'node:fs'，因此**不能**进入浏览器可达的主 barrel（'@proma/session-core'）。
+ * 它只通过子路径 '@proma/session-core/node' 暴露，避免 Vite 把 node:fs 打进渲染层 bundle。
+ */
+import { readFileSync } from 'node:fs'
+import type { SDKMessage } from '@proma/shared'
+import { readSessionMessagesFromString } from './read'
+
+/**
+ * 从磁盘读取一份会话 JSONL 并解析为 SDKMessage[]。
+ */
+export function readSessionMessages(filePath: string): SDKMessage[] {
+  const raw = readFileSync(filePath, 'utf-8')
+  return readSessionMessagesFromString(raw)
+}

--- a/packages/session-core/src/read.ts
+++ b/packages/session-core/src/read.ts
@@ -1,0 +1,101 @@
+/**
+ * 读取 Proma 会话 JSONL → SDKMessage[]
+ *
+ * 逻辑迁移自 apps/electron 主进程 agent-session-manager.ts 的
+ * getAgentSessionSDKMessages / convertLegacyMessage，作为唯一真源由
+ * Electron 主进程与 proma CLI 共用。旧扁平格式（AgentMessage，带 role 字段）
+ * 在此统一归一为近似 SDKMessage，下游无需再区分「格式 A / 格式 B」。
+ */
+import { readFileSync } from 'node:fs'
+import type { AgentMessage, SDKMessage } from '@proma/shared'
+
+/**
+ * 将旧的 AgentMessage 转换为近似的 SDKMessage（向后兼容）。
+ * 不需要完美还原，只需在渲染/导出中可读即可。
+ */
+export function convertLegacyMessage(legacy: AgentMessage): SDKMessage {
+  if (legacy.role === 'user') {
+    return {
+      type: 'user',
+      message: {
+        content: [{ type: 'text', text: legacy.content }],
+      },
+      parent_tool_use_id: null,
+      _legacy: true,
+      _createdAt: legacy.createdAt,
+    } as unknown as SDKMessage
+  }
+
+  if (legacy.role === 'assistant') {
+    return {
+      type: 'assistant',
+      message: {
+        content: [{ type: 'text', text: legacy.content }],
+        model: legacy.model,
+      },
+      parent_tool_use_id: null,
+      _legacy: true,
+      _createdAt: legacy.createdAt,
+    } as unknown as SDKMessage
+  }
+
+  if (legacy.role === 'status') {
+    // 错误消息转换为 assistant error 格式
+    return {
+      type: 'assistant',
+      message: {
+        content: [{ type: 'text', text: legacy.content }],
+      },
+      parent_tool_use_id: null,
+      error: { message: legacy.content, errorType: legacy.errorCode },
+      _legacy: true,
+      _createdAt: legacy.createdAt,
+      _errorCode: legacy.errorCode,
+      _errorTitle: legacy.errorTitle,
+      _errorDetails: legacy.errorDetails,
+      _errorCanRetry: legacy.errorCanRetry,
+      _errorActions: legacy.errorActions,
+    } as unknown as SDKMessage
+  }
+
+  // 其他类型，作为 system 消息返回
+  return {
+    type: 'system',
+    subtype: 'init',
+    _legacy: true,
+    _createdAt: legacy.createdAt,
+  } as unknown as SDKMessage
+}
+
+/**
+ * 解析 JSONL 文本为 SDKMessage[]（纯函数，便于测试与非文件来源）。
+ * 损坏行（截断的 JSON）静默跳过，不中断整份会话解析。
+ */
+export function readSessionMessagesFromString(raw: string): SDKMessage[] {
+  const lines = raw.split('\n')
+  const messages: SDKMessage[] = []
+  for (const line of lines) {
+    if (!line.trim()) continue
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(line)
+    } catch {
+      continue // 容错：跳过损坏行
+    }
+    // 旧格式检测：AgentMessage 有 `role` 字段，SDKMessage 有 `type` 字段
+    if (parsed && typeof parsed === 'object' && 'role' in parsed && !('type' in parsed)) {
+      messages.push(convertLegacyMessage(parsed as AgentMessage))
+    } else {
+      messages.push(parsed as SDKMessage)
+    }
+  }
+  return messages
+}
+
+/**
+ * 从磁盘读取一份会话 JSONL 并解析为 SDKMessage[]。
+ */
+export function readSessionMessages(filePath: string): SDKMessage[] {
+  const raw = readFileSync(filePath, 'utf-8')
+  return readSessionMessagesFromString(raw)
+}

--- a/packages/session-core/src/read.ts
+++ b/packages/session-core/src/read.ts
@@ -6,7 +6,13 @@
  * Electron 主进程与 proma CLI 共用。旧扁平格式（AgentMessage，带 role 字段）
  * 在此统一归一为近似 SDKMessage，下游无需再区分「格式 A / 格式 B」。
  */
-import { readFileSync } from 'node:fs'
+/**
+ * 解析会话 JSONL 文本为 SDKMessage[]（纯函数，浏览器安全，无文件 IO）。
+ *
+ * 注意：本文件刻意不 import 'node:fs'，以便被 Electron 渲染层（浏览器环境）
+ * 经主 barrel 引入。需要从磁盘读取的 readSessionMessages 在 './read-fs' 中，
+ * 仅通过 '@proma/session-core/node' 子路径暴露给 Node 侧（CLI / 主进程）。
+ */
 import type { AgentMessage, SDKMessage } from '@proma/shared'
 
 /**
@@ -90,12 +96,4 @@ export function readSessionMessagesFromString(raw: string): SDKMessage[] {
     }
   }
   return messages
-}
-
-/**
- * 从磁盘读取一份会话 JSONL 并解析为 SDKMessage[]。
- */
-export function readSessionMessages(filePath: string): SDKMessage[] {
-  const raw = readFileSync(filePath, 'utf-8')
-  return readSessionMessagesFromString(raw)
 }

--- a/packages/session-core/src/render-markdown.ts
+++ b/packages/session-core/src/render-markdown.ts
@@ -1,0 +1,44 @@
+import type { TranscriptTurn, TurnRole } from './transcript'
+
+export interface RenderMarkdownOptions {
+  /** 文档标题用的会话 id。 */
+  sessionId?: string
+  /** 是否输出顶部标题与说明（默认 true）。截取片段时可设 false。 */
+  header?: boolean
+}
+
+const HEADING: Record<TurnRole, string> = {
+  user: '## 用户',
+  assistant: '## 助手',
+  system: '## 系统',
+}
+
+/**
+ * 把 TranscriptTurn[] 渲染为干净 Markdown 对话。
+ * 连续同角色合并到同一标题下；工具调用以 `> [工具: …]` 引用行呈现。
+ */
+export function renderTranscriptMarkdown(turns: TranscriptTurn[], opts: RenderMarkdownOptions = {}): string {
+  const { sessionId, header = true } = opts
+  const lines: string[] = []
+
+  if (header) {
+    lines.push(`# Session: ${sessionId ?? ''}`.trimEnd(), '')
+    lines.push('> 自动清洗自会话 JSONL，流式快照与工具回包已过滤。', '')
+  }
+
+  let currentRole: TurnRole | null = null
+  for (const t of turns) {
+    if (t.role !== currentRole) {
+      lines.push(HEADING[t.role], '')
+      currentRole = t.role
+    }
+    if (t.text) {
+      lines.push(t.text, '')
+    }
+    for (const tool of t.toolSummaries) {
+      lines.push(`> [工具: ${tool}]`, '')
+    }
+  }
+
+  return lines.join('\n').replace(/\n{3,}/g, '\n\n').trimEnd() + '\n'
+}

--- a/packages/session-core/src/search.ts
+++ b/packages/session-core/src/search.ts
@@ -1,0 +1,57 @@
+import type { TranscriptTurn, TurnRole } from './transcript'
+
+export interface SearchHit {
+  index: number
+  role: TurnRole
+  /** 命中处上下文片段。 */
+  snippet: string
+  /** 该 turn 内匹配次数。 */
+  matchCount: number
+}
+
+export interface SearchOptions {
+  caseSensitive?: boolean
+  /** 片段在命中点前后保留的字符数（默认 60）。 */
+  context?: number
+  /** 最多返回的命中 turn 数。 */
+  limit?: number
+}
+
+/**
+ * 在转录上做子串搜索（正文 + 工具摘要），返回命中 turn 的下标与片段。
+ * Agent 据此再用 selectTurns / export --turns 取命中邻域，避免全量读。
+ */
+export function searchTurns(turns: TranscriptTurn[], query: string, opts: SearchOptions = {}): SearchHit[] {
+  const { caseSensitive = false, context = 60, limit } = opts
+  if (!query) return []
+  const needle = caseSensitive ? query : query.toLowerCase()
+  const hits: SearchHit[] = []
+
+  for (const t of turns) {
+    const haystackRaw = [t.text, ...t.toolSummaries].join('\n')
+    const haystack = caseSensitive ? haystackRaw : haystackRaw.toLowerCase()
+    let from = 0
+    let matchCount = 0
+    let firstIdx = -1
+    for (;;) {
+      const idx = haystack.indexOf(needle, from)
+      if (idx === -1) break
+      if (firstIdx === -1) firstIdx = idx
+      matchCount++
+      from = idx + needle.length
+    }
+    if (matchCount === 0) continue
+
+    const start = Math.max(0, firstIdx - context)
+    const end = Math.min(haystackRaw.length, firstIdx + needle.length + context)
+    const snippet =
+      (start > 0 ? '…' : '') +
+      haystackRaw.slice(start, end).replace(/\s+/g, ' ').trim() +
+      (end < haystackRaw.length ? '…' : '')
+
+    hits.push({ index: t.index, role: t.role, snippet, matchCount })
+    if (limit && hits.length >= limit) break
+  }
+
+  return hits
+}

--- a/packages/session-core/src/select.ts
+++ b/packages/session-core/src/select.ts
@@ -1,0 +1,36 @@
+import type { TranscriptTurn } from './transcript'
+
+export interface SelectOptions {
+  /** 闭区间 turn 下标 [a, b]（含两端）。 */
+  range?: [number, number]
+  /** 取前 N 个 turn。 */
+  head?: number
+  /** 取后 N 个 turn。 */
+  tail?: number
+  /** 从下标 offset 起。 */
+  offset?: number
+  /** 配合 offset，取 limit 个。 */
+  limit?: number
+}
+
+/**
+ * 按窗口截取 turn 子集（下标稳定）。优先级：range > head > tail > offset/limit。
+ * 不传任何窗口 → 返回全部。
+ */
+export function selectTurns(turns: TranscriptTurn[], opts: SelectOptions = {}): TranscriptTurn[] {
+  const { range, head, tail, offset, limit } = opts
+  if (range) {
+    const [a, b] = range
+    const lo = Math.min(a, b)
+    const hi = Math.max(a, b)
+    return turns.filter((t) => t.index >= lo && t.index <= hi)
+  }
+  if (typeof head === 'number') return turns.slice(0, Math.max(0, head))
+  if (typeof tail === 'number') return turns.slice(Math.max(0, turns.length - tail))
+  if (typeof offset === 'number' || typeof limit === 'number') {
+    const start = offset ?? 0
+    const end = typeof limit === 'number' ? start + limit : undefined
+    return turns.slice(start, end)
+  }
+  return turns
+}

--- a/packages/session-core/src/session-core.test.ts
+++ b/packages/session-core/src/session-core.test.ts
@@ -1,0 +1,118 @@
+import { test, expect, describe } from 'bun:test'
+import {
+  readSessionMessagesFromString,
+  groupIntoTurns,
+  toTranscript,
+  searchTurns,
+  selectTurns,
+  renderTranscriptMarkdown,
+  collapseToolSummaries,
+  summarizeToolInput,
+} from './index'
+
+/** 把对象数组序列化为 JSONL（每行一个 JSON）。 */
+function jsonl(rows: unknown[]): string {
+  return rows.map((r) => JSON.stringify(r)).join('\n')
+}
+
+describe('快照去重（格式 B）', () => {
+  // 同一 assistant 回合的 3 行递增快照，共享 message.id='m1'
+  const raw = jsonl([
+    { type: 'user', message: { content: [{ type: 'text', text: '读取文件' }] }, parent_tool_use_id: null },
+    { type: 'assistant', message: { id: 'm1', content: [{ type: 'text', text: 'Hel' }] }, parent_tool_use_id: null },
+    { type: 'assistant', message: { id: 'm1', content: [{ type: 'text', text: 'Hello' }, { type: 'tool_use', id: 't1', name: 'Read', input: { file_path: '/a' } }] }, parent_tool_use_id: null },
+    { type: 'assistant', message: { id: 'm1', content: [{ type: 'thinking', thinking: '想一下' }, { type: 'text', text: 'Hello world' }, { type: 'tool_use', id: 't1', name: 'Read', input: { file_path: '/a' } }] }, parent_tool_use_id: null },
+    { type: 'user', message: { content: [{ type: 'tool_result', tool_use_id: 't1', content: 'data' }] }, parent_tool_use_id: null },
+    { type: 'result', subtype: 'success' },
+  ])
+
+  const turns = toTranscript(groupIntoTurns(readSessionMessagesFromString(raw)))
+
+  test('合并为 user + assistant 两个 turn，下标稳定', () => {
+    expect(turns.map((t) => t.role)).toEqual(['user', 'assistant'])
+    expect(turns.map((t) => t.index)).toEqual([0, 1])
+  })
+
+  test('assistant 只取最完整快照，无拼接重复', () => {
+    const a = turns[1]!
+    expect(a.text).toBe('Hello world')
+    expect(a.text).not.toContain('Hel\n')
+  })
+
+  test('thinking 块被丢弃', () => {
+    expect(turns[1]!.text).not.toContain('想一下')
+  })
+
+  test('tool_use 压缩为单行摘要；tool_result 不进正文', () => {
+    expect(turns[1]!.toolSummaries).toEqual(['Read file_path=/a'])
+    expect(turns[1]!.text).not.toContain('data')
+  })
+
+  test('纯 tool_result 的 user 行不产生用户 turn', () => {
+    expect(turns.filter((t) => t.role === 'user')).toHaveLength(1)
+  })
+})
+
+describe('工具折叠 ×N', () => {
+  test('连续相同工具摘要折叠计数', () => {
+    expect(collapseToolSummaries(['OCR p=1', 'OCR p=1', 'OCR p=1', 'Read f=a'])).toEqual(['OCR p=1 ×3', 'Read f=a'])
+  })
+
+  test('summarizeToolInput 跳过空值并截断长值', () => {
+    expect(summarizeToolInput('Read', { file_path: '/a', limit: 0, empty: '' })).toBe('Read file_path=/a limit=0')
+    const long = 'x'.repeat(200)
+    expect(summarizeToolInput('Bash', { command: long }).length).toBeLessThan(100)
+  })
+})
+
+describe('旧扁平格式（格式 A）归一', () => {
+  const raw = jsonl([
+    { id: '1', role: 'user', content: '你好', createdAt: 1 },
+    { id: '2', role: 'assistant', content: '旧版回复', createdAt: 2 },
+    { id: '3', role: 'assistant', content: '', createdAt: 3 },
+  ])
+  const turns = toTranscript(groupIntoTurns(readSessionMessagesFromString(raw)))
+
+  test('role 字段被识别并转换为 SDKMessage', () => {
+    expect(turns[0]).toMatchObject({ role: 'user', text: '你好' })
+    expect(turns[1]).toMatchObject({ role: 'assistant', text: '旧版回复' })
+  })
+})
+
+describe('容错与渐进式读取原语', () => {
+  const raw = jsonl([
+    { type: 'user', message: { content: [{ type: 'text', text: '问题甲' }] }, parent_tool_use_id: null },
+    { type: 'assistant', message: { id: 'a1', content: [{ type: 'text', text: '答案含关键词 needle' }] }, parent_tool_use_id: null },
+    { type: 'user', message: { content: [{ type: 'text', text: '问题乙' }] }, parent_tool_use_id: null },
+    { type: 'assistant', message: { id: 'a2', content: [{ type: 'text', text: '无关回答' }] }, parent_tool_use_id: null },
+  ])
+
+  test('损坏行被静默跳过', () => {
+    const withBad = raw + '\n{ 坏行不是 json\n'
+    const msgs = readSessionMessagesFromString(withBad)
+    expect(msgs.length).toBe(4)
+  })
+
+  const turns = toTranscript(groupIntoTurns(readSessionMessagesFromString(raw)))
+
+  test('searchTurns 返回命中 turn 下标', () => {
+    const hits = searchTurns(turns, 'needle')
+    expect(hits).toHaveLength(1)
+    expect(hits[0]!.index).toBe(1)
+    expect(hits[0]!.snippet).toContain('needle')
+  })
+
+  test('selectTurns 按 range 截取', () => {
+    expect(selectTurns(turns, { range: [2, 3] }).map((t) => t.index)).toEqual([2, 3])
+    expect(selectTurns(turns, { head: 1 }).map((t) => t.index)).toEqual([0])
+    expect(selectTurns(turns, { tail: 1 }).map((t) => t.index)).toEqual([3])
+  })
+
+  test('renderTranscriptMarkdown 按角色分段', () => {
+    const md = renderTranscriptMarkdown(turns, { sessionId: 'demo' })
+    expect(md).toContain('# Session: demo')
+    expect(md).toContain('## 用户')
+    expect(md).toContain('## 助手')
+    expect(md).toContain('答案含关键词 needle')
+  })
+})

--- a/packages/session-core/src/thinking-tags.ts
+++ b/packages/session-core/src/thinking-tags.ts
@@ -1,0 +1,64 @@
+import type { SDKContentBlock, SDKTextBlock } from '@proma/shared'
+
+const THINK_OPEN_TAG = '<think>'
+const THINK_CLOSE_TAG = '</think>'
+
+function appendTextBlock(blocks: SDKContentBlock[], text: string): void {
+  if (!text.trim()) return
+  blocks.push({ type: 'text', text })
+}
+
+function appendThinkingBlock(blocks: SDKContentBlock[], thinking: string): void {
+  const content = thinking.trim()
+  if (!content) return
+  blocks.push({ type: 'thinking', thinking: content })
+}
+
+/**
+ * 兼容部分模型把思考内容包在 <think> 标签里的返回格式。
+ * 未闭合的 <think> 在流式阶段按思考块处理，等闭合标签到达后会自然拆出后续正文。
+ */
+export function parseThinkTagsFromText(text: string): SDKContentBlock[] {
+  const lowerText = text.toLowerCase()
+  const blocks: SDKContentBlock[] = []
+  let cursor = 0
+
+  while (cursor < text.length) {
+    const openIndex = lowerText.indexOf(THINK_OPEN_TAG, cursor)
+    if (openIndex === -1) {
+      appendTextBlock(blocks, text.slice(cursor))
+      break
+    }
+
+    appendTextBlock(blocks, text.slice(cursor, openIndex))
+
+    const contentStart = openIndex + THINK_OPEN_TAG.length
+    const closeIndex = lowerText.indexOf(THINK_CLOSE_TAG, contentStart)
+    if (closeIndex === -1) {
+      appendThinkingBlock(blocks, text.slice(contentStart))
+      break
+    }
+
+    appendThinkingBlock(blocks, text.slice(contentStart, closeIndex))
+    cursor = closeIndex + THINK_CLOSE_TAG.length
+  }
+
+  return blocks
+}
+
+export function splitThinkTagsInTextBlock(block: SDKTextBlock): SDKContentBlock[] {
+  if (!block.text.toLowerCase().includes(THINK_OPEN_TAG)) return [block]
+  return parseThinkTagsFromText(block.text)
+}
+
+export function normalizeThinkTagsInContentBlocks(blocks: SDKContentBlock[]): SDKContentBlock[] {
+  const normalized: SDKContentBlock[] = []
+  for (const block of blocks) {
+    if (block.type === 'text' && 'text' in block && typeof block.text === 'string') {
+      normalized.push(...splitThinkTagsInTextBlock(block as SDKTextBlock))
+    } else {
+      normalized.push(block)
+    }
+  }
+  return normalized
+}

--- a/packages/session-core/src/tokens.ts
+++ b/packages/session-core/src/tokens.ts
@@ -1,0 +1,16 @@
+/**
+ * 近似 token 估算。无第三方 tokenizer 依赖，用便宜启发式：
+ * 约 4 字符/token（英文）；CJK 字符按约 1.5 字符/token 加权。
+ * 仅用于 info / outline 的"够不够塞进上下文"量级判断，非精确计费。
+ */
+export function estimateTokens(text: string): number {
+  if (!text) return 0
+  let cjk = 0
+  for (const ch of text) {
+    const code = ch.codePointAt(0) ?? 0
+    // CJK 统一表意文字 + 常见中日韩区段
+    if (code >= 0x3000 && code <= 0x9fff) cjk++
+  }
+  const ascii = text.length - cjk
+  return Math.ceil(ascii / 4 + cjk / 1.5)
+}

--- a/packages/session-core/src/transcript.ts
+++ b/packages/session-core/src/transcript.ts
@@ -1,0 +1,139 @@
+/**
+ * 转录层 — 把 MessageGroup[] 规整为带稳定下标的扁平 TranscriptTurn[]，
+ * 供 CLI 的 outline / search / select / export 复用。
+ *
+ * 关键：groupIntoTurns 会把同一回合的多行流式快照都保留在 assistantMessages 中
+ * （每行共享同一 message.id，是逐步增长的完整快照）。本层按 message.id 取最后一条
+ * （最完整）快照来消除「拼接单字 / 重复段落」，这是会话「快照去重」的落地实现。
+ */
+import type { SDKAssistantMessage, SDKContentBlock, SDKToolUseBlock } from '@proma/shared'
+import { type MessageGroup, extractUserText, getGroupPreview, stripScheduledRunMarker } from './group'
+import { estimateTokens } from './tokens'
+
+export type TurnRole = 'user' | 'assistant' | 'system'
+
+export interface TranscriptTurn {
+  /** 稳定下标：在 groupIntoTurns 输出中的 0 基位置。outline/search/export 共享。 */
+  index: number
+  role: TurnRole
+  model?: string
+  createdAt?: number
+  /** 可见正文（thinking 与 tool_result 已丢弃；assistant 多快照已去重）。 */
+  text: string
+  /** assistant 回合的工具调用摘要，已折叠连续重复为 "name args ×N"。 */
+  toolSummaries: string[]
+  /** 单行预览（<=200 字）。 */
+  preview: string
+  /** 近似 token 数（正文 + 工具摘要）。 */
+  tokens: number
+}
+
+/** 把工具 input 压缩成可读单行摘要：name key=value …（空值跳过，超 80 字符截断）。 */
+export function summarizeToolInput(name: string, input: unknown): string {
+  if (!input || typeof input !== 'object') return name
+  const parts: string[] = []
+  for (const [k, v] of Object.entries(input as Record<string, unknown>)) {
+    if (v === null || v === undefined || v === '' ) continue
+    if (Array.isArray(v) && v.length === 0) continue
+    if (typeof v === 'object' && !Array.isArray(v) && Object.keys(v as object).length === 0) continue
+    let sv = typeof v === 'string' ? v : JSON.stringify(v)
+    sv = sv.replace(/\s+/g, ' ')
+    if (sv.length > 80) sv = sv.slice(0, 77) + '...'
+    parts.push(`${k}=${sv}`)
+  }
+  return parts.length ? `${name} ${parts.join(' ')}` : name
+}
+
+/** 折叠连续相同的工具摘要为一条，末尾加 ×N。 */
+export function collapseToolSummaries(summaries: string[]): string[] {
+  const out: string[] = []
+  let i = 0
+  while (i < summaries.length) {
+    let j = i + 1
+    while (j < summaries.length && summaries[j] === summaries[i]) j++
+    const count = j - i
+    out.push(count === 1 ? summaries[i]! : `${summaries[i]} ×${count}`)
+    i = j
+  }
+  return out
+}
+
+/** 按 message.id 取每个逻辑消息的最后一条（最完整）快照，保留首次出现顺序。 */
+function dedupSnapshotsByMessageId(messages: SDKAssistantMessage[]): SDKAssistantMessage[] {
+  const lastById = new Map<string, SDKAssistantMessage>()
+  const order: string[] = []
+  let anon = 0
+  for (const m of messages) {
+    // message.id 在真实 JSONL 中存在（同一回合的多行快照共享它），但 SDK 类型未建模 → 安全读取。
+    const id = (m.message as unknown as { id?: string } | undefined)?.id ?? `__anon_${anon++}`
+    if (!lastById.has(id)) order.push(id)
+    lastById.set(id, m)
+  }
+  return order.map((id) => lastById.get(id)!)
+}
+
+/** 从去重后的 assistant 消息中抽取正文与工具摘要（thinking / tool_result 丢弃）。 */
+function buildAssistantContent(messages: SDKAssistantMessage[]): { text: string; toolSummaries: string[] } {
+  const texts: string[] = []
+  const rawToolSummaries: string[] = []
+  for (const m of dedupSnapshotsByMessageId(messages)) {
+    const blocks = m.message?.content
+    if (!Array.isArray(blocks)) continue
+    for (const block of blocks as SDKContentBlock[]) {
+      if (block.type === 'text' && 'text' in block) {
+        const t = (block as { text: string }).text.trim()
+        if (t) texts.push(t)
+      } else if (block.type === 'tool_use') {
+        const tu = block as SDKToolUseBlock
+        rawToolSummaries.push(summarizeToolInput(tu.name ?? 'tool', tu.input))
+      }
+      // thinking / 其他块：丢弃
+    }
+  }
+  return { text: texts.join('\n\n'), toolSummaries: collapseToolSummaries(rawToolSummaries) }
+}
+
+/**
+ * MessageGroup[] → TranscriptTurn[]（稳定下标）。
+ */
+export function toTranscript(groups: MessageGroup[]): TranscriptTurn[] {
+  return groups.map((group, index) => {
+    if (group.type === 'user') {
+      const text = stripScheduledRunMarker(extractUserText(group.message) ?? '')
+        .replace(/<attached_files>[\s\S]*?<\/attached_files>\n*/g, '')
+        .replace(/<quoted_file[^>]*>[\s\S]*?<\/quoted_file>\n*/g, '')
+        .trim()
+      return {
+        index,
+        role: 'user' as const,
+        createdAt: (group.message as unknown as { _createdAt?: number })._createdAt,
+        text,
+        toolSummaries: [],
+        preview: getGroupPreview(group),
+        tokens: estimateTokens(text),
+      }
+    }
+    if (group.type === 'system') {
+      const preview = getGroupPreview(group)
+      return {
+        index,
+        role: 'system' as const,
+        text: preview,
+        toolSummaries: [],
+        preview,
+        tokens: estimateTokens(preview),
+      }
+    }
+    const { text, toolSummaries } = buildAssistantContent(group.assistantMessages)
+    return {
+      index,
+      role: 'assistant' as const,
+      model: group.model,
+      createdAt: group.createdAt,
+      text,
+      toolSummaries,
+      preview: getGroupPreview(group),
+      tokens: estimateTokens(text + ' ' + toolSummaries.join(' ')),
+    }
+  })
+}

--- a/packages/session-core/tsconfig.json
+++ b/packages/session-core/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {},
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## 背景

取代并重构 #940（session-cleaner skill）。#940 的目标——把会话 JSONL 清洗为干净 Markdown——是真需求（实测一个会话 246 个 assistant message.id 中 132 个被流式拆成多行快照），但其实现是在仓库外侧用 Python 重抄了一份会随内部格式漂移的解析器。本 PR 改为把这套逻辑沉淀为仓库内的唯一真源。

这是三步计划的第 1 步：

- **PR1（本 PR）**：抽取 `@proma/session-core`，Electron 复用。
- PR2：基于 core 新建独立、可扩展的 `proma` CLI（渐进式读取命令面 list/info/outline/search/export）。
- PR3：`session-cleaner` skill 改薄为调用 CLI，删掉自带 Python parser，CLI 打进桌面构建。

## 本 PR 做了什么

新增 `@proma/session-core`（纯函数 headless 核心，无 Electron 依赖），作为会话读取 / 快照去重 / 转录 / 渲染的唯一真源：

- `readSessionMessages` / `convertLegacyMessage` — 读 JSONL 并把旧扁平格式归一为 SDKMessage（消除「格式 A/B」分叉）
- `groupIntoTurns` 一族 — 从渲染层 `SDKMessageRenderer` 抽出的 turn 分组（快照合并）
- `toTranscript` — 按 `message.id` 取最完整快照消除流式拼接重复；工具调用压一行并折叠 ×N；thinking / tool_result 丢弃
- 渐进式读取原语 `outline` / `searchTurns` / `selectTurns` / `renderTranscriptMarkdown` / `estimateTokens`（供 PR2 的 CLI 避免全量读撑爆上下文）

Electron 侧改为复用 core，**零行为变化**：

- `SDKMessageRenderer.tsx` 与 `thinking-tag-parser.ts` 改为从 core import 并 re-export（既有导入方零改动）
- 主进程 `agent-session-manager.ts` 的 `convertLegacyMessage` 删除，复用 core（不再主进程/渲染层各存一份）

## 验证

- `bun test packages/session-core` → **12/12 通过**（快照去重 / thinking 丢弃 / 工具折叠 / legacy 归一 / search / select / 损坏行容错）
- `tsc --noEmit` → session-core 与 apps/electron **均 0 error**
- 真实数据冒烟：一个 **51MB** 会话 JSONL → 14 个干净 turn，清洗后 Markdown ~33KB（约 1500× 压缩）

## 风险

纯增量 + 行为保持的重构。渲染层删除的符号全部通过 re-export shim 保持对外签名不变；唯一语义变更是主进程与渲染层现在共用同一份 `convertLegacyMessage`（逻辑逐字一致）。