### PR TITLE
fix(mcp): 修复内置 MCP 工具名被 Agent 调错 + default-mcp.json 单一事实源

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -45,12 +45,13 @@ import { getWorkspaceAttachedDirectories, getWorkspaceAttachedFiles } from './ag
 import { getRuntimeStatus } from './runtime-init'
 import { getSettings } from './settings-service'
 import { buildSystemPrompt, buildDynamicContext, buildBuiltinAgents } from './agent-prompt-builder'
+import { injectBuiltinMcpServers } from './builtin-mcp/registry'
+import { RESERVED_BUILTIN_KEYS } from './builtin-mcp/baseline'
 import { permissionService } from './agent-permission-service'
 import type { PermissionResult, CanUseToolOptions } from './agent-permission-service'
 import { askUserService } from './agent-ask-user-service'
 import { exitPlanService, type ExitPlanPermissionResult } from './agent-exit-plan-service'
 import { getMemoryConfig } from './memory-service'
-import { searchMemory, addMemory, formatSearchResult } from './memos-client'
 import { validateToolInput } from './agent-tool-input-validator'
 import { estimateTokenCount, WRITE_CONTENT_TOKEN_THRESHOLD } from './agent-tool-token-estimator'
 
@@ -639,80 +640,6 @@ export class AgentOrchestrator {
   }
 
   /**
-   * 注入 SDK 内置记忆工具（全局，不依赖工作区）
-   */
-  private async injectMemoryTools(
-    sdk: typeof import('@anthropic-ai/claude-agent-sdk'),
-    mcpServers: Record<string, Record<string, unknown>>,
-  ): Promise<void> {
-    const memoryConfig = getMemoryConfig()
-    const memUserId = memoryConfig.userId?.trim() || 'proma-user'
-    if (!memoryConfig.enabled || !memoryConfig.apiKey) return
-
-    try {
-      const { z } = await import('zod')
-      const memosServer = sdk.createSdkMcpServer({
-        name: 'mem',
-        version: '1.0.0',
-        tools: [
-          sdk.tool(
-            'recall_memory',
-            'Search user memories (facts and preferences) from MemOS Cloud. Use this to recall relevant context about the user.',
-            { query: z.string().describe('Search query for memory retrieval'), limit: z.number().optional().describe('Max results (default 6)') },
-            async (args) => {
-              const result = await searchMemory(
-                { apiKey: memoryConfig.apiKey, userId: memUserId, baseUrl: memoryConfig.baseUrl },
-                args.query,
-                args.limit,
-              )
-              return { content: [{ type: 'text' as const, text: formatSearchResult(result) }] }
-            },
-            { annotations: { readOnlyHint: true } },
-          ),
-          sdk.tool(
-            'add_memory',
-            'Store a conversation message pair into MemOS Cloud for long-term memory. Call this after meaningful exchanges worth remembering.',
-            {
-              userMessage: z.string().describe('The user message to store'),
-              assistantMessage: z.string().optional().describe('The assistant response to store'),
-              conversationId: z.string().optional().describe('Conversation ID for grouping'),
-              tags: z.array(z.string()).optional().describe('Tags for categorization'),
-            },
-            async (args) => {
-              await addMemory(
-                { apiKey: memoryConfig.apiKey, userId: memUserId, baseUrl: memoryConfig.baseUrl },
-                args,
-              )
-              return { content: [{ type: 'text' as const, text: 'Memory stored successfully.' }] }
-            },
-          ),
-        ],
-      })
-      mcpServers['mem'] = memosServer as unknown as Record<string, unknown>
-      console.log(`[Agent 编排] 已注入内置记忆工具 (mem)`)
-    } catch (err) {
-      console.error(`[Agent 编排] 注入记忆工具失败:`, err)
-    }
-  }
-
-  /**
-   * 注入 SDK 内置生图工具（Nano Banana）
-   */
-  private async injectNanoBananaTools(
-    sdk: typeof import('@anthropic-ai/claude-agent-sdk'),
-    mcpServers: Record<string, Record<string, unknown>>,
-    sessionId: string,
-    agentCwd?: string,
-  ): Promise<void> {
-    try {
-      const { injectNanoBananaMcpServer } = await import('./chat-tools/nano-banana-mcp')
-      await injectNanoBananaMcpServer(sdk, mcpServers, sessionId, agentCwd)
-    } catch (err) {
-      console.error(`[Agent 编排] 注入 Nano Banana MCP 失败:`, err)
-    }
-  }
-
-  /**
    * 生成 Agent 会话标题
    *
    * 使用 Provider 适配器系统，支持所有渠道。任何错误返回 null。
@@ -1155,10 +1082,9 @@ export class AgentOrchestrator {
         console.log(`[Agent 编排] 将直接使用已保存的 sdkSessionId 进行 resume: ${existingSdkSessionId}`)
       }
 
-      // 10. 构建 MCP 服务器配置 + 记忆工具 + 生图工具 + 自定义工具
+      // 10. 构建 MCP 服务器配置 + 内置 MCP（记忆/生图）+ 自定义工具
       const mcpServers = this.buildMcpServers(workspaceSlug)
-      await this.injectMemoryTools(sdk, mcpServers)
-      await this.injectNanoBananaTools(sdk, mcpServers, sessionId, agentCwd)
+      await injectBuiltinMcpServers({ sdk, mcpServers, sessionId, agentCwd })
 
       // 合并外部注入的自定义 MCP 服务器（如飞书群聊工具）
       if (customMcpServers) {
@@ -1167,10 +1093,16 @@ export class AgentOrchestrator {
       }
 
       // 11. 构建动态上下文和最终 prompt
+      // 收集本次实际注入的内置 MCP server 真实名（mcpServers 的 key 已是下划线安全名），
+      // 供动态上下文按真实名枚举，杜绝模型凭配置名手写错误的工具名。
+      const builtinMcpServerNames = Object.keys(mcpServers).filter((name) =>
+        RESERVED_BUILTIN_KEYS.has(name),
+      )
       const dynamicCtx = buildDynamicContext({
         workspaceName: workspace?.name,
         workspaceSlug,
         agentCwd,
+        builtinMcpServerNames,
       })
 
       // 11.5 注入 mention 引用指令（Skill/MCP/会话）— 仅影响 prompt，不影响持久化

--- a/apps/electron/src/main/lib/agent-prompt-builder.ts
+++ b/apps/electron/src/main/lib/agent-prompt-builder.ts
@@ -408,6 +408,11 @@ interface DynamicContext {
   workspaceName?: string
   workspaceSlug?: string
   agentCwd?: string
+  /**
+   * 本次会话实际注入的内置 MCP server 真实名（mcpServers 的 key，已是下划线安全名）。
+   * 用于在动态上下文中按真实名枚举，杜绝模型凭配置名手写错误的工具名。
+   */
+  builtinMcpServerNames?: string[]
 }
 
 /**
@@ -451,6 +456,15 @@ export function buildDynamicContext(ctx: DynamicContext): string {
           ? `${entry.command}${entry.args?.length ? ' ' + entry.args.join(' ') : ''}`
           : entry.url || ''
         wsLines.push(`- ${name} (${entry.type}, ${status}): ${detail}`)
+      }
+    }
+
+    // 本次会话实际注入的内置 MCP 工具（按真实 server 名枚举，杜绝模型手写错误名）
+    const builtinNames = ctx.builtinMcpServerNames ?? []
+    if (builtinNames.length > 0) {
+      wsLines.push('内置 MCP 工具（本次会话可用，调用时照抄以下真实名）:')
+      for (const name of builtinNames) {
+        wsLines.push(`- mcp__${name}__*`)
       }
     }
 

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -20,6 +20,7 @@ import {
   parseSkillVersion,
 } from './config-paths'
 import type { AgentWorkspace, WorkspaceMcpConfig, SkillMeta, SkillImportSource, OtherWorkspaceSkillsGroup, WorkspaceCapabilities, SkillFileNode, SkillFileContent } from '@proma/shared'
+import { RESERVED_BUILTIN_KEYS } from './builtin-mcp/baseline'
 
 interface AgentWorkspacesIndex {
   version: number
@@ -442,6 +443,25 @@ export function ensurePluginManifest(workspaceSlug: string, workspaceName: strin
 
 // ===== MCP 配置管理 =====
 
+/**
+ * 剔除与内置 MCP 保留名冲突的 server。
+ *
+ * 内置 MCP（kind=internal，由代码注入）的保留名不允许出现在工作区 mcp.json。
+ * 任何同名条目都是误写或冲突——剔除它，既防止用户/UI 占用保留名，也让手改
+ * mcp.json 写入的冲突项在下次读写时自愈。内置 MCP 的开关由内置机制管理，不在此文件。
+ */
+function stripReservedBuiltinServers(servers: WorkspaceMcpConfig['servers']): WorkspaceMcpConfig['servers'] {
+  const result: WorkspaceMcpConfig['servers'] = {}
+  for (const [name, entry] of Object.entries(servers ?? {})) {
+    if (RESERVED_BUILTIN_KEYS.has(name)) {
+      console.warn(`[Agent 工作区] MCP 服务器 "${name}" 与内置 MCP 保留名冲突，已忽略（内置 MCP 不写入 mcp.json）`)
+      continue
+    }
+    result[name] = entry
+  }
+  return result
+}
+
 export function getWorkspaceMcpConfig(workspaceSlug: string): WorkspaceMcpConfig {
   const mcpPath = getWorkspaceMcpPath(workspaceSlug)
 
@@ -452,7 +472,7 @@ export function getWorkspaceMcpConfig(workspaceSlug: string): WorkspaceMcpConfig
   try {
     const raw = readFileSync(mcpPath, 'utf-8')
     const parsed = JSON.parse(raw) as Partial<WorkspaceMcpConfig>
-    return { servers: parsed.servers ?? {} }
+    return { servers: stripReservedBuiltinServers(parsed.servers ?? {}) }
   } catch (error) {
     console.error('[Agent 工作区] 读取 MCP 配置失败:', error)
     return { servers: {} }
@@ -463,7 +483,8 @@ export function saveWorkspaceMcpConfig(workspaceSlug: string, config: WorkspaceM
   const mcpPath = getWorkspaceMcpPath(workspaceSlug)
 
   try {
-    writeFileSync(mcpPath, JSON.stringify(config, null, 2), 'utf-8')
+    const safeConfig: WorkspaceMcpConfig = { servers: stripReservedBuiltinServers(config.servers ?? {}) }
+    writeFileSync(mcpPath, JSON.stringify(safeConfig, null, 2), 'utf-8')
     console.log(`[Agent 工作区] 已保存 MCP 配置: ${workspaceSlug}`)
   } catch (error) {
     console.error('[Agent 工作区] 保存 MCP 配置失败:', error)

--- a/apps/electron/src/main/lib/builtin-mcp/baseline.ts
+++ b/apps/electron/src/main/lib/builtin-mcp/baseline.ts
@@ -1,0 +1,66 @@
+/**
+ * Proma 内置 MCP 单一事实源加载层
+ *
+ * 唯一从 default-mcp.json 读取内置 MCP 定义的地方。注入器、UI catalog、
+ * 系统提示词全部通过这里取 name / displayName / 约束，杜绝多处手写漂移。
+ *
+ * default-mcp.json 随构建编译进包（参考 channel-manager / agent-orchestrator
+ * 的 `import pkg from 'package.json' with { type: 'json' }` 模式），
+ * Proma 每次发布即覆盖升级，无需运行时同步到用户目录。
+ */
+
+import type { BuiltinMcpCategory, McpToolSummary } from '@proma/shared'
+import manifest from './default-mcp.json' with { type: 'json' }
+
+export interface BuiltinMcpDefinition {
+  /** 设置 / 凭据键，历史值，向后兼容（如 'proma-cloud'、'nano-banana'） */
+  id: string
+  /** 运行时真实 server 名，下划线安全（= prompt = 注入 = UI 真实名） */
+  name: string
+  displayName: string
+  description: string
+  category: BuiltinMcpCategory
+  /** internal=代码注入，不写入工作区 mcp.json */
+  kind: 'internal'
+  /** 是否允许用户删除（内置项恒为 false，删除护栏的事实源） */
+  deletable: boolean
+  /** 默认是否向 Agent 注入（如 mem/nano-banana 需用户手动开启） */
+  defaultEnabled: boolean
+  /** 是否提供开关（基础设施型如 proma-cloud 置 false） */
+  toggleable: boolean
+  tools: McpToolSummary[]
+}
+
+const DEFINITIONS: BuiltinMcpDefinition[] = (manifest.servers as unknown as BuiltinMcpDefinition[]).map((s) => ({
+  ...s,
+}))
+
+const BY_ID = new Map<string, BuiltinMcpDefinition>(DEFINITIONS.map((d) => [d.id, d]))
+
+/** 所有内置 MCP 定义（来自 default-mcp.json，按声明顺序） */
+export function getBuiltinMcpDefinitions(): BuiltinMcpDefinition[] {
+  return DEFINITIONS
+}
+
+/** 按 id 取定义 */
+export function getBuiltinMcpById(id: string): BuiltinMcpDefinition | undefined {
+  return BY_ID.get(id)
+}
+
+/**
+ * 取某个内置 MCP 的运行时真实 server 名。
+ * 注入器、catalog、prompt 一律通过此函数取名，确保和 default-mcp.json 一致。
+ * 未登记的 id 回退为 id 本身（容错，不致崩溃）。
+ */
+export function getBuiltinMcpName(id: string): string {
+  return BY_ID.get(id)?.name ?? id
+}
+
+/**
+ * 内置 MCP 占用的全部保留名（id + 运行时 name）。
+ * 工作区 mcp.json 不允许出现这些 key——内置项是 kind=internal，由代码注入，
+ * 任何同名条目都是误写/冲突，应在保存时剔除。
+ */
+export const RESERVED_BUILTIN_KEYS: ReadonlySet<string> = new Set(
+  DEFINITIONS.flatMap((d) => [d.id, d.name]),
+)

--- a/apps/electron/src/main/lib/builtin-mcp/default-mcp.json
+++ b/apps/electron/src/main/lib/builtin-mcp/default-mcp.json
@@ -1,0 +1,35 @@
+{
+  "comment": "Proma 内置 MCP 单一事实源。这里是唯一定义内置 MCP 运行时名字（name）、展示信息和约束的地方，注入器、UI catalog、系统提示词全部从这里取值，杜绝三处手写漂移。name 必须是下划线安全名（SDK 会把 server 名里的连字符规范化成下划线，源名与运行名不一致正是工具被 Agent 调错的根因），id 保持历史值（设置/凭据键，向后兼容）。kind=internal 表示由代码注入、不写入工作区 mcp.json。",
+  "version": 1,
+  "servers": [
+    {
+      "id": "mem",
+      "name": "mem",
+      "displayName": "记忆",
+      "description": "通过 MemOS Cloud 检索和写入长期记忆。",
+      "category": "memory",
+      "kind": "internal",
+      "deletable": false,
+      "defaultEnabled": false,
+      "toggleable": true,
+      "tools": [
+        { "name": "recall_memory", "description": "检索用户长期记忆。", "readOnly": true },
+        { "name": "add_memory", "description": "写入一条长期记忆。" }
+      ]
+    },
+    {
+      "id": "nano-banana",
+      "name": "nano_banana",
+      "displayName": "Nano Banana 生图",
+      "description": "通过 Gemini Image Generation 为 Agent 提供图片生成和编辑能力。",
+      "category": "media",
+      "kind": "internal",
+      "deletable": false,
+      "defaultEnabled": false,
+      "toggleable": true,
+      "tools": [
+        { "name": "generate_image", "description": "生成或编辑图片。" }
+      ]
+    }
+  ]
+}

--- a/apps/electron/src/main/lib/builtin-mcp/memory.ts
+++ b/apps/electron/src/main/lib/builtin-mcp/memory.ts
@@ -1,0 +1,62 @@
+/**
+ * Proma 内置记忆 MCP
+ *
+ * 运行时注入 MemOS Cloud 工具。配置来源仍沿用 memory-service，
+ * 不写入工作区 mcp.json。
+ */
+
+import { getMemoryConfig } from '../memory-service'
+import { addMemory, formatSearchResult, searchMemory } from '../memos-client'
+import { getBuiltinMcpName } from './baseline'
+
+export async function injectMemoryMcpServer(
+  sdk: typeof import('@anthropic-ai/claude-agent-sdk'),
+  mcpServers: Record<string, Record<string, unknown>>,
+): Promise<void> {
+  const memoryConfig = getMemoryConfig()
+  const memUserId = memoryConfig.userId?.trim() || 'proma-user'
+  if (!memoryConfig.enabled || !memoryConfig.apiKey) return
+
+  const { z } = await import('zod')
+  const serverName = getBuiltinMcpName('mem')
+  const memosServer = sdk.createSdkMcpServer({
+    name: serverName,
+    version: '1.0.0',
+    tools: [
+      sdk.tool(
+        'recall_memory',
+        'Search user memories (facts and preferences) from MemOS Cloud. Use this to recall relevant context about the user.',
+        { query: z.string().describe('Search query for memory retrieval'), limit: z.number().optional().describe('Max results (default 6)') },
+        async (args) => {
+          const result = await searchMemory(
+            { apiKey: memoryConfig.apiKey, userId: memUserId, baseUrl: memoryConfig.baseUrl },
+            args.query,
+            args.limit,
+          )
+          return { content: [{ type: 'text' as const, text: formatSearchResult(result) }] }
+        },
+        { annotations: { readOnlyHint: true } },
+      ),
+      sdk.tool(
+        'add_memory',
+        'Store a conversation message pair into MemOS Cloud for long-term memory. Call this after meaningful exchanges worth remembering.',
+        {
+          userMessage: z.string().describe('The user message to store'),
+          assistantMessage: z.string().optional().describe('The assistant response to store'),
+          conversationId: z.string().optional().describe('Conversation ID for grouping'),
+          tags: z.array(z.string()).optional().describe('Tags for categorization'),
+        },
+        async (args) => {
+          await addMemory(
+            { apiKey: memoryConfig.apiKey, userId: memUserId, baseUrl: memoryConfig.baseUrl },
+            args,
+          )
+          return { content: [{ type: 'text' as const, text: 'Memory stored successfully.' }] }
+        },
+      ),
+    ],
+  })
+
+  mcpServers[serverName] = memosServer as unknown as Record<string, unknown>
+  console.log(`[Agent 编排] 已注入内置记忆工具 (${serverName})`)
+}

--- a/apps/electron/src/main/lib/builtin-mcp/registry.ts
+++ b/apps/electron/src/main/lib/builtin-mcp/registry.ts
@@ -1,0 +1,35 @@
+/**
+ * Proma 内置 MCP 注册中心
+ *
+ * Orchestrator 只调用这里的统一入口；各内置 MCP 的可用性、注入条件和错误隔离
+ * 都收敛在本模块，避免主编排流程继续膨胀。
+ */
+
+import { injectNanoBananaMcpServer } from '../chat-tools/nano-banana-mcp'
+import { injectMemoryMcpServer } from './memory'
+
+export interface BuiltinMcpInjectContext {
+  sdk: typeof import('@anthropic-ai/claude-agent-sdk')
+  mcpServers: Record<string, Record<string, unknown>>
+  sessionId: string
+  agentCwd?: string
+}
+
+async function injectBuiltinSafely(name: string, task: () => Promise<void>): Promise<void> {
+  try {
+    await task()
+  } catch (error) {
+    console.error(`[Agent 编排] 注入内置 MCP 失败 (${name}):`, error)
+  }
+}
+
+export async function injectBuiltinMcpServers(ctx: BuiltinMcpInjectContext): Promise<void> {
+  await injectBuiltinSafely('mem', () => injectMemoryMcpServer(ctx.sdk, ctx.mcpServers))
+
+  await injectBuiltinSafely('nano-banana', () => injectNanoBananaMcpServer(
+    ctx.sdk,
+    ctx.mcpServers,
+    ctx.sessionId,
+    ctx.agentCwd,
+  ))
+}

--- a/apps/electron/src/main/lib/chat-tools/nano-banana-mcp.ts
+++ b/apps/electron/src/main/lib/chat-tools/nano-banana-mcp.ts
@@ -10,6 +10,7 @@ import { randomUUID } from 'node:crypto'
 import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'node:fs'
 import { extname, resolve, isAbsolute, join } from 'node:path'
 import { getToolState, getToolCredentials } from '../chat-tool-config'
+import { getBuiltinMcpName } from '../builtin-mcp/baseline'
 import { saveAttachment, isImageAttachment } from '../attachment-service'
 
 // ===== Gemini API 类型（REST API 使用 camelCase） =====
@@ -336,9 +337,10 @@ export async function injectNanoBananaMcpServer(
   if (!toolState.enabled || !credentials.apiKey) return
 
   const { z } = await import('zod')
+  const serverName = getBuiltinMcpName('nano-banana')
 
   const server = sdk.createSdkMcpServer({
-    name: 'nano-banana',
+    name: serverName,
     version: '1.0.0',
     tools: [
       sdk.tool(
@@ -370,8 +372,8 @@ export async function injectNanoBananaMcpServer(
     ],
   })
 
-  mcpServers['nano-banana'] = server as unknown as Record<string, unknown>
-  console.log(`[Nano Banana MCP] 已注入内置生图工具 (nano-banana)`)
+  mcpServers[serverName] = server as unknown as Record<string, unknown>
+  console.log(`[Nano Banana MCP] 已注入内置生图工具 (${serverName})`)
 }
 
 // ===== 清理 =====

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -703,6 +703,31 @@ export interface McpServerEntry {
   }
 }
 
+/** MCP 工具摘要，用于前端只读展示 */
+export interface McpToolSummary {
+  name: string
+  description: string
+  readOnly?: boolean
+}
+
+/** Proma 内置 MCP 分类 */
+export type BuiltinMcpCategory = 'system' | 'automation' | 'collaboration' | 'memory' | 'media'
+
+/** Proma 内置 MCP 摘要，不写入工作区 mcp.json */
+export interface BuiltinMcpServerSummary {
+  id: string
+  name: string
+  displayName: string
+  description: string
+  category: BuiltinMcpCategory
+  enabled: boolean
+  available: boolean
+  availabilityReason?: string
+  tools: McpToolSummary[]
+  /** 是否允许用户开关。基础设施型 MCP（如 proma-cloud）始终注入、不提供开关，置 false */
+  toggleable?: boolean
+}
+
 /** 工作区 MCP 配置文件 */
 export interface WorkspaceMcpConfig {
   servers: Record<string, McpServerEntry>


### PR DESCRIPTION
## 背景 / 根因

内置 MCP 工具（如 `nano-banana`）经常被 Agent 调错名字导致 tool-not-found，尤其在 Claude Opus 系列上不稳定。

**根因**：SDK 会把 `createSdkMcpServer({ name })` 里 server 名的连字符规范化成下划线——`nano-banana` 实际注册为 `mcp__nano_banana__*`。但工具名此前在注入器、prompt 等多处硬编码、各自漂移，模型按错误的连字符名调用就会 404。带连字符的内置 MCP 全部中招，单词名（无连字符）的则正常，正好解释了"时好时坏"。

## 方案

把"叫什么名字、是否可删、怎么展示"收敛到唯一事实源，并让源名 == 运行名：

1. **单一事实源** `builtin-mcp/default-mcp.json`：每个内置 MCP 声明 `id`（历史值，设置/凭据键，向后兼容）+ `name`（下划线安全的运行时真实名）。经 JSON import 编译进包，随版本覆盖升级。
2. **baseline.ts**：统一加载，提供 `getBuiltinMcpName()` / `RESERVED_BUILTIN_KEYS`。
3. **registry.ts + memory.ts**：把内置注入收敛到 `injectBuiltinMcpServers()` 统一入口；mem 从 orchestrator 抽成独立注入器。
4. **orchestrator**：改用 registry 入口（删除内联 `injectMemoryTools`/`injectNanoBananaTools`），并收集本次实际注入的真实 server 名。
5. **nano-banana**：name 与 `mcpServers` key 改为从 baseline 取真实名。
6. **prompt**：`buildDynamicContext` 按本次会话真实 server 名枚举可用内置工具，prompt 永远与运行时一致。
7. **护栏**：`getWorkspaceMcpConfig`/`saveWorkspaceMcpConfig` 剔除与内置保留名冲突的条目（内置是 `kind=internal` 由代码注入、不写入 mcp.json），手改 mcp.json 也能自愈。

## Commits

1. `feat(mcp): add builtin MCP summary types` — 共享类型骨架
2. `feat(mcp): single-source builtin MCP names via default-mcp.json` — 模块骨架 + orchestrator registry 重构 + nano 命名修复
3. `feat(mcp): enumerate real builtin tool names in dynamic context` — prompt 真实名枚举
4. `feat(mcp): guard workspace mcp.json against builtin reserved names` — 保留名护栏

## 验证

- `tsc --noEmit`：0 错误
- `build:main`：成功，`default-mcp.json` 数据（`nano_banana` / `mem`）已正确内联进 bundle

## 影响面

- 运行时工具名**与改动前完全一致**（本就是下划线），仅源名对齐，**零迁移**、不破坏已有调用记录
- 设置/凭据键沿用 `id`（如 `nano-banana`），不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)