### PR TITLE
feat(agent): 引用会话改用 session-cleaner skill 渐进式读取

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -435,15 +435,15 @@ function buildReferencedSessionsPrompt(
 
   if (sessionBlocks.length === 0) return ''
 
-  // 打包模式下 proma CLI 二进制随 App 分发，可用 session-cleaner skill 对引用会话做渐进式读取
-  //（先看体量/大纲，再搜索定位，最后只取相关 turn 区间），避免一次性读入大 .jsonl 撑爆上下文。
+  // 打包模式下 proma CLI 二进制随 App 分发，可用 session-cleaner skill 读取引用会话：
+  // 默认正常完整读取（export 全量）；仅当会话过大、完整读入会撑爆上下文时，才用搜索 + turn 区间省着读。
   // 开发模式（getBundledCliPath 返回 undefined，CLI 不可用）回退到原有的 Grep 局部读指引。
   const cliAvailable = !!getBundledCliPath()
   if (cliAvailable) {
     const skillName = workspaceSlug
       ? `proma-workspace-${workspaceSlug}:session-cleaner`
       : 'session-cleaner'
-    return `<referenced_sessions>\n用户在消息中明确引用了以下同工作区 Agent 会话。需要这些会话的上下文时，使用 session-cleaner skill（${skillName}）读取——它会通过 proma CLI 对会话做渐进式读取：先看体量与大纲、再按关键词搜索定位、最后只导出相关的 turn 区间。不要假设会话内容，也不要直接 Read 原始 .jsonl 历史文件（可能非常大）。\n${sessionBlocks.join('\n\n')}\n</referenced_sessions>`
+    return `<referenced_sessions>\n用户在消息中明确引用了以下同工作区 Agent 会话。需要这些会话的上下文时，使用 session-cleaner skill（${skillName}）读取——它通过 proma CLI 把会话清洗为干净对话。默认正常完整读取整个会话；仅当某个会话过大、完整读入会撑爆上下文时，才改用 skill 的搜索 + turn 区间能力按需节省。不要假设会话内容，也不要直接 Read 原始 .jsonl 历史文件。\n${sessionBlocks.join('\n\n')}\n</referenced_sessions>`
   }
 
   return `<referenced_sessions>\n用户在消息中明确引用了以下同工作区 Agent 会话。不要假设这些会话的内容；需要上下文时，请先读取对应的 History path，再基于读取结果继续完成任务。\n\n重要提示：会话历史文件（.jsonl）可能包含大量消息和 tool results，文件较大。请优先使用 Grep 搜索关键词定位相关消息片段，再局部读取。避免一次性 Read 整个大文件。\n${sessionBlocks.join('\n\n')}\n</referenced_sessions>`

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -409,6 +409,7 @@ function buildReferencedSessionsPrompt(
   currentSessionId: string,
   mentionedSessionIds?: string[],
   workspaceId?: string,
+  workspaceSlug?: string,
 ): string {
   const uniqueIds = [...new Set((mentionedSessionIds ?? []).filter(Boolean))]
   if (uniqueIds.length === 0) return ''
@@ -433,6 +434,17 @@ function buildReferencedSessionsPrompt(
   }
 
   if (sessionBlocks.length === 0) return ''
+
+  // 打包模式下 proma CLI 二进制随 App 分发，可用 session-cleaner skill 对引用会话做渐进式读取
+  //（先看体量/大纲，再搜索定位，最后只取相关 turn 区间），避免一次性读入大 .jsonl 撑爆上下文。
+  // 开发模式（getBundledCliPath 返回 undefined，CLI 不可用）回退到原有的 Grep 局部读指引。
+  const cliAvailable = !!getBundledCliPath()
+  if (cliAvailable) {
+    const skillName = workspaceSlug
+      ? `proma-workspace-${workspaceSlug}:session-cleaner`
+      : 'session-cleaner'
+    return `<referenced_sessions>\n用户在消息中明确引用了以下同工作区 Agent 会话。需要这些会话的上下文时，使用 session-cleaner skill（${skillName}）读取——它会通过 proma CLI 对会话做渐进式读取：先看体量与大纲、再按关键词搜索定位、最后只导出相关的 turn 区间。不要假设会话内容，也不要直接 Read 原始 .jsonl 历史文件（可能非常大）。\n${sessionBlocks.join('\n\n')}\n</referenced_sessions>`
+  }
 
   return `<referenced_sessions>\n用户在消息中明确引用了以下同工作区 Agent 会话。不要假设这些会话的内容；需要上下文时，请先读取对应的 History path，再基于读取结果继续完成任务。\n\n重要提示：会话历史文件（.jsonl）可能包含大量消息和 tool results，文件较大。请优先使用 Grep 搜索关键词定位相关消息片段，再局部读取。避免一次性 Read 整个大文件。\n${sessionBlocks.join('\n\n')}\n</referenced_sessions>`
 }
@@ -1200,7 +1212,7 @@ export class AgentOrchestrator {
 
       // 11.5 注入 mention 引用指令（Skill/MCP/会话）— 仅影响 prompt，不影响持久化
       let enrichedMessage = userMessage
-      const referencedSessionsBlock = buildReferencedSessionsPrompt(sessionId, mentionedSessionIds, workspaceId)
+      const referencedSessionsBlock = buildReferencedSessionsPrompt(sessionId, mentionedSessionIds, workspaceId, workspaceSlug)
       if (referencedSessionsBlock) {
         enrichedMessage = `${referencedSessionsBlock}\n\n${enrichedMessage}`
         console.log(`[Agent 编排] 注入 referenced_sessions: ${mentionedSessionIds?.length ?? 0} sessions`)


### PR DESCRIPTION
## 背景

Agent 模式的「@引用会话」功能：用户在消息里引用同工作区的历史 Agent 会话后，`buildReferencedSessionsPrompt` 会注入一段 `<referenced_sessions>` prompt 告诉 Agent 怎么读取被引会话。

此前这段 prompt 指引 Agent **直接 Grep + 局部 Read 原始 `.jsonl`**——而原始会话文件可能极大（实测单个达 50MB），即便"局部读"也容易读入过多内容撑爆上下文。这正是 #988~#991 引入的 `proma` CLI + `session-cleaner` skill 要解决的问题。

## 改动

把注入的 prompt 改为**触发 `session-cleaner` skill** 做渐进式读取（先看体量/大纲 → 搜索定位 → 只导出相关 turn 区间），不再让 Agent 啃原始 jsonl。

- `buildReferencedSessionsPrompt` 增加 `workspaceSlug` 参数，构造带工作区前缀的 skill 限定名（`proma-workspace-<slug>:session-cleaner`），与现有 `mentioned_tools` 注入格式一致
- 用 `getBundledCliPath()` 作为 gate：
  - **打包模式**（CLI 二进制可用）→ 注入 skill 触发指引
  - **开发模式**（`getBundledCliPath()` 返回 undefined，CLI 不可用）→ **回退到原有的 Grep 局部读指引**，保证开发环境不回归

## 依赖

依赖已合入 main 的 `session-cleaner` skill（#990）与 `proma` CLI 打包（#991）。

## 验证

- `tsc --noEmit`：改动对 `agent-orchestrator` 零类型错误（唯一报错是 main 上预存的 `tsconfig baseUrl` 弃用告警，与本 PR 无关）
- 改动仅 +13/-1 行，集中在单个 prompt 构造函数