### PR TITLE
【已审核】fix(build): Windows bun --compile 短路径 workaround

### DIFF
--- a/apps/electron/scripts/build-cli.ts
+++ b/apps/electron/scripts/build-cli.ts
@@ -55,52 +55,47 @@ console.log(`${color.cyan}[build:cli]${color.reset} 编译 proma CLI → ${color
 // bun build --compile 在 Windows 上尝试复制自身到临时目录时，
 // 若 bun.exe 位于过长路径（如 ~/.bun/bin/bun.exe）会报 ENOENT。
 // 解决：将 bun.exe 复制到短路径（os.tmpdir()）后通过
-// --compile-executable-path 指向副本，编译后清理。
+// --compile-executable-path 指向副本，编译后清理（try/finally 保证清理）。
 let tempBunPath: string | undefined
 const compileArgs = ['build', '--compile', '--outfile', outFile, cliEntry]
 
 if (isWindows) {
-  const bunExe = process.execPath // bun 中即 bun.exe 自身
   const tmpDir = tmpdir()
-  const bunName = `bun-temp-${Date.now()}.exe`
+  const bunName = `bun-temp-${Date.now()}-${process.pid}.exe`
   tempBunPath = join(tmpDir, bunName)
 
   try {
-    copyFileSync(bunExe, tempBunPath)
+    copyFileSync(process.execPath, tempBunPath)
     compileArgs.splice(2, 0, '--compile-executable-path', tempBunPath)
     console.log(`${color.dim}[build:cli] Windows 短路径 workaround: ${tempBunPath}${color.reset}`)
-  } catch {
-    console.warn(`${color.yellow}[build:cli] 无法复制 bun 到临时目录，尝试直接编译${color.reset}`)
+  } catch (err) {
+    tempBunPath = undefined // copy 失败，无需清理
+    console.warn(`${color.yellow}[build:cli] 无法复制 bun 到临时目录: ${err}，尝试直接编译${color.reset}`)
   }
 }
 
 const started = Date.now()
-const result = spawnSync(
-  'bun',
-  compileArgs,
-  { cwd: join(repoRoot, 'apps/cli'), stdio: 'inherit' },
-)
+try {
+  const result = spawnSync(
+    'bun',
+    compileArgs,
+    { cwd: join(repoRoot, 'apps/cli'), stdio: 'inherit' },
+  )
 
-if (result.status !== 0) {
-  // 清理临时 bun 副本后再报错
-  if (tempBunPath) {
-    try { unlinkSync(tempBunPath) } catch { /* ignore */ }
+  if (result.status !== 0) {
+    fail(`bun build --compile 失败（exit ${result.status}）`)
   }
-  fail(`bun build --compile 失败（exit ${result.status}）`)
-}
-if (!existsSync(outFile)) {
-  if (tempBunPath) {
-    try { unlinkSync(tempBunPath) } catch { /* ignore */ }
+  if (!existsSync(outFile)) {
+    fail(`编译完成但未产出二进制: ${outFile}`)
   }
-  fail(`编译完成但未产出二进制: ${outFile}`)
-}
-
-// 清理临时 bun 副本
-if (tempBunPath) {
-  try {
-    unlinkSync(tempBunPath)
-  } catch {
-    console.warn(`${color.yellow}[build:cli] 无法删除临时 bun 副本: ${tempBunPath}${color.reset}`)
+} finally {
+  // 始终清理临时 bun 副本
+  if (tempBunPath) {
+    try {
+      unlinkSync(tempBunPath)
+    } catch {
+      console.warn(`${color.yellow}[build:cli] 无法删除临时 bun 副本: ${tempBunPath}${color.reset}`)
+    }
   }
 }
 

--- a/apps/electron/scripts/build-cli.ts
+++ b/apps/electron/scripts/build-cli.ts
@@ -15,7 +15,8 @@
  * 在 electron app 的 build 链中调用（见 package.json build:cli）。
  */
 import { spawnSync } from 'node:child_process'
-import { existsSync, mkdirSync, statSync } from 'node:fs'
+import { copyFileSync, existsSync, mkdirSync, statSync, unlinkSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 
 const color = {
@@ -50,18 +51,57 @@ mkdirSync(outDir, { recursive: true })
 
 console.log(`${color.cyan}[build:cli]${color.reset} 编译 proma CLI → ${color.dim}${outFile}${color.reset}`)
 
+// ── Windows 短路径 workaround ──
+// bun build --compile 在 Windows 上尝试复制自身到临时目录时，
+// 若 bun.exe 位于过长路径（如 ~/.bun/bin/bun.exe）会报 ENOENT。
+// 解决：将 bun.exe 复制到短路径（os.tmpdir()）后通过
+// --compile-executable-path 指向副本，编译后清理。
+let tempBunPath: string | undefined
+const compileArgs = ['build', '--compile', '--outfile', outFile, cliEntry]
+
+if (isWindows) {
+  const bunExe = process.execPath // bun 中即 bun.exe 自身
+  const tmpDir = tmpdir()
+  const bunName = `bun-temp-${Date.now()}.exe`
+  tempBunPath = join(tmpDir, bunName)
+
+  try {
+    copyFileSync(bunExe, tempBunPath)
+    compileArgs.splice(2, 0, '--compile-executable-path', tempBunPath)
+    console.log(`${color.dim}[build:cli] Windows 短路径 workaround: ${tempBunPath}${color.reset}`)
+  } catch {
+    console.warn(`${color.yellow}[build:cli] 无法复制 bun 到临时目录，尝试直接编译${color.reset}`)
+  }
+}
+
 const started = Date.now()
 const result = spawnSync(
   'bun',
-  ['build', '--compile', '--outfile', outFile, cliEntry],
+  compileArgs,
   { cwd: join(repoRoot, 'apps/cli'), stdio: 'inherit' },
 )
 
 if (result.status !== 0) {
+  // 清理临时 bun 副本后再报错
+  if (tempBunPath) {
+    try { unlinkSync(tempBunPath) } catch { /* ignore */ }
+  }
   fail(`bun build --compile 失败（exit ${result.status}）`)
 }
 if (!existsSync(outFile)) {
+  if (tempBunPath) {
+    try { unlinkSync(tempBunPath) } catch { /* ignore */ }
+  }
   fail(`编译完成但未产出二进制: ${outFile}`)
+}
+
+// 清理临时 bun 副本
+if (tempBunPath) {
+  try {
+    unlinkSync(tempBunPath)
+  } catch {
+    console.warn(`${color.yellow}[build:cli] 无法删除临时 bun 副本: ${tempBunPath}${color.reset}`)
+  }
 }
 
 const sizeMb = (statSync(outFile).size / 1024 / 1024).toFixed(0)


### PR DESCRIPTION
## 概述

`bun build --compile` 在 Windows 上执行时，bun 会复制自身（bun.exe）到临时目录再追加打包后的 JS。当 bun.exe 位于长路径（如 `~/.bun/bin/bun.exe`）时，自复制操作因 ENOENT 失败：

```
error: failed to copy bun executable into temporary file: ENOENT
Failed to get temp file path: FileNotFound
```

### 根因

Bun 的 Rust 运行时在 Windows 上调用 `--compile` 时，内部 `std::fs::copy` 操作对源文件路径长度敏感，长路径（`C:\Users\...`）下触发 `ENOENT`。

### 解决

在 Windows 上将 bun.exe 复制到 `os.tmpdir()` 下的短路径，通过 `--compile-executable-path` 指向副本让 bun 跳过自有复制逻辑，编译完成后清理临时文件。

## 改动

`apps/electron/scripts/build-cli.ts` — 42 行新增 → 24 行净增（审查优化后）

- 新增 `copyFileSync`/`unlinkSync`/`tmpdir` 导入
- Windows 专属：复制 bun.exe 到 `os.tmpdir()` 下的短路径（文件名含 `process.pid` 防碰撞）
- 通过 `--compile-executable-path` 传递副本路径
- try/finally 保证编译完成/失败时始终清理临时文件
- catch 绑定 err 对象，复制失败时输出具体原因

## 测试

```
$ bun run build:cli
[build:cli] Windows 短路径 workaround: C:\Temp\bun-temp-1782819388199-41744.exe
  [21ms]  bundle  23 modules
 [474ms] compile  resources/bin/proma.exe
[build:cli] ✓ proma.exe (94MB, 5.4s)
```

- bun run typecheck: ✅ 全部 6 包通过
- electron-builder --win --x64: ✅ 安装包 197MB，含 proma.exe
- 临时 bun 副本编译后自动清理

## 紧急度

中 — Windows 开发环境无法独立打包 CLI

## 备注

- 仅在 Windows 平台生效，macOS/Linux 行为不变