### PR TITLE
refactor(ui): extract WINDOW_CONTROLS_WIDTH constants

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentHeader.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentHeader.tsx
@@ -11,7 +11,7 @@ import { Pencil, Check, X } from 'lucide-react'
 import { agentSessionsAtom } from '@/atoms/agent-atoms'
 import { tabsAtom, updateTabTitle } from '@/atoms/tab-atoms'
 import { replaceAgentSessionInFreshnessOrder } from '@/lib/agent-session-list'
-import { detectIsWindows } from '@/lib/platform'
+import { detectIsWindows, WINDOW_CONTROLS_INSET_RIGHT } from '@/lib/platform'
 import { cn } from '@/lib/utils'
 
 /** AgentHeader 属性接口 */
@@ -71,7 +71,7 @@ export function AgentHeader({ sessionId }: AgentHeaderProps): React.ReactElement
   return (
     <div className="relative z-[51] flex items-center gap-2 px-4 h-[48px]">
       {/* 拖拽层覆盖整行（Windows 避开右上角 WindowControls ~126px），编辑/标题按钮内部已自带 titlebar-no-drag。 */}
-      <div className={cn("absolute inset-0 titlebar-drag-region pointer-events-none", isWindows && "right-[126px]")} />
+      <div className={cn("absolute inset-0 titlebar-drag-region pointer-events-none", isWindows && WINDOW_CONTROLS_INSET_RIGHT)} />
       {editing ? (
         <div className="flex items-center gap-1.5 flex-1 min-w-0 titlebar-no-drag">
           <input

--- a/apps/electron/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/electron/src/renderer/components/app-shell/AppShell.tsx
@@ -18,7 +18,7 @@ import { automationFormAtom } from '@/atoms/automation-atoms'
 import { activeViewAtom } from '@/atoms/active-view'
 import { interfaceVariantAtom } from '@/atoms/theme'
 import { WindowControls } from '@/components/WindowControls'
-import { detectIsWindows } from '@/lib/platform'
+import { detectIsWindows, WINDOW_CONTROLS_INSET_RIGHT } from '@/lib/platform'
 import { cn } from '@/lib/utils'
 
 const MIN_RIGHT_PANEL_WIDTH = 300
@@ -94,7 +94,7 @@ export function AppShell({ contextValue }: AppShellProps): React.ReactElement {
       <div
         className={cn(
           'titlebar-drag-region fixed top-0 left-0 h-[50px] z-50',
-          isWindows ? 'right-[126px]' : 'right-0'
+          isWindows ? WINDOW_CONTROLS_INSET_RIGHT : 'right-0'
         )}
       />
 

--- a/apps/electron/src/renderer/components/chat/ChatHeader.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatHeader.tsx
@@ -13,7 +13,7 @@ import type { ConversationMeta } from '@proma/shared'
 import { SystemPromptSelector } from './SystemPromptSelector'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { detectIsWindows } from '@/lib/platform'
+import { detectIsWindows, WINDOW_CONTROLS_INSET_RIGHT } from '@/lib/platform'
 import { cn } from '@/lib/utils'
 
 interface ChatHeaderProps {
@@ -70,7 +70,7 @@ export function ChatHeader({ conversation }: ChatHeaderProps): React.ReactElemen
     <div className="relative z-[51] flex items-center gap-2 px-4 h-[48px]">
       {/* 拖拽层仅覆盖左侧区域，Windows 上避开右上角 WindowControls（~126px）。
           否则 header 的 drag-region 会与按钮重叠，导致 OS hitmask 把单击当成标题栏点击。 */}
-      <div className={cn("absolute inset-0 titlebar-drag-region pointer-events-none", isWindows && "right-[126px]")} />
+      <div className={cn("absolute inset-0 titlebar-drag-region pointer-events-none", isWindows && WINDOW_CONTROLS_INSET_RIGHT)} />
       {editing ? (
         <div className="flex items-center gap-1.5 flex-1 min-w-0 titlebar-no-drag">
           <input

--- a/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
@@ -8,6 +8,7 @@ import * as React from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { PanelRightClose } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { WINDOW_CONTROLS_INSET_RIGHT } from '@/lib/platform'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { agentDiffUnseenChangesAtom, currentAgentSessionIdAtom } from '@/atoms/agent-atoms'
 import { interfaceVariantAtom } from '@/atoms/theme'
@@ -63,7 +64,7 @@ export function DiffPanelTabBar({ activeTab, onTabChange, onClose, isWindows = f
 
   return (
     <div className="flex items-end h-[34px] tabbar-bg relative flex-shrink-0">
-      <div className={cn("absolute inset-0 titlebar-drag-region", isWindows && "right-[126px]")} />
+      <div className={cn("absolute inset-0 titlebar-drag-region", isWindows && WINDOW_CONTROLS_INSET_RIGHT)} />
       <div className="relative flex items-end flex-1 titlebar-no-drag">
         <button
           type="button"

--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -34,7 +34,7 @@ import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { TabBarItem } from './TabBarItem'
 import { useCloseTab } from '@/hooks/useCloseTab'
-import { detectIsWindows } from '@/lib/platform'
+import { detectIsWindows, WINDOW_CONTROLS_INSET_RIGHT, WINDOW_CONTROLS_PADDING_RIGHT } from '@/lib/platform'
 import { registerShortcut } from '@/lib/shortcut-registry'
 import { cn } from '@/lib/utils'
 
@@ -365,7 +365,7 @@ function TabBarInner({
           注意：不要把 titlebar-no-drag 加到下面的整条 flex 容器上，否则标签右侧空白会再次失去拖拽能力。
           Windows 上背景拖拽层避开右上角 WindowControls 区域（126px），防止 hitmask 重叠。
           需要交互的单个 Tab 会在 TabBarItem 内部自己声明 titlebar-no-drag。 */}
-      <div className={cn("absolute inset-0 titlebar-drag-region", isWindows && "right-[126px]")} />
+      <div className={cn("absolute inset-0 titlebar-drag-region", isWindows && WINDOW_CONTROLS_INSET_RIGHT)} />
 
       {/* Tear-off 提示遮罩：拖出 TabBar 区域时，让 TabBar 下方出现一条高亮分割线 */}
       {tearingOff && (
@@ -377,7 +377,7 @@ function TabBarInner({
         className={cn(
           "relative flex items-end flex-1 min-w-0 overflow-x-auto scrollbar-none",
           // Windows 始终避开 WindowControls（~126px）；非 Windows 打开按钮时给 scroll 预留空间
-          isWindows && "pr-[126px]",
+          isWindows && WINDOW_CONTROLS_PADDING_RIGHT,
           !isWindows && showOpenPanelButton && "pr-10",
         )}
       >

--- a/apps/electron/src/renderer/lib/platform.ts
+++ b/apps/electron/src/renderer/lib/platform.ts
@@ -1,3 +1,11 @@
+/**
+ * Windows 自定义 WindowControls 按钮区域总宽度（3 buttons × ~42px）。
+ * 拖拽层和内容区需避让此宽度，防止 OS hitmask 冲突。
+ */
+export const WINDOW_CONTROLS_WIDTH_PX = 126
+export const WINDOW_CONTROLS_INSET_RIGHT = 'right-[126px]'
+export const WINDOW_CONTROLS_PADDING_RIGHT = 'pr-[126px]'
+
 export function detectIsWindows(): boolean {
   const platform =
     typeof navigator !== 'undefined' &&


### PR DESCRIPTION
## Summary

- 将 6 个文件中散布的 `right-[126px]` / `pr-[126px]` 魔法字符串提取为 `platform.ts` 中的共享常量（`WINDOW_CONTROLS_INSET_RIGHT`、`WINDOW_CONTROLS_PADDING_RIGHT`、`WINDOW_CONTROLS_WIDTH_PX`）
- 未来 WindowControls 按钮尺寸变动时只需修改一处

## 改动

| 文件 | 说明 |
|------|------|
| `lib/platform.ts` | 新增 3 个常量 |
| `AgentHeader.tsx` | 引用常量 |
| `AppShell.tsx` | 引用常量 |
| `ChatHeader.tsx` | 引用常量 |
| `DiffPanelTabBar.tsx` | 引用常量 |
| `TabBar.tsx` | 引用常量（含 `pr-[126px]`） |

## Test plan

- [x] `bun run typecheck` 四包通过
- [ ] Windows 上拖拽区和 WindowControls 按钮行为无回归

Follow-up to #963.