### PR TITLE
feat(input): 新增输入框 Markdown 渲染开关

### DIFF
--- a/apps/electron/src/main/lib/settings-service.ts
+++ b/apps/electron/src/main/lib/settings-service.ts
@@ -26,6 +26,7 @@ export function getSettings(): AppSettings {
       environmentCheckSkipped: false,
       notificationsEnabled: true,
       longTextPasteAsAttachmentEnabled: false,
+      richTextRenderingEnabled: false,
       feishuSessionMirror: { mode: 'off' },
       builtinMcpDisabledIds: [],
     }
@@ -42,6 +43,7 @@ export function getSettings(): AppSettings {
       environmentCheckSkipped: data.environmentCheckSkipped ?? false,
       notificationsEnabled: data.notificationsEnabled ?? true,
       longTextPasteAsAttachmentEnabled: data.longTextPasteAsAttachmentEnabled ?? false,
+      richTextRenderingEnabled: data.richTextRenderingEnabled ?? false,
       feishuSessionMirror: data.feishuSessionMirror ?? { mode: 'off' },
       builtinMcpDisabledIds: data.builtinMcpDisabledIds ?? [],
     }
@@ -54,6 +56,7 @@ export function getSettings(): AppSettings {
       environmentCheckSkipped: false,
       notificationsEnabled: true,
       longTextPasteAsAttachmentEnabled: false,
+      richTextRenderingEnabled: false,
       feishuSessionMirror: { mode: 'off' },
       builtinMcpDisabledIds: [],
     }

--- a/apps/electron/src/renderer/atoms/ui-preferences.ts
+++ b/apps/electron/src/renderer/atoms/ui-preferences.ts
@@ -14,7 +14,7 @@ export const stickyUserMessageEnabledAtom = atom<boolean>(true)
 /** 粘贴长文本时是否自动转为附件 */
 export const longTextPasteAsAttachmentEnabledAtom = atom<boolean>(false)
 
-/** 输入框是否渲染 Markdown 富文本格式（关闭后为纯文本模式，仍保留 Mention 引用） */
+/** 输入框是否渲染 Markdown 富文本格式（默认关闭，纯文本模式；开启后渲染富文本，仍保留 Mention 引用） */
 export const richTextRenderingEnabledAtom = atom<boolean>(false)
 
 // ===== 初始化 =====

--- a/apps/electron/src/renderer/atoms/ui-preferences.ts
+++ b/apps/electron/src/renderer/atoms/ui-preferences.ts
@@ -1,7 +1,7 @@
 /**
  * UI 偏好设置状态管理
  *
- * 管理用户界面相关的显示偏好，如悬浮置顶条等。
+ * 管理用户界面相关的显示偏好，如悬浮置顶条、输入框 Markdown 渲染等。
  */
 
 import { atom } from 'jotai'
@@ -14,6 +14,9 @@ export const stickyUserMessageEnabledAtom = atom<boolean>(true)
 /** 粘贴长文本时是否自动转为附件 */
 export const longTextPasteAsAttachmentEnabledAtom = atom<boolean>(false)
 
+/** 输入框是否渲染 Markdown 富文本格式（关闭后为纯文本模式，仍保留 Mention 引用） */
+export const richTextRenderingEnabledAtom = atom<boolean>(false)
+
 // ===== 初始化 =====
 
 /**
@@ -21,12 +24,14 @@ export const longTextPasteAsAttachmentEnabledAtom = atom<boolean>(false)
  */
 export async function initializeUiPreferences(
   setStickyUserMessageEnabled: (enabled: boolean) => void,
-  setLongTextPasteAsAttachmentEnabled?: (enabled: boolean) => void
+  setLongTextPasteAsAttachmentEnabled?: (enabled: boolean) => void,
+  setRichTextRenderingEnabled?: (enabled: boolean) => void
 ): Promise<void> {
   try {
     const settings = await window.electronAPI.getSettings()
     setStickyUserMessageEnabled(settings.stickyUserMessageEnabled ?? true)
     setLongTextPasteAsAttachmentEnabled?.(settings.longTextPasteAsAttachmentEnabled ?? false)
+    setRichTextRenderingEnabled?.(settings.richTextRenderingEnabled ?? false)
   } catch (error) {
     console.error('[UI偏好] 初始化失败:', error)
   }
@@ -53,5 +58,16 @@ export async function updateLongTextPasteAsAttachmentEnabled(enabled: boolean): 
     await window.electronAPI.updateSettings({ longTextPasteAsAttachmentEnabled: enabled })
   } catch (error) {
     console.error('[UI偏好] 更新长文本粘贴附件设置失败:', error)
+  }
+}
+
+/**
+ * 更新输入框 Markdown 渲染开关并持久化
+ */
+export async function updateRichTextRenderingEnabled(enabled: boolean): Promise<void> {
+  try {
+    await window.electronAPI.updateSettings({ richTextRenderingEnabled: enabled })
+  } catch (error) {
+    console.error('[UI偏好] 更新输入框 Markdown 渲染设置失败:', error)
   }
 }

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -14,6 +14,7 @@
  */
 
 import { useState, useEffect, useRef, useMemo } from 'react'
+import { useAtomValue } from 'jotai'
 import { useEditor, EditorContent } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import Placeholder from '@tiptap/extension-placeholder'
@@ -26,6 +27,7 @@ import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip
 import { cn } from '@/lib/utils'
 import { lowlight } from '@/lib/lowlight'
 import { htmlToMarkdown } from '@/lib/markdown-rich-text'
+import { richTextRenderingEnabledAtom } from '@/atoms/ui-preferences'
 import { createFileMentionSuggestion } from '@/components/file-browser/file-mention-suggestion'
 import { createSkillMentionSuggestion, createMcpMentionSuggestion, createSessionMentionSuggestion } from '@/components/agent/mention-suggestions'
 import { shouldConvertClipboardTextToAttachment } from '@/lib/clipboard-text-attachment'
@@ -201,6 +203,11 @@ export function RichTextInput({
   // 是否启用 Mention 功能：Agent 首帧可能尚未拿到路径/slug/id，但扩展必须先注册。
   const hasMentionSupport = enableMentions ?? (workspacePath !== undefined || workspaceSlug !== undefined || workspaceId !== undefined)
 
+  // 输入框 Markdown 渲染开关：关闭后为纯文本模式（禁用格式化扩展 + 粘贴不解析 HTML），仍保留 Mention 引用
+  const richTextEnabled = useAtomValue(richTextRenderingEnabledAtom)
+  const richTextEnabledRef = useRef(richTextEnabled)
+  richTextEnabledRef.current = richTextEnabled
+
   // Mention Suggestion 配置（稳定引用，不随 workspacePath 变化重建）
   const mentionSuggestion = useMemo(
     () => createFileMentionSuggestion(workspacePathRef, mentionActiveRef, attachedDirsRef, mentionItemCountRef, sessionAttachedDirsRef),
@@ -233,28 +240,44 @@ export function RichTextInput({
         // 禁用内置版本，使用下面单独配置的版本
         link: false,
         underline: false,
+        // 纯文本模式：禁用所有格式化扩展，仅保留 Document/Paragraph/Text/HardBreak/History
+        ...(richTextEnabled ? {} : {
+          blockquote: false,
+          bold: false,
+          bulletList: false,
+          code: false,
+          heading: false,
+          horizontalRule: false,
+          italic: false,
+          orderedList: false,
+          strike: false,
+        }),
       }),
-      Underline,
-      Link.configure({
-        openOnClick: false,
-        autolink: false,
-        linkOnPaste: false,
-        HTMLAttributes: {
-          class: 'text-primary underline',
-        },
-      }),
-      CodeBlockLowlight.configure({
-        lowlight,
-        HTMLAttributes: {
-          class: 'rounded-md p-3 font-mono text-sm',
-        },
-      }),
+      // 富文本模式下注册格式化扩展；纯文本模式下跳过
+      ...(richTextEnabled ? [
+        Underline,
+        Link.configure({
+          openOnClick: false,
+          autolink: false,
+          linkOnPaste: false,
+          HTMLAttributes: {
+            class: 'text-primary underline',
+          },
+        }),
+        CodeBlockLowlight.configure({
+          lowlight,
+          HTMLAttributes: {
+            class: 'rounded-md p-3 font-mono text-sm',
+          },
+        }),
+      ] : []),
       Placeholder.configure({
         placeholder,
         emptyEditorClass: 'is-editor-empty',
       }),
       // Mention 扩展：启用时注册，路径/slug 后续通过 ref 异步更新
       // @ 引用文件、/ 触发 Skill、# 触发 MCP
+      // 纯文本模式下仍然保留，确保引用功能可用
       ...(hasMentionSupport ? [
         Mention.extend({
           addAttributes() {
@@ -352,6 +375,25 @@ export function RichTextInput({
 
         const threshold = longTextPasteThresholdRef.current
         const plainText = event.clipboardData?.getData('text/plain') ?? ''
+
+        // 纯文本模式：直接插入原始文本，不经过 HTML 解析
+        if (!richTextEnabledRef.current) {
+          // 超长文本转附件逻辑仍然生效（按纯文本长度判断）
+          if (
+            threshold &&
+            threshold > 0 &&
+            plainText.length >= threshold &&
+            onPasteLongTextRef.current
+          ) {
+            event.preventDefault()
+            onPasteLongTextRef.current(plainText)
+            return true
+          }
+          event.preventDefault()
+          view.dispatch(view.state.tr.insertText(plainText))
+          return true
+        }
+
         const html = event.clipboardData?.getData('text/html') ?? ''
         // 预处理 HTML：将 <div> 替换为 <p>，避免 htmlToMarkdown 对 <div> 不分段导致换行丢失
         const text = html
@@ -378,18 +420,21 @@ export function RichTextInput({
       },
       handleKeyDown: (view, event) => {
         // macOS 上 Cmd+B/S 被全局快捷键占用，用 Ctrl+B/S 作为格式化替代键
-        const isMacOS = navigator.platform.startsWith('Mac')
-        if (isMacOS && event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey) {
-          const key = event.key.toLowerCase()
-          if (key === 'b') {
-            event.preventDefault()
-            editor?.chain().focus().toggleBold().run()
-            return true
-          }
-          if (key === 's') {
-            event.preventDefault()
-            editor?.chain().focus().toggleStrike().run()
-            return true
+        // 纯文本模式下富文本快捷键不生效，直接跳过（不解发事件）
+        if (richTextEnabledRef.current) {
+          const isMacOS = navigator.platform.startsWith('Mac')
+          if (isMacOS && event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey) {
+            const key = event.key.toLowerCase()
+            if (key === 'b') {
+              event.preventDefault()
+              editor?.chain().focus().toggleBold().run()
+              return true
+            }
+            if (key === 's') {
+              event.preventDefault()
+              editor?.chain().focus().toggleStrike().run()
+              return true
+            }
           }
         }
 
@@ -518,7 +563,7 @@ export function RichTextInput({
         })
       }
     },
-  })
+  }, [richTextEnabled])
 
   // 卸载时取消未触发的 rAF 行数检查，避免泄漏 / 在卸载组件上 setState
   useEffect(() => {
@@ -531,11 +576,16 @@ export function RichTextInput({
   }, [])
 
   // 同步外部 value 变化（清空时）
+  // 追踪编辑器实例，重建时强制同步（避免 htmlValue 草稿丢失）
+  const editorInstanceRef = useRef(editor)
   useEffect(() => {
     if (editor) {
       const controllerValue = value
+      const isEditorRecreated = editor !== editorInstanceRef.current
+      editorInstanceRef.current = editor
       // 如果值是编辑器自己设置的，跳过同步
-      if (controllerValue === lastEditorValueRef.current) {
+      // 但编辑器重建后必须强制同步（即使 value 未变，htmlValue 草稿可能不同）
+      if (!isEditorRecreated && controllerValue === lastEditorValueRef.current) {
         return
       }
 

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -203,7 +203,7 @@ export function RichTextInput({
   // 是否启用 Mention 功能：Agent 首帧可能尚未拿到路径/slug/id，但扩展必须先注册。
   const hasMentionSupport = enableMentions ?? (workspacePath !== undefined || workspaceSlug !== undefined || workspaceId !== undefined)
 
-  // 输入框 Markdown 渲染开关：关闭后为纯文本模式（禁用格式化扩展 + 粘贴不解析 HTML），仍保留 Mention 引用
+  // 输入框 Markdown 渲染开关：关闭后为纯文本模式（禁用格式化扩展 + 粘贴跳过 HTML 解析），Mention 仍保留
   const richTextEnabled = useAtomValue(richTextRenderingEnabledAtom)
   const richTextEnabledRef = useRef(richTextEnabled)
   richTextEnabledRef.current = richTextEnabled
@@ -420,7 +420,7 @@ export function RichTextInput({
       },
       handleKeyDown: (view, event) => {
         // macOS 上 Cmd+B/S 被全局快捷键占用，用 Ctrl+B/S 作为格式化替代键
-        // 纯文本模式下富文本快捷键不生效，直接跳过（不解发事件）
+        // 纯文本模式下跳过，避免无效操作且不吃事件
         if (richTextEnabledRef.current) {
           const isMacOS = navigator.platform.startsWith('Mac')
           if (isMacOS && event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey) {
@@ -543,7 +543,9 @@ export function RichTextInput({
         }
         setIsManuallyCollapsed(false)
       } else {
-        const markdown = htmlToMarkdown(html)
+        // 纯文本模式下跳过 markdown 特殊字符转义，保持用户所见即所得
+        // 纯文本模式下跳过 markdown 特殊字符转义，保持用户所见即所得
+        const markdown = htmlToMarkdown(html, { skipMarkdownEscape: !richTextEnabled })
         lastEditorValueRef.current = markdown
         onChange(markdown)
         onHtmlChangeRef.current?.(html)
@@ -575,9 +577,9 @@ export function RichTextInput({
     }
   }, [])
 
-  // 同步外部 value 变化（清空时）
   // 追踪编辑器实例，重建时强制同步（避免 htmlValue 草稿丢失）
   const editorInstanceRef = useRef(editor)
+  // 同步外部 value 变化（清空时）
   useEffect(() => {
     if (editor) {
       const controllerValue = value

--- a/apps/electron/src/renderer/components/settings/GeneralSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/GeneralSettings.tsx
@@ -39,8 +39,10 @@ import {
 } from '@/atoms/notifications'
 import {
   longTextPasteAsAttachmentEnabledAtom,
+  richTextRenderingEnabledAtom,
   stickyUserMessageEnabledAtom,
   updateLongTextPasteAsAttachmentEnabled,
+  updateRichTextRenderingEnabled,
   updateStickyUserMessageEnabled,
 } from '@/atoms/ui-preferences'
 import { cn } from '@/lib/utils'
@@ -64,6 +66,7 @@ export function GeneralSettings(): React.ReactElement {
   const [notificationSounds, setNotificationSounds] = useAtom(notificationSoundsAtom)
   const [stickyUserMessageEnabled, setStickyUserMessageEnabled] = useAtom(stickyUserMessageEnabledAtom)
   const [longTextPasteAsAttachmentEnabled, setLongTextPasteAsAttachmentEnabled] = useAtom(longTextPasteAsAttachmentEnabledAtom)
+  const [richTextRenderingEnabled, setRichTextRenderingEnabled] = useAtom(richTextRenderingEnabledAtom)
   const [isEditingName, setIsEditingName] = React.useState(false)
   const [nameInput, setNameInput] = React.useState(userProfile.userName)
   const [showEmojiPicker, setShowEmojiPicker] = React.useState(false)
@@ -329,6 +332,15 @@ export function GeneralSettings(): React.ReactElement {
             onCheckedChange={(checked) => {
               setLongTextPasteAsAttachmentEnabled(checked)
               updateLongTextPasteAsAttachmentEnabled(checked)
+            }}
+          />
+          <SettingsToggle
+            label="输入框 Markdown 渲染"
+            description="开启后，输入框中的 Markdown 语法（如 **粗体**、# 标题）会实时渲染为富文本；关闭后为纯文本模式，保留 @ 引用等功能"
+            checked={richTextRenderingEnabled}
+            onCheckedChange={(checked) => {
+              setRichTextRenderingEnabled(checked)
+              updateRichTextRenderingEnabled(checked)
             }}
           />
         </SettingsCard>

--- a/apps/electron/src/renderer/lib/markdown-rich-text.ts
+++ b/apps/electron/src/renderer/lib/markdown-rich-text.ts
@@ -357,7 +357,7 @@ export function markdownToHtml(markdown: string): string {
 }
 
 /** 将 TipTap 输出的 HTML 转换为 Markdown 格式 */
-export function htmlToMarkdown(html: string): string {
+export function htmlToMarkdown(html: string, options?: { skipMarkdownEscape?: boolean }): string {
   if (!html || html === '<p></p>') return ''
 
   const div = document.createElement('div')
@@ -366,7 +366,8 @@ export function htmlToMarkdown(html: string): string {
   function processNode(node: Node, context: 'normal' | 'code' = 'normal'): string {
     if (node.nodeType === Node.TEXT_NODE) {
       const text = node.textContent || ''
-      return context === 'code' ? text : escapeMarkdownText(text)
+      if (context === 'code' || options?.skipMarkdownEscape) return text
+      return escapeMarkdownText(text)
     }
 
     if (node.nodeType !== Node.ELEMENT_NODE) {

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -53,6 +53,7 @@ import {
 import {
   stickyUserMessageEnabledAtom,
   longTextPasteAsAttachmentEnabledAtom,
+  richTextRenderingEnabledAtom,
   initializeUiPreferences,
 } from './atoms/ui-preferences'
 import {
@@ -426,15 +427,20 @@ function DockBadgeInitializer(): null {
 /**
  * UI 偏好初始化组件
  *
- * 从主进程加载 UI 偏好设置（悬浮置顶条等）。
+ * 从主进程加载 UI 偏好设置（悬浮置顶条、输入框 Markdown 渲染等）。
  */
 function UiPreferencesInitializer(): null {
   const setStickyUserMessageEnabled = useSetAtom(stickyUserMessageEnabledAtom)
   const setLongTextPasteAsAttachmentEnabled = useSetAtom(longTextPasteAsAttachmentEnabledAtom)
+  const setRichTextRenderingEnabled = useSetAtom(richTextRenderingEnabledAtom)
 
   useEffect(() => {
-    initializeUiPreferences(setStickyUserMessageEnabled, setLongTextPasteAsAttachmentEnabled)
-  }, [setStickyUserMessageEnabled, setLongTextPasteAsAttachmentEnabled])
+    initializeUiPreferences(
+      setStickyUserMessageEnabled,
+      setLongTextPasteAsAttachmentEnabled,
+      setRichTextRenderingEnabled
+    )
+  }, [setStickyUserMessageEnabled, setLongTextPasteAsAttachmentEnabled, setRichTextRenderingEnabled])
 
   return null
 }

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -238,7 +238,7 @@ export interface AppSettings {
   stickyUserMessageEnabled?: boolean
   /** 粘贴超过阈值的长文本时是否自动转为附件（默认 false） */
   longTextPasteAsAttachmentEnabled?: boolean
-  /** 输入框是否渲染 Markdown 富文本格式（默认 false；关闭后为纯文本模式，保留 Mention 引用） */
+  /** 输入框是否渲染 Markdown 富文本格式（默认 false，关闭后为纯文本模式，仍保留 Mention 引用） */
   richTextRenderingEnabled?: boolean
   /** Markdown 预览字号档位（默认 'medium'，对应 15px） */
   markdownFontSize?: MarkdownFontSize

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -238,6 +238,8 @@ export interface AppSettings {
   stickyUserMessageEnabled?: boolean
   /** 粘贴超过阈值的长文本时是否自动转为附件（默认 false） */
   longTextPasteAsAttachmentEnabled?: boolean
+  /** 输入框是否渲染 Markdown 富文本格式（默认 false；关闭后为纯文本模式，保留 Mention 引用） */
+  richTextRenderingEnabled?: boolean
   /** Markdown 预览字号档位（默认 'medium'，对应 15px） */
   markdownFontSize?: MarkdownFontSize
   /** 上次是否在 Scratch Pad 页（用于重启恢复） */


### PR DESCRIPTION
## 功能

在「设置 → 通用设置」新增「输入框 Markdown 渲染」开关，**默认关闭**。关闭时输入框为纯文本模式，Markdown 语法字符原样显示，不再实时渲染为富文本。用户可随时开启恢复 WYSIWYG 编辑体验。

## 实现方式

**条件扩展集**：与之前两个 PR（仅禁用 input/paste rules 或只改粘贴行为）不同，本方案从根源解决——开关关闭时 **Bold/Italic/Heading/CodeBlock/List/Link 等格式化扩展压根不注册**，编辑器只剩 Document+Paragraph+Text+HardBreak+History，本质就是纯文本编辑器。

| 场景 | 开关关闭（默认） | 开关开启 |
|------|---------|------|
| 输入 `**bold**` | 显示 `**bold**` 原文 | 渲染为**粗体** |
| `Cmd+B` 快捷键 | 不生效、不吃事件 | 正常加粗 |
| 粘贴富文本 | 只取纯文本 `insertText` | HTML→Markdown 渲染 |
| Mention（@/Skill/#MCP/&会话） | ✅ 仍可用 | ✅ 正常 |
| 超长文本转附件 | ✅ 仍生效 | ✅ 正常 |

## 改动文件

| 文件 | 改动 |
|------|------|
| `types/settings.ts` | 新增 `richTextRenderingEnabled` 字段 |
| `settings-service.ts` | 默认值 + `??` 回退 |
| `ui-preferences.ts` | atom + initialize + update |
| `main.tsx` | `UiPreferencesInitializer` 加载 |
| `rich-text-input.tsx` | **核心**：条件扩展集 + 粘贴 + 快捷键守卫 + 编辑器重建守卫 |
| `GeneralSettings.tsx` | SettingsToggle UI |

## 调用方影响

**零改动。** `ChatInput` 和 `AgentView` 通过 atom 全局生效，不需要传新 prop。

## 自检

- [x] `bun run typecheck` 全部通过
- [x] 设置持久化正常（重启后保留）
- [x] Mention 引用在纯文本模式下仍可用
- [x] 编辑器重建时 htmlValue 草稿不丢失
- [x] 快捷键在纯文本模式下不混淆

🤖 Generated with [Claude Code](https://claude.com/claude-code)