### PR TITLE
[codex] Stabilize default app preview button

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.13.26",
+  "version": "0.13.27",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -189,6 +189,7 @@ import { permissionService } from './lib/agent-permission-service'
 import { askUserService } from './lib/agent-ask-user-service'
 import { exitPlanService } from './lib/agent-exit-plan-service'
 import { getAgentSessionWorkspacePath, getAgentWorkspacesDir, getWorkspaceSkillsDir, getWorkspaceFilesDir, getScratchPadPath } from './lib/config-paths'
+import { getCachedDefaultAppInfo, saveCachedDefaultAppInfo } from './lib/default-app-cache'
 import { calculateStorageStats, cleanupStorage, cleanupTempFiles } from './lib/storage-service'
 import type { CleanupOptions } from './lib/storage-service'
 import {
@@ -441,10 +442,12 @@ function getBundledResourcesDir(): string {
 }
 
 /**
- * 默认 App 探测结果按文件后缀缓存（含 null 负缓存），避免反复 spawn osascript / 注册表查询。
- * 进程级别一次会话足够，无需失效策略——用户切换默认 App 是低频行为，下次重启生效即可。
+ * 默认 App 探测结果按文件后缀缓存，避免反复 spawn Swift / 注册表查询。
+ * 成功结果会落盘；失败只做短暂内存冷却，避免一次瞬时失败导致整会话都隐藏按钮。
  */
-const defaultAppCache = new Map<string, import('@proma/shared').DefaultAppInfo | null>()
+const defaultAppCache = new Map<string, import('@proma/shared').DefaultAppInfo>()
+const defaultAppFailureCache = new Map<string, number>()
+const DEFAULT_APP_FAILURE_RETRY_MS = 60_000
 
 function extOf(filePath: string): string {
   const base = filePath.split(/[\\/]/).pop() ?? ''
@@ -710,7 +713,12 @@ async function getDefaultAppInfoForFile(
   const absPath = resolve(filePath)
 
   const cacheKey = `${process.platform}:${extOf(filePath) || filePath}`
-  if (defaultAppCache.has(cacheKey)) return defaultAppCache.get(cacheKey) ?? null
+  const cachedInfo = defaultAppCache.get(cacheKey) ?? getCachedDefaultAppInfo(cacheKey)
+  if (cachedInfo) {
+    defaultAppCache.set(cacheKey, cachedInfo)
+    return cachedInfo
+  }
+  if (isFailureCacheFresh(cacheKey)) return null
 
   let appPath = ''
   let appName = ''
@@ -733,6 +741,7 @@ if let appUrl = NSWorkspace.shared.urlForApplication(toOpen: url) {
     if (r.status === 0) {
       appPath = r.stdout.trim().replace(/\/$/, '')
     }
+    console.log('[DefaultApp] darwin swift 结果: status=%s appPath=%s', r.status, appPath)
     if (appPath.endsWith('.app')) {
       const base = appPath.split('/').pop() || ''
       appName = base.replace(/\.app$/, '')
@@ -777,11 +786,21 @@ if let appUrl = NSWorkspace.shared.urlForApplication(toOpen: url) {
 
   const info: import('@proma/shared').DefaultAppInfo = { name: appName, appPath, iconDataUrl }
   defaultAppCache.set(cacheKey, info)
+  defaultAppFailureCache.delete(cacheKey)
+  saveCachedDefaultAppInfo(cacheKey, info)
   return info
 }
 
+function isFailureCacheFresh(key: string): boolean {
+  const failedAt = defaultAppFailureCache.get(key)
+  if (failedAt === undefined) return false
+  if (Date.now() - failedAt < DEFAULT_APP_FAILURE_RETRY_MS) return true
+  defaultAppFailureCache.delete(key)
+  return false
+}
+
 function cacheNull(key: string): null {
-  defaultAppCache.set(key, null)
+  defaultAppFailureCache.set(key, Date.now())
   return null
 }
 

--- a/apps/electron/src/main/lib/config-paths.ts
+++ b/apps/electron/src/main/lib/config-paths.ts
@@ -158,6 +158,15 @@ export function getSettingsPath(): string {
 }
 
 /**
+ * 获取系统默认 App 探测缓存路径
+ *
+ * @returns ~/.proma/default-apps.json
+ */
+export function getDefaultAppsCachePath(): string {
+  return join(getConfigDir(), 'default-apps.json')
+}
+
+/**
  * 获取用户档案文件路径
  *
  * @returns ~/.proma/user-profile.json

--- a/apps/electron/src/main/lib/default-app-cache.ts
+++ b/apps/electron/src/main/lib/default-app-cache.ts
@@ -1,0 +1,106 @@
+/**
+ * 默认 App 探测成功缓存
+ *
+ * 只持久化成功结果。系统探测依赖 Swift/LaunchServices/图标服务，失败可能是瞬时的，
+ * 不应把 null 写入本地配置后长期隐藏按钮。
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import type { DefaultAppInfo } from '@proma/shared'
+import { getDefaultAppsCachePath } from './config-paths'
+
+interface DefaultAppCacheEntry extends DefaultAppInfo {
+  updatedAt: number
+}
+
+interface DefaultAppCacheFile {
+  version: 1
+  entries: Record<string, DefaultAppCacheEntry>
+}
+
+const CACHE_VERSION = 1
+const MAX_CACHE_ENTRIES = 80
+
+let loaded = false
+let entries = new Map<string, DefaultAppCacheEntry>()
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function normalizeEntry(value: unknown): DefaultAppCacheEntry | null {
+  if (!isRecord(value)) return null
+  const { name, appPath, iconDataUrl, updatedAt } = value
+  if (
+    typeof name !== 'string' ||
+    typeof appPath !== 'string' ||
+    typeof iconDataUrl !== 'string' ||
+    typeof updatedAt !== 'number'
+  ) {
+    return null
+  }
+  if (!name || !appPath || !iconDataUrl) return null
+  return { name, appPath, iconDataUrl, updatedAt }
+}
+
+function loadCache(): void {
+  if (loaded) return
+  loaded = true
+
+  const cachePath = getDefaultAppsCachePath()
+  if (!existsSync(cachePath)) return
+
+  try {
+    const raw = readFileSync(cachePath, 'utf-8')
+    const parsed = JSON.parse(raw) as unknown
+    if (!isRecord(parsed) || parsed.version !== CACHE_VERSION || !isRecord(parsed.entries)) return
+
+    entries = new Map<string, DefaultAppCacheEntry>()
+    for (const [key, value] of Object.entries(parsed.entries)) {
+      const entry = normalizeEntry(value)
+      if (entry) entries.set(key, entry)
+    }
+  } catch (error) {
+    console.warn('[DefaultApp] 读取默认 App 缓存失败:', error)
+  }
+}
+
+function persistCache(): void {
+  const cachePath = getDefaultAppsCachePath()
+  const sortedEntries = Array.from(entries.entries())
+    .sort(([, a], [, b]) => b.updatedAt - a.updatedAt)
+    .slice(0, MAX_CACHE_ENTRIES)
+
+  entries = new Map(sortedEntries)
+
+  const file: DefaultAppCacheFile = {
+    version: CACHE_VERSION,
+    entries: Object.fromEntries(sortedEntries),
+  }
+
+  try {
+    writeFileSync(cachePath, JSON.stringify(file, null, 2), 'utf-8')
+  } catch (error) {
+    console.warn('[DefaultApp] 写入默认 App 缓存失败:', error)
+  }
+}
+
+export function getCachedDefaultAppInfo(cacheKey: string): DefaultAppInfo | null {
+  loadCache()
+  const entry = entries.get(cacheKey)
+  if (!entry) return null
+  return {
+    name: entry.name,
+    appPath: entry.appPath,
+    iconDataUrl: entry.iconDataUrl,
+  }
+}
+
+export function saveCachedDefaultAppInfo(cacheKey: string, info: DefaultAppInfo): void {
+  loadCache()
+  entries.set(cacheKey, {
+    ...info,
+    updatedAt: Date.now(),
+  })
+  persistCache()
+}

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -982,7 +982,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   return (
     <div className="flex flex-col h-full">
       <div className="flex items-center gap-2 px-3 py-1.5 flex-shrink-0">
-        <span className="text-[12px] text-foreground/60 truncate" title={filePath}>
+        <span className="min-w-0 flex-1 text-[12px] text-foreground/60 truncate" title={filePath}>
           {filePath}
         </span>
 


### PR DESCRIPTION
## Summary
Persist successful default-app lookup results and avoid caching null results for the full app session.
Add a short failure cooldown plus macOS lookup logging so transient Swift or icon failures do not permanently hide the preview button.
Fix the Markdown preview toolbar path flex behavior so long paths cannot push toolbar actions out of view.

## Validation
Ran `bun run typecheck`, `bun test`, and `git diff --check`.