### PR TITLE
fix(agent): JSONL 单行损坏不再导致全量数据丢失

### DIFF
--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -58,6 +58,22 @@ interface AgentSessionsIndex {
 const INDEX_VERSION = 1
 
 /**
+ * 安全解析 JSONL 行数组，逐行 try-catch。
+ * 单行损坏时跳过该行并记录 warning，不会导致全量数据丢失。
+ */
+function safeParseJsonl<T>(lines: string[], context: string): T[] {
+  const results: T[] = []
+  for (let i = 0; i < lines.length; i++) {
+    try {
+      results.push(JSON.parse(lines[i]!) as T)
+    } catch (err) {
+      console.warn(`[Agent 会话] ${context} — JSONL 第 ${i + 1} 行解析失败，已跳过:`, (err as Error).message)
+    }
+  }
+  return results
+}
+
+/**
  * 读取会话索引文件
  */
 function readIndex(): AgentSessionsIndex {
@@ -175,7 +191,7 @@ export function getAgentSessionMessages(id: string): AgentMessage[] {
   try {
     const raw = readFileSync(filePath, 'utf-8')
     const lines = raw.split('\n').filter((line) => line.trim())
-    return lines.map((line) => JSON.parse(line) as AgentMessage)
+    return safeParseJsonl<AgentMessage>(lines, `读取会话消息 (${id})`)
   } catch (error) {
     console.error(`[Agent 会话] 读取消息失败 (${id}):`, error)
     return []
@@ -1041,7 +1057,7 @@ export function resolveUserUuidFromSDK(
   // 读取并解析 SDK JSONL
   try {
     const lines = readFileSync(sessionFilePath, 'utf-8').split('\n').filter(Boolean)
-    const messages = lines.map((l) => JSON.parse(l) as Record<string, unknown>)
+    const messages = safeParseJsonl<Record<string, unknown>>(lines, `rewind 解析 SDK JSONL (${usingSourceSession ? '源会话' : '当前会话'})`)
 
     // 找到 assistant message 的位置
     const assistantIdx = messages.findIndex((m) => m.uuid === assistantMessageUuid)
@@ -1146,7 +1162,7 @@ export function rewindFilesFromSnapshot(
     let messages: Record<string, unknown>[] = []
     if (sessionFilePath) {
       const lines = readFileSync(sessionFilePath, 'utf-8').split('\n').filter(Boolean)
-      messages = lines.map((l) => JSON.parse(l) as Record<string, unknown>)
+      messages = safeParseJsonl<Record<string, unknown>>(lines, 'rewindFilesFromSnapshot 解析当前 JSONL')
     }
 
     // 找到目标 user message 的位置
@@ -1161,7 +1177,7 @@ export function rewindFilesFromSnapshot(
         return { canRewind: false, error: '未找到源会话 SDK session JSONL（fork 回退需要源会话数据）' }
       }
       const sourceLines = readFileSync(sourceFilePath, 'utf-8').split('\n').filter(Boolean)
-      messages = sourceLines.map((l) => JSON.parse(l) as Record<string, unknown>)
+      messages = safeParseJsonl<Record<string, unknown>>(sourceLines, 'rewindFilesFromSnapshot 解析源会话 JSONL')
       targetIdx = messages.findIndex((m) => m.uuid === userMessageUuid)
       effectiveSdkSessionId = forkSourceSdkSessionId
       isForkFallback = true


### PR DESCRIPTION
## 问题

`agent-session-manager.ts` 中 4 处使用 `.map(l => JSON.parse(l))` 包在单个 try-catch 中。任意一行 JSONL 损坏（如崩溃写中断），整个 map 抛出异常，catch 返回空数组或丢弃所有已解析的消息。

来自 bug-analysis-2025-06-23 的 **P0#1** 问题。

### 影响的 4 处位置

| 方法 | 后果 |
|------|------|
| `getAgentSessionMessages()` | 会话消息全量丢失，返回 `[]` |
| `resolveUserUuidFromSDK()` | Rewind 失败，无法回退到历史 turn |
| `rewindFilesFromSnapshot()` x2 | 文件快照恢复失败；Fork 场景下源会话回退失败 |

## 修复

提取 `safeParseJsonl<T>` 公共 helper，逐行 try-catch：
- **坏行**：跳过并记录 `console.warn`（含行号和具体错误信息）
- **好行**：照常保留

```ts
function safeParseJsonl<T>(lines: string[], context: string): T[] {
  const results: T[] = []
  for (let i = 0; i < lines.length; i++) {
    try {
      results.push(JSON.parse(lines[i]!) as T)
    } catch (err) {
      console.warn(`[Agent 会话] ${context} — JSONL 第 ${i + 1} 行解析失败，已跳过:`, (err as Error).message)
    }
  }
  return results
}
```

## 变更

- 1 file changed, 20 insertions(+), 4 deletions(-)
- 4 处 `.map(l => JSON.parse(l))` 全部替换为 `safeParseJsonl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
