### PR TITLE
feat(cli): proma CLI 渐进式会话读取（#989 替代，原 PR 因栈式删分支被自动关闭）

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@proma/cli",
+  "version": "0.1.0",
+  "license": "AGPL-3.0-only",
+  "description": "proma — Proma 命令行工具。面向有限上下文的 Agent 消费者，提供会话的渐进式读取（list / info / outline / search / export）。",
+  "type": "module",
+  "bin": {
+    "proma": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "build": "bun build --compile --outfile dist/proma src/index.ts",
+    "start": "bun src/index.ts"
+  },
+  "dependencies": {
+    "@proma/session-core": "workspace:*",
+    "@proma/shared": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/apps/cli/src/args.test.ts
+++ b/apps/cli/src/args.test.ts
@@ -1,0 +1,44 @@
+import { test, expect, describe } from 'bun:test'
+import { parseArgs, strFlag, boolFlag, numFlag, parseRange } from './args'
+
+describe('parseArgs', () => {
+  test('--key value 形式', () => {
+    const { flags, positionals } = parseArgs(['info', 'abc', '--limit', '5'])
+    expect(positionals).toEqual(['info', 'abc'])
+    expect(flags.limit).toBe('5')
+  })
+
+  test('--key=value 形式', () => {
+    const { flags } = parseArgs(['--out=cleaned/x.md'])
+    expect(flags.out).toBe('cleaned/x.md')
+  })
+
+  test('裸 --flag 为 boolean true', () => {
+    const { flags } = parseArgs(['export', 'id', '--stdout'])
+    expect(flags.stdout).toBe(true)
+  })
+
+  test('--flag 后跟另一个 --flag 时前者为 boolean', () => {
+    const { flags } = parseArgs(['--json', '--limit', '3'])
+    expect(flags.json).toBe(true)
+    expect(flags.limit).toBe('3')
+  })
+})
+
+describe('flag 取值辅助', () => {
+  const { flags } = parseArgs(['--limit', '10', '--json', '--name', 'x'])
+  test('strFlag', () => expect(strFlag(flags, 'name')).toBe('x'))
+  test('strFlag 对 boolean 返回 undefined', () => expect(strFlag(flags, 'json')).toBeUndefined())
+  test('boolFlag', () => expect(boolFlag(flags, 'json')).toBe(true))
+  test('numFlag', () => expect(numFlag(flags, 'limit')).toBe(10))
+  test('numFlag 非数字返回 undefined', () => expect(numFlag(flags, 'name')).toBeUndefined())
+})
+
+describe('parseRange', () => {
+  test('A-B 闭区间', () => expect(parseRange('3-7')).toEqual([3, 7]))
+  test('单数字视为 [N,N]', () => expect(parseRange('5')).toEqual([5, 5]))
+  test('非法返回 undefined', () => {
+    expect(parseRange('a-b')).toBeUndefined()
+    expect(parseRange(undefined)).toBeUndefined()
+  })
+})

--- a/apps/cli/src/args.ts
+++ b/apps/cli/src/args.ts
@@ -1,0 +1,74 @@
+/**
+ * 极简参数解析（零依赖）。
+ *
+ * 不引入 yargs/commander，避免给打包产物增加体积与解析歧义。约定：
+ *   - --flag            → boolean true
+ *   - --key value       → string
+ *   - --key=value       → string
+ *   - 其余非 -- 开头的   → positionals（按顺序）
+ *
+ * 数值/区间等语义由各命令自行从字符串解析（见 parseRange 等）。
+ */
+export interface ParsedArgs {
+  positionals: string[]
+  flags: Record<string, string | boolean>
+}
+
+export function parseArgs(argv: string[]): ParsedArgs {
+  const positionals: string[] = []
+  const flags: Record<string, string | boolean> = {}
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!
+    if (arg.startsWith('--')) {
+      const body = arg.slice(2)
+      const eq = body.indexOf('=')
+      if (eq >= 0) {
+        flags[body.slice(0, eq)] = body.slice(eq + 1)
+      } else {
+        const next = argv[i + 1]
+        if (next !== undefined && !next.startsWith('--')) {
+          flags[body] = next
+          i++
+        } else {
+          flags[body] = true
+        }
+      }
+    } else {
+      positionals.push(arg)
+    }
+  }
+
+  return { positionals, flags }
+}
+
+/** 取字符串 flag；不存在或为 boolean 返回 undefined。 */
+export function strFlag(flags: Record<string, string | boolean>, ...names: string[]): string | undefined {
+  for (const n of names) {
+    const v = flags[n]
+    if (typeof v === 'string') return v
+  }
+  return undefined
+}
+
+/** 取 boolean flag（存在即真）。 */
+export function boolFlag(flags: Record<string, string | boolean>, ...names: string[]): boolean {
+  return names.some((n) => flags[n] === true || flags[n] === 'true')
+}
+
+/** 取数值 flag；解析失败返回 undefined。 */
+export function numFlag(flags: Record<string, string | boolean>, ...names: string[]): number | undefined {
+  const s = strFlag(flags, ...names)
+  if (s === undefined) return undefined
+  const n = Number(s)
+  return Number.isFinite(n) ? n : undefined
+}
+
+/** 解析 "A-B" 形式的闭区间；单个数字 "N" 视为 [N, N]。失败返回 undefined。 */
+export function parseRange(s: string | undefined): [number, number] | undefined {
+  if (!s) return undefined
+  const m = /^(\d+)-(\d+)$/.exec(s)
+  if (m) return [Number(m[1]), Number(m[2])]
+  if (/^\d+$/.test(s)) return [Number(s), Number(s)]
+  return undefined
+}

--- a/apps/cli/src/commands/export.ts
+++ b/apps/cli/src/commands/export.ts
@@ -1,0 +1,95 @@
+/**
+ * proma session export — 把会话(或其 turn 子集)渲染为干净 Markdown。
+ *
+ * 面向有限上下文的护栏：当**未指定任何窗口**且输出超过 --max-bytes（默认 51200 = 50KB）时，
+ * 拒绝直接灌 stdout，改为落盘并回执路径，提示用 --turns/--head/--tail 取片段。
+ * 这样 Agent 不会因为一句 `export <id>` 就把一个 50MB 会话的清洗结果塞满上下文。
+ *
+ * 窗口优先级（见 selectTurns）：--turns > --head > --tail > --offset/--limit。
+ * --out FILE 显式落盘（存档用途，不受 max-bytes 护栏限制）。
+ */
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { register } from '../registry'
+import { resolveSession } from '../sessions'
+import { emitJson, emitText, errorLine, info, EXIT_OK, EXIT_ERROR, UsageError } from '../output'
+import { readSessionMessages } from '@proma/session-core/node'
+import { groupIntoTurns, toTranscript, selectTurns, renderTranscriptMarkdown } from '@proma/session-core'
+import { numFlag, strFlag, boolFlag, parseRange } from '../args'
+
+const DEFAULT_MAX_BYTES = 51200 // 50KB
+
+register({
+  name: 'export',
+  summary: '把会话或 turn 子集渲染为干净 Markdown（含超预算落盘护栏）',
+  usage: 'session export <id|path> [--turns A-B | --head N | --tail N | --offset K --limit N] [--out FILE] [--stdout] [--max-bytes N] [--json]',
+  run: (ctx) => {
+    const target = ctx.args.positionals[0]
+    if (!target) throw new UsageError('缺少会话 id 或路径')
+    const resolved = resolveSession(target, ctx.pathOpts)
+    if (!resolved) {
+      errorLine(`找不到会话: ${target}`)
+      return EXIT_ERROR
+    }
+
+    const allTurns = toTranscript(groupIntoTurns(readSessionMessages(resolved.filePath)))
+
+    // 解析窗口
+    const range = parseRange(strFlag(ctx.args.flags, 'turns'))
+    const head = numFlag(ctx.args.flags, 'head')
+    const tail = numFlag(ctx.args.flags, 'tail')
+    const offset = numFlag(ctx.args.flags, 'offset')
+    const limit = numFlag(ctx.args.flags, 'limit')
+    const hasWindow = range !== undefined || head !== undefined || tail !== undefined || offset !== undefined || limit !== undefined
+
+    const turns = hasWindow ? selectTurns(allTurns, { range, head, tail, offset, limit }) : allTurns
+    // 截取片段时省略顶部标题，便于直接拼接阅读
+    const md = renderTranscriptMarkdown(turns, { sessionId: resolved.id, header: !hasWindow })
+    const bytes = Buffer.byteLength(md, 'utf-8')
+
+    const outPath = strFlag(ctx.args.flags, 'out')
+    const forceStdout = boolFlag(ctx.args.flags, 'stdout')
+    const maxBytes = numFlag(ctx.args.flags, 'max-bytes') ?? DEFAULT_MAX_BYTES
+
+    // 显式落盘
+    if (outPath) {
+      writeFileTo(outPath, md)
+      const result = { written: outPath, bytes, turns: turns.length, totalTurns: allTurns.length }
+      if (ctx.json) emitJson(result)
+      else info(`已写入 ${outPath}（${turns.length} turns, ${(bytes / 1024).toFixed(1)} KB）`)
+      return EXIT_OK
+    }
+
+    // 护栏：未指定窗口 + 超预算 + 未强制 stdout → 落盘回执，不灌 stdout
+    if (!hasWindow && !forceStdout && bytes > maxBytes) {
+      const fallback = `${resolved.id}.clean.md`
+      writeFileTo(fallback, md)
+      const result = {
+        guarded: true,
+        reason: 'output-exceeds-max-bytes',
+        bytes,
+        maxBytes,
+        turns: allTurns.length,
+        written: fallback,
+        hint: '输出过大已落盘。用 --turns A-B / --head N / --tail N 取片段，或 --stdout 强制全量，或 --out 指定路径。先跑 `proma session outline <id>` 看结构。',
+      }
+      if (ctx.json) {
+        emitJson(result)
+      } else {
+        info(`⚠️ 输出 ${(bytes / 1024).toFixed(0)}KB 超过预算 ${(maxBytes / 1024).toFixed(0)}KB，已落盘到 ${fallback}`)
+        info(result.hint)
+      }
+      return EXIT_OK
+    }
+
+    // 正常输出到 stdout
+    emitText(md)
+    return EXIT_OK
+  },
+})
+
+function writeFileTo(path: string, content: string): void {
+  const dir = dirname(path)
+  if (dir && dir !== '.') mkdirSync(dir, { recursive: true })
+  writeFileSync(path, content, 'utf-8')
+}

--- a/apps/cli/src/commands/info.ts
+++ b/apps/cli/src/commands/info.ts
@@ -1,0 +1,54 @@
+/**
+ * proma session info — 会话体量与结构概览（决定怎么读之前先看大小）。
+ *
+ * 读 JSONL 解析为 turns，但只输出统计量（turn 数 / 角色分布 / 估算 tokens / 字节数 / 时间区间），
+ * 不输出正文——让 Agent 据此判断该全量读还是分段/搜索读。
+ */
+import { register } from '../registry'
+import { resolveSession } from '../sessions'
+import { emitJson, emitText, errorLine, info, EXIT_OK, EXIT_ERROR, UsageError } from '../output'
+import { readSessionMessages } from '@proma/session-core/node'
+import { groupIntoTurns, toTranscript } from '@proma/session-core'
+
+register({
+  name: 'info',
+  summary: '会话体量/结构概览：turn 数、角色分布、估算 tokens、字节数',
+  usage: 'session info <id|path> [--json]',
+  run: (ctx) => {
+    const target = ctx.args.positionals[0]
+    if (!target) throw new UsageError('缺少会话 id 或路径')
+    const resolved = resolveSession(target, ctx.pathOpts)
+    if (!resolved) {
+      errorLine(`找不到会话: ${target}`)
+      return EXIT_ERROR
+    }
+
+    const turns = toTranscript(groupIntoTurns(readSessionMessages(resolved.filePath)))
+    const byRole = turns.reduce<Record<string, number>>((m, t) => {
+      m[t.role] = (m[t.role] ?? 0) + 1
+      return m
+    }, {})
+    const totalTokens = turns.reduce((s, t) => s + t.tokens, 0)
+
+    const report = {
+      id: resolved.id,
+      title: resolved.meta?.title,
+      bytes: resolved.bytes,
+      turns: turns.length,
+      roles: byRole,
+      estimatedTokens: totalTokens,
+      model: (resolved.meta as { modelId?: string } | undefined)?.modelId,
+    }
+
+    if (ctx.json) {
+      emitJson(report)
+      return EXIT_OK
+    }
+
+    info(`会话 ${report.id}${report.title ? `  «${report.title}»` : ''}`)
+    emitText(`turns: ${report.turns}  (${Object.entries(byRole).map(([r, n]) => `${r}:${n}`).join(' ')})`)
+    emitText(`估算 tokens: ~${totalTokens}`)
+    if (report.bytes != null) emitText(`原始 JSONL: ${(report.bytes / 1024).toFixed(0)} KB`)
+    return EXIT_OK
+  },
+})

--- a/apps/cli/src/commands/list.ts
+++ b/apps/cli/src/commands/list.ts
@@ -1,0 +1,52 @@
+/**
+ * proma session list — 列出会话索引（便宜，不读 JSONL 正文）。
+ */
+import { register } from '../registry'
+import { listSessions } from '../sessions'
+import { emitJson, emitText, info, EXIT_OK } from '../output'
+import { numFlag, strFlag } from '../args'
+
+interface MetaLike {
+  id: string
+  title?: string
+  updatedAt?: number
+  workspaceId?: string
+  modelId?: string
+  archived?: boolean
+}
+
+register({
+  name: 'list',
+  summary: '列出会话（id / 标题 / 更新时间 / 工作区），按更新时间降序',
+  usage: 'session list [--limit N] [--workspace W] [--json]',
+  run: (ctx) => {
+    const limit = numFlag(ctx.args.flags, 'limit')
+    const workspace = strFlag(ctx.args.flags, 'workspace')
+    let sessions = listSessions(ctx.pathOpts) as MetaLike[]
+    if (workspace) sessions = sessions.filter((s) => s.workspaceId === workspace)
+    if (limit && limit > 0) sessions = sessions.slice(0, limit)
+
+    if (ctx.json) {
+      emitJson(sessions.map((s) => ({
+        id: s.id,
+        title: s.title ?? '',
+        updatedAt: s.updatedAt,
+        workspaceId: s.workspaceId,
+        modelId: s.modelId,
+        archived: !!s.archived,
+      })))
+      return EXIT_OK
+    }
+
+    if (sessions.length === 0) {
+      info('（没有会话）')
+      return EXIT_OK
+    }
+    for (const s of sessions) {
+      const when = s.updatedAt ? new Date(s.updatedAt).toISOString().slice(0, 16).replace('T', ' ') : '—'
+      const title = (s.title ?? '').replace(/\s+/g, ' ').slice(0, 50) || '(无标题)'
+      emitText(`${s.id}  ${when}  ${title}`)
+    }
+    return EXIT_OK
+  },
+})

--- a/apps/cli/src/commands/outline.ts
+++ b/apps/cli/src/commands/outline.ts
@@ -1,0 +1,40 @@
+/**
+ * proma session outline — turn 级地图。每 turn 一行的结构概览，
+ * 让 Agent 先看地图再决定读哪段，避免全量读正文。
+ */
+import { register } from '../registry'
+import { resolveSession } from '../sessions'
+import { emitJson, emitText, errorLine, EXIT_OK, EXIT_ERROR, UsageError } from '../output'
+import { readSessionMessages } from '@proma/session-core/node'
+import { groupIntoTurns, toTranscript, outline, formatOutlineLine, selectTurns } from '@proma/session-core'
+import { numFlag } from '../args'
+
+register({
+  name: 'outline',
+  summary: 'turn 级地图：每 turn 一行（角色 / 预览 / 工具概览 / 估算 tokens）',
+  usage: 'session outline <id|path> [--offset K] [--limit N] [--json]',
+  run: (ctx) => {
+    const target = ctx.args.positionals[0]
+    if (!target) throw new UsageError('缺少会话 id 或路径')
+    const resolved = resolveSession(target, ctx.pathOpts)
+    if (!resolved) {
+      errorLine(`找不到会话: ${target}`)
+      return EXIT_ERROR
+    }
+
+    let turns = toTranscript(groupIntoTurns(readSessionMessages(resolved.filePath)))
+    const offset = numFlag(ctx.args.flags, 'offset')
+    const limit = numFlag(ctx.args.flags, 'limit')
+    if (offset !== undefined || limit !== undefined) {
+      turns = selectTurns(turns, { offset, limit })
+    }
+    const entries = outline(turns)
+
+    if (ctx.json) {
+      emitJson(entries)
+      return EXIT_OK
+    }
+    for (const e of entries) emitText(formatOutlineLine(e))
+    return EXIT_OK
+  },
+})

--- a/apps/cli/src/commands/search.ts
+++ b/apps/cli/src/commands/search.ts
@@ -1,0 +1,46 @@
+/**
+ * proma session search — 在会话内子串搜索，返回命中 turn 的下标与片段。
+ * Agent 据此再用 export --turns 取命中邻域，避免全量读。
+ */
+import { register } from '../registry'
+import { resolveSession } from '../sessions'
+import { emitJson, emitText, errorLine, info, EXIT_OK, EXIT_ERROR, UsageError } from '../output'
+import { readSessionMessages } from '@proma/session-core/node'
+import { groupIntoTurns, toTranscript, searchTurns } from '@proma/session-core'
+import { numFlag, boolFlag } from '../args'
+
+register({
+  name: 'search',
+  summary: '在会话内搜索关键词，返回命中 turn 下标 + 片段',
+  usage: 'session search <query> <id|path> [--context N] [--limit N] [--case-sensitive] [--json]',
+  run: (ctx) => {
+    const [query, target] = ctx.args.positionals
+    if (!query) throw new UsageError('缺少搜索词')
+    if (!target) throw new UsageError('缺少会话 id 或路径')
+    const resolved = resolveSession(target, ctx.pathOpts)
+    if (!resolved) {
+      errorLine(`找不到会话: ${target}`)
+      return EXIT_ERROR
+    }
+
+    const turns = toTranscript(groupIntoTurns(readSessionMessages(resolved.filePath)))
+    const hits = searchTurns(turns, query, {
+      context: numFlag(ctx.args.flags, 'context'),
+      limit: numFlag(ctx.args.flags, 'limit'),
+      caseSensitive: boolFlag(ctx.args.flags, 'case-sensitive'),
+    })
+
+    if (ctx.json) {
+      emitJson(hits)
+      return EXIT_OK
+    }
+    if (hits.length === 0) {
+      info(`未命中: "${query}"`)
+      return EXIT_OK
+    }
+    for (const h of hits) {
+      emitText(`#${h.index} [${h.role}] (${h.matchCount}处) ${h.snippet}`)
+    }
+    return EXIT_OK
+  },
+})

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,0 +1,84 @@
+#!/usr/bin/env bun
+/**
+ * proma — Proma 命令行工具入口。
+ *
+ * 用法：
+ *   proma <command> [subcommand] [args] [--flags]
+ *   proma session list|info|outline|search|export ...
+ *
+ * 全局 flag：
+ *   --json            输出机器可读 JSON
+ *   --config-dir DIR  指定 Proma 配置目录（默认 ~/.proma，PROMA_DEV=1 → ~/.proma-dev）
+ *   --dev             使用 ~/.proma-dev
+ *
+ * 设计：命令注册表驱动（registry.ts）。`session` 是一个命名空间，
+ * 其下的 list/info/outline/search/export 各自在 commands/ 注册。扩面只加文件。
+ */
+import { parseArgs, boolFlag, strFlag } from './args'
+import { getCommand, allCommands } from './registry'
+import { EXIT_OK, EXIT_USAGE, EXIT_ERROR, UsageError, errorLine, info, emitText } from './output'
+import type { PathOptions } from './paths'
+
+// 注册命令（import 即注册）
+import './commands/list'
+import './commands/info'
+import './commands/outline'
+import './commands/search'
+import './commands/export'
+
+function printHelp(): void {
+  info('proma — Proma 会话渐进式读取 CLI\n')
+  info('用法: proma session <command> [args] [--flags]\n')
+  info('命令:')
+  for (const c of allCommands()) {
+    info(`  ${c.usage.padEnd(64)} ${c.summary}`)
+  }
+  info('\n全局 flag: --json  --config-dir DIR  --dev')
+  info('\n渐进式读取建议: 先 info/outline 看结构 → search 定位 → export --turns 取片段')
+}
+
+async function main(): Promise<number> {
+  const argv = process.argv.slice(2)
+  if (argv.length === 0 || argv[0] === 'help' || argv[0] === '--help' || argv[0] === '-h') {
+    printHelp()
+    return EXIT_OK
+  }
+
+  // 命名空间：当前只有 session，支持 `proma session <cmd>` 与直接 `proma <cmd>`
+  let rest = argv
+  if (argv[0] === 'session') rest = argv.slice(1)
+
+  const cmdName = rest[0]
+  if (!cmdName) {
+    printHelp()
+    return EXIT_USAGE
+  }
+
+  const command = getCommand(cmdName)
+  if (!command) {
+    errorLine(`未知命令: ${cmdName}`)
+    printHelp()
+    return EXIT_USAGE
+  }
+
+  const parsed = parseArgs(rest.slice(1))
+  const pathOpts: PathOptions = {
+    configDir: strFlag(parsed.flags, 'config-dir'),
+    dev: boolFlag(parsed.flags, 'dev'),
+  }
+  const json = boolFlag(parsed.flags, 'json')
+
+  try {
+    return await command.run({ args: parsed, pathOpts, json })
+  } catch (err) {
+    if (err instanceof UsageError) {
+      errorLine(err.message)
+      info(`用法: proma ${command.usage}`)
+      return EXIT_USAGE
+    }
+    errorLine(err instanceof Error ? err.message : String(err))
+    return EXIT_ERROR
+  }
+}
+
+main().then((code) => process.exit(code))

--- a/apps/cli/src/output.ts
+++ b/apps/cli/src/output.ts
@@ -1,0 +1,38 @@
+/**
+ * 统一输出与退出码约定。
+ *
+ * 设计目标：CLI 主要消费者是「上下文有限的 Agent」。因此：
+ *   - 机器可读结果走 stdout（--json 时为单个 JSON）
+ *   - 人读日志 / 进度 / 错误走 stderr，绝不污染 stdout 的数据
+ *   - 退出码：0 成功，1 运行期错误（找不到会话等），2 用法错误（参数非法）
+ */
+
+export const EXIT_OK = 0
+export const EXIT_ERROR = 1
+export const EXIT_USAGE = 2
+
+/** 写一行人读信息到 stderr。 */
+export function info(msg: string): void {
+  process.stderr.write(msg + '\n')
+}
+
+/** 写错误到 stderr（带 error: 前缀）。 */
+export function errorLine(msg: string): void {
+  process.stderr.write(`error: ${msg}\n`)
+}
+
+/** 输出机器可读 JSON 到 stdout。 */
+export function emitJson(data: unknown): void {
+  process.stdout.write(JSON.stringify(data, null, 2) + '\n')
+}
+
+/** 输出纯文本到 stdout（不加额外换行外的内容）。 */
+export function emitText(text: string): void {
+  process.stdout.write(text.endsWith('\n') ? text : text + '\n')
+}
+
+/** 命令处理函数约定的返回：退出码。 */
+export type CommandExit = number
+
+/** 抛出此错误表示用法错误（参数非法），主入口据此返回 EXIT_USAGE。 */
+export class UsageError extends Error {}

--- a/apps/cli/src/paths.ts
+++ b/apps/cli/src/paths.ts
@@ -1,0 +1,41 @@
+/**
+ * 会话存储路径解析（electron-free）。
+ *
+ * Proma 主进程用 config-paths.ts 里的 getConfigDir()，其中通过 require('electron')
+ * 判断 isPackaged 来在 .proma / .proma-dev 间切换——CLI 没有 electron 运行时，
+ * 因此这里独立实现一份等价逻辑：
+ *   - 默认 ~/.proma
+ *   - 环境变量 PROMA_DEV=1 → ~/.proma-dev
+ *   - 显式 configDir 覆盖（CLI 的 --config-dir）优先级最高
+ *
+ * 与 config-paths.ts 的目录布局保持一致：
+ *   <configDir>/agent-sessions.json        会话索引
+ *   <configDir>/agent-sessions/<id>.jsonl   单会话消息
+ */
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+export interface PathOptions {
+  /** 显式指定配置目录（绝对路径）。优先级最高。 */
+  configDir?: string
+  /** 使用开发目录 .proma-dev（等价于 PROMA_DEV=1）。 */
+  dev?: boolean
+}
+
+export function resolveConfigDir(opts: PathOptions = {}): string {
+  if (opts.configDir) return opts.configDir
+  const useDev = opts.dev || process.env.PROMA_DEV === '1'
+  return join(homedir(), useDev ? '.proma-dev' : '.proma')
+}
+
+export function getSessionsIndexPath(opts: PathOptions = {}): string {
+  return join(resolveConfigDir(opts), 'agent-sessions.json')
+}
+
+export function getSessionsDir(opts: PathOptions = {}): string {
+  return join(resolveConfigDir(opts), 'agent-sessions')
+}
+
+export function getSessionMessagesPath(id: string, opts: PathOptions = {}): string {
+  return join(getSessionsDir(opts), `${id}.jsonl`)
+}

--- a/apps/cli/src/registry.ts
+++ b/apps/cli/src/registry.ts
@@ -1,0 +1,38 @@
+/**
+ * 命令注册表。新增命令 = 在 commands/ 下加一个文件并 register() —— 扩面只加文件，不动主入口。
+ */
+import type { ParsedArgs } from './args'
+import type { PathOptions } from './paths'
+import { type CommandExit, UsageError } from './output'
+
+export interface CommandContext {
+  args: ParsedArgs
+  /** 从全局 flag 解析出的路径选项（--config-dir / --dev / PROMA_DEV）。 */
+  pathOpts: PathOptions
+  /** 是否输出机器可读 JSON（--json）。 */
+  json: boolean
+}
+
+export interface Command {
+  name: string
+  summary: string
+  /** 一行用法示例（不含 "proma " 前缀）。 */
+  usage: string
+  run: (ctx: CommandContext) => Promise<CommandExit> | CommandExit
+}
+
+const registry = new Map<string, Command>()
+
+export function register(cmd: Command): void {
+  registry.set(cmd.name, cmd)
+}
+
+export function getCommand(name: string): Command | undefined {
+  return registry.get(name)
+}
+
+export function allCommands(): Command[] {
+  return [...registry.values()]
+}
+
+export { UsageError }

--- a/apps/cli/src/sessions.ts
+++ b/apps/cli/src/sessions.ts
@@ -1,0 +1,72 @@
+/**
+ * 会话索引读取（electron-free）。
+ *
+ * 与主进程 agent-session-manager.ts 的 readIndex/listAgentSessions 等价，
+ * 但不依赖 electron——直接读 <configDir>/agent-sessions.json。CLI 只做只读，
+ * 不写索引（导出/清洗不修改用户数据）。
+ */
+import { existsSync, readFileSync, statSync } from 'node:fs'
+import type { AgentSessionMeta } from '@proma/shared'
+import { getSessionsIndexPath, getSessionMessagesPath, type PathOptions } from './paths'
+
+interface AgentSessionsIndex {
+  version: number
+  sessions: AgentSessionMeta[]
+}
+
+/** 读取会话索引；文件不存在或损坏时返回空列表。 */
+export function readSessionIndex(opts: PathOptions = {}): AgentSessionMeta[] {
+  const indexPath = getSessionsIndexPath(opts)
+  if (!existsSync(indexPath)) return []
+  try {
+    const data = JSON.parse(readFileSync(indexPath, 'utf-8')) as AgentSessionsIndex
+    return Array.isArray(data?.sessions) ? data.sessions : []
+  } catch {
+    return []
+  }
+}
+
+/** 列出会话，按 updatedAt 降序（无 updatedAt 的排后）。 */
+export function listSessions(opts: PathOptions = {}): AgentSessionMeta[] {
+  return readSessionIndex(opts).sort(
+    (a, b) => ((b as { updatedAt?: number }).updatedAt ?? 0) - ((a as { updatedAt?: number }).updatedAt ?? 0),
+  )
+}
+
+export function getSessionMeta(id: string, opts: PathOptions = {}): AgentSessionMeta | undefined {
+  return readSessionIndex(opts).find((s) => s.id === id)
+}
+
+export interface ResolvedSession {
+  id: string
+  filePath: string
+  meta?: AgentSessionMeta
+  /** JSONL 文件字节数（不存在为 undefined）。 */
+  bytes?: number
+}
+
+/**
+ * 把用户给的 target 解析为会话文件：
+ *   - 形如已存在的 .jsonl 路径 → 直接用
+ *   - 否则当作 session id，定位 <configDir>/agent-sessions/<id>.jsonl
+ * 解析失败（文件不存在）返回 undefined，由命令层报错。
+ */
+export function resolveSession(target: string, opts: PathOptions = {}): ResolvedSession | undefined {
+  // 直接文件路径
+  if (target.endsWith('.jsonl') && existsSync(target)) {
+    const id = target.replace(/\.jsonl$/, '').split('/').pop() ?? target
+    return { id, filePath: target, meta: getSessionMeta(id, opts), bytes: safeBytes(target) }
+  }
+  // 当作 session id
+  const filePath = getSessionMessagesPath(target, opts)
+  if (!existsSync(filePath)) return undefined
+  return { id: target, filePath, meta: getSessionMeta(target, opts), bytes: safeBytes(filePath) }
+}
+
+function safeBytes(path: string): number | undefined {
+  try {
+    return statSync(path).size
+  } catch {
+    return undefined
+  }
+}

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {},
+  "include": ["src/**/*"]
+}

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -58,6 +58,7 @@
     "@emoji-mart/react": "^1.1.1",
     "@larksuiteoapi/node-sdk": "^1.65.0",
     "@proma/core": "workspace:*",
+    "@proma/session-core": "workspace:*",
     "@proma/shared": "workspace:*",
     "@proma/ui": "workspace:*",
     "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -38,6 +38,8 @@ import type {
   AgentSessionReferenceSearchResult,
 } from '@proma/shared'
 import { getConversationMessages } from './conversation-manager'
+// 旧格式 → SDKMessage 的转换逻辑下沉到 @proma/session-core 作为唯一真源，避免主进程与渲染层各存一份。
+import { convertLegacyMessage } from '@proma/session-core'
 import { clearNanoBananaAgentHistory } from './chat-tools/nano-banana-mcp'
 import { assertEnabledModelForChannel } from './agent-model-selection'
 import { copyForkWorkspaceFiles } from './agent-fork-workspace-copy'
@@ -310,64 +312,8 @@ export function getAgentSessionSDKMessages(id: string): SDKMessage[] {
 }
 
 /**
- * 将旧的 AgentMessage 转换为近似的 SDKMessage（向后兼容）
- *
- * 不需要完美还原，只需在 UI 中可读即可。
+ * convertLegacyMessage 已迁移至 @proma/session-core（本文件从该包 import 使用）。
  */
-function convertLegacyMessage(legacy: AgentMessage): SDKMessage {
-  if (legacy.role === 'user') {
-    return {
-      type: 'user',
-      message: {
-        content: [{ type: 'text', text: legacy.content }],
-      },
-      parent_tool_use_id: null,
-      // 附加元数据供渲染器使用
-      _legacy: true,
-      _createdAt: legacy.createdAt,
-    } as unknown as SDKMessage
-  }
-
-  if (legacy.role === 'assistant') {
-    return {
-      type: 'assistant',
-      message: {
-        content: [{ type: 'text', text: legacy.content }],
-        model: legacy.model,
-      },
-      parent_tool_use_id: null,
-      _legacy: true,
-      _createdAt: legacy.createdAt,
-    } as unknown as SDKMessage
-  }
-
-  if (legacy.role === 'status') {
-    // 错误消息转换为 assistant error 格式
-    return {
-      type: 'assistant',
-      message: {
-        content: [{ type: 'text', text: legacy.content }],
-      },
-      parent_tool_use_id: null,
-      error: { message: legacy.content, errorType: legacy.errorCode },
-      _legacy: true,
-      _createdAt: legacy.createdAt,
-      _errorCode: legacy.errorCode,
-      _errorTitle: legacy.errorTitle,
-      _errorDetails: legacy.errorDetails,
-      _errorCanRetry: legacy.errorCanRetry,
-      _errorActions: legacy.errorActions,
-    } as unknown as SDKMessage
-  }
-
-  // 其他类型，作为 system 消息返回
-  return {
-    type: 'system',
-    subtype: 'init',
-    _legacy: true,
-    _createdAt: legacy.createdAt,
-  } as unknown as SDKMessage
-}
 
 /**
  * 更新会话元数据

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -22,6 +22,20 @@ import { TurnFileChangesSummary } from './TurnFileChangesSummary'
 import { ProcessBlockGroup, buildAssistantTurnRenderItems, buildCompletedToolResultIds } from './ProcessBlockGroup'
 import { extractToolResultText, parseTaskCreateResult, TASK_TOOL_NAMES } from './task-progress'
 import { normalizeThinkTagsInContentBlocks } from './thinking-tag-parser'
+// 会话转录的纯逻辑(Turn 分组 / 快照去重 / 预览)已下沉到 @proma/session-core 作为唯一真源。
+// 这里 import 供本文件内部使用，并 re-export 以保持既有 `from './SDKMessageRenderer'` 导入方零改动。
+import {
+  groupIntoTurns,
+  getGroupPreview,
+  extractUserText,
+  extractMeta,
+  isUserInputMessage,
+  stripScheduledRunMarker,
+  type MessageGroup,
+  type AssistantTurn,
+} from '@proma/session-core'
+export { groupIntoTurns, getGroupPreview, extractUserText } from '@proma/session-core'
+export type { MessageGroup, AssistantTurn } from '@proma/session-core'
 import { DurationBadge } from './AgentMessages'
 import {
   Message,
@@ -152,18 +166,7 @@ export function CompactingIndicator(): React.ReactElement {
   )
 }
 
-// ===== 辅助：从 SDKMessage 提取元数据 =====
-
-interface MessageMeta {
-  createdAt?: number
-}
-
-function extractMeta(message: SDKMessage): MessageMeta {
-  const msg = message as Record<string, unknown>
-  return {
-    createdAt: typeof msg._createdAt === 'number' ? msg._createdAt : undefined,
-  }
-}
+// extractMeta / MessageMeta 已迁移至 @proma/session-core
 
 /** 从 turn 消息列表中提取 result 消息的耗时和用量数据 */
 function extractTurnUsage(turnMessages: SDKMessage[]): { durationMs?: number; usage?: AgentEventUsage } {
@@ -192,21 +195,7 @@ function extractTurnUsage(turnMessages: SDKMessage[]): { durationMs?: number; us
   return {}
 }
 
-// ===== 辅助：从 user 消息中提取纯文本内容 =====
-
-export function extractUserText(message: SDKUserMessage): string | null {
-  const content = message.message?.content
-  if (!Array.isArray(content)) return null
-
-  const texts: string[] = []
-  for (const block of content) {
-    if (block.type === 'text' && 'text' in block) {
-      texts.push((block as { text: string }).text)
-    }
-  }
-
-  return texts.length > 0 ? texts.join('\n') : null
-}
+// extractUserText 已迁移至 @proma/session-core
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
@@ -227,17 +216,7 @@ function extractToolResultForTask(message: SDKUserMessage, resultBlock: SDKToolR
   return extractStructuredToolResultText(message) ?? extractToolResultText(resultBlock.content)
 }
 
-// ===== 辅助：判断 user 消息是否为真正的人类用户输入（非工具结果/子代理提示） =====
-
-function isUserInputMessage(message: SDKUserMessage): boolean {
-  if (message.parent_tool_use_id) return false
-  // SDK 合成消息（如 Skill 展开 prompt）不是用户输入
-  if (message.isSynthetic) return false
-  // 包含 tool_result 块的消息是工具结果，不是用户输入
-  const content = message.message?.content
-  if (Array.isArray(content) && content.some((b) => b.type === 'tool_result')) return false
-  return extractUserText(message) !== null
-}
+// isUserInputMessage 已迁移至 @proma/session-core
 
 // ===== 助手头像 =====
 
@@ -259,176 +238,9 @@ function AssistantLogo({ model }: { model?: string }): React.ReactElement {
   )
 }
 
-// ===== Turn 分组类型 =====
+// AssistantTurn / MessageGroup 类型已迁移至 @proma/session-core
 
-export interface AssistantTurn {
-  type: 'assistant-turn'
-  /** 当前 turn 内所有 assistant 消息 */
-  assistantMessages: SDKAssistantMessage[]
-  /** 当前 turn 内所有消息（含 tool_result user 消息，供工具结果查找） */
-  turnMessages: SDKMessage[]
-  /** 模型名称（取首条 assistant 消息的 model） */
-  model?: string
-  /** 创建时间（取首条 assistant 消息的时间） */
-  createdAt?: number
-  /**
-   * 该 turn 由后台任务完成通知（task_notification）唤醒后开始。
-   * 用于阻断与前一 turn 的合并，让自动唤醒的新输出独立成块，而不是被追加进上一轮的消息块。
-   */
-  startsAfterWake?: boolean
-}
-
-export type MessageGroup =
-  | { type: 'user'; message: SDKUserMessage }
-  | { type: 'system'; message: SDKSystemMessage }
-  | AssistantTurn
-
-/**
- * 将 SDKMessage 列表分组为可渲染的 Turn
- *
- * 规则：
- * 1. user（真正用户输入）→ 单独的 user group
- * 2. assistant + user(tool_result) + assistant... → 合并为一个 assistant-turn
- * 3. system（compact_boundary / compacting / permission_denied）→ 独立渲染，其他归入当前 turn
- * 4. 其他类型（result, tool_progress 等）→ 归入当前 assistant-turn
- * 5. 后处理：合并相邻同模型的 assistant-turn（处理子代理切换模型导致的碎片化）
- */
-export function groupIntoTurns(messages: SDKMessage[], sessionModelId?: string): MessageGroup[] {
-  const groups: MessageGroup[] = []
-  let currentTurn: AssistantTurn | null = null
-  // 收到后台任务完成通知（task_notification）后，若没有用户输入就直接出现新的 assistant 输出，
-  // 说明这是自动唤醒的新一轮，应另起独立消息块，而不是续接上一轮。
-  // 注意：不能用 result 做信号——正常对话每轮也以 result 结束，会误伤普通回复。
-  let pendingWakeBoundary = false
-
-  const flushTurn = (): void => {
-    if (currentTurn && currentTurn.assistantMessages.length > 0) {
-      groups.push(currentTurn)
-    }
-    currentTurn = null
-  }
-
-  for (const msg of messages) {
-    if (msg.type === 'user') {
-      const userMsg = msg as SDKUserMessage
-      if (isUserInputMessage(userMsg)) {
-        // 真正的用户输入 → 结束当前 turn，开始新段落
-        flushTurn()
-        groups.push({ type: 'user', message: userMsg })
-        pendingWakeBoundary = false
-      } else {
-        // tool_result 消息 → 归入当前 turn
-        if (currentTurn) {
-          currentTurn.turnMessages.push(msg)
-        }
-      }
-    } else if (msg.type === 'assistant') {
-      const aMsg = msg as SDKAssistantMessage
-      // 跳过重放消息
-      if (aMsg.isReplay) continue
-
-      if (!currentTurn) {
-        // 开始新 turn
-        const meta = extractMeta(msg)
-        currentTurn = {
-          type: 'assistant-turn',
-          assistantMessages: [aMsg],
-          turnMessages: [msg],
-          model: aMsg._channelModelId || aMsg.message?.model || sessionModelId,
-          createdAt: meta.createdAt,
-          // 紧跟在后台任务唤醒之后的新 turn：阻断与上一轮的合并
-          startsAfterWake: pendingWakeBoundary || undefined,
-        }
-        pendingWakeBoundary = false
-      } else {
-        // 继续当前 turn
-        currentTurn.assistantMessages.push(aMsg)
-        currentTurn.turnMessages.push(msg)
-      }
-    } else if (msg.type === 'system') {
-      const sysMsg = msg as SDKSystemMessage
-      // 仅需要独立渲染的 system 消息才中断 turn（compact_boundary / compacting / permission_denied）
-      // 其他 system 消息（如 init、task_started、task_progress）归入当前 turn，不中断分组
-      if (sysMsg.subtype === 'compact_boundary' || sysMsg.subtype === 'compacting' || sysMsg.subtype === 'permission_denied') {
-        flushTurn()
-        groups.push({ type: 'system', message: sysMsg })
-      } else if (sysMsg.subtype === 'task_notification') {
-        // 后台任务完成通知：仅在没有进行中的 turn 时标记唤醒边界（真正的唤醒场景）。
-        // 若当前有 turn 正在进行，归入当前 turn 不截断。
-        if (currentTurn) {
-          currentTurn.turnMessages.push(msg)
-        } else {
-          pendingWakeBoundary = true
-        }
-      } else if (currentTurn) {
-        currentTurn.turnMessages.push(msg)
-      }
-    } else {
-      // result, tool_progress 等 → 归入当前 turn
-      // prompt_suggestion 不属于对话转录，不入 turn，避免被当作文本附加到助手消息末尾
-      if ((msg as { type: string }).type === 'prompt_suggestion') {
-        continue
-      }
-      if (currentTurn) {
-        currentTurn.turnMessages.push(msg)
-      }
-    }
-  }
-
-  flushTurn()
-  return mergeAdjacentSameModelTurns(groups)
-}
-
-/**
- * 后处理：合并相邻同模型的 assistant-turn
- *
- * 当子代理（如 haiku）执行多个工具调用时，中间的 user(tool_result) 消息
- * 可能导致 turn 被拆分为多个碎片。此函数将同模型的相邻 assistant-turn 合并，
- * 同时吸收它们之间的非用户输入 group（如被误判为用户输入的子代理内部消息）。
- */
-function mergeAdjacentSameModelTurns(groups: MessageGroup[]): MessageGroup[] {
-  if (groups.length <= 1) return groups
-
-  const result: MessageGroup[] = []
-
-  for (const group of groups) {
-    if (group.type !== 'assistant-turn') {
-      result.push(group)
-      continue
-    }
-
-    // 后台任务唤醒后开始的 turn：独立成块，不向前合并。
-    if (group.startsAfterWake) {
-      result.push(group)
-      continue
-    }
-
-    // 向前查找可合并的同模型 assistant-turn（跳过非 user-input 的中间 group）
-    let mergeTargetIdx = -1
-    for (let i = result.length - 1; i >= 0; i--) {
-      const prev = result[i]!
-      if (prev.type === 'user') break // 真正的用户输入阻断合并
-      if (prev.type === 'system' && ['compact_boundary', 'permission_denied'].includes((prev.message as SDKSystemMessage).subtype ?? '')) break
-      if (prev.type === 'assistant-turn') {
-        if (prev.model === group.model) {
-          mergeTargetIdx = i
-        }
-        break // 遇到第一个 assistant-turn 就停止（不跨越不同模型的 turn）
-      }
-      // system 或其他 group：继续向前查找
-    }
-
-    if (mergeTargetIdx >= 0) {
-      const target = result[mergeTargetIdx] as AssistantTurn
-      target.assistantMessages.push(...group.assistantMessages)
-      target.turnMessages.push(...group.turnMessages)
-    } else {
-      result.push(group)
-    }
-  }
-
-  return result
-}
+// groupIntoTurns / mergeAdjacentSameModelTurns 已迁移至 @proma/session-core
 
 function buildTaskProgressData(
   topLevelBlocks: SDKContentBlock[],
@@ -1031,9 +843,7 @@ function QuoteChip({ quote }: { quote: QuotedFileRef }): React.ReactElement {
 
 const SCHEDULED_RUN_MARKER = '<!--PROMA_SCHEDULED_RUN-->'
 
-function stripScheduledRunMarker(text: string): string {
-  return text.replaceAll(SCHEDULED_RUN_MARKER, '').trim()
-}
+// stripScheduledRunMarker 已迁移至 @proma/session-core（本文件从该包 import 使用）
 
 function ScheduledRunBadge(): React.ReactElement {
   const activeSessionId = useAtomValue(activeSessionIdAtom)
@@ -1423,35 +1233,7 @@ export function getGroupId(group: MessageGroup): string {
   return `turn-empty-${++fallbackIdCounter}`
 }
 
-/**
- * 从 MessageGroup 中提取纯文本预览，供迷你地图使用
- */
-export function getGroupPreview(group: MessageGroup): string {
-  if (group.type === 'user') {
-    return stripScheduledRunMarker(extractUserText(group.message) ?? '')
-      .replace(/<attached_files>[\s\S]*?<\/attached_files>\n*/, '')
-      .replace(/<quoted_file[^>]*>[\s\S]*?<\/quoted_file>\n*/g, '')
-      .slice(0, 200)
-  }
-  if (group.type === 'system') {
-    if (group.message.subtype === 'compact_boundary') return '上下文已压缩'
-    if (group.message.subtype === 'compacting') return '正在压缩上下文...'
-    if (group.message.subtype === 'permission_denied') return '自动审批已拒绝操作'
-    return ''
-  }
-  // assistant-turn：收集所有 text 块
-  const texts: string[] = []
-  for (const aMsg of group.assistantMessages) {
-    const rawBlocks = aMsg.message?.content
-    if (!Array.isArray(rawBlocks)) continue
-    for (const block of normalizeThinkTagsInContentBlocks(rawBlocks)) {
-      if (block.type === 'text' && 'text' in block) {
-        texts.push((block as { text: string }).text)
-      }
-    }
-  }
-  return texts.join(' ').slice(0, 200)
-}
+// getGroupPreview 已迁移至 @proma/session-core（本文件从该包 import 并 re-export）
 
 export function MessageGroupRenderer({ group, allMessages, historicalTaskSubjects, basePath, onFork, onRewind, onRetry, onRetryInNewSession, onCompact, isStreaming, stoppedByUser, sessionModelId }: MessageGroupRendererProps): React.ReactElement | null {
   const groupId = getGroupId(group)

--- a/apps/electron/src/renderer/components/agent/thinking-tag-parser.ts
+++ b/apps/electron/src/renderer/components/agent/thinking-tag-parser.ts
@@ -1,64 +1,9 @@
-import type { SDKContentBlock, SDKTextBlock } from '@proma/shared'
-
-const THINK_OPEN_TAG = '<think>'
-const THINK_CLOSE_TAG = '</think>'
-
-function appendTextBlock(blocks: SDKContentBlock[], text: string): void {
-  if (!text.trim()) return
-  blocks.push({ type: 'text', text })
-}
-
-function appendThinkingBlock(blocks: SDKContentBlock[], thinking: string): void {
-  const content = thinking.trim()
-  if (!content) return
-  blocks.push({ type: 'thinking', thinking: content })
-}
-
 /**
- * 兼容部分模型把思考内容包在 <think> 标签里的返回格式。
- * 未闭合的 <think> 在流式阶段按思考块处理，等闭合标签到达后会自然拆出后续正文。
+ * 该模块实现已迁移至 @proma/session-core（headless 核心，纯函数）。
+ * 保留此文件为 re-export shim，使既有 `from './thinking-tag-parser'` 导入方零改动。
  */
-export function parseThinkTagsFromText(text: string): SDKContentBlock[] {
-  const lowerText = text.toLowerCase()
-  const blocks: SDKContentBlock[] = []
-  let cursor = 0
-
-  while (cursor < text.length) {
-    const openIndex = lowerText.indexOf(THINK_OPEN_TAG, cursor)
-    if (openIndex === -1) {
-      appendTextBlock(blocks, text.slice(cursor))
-      break
-    }
-
-    appendTextBlock(blocks, text.slice(cursor, openIndex))
-
-    const contentStart = openIndex + THINK_OPEN_TAG.length
-    const closeIndex = lowerText.indexOf(THINK_CLOSE_TAG, contentStart)
-    if (closeIndex === -1) {
-      appendThinkingBlock(blocks, text.slice(contentStart))
-      break
-    }
-
-    appendThinkingBlock(blocks, text.slice(contentStart, closeIndex))
-    cursor = closeIndex + THINK_CLOSE_TAG.length
-  }
-
-  return blocks
-}
-
-export function splitThinkTagsInTextBlock(block: SDKTextBlock): SDKContentBlock[] {
-  if (!block.text.toLowerCase().includes(THINK_OPEN_TAG)) return [block]
-  return parseThinkTagsFromText(block.text)
-}
-
-export function normalizeThinkTagsInContentBlocks(blocks: SDKContentBlock[]): SDKContentBlock[] {
-  const normalized: SDKContentBlock[] = []
-  for (const block of blocks) {
-    if (block.type === 'text' && 'text' in block && typeof block.text === 'string') {
-      normalized.push(...splitThinkTagsInTextBlock(block as SDKTextBlock))
-    } else {
-      normalized.push(block)
-    }
-  }
-  return normalized
-}
+export {
+  normalizeThinkTagsInContentBlocks,
+  parseThinkTagsFromText,
+  splitThinkTagsInTextBlock,
+} from '@proma/session-core'

--- a/bun.lock
+++ b/bun.lock
@@ -41,6 +41,7 @@
         "@emoji-mart/react": "^1.1.1",
         "@larksuiteoapi/node-sdk": "^1.65.0",
         "@proma/core": "workspace:*",
+        "@proma/session-core": "workspace:*",
         "@proma/shared": "workspace:*",
         "@proma/ui": "workspace:*",
         "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -100,6 +101,7 @@
         "electron-updater": "^6.7.3",
         "electronmon": "^2.0.4",
         "esbuild": "^0.24.0",
+        "jszip": "^3.10.1",
         "katex": "^0.16",
         "lowlight": "^3.3.0",
         "lucide-react": "^0.460.0",
@@ -154,9 +156,19 @@
         "@modelcontextprotocol/sdk": ">=1.0.0",
       },
     },
+    "packages/session-core": {
+      "name": "@proma/session-core",
+      "version": "0.1.0",
+      "dependencies": {
+        "@proma/shared": "workspace:*",
+      },
+      "devDependencies": {
+        "typescript": "^5.0.0",
+      },
+    },
     "packages/shared": {
       "name": "@proma/shared",
-      "version": "0.1.31",
+      "version": "0.1.35",
       "devDependencies": {
         "typescript": "^5.0.0",
       },
@@ -416,6 +428,8 @@
     "@proma/core": ["@proma/core@workspace:packages/core"],
 
     "@proma/electron": ["@proma/electron@workspace:apps/electron"],
+
+    "@proma/session-core": ["@proma/session-core@workspace:packages/session-core"],
 
     "@proma/shared": ["@proma/shared@workspace:packages/shared"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,20 @@
         "typescript": "^5",
       },
     },
+    "apps/cli": {
+      "name": "@proma/cli",
+      "version": "0.1.0",
+      "bin": {
+        "proma": "./src/index.ts",
+      },
+      "dependencies": {
+        "@proma/session-core": "workspace:*",
+        "@proma/shared": "workspace:*",
+      },
+      "devDependencies": {
+        "typescript": "^5.0.0",
+      },
+    },
     "apps/electron": {
       "name": "@proma/electron",
       "version": "0.13.21",
@@ -424,6 +438,8 @@
     "@pierre/theme": ["@pierre/theme@0.0.28", "", {}, "sha512-1j/H/fECBuc9dEvntdWI+l435HZapw+RCJTlqCA6BboQ5TjlnE005j/ROWutXIs8aq5OAc82JI2Kwk4A1WWBgw=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@proma/cli": ["@proma/cli@workspace:apps/cli"],
 
     "@proma/core": ["@proma/core@workspace:packages/core"],
 

--- a/packages/session-core/package.json
+++ b/packages/session-core/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@proma/session-core",
+  "version": "0.1.0",
+  "license": "AGPL-3.0-only",
+  "description": "Headless core for reading, grouping, searching and rendering Proma agent sessions. Single source of truth shared by the Electron app, the proma CLI and future query surfaces.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@proma/shared": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/session-core/package.json
+++ b/packages/session-core/package.json
@@ -7,7 +7,8 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./node": "./src/node.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/session-core/src/group.ts
+++ b/packages/session-core/src/group.ts
@@ -1,0 +1,266 @@
+/**
+ * Turn 分组 — 将流式产生的 SDKMessage 列表(含同一回合的多行快照碎片)
+ * 合并为可渲染/可导出的 Turn 分组。
+ *
+ * 这是 Proma 会话「快照去重」的唯一真源：Electron 渲染层、proma CLI 以及
+ * 未来的 query 型接口都复用本模块，避免各处重抄一份会随存储格式漂移的解析器。
+ *
+ * 逻辑逐字迁移自 apps/electron 渲染层 SDKMessageRenderer.tsx，保持行为一致。
+ */
+import type {
+  SDKMessage,
+  SDKAssistantMessage,
+  SDKUserMessage,
+  SDKSystemMessage,
+} from '@proma/shared'
+import { normalizeThinkTagsInContentBlocks } from './thinking-tags'
+
+// ===== 辅助：从 SDKMessage 提取元数据 =====
+
+export interface MessageMeta {
+  createdAt?: number
+}
+
+export function extractMeta(message: SDKMessage): MessageMeta {
+  const msg = message as Record<string, unknown>
+  return {
+    createdAt: typeof msg._createdAt === 'number' ? msg._createdAt : undefined,
+  }
+}
+
+// ===== 辅助：从 user 消息中提取纯文本内容 =====
+
+export function extractUserText(message: SDKUserMessage): string | null {
+  const content = message.message?.content
+  if (!Array.isArray(content)) return null
+
+  const texts: string[] = []
+  for (const block of content) {
+    if (block.type === 'text' && 'text' in block) {
+      texts.push((block as { text: string }).text)
+    }
+  }
+
+  return texts.length > 0 ? texts.join('\n') : null
+}
+
+// ===== 辅助：判断 user 消息是否为真正的人类用户输入（非工具结果/子代理提示） =====
+
+export function isUserInputMessage(message: SDKUserMessage): boolean {
+  if (message.parent_tool_use_id) return false
+  // SDK 合成消息（如 Skill 展开 prompt）不是用户输入
+  if (message.isSynthetic) return false
+  // 包含 tool_result 块的消息是工具结果，不是用户输入
+  const content = message.message?.content
+  if (Array.isArray(content) && content.some((b) => b.type === 'tool_result')) return false
+  return extractUserText(message) !== null
+}
+
+// ===== Turn 分组类型 =====
+
+export interface AssistantTurn {
+  type: 'assistant-turn'
+  /** 当前 turn 内所有 assistant 消息 */
+  assistantMessages: SDKAssistantMessage[]
+  /** 当前 turn 内所有消息（含 tool_result user 消息，供工具结果查找） */
+  turnMessages: SDKMessage[]
+  /** 模型名称（取首条 assistant 消息的 model） */
+  model?: string
+  /** 创建时间（取首条 assistant 消息的时间） */
+  createdAt?: number
+  /**
+   * 该 turn 由后台任务完成通知（task_notification）唤醒后开始。
+   * 用于阻断与前一 turn 的合并，让自动唤醒的新输出独立成块，而不是被追加进上一轮的消息块。
+   */
+  startsAfterWake?: boolean
+}
+
+export type MessageGroup =
+  | { type: 'user'; message: SDKUserMessage }
+  | { type: 'system'; message: SDKSystemMessage }
+  | AssistantTurn
+
+/**
+ * 将 SDKMessage 列表分组为可渲染的 Turn
+ *
+ * 规则：
+ * 1. user（真正用户输入）→ 单独的 user group
+ * 2. assistant + user(tool_result) + assistant... → 合并为一个 assistant-turn
+ * 3. system（compact_boundary / compacting / permission_denied）→ 独立渲染，其他归入当前 turn
+ * 4. 其他类型（result, tool_progress 等）→ 归入当前 assistant-turn
+ * 5. 后处理：合并相邻同模型的 assistant-turn（处理子代理切换模型导致的碎片化）
+ */
+export function groupIntoTurns(messages: SDKMessage[], sessionModelId?: string): MessageGroup[] {
+  const groups: MessageGroup[] = []
+  let currentTurn: AssistantTurn | null = null
+  // 收到后台任务完成通知（task_notification）后，若没有用户输入就直接出现新的 assistant 输出，
+  // 说明这是自动唤醒的新一轮，应另起独立消息块，而不是续接上一轮。
+  // 注意：不能用 result 做信号——正常对话每轮也以 result 结束，会误伤普通回复。
+  let pendingWakeBoundary = false
+
+  const flushTurn = (): void => {
+    if (currentTurn && currentTurn.assistantMessages.length > 0) {
+      groups.push(currentTurn)
+    }
+    currentTurn = null
+  }
+
+  for (const msg of messages) {
+    if (msg.type === 'user') {
+      const userMsg = msg as SDKUserMessage
+      if (isUserInputMessage(userMsg)) {
+        // 真正的用户输入 → 结束当前 turn，开始新段落
+        flushTurn()
+        groups.push({ type: 'user', message: userMsg })
+        pendingWakeBoundary = false
+      } else {
+        // tool_result 消息 → 归入当前 turn
+        if (currentTurn) {
+          currentTurn.turnMessages.push(msg)
+        }
+      }
+    } else if (msg.type === 'assistant') {
+      const aMsg = msg as SDKAssistantMessage
+      // 跳过重放消息
+      if (aMsg.isReplay) continue
+
+      if (!currentTurn) {
+        // 开始新 turn
+        const meta = extractMeta(msg)
+        currentTurn = {
+          type: 'assistant-turn',
+          assistantMessages: [aMsg],
+          turnMessages: [msg],
+          model: aMsg._channelModelId || aMsg.message?.model || sessionModelId,
+          createdAt: meta.createdAt,
+          // 紧跟在后台任务唤醒之后的新 turn：阻断与上一轮的合并
+          startsAfterWake: pendingWakeBoundary || undefined,
+        }
+        pendingWakeBoundary = false
+      } else {
+        // 继续当前 turn
+        currentTurn.assistantMessages.push(aMsg)
+        currentTurn.turnMessages.push(msg)
+      }
+    } else if (msg.type === 'system') {
+      const sysMsg = msg as SDKSystemMessage
+      // 仅需要独立渲染的 system 消息才中断 turn（compact_boundary / compacting / permission_denied）
+      // 其他 system 消息（如 init、task_started、task_progress）归入当前 turn，不中断分组
+      if (sysMsg.subtype === 'compact_boundary' || sysMsg.subtype === 'compacting' || sysMsg.subtype === 'permission_denied') {
+        flushTurn()
+        groups.push({ type: 'system', message: sysMsg })
+      } else if (sysMsg.subtype === 'task_notification') {
+        // 后台任务完成通知：仅在没有进行中的 turn 时标记唤醒边界（真正的唤醒场景）。
+        // 若当前有 turn 正在进行，归入当前 turn 不截断。
+        if (currentTurn) {
+          currentTurn.turnMessages.push(msg)
+        } else {
+          pendingWakeBoundary = true
+        }
+      } else if (currentTurn) {
+        currentTurn.turnMessages.push(msg)
+      }
+    } else {
+      // result, tool_progress 等 → 归入当前 turn
+      // prompt_suggestion 不属于对话转录，不入 turn，避免被当作文本附加到助手消息末尾
+      if ((msg as { type: string }).type === 'prompt_suggestion') {
+        continue
+      }
+      if (currentTurn) {
+        currentTurn.turnMessages.push(msg)
+      }
+    }
+  }
+
+  flushTurn()
+  return mergeAdjacentSameModelTurns(groups)
+}
+
+/**
+ * 后处理：合并相邻同模型的 assistant-turn
+ *
+ * 当子代理（如 haiku）执行多个工具调用时，中间的 user(tool_result) 消息
+ * 可能导致 turn 被拆分为多个碎片。此函数将同模型的相邻 assistant-turn 合并，
+ * 同时吸收它们之间的非用户输入 group（如被误判为用户输入的子代理内部消息）。
+ */
+function mergeAdjacentSameModelTurns(groups: MessageGroup[]): MessageGroup[] {
+  if (groups.length <= 1) return groups
+
+  const result: MessageGroup[] = []
+
+  for (const group of groups) {
+    if (group.type !== 'assistant-turn') {
+      result.push(group)
+      continue
+    }
+
+    // 后台任务唤醒后开始的 turn：独立成块，不向前合并。
+    if (group.startsAfterWake) {
+      result.push(group)
+      continue
+    }
+
+    // 向前查找可合并的同模型 assistant-turn（跳过非 user-input 的中间 group）
+    let mergeTargetIdx = -1
+    for (let i = result.length - 1; i >= 0; i--) {
+      const prev = result[i]!
+      if (prev.type === 'user') break // 真正的用户输入阻断合并
+      if (prev.type === 'system' && ['compact_boundary', 'permission_denied'].includes((prev.message as SDKSystemMessage).subtype ?? '')) break
+      if (prev.type === 'assistant-turn') {
+        if (prev.model === group.model) {
+          mergeTargetIdx = i
+        }
+        break // 遇到第一个 assistant-turn 就停止（不跨越不同模型的 turn）
+      }
+      // system 或其他 group：继续向前查找
+    }
+
+    if (mergeTargetIdx >= 0) {
+      const target = result[mergeTargetIdx] as AssistantTurn
+      target.assistantMessages.push(...group.assistantMessages)
+      target.turnMessages.push(...group.turnMessages)
+    } else {
+      result.push(group)
+    }
+  }
+
+  return result
+}
+
+// ===== 预览/摘要 =====
+
+const SCHEDULED_RUN_MARKER = '<!--PROMA_SCHEDULED_RUN-->'
+
+export function stripScheduledRunMarker(text: string): string {
+  return text.replaceAll(SCHEDULED_RUN_MARKER, '').trim()
+}
+
+/**
+ * 从 MessageGroup 中提取纯文本预览，供迷你地图 / outline 使用
+ */
+export function getGroupPreview(group: MessageGroup): string {
+  if (group.type === 'user') {
+    return stripScheduledRunMarker(extractUserText(group.message) ?? '')
+      .replace(/<attached_files>[\s\S]*?<\/attached_files>\n*/, '')
+      .replace(/<quoted_file[^>]*>[\s\S]*?<\/quoted_file>\n*/g, '')
+      .slice(0, 200)
+  }
+  if (group.type === 'system') {
+    if (group.message.subtype === 'compact_boundary') return '上下文已压缩'
+    if (group.message.subtype === 'compacting') return '正在压缩上下文...'
+    if (group.message.subtype === 'permission_denied') return '自动审批已拒绝操作'
+    return ''
+  }
+  // assistant-turn：收集所有 text 块
+  const texts: string[] = []
+  for (const aMsg of group.assistantMessages) {
+    const rawBlocks = aMsg.message?.content
+    if (!Array.isArray(rawBlocks)) continue
+    for (const block of normalizeThinkTagsInContentBlocks(rawBlocks)) {
+      if (block.type === 'text' && 'text' in block) {
+        texts.push((block as { text: string }).text)
+      }
+    }
+  }
+  return texts.join(' ').slice(0, 200)
+}

--- a/packages/session-core/src/index.ts
+++ b/packages/session-core/src/index.ts
@@ -2,12 +2,15 @@
  * @proma/session-core — Proma 会话读取 / 快照去重 / 转录 / 渲染的 headless 核心。
  *
  * 唯一真源：Electron 主进程、proma CLI、未来的 query 型接口共用本包，
- * 避免在仓库外侧重抄一份会随存储格式漂移的解析器。全部为纯函数（除 read 的文件 IO）。
+ * 避免在仓库外侧重抄一份会随存储格式漂移的解析器。
+ *
+ * 本主入口（'.'）**全部为纯函数，浏览器安全**，可被 Electron 渲染层直接 import。
+ * 涉及文件 IO（node:fs）的 readSessionMessages 在子入口 '@proma/session-core/node'，
+ * 仅供 Node 侧（proma CLI / 主进程）使用，避免 Vite 把 node:fs 打进渲染层 bundle。
  */
 
-// 读取与格式归一
+// 解析与格式归一（纯函数，无文件 IO）
 export {
-  readSessionMessages,
   readSessionMessagesFromString,
   convertLegacyMessage,
 } from './read'

--- a/packages/session-core/src/index.ts
+++ b/packages/session-core/src/index.ts
@@ -1,0 +1,49 @@
+/**
+ * @proma/session-core — Proma 会话读取 / 快照去重 / 转录 / 渲染的 headless 核心。
+ *
+ * 唯一真源：Electron 主进程、proma CLI、未来的 query 型接口共用本包，
+ * 避免在仓库外侧重抄一份会随存储格式漂移的解析器。全部为纯函数（除 read 的文件 IO）。
+ */
+
+// 读取与格式归一
+export {
+  readSessionMessages,
+  readSessionMessagesFromString,
+  convertLegacyMessage,
+} from './read'
+
+// Turn 分组（快照合并去重的唯一真源）
+export {
+  groupIntoTurns,
+  getGroupPreview,
+  extractUserText,
+  extractMeta,
+  isUserInputMessage,
+  stripScheduledRunMarker,
+  type MessageGroup,
+  type AssistantTurn,
+  type MessageMeta,
+} from './group'
+
+// <think> 标签归一
+export {
+  normalizeThinkTagsInContentBlocks,
+  parseThinkTagsFromText,
+  splitThinkTagsInTextBlock,
+} from './thinking-tags'
+
+// 转录（稳定下标 + assistant 多快照去重 + 工具摘要折叠）
+export {
+  toTranscript,
+  summarizeToolInput,
+  collapseToolSummaries,
+  type TranscriptTurn,
+  type TurnRole,
+} from './transcript'
+
+// 渐进式读取原语
+export { outline, formatOutlineLine, type OutlineEntry } from './outline'
+export { searchTurns, type SearchHit, type SearchOptions } from './search'
+export { selectTurns, type SelectOptions } from './select'
+export { renderTranscriptMarkdown, type RenderMarkdownOptions } from './render-markdown'
+export { estimateTokens } from './tokens'

--- a/packages/session-core/src/node.ts
+++ b/packages/session-core/src/node.ts
@@ -1,0 +1,8 @@
+/**
+ * @proma/session-core/node — Node 侧子入口（含文件 IO，import 'node:fs'）。
+ *
+ * 仅供 proma CLI 与 Electron 主进程使用。**不要**从浏览器/渲染层 import 本入口，
+ * 否则 Vite 会把 node:fs 打进 bundle 导致运行时报错。浏览器侧请用主入口
+ * '@proma/session-core'（纯函数）。
+ */
+export { readSessionMessages } from './read-fs'

--- a/packages/session-core/src/outline.ts
+++ b/packages/session-core/src/outline.ts
@@ -1,0 +1,43 @@
+import type { TranscriptTurn, TurnRole } from './transcript'
+
+export interface OutlineEntry {
+  index: number
+  role: TurnRole
+  preview: string
+  /** assistant 回合的工具摘要计数概览，如 "Read ×3, Bash ×1"。 */
+  tools?: string
+  tokens: number
+}
+
+/** 生成 turn 级地图：每 turn 一行的结构概览，便于 Agent 决定读哪段。 */
+export function outline(turns: TranscriptTurn[]): OutlineEntry[] {
+  return turns.map((t) => ({
+    index: t.index,
+    role: t.role,
+    preview: t.preview,
+    tools: t.toolSummaries.length ? summarizeToolCounts(t.toolSummaries) : undefined,
+    tokens: t.tokens,
+  }))
+}
+
+/** 把工具摘要列表收敛成 "ToolName ×N" 概览（取工具名首词）。 */
+function summarizeToolCounts(toolSummaries: string[]): string {
+  const counts = new Map<string, number>()
+  for (const s of toolSummaries) {
+    const m = /^(\S+)(?:.*?×(\d+))?$/.exec(s)
+    const name = m?.[1] ?? 'tool'
+    const n = m?.[2] ? Number(m[2]) : 1
+    counts.set(name, (counts.get(name) ?? 0) + n)
+  }
+  return [...counts.entries()].map(([name, n]) => `${name} ×${n}`).join(', ')
+}
+
+const ROLE_LABEL: Record<TurnRole, string> = { user: '用户', assistant: '助手', system: '系统' }
+
+/** 单行渲染一个 outline 条目。 */
+export function formatOutlineLine(e: OutlineEntry): string {
+  const head = `#${e.index} ${ROLE_LABEL[e.role]}`
+  const body = e.preview ? ` · ${e.preview.replace(/\s+/g, ' ').slice(0, 80)}` : ''
+  const tools = e.tools ? ` · [${e.tools}]` : ''
+  return `${head}${body}${tools} (~${e.tokens}t)`
+}

--- a/packages/session-core/src/read-fs.ts
+++ b/packages/session-core/src/read-fs.ts
@@ -1,0 +1,17 @@
+/**
+ * 文件 IO 层 — 仅供 Node 侧（proma CLI / Electron 主进程）使用。
+ *
+ * 本文件 import 'node:fs'，因此**不能**进入浏览器可达的主 barrel（'@proma/session-core'）。
+ * 它只通过子路径 '@proma/session-core/node' 暴露，避免 Vite 把 node:fs 打进渲染层 bundle。
+ */
+import { readFileSync } from 'node:fs'
+import type { SDKMessage } from '@proma/shared'
+import { readSessionMessagesFromString } from './read'
+
+/**
+ * 从磁盘读取一份会话 JSONL 并解析为 SDKMessage[]。
+ */
+export function readSessionMessages(filePath: string): SDKMessage[] {
+  const raw = readFileSync(filePath, 'utf-8')
+  return readSessionMessagesFromString(raw)
+}

--- a/packages/session-core/src/read.ts
+++ b/packages/session-core/src/read.ts
@@ -1,0 +1,101 @@
+/**
+ * 读取 Proma 会话 JSONL → SDKMessage[]
+ *
+ * 逻辑迁移自 apps/electron 主进程 agent-session-manager.ts 的
+ * getAgentSessionSDKMessages / convertLegacyMessage，作为唯一真源由
+ * Electron 主进程与 proma CLI 共用。旧扁平格式（AgentMessage，带 role 字段）
+ * 在此统一归一为近似 SDKMessage，下游无需再区分「格式 A / 格式 B」。
+ */
+import { readFileSync } from 'node:fs'
+import type { AgentMessage, SDKMessage } from '@proma/shared'
+
+/**
+ * 将旧的 AgentMessage 转换为近似的 SDKMessage（向后兼容）。
+ * 不需要完美还原，只需在渲染/导出中可读即可。
+ */
+export function convertLegacyMessage(legacy: AgentMessage): SDKMessage {
+  if (legacy.role === 'user') {
+    return {
+      type: 'user',
+      message: {
+        content: [{ type: 'text', text: legacy.content }],
+      },
+      parent_tool_use_id: null,
+      _legacy: true,
+      _createdAt: legacy.createdAt,
+    } as unknown as SDKMessage
+  }
+
+  if (legacy.role === 'assistant') {
+    return {
+      type: 'assistant',
+      message: {
+        content: [{ type: 'text', text: legacy.content }],
+        model: legacy.model,
+      },
+      parent_tool_use_id: null,
+      _legacy: true,
+      _createdAt: legacy.createdAt,
+    } as unknown as SDKMessage
+  }
+
+  if (legacy.role === 'status') {
+    // 错误消息转换为 assistant error 格式
+    return {
+      type: 'assistant',
+      message: {
+        content: [{ type: 'text', text: legacy.content }],
+      },
+      parent_tool_use_id: null,
+      error: { message: legacy.content, errorType: legacy.errorCode },
+      _legacy: true,
+      _createdAt: legacy.createdAt,
+      _errorCode: legacy.errorCode,
+      _errorTitle: legacy.errorTitle,
+      _errorDetails: legacy.errorDetails,
+      _errorCanRetry: legacy.errorCanRetry,
+      _errorActions: legacy.errorActions,
+    } as unknown as SDKMessage
+  }
+
+  // 其他类型，作为 system 消息返回
+  return {
+    type: 'system',
+    subtype: 'init',
+    _legacy: true,
+    _createdAt: legacy.createdAt,
+  } as unknown as SDKMessage
+}
+
+/**
+ * 解析 JSONL 文本为 SDKMessage[]（纯函数，便于测试与非文件来源）。
+ * 损坏行（截断的 JSON）静默跳过，不中断整份会话解析。
+ */
+export function readSessionMessagesFromString(raw: string): SDKMessage[] {
+  const lines = raw.split('\n')
+  const messages: SDKMessage[] = []
+  for (const line of lines) {
+    if (!line.trim()) continue
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(line)
+    } catch {
+      continue // 容错：跳过损坏行
+    }
+    // 旧格式检测：AgentMessage 有 `role` 字段，SDKMessage 有 `type` 字段
+    if (parsed && typeof parsed === 'object' && 'role' in parsed && !('type' in parsed)) {
+      messages.push(convertLegacyMessage(parsed as AgentMessage))
+    } else {
+      messages.push(parsed as SDKMessage)
+    }
+  }
+  return messages
+}
+
+/**
+ * 从磁盘读取一份会话 JSONL 并解析为 SDKMessage[]。
+ */
+export function readSessionMessages(filePath: string): SDKMessage[] {
+  const raw = readFileSync(filePath, 'utf-8')
+  return readSessionMessagesFromString(raw)
+}

--- a/packages/session-core/src/read.ts
+++ b/packages/session-core/src/read.ts
@@ -6,7 +6,13 @@
  * Electron 主进程与 proma CLI 共用。旧扁平格式（AgentMessage，带 role 字段）
  * 在此统一归一为近似 SDKMessage，下游无需再区分「格式 A / 格式 B」。
  */
-import { readFileSync } from 'node:fs'
+/**
+ * 解析会话 JSONL 文本为 SDKMessage[]（纯函数，浏览器安全，无文件 IO）。
+ *
+ * 注意：本文件刻意不 import 'node:fs'，以便被 Electron 渲染层（浏览器环境）
+ * 经主 barrel 引入。需要从磁盘读取的 readSessionMessages 在 './read-fs' 中，
+ * 仅通过 '@proma/session-core/node' 子路径暴露给 Node 侧（CLI / 主进程）。
+ */
 import type { AgentMessage, SDKMessage } from '@proma/shared'
 
 /**
@@ -90,12 +96,4 @@ export function readSessionMessagesFromString(raw: string): SDKMessage[] {
     }
   }
   return messages
-}
-
-/**
- * 从磁盘读取一份会话 JSONL 并解析为 SDKMessage[]。
- */
-export function readSessionMessages(filePath: string): SDKMessage[] {
-  const raw = readFileSync(filePath, 'utf-8')
-  return readSessionMessagesFromString(raw)
 }

--- a/packages/session-core/src/render-markdown.ts
+++ b/packages/session-core/src/render-markdown.ts
@@ -1,0 +1,44 @@
+import type { TranscriptTurn, TurnRole } from './transcript'
+
+export interface RenderMarkdownOptions {
+  /** 文档标题用的会话 id。 */
+  sessionId?: string
+  /** 是否输出顶部标题与说明（默认 true）。截取片段时可设 false。 */
+  header?: boolean
+}
+
+const HEADING: Record<TurnRole, string> = {
+  user: '## 用户',
+  assistant: '## 助手',
+  system: '## 系统',
+}
+
+/**
+ * 把 TranscriptTurn[] 渲染为干净 Markdown 对话。
+ * 连续同角色合并到同一标题下；工具调用以 `> [工具: …]` 引用行呈现。
+ */
+export function renderTranscriptMarkdown(turns: TranscriptTurn[], opts: RenderMarkdownOptions = {}): string {
+  const { sessionId, header = true } = opts
+  const lines: string[] = []
+
+  if (header) {
+    lines.push(`# Session: ${sessionId ?? ''}`.trimEnd(), '')
+    lines.push('> 自动清洗自会话 JSONL，流式快照与工具回包已过滤。', '')
+  }
+
+  let currentRole: TurnRole | null = null
+  for (const t of turns) {
+    if (t.role !== currentRole) {
+      lines.push(HEADING[t.role], '')
+      currentRole = t.role
+    }
+    if (t.text) {
+      lines.push(t.text, '')
+    }
+    for (const tool of t.toolSummaries) {
+      lines.push(`> [工具: ${tool}]`, '')
+    }
+  }
+
+  return lines.join('\n').replace(/\n{3,}/g, '\n\n').trimEnd() + '\n'
+}

--- a/packages/session-core/src/search.ts
+++ b/packages/session-core/src/search.ts
@@ -1,0 +1,57 @@
+import type { TranscriptTurn, TurnRole } from './transcript'
+
+export interface SearchHit {
+  index: number
+  role: TurnRole
+  /** 命中处上下文片段。 */
+  snippet: string
+  /** 该 turn 内匹配次数。 */
+  matchCount: number
+}
+
+export interface SearchOptions {
+  caseSensitive?: boolean
+  /** 片段在命中点前后保留的字符数（默认 60）。 */
+  context?: number
+  /** 最多返回的命中 turn 数。 */
+  limit?: number
+}
+
+/**
+ * 在转录上做子串搜索（正文 + 工具摘要），返回命中 turn 的下标与片段。
+ * Agent 据此再用 selectTurns / export --turns 取命中邻域，避免全量读。
+ */
+export function searchTurns(turns: TranscriptTurn[], query: string, opts: SearchOptions = {}): SearchHit[] {
+  const { caseSensitive = false, context = 60, limit } = opts
+  if (!query) return []
+  const needle = caseSensitive ? query : query.toLowerCase()
+  const hits: SearchHit[] = []
+
+  for (const t of turns) {
+    const haystackRaw = [t.text, ...t.toolSummaries].join('\n')
+    const haystack = caseSensitive ? haystackRaw : haystackRaw.toLowerCase()
+    let from = 0
+    let matchCount = 0
+    let firstIdx = -1
+    for (;;) {
+      const idx = haystack.indexOf(needle, from)
+      if (idx === -1) break
+      if (firstIdx === -1) firstIdx = idx
+      matchCount++
+      from = idx + needle.length
+    }
+    if (matchCount === 0) continue
+
+    const start = Math.max(0, firstIdx - context)
+    const end = Math.min(haystackRaw.length, firstIdx + needle.length + context)
+    const snippet =
+      (start > 0 ? '…' : '') +
+      haystackRaw.slice(start, end).replace(/\s+/g, ' ').trim() +
+      (end < haystackRaw.length ? '…' : '')
+
+    hits.push({ index: t.index, role: t.role, snippet, matchCount })
+    if (limit && hits.length >= limit) break
+  }
+
+  return hits
+}

--- a/packages/session-core/src/select.ts
+++ b/packages/session-core/src/select.ts
@@ -1,0 +1,36 @@
+import type { TranscriptTurn } from './transcript'
+
+export interface SelectOptions {
+  /** 闭区间 turn 下标 [a, b]（含两端）。 */
+  range?: [number, number]
+  /** 取前 N 个 turn。 */
+  head?: number
+  /** 取后 N 个 turn。 */
+  tail?: number
+  /** 从下标 offset 起。 */
+  offset?: number
+  /** 配合 offset，取 limit 个。 */
+  limit?: number
+}
+
+/**
+ * 按窗口截取 turn 子集（下标稳定）。优先级：range > head > tail > offset/limit。
+ * 不传任何窗口 → 返回全部。
+ */
+export function selectTurns(turns: TranscriptTurn[], opts: SelectOptions = {}): TranscriptTurn[] {
+  const { range, head, tail, offset, limit } = opts
+  if (range) {
+    const [a, b] = range
+    const lo = Math.min(a, b)
+    const hi = Math.max(a, b)
+    return turns.filter((t) => t.index >= lo && t.index <= hi)
+  }
+  if (typeof head === 'number') return turns.slice(0, Math.max(0, head))
+  if (typeof tail === 'number') return turns.slice(Math.max(0, turns.length - tail))
+  if (typeof offset === 'number' || typeof limit === 'number') {
+    const start = offset ?? 0
+    const end = typeof limit === 'number' ? start + limit : undefined
+    return turns.slice(start, end)
+  }
+  return turns
+}

--- a/packages/session-core/src/session-core.test.ts
+++ b/packages/session-core/src/session-core.test.ts
@@ -1,0 +1,118 @@
+import { test, expect, describe } from 'bun:test'
+import {
+  readSessionMessagesFromString,
+  groupIntoTurns,
+  toTranscript,
+  searchTurns,
+  selectTurns,
+  renderTranscriptMarkdown,
+  collapseToolSummaries,
+  summarizeToolInput,
+} from './index'
+
+/** 把对象数组序列化为 JSONL（每行一个 JSON）。 */
+function jsonl(rows: unknown[]): string {
+  return rows.map((r) => JSON.stringify(r)).join('\n')
+}
+
+describe('快照去重（格式 B）', () => {
+  // 同一 assistant 回合的 3 行递增快照，共享 message.id='m1'
+  const raw = jsonl([
+    { type: 'user', message: { content: [{ type: 'text', text: '读取文件' }] }, parent_tool_use_id: null },
+    { type: 'assistant', message: { id: 'm1', content: [{ type: 'text', text: 'Hel' }] }, parent_tool_use_id: null },
+    { type: 'assistant', message: { id: 'm1', content: [{ type: 'text', text: 'Hello' }, { type: 'tool_use', id: 't1', name: 'Read', input: { file_path: '/a' } }] }, parent_tool_use_id: null },
+    { type: 'assistant', message: { id: 'm1', content: [{ type: 'thinking', thinking: '想一下' }, { type: 'text', text: 'Hello world' }, { type: 'tool_use', id: 't1', name: 'Read', input: { file_path: '/a' } }] }, parent_tool_use_id: null },
+    { type: 'user', message: { content: [{ type: 'tool_result', tool_use_id: 't1', content: 'data' }] }, parent_tool_use_id: null },
+    { type: 'result', subtype: 'success' },
+  ])
+
+  const turns = toTranscript(groupIntoTurns(readSessionMessagesFromString(raw)))
+
+  test('合并为 user + assistant 两个 turn，下标稳定', () => {
+    expect(turns.map((t) => t.role)).toEqual(['user', 'assistant'])
+    expect(turns.map((t) => t.index)).toEqual([0, 1])
+  })
+
+  test('assistant 只取最完整快照，无拼接重复', () => {
+    const a = turns[1]!
+    expect(a.text).toBe('Hello world')
+    expect(a.text).not.toContain('Hel\n')
+  })
+
+  test('thinking 块被丢弃', () => {
+    expect(turns[1]!.text).not.toContain('想一下')
+  })
+
+  test('tool_use 压缩为单行摘要；tool_result 不进正文', () => {
+    expect(turns[1]!.toolSummaries).toEqual(['Read file_path=/a'])
+    expect(turns[1]!.text).not.toContain('data')
+  })
+
+  test('纯 tool_result 的 user 行不产生用户 turn', () => {
+    expect(turns.filter((t) => t.role === 'user')).toHaveLength(1)
+  })
+})
+
+describe('工具折叠 ×N', () => {
+  test('连续相同工具摘要折叠计数', () => {
+    expect(collapseToolSummaries(['OCR p=1', 'OCR p=1', 'OCR p=1', 'Read f=a'])).toEqual(['OCR p=1 ×3', 'Read f=a'])
+  })
+
+  test('summarizeToolInput 跳过空值并截断长值', () => {
+    expect(summarizeToolInput('Read', { file_path: '/a', limit: 0, empty: '' })).toBe('Read file_path=/a limit=0')
+    const long = 'x'.repeat(200)
+    expect(summarizeToolInput('Bash', { command: long }).length).toBeLessThan(100)
+  })
+})
+
+describe('旧扁平格式（格式 A）归一', () => {
+  const raw = jsonl([
+    { id: '1', role: 'user', content: '你好', createdAt: 1 },
+    { id: '2', role: 'assistant', content: '旧版回复', createdAt: 2 },
+    { id: '3', role: 'assistant', content: '', createdAt: 3 },
+  ])
+  const turns = toTranscript(groupIntoTurns(readSessionMessagesFromString(raw)))
+
+  test('role 字段被识别并转换为 SDKMessage', () => {
+    expect(turns[0]).toMatchObject({ role: 'user', text: '你好' })
+    expect(turns[1]).toMatchObject({ role: 'assistant', text: '旧版回复' })
+  })
+})
+
+describe('容错与渐进式读取原语', () => {
+  const raw = jsonl([
+    { type: 'user', message: { content: [{ type: 'text', text: '问题甲' }] }, parent_tool_use_id: null },
+    { type: 'assistant', message: { id: 'a1', content: [{ type: 'text', text: '答案含关键词 needle' }] }, parent_tool_use_id: null },
+    { type: 'user', message: { content: [{ type: 'text', text: '问题乙' }] }, parent_tool_use_id: null },
+    { type: 'assistant', message: { id: 'a2', content: [{ type: 'text', text: '无关回答' }] }, parent_tool_use_id: null },
+  ])
+
+  test('损坏行被静默跳过', () => {
+    const withBad = raw + '\n{ 坏行不是 json\n'
+    const msgs = readSessionMessagesFromString(withBad)
+    expect(msgs.length).toBe(4)
+  })
+
+  const turns = toTranscript(groupIntoTurns(readSessionMessagesFromString(raw)))
+
+  test('searchTurns 返回命中 turn 下标', () => {
+    const hits = searchTurns(turns, 'needle')
+    expect(hits).toHaveLength(1)
+    expect(hits[0]!.index).toBe(1)
+    expect(hits[0]!.snippet).toContain('needle')
+  })
+
+  test('selectTurns 按 range 截取', () => {
+    expect(selectTurns(turns, { range: [2, 3] }).map((t) => t.index)).toEqual([2, 3])
+    expect(selectTurns(turns, { head: 1 }).map((t) => t.index)).toEqual([0])
+    expect(selectTurns(turns, { tail: 1 }).map((t) => t.index)).toEqual([3])
+  })
+
+  test('renderTranscriptMarkdown 按角色分段', () => {
+    const md = renderTranscriptMarkdown(turns, { sessionId: 'demo' })
+    expect(md).toContain('# Session: demo')
+    expect(md).toContain('## 用户')
+    expect(md).toContain('## 助手')
+    expect(md).toContain('答案含关键词 needle')
+  })
+})

--- a/packages/session-core/src/thinking-tags.ts
+++ b/packages/session-core/src/thinking-tags.ts
@@ -1,0 +1,64 @@
+import type { SDKContentBlock, SDKTextBlock } from '@proma/shared'
+
+const THINK_OPEN_TAG = '<think>'
+const THINK_CLOSE_TAG = '</think>'
+
+function appendTextBlock(blocks: SDKContentBlock[], text: string): void {
+  if (!text.trim()) return
+  blocks.push({ type: 'text', text })
+}
+
+function appendThinkingBlock(blocks: SDKContentBlock[], thinking: string): void {
+  const content = thinking.trim()
+  if (!content) return
+  blocks.push({ type: 'thinking', thinking: content })
+}
+
+/**
+ * 兼容部分模型把思考内容包在 <think> 标签里的返回格式。
+ * 未闭合的 <think> 在流式阶段按思考块处理，等闭合标签到达后会自然拆出后续正文。
+ */
+export function parseThinkTagsFromText(text: string): SDKContentBlock[] {
+  const lowerText = text.toLowerCase()
+  const blocks: SDKContentBlock[] = []
+  let cursor = 0
+
+  while (cursor < text.length) {
+    const openIndex = lowerText.indexOf(THINK_OPEN_TAG, cursor)
+    if (openIndex === -1) {
+      appendTextBlock(blocks, text.slice(cursor))
+      break
+    }
+
+    appendTextBlock(blocks, text.slice(cursor, openIndex))
+
+    const contentStart = openIndex + THINK_OPEN_TAG.length
+    const closeIndex = lowerText.indexOf(THINK_CLOSE_TAG, contentStart)
+    if (closeIndex === -1) {
+      appendThinkingBlock(blocks, text.slice(contentStart))
+      break
+    }
+
+    appendThinkingBlock(blocks, text.slice(contentStart, closeIndex))
+    cursor = closeIndex + THINK_CLOSE_TAG.length
+  }
+
+  return blocks
+}
+
+export function splitThinkTagsInTextBlock(block: SDKTextBlock): SDKContentBlock[] {
+  if (!block.text.toLowerCase().includes(THINK_OPEN_TAG)) return [block]
+  return parseThinkTagsFromText(block.text)
+}
+
+export function normalizeThinkTagsInContentBlocks(blocks: SDKContentBlock[]): SDKContentBlock[] {
+  const normalized: SDKContentBlock[] = []
+  for (const block of blocks) {
+    if (block.type === 'text' && 'text' in block && typeof block.text === 'string') {
+      normalized.push(...splitThinkTagsInTextBlock(block as SDKTextBlock))
+    } else {
+      normalized.push(block)
+    }
+  }
+  return normalized
+}

--- a/packages/session-core/src/tokens.ts
+++ b/packages/session-core/src/tokens.ts
@@ -1,0 +1,16 @@
+/**
+ * 近似 token 估算。无第三方 tokenizer 依赖，用便宜启发式：
+ * 约 4 字符/token（英文）；CJK 字符按约 1.5 字符/token 加权。
+ * 仅用于 info / outline 的"够不够塞进上下文"量级判断，非精确计费。
+ */
+export function estimateTokens(text: string): number {
+  if (!text) return 0
+  let cjk = 0
+  for (const ch of text) {
+    const code = ch.codePointAt(0) ?? 0
+    // CJK 统一表意文字 + 常见中日韩区段
+    if (code >= 0x3000 && code <= 0x9fff) cjk++
+  }
+  const ascii = text.length - cjk
+  return Math.ceil(ascii / 4 + cjk / 1.5)
+}

--- a/packages/session-core/src/transcript.ts
+++ b/packages/session-core/src/transcript.ts
@@ -1,0 +1,139 @@
+/**
+ * 转录层 — 把 MessageGroup[] 规整为带稳定下标的扁平 TranscriptTurn[]，
+ * 供 CLI 的 outline / search / select / export 复用。
+ *
+ * 关键：groupIntoTurns 会把同一回合的多行流式快照都保留在 assistantMessages 中
+ * （每行共享同一 message.id，是逐步增长的完整快照）。本层按 message.id 取最后一条
+ * （最完整）快照来消除「拼接单字 / 重复段落」，这是会话「快照去重」的落地实现。
+ */
+import type { SDKAssistantMessage, SDKContentBlock, SDKToolUseBlock } from '@proma/shared'
+import { type MessageGroup, extractUserText, getGroupPreview, stripScheduledRunMarker } from './group'
+import { estimateTokens } from './tokens'
+
+export type TurnRole = 'user' | 'assistant' | 'system'
+
+export interface TranscriptTurn {
+  /** 稳定下标：在 groupIntoTurns 输出中的 0 基位置。outline/search/export 共享。 */
+  index: number
+  role: TurnRole
+  model?: string
+  createdAt?: number
+  /** 可见正文（thinking 与 tool_result 已丢弃；assistant 多快照已去重）。 */
+  text: string
+  /** assistant 回合的工具调用摘要，已折叠连续重复为 "name args ×N"。 */
+  toolSummaries: string[]
+  /** 单行预览（<=200 字）。 */
+  preview: string
+  /** 近似 token 数（正文 + 工具摘要）。 */
+  tokens: number
+}
+
+/** 把工具 input 压缩成可读单行摘要：name key=value …（空值跳过，超 80 字符截断）。 */
+export function summarizeToolInput(name: string, input: unknown): string {
+  if (!input || typeof input !== 'object') return name
+  const parts: string[] = []
+  for (const [k, v] of Object.entries(input as Record<string, unknown>)) {
+    if (v === null || v === undefined || v === '' ) continue
+    if (Array.isArray(v) && v.length === 0) continue
+    if (typeof v === 'object' && !Array.isArray(v) && Object.keys(v as object).length === 0) continue
+    let sv = typeof v === 'string' ? v : JSON.stringify(v)
+    sv = sv.replace(/\s+/g, ' ')
+    if (sv.length > 80) sv = sv.slice(0, 77) + '...'
+    parts.push(`${k}=${sv}`)
+  }
+  return parts.length ? `${name} ${parts.join(' ')}` : name
+}
+
+/** 折叠连续相同的工具摘要为一条，末尾加 ×N。 */
+export function collapseToolSummaries(summaries: string[]): string[] {
+  const out: string[] = []
+  let i = 0
+  while (i < summaries.length) {
+    let j = i + 1
+    while (j < summaries.length && summaries[j] === summaries[i]) j++
+    const count = j - i
+    out.push(count === 1 ? summaries[i]! : `${summaries[i]} ×${count}`)
+    i = j
+  }
+  return out
+}
+
+/** 按 message.id 取每个逻辑消息的最后一条（最完整）快照，保留首次出现顺序。 */
+function dedupSnapshotsByMessageId(messages: SDKAssistantMessage[]): SDKAssistantMessage[] {
+  const lastById = new Map<string, SDKAssistantMessage>()
+  const order: string[] = []
+  let anon = 0
+  for (const m of messages) {
+    // message.id 在真实 JSONL 中存在（同一回合的多行快照共享它），但 SDK 类型未建模 → 安全读取。
+    const id = (m.message as unknown as { id?: string } | undefined)?.id ?? `__anon_${anon++}`
+    if (!lastById.has(id)) order.push(id)
+    lastById.set(id, m)
+  }
+  return order.map((id) => lastById.get(id)!)
+}
+
+/** 从去重后的 assistant 消息中抽取正文与工具摘要（thinking / tool_result 丢弃）。 */
+function buildAssistantContent(messages: SDKAssistantMessage[]): { text: string; toolSummaries: string[] } {
+  const texts: string[] = []
+  const rawToolSummaries: string[] = []
+  for (const m of dedupSnapshotsByMessageId(messages)) {
+    const blocks = m.message?.content
+    if (!Array.isArray(blocks)) continue
+    for (const block of blocks as SDKContentBlock[]) {
+      if (block.type === 'text' && 'text' in block) {
+        const t = (block as { text: string }).text.trim()
+        if (t) texts.push(t)
+      } else if (block.type === 'tool_use') {
+        const tu = block as SDKToolUseBlock
+        rawToolSummaries.push(summarizeToolInput(tu.name ?? 'tool', tu.input))
+      }
+      // thinking / 其他块：丢弃
+    }
+  }
+  return { text: texts.join('\n\n'), toolSummaries: collapseToolSummaries(rawToolSummaries) }
+}
+
+/**
+ * MessageGroup[] → TranscriptTurn[]（稳定下标）。
+ */
+export function toTranscript(groups: MessageGroup[]): TranscriptTurn[] {
+  return groups.map((group, index) => {
+    if (group.type === 'user') {
+      const text = stripScheduledRunMarker(extractUserText(group.message) ?? '')
+        .replace(/<attached_files>[\s\S]*?<\/attached_files>\n*/g, '')
+        .replace(/<quoted_file[^>]*>[\s\S]*?<\/quoted_file>\n*/g, '')
+        .trim()
+      return {
+        index,
+        role: 'user' as const,
+        createdAt: (group.message as unknown as { _createdAt?: number })._createdAt,
+        text,
+        toolSummaries: [],
+        preview: getGroupPreview(group),
+        tokens: estimateTokens(text),
+      }
+    }
+    if (group.type === 'system') {
+      const preview = getGroupPreview(group)
+      return {
+        index,
+        role: 'system' as const,
+        text: preview,
+        toolSummaries: [],
+        preview,
+        tokens: estimateTokens(preview),
+      }
+    }
+    const { text, toolSummaries } = buildAssistantContent(group.assistantMessages)
+    return {
+      index,
+      role: 'assistant' as const,
+      model: group.model,
+      createdAt: group.createdAt,
+      text,
+      toolSummaries,
+      preview: getGroupPreview(group),
+      tokens: estimateTokens(text + ' ' + toolSummaries.join(' ')),
+    }
+  })
+}

--- a/packages/session-core/tsconfig.json
+++ b/packages/session-core/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {},
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
替代被意外关闭的 #989（合并 #988 时 \`--delete-branch\` 删掉了 base 分支 \`feat-session-core\`，导致栈在其上的 #989 被 GitHub 自动关闭，无法 reopen）。

分支 \`feat-proma-cli\` 代码完整无损，现 retarget 到 main 重新合并。

## 内容

独立 \`proma\` CLI（\`apps/cli\`），基于 \`@proma/session-core\`（已随 #988 合入 main），面向有限上下文的 Agent 提供渐进式会话读取：

- \`session list / info / outline / search / export\`
- export 窗口化（\`--turns/--head/--tail\`）+ 超预算落盘护栏
- electron-free 路径解析，\`--json\` 机器可读，退出码 0/1/2

> session-core 部分已在 main（#988），本 PR 的净增量是 \`apps/cli/\`。bun test 24/24，typecheck 0。