### PR TITLE
fix builtin mcp reserved names

### DIFF
--- a/apps/electron/src/main/lib/agent-workspace-manager.test.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'bun:test'
+import { normalizeWorkspaceMcpConfig } from './agent-workspace-manager'
+
+describe('Agent 工作区 MCP 配置', () => {
+  test('Given 工作区 MCP 包含内置保留名 When 归一化配置 Then 剔除冲突项并保留普通服务器', () => {
+    const normalized = normalizeWorkspaceMcpConfig({
+      servers: {
+        automation: {
+          type: 'stdio',
+          command: 'custom-automation',
+          enabled: true,
+        },
+        nano_banana: {
+          type: 'stdio',
+          command: 'custom-nano',
+          enabled: true,
+        },
+        github: {
+          type: 'stdio',
+          command: 'github-mcp',
+          enabled: true,
+        },
+      },
+    })
+
+    expect(Object.keys(normalized.servers).sort()).toEqual(['github'])
+    expect(normalized.servers.github?.command).toBe('github-mcp')
+  })
+})

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -22,6 +22,7 @@ import {
 } from './config-paths'
 import { findAllGitRoots, normalizeGitRoot } from './git-diff-service'
 import { listBuiltinMcpServers } from './builtin-mcp/catalog'
+import { RESERVED_BUILTIN_KEYS } from './builtin-mcp/baseline'
 import { inferMcpTransportType, normalizeMcpTransportType } from '@proma/shared'
 import type { AgentWorkspace, WorkspaceMcpConfig, SkillMeta, SkillImportSource, OtherWorkspaceSkillsGroup, WorkspaceCapabilities, SkillFileNode, SkillFileContent } from '@proma/shared'
 
@@ -473,12 +474,16 @@ export function ensurePluginManifest(workspaceSlug: string, workspaceName: strin
 
 // ===== MCP 配置管理 =====
 
-function normalizeWorkspaceMcpConfig(config: Partial<WorkspaceMcpConfig>): WorkspaceMcpConfig {
+export function normalizeWorkspaceMcpConfig(config: Partial<WorkspaceMcpConfig>): WorkspaceMcpConfig {
   const servers: WorkspaceMcpConfig['servers'] = {}
   const rawServers = config.servers ?? {}
 
   for (const [name, rawEntry] of Object.entries(rawServers)) {
     if (!rawEntry || typeof rawEntry !== 'object') continue
+    if (RESERVED_BUILTIN_KEYS.has(name)) {
+      console.warn(`[Agent 工作区] MCP 服务器 "${name}" 与内置 MCP 保留名冲突，已忽略（内置 MCP 不写入 mcp.json）`)
+      continue
+    }
 
     const entryRecord = { ...(rawEntry as unknown as Record<string, unknown>) }
     const entry = entryRecord as unknown as WorkspaceMcpConfig['servers'][string] & { type?: unknown }


### PR DESCRIPTION
## Summary

- Strip Proma built-in MCP reserved names from workspace MCP config normalization.
- Keep existing transport normalization for normal custom MCP servers.
- Add focused coverage for reserved-name filtering.

## Root Cause

`builtin-mcp/baseline.ts` defines `RESERVED_BUILTIN_KEYS` for built-in MCP IDs and runtime names, but workspace MCP config normalization did not use it. A workspace `mcp.json` entry named `automation`, `collaboration`, `mem`, `nano-banana`, or `nano_banana` could still be loaded as a custom MCP and conflict with Proma’s code-injected built-in MCP servers.

## What Changed

`normalizeWorkspaceMcpConfig()` now skips reserved built-in MCP names before normalizing transport details. The function is exported so the regression test can cover the normalization behavior directly.

## Validation

- `bun test apps/electron/src/main/lib/agent-workspace-manager.test.ts`
- `bun run --cwd apps/electron typecheck`
- `git diff --check`