### PR TITLE
fix(agent): disable Tool Search to fix HTTP MCP tool registration

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -433,6 +433,11 @@ export class AgentOrchestrator {
       CLAUDE_CODE_DISABLE_WORKFLOWS: '1',
       // 禁用实验性 beta 功能，使用稳定模式
       CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: '1',
+      // 禁用 Tool Search：Claude 模型连接第一方 Anthropic API 时，SDK CLI 会自动启用
+      // Tool Search（optimistic 模式），将外部 MCP 工具标记为 deferred 而非 eager 注册，
+      // 导致 HTTP MCP 服务器（如 Nowledge Mem）的工具无法直接调用。
+      // Proma 自行管理工具呈现和 MCP 连接，不依赖此机制。
+      ENABLE_TOOL_SEARCH: 'false',
       // 禁用 attribution block：SDK 默认会在 system prompt 最前面注入一段
       // 文本（含客户端版本号与基于会话内容计算的指纹），且每次请求都变化。
       // 经第三方 Anthropic 兼容代理/网关中转时，会导致缓存前缀变化、命中率骤降。


### PR DESCRIPTION
## Summary

- Claude Code CLI 在连接第一方 Anthropic API 时自动启用 Tool Search（optimistic 模式），将外部 MCP 工具标记为 deferred 而非 eager 注册
- 这导致 HTTP MCP 服务器（如 Nowledge Mem）的工具虽然出现在 prompt 中，但运行时调用报 "No such tool available"
- DeepSeek 不受影响是因为 `ANTHROPIC_BASE_URL` 指向非 Anthropic 主机，CLI 自动禁用了 Tool Search
- 修复：在 `buildSdkEnv` 中设置 `ENABLE_TOOL_SEARCH=false`，确保所有 provider 一致使用 eager MCP 注册

## Test plan

- [ ] 使用 Claude 模型新建会话，验证 `mcp__nowledge_mem__*` 工具可正常调用
- [ ] 使用 DeepSeek 模型新建会话，确认无回归
- [ ] 验证内置 MCP 工具（automation、collaboration、proma_cloud）不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)