### PR TITLE
[codex] Limit Claude MCP discovery scope

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
@@ -141,8 +141,10 @@ export interface ClaudeAgentQueryOptions extends AgentQueryInput {
   resumeSessionAt?: string
   /** MCP 服务器配置 */
   mcpServers?: Record<string, unknown>
+  /** 仅使用 Proma 显式传入的 MCP 配置，避免 SDK 从其它来源发现额外 MCP */
+  strictMcpConfig?: boolean
   /** 插件配置 */
-  plugins?: Array<{ type: 'local'; path: string }>
+  plugins?: Array<{ type: 'local'; path: string; skipMcpDiscovery?: boolean }>
   /** stderr 回调 */
   onStderr?: (data: string) => void
   /** SDK session ID 捕获回调 */
@@ -761,6 +763,7 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
         ...(options.mcpServers && Object.keys(options.mcpServers).length > 0 && {
           mcpServers: options.mcpServers as Record<string, import('@anthropic-ai/claude-agent-sdk').McpServerConfig>,
         }),
+        ...(options.strictMcpConfig != null && { strictMcpConfig: options.strictMcpConfig }),
         ...(options.plugins && { plugins: options.plugins }),
         ...(options.onStderr && { stderr: options.onStderr }),
 

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -1534,7 +1534,10 @@ export class AgentOrchestrator {
         // 回退后 resume：从指定消息处继续（SDK 在同一 JSONL 内创建分支）
         ...(rewindResumeAt && { resumeSessionAt: rewindResumeAt }),
         ...(Object.keys(mcpServers).length > 0 && { mcpServers }),
-        ...(workspaceSlug && { plugins: [{ type: 'local' as const, path: getAgentWorkspacePath(workspaceSlug) }] }),
+        strictMcpConfig: true,
+        ...(workspaceSlug && {
+          plugins: [{ type: 'local' as const, path: getAgentWorkspacePath(workspaceSlug), skipMcpDiscovery: true }],
+        }),
         // 合并附加目录：用户当次输入 + 会话级 + 工作区级（详见 collectAttachedDirectories）
         ...(() => {
           const allDirs = collectAttachedDirectories({


### PR DESCRIPTION
## Summary

This PR limits Claude Agent SDK MCP discovery to the MCP servers Proma explicitly passes at runtime. It enables `strictMcpConfig`, marks workspace plugins with `skipMcpDiscovery`, and keeps existing user/project settings sources intact so Nowledge Mem hooks and workspace auto-memory settings continue working. The Electron package patch version is bumped to `0.14.2`.

## Validation

- `bun run --cwd apps/electron typecheck`
- `bun run --cwd apps/electron build:main`
- `git diff --check`
