### PR TITLE
fix: 修复内置 MCP 详情面板关闭按钮失效

### DIFF
--- a/apps/electron/src/renderer/components/agent-skills/BuiltinMcpDetailSheet.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/BuiltinMcpDetailSheet.tsx
@@ -3,7 +3,7 @@
  */
 
 import * as React from 'react'
-import { CheckCircle2, Settings2, XCircle } from 'lucide-react'
+import { ArrowLeft, CheckCircle2, Plug, Settings2, XCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Sheet, SheetContent, SheetDescription, SheetTitle } from '@/components/ui/sheet'
 import { cn } from '@/lib/utils'
@@ -61,67 +61,89 @@ export function BuiltinMcpDetailSheet({ open, server, onOpenChange, onConfigure 
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="right" className="w-[560px] sm:max-w-[560px] overflow-y-auto scrollbar-thin pt-12">
-        {server && configInfo && (
-          <div className="flex flex-col gap-6">
-            <div className="flex flex-col gap-2">
-              <div className="flex items-center gap-2">
-                <SheetTitle>{server.displayName}</SheetTitle>
-                <span className="rounded-md bg-blue-500/10 px-1.5 py-0.5 text-[11px] font-medium text-blue-600 dark:text-blue-400">
-                  Proma 内置
-                </span>
-              </div>
-              <SheetDescription>{server.description}</SheetDescription>
+      <SheetContent hideClose side="right" className="w-[560px] sm:max-w-[560px] p-0 flex flex-col gap-0">
+        <SheetTitle className="sr-only">{server ? `MCP 详情 · ${server.displayName}` : 'MCP 详情'}</SheetTitle>
+        <div className="flex h-full flex-col min-h-0">
+          <div className="shrink-0 border-b border-border/60 px-5 pb-4 pt-5">
+            <div className="flex items-center gap-3">
+              <Button variant="ghost" size="icon" className="h-8 w-8" type="button" onClick={() => onOpenChange(false)}>
+                <ArrowLeft size={18} />
+              </Button>
+              <h3 className="text-lg font-medium text-foreground">MCP 详情</h3>
             </div>
-
-            <div className="grid gap-3 sm:grid-cols-2">
-              <InfoItem label="MCP 名称" value={server.name} />
-              <InfoItem label="分类" value={CATEGORY_LABELS[server.category]} />
-              <InfoItem label="注入开关" value={server.enabled ? '允许注入' : '已手动关闭'} tone={server.enabled ? 'success' : 'muted'} />
-              <InfoItem label="可用状态" value={server.available ? '当前可用' : (server.availabilityReason ?? '不可用')} tone={server.available ? 'success' : 'muted'} />
-              <InfoItem label="配置来源" value={configInfo.source} />
-            </div>
-
-            <section className="rounded-lg bg-muted/45 p-3">
-              <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0">
-                  <div className="text-sm font-medium text-foreground">如何配置</div>
-                  <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{configInfo.description}</p>
+            {server && (
+              <div className="mt-4 flex items-start gap-3">
+                <div className="rounded-xl bg-blue-500/12 p-2 text-blue-500 shadow-sm shrink-0">
+                  <Plug size={18} />
                 </div>
-                {configInfo.actionLabel && onConfigure && (
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    className="shrink-0"
-                    onClick={() => onConfigure(server.id)}
-                  >
-                    <Settings2 size={14} />
-                    <span>{configInfo.actionLabel}</span>
-                  </Button>
-                )}
-              </div>
-            </section>
-
-            <section className="flex flex-col gap-3">
-              <div className="text-sm font-medium text-foreground">工具</div>
-              <div className="flex flex-col gap-2">
-                {server.tools.map((tool) => (
-                  <div key={tool.name} className="rounded-lg bg-muted/45 p-3">
-                    <div className="flex items-center gap-2">
-                      <span className="text-sm font-medium text-foreground">{tool.name}</span>
-                      {tool.readOnly && (
-                        <span className="rounded-md bg-foreground/5 px-1.5 py-0.5 text-[11px] text-muted-foreground">
-                          只读
-                        </span>
-                      )}
-                    </div>
-                    <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{tool.description}</p>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <h3 className="truncate text-base font-semibold text-foreground">{server.displayName}</h3>
+                    <span className="shrink-0 rounded-md bg-blue-500/10 px-1.5 py-0.5 text-[11px] font-medium text-blue-600 dark:text-blue-400">
+                      Proma 内置
+                    </span>
                   </div>
-                ))}
+                  <div className="mt-0.5 truncate text-xs text-muted-foreground">{server.name}</div>
+                </div>
               </div>
-            </section>
+            )}
           </div>
-        )}
+
+          <div className="flex-1 overflow-y-auto scrollbar-thin p-5">
+            {server && configInfo && (
+              <div className="flex flex-col gap-6">
+                <SheetDescription>{server.description}</SheetDescription>
+
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <InfoItem label="MCP 名称" value={server.name} />
+                  <InfoItem label="分类" value={CATEGORY_LABELS[server.category]} />
+                  <InfoItem label="注入开关" value={server.enabled ? '允许注入' : '已手动关闭'} tone={server.enabled ? 'success' : 'muted'} />
+                  <InfoItem label="可用状态" value={server.available ? '当前可用' : (server.availabilityReason ?? '不可用')} tone={server.available ? 'success' : 'muted'} />
+                  <InfoItem label="配置来源" value={configInfo.source} />
+                </div>
+
+                <section className="rounded-lg bg-muted/45 p-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="text-sm font-medium text-foreground">如何配置</div>
+                      <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{configInfo.description}</p>
+                    </div>
+                    {configInfo.actionLabel && onConfigure && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="shrink-0"
+                        onClick={() => onConfigure(server.id)}
+                      >
+                        <Settings2 size={14} />
+                        <span>{configInfo.actionLabel}</span>
+                      </Button>
+                    )}
+                  </div>
+                </section>
+
+                <section className="flex flex-col gap-3">
+                  <div className="text-sm font-medium text-foreground">工具</div>
+                  <div className="flex flex-col gap-2">
+                    {server.tools.map((tool) => (
+                      <div key={tool.name} className="rounded-lg bg-muted/45 p-3">
+                        <div className="flex items-center gap-2">
+                          <span className="text-sm font-medium text-foreground">{tool.name}</span>
+                          {tool.readOnly && (
+                            <span className="rounded-md bg-foreground/5 px-1.5 py-0.5 text-[11px] text-muted-foreground">
+                              只读
+                            </span>
+                          )}
+                        </div>
+                        <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{tool.description}</p>
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              </div>
+            )}
+          </div>
+        </div>
       </SheetContent>
     </Sheet>
   )


### PR DESCRIPTION
## 问题根因

点击内置 MCP 卡片弹出的右侧详情面板后，右上角关闭按钮点击/hover 都无反应，只能点击遮罩空白处关闭。

排查发现两层原因：

1. `BuiltinMcpDetailSheet` 使用的是 `SheetContent` 默认的 Radix `SheetPrimitive.Close`。这个默认关闭按钮此前已经在 `McpDetailSheet`/`SkillDetailSheet` 里被确认过是"失效"的（见历史提交 `da15ace4`），因为它的位置（`right-4 top-4`）正好落在 `AppShell.tsx` 里全局可拖拽标题栏区域（`titlebar-drag-region`，顶部 50px，`app-region: drag`）内——这个拖拽区域在 OS 层面做点击命中测试，会无视 DOM 的 z-index 堆叠顺序，把单击当成了"拖动窗口"。
2. `BuiltinMcpDetailSheet` 是在那次修复之后才新增的组件（`ae5f7a23`），新增时没有沿用已验证过的修复方案，所以重新踩了同一个坑。

## 具体修改

`apps/electron/src/renderer/components/agent-skills/BuiltinMcpDetailSheet.tsx`：

- `SheetContent` 加 `hideClose`，移除失效的默认关闭按钮
- 头部结构改为和 `SkillDetailSheet.tsx` 完全一致的样式：固定头部（`border-b` 分隔）+ 左上角 `ArrowLeft` 返回按钮 + 通用标题「MCP 详情」+ 名称/徽标/副标题行（图标框、配色均与外部 MCP 卡片列表的 `Plug` 图标保持一致），正文改为独立滚动区域
- 顺带修正了一处无障碍回退：多次迭代中曾从 `SkillDetailSheet` 抄了 `aria-describedby={undefined}`，但本组件仍渲染着实际的 `<SheetDescription>`，这个覆盖会切断 Radix 默认的描述关联；现已移除该覆盖，并让 `SheetTitle`（sr-only）动态带上具体的 MCP 名称

## 审查情况

- 用 `/code-review`（high effort，8 个角度）审查了完整 diff，唯一确认的问题是上面提到的 `aria-describedby` 无障碍回退，已修复；其余候选项（标题/副标题重复、border 用法等）都是忠实复刻 `SkillDetailSheet` 既有模式，不算新问题
- `tsc --noEmit` 类型检查通过
- 用户在本地 dev 环境手动测试确认关闭按钮可正常 hover/点击，头部样式与 Skill 详情面板视觉一致