### PR TITLE
fix(agent): queueMessage 补传 workspaceSlug 并修复持久化写入 enrichedText

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -2352,7 +2352,7 @@ export class AgentOrchestrator {
       : undefined
 
     let enrichedText = text
-    const referencedSessionsBlock = buildReferencedSessionsPrompt(sessionId, mentionedSessionIds, meta?.workspaceId)
+    const referencedSessionsBlock = buildReferencedSessionsPrompt(sessionId, mentionedSessionIds, meta?.workspaceId, workspaceSlug)
     if (referencedSessionsBlock) {
       enrichedText = `${referencedSessionsBlock}\n\n${enrichedText}`
     }
@@ -2402,12 +2402,12 @@ export class AgentOrchestrator {
       await this.adapter.sendQueuedMessage(sessionId, sdkMessage)
       console.log(`[Agent 编排] 追加消息已注入: sessionId=${sessionId}, uuid=${uuid}, interrupt=${!!opts?.interrupt}`)
 
-      // 立即持久化到 JSONL
+      // 立即持久化到 JSONL — 仅存原始文本，不含 prompt 工程块（与 sendMessage 路径一致）
       const persistMsg: SDKMessage = {
         type: 'user',
         uuid,
         message: {
-          content: [{ type: 'text', text: enrichedText }],
+          content: [{ type: 'text', text }],
         },
         parent_tool_use_id: null,
         _createdAt: Date.now(),


### PR DESCRIPTION
## Summary

#965 的两个 follow-up 修复：

1. **`buildReferencedSessionsPrompt` 缺少 `workspaceSlug` 参数** — `queueMessage` 路径只传了 3 个参数，导致生成的 `<referenced_sessions>` 块中 session-cleaner skill 名称缺少 workspace 前缀（`session-cleaner` vs 正确的 `proma-workspace-xxx:session-cleaner`），LLM 无法路由到正确的 skill。

2. **JSONL 持久化写入了 `enrichedText` 而非原始文本** — 持久化消息包含 `<mentioned_tools>` / `<referenced_sessions>` XML prompt 工程块，导致会话回放时用户消息气泡显示 prompt 注入内容，且被其他会话通过 `&session:` 引用时产生嵌套 prompt 块。现与 `sendMessage` 路径保持一致：enrichment 仅影响 SDK 注入，不影响持久化。

## Changes

- `agent-orchestrator.ts`: 补传第 4 个参数 `workspaceSlug`；持久化时使用原始 `text` 替代 `enrichedText`

## Test plan

- [ ] TypeCheck 通过（已验证 ✅）
- [ ] 流式注入 `/skill:xxx` 后检查 JSONL 不含 `<mentioned_tools>` 块
- [ ] 流式注入 `&session:xxx` 后检查 `<referenced_sessions>` 中 skill 名称带 workspace 前缀