### PR TITLE
fix: 后台等待中发送失败时恢复输入框内容

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -1523,6 +1523,14 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       sendPlainTextAgentMessage(message).catch((error) => {
         console.error('[AgentView] 追加消息失败:', error)
         toast.error('追加消息失败', { description: String(error) })
+        // 回滚：恢复输入框内容和建议，避免用户输入丢失
+        setInputContent(effectiveText)
+        setInputHtmlContent('')
+        setPromptSuggestions((prev) => {
+          const map = new Map(prev)
+          map.set(sessionId, suggestion ?? null)
+          return map
+        })
       })
       return
     }


### PR DESCRIPTION
## 背景
PR #1075（Agent 消息托管队列）中，`handleSend` 在 `backgroundWaiting` 分支调用 `sendPlainTextAgentMessage` 前已清空输入框。如果注入失败（如 IPC 异常），用户的输入文本会丢失——只有 toast 提示但无法恢复。

## 修改
在 `sendPlainTextAgentMessage` 的 `.catch()` 中回滚：
- 恢复 `inputContent` 为原始 `effectiveText`
- 恢复 `promptSuggestions`（保留原 `suggestion`）

对比队列发送路径（`handleSendQueuedNow` / auto-drain effect）有 `restoreQueuedMessageToFront` 回滚，此处应保持一致。

## 影响范围
`apps/electron/src/renderer/components/agent/AgentView.tsx` — `handleSend` 的 `backgroundWaiting` 分支 catch 块。

Co-Authored-By: Claude <noreply@anthropic.com>