### PR TITLE
refactor(chips): 提取路径分隔符常量 + 修复 isRelativeFilePath 反斜杠支持

### DIFF
--- a/apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx
@@ -55,9 +55,18 @@ const DOC_EXTS = new Set(['pdf', 'docx'])
 /** 所有可预览的扩展名集合（用于相对路径检测） */
 const ALL_PREVIEWABLE_EXTS = new Set([...IMAGE_EXTS, ...VIDEO_EXTS, ...CODE_EXTS, ...DOC_EXTS])
 
+/** 路径分隔符正则（同时匹配 / 和 \） */
+const PATH_SEP_RE = /[\\/]/
+
+/** 末尾路径分隔符正则（用于剥除 base 末尾的斜杠） */
+const TRAILING_SEP_RE = /[\\/]+$/
+
+/** Windows 盘符绝对路径前缀（如 C:\ D:/ e:\） */
+const WIN_DRIVE_RE = /^[A-Za-z]:[\\/]/
+
 /** 从路径提取文件名（同时支持 / 和 \） */
 function getFileName(filePath: string): string {
-  const parts = filePath.split(/[\\/]/)
+  const parts = filePath.split(PATH_SEP_RE)
   return parts[parts.length - 1] || filePath
 }
 
@@ -97,7 +106,7 @@ export function FilePathChip({ filePath, basePath, basePaths, className }: FileP
 
   const filename = getFileName(cleanPath)
 
-  const isAbsolute = cleanPath.startsWith('/') || /^[A-Za-z]:[\\/]/.test(cleanPath)
+  const isAbsolute = cleanPath.startsWith('/') || WIN_DRIVE_RE.test(cleanPath)
 
   const chipRef = React.useRef<HTMLButtonElement>(null)
   const [fileStatus, setFileStatus] = React.useState<'idle' | 'resolved' | 'broken'>('idle')
@@ -116,15 +125,15 @@ export function FilePathChip({ filePath, basePath, basePaths, className }: FileP
     if (isAbsolute) return trimmedPath
     if (candidateBases.length > 0) {
       // 同时支持 / 和 \ 路径分隔符（Windows 兼容）
-      const segments = cleanPath.split(/[\\/]/)
+      const segments = cleanPath.split(PATH_SEP_RE)
       const firstSegment = segments[0]
       if (firstSegment) {
         for (const base of candidateBases) {
           // 剥除末尾分隔符后取最后一段作为目录名
-          const baseName = base.replace(/[\\/]+$/, '').split(/[\\/]/).pop()
+          const normalized = base.replace(TRAILING_SEP_RE, '')
+          const baseName = normalized.split(PATH_SEP_RE).pop()
           if (baseName === firstSegment) {
             // 剥除最后一段得到父目录
-            const normalized = base.replace(/[\\/]+$/, '')
             const lastSep = Math.max(normalized.lastIndexOf('/'), normalized.lastIndexOf('\\'))
             const parentDir = lastSep >= 0 ? normalized.slice(0, lastSep) : ''
             if (!normalized) return cleanPath
@@ -133,7 +142,7 @@ export function FilePathChip({ filePath, basePath, basePaths, className }: FileP
         }
       }
       const base = candidateBases[0]!
-      return base.endsWith('/') || base.endsWith('\\') ? `${base}${cleanPath}` : `${base}/${cleanPath}`
+      return TRAILING_SEP_RE.test(base) ? `${base}${cleanPath}` : `${base}/${cleanPath}`
     }
     return trimmedPath
   }, [trimmedPath, cleanPath, isAbsolute, candidateBases])
@@ -242,7 +251,7 @@ export function isAbsoluteFilePath(text: string): boolean {
   }
 
   // Windows 绝对路径（支持反斜杠和正斜杠、大小写盘符）
-  if (/^[A-Za-z]:[\\/]/.test(clean)) return true
+  if (WIN_DRIVE_RE.test(clean)) return true
 
   return false
 }
@@ -254,6 +263,7 @@ export function isAbsoluteFilePath(text: string): boolean {
  * - 含有可预览的文件扩展名
  * - 看起来像文件名或相对路径（不含空格、不含特殊字符）
  * - 排除常见的非路径 inline code（如命令、变量名等）
+ * - 同时支持 / 和 \ 路径分隔符
  */
 export function isRelativeFilePath(text: string): boolean {
   const trimmed = text.trim()
@@ -266,12 +276,12 @@ export function isRelativeFilePath(text: string): boolean {
   const ext = getExtension(clean)
   if (!ext || !ALL_PREVIEWABLE_EXTS.has(ext)) return false
 
-  // 必须看起来像文件路径：允许 字母数字、点、横线、下划线、斜杠
+  // 必须看起来像文件路径：允许 字母数字、点、横线、下划线、斜杠（含反斜杠）
   // 排除含空格或特殊字符的（太可能是其他内容）
-  if (!/^[\w./@-]+$/.test(clean)) return false
+  if (!/^[\w./@\\-]+$/.test(clean)) return false
 
-  // 排除以点开头的隐藏文件（如 .gitignore），但保留含子路径的目录相对路径（如 .context/file.md）
-  if (clean.startsWith('.') && !clean.startsWith('./') && !clean.includes('/')) return false
+  // 排除以点开头的隐藏文件（如 .gitignore），但保留含子路径的相对路径（如 .context/file.md）
+  if (clean.startsWith('.') && !PATH_SEP_RE.test(clean)) return false
 
   return true
 }


### PR DESCRIPTION
## 概述

修复两项技术债，均位于 `file-path-chip.tsx`：

1. **`isRelativeFilePath` 不支持反斜杠** — Windows 用户消息中的 `foo\bar\baz.ts` 不会被渲染为 chip
2. **路径分隔符正则重复** — `/[\\/]/` 在文件中出现 8 次，`WIN_DRIVE_RE` 出现 2 次

## 改动

- `file-path-chip.tsx` (+21/-11)

### 提取 3 个模块级常量
```typescript
const PATH_SEP_RE = /[\\/]/           // 替换 5 处 split(/[\\/]/) 和 test()
const TRAILING_SEP_RE = /[\\/]+$/     // 替换 2 处 replace(/[\\/]+$/, '')
const WIN_DRIVE_RE = /^[A-Za-z]:[\\/]/ // 替换 2 处 /^[A-Za-z]:[\\/]/
```

### 修复 `isRelativeFilePath`
- 路径验证正则：`/^[\w./@-]+$/` → `/^[\w./@\\-]+$/`（新增反斜杠支持）
- 隐藏文件排除：分支条件改为 `!PATH_SEP_RE.test(clean)`，同时支持 `/` 和 `\` 分隔的嵌套路径
- JSDoc 更新

## 测试

1. `bun run typecheck` 通过
2. 逻辑验证（13 个场景）：
   - ✅ Unix 相对路径、Windows 反斜杠相对路径、混合斜杠
   - ✅ 隐藏文件、命令、绝对路径均正确拒绝
   - ✅ `.context/file.md` / `.context\file.md` 等点前缀嵌套路径正确接受

## 紧急度

低 — 实际影响有限（Agent 输出很少含反斜杠的相对路径），属于技术债清理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
