### PR TITLE
【已审核】feat(theme): 新增按真实日出日落自动切换深浅色主题模式

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -1475,11 +1475,12 @@ export function registerIpcHandlers(): void {
       }
 
       // 主题相关设置变化时，广播给所有窗口（跨窗口同步，如 Quick Task 面板）
-      if (updates.themeMode !== undefined || updates.themeStyle !== undefined || updates.interfaceVariant !== undefined) {
+      if (updates.themeMode !== undefined || updates.themeStyle !== undefined || updates.interfaceVariant !== undefined || updates.solarLocation !== undefined) {
         const payload = {
           themeMode: result.themeMode,
           themeStyle: result.themeStyle,
           interfaceVariant: result.interfaceVariant,
+          solarLocation: result.solarLocation,
         }
         BrowserWindow.getAllWindows().forEach((win) => {
           // 跳过发起者窗口，避免重复应用

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -328,7 +328,7 @@ export interface ElectronAPI {
   onSystemThemeChanged: (callback: (isDark: boolean) => void) => () => void
 
   /** 订阅用户手动切换主题事件（跨窗口同步，返回清理函数） */
-  onThemeSettingsChanged: (callback: (payload: { themeMode: string; themeStyle: string; interfaceVariant?: string }) => void) => () => void
+  onThemeSettingsChanged: (callback: (payload: { themeMode: string; themeStyle: string; interfaceVariant?: string; solarLocation?: { lat: number; lng: number; name: string } | null }) => void) => () => void
 
   // ===== Scratch Pad =====
 
@@ -1304,8 +1304,8 @@ const electronAPI: ElectronAPI = {
     return () => { ipcRenderer.removeListener(SETTINGS_IPC_CHANNELS.ON_SYSTEM_THEME_CHANGED, listener) }
   },
 
-  onThemeSettingsChanged: (callback: (payload: { themeMode: string; themeStyle: string; interfaceVariant?: string }) => void) => {
-    const listener = (_: unknown, payload: { themeMode: string; themeStyle: string; interfaceVariant?: string }): void => callback(payload)
+  onThemeSettingsChanged: (callback: (payload: { themeMode: string; themeStyle: string; interfaceVariant?: string; solarLocation?: { lat: number; lng: number; name: string } | null }) => void) => {
+    const listener = (_: unknown, payload: { themeMode: string; themeStyle: string; interfaceVariant?: string; solarLocation?: { lat: number; lng: number; name: string } | null }): void => callback(payload)
     ipcRenderer.on(SETTINGS_IPC_CHANNELS.ON_THEME_SETTINGS_CHANGED, listener)
     return () => { ipcRenderer.removeListener(SETTINGS_IPC_CHANNELS.ON_THEME_SETTINGS_CHANGED, listener) }
   },

--- a/apps/electron/src/renderer/atoms/theme.ts
+++ b/apps/electron/src/renderer/atoms/theme.ts
@@ -24,7 +24,7 @@ const INTERFACE_VARIANT_CACHE_KEY = 'proma-interface-variant'
 function getCachedThemeMode(): ThemeMode {
   try {
     const cached = localStorage.getItem(THEME_CACHE_KEY)
-    if (cached === 'light' || cached === 'dark' || cached === 'system' || cached === 'special') {
+    if (cached === 'light' || cached === 'dark' || cached === 'system' || cached === 'special' || cached === 'solar') {
       return cached
     }
   } catch {
@@ -99,6 +99,18 @@ function cacheInterfaceVariant(variant: InterfaceVariant): void {
 /** 用户选择的主题模式 */
 export const themeModeAtom = atom<ThemeMode>(getCachedThemeMode())
 
+/** 日出日落模式的位置（用户选定城市），themeMode='solar' 时使用 */
+export const solarLocationAtom = atom<{ lat: number; lng: number; name: string } | null>(null)
+
+/**
+ * 日出日落模式当前是否白天（true）/ 夜晚（false）
+ *
+ * 由 main.tsx 的每分钟轮询 effect 写入，确保跨过日出/日落时刻时
+ * resolvedThemeAtom 能自动重算，让 diff/toast 等消费 resolvedThemeAtom
+ * 的组件配色与主 UI 同步切换。
+ */
+export const solarIsDaytimeAtom = atom<boolean>(true)
+
 /** 用户选择的特殊风格 */
 export const themeStyleAtom = atom<ThemeStyle>(getCachedThemeStyle())
 
@@ -113,6 +125,11 @@ export const resolvedThemeAtom = atom<'light' | 'dark'>((get) => {
   const mode = get(themeModeAtom)
   if (mode === 'system') {
     return get(systemIsDarkAtom) ? 'dark' : 'light'
+  }
+  if (mode === 'solar') {
+    const loc = get(solarLocationAtom)
+    if (!loc) return 'dark' // 未配置位置临时退回深色
+    return get(solarIsDaytimeAtom) ? 'light' : 'dark'
   }
   if (mode === 'special') {
     const style = get(themeStyleAtom)
@@ -147,6 +164,10 @@ export function applyThemeToDOM(themeMode: ThemeMode, themeStyle: ThemeStyle = '
     targetStyleClass = `theme-${themeStyle}`
     targetIsDark = themeStyle.endsWith('-dark')
   } else if (themeMode === 'system') {
+    targetIsDark = systemIsDark
+  } else if (themeMode === 'solar') {
+    // solar 模式：第三个形参 systemIsDark 在此复用为「是否夜晚」槽位
+    // （调用方传入 !isDaytime(...)），不读取真实系统主题
     targetIsDark = systemIsDark
   } else {
     targetIsDark = themeMode === 'dark'
@@ -213,11 +234,17 @@ export async function initializeTheme(
   setSystemIsDark: (isDark: boolean) => void,
   setThemeStyle?: (style: ThemeStyle) => void,
   setInterfaceVariant?: (variant: InterfaceVariant) => void,
+  setSolarLocation?: (loc: { lat: number; lng: number; name: string } | null) => void,
 ): Promise<() => void> {
   // 从主进程加载持久化设置
   const settings = await window.electronAPI.getSettings()
   setThemeMode(settings.themeMode)
   cacheThemeMode(settings.themeMode)
+
+  // 加载日出日落位置
+  if (setSolarLocation) {
+    setSolarLocation(settings.solarLocation ?? null)
+  }
 
   // 加载特殊风格
   if (setThemeStyle && settings.themeStyle) {
@@ -255,6 +282,9 @@ export async function initializeTheme(
       setInterfaceVariant(variant)
       cacheInterfaceVariant(variant)
     }
+    if (setSolarLocation && payload.solarLocation !== undefined) {
+      setSolarLocation(payload.solarLocation ?? null)
+    }
   })
 
   return () => {
@@ -279,6 +309,13 @@ export async function updateThemeMode(mode: ThemeMode): Promise<void> {
 export async function updateThemeStyle(style: ThemeStyle): Promise<void> {
   cacheThemeStyle(style)
   await window.electronAPI.updateSettings({ themeStyle: style })
+}
+
+/**
+ * 更新日出日落位置并持久化
+ */
+export async function updateSolarLocation(loc: { lat: number; lng: number; name: string } | null): Promise<void> {
+  await window.electronAPI.updateSettings({ solarLocation: loc ?? undefined })
 }
 
 /**

--- a/apps/electron/src/renderer/components/settings/AppearanceSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AppearanceSettings.tsx
@@ -20,12 +20,16 @@ import {
   themeStyleAtom,
   interfaceVariantAtom,
   systemIsDarkAtom,
+  solarLocationAtom,
   updateThemeMode,
   updateThemeStyle,
   updateInterfaceVariant,
+  updateSolarLocation,
   applyThemeToDOM,
   applyInterfaceVariantToDOM,
 } from '@/atoms/theme'
+import { searchCities, type City } from '@/lib/cities'
+import { getSunriseSunset, isDaytime, nextTransition } from '@/lib/solar'
 import {
   markdownFontSizeAtom,
   updateMarkdownFontSize,
@@ -64,6 +68,7 @@ const THEME_OPTIONS = [
   { value: 'light', label: '浅色' },
   { value: 'dark', label: '深色' },
   { value: 'system', label: '跟随系统' },
+  { value: 'solar', label: '日出日落' },
   { value: 'special', label: '特殊风格' },
 ]
 
@@ -190,6 +195,7 @@ export function AppearanceSettings(): React.ReactElement {
   const [themeStyle, setThemeStyle] = useAtom(themeStyleAtom)
   const [interfaceVariant, setInterfaceVariant] = useAtom(interfaceVariantAtom)
   const systemIsDark = useAtomValue(systemIsDarkAtom)
+  const [solarLocation, setSolarLocation] = useAtom(solarLocationAtom)
   const [markdownFontSize, setMarkdownFontSize] = useAtom(markdownFontSizeAtom)
   const [previewModePref, setPreviewModePref] = useAtom(previewModePreferenceAtom)
 
@@ -202,9 +208,24 @@ export function AppearanceSettings(): React.ReactElement {
     if (mode !== 'special') {
       setThemeStyle('default')
       updateThemeStyle('default')
+    }
+    if (mode === 'solar') {
+      // solar 模式根据当前位置计算深浅，未配置位置时退回深色
+      const isDark = solarLocation ? !isDaytime(solarLocation.lat, solarLocation.lng) : true
+      applyThemeToDOM('solar', 'default', isDark)
+    } else {
       applyThemeToDOM(mode, 'default', systemIsDark)
     }
-  }, [setThemeMode, setThemeStyle, systemIsDark])
+  }, [setThemeMode, setThemeStyle, systemIsDark, solarLocation])
+
+  /** 选择日出日落位置 */
+  const handleSolarLocationSelect = React.useCallback((city: City) => {
+    const loc = { lat: city.lat, lng: city.lng, name: city.name }
+    setSolarLocation(loc)
+    updateSolarLocation(loc)
+    // 选定位置后立即应用一次主题
+    applyThemeToDOM('solar', 'default', !isDaytime(city.lat, city.lng))
+  }, [setSolarLocation])
 
   /** 选择特殊风格 */
   const handleStyleSelect = React.useCallback((style: ThemeStyle) => {
@@ -246,6 +267,18 @@ export function AppearanceSettings(): React.ReactElement {
             onValueChange={handleThemeChange}
             options={THEME_OPTIONS}
           />
+
+          {/* 日出日落模式：城市选择 + 下次切换预览 */}
+          {themeMode === 'solar' && (
+            <SolarLocationPicker
+              location={solarLocation}
+              onSelect={handleSolarLocationSelect}
+              onClear={() => {
+                setSolarLocation(null)
+                updateSolarLocation(null)
+              }}
+            />
+          )}
 
           <SettingsSegmentedControl
             label="界面风格"
@@ -476,5 +509,127 @@ function StyleCard({
         {style.name}
       </span>
     </button>
+  )
+}
+
+/** 日出日落模式的城市选择器 + 下次切换预览 */
+function SolarLocationPicker({
+  location,
+  onSelect,
+  onClear,
+}: {
+  location: { lat: number; lng: number; name: string } | null
+  onSelect: (city: City) => void
+  onClear: () => void
+}): React.ReactElement {
+  const [query, setQuery] = React.useState('')
+  const [showResults, setShowResults] = React.useState(false)
+  const results = React.useMemo(() => (showResults ? searchCities(query, 30) : []), [query, showResults])
+
+  // 下次切换预览（位置已配置时）
+  const transition = React.useMemo(() => {
+    if (!location) return null
+    return nextTransition(location.lat, location.lng)
+  }, [location])
+
+  // 当前日出日落时刻（位置已配置时）
+  const sunTimes = React.useMemo(() => {
+    if (!location) return null
+    return getSunriseSunset(new Date(), location.lat, location.lng)
+  }, [location])
+
+  const formatTime = (d: Date | null): string => {
+    if (!d) return '—（极昼/极夜）'
+    return d.toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit', hour12: false })
+  }
+
+  return (
+    <div className="px-4 py-3 space-y-3">
+      <div className="space-y-1">
+        <div className="text-sm font-medium text-foreground">日出日落位置</div>
+        <div className="text-xs text-muted-foreground">
+          应用将根据此位置的日出日落时刻自动切换深浅色，不依赖系统设置
+        </div>
+      </div>
+
+      {/* 当前位置 + 下次切换预览 */}
+      {location && (
+        <div className="rounded-lg bg-muted/40 px-3 py-2 space-y-1 text-xs">
+          <div className="flex items-center justify-between">
+            <span className="text-muted-foreground">当前位置</span>
+            <span className="font-medium text-foreground">{location.name}</span>
+          </div>
+          {sunTimes && (
+            <>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">今日日出</span>
+                <span className="text-foreground">{formatTime(sunTimes.sunrise)}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">今日日落</span>
+                <span className="text-foreground">{formatTime(sunTimes.sunset)}</span>
+              </div>
+            </>
+          )}
+          {transition && (
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground">下次切换</span>
+              <span className="text-foreground">
+                {formatTime(transition.at)} → {transition.to === 'dark' ? '深色' : '浅色'}
+              </span>
+            </div>
+          )}
+          <button
+            type="button"
+            onClick={onClear}
+            className="text-xs text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+          >
+            清除位置
+          </button>
+        </div>
+      )}
+
+      {/* 搜索框 */}
+      <div className="relative">
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value)
+            setShowResults(true)
+          }}
+          onFocus={() => setShowResults(true)}
+          onBlur={() => setTimeout(() => setShowResults(false), 150)}
+          placeholder="搜索城市（如 北京、东京、纽约）"
+          className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/30"
+        />
+        {showResults && results.length > 0 && (
+          <div className="absolute z-10 mt-1 w-full max-h-60 overflow-auto rounded-md border border-border bg-background shadow-lg">
+            {results.map((c) => (
+              <button
+                key={`${c.country}-${c.name}`}
+                type="button"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => {
+                  onSelect(c)
+                  setQuery('')
+                  setShowResults(false)
+                }}
+                className="flex w-full items-center justify-between px-3 py-2 text-sm hover:bg-muted/50 text-left"
+              >
+                <span className="text-foreground">{c.name}</span>
+                <span className="text-xs text-muted-foreground">{c.country}</span>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {!location && (
+        <div className="text-xs text-muted-foreground">
+          请先选择一个城市以启用日出日落切换
+        </div>
+      )}
+    </div>
   )
 }

--- a/apps/electron/src/renderer/lib/cities.ts
+++ b/apps/electron/src/renderer/lib/cities.ts
@@ -1,0 +1,221 @@
+/**
+ * 内置城市经纬度表
+ *
+ * 用于「日出日落」主题模式的位置选择。覆盖全球主要城市，
+ * 按国家/地区分组，每条记录含名称、纬度、经度。
+ * 数据为公开地理坐标，精度到 0.01°（约 1km），足够日出日落计算。
+ */
+
+export interface City {
+  name: string
+  /** 纬度（北正南负） */
+  lat: number
+  /** 经度（东正西负） */
+  lng: number
+  /** 国家/地区 */
+  country: string
+}
+
+export const CITIES: readonly City[] = [
+  // ===== 中国 =====
+  { name: '北京', lat: 39.90, lng: 116.41, country: '中国' },
+  { name: '上海', lat: 31.23, lng: 121.47, country: '中国' },
+  { name: '广州', lat: 23.13, lng: 113.26, country: '中国' },
+  { name: '深圳', lat: 22.54, lng: 114.06, country: '中国' },
+  { name: '成都', lat: 30.67, lng: 104.07, country: '中国' },
+  { name: '重庆', lat: 29.56, lng: 106.55, country: '中国' },
+  { name: '杭州', lat: 30.27, lng: 120.15, country: '中国' },
+  { name: '南京', lat: 32.06, lng: 118.80, country: '中国' },
+  { name: '武汉', lat: 30.59, lng: 114.31, country: '中国' },
+  { name: '西安', lat: 34.34, lng: 108.94, country: '中国' },
+  { name: '天津', lat: 39.08, lng: 117.20, country: '中国' },
+  { name: '苏州', lat: 31.30, lng: 120.62, country: '中国' },
+  { name: '长沙', lat: 28.23, lng: 112.94, country: '中国' },
+  { name: '青岛', lat: 36.07, lng: 120.38, country: '中国' },
+  { name: '郑州', lat: 34.75, lng: 113.62, country: '中国' },
+  { name: '沈阳', lat: 41.80, lng: 123.43, country: '中国' },
+  { name: '大连', lat: 38.91, lng: 121.60, country: '中国' },
+  { name: '哈尔滨', lat: 45.80, lng: 126.53, country: '中国' },
+  { name: '济南', lat: 36.65, lng: 117.00, country: '中国' },
+  { name: '昆明', lat: 25.04, lng: 102.71, country: '中国' },
+  { name: '南宁', lat: 22.82, lng: 108.37, country: '中国' },
+  { name: '福州', lat: 26.07, lng: 119.30, country: '中国' },
+  { name: '厦门', lat: 24.48, lng: 118.09, country: '中国' },
+  { name: '合肥', lat: 31.82, lng: 117.23, country: '中国' },
+  { name: '南昌', lat: 28.68, lng: 115.86, country: '中国' },
+  { name: '太原', lat: 37.87, lng: 112.55, country: '中国' },
+  { name: '石家庄', lat: 38.04, lng: 114.51, country: '中国' },
+  { name: '兰州', lat: 36.06, lng: 103.83, country: '中国' },
+  { name: '海口', lat: 20.04, lng: 110.20, country: '中国' },
+  { name: '贵阳', lat: 26.65, lng: 106.71, country: '中国' },
+  { name: '拉萨', lat: 29.65, lng: 91.11, country: '中国' },
+  { name: '乌鲁木齐', lat: 43.83, lng: 87.62, country: '中国' },
+  { name: '呼和浩特', lat: 40.84, lng: 111.75, country: '中国' },
+  { name: '银川', lat: 38.49, lng: 106.21, country: '中国' },
+  { name: '西宁', lat: 36.62, lng: 101.78, country: '中国' },
+  { name: '香港', lat: 22.32, lng: 114.17, country: '中国' },
+  { name: '台北', lat: 25.03, lng: 121.57, country: '中国' },
+  { name: '澳门', lat: 22.20, lng: 113.55, country: '中国' },
+
+  // ===== 东亚其他 =====
+  { name: '东京', lat: 35.68, lng: 139.69, country: '日本' },
+  { name: '大阪', lat: 34.69, lng: 135.50, country: '日本' },
+  { name: '名古屋', lat: 35.18, lng: 136.91, country: '日本' },
+  { name: '札幌', lat: 43.06, lng: 141.35, country: '日本' },
+  { name: '福冈', lat: 33.59, lng: 130.40, country: '日本' },
+  { name: '首尔', lat: 37.57, lng: 126.98, country: '韩国' },
+  { name: '釜山', lat: 35.18, lng: 129.08, country: '韩国' },
+  { name: '平壤', lat: 39.02, lng: 125.75, country: '朝鲜' },
+  { name: '乌兰巴托', lat: 47.92, lng: 106.92, country: '蒙古' },
+
+  // ===== 东南亚 =====
+  { name: '新加坡', lat: 1.35, lng: 103.82, country: '新加坡' },
+  { name: '曼谷', lat: 13.76, lng: 100.50, country: '泰国' },
+  { name: '吉隆坡', lat: 3.14, lng: 101.69, country: '马来西亚' },
+  { name: '雅加达', lat: -6.21, lng: 106.85, country: '印度尼西亚' },
+  { name: '马尼拉', lat: 14.60, lng: 120.98, country: '菲律宾' },
+  { name: '河内', lat: 21.03, lng: 105.85, country: '越南' },
+  { name: '胡志明市', lat: 10.82, lng: 106.63, country: '越南' },
+  { name: '金边', lat: 11.56, lng: 104.93, country: '柬埔寨' },
+  { name: '仰光', lat: 16.84, lng: 96.17, country: '缅甸' },
+  { name: '万象', lat: 17.97, lng: 102.63, country: '老挝' },
+
+  // ===== 南亚 =====
+  { name: '新德里', lat: 28.61, lng: 77.21, country: '印度' },
+  { name: '孟买', lat: 19.08, lng: 72.88, country: '印度' },
+  { name: '加尔各答', lat: 22.57, lng: 88.36, country: '印度' },
+  { name: '班加罗尔', lat: 12.97, lng: 77.59, country: '印度' },
+  { name: '金奈', lat: 13.08, lng: 80.27, country: '印度' },
+  { name: '卡拉奇', lat: 24.86, lng: 67.01, country: '巴基斯坦' },
+  { name: '伊斯兰堡', lat: 33.69, lng: 73.05, country: '巴基斯坦' },
+  { name: '达卡', lat: 23.81, lng: 90.41, country: '孟加拉国' },
+  { name: '科伦坡', lat: 6.93, lng: 79.86, country: '斯里兰卡' },
+  { name: '加德满都', lat: 27.71, lng: 85.32, country: '尼泊尔' },
+
+  // ===== 中亚 / 西亚 =====
+  { name: '迪拜', lat: 25.20, lng: 55.27, country: '阿联酋' },
+  { name: '阿布扎比', lat: 24.45, lng: 54.38, country: '阿联酋' },
+  { name: '多哈', lat: 25.29, lng: 51.21, country: '卡塔尔' },
+  { name: '利雅得', lat: 24.71, lng: 46.68, country: '沙特阿拉伯' },
+  { name: '德黑兰', lat: 35.70, lng: 51.39, country: '伊朗' },
+  { name: '巴格达', lat: 33.31, lng: 44.36, country: '伊拉克' },
+  { name: '安卡拉', lat: 39.93, lng: 32.86, country: '土耳其' },
+  { name: '伊斯坦布尔', lat: 41.01, lng: 28.98, country: '土耳其' },
+  { name: '耶路撒冷', lat: 31.78, lng: 35.22, country: '以色列' },
+  { name: '特拉维夫', lat: 32.08, lng: 34.78, country: '以色列' },
+  { name: '贝鲁特', lat: 33.89, lng: 35.50, country: '黎巴嫩' },
+  { name: '大马士革', lat: 33.51, lng: 36.29, country: '叙利亚' },
+  { name: '阿斯塔纳', lat: 51.16, lng: 71.43, country: '哈萨克斯坦' },
+  { name: '塔什干', lat: 41.31, lng: 69.24, country: '乌兹别克斯坦' },
+
+  // ===== 欧洲 =====
+  { name: '伦敦', lat: 51.51, lng: -0.13, country: '英国' },
+  { name: '爱丁堡', lat: 55.95, lng: -3.19, country: '英国' },
+  { name: '都柏林', lat: 53.35, lng: -6.26, country: '爱尔兰' },
+  { name: '巴黎', lat: 48.86, lng: 2.35, country: '法国' },
+  { name: '马赛', lat: 43.30, lng: 5.37, country: '法国' },
+  { name: '柏林', lat: 52.52, lng: 13.40, country: '德国' },
+  { name: '慕尼黑', lat: 48.14, lng: 11.58, country: '德国' },
+  { name: '法兰克福', lat: 50.11, lng: 8.68, country: '德国' },
+  { name: '罗马', lat: 41.90, lng: 12.50, country: '意大利' },
+  { name: '米兰', lat: 45.46, lng: 9.19, country: '意大利' },
+  { name: '马德里', lat: 40.42, lng: -3.70, country: '西班牙' },
+  { name: '巴塞罗那', lat: 41.39, lng: 2.17, country: '西班牙' },
+  { name: '里斯本', lat: 38.72, lng: -9.14, country: '葡萄牙' },
+  { name: '阿姆斯特丹', lat: 52.37, lng: 4.90, country: '荷兰' },
+  { name: '布鲁塞尔', lat: 50.85, lng: 4.35, country: '比利时' },
+  { name: '维也纳', lat: 48.21, lng: 16.37, country: '奥地利' },
+  { name: '苏黎世', lat: 47.38, lng: 8.54, country: '瑞士' },
+  { name: '日内瓦', lat: 46.20, lng: 6.14, country: '瑞士' },
+  { name: '哥本哈根', lat: 55.68, lng: 12.57, country: '丹麦' },
+  { name: '斯德哥尔摩', lat: 59.33, lng: 18.07, country: '瑞典' },
+  { name: '奥斯陆', lat: 59.91, lng: 10.75, country: '挪威' },
+  { name: '赫尔辛基', lat: 60.17, lng: 24.94, country: '芬兰' },
+  { name: '雷克雅未克', lat: 64.15, lng: -21.94, country: '冰岛' },
+  { name: '华沙', lat: 52.23, lng: 21.01, country: '波兰' },
+  { name: '布拉格', lat: 50.08, lng: 14.44, country: '捷克' },
+  { name: '布达佩斯', lat: 47.50, lng: 19.04, country: '匈牙利' },
+  { name: '雅典', lat: 37.98, lng: 23.73, country: '希腊' },
+  { name: '莫斯科', lat: 55.76, lng: 37.62, country: '俄罗斯' },
+  { name: '圣彼得堡', lat: 59.93, lng: 30.34, country: '俄罗斯' },
+  { name: '基辅', lat: 50.45, lng: 30.52, country: '乌克兰' },
+  { name: '布加勒斯特', lat: 44.43, lng: 26.10, country: '罗马尼亚' },
+  { name: '索菲亚', lat: 42.70, lng: 23.32, country: '保加利亚' },
+  { name: '贝尔格莱德', lat: 44.79, lng: 20.46, country: '塞尔维亚' },
+
+  // ===== 北美 =====
+  { name: '纽约', lat: 40.71, lng: -74.01, country: '美国' },
+  { name: '洛杉矶', lat: 34.05, lng: -118.24, country: '美国' },
+  { name: '芝加哥', lat: 41.88, lng: -87.63, country: '美国' },
+  { name: '休斯顿', lat: 29.76, lng: -95.37, country: '美国' },
+  { name: '凤凰城', lat: 33.45, lng: -112.07, country: '美国' },
+  { name: '费城', lat: 39.95, lng: -75.17, country: '美国' },
+  { name: '旧金山', lat: 37.77, lng: -122.42, country: '美国' },
+  { name: '西雅图', lat: 47.61, lng: -122.33, country: '美国' },
+  { name: '波士顿', lat: 42.36, lng: -71.06, country: '美国' },
+  { name: '丹佛', lat: 39.74, lng: -104.99, country: '美国' },
+  { name: '迈阿密', lat: 25.76, lng: -80.19, country: '美国' },
+  { name: '亚特兰大', lat: 33.75, lng: -84.39, country: '美国' },
+  { name: '达拉斯', lat: 32.78, lng: -96.80, country: '美国' },
+  { name: '华盛顿', lat: 38.91, lng: -77.04, country: '美国' },
+  { name: '拉斯维加斯', lat: 36.17, lng: -115.14, country: '美国' },
+  { name: '檀香山', lat: 21.31, lng: -157.86, country: '美国' },
+  { name: '安克雷奇', lat: 61.22, lng: -149.90, country: '美国' },
+  { name: '多伦多', lat: 43.65, lng: -79.38, country: '加拿大' },
+  { name: '温哥华', lat: 49.28, lng: -123.12, country: '加拿大' },
+  { name: '蒙特利尔', lat: 45.50, lng: -73.57, country: '加拿大' },
+  { name: '卡尔加里', lat: 51.05, lng: -114.07, country: '加拿大' },
+  { name: '渥太华', lat: 45.42, lng: -75.70, country: '加拿大' },
+  { name: '埃德蒙顿', lat: 53.55, lng: -113.49, country: '加拿大' },
+  { name: '墨西哥城', lat: 19.43, lng: -99.13, country: '墨西哥' },
+  { name: '坎昆', lat: 21.16, lng: -86.85, country: '墨西哥' },
+
+  // ===== 南美 =====
+  { name: '圣保罗', lat: -23.55, lng: -46.63, country: '巴西' },
+  { name: '里约热内卢', lat: -22.91, lng: -43.17, country: '巴西' },
+  { name: '巴西利亚', lat: -15.79, lng: -47.88, country: '巴西' },
+  { name: '布宜诺斯艾利斯', lat: -34.60, lng: -58.38, country: '阿根廷' },
+  { name: '圣地亚哥', lat: -33.45, lng: -70.67, country: '智利' },
+  { name: '利马', lat: -12.05, lng: -77.04, country: '秘鲁' },
+  { name: '波哥大', lat: 4.71, lng: -74.07, country: '哥伦比亚' },
+  { name: '基多', lat: -0.18, lng: -78.47, country: '厄瓜多尔' },
+  { name: '加拉加斯', lat: 10.49, lng: -66.88, country: '委内瑞拉' },
+  { name: '蒙得维的亚', lat: -34.90, lng: -56.16, country: '乌拉圭' },
+
+  // ===== 大洋洲 =====
+  { name: '悉尼', lat: -33.87, lng: 151.21, country: '澳大利亚' },
+  { name: '墨尔本', lat: -37.81, lng: 144.96, country: '澳大利亚' },
+  { name: '布里斯班', lat: -27.47, lng: 153.03, country: '澳大利亚' },
+  { name: '珀斯', lat: -31.95, lng: 115.86, country: '澳大利亚' },
+  { name: '阿德莱德', lat: -34.93, lng: 138.60, country: '澳大利亚' },
+  { name: '堪培拉', lat: -35.28, lng: 149.13, country: '澳大利亚' },
+  { name: '达尔文', lat: -12.46, lng: 130.84, country: '澳大利亚' },
+  { name: '奥克兰', lat: -36.85, lng: 174.76, country: '新西兰' },
+  { name: '惠灵顿', lat: -41.29, lng: 174.78, country: '新西兰' },
+
+  // ===== 非洲 =====
+  { name: '开罗', lat: 30.04, lng: 31.24, country: '埃及' },
+  { name: '拉各斯', lat: 6.52, lng: 3.38, country: '尼日利亚' },
+  { name: '内罗毕', lat: -1.29, lng: 36.82, country: '肯尼亚' },
+  { name: '约翰内斯堡', lat: -26.20, lng: 28.05, country: '南非' },
+  { name: '开普敦', lat: -33.92, lng: 18.42, country: '南非' },
+  { name: '德班', lat: -29.86, lng: 31.03, country: '南非' },
+  { name: '卡萨布兰卡', lat: 33.57, lng: -7.59, country: '摩洛哥' },
+  { name: '阿尔及尔', lat: 36.75, lng: 3.06, country: '阿尔及利亚' },
+  { name: '突尼斯', lat: 36.81, lng: 10.18, country: '突尼斯' },
+  { name: '阿克拉', lat: 5.60, lng: -0.19, country: '加纳' },
+  { name: '亚的斯亚贝巴', lat: 9.03, lng: 38.74, country: '埃塞俄比亚' },
+  { name: '达累斯萨拉姆', lat: -6.82, lng: 39.30, country: '坦桑尼亚' },
+  { name: '坎帕拉', lat: 0.35, lng: 32.58, country: '乌干达' },
+  { name: '哈拉雷', lat: -17.83, lng: 31.05, country: '津巴布韦' },
+  { name: '达喀尔', lat: 14.69, lng: -17.45, country: '塞内加尔' },
+]
+
+/** 按名称或国家模糊搜索城市 */
+export function searchCities(query: string, limit = 20): City[] {
+  const q = query.trim().toLowerCase()
+  if (!q) return CITIES.slice(0, limit)
+  return CITIES.filter(
+    (c) => c.name.toLowerCase().includes(q) || c.country.toLowerCase().includes(q),
+  ).slice(0, limit)
+}

--- a/apps/electron/src/renderer/lib/solar.ts
+++ b/apps/electron/src/renderer/lib/solar.ts
@@ -1,0 +1,204 @@
+/**
+ * 日出日落计算（NOAA Solar Position Algorithm）
+ *
+ * 零依赖实现，基于 NOAA 日照算法。输入日期 + 经纬度，
+ * 返回当日日出/日落时刻（本地时区 Date 对象）。
+ *
+ * 参考：https://gml.noaa.gov/grad/solcalc/calcdetails.html
+ */
+
+const RAD = Math.PI / 180
+const DEG = 180 / Math.PI
+
+/** 将日历日期转换为儒略日（Julian Day） */
+function toJulianDay(date: Date): number {
+  // 取本地日期分量，时分秒忽略（日出日落按天计算）。
+  // 必须用本地日期而非 UTC 日期：用户关心的是「我所在本地日期的日出日落」，
+  // 若用 getUTCDate()，在本地时间与 UTC 日期不一致时（如 UTC+8 凌晨 0-8 点，
+  // UTC 仍是前一天），会算出前一天 UTC 的日出日落，导致 isDaytime 误判、
+  // 跨过本地日出/日落时刻时主题不切换。
+  const y = date.getFullYear()
+  const m = date.getMonth() + 1
+  const d = date.getDate()
+  let yy = y
+  let mm = m
+  if (m <= 2) {
+    yy -= 1
+    mm += 12
+  }
+  const a = Math.floor(yy / 100)
+  const b = 2 - a + Math.floor(a / 4)
+  return Math.floor(365.25 * (yy + 4716)) + Math.floor(30.6001 * (mm + 1)) + d + b - 1524.5
+}
+
+/** 计算 Julian Century（自 J2000.0 起的世纪数） */
+function toJulianCentury(jd: number): number {
+  return (jd - 2451545.0) / 36525.0
+}
+
+/** NOAA 太阳平黄经（mean longitude） */
+function sunMeanLongitude(t: number): number {
+  const l = (280.46646 + t * (36000.76983 + t * 0.0003032)) % 360
+  return l < 0 ? l + 360 : l
+}
+
+/** NOAA 太阳平近点角（mean anomaly） */
+function sunMeanAnomaly(t: number): number {
+  return 357.52911 + t * (35999.05029 - 0.0001537 * t)
+}
+
+/** NOAA 地球轨道偏心率 */
+function earthEccentricity(t: number): number {
+  return 0.016708634 - t * (0.000042037 + 0.0000001267 * t)
+}
+
+/** NOAA 太阳方程中心（equation of center） */
+function sunEquationOfCenter(t: number, m: number): number {
+  const mr = m * RAD
+  return (
+    Math.sin(mr) * (1.914602 - t * (0.004817 + 0.000014 * t)) +
+    Math.sin(2 * mr) * (0.019993 - 0.000101 * t) +
+    Math.sin(3 * mr) * 0.000289
+  )
+}
+
+/** 计算给定太阳天顶角对应的时角（hour angle） */
+function hourAngle(lat: number, solarDec: number, zenith: number): number | null {
+  const latR = lat * RAD
+  const decR = solarDec * RAD
+  const zenR = zenith * RAD
+  const cosH =
+    (Math.cos(zenR) - Math.sin(latR) * Math.sin(decR)) / (Math.cos(latR) * Math.cos(decR))
+  // 极昼/极夜：超出 [-1, 1] 范围，无日出或日落
+  if (cosH > 1 || cosH < -1) return null
+  return Math.acos(cosH) * DEG
+}
+
+/** 计算时差（equation of time），单位分钟 */
+function equationOfTime(t: number): number {
+  const epsilon = (23.439291 - 0.0130042 * t) * RAD
+  const l = sunMeanLongitude(t) * RAD
+  const e = earthEccentricity(t)
+  const m = sunMeanAnomaly(t) * RAD
+  const y = Math.tan(epsilon / 2) ** 2
+  const sin2l = Math.sin(2 * l)
+  const cos2l = Math.cos(2 * l)
+  const sin4l = Math.sin(4 * l)
+  const sin2m = Math.sin(2 * m)
+  return (
+    y * sin2l -
+    2 * e * Math.sin(m) +
+    4 * e * y * Math.sin(m) * cos2l -
+    0.5 * y * y * sin4l -
+    1.25 * e * e * sin2m
+  ) * DEG * 4 // 弧度→度→分钟
+}
+
+/** 计算太阳赤纬（declination），单位度 */
+function solarDeclination(t: number): number {
+  const l = sunMeanLongitude(t)
+  const m = sunMeanAnomaly(t)
+  const c = sunEquationOfCenter(t, m)
+  const trueLong = l + c // 太阳真黄经
+  // 赤纬 = 真黄经 在黄赤交角下的投影
+  const epsilon = (23.439291 - 0.0130042 * t) * RAD
+  return Math.asin(Math.sin(trueLong * RAD) * Math.sin(epsilon)) * DEG
+}
+
+/**
+ * 给定日期 + 经纬度，返回当日日出日落时刻（本地时区 Date 对象）
+ *
+ * 极昼（夏极圈）或极夜（冬极圈）时对应项返回 null。
+ *
+ * @param zenith 太阳天顶角，官方日出日落用 90.833°（含大气折射 + 太阳半径补偿）
+ */
+export function getSunriseSunset(
+  date: Date,
+  lat: number,
+  lng: number,
+  zenith = 90.833,
+): { sunrise: Date | null; sunset: Date | null } {
+  const jd = toJulianDay(date)
+  const t = toJulianCentury(jd)
+  const dec = solarDeclination(t)
+  const eot = equationOfTime(t) // 分钟
+
+  const ha = hourAngle(lat, dec, zenith)
+  if (ha === null) {
+    // 极昼返回两个 null（无日出日落）；极夜同理
+    return { sunrise: null, sunset: null }
+  }
+
+  // 日出/日落的太阳子午圈时角（度），再换算到本地时
+  const noonMin = (720 - 4 * lng - eot) % 1440 // 太阳正午（UTC 分钟）
+  const sunriseMin = noonMin - 4 * ha
+  const sunsetMin = noonMin + 4 * ha
+
+  // 用本地日期分量构造，但 noonMin/sunriseMin/sunsetMin 是 UTC 分钟。
+  // Date.UTC 把 (本地日期 + UTC 时刻) 拼成绝对时间戳：sunrise/sunset 落在
+  // 用户本地日期对应的那一天，与 new Date() 比较时区一致。
+  // 旧实现用 getUTCFullYear/getUTCMonth/getUTCDate，在本地时间与 UTC 日期
+  // 不一致时（如 UTC+8 凌晨）会取到前一天的日出日落，导致 isDaytime 误判。
+  const y = date.getFullYear()
+  const mo = date.getMonth()
+  const d = date.getDate()
+
+  const toLocalDate = (totalMin: number): Date => {
+    let dayOffset = 0
+    let m = totalMin % 1440
+    if (m < 0) {
+      m += 1440
+      dayOffset = -1
+    } else if (m >= 1440) {
+      // 极少出现，但保留健壮性
+      dayOffset = 1
+    }
+    const hh = Math.floor(m / 60)
+    const mm = Math.floor(m % 60)
+    const dt = new Date(Date.UTC(y, mo, d + dayOffset, hh, mm, 0))
+    return dt
+  }
+
+  return {
+    sunrise: toLocalDate(sunriseMin),
+    sunset: toLocalDate(sunsetMin),
+  }
+}
+
+/**
+ * 当前时刻是否处于白天（日出后、日落前）
+ *
+ * 极昼恒返回 true，极夜恒返回 false；
+ * 其他情况比较当前时刻与今日日出日落。
+ * 极昼/极夜判定：getSunriseSunset 返回 null 时，按纬度 + 月份近似——
+ * 若无日出日落且当前为夏季半球则视为极昼白天，否则极夜。
+ */
+export function isDaytime(lat: number, lng: number, now: Date = new Date()): boolean {
+  const { sunrise, sunset } = getSunriseSunset(now, lat, lng)
+  if (!sunrise || !sunset) {
+    // 极昼/极夜 fallback：北半球 4-9 月、南半球 10-3 月视为白天（极昼）
+    // 用本地月份与 getSunriseSunset 内部的本地日期分量对齐，避免时区边界月份错位
+    const month = now.getMonth() + 1
+    const northSummer = month >= 4 && month <= 9
+    const isNorth = lat >= 0
+    return isNorth ? northSummer : !northSummer
+  }
+  return now >= sunrise && now < sunset
+}
+
+/**
+ * 给定位置，返回下一次日夜切换的时刻（用于 UI 预览「下次切换」）
+ *
+ * 若当前为白天，返回今日日落；若当前为夜晚，返回今日日出（若已过则明日日出）。
+ */
+export function nextTransition(lat: number, lng: number, now: Date = new Date()): { at: Date; to: 'light' | 'dark' } | null {
+  const { sunrise, sunset } = getSunriseSunset(now, lat, lng)
+  if (!sunrise || !sunset) return null
+  if (now < sunrise) return { at: sunrise, to: 'light' }
+  if (now < sunset) return { at: sunset, to: 'dark' }
+  // 已过日落 → 明日日出
+  const tomorrow = new Date(now)
+  tomorrow.setDate(tomorrow.getDate() + 1)
+  const next = getSunriseSunset(tomorrow, lat, lng)
+  return next.sunrise ? { at: next.sunrise, to: 'light' } : null
+}

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -18,11 +18,14 @@ import {
   themeStyleAtom,
   interfaceVariantAtom,
   systemIsDarkAtom,
+  solarLocationAtom,
+  solarIsDaytimeAtom,
   resolvedThemeAtom,
   applyThemeToDOM,
   applyInterfaceVariantToDOM,
   initializeTheme,
 } from './atoms/theme'
+import { isDaytime } from './lib/solar'
 import {
   agentChannelIdAtom,
   agentModelIdAtom,
@@ -96,17 +99,21 @@ function ThemeInitializer(): null {
   const setThemeStyle = useSetAtom(themeStyleAtom)
   const setInterfaceVariant = useSetAtom(interfaceVariantAtom)
   const setSystemIsDark = useSetAtom(systemIsDarkAtom)
+  const setSolarLocation = useSetAtom(solarLocationAtom)
+  const setSolarIsDaytime = useSetAtom(solarIsDaytimeAtom)
   const themeMode = useAtomValue(themeModeAtom)
   const themeStyle = useAtomValue(themeStyleAtom)
   const interfaceVariant = useAtomValue(interfaceVariantAtom)
   const systemIsDark = useAtomValue(systemIsDarkAtom)
+  const solarLocation = useAtomValue(solarLocationAtom)
+  const solarIsDaytime = useAtomValue(solarIsDaytimeAtom)
 
   // 初始化：从主进程加载设置 + 订阅系统主题变化
   useEffect(() => {
     let isMounted = true
     let cleanup: (() => void) | undefined
 
-    initializeTheme(setThemeMode, setSystemIsDark, setThemeStyle, setInterfaceVariant).then((fn) => {
+    initializeTheme(setThemeMode, setSystemIsDark, setThemeStyle, setInterfaceVariant, setSolarLocation).then((fn) => {
       if (isMounted) {
         cleanup = fn
       } else {
@@ -119,12 +126,35 @@ function ThemeInitializer(): null {
       isMounted = false
       cleanup?.()
     }
-  }, [setThemeMode, setSystemIsDark, setThemeStyle, setInterfaceVariant])
+  }, [setThemeMode, setSystemIsDark, setThemeStyle, setInterfaceVariant, setSolarLocation])
+
+  // solar 模式：每分钟轮询日出日落状态，跨过日出/日落时刻时刷新主题
+  // 同时写入 solarIsDaytimeAtom，驱动 resolvedThemeAtom 重算（diff/toast 等消费方同步切换）
+  // 窗口从后台/睡眠恢复时 visibilitychange 立即刷新，避免最长 60s 延迟
+  useEffect(() => {
+    if (themeMode !== 'solar' || !solarLocation) return
+    const refresh = (): void => {
+      const daytime = isDaytime(solarLocation.lat, solarLocation.lng)
+      setSolarIsDaytime(daytime)
+      applyThemeToDOM('solar', 'default', !daytime)
+    }
+    refresh() // 立即执行一次，避免切到 solar 后等 60s 才首次应用
+    const interval = setInterval(refresh, 60_000)
+    const onVisible = (): void => {
+      if (document.visibilityState === 'visible') refresh()
+    }
+    document.addEventListener('visibilitychange', onVisible)
+    return () => {
+      clearInterval(interval)
+      document.removeEventListener('visibilitychange', onVisible)
+    }
+  }, [themeMode, solarLocation, setSolarIsDaytime])
 
   // 响应式应用主题到 DOM
   // 用 useMemo 计算"实际会影响 DOM 的状态签名"作为唯一依赖：
   // special 模式下 systemIsDark 不影响最终 class，避免系统主题变化时触发无意义的
   // applyThemeToDOM 调用（配合 applyThemeToDOM 内部的幂等检查双重兜底）。
+  // solar 模式下签名包含当前白天/黑夜状态，确保跨过日出/日落时刻时触发切换。
   const themeSignature = useMemo(() => {
     if (themeMode === 'special') {
       return `special:${themeStyle}`
@@ -132,11 +162,20 @@ function ThemeInitializer(): null {
     if (themeMode === 'system') {
       return `system:${systemIsDark ? 'dark' : 'light'}`
     }
+    if (themeMode === 'solar') {
+      if (!solarLocation) return 'solar:unconfigured'
+      return `solar:${solarIsDaytime ? 'light' : 'dark'}`
+    }
     return themeMode
-  }, [themeMode, themeStyle, systemIsDark])
+  }, [themeMode, themeStyle, systemIsDark, solarLocation, solarIsDaytime])
 
   useEffect(() => {
-    applyThemeToDOM(themeMode, themeStyle, systemIsDark)
+    if (themeMode === 'solar') {
+      const isDark = solarLocation ? !solarIsDaytime : true
+      applyThemeToDOM('solar', 'default', isDark)
+    } else {
+      applyThemeToDOM(themeMode, themeStyle, systemIsDark)
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [themeSignature])
 

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -150,8 +150,8 @@ export interface ShortcutOverrides {
   }
 }
 
-/** 主题模式 */
-export type ThemeMode = 'light' | 'dark' | 'system' | 'special'
+/** 主题模式：solar 为按真实日出日落自动切换 */
+export type ThemeMode = 'light' | 'dark' | 'system' | 'special' | 'solar'
 
 /** 所有合法的特殊风格值（白名单，新增主题时只需追加这里） */
 export const THEME_STYLES = [
@@ -190,6 +190,8 @@ export const DEFAULT_MARKDOWN_FONT_SIZE: MarkdownFontSize = 'medium'
 export interface AppSettings {
   /** 主题模式 */
   themeMode: ThemeMode
+  /** 日出日落模式的位置（用户选定城市），themeMode='solar' 时使用 */
+  solarLocation?: { lat: number; lng: number; name: string }
   /** 特殊风格主题 */
   themeStyle?: ThemeStyle
   /** 界面风格 */


### PR DESCRIPTION
## 概述

新增「日出日落」主题模式（`themeMode='solar'`）。应用自身根据用户选定城市的经纬度与当前日期，离线计算真实日出日落时刻，在日出时切到浅色、日落时切到深色，不依赖操作系统的深浅色切换能力，跨平台行为一致。

现有的「跟随系统」模式被动跟随 OS，依赖 macOS / Windows 11 22H2+ 的系统层日落切换，Linux 及更早 Windows 无此能力，且多设备需各自在 OS 层配置。本模式由应用主动按真实天文时刻切换，弥补这一缺口。

## 改动

- `types/settings.ts`：`ThemeMode` 新增 `'solar'`；`AppSettings` 新增 `solarLocation?: { lat, lng, name }`
- `renderer/lib/solar.ts`（新增）：NOAA 日出日落算法（零依赖），导出 `getSunriseSunset` / `isDaytime` / `nextTransition`；极昼/极夜返回 null 并 fallback
- `renderer/lib/cities.ts`（新增）：内置 ~170 个全球主要城市经纬度表 + `searchCities`
- `renderer/atoms/theme.ts`：新增 `solarLocationAtom` 与 `solarIsDaytimeAtom`；`resolvedThemeAtom` 增加 solar 分支；`applyThemeToDOM` 增加 solar 分支；`initializeTheme` 加载并监听位置；新增 `updateSolarLocation`
- `renderer/main.tsx`：`ThemeInitializer` 增加 solar 模式每分钟轮询（首次立即执行 + `visibilitychange` 监听，窗口从睡眠/后台恢复时即时刷新），写入 `solarIsDaytimeAtom` 驱动 `resolvedThemeAtom` 重算，使 diff/toast 等消费方配色同步切换
- `renderer/components/settings/AppearanceSettings.tsx`：`THEME_OPTIONS` 增加「日出日落」；新增 `SolarLocationPicker`（城市搜索 + 选择 + 今日日出日落时刻 + 下次切换预览）
- `main/ipc.ts` / `preload/index.ts`：主题设置广播的条件与 payload 增加 `solarLocation`，跨窗口（如 Quick Task 面板）同步位置

## 测试

- `bun run typecheck` 全包通过
- `bun run dev` 启动开发版，设置 → 外观 → 主题模式选「日出日落」→ 选择城市（如北京）→ 验证当前白天切浅色 / 夜晚切深色
- 改选对侧半球当前处于黑夜的城市，验证主题随之切换
- 打开 Quick Task 面板验证跨窗口同步
- 重启应用验证 `solarLocation` 持久化与主题恢复

## 紧急度

常规

## 备注

Closes #1057

位置获取采用纯手动选城市（零体积、零隐私外发、一次配置）。IP 库自动定位、旅行换网络自动重定位等增强留作后续 PR。
