### PR TITLE
Fix compatible provider model discovery

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.14.6",
+  "version": "0.14.7",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/channel-manager.ts
+++ b/apps/electron/src/main/lib/channel-manager.ts
@@ -28,9 +28,7 @@ import {
   getPromaUserAgent,
   migrateCompatibleChannelBaseUrl,
   normalizeBaseUrl,
-  resolveAnthropicMessagesUrl,
   resolveAnthropicModelsUrl,
-  resolveOpenAIChatCompletionsUrl,
   resolveOpenAIModelsUrl,
 } from '@proma/core'
 import { normalizeHttpResponse, normalizeRequestError } from './channel-test-error'
@@ -368,40 +366,11 @@ async function testAnthropicCompatible(
   proxyUrl?: string,
   provider: ProviderType = 'anthropic',
 ): Promise<ChannelTestResult> {
-  const url = resolveAnthropicMessagesUrl(baseUrl, provider)
+  const url = resolveAnthropicModelsUrl(baseUrl, provider)
   const fetchFn = getFetchFn(proxyUrl)
-
-  let testModel: string
-  switch (provider) {
-    case 'deepseek':
-      testModel = 'deepseek-v4-pro'
-      break
-    case 'kimi-api':
-      testModel = 'kimi-k2.6'
-      break
-    case 'kimi-coding':
-      testModel = 'kimi-for-coding'
-      break
-    case 'zhipu-coding':
-      testModel = 'glm-5.2'
-      break
-    case 'minimax':
-      testModel = 'MiniMax-M3'
-      break
-    case 'xiaomi':
-    case 'xiaomi-token-plan':
-      testModel = 'mimo-v2.5-pro'
-      break
-    case 'qwen-anthropic':
-      testModel = 'qwen3.7-plus'
-      break
-    default:
-      testModel = 'claude-sonnet-5'
-  }
 
   const headers: Record<string, string> = {
     'anthropic-version': '2023-06-01',
-    'content-type': 'application/json',
   }
   if (provider === 'kimi-coding' || provider === 'zhipu-coding') {
     headers.Authorization = `Bearer ${apiKey}`
@@ -417,13 +386,8 @@ async function testAnthropicCompatible(
   }
 
   const response = await fetchFn(url, withTimeout({
-    method: 'POST',
+    method: 'GET',
     headers,
-    body: JSON.stringify({
-      model: testModel,
-      max_tokens: 1,
-      messages: [{ role: 'user', content: 'hi' }],
-    }),
   }))
 
   return normalizeHttpResponse(response)
@@ -438,24 +402,6 @@ async function testOpenAICompatible(
   proxyUrl?: string,
   provider: ProviderType = 'openai',
 ): Promise<ChannelTestResult> {
-  if (provider === 'custom') {
-    const url = resolveOpenAIChatCompletionsUrl(baseUrl, provider)
-    const fetchFn = getFetchFn(proxyUrl)
-    const response = await fetchFn(url, withTimeout({
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify({
-        model: 'gpt-4o-mini',
-        messages: [{ role: 'user', content: 'hi' }],
-        max_tokens: 1,
-      }),
-    }))
-    return normalizeHttpResponse(response)
-  }
-
   const url = resolveOpenAIModelsUrl(baseUrl)
   const fetchFn = getFetchFn(proxyUrl)
 
@@ -588,10 +534,6 @@ async function fetchAnthropicCompatibleModels(
   proxyUrl?: string,
   provider: ProviderType = 'anthropic',
 ): Promise<FetchModelsResult> {
-  if (provider === 'anthropic-compatible') {
-    return { success: false, message: 'Anthropic 兼容格式使用完整请求地址，请手动添加模型', models: [] }
-  }
-
   const url = resolveAnthropicModelsUrl(baseUrl, provider)
   const fetchFn = getFetchFn(proxyUrl)
 
@@ -657,10 +599,6 @@ async function fetchOpenAICompatibleModels(
   proxyUrl?: string,
   provider: ProviderType = 'openai',
 ): Promise<FetchModelsResult> {
-  if (provider === 'custom') {
-    return { success: false, message: 'OpenAI 兼容格式使用完整请求地址，请手动添加模型', models: [] }
-  }
-
   const url = resolveOpenAIModelsUrl(baseUrl)
   const fetchFn = getFetchFn(proxyUrl)
 

--- a/apps/electron/src/renderer/components/settings/ChannelForm.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelForm.tsx
@@ -342,13 +342,14 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
 
       setFetchResult(result)
 
-      // 用拉取结果作为权威清单替换：
+      // 用成功拉取的结果作为权威清单替换：
       // - source==='manual' 的模型一律保留（即便不在新结果里）
       // - 在新结果里也存在的旧模型保留 enabled 状态
       // - 新出现的模型默认未启用
       // - 既不在新结果里、也不是手动添加的旧模型一律丢弃（清除残留）
-      // 失败（result.success===false）时 result.models 为空，等价于清掉所有非手动模型
-      const fetchedModels = result.success ? result.models : []
+      // 拉取失败时保留现有列表，避免 auto-save 持久化空模型列表
+      if (!result.success) return
+      const fetchedModels = result.models
       const fetchedById = new Map(fetchedModels.map((m) => [m.id, m]))
       setModels((prev) => {
         const manualKept = prev.filter((m) => m.source === 'manual' && !fetchedById.has(m.id))
@@ -360,8 +361,6 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
       })
     } catch (error) {
       setFetchResult({ success: false, message: '拉取模型请求失败', models: [] })
-      // IPC 异常等同样按"拉取结果为空"处理：清掉所有非手动模型，保留手动添加的
-      setModels((prev) => prev.filter((m) => m.source === 'manual'))
     } finally {
       setFetchingModels(false)
     }

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.14.6",
+      "version": "0.14.7",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.201",
         "@anthropic-ai/sdk": "^0.93.0",
@@ -154,7 +154,7 @@
     },
     "packages/core": {
       "name": "@proma/core",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "dependencies": {
         "@proma/shared": "workspace:*",
         "highlight.js": "^11.11.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/core",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "license": "AGPL-3.0-only",
   "description": "proma core types,storage and core logic with agents",
   "type": "module",

--- a/packages/core/src/providers/url-utils.test.ts
+++ b/packages/core/src/providers/url-utils.test.ts
@@ -239,9 +239,21 @@ describe('resolveAnthropicMessagesUrl', () => {
 })
 
 describe('resolveAnthropicModelsUrl', () => {
-  test('anthropic-compatible 原样使用（不推导模型端点）', () => {
+  test('anthropic-compatible 从完整 messages 端点推导同级 /models', () => {
     expect(resolveAnthropicModelsUrl('https://gateway.example.com/v1/messages', 'anthropic-compatible')).toBe(
-      'https://gateway.example.com/v1/messages',
+      'https://gateway.example.com/v1/models',
+    )
+  })
+
+  test('anthropic-compatible 协议根地址推导 /models', () => {
+    expect(resolveAnthropicModelsUrl('https://gateway.example.com/v1', 'anthropic-compatible')).toBe(
+      'https://gateway.example.com/v1/models',
+    )
+  })
+
+  test('anthropic-compatible 推导模型端点时保留查询参数', () => {
+    expect(resolveAnthropicModelsUrl('https://gateway.example.com/v1/messages?api-version=2024', 'anthropic-compatible')).toBe(
+      'https://gateway.example.com/v1/models?api-version=2024',
     )
   })
 

--- a/packages/core/src/providers/url-utils.ts
+++ b/packages/core/src/providers/url-utils.ts
@@ -204,12 +204,10 @@ export function resolveAnthropicMessagesUrl(baseUrl: string, provider: ProviderT
 /**
  * 解析 Anthropic Models 地址。
  *
- * Anthropic 兼容格式不推导模型端点；内置供应商按协议根地址推导 /models。
+ * Anthropic 兼容格式使用用户填写的请求地址推导同级模型端点；
+ * 内置供应商按协议根地址推导 /models。
  */
 export function resolveAnthropicModelsUrl(baseUrl: string, provider: ProviderType): string {
-  if (provider === 'anthropic-compatible') {
-    return trimTrailingUrlPathSlash(baseUrl)
-  }
   if (hasPathSuffix(baseUrl, '/messages')) {
     return replacePathSuffix(baseUrl, '/messages', '/models')
   }


### PR DESCRIPTION
This fixes compatible-provider model discovery by deriving `/models` from Anthropic-compatible `/messages` endpoints and enabling model fetch for OpenAI-compatible custom endpoints.
Connection tests now validate credentials through the models endpoint instead of sending a chat request with hardcoded model names, which avoids false failures on third-party providers.
The channel form also keeps the existing model list when a model refresh fails, preventing auto-save from persisting an empty list.
Versions for @proma/core and @proma/electron were bumped with the matching bun.lock entries.
Validation: `bun test packages/core/src/providers/url-utils.test.ts` passed; `git diff --check` passed; full `bun run typecheck` is blocked because `tsc` is not installed in this workspace.
