### PR TITLE
Default code preview to unified diff

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.13.27",
+  "version": "0.13.28",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -299,8 +299,8 @@ export const agentSidePanelOpenMapAtom = atom<Map<string, boolean>>(new Map())
 /** 侧面板当前 Tab：'session' | 'workspace' | 'changes'（per-session Map） */
 export const agentDiffPanelTabAtom = atom<Map<string, 'session' | 'workspace' | 'changes'>>(new Map())
 
-/** Diff 视图模式：'split' | 'unified' */
-export const agentDiffViewModeAtom = atom<'split' | 'unified'>('split')
+/** Diff 视图模式：'split' | 'unified'，默认使用统一预览 */
+export const agentDiffViewModeAtom = atom<'split' | 'unified'>('unified')
 
 /** Diff 刷新版本号 — 按 session 隔离，Agent 写工具完成时递增 */
 export const agentDiffRefreshVersionAtom = atom(new Map<string, number>())

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.13.26",
+      "version": "0.13.28",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.197",
         "@anthropic-ai/sdk": "^0.93.0",


### PR DESCRIPTION
## Summary

Default the Agent code diff preview to unified mode instead of split mode.

Bump the Electron package version and synchronize the workspace lock metadata.

## Validation

- `git diff --check`
- `bun run --cwd apps/electron typecheck`