### PR TITLE
fix(agent): remove custom auto compact settings

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/agent-auto-compact-settings.test.ts
+++ b/apps/electron/src/main/lib/agent-auto-compact-settings.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test'
+import { removePromaAutoCompactSettings } from './agent-auto-compact-settings'
+
+describe('Agent 自动压缩设置清理', () => {
+  test('Given settings 含自动压缩窗口和开关 When 清理 Proma 自动压缩设置 Then 删除两个字段', () => {
+    const settings: Record<string, unknown> = {
+      plansDirectory: '.context',
+      autoCompactEnabled: true,
+      autoCompactWindow: 850_000,
+    }
+
+    const changed = removePromaAutoCompactSettings(settings)
+
+    expect(changed).toBe(true)
+    expect(settings).toEqual({ plansDirectory: '.context' })
+  })
+
+  test('Given settings 只含自动压缩开关 When 清理 Proma 自动压缩设置 Then 删除开关字段', () => {
+    const settings: Record<string, unknown> = {
+      autoCompactEnabled: false,
+      skipWebFetchPreflight: true,
+    }
+
+    const changed = removePromaAutoCompactSettings(settings)
+
+    expect(changed).toBe(true)
+    expect(settings).toEqual({ skipWebFetchPreflight: true })
+  })
+
+  test('Given settings 没有自动压缩字段 When 清理 Proma 自动压缩设置 Then 不改动', () => {
+    const settings: Record<string, unknown> = {
+      plansDirectory: '.context',
+      skipWebFetchPreflight: true,
+    }
+
+    const changed = removePromaAutoCompactSettings(settings)
+
+    expect(changed).toBe(false)
+    expect(settings).toEqual({
+      plansDirectory: '.context',
+      skipWebFetchPreflight: true,
+    })
+  })
+})

--- a/apps/electron/src/main/lib/agent-auto-compact-settings.ts
+++ b/apps/electron/src/main/lib/agent-auto-compact-settings.ts
@@ -1,0 +1,15 @@
+export function removePromaAutoCompactSettings(settings: Record<string, unknown>): boolean {
+  let changed = false
+
+  if ('autoCompactWindow' in settings) {
+    delete settings.autoCompactWindow
+    changed = true
+  }
+
+  if ('autoCompactEnabled' in settings) {
+    delete settings.autoCompactEnabled
+    changed = true
+  }
+
+  return changed
+}

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -51,6 +51,7 @@ import { permissionService } from './agent-permission-service'
 import type { PermissionResult, CanUseToolOptions } from './agent-permission-service'
 import { askUserService } from './agent-ask-user-service'
 import { exitPlanService, type ExitPlanPermissionResult } from './agent-exit-plan-service'
+import { removePromaAutoCompactSettings } from './agent-auto-compact-settings'
 import { applyAgentModelRoutingToEnv, resolveAgentModelRouting } from './agent-model-routing'
 import { validateToolInput } from './agent-tool-input-validator'
 import { estimateTokenCount, WRITE_CONTENT_TOKEN_THRESHOLD } from './agent-tool-token-estimator'
@@ -268,47 +269,6 @@ function resolveSDKCliPath(): string {
   }
 
   return binaryPath
-}
-
-/** DeepSeek 1M 上下文的保守自动压缩窗口，给上游真实限制和输出预留安全垫。 */
-const DEEPSEEK_AUTO_COMPACT_WINDOW = 850_000
-
-function resolvePromaAutoCompactWindow(provider: ProviderType, modelId: string | undefined): number | undefined {
-  const model = (modelId || '').toLowerCase()
-  if (provider === 'deepseek' || model.startsWith('deepseek-v4') || model.includes('/deepseek-v4')) {
-    return DEEPSEEK_AUTO_COMPACT_WINDOW
-  }
-  return undefined
-}
-
-function applyPromaAutoCompactSettings(settings: Record<string, unknown>, targetWindow: number | undefined): boolean {
-  let changed = false
-
-  if (targetWindow != null) {
-    if (settings.autoCompactEnabled !== true) {
-      settings.autoCompactEnabled = true
-      changed = true
-    }
-
-    const currentWindow = typeof settings.autoCompactWindow === 'number'
-      ? settings.autoCompactWindow
-      : undefined
-    const nextWindow = currentWindow != null && currentWindow > 0
-      ? Math.min(currentWindow, targetWindow)
-      : targetWindow
-    if (settings.autoCompactWindow !== nextWindow) {
-      settings.autoCompactWindow = nextWindow
-      changed = true
-    }
-    return changed
-  }
-
-  if (settings.autoCompactWindow === DEEPSEEK_AUTO_COMPACT_WINDOW) {
-    delete settings.autoCompactWindow
-    changed = true
-  }
-
-  return changed
 }
 
 /** 标题生成 Prompt */
@@ -1053,10 +1013,7 @@ export class AgentOrchestrator {
             needsWrite = true
           }
         }
-        if (applyPromaAutoCompactSettings(
-          sdkProjectSettings,
-          resolvePromaAutoCompactWindow(channel.provider, modelId || DEFAULT_MODEL_ID),
-        )) {
+        if (removePromaAutoCompactSettings(sdkProjectSettings)) {
           needsWrite = true
         }
         if (needsWrite) {

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -37,7 +37,8 @@ import { groupIntoTurns, MessageGroupRenderer, getGroupId, getGroupPreview, extr
 import { buildLiveGroupSet } from './live-group-set'
 import { ContentBlock } from './ContentBlock'
 import { parseThinkTagsFromText } from './thinking-tag-parser'
-import type { AgentEventUsage, RetryAttempt, SDKMessage } from '@proma/shared'
+import type { AgentEventUsage, RetryAttempt, SDKMessage, SDKSystemMessage } from '@proma/shared'
+import { getSDKCompactStatus } from '@proma/shared'
 import type { AgentStreamState } from '@/atoms/agent-atoms'
 
 function stableStringify(value: unknown): string {
@@ -84,6 +85,13 @@ function getSDKMessageStableKey(message: SDKMessage): string {
 
   stableKeyCache.set(message, key)
   return key
+}
+
+function hasCompactStatus(messages: SDKMessage[]): boolean {
+  return messages.some((message) => {
+    if (message.type !== 'system') return false
+    return getSDKCompactStatus(message as SDKSystemMessage) != null
+  })
 }
 
 /** AgentMessages 属性接口 */
@@ -538,6 +546,9 @@ export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persi
   // compactInFlight 从点击压缩 / SDK compacting 事件开始为 true，
   // 直到整个 stream 结束（stream state 被删除）才消失。
   const suppressAgentRunning = streamState?.isCompacting || streamState?.compactInFlight
+  const compactStatusInLiveMessages = React.useMemo(() => {
+    return hasCompactStatus(liveMessages ?? [])
+  }, [liveMessages])
 
   // 统一分组：将持久化 + 实时消息合并后再分组，确保 system 消息（如压缩分割线）出现在正确位置
   const allGroups = React.useMemo(() => {
@@ -694,7 +705,7 @@ export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persi
 
             {/* 压缩中指示器：由 isCompacting flag 驱动的尾部元素，compact_boundary 到达时 flag 翻 false 自然消失，
                 视觉上被流中新出现的"上下文已压缩"分隔符无缝替换 */}
-            {streamState?.isCompacting && <CompactingIndicator />}
+            {streamState?.isCompacting && !compactStatusInLiveMessages && <CompactingIndicator />}
 
           </>
         )}

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -1527,7 +1527,11 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         setInputHtmlContent('')
         setPromptSuggestions((prev) => {
           const map = new Map(prev)
-          map.set(sessionId, suggestion ?? null)
+          if (suggestion) {
+            map.set(sessionId, suggestion)
+          } else {
+            map.delete(sessionId)
+          }
           return map
         })
       })


### PR DESCRIPTION
Removes Proma's custom autoCompactWindow and autoCompactEnabled writes from Agent session settings, and cleans those fields from existing session settings during normal maintenance. This avoids misleading DeepSeek behavior where SDK auto-compact still triggers around the SDK's own context window rather than Proma's attempted 850K override. The PR also suppresses duplicate live compacting indicators and fixes prompt suggestion rollback so it never writes null into a string-only map. Validated with targeted Bun tests, Electron typecheck, and git diff whitespace checks.