### PR TITLE
fix(sidebar): 修复自动任务父会话置顶/归档时委派子会话不跟随级联【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -492,7 +492,6 @@ function getSyncableDelegatedChildren(
   return getDirectDelegatedChildren(sessions, parentSessionId).filter((child) => (
     !child.archived
     && !draftSessionIds.has(child.id)
-    && !isHiddenAutomationSession(child)
   ))
 }
 
@@ -508,7 +507,6 @@ function getArchivedDelegatedChildren(
   return getDirectDelegatedChildren(sessions, parentSessionId).filter((child) => (
     child.archived
     && !draftSessionIds.has(child.id)
-    && !isHiddenAutomationSession(child)
   ))
 }
 
@@ -1817,13 +1815,14 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     [agentProjectGroups, automationGroup, automationGroupOrder],
   )
 
-  /** Agent 归档会话按日期分组（跨项目） */
-  const agentSessionGroups = React.useMemo(
-    () => groupByDate(sortAgentSessionsByUpdatedAtDesc(
-      agentSessions.filter((session) => session.archived && !draftSessionIds.has(session.id))
-    )),
-    [agentSessions, draftSessionIds]
-  )
+  /** Agent 归档会话按日期分组（跨项目），含委派树 */
+  const archivedAgentSessionTrees = React.useMemo(() => {
+    const archived = agentSessions.filter((s) => s.archived && !draftSessionIds.has(s.id))
+    const trees = buildAgentSessionTrees(archived)
+    // groupByDate 要求 T extends { updatedAt: number }，AgentSessionTreeItem 不直接满足
+    const wrapped = trees.map((tree) => ({ updatedAt: tree.session.updatedAt, tree }))
+    return groupByDate(wrapped).map((g) => ({ label: g.label, items: g.items.map((w) => w.tree) }))
+  }, [agentSessions, draftSessionIds])
 
   const handleRailModeSwitch = React.useCallback((targetMode: AppMode) => {
     setViewMode('active')
@@ -2623,31 +2622,70 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
                 </div>
               ))
             ) : (
-              /* Agent 模式归档：Agent 会话按日期分组 */
-              agentSessionGroups.map((group) => (
+              /* Agent 模式归档：Agent 会话按日期分组，含委派树 */
+              archivedAgentSessionTrees.map((group) => (
                 <div key={group.label} className="mb-1">
                   <div className="px-3 pt-2 pb-1 text-[11px] font-medium text-foreground/40 select-none">
                     {group.label}
                   </div>
                   <div className="flex flex-col gap-0.5">
-                    {group.items.map((session) => (
-                      <AgentSessionItem
-                        key={session.id}
-                        session={session}
-                        active={session.id === activeSessionId}
-                        indicatorStatus={agentIndicatorMap.get(session.id) ?? 'idle'}
-                        showPinIcon={!!session.pinned}
-                        leftAccent={getSessionLeftAccent(agentIndicatorMap.get(session.id) ?? 'idle')}
-                        workspaceName={session.workspaceId ? workspaceNameMap.get(session.workspaceId) : undefined}
-                        relativeTimeNow={relativeTimeNow}
-                        onSelect={handleSelectAgentSession}
-                        onRequestDelete={handleRequestDelete}
-                        onRequestMove={handleRequestMove}
-                        onRename={handleAgentRename}
-                        onTogglePin={handleTogglePinAgent}
-                        onToggleArchive={handleToggleArchiveAgent}
-                      />
-                    ))}
+                    {group.items.map((item) => {
+                      const childCount = item.childSessions.length
+                      const rowStatus = getSessionTreeStatus(item, agentIndicatorMap)
+                      const treeActive = treeContainsSessionId(item, activeSessionId)
+                      const activeChildVisible = item.childSessions.some((child) => child.id === activeSessionId)
+                      const expandedChildren = expandedDelegationParentIds.has(item.session.id)
+                        || (activeChildVisible && !collapsedDelegationParentIds.has(item.session.id))
+
+                      return (
+                        <div key={item.session.id} className="flex flex-col gap-0.5">
+                          <AgentSessionItem
+                            session={item.session}
+                            active={treeActive}
+                            indicatorStatus={rowStatus}
+                            showPinIcon={!!item.session.pinned}
+                            delegationSummary={childCount > 0
+                              ? {
+                                total: childCount,
+                                completed: countCompletedDelegatedChildren(item.childSessions),
+                                expanded: expandedChildren,
+                                onToggle: () => handleToggleDelegationParent(item.session.id, expandedChildren),
+                              }
+                              : undefined}
+                            leftAccent={getSessionLeftAccent(rowStatus)}
+                            workspaceName={item.session.workspaceId ? workspaceNameMap.get(item.session.workspaceId) : undefined}
+                            relativeTimeNow={relativeTimeNow}
+                            onSelect={handleSelectAgentSession}
+                            onRequestDelete={handleRequestDelete}
+                            onRequestMove={handleRequestMove}
+                            onRename={handleAgentRename}
+                            onTogglePin={handleTogglePinAgent}
+                            onToggleArchive={handleToggleArchiveAgent}
+                          />
+
+                          {childCount > 0 && expandedChildren && (
+                            <div className="ml-3 border-l border-foreground/10 pl-2 flex flex-col gap-0.5">
+                              {item.childSessions.map((childSession) => (
+                                <DelegatedChildSessionItem
+                                  key={childSession.id}
+                                  session={childSession}
+                                  activeSessionId={activeSessionId}
+                                  agentIndicatorMap={agentIndicatorMap}
+                                  relativeTimeNow={relativeTimeNow}
+                                  workspaceName={childSession.workspaceId ? workspaceNameMap.get(childSession.workspaceId) : undefined}
+                                  onSelect={handleSelectAgentSession}
+                                  onRequestDelete={handleRequestDelete}
+                                  onRequestMove={handleRequestMove}
+                                  onRename={handleAgentRename}
+                                  onTogglePin={handleTogglePinAgent}
+                                  onToggleArchive={handleToggleArchiveAgent}
+                                />
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                      )
+                    })}
                   </div>
                 </div>
               ))


### PR DESCRIPTION
## 概述

修复自动任务（automation）父会话被置顶或归档时，其委派子会话不跟随级联的 bug。

**根因**：委派子会话在创建时会继承父会话的 `sourceAutomationId`（`agent-collaboration-tools.ts:646`），导致 `isHiddenAutomationSession()` 对它们返回 `true`，从而被 `getSyncableDelegatedChildren()` 和 `getArchivedDelegatedChildren()` 错误排除在级联之外。

## 改动

- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx`
  - **`getSyncableDelegatedChildren()`**：移除 `.filter()` 中的 `!isHiddenAutomationSession(child)` 条件。委派子会话已通过 `parentSessionId` + `sourceDelegationId` 被 `getDirectDelegatedChildren()` 识别，不应再被隐藏自动化会话过滤排除
  - **`getArchivedDelegatedChildren()`**：同上
  - **`agentSessionGroups` → `archivedAgentSessionTrees`**：用 `buildAgentSessionTrees()` 构建委派树后再按日期分组（通过轻量适配器适配 `groupByDate` 的类型要求）
  - **归档视图 JSX**：从平铺 `AgentSessionItem` 改为树形渲染（父 `AgentSessionItem` + `delegationSummary` 展开箭头 + 缩进 `DelegatedChildSessionItem`），与置顶区域和项目分组的活跃视图保持一致的交互模式

## 测试方法

1. 启动 Proma 开发环境：`cd apps/electron && bun run dev`
2. 使用自动化任务创建一个会委派子 Agent 的会话（如定时任务中调用 `delegate_agent`）
3. **置顶测试**：对父会话执行置顶/取消置顶 → 确认委派子会话跟随
4. **归档测试**：对父会话执行归档 → 切换到归档视图 → 确认子会话嵌套在父会话下方（有左边框缩进、展开/折叠正常）
5. **解归档测试**：解归档父会话 → 确认子会话跟随恢复
6. 验证普通委派会话（非自动化）的级联行为不受影响
7. 验证无子会话的归档会话正常显示（无展开箭头）

## 备注

- TypeScript 类型检查全部通过
- 修改为纯 React/TypeScript UI 渲染逻辑，无 Windows 兼容性风险
- `isHiddenAutomationSession` 函数保持不变，在其他场景（项目列表过滤、Rail 视图）的语义不变