### PR TITLE
【已审核】fix(agent): 后台任务运行时显示视觉提示

### DIFF
--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -515,15 +515,6 @@ export const agentStartedAtAtom = atom<number | undefined>((get) => {
   return get(agentStreamingStatesAtom).get(currentId)?.startedAt
 })
 
-export const agentRunningSessionIdsAtom = atom<Set<string>>((get) => {
-  const states = get(agentStreamingStatesAtom)
-  const ids = new Set<string>()
-  for (const [id, state] of states) {
-    if (state.running) ids.add(id)
-  }
-  return ids
-})
-
 /** 侧边栏会话指示点状态 */
 export type SessionIndicatorStatus = 'idle' | 'running' | 'blocked' | 'completed'
 
@@ -555,6 +546,10 @@ export const dockBadgeCountAtom = atom<number>((get) => {
 /**
  * 每个会话的指示点状态（只包含非 idle 的会话）
  * 优先级：blocked > running > completed > idle
+ *
+ * backgroundWaiting 状态（后台任务运行中、主循环已空闲）也映射为 'running'，
+ * 与真运行态同态显示蓝色脉冲——侧边栏与 Tab 不区分两者；
+ * AgentView 输入区通过独立的 backgroundWaiting 徽章做差异化提示。
  */
 export const agentSessionIndicatorMapAtom = atom<Map<string, SessionIndicatorStatus>>((get) => {
   const streamStates = get(agentStreamingStatesAtom)
@@ -566,7 +561,7 @@ export const agentSessionIndicatorMapAtom = atom<Map<string, SessionIndicatorSta
   const map = new Map<string, SessionIndicatorStatus>()
 
   for (const [id, state] of streamStates) {
-    if (!state.running) continue
+    if (!state.running && !state.backgroundWaiting) continue
     const hasBlock = (pendingPerms.get(id)?.length ?? 0) > 0
       || (pendingAskUser.get(id)?.length ?? 0) > 0
       || (pendingExitPlan.get(id)?.length ?? 0) > 0

--- a/apps/electron/src/renderer/atoms/tab-atoms.ts
+++ b/apps/electron/src/renderer/atoms/tab-atoms.ts
@@ -12,7 +12,6 @@ import {
   streamingConversationIdsAtom,
 } from './chat-atoms'
 import {
-  agentRunningSessionIdsAtom,
   agentSessionIndicatorMapAtom,
   unviewedCompletedSessionIdsAtom,
 } from './agent-atoms'
@@ -141,14 +140,15 @@ export const activeSessionIdAtom = atom<string | null>((get) => {
 export const tabStreamingMapAtom = atom<Map<string, boolean>>((get) => {
   const tabs = get(tabsAtom)
   const chatStreaming = get(streamingConversationIdsAtom)
-  const agentRunning = get(agentRunningSessionIdsAtom)
+  const agentIndicator = get(agentSessionIndicatorMapAtom)
   const map = new Map<string, boolean>()
   for (const tab of tabs) {
     if (tab.type === 'scratch') continue
     if (tab.type === 'chat') {
       map.set(tab.id, chatStreaming.has(tab.sessionId))
     } else if (tab.type === 'agent') {
-      map.set(tab.id, agentRunning.has(tab.sessionId))
+      const status = agentIndicator.get(tab.sessionId)
+      map.set(tab.id, status === 'running' || status === 'blocked')
     }
   }
   return map

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -17,7 +17,7 @@ import * as React from 'react'
 import { unstable_batchedUpdates } from 'react-dom'
 import { useAtom, useAtomValue, useSetAtom, useStore } from 'jotai'
 import { toast } from 'sonner'
-import { Bot, CornerDownLeft, Square, Settings, Paperclip, FolderPlus, X, Copy, Check, Brain, Sparkles, Eye } from 'lucide-react'
+import { Bot, CornerDownLeft, Square, Settings, Paperclip, FolderPlus, X, Copy, Check, Brain, Sparkles, Eye, Loader2 } from 'lucide-react'
 import { AgentMessages } from './AgentMessages'
 import { AgentHeader } from './AgentHeader'
 import { ContextUsageBadge } from './ContextUsageBadge'
@@ -2051,6 +2051,9 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     setProcessGroupsKeepExpanded,
   ])
 
+  // 后台任务运行中且无输入文本时显示状态标签；用户开始输入后让出位置给 Send 按钮，
+  // 避免用户在后台任务运行期间无法发送新消息（backgroundWaiting 状态支持注入式发送）
+  const showBackgroundWaitingBadge = backgroundWaiting && !hasTextInput
   const inputTrailingNode = streaming && !hasTextInput ? (
     <Tooltip>
       <TooltipTrigger asChild>
@@ -2066,6 +2069,18 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       </TooltipTrigger>
       <TooltipContent side="top">
         <p>停止 Agent ({getAcceleratorDisplay(getActiveAccelerator('stop-generation'))})</p>
+      </TooltipContent>
+    </Tooltip>
+  ) : showBackgroundWaitingBadge ? (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div className="flex items-center gap-1.5 px-2 h-[36px] rounded-full bg-blue-500/10 text-blue-500/80">
+          <Loader2 className="size-4 animate-spin" />
+          <span className="text-xs font-medium whitespace-nowrap">后台任务运行中</span>
+        </div>
+      </TooltipTrigger>
+      <TooltipContent side="top">
+        <p>Agent 正在后台执行任务，您可以继续输入消息</p>
       </TooltipContent>
     </Tooltip>
   ) : (


### PR DESCRIPTION
## 概述

修复 Agent 后台任务（backgroundWaiting）运行期间 UI 显示为"已完成"状态的问题。原实现中 `agentSessionIndicatorMapAtom` 未覆盖 `backgroundWaiting`，导致侧边栏指示点变灰、Tab 标题无 spinner、输入区显示 Send 按钮——与 Agent 彻底跑完后无法区分，用户易误切走或发新消息打断后台进度。

## 改动

- `apps/electron/src/renderer/atoms/agent-atoms.ts` (+9/-6)
  - `agentSessionIndicatorMapAtom` 纳入 `backgroundWaiting`，映射为 `'running'`，侧边栏指示点显示蓝色脉冲（与 running 同态）
  - 删除死代码 `agentRunningSessionIdsAtom`（改用 indicator map 后无消费者）
- `apps/electron/src/renderer/atoms/tab-atoms.ts` (+3/-3)
  - `tabStreamingMapAtom` 改派生自 indicator map，Tab 标题通过 `showAgentSpinner` 显示 spinner
- `apps/electron/src/renderer/components/agent/AgentView.tsx` (+16/-1)
  - 输入区 trailing 在 `backgroundWaiting` 且无输入文本时显示"后台任务运行中"蓝色徽标
  - 用户开始输入后让出位置给 Send 按钮，保证后台任务期间可正常发新消息（走注入通道）

## 测试

1. `bun run typecheck` 通过
2. `bun run dev` 启动应用
3. 对 Agent 说"帮我在后台跑一个长时间任务"
4. 验证：
   - 侧边栏会话指示点为**蓝色脉冲**（不是灰色）
   - Tab 栏会话标题显示** spinner**
   - 输入区右下角显示**"后台任务运行中"蓝色徽标**（无输入文本时）
   - 开始输入后徽标让位给 Send 按钮，可正常发新消息（走注入通道，不打断后台任务）

## 紧急度

中

> 后台任务状态盲区会导致用户误切走（错过 Agent 唤醒后的后续输出）或误发新消息（打断后台进度），影响多数使用 Agent 后台任务的用户的核心工作流。

## 备注

Closes #1013
