### PR TITLE
fix(agent): hide Claude subprocess window on Windows

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.13.23",
+  "version": "0.13.24",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
@@ -809,6 +809,8 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
             env: spawnOpts.env,
             signal: spawnOpts.signal,
             stdio: ['pipe', 'pipe', 'pipe'],
+            // 与 SDK 默认 spawnLocalProcess 保持一致，避免 Windows 上为 claude.exe 创建独立控制台。
+            windowsHide: true,
           })
           // 手动转发 stderr（SDK 默认在 spawnLocalProcess 里做，自定义 spawn 需自己做）
           // 同时必须消费 stderr 流避免缓冲区满（默认 64KB）导致子进程挂起

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.13.23",
+      "version": "0.13.24",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.185",
         "@anthropic-ai/sdk": "^0.93.0",


### PR DESCRIPTION
## Summary

- Keep Proma's custom Claude Agent SDK spawn behavior aligned with the SDK default on Windows by passing `windowsHide: true`.
- Bump `@proma/electron` from `0.13.23` to `0.13.24`.

## Root Cause

Proma overrides `spawnClaudeCodeProcess` so it can record the Claude subprocess PID and force-kill residual processes when needed. That custom spawn path bypasses the SDK's default `spawnLocalProcess`, which already passes `windowsHide: true` on Windows.

Without that option, Windows can create a separate console for `claude.exe`. In affected environments the subprocess can then exit immediately with `0x40010004` (`1073807364`), which the SDK reports as `Claude Code process exited with code 1073807364`.

## Validation

- `bun install --frozen-lockfile`
- `bun run --filter='@proma/electron' build:main`
- `bun run --filter='@proma/electron' typecheck`
- `git diff --check`

Windows packaged-app validation is still recommended because this failure depends on Windows process/session behavior.
