### PR TITLE
feat: 输入框富文本渲染开关 (markdown render toggle)

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.13.22",
+  "version": "0.13.23",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/settings-service.ts
+++ b/apps/electron/src/main/lib/settings-service.ts
@@ -26,6 +26,7 @@ export function getSettings(): AppSettings {
       environmentCheckSkipped: false,
       notificationsEnabled: true,
       longTextPasteAsAttachmentEnabled: false,
+      renderInputAsRichTextEnabled: true,
       feishuSessionMirror: { mode: 'off' },
       builtinMcpDisabledIds: [],
     }
@@ -42,6 +43,7 @@ export function getSettings(): AppSettings {
       environmentCheckSkipped: data.environmentCheckSkipped ?? false,
       notificationsEnabled: data.notificationsEnabled ?? true,
       longTextPasteAsAttachmentEnabled: data.longTextPasteAsAttachmentEnabled ?? false,
+      renderInputAsRichTextEnabled: data.renderInputAsRichTextEnabled ?? true,
       feishuSessionMirror: data.feishuSessionMirror ?? { mode: 'off' },
       builtinMcpDisabledIds: data.builtinMcpDisabledIds ?? [],
     }
@@ -54,6 +56,7 @@ export function getSettings(): AppSettings {
       environmentCheckSkipped: false,
       notificationsEnabled: true,
       longTextPasteAsAttachmentEnabled: false,
+      renderInputAsRichTextEnabled: true,
       feishuSessionMirror: { mode: 'off' },
       builtinMcpDisabledIds: [],
     }

--- a/apps/electron/src/renderer/atoms/ui-preferences.test.ts
+++ b/apps/electron/src/renderer/atoms/ui-preferences.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, expect, mock, test } from 'bun:test'
+import type { AppSettings } from '../../types'
+import { initializeUiPreferences, updateRenderInputAsRichTextEnabled } from './ui-preferences'
+
+interface TestElectronAPI {
+  getSettings: () => Promise<Partial<AppSettings>>
+  updateSettings: (updates: Partial<AppSettings>) => Promise<Partial<AppSettings>>
+}
+
+const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window')
+
+function setTestWindow(electronAPI: TestElectronAPI): void {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: { electronAPI },
+  })
+}
+
+afterEach(() => {
+  if (originalWindowDescriptor) {
+    Object.defineProperty(globalThis, 'window', originalWindowDescriptor)
+  } else {
+    Reflect.deleteProperty(globalThis, 'window')
+  }
+})
+
+test('initializeUiPreferences 默认开启输入框富文本渲染', async () => {
+  setTestWindow({
+    getSettings: async () => ({}),
+    updateSettings: mock(async (updates: Partial<AppSettings>) => updates),
+  })
+
+  let renderInputAsRichTextEnabled = false
+  await initializeUiPreferences(
+    () => {},
+    undefined,
+    (enabled) => {
+      renderInputAsRichTextEnabled = enabled
+    }
+  )
+
+  expect(renderInputAsRichTextEnabled).toBe(true)
+})
+
+test('initializeUiPreferences 读取关闭的输入框富文本渲染设置', async () => {
+  setTestWindow({
+    getSettings: async () => ({ renderInputAsRichTextEnabled: false }),
+    updateSettings: mock(async (updates: Partial<AppSettings>) => updates),
+  })
+
+  let renderInputAsRichTextEnabled = true
+  await initializeUiPreferences(
+    () => {},
+    undefined,
+    (enabled) => {
+      renderInputAsRichTextEnabled = enabled
+    }
+  )
+
+  expect(renderInputAsRichTextEnabled).toBe(false)
+})
+
+test('updateRenderInputAsRichTextEnabled 持久化关闭状态', async () => {
+  const updateSettings = mock(async (updates: Partial<AppSettings>) => updates)
+  setTestWindow({
+    getSettings: async () => ({}),
+    updateSettings,
+  })
+
+  await updateRenderInputAsRichTextEnabled(false)
+
+  expect(updateSettings).toHaveBeenCalledWith({ renderInputAsRichTextEnabled: false })
+})

--- a/apps/electron/src/renderer/atoms/ui-preferences.ts
+++ b/apps/electron/src/renderer/atoms/ui-preferences.ts
@@ -14,6 +14,9 @@ export const stickyUserMessageEnabledAtom = atom<boolean>(true)
 /** 粘贴长文本时是否自动转为附件 */
 export const longTextPasteAsAttachmentEnabledAtom = atom<boolean>(false)
 
+/** 输入框是否按富文本/Markdown 渲染粘贴内容 */
+export const renderInputAsRichTextEnabledAtom = atom<boolean>(true)
+
 // ===== 初始化 =====
 
 /**
@@ -21,12 +24,14 @@ export const longTextPasteAsAttachmentEnabledAtom = atom<boolean>(false)
  */
 export async function initializeUiPreferences(
   setStickyUserMessageEnabled: (enabled: boolean) => void,
-  setLongTextPasteAsAttachmentEnabled?: (enabled: boolean) => void
+  setLongTextPasteAsAttachmentEnabled?: (enabled: boolean) => void,
+  setRenderInputAsRichTextEnabled?: (enabled: boolean) => void
 ): Promise<void> {
   try {
     const settings = await window.electronAPI.getSettings()
     setStickyUserMessageEnabled(settings.stickyUserMessageEnabled ?? true)
     setLongTextPasteAsAttachmentEnabled?.(settings.longTextPasteAsAttachmentEnabled ?? false)
+    setRenderInputAsRichTextEnabled?.(settings.renderInputAsRichTextEnabled ?? true)
   } catch (error) {
     console.error('[UI偏好] 初始化失败:', error)
   }
@@ -53,5 +58,16 @@ export async function updateLongTextPasteAsAttachmentEnabled(enabled: boolean): 
     await window.electronAPI.updateSettings({ longTextPasteAsAttachmentEnabled: enabled })
   } catch (error) {
     console.error('[UI偏好] 更新长文本粘贴附件设置失败:', error)
+  }
+}
+
+/**
+ * 更新输入框富文本粘贴开关并持久化
+ */
+export async function updateRenderInputAsRichTextEnabled(enabled: boolean): Promise<void> {
+  try {
+    await window.electronAPI.updateSettings({ renderInputAsRichTextEnabled: enabled })
+  } catch (error) {
+    console.error('[UI偏好] 更新输入框富文本粘贴设置失败:', error)
   }
 }

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -92,7 +92,7 @@ import {
 } from '@/atoms/agent-atoms'
 import type { AgentContextStatus } from '@/atoms/agent-atoms'
 import { settingsOpenAtom } from '@/atoms/settings-tab'
-import { longTextPasteAsAttachmentEnabledAtom } from '@/atoms/ui-preferences'
+import { longTextPasteAsAttachmentEnabledAtom, renderInputAsRichTextEnabledAtom } from '@/atoms/ui-preferences'
 import { channelsAtom, thinkingExpandedAtom } from '@/atoms/chat-atoms'
 import { useOpenSession } from '@/hooks/useOpenSession'
 import { AgentSessionProvider } from '@/contexts/session-context'
@@ -303,6 +303,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const stoppedByUserSessions = useAtomValue(stoppedByUserSessionsAtom)
   const sendWithCmdEnter = useAtomValue(sendWithCmdEnterAtom)
   const longTextPasteAsAttachmentEnabled = useAtomValue(longTextPasteAsAttachmentEnabledAtom)
+  const renderInputAsRichText = useAtomValue(renderInputAsRichTextEnabledAtom)
   const stoppedByUser = stoppedByUserSessions.has(sessionId)
   const liveMessagesMap = useAtomValue(liveMessagesMapAtom)
   const setLiveMessagesMap = useSetAtom(liveMessagesMapAtom)
@@ -2169,6 +2170,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
               onPasteFiles={handlePasteFiles}
               onPasteLongText={handlePasteLongText}
               longTextPasteThreshold={longTextPasteAsAttachmentEnabled ? LONG_TEXT_ATTACHMENT_THRESHOLD : undefined}
+              renderPastedAsRichText={renderInputAsRichText}
               placeholder={
                 agentChannelId && hasAvailableModel
                   ? sendWithCmdEnter

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -83,6 +83,8 @@ interface RichTextInputProps {
   onPasteLongText?: (text: string) => void
   /** 触发超长文本粘贴回调的字符数阈值 */
   longTextPasteThreshold?: number
+  /** 是否将粘贴内容按富文本/Markdown 渲染（false 时粘贴为纯文本，默认 true） */
+  renderPastedAsRichText?: boolean
   /** 占位文字 */
   placeholder?: string
   /** 是否显示建议样式（斜体占位符） */
@@ -129,6 +131,7 @@ export function RichTextInput({
   onPasteFiles,
   onPasteLongText,
   longTextPasteThreshold,
+  renderPastedAsRichText = true,
   placeholder = '有什么可以帮助到你的呢？',
   suggestionActive = false,
   className,
@@ -169,6 +172,9 @@ export function RichTextInput({
   onPasteLongTextRef.current = onPasteLongText
   const longTextPasteThresholdRef = useRef(longTextPasteThreshold)
   longTextPasteThresholdRef.current = longTextPasteThreshold
+  // 保持粘贴富文本配置最新
+  const renderPastedAsRichTextRef = useRef(renderPastedAsRichText)
+  renderPastedAsRichTextRef.current = renderPastedAsRichText
   // 保持 onHtmlChange 引用最新
   const onHtmlChangeRef = useRef(onHtmlChange)
   onHtmlChangeRef.current = onHtmlChange
@@ -361,17 +367,23 @@ export function RichTextInput({
                 .replace(/<\/div>/gi, '</p>')
             ).trim() || plainText)
           : plainText
+        const longPasteText = renderPastedAsRichTextRef.current ? text : plainText
         if (
           shouldConvertClipboardTextToAttachment({
             enabled: Boolean(threshold && onPasteLongTextRef.current),
             plainText,
-            normalizedText: text,
+            normalizedText: longPasteText,
             threshold: threshold ?? 0,
           }) &&
           onPasteLongTextRef.current
         ) {
           event.preventDefault()
-          onPasteLongTextRef.current(text)
+          onPasteLongTextRef.current(longPasteText)
+          return true
+        }
+        if (!renderPastedAsRichTextRef.current) {
+          event.preventDefault()
+          view.dispatch(view.state.tr.insertText(plainText))
           return true
         }
         return false

--- a/apps/electron/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatInput.tsx
@@ -42,6 +42,7 @@ import { cn } from '@/lib/utils'
 import { fileToBase64, formatFileNames } from '@/lib/file-utils'
 import { MAX_ATTACHMENT_SIZE } from '@proma/shared'
 import { sendWithCmdEnterAtom } from '@/atoms/shortcut-atoms'
+import { renderInputAsRichTextEnabledAtom } from '@/atoms/ui-preferences'
 import { toast } from 'sonner'
 
 interface ChatInputProps {
@@ -63,6 +64,7 @@ interface ChatInputProps {
 
 export function ChatInput({ conversationId, streaming, pendingAttachments, onSetPendingAttachments, onSend, onStop, onClearContext }: ChatInputProps): React.ReactElement {
   const sendWithCmdEnter = useAtomValue(sendWithCmdEnterAtom)
+  const renderInputAsRichText = useAtomValue(renderInputAsRichTextEnabledAtom)
   // 从 Map atom 读写草稿
   const draftsMap = useAtomValue(conversationDraftsAtom)
   const setDraftsMap = useSetAtom(conversationDraftsAtom)
@@ -413,6 +415,7 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
             onChange={setContent}
             onSubmit={handleSend}
             onPasteFiles={handlePasteFiles}
+            renderPastedAsRichText={renderInputAsRichText}
             placeholder={sendWithCmdEnter ? '输入消息... (⌘/Ctrl+Enter 发送，Enter 换行)' : '输入消息... (Enter 发送，Shift+Enter 换行)'}
             autoFocusTrigger={conversationId}
             sendWithCmdEnter={sendWithCmdEnter}

--- a/apps/electron/src/renderer/components/settings/GeneralSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/GeneralSettings.tsx
@@ -39,8 +39,10 @@ import {
 } from '@/atoms/notifications'
 import {
   longTextPasteAsAttachmentEnabledAtom,
+  renderInputAsRichTextEnabledAtom,
   stickyUserMessageEnabledAtom,
   updateLongTextPasteAsAttachmentEnabled,
+  updateRenderInputAsRichTextEnabled,
   updateStickyUserMessageEnabled,
 } from '@/atoms/ui-preferences'
 import { cn } from '@/lib/utils'
@@ -64,6 +66,7 @@ export function GeneralSettings(): React.ReactElement {
   const [notificationSounds, setNotificationSounds] = useAtom(notificationSoundsAtom)
   const [stickyUserMessageEnabled, setStickyUserMessageEnabled] = useAtom(stickyUserMessageEnabledAtom)
   const [longTextPasteAsAttachmentEnabled, setLongTextPasteAsAttachmentEnabled] = useAtom(longTextPasteAsAttachmentEnabledAtom)
+  const [renderInputAsRichText, setRenderInputAsRichText] = useAtom(renderInputAsRichTextEnabledAtom)
   const [isEditingName, setIsEditingName] = React.useState(false)
   const [nameInput, setNameInput] = React.useState(userProfile.userName)
   const [showEmojiPicker, setShowEmojiPicker] = React.useState(false)
@@ -329,6 +332,15 @@ export function GeneralSettings(): React.ReactElement {
             onCheckedChange={(checked) => {
               setLongTextPasteAsAttachmentEnabled(checked)
               updateLongTextPasteAsAttachmentEnabled(checked)
+            }}
+          />
+          <SettingsToggle
+            label="输入框富文本渲染"
+            description="开启后，粘贴的内容会按 Markdown/富文本格式渲染；关闭后粘贴为纯文本，便于引用或编辑原始内容"
+            checked={renderInputAsRichText}
+            onCheckedChange={(checked) => {
+              setRenderInputAsRichText(checked)
+              updateRenderInputAsRichTextEnabled(checked)
             }}
           />
         </SettingsCard>

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -53,6 +53,7 @@ import {
 import {
   stickyUserMessageEnabledAtom,
   longTextPasteAsAttachmentEnabledAtom,
+  renderInputAsRichTextEnabledAtom,
   initializeUiPreferences,
 } from './atoms/ui-preferences'
 import {
@@ -432,10 +433,15 @@ function DockBadgeInitializer(): null {
 function UiPreferencesInitializer(): null {
   const setStickyUserMessageEnabled = useSetAtom(stickyUserMessageEnabledAtom)
   const setLongTextPasteAsAttachmentEnabled = useSetAtom(longTextPasteAsAttachmentEnabledAtom)
+  const setRenderInputAsRichTextEnabled = useSetAtom(renderInputAsRichTextEnabledAtom)
 
   useEffect(() => {
-    initializeUiPreferences(setStickyUserMessageEnabled, setLongTextPasteAsAttachmentEnabled)
-  }, [setStickyUserMessageEnabled, setLongTextPasteAsAttachmentEnabled])
+    initializeUiPreferences(
+      setStickyUserMessageEnabled,
+      setLongTextPasteAsAttachmentEnabled,
+      setRenderInputAsRichTextEnabled
+    )
+  }, [setStickyUserMessageEnabled, setLongTextPasteAsAttachmentEnabled, setRenderInputAsRichTextEnabled])
 
   return null
 }

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -238,6 +238,8 @@ export interface AppSettings {
   stickyUserMessageEnabled?: boolean
   /** 粘贴超过阈值的长文本时是否自动转为附件（默认 false） */
   longTextPasteAsAttachmentEnabled?: boolean
+  /** 输入框粘贴内容是否按富文本/Markdown 渲染（默认 true，关闭后粘贴为纯文本） */
+  renderInputAsRichTextEnabled?: boolean
   /** Markdown 预览字号档位（默认 'medium'，对应 15px） */
   markdownFontSize?: MarkdownFontSize
   /** 上次是否在 Scratch Pad 页（用于重启恢复） */


### PR DESCRIPTION
## Summary

在「设置 - 通用」中新增「输入框富文本渲染」开关，控制聊天输入框粘贴内容时是否按 Markdown/富文本格式渲染。关闭后，粘贴的内容会以纯文本插入，不再套用来源格式，方便只引用或编辑部分原始内容。默认开启，保持现有行为不变。

## Background

Issue #882 反馈：从 AI 回复或 Markdown 文档复制内容粘贴到输入框时，会自动套用来源格式，但用户有时只想引用片段或按纯文本编辑。维护者也在讨论中希望由用户自行选择。这个开关把渲染方式交给用户决定。

## Changes

- `types/settings.ts` / `main/lib/settings-service.ts`：新增持久化设置 `renderInputAsRichTextEnabled`，默认 `true`，沿用 `longTextPasteAsAttachmentEnabled` 的读写方式。
- `atoms/ui-preferences.ts` + `main.tsx`：新增 Jotai atom、初始化读取与持久化更新函数。
- `components/settings/GeneralSettings.tsx`：在「长文本粘贴转附件」下方新增同款 `SettingsToggle`。
- `components/ai-elements/rich-text-input.tsx`：粘贴处理中，开关关闭时只插入 `text/plain`，跳过 Markdown/HTML 解析；文件粘贴与长文本转附件逻辑保持不变，@/#/& 等 Mention 扩展不受影响。
- `components/chat/ChatInput.tsx` / `components/agent/AgentView.tsx`：读取 atom 并下传到输入框。

## Testing

- `bun run typecheck`：全部包通过。
- `bun test apps/electron/src/renderer/atoms/ui-preferences.test.ts`：新增 3 个用例（默认 true、读取 false、更新持久化）全部通过。

Fixes #882
