### PR TITLE
fix(input): 统一输入框工具栏按钮状态【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.13.23",
+  "version": "0.13.24",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -32,6 +32,13 @@ import { QuotedSelectionChip } from '@/components/diff/QuotedSelectionChip'
 import { RichTextInput } from '@/components/ai-elements/rich-text-input'
 import { SpeechButton } from '@/components/ai-elements/speech-button'
 import { InputToolbarOverflow, type ToolbarItem } from '@/components/ai-elements/InputToolbarOverflow'
+import {
+  inputToolbarActiveButtonClass,
+  inputToolbarButtonClass,
+  inputToolbarDangerButtonClass,
+  inputToolbarDisabledButtonClass,
+  inputToolbarSendButtonClass,
+} from '@/components/ai-elements/input-toolbar-styles'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
@@ -175,8 +182,8 @@ function AgentThinkingPopover({ agentThinking, onToggle }: AgentThinkingPopoverP
           variant="ghost"
           size="icon"
           className={cn(
-            'size-[36px] rounded-full',
-            isEnabled ? 'text-green-500' : 'text-foreground/60 hover:text-foreground'
+            inputToolbarButtonClass,
+            isEnabled && inputToolbarActiveButtonClass
           )}
           onClick={onToggle}
           onMouseEnter={handleMouseEnter}
@@ -253,14 +260,14 @@ function DisplayOptionsPopover({
           variant="ghost"
           size="icon"
           className={cn(
-            'size-[36px] rounded-full',
-            processGroupsKeepExpanded ? 'text-green-500' : 'text-foreground/60 hover:text-foreground'
+            inputToolbarButtonClass,
+            processGroupsKeepExpanded && inputToolbarActiveButtonClass
           )}
           aria-label="显示选项"
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
         >
-          <Eye className={cn('size-5', processGroupsKeepExpanded && 'text-green-500')} />
+          <Eye className="size-5" />
         </Button>
       </PopoverTrigger>
       <PopoverContent
@@ -1953,7 +1960,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         />
       ),
     },
-    { key: 'speech', node: <SpeechButton className="size-[36px] shrink-0 rounded-full" /> },
+    { key: 'speech', node: <SpeechButton className={inputToolbarButtonClass} /> },
     {
       key: 'attach-file',
       node: (
@@ -1963,7 +1970,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
               type="button"
               variant="ghost"
               size="icon"
-              className="size-[36px] shrink-0 rounded-full text-foreground/60 hover:text-foreground"
+              className={inputToolbarButtonClass}
               onClick={handleOpenFileDialog}
             >
               <Paperclip className="size-5" />
@@ -1984,7 +1991,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
               type="button"
               variant="ghost"
               size="icon"
-              className="size-[36px] shrink-0 rounded-full text-foreground/60 hover:text-foreground"
+              className={inputToolbarButtonClass}
               onClick={handleAttachFolder}
             >
               <FolderPlus className="size-5" />
@@ -2051,7 +2058,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           type="button"
           variant="ghost"
           size="icon"
-          className="size-[36px] rounded-full text-destructive hover:!text-[hsl(0,75%,55%)] hover:!bg-[var(--stop-hover-bg)]"
+          className={inputToolbarDangerButtonClass}
           onClick={handleStop}
         >
           <Square className="size-[16px]" fill="currentColor" strokeWidth={0} />
@@ -2067,10 +2074,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       variant="ghost"
       size="icon"
       className={cn(
-        'size-[36px] rounded-full',
-        canSend
-          ? 'text-primary hover:bg-primary/10'
-          : 'text-foreground/30 cursor-not-allowed'
+        canSend ? inputToolbarSendButtonClass : inputToolbarDisabledButtonClass
       )}
       onClick={() => handleSend()}
       disabled={!canSend}

--- a/apps/electron/src/renderer/components/agent/ContextUsageBadge.tsx
+++ b/apps/electron/src/renderer/components/agent/ContextUsageBadge.tsx
@@ -1,7 +1,7 @@
 /**
  * ContextUsageBadge — 上下文使用量指示器
  *
- * 输入框工具栏上的一个 36×36 圆形按钮：
+ * 输入框工具栏上的一个 36×36 按钮：
  * - 内部为 16px 圆环，按 displayTokens / displayWindow 比例渲染
  * - hover / click 弹出 Popover，内含 token 明细 + 手动压缩按钮
  * - 压缩中时按钮位置显示 Loader2 旋转图标
@@ -13,6 +13,7 @@ import * as React from 'react'
 import { Loader2, Minimize2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { inputToolbarButtonClass } from '@/components/ai-elements/input-toolbar-styles'
 import { cn } from '@/lib/utils'
 
 /** 压缩阈值比例（SDK 在 ~77.5% 窗口大小时自动压缩） */
@@ -173,7 +174,7 @@ export function ContextUsageBadge({
         type="button"
         variant="ghost"
         size="icon"
-        className="size-[36px] rounded-full text-muted-foreground cursor-default"
+        className={cn(inputToolbarButtonClass, 'text-muted-foreground cursor-default')}
         disabled
       >
         <Loader2 className="size-4 animate-spin" />
@@ -235,7 +236,7 @@ export function ContextUsageBadge({
           variant="ghost"
           size="icon"
           className={cn(
-            'size-[36px] rounded-full',
+            inputToolbarButtonClass,
             isWarning ? 'text-amber-600 dark:text-amber-400' : 'text-foreground/60 hover:text-foreground',
           )}
           onMouseEnter={() => {

--- a/apps/electron/src/renderer/components/agent/PermissionModeSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/PermissionModeSelector.tsx
@@ -15,6 +15,7 @@ import { agentPermissionModeMapAtom, agentDefaultPermissionModeAtom, sessionPers
 import type { PromaPermissionMode } from '@proma/shared'
 import { PROMA_PERMISSION_MODE_CONFIG, PROMA_PERMISSION_MODE_ORDER } from '@proma/shared'
 import { updatePlanModeSessionSet } from '@/lib/agent-plan-mode'
+import { inputToolbarButtonClass } from '@/components/ai-elements/input-toolbar-styles'
 
 const MODE_ICONS: Record<PromaPermissionMode, React.ComponentType<{ className?: string }>> = {
   auto: Compass,
@@ -95,7 +96,7 @@ export function PermissionModeSelector({ sessionId }: PermissionModeSelectorProp
             size="icon"
             aria-label={config.label}
             onClick={() => { cycleMode(); requestAnimationFrame(() => document.querySelector<HTMLElement>('.ProseMirror')?.focus()) }}
-            className="size-[36px] rounded-full text-foreground/60 hover:text-foreground"
+            className={inputToolbarButtonClass}
           >
             <Icon className="size-5" />
           </Button>

--- a/apps/electron/src/renderer/components/ai-elements/InputToolbarOverflow.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/InputToolbarOverflow.tsx
@@ -24,11 +24,12 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
+import { inputToolbarButtonClass } from './input-toolbar-styles'
 
 export interface ToolbarItem {
   /** 唯一标识 */
   key: string
-  /** 行内渲染的节点（建议是 36px 圆形按钮或带文本的紧凑按钮） */
+  /** 行内渲染的节点（建议是 36px 圆角矩形按钮或带文本的紧凑按钮） */
   node: React.ReactNode
 }
 
@@ -183,7 +184,7 @@ export function InputToolbarOverflow({
                     type="button"
                     variant="ghost"
                     size="icon"
-                    className="size-[36px] shrink-0 rounded-full text-foreground/60 hover:text-foreground"
+                    className={inputToolbarButtonClass}
                     aria-label="更多工具"
                   >
                     <MoreHorizontal className="size-5" />

--- a/apps/electron/src/renderer/components/ai-elements/input-toolbar-styles.ts
+++ b/apps/electron/src/renderer/components/ai-elements/input-toolbar-styles.ts
@@ -1,0 +1,14 @@
+export const inputToolbarButtonClass =
+  'size-[32px] shrink-0 rounded-md text-foreground/60 hover:text-foreground hover:bg-muted/50 data-[state=open]:bg-muted/50 data-[state=open]:text-foreground'
+
+export const inputToolbarActiveButtonClass =
+  '!bg-transparent text-primary shadow-none hover:!bg-transparent hover:text-primary data-[state=open]:!bg-transparent [&_svg]:stroke-[2.75]'
+
+export const inputToolbarDangerButtonClass =
+  'size-[32px] shrink-0 rounded-md text-destructive hover:!text-[hsl(0,75%,55%)] hover:!bg-[var(--stop-hover-bg)]'
+
+export const inputToolbarSendButtonClass =
+  'size-[32px] shrink-0 rounded-md text-primary hover:bg-primary/10'
+
+export const inputToolbarDisabledButtonClass =
+  'size-[32px] shrink-0 rounded-md text-foreground/30 cursor-not-allowed'

--- a/apps/electron/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatInput.tsx
@@ -23,6 +23,13 @@ import { AttachmentPreviewItem } from './AttachmentPreviewItem'
 import { RichTextInput } from '@/components/ai-elements/rich-text-input'
 import { SpeechButton } from '@/components/ai-elements/speech-button'
 import { InputToolbarOverflow, type ToolbarItem } from '@/components/ai-elements/InputToolbarOverflow'
+import {
+  inputToolbarActiveButtonClass,
+  inputToolbarButtonClass,
+  inputToolbarDangerButtonClass,
+  inputToolbarDisabledButtonClass,
+  inputToolbarSendButtonClass,
+} from '@/components/ai-elements/input-toolbar-styles'
 import { Button } from '@/components/ui/button'
 import {
   Tooltip,
@@ -302,8 +309,8 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
               variant="ghost"
               size="icon"
               className={cn(
-                'size-[36px] shrink-0 rounded-full',
-                thinkingEnabled ? 'text-green-500' : 'text-foreground/60 hover:text-foreground'
+                inputToolbarButtonClass,
+                thinkingEnabled && inputToolbarActiveButtonClass
               )}
               onClick={() => setThinkingEnabled(!thinkingEnabled)}
             >
@@ -325,7 +332,7 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
               type="button"
               variant="ghost"
               size="icon"
-              className="size-[36px] shrink-0 rounded-full text-foreground/60 hover:text-foreground"
+              className={inputToolbarButtonClass}
               onClick={handleOpenFileDialog}
             >
               <Paperclip className="size-5" />
@@ -337,7 +344,7 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
         </Tooltip>
       ),
     },
-    { key: 'speech', node: <SpeechButton className="size-[36px] shrink-0 rounded-full" /> },
+    { key: 'speech', node: <SpeechButton className={inputToolbarButtonClass} /> },
     { key: 'tools', node: <ToolSelectorPopover /> },
     { key: 'context', node: <ContextSettingsPopover /> },
     { key: 'clear', node: <ClearContextButton onClick={onClearContext} /> },
@@ -350,7 +357,7 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
           type="button"
           variant="ghost"
           size="icon"
-          className="size-[36px] rounded-full text-destructive hover:!text-[hsl(0,75%,55%)] hover:!bg-[var(--stop-hover-bg)]"
+          className={inputToolbarDangerButtonClass}
           onClick={onStop}
         >
           <Square className="size-[16px]" fill="currentColor" strokeWidth={0} />
@@ -366,10 +373,7 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
       variant="ghost"
       size="icon"
       className={cn(
-        'size-[36px] rounded-full',
-        canSend
-          ? 'text-primary hover:bg-primary/10'
-          : 'text-foreground/30 cursor-not-allowed'
+        canSend ? inputToolbarSendButtonClass : inputToolbarDisabledButtonClass
       )}
       onClick={handleSend}
       disabled={!canSend}

--- a/apps/electron/src/renderer/components/chat/ClearContextButton.tsx
+++ b/apps/electron/src/renderer/components/chat/ClearContextButton.tsx
@@ -12,6 +12,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
+import { inputToolbarButtonClass } from '@/components/ai-elements/input-toolbar-styles'
 import { Eraser } from 'lucide-react'
 import type { ComponentProps } from 'react'
 
@@ -39,12 +40,12 @@ export function ClearContextButton({
           type="button"
           variant="ghost"
           size="icon"
-          className={cn('h-8 w-8', className)}
+          className={cn(inputToolbarButtonClass, className)}
           onClick={onClick}
           aria-label="清除上下文"
           {...props}
         >
-          <Eraser className="h-4 w-4 text-muted-foreground" />
+          <Eraser className="size-4" />
         </Button>
       </TooltipTrigger>
       <TooltipContent side="top">

--- a/apps/electron/src/renderer/components/chat/ContextSettingsPopover.tsx
+++ b/apps/electron/src/renderer/components/chat/ContextSettingsPopover.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { Settings2 } from 'lucide-react'
+import { inputToolbarButtonClass } from '@/components/ai-elements/input-toolbar-styles'
 import {
   CONTEXT_LENGTH_OPTIONS,
   type ContextLengthValue,
@@ -61,8 +62,8 @@ export function ContextSettingsPopover(): React.ReactElement {
       <Tooltip open={open ? false : undefined}>
         <TooltipTrigger asChild>
           <PopoverTrigger asChild>
-            <Button type="button" variant="ghost" size="icon" className="h-8 w-8">
-              <Settings2 className="h-4 w-4 text-muted-foreground" />
+            <Button type="button" variant="ghost" size="icon" className={inputToolbarButtonClass}>
+              <Settings2 className="size-4" />
             </Button>
           </PopoverTrigger>
         </TooltipTrigger>

--- a/apps/electron/src/renderer/components/chat/ToolSelectorPopover.tsx
+++ b/apps/electron/src/renderer/components/chat/ToolSelectorPopover.tsx
@@ -24,6 +24,7 @@ import { cn } from '@/lib/utils'
 import { Wrench, Brain, Globe, Settings, ImagePlus } from 'lucide-react'
 import { chatToolsAtom, hasActiveToolsAtom } from '@/atoms/chat-tool-atoms'
 import { settingsTabAtom, settingsOpenAtom } from '@/atoms/settings-tab'
+import { inputToolbarActiveButtonClass, inputToolbarButtonClass } from '@/components/ai-elements/input-toolbar-styles'
 
 /** 工具 ID 到图标的映射 */
 function getToolIcon(iconName?: string): React.ReactElement {
@@ -75,8 +76,8 @@ export function ToolSelectorPopover(): React.ReactElement {
               variant="ghost"
               size="icon"
               className={cn(
-                'size-[30px] rounded-full',
-                hasActiveTools ? 'text-blue-500' : 'text-foreground/60 hover:text-foreground',
+                inputToolbarButtonClass,
+                hasActiveTools && inputToolbarActiveButtonClass,
               )}
             >
               <Wrench className="size-5" />


### PR DESCRIPTION
## 概述
统一 Chat 和 Agent 输入框工具栏按钮的基础尺寸、圆角矩形 hover 样式，并调整 active 状态：不再显示高亮背景块或阴影，只通过主题色和更粗的图标线条表达选中。

## 改动
- `apps/electron/src/renderer/components/ai-elements/input-toolbar-styles.ts` — 新增输入框工具栏按钮共享 class，集中管理普通、active、危险、发送和禁用状态。
- `apps/electron/src/renderer/components/chat/ChatInput.tsx` — Chat 输入框思考模式、附件、语音、停止、发送按钮接入共享样式。
- `apps/electron/src/renderer/components/chat/ToolSelectorPopover.tsx` — 工具按钮接入共享样式，active 时保持透明背景并加粗图标。
- `apps/electron/src/renderer/components/chat/ClearContextButton.tsx` — 清理上下文按钮接入共享样式。
- `apps/electron/src/renderer/components/chat/ContextSettingsPopover.tsx` — 上下文设置按钮接入共享样式。
- `apps/electron/src/renderer/components/agent/AgentView.tsx` — Agent 输入框 thinking、显示选项、附件、停止、发送等按钮接入共享样式。
- `apps/electron/src/renderer/components/agent/ContextUsageBadge.tsx` — 上下文使用量按钮接入共享样式。
- `apps/electron/src/renderer/components/agent/PermissionModeSelector.tsx` — 权限模式按钮接入共享样式。
- `apps/electron/src/renderer/components/ai-elements/InputToolbarOverflow.tsx` — 溢出菜单按钮改用共享样式，并更新说明注释。
- `apps/electron/package.json` — Electron 包 patch 版本从 `0.13.23` 升到 `0.13.24`。

## 测试方法
1. 运行 `bun run typecheck`。
2. 运行 `bun run --filter='@proma/electron' build:renderer`。
3. 手动检查输入框工具栏 active 状态：按钮周边不出现选中背景或阴影，图标使用主题色且线条更粗。

## 备注
- 本 PR 不再包含模型 logo、ModelSelector 触发器或模型选择弹窗相关改动。
- renderer build 仍会输出现有的大 chunk warning，本次没有新增该类问题。