### PR TITLE
feat(mcp): 内置 MCP 单一事实源（default-mcp.json）+ 修复 nano-banana 命名漂移

### DIFF
--- a/apps/electron/src/main/lib/builtin-mcp/baseline.ts
+++ b/apps/electron/src/main/lib/builtin-mcp/baseline.ts
@@ -1,0 +1,66 @@
+/**
+ * Proma 内置 MCP 单一事实源加载层
+ *
+ * 唯一从 default-mcp.json 读取内置 MCP 定义的地方。注入器、UI catalog、
+ * 系统提示词全部通过这里取 name / displayName / 约束，杜绝多处手写漂移。
+ *
+ * default-mcp.json 随构建编译进包（参考 channel-manager / agent-orchestrator
+ * 的 `import pkg from 'package.json' with { type: 'json' }` 模式），
+ * Proma 每次发布即覆盖升级，无需运行时同步到用户目录。
+ */
+
+import type { BuiltinMcpCategory, McpToolSummary } from '@proma/shared'
+import manifest from './default-mcp.json' with { type: 'json' }
+
+export interface BuiltinMcpDefinition {
+  /** 设置 / 凭据键，历史值，向后兼容（如 'proma-cloud'、'nano-banana'） */
+  id: string
+  /** 运行时真实 server 名，下划线安全（= prompt = 注入 = UI 真实名） */
+  name: string
+  displayName: string
+  description: string
+  category: BuiltinMcpCategory
+  /** internal=代码注入，不写入工作区 mcp.json */
+  kind: 'internal'
+  /** 是否允许用户删除（内置项恒为 false，删除护栏的事实源） */
+  deletable: boolean
+  /** 默认是否向 Agent 注入（如 mem/nano-banana 需用户手动开启） */
+  defaultEnabled: boolean
+  /** 是否提供开关（基础设施型如 proma-cloud 置 false） */
+  toggleable: boolean
+  tools: McpToolSummary[]
+}
+
+const DEFINITIONS: BuiltinMcpDefinition[] = (manifest.servers as unknown as BuiltinMcpDefinition[]).map((s) => ({
+  ...s,
+}))
+
+const BY_ID = new Map<string, BuiltinMcpDefinition>(DEFINITIONS.map((d) => [d.id, d]))
+
+/** 所有内置 MCP 定义（来自 default-mcp.json，按声明顺序） */
+export function getBuiltinMcpDefinitions(): BuiltinMcpDefinition[] {
+  return DEFINITIONS
+}
+
+/** 按 id 取定义 */
+export function getBuiltinMcpById(id: string): BuiltinMcpDefinition | undefined {
+  return BY_ID.get(id)
+}
+
+/**
+ * 取某个内置 MCP 的运行时真实 server 名。
+ * 注入器、catalog、prompt 一律通过此函数取名，确保和 default-mcp.json 一致。
+ * 未登记的 id 回退为 id 本身（容错，不致崩溃）。
+ */
+export function getBuiltinMcpName(id: string): string {
+  return BY_ID.get(id)?.name ?? id
+}
+
+/**
+ * 内置 MCP 占用的全部保留名（id + 运行时 name）。
+ * 工作区 mcp.json 不允许出现这些 key——内置项是 kind=internal，由代码注入，
+ * 任何同名条目都是误写/冲突，应在保存时剔除。
+ */
+export const RESERVED_BUILTIN_KEYS: ReadonlySet<string> = new Set(
+  DEFINITIONS.flatMap((d) => [d.id, d.name]),
+)

--- a/apps/electron/src/main/lib/builtin-mcp/catalog.ts
+++ b/apps/electron/src/main/lib/builtin-mcp/catalog.ts
@@ -2,93 +2,38 @@
  * Proma 内置 MCP 能力目录
  *
  * 这里只维护可展示的元数据和可用性判断，不负责运行时注入。
- * 这样前端能力摘要可以安全读取内置 MCP 列表，而不会引入 Agent 编排层循环依赖。
+ * 元数据本身来自 default-mcp.json（经 baseline 加载），本文件只在其上叠加
+ * 运行时可用性判断（API Key、工作区、登录态等）。这样前端能力摘要可以安全读取
+ * 内置 MCP 列表，而不会引入 Agent 编排层循环依赖。
  */
 
-import type { BuiltinMcpServerSummary, McpToolSummary } from '@proma/shared'
+import type { BuiltinMcpServerSummary } from '@proma/shared'
 import { getToolCredentials, getToolState } from '../chat-tool-config'
 import { getMemoryConfig } from '../memory-service'
-import { isBuiltinMcpUserEnabled } from './settings'
-
-interface BuiltinMcpCatalogItem {
-  id: string
-  name: string
-  displayName: string
-  description: string
-  category: BuiltinMcpServerSummary['category']
-  tools: McpToolSummary[]
-}
+import { getBuiltinMcpDefinitions, type BuiltinMcpDefinition } from './baseline'
+import { isBuiltinMcpDefaultDisabled, isBuiltinMcpUserEnabled } from './settings'
 
 interface BuiltinMcpListContext {
   workspaceSlug?: string
 }
 
-const BUILTIN_MCP_CATALOG: BuiltinMcpCatalogItem[] = [
-  {
-    id: 'automation',
-    name: 'automation',
-    displayName: '定时任务',
-    description: '创建、查看、更新、删除和立即运行 Proma 持久化定时任务。',
-    category: 'automation',
-    tools: [
-      { name: 'list_automations', description: '列出 Proma 定时任务。', readOnly: true },
-      { name: 'get_automation', description: '读取单个定时任务详情和运行记录。', readOnly: true },
-      { name: 'create_automation', description: '创建持久化定时任务。' },
-      { name: 'update_automation', description: '更新定时任务配置。' },
-      { name: 'delete_automation', description: '删除定时任务。' },
-      { name: 'run_automation_now', description: '立即运行一次定时任务。' },
-    ],
-  },
-  {
-    id: 'collaboration',
-    name: 'collaboration',
-    displayName: '协作子 Agent',
-    description: '创建、等待、读取和停止真实可见的 Proma 协作子 Agent 会话。',
-    category: 'collaboration',
-    tools: [
-      { name: 'list_available_agent_models', description: '列出当前渠道下可用于协作子 Agent 的模型。', readOnly: true },
-      { name: 'delegate_agent', description: '创建单个协作子 Agent 会话。' },
-      { name: 'delegate_agents', description: '批量创建协作子 Agent 会话。' },
-      { name: 'wait_for_delegations', description: '等待一组协作子会话完成。', readOnly: true },
-      { name: 'list_delegations', description: '列出当前父会话创建的子会话。', readOnly: true },
-      { name: 'get_delegation_results', description: '按委派 ID 读取子会话结果摘要。', readOnly: true },
-      { name: 'stop_delegation', description: '停止单个协作子会话。' },
-      { name: 'stop_delegations', description: '批量停止协作子会话。' },
-    ],
-  },
-  {
-    id: 'mem',
-    name: 'mem',
-    displayName: '记忆',
-    description: '通过 MemOS Cloud 检索和写入长期记忆。',
-    category: 'memory',
-    tools: [
-      { name: 'recall_memory', description: '检索用户长期记忆。', readOnly: true },
-      { name: 'add_memory', description: '写入一条长期记忆。' },
-    ],
-  },
-  {
-    id: 'nano-banana',
-    name: 'nano-banana',
-    displayName: 'Nano Banana 生图',
-    description: '通过 Gemini Image Generation 为 Agent 提供图片生成和编辑能力。',
-    category: 'media',
-    tools: [
-      { name: 'generate_image', description: '生成或编辑图片。' },
-    ],
-  },
-]
-
 function resolveAvailability(
-  item: BuiltinMcpCatalogItem,
+  item: BuiltinMcpDefinition,
   ctx: BuiltinMcpListContext,
 ): Pick<BuiltinMcpServerSummary, 'enabled' | 'available' | 'availabilityReason'> {
+  // 基础设施型（如 proma-cloud）：登录后始终注入，不受用户开关影响
+  if (item.toggleable === false) {
+    return { enabled: true, available: true }
+  }
+
   const userEnabled = isBuiltinMcpUserEnabled(item.id)
   if (!userEnabled) {
     return {
       enabled: false,
       available: false,
-      availabilityReason: '已手动关闭',
+      availabilityReason: isBuiltinMcpDefaultDisabled(item.id)
+        ? '默认关闭，可手动开启'
+        : '已手动关闭',
     }
   }
 
@@ -130,8 +75,14 @@ function resolveAvailability(
 }
 
 export function listBuiltinMcpServers(ctx: BuiltinMcpListContext = {}): BuiltinMcpServerSummary[] {
-  return BUILTIN_MCP_CATALOG.map((item) => ({
-    ...item,
+  return getBuiltinMcpDefinitions().map((item) => ({
+    id: item.id,
+    name: item.name,
+    displayName: item.displayName,
+    description: item.description,
+    category: item.category,
+    tools: item.tools,
+    toggleable: item.toggleable,
     ...resolveAvailability(item, ctx),
   }))
 }

--- a/apps/electron/src/main/lib/builtin-mcp/default-mcp.json
+++ b/apps/electron/src/main/lib/builtin-mcp/default-mcp.json
@@ -1,0 +1,75 @@
+{
+  "comment": "Proma 内置 MCP 单一事实源。这里是唯一定义内置 MCP 运行时名字（name）、展示信息和约束的地方，注入器、UI catalog、系统提示词全部从这里取值，杜绝三处手写漂移。name 必须是下划线安全名（SDK 会把 server 名里的连字符规范化成下划线，源名与运行名不一致正是工具被 Agent 调错的根因），id 保持历史值（设置/凭据键，向后兼容）。kind=internal 表示由代码注入、不写入工作区 mcp.json。",
+  "version": 1,
+  "servers": [
+    {
+      "id": "automation",
+      "name": "automation",
+      "displayName": "定时任务",
+      "description": "创建、查看、更新、删除和立即运行 Proma 持久化定时任务。",
+      "category": "automation",
+      "kind": "internal",
+      "deletable": false,
+      "defaultEnabled": true,
+      "toggleable": true,
+      "tools": [
+        { "name": "list_automations", "description": "列出 Proma 定时任务。", "readOnly": true },
+        { "name": "get_automation", "description": "读取单个定时任务详情和运行记录。", "readOnly": true },
+        { "name": "create_automation", "description": "创建持久化定时任务。" },
+        { "name": "update_automation", "description": "更新定时任务配置。" },
+        { "name": "delete_automation", "description": "删除定时任务。" },
+        { "name": "run_automation_now", "description": "立即运行一次定时任务。" }
+      ]
+    },
+    {
+      "id": "collaboration",
+      "name": "collaboration",
+      "displayName": "协作子 Agent",
+      "description": "创建、等待、读取和停止真实可见的 Proma 协作子 Agent 会话。",
+      "category": "collaboration",
+      "kind": "internal",
+      "deletable": false,
+      "defaultEnabled": true,
+      "toggleable": true,
+      "tools": [
+        { "name": "list_available_agent_models", "description": "列出当前渠道下可用于协作子 Agent 的模型。", "readOnly": true },
+        { "name": "delegate_agent", "description": "创建单个协作子 Agent 会话。" },
+        { "name": "delegate_agents", "description": "批量创建协作子 Agent 会话。" },
+        { "name": "wait_for_delegations", "description": "等待一组协作子会话完成。", "readOnly": true },
+        { "name": "list_delegations", "description": "列出当前父会话创建的子会话。", "readOnly": true },
+        { "name": "get_delegation_results", "description": "按委派 ID 读取子会话结果摘要。", "readOnly": true },
+        { "name": "stop_delegation", "description": "停止单个协作子会话。" },
+        { "name": "stop_delegations", "description": "批量停止协作子会话。" }
+      ]
+    },
+    {
+      "id": "mem",
+      "name": "mem",
+      "displayName": "记忆",
+      "description": "通过 MemOS Cloud 检索和写入长期记忆。",
+      "category": "memory",
+      "kind": "internal",
+      "deletable": false,
+      "defaultEnabled": false,
+      "toggleable": true,
+      "tools": [
+        { "name": "recall_memory", "description": "检索用户长期记忆。", "readOnly": true },
+        { "name": "add_memory", "description": "写入一条长期记忆。" }
+      ]
+    },
+    {
+      "id": "nano-banana",
+      "name": "nano_banana",
+      "displayName": "Nano Banana 生图",
+      "description": "通过 Gemini Image Generation 为 Agent 提供图片生成和编辑能力。",
+      "category": "media",
+      "kind": "internal",
+      "deletable": false,
+      "defaultEnabled": false,
+      "toggleable": true,
+      "tools": [
+        { "name": "generate_image", "description": "生成或编辑图片。" }
+      ]
+    }
+  ]
+}

--- a/apps/electron/src/main/lib/builtin-mcp/memory.ts
+++ b/apps/electron/src/main/lib/builtin-mcp/memory.ts
@@ -7,6 +7,7 @@
 
 import { getMemoryConfig } from '../memory-service'
 import { addMemory, formatSearchResult, searchMemory } from '../memos-client'
+import { getBuiltinMcpName } from './baseline'
 
 export async function injectMemoryMcpServer(
   sdk: typeof import('@anthropic-ai/claude-agent-sdk'),
@@ -17,8 +18,9 @@ export async function injectMemoryMcpServer(
   if (!memoryConfig.enabled || !memoryConfig.apiKey) return
 
   const { z } = await import('zod')
+  const serverName = getBuiltinMcpName('mem')
   const memosServer = sdk.createSdkMcpServer({
-    name: 'mem',
+    name: serverName,
     version: '1.0.0',
     tools: [
       sdk.tool(

--- a/apps/electron/src/main/lib/builtin-mcp/settings.ts
+++ b/apps/electron/src/main/lib/builtin-mcp/settings.ts
@@ -1,17 +1,46 @@
 /**
  * Proma 内置 MCP 开关设置
  *
- * 仅管理用户是否允许注入某个内置 MCP。依赖是否可用（如 API Key）
- * 由各 MCP 自己的配置判断。
+ * 大部分内置 MCP 默认开启，由 builtinMcpDisabledIds 黑名单管理关闭项；
+ * 少数内置 MCP（DEFAULT_DISABLED_IDS）默认关闭，由 builtinMcpEnabledIds 白名单
+ * 管理用户手动开启的项。是否真正可用（如 API Key）仍由各 MCP 自己的配置判断。
  */
 
 import { getSettings, updateSettings } from '../settings-service'
 
+/**
+ * 默认关闭的内置 MCP ID。
+ * 这些 MCP 需要用户额外配置（如 API Key）才有意义，默认不向 Agent 注入，
+ * 需用户在能力列表中手动开启。
+ */
+const DEFAULT_DISABLED_IDS = new Set<string>(['nano-banana', 'mem'])
+
+/** 判断某个内置 MCP 是否默认关闭（需用户手动开启） */
+export function isBuiltinMcpDefaultDisabled(id: string): boolean {
+  return DEFAULT_DISABLED_IDS.has(id)
+}
+
 export function isBuiltinMcpUserEnabled(id: string): boolean {
+  if (DEFAULT_DISABLED_IDS.has(id)) {
+    // 默认关闭：仅当用户显式加入白名单时才启用
+    return (getSettings().builtinMcpEnabledIds ?? []).includes(id)
+  }
+  // 默认开启:仅当用户显式加入黑名单时才关闭
   return !(getSettings().builtinMcpDisabledIds ?? []).includes(id)
 }
 
 export function setBuiltinMcpUserEnabled(id: string, enabled: boolean): void {
+  if (DEFAULT_DISABLED_IDS.has(id)) {
+    const enabledIds = new Set(getSettings().builtinMcpEnabledIds ?? [])
+    if (enabled) {
+      enabledIds.add(id)
+    } else {
+      enabledIds.delete(id)
+    }
+    updateSettings({ builtinMcpEnabledIds: Array.from(enabledIds).sort() })
+    return
+  }
+
   const disabledIds = new Set(getSettings().builtinMcpDisabledIds ?? [])
   if (enabled) {
     disabledIds.delete(id)

--- a/apps/electron/src/main/lib/chat-tools/nano-banana-mcp.ts
+++ b/apps/electron/src/main/lib/chat-tools/nano-banana-mcp.ts
@@ -10,6 +10,7 @@ import { randomUUID } from 'node:crypto'
 import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'node:fs'
 import { extname, resolve, isAbsolute, join } from 'node:path'
 import { getToolState, getToolCredentials } from '../chat-tool-config'
+import { getBuiltinMcpName } from '../builtin-mcp/baseline'
 import { saveAttachment, isImageAttachment } from '../attachment-service'
 
 // ===== Gemini API 类型（REST API 使用 camelCase） =====
@@ -336,9 +337,10 @@ export async function injectNanoBananaMcpServer(
   if (!toolState.enabled || !credentials.apiKey) return
 
   const { z } = await import('zod')
+  const serverName = getBuiltinMcpName('nano-banana')
 
   const server = sdk.createSdkMcpServer({
-    name: 'nano-banana',
+    name: serverName,
     version: '1.0.0',
     tools: [
       sdk.tool(
@@ -370,8 +372,8 @@ export async function injectNanoBananaMcpServer(
     ],
   })
 
-  mcpServers['nano-banana'] = server as unknown as Record<string, unknown>
-  console.log(`[Nano Banana MCP] 已注入内置生图工具 (nano-banana)`)
+  mcpServers[serverName] = server as unknown as Record<string, unknown>
+  console.log(`[Nano Banana MCP] 已注入内置生图工具 (${serverName})`)
 }
 
 // ===== 清理 =====

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -248,8 +248,10 @@ export interface AppSettings {
   voiceDictation?: VoiceDictationPersistedSettings
   /** 飞书 Session 镜像设置：每个 Proma Session 可创建一个仅包含用户与指定 Bot 的飞书群 */
   feishuSessionMirror?: FeishuSessionMirrorSettings
-  /** 用户手动关闭的 Proma 内置 MCP ID 列表 */
+  /** 用户手动关闭的 Proma 内置 MCP ID 列表（针对默认开启的内置 MCP） */
   builtinMcpDisabledIds?: string[]
+  /** 用户手动开启的 Proma 内置 MCP ID 列表（针对默认关闭的内置 MCP，如 nano-banana、mem） */
+  builtinMcpEnabledIds?: string[]
   /** 启动时自动清理临时文件（proma-preview、proma-installers），默认 true */
   autoCleanupTempOnStart?: boolean
   /** 自动清理 N 天前已归档会话的 SDK 数据（0 = 禁用，默认 0） */


### PR DESCRIPTION
## 背景

内置 MCP 的"叫什么名、能否删、怎么展示"此前散落在 catalog.ts（硬编码数组）和各注入器（`createSdkMcpServer({ name })`）两处手写，已经产生漂移：

- **nano-banana 命名漂移**：注入器写 `name: 'nano-banana'`，但 SDK 会把 server 名里的连字符规范化成下划线，实际注册为 `mcp__nano_banana__*`。catalog 展示名也停在连字符，与运行时不一致。
- 未来新增内置 MCP 时，catalog 与注入器要改两处，容易再次漂移。

## 方案

引入单一事实源，让源名 == 运行名：

1. **`builtin-mcp/default-mcp.json`**：内置 MCP 的唯一定义（`id` 历史值/设置键，`name` 下划线安全的运行时真实名），经 JSON import 编译进包，随版本覆盖升级。
2. **`baseline.ts`**：统一加载，提供 `getBuiltinMcpName()` / `RESERVED_BUILTIN_KEYS`。
3. **`catalog.ts`**：从 baseline 读取元数据，删除硬编码 `BUILTIN_MCP_CATALOG`（-95 行），只保留运行时可用性判断。
4. **memory / nano-banana 注入器**：name 与 mcpServers key 改为从 baseline 取真实名。
5. **`settings.ts`**：引入 `DEFAULT_DISABLED_IDS` 机制——`nano-banana` / `mem` 默认关闭（依赖额外 API Key 才有意义），需用户在能力列表手动开启；为默认关闭项启用 `builtinMcpEnabledIds` 白名单。`AppSettings` 相应新增该字段。

## Commits

1. `feat(mcp): single-source builtin MCP names via default-mcp.json` — baseline + default-mcp.json + 注入器命名修复
2. `feat(mcp): drive builtin MCP catalog from single source, add default-disabled` — catalog 读 baseline + nano/mem 默认关闭

## 影响面

- nano-banana 运行时工具名**与改动前完全一致**（本就是 `mcp__nano_banana__*`），仅源名对齐，**零迁移**。
- **行为变化**：nano-banana / mem 由"默认注入"改为"默认关闭、需手动开启"——这两个依赖用户额外配置 API Key 才有意义，默认关闭更合理。

## 验证

- 改动文件 typecheck 无新增错误（仓库现存的 30 个 typecheck error 与 `@proma/session-core` build error 在未改动的 main 上同样存在，属预存环境问题，与本 PR 无关）。
- `default-mcp.json` 已确认正确内联进 `dist/main.cjs`（JSON import 编译进包）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)