### PR TITLE
feat: Agent 运行中输入进入可见托管队列

### DIFF
--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -10,6 +10,7 @@ import { atomFamily, atomWithStorage } from 'jotai/utils'
 import type { AgentSessionMeta, AgentEvent, AgentWorkspace, AgentPendingFile, RetryAttempt, PromaPermissionMode, PermissionRequest, AskUserRequest, ExitPlanModeRequest, ThinkingConfig, AgentEffort, SDKMessage, UnstagedChangesResult } from '@proma/shared'
 import { PROMA_DEFAULT_PERMISSION_MODE } from '@proma/shared'
 import { calculateDockBadgeCount, countPendingRequests } from '@/lib/dock-badge-count'
+import type { AgentQueuedMessage } from '@/lib/agent-message-queue'
 
 /** 活动状态 */
 export type ActivityStatus = 'pending' | 'running' | 'completed' | 'error' | 'backgrounded'
@@ -265,6 +266,35 @@ export const agentPendingFilesAtomFamily = atomFamily((sessionId: string) =>
     (get) => get(agentSessionPendingFilesAtom).get(sessionId) ?? [],
     (_get, set, update: AgentPendingFile[] | ((prev: AgentPendingFile[]) => AgentPendingFile[])) => {
       set(agentSessionPendingFilesAtom, (prev) => {
+        const current = prev.get(sessionId) ?? []
+        const next = typeof update === 'function' ? update(current) : update
+        const map = new Map(prev)
+        if (next.length === 0) {
+          map.delete(sessionId)
+        } else {
+          map.set(sessionId, next)
+        }
+        return map
+      })
+    },
+  ),
+)
+
+/**
+ * Agent 运行中待发送消息队列 Map — 以 sessionId 为 key。
+ * 队列只保存在渲染进程内存中，避免跨重启恢复时误把过期上下文继续发送。
+ */
+export const agentSessionMessageQueueAtom = atom<Map<string, AgentQueuedMessage[]>>(new Map())
+
+/**
+ * 单个 session 的队列派生 atom（读写）。
+ * 空队列写回时删除 Map entry，避免长时间使用后残留空数组。
+ */
+export const agentMessageQueueAtomFamily = atomFamily((sessionId: string) =>
+  atom(
+    (get) => get(agentSessionMessageQueueAtom).get(sessionId) ?? [],
+    (_get, set, update: AgentQueuedMessage[] | ((prev: AgentQueuedMessage[]) => AgentQueuedMessage[])) => {
+      set(agentSessionMessageQueueAtom, (prev) => {
         const current = prev.get(sessionId) ?? []
         const next = typeof update === 'function' ? update(current) : update
         const map = new Map(prev)

--- a/apps/electron/src/renderer/components/agent/AgentMessageQueue.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessageQueue.tsx
@@ -1,0 +1,178 @@
+import * as React from 'react'
+import { Clock3, CornerDownLeft, GripVertical, Trash2, Undo2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import type { AgentQueuedMessage, QueueDropPlacement } from '@/lib/agent-message-queue'
+
+interface AgentMessageQueueProps {
+  items: AgentQueuedMessage[]
+  canSendNow: boolean
+  onSendNow: (messageId: string) => void
+  onRecall: (messageId: string) => void
+  onRemove: (messageId: string) => void
+  onMove: (sourceId: string, targetId: string, placement: QueueDropPlacement) => void
+}
+
+export function AgentMessageQueue({
+  items,
+  canSendNow,
+  onSendNow,
+  onRecall,
+  onRemove,
+  onMove,
+}: AgentMessageQueueProps): React.ReactElement | null {
+  const [draggingId, setDraggingId] = React.useState<string | null>(null)
+  const [dropTarget, setDropTarget] = React.useState<{ id: string; placement: QueueDropPlacement } | null>(null)
+
+  if (items.length === 0) return null
+
+  const resolvePlacement = (event: React.DragEvent<HTMLDivElement>): QueueDropPlacement => {
+    const rect = event.currentTarget.getBoundingClientRect()
+    return event.clientY > rect.top + rect.height / 2 ? 'after' : 'before'
+  }
+
+  const handleDragOver = (
+    event: React.DragEvent<HTMLDivElement>,
+    targetId: string,
+  ): void => {
+    event.stopPropagation()
+    if (!draggingId || draggingId === targetId) return
+    event.preventDefault()
+    setDropTarget({ id: targetId, placement: resolvePlacement(event) })
+  }
+
+  const handleDrop = (
+    event: React.DragEvent<HTMLDivElement>,
+    targetId: string,
+  ): void => {
+    event.stopPropagation()
+    event.preventDefault()
+    if (!draggingId || draggingId === targetId) return
+    onMove(draggingId, targetId, resolvePlacement(event))
+    setDraggingId(null)
+    setDropTarget(null)
+  }
+
+  return (
+    <div
+      className="border-b border-border/35 bg-muted/[0.18] px-2.5 pt-2 pb-1.5"
+      onDragEnter={(event) => event.stopPropagation()}
+      onDragOver={(event) => {
+        event.stopPropagation()
+        if (draggingId) event.preventDefault()
+      }}
+      onDragLeave={(event) => event.stopPropagation()}
+      onDrop={(event) => event.stopPropagation()}
+    >
+      <div className="flex items-center justify-between gap-2 px-1 pb-1 text-[12px] text-muted-foreground">
+        <span className="inline-flex items-center gap-1.5">
+          <Clock3 className="size-3.5" />
+          <span>队列</span>
+        </span>
+        <span className="tabular-nums">{items.length}</span>
+      </div>
+      <div className="space-y-1">
+        {items.map((item, index) => {
+          const isDragging = draggingId === item.id
+          const isDropBefore = dropTarget?.id === item.id && dropTarget.placement === 'before'
+          const isDropAfter = dropTarget?.id === item.id && dropTarget.placement === 'after'
+
+          return (
+            <div
+              key={item.id}
+              draggable
+              onDragStart={(event) => {
+                event.stopPropagation()
+                event.dataTransfer.effectAllowed = 'move'
+                event.dataTransfer.setData('text/plain', item.id)
+                setDraggingId(item.id)
+              }}
+              onDragOver={(event) => handleDragOver(event, item.id)}
+              onDrop={(event) => handleDrop(event, item.id)}
+              onDragEnd={(event) => {
+                event.stopPropagation()
+                setDraggingId(null)
+                setDropTarget(null)
+              }}
+              className={cn(
+                'relative flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors',
+                index === 0 ? 'bg-primary/[0.05]' : 'bg-background/35',
+                isDragging && 'opacity-45',
+                'hover:bg-background/60',
+              )}
+            >
+              {isDropBefore && <div className="absolute left-2 right-2 top-0 h-0.5 rounded-full bg-primary" />}
+              {isDropAfter && <div className="absolute left-2 right-2 bottom-0 h-0.5 rounded-full bg-primary" />}
+              <GripVertical className="size-4 shrink-0 cursor-grab text-muted-foreground/55 active:cursor-grabbing" />
+              <div className="min-w-0 flex-1 text-[13px] leading-5 text-foreground/80 line-clamp-2">
+                {item.text}
+              </div>
+              <div className="flex shrink-0 items-center gap-0.5">
+                <QueueIconButton
+                  label="立即发送"
+                  disabled={!canSendNow}
+                  onClick={() => onSendNow(item.id)}
+                >
+                  <CornerDownLeft className="size-3.5" />
+                </QueueIconButton>
+                <QueueIconButton
+                  label="撤回到输入框"
+                  onClick={() => onRecall(item.id)}
+                >
+                  <Undo2 className="size-3.5" />
+                </QueueIconButton>
+                <QueueIconButton
+                  label="删除"
+                  onClick={() => onRemove(item.id)}
+                  danger
+                >
+                  <Trash2 className="size-3.5" />
+                </QueueIconButton>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+interface QueueIconButtonProps {
+  label: string
+  disabled?: boolean
+  danger?: boolean
+  onClick: () => void
+  children: React.ReactNode
+}
+
+function QueueIconButton({
+  label,
+  disabled,
+  danger,
+  onClick,
+  children,
+}: QueueIconButtonProps): React.ReactElement {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          disabled={disabled}
+          className={cn(
+            'size-7 rounded-md text-muted-foreground hover:text-foreground',
+            danger && 'hover:text-destructive',
+          )}
+          onClick={onClick}
+        >
+          {children}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="top">
+        <p>{label}</p>
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -20,6 +20,7 @@ import { toast } from 'sonner'
 import { Bot, CornerDownLeft, Square, Settings, Paperclip, FolderPlus, X, Copy, Check, Brain, Sparkles, Eye } from 'lucide-react'
 import { AgentMessages } from './AgentMessages'
 import { AgentHeader } from './AgentHeader'
+import { AgentMessageQueue } from './AgentMessageQueue'
 import { ContextUsageBadge } from './ContextUsageBadge'
 import { PermissionBanner } from './PermissionBanner'
 import { PermissionModeSelector } from './PermissionModeSelector'
@@ -68,6 +69,7 @@ import {
   currentAgentWorkspaceIdAtom,
   agentPendingPromptAtom,
   agentPendingFilesAtomFamily,
+  agentMessageQueueAtomFamily,
   agentWorkspacesAtom,
   agentStreamErrorsAtom,
   agentSessionDraftsAtom,
@@ -93,6 +95,7 @@ import {
   sessionPersistedPermissionModeAtom,
   agentSessionPathMapAtom,
   allPendingAskUserRequestsAtom,
+  allPendingPermissionRequestsAtom,
   allPendingExitPlanRequestsAtom,
   finalizeStreamingActivities,
   agentProcessGroupsKeepExpandedAtom,
@@ -106,14 +109,40 @@ import { AgentSessionProvider } from '@/contexts/session-context'
 import { draftSessionIdsAtom } from '@/atoms/draft-session-atoms'
 import { sendWithCmdEnterAtom } from '@/atoms/shortcut-atoms'
 import { useOpenPreview } from '@/components/diff/preview-opener'
-import type { AgentSendInput, AgentPendingFile, FileDialogLargeFile, ModelOption, SDKMessage } from '@proma/shared'
+import type { AgentSendInput, AgentPendingFile, FileDialogLargeFile, ModelOption, SDKMessage, SDKUserMessage } from '@proma/shared'
 import { MAX_ATTACHMENT_SIZE } from '@proma/shared'
 import { fileToBase64, formatFileNames, getFileParentPath } from '@/lib/file-utils'
 import { createClipboardPendingFile, createClipboardTextDraft, makeUniqueAttachmentName } from '@/lib/clipboard-text-attachment'
+import {
+  createAgentQueuedMessage,
+  moveQueuedMessage,
+  parseQueuedMessageMentions,
+  queuedTextToParagraphHtml,
+  removeQueuedMessage,
+  restoreQueuedMessageToFront,
+} from '@/lib/agent-message-queue'
+import type { AgentQueuedMessage, QueueDropPlacement } from '@/lib/agent-message-queue'
 
 /** 稳定的空 SDKMessage 数组引用，避免 ?? [] 每次创建新引用 */
 const EMPTY_SDK_MESSAGES: SDKMessage[] = []
 const LONG_TEXT_ATTACHMENT_THRESHOLD = 2000
+
+interface OptimisticSDKUserMessage extends SDKUserMessage {
+  _createdAt: number
+}
+
+function createUserSDKMessage(text: string, uuid?: string, createdAt = Date.now()): SDKMessage {
+  const message: OptimisticSDKUserMessage = {
+    type: 'user',
+    uuid,
+    message: {
+      content: [{ type: 'text', text }],
+    },
+    parent_tool_use_id: null,
+    _createdAt: createdAt,
+  }
+  return message
+}
 
 interface SDKMessageRecord {
   type?: string
@@ -339,6 +368,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   }, [sessions, sessionId, globalWorkspaceId])
   const [pendingPrompt, setPendingPrompt] = useAtom(agentPendingPromptAtom)
   const [pendingFiles, setPendingFiles] = useAtom(agentPendingFilesAtomFamily(sessionId))
+  const [queuedMessages, setQueuedMessages] = useAtom(agentMessageQueueAtomFamily(sessionId))
   const workspaces = useAtomValue(agentWorkspacesAtom)
   // 保持 channelId 稳定：初始化前使用上次有效值，避免工具栏抖动
   const stableChannelIdRef = React.useRef(agentChannelId)
@@ -620,6 +650,14 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     return dirs
   }, [attachedDirs, workspaceDirs, attachedFiles, wsAttachedFiles])
 
+  const createBaseAdditionalDirectories = React.useCallback((): Set<string> => {
+    const dirs = new Set(attachedDirs)
+    for (const dir of attachedFileDirectories) {
+      dirs.add(dir)
+    }
+    return dirs
+  }, [attachedDirs, attachedFileDirectories])
+
   // 监听消息刷新版本号
   const refreshMap = useAtomValue(agentMessageRefreshAtom)
   const refreshVersion = refreshMap.get(sessionId) ?? 0
@@ -635,8 +673,156 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     setMessagesCache((prev) => setSessionMessagesCache(prev, sessionId, next))
   }, [sessionId, setMessagesCache])
 
+  const appendLiveUserMessage = React.useCallback((message: SDKMessage) => {
+    store.set(liveMessagesMapAtom, (prev) => {
+      const map = new Map(prev)
+      const current = map.get(sessionId) ?? []
+      map.set(sessionId, [...current, message])
+      return map
+    })
+  }, [sessionId, store])
+
+  const removeLiveUserMessage = React.useCallback((messageId: string) => {
+    store.set(liveMessagesMapAtom, (prev) => {
+      const map = new Map(prev)
+      const current = (map.get(sessionId) ?? []).filter(
+        (item) => (item as Record<string, unknown>).uuid !== messageId,
+      )
+      map.set(sessionId, current)
+      return map
+    })
+  }, [sessionId, store])
+
+  const clearStoppedByUser = React.useCallback(() => {
+    store.set(stoppedByUserSessionsAtom, (prev: Set<string>) => {
+      if (!prev.has(sessionId)) return prev
+      const next = new Set(prev)
+      next.delete(sessionId)
+      return next
+    })
+  }, [sessionId, store])
+
+  const queueMessageIntoActiveAgent = React.useCallback(async (
+    message: AgentQueuedMessage,
+    text: string,
+    mentions: ReturnType<typeof parseQueuedMessageMentions>,
+    interruptCurrentTurn: boolean,
+  ): Promise<void> => {
+    // 气泡显示用原文 text（保留 /skill: #mcp: &session: 语法），
+    // 让 message.tsx 的 remarkMentions 立即渲染出引用芯片；
+    // 剥离后的 cleanedText 仅用于传给 SDK，不作为展示文本。
+    appendLiveUserMessage(createUserSDKMessage(text, message.id, Date.now()))
+
+    try {
+      await window.electronAPI.queueAgentMessage({
+        sessionId,
+        userMessage: mentions.cleanedText,
+        rawUserMessage: text,
+        uuid: message.id,
+        interrupt: interruptCurrentTurn,
+        ...(mentions.mentionedSkills.length > 0 && { mentionedSkills: mentions.mentionedSkills }),
+        ...(mentions.mentionedMcpServers.length > 0 && { mentionedMcpServers: mentions.mentionedMcpServers }),
+        ...(mentions.mentionedSessionIds.length > 0 && { mentionedSessionIds: mentions.mentionedSessionIds }),
+      })
+    } catch (error) {
+      removeLiveUserMessage(message.id)
+      throw error
+    }
+  }, [appendLiveUserMessage, removeLiveUserMessage, sessionId])
+
+  const startQueuedMessageRun = React.useCallback(async (
+    text: string,
+    mentions: ReturnType<typeof parseQueuedMessageMentions>,
+    channelId: string,
+  ): Promise<void> => {
+    const streamStartedAt = Date.now()
+    const additionalDirectoriesForRun = createBaseAdditionalDirectories()
+    setStreamingStates((prev) => {
+      const map = new Map(prev)
+      const existing = prev.get(sessionId)
+      map.set(sessionId, {
+        running: true,
+        content: '',
+        toolActivities: [],
+        model: agentModelId || undefined,
+        startedAt: streamStartedAt,
+        inputTokens: existing?.inputTokens,
+        contextWindow: existing?.contextWindow,
+      })
+      return map
+    })
+
+    appendOptimisticPersistedMessage(createUserSDKMessage(text, undefined, streamStartedAt))
+
+    try {
+      await window.electronAPI.sendAgentMessage({
+        sessionId,
+        userMessage: text,
+        channelId,
+        modelId: agentModelId || undefined,
+        workspaceId: currentWorkspaceId || undefined,
+        startedAt: streamStartedAt,
+        permissionModeOverride: permissionMode,
+        ...(additionalDirectoriesForRun.size > 0 && {
+          additionalDirectories: Array.from(additionalDirectoriesForRun),
+        }),
+        ...(mentions.mentionedSkills.length > 0 && { mentionedSkills: mentions.mentionedSkills }),
+        ...(mentions.mentionedMcpServers.length > 0 && { mentionedMcpServers: mentions.mentionedMcpServers }),
+        ...(mentions.mentionedSessionIds.length > 0 && { mentionedSessionIds: mentions.mentionedSessionIds }),
+      })
+    } catch (error) {
+      setStreamingStates((prev) => {
+        const current = prev.get(sessionId)
+        if (!current) return prev
+        const map = new Map(prev)
+        map.set(sessionId, { ...current, running: false })
+        return map
+      })
+      throw error
+    }
+  }, [
+    agentModelId,
+    appendOptimisticPersistedMessage,
+    createBaseAdditionalDirectories,
+    currentWorkspaceId,
+    permissionMode,
+    sessionId,
+    setStreamingStates,
+  ])
+
+  const sendPlainTextAgentMessage = React.useCallback(async (
+    message: AgentQueuedMessage,
+  ): Promise<void> => {
+    const text = message.text.trim()
+    if (!text || !agentChannelId || !hasAvailableModel) return
+
+    const mentions = parseQueuedMessageMentions(text)
+    clearStoppedByUser()
+
+    // interrupt 由本函数读到的实时 streaming 决定，而非调用方传入的快照：
+    // - streaming（本轮真正进行中）：注入前需软中断当前 turn
+    // - backgroundWaiting（软空闲，无活跃 turn）：直接注入，无需中断
+    // 避免"外层判定 streaming、内层已结束"两个快照不一致导致的竞态。
+    if (streaming || backgroundWaiting) {
+      await queueMessageIntoActiveAgent(message, text, mentions, streaming)
+      return
+    }
+
+    await startQueuedMessageRun(text, mentions, agentChannelId)
+  }, [
+    agentChannelId,
+    backgroundWaiting,
+    clearStoppedByUser,
+    hasAvailableModel,
+    queueMessageIntoActiveAgent,
+    startQueuedMessageRun,
+    streaming,
+  ])
+
   // 消息是否已完成首次加载（用于 auto-send 等待）
   const [messagesLoaded, setMessagesLoaded] = React.useState(false)
+  const [messagesRefreshing, setMessagesRefreshing] = React.useState(false)
+  const messagesRefreshingRef = React.useRef(false)
   const loadingSessionIdRef = React.useRef<string | null>(null)
 
   // 加载当前会话消息
@@ -659,6 +845,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         setMessagesLoaded(false)
       }
     }
+    messagesRefreshingRef.current = true
+    setMessagesRefreshing(true)
     let cancelled = false
     window.electronAPI.getAgentSessionSDKMessages(sessionId)
       .then((sdkMsgs) => {
@@ -666,8 +854,11 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         // 写入缓存（含 LRU 淘汰，防止会话数增长导致内存无限膨胀）
         setMessagesCache((prev) => setSessionMessagesCache(prev, sessionId, sdkMsgs))
         unstable_batchedUpdates(() => {
+          persistedSDKMessagesRef.current = sdkMsgs
           setPersistedSDKMessages(sdkMsgs)
           setMessagesLoaded(true)
+          messagesRefreshingRef.current = false
+          setMessagesRefreshing(false)
 
           // 消息加载完成后，同步清除流式展示状态和实时消息，
           // 确保 React 在一次渲染中同时显示持久化消息并移除流式气泡/实时消息，
@@ -722,6 +913,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         if (cancelled) return
         console.error(error)
         setMessagesLoaded(true)
+        messagesRefreshingRef.current = false
+        setMessagesRefreshing(false)
       })
     return () => { cancelled = true }
   }, [sessionId, refreshVersion, setStreamingStates, setLiveMessagesMap, setMessagesCache, store])
@@ -1267,17 +1460,16 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     const effectiveText = text || suggestion || ''
     const pendingFilesSnapshot = pendingFilesRef.current
     if (!messagesLoaded || (!effectiveText && pendingFilesSnapshot.length === 0) || !agentChannelId || !hasAvailableModel) return
-    const additionalDirectoriesForRun = new Set(attachedDirs)
-    for (const dir of attachedFileDirectories) {
-      additionalDirectoriesForRun.add(dir)
+    if (!streaming && messagesRefreshingRef.current) {
+      toast.info('上一轮消息正在同步', {
+        description: '请稍等片刻再发送；队列会在同步完成后继续。',
+      })
+      return
     }
+    const additionalDirectoriesForRun = createBaseAdditionalDirectories()
 
-    // 上一条消息仍在处理中（streaming），或后台任务等待态（backgroundWaiting，通道仍开着）：
-    // 都走注入通道而非新建 run，避免被服务端并发守卫拒绝。
-    // - streaming：本轮真正进行中，注入时需先软中断当前 turn
-    // - backgroundWaiting：软空闲、无活跃 turn，直接注入即可，无需中断
-    if (streaming || backgroundWaiting) {
-      // 流式追加时不处理附件（仅支持纯文本）
+    if (streaming) {
+      // Agent 正在输出时，用户消息默认进入 Proma 托管队列，不打断当前 turn。
       if (pendingFilesSnapshot.length > 0) {
         toast.info('Agent 运行中暂不支持追加发送附件', {
           description: '请等待完成后再发送附件，或先撤除附件仅发送文本',
@@ -1285,57 +1477,10 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         return
       }
 
-      // 流式注入路径：提取 Proma 引用语法并结构化传递，剥离引用文本后其余原样透传 SDK
-      // queueMessage 已支持 mentionedSkills/Mcp/SessionIds，引用可完整传递。
-      const REF_PATTERN = /\/skill:(?<skill>\S+)|#mcp:(?<mcp>\S+)|&session:(?<session>\S+)/g
-      const mentionedSkills: string[] = []
-      const mentionedMcpServers: string[] = []
-      const mentionedSessionIds: string[] = []
-      for (const m of effectiveText.matchAll(REF_PATTERN)) {
-        const { skill, mcp, session } = m.groups ?? {}
-        if (skill) mentionedSkills.push(skill)
-        else if (mcp) mentionedMcpServers.push(mcp)
-        else if (session) mentionedSessionIds.push(session)
-      }
-      const cleanedText = effectiveText.replace(REF_PATTERN, '').trim()
-      // 引用已受理：告知用户引用将注入下一轮 prompt
-      const hasRefs = mentionedSkills.length > 0 || mentionedMcpServers.length > 0 || mentionedSessionIds.length > 0
-      if (hasRefs) {
-        const labels = [
-          ...mentionedSkills.map(s => `/skill:${s}`),
-          ...mentionedMcpServers.map(m => `#mcp:${m}`),
-          ...mentionedSessionIds.map(id => `&session:${id}`),
-        ]
-        toast.info(`已受理引用：${labels.join('、')}`, {
-          description: '将在下一轮 Agent 回复中生效',
-        })
-      }
-
-      const localUuid = crypto.randomUUID()
-
-      // 1. 立即注入 liveMessages（作为普通用户消息显示）
-      // 若纯引用无实质文本，用原始输入作为气泡内容（避免空气泡）
-      const displayText = cleanedText || effectiveText
-      const syntheticMsg: import('@proma/shared').SDKMessage = {
-        type: 'user',
-        uuid: localUuid,
-        message: {
-          content: [{ type: 'text', text: displayText }],
-        },
-        parent_tool_use_id: null,
-        _createdAt: Date.now(),
-      } as unknown as import('@proma/shared').SDKMessage
-
-      store.set(liveMessagesMapAtom, (prev) => {
-        const map = new Map(prev)
-        const current = map.get(sessionId) ?? []
-        map.set(sessionId, [...current, syntheticMsg])
-        return map
-      })
-
-      // 2. 清空输入框（仅当发送的是用户自己输入的内容，而非推荐建议时）
-      // 用 === undefined 与上方 `overrideText ?? inputContent` 的取值语义保持一致，
-      // 避免未来出现 handleSend('') 时两条路径行为割裂
+      setQueuedMessages((prev) => [
+        ...prev,
+        createAgentQueuedMessage(effectiveText, crypto.randomUUID(), Date.now()),
+      ])
       if (overrideText === undefined) {
         setInputContent('')
         setInputHtmlContent('')
@@ -1347,30 +1492,32 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         return map
       })
 
-      // 3. 异步发送到后端，注入消息作为新一轮输入。
-      //    - streaming（本轮真正进行中）：先软中断当前 turn 再注入
-      //    - backgroundWaiting（软空闲，无活跃 turn）：直接注入，无需中断
-      window.electronAPI.queueAgentMessage({
-        sessionId,
-        userMessage: cleanedText,
-        rawUserMessage: effectiveText,
-        uuid: localUuid,
-        interrupt: streaming,
-        ...(mentionedSkills.length > 0 && { mentionedSkills }),
-        ...(mentionedMcpServers.length > 0 && { mentionedMcpServers }),
-        ...(mentionedSessionIds.length > 0 && { mentionedSessionIds }),
-      }).catch((error) => {
+      return
+    }
+
+    if (backgroundWaiting) {
+      // 软空闲态没有活跃输出，直接注入，无需中断。
+      if (pendingFilesSnapshot.length > 0) {
+        toast.info('Agent 后台等待中暂不支持追加发送附件', {
+          description: '请等待完成后再发送附件，或先撤除附件仅发送文本',
+        })
+        return
+      }
+
+      const message = createAgentQueuedMessage(effectiveText, crypto.randomUUID(), Date.now())
+      if (overrideText === undefined) {
+        setInputContent('')
+        setInputHtmlContent('')
+      }
+      setPromptSuggestions((prev) => {
+        if (!prev.has(sessionId)) return prev
+        const map = new Map(prev)
+        map.delete(sessionId)
+        return map
+      })
+      sendPlainTextAgentMessage(message).catch((error) => {
         console.error('[AgentView] 追加消息失败:', error)
         toast.error('追加消息失败', { description: String(error) })
-        // 回滚：从 liveMessages 移除
-        store.set(liveMessagesMapAtom, (prev) => {
-          const map = new Map(prev)
-          const current = (map.get(sessionId) ?? []).filter(
-            (m) => (m as unknown as { uuid?: string }).uuid !== localUuid
-          )
-          map.set(sessionId, current)
-          return map
-        })
       })
       return
     }
@@ -1523,6 +1670,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
 
     // 2. 构建最终消息
     const finalMessage = fileReferences + effectiveText
+    const mentions = parseQueuedMessageMentions(effectiveText)
 
     // 清除打断状态（上一轮的打断标记不再显示）
     store.set(stoppedByUserSessionsAtom, (prev: Set<string>) => {
@@ -1577,17 +1725,9 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       startedAt: streamStartedAt,
       permissionModeOverride: permissionMode,
       ...(additionalDirectoriesForRun.size > 0 && { additionalDirectories: Array.from(additionalDirectoriesForRun) }),
-      // 解析用户消息中的 Skill/MCP/会话引用，传递结构化元数据给后端
-      ...(() => {
-        const skills = [...effectiveText.matchAll(/\/skill:(\S+)/g)].map(m => m[1]).filter(Boolean) as string[]
-        const mcps = [...effectiveText.matchAll(/#mcp:(\S+)/g)].map(m => m[1]).filter(Boolean) as string[]
-        const sessionIds = [...effectiveText.matchAll(/&session:(\S+)/g)].map(m => m[1]).filter(Boolean) as string[]
-        return {
-          ...(skills.length > 0 && { mentionedSkills: skills }),
-          ...(mcps.length > 0 && { mentionedMcpServers: mcps }),
-          ...(sessionIds.length > 0 && { mentionedSessionIds: sessionIds }),
-        }
-      })(),
+      ...(mentions.mentionedSkills.length > 0 && { mentionedSkills: mentions.mentionedSkills }),
+      ...(mentions.mentionedMcpServers.length > 0 && { mentionedMcpServers: mentions.mentionedMcpServers }),
+      ...(mentions.mentionedSessionIds.length > 0 && { mentionedSessionIds: mentions.mentionedSessionIds }),
     }
 
     // 清空输入框（仅当发送的是用户自己输入的内容，而非推荐建议时）
@@ -1608,10 +1748,16 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         return map
       })
     })
-  }, [inputContent, attachedDirs, attachedFileDirectories, sessionId, agentChannelId, agentModelId, currentWorkspaceId, workspaces, streaming, backgroundWaiting, suggestion, hasAvailableModel, store, setStreamingStates, setPendingFiles, setAgentStreamErrors, setPromptSuggestions, setInputContent, setLiveMessagesMap, permissionMode, messagesLoaded])
+  }, [inputContent, createBaseAdditionalDirectories, sessionId, agentChannelId, agentModelId, currentWorkspaceId, workspaces, streaming, backgroundWaiting, suggestion, hasAvailableModel, store, setStreamingStates, setPendingFiles, setAgentStreamErrors, setPromptSuggestions, setInputContent, setLiveMessagesMap, permissionMode, messagesLoaded, setQueuedMessages, sendPlainTextAgentMessage])
 
   /** 停止生成 */
   const handleStop = React.useCallback((): void => {
+    store.set(stoppedByUserSessionsAtom, (prev: Set<string>) => {
+      const next = new Set(prev)
+      next.add(sessionId)
+      return next
+    })
+
     setStreamingStates((prev) => {
       const current = prev.get(sessionId)
       if (!current || !current.running) return prev
@@ -1625,7 +1771,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     })
 
     window.electronAPI.stopAgent(sessionId).catch(console.error)
-  }, [sessionId, setStreamingStates])
+  }, [sessionId, setStreamingStates, store])
 
   /** 手动发送 /compact 命令 */
   const handleCompact = React.useCallback((): void => {
@@ -1908,10 +2054,102 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   }, [])
 
   const allAskUserRequests = useAtomValue(allPendingAskUserRequestsAtom)
+  const allPermissionRequests = useAtomValue(allPendingPermissionRequestsAtom)
   const allExitPlanRequests = useAtomValue(allPendingExitPlanRequestsAtom)
   const hasBannerOverlay =
     (allAskUserRequests.get(sessionId)?.length ?? 0) > 0 ||
     (allExitPlanRequests.get(sessionId)?.length ?? 0) > 0
+  const hasBlockingRequests = hasBannerOverlay || (allPermissionRequests.get(sessionId)?.length ?? 0) > 0
+  const canSendQueuedNow = messagesLoaded && (streaming || !messagesRefreshing) && !!agentChannelId && hasAvailableModel && !hasBlockingRequests
+  const autoSendingQueuedRef = React.useRef(false)
+  const queuedSendInFlightRef = React.useRef(false)
+  const sendingQueuedMessageIdsRef = React.useRef<Set<string>>(new Set())
+
+  const handleSendQueuedNow = React.useCallback((messageId: string): void => {
+    if (!canSendQueuedNow) return
+    if (!streaming && messagesRefreshingRef.current) return
+    if (queuedSendInFlightRef.current || sendingQueuedMessageIdsRef.current.has(messageId)) return
+    const message = queuedMessages.find((item) => item.id === messageId)
+    if (!message) return
+
+    queuedSendInFlightRef.current = true
+    sendingQueuedMessageIdsRef.current.add(messageId)
+    setQueuedMessages((prev) => removeQueuedMessage(prev, messageId))
+    sendPlainTextAgentMessage(message)
+      .catch((error) => {
+        console.error('[AgentView] 队列消息发送失败:', error)
+        toast.error('队列消息发送失败', { description: String(error) })
+        setQueuedMessages((prev) => restoreQueuedMessageToFront(prev, message))
+      })
+      .finally(() => {
+        sendingQueuedMessageIdsRef.current.delete(messageId)
+        queuedSendInFlightRef.current = false
+      })
+  }, [canSendQueuedNow, queuedMessages, sendPlainTextAgentMessage, setQueuedMessages, streaming])
+
+  const handleRecallQueuedMessage = React.useCallback((messageId: string): void => {
+    const message = queuedMessages.find((item) => item.id === messageId)
+    if (!message) return
+
+    setQueuedMessages((prev) => removeQueuedMessage(prev, messageId))
+
+    const hasDraft = inputContent.trim().length > 0
+    const nextDraft = hasDraft
+      ? `${inputContent.trimEnd()}\n\n${message.text}`
+      : message.text
+    setInputContent(nextDraft)
+
+    // 已有草稿时，用「原草稿 HTML + 队列文本段落 HTML」合并，保留原草稿的 mention 等富文本节点；
+    // 空草稿时留空 HTML，交给编辑器按纯文本重建（与正常输入渲染一致）。
+    if (hasDraft) {
+      const draftHtml = inputHtmlContent.trim().length > 0
+        ? inputHtmlContent
+        : queuedTextToParagraphHtml(inputContent)
+      setInputHtmlContent(`${draftHtml}${queuedTextToParagraphHtml(message.text)}`)
+    } else {
+      setInputHtmlContent('')
+    }
+  }, [inputContent, inputHtmlContent, queuedMessages, setInputContent, setInputHtmlContent, setQueuedMessages])
+
+  const handleRemoveQueuedMessage = React.useCallback((messageId: string): void => {
+    setQueuedMessages((prev) => removeQueuedMessage(prev, messageId))
+  }, [setQueuedMessages])
+
+  const handleMoveQueuedMessage = React.useCallback((
+    sourceId: string,
+    targetId: string,
+    placement: QueueDropPlacement,
+  ): void => {
+    setQueuedMessages((prev) => moveQueuedMessage(prev, sourceId, targetId, placement))
+  }, [setQueuedMessages])
+
+  React.useEffect(() => {
+    if (autoSendingQueuedRef.current) return
+    if (queuedSendInFlightRef.current) return
+    if (queuedMessages.length === 0) return
+    if (messagesRefreshingRef.current) return
+    if (!canSendQueuedNow || streaming || stoppedByUser) return
+
+    const message = queuedMessages[0]
+    if (!message) return
+    if (sendingQueuedMessageIdsRef.current.has(message.id)) return
+
+    autoSendingQueuedRef.current = true
+    queuedSendInFlightRef.current = true
+    sendingQueuedMessageIdsRef.current.add(message.id)
+    setQueuedMessages((prev) => removeQueuedMessage(prev, message.id))
+    sendPlainTextAgentMessage(message)
+      .catch((error) => {
+        console.error('[AgentView] 自动发送队列消息失败:', error)
+        toast.error('自动发送队列消息失败', { description: String(error) })
+        setQueuedMessages((prev) => restoreQueuedMessageToFront(prev, message))
+      })
+      .finally(() => {
+        sendingQueuedMessageIdsRef.current.delete(message.id)
+        queuedSendInFlightRef.current = false
+        autoSendingQueuedRef.current = false
+      })
+  }, [canSendQueuedNow, queuedMessages, sendPlainTextAgentMessage, setQueuedMessages, stoppedByUser, streaming])
 
   // ===== 预览面板状态（toggle 快捷键，分屏布局在 MainArea） =====
   const setPreviewOpenMap = useSetAtom(previewPanelOpenMapAtom)
@@ -1931,7 +2169,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   }, [togglePreviewPanel])
 
   const hasTextInput = inputContent.trim().length > 0
-  const canSend = messagesLoaded && (hasTextInput || pendingFiles.length > 0 || !!suggestion) && agentChannelId !== null && hasAvailableModel && (!streaming || hasTextInput)
+  const canSend = messagesLoaded && (streaming || !messagesRefreshing) && (hasTextInput || pendingFiles.length > 0 || !!suggestion) && agentChannelId !== null && hasAvailableModel && (!streaming || hasTextInput)
 
   const inputToolbarItems = React.useMemo<ToolbarItem[]>(() => [
     {
@@ -2172,6 +2410,15 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
                 )}
               </div>
             )}
+
+            <AgentMessageQueue
+              items={queuedMessages}
+              canSendNow={canSendQueuedNow}
+              onSendNow={handleSendQueuedNow}
+              onRecall={handleRecallQueuedMessage}
+              onRemove={handleRemoveQueuedMessage}
+              onMove={handleMoveQueuedMessage}
+            />
 
             {/* Agent 建议提示 */}
             {suggestion && !streaming && (

--- a/apps/electron/src/renderer/lib/agent-message-queue.ts
+++ b/apps/electron/src/renderer/lib/agent-message-queue.ts
@@ -1,0 +1,108 @@
+export type QueueDropPlacement = 'before' | 'after'
+
+export interface AgentQueuedMessage {
+  id: string
+  text: string
+  createdAt: number
+}
+
+export function createAgentQueuedMessage(
+  text: string,
+  id: string,
+  createdAt: number,
+): AgentQueuedMessage {
+  return {
+    id,
+    text: text.trim(),
+    createdAt,
+  }
+}
+
+export function removeQueuedMessage(
+  queue: AgentQueuedMessage[],
+  messageId: string,
+): AgentQueuedMessage[] {
+  return queue.filter((item) => item.id !== messageId)
+}
+
+export function restoreQueuedMessageToFront(
+  queue: AgentQueuedMessage[],
+  message: AgentQueuedMessage,
+): AgentQueuedMessage[] {
+  if (queue.some((item) => item.id === message.id)) return queue
+  return [message, ...queue]
+}
+
+export function moveQueuedMessage(
+  queue: AgentQueuedMessage[],
+  sourceId: string,
+  targetId: string,
+  placement: QueueDropPlacement,
+): AgentQueuedMessage[] {
+  if (sourceId === targetId) return queue
+
+  const source = queue.find((item) => item.id === sourceId)
+  if (!source) return queue
+
+  const withoutSource = queue.filter((item) => item.id !== sourceId)
+  const targetIndex = withoutSource.findIndex((item) => item.id === targetId)
+  if (targetIndex === -1) return queue
+
+  const insertIndex = placement === 'after' ? targetIndex + 1 : targetIndex
+  return [
+    ...withoutSource.slice(0, insertIndex),
+    source,
+    ...withoutSource.slice(insertIndex),
+  ]
+}
+
+export interface ParsedQueuedMessageMentions {
+  cleanedText: string
+  mentionedSkills: string[]
+  mentionedMcpServers: string[]
+  mentionedSessionIds: string[]
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+/**
+ * 把纯文本队列消息转成与 RichTextInput 段落渲染一致的 HTML：
+ * 双换行分段落，单换行转 <br>，并转义 HTML 特殊字符避免破坏结构。
+ * 用于撤回时保留已有草稿的富文本节点（mention 等），同时让队列文本按正常段落显示。
+ */
+export function queuedTextToParagraphHtml(text: string): string {
+  const normalized = text.trim()
+  if (!normalized) return ''
+  return normalized
+    .split(/\n\n+/)
+    .map((para) => `<p>${escapeHtml(para).replace(/\n/g, '<br>')}</p>`)
+    .join('')
+}
+
+
+const REF_PATTERN = /\/skill:(?<skill>\S+)|#mcp:(?<mcp>\S+)|&session:(?<session>\S+)/g
+
+export function parseQueuedMessageMentions(text: string): ParsedQueuedMessageMentions {
+  const mentionedSkills: string[] = []
+  const mentionedMcpServers: string[] = []
+  const mentionedSessionIds: string[] = []
+
+  for (const match of text.matchAll(REF_PATTERN)) {
+    const { skill, mcp, session } = match.groups ?? {}
+    if (skill) mentionedSkills.push(skill)
+    else if (mcp) mentionedMcpServers.push(mcp)
+    else if (session) mentionedSessionIds.push(session)
+  }
+
+  return {
+    cleanedText: text.replace(REF_PATTERN, '').trim(),
+    mentionedSkills,
+    mentionedMcpServers,
+    mentionedSessionIds,
+  }
+}


### PR DESCRIPTION
## 背景 / 问题
Agent 正在输出时，用户新输入会直接软中断当前 turn 再注入，用户无法提前做下一步任务派发，缺少可见的排队与管理能力，也无法在发送前调整顺序或撤回。

## 具体修改
新增渲染进程内存中的 **Agent 消息托管队列**：

- `lib/agent-message-queue.ts`（新增）— 队列纯函数：增/删/移动、引用语法解析（`/skill:` `#mcp:` `&session:`）、纯文本转段落 HTML。无副作用，易测试。
- `components/agent/AgentMessageQueue.tsx`（新增）— 队列 UI：拖拽排序、立即发送、撤回到输入框、删除，附插入位提示线。
- `atoms/agent-atoms.ts` — 新增以 sessionId 为 key 的队列 atom family，空队列自动清理 Map entry。
- `components/agent/AgentView.tsx` — 接入队列：
  - Agent 输出时用户消息进入队列而非直接打断；turn 结束后按序自动发送。
  - 停止（handleStop）即暂停队列 drain，符合"停止即停止"直觉。
  - 统一并去重了原先散落两处的引用解析逻辑。

### 本次修复的问题
1. **interrupt 竞态** — 立即发送的 interrupt 由函数内部实时 `streaming` 派生，消除"外层判定 streaming、内层已结束"的快照不一致。
2. **撤回样式一致** — 已有草稿时合并原草稿 HTML + 队列文本段落 HTML，保留 mention 等富文本节点，不再压平成字面文本。
3. **拖拽 placement 计算** — 抽出复用，去重。
4. **立即发送时 skill 芯片丢失** — 乐观气泡改用原文（保留 `/skill:` 语法），芯片即时渲染，不再等回答结束后才出现。

## 审查情况
- 自审查：最小修改、乐观更新/回滚路径完整、队列刻意不持久化。
- `tsc --noEmit` 编译通过。
- 用户已手动测试，功能与四项修复均验证通过。
<img width="4476" height="2424" alt="image" src="https://github.com/user-attachments/assets/5f2fcf88-d652-4e40-9000-be3da8fa927b" />
