### PR TITLE
[codex] Fix agent JSONL parse strategy

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.13.28",
+  "version": "0.13.29",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/agent-session-manager.test.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.test.ts
@@ -1,0 +1,129 @@
+import { afterAll, beforeAll, describe, expect, mock, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import * as os from 'node:os'
+import { join } from 'node:path'
+
+type AgentSessionManager = typeof import('./agent-session-manager')
+
+let manager: AgentSessionManager
+let tempHome: string
+const originalHome = process.env.HOME
+const originalPromaDev = process.env.PROMA_DEV
+const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR
+
+mock.module('electron', () => ({
+  app: {
+    isPackaged: true,
+    getPath: () => join(process.env.HOME ?? tempHome, 'Library', 'Application Support'),
+  },
+  BrowserWindow: class {},
+  clipboard: {},
+  dialog: {},
+  nativeImage: { createFromPath: () => ({}) },
+  nativeTheme: {},
+  powerMonitor: {},
+  powerSaveBlocker: {},
+  screen: {},
+  shell: {},
+  safeStorage: {
+    isEncryptionAvailable: () => false,
+    encryptString: (value: string) => Buffer.from(value),
+    decryptString: (value: Buffer) => value.toString('utf-8'),
+  },
+}))
+
+mock.module('node:os', () => ({
+  ...os,
+  homedir: () => tempHome,
+}))
+
+function jsonl(rows: string[]): string {
+  return rows.join('\n') + '\n'
+}
+
+function writeAgentSessionJsonl(sessionId: string, rows: string[]): void {
+  const dir = join(tempHome, '.proma', 'agent-sessions')
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, `${sessionId}.jsonl`), jsonl(rows), 'utf-8')
+}
+
+function writeSdkSessionJsonl(sdkSessionId: string, rows: string[]): void {
+  const dir = join(tempHome, '.proma', 'sdk-config', 'projects', 'test-project')
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, `${sdkSessionId}.jsonl`), jsonl(rows), 'utf-8')
+}
+
+beforeAll(async () => {
+  tempHome = mkdtempSync(join(os.tmpdir(), 'proma-agent-session-manager-'))
+  process.env.HOME = tempHome
+  process.env.PROMA_DEV = '0'
+  delete process.env.CLAUDE_CONFIG_DIR
+  manager = await import('./agent-session-manager')
+})
+
+afterAll(() => {
+  if (originalHome === undefined) {
+    delete process.env.HOME
+  } else {
+    process.env.HOME = originalHome
+  }
+  if (originalPromaDev === undefined) {
+    delete process.env.PROMA_DEV
+  } else {
+    process.env.PROMA_DEV = originalPromaDev
+  }
+  if (originalClaudeConfigDir === undefined) {
+    delete process.env.CLAUDE_CONFIG_DIR
+  } else {
+    process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir
+  }
+  rmSync(tempHome, { recursive: true, force: true })
+})
+
+describe('Agent 会话 JSONL 读取', () => {
+  test('Given 会话 JSONL 混入损坏行 When 读取 SDKMessage Then 跳过坏行并保留其它消息', () => {
+    writeAgentSessionJsonl('session-with-bad-line', [
+      JSON.stringify({ type: 'user', message: { content: [{ type: 'text', text: '你好' }] }, parent_tool_use_id: null }),
+      '{ 这不是合法 JSON',
+      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: '仍然可读' }] }, parent_tool_use_id: null }),
+    ])
+
+    const messages = manager.getAgentSessionSDKMessages('session-with-bad-line')
+
+    expect(messages.map((message) => message.type)).toEqual(['user', 'assistant'])
+  })
+
+  test('Given SDK rewind JSONL 存在损坏行 When 从快照恢复文件 Then 严格失败避免误报成功', () => {
+    const cwd = join(tempHome, 'workspace')
+    mkdirSync(cwd, { recursive: true })
+    writeSdkSessionJsonl('sdk-session-with-bad-line', [
+      JSON.stringify({ type: 'user', uuid: 'user-1', message: { content: [{ type: 'text', text: '修改文件' }] } }),
+      '{ 这不是合法 JSON',
+      JSON.stringify({
+        type: 'file-history-snapshot',
+        isSnapshotUpdate: false,
+        snapshot: {
+          messageId: 'user-1',
+          trackedFileBackups: {
+            'a.txt': { backupFileName: null },
+          },
+        },
+      }),
+    ])
+
+    const result = manager.rewindFilesFromSnapshot('sdk-session-with-bad-line', 'user-1', cwd)
+
+    expect(result.canRewind).toBe(false)
+    expect(result.error).toContain('JSONL 第 2 行解析失败')
+  })
+
+  test('Given 会话 JSONL 存在损坏行 When 截断 SDKMessage Then 抛错避免重写不完整历史', () => {
+    writeAgentSessionJsonl('session-truncate-bad-line', [
+      JSON.stringify({ type: 'assistant', uuid: 'assistant-1', message: { content: [{ type: 'text', text: '完成' }] } }),
+      '{ 这不是合法 JSON',
+    ])
+
+    expect(() => manager.truncateSDKMessages('session-truncate-bad-line', 'assistant-1'))
+      .toThrow('JSONL 第 2 行解析失败')
+  })
+})

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -57,6 +57,61 @@ interface AgentSessionsIndex {
 /** 当前索引版本 */
 const INDEX_VERSION = 1
 
+interface JsonlParseError {
+  lineNumber: number
+  message: string
+}
+
+/**
+ * 逐行解析 JSONL，调用方按业务场景决定容错或严格失败。
+ */
+function parseJsonlLines<T>(lines: string[]): { records: T[]; errors: JsonlParseError[] } {
+  const records: T[] = []
+  const errors: JsonlParseError[] = []
+  for (let i = 0; i < lines.length; i++) {
+    try {
+      records.push(JSON.parse(lines[i]!) as T)
+    } catch (err) {
+      errors.push({
+        lineNumber: i + 1,
+        message: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+  return { records, errors }
+}
+
+/**
+ * 展示/检索类读取：跳过损坏行，保留其它可读消息。
+ */
+function parseJsonlLenient<T>(lines: string[], context: string): T[] {
+  const { records, errors } = parseJsonlLines<T>(lines)
+  for (const error of errors) {
+    console.warn(`[Agent 会话] ${context} — JSONL 第 ${error.lineNumber} 行解析失败，已跳过:`, error.message)
+  }
+  return records
+}
+
+/**
+ * 回退/文件恢复类读取：任何损坏行都可能破坏消息顺序或快照完整性，必须停止。
+ */
+function parseJsonlStrict<T>(lines: string[], context: string): T[] {
+  const { records, errors } = parseJsonlLines<T>(lines)
+  if (errors.length > 0) {
+    const first = errors[0]!
+    throw new Error(`${context} 失败：JSONL 第 ${first.lineNumber} 行解析失败: ${first.message}`)
+  }
+  return records
+}
+
+function normalizePersistedSDKMessage(parsed: unknown): SDKMessage {
+  // 旧格式检测：AgentMessage 有 `role` 字段，SDKMessage 有 `type` 字段
+  if (parsed && typeof parsed === 'object' && 'role' in parsed && !('type' in parsed)) {
+    return convertLegacyMessage(parsed as AgentMessage)
+  }
+  return parsed as SDKMessage
+}
+
 /**
  * 读取会话索引文件
  */
@@ -175,7 +230,7 @@ export function getAgentSessionMessages(id: string): AgentMessage[] {
   try {
     const raw = readFileSync(filePath, 'utf-8')
     const lines = raw.split('\n').filter((line) => line.trim())
-    return lines.map((line) => JSON.parse(line) as AgentMessage)
+    return parseJsonlLenient<AgentMessage>(lines, `读取会话消息 (${id})`)
   } catch (error) {
     console.error(`[Agent 会话] 读取消息失败 (${id}):`, error)
     return []
@@ -297,14 +352,7 @@ export function getAgentSessionSDKMessages(id: string): SDKMessage[] {
   try {
     const raw = readFileSync(filePath, 'utf-8')
     const lines = raw.split('\n').filter((line) => line.trim())
-    return lines.map((line) => {
-      const parsed = JSON.parse(line)
-      // 旧格式检测：AgentMessage 有 `role` 字段，SDKMessage 有 `type` 字段
-      if ('role' in parsed && !('type' in parsed)) {
-        return convertLegacyMessage(parsed as AgentMessage)
-      }
-      return parsed as SDKMessage
-    })
+    return parseJsonlLenient<unknown>(lines, `读取 SDKMessage (${id})`).map(normalizePersistedSDKMessage)
   } catch (error) {
     console.error(`[Agent 会话] 读取 SDKMessage 失败 (${id}):`, error)
     return []
@@ -960,7 +1008,14 @@ function rewriteSourceToDest(content: string, sourceDir: string, destDir: string
  * @returns 截断后保留的消息列表
  */
 export function truncateSDKMessages(id: string, upToUuidInclusive: string): SDKMessage[] {
-  const messages = getAgentSessionSDKMessages(id)
+  const filePath = getAgentSessionMessagesPath(id)
+  if (!existsSync(filePath)) {
+    throw new Error(`[Agent 会话] 截断失败: 会话消息文件不存在, sessionId=${id}`)
+  }
+
+  const raw = readFileSync(filePath, 'utf-8')
+  const lines = raw.split('\n').filter((line) => line.trim())
+  const messages = parseJsonlStrict<unknown>(lines, `截断读取 SDKMessage (${id})`).map(normalizePersistedSDKMessage)
   const cutIndex = messages.findIndex(
     (m) => 'uuid' in m && (m as { uuid?: string }).uuid === upToUuidInclusive,
   )
@@ -969,7 +1024,6 @@ export function truncateSDKMessages(id: string, upToUuidInclusive: string): SDKM
   }
   const kept = messages.slice(0, cutIndex + 1)
 
-  const filePath = getAgentSessionMessagesPath(id)
   const content = kept.map((m) => JSON.stringify(m)).join('\n') + (kept.length > 0 ? '\n' : '')
   writeFileSync(filePath, content, 'utf-8')
 
@@ -1041,7 +1095,7 @@ export function resolveUserUuidFromSDK(
   // 读取并解析 SDK JSONL
   try {
     const lines = readFileSync(sessionFilePath, 'utf-8').split('\n').filter(Boolean)
-    const messages = lines.map((l) => JSON.parse(l) as Record<string, unknown>)
+    const messages = parseJsonlStrict<Record<string, unknown>>(lines, `rewind 解析 SDK JSONL (${usingSourceSession ? '源会话' : '当前会话'})`)
 
     // 找到 assistant message 的位置
     const assistantIdx = messages.findIndex((m) => m.uuid === assistantMessageUuid)
@@ -1146,7 +1200,7 @@ export function rewindFilesFromSnapshot(
     let messages: Record<string, unknown>[] = []
     if (sessionFilePath) {
       const lines = readFileSync(sessionFilePath, 'utf-8').split('\n').filter(Boolean)
-      messages = lines.map((l) => JSON.parse(l) as Record<string, unknown>)
+      messages = parseJsonlStrict<Record<string, unknown>>(lines, 'rewindFilesFromSnapshot 解析当前 JSONL')
     }
 
     // 找到目标 user message 的位置
@@ -1161,7 +1215,7 @@ export function rewindFilesFromSnapshot(
         return { canRewind: false, error: '未找到源会话 SDK session JSONL（fork 回退需要源会话数据）' }
       }
       const sourceLines = readFileSync(sourceFilePath, 'utf-8').split('\n').filter(Boolean)
-      messages = sourceLines.map((l) => JSON.parse(l) as Record<string, unknown>)
+      messages = parseJsonlStrict<Record<string, unknown>>(sourceLines, 'rewindFilesFromSnapshot 解析源会话 JSONL')
       targetIdx = messages.findIndex((m) => m.uuid === userMessageUuid)
       effectiveSdkSessionId = forkSourceSdkSessionId
       isForkFallback = true
@@ -1556,7 +1610,14 @@ function findSessionMessageSnippet(sessionId: string, query: string): string | u
     const lines = raw.split('\n').filter((line) => line.trim())
 
     for (const line of lines) {
-      const textContent = extractTextFromPersistedMessage(JSON.parse(line))
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(line)
+      } catch (error) {
+        console.warn(`[Agent 会话] 会话引用摘要跳过无法解析的 JSONL 行 (${sessionId}):`, error)
+        continue
+      }
+      const textContent = extractTextFromPersistedMessage(parsed)
       if (!textContent) continue
 
       const matchIndex = textContent.toLowerCase().indexOf(queryLower)


### PR DESCRIPTION
## Summary
- split Agent JSONL parsing into lenient reads for display/search paths and strict reads for rewind/truncation paths
- make `getAgentSessionSDKMessages()` tolerate single-line JSONL corruption so Agent sessions do not render as empty
- fail closed for SDK rewind and Proma JSONL truncation when corruption could break message order or file snapshot integrity
- add focused Bun tests and bump `@proma/electron` to `0.13.29`

## Root Cause
PR #1046 made some JSONL reads skip bad lines, but the main Agent UI path still used `getAgentSessionSDKMessages()` with full-array `JSON.parse`. A single corrupted line could still make the session load as empty. The same skip-bad-line strategy is also unsafe for rewind/truncation paths, because missing SDK messages or file-history snapshots can make file recovery incomplete while reporting success.

## What Changed
- Added shared JSONL parse helpers that return parsed records plus per-line errors.
- Display/read-only paths use lenient parsing and warn while preserving readable messages.
- `resolveUserUuidFromSDK()`, `rewindFilesFromSnapshot()`, and `truncateSDKMessages()` use strict parsing and stop on corruption.
- Session reference snippet extraction now skips isolated corrupt lines instead of aborting the whole scan.

## Validation
- `bun test apps/electron/src/main/lib/agent-session-manager.test.ts packages/session-core/src/session-core.test.ts`
- `bun run --filter='@proma/electron' typecheck`
- `git diff --check`

Replaces #1046.