### PR TITLE
fix(agent): 修复 AskUser 自定义答案语音输入路由【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.13.24",
+  "version": "0.13.25",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/agent/AskUserBanner.tsx
+++ b/apps/electron/src/renderer/components/agent/AskUserBanner.tsx
@@ -12,6 +12,11 @@ import Markdown, { defaultUrlTransform } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { Button } from '@/components/ui/button'
 import {
+  VOICE_DICTATION_INSERT_EVENT,
+  getLastFocusedVoiceInputId,
+  setLastFocusedVoiceInputId,
+} from '@/lib/voice-input-focus'
+import {
   allPendingAskUserRequestsAtom,
   agentStreamingStatesAtom,
   askUserDraftsAtom,
@@ -415,11 +420,48 @@ function QuestionCard({
   onCustomTextChange: (text: string) => void
   onSubmit: () => void
 }): React.ReactElement {
+  const customInputRef = React.useRef<HTMLInputElement | null>(null)
+  const voiceInputIdRef = React.useRef(`ask-user-custom-${Math.random().toString(36).slice(2)}`)
+  const customTextRef = React.useRef(answer.customText)
+  const onCustomTextChangeRef = React.useRef(onCustomTextChange)
   const optionCount = question.options.length
   const previewOption = focusedIndex >= 0 && focusedIndex < optionCount
     ? question.options[focusedIndex]
     : question.options.find((o) => answer.selected.includes(o.label))
   const previewContent = previewOption?.preview
+
+  customTextRef.current = answer.customText
+  onCustomTextChangeRef.current = onCustomTextChange
+
+  React.useEffect(() => {
+    if (!answer.showCustom) return
+
+    const handler = (event: Event): void => {
+      if (getLastFocusedVoiceInputId() !== voiceInputIdRef.current) return
+
+      const customEvent = event as CustomEvent<{ text?: string }>
+      const text = customEvent.detail?.text?.trim()
+      if (!text) return
+
+      const input = customInputRef.current
+      const currentText = customTextRef.current
+      const start = input?.selectionStart ?? currentText.length
+      const end = input?.selectionEnd ?? start
+      const nextText = `${currentText.slice(0, start)}${text}${currentText.slice(end)}`
+      const nextCursor = start + text.length
+
+      onCustomTextChangeRef.current(nextText)
+      event.preventDefault()
+
+      requestAnimationFrame(() => {
+        input?.focus()
+        input?.setSelectionRange(nextCursor, nextCursor)
+      })
+    }
+
+    window.addEventListener(VOICE_DICTATION_INSERT_EVENT, handler)
+    return () => window.removeEventListener(VOICE_DICTATION_INSERT_EVENT, handler)
+  }, [answer.showCustom])
 
   return (
     <div className="space-y-2">
@@ -488,11 +530,13 @@ function QuestionCard({
       {/* 自由文本输入 */}
       {answer.showCustom && (
         <input
+          ref={customInputRef}
           type="text"
           className="w-full px-3 py-2 rounded-lg text-xs bg-muted/40 focus:bg-muted/60 focus:outline-none focus:ring-2 focus:ring-primary/30 placeholder:text-muted-foreground/40 transition-colors"
           placeholder="输入自定义答案..."
           value={answer.customText}
           onChange={(e) => onCustomTextChange(e.target.value)}
+          onFocus={() => setLastFocusedVoiceInputId(voiceInputIdRef.current)}
           onKeyDown={(e) => {
             if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
               e.preventDefault()

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.13.24",
+      "version": "0.13.25",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.185",
         "@anthropic-ai/sdk": "^0.93.0",


### PR DESCRIPTION
## 概述
修复 Agent AskUserQuestion 中选择「其他...」并填写自定义答案时，快捷键唤起的语音输入仍然回填到主对话输入框的问题。该 PR 让 AskUser 自定义答案输入框接入现有语音输入焦点路由，确保语音识别结果进入用户当前正在填写的自定义答案。

## 改动
- `apps/electron/src/renderer/components/agent/AskUserBanner.tsx` — 复用 `voice-input-focus` 机制，在自定义答案输入框聚焦时注册为语音输入目标；监听语音回填事件并将文本插入当前光标位置，同时阻止全局 fallback 写入主输入框。
- `apps/electron/package.json` — 按版本管理规则将 `@proma/electron` patch 版本从 `0.13.24` 提升到 `0.13.25`。
- `bun.lock` — 同步 workspace 版本记录。

## 测试方法
1. 运行 `bun run typecheck`，确认所有 workspace 类型检查通过。
2. 在 Agent 会话触发 AskUserQuestion。
3. 选择「其他...」并聚焦自定义答案输入框。
4. 使用语音输入快捷键唤起语音输入，说话并提交识别结果。
5. 确认识别文本进入自定义答案输入框，而不是主对话输入框。

## 备注
- 已按 Review-Proma-PR 流程审查本次改动，未发现代码质量问题或 Windows 兼容性风险。
- 文档未更新，因为本次是输入路由行为修复，不改变用户可见配置或公开 API。