### PR TITLE
【已审核】fix(chips): 识别 Windows 正斜杠绝对路径

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ vendor
 # pnpm (本项目用 bun，禁止误提交 pnpm lockfile)
 pnpm-lock.yaml
 pnpm-workspace.yaml
+
+# Proma 会话/工作区文档（不应入仓，见 CLAUDE.md 红线）
+.context/

--- a/apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx
@@ -55,9 +55,9 @@ const DOC_EXTS = new Set(['pdf', 'docx'])
 /** 所有可预览的扩展名集合（用于相对路径检测） */
 const ALL_PREVIEWABLE_EXTS = new Set([...IMAGE_EXTS, ...VIDEO_EXTS, ...CODE_EXTS, ...DOC_EXTS])
 
-/** 从路径提取文件名 */
+/** 从路径提取文件名（同时支持 / 和 \） */
 function getFileName(filePath: string): string {
-  const parts = filePath.split('/')
+  const parts = filePath.split(/[\\/]/)
   return parts[parts.length - 1] || filePath
 }
 
@@ -97,7 +97,7 @@ export function FilePathChip({ filePath, basePath, basePaths, className }: FileP
 
   const filename = getFileName(cleanPath)
 
-  const isAbsolute = cleanPath.startsWith('/') || /^[A-Z]:\\/.test(cleanPath)
+  const isAbsolute = cleanPath.startsWith('/') || /^[A-Za-z]:[\\/]/.test(cleanPath)
 
   const chipRef = React.useRef<HTMLButtonElement>(null)
   const [fileStatus, setFileStatus] = React.useState<'idle' | 'resolved' | 'broken'>('idle')
@@ -220,7 +220,7 @@ export function FilePathChip({ filePath, basePath, basePaths, className }: FileP
  *
  * 匹配规则：
  * - macOS/Linux: 以 / 开头，至少两级路径
- * - Windows: 以 C:\ 等盘符开头
+ * - Windows: 以 C:\ 或 C:/ 等盘符开头（大小写盘符均支持，反斜杠和正斜杠均支持）
  */
 export function isAbsoluteFilePath(text: string): boolean {
   const trimmed = text.trim()
@@ -236,8 +236,8 @@ export function isAbsoluteFilePath(text: string): boolean {
     return true
   }
 
-  // Windows 绝对路径
-  if (/^[A-Z]:\\/.test(clean)) return true
+  // Windows 绝对路径（支持反斜杠和正斜杠、大小写盘符）
+  if (/^[A-Za-z]:[\\/]/.test(clean)) return true
 
   return false
 }


### PR DESCRIPTION
## 概述

修复 Windows 上 Agent 输出的正斜杠绝对路径（如 `C:/Users/foo/bar.ts`）不被识别为文件路径 chip 的问题。原 `isAbsoluteFilePath` 和 `FilePathChip` 的 `isAbsolute` 判断只匹配 `[A-Z]:\`（反斜杠 + 大写盘符），导致正斜杠路径不渲染为可点击 chip，用户无法直接跳转。

## 改动

- `apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx` (+6/-6)
  - 两处正则从 `/^[A-Z]:\//` 改为 `/^[A-Za-z]:[\/]/`，同时支持反斜杠/正斜杠、大写/小写盘符
  - `getFileName` 的 `split('/')` 改为 `split(/[\/]/)`，正确拆分混合斜杠路径
- `.gitignore` (+3)
  - 加入 `.context/` 排除规则（CLAUDE.md 红线：禁止在项目代码仓库中创建 `.context/` 目录）

## 测试

1. `bun run typecheck` 通过
2. `bun run dev` 启动应用
3. 让 Agent 输出以下路径，验证均渲染为可点击 chip 且点击后正确打开文件：
   - `C:/Users/foo/bar.ts`（正斜杠 + 大写盘符）
   - `c:/Users/foo/bar.ts`（正斜杠 + 小写盘符）
   - `C:\Users\foo\bar.ts`（反斜杠，回归验证）
   - `C:\Users\foo\bar/baz.ts`（混合斜杠，文件名正确拆分）

## 紧急度

低

> 仅影响 Windows 上 Agent 输出正斜杠路径时的 chip 渲染，不影响核心功能；但缺失会让用户失去点击跳转能力，需修复。

## 备注

Closes #1014
