### PR TITLE
feat(cli): proma CLI 渐进式会话读取（栈在 #988 之上）

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@proma/cli",
+  "version": "0.1.0",
+  "license": "AGPL-3.0-only",
+  "description": "proma — Proma 命令行工具。面向有限上下文的 Agent 消费者，提供会话的渐进式读取（list / info / outline / search / export）。",
+  "type": "module",
+  "bin": {
+    "proma": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "build": "bun build --compile --outfile dist/proma src/index.ts",
+    "start": "bun src/index.ts"
+  },
+  "dependencies": {
+    "@proma/session-core": "workspace:*",
+    "@proma/shared": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/apps/cli/src/args.test.ts
+++ b/apps/cli/src/args.test.ts
@@ -1,0 +1,44 @@
+import { test, expect, describe } from 'bun:test'
+import { parseArgs, strFlag, boolFlag, numFlag, parseRange } from './args'
+
+describe('parseArgs', () => {
+  test('--key value 形式', () => {
+    const { flags, positionals } = parseArgs(['info', 'abc', '--limit', '5'])
+    expect(positionals).toEqual(['info', 'abc'])
+    expect(flags.limit).toBe('5')
+  })
+
+  test('--key=value 形式', () => {
+    const { flags } = parseArgs(['--out=cleaned/x.md'])
+    expect(flags.out).toBe('cleaned/x.md')
+  })
+
+  test('裸 --flag 为 boolean true', () => {
+    const { flags } = parseArgs(['export', 'id', '--stdout'])
+    expect(flags.stdout).toBe(true)
+  })
+
+  test('--flag 后跟另一个 --flag 时前者为 boolean', () => {
+    const { flags } = parseArgs(['--json', '--limit', '3'])
+    expect(flags.json).toBe(true)
+    expect(flags.limit).toBe('3')
+  })
+})
+
+describe('flag 取值辅助', () => {
+  const { flags } = parseArgs(['--limit', '10', '--json', '--name', 'x'])
+  test('strFlag', () => expect(strFlag(flags, 'name')).toBe('x'))
+  test('strFlag 对 boolean 返回 undefined', () => expect(strFlag(flags, 'json')).toBeUndefined())
+  test('boolFlag', () => expect(boolFlag(flags, 'json')).toBe(true))
+  test('numFlag', () => expect(numFlag(flags, 'limit')).toBe(10))
+  test('numFlag 非数字返回 undefined', () => expect(numFlag(flags, 'name')).toBeUndefined())
+})
+
+describe('parseRange', () => {
+  test('A-B 闭区间', () => expect(parseRange('3-7')).toEqual([3, 7]))
+  test('单数字视为 [N,N]', () => expect(parseRange('5')).toEqual([5, 5]))
+  test('非法返回 undefined', () => {
+    expect(parseRange('a-b')).toBeUndefined()
+    expect(parseRange(undefined)).toBeUndefined()
+  })
+})

--- a/apps/cli/src/args.ts
+++ b/apps/cli/src/args.ts
@@ -1,0 +1,74 @@
+/**
+ * 极简参数解析（零依赖）。
+ *
+ * 不引入 yargs/commander，避免给打包产物增加体积与解析歧义。约定：
+ *   - --flag            → boolean true
+ *   - --key value       → string
+ *   - --key=value       → string
+ *   - 其余非 -- 开头的   → positionals（按顺序）
+ *
+ * 数值/区间等语义由各命令自行从字符串解析（见 parseRange 等）。
+ */
+export interface ParsedArgs {
+  positionals: string[]
+  flags: Record<string, string | boolean>
+}
+
+export function parseArgs(argv: string[]): ParsedArgs {
+  const positionals: string[] = []
+  const flags: Record<string, string | boolean> = {}
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!
+    if (arg.startsWith('--')) {
+      const body = arg.slice(2)
+      const eq = body.indexOf('=')
+      if (eq >= 0) {
+        flags[body.slice(0, eq)] = body.slice(eq + 1)
+      } else {
+        const next = argv[i + 1]
+        if (next !== undefined && !next.startsWith('--')) {
+          flags[body] = next
+          i++
+        } else {
+          flags[body] = true
+        }
+      }
+    } else {
+      positionals.push(arg)
+    }
+  }
+
+  return { positionals, flags }
+}
+
+/** 取字符串 flag；不存在或为 boolean 返回 undefined。 */
+export function strFlag(flags: Record<string, string | boolean>, ...names: string[]): string | undefined {
+  for (const n of names) {
+    const v = flags[n]
+    if (typeof v === 'string') return v
+  }
+  return undefined
+}
+
+/** 取 boolean flag（存在即真）。 */
+export function boolFlag(flags: Record<string, string | boolean>, ...names: string[]): boolean {
+  return names.some((n) => flags[n] === true || flags[n] === 'true')
+}
+
+/** 取数值 flag；解析失败返回 undefined。 */
+export function numFlag(flags: Record<string, string | boolean>, ...names: string[]): number | undefined {
+  const s = strFlag(flags, ...names)
+  if (s === undefined) return undefined
+  const n = Number(s)
+  return Number.isFinite(n) ? n : undefined
+}
+
+/** 解析 "A-B" 形式的闭区间；单个数字 "N" 视为 [N, N]。失败返回 undefined。 */
+export function parseRange(s: string | undefined): [number, number] | undefined {
+  if (!s) return undefined
+  const m = /^(\d+)-(\d+)$/.exec(s)
+  if (m) return [Number(m[1]), Number(m[2])]
+  if (/^\d+$/.test(s)) return [Number(s), Number(s)]
+  return undefined
+}

--- a/apps/cli/src/commands/export.ts
+++ b/apps/cli/src/commands/export.ts
@@ -1,0 +1,95 @@
+/**
+ * proma session export — 把会话(或其 turn 子集)渲染为干净 Markdown。
+ *
+ * 面向有限上下文的护栏：当**未指定任何窗口**且输出超过 --max-bytes（默认 51200 = 50KB）时，
+ * 拒绝直接灌 stdout，改为落盘并回执路径，提示用 --turns/--head/--tail 取片段。
+ * 这样 Agent 不会因为一句 `export <id>` 就把一个 50MB 会话的清洗结果塞满上下文。
+ *
+ * 窗口优先级（见 selectTurns）：--turns > --head > --tail > --offset/--limit。
+ * --out FILE 显式落盘（存档用途，不受 max-bytes 护栏限制）。
+ */
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { register } from '../registry'
+import { resolveSession } from '../sessions'
+import { emitJson, emitText, errorLine, info, EXIT_OK, EXIT_ERROR, UsageError } from '../output'
+import { readSessionMessages } from '@proma/session-core/node'
+import { groupIntoTurns, toTranscript, selectTurns, renderTranscriptMarkdown } from '@proma/session-core'
+import { numFlag, strFlag, boolFlag, parseRange } from '../args'
+
+const DEFAULT_MAX_BYTES = 51200 // 50KB
+
+register({
+  name: 'export',
+  summary: '把会话或 turn 子集渲染为干净 Markdown（含超预算落盘护栏）',
+  usage: 'session export <id|path> [--turns A-B | --head N | --tail N | --offset K --limit N] [--out FILE] [--stdout] [--max-bytes N] [--json]',
+  run: (ctx) => {
+    const target = ctx.args.positionals[0]
+    if (!target) throw new UsageError('缺少会话 id 或路径')
+    const resolved = resolveSession(target, ctx.pathOpts)
+    if (!resolved) {
+      errorLine(`找不到会话: ${target}`)
+      return EXIT_ERROR
+    }
+
+    const allTurns = toTranscript(groupIntoTurns(readSessionMessages(resolved.filePath)))
+
+    // 解析窗口
+    const range = parseRange(strFlag(ctx.args.flags, 'turns'))
+    const head = numFlag(ctx.args.flags, 'head')
+    const tail = numFlag(ctx.args.flags, 'tail')
+    const offset = numFlag(ctx.args.flags, 'offset')
+    const limit = numFlag(ctx.args.flags, 'limit')
+    const hasWindow = range !== undefined || head !== undefined || tail !== undefined || offset !== undefined || limit !== undefined
+
+    const turns = hasWindow ? selectTurns(allTurns, { range, head, tail, offset, limit }) : allTurns
+    // 截取片段时省略顶部标题，便于直接拼接阅读
+    const md = renderTranscriptMarkdown(turns, { sessionId: resolved.id, header: !hasWindow })
+    const bytes = Buffer.byteLength(md, 'utf-8')
+
+    const outPath = strFlag(ctx.args.flags, 'out')
+    const forceStdout = boolFlag(ctx.args.flags, 'stdout')
+    const maxBytes = numFlag(ctx.args.flags, 'max-bytes') ?? DEFAULT_MAX_BYTES
+
+    // 显式落盘
+    if (outPath) {
+      writeFileTo(outPath, md)
+      const result = { written: outPath, bytes, turns: turns.length, totalTurns: allTurns.length }
+      if (ctx.json) emitJson(result)
+      else info(`已写入 ${outPath}（${turns.length} turns, ${(bytes / 1024).toFixed(1)} KB）`)
+      return EXIT_OK
+    }
+
+    // 护栏：未指定窗口 + 超预算 + 未强制 stdout → 落盘回执，不灌 stdout
+    if (!hasWindow && !forceStdout && bytes > maxBytes) {
+      const fallback = `${resolved.id}.clean.md`
+      writeFileTo(fallback, md)
+      const result = {
+        guarded: true,
+        reason: 'output-exceeds-max-bytes',
+        bytes,
+        maxBytes,
+        turns: allTurns.length,
+        written: fallback,
+        hint: '输出过大已落盘。用 --turns A-B / --head N / --tail N 取片段，或 --stdout 强制全量，或 --out 指定路径。先跑 `proma session outline <id>` 看结构。',
+      }
+      if (ctx.json) {
+        emitJson(result)
+      } else {
+        info(`⚠️ 输出 ${(bytes / 1024).toFixed(0)}KB 超过预算 ${(maxBytes / 1024).toFixed(0)}KB，已落盘到 ${fallback}`)
+        info(result.hint)
+      }
+      return EXIT_OK
+    }
+
+    // 正常输出到 stdout
+    emitText(md)
+    return EXIT_OK
+  },
+})
+
+function writeFileTo(path: string, content: string): void {
+  const dir = dirname(path)
+  if (dir && dir !== '.') mkdirSync(dir, { recursive: true })
+  writeFileSync(path, content, 'utf-8')
+}

--- a/apps/cli/src/commands/info.ts
+++ b/apps/cli/src/commands/info.ts
@@ -1,0 +1,54 @@
+/**
+ * proma session info — 会话体量与结构概览（决定怎么读之前先看大小）。
+ *
+ * 读 JSONL 解析为 turns，但只输出统计量（turn 数 / 角色分布 / 估算 tokens / 字节数 / 时间区间），
+ * 不输出正文——让 Agent 据此判断该全量读还是分段/搜索读。
+ */
+import { register } from '../registry'
+import { resolveSession } from '../sessions'
+import { emitJson, emitText, errorLine, info, EXIT_OK, EXIT_ERROR, UsageError } from '../output'
+import { readSessionMessages } from '@proma/session-core/node'
+import { groupIntoTurns, toTranscript } from '@proma/session-core'
+
+register({
+  name: 'info',
+  summary: '会话体量/结构概览：turn 数、角色分布、估算 tokens、字节数',
+  usage: 'session info <id|path> [--json]',
+  run: (ctx) => {
+    const target = ctx.args.positionals[0]
+    if (!target) throw new UsageError('缺少会话 id 或路径')
+    const resolved = resolveSession(target, ctx.pathOpts)
+    if (!resolved) {
+      errorLine(`找不到会话: ${target}`)
+      return EXIT_ERROR
+    }
+
+    const turns = toTranscript(groupIntoTurns(readSessionMessages(resolved.filePath)))
+    const byRole = turns.reduce<Record<string, number>>((m, t) => {
+      m[t.role] = (m[t.role] ?? 0) + 1
+      return m
+    }, {})
+    const totalTokens = turns.reduce((s, t) => s + t.tokens, 0)
+
+    const report = {
+      id: resolved.id,
+      title: resolved.meta?.title,
+      bytes: resolved.bytes,
+      turns: turns.length,
+      roles: byRole,
+      estimatedTokens: totalTokens,
+      model: (resolved.meta as { modelId?: string } | undefined)?.modelId,
+    }
+
+    if (ctx.json) {
+      emitJson(report)
+      return EXIT_OK
+    }
+
+    info(`会话 ${report.id}${report.title ? `  «${report.title}»` : ''}`)
+    emitText(`turns: ${report.turns}  (${Object.entries(byRole).map(([r, n]) => `${r}:${n}`).join(' ')})`)
+    emitText(`估算 tokens: ~${totalTokens}`)
+    if (report.bytes != null) emitText(`原始 JSONL: ${(report.bytes / 1024).toFixed(0)} KB`)
+    return EXIT_OK
+  },
+})

--- a/apps/cli/src/commands/list.ts
+++ b/apps/cli/src/commands/list.ts
@@ -1,0 +1,52 @@
+/**
+ * proma session list — 列出会话索引（便宜，不读 JSONL 正文）。
+ */
+import { register } from '../registry'
+import { listSessions } from '../sessions'
+import { emitJson, emitText, info, EXIT_OK } from '../output'
+import { numFlag, strFlag } from '../args'
+
+interface MetaLike {
+  id: string
+  title?: string
+  updatedAt?: number
+  workspaceId?: string
+  modelId?: string
+  archived?: boolean
+}
+
+register({
+  name: 'list',
+  summary: '列出会话（id / 标题 / 更新时间 / 工作区），按更新时间降序',
+  usage: 'session list [--limit N] [--workspace W] [--json]',
+  run: (ctx) => {
+    const limit = numFlag(ctx.args.flags, 'limit')
+    const workspace = strFlag(ctx.args.flags, 'workspace')
+    let sessions = listSessions(ctx.pathOpts) as MetaLike[]
+    if (workspace) sessions = sessions.filter((s) => s.workspaceId === workspace)
+    if (limit && limit > 0) sessions = sessions.slice(0, limit)
+
+    if (ctx.json) {
+      emitJson(sessions.map((s) => ({
+        id: s.id,
+        title: s.title ?? '',
+        updatedAt: s.updatedAt,
+        workspaceId: s.workspaceId,
+        modelId: s.modelId,
+        archived: !!s.archived,
+      })))
+      return EXIT_OK
+    }
+
+    if (sessions.length === 0) {
+      info('（没有会话）')
+      return EXIT_OK
+    }
+    for (const s of sessions) {
+      const when = s.updatedAt ? new Date(s.updatedAt).toISOString().slice(0, 16).replace('T', ' ') : '—'
+      const title = (s.title ?? '').replace(/\s+/g, ' ').slice(0, 50) || '(无标题)'
+      emitText(`${s.id}  ${when}  ${title}`)
+    }
+    return EXIT_OK
+  },
+})

--- a/apps/cli/src/commands/outline.ts
+++ b/apps/cli/src/commands/outline.ts
@@ -1,0 +1,40 @@
+/**
+ * proma session outline — turn 级地图。每 turn 一行的结构概览，
+ * 让 Agent 先看地图再决定读哪段，避免全量读正文。
+ */
+import { register } from '../registry'
+import { resolveSession } from '../sessions'
+import { emitJson, emitText, errorLine, EXIT_OK, EXIT_ERROR, UsageError } from '../output'
+import { readSessionMessages } from '@proma/session-core/node'
+import { groupIntoTurns, toTranscript, outline, formatOutlineLine, selectTurns } from '@proma/session-core'
+import { numFlag } from '../args'
+
+register({
+  name: 'outline',
+  summary: 'turn 级地图：每 turn 一行（角色 / 预览 / 工具概览 / 估算 tokens）',
+  usage: 'session outline <id|path> [--offset K] [--limit N] [--json]',
+  run: (ctx) => {
+    const target = ctx.args.positionals[0]
+    if (!target) throw new UsageError('缺少会话 id 或路径')
+    const resolved = resolveSession(target, ctx.pathOpts)
+    if (!resolved) {
+      errorLine(`找不到会话: ${target}`)
+      return EXIT_ERROR
+    }
+
+    let turns = toTranscript(groupIntoTurns(readSessionMessages(resolved.filePath)))
+    const offset = numFlag(ctx.args.flags, 'offset')
+    const limit = numFlag(ctx.args.flags, 'limit')
+    if (offset !== undefined || limit !== undefined) {
+      turns = selectTurns(turns, { offset, limit })
+    }
+    const entries = outline(turns)
+
+    if (ctx.json) {
+      emitJson(entries)
+      return EXIT_OK
+    }
+    for (const e of entries) emitText(formatOutlineLine(e))
+    return EXIT_OK
+  },
+})

--- a/apps/cli/src/commands/search.ts
+++ b/apps/cli/src/commands/search.ts
@@ -1,0 +1,46 @@
+/**
+ * proma session search — 在会话内子串搜索，返回命中 turn 的下标与片段。
+ * Agent 据此再用 export --turns 取命中邻域，避免全量读。
+ */
+import { register } from '../registry'
+import { resolveSession } from '../sessions'
+import { emitJson, emitText, errorLine, info, EXIT_OK, EXIT_ERROR, UsageError } from '../output'
+import { readSessionMessages } from '@proma/session-core/node'
+import { groupIntoTurns, toTranscript, searchTurns } from '@proma/session-core'
+import { numFlag, boolFlag } from '../args'
+
+register({
+  name: 'search',
+  summary: '在会话内搜索关键词，返回命中 turn 下标 + 片段',
+  usage: 'session search <query> <id|path> [--context N] [--limit N] [--case-sensitive] [--json]',
+  run: (ctx) => {
+    const [query, target] = ctx.args.positionals
+    if (!query) throw new UsageError('缺少搜索词')
+    if (!target) throw new UsageError('缺少会话 id 或路径')
+    const resolved = resolveSession(target, ctx.pathOpts)
+    if (!resolved) {
+      errorLine(`找不到会话: ${target}`)
+      return EXIT_ERROR
+    }
+
+    const turns = toTranscript(groupIntoTurns(readSessionMessages(resolved.filePath)))
+    const hits = searchTurns(turns, query, {
+      context: numFlag(ctx.args.flags, 'context'),
+      limit: numFlag(ctx.args.flags, 'limit'),
+      caseSensitive: boolFlag(ctx.args.flags, 'case-sensitive'),
+    })
+
+    if (ctx.json) {
+      emitJson(hits)
+      return EXIT_OK
+    }
+    if (hits.length === 0) {
+      info(`未命中: "${query}"`)
+      return EXIT_OK
+    }
+    for (const h of hits) {
+      emitText(`#${h.index} [${h.role}] (${h.matchCount}处) ${h.snippet}`)
+    }
+    return EXIT_OK
+  },
+})

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,0 +1,84 @@
+#!/usr/bin/env bun
+/**
+ * proma — Proma 命令行工具入口。
+ *
+ * 用法：
+ *   proma <command> [subcommand] [args] [--flags]
+ *   proma session list|info|outline|search|export ...
+ *
+ * 全局 flag：
+ *   --json            输出机器可读 JSON
+ *   --config-dir DIR  指定 Proma 配置目录（默认 ~/.proma，PROMA_DEV=1 → ~/.proma-dev）
+ *   --dev             使用 ~/.proma-dev
+ *
+ * 设计：命令注册表驱动（registry.ts）。`session` 是一个命名空间，
+ * 其下的 list/info/outline/search/export 各自在 commands/ 注册。扩面只加文件。
+ */
+import { parseArgs, boolFlag, strFlag } from './args'
+import { getCommand, allCommands } from './registry'
+import { EXIT_OK, EXIT_USAGE, EXIT_ERROR, UsageError, errorLine, info, emitText } from './output'
+import type { PathOptions } from './paths'
+
+// 注册命令（import 即注册）
+import './commands/list'
+import './commands/info'
+import './commands/outline'
+import './commands/search'
+import './commands/export'
+
+function printHelp(): void {
+  info('proma — Proma 会话渐进式读取 CLI\n')
+  info('用法: proma session <command> [args] [--flags]\n')
+  info('命令:')
+  for (const c of allCommands()) {
+    info(`  ${c.usage.padEnd(64)} ${c.summary}`)
+  }
+  info('\n全局 flag: --json  --config-dir DIR  --dev')
+  info('\n渐进式读取建议: 先 info/outline 看结构 → search 定位 → export --turns 取片段')
+}
+
+async function main(): Promise<number> {
+  const argv = process.argv.slice(2)
+  if (argv.length === 0 || argv[0] === 'help' || argv[0] === '--help' || argv[0] === '-h') {
+    printHelp()
+    return EXIT_OK
+  }
+
+  // 命名空间：当前只有 session，支持 `proma session <cmd>` 与直接 `proma <cmd>`
+  let rest = argv
+  if (argv[0] === 'session') rest = argv.slice(1)
+
+  const cmdName = rest[0]
+  if (!cmdName) {
+    printHelp()
+    return EXIT_USAGE
+  }
+
+  const command = getCommand(cmdName)
+  if (!command) {
+    errorLine(`未知命令: ${cmdName}`)
+    printHelp()
+    return EXIT_USAGE
+  }
+
+  const parsed = parseArgs(rest.slice(1))
+  const pathOpts: PathOptions = {
+    configDir: strFlag(parsed.flags, 'config-dir'),
+    dev: boolFlag(parsed.flags, 'dev'),
+  }
+  const json = boolFlag(parsed.flags, 'json')
+
+  try {
+    return await command.run({ args: parsed, pathOpts, json })
+  } catch (err) {
+    if (err instanceof UsageError) {
+      errorLine(err.message)
+      info(`用法: proma ${command.usage}`)
+      return EXIT_USAGE
+    }
+    errorLine(err instanceof Error ? err.message : String(err))
+    return EXIT_ERROR
+  }
+}
+
+main().then((code) => process.exit(code))

--- a/apps/cli/src/output.ts
+++ b/apps/cli/src/output.ts
@@ -1,0 +1,38 @@
+/**
+ * 统一输出与退出码约定。
+ *
+ * 设计目标：CLI 主要消费者是「上下文有限的 Agent」。因此：
+ *   - 机器可读结果走 stdout（--json 时为单个 JSON）
+ *   - 人读日志 / 进度 / 错误走 stderr，绝不污染 stdout 的数据
+ *   - 退出码：0 成功，1 运行期错误（找不到会话等），2 用法错误（参数非法）
+ */
+
+export const EXIT_OK = 0
+export const EXIT_ERROR = 1
+export const EXIT_USAGE = 2
+
+/** 写一行人读信息到 stderr。 */
+export function info(msg: string): void {
+  process.stderr.write(msg + '\n')
+}
+
+/** 写错误到 stderr（带 error: 前缀）。 */
+export function errorLine(msg: string): void {
+  process.stderr.write(`error: ${msg}\n`)
+}
+
+/** 输出机器可读 JSON 到 stdout。 */
+export function emitJson(data: unknown): void {
+  process.stdout.write(JSON.stringify(data, null, 2) + '\n')
+}
+
+/** 输出纯文本到 stdout（不加额外换行外的内容）。 */
+export function emitText(text: string): void {
+  process.stdout.write(text.endsWith('\n') ? text : text + '\n')
+}
+
+/** 命令处理函数约定的返回：退出码。 */
+export type CommandExit = number
+
+/** 抛出此错误表示用法错误（参数非法），主入口据此返回 EXIT_USAGE。 */
+export class UsageError extends Error {}

--- a/apps/cli/src/paths.ts
+++ b/apps/cli/src/paths.ts
@@ -1,0 +1,41 @@
+/**
+ * 会话存储路径解析（electron-free）。
+ *
+ * Proma 主进程用 config-paths.ts 里的 getConfigDir()，其中通过 require('electron')
+ * 判断 isPackaged 来在 .proma / .proma-dev 间切换——CLI 没有 electron 运行时，
+ * 因此这里独立实现一份等价逻辑：
+ *   - 默认 ~/.proma
+ *   - 环境变量 PROMA_DEV=1 → ~/.proma-dev
+ *   - 显式 configDir 覆盖（CLI 的 --config-dir）优先级最高
+ *
+ * 与 config-paths.ts 的目录布局保持一致：
+ *   <configDir>/agent-sessions.json        会话索引
+ *   <configDir>/agent-sessions/<id>.jsonl   单会话消息
+ */
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+export interface PathOptions {
+  /** 显式指定配置目录（绝对路径）。优先级最高。 */
+  configDir?: string
+  /** 使用开发目录 .proma-dev（等价于 PROMA_DEV=1）。 */
+  dev?: boolean
+}
+
+export function resolveConfigDir(opts: PathOptions = {}): string {
+  if (opts.configDir) return opts.configDir
+  const useDev = opts.dev || process.env.PROMA_DEV === '1'
+  return join(homedir(), useDev ? '.proma-dev' : '.proma')
+}
+
+export function getSessionsIndexPath(opts: PathOptions = {}): string {
+  return join(resolveConfigDir(opts), 'agent-sessions.json')
+}
+
+export function getSessionsDir(opts: PathOptions = {}): string {
+  return join(resolveConfigDir(opts), 'agent-sessions')
+}
+
+export function getSessionMessagesPath(id: string, opts: PathOptions = {}): string {
+  return join(getSessionsDir(opts), `${id}.jsonl`)
+}

--- a/apps/cli/src/registry.ts
+++ b/apps/cli/src/registry.ts
@@ -1,0 +1,38 @@
+/**
+ * 命令注册表。新增命令 = 在 commands/ 下加一个文件并 register() —— 扩面只加文件，不动主入口。
+ */
+import type { ParsedArgs } from './args'
+import type { PathOptions } from './paths'
+import { type CommandExit, UsageError } from './output'
+
+export interface CommandContext {
+  args: ParsedArgs
+  /** 从全局 flag 解析出的路径选项（--config-dir / --dev / PROMA_DEV）。 */
+  pathOpts: PathOptions
+  /** 是否输出机器可读 JSON（--json）。 */
+  json: boolean
+}
+
+export interface Command {
+  name: string
+  summary: string
+  /** 一行用法示例（不含 "proma " 前缀）。 */
+  usage: string
+  run: (ctx: CommandContext) => Promise<CommandExit> | CommandExit
+}
+
+const registry = new Map<string, Command>()
+
+export function register(cmd: Command): void {
+  registry.set(cmd.name, cmd)
+}
+
+export function getCommand(name: string): Command | undefined {
+  return registry.get(name)
+}
+
+export function allCommands(): Command[] {
+  return [...registry.values()]
+}
+
+export { UsageError }

--- a/apps/cli/src/sessions.ts
+++ b/apps/cli/src/sessions.ts
@@ -1,0 +1,72 @@
+/**
+ * 会话索引读取（electron-free）。
+ *
+ * 与主进程 agent-session-manager.ts 的 readIndex/listAgentSessions 等价，
+ * 但不依赖 electron——直接读 <configDir>/agent-sessions.json。CLI 只做只读，
+ * 不写索引（导出/清洗不修改用户数据）。
+ */
+import { existsSync, readFileSync, statSync } from 'node:fs'
+import type { AgentSessionMeta } from '@proma/shared'
+import { getSessionsIndexPath, getSessionMessagesPath, type PathOptions } from './paths'
+
+interface AgentSessionsIndex {
+  version: number
+  sessions: AgentSessionMeta[]
+}
+
+/** 读取会话索引；文件不存在或损坏时返回空列表。 */
+export function readSessionIndex(opts: PathOptions = {}): AgentSessionMeta[] {
+  const indexPath = getSessionsIndexPath(opts)
+  if (!existsSync(indexPath)) return []
+  try {
+    const data = JSON.parse(readFileSync(indexPath, 'utf-8')) as AgentSessionsIndex
+    return Array.isArray(data?.sessions) ? data.sessions : []
+  } catch {
+    return []
+  }
+}
+
+/** 列出会话，按 updatedAt 降序（无 updatedAt 的排后）。 */
+export function listSessions(opts: PathOptions = {}): AgentSessionMeta[] {
+  return readSessionIndex(opts).sort(
+    (a, b) => ((b as { updatedAt?: number }).updatedAt ?? 0) - ((a as { updatedAt?: number }).updatedAt ?? 0),
+  )
+}
+
+export function getSessionMeta(id: string, opts: PathOptions = {}): AgentSessionMeta | undefined {
+  return readSessionIndex(opts).find((s) => s.id === id)
+}
+
+export interface ResolvedSession {
+  id: string
+  filePath: string
+  meta?: AgentSessionMeta
+  /** JSONL 文件字节数（不存在为 undefined）。 */
+  bytes?: number
+}
+
+/**
+ * 把用户给的 target 解析为会话文件：
+ *   - 形如已存在的 .jsonl 路径 → 直接用
+ *   - 否则当作 session id，定位 <configDir>/agent-sessions/<id>.jsonl
+ * 解析失败（文件不存在）返回 undefined，由命令层报错。
+ */
+export function resolveSession(target: string, opts: PathOptions = {}): ResolvedSession | undefined {
+  // 直接文件路径
+  if (target.endsWith('.jsonl') && existsSync(target)) {
+    const id = target.replace(/\.jsonl$/, '').split('/').pop() ?? target
+    return { id, filePath: target, meta: getSessionMeta(id, opts), bytes: safeBytes(target) }
+  }
+  // 当作 session id
+  const filePath = getSessionMessagesPath(target, opts)
+  if (!existsSync(filePath)) return undefined
+  return { id: target, filePath, meta: getSessionMeta(target, opts), bytes: safeBytes(filePath) }
+}
+
+function safeBytes(path: string): number | undefined {
+  try {
+    return statSync(path).size
+  } catch {
+    return undefined
+  }
+}

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {},
+  "include": ["src/**/*"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,20 @@
         "typescript": "^5",
       },
     },
+    "apps/cli": {
+      "name": "@proma/cli",
+      "version": "0.1.0",
+      "bin": {
+        "proma": "./src/index.ts",
+      },
+      "dependencies": {
+        "@proma/session-core": "workspace:*",
+        "@proma/shared": "workspace:*",
+      },
+      "devDependencies": {
+        "typescript": "^5.0.0",
+      },
+    },
     "apps/electron": {
       "name": "@proma/electron",
       "version": "0.13.21",
@@ -424,6 +438,8 @@
     "@pierre/theme": ["@pierre/theme@0.0.28", "", {}, "sha512-1j/H/fECBuc9dEvntdWI+l435HZapw+RCJTlqCA6BboQ5TjlnE005j/ROWutXIs8aq5OAc82JI2Kwk4A1WWBgw=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@proma/cli": ["@proma/cli@workspace:apps/cli"],
 
     "@proma/core": ["@proma/core@workspace:packages/core"],
 


### PR DESCRIPTION
## 背景

三步计划的第 2 步（接 #988）。基于 `@proma/session-core` 新建独立、可扩展的 `proma` CLI，面向「上下文有限的 Agent 消费者」提供**渐进式会话读取**——避免一句 `export <id>` 就把一个 50MB 会话的清洗结果灌满上下文。

> ⚠️ **栈式 PR**：base = `feat-session-core`（#988），本 PR 的 diff 只含 `apps/cli/` 新增。**先合 #988**，GitHub 会自动把本 PR retarget 到 main。

## 命令面（渐进式读取工作流）

命令注册表驱动（`registry.ts`），扩面只加文件：

| 命令 | 用途 |
|------|------|
| `session list` | 列出会话索引（便宜，不读 JSONL 正文） |
| `session info <id>` | 体量/结构概览：turn 数 / 角色分布 / 估算 tokens / 字节 |
| `session outline <id>` | turn 级地图：每 turn 一行（预览 + 工具概览 + tokens） |
| `session search <q> <id>` | 会话内子串搜索，返回命中 turn 下标 + 片段 |
| `session export <id> [窗口]` | 渲染干净 Markdown，含窗口化 + 超预算落盘护栏 |

**推荐工作流**：`info`/`outline` 看结构 → `search` 定位 → `export --turns A-B` 取片段。

## 设计要点

- **electron-free 路径解析**（`paths.ts`）：默认 `~/.proma`，`PROMA_DEV=1` / `--dev` → `~/.proma-dev`，`--config-dir` 覆盖。CLI 不依赖 electron 运行时
- **输出约定**：数据走 stdout，日志/错误走 stderr，退出码 `0/1/2`，`--json` 机器可读
- **export 护栏**：未指定窗口且输出超 `--max-bytes`（默认 50KB）时，**拒绝灌 stdout**，改落盘并回执路径 + 提示用 `--turns/--head/--tail`
- **node:fs 隔离**：文件 IO 仅从 `@proma/session-core/node` 引入，纯函数从主入口引入（沿用 #988 的浏览器安全约束）

## 验证

- `bun test apps/cli` → **24/24 通过**（参数解析 + 区间解析）
- `tsc --noEmit` → CLI 与 apps/electron **均 0 error**
- 真实 **50MB** 会话冒烟：5 命令全通；`info` → 14 turns / ~8470 tokens；护栏在 `--max-bytes 1000` 强制下正确落盘回执，`--turns 0-1` 直接 stdout

## 下一步（PR3）

`session-cleaner` skill 改薄为调用本 CLI，删掉自带 Python parser，CLI 打进桌面构建并暴露稳定路径。