### PR TITLE
fix: 持有 AudioBufferSourceNode 引用防止 GC 中途回收导致通知音截断

### DIFF
--- a/apps/electron/src/renderer/atoms/notifications.ts
+++ b/apps/electron/src/renderer/atoms/notifications.ts
@@ -150,6 +150,14 @@ let lastPlayTime = 0
 const MIN_PLAY_INTERVAL_MS = 300
 
 /**
+ * 正在播放的 AudioBufferSourceNode 集合。
+ *
+ * 必须持有 source 的 JS 引用直到播放完成，否则 GC 可能在音频播完前回收 source，
+ * 导致声音被截断（Web Audio API 的常见陷阱）。
+ */
+const activeSources = new Set<AudioBufferSourceNode>()
+
+/**
  * 通过 XHR 加载音频文件（Electron file:// 协议下 fetch 可能受限的 fallback）
  */
 function loadAudioViaXHR(url: string): Promise<ArrayBuffer> {
@@ -249,6 +257,9 @@ export async function playNotificationSound(soundId: NotificationSoundId): Promi
     const source = ctx.createBufferSource()
     source.buffer = buffer
     source.connect(ctx.destination)
+    // 持有引用直到播放完成，防止 GC 中途回收导致声音截断
+    activeSources.add(source)
+    source.onended = () => { activeSources.delete(source) }
     source.start(0)
   } catch (error) {
     console.warn('[通知] 播放通知音失败:', soundId, error)


### PR DESCRIPTION
## 问题

#1082 将通知音从 HTML5 Audio 改为 Web Audio API 后，在 production 构建中发现通知音被截断——只播放了很短的片段就停止了。

## 根因

Web Audio API 的经典陷阱：AudioBufferSourceNode 在 source.start(0) 后如果失去 JS 引用，GC 可能在音频播完前回收节点。Production 构建内存占用低、GC 更激进，问题尤为明显。

## 修复

用 Set<AudioBufferSourceNode> 持有所有正在播放的 source 引用，onended 回调中自动释放。

## 验证

- bun run typecheck ✅ 全部通过
- 第二轮子 Agent 审查 ✅ 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)