### PR TITLE
feat(agent): support select_model recovery action via shared model selector state

### DIFF
--- a/apps/electron/src/renderer/atoms/chat-atoms.ts
+++ b/apps/electron/src/renderer/atoms/chat-atoms.ts
@@ -15,6 +15,9 @@ export const channelsAtom = atom<Channel[]>([])
 /** 渠道列表是否已完成首次加载 */
 export const channelsLoadedAtom = atom(false)
 
+/** 主输入框「模型选择器」是否打开（错误卡片的「重新选择模型」按钮会置 true） */
+export const modelSelectorOpenAtom = atom(false)
+
 /** 选中的模型信息 */
 export interface SelectedModel {
   channelId: string

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -1941,6 +1941,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           filterChannelIds={agentChannelIds}
           externalSelectedModel={externalSelectedModel}
           onModelSelect={handleModelSelect}
+          useSharedOpenState
         />
       ),
     },

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -12,7 +12,7 @@
  */
 
 import * as React from 'react'
-import { Bot, Loader2, AlertTriangle, FileText, FileImage, Download, Split, Undo2, RotateCw, Plus, Minimize2, Wrench, Settings, ExternalLink, Quote, Clock } from 'lucide-react'
+import { Bot, Loader2, AlertTriangle, FileText, FileImage, Download, Split, Undo2, RotateCw, Plus, Minimize2, Wrench, Settings, Cpu, ExternalLink, Quote, Clock } from 'lucide-react'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { cn } from '@/lib/utils'
 import { ImageLightbox } from '@/components/ui/image-lightbox'
@@ -53,7 +53,7 @@ import { Badge } from '@/components/ui/badge'
 import { formatMessageTime } from '@/components/chat/ChatMessageItem'
 import { getModelLogo, resolveModelDisplayName, resolveModelProvider } from '@/lib/model-logo'
 import { userProfileAtom } from '@/atoms/user-profile'
-import { channelsAtom } from '@/atoms/chat-atoms'
+import { channelsAtom, modelSelectorOpenAtom } from '@/atoms/chat-atoms'
 import { agentProcessGroupsKeepExpandedAtom, agentSessionPendingFilesAtom } from '@/atoms/agent-atoms'
 import { agentSessionsAtom } from '@/atoms/agent-atoms'
 import { activeSessionIdAtom } from '@/atoms/tab-atoms'
@@ -1000,6 +1000,7 @@ function ErrorMessage({ message, onRetry, onRetryInNewSession, onCompact }: Erro
   const setEnvDialogOpen = useSetAtom(environmentCheckDialogOpenAtom)
   const setSettingsOpen = useSetAtom(settingsOpenAtom)
   const setSettingsTab = useSetAtom(settingsTabAtom)
+  const setModelSelectorOpen = useSetAtom(modelSelectorOpenAtom)
   const [detailsOpen, setDetailsOpen] = React.useState(false)
 
   const contentText = message.message?.content
@@ -1029,6 +1030,9 @@ function ErrorMessage({ message, onRetry, onRetryInNewSession, onCompact }: Erro
       case 'settings':
         setSettingsOpen(true)
         break
+      case 'select_model':
+        setModelSelectorOpen(true)
+        break
       case 'open_external':
         if (action.payload) {
           window.electronAPI.openExternal(action.payload)
@@ -1055,6 +1059,8 @@ function ErrorMessage({ message, onRetry, onRetryInNewSession, onCompact }: Erro
       case 'open_channel_settings':
       case 'settings':
         return <Settings className="size-3.5 mr-1.5" />
+      case 'select_model':
+        return <Cpu className="size-3.5 mr-1.5" />
       case 'open_external':
         return <ExternalLink className="size-3.5 mr-1.5" />
       case 'retry':

--- a/apps/electron/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatInput.tsx
@@ -298,7 +298,7 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
   }, [])
 
   const toolbarItems = React.useMemo<ToolbarItem[]>(() => [
-    { key: 'model', node: <ModelSelector /> },
+    { key: 'model', node: <ModelSelector useSharedOpenState /> },
     {
       key: 'thinking',
       node: (

--- a/apps/electron/src/renderer/components/chat/ModelSelector.tsx
+++ b/apps/electron/src/renderer/components/chat/ModelSelector.tsx
@@ -9,7 +9,7 @@
  */
 
 import * as React from 'react'
-import { useAtomValue, useSetAtom } from 'jotai'
+import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { ChevronDown, Cpu, Search } from 'lucide-react'
 import {
   Dialog,
@@ -22,6 +22,7 @@ import {
   selectedModelAtom,
   channelsAtom,
   channelsLoadedAtom,
+  modelSelectorOpenAtom,
 } from '@/atoms/chat-atoms'
 import { useConversationModelOptional } from '@/hooks/useConversationSettings'
 import { useConversationIdOptional } from '@/contexts/session-context'
@@ -80,6 +81,8 @@ interface ModelSelectorProps {
   onModelSelect?: (option: ModelOption) => void
   /** 触发按钮是否显示「渠道 · 模型」（默认只显示模型名） */
   showChannelInTrigger?: boolean
+  /** 是否使用全局 modelSelectorOpenAtom 控制打开状态（用于外部拉起，如错误提示按钮） */
+  useSharedOpenState?: boolean
 }
 
 export function ModelSelector({
@@ -88,6 +91,7 @@ export function ModelSelector({
   externalSelectedModel,
   onModelSelect,
   showChannelInTrigger = false,
+  useSharedOpenState = false,
 }: ModelSelectorProps = {}): React.ReactElement {
   const [conversationModel, setConversationModel] = useConversationModelOptional()
   const conversationId = useConversationIdOptional()
@@ -96,7 +100,10 @@ export function ModelSelector({
   const channels = useAtomValue(channelsAtom)
   const channelsLoaded = useAtomValue(channelsLoadedAtom)
   const setChannels = useSetAtom(channelsAtom)
-  const [open, setOpen] = React.useState(false)
+  const [localOpen, setLocalOpen] = React.useState(false)
+  const [sharedOpen, setSharedOpen] = useAtom(modelSelectorOpenAtom)
+  const open = useSharedOpenState ? sharedOpen : localOpen
+  const setOpen = useSharedOpenState ? setSharedOpen : setLocalOpen
   const [search, setSearch] = React.useState('')
 
   // 外部模型优先 → per-conversation 模型

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -394,6 +394,7 @@ export interface RecoveryAction {
     | 'compact'
     | 'open_environment_check'
     | 'open_channel_settings'
+    | 'select_model'
     | 'open_external'
     | (string & {})
   /** 操作附带的载荷，例如 open_external 的 URL */


### PR DESCRIPTION
## Summary
- `RecoveryAction` 新增 `select_model` 动作类型，用于错误提示卡片直接拉起模型选择器
- `ModelSelector` 新增 `useSharedOpenState` prop，由新的 `modelSelectorOpenAtom` 控制打开状态（用于跨组件外部拉起）
- `ChatInput`（Chat 模式）与 `AgentView`（Agent 模式）均接入共享状态；`SDKMessageRenderer` 的错误卡片新增「重新选择模型」按钮（Cpu 图标）

## Test plan
- [x] 手动验证：点击错误提示中的「重新选择模型」按钮，Chat 模式下选择器正常弹出
- [x] 手动验证：Agent 模式下同样正常弹出
- [x] `tsc --noEmit` 通过

Co-Authored-By: Claude <noreply@anthropic.com>