### PR TITLE
Disable Claude SDK workflows in Agent sessions

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
@@ -752,7 +752,7 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
         abortController: controller,
         env: options.env,
         systemPrompt: options.systemPrompt,
-        // 不加载 user 级别的 ~/.claude/settings.json
+        // 不加载 local 级别的 .claude/settings.local.json
         settingSources: ['user', 'project'],
 
         // 条件字段

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -578,6 +578,8 @@ export class AgentOrchestrator {
       ...(getBundledCliPath() ? { PROMA_CLI: getBundledCliPath() } : {}),
       // 启用 Tasks 功能
       CLAUDE_CODE_ENABLE_TASKS: 'true',
+      // 禁用 SDK 内置 Workflows，避免每轮注入 workflow 相关提示词。
+      CLAUDE_CODE_DISABLE_WORKFLOWS: '1',
       // 禁用实验性 beta 功能，使用稳定模式
       CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: '1',
       // 禁用 attribution block：SDK 默认会在 system prompt 最前面注入一段


### PR DESCRIPTION
## Summary
- Disable Claude Agent SDK Workflows for Proma Agent sessions by setting CLAUDE_CODE_DISABLE_WORKFLOWS in the SDK subprocess environment.
- Correct the settingSources comment so it matches the actual user/project behavior, and bump the Electron patch version.

## Validation
- bun run --filter='@proma/electron' typecheck
- bun run --filter='@proma/electron' build:main