### PR TITLE
fix(chips): displayPath 支持 Windows 反斜杠路径分隔符

### DIFF
--- a/apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx
@@ -115,20 +115,25 @@ export function FilePathChip({ filePath, basePath, basePaths, className }: FileP
   const displayPath = React.useMemo(() => {
     if (isAbsolute) return trimmedPath
     if (candidateBases.length > 0) {
-      const firstSegment = cleanPath.split('/')[0]
+      // 同时支持 / 和 \ 路径分隔符（Windows 兼容）
+      const segments = cleanPath.split(/[\\/]/)
+      const firstSegment = segments[0]
       if (firstSegment) {
         for (const base of candidateBases) {
-          const baseName = base.endsWith('/') ? base.slice(0, -1).split('/').pop() : base.split('/').pop()
+          // 剥除末尾分隔符后取最后一段作为目录名
+          const baseName = base.replace(/[\\/]+$/, '').split(/[\\/]/).pop()
           if (baseName === firstSegment) {
-            const parentDir = base.endsWith('/')
-              ? base.slice(0, base.slice(0, -1).lastIndexOf('/'))
-              : base.slice(0, base.lastIndexOf('/'))
-            return parentDir.endsWith('/') ? `${parentDir}${cleanPath}` : `${parentDir}/${cleanPath}`
+            // 剥除最后一段得到父目录
+            const normalized = base.replace(/[\\/]+$/, '')
+            const lastSep = Math.max(normalized.lastIndexOf('/'), normalized.lastIndexOf('\\'))
+            const parentDir = lastSep >= 0 ? normalized.slice(0, lastSep) : ''
+            if (!normalized) return cleanPath
+            return parentDir ? `${parentDir}/${cleanPath}` : `/${cleanPath}`
           }
         }
       }
       const base = candidateBases[0]!
-      return base.endsWith('/') ? `${base}${cleanPath}` : `${base}/${cleanPath}`
+      return base.endsWith('/') || base.endsWith('\\') ? `${base}${cleanPath}` : `${base}/${cleanPath}`
     }
     return trimmedPath
   }, [trimmedPath, cleanPath, isAbsolute, candidateBases])


### PR DESCRIPTION
## 概述

修复 #1026 遗留问题：`FilePathChip` 中 `displayPath` 计算逻辑仅用 `split('/')` 处理路径分隔符，导致 Windows 反斜杠 `basePaths` 场景下 chip tooltip 提示显示错误的解析路径。

## 问题分析

PR #1026 修复了 `isAbsolute` 和 `isAbsoluteFilePath` 的正则，以及 `getFileName` 的分隔符处理，但 `displayPath` 中的 4 处位置仍然假设路径只包含正斜杠：

| 位置 | 问题 |
|------|------|
| `cleanPath.split('/')` | 无法正确拆分反斜杠路径的首段 |
| `base.split('/').pop()` | Windows 反斜杠 base 返回整个字符串 |
| `base.lastIndexOf('/')` | 反斜杠路径找不到分隔符 |
| `base.endsWith('/')` | 不匹配反斜杠末尾 |

## 改动

- `file-path-chip.tsx` (+12/-7)
  - 首段提取：`split('/')` → `split(/[\\/]/)`
  - baseName 提取：统一用 `replace(/[\\/]+$/, '').split(/[\\/]/).pop()`
  - parentDir 计算：`Math.max(lastIndexOf('/'), lastIndexOf('\\'))`
  - 末尾分隔符判断：同时检查 `/` 和 `\`

## 测试

1. `bun run typecheck` 通过
2. 逻辑验证（Node.js）：
   - Unix base + Unix path → 正确拼接
   - Win base + Agent 路径 → 正确提取父目录
   - 首段不匹配 fallback → 正确降级
   - 末尾分隔符 base → 正确处理

## 紧急度

低 — 仅影响 Windows 上 basePaths 含反斜杠时 chip tooltip 的显示文本，不影响点击跳转核心功能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
