### PR TITLE
fix(sidebar): 新建会话后自动展开项目【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.13.22",
+  "version": "0.13.23",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -1026,12 +1026,14 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
         setCurrentWorkspaceId(targetWorkspaceId)
         window.electronAPI.updateSettings({ agentWorkspaceId: targetWorkspaceId }).catch(console.error)
       }
-
       const meta = await window.electronAPI.createAgentSession(
         undefined,
         agentChannelId || undefined,
         targetWorkspaceId,
       )
+      if (targetWorkspaceId) {
+        setCollapsedWorkspaceIds((prev) => deleteSetEntry(prev, targetWorkspaceId))
+      }
       setAgentSessions((prev) => [meta, ...prev])
       // 从全局默认值初始化 per-session 渠道/模型配置
       if (agentChannelId) {

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.13.22",
+      "version": "0.13.23",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.185",
         "@anthropic-ai/sdk": "^0.93.0",


### PR DESCRIPTION
## 概述
修复 Agent 侧边栏中新建会话后的可见性问题：当当前项目或目标项目处于折叠状态时，新建会话成功后会自动展开该项目，确保新会话立即出现在左侧会话列表中。

## 改动
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 在共享的 `createAgentSessionInWorkspace` 创建成功后，将目标 workspace 从折叠集合中移除，让顶部「新会话」和项目旁加号的行为保持一致。
- `apps/electron/package.json` — 按仓库版本规则递增 `@proma/electron` patch 版本到 `0.13.23`。
- `bun.lock` — 同步 workspace 版本号。

## 测试方法
1. 运行 `bun run typecheck`，确认所有 workspace 包类型检查通过。
2. 运行 `git diff --check`，确认 diff 中没有空白格式问题。
3. 手动场景建议：在 Agent 侧边栏折叠当前项目后点击顶部「新会话」，确认项目自动展开且新会话可见。
4. 手动场景建议：折叠某个项目后点击该项目右侧加号，确认目标项目自动展开且新会话可见。

## 备注
- 已按 Review-Proma-PR 流程审查当前 diff，未发现代码质量、类型安全或 Windows 兼容性问题。
- 推送到 upstream 时当前账号无直接写权限，因此已通过 fork 分支创建 PR。