### PR TITLE
【已审核】fix(diff): 预览面板滚动位置在写无关文件时不再重置

### DIFF
--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -302,8 +302,41 @@ export const agentDiffPanelTabAtom = atom<Map<string, 'session' | 'workspace' | 
 /** Diff 视图模式：'split' | 'unified'，默认使用统一预览 */
 export const agentDiffViewModeAtom = atom<'split' | 'unified'>('unified')
 
-/** Diff 刷新版本号 — 按 session 隔离，Agent 写工具完成时递增 */
-export const agentDiffRefreshVersionAtom = atom(new Map<string, number>())
+/**
+ * Diff 刷新版本号 — 按 session 隔离，Agent 写工具完成时递增。
+ *
+ * value 为 { version, writtenPath? }：
+ * - version：单调递增，缓存 key 含 version 使旧缓存自然失效
+ * - writtenPath：可选，定向失效时携带被写文件路径；消费方据此跳过无关路径的刷新
+ *   - 写工具 / Markdown 保存：带 writtenPath，仅刷新命中该路径的面板/目录
+ *   - git 突变 / revert / 手动刷新 / 独立窗口刷新：不带 writtenPath，全域刷新
+ */
+export interface AgentDiffRefreshVersion {
+  version: number
+  /** 定向失效的被写文件路径；undefined 表示全域刷新 */
+  writtenPath?: string
+}
+export const agentDiffRefreshVersionAtom = atom(new Map<string, AgentDiffRefreshVersion>())
+
+/**
+ * 递增 session 的 diff 刷新版本号，返回新 Map。
+ *
+ * 定向失效语义：携带 writtenPath 时仅刷新命中该路径的面板；
+ * 消费方（DiffTabContent）按 version 单调递增响应，每帧定向信息独立生效，
+ * 无需担心连续写不同文件时中间态被覆盖——每个 version 都会被订阅消费一次。
+ *
+ * @param writtenPath 省略表示显式全域刷新（git 突变/revert/手动/聚焦检测）
+ */
+export function bumpDiffRefreshVersion(
+  prev: Map<string, AgentDiffRefreshVersion>,
+  sessionId: string,
+  writtenPath?: string,
+): Map<string, AgentDiffRefreshVersion> {
+  const m = new Map(prev)
+  const prevVersion = prev.get(sessionId)?.version ?? 0
+  m.set(sessionId, { version: prevVersion + 1, writtenPath })
+  return m
+}
 
 /** 当前会话选中的 worktree 路径，null = 默认行为（显示 session 改动） */
 export const agentSelectedWorktreeAtom = atom(new Map<string, string | null>())

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -96,6 +96,7 @@ import {
   allPendingExitPlanRequestsAtom,
   finalizeStreamingActivities,
   agentProcessGroupsKeepExpandedAtom,
+  bumpDiffRefreshVersion,
 } from '@/atoms/agent-atoms'
 import type { AgentContextStatus } from '@/atoms/agent-atoms'
 import { settingsOpenAtom } from '@/atoms/settings-tab'
@@ -1864,9 +1865,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       })
 
       // 刷新预览面板的 diff（文件已被回退，当前显示的内容已过期）
-      store.set(agentDiffRefreshVersionAtom, (prev) => {
-        const m = new Map(prev); m.set(sessionId, (prev.get(sessionId) ?? 0) + 1); return m
-      })
+      // revert 可能影响多文件，保持全域刷新
+      store.set(agentDiffRefreshVersionAtom, (prev) => bumpDiffRefreshVersion(prev, sessionId))
 
       if (result.fileRewind?.canRewind) {
         const fileCount = result.fileRewind.filesChanged?.length ?? 0

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -110,7 +110,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   const filesVersion = useAtomValue(workspaceFilesVersionAtom)
   const setFilesVersion = useSetAtom(workspaceFilesVersionAtom)
   const diffRefreshVersionMap = useAtomValue(agentDiffRefreshVersionAtom)
-  const diffRefreshVersion = diffRefreshVersionMap.get(sessionId) ?? 0
+  const diffRefreshVersion = diffRefreshVersionMap.get(sessionId)?.version ?? 0
   const hasFileChanges = filesVersion > 0
 
   // 派生当前工作区 slug（用于 FileDropZone IPC 调用）

--- a/apps/electron/src/renderer/components/diff/DetachedPreviewApp.tsx
+++ b/apps/electron/src/renderer/components/diff/DetachedPreviewApp.tsx
@@ -8,7 +8,7 @@ import * as React from 'react'
 import { AlertCircle, RefreshCw } from 'lucide-react'
 import { useSetAtom } from 'jotai'
 import type { DetachedPreviewWindowData } from '@proma/shared'
-import { agentDiffRefreshVersionAtom } from '@/atoms/agent-atoms'
+import { agentDiffRefreshVersionAtom, bumpDiffRefreshVersion } from '@/atoms/agent-atoms'
 import { cn } from '@/lib/utils'
 import { DiffTabContent } from './DiffTabContent'
 import { DefaultAppOpenButton } from './DefaultAppOpenButton'
@@ -54,11 +54,8 @@ export function DetachedPreviewApp(): React.ReactElement {
 
   const handleRefresh = React.useCallback(() => {
     if (!data) return
-    setRefreshVersionMap((prev) => {
-      const map = new Map(prev)
-      map.set(data.sessionId, (prev.get(data.sessionId) ?? 0) + 1)
-      return map
-    })
+    // 用户主动刷新：全域失效
+    setRefreshVersionMap((prev) => bumpDiffRefreshVersion(prev, data.sessionId))
   }, [data, setRefreshVersionMap])
 
   if (loading) {

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -12,7 +12,7 @@ import DOMPurify from 'dompurify'
 import { File as PierreFile } from '@pierre/diffs/react'
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
-import { agentDiffViewModeAtom, agentDiffRefreshVersionAtom } from '@/atoms/agent-atoms'
+import { agentDiffViewModeAtom, agentDiffRefreshVersionAtom, bumpDiffRefreshVersion } from '@/atoms/agent-atoms'
 import { resolvedThemeAtom } from '@/atoms/theme'
 import { quotedSelectionMapAtom } from '@/atoms/preview-atoms'
 import { markdownTocOpenAtom } from '@/atoms/markdown-toc'
@@ -24,6 +24,19 @@ import { PreviewFindBar } from './PreviewFindBar'
 import { MarkdownToc } from './MarkdownToc'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { PIERRE_FILE_CSS } from '@/components/agent/tool-result-renderers/pierre-styles'
+
+/**
+ * 判断定向失效的 writtenPath 是否指向当前预览文件。
+ * writtenPath 来自 Agent 工具 input.file_path（可能绝对路径），
+ * filePath 来自 previewFileMap（可能相对路径），两者形态可能不一致。
+ * 统一正斜杠后比较：完全相等，或 writtenPath 以 '/'+filePath 结尾（绝对路径包住相对路径）。
+ * Windows 文件系统大小写不敏感，比较前统一 toLowerCase，避免同文件因大小写差异被误判为无关。
+ */
+function isSameFile(writtenPath: string, filePath: string): boolean {
+  const w = writtenPath.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase()
+  const f = filePath.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase()
+  return w === f || (f.length > 0 && w.endsWith('/' + f))
+}
 
 const MD_EXTS = new Set(['.md', '.markdown'])
 const PLAIN_TEXT_EDIT_EXTS = new Set(['.txt', '.text', '.log'])
@@ -229,7 +242,12 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   const [copied, setCopied] = React.useState(false)
   const refreshVersionMap = useAtomValue(agentDiffRefreshVersionAtom)
   const setRefreshVersionMap = useSetAtom(agentDiffRefreshVersionAtom)
-  const refreshVersion = refreshVersionMap.get(sessionId) ?? 0
+  const refreshEntry = refreshVersionMap.get(sessionId) ?? { version: 0 }
+  const refreshVersion = refreshEntry.version
+  /** 定向失效的被写文件路径；undefined 表示全域刷新（git 突变/revert/手动/聚焦检测） */
+  const refreshWrittenPath = refreshEntry.writtenPath
+  /** 本次定向失效未命中当前预览文件 → 无关刷新，跳过重读/清滚动以保留位置 */
+  const isUnrelatedRefresh = refreshWrittenPath !== undefined && !isSameFile(refreshWrittenPath, filePath)
   const previewContentVersion = previewOnly ? refreshVersion : 0
   const theme = useAtomValue(resolvedThemeAtom)
   const [tocOpen, setTocOpen] = useAtom(markdownTocOpenAtom)
@@ -524,9 +542,16 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
 
   // 主加载 effect：上下文变化（filePath/dirPath/gitRoot/previewOnly）时触发；
   // 纯预览模式也跟随 refreshVersion 失效，保证同一文件二次写入后重新读盘。
-  // 命中缓存时跳过 loading 闪烁直接渲染；未命中走 IPC 拉取
+  // 命中缓存时跳过 loading 闪烁直接渲染；未命中走 IPC 拉取。
+  // 定向失效优化：若 bump 携带 writtenPath 且不是当前预览文件，说明改的是别的文件，
+  // 当前预览内容未变，跳过重读以保留滚动位置和渲染态。
   React.useEffect(() => {
     let cancelled = false
+
+    if (previewOnly && isUnrelatedRefresh) {
+      // 与本次 bump 无关：内容未变，不重读、不清空，保留当前渲染与滚动位置
+      return
+    }
 
     // 所有文件类型均可缓存（含 PDF/DOCX/Office/Image）
     const cacheKey = previewOnly
@@ -655,7 +680,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     load()
     return () => { cancelled = true }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filePath, dirPath, gitRoot, previewOnly, previewContentVersion, fileAccess, isPdf, isDocx, isOfficePreview, isLegacyOffice, isImage, sessionId, ext, getContentCacheKey])
+  }, [filePath, dirPath, gitRoot, previewOnly, previewContentVersion, isUnrelatedRefresh, fileAccess, isPdf, isDocx, isOfficePreview, isLegacyOffice, isImage, sessionId, ext, getContentCacheKey])
 
   // refreshVersion 触发的静默刷新：仅 diff 模式、内容有变化时才更新 state
   const prevRefreshRef = React.useRef(-1)
@@ -736,15 +761,19 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   const restoreRafRef = React.useRef(0)
 
   // WHEN content version changes (refreshVersion bump): delete stored scroll position
-  // 只在内容变化时清除，切换文件时保留位置以支持返回导航
+  // 只在内容变化时清除，切换文件时保留位置以支持返回导航。
+  // 定向失效：若 bump 携带 writtenPath 且不是当前预览文件，说明改的是别的文件，
+  // 当前预览内容未变，保留滚动位置不动。
   React.useEffect(() => {
     if (loading) return // still loading, don't clear yet
     if (prevRefreshVersionRef.current !== refreshVersion) {
-      scrollPositionCache.delete(scrollKey)
-      restoreScrollRef.current = false
+      if (!isUnrelatedRefresh) {
+        scrollPositionCache.delete(scrollKey)
+        restoreScrollRef.current = false
+      }
       prevRefreshVersionRef.current = refreshVersion
     }
-  }, [scrollKey, refreshVersion, loading])
+  }, [scrollKey, refreshVersion, isUnrelatedRefresh, loading])
 
   // RESTORE scroll position after cached content renders.
   // 等待滚动容器内容高度连续 3 帧稳定后再恢复，避免异步渲染
@@ -877,9 +906,8 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
         setNewContent(draft)
         cacheSet(getContentCacheKey('preview', refreshVersion + 1), { oldContent: '', newContent: draft })
         setRefreshVersionMap((prev) => {
-          const m = new Map(prev)
-          m.set(sessionId, (prev.get(sessionId) ?? 0) + 1)
-          return m
+          // 自己改自己：定向失效到当前文件，避免误清其他预览面板的滚动位置
+          return bumpDiffRefreshVersion(prev, sessionId, fp)
         })
         setAutosaveStatus('saved')
       }
@@ -912,11 +940,8 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   }, [fileAccess, filePath, isEditableText, markdownDraft, markdownSaving, persistMarkdownDraft])
 
   const handleManualRefresh = React.useCallback(() => {
-    setRefreshVersionMap((prev) => {
-      const m = new Map(prev)
-      m.set(sessionId, (prev.get(sessionId) ?? 0) + 1)
-      return m
-    })
+    // 用户主动刷新：全域失效
+    setRefreshVersionMap((prev) => bumpDiffRefreshVersion(prev, sessionId))
   }, [sessionId, setRefreshVersionMap])
 
   // persistRef 始终持有最新 persistMarkdownDraft，供 setTimeout / unmount cleanup 调用。

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -52,7 +52,7 @@ import {
 import { appModeAtom } from '@/atoms/app-mode'
 import { tabsAtom, activeTabIdAtom, openTab, updateTabTitle } from '@/atoms/tab-atoms'
 import type { AgentStreamState } from '@/atoms/agent-atoms'
-import { agentDiffUnseenChangesAtom, agentDiffUnseenFilesAtom } from '@/atoms/agent-atoms'
+import { agentDiffUnseenChangesAtom, agentDiffUnseenFilesAtom, bumpDiffRefreshVersion } from '@/atoms/agent-atoms'
 import { previewFileMapAtom } from '@/atoms/preview-atoms'
 import type { NotificationSoundType } from '@/types/settings'
 import { toast } from 'sonner'
@@ -750,9 +750,7 @@ export function useGlobalAgentListeners(): void {
               const entry = pendingWriteTools.get(event.toolUseId)!
               const writtenPath = entry.path
               pendingWriteTools.delete(event.toolUseId)
-              store.set(agentDiffRefreshVersionAtom, (prev) => {
-                const m = new Map(prev); m.set(sessionId, (prev.get(sessionId) ?? 0) + 1); return m
-              })
+              store.set(agentDiffRefreshVersionAtom, (prev) => bumpDiffRefreshVersion(prev, sessionId, writtenPath))
               if (writtenPath) {
                 buildWrittenFilePreviewInfo(sessionId, writtenPath).then((previewFile) => {
                   if (!previewFile || previewFile.previewOnly || !previewFile.inDiffScope) return
@@ -774,9 +772,8 @@ export function useGlobalAgentListeners(): void {
             // Bash git 突变命令完成时，仅刷新 diff 列表（不标记 unseen，避免红点）
             if (pendingGitMutateTools.has(event.toolUseId)) {
               pendingGitMutateTools.delete(event.toolUseId)
-              store.set(agentDiffRefreshVersionAtom, (prev) => {
-                const m = new Map(prev); m.set(sessionId, (prev.get(sessionId) ?? 0) + 1); return m
-              })
+              // git 突变（commit/checkout/reset 等）可能影响多文件，保持全域刷新
+              store.set(agentDiffRefreshVersionAtom, (prev) => bumpDiffRefreshVersion(prev, sessionId))
             }
           } else if (event.type === 'shell_killed') {
             store.set(backgroundTasksAtomFamily(sessionId), (prev) => {
@@ -1141,12 +1138,8 @@ export function useGlobalAgentListeners(): void {
     const fileContentHashMap = new Map<string, string>()
     const HASH_MAX = 100
     let focusCheckSeq = 0
-    const bumpDiffRefresh = (sessionId: string) => {
-      store.set(agentDiffRefreshVersionAtom, (prev) => {
-        const m = new Map(prev)
-        m.set(sessionId, (prev.get(sessionId) ?? 0) + 1)
-        return m
-      })
+    const bumpDiffRefresh = (sessionId: string, writtenPath?: string) => {
+      store.set(agentDiffRefreshVersionAtom, (prev) => bumpDiffRefreshVersion(prev, sessionId, writtenPath))
     }
 
     const onWindowFocus = async () => {


### PR DESCRIPTION
## 概述

修复预览面板在 AI 写"其他文件"时滚动位置被清空跳回顶部的问题。

**根因**：`agentDiffRefreshVersionAtom` 是按 session 隔离的刷新版本号，AI 每次写文件完成时全局自增，所有依赖该版本号的预览面板（分屏/标签页/独立窗口）都被刷新。即便写的是其他文件、当前预览文件并未被修改，滚动位置也会被一并清除。流式连续写文件时预览面板反复跳回顶部，无法稳定停留在阅读位置。

**方案**：把版本号的 value 从 `number` 改为 `{ version, writtenPath? }`，引入定向失效语义——写文件完成时携带被写文件路径，消费侧据此跳过无关路径的刷新。

## 改动

- `apps/electron/src/renderer/atoms/agent-atoms.ts`：`AgentDiffRefreshVersion` 接口（`{ version, writtenPath? }`）+ 统一入口 `bumpDiffRefreshVersion(prev, sessionId, writtenPath?)`。携带 `writtenPath` 时定向失效；省略时全域刷新。
- `apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts`：写工具完成调用 `bumpDiffRefreshVersion(prev, sessionId, writtenPath)` 定向；git 突变命令完成保持全域；聚焦检测辅助函数签名统一。
- `apps/electron/src/renderer/components/diff/DiffTabContent.tsx`：新增 `isSameFile(writtenPath, filePath)`（统一正斜杠 + `toLowerCase` 处理 Windows 大小写不敏感）；`isUnrelatedRefresh` 派生标志；主加载 effect 与滚动清除 effect 在无关刷新时早退，跳过重读与滚动位置清除；Markdown 自保存改为定向失效到当前文件。
- `apps/electron/src/renderer/components/agent/AgentView.tsx`：revert 操作保持全域刷新（可能影响多文件）。
- `apps/electron/src/renderer/components/diff/DetachedPreviewApp.tsx`：独立窗口手动刷新保持全域。
- `apps/electron/src/renderer/components/agent/SidePanel.tsx`：消费侧适配新结构，`.version` 取值。

## 定向失效语义

| 触发场景 | writtenPath | 行为 |
|---|---|---|
| 写工具完成 / Markdown 自保存 | 被写文件路径 | 仅刷新命中该路径的面板 |
| git 突变（commit/checkout/reset）/ revert / 手动刷新 / 聚焦检测 / 独立窗口刷新 | 省略 | 全域刷新 |

连续写不同文件时，每个 version 帧的定向信息独立生效（预览 A 的面板在写 B 时跳过刷新保留滚动，写 A 时刷新），无需退化逻辑。

## 测试

- `bun run typecheck` 全包通过。
- 本地验证：打开长 Markdown 预览滚到中段 → 让 AI 连续写其他文件 → 滚动位置保持不再跳回顶部；让 AI 改所预览文件本身 → 内容正确刷新。
- 边界覆盖：Windows 路径大小写不一致时同文件仍能正确识别刷新（非误判为无关跳过）。

## 紧急度

低

> 影响预览阅读体验（流式连续改多个文件时滚动被打断），非核心功能阻塞，无数据丢失风险。

## 备注

Closes #1059
