### PR TITLE
Allow previewing arbitrary local paths

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.13.27",
+  "version": "0.13.28",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -368,6 +368,11 @@ function getAllowedCandidateBasePaths(options?: FileAccessOptions): string[] | u
   return allowed.length > 0 ? allowed : undefined
 }
 
+function getPreviewCandidateBasePaths(options?: FileAccessOptions): string[] | undefined {
+  const bases = options?.candidateBasePaths?.filter((p) => typeof p === 'string' && p.length > 0) ?? []
+  return bases.length > 0 ? bases : undefined
+}
+
 async function getAccessRootMainRepo(root: string): Promise<string | null> {
   if (!existsSync(root)) return null
   let probePath = root
@@ -2874,10 +2879,8 @@ export function registerIpcHandlers(): void {
     async (_, filePath: string, access?: FileAccessOptions | string[]): Promise<{ resolvedPath: string; content: string } | null> => {
       const { resolveAndReadFile, resolveFilePath } = await import('./lib/file-preview-service')
       const options = normalizeFileAccessOptions(access)
-      const allowedBasePaths = getAllowedCandidateBasePaths(options)
-      const resolved = resolveFilePath(filePath, allowedBasePaths)
-      if (!resolved || !isPathAllowed(resolved, options)) {
-        console.warn('[IPC] file:resolve-and-read 拒绝越界路径:', resolved ?? filePath)
+      const resolved = resolveFilePath(filePath, getPreviewCandidateBasePaths(options))
+      if (!resolved) {
         return null
       }
       const result = resolveAndReadFile(resolved)
@@ -2910,11 +2913,7 @@ export function registerIpcHandlers(): void {
     async (_, filePath: string, access?: FileAccessOptions | string[]): Promise<ResolvedFileUrl | null> => {
       const { resolveFilePath } = await import('./lib/file-preview-service')
       const options = normalizeFileAccessOptions(access)
-      const result = resolveFilePath(filePath, getAllowedCandidateBasePaths(options))
-      if (result && !isPathAllowed(result, options)) {
-        console.warn('[IPC] file:resolve-path 拒绝越界路径:', result)
-        return null
-      }
+      const result = resolveFilePath(filePath, getPreviewCandidateBasePaths(options))
       if (!result) return null
       // registerPromaFilePath 对目录路径会抛「不是文件」。渲染端（如悬浮预览解析 markdown
       // 链接）可能传入目录路径，此处优雅降级为 null，而不是让异常冒泡成未捕获的 handler 错误。
@@ -2933,10 +2932,8 @@ export function registerIpcHandlers(): void {
     async (_, filePath: string, access?: FileAccessOptions | string[]): Promise<{ tmpHtmlUrl: string } | null> => {
       const { preparePdfPreview, resolveFilePath } = await import('./lib/file-preview-service')
       const options = normalizeFileAccessOptions(access)
-      const allowedBasePaths = getAllowedCandidateBasePaths(options)
-      const resolved = resolveFilePath(filePath, allowedBasePaths)
-      if (!resolved || !isPathAllowed(resolved, options)) {
-        console.warn('[IPC] file:prepare-pdf-preview 拒绝越界路径:', resolved ?? filePath)
+      const resolved = resolveFilePath(filePath, getPreviewCandidateBasePaths(options))
+      if (!resolved) {
         return null
       }
       const result = await preparePdfPreview(resolved)
@@ -2950,10 +2947,8 @@ export function registerIpcHandlers(): void {
     async (_, filePath: string, access?: FileAccessOptions | string[]): Promise<{ resolvedPath: string; html: string } | null> => {
       const { convertDocxToHtml, resolveFilePath } = await import('./lib/file-preview-service')
       const options = normalizeFileAccessOptions(access)
-      const allowedBasePaths = getAllowedCandidateBasePaths(options)
-      const resolved = resolveFilePath(filePath, allowedBasePaths)
-      if (!resolved || !isPathAllowed(resolved, options)) {
-        console.warn('[IPC] file:docx-to-html 拒绝越界路径:', resolved ?? filePath)
+      const resolved = resolveFilePath(filePath, getPreviewCandidateBasePaths(options))
+      if (!resolved) {
         return null
       }
       const result = await convertDocxToHtml(resolved)
@@ -2967,25 +2962,23 @@ export function registerIpcHandlers(): void {
     async (_, filePath: string, access?: FileAccessOptions | string[]): Promise<import('@proma/shared').OfficePreviewResult | null> => {
       const { convertOfficeToHtml, resolveFilePath } = await import('./lib/file-preview-service')
       const options = normalizeFileAccessOptions(access)
-      const allowedBasePaths = getAllowedCandidateBasePaths(options)
-      const resolved = resolveFilePath(filePath, allowedBasePaths)
-      if (!resolved || !isPathAllowed(resolved, options)) {
-        console.warn('[IPC] file:office-to-html 拒绝越界路径:', resolved ?? filePath)
+      const resolved = resolveFilePath(filePath, getPreviewCandidateBasePaths(options))
+      if (!resolved) {
         return null
       }
       return convertOfficeToHtml(resolved)
     }
   )
 
-  // 读取文件为 base64（带路径校验，供内联图片预览等使用）
+  // 读取文件为 base64（供内联图片预览等使用）
   ipcMain.handle(
     'file:read-binary-base64',
     async (_, filePath: string, access?: FileAccessOptions | string[], maxSize?: number): Promise<string | null> => {
       const { readFileSync, statSync } = await import('node:fs')
       const { resolveFilePath } = await import('./lib/file-preview-service')
       const options = normalizeFileAccessOptions(access)
-      const resolved = resolveFilePath(filePath, getAllowedCandidateBasePaths(options))
-      if (!resolved || !isPathAllowed(resolved, options)) return null
+      const resolved = resolveFilePath(filePath, getPreviewCandidateBasePaths(options))
+      if (!resolved) return null
       const st = statSync(resolved)
       if (maxSize && st.size > maxSize) return null
       return readFileSync(resolved).toString('base64')


### PR DESCRIPTION
## Summary
Allow file preview IPC handlers to resolve and read any existing local path so absolute paths from other Proma config roots do not fail as out-of-bounds.
Keep mutating file operations on the existing authorized-root checks, and bump @proma/electron to 0.13.28.

## Validation
Ran `bun install --frozen-lockfile`, `bun run typecheck`, and `bun run --cwd apps/electron build:main`.