### PR TITLE
[codex] fix queued reference persistence

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -2330,6 +2330,7 @@ export class AgentOrchestrator {
   async queueMessage(
     sessionId: string,
     text: string,
+    rawText?: string,
     _priority?: string,
     presetUuid?: string,
     opts?: { interrupt?: boolean },
@@ -2407,7 +2408,7 @@ export class AgentOrchestrator {
         type: 'user',
         uuid,
         message: {
-          content: [{ type: 'text', text }],
+          content: [{ type: 'text', text: rawText ?? text }],
         },
         parent_tool_use_id: null,
         _createdAt: Date.now(),

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -373,6 +373,7 @@ export async function queueAgentMessage(
   return orchestrator.queueMessage(
     input.sessionId,
     input.userMessage,
+    input.rawUserMessage,
     undefined,
     input.uuid,
     { interrupt: input.interrupt },

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -1346,6 +1346,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       window.electronAPI.queueAgentMessage({
         sessionId,
         userMessage: cleanedText,
+        rawUserMessage: effectiveText,
         uuid: localUuid,
         interrupt: streaming,
         ...(mentionedSkills.length > 0 && { mentionedSkills }),

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -932,6 +932,8 @@ export interface AgentQueueMessageInput {
   sessionId: string
   /** 用户消息内容 */
   userMessage: string
+  /** 仅用于持久化/重放的原始用户输入；省略时回退到 userMessage */
+  rawUserMessage?: string
   /** 前端预生成的 UUID（用于乐观更新去重） */
   uuid?: string
   /**


### PR DESCRIPTION
## Summary
- preserve the raw queued user input for JSONL persistence and replay
- keep using cleaned reference-stripped text for SDK injection during queued sends
- thread the optional raw message through the queue IPC/service boundary

## Validation
- bun run --cwd apps/electron typecheck