### PR TITLE
fix(agent): 将 bundled CLI 目录加入 Agent PATH

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -389,7 +389,12 @@ export class AgentOrchestrator {
       // 暴露打包进 App 的 proma CLI 路径，供 session-cleaner 等 skill / Agent 调用
       // （开发模式无编译二进制，getBundledCliPath 返回 undefined，此处不注入，
       //   skill 回退到源码运行 bun apps/cli/src/index.ts）。
-      ...(getBundledCliPath() ? { PROMA_CLI: getBundledCliPath() } : {}),
+      ...(getBundledCliPath()
+        ? {
+            PROMA_CLI: getBundledCliPath(),
+            PATH: `${dirname(getBundledCliPath()!)}${process.platform === 'win32' ? ';' : ':'}${cleanEnv.PATH ?? ''}`,
+          }
+        : {}),
       // 启用 Tasks 功能
       CLAUDE_CODE_ENABLE_TASKS: 'true',
       // 禁用 SDK 内置 Workflows，避免每轮注入 workflow 相关提示词。


### PR DESCRIPTION
## Summary

- `buildSdkEnv()` 只设置了 `PROMA_CLI` 环境变量指向 bundled binary 的绝对路径，但未将其所在目录加入 `PATH`
- Agent 内无法直接用 `proma` 命令调用 CLI，必须使用 `$PROMA_CLI` 绝对路径
- 现在当 `getBundledCliPath()` 存在时，将其 `dirname` prepend 到 `PATH`，正确处理 Windows (`;`) 和 Unix (`:`) 路径分隔符

## Test plan

- [ ] 打包后启动 Proma，在 Agent 会话中直接运行 `which proma` 确认命令可找到
- [ ] 在 Agent 会话中运行 `proma --version` 确认能正常执行
- [ ] 开发模式下（`getBundledCliPath()` 返回 undefined）确认不会向 PATH 注入空路径

🤖 Generated with [Claude Code](https://claude.com/claude-code)