### PR TITLE
fix(chat): use Bearer auth for Tavily search

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.14.6",
+  "version": "0.14.7",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -2384,9 +2384,11 @@ export function registerIpcHandlers(): void {
         try {
           const response = await fetch('https://api.tavily.com/search', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${credentials.apiKey}`,
+            },
             body: JSON.stringify({
-              api_key: credentials.apiKey,
               query: 'test connection',
               search_depth: 'basic',
               max_results: 1,

--- a/apps/electron/src/main/lib/chat-tools/web-search-tool.ts
+++ b/apps/electron/src/main/lib/chat-tools/web-search-tool.ts
@@ -113,9 +113,11 @@ export async function executeWebSearchTool(toolCall: ToolCall): Promise<ToolResu
 
     const response = await fetch('https://api.tavily.com/search', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${credentials.apiKey}`,
+      },
       body: JSON.stringify({
-        api_key: credentials.apiKey,
         query,
         search_depth: 'basic',
         max_results: 5,

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.14.6",
+      "version": "0.14.7",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.201",
         "@anthropic-ai/sdk": "^0.93.0",


### PR DESCRIPTION
Fixes #1093.

This changes the Chat web_search Tavily request and the settings test connection to authenticate with Authorization: Bearer instead of sending api_key in the JSON body. The root cause was that dev-tier Tavily keys reject the body-based credential path, so configured search could fail even though the API key was present. The Electron package version and lockfile workspace metadata are bumped to 0.14.7.

Validation: bun install --frozen-lockfile; bun run --cwd apps/electron typecheck; git diff --check.