### PR TITLE
【已审核】fix(agent): 迁移会话对话框排除基准从当前工作区改为会话所属工作区

### DIFF
--- a/apps/electron/src/renderer/components/agent/MoveSessionDialog.tsx
+++ b/apps/electron/src/renderer/components/agent/MoveSessionDialog.tsx
@@ -26,7 +26,7 @@ interface MoveSessionDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   sessionId: string
-  currentWorkspaceId: string | undefined
+  sourceWorkspaceId: string | undefined
   workspaces: AgentWorkspace[]
   onMoved: (updatedSession: AgentSessionMeta, targetWorkspaceName: string) => void
 }
@@ -35,17 +35,17 @@ export function MoveSessionDialog({
   open,
   onOpenChange,
   sessionId,
-  currentWorkspaceId,
+  sourceWorkspaceId,
   workspaces,
   onMoved,
 }: MoveSessionDialogProps): React.ReactElement {
   const [selectedWorkspaceId, setSelectedWorkspaceId] = React.useState<string>('')
   const [moving, setMoving] = React.useState(false)
 
-  // 过滤掉当前工作区
+  // 过滤掉会话已属的工作区
   const availableWorkspaces = React.useMemo(
-    () => workspaces.filter((ws) => ws.id !== currentWorkspaceId),
-    [workspaces, currentWorkspaceId]
+    () => workspaces.filter((ws) => ws.id !== sourceWorkspaceId),
+    [workspaces, sourceWorkspaceId]
   )
 
   // 打开时重置选择

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -1856,7 +1856,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       open={moveTargetId !== null}
       onOpenChange={(open) => { if (!open) setMoveTargetId(null) }}
       sessionId={moveTargetId ?? ''}
-      currentWorkspaceId={moveSourceWorkspaceId ?? undefined}
+      sourceWorkspaceId={moveSourceWorkspaceId ?? undefined}
       workspaces={workspaces}
       onMoved={handleSessionMoved}
     />


### PR DESCRIPTION
## 概述

修复迁移会话对话框把"用户当前所在工作区"作为排除基准的问题。原实现导致用户无法把会话迁移到当前所在的工作区——比如用户在 A 工作区，想把某个会话从 B 迁到 A，下拉列表里却找不到 A。改为基于被迁移会话的 `workspaceId` 过滤，语义对齐：迁移的目标是"另一个工作区"，排除基准应该是会话当前所属的工作区，而不是用户 UI 激活的工作区。

## 改动

- `apps/electron/src/renderer/components/agent/MoveSessionDialog.tsx` (+5/-5)
  - props `currentWorkspaceId` → `sourceWorkspaceId`，语义对齐
  - 过滤逻辑基于会话所属工作区排除
  - 注释同步更新
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` (+1/-1)
  - `handleRequestMove` 取 `session.workspaceId` 而非 UI 激活工作区

## 测试

1. `bun run typecheck` 通过
2. `bun run dev` 启动应用
3. 场景验证：
   - 用户在 A 工作区，把 B 工作区的会话迁到 A：下拉列表应包含 A，排除 B
   - 用户在 A 工作区，把 A 工作区的会话迁到 B：下拉列表应包含 B，排除 A（回归）
   - 跨多个工作区迁移：每次下拉列表只排除会话当前所属工作区

## 紧急度

中

> 跨工作区迁移是常用操作，排除基准错误导致用户找不到目标工作区，影响核心工作流。

## 备注

Closes #1019
