### PR TITLE
【已审核】fix(file-chip): 右键菜单 z-index 提升到 z-[9999] 避免被终端暗色主题覆盖层遮挡

### DIFF
--- a/apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx
@@ -202,7 +202,7 @@ export function FilePathChip({ filePath, basePath, basePaths, className }: FileP
           <span className="truncate max-w-[240px] leading-none">{filename}{lineColSuffix}</span>
         </button>
       </ContextMenuTrigger>
-      <ContextMenuContent className="w-48">
+      <ContextMenuContent className="w-48 z-[9999]">
         <ContextMenuItem onClick={handleClick}>
           打开预览
         </ContextMenuItem>


### PR DESCRIPTION
## 概述

修复 FilePathChip 右键菜单被终端暗色主题（`theme-terminal-dark`）覆盖层遮挡的问题。原 `ContextMenuContent` 用默认 `z-50`，被该主题 `body::before`（CRT 扫描线，`z-100`）/`body::after`（暗角，`z-100`）覆盖层盖住，导致右键菜单看不见或只能看到一部分。

## 改动

- `apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx` (+1/-1)
  - `ContextMenuContent` 显式提升 `z-index` 到 `z-[9999]`，越过终端主题的 `z-100` 覆盖层
  - 与 `LeftSidebar` 中已生效的 `ContextMenuContent` 保持一致

## 测试

1. `bun run typecheck` 通过
2. `bun run dev` 启动应用
3. 切到终端暗色主题（`theme-terminal-dark`）
4. 对 Agent 输出的文件路径 chip 右键
5. 验证：右键菜单完整可见、可点击、不被扫描线/暗角覆盖层遮挡
6. 切回其他主题回归验证：右键菜单仍正常显示

## 紧急度

低

> 仅影响终端暗色主题下的右键菜单可见性，不影响核心功能；但视觉缺失会让用户误以为右键菜单坏掉。

## 备注

Closes #1015
