### PR TITLE
fix(agent): 同步计划阶段权限图标【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.13.24",
+  "version": "0.13.25",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/agent/PermissionModeSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/PermissionModeSelector.tsx
@@ -14,7 +14,7 @@ import { Button } from '@/components/ui/button'
 import { agentPermissionModeMapAtom, agentDefaultPermissionModeAtom, sessionPersistedPermissionModeAtom, sessionExistsAtom, agentPlanModeSessionsAtom } from '@/atoms/agent-atoms'
 import type { PromaPermissionMode } from '@proma/shared'
 import { PROMA_PERMISSION_MODE_CONFIG, PROMA_PERMISSION_MODE_ORDER } from '@proma/shared'
-import { updatePlanModeSessionSet } from '@/lib/agent-plan-mode'
+import { getDisplayedPermissionMode, updatePlanModeSessionSet } from '@/lib/agent-plan-mode'
 import { inputToolbarButtonClass } from '@/components/ai-elements/input-toolbar-styles'
 
 const MODE_ICONS: Record<PromaPermissionMode, React.ComponentType<{ className?: string }>> = {
@@ -30,9 +30,12 @@ interface PermissionModeSelectorProps {
 export function PermissionModeSelector({ sessionId }: PermissionModeSelectorProps): React.ReactElement | null {
   const [modeMap, setModeMap] = useAtom(agentPermissionModeMapAtom)
   const setPlanModeSessions = useSetAtom(agentPlanModeSessionsAtom)
+  const planModeSessions = useAtomValue(agentPlanModeSessionsAtom)
   const defaultMode = useAtomValue(agentDefaultPermissionModeAtom)
   const persistedSessionMode = useAtomValue(sessionPersistedPermissionModeAtom(sessionId))
   const mode = modeMap.get(sessionId) ?? persistedSessionMode ?? defaultMode
+  const planModeActive = planModeSessions.has(sessionId)
+  const displayMode = getDisplayedPermissionMode(mode, planModeActive)
   const sessionExistsInList = useAtomValue(sessionExistsAtom(sessionId))
 
   // 初始化：如果当前 session 不在 Map 中，按以下优先级读回：
@@ -52,10 +55,11 @@ export function PermissionModeSelector({ sessionId }: PermissionModeSelectorProp
 
   /** 循环切换模式 */
   const cycleMode = React.useCallback(async () => {
-    const currentIndex = PROMA_PERMISSION_MODE_ORDER.indexOf(mode)
+    const currentIndex = PROMA_PERMISSION_MODE_ORDER.indexOf(displayMode)
     const nextIndex = (currentIndex + 1) % PROMA_PERMISSION_MODE_ORDER.length
     const nextMode = PROMA_PERMISSION_MODE_ORDER[nextIndex]!
     const prevMode = mode
+    const prevPlanModeActive = planModeActive
 
     // 乐观更新当前 session 的模式
     setModeMap((prev: Map<string, PromaPermissionMode>) => {
@@ -78,13 +82,13 @@ export function PermissionModeSelector({ sessionId }: PermissionModeSelectorProp
         return next
       })
       setPlanModeSessions((prev: Set<string>) =>
-        updatePlanModeSessionSet(prev, sessionId, prevMode === 'plan')
+        updatePlanModeSessionSet(prev, sessionId, prevPlanModeActive || prevMode === 'plan')
       )
     }
-  }, [mode, sessionId, setModeMap, setPlanModeSessions])
+  }, [displayMode, mode, planModeActive, sessionId, setModeMap, setPlanModeSessions])
 
-  const config = PROMA_PERMISSION_MODE_CONFIG[mode]
-  const Icon = MODE_ICONS[mode]
+  const config = PROMA_PERMISSION_MODE_CONFIG[displayMode]
+  const Icon = MODE_ICONS[displayMode]
 
   return (
     <TooltipProvider delayDuration={300}>

--- a/apps/electron/src/renderer/lib/agent-plan-mode.test.ts
+++ b/apps/electron/src/renderer/lib/agent-plan-mode.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { getPlanModeChangeFromToolName, updatePlanModeSessionSet } from './agent-plan-mode'
+import { getDisplayedPermissionMode, getPlanModeChangeFromToolName, updatePlanModeSessionSet } from './agent-plan-mode'
 
 describe('Agent 计划阶段状态', () => {
   test('Given EnterPlanMode 工具 When 解析计划状态 Then 标记进入计划阶段', () => {
@@ -38,5 +38,16 @@ describe('Agent 计划阶段状态', () => {
 
     expect(updatePlanModeSessionSet(prev, 'session-a', true)).toBe(prev)
     expect(updatePlanModeSessionSet(prev, 'session-b', false)).toBe(prev)
+  })
+
+  test('Given Agent 自己进入计划阶段 When 权限按钮显示模式 Then 优先显示计划模式', () => {
+    expect(getDisplayedPermissionMode('auto', true)).toBe('plan')
+    expect(getDisplayedPermissionMode('bypassPermissions', true)).toBe('plan')
+  })
+
+  test('Given Agent 不在计划阶段 When 权限按钮显示模式 Then 保留真实权限模式', () => {
+    expect(getDisplayedPermissionMode('auto', false)).toBe('auto')
+    expect(getDisplayedPermissionMode('bypassPermissions', false)).toBe('bypassPermissions')
+    expect(getDisplayedPermissionMode('plan', false)).toBe('plan')
   })
 })

--- a/apps/electron/src/renderer/lib/agent-plan-mode.ts
+++ b/apps/electron/src/renderer/lib/agent-plan-mode.ts
@@ -1,4 +1,4 @@
-import type { AgentPlanModeChangeSource } from '@proma/shared'
+import type { AgentPlanModeChangeSource, PromaPermissionMode } from '@proma/shared'
 
 export interface PlanModeChange {
   active: boolean
@@ -32,4 +32,12 @@ export function updatePlanModeSessionSet(
   const next = new Set(prev)
   next.delete(sessionId)
   return next
+}
+
+/** 输入区处于计划阶段时，权限按钮也优先展示计划模式图标。 */
+export function getDisplayedPermissionMode(
+  permissionMode: PromaPermissionMode,
+  planModeActive: boolean,
+): PromaPermissionMode {
+  return planModeActive ? 'plan' : permissionMode
 }

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.13.24",
+      "version": "0.13.25",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.185",
         "@anthropic-ai/sdk": "^0.93.0",


### PR DESCRIPTION
## 概述

这个 PR 修复 Agent 输入区计划阶段的状态显示不一致问题：当 Agent 自己通过 EnterPlanMode 实际进入计划模式时，输入框已经出现计划模式的虚线边框，但底部权限按钮仍然显示「自动审批」或「完全自动」图标。用户看到的是同一个输入框同时表达两种模式，容易误以为 Agent 仍在自动执行权限模式下运行，状态非常 confused。

修复后，权限按钮的可见状态会跟随当前会话的计划阶段状态：只要会话实际处于计划阶段，就优先显示「计划模式」图标和说明；真实权限模式仍保留在原有状态中，不改变后端权限持久化语义。

## 改动

- `apps/electron/src/renderer/components/agent/PermissionModeSelector.tsx` — 读取 `agentPlanModeSessionsAtom`，基于当前会话是否处于计划阶段派生按钮显示模式，让图标、aria-label 和 tooltip 与虚线输入框状态保持一致。
- `apps/electron/src/renderer/lib/agent-plan-mode.ts` — 新增 `getDisplayedPermissionMode()`，把「计划阶段优先显示计划模式」的规则集中成可测试的纯函数。
- `apps/electron/src/renderer/lib/agent-plan-mode.test.ts` — 增加 BDD 风格单测，覆盖真实权限为 `auto` / `bypassPermissions` 但 Agent 已进入计划阶段时，按钮应显示 `plan` 的场景。
- `apps/electron/package.json`、`bun.lock` — 按仓库版本规则将 `@proma/electron` patch 版本从 `0.13.24` 升到 `0.13.25`。

## 测试方法

1. `bun test apps/electron/src/renderer/lib/agent-plan-mode.test.ts`
2. `git diff --check`
3. `bun run typecheck`
4. 手动场景：让 Agent 自己进入计划模式，确认输入框出现虚线边框时，底部权限按钮也显示计划模式图标。

## 备注

- 当前账号没有 `ErlichLiu/Proma` 的直接 push 权限，分支已推送到 `Andreaseszhang/Proma` fork，并创建到 upstream `main` 的 PR。
