### PR TITLE
fix(agent): 修复上下文指示器 contextWindow 被 Task 子 Agent 拉低导致飘忽和误触发自动压缩

### DIFF
--- a/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/claude-agent-adapter.ts
@@ -907,15 +907,22 @@ export class ClaudeAgentAdapter implements AgentProviderAdapter {
         }
 
         // 捕获 result 中的 contextWindow
+        // 多 entry 场景（Task 子 Agent 等）：取最大 contextWindow 作为分母，
+        // 避免子 Agent 的小窗口覆盖主模型的大窗口、导致 UI 指示器飘忽。
         if (msg.type === 'result') {
           const resultMsg = msg as {
             modelUsage?: Record<string, { contextWindow?: number }>
             terminal_reason?: string
           }
           if (resultMsg.modelUsage) {
-            const firstEntry = Object.values(resultMsg.modelUsage)[0]
-            if (firstEntry?.contextWindow) {
-              options.onContextWindow?.(firstEntry.contextWindow)
+            let bestWindow: number | undefined
+            for (const info of Object.values(resultMsg.modelUsage)) {
+              if (info?.contextWindow && (bestWindow === undefined || info.contextWindow > bestWindow)) {
+                bestWindow = info.contextWindow
+              }
+            }
+            if (bestWindow != null) {
+              options.onContextWindow?.(bestWindow)
             }
           }
           // 被软中断 / 延迟工具 / hook 暂停等场景产生的 result：不关闭通道，

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -720,15 +720,20 @@ export function applyAgentEvent(
       //
       // 折中：仅当「整个 query 期间从未收到流式 usage_update」（prev.inputTokens 为空/0）
       // 才从 result.usage 兜底写入 token 字段；已有流式真实值时不动。
-      // - contextWindow：始终覆盖（result 才是权威分母）
+      // - contextWindow：取流式与 result 的较大值（result 未必更权威——多 entry 时
+      //   子 Agent 的小窗口可能拉低值，Fix 1/2 已从源头取 max，此处作为安全网）。
       // - costUsd：始终覆盖（本就该是整轮累计成本）
       const needResultFallback = !prev.inputTokens || prev.inputTokens <= 0
       return {
         ...prev,
         ...(event.usage ? {
           ...(event.usage.costUsd != null && { costUsd: event.usage.costUsd }),
-          ...(event.usage.contextWindow != null && { contextWindow: event.usage.contextWindow }),
-          ...(event.usage.contextWindow != null && { usageUpdatedAt: Date.now() }),
+          ...(event.usage.contextWindow != null && {
+            contextWindow: prev.contextWindow != null
+              ? Math.max(prev.contextWindow, event.usage.contextWindow)
+              : event.usage.contextWindow,
+            usageUpdatedAt: Date.now(),
+          }),
           ...(needResultFallback && event.usage.inputTokens != null && { inputTokens: event.usage.inputTokens }),
           ...(needResultFallback && event.usage.outputTokens != null && { outputTokens: event.usage.outputTokens }),
           ...(needResultFallback && event.usage.cacheReadTokens != null && { cacheReadTokens: event.usage.cacheReadTokens }),
@@ -762,9 +767,13 @@ export function applyAgentEvent(
         ...(event.usage.cacheReadTokens != null && { cacheReadTokens: event.usage.cacheReadTokens }),
         ...(event.usage.cacheCreationTokens != null && { cacheCreationTokens: event.usage.cacheCreationTokens }),
         ...(event.usage.costUsd != null && { costUsd: event.usage.costUsd }),
-        // 流式中 assistant 消息的 usage_update 可能携带推断的 contextWindow，
-        // 若已有 result 消息提供的真实值，则不再覆盖
-        ...(event.usage.contextWindow && !prev.contextWindow && { contextWindow: event.usage.contextWindow }),
+        // contextWindow 取 max：本分支同时承载「流式 assistant 消息按模型名推断的窗口」
+        // 与「后端从 SDK result 透传的真实窗口（context_window 事件）」两个来源。
+        // 模型窗口在同一会话内不会缩小，取更大值可兼顾两类端点——既不会让推断偏小的
+        // 端点（如 GLM 剥掉 [1m] 后缀）挡住真实的 1M，也不会让回报偏小的端点覆盖正确的 1M。
+        ...(event.usage.contextWindow && {
+          contextWindow: Math.max(prev.contextWindow ?? 0, event.usage.contextWindow),
+        }),
         usageUpdatedAt: Date.now(),
       }
 

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -210,9 +210,15 @@ function extractTurnUsage(turnMessages: SDKMessage[]): { durationMs?: number; us
     const durationMs = typeof raw._durationMs === 'number' ? raw._durationMs : undefined
     const u = resultMsg.usage
     if (!u) return { durationMs }
-    const contextWindow = resultMsg.modelUsage
-      ? Object.values(resultMsg.modelUsage)[0]?.contextWindow
-      : undefined
+    // 多 entry 场景（Task 子 Agent 等）：取最大 contextWindow
+    let contextWindow: number | undefined
+    if (resultMsg.modelUsage) {
+      for (const info of Object.values(resultMsg.modelUsage)) {
+        if (info?.contextWindow && (contextWindow === undefined || info.contextWindow > contextWindow)) {
+          contextWindow = info.contextWindow
+        }
+      }
+    }
     return {
       durationMs,
       usage: {

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -243,7 +243,16 @@ function payloadToLegacyEvents(payload: AgentStreamPayload): AgentEvent[] {
         modelUsage?: Record<string, { contextWindow?: number }>
         usage?: { input_tokens: number; output_tokens: number; cache_read_input_tokens: number; cache_creation_input_tokens: number }
       }
-      const contextWindow = rMsg.modelUsage ? Object.values(rMsg.modelUsage)[0]?.contextWindow : undefined
+      // 多 entry 场景（Task 子 Agent 等）：取最大 contextWindow，
+      // 避免子 Agent 的小窗口覆盖主模型的大窗口、导致指示器飘忽。
+      let contextWindow: number | undefined
+      if (rMsg.modelUsage) {
+        for (const info of Object.values(rMsg.modelUsage)) {
+          if (info?.contextWindow && (contextWindow === undefined || info.contextWindow > contextWindow)) {
+            contextWindow = info.contextWindow
+          }
+        }
+      }
       // result.usage 是整个 query 内所有模型调用的累计求和，不能当成当前上下文占用，
       // 否则进度环会虚高、冲破 100%（PR #821 修的正是这个问题）。
       //


### PR DESCRIPTION
## Summary

- ba3cd44b fix(agent): prevent contextWindow from being pulled down by sub-agent model entries

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归