### PR TITLE
fix: 侧边栏与文件面板按钮尺寸/间距对齐优化

### DIFF
--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -641,7 +641,7 @@ function AttachedFilesSection({ attachedFiles, onDetach, onAddToChat, onFilePrev
             <FileTypeIcon name={name} isDirectory={false} />
             <span className="text-xs truncate flex-1" title={filePath}>{name}</span>
             <div
-              className="flex-shrink-0"
+              className="flex-shrink-0 mr-1"
               onClick={(e) => e.stopPropagation()}
               onMouseDown={(e) => e.stopPropagation()}
             >
@@ -899,7 +899,7 @@ function AttachedDirTree({ dirPath, onDetach, selectedPaths, onSelect, refreshVe
           type="button"
           variant="ghost"
           size="icon"
-          className="relative z-10 h-5 w-5 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0"
+          className="relative z-10 h-5 w-5 mr-1 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0"
           onClick={(e) => { e.stopPropagation(); onDetach() }}
         >
           <X className="size-3" />
@@ -1157,7 +1157,7 @@ function AttachedDirItem({ entry, depth, selectedPaths, onSelect, refreshVersion
 
         {/* 右侧操作按钮占位 */}
         <div
-          className="relative z-10 flex-shrink-0"
+          className="relative z-10 flex-shrink-0 mr-1"
           onClick={(e) => e.stopPropagation()}
           onMouseDown={(e) => e.stopPropagation()}
         >

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -2224,7 +2224,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
       <div className="px-3 pt-2 flex items-center gap-1.5">
         <button
           onClick={mode === 'agent' ? handleNewAgentSession : handleNewConversation}
-          className="flex-1 flex items-center gap-2 px-3 py-2 rounded-[10px] text-[13px] font-medium text-foreground/70 sidebar-control-surface hover:text-foreground transition-[background-color,color] duration-150 titlebar-no-drag"
+          className="flex-1 flex items-center gap-2 h-10 px-3 rounded-[10px] text-[13px] font-medium text-foreground/70 sidebar-control-surface hover:text-foreground transition-[background-color,color] duration-150 titlebar-no-drag"
         >
           <Plus size={14} />
           <span>{mode === 'agent' ? '新会话' : '新对话'}</span>
@@ -2233,7 +2233,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
           <TooltipTrigger asChild>
             <button
               onClick={() => setSearchDialogOpen(true)}
-              className="flex-shrink-0 size-[36px] flex items-center justify-center rounded-[10px] text-foreground/40 sidebar-control-surface hover:text-foreground/60 transition-[background-color,color] duration-150 titlebar-no-drag"
+              className="flex-shrink-0 size-10 flex items-center justify-center rounded-[10px] text-foreground/40 sidebar-control-surface hover:text-foreground/60 transition-[background-color,color] duration-150 titlebar-no-drag"
             >
               <Search size={14} />
             </button>
@@ -2816,7 +2816,7 @@ function SessionItemActions({
       </span>
       <div
         className={cn(
-          'absolute right-0 top-0 flex items-center gap-0.5 transition-opacity duration-100',
+          'absolute right-1 top-0 flex items-center gap-0.5 transition-opacity duration-100',
           forceVisible
             ? 'opacity-100 pointer-events-auto'
             : 'opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto',

--- a/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
@@ -761,7 +761,7 @@ function FileTreeItem({
 
         {/* 右侧操作按钮占位（始终占位，避免行宽跳动） */}
         <div
-          className="relative z-10 flex-shrink-0"
+          className="relative z-10 flex-shrink-0 mr-1"
           onClick={(e) => e.stopPropagation()}
           onMouseDown={(e) => e.stopPropagation()}
         >


### PR DESCRIPTION
## 问题根因
1. 左上角新会话按钮的高度与下方 Chat/Agent 切换器不一致，搜索按钮尺寸（36px）与旁边的收起侧边栏按钮（40px）不一致。
2. 会话列表 hover 显示的置顶/归档/更多操作按钮组，以及会话文件/工作区文件面板 hover 显示的删除按钮、更多操作按钮，均贴着容器右边缘定位（`right-0` 或紧贴 `pr-2` 末端），hover 高亮背景会显得贴边。

## 具体修改
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx`
  - 新会话按钮：`px-3 py-2` → `h-10 px-3`，高度对齐 ModeSwitcher（40px）
  - 搜索按钮：`size-[36px]` → `size-10`，对齐收起侧边栏按钮
  - 会话项 hover 按钮组容器：`right-0` → `right-1`，增加与右边缘的间距
- `apps/electron/src/renderer/components/agent/SidePanel.tsx`
  - 附加文件/附加目录（含子项）hover 出现的删除按钮、更多操作按钮容器均增加 `mr-1`
- `apps/electron/src/renderer/components/file-browser/FileBrowser.tsx`
  - 文件树行 hover 出现的更多操作按钮容器增加 `mr-1`

均为 Tailwind className 调整，未改动任何业务逻辑。

## 审查情况
自审查确认改动范围精准、无副作用；已跑 `bun run --filter='@proma/electron' dev` 实际操作验证，尺寸对齐和按钮间距符合预期。代码审查（/code-review）发现两处可选优化项（会话项按钮组容器宽度可再加宽 4px 以完全消除极端情况下的溢出、package.json 版本号待合并时统一递增），评估后不影响功能，本次不处理。