### PR TITLE
refactor(main): 提取 fs-retry 共享模块 + 全仓 rmSync/renameSync EBUSY 加固

### DIFF
--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -8,10 +8,11 @@
  * 照搬 conversation-manager.ts 的模式。
  */
 
-import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync, unlinkSync, rmSync, renameSync, readdirSync, createReadStream, createWriteStream, type WriteStream, type RmOptions, cpSync } from 'node:fs'
+import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync, unlinkSync, readdirSync, createReadStream, createWriteStream, type WriteStream } from 'node:fs'
 import { createInterface } from 'node:readline'
 import { writeJsonFileAtomic, readJsonFileSafe } from './safe-file'
 import { randomUUID } from 'node:crypto'
+import { rmSyncWithRetry, renameWithRetry } from './fs-retry'
 import { join, resolve, dirname } from 'node:path'
 import {
   getAgentSessionsIndexPath,
@@ -44,15 +45,6 @@ import { convertLegacyMessage } from '@proma/session-core'
 import { clearNanoBananaAgentHistory } from './chat-tools/nano-banana-mcp'
 import { assertEnabledModelForChannel } from './agent-model-selection'
 import { copyForkWorkspaceFiles } from './agent-fork-workspace-copy'
-
-// Windows 上 fs.watch 递归监听持有的句柄释放是毫秒级延迟，
-// rmSync/renameSync 可能抛 EBUSY/EPERM/EACCES/ENOTEMPTY，这些错误可重试。
-// 注意：EPERM/EACCES 在非 Windows 平台通常是真实的权限拒绝，不应重试，故按平台区分。
-const RETRYABLE_FS_CODES = new Set(
-  process.platform === 'win32'
-    ? ['EBUSY', 'EPERM', 'EACCES', 'ENOTEMPTY']
-    : ['EBUSY', 'ENOTEMPTY'],
-)
 
 /**
  * 会话索引文件格式
@@ -520,49 +512,6 @@ export function deleteAgentSession(id: string): void {
 }
 
 /**
- * 在 Windows 上删除被 fs.watch 递归监听的目录时，可能因句柄尚未释放而抛出
- * EBUSY / EPERM / ENOTEMPTY。带退避重试以等待 watcher 释放句柄。
- *
- * 仅对可重试的 Windows 文件占用错误进行重试，其他错误（如权限拒绝）直接抛出。
- *
- * 阻塞策略：优先用 Atomics.wait 同步等待（不占 CPU）；
- * SharedArrayBuffer 不可用时降级为 busy-wait。最坏情况累计 750ms 同步阻塞，
- * 这是为保持函数同步签名所做的取舍。
- */
-function rmSyncWithRetry(target: string, options: RmOptions, maxAttempts = 5): void {
-  let lastErr: unknown
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      rmSync(target, options)
-      return
-    } catch (err) {
-      lastErr = err
-      const code = (err as NodeJS.ErrnoException)?.code
-      if (!code || !RETRYABLE_FS_CODES.has(code)) throw err
-      if (attempt === maxAttempts) break
-      // 指数退避: 50ms, 100ms, 200ms, 400ms — 累计 750ms 内重试 5 次
-      const delayMs = 50 * Math.pow(2, attempt - 1)
-      sleepSync(delayMs)
-    }
-  }
-  throw lastErr
-}
-
-/**
- * 同步阻塞等待指定毫秒数。优先用 Atomics.wait（不占 CPU），
- * SharedArrayBuffer 不可用时降级为 busy-wait。
- */
-function sleepSync(ms: number): void {
-  try {
-    const buf = new Int32Array(new SharedArrayBuffer(4))
-    Atomics.wait(buf, 0, 0, ms)
-  } catch {
-    const start = Date.now()
-    while (Date.now() - start < ms) { /* busy wait fallback */ }
-  }
-}
-
-/**
  * 迁移 Agent 会话到另一个工作区
  *
  * 操作步骤：
@@ -614,30 +563,8 @@ export function moveSessionToWorkspace(sessionId: string, targetWorkspaceId: str
             throw cleanupError
           }
         }
-        // 优先使用 renameSync（原子、快速、无需复制）。
-        // 仅在跨设备（EXDEV）或 Windows 上 fs.watch 句柄占用导致 rename 失败时
-        // （EBUSY/EPERM/EACCES，见 RETRYABLE_FS_CODES）降级为 cpSync + rmSyncWithRetry。
-        try {
-          renameSync(srcDir, destDir)
-        } catch (renameErr) {
-          const code = (renameErr as NodeJS.ErrnoException)?.code
-          // 非跨设备且非可重试的文件占用错误 → 真实错误，直接抛出
-          if (code !== 'EXDEV' && !(code && RETRYABLE_FS_CODES.has(code))) throw renameErr
-          // 降级：复制后删除源目录；rmSync 仍可能因 watcher 句柄未释放抛错，带退避重试
-          try {
-            cpSync(srcDir, destDir, { recursive: true, force: true })
-            rmSyncWithRetry(srcDir, { recursive: true, force: true })
-          } catch (moveErr) {
-            // cpSync 成功但 rmSync 失败：回滚 destDir 副本，保证失败语义干净
-            // （索引未更新，下次重试时 destDir 不应残留）
-            try {
-              rmSyncWithRetry(destDir, { recursive: true, force: true })
-            } catch (rollbackErr) {
-              console.warn(`[Agent 会话] 回滚目标目录失败:`, rollbackErr)
-            }
-            throw moveErr
-          }
-        }
+        // renameWithRetry：优先 renameSync（原子），跨设备或句柄占用时自动降级 cpSync + rmSyncWithRetry
+        renameWithRetry(srcDir, destDir)
         console.log(`[Agent 会话] 已移动工作目录: ${srcDir} → ${destDir}`)
       }
     }

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -6,7 +6,8 @@
  * - 工作区目录：~/.proma/agent-workspaces/{slug}/（Agent 的 cwd）
  */
 
-import { readFileSync, writeFileSync, existsSync, readdirSync, cpSync, rmSync, mkdirSync, statSync, renameSync, openSync, readSync, closeSync, realpathSync } from 'node:fs'
+import { readFileSync, writeFileSync, existsSync, readdirSync, cpSync, mkdirSync, statSync, openSync, readSync, closeSync, realpathSync } from 'node:fs'
+import { rmSyncWithRetry, renameWithRetry } from './fs-retry'
 import { writeJsonFileAtomic, readJsonFileSafe } from './safe-file'
 import { randomUUID } from 'node:crypto'
 import { join, resolve, relative, isAbsolute, dirname, basename } from 'node:path'
@@ -77,7 +78,7 @@ function activateSkillCreatorInAllWorkspaces(index: AgentWorkspacesIndex): void 
       if (!existsSync(activeDir)) {
         mkdirSync(activeDir, { recursive: true })
       }
-      renameSync(inactivePath, activePath)
+      renameWithRetry(inactivePath, activePath)
       console.log(`[Agent 工作区] 已为 ${workspace.slug} 启用 skill-creator`)
     } catch (err) {
       console.warn(`[Agent 工作区] 启用 skill-creator 失败 (${workspace.slug}):`, err)
@@ -272,7 +273,7 @@ export function deleteAgentWorkspace(id: string): void {
 
   if (existsSync(workspaceDir)) {
     try {
-      rmSync(workspaceDir, { recursive: true, force: true })
+      rmSyncWithRetry(workspaceDir, { recursive: true, force: true })
       console.log(`[Agent 工作区] 已删除工作区目录: ${workspaceDir}`)
     } catch (error) {
       console.warn(`[Agent 工作区] 删除工作区目录失败，已残留无引用目录 (${target.slug}):`, error)
@@ -412,7 +413,7 @@ export function upgradeDefaultSkillsInWorkspaces(): void {
  */
 function safeReplaceSkillDir(sourcePath: string, targetPath: string): boolean {
   try {
-    rmSync(targetPath, { recursive: true, force: true })
+    rmSyncWithRetry(targetPath, { recursive: true, force: true })
     cpSync(sourcePath, targetPath, { recursive: true, filter: skillCopyFilter })
     return true
   } catch (err) {
@@ -623,7 +624,7 @@ export function deleteWorkspaceSkill(workspaceSlug: string, skillSlug: string): 
     throw new Error(`Skill 不存在: ${skillSlug}`)
   }
 
-  rmSync(skillPath, { recursive: true, force: true })
+  rmSyncWithRetry(skillPath, { recursive: true, force: true })
   console.log(`[Agent 工作区] 已删除 Skill: ${workspaceSlug}/${skillSlug}`)
 }
 
@@ -708,7 +709,7 @@ export function toggleWorkspaceSkill(workspaceSlug: string, skillSlug: string, e
     throw new Error(`目标目录已存在同名 Skill: ${skillSlug}`)
   }
 
-  renameSync(srcPath, destPath)
+  renameWithRetry(srcPath, destPath)
   console.log(`[Agent 工作区] Skill ${enabled ? '启用' : '禁用'}: ${workspaceSlug}/${skillSlug}`)
 }
 
@@ -828,11 +829,11 @@ export function updateSkillFromSource(
     cpSync(sourcePath, tmpPath, { recursive: true })
   } catch (err) {
     // 复制失败时清理临时目录，保留原目录不变
-    if (existsSync(tmpPath)) rmSync(tmpPath, { recursive: true, force: true })
+    if (existsSync(tmpPath)) rmSyncWithRetry(tmpPath, { recursive: true, force: true })
     throw err
   }
-  rmSync(targetPath, { recursive: true, force: true })
-  renameSync(tmpPath, targetPath)
+  rmSyncWithRetry(targetPath, { recursive: true, force: true })
+  renameWithRetry(tmpPath, targetPath)
 
   // 更新来源元数据（保留原始 importedAt）
   const sourceWorkspace = listAgentWorkspaces().find((w) => w.slug === existingSource.sourceWorkspaceSlug)
@@ -1304,7 +1305,7 @@ export function deleteSkillEntry(workspaceSlug: string, skillSlug: string, relat
   if (!existsSync(abs)) {
     throw new Error(`目标不存在: ${relativePath}`)
   }
-  rmSync(abs, { recursive: true, force: true })
+  rmSyncWithRetry(abs, { recursive: true, force: true })
   console.log(`[Agent 工作区] 已删除 Skill 子项: ${workspaceSlug}/${skillSlug}/${relativePath}`)
 }
 
@@ -1328,7 +1329,7 @@ export function renameSkillEntry(
   if (!existsSync(parent)) {
     mkdirSync(parent, { recursive: true })
   }
-  renameSync(fromAbs, toAbs)
+  renameWithRetry(fromAbs, toAbs)
   console.log(`[Agent 工作区] Skill 子项重命名: ${workspaceSlug}/${skillSlug}: ${fromRelative} → ${toRelative}`)
 }
 

--- a/apps/electron/src/main/lib/fs-retry.ts
+++ b/apps/electron/src/main/lib/fs-retry.ts
@@ -5,16 +5,16 @@
  * 可重试文件系统错误的统一重试逻辑，供全仓复用。
  */
 
-import { rmSync, renameSync, cpSync, type RmOptions } from 'node:fs'
+import { rmSync, renameSync, cpSync, existsSync, type RmOptions } from 'node:fs'
 
 /**
  * Windows 上 fs.watch 递归监听持有的句柄释放是毫秒级延迟，
  * rmSync/renameSync 可能抛 EBUSY/EPERM/EACCES/ENOTEMPTY，这些错误可重试。
  * 注意：EPERM/EACCES 在非 Windows 平台通常是真实的权限拒绝，不应重试，故按平台区分。
  *
- * @public — 其他模块可通过 RETRYABLE_FS_CODES.has(code) 判断错误码是否可重试
+ * @internal — 仅在模块内部使用，通过 rmSyncWithRetry / renameWithRetry 间接暴露重试逻辑
  */
-export const RETRYABLE_FS_CODES = new Set(
+const RETRYABLE_FS_CODES = new Set(
   process.platform === 'win32'
     ? ['EBUSY', 'EPERM', 'EACCES', 'ENOTEMPTY']
     : ['EBUSY', 'ENOTEMPTY'],
@@ -84,8 +84,11 @@ export function rmSyncWithRetry(
  * 捕获 EXDEV（跨设备）或 RETRYABLE_FS_CODES 命中（Windows fs.watch 句柄占用）
  * 时自动降级为 cpSync + rmSyncWithRetry，cpSync 成功后若 rmSync 失败则回滚目标副本。
  *
+ * 降级路径会先清理已存在的 destPath 以匹配 rename 的"替换"语义
+ * （原生 renameSync 在 destPath 已存在且非空时抛 ENOTEMPTY/EEXIST）。
+ *
  * @param srcPath   源路径
- * @param destPath  目标路径
+ * @param destPath  目标路径（若已存在将被替换）
  *
  * @public — 全仓任何需要 renameSync 的位置都应优先使用本函数
  */
@@ -96,6 +99,10 @@ export function renameWithRetry(srcPath: string, destPath: string): void {
     const code = (renameErr as NodeJS.ErrnoException)?.code
     // 非跨设备且非可重试的文件占用错误 → 真实错误，直接抛出
     if (code !== 'EXDEV' && !(code && RETRYABLE_FS_CODES.has(code))) throw renameErr
+    // 降级：确保目标不存在以匹配 rename 替换语义（cpSync 默认是合并）
+    if (existsSync(destPath)) {
+      rmSyncWithRetry(destPath, { recursive: true, force: true })
+    }
     // 降级：复制后删除源目录；rmSync 仍可能因 watcher 句柄未释放抛错，带退避重试
     try {
       cpSync(srcPath, destPath, { recursive: true, force: true })

--- a/apps/electron/src/main/lib/fs-retry.ts
+++ b/apps/electron/src/main/lib/fs-retry.ts
@@ -1,0 +1,113 @@
+/**
+ * 文件系统操作重试工具模块
+ *
+ * 提供 Windows 上因 fs.watch 句柄延迟释放导致的 EBUSY/EPERM 等
+ * 可重试文件系统错误的统一重试逻辑，供全仓复用。
+ */
+
+import { rmSync, renameSync, cpSync, type RmOptions } from 'node:fs'
+
+/**
+ * Windows 上 fs.watch 递归监听持有的句柄释放是毫秒级延迟，
+ * rmSync/renameSync 可能抛 EBUSY/EPERM/EACCES/ENOTEMPTY，这些错误可重试。
+ * 注意：EPERM/EACCES 在非 Windows 平台通常是真实的权限拒绝，不应重试，故按平台区分。
+ *
+ * @public — 其他模块可通过 RETRYABLE_FS_CODES.has(code) 判断错误码是否可重试
+ */
+export const RETRYABLE_FS_CODES = new Set(
+  process.platform === 'win32'
+    ? ['EBUSY', 'EPERM', 'EACCES', 'ENOTEMPTY']
+    : ['EBUSY', 'ENOTEMPTY'],
+)
+
+/**
+ * 同步阻塞等待指定毫秒数。优先用 Atomics.wait（不占 CPU），
+ * SharedArrayBuffer 不可用时降级为 busy-wait。
+ *
+ * @internal — 仅在 rmSyncWithRetry 内部使用，不导出
+ */
+function sleepSync(ms: number): void {
+  try {
+    const buf = new Int32Array(new SharedArrayBuffer(4))
+    Atomics.wait(buf, 0, 0, ms)
+  } catch {
+    const start = Date.now()
+    while (Date.now() - start < ms) { /* busy wait fallback */ }
+  }
+}
+
+/**
+ * 带退避重试的 rmSync。
+ *
+ * 在 Windows 上删除被 fs.watch 递归监听的目录时，可能因句柄尚未释放而抛出
+ * EBUSY / EPERM / ENOTEMPTY。带指数退避重试以等待 watcher 释放句柄。
+ *
+ * 仅对 RETRYABLE_FS_CODES 中的错误进行重试，其他错误直接抛出。
+ *
+ * 阻塞策略：优先用 Atomics.wait 同步等待（不占 CPU）；
+ * SharedArrayBuffer 不可用时降级为 busy-wait。最坏情况累计 750ms 同步阻塞，
+ * 这是为保持函数同步签名所做的取舍。
+ *
+ * @param target    目标路径
+ * @param options   rmSync 选项
+ * @param maxAttempts  最大重试次数，默认 5（指数退避: 50ms → 100ms → 200ms → 400ms）
+ *
+ * @public — 全仓任何需要删除目录/文件的位置都应优先使用本函数替代裸 rmSync
+ */
+export function rmSyncWithRetry(
+  target: string,
+  options: RmOptions,
+  maxAttempts = 5,
+): void {
+  let lastErr: unknown
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      rmSync(target, options)
+      return
+    } catch (err) {
+      lastErr = err
+      const code = (err as NodeJS.ErrnoException)?.code
+      if (!code || !RETRYABLE_FS_CODES.has(code)) throw err
+      if (attempt === maxAttempts) break
+      // 指数退避: 50ms, 100ms, 200ms, 400ms — 累计 750ms 内重试 5 次
+      const delayMs = 50 * Math.pow(2, attempt - 1)
+      sleepSync(delayMs)
+    }
+  }
+  throw lastErr
+}
+
+/**
+ * 带降级策略的 renameSync 封装。
+ *
+ * 优先使用 renameSync（原子、快速、无需复制）。
+ * 捕获 EXDEV（跨设备）或 RETRYABLE_FS_CODES 命中（Windows fs.watch 句柄占用）
+ * 时自动降级为 cpSync + rmSyncWithRetry，cpSync 成功后若 rmSync 失败则回滚目标副本。
+ *
+ * @param srcPath   源路径
+ * @param destPath  目标路径
+ *
+ * @public — 全仓任何需要 renameSync 的位置都应优先使用本函数
+ */
+export function renameWithRetry(srcPath: string, destPath: string): void {
+  try {
+    renameSync(srcPath, destPath)
+  } catch (renameErr) {
+    const code = (renameErr as NodeJS.ErrnoException)?.code
+    // 非跨设备且非可重试的文件占用错误 → 真实错误，直接抛出
+    if (code !== 'EXDEV' && !(code && RETRYABLE_FS_CODES.has(code))) throw renameErr
+    // 降级：复制后删除源目录；rmSync 仍可能因 watcher 句柄未释放抛错，带退避重试
+    try {
+      cpSync(srcPath, destPath, { recursive: true, force: true })
+      rmSyncWithRetry(srcPath, { recursive: true, force: true })
+    } catch (moveErr) {
+      // cpSync 成功但 rmSync 失败：回滚 destPath 副本，保证失败语义干净
+      try {
+        rmSyncWithRetry(destPath, { recursive: true, force: true })
+      } catch (rollbackErr) {
+        console.warn(`[fs-retry] 回滚目标目录失败:`, rollbackErr)
+      }
+      throw moveErr
+    }
+  }
+}

--- a/apps/electron/src/main/lib/migration-service.ts
+++ b/apps/electron/src/main/lib/migration-service.ts
@@ -8,7 +8,8 @@
  * 导入时自动检测跨平台差异并提示用户处理路径映射。
  */
 
-import { existsSync, mkdirSync, cpSync, readFileSync, writeFileSync, readdirSync, rmSync, type Dirent } from 'node:fs'
+import { existsSync, mkdirSync, cpSync, readFileSync, writeFileSync, readdirSync, type Dirent } from 'node:fs'
+import { rmSyncWithRetry } from './fs-retry'
 import { join, resolve, relative, isAbsolute, sep } from 'node:path'
 import { homedir, platform, arch, tmpdir } from 'node:os'
 import { randomUUID } from 'node:crypto'
@@ -613,13 +614,13 @@ export async function parseImportFile(filePath: string): Promise<ImportPreview |
 
   const manifestPath = join(tempDir, 'manifest.json')
   if (!existsSync(manifestPath)) {
-    rmSync(tempDir, { recursive: true, force: true })
+    rmSyncWithRetry(tempDir, { recursive: true, force: true })
     throw new Error('无效的迁移文件：缺少 manifest.json')
   }
 
   const rawManifest = readJsonSafe<MigrationManifest & { workspaces?: WorkspaceExportEntry[] }>(manifestPath)
   if (!rawManifest) {
-    rmSync(tempDir, { recursive: true, force: true })
+    rmSyncWithRetry(tempDir, { recursive: true, force: true })
     throw new Error('无法解析 manifest.json')
   }
 
@@ -829,7 +830,7 @@ export async function confirmImport(options: ConfirmImportOptions | ConfirmImpor
     return { success: true }
   } finally {
     try {
-      rmSync(tempDir, { recursive: true, force: true })
+      rmSyncWithRetry(tempDir, { recursive: true, force: true })
     } catch {
       // 忽略清理失败
     }
@@ -990,7 +991,7 @@ function _importSkills(tempDir: string, targetWorkspace: AgentWorkspace, overwri
       const dest = join(targetSkillsDir, skillName)
       if (existsSync(dest)) {
         if (!overwrite) continue
-        rmSync(dest, { recursive: true, force: true })
+        rmSyncWithRetry(dest, { recursive: true, force: true })
       }
       cpSync(src, dest, { recursive: true })
     }
@@ -1141,7 +1142,7 @@ function _importSkillsV2(tempDir: string, sourceSlug: string, targetWorkspace: A
       const dest = join(targetSkillsDir, entry.name)
       if (existsSync(dest)) {
         if (!overwrite) continue
-        rmSync(dest, { recursive: true, force: true })
+        rmSyncWithRetry(dest, { recursive: true, force: true })
       }
       cpSync(join(activeDir, entry.name), dest, { recursive: true })
     }
@@ -1155,7 +1156,7 @@ function _importSkillsV2(tempDir: string, sourceSlug: string, targetWorkspace: A
       const dest = join(targetInactiveDir, entry.name)
       if (existsSync(dest)) {
         if (!overwrite) continue
-        rmSync(dest, { recursive: true, force: true })
+        rmSyncWithRetry(dest, { recursive: true, force: true })
       }
       cpSync(join(inactiveDir, entry.name), dest, { recursive: true })
     }

--- a/apps/electron/src/main/lib/storage-service.ts
+++ b/apps/electron/src/main/lib/storage-service.ts
@@ -5,7 +5,8 @@
  * 由设置面板"磁盘管理"Tab 和启动时自动清理逻辑调用。
  */
 
-import { existsSync, statSync, unlinkSync, rmSync } from 'node:fs'
+import { existsSync, statSync, unlinkSync } from 'node:fs'
+import { rmSyncWithRetry } from './fs-retry'
 import { promises as fsPromises } from 'node:fs'
 import { join, basename } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -117,7 +118,7 @@ function safeUnlink(filePath: string): number {
 async function safeRmDir(dirPath: string): Promise<number> {
   try {
     const { bytes } = await getDirSize(dirPath)
-    rmSync(dirPath, { recursive: true, force: true })
+    rmSyncWithRetry(dirPath, { recursive: true, force: true })
     return bytes
   } catch {
     return 0
@@ -454,7 +455,7 @@ async function cleanupOrphanSdkConfig(): Promise<CleanupResult> {
           // 若目录为空则删除
           const remaining = await fsPromises.readdir(projPath)
           if (remaining.length === 0) {
-            rmSync(projPath, { recursive: true, force: true })
+            rmSyncWithRetry(projPath, { recursive: true, force: true })
           }
         } catch { /* skip */ }
       }
@@ -541,7 +542,7 @@ function cleanupArchivedSessions(beforeDays: number): CleanupResult {
       const histDir = join(sdkDir, 'file-history', session.sdkSessionId)
       if (existsSync(histDir)) {
         try {
-          rmSync(histDir, { recursive: true, force: true })
+          rmSyncWithRetry(histDir, { recursive: true, force: true })
           deletedCount++
         } catch { /* skip */ }
       }


### PR DESCRIPTION
## 概述

PR #1028 的后续工作：将在 `agent-session-manager.ts` 中实现的 `rmSyncWithRetry` + `sleepSync` + `RETRYABLE_FS_CODES` 提取为共享工具模块 `fs-retry.ts`，新增 `renameWithRetry` 封装，并加固全仓其他同样面临 Windows EBUSY 风险的 `rmSync`/`renameSync` 调用。

## 改动

### 新增 `apps/electron/src/main/lib/fs-retry.ts`
- `rmSyncWithRetry(target, options, maxAttempts?)` — 带指数退避重试的 rmSync
- `renameWithRetry(srcPath, destPath)` — renameSync 优先 + EXDEV/句柄占用降级 cpSync+rmSyncWithRetry + 回滚
- 降级路径自动清理已存在的 destPath，确保与 rename 替换语义一致
- `sleepSync` (内部) — Atomics.wait 优先（Node 主进程可用），SAB 不可用时 busy-wait 降级

### `agent-session-manager.ts`
- 移除内联定义，改为 `import { rmSyncWithRetry, renameWithRetry } from ./fs-retry`
- `moveSessionToWorkspace` 中的 renameSync 降级逻辑替换为 `renameWithRetry(srcDir, destDir)`

### `agent-workspace-manager.ts`
- 6 处 `rmSync` → `rmSyncWithRetry`
- 4 处 `renameSync` → `renameWithRetry`

### `storage-service.ts`
- 3 处 `rmSync` → `rmSyncWithRetry`

### `migration-service.ts`
- 6 处 `rmSync` → `rmSyncWithRetry`

## 对抗审查

经由 Proma Agent: 2 路 Opus 4.8 并行审查（正确性 + 架构设计）。

审查发现已修复：
- ✅ `renameWithRetry` 降级路径增加 destPath 清理，消除 ENOTEMPTY→cpSync 合并语义隐患
- ✅ `RETRYABLE_FS_CODES` 改 @internal（无外部引用，避免可变 Set 暴露）

## 验证
- `bun run typecheck` ✅ 6/6
- 无循环依赖

## 已知后续项

| 优先级 | 事项 | 说明 |
|--------|------|------|
| High | `ipc.ts` 文件管理器操作 | 面向用户的 rmSync/renameSync 尚未加固（动态 import，需单独处理） |
| Medium | `attachment-service.ts` 附件删除 | 单处 rmSync，工作区内附件同样可能 EBUSY |
| Medium | `fs-retry.test.ts` 单元测试 | 提取为共享模块后应补重试/降级/回滚覆盖 |
| Low | `config-paths.ts:521` git config rmSync | 不在 watch 范围内，大概率不需要加固，建议加注释说明 |
| Low | `storage-service` 异步化 | 启动清理路径可考虑异步退避避免主线程阻塞叠加 |
| Low | `cpSync` 加固 | 全仓 cpSync 在 Windows 读被锁文件同样可能 EBUSY，可后续统一处理 |

---

🤖 由 Proma Agent 多路对抗审查生成