### PR TITLE
Persist IM bridge chat bindings

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.13.25",
+  "version": "0.13.26",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.13.24",
+  "version": "0.13.25",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/bridge-binding-store.test.ts
+++ b/apps/electron/src/main/lib/bridge-binding-store.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import {
+  createJsonBridgeChatBindingStore,
+  filterExistingBridgeBindings,
+  loadBridgeChatBindings,
+} from './bridge-binding-store'
+import type { BridgeChatBinding } from './bridge-command-handler'
+
+let tempDir: string | null = null
+
+function tempFile(name: string): string {
+  if (!tempDir) {
+    tempDir = mkdtempSync(join(tmpdir(), 'proma-bridge-bindings-'))
+  }
+  return join(tempDir, name)
+}
+
+afterEach(() => {
+  if (!tempDir) return
+  rmSync(tempDir, { recursive: true, force: true })
+  tempDir = null
+})
+
+describe('bridge binding store', () => {
+  test('Given 有效绑定 When 保存并加载 Then 保留 chatId 到 sessionId 的映射', () => {
+    const filePath = tempFile('bindings.json')
+    const store = createJsonBridgeChatBindingStore(filePath, '测试 Bridge')
+    const bindings: BridgeChatBinding[] = [
+      {
+        chatId: 'ding-conversation-1',
+        sessionId: 'session-1',
+        workspaceId: 'workspace-1',
+        channelId: 'channel-1',
+        modelId: 'model-1',
+      },
+    ]
+
+    store.save(bindings)
+
+    expect(JSON.parse(readFileSync(filePath, 'utf-8'))).toEqual(bindings)
+    expect(store.load()).toEqual(bindings)
+  })
+
+  test('Given 绑定文件混入无效项 When 加载 Then 只返回结构完整的绑定', () => {
+    const filePath = tempFile('mixed.json')
+    const valid: BridgeChatBinding = {
+      chatId: 'chat-1',
+      sessionId: 'session-1',
+      workspaceId: 'workspace-1',
+      channelId: 'channel-1',
+    }
+    writeFileSync(filePath, JSON.stringify([
+      valid,
+      { chatId: 'missing-session', workspaceId: 'workspace-1', channelId: 'channel-1' },
+      {
+        chatId: 'bad-model',
+        sessionId: 'session-2',
+        workspaceId: 'workspace-1',
+        channelId: 'channel-1',
+        modelId: 42,
+      },
+    ]), 'utf-8')
+
+    expect(loadBridgeChatBindings(filePath, '测试 Bridge')).toEqual([valid])
+  })
+
+  test('Given 旧绑定指向已删除会话 When 过滤 Then 只恢复仍存在的会话', () => {
+    const bindings: BridgeChatBinding[] = [
+      { chatId: 'chat-1', sessionId: 'alive', workspaceId: 'workspace-1', channelId: 'channel-1' },
+      { chatId: 'chat-2', sessionId: 'deleted', workspaceId: 'workspace-1', channelId: 'channel-1' },
+    ]
+
+    expect(filterExistingBridgeBindings(bindings, (sessionId) => sessionId === 'alive')).toEqual([bindings[0]!])
+  })
+})

--- a/apps/electron/src/main/lib/bridge-binding-store.ts
+++ b/apps/electron/src/main/lib/bridge-binding-store.ts
@@ -1,0 +1,64 @@
+/**
+ * IM Bridge 聊天绑定持久化工具。
+ *
+ * 用于钉钉/微信等共享 BridgeCommandHandler 的平台，将外部 chatId
+ * 与 Proma Agent sessionId 的映射保存到本地 JSON 文件。
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import type { BridgeChatBinding } from './bridge-command-handler'
+
+export interface BridgeChatBindingStore {
+  load(): BridgeChatBinding[]
+  save(bindings: BridgeChatBinding[]): void
+}
+
+export function createJsonBridgeChatBindingStore(filePath: string, logPrefix: string): BridgeChatBindingStore {
+  return {
+    load: () => loadBridgeChatBindings(filePath, logPrefix),
+    save: (bindings) => saveBridgeChatBindings(filePath, bindings, logPrefix),
+  }
+}
+
+export function loadBridgeChatBindings(filePath: string, logPrefix: string): BridgeChatBinding[] {
+  if (!existsSync(filePath)) return []
+
+  try {
+    const raw = readFileSync(filePath, 'utf-8')
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) {
+      console.warn(`[${logPrefix}] 绑定文件格式无效，已忽略`)
+      return []
+    }
+
+    return parsed.filter(isBridgeChatBinding)
+  } catch (error) {
+    console.error(`[${logPrefix}] 加载聊天绑定失败:`, error)
+    return []
+  }
+}
+
+export function saveBridgeChatBindings(filePath: string, bindings: BridgeChatBinding[], logPrefix: string): void {
+  try {
+    writeFileSync(filePath, JSON.stringify(bindings, null, 2), 'utf-8')
+  } catch (error) {
+    console.error(`[${logPrefix}] 保存聊天绑定失败:`, error)
+  }
+}
+
+export function filterExistingBridgeBindings(
+  bindings: BridgeChatBinding[],
+  hasSession: (sessionId: string) => boolean,
+): BridgeChatBinding[] {
+  return bindings.filter((binding) => hasSession(binding.sessionId))
+}
+
+function isBridgeChatBinding(value: unknown): value is BridgeChatBinding {
+  if (!value || typeof value !== 'object') return false
+  const record = value as Record<string, unknown>
+  return typeof record.chatId === 'string'
+    && typeof record.sessionId === 'string'
+    && typeof record.workspaceId === 'string'
+    && typeof record.channelId === 'string'
+    && (record.modelId === undefined || typeof record.modelId === 'string')
+}

--- a/apps/electron/src/main/lib/bridge-command-handler.ts
+++ b/apps/electron/src/main/lib/bridge-command-handler.ts
@@ -27,6 +27,8 @@ import {
   resolveModelByIndex,
   describeBindingModel,
 } from './bridge-model-utils'
+import type { BridgeChatBindingStore } from './bridge-binding-store'
+import { filterExistingBridgeBindings } from './bridge-binding-store'
 
 // ===== 接口定义 =====
 
@@ -56,6 +58,8 @@ export interface BridgeCommandHandlerConfig {
   getDefaultWorkspaceId?: () => string | undefined
   /** 工作区切换后的回调 */
   onWorkspaceSwitched?: (workspaceId: string) => void
+  /** 可选持久化存储：用于跨应用重启恢复 chatId → sessionId 绑定 */
+  bindingStore?: BridgeChatBindingStore
 }
 
 /** 通用聊天绑定 */
@@ -106,6 +110,7 @@ export class BridgeCommandHandler {
   constructor(config: BridgeCommandHandlerConfig) {
     this.config = config
     this.log = (msg: string) => console.log(`[${config.platformName} Bridge] ${msg}`)
+    this.loadPersistedBindings()
   }
 
   // ===== 公开 API =====
@@ -155,6 +160,7 @@ export class BridgeCommandHandler {
     }
     this.chatBindings.set(chatId, binding)
     this.sessionToChat.set(session.id, chatId)
+    this.saveBindings()
     this.log(`为 ${chatId.slice(0, 8)}... 创建会话: ${session.id.slice(0, 8)}`)
     this.notifySessionCreated(session.id, session.title)
     return binding
@@ -192,6 +198,29 @@ export class BridgeCommandHandler {
     this.chatBindings.clear()
     this.sessionToChat.clear()
     this.sessionBuffers.clear()
+    this.saveBindings()
+  }
+
+  private loadPersistedBindings(): void {
+    const bindings = this.config.bindingStore?.load()
+    if (!bindings || bindings.length === 0) return
+
+    const existingBindings = filterExistingBridgeBindings(bindings, (sessionId) => Boolean(getAgentSessionMeta(sessionId)))
+    for (const binding of existingBindings) {
+      this.chatBindings.set(binding.chatId, binding)
+      this.sessionToChat.set(binding.sessionId, binding.chatId)
+    }
+
+    if (existingBindings.length !== bindings.length) {
+      this.config.bindingStore?.save(existingBindings)
+    }
+    if (existingBindings.length > 0) {
+      this.log(`已恢复 ${existingBindings.length} 个聊天绑定`)
+    }
+  }
+
+  private saveBindings(): void {
+    this.config.bindingStore?.save(Array.from(this.chatBindings.values()))
   }
 
   // ===== 命令路由 =====
@@ -299,6 +328,7 @@ export class BridgeCommandHandler {
     }
     this.chatBindings.set(chatId, binding)
     this.sessionToChat.set(session.id, chatId)
+    this.saveBindings()
 
     // 通知渲染进程刷新会话列表
     this.notifySessionCreated(session.id, session.title)
@@ -397,6 +427,7 @@ export class BridgeCommandHandler {
     }
     this.chatBindings.set(chatId, binding)
     this.sessionToChat.set(match.id, chatId)
+    this.saveBindings()
 
     await this.send(chatId, `✅ 已切换到会话: ${match.title} (${match.id.slice(0, 8)})`, contextData)
   }
@@ -441,6 +472,7 @@ export class BridgeCommandHandler {
     if (binding) {
       this.sessionToChat.delete(binding.sessionId)
       this.chatBindings.delete(chatId)
+      this.saveBindings()
     }
 
     // 通知平台持久化
@@ -632,6 +664,7 @@ export class BridgeCommandHandler {
 
     binding.channelId = channel.id
     binding.modelId = model.id
+    this.saveBindings()
 
     await this.send(
       chatId,

--- a/apps/electron/src/main/lib/config-paths.ts
+++ b/apps/electron/src/main/lib/config-paths.ts
@@ -552,6 +552,15 @@ export function getWeChatSyncPath(): string {
 }
 
 /**
+ * 获取微信聊天绑定持久化路径
+ *
+ * @returns ~/.proma/wechat-bindings.json
+ */
+export function getWeChatBindingsPath(): string {
+  return join(getConfigDir(), 'wechat-bindings.json')
+}
+
+/**
  * 获取钉钉配置文件路径
  *
  * @returns ~/.proma/dingtalk.json

--- a/apps/electron/src/main/lib/config-paths.ts
+++ b/apps/electron/src/main/lib/config-paths.ts
@@ -561,6 +561,15 @@ export function getDingTalkConfigPath(): string {
 }
 
 /**
+ * 获取某个钉钉 Bot 的聊天绑定持久化路径
+ *
+ * @returns ~/.proma/dingtalk-bindings-{botId}.json
+ */
+export function getDingTalkBotBindingsPath(botId: string): string {
+  return join(getConfigDir(), `dingtalk-bindings-${botId}.json`)
+}
+
+/**
  * 获取飞书配置文件路径
  *
  * @returns ~/.proma/feishu.json

--- a/apps/electron/src/main/lib/dingtalk-bridge.ts
+++ b/apps/electron/src/main/lib/dingtalk-bridge.ts
@@ -22,6 +22,8 @@ import { BridgeCommandHandler, type BridgeAttachment } from './bridge-command-ha
 import { inferImageMediaType, saveImageToSession, inferExtension, MAX_IMAGE_SIZE } from './bridge-attachment-utils'
 import { getAgentWorkspace } from './agent-workspace-manager'
 import { getSettings } from './settings-service'
+import { getDingTalkBotBindingsPath } from './config-paths'
+import { createJsonBridgeChatBindingStore } from './bridge-binding-store'
 
 // ===== 类型声明 =====
 
@@ -149,6 +151,10 @@ class DingTalkBridge {
         },
       },
       getDefaultWorkspaceId: () => this.botConfig.defaultWorkspaceId,
+      bindingStore: createJsonBridgeChatBindingStore(
+        getDingTalkBotBindingsPath(botConfig.id),
+        `钉钉 Bridge/${botConfig.name}`,
+      ),
       onWorkspaceSwitched: async (workspaceId) => {
         const { saveDingTalkBotConfig } = await import('./dingtalk-config')
         saveDingTalkBotConfig({

--- a/apps/electron/src/main/lib/wechat-bridge.ts
+++ b/apps/electron/src/main/lib/wechat-bridge.ts
@@ -18,8 +18,9 @@ import type {
 } from '@proma/shared'
 import { WECHAT_IPC_CHANNELS, WECHAT_ITEM_TYPE, WECHAT_MESSAGE_TYPE, WECHAT_MESSAGE_STATE } from '@proma/shared'
 import { getDecryptedCredentials, saveWeChatCredentials, clearWeChatCredentials, getWeChatConfig, updateWeChatDefaultWorkspace } from './wechat-config'
-import { getWeChatSyncPath } from './config-paths'
+import { getWeChatBindingsPath, getWeChatSyncPath } from './config-paths'
 import { BridgeCommandHandler, type BridgeAttachment } from './bridge-command-handler'
+import { createJsonBridgeChatBindingStore } from './bridge-binding-store'
 import { inferImageMediaType, saveImageToSession, saveFileToSession, inferExtension, MAX_IMAGE_SIZE } from './bridge-attachment-utils'
 import { getAgentWorkspace } from './agent-workspace-manager'
 import { readFileSync, writeFileSync, existsSync } from 'node:fs'
@@ -408,6 +409,7 @@ class WeChatBridge {
       },
     },
     getDefaultWorkspaceId: () => getWeChatConfig().defaultWorkspaceId,
+    bindingStore: createJsonBridgeChatBindingStore(getWeChatBindingsPath(), '微信 Bridge'),
     onWorkspaceSwitched: (workspaceId) => updateWeChatDefaultWorkspace(workspaceId),
   })
 

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.13.25",
+      "version": "0.13.26",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.185",
         "@anthropic-ai/sdk": "^0.93.0",

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.13.24",
+      "version": "0.13.25",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.185",
         "@anthropic-ai/sdk": "^0.93.0",


### PR DESCRIPTION
## Summary
Persist shared IM bridge chat bindings and wire DingTalk bots plus WeChat to JSON-backed binding files so upgrades or restarts keep routing the same external conversation to the same Proma Agent session.
The root cause was that DingTalk and WeChat only kept `chatId -> sessionId` in the in-memory `BridgeCommandHandler` map, so a restarted app treated the next message as unbound and created a new session.
The new store validates binding JSON, drops bindings whose sessions no longer exist, saves binding changes after create/switch/workspace/model updates, and bumps `@proma/electron` to `0.13.26`.

## Validation
`bun test apps/electron/src/main/lib/bridge-binding-store.test.ts`; `bun run --filter=@proma/electron typecheck`; `bun run --filter=@proma/electron build:main`; `git diff --check`.