### PR TITLE
Remove Agent auto approval mode

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -4236,8 +4236,8 @@ export function registerIpcHandlers(): void {
   const isFiniteInt = (v: unknown): v is number => typeof v === 'number' && Number.isFinite(v) && Number.isInteger(v)
   const validScheduleType = (v: unknown): v is 'interval' | 'daily' | 'weekly' | 'monthly' =>
     v === 'interval' || v === 'daily' || v === 'weekly' || v === 'monthly'
-  const validPermissionMode = (v: unknown): v is 'auto' | 'bypassPermissions' =>
-    v === 'auto' || v === 'bypassPermissions'
+  const validPermissionMode = (v: unknown): v is 'bypassPermissions' =>
+    v === 'bypassPermissions'
   const validAutomationNotificationTrigger = (v: unknown): v is 'always' | 'success' | 'error' =>
     v === 'always' || v === 'success' || v === 'error'
   const validTimeOfDay = (v: unknown): boolean => typeof v === 'string' && /^([01]\d|2[0-3]):[0-5]\d$/.test(v)

--- a/apps/electron/src/main/lib/agent-collaboration-tools.ts
+++ b/apps/electron/src/main/lib/agent-collaboration-tools.ts
@@ -714,7 +714,7 @@ function startDelegation(
 function buildCollaborationSchemas(z: ZodModule['z']) {
   const nonBlankString = z.string().trim().min(1)
   const role = z.enum(['explore', 'research', 'implement', 'review', 'custom'])
-  const permissionMode = z.enum(['plan', 'auto', 'bypassPermissions'])
+  const permissionMode = z.enum(['plan', 'bypassPermissions'])
   const delegateItem = z.object({
     title: z.string().optional().describe('子会话标题，简短说明子任务'),
     role: role.optional().describe('子任务角色：explore/research/implement/review/custom'),

--- a/apps/electron/src/main/lib/agent-collaboration-utils.ts
+++ b/apps/electron/src/main/lib/agent-collaboration-utils.ts
@@ -14,8 +14,7 @@ import {
 
 const PERMISSION_RANK: Record<PromaPermissionMode, number> = {
   plan: 0,
-  auto: 1,
-  bypassPermissions: 2,
+  bypassPermissions: 1,
 }
 
 export const MAX_RUNNING_DELEGATIONS_PER_PARENT = 50

--- a/apps/electron/src/main/lib/agent-exit-plan-service.ts
+++ b/apps/electron/src/main/lib/agent-exit-plan-service.ts
@@ -100,7 +100,7 @@ export class AgentExitPlanService {
     this.pendingRequests.delete(response.requestId)
 
     switch (response.action) {
-      case 'approve_auto': {
+      case 'approve_bypass': {
         // 批准 + 切换到完全自动模式
         pending.resolve({
           behavior: 'allow' as const,
@@ -108,15 +108,6 @@ export class AgentExitPlanService {
           targetMode: 'bypassPermissions',
         })
         return { sessionId, targetMode: 'bypassPermissions' }
-      }
-      case 'approve_edit': {
-        // 批准 + 切换到自动审批模式
-        pending.resolve({
-          behavior: 'allow' as const,
-          updatedInput: pending.toolInput,
-          targetMode: 'auto',
-        })
-        return { sessionId, targetMode: 'auto' }
       }
       case 'deny': {
         // 拒绝计划

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -24,13 +24,12 @@ import type { AgentSendInput, AgentMessage, AgentGenerateTitleInput, AgentProvid
 import {
   PROMA_DEFAULT_PERMISSION_MODE,
   PROMA_PERMISSION_MODE_CONFIG,
-  SAFE_TOOLS,
   THINKING_SIGNATURE_ERROR_CODE,
   THINKING_SIGNATURE_ERROR_MESSAGE,
   THINKING_SIGNATURE_ERROR_TITLE,
   normalizeMcpTransportType,
 } from '@proma/shared'
-import type { PermissionRequest, PromaPermissionMode, AskUserRequest, ExitPlanModeRequest } from '@proma/shared'
+import type { PromaPermissionMode, AskUserRequest, ExitPlanModeRequest } from '@proma/shared'
 import type { ClaudeAgentQueryOptions } from './adapters/claude-agent-adapter'
 import { isPromptTooLongError, isThinkingSignatureError, friendlyErrorMessage, mapSDKErrorToTypedError, extractErrorDetails, shouldKeepChannelOpen } from './adapters/claude-agent-adapter'
 import { isTransientNetworkError, isMalformedResponseError } from './error-patterns'
@@ -1289,18 +1288,6 @@ export class AgentOrchestrator {
         )
       }
 
-      // 始终创建 auto 权限回调（运行中可能切换到 auto）
-      const autoCanUseTool = permissionService.createCanUseTool(
-        sessionId,
-        (request: PermissionRequest) => {
-          this.eventBus.emit(sessionId, { kind: 'proma_event', event: { type: 'permission_request', request } })
-        },
-        (sid, toolInput, signal, sendAskUser) => askUserService.handleAskUserQuestion(sid, toolInput, signal, sendAskUser),
-        (request: AskUserRequest) => {
-          this.eventBus.emit(sessionId, { kind: 'proma_event', event: { type: 'ask_user_request', request } })
-        },
-      )
-
       /**
        * 判断 Bash 命令是否是只读的（计划模式下安全可执行）
        * 检测写操作特征：文件重定向、破坏性命令、包管理写操作、git 写操作等
@@ -1394,7 +1381,7 @@ export class AgentOrchestrator {
           return { behavior: 'allow' as const, updatedInput: input }
         }
 
-        // ExitPlanMode：auto/plan 模式下必须让用户确认计划。
+        // ExitPlanMode：plan 模式下必须让用户确认计划。
         if (toolName === 'ExitPlanMode') {
           console.log(`[canUseTool] ExitPlanMode: signal.aborted=${options.signal.aborted}, planModeEntered=${planModeEntered}, mode=${currentMode}`)
           const result = await handleExitPlanMode(input, options.signal)
@@ -1467,10 +1454,6 @@ export class AgentOrchestrator {
             // 其余工具拒绝
             return { behavior: 'deny' as const, message: '计划模式下不允许执行写操作，请在计划审批通过后再执行' }
           }
-
-          case 'auto':
-            return autoCanUseTool(toolName, input, options)
-
           default:
             return { behavior: 'allow' as const, updatedInput: input }
         }
@@ -1491,7 +1474,7 @@ export class AgentOrchestrator {
         env: sdkEnv,
         ...(maxTurns != null && { maxTurns }),
         sdkPermissionMode: sdkPermissionModeForPromaMode(initialPermissionMode),
-        // permissionMode 负责表达 auto/plan/bypassPermissions。
+        // permissionMode 负责表达 plan/bypassPermissions。
         // 当提供 canUseTool 回调时这里必须为 false，否则 CLI 同时收到
         // --allow-dangerously-skip-permissions 和 --permission-prompt-tool stdio
         // 两个矛盾的指令，导致 ExitPlanMode/AskUserQuestion 等交互式工具失败。
@@ -1499,7 +1482,6 @@ export class AgentOrchestrator {
         // 从实际 tool_use 流里同步，避免 UI 停留在计划阶段。
         allowDangerouslySkipPermissions: !canUseTool,
         canUseTool,
-        ...(sdkPermissionModeForPromaMode(initialPermissionMode) === 'auto' && { allowedTools: [...SAFE_TOOLS] }),
         // claude_code preset 提供基础环境信息（platform/shell/OS/git/model/知识截止日期等）
         // buildSystemPrompt 追加 Proma 特有指令（角色定义、SubAgent 策略、工作区信息等）
         systemPrompt: {

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -37,6 +37,7 @@ import type {
   AgentSessionReferenceSearchInput,
   AgentSessionReferenceSearchResult,
 } from '@proma/shared'
+import { migratePermissionMode } from '@proma/shared'
 import { getConversationMessages } from './conversation-manager'
 // 旧格式 → SDKMessage 的转换逻辑下沉到 @proma/session-core 作为唯一真源，避免主进程与渲染层各存一份。
 import { convertLegacyMessage } from '@proma/session-core'
@@ -112,13 +113,33 @@ function normalizePersistedSDKMessage(parsed: unknown): SDKMessage {
   return parsed as SDKMessage
 }
 
+function migrateLegacyPermissionMode(index: AgentSessionsIndex): boolean {
+  let changed = false
+  for (const session of index.sessions) {
+    const rawMode = session.permissionMode as string | undefined
+    if (!rawMode) continue
+    const nextMode = migratePermissionMode(rawMode)
+    if (nextMode !== rawMode) {
+      session.permissionMode = nextMode
+      changed = true
+    }
+  }
+  return changed
+}
+
 /**
  * 读取会话索引文件
  */
 function readIndex(): AgentSessionsIndex {
   const indexPath = getAgentSessionsIndexPath()
   const data = readJsonFileSafe<AgentSessionsIndex>(indexPath)
-  if (data) return data
+  if (data) {
+    if (migrateLegacyPermissionMode(data)) {
+      writeIndex(data)
+      console.log('[Agent 会话] 已迁移历史权限模式 auto → bypassPermissions')
+    }
+    return data
+  }
   return { version: INDEX_VERSION, sessions: [] }
 }
 

--- a/apps/electron/src/main/lib/automation-agent-tools.ts
+++ b/apps/electron/src/main/lib/automation-agent-tools.ts
@@ -7,7 +7,6 @@
 
 import {
   type Automation,
-  type AutomationPermissionMode,
   type AutomationScheduleType,
   type CreateAutomationInput,
   type UpdateAutomationInput,
@@ -45,10 +44,6 @@ function validScheduleType(v: unknown): v is AutomationScheduleType {
   return v === 'interval' || v === 'daily' || v === 'weekly' || v === 'monthly' || v === 'once'
 }
 
-function validPermissionMode(v: unknown): v is AutomationPermissionMode {
-  return v === 'auto' || v === 'bypassPermissions'
-}
-
 function isFiniteInt(v: unknown): v is number {
   return typeof v === 'number' && Number.isFinite(v) && Number.isInteger(v)
 }
@@ -82,9 +77,6 @@ function validateScheduleFields(input: Partial<CreateAutomationInput | UpdateAut
   if (input.maxRuns !== undefined && (!isFiniteInt(input.maxRuns) || input.maxRuns < 1)) {
     throw new Error(`非法的 maxRuns: ${String(input.maxRuns)}（应为 ≥1 的整数）`)
   }
-  if (input.permissionMode !== undefined && !validPermissionMode(input.permissionMode)) {
-    throw new Error(`非法的 permissionMode: ${String(input.permissionMode)}`)
-  }
   if (input.sessionMode !== undefined && input.sessionMode !== 'daily' && input.sessionMode !== 'reuse') {
     throw new Error(`非法的 sessionMode: ${String(input.sessionMode)}`)
   }
@@ -104,7 +96,6 @@ function summarizeAutomation(a: Automation, includeHistory: boolean): Record<str
     maxRuns: a.maxRuns,
     runCount: a.runCount ?? 0,
     completedAt: a.completedAt,
-    permissionMode: a.permissionMode,
     sessionMode: a.sessionMode,
     workspaceId: a.workspaceId,
     sourceSessionId: a.sourceSessionId,
@@ -136,7 +127,6 @@ function getCurrentAutomationId(ctx: AutomationAgentToolContext): string | undef
 
 function buildAutomationSchemas(z: ZodModule['z']) {
   const scheduleType = z.enum(['interval', 'daily', 'weekly', 'monthly', 'once'])
-  const permissionMode = z.enum(['auto', 'bypassPermissions'])
   const sessionMode = z.enum(['daily', 'reuse'])
   return {
     list: {
@@ -157,7 +147,6 @@ function buildAutomationSchemas(z: ZodModule['z']) {
       scheduledAt: z.number().int().positive().optional().describe('一次性任务的绝对触发时间（毫秒时间戳）；scheduleType=once 时必填。用于"在某个具体时间点跑一次"，如 N 小时/天后或某个日期时刻'),
       maxRuns: z.number().int().min(1).optional().describe('最大运行次数上限（按实际执行次数计，成功+失败都算）；达到后任务自动停用。不传=不限次。可与任意 scheduleType 叠加，如 interval+maxRuns=3 表示"每隔一段时间跑，共跑 3 次就停"'),
       active: z.boolean().optional().describe('创建后是否启用，默认 true'),
-      permissionMode: permissionMode.optional().describe('无人值守权限模式，默认 bypassPermissions；高风险任务可用 auto'),
       sessionMode: sessionMode.optional().describe('会话模式：daily=同一自然日内的触发复用同一个子会话，跨日新建（默认）；reuse=始终复用同一个子会话（保留长期上下文，token 成本更高）'),
     },
     update: {
@@ -172,7 +161,6 @@ function buildAutomationSchemas(z: ZodModule['z']) {
       scheduledAt: z.number().int().positive().optional().describe('新的一次性触发时间（毫秒时间戳），scheduleType=once 时使用'),
       maxRuns: z.number().int().min(1).optional().describe('新的最大运行次数上限（按实际执行次数计）；改动会重置已执行次数计数'),
       active: z.boolean().optional().describe('启用或暂停任务'),
-      permissionMode: permissionMode.optional().describe('新的无人值守权限模式'),
       sessionMode: sessionMode.optional().describe('新的会话模式：daily=同一自然日内复用，跨日新建；reuse=始终复用同一个子会话'),
     },
     delete: {
@@ -242,7 +230,6 @@ export async function injectAutomationMcpServer(
             channelId: ctx.channelId,
             modelId: ctx.modelId,
             workspaceId: ctx.workspaceId,
-            permissionMode: args.permissionMode,
             sessionMode: args.sessionMode,
             sourceSessionId: ctx.sessionId,
             active: args.active ?? true,
@@ -270,7 +257,7 @@ export async function injectAutomationMcpServer(
       ),
       sdk.tool(
         'update_automation',
-        '修改 Proma 定时任务，包括名称、执行提示词、频率、启用状态和权限模式。定时任务自动执行中可以省略 id 来修改当前任务。',
+        '修改 Proma 定时任务，包括名称、执行提示词、频率和启用状态。定时任务自动执行中可以省略 id 来修改当前任务。',
         schemas.update,
         async (args) => {
           const id = args.id?.trim() || getCurrentAutomationId(ctx)
@@ -287,7 +274,6 @@ export async function injectAutomationMcpServer(
             scheduledAt: args.scheduledAt,
             maxRuns: args.maxRuns,
             active: args.active,
-            permissionMode: args.permissionMode,
             sessionMode: args.sessionMode,
           }
           if (input.name !== undefined) assertNonBlank(input.name, 'name')

--- a/apps/electron/src/main/lib/automation-manager.ts
+++ b/apps/electron/src/main/lib/automation-manager.ts
@@ -29,17 +29,24 @@ interface AutomationsIndex {
 const INDEX_VERSION = 2
 
 /**
- * 兼容历史 sessionMode 字面量：v1 用过的 'new' 值统一改为 'daily'。
+ * 兼容历史字段：
+ * - sessionMode：v1 用过的 'new' 值统一改为 'daily'。
+ * - permissionMode：已移除的 'auto' 统一改为默认完全自动模式。
  * - v1 默认值 'new' 的语义是「每次新建会话」；v2 的 'daily' 默认行为是「同日复用、跨日新建」，
  *   高频任务可少占左侧栏 tab，低频任务（间隔 ≥ 24h）的实际行为等价于「每次新建」，对用户无负面影响。
  * - 同时把 index.version bump 到当前值，避免下次启动反复迁移。
  * 返回是否发生改动，由调用方决定是否写回磁盘。
  */
-function migrateLegacySessionMode(data: AutomationsIndex): boolean {
+function migrateLegacyFields(data: AutomationsIndex): boolean {
   let changed = false
   for (const a of data.automations) {
     if ((a.sessionMode as string | undefined) === 'new') {
       a.sessionMode = 'daily'
+      changed = true
+    }
+    const permissionMode = a.permissionMode as string | undefined
+    if (permissionMode && permissionMode !== AUTOMATION_DEFAULT_PERMISSION_MODE) {
+      a.permissionMode = AUTOMATION_DEFAULT_PERMISSION_MODE
       changed = true
     }
   }
@@ -89,11 +96,11 @@ function readIndex(): AutomationsIndex {
     cachedIndex = { version: INDEX_VERSION, automations: [] }
     return cachedIndex
   }
-  const migrated = migrateLegacySessionMode(data)
+  const migrated = migrateLegacyFields(data)
   cachedIndex = data
   if (migrated) {
     writeIndex(data)
-    console.log('[定时任务] 索引已迁移至最新版本（sessionMode: new → daily）')
+    console.log('[定时任务] 索引已迁移至最新版本（sessionMode: new → daily，permissionMode: auto → bypassPermissions）')
   }
   return cachedIndex
 }

--- a/apps/electron/src/renderer/components/agent/ExitPlanModeBanner.tsx
+++ b/apps/electron/src/renderer/components/agent/ExitPlanModeBanner.tsx
@@ -1,11 +1,10 @@
 /**
  * ExitPlanModeBanner — Agent ExitPlanMode 计划审批横幅
  *
- * 仿照 Claude Code 的计划审批 UI，提供 4 个选项：
+ * 仿照 Claude Code 的计划审批 UI，提供 3 个选项：
  * 1. 批准并完全自动执行 — 切换到 bypassPermissions
- * 2. 批准并自动审批 — 切换到 auto
- * 3. 拒绝计划 — deny
- * 4. 提供反馈 — 自由输入修改意见
+ * 2. 拒绝计划 — deny
+ * 3. 提供反馈 — 自由输入修改意见
  *
  * 键盘：↑↓ 选择，Enter 确认，数字键快速选择。
  */
@@ -14,7 +13,6 @@ import * as React from 'react'
 import { useAtom, useSetAtom } from 'jotai'
 import {
   Check,
-  ShieldCheck,
   X,
   MessageSquare,
   Send,
@@ -35,18 +33,11 @@ interface PlanOption {
 
 const PLAN_OPTIONS: PlanOption[] = [
   {
-    action: 'approve_auto',
+    action: 'approve_bypass',
     label: '批准并完全自动执行',
     description: '后续工具调用全部自动允许',
     icon: <Check className="size-3.5" />,
     variant: 'default',
-  },
-  {
-    action: 'approve_edit',
-    label: '批准并自动审批',
-    description: '使用 SDK 自动审批器判断后续操作',
-    icon: <ShieldCheck className="size-3.5" />,
-    variant: 'secondary',
   },
   {
     action: 'deny',
@@ -181,7 +172,7 @@ export function ExitPlanModeBanner({ sessionId }: ExitPlanModeBannerProps): Reac
             handleActionRef.current?.(option.action)
           }
         }
-      } else if (e.key >= '1' && e.key <= '4') {
+      } else if (e.key >= '1' && e.key <= '3') {
         const idx = parseInt(e.key) - 1
         const option = PLAN_OPTIONS[idx]
         if (option) {
@@ -306,7 +297,7 @@ export function ExitPlanModeBanner({ sessionId }: ExitPlanModeBannerProps): Reac
       {/* 底部提示 */}
       <div className="flex items-center px-4 pb-3">
         <span className="text-[10px] text-muted-foreground/40">
-          点击选择 · ↑↓ Enter 确认 · 1-4 快速选择
+          点击选择 · ↑↓ Enter 确认 · 1-3 快速选择
         </span>
       </div>
     </div>

--- a/apps/electron/src/renderer/components/agent/PermissionModeSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/PermissionModeSelector.tsx
@@ -1,14 +1,14 @@
 /**
  * PermissionModeSelector — Agent 权限模式切换器
  *
- * 集成在 AgentHeader 中，紧凑的三模式切换按钮。
+ * 集成在 AgentHeader 中，紧凑的双模式切换按钮。
  * 支持循环切换和工作区级别的持久化。
  * 每个会话独立维护自己的权限模式。
  */
 
 import * as React from 'react'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
-import { Zap, Compass, Map as MapIcon } from 'lucide-react'
+import { Zap, Map as MapIcon } from 'lucide-react'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { Button } from '@/components/ui/button'
 import { agentPermissionModeMapAtom, agentDefaultPermissionModeAtom, sessionPersistedPermissionModeAtom, sessionExistsAtom, agentPlanModeSessionsAtom } from '@/atoms/agent-atoms'
@@ -18,7 +18,6 @@ import { getDisplayedPermissionMode, updatePlanModeSessionSet } from '@/lib/agen
 import { inputToolbarButtonClass } from '@/components/ai-elements/input-toolbar-styles'
 
 const MODE_ICONS: Record<PromaPermissionMode, React.ComponentType<{ className?: string }>> = {
-  auto: Compass,
   bypassPermissions: Zap,
   plan: MapIcon,
 }

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -132,7 +132,7 @@ function PermissionDeniedNotice({ message }: { message: SDKSystemMessage }): Rea
         <AlertTriangle className="mt-0.5 size-3.5 shrink-0 text-amber-500" />
         <div className="min-w-0 space-y-1">
           <div className="flex flex-wrap items-center gap-2">
-            <span className="font-medium text-foreground">自动审批已拒绝操作</span>
+            <span className="font-medium text-foreground">权限检查已拒绝操作</span>
             {toolName && (
               <span className="rounded bg-background/60 px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground">
                 {toolName}

--- a/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
+++ b/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
@@ -1051,32 +1051,10 @@ export function AutomationFormView(): React.ReactElement | null {
           {/* 会话模式选择已隐藏：默认采用 daily（同日复用、跨日新建）。
               schema/scheduler/Agent 工具层仍保留 reuse 模式，方便老配置和高级用户继续使用。 */}
 
-          {/* 权限模式 */}
-          <div className="flex flex-col gap-2">
-            <Label>运行权限</Label>
-            <Select
-              value={form.permissionMode}
-              onValueChange={(v) => update({ permissionMode: v as AutomationDraft['permissionMode'] })}
-            >
-              <SelectTrigger><SelectValue /></SelectTrigger>
-              <SelectContent>
-                <SelectItem value="bypassPermissions">完全自动</SelectItem>
-                <SelectItem value="auto">自动审批</SelectItem>
-              </SelectContent>
-            </Select>
-            <span className="text-xs text-muted-foreground leading-relaxed">
-              {form.permissionMode === 'bypassPermissions'
-                ? '所有工具调用自动允许（推荐用于无人值守）。'
-                : '由 SDK 内置审批器判断，危险操作仍会请求确认；无人值守时这些请求会一直挂起，需手动到会话中处理。'}
-            </span>
+          <div className="flex gap-2 rounded-lg bg-amber-500/10 p-3 text-xs text-amber-700 dark:text-amber-400">
+            <AlertTriangle className="size-4 shrink-0 mt-0.5" />
+            <span>此任务将以「完全权限」无人值守运行，可自主读写文件、执行命令。请确认任务内容安全可信。</span>
           </div>
-
-          {form.permissionMode === 'bypassPermissions' && (
-            <div className="flex gap-2 rounded-lg bg-amber-500/10 p-3 text-xs text-amber-700 dark:text-amber-400">
-              <AlertTriangle className="size-4 shrink-0 mt-0.5" />
-              <span>此任务将以「完全权限」无人值守运行，可自主读写文件、执行命令。请确认任务内容安全可信。</span>
-            </div>
-          )}
 
           {/* 运行历史（编辑模式） */}
           {isEdit && live && (

--- a/apps/electron/src/renderer/components/session-preview/SessionMiniMapPopover.tsx
+++ b/apps/electron/src/renderer/components/session-preview/SessionMiniMapPopover.tsx
@@ -229,7 +229,7 @@ function buildAgentMinimapItems(messages: SDKMessage[], userAvatar?: string): Ta
         : system.subtype === 'compacting'
           ? '正在压缩上下文...'
           : system.subtype === 'permission_denied'
-            ? '自动审批已拒绝操作'
+            ? '权限检查已拒绝操作'
             : ''
       if (preview) {
         items.push({

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -876,7 +876,7 @@ export function useGlobalAgentListeners(): void {
               updatePlanModeSessionSet(prev, sessionId, event.active)
             )
           } else if (event.type === 'permission_mode_changed') {
-            // 权限模式变更（如 Plan 模式退出后切换到自动审批或完全自动）
+            // 权限模式变更（如 Plan 模式退出后切换到完全自动）
             console.log(`[GlobalAgentListeners] 权限模式变更: ${event.mode}`)
             store.set(agentPermissionModeMapAtom, (prev: Map<string, import('@proma/shared').PromaPermissionMode>) => {
               const next = new Map(prev)

--- a/apps/electron/src/renderer/lib/agent-plan-mode.test.ts
+++ b/apps/electron/src/renderer/lib/agent-plan-mode.test.ts
@@ -41,12 +41,10 @@ describe('Agent 计划阶段状态', () => {
   })
 
   test('Given Agent 自己进入计划阶段 When 权限按钮显示模式 Then 优先显示计划模式', () => {
-    expect(getDisplayedPermissionMode('auto', true)).toBe('plan')
     expect(getDisplayedPermissionMode('bypassPermissions', true)).toBe('plan')
   })
 
   test('Given Agent 不在计划阶段 When 权限按钮显示模式 Then 保留真实权限模式', () => {
-    expect(getDisplayedPermissionMode('auto', false)).toBe('auto')
     expect(getDisplayedPermissionMode('bypassPermissions', false)).toBe('bypassPermissions')
     expect(getDisplayedPermissionMode('plan', false)).toBe('plan')
   })

--- a/packages/session-core/package.json
+++ b/packages/session-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/session-core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "AGPL-3.0-only",
   "description": "Headless core for reading, grouping, searching and rendering Proma agent sessions. Single source of truth shared by the Electron app, the proma CLI and future query surfaces.",
   "type": "module",

--- a/packages/session-core/src/group.ts
+++ b/packages/session-core/src/group.ts
@@ -248,7 +248,7 @@ export function getGroupPreview(group: MessageGroup): string {
   if (group.type === 'system') {
     if (group.message.subtype === 'compact_boundary') return '上下文已压缩'
     if (group.message.subtype === 'compacting') return '正在压缩上下文...'
-    if (group.message.subtype === 'permission_denied') return '自动审批已拒绝操作'
+    if (group.message.subtype === 'permission_denied') return '权限检查已拒绝操作'
     return ''
   }
   // assistant-turn：收集所有 text 块

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/shared",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "license": "AGPL-3.0-only",
   "description": "Shared types, configs and utilities for proma",
   "type": "module",

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1249,7 +1249,7 @@ export interface ExitPlanModeRequest {
 }
 
 /** ExitPlanMode 用户选择行为 */
-export type ExitPlanModeAction = 'approve_auto' | 'approve_edit' | 'deny' | 'feedback'
+export type ExitPlanModeAction = 'approve_bypass' | 'deny' | 'feedback'
 
 /** ExitPlanMode 响应（渲染进程 → 主进程） */
 export interface ExitPlanModeResponse {
@@ -1264,7 +1264,7 @@ export interface ExitPlanModeResponse {
 // ===== 权限系统类型 =====
 
 /** 当前 Proma 支持的权限模式，值直接映射 SDK 原生 permissionMode */
-export const PROMA_PERMISSION_MODES = ['auto', 'bypassPermissions', 'plan'] as const
+export const PROMA_PERMISSION_MODES = ['bypassPermissions', 'plan'] as const
 
 export type PromaPermissionMode = typeof PROMA_PERMISSION_MODES[number]
 
@@ -1279,11 +1279,6 @@ export interface PromaPermissionModeConfig {
 
 /** Proma 权限模式的单一配置来源 */
 export const PROMA_PERMISSION_MODE_CONFIG = {
-  auto: {
-    sdkMode: 'auto',
-    label: '自动审批',
-    description: 'SDK 内置审批器自动判断，危险操作才需确认',
-  },
   bypassPermissions: {
     sdkMode: 'bypassPermissions',
     label: '完全自动',
@@ -1303,7 +1298,7 @@ export function isPromaPermissionMode(mode: string): mode is PromaPermissionMode
   return (PROMA_PERMISSION_MODES as readonly string[]).includes(mode)
 }
 
-/** 规范化权限模式：不匹配当前三种模式时统一回到默认自动审批 */
+/** 规范化权限模式：历史 auto 或其它非法值统一回到默认完全自动模式 */
 export function migratePermissionMode(mode: string): PromaPermissionMode {
   if (isPromaPermissionMode(mode)) return mode
   return PROMA_DEFAULT_PERMISSION_MODE

--- a/packages/shared/src/types/automation.ts
+++ b/packages/shared/src/types/automation.ts
@@ -26,11 +26,10 @@ export type AutomationScheduleType = 'interval' | 'daily' | 'weekly' | 'monthly'
 
 /**
  * 定时任务的权限模式（无人值守运行场景）
- * - auto：自动审批，SDK 内置审批器判断，危险操作可能挂起等待（不推荐用于无人值守）
  * - bypassPermissions：完全自动，所有工具调用自动允许
  * 不含 plan（计划模式只规划不执行，对定时任务无意义）
  */
-export type AutomationPermissionMode = 'auto' | 'bypassPermissions'
+export type AutomationPermissionMode = 'bypassPermissions'
 
 /** 定时任务默认权限模式（向后兼容：旧任务无此字段时按此值运行） */
 export const AUTOMATION_DEFAULT_PERMISSION_MODE: AutomationPermissionMode = 'bypassPermissions'


### PR DESCRIPTION
Removes the Agent Auto approval mode so permission choices are limited to Plan and full auto execution.
Updates runtime validation, delegation, automation, and ExitPlanMode handling so `auto` is no longer accepted or passed to the SDK.
Migrates legacy saved session and automation `auto` values to `bypassPermissions`, and updates user-facing permission-denied copy.
Validation: `bun run --filter='@proma/shared' typecheck`, `bun run --filter='@proma/session-core' typecheck`, `bun run --filter='@proma/electron' typecheck`, `bun test`, and `git diff --check`.