### PR TITLE
[codex] fix sidebar child session visibility

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.13.23",
+  "version": "0.13.24",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -94,6 +94,8 @@ import {
 import { detectIsMac } from '@/lib/platform'
 import { getActiveAccelerator, getAcceleratorDisplay } from '@/lib/shortcut-registry'
 import {
+  collectAgentSessionTreeIds,
+  isAgentSessionVisibleInTrees,
   replaceAgentSessionInFreshnessOrder,
   sortAgentSessionsByUpdatedAtDesc,
 } from '@/lib/agent-session-list'
@@ -386,15 +388,6 @@ function countCompletedDelegatedChildren(childSessions: AgentSessionMeta[]): num
 function treeContainsSessionId(item: AgentSessionTreeItem, sessionId: string | null): boolean {
   if (!sessionId) return false
   return item.session.id === sessionId || item.childSessions.some((session) => session.id === sessionId)
-}
-
-function collectTreeSessionIds(items: AgentSessionTreeItem[]): Set<string> {
-  const ids = new Set<string>()
-  for (const item of items) {
-    ids.add(item.session.id)
-    for (const child of item.childSessions) ids.add(child.id)
-  }
-  return ids
 }
 
 function getDirectDelegatedChildren(
@@ -3427,7 +3420,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
       if (delta !== 0) return delta
       return b.session.updatedAt - a.session.updatedAt
     })
-  const activeIds = collectTreeSessionIds(activeSessions)
+  const activeIds = collectAgentSessionTreeIds(activeSessions)
   // 非活跃部分按自然策略（最近 3 天窗口 + 预览上限）计算，且不依赖当前选中态，
   // 保持 group.sessions 的 updatedAt 倒序——这样点击已可见会话时顺序保持稳定，
   // 不会因为它变成 activeSessionId 而被提到顶部。
@@ -3445,8 +3438,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
   const sessionsWithoutPinned = [...collapsedSessions, ...extraSessions]
   // 仅当选中会话不在当前可见列表中时才置顶（如搜索结果打开旧会话），
   // 若会话已在可见区域则保持原位不跳
-  const sessionIds = new Set(sessionsWithoutPinned.map((item) => item.session.id))
-  const currentSession = activeSessionId && !sessionIds.has(activeSessionId)
+  const currentSession = activeSessionId && !isAgentSessionVisibleInTrees(sessionsWithoutPinned, activeSessionId)
     ? treeItems.find((item) => treeContainsSessionId(item, activeSessionId)) ?? null
     : null
   const pinnedCurrent = currentSession ? [currentSession] : []

--- a/apps/electron/src/renderer/lib/agent-session-list.ts
+++ b/apps/electron/src/renderer/lib/agent-session-list.ts
@@ -1,5 +1,10 @@
 import type { AgentSessionMeta } from '@proma/shared'
 
+interface AgentSessionTreeLike {
+  session: Pick<AgentSessionMeta, 'id'>
+  childSessions: readonly Pick<AgentSessionMeta, 'id'>[]
+}
+
 /** 按最近更新时间排序 Agent 会话，保持与主进程 listAgentSessions 一致。 */
 export function sortAgentSessionsByUpdatedAtDesc(
   sessions: readonly AgentSessionMeta[],
@@ -74,4 +79,24 @@ export function mergeFetchedAgentSessions(
   )
 
   return sortAgentSessionsByUpdatedAtDesc([...fetched, ...survivingLocalOnly])
+}
+
+/** 收集可见会话树里的父/子会话 id，用于判断当前会话是否已显示在侧栏中。 */
+export function collectAgentSessionTreeIds(
+  items: readonly AgentSessionTreeLike[],
+): Set<string> {
+  const ids = new Set<string>()
+  for (const item of items) {
+    ids.add(item.session.id)
+    for (const child of item.childSessions) ids.add(child.id)
+  }
+  return ids
+}
+
+export function isAgentSessionVisibleInTrees(
+  items: readonly AgentSessionTreeLike[],
+  sessionId: string | null,
+): boolean {
+  if (!sessionId) return false
+  return collectAgentSessionTreeIds(items).has(sessionId)
 }

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.13.23",
+      "version": "0.13.24",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.185",
         "@anthropic-ai/sdk": "^0.93.0",


### PR DESCRIPTION
## Summary

Fix the left sidebar visibility check for delegated child sessions. The project session list now treats a visible tree as containing both the parent session id and all child session ids.

## Root cause

PR #958 changed the pinned-current logic to check the full visible list before force-inserting the active session. That check only collected `item.session.id` from each visible tree, so an already-visible child session was still treated as hidden. Clicking the child could then insert its parent tree again and make the sidebar look like a different parent session expanded.

## Changes

- Move tree id collection into `agent-session-list.ts` so parent and child ids are handled consistently.
- Use the full tree visibility check before force-inserting the active session in `LeftSidebar`.
- Bump `@proma/electron` patch version to `0.13.24`.

## Validation

- `bun test apps/electron/src/renderer/lib/agent-session-list.test.ts`
- `bun run --filter='@proma/electron' typecheck`
- `git diff --check`
