### PR TITLE
Fix Feishu binding management performance

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.14.7",
+  "version": "0.14.8",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -3611,7 +3611,7 @@ export function registerIpcHandlers(): void {
     }
   )
 
-  // 获取活跃绑定列表
+  // 获取绑定列表（包含已归档，前端按视图过滤）
   ipcMain.handle(
     FEISHU_IPC_CHANNELS.LIST_BINDINGS,
     async (): Promise<FeishuChatBinding[]> => {

--- a/apps/electron/src/main/lib/feishu-bridge.ts
+++ b/apps/electron/src/main/lib/feishu-bridge.ts
@@ -366,6 +366,10 @@ class FeishuBridge {
         // 验证对应会话仍然存在
         const session = getAgentSessionMeta(b.sessionId)
         if (session) {
+          if (b.source === 'session-mirror' && session.archived) {
+            b.archived = true
+            b.archivedAt ??= session.updatedAt
+          }
           // 同步最新的渠道和模型设置（用户可能已更改）
           if (appSettings.agentChannelId) {
             b.channelId = appSettings.agentChannelId
@@ -374,12 +378,14 @@ class FeishuBridge {
             b.modelId = appSettings.agentModelId
           }
           this.chatBindings.set(b.chatId, b)
-          this.sessionToChat.set(b.sessionId, b.chatId)
+          if (!b.archived) {
+            this.sessionToChat.set(b.sessionId, b.chatId)
+          }
         }
       }
       if (this.chatBindings.size > 0) {
         console.log(`[飞书 Bridge] 已恢复 ${this.chatBindings.size} 个聊天绑定`)
-        this.updateStatus({ activeBindings: this.chatBindings.size })
+        this.updateStatus({ activeBindings: this.getActiveBindingCount() })
       }
     } catch (error) {
       console.error('[飞书 Bridge] 加载绑定失败:', error)
@@ -445,6 +451,29 @@ class FeishuBridge {
     return Array.from(this.chatBindings.values())
   }
 
+  private getActiveBindingCount(): number {
+    return Array.from(this.chatBindings.values()).filter((binding) => !binding.archived).length
+  }
+
+  private markBindingUsed(chatId: string): void {
+    const binding = this.chatBindings.get(chatId)
+    if (!binding) return
+
+    const wasArchived = !!binding.archived
+    const now = Date.now()
+    const shouldPersistLastUsedAt = now - (binding.lastUsedAt ?? 0) > 60_000
+    binding.lastUsedAt = now
+    if (wasArchived) {
+      binding.archived = false
+      binding.archivedAt = undefined
+      this.sessionToChat.set(binding.sessionId, chatId)
+      this.updateStatus({ activeBindings: this.getActiveBindingCount() })
+    }
+    if (wasArchived || shouldPersistLastUsedAt) {
+      this.saveBindings()
+    }
+  }
+
   /** 更新绑定的工作区/会话（从设置页调用） */
   updateBinding(input: FeishuUpdateBindingInput): FeishuChatBinding | null {
     const binding = this.chatBindings.get(input.chatId)
@@ -457,7 +486,20 @@ class FeishuBridge {
       // 清理旧反向索引，建立新的
       this.sessionToChat.delete(binding.sessionId)
       binding.sessionId = input.sessionId
-      this.sessionToChat.set(input.sessionId, input.chatId)
+      if (!binding.archived) {
+        this.sessionToChat.set(input.sessionId, input.chatId)
+      }
+    }
+    if (input.archived !== undefined) {
+      binding.archived = input.archived
+      binding.archivedAt = input.archived ? Date.now() : undefined
+      if (input.archived) {
+        this.sessionToChat.delete(binding.sessionId)
+      } else {
+        this.sessionToChat.set(binding.sessionId, input.chatId)
+        binding.lastUsedAt ??= Date.now()
+      }
+      this.updateStatus({ activeBindings: this.getActiveBindingCount() })
     }
 
     this.saveBindings()
@@ -472,7 +514,7 @@ class FeishuBridge {
     this.sessionToChat.delete(binding.sessionId)
     this.streamingTerminalHandledSessions.delete(binding.sessionId)
     this.chatBindings.delete(chatId)
-    this.updateStatus({ activeBindings: this.chatBindings.size })
+    this.updateStatus({ activeBindings: this.getActiveBindingCount() })
     this.saveBindings()
     return true
   }
@@ -523,11 +565,12 @@ class FeishuBridge {
       chatType: 'group',
       groupName,
       createdAt: Date.now(),
+      lastUsedAt: Date.now(),
     }
 
     this.chatBindings.set(chatId, binding)
     this.sessionToChat.set(session.id, chatId)
-    this.updateStatus({ activeBindings: this.chatBindings.size })
+    this.updateStatus({ activeBindings: this.getActiveBindingCount() })
     this.saveBindings()
     console.log(`[飞书 Session 镜像] 已创建群: session=${session.id.slice(0, 8)}, chat=${chatId}`)
   }
@@ -817,6 +860,7 @@ class FeishuBridge {
 
     const hasAttachments = imageAttachments.length > 0 || fileAttachments.length > 0
     if (!text && !hasAttachments) return
+    this.markBindingUsed(chatId)
 
     // 纯附件消息（无文本）：暂存，等待后续文本一起触发 Agent
     if (!text && hasAttachments) {
@@ -1068,10 +1112,11 @@ class FeishuBridge {
       chatType: msgCtx.chatType,
       groupName: msgCtx.groupName,
       createdAt: Date.now(),
+      lastUsedAt: Date.now(),
     }
     this.chatBindings.set(chatId, binding)
     this.sessionToChat.set(session.id, chatId)
-    this.updateStatus({ activeBindings: this.chatBindings.size })
+    this.updateStatus({ activeBindings: this.getActiveBindingCount() })
     this.saveBindings()
 
     // 通知渲染进程刷新会话列表（复用 TITLE_UPDATED 通道触发列表刷新）
@@ -1265,10 +1310,11 @@ class FeishuBridge {
       chatType: msgCtx.chatType,
       groupName: msgCtx.groupName,
       createdAt: Date.now(),
+      lastUsedAt: Date.now(),
     }
     this.chatBindings.set(chatId, binding)
     this.sessionToChat.set(match.id, chatId)
-    this.updateStatus({ activeBindings: this.chatBindings.size })
+    this.updateStatus({ activeBindings: this.getActiveBindingCount() })
     this.saveBindings()
 
     await this.sendMessage(chatId, `已切换到会话: ${match.title} (${match.id.slice(0, 8)})`)
@@ -1309,7 +1355,7 @@ class FeishuBridge {
     if (binding) {
       this.sessionToChat.delete(binding.sessionId)
       this.chatBindings.delete(chatId)
-      this.updateStatus({ activeBindings: this.chatBindings.size })
+      this.updateStatus({ activeBindings: this.getActiveBindingCount() })
       this.saveBindings()
     }
 

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -835,7 +835,7 @@ export interface ElectronAPI {
   stopFeishuBridge: () => Promise<void>
   /** 获取飞书 Bridge 状态 */
   getFeishuStatus: () => Promise<FeishuBridgeState>
-  /** 获取活跃绑定列表 */
+  /** 获取绑定列表（包含已归档，调用方按视图过滤） */
   listFeishuBindings: () => Promise<FeishuChatBinding[]>
   /** 更新绑定（修改工作区/会话） */
   updateFeishuBinding: (input: FeishuUpdateBindingInput) => Promise<FeishuChatBinding | null>

--- a/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
+++ b/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
@@ -321,7 +321,7 @@ export function AutomationFormView(): React.ReactElement | null {
   React.useEffect(() => {
     if (!formState.open) return
     window.electronAPI.listFeishuBindings()
-      .then(setFeishuBindings)
+      .then((bindings) => setFeishuBindings(bindings.filter((binding) => !binding.archived)))
       .catch((err: unknown) => {
         console.error('[定时任务] 获取飞书绑定失败:', err)
       })

--- a/apps/electron/src/renderer/components/settings/FeishuSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/FeishuSettings.tsx
@@ -9,8 +9,9 @@
 import * as React from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { toast } from 'sonner'
-import { Loader2, CheckCircle2, XCircle, ExternalLink, Users, User, Trash2, RefreshCw, Copy, Check, Power, PowerOff, Plus, ChevronRight, PlayCircle, QrCode, MessageSquare, AlertTriangle } from 'lucide-react'
+import { Loader2, CheckCircle2, XCircle, ExternalLink, Users, User, Trash2, RefreshCw, Copy, Check, Power, PowerOff, Plus, ChevronRight, PlayCircle, QrCode, MessageSquare, AlertTriangle, Archive, ArchiveRestore, Search } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import {
   Select,
   SelectContent,
@@ -45,7 +46,15 @@ import { SettingsRow } from './primitives/SettingsRow'
 import { feishuBotStatesAtom, feishuBindingsAtom } from '@/atoms/feishu-atoms'
 import { agentWorkspacesAtom, agentSessionsAtom } from '@/atoms/agent-atoms'
 import { cn } from '@/lib/utils'
-import type { FeishuTestResult, FeishuChatBinding, FeishuBotConfig, FeishuBotBridgeState, FeishuRegisterAppQRCode, FeishuRegisterAppStatus, FeishuSessionMirrorSettings, FeishuSessionSyncMode } from '@proma/shared'
+import {
+  FEISHU_BINDING_PAGE_SIZE,
+  filterFeishuBindings,
+  groupFeishuBindings,
+  type FeishuBindingSourceFilter,
+  type FeishuBindingTypeFilter,
+  type FeishuBindingViewMode,
+} from '@/lib/feishu-bindings'
+import type { AgentSessionMeta, AgentWorkspace, FeishuTestResult, FeishuChatBinding, FeishuBotConfig, FeishuBotBridgeState, FeishuRegisterAppQRCode, FeishuRegisterAppStatus, FeishuSessionMirrorSettings, FeishuSessionSyncMode } from '@proma/shared'
 
 // ===== 常量 =====
 
@@ -398,28 +407,43 @@ function FeishuCliSection(): React.ReactElement {
 
 interface FeishuBindingCardProps {
   binding: FeishuChatBinding
+  workspaces: AgentWorkspace[]
+  workspaceById: Map<string, AgentWorkspace>
+  sessionById: Map<string, AgentSessionMeta>
+  sessionsByWorkspaceId: Map<string, AgentSessionMeta[]>
   onUpdate: (chatId: string, updates: { workspaceId?: string; sessionId?: string }) => void
+  onArchive: (chatId: string, archived: boolean) => void
   onRemove: (chatId: string) => void
 }
 
-function FeishuBindingCard({ binding, onUpdate, onRemove }: FeishuBindingCardProps): React.ReactElement {
-  const workspaces = useAtomValue(agentWorkspacesAtom)
-  const sessions = useAtomValue(agentSessionsAtom)
-
+const FeishuBindingCard = React.memo(function FeishuBindingCard({
+  binding,
+  workspaces,
+  workspaceById,
+  sessionById,
+  sessionsByWorkspaceId,
+  onUpdate,
+  onArchive,
+  onRemove,
+}: FeishuBindingCardProps): React.ReactElement {
+  const [workspaceSelectOpen, setWorkspaceSelectOpen] = React.useState(false)
+  const [sessionSelectOpen, setSessionSelectOpen] = React.useState(false)
   const isGroup = binding.chatType === 'group'
   const displayName = isGroup ? (binding.groupName ?? '未知群组') : '单聊'
+  const isArchived = !!binding.archived
 
   // 当前绑定工作区下的会话列表
   const workspaceSessions = React.useMemo(
-    () => sessions.filter((s) => s.workspaceId === binding.workspaceId),
-    [sessions, binding.workspaceId]
+    () => sessionsByWorkspaceId.get(binding.workspaceId) ?? [],
+    [sessionsByWorkspaceId, binding.workspaceId]
   )
 
-  const currentWorkspace = workspaces.find((w) => w.id === binding.workspaceId)
-  const currentSession = sessions.find((s) => s.id === binding.sessionId)
+  const currentWorkspace = workspaceById.get(binding.workspaceId)
+  const currentSession = sessionById.get(binding.sessionId)
+  const lastUsedAt = binding.lastUsedAt ?? binding.createdAt
 
   return (
-    <div className="px-4 py-3 space-y-3">
+    <div className={cn('px-4 py-3 space-y-3', isArchived && 'opacity-75')}>
       {/* 头部：类型图标 + 名称 + 删除 */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2.5">
@@ -432,32 +456,44 @@ function FeishuBindingCard({ binding, onUpdate, onRemove }: FeishuBindingCardPro
           <div>
             <div className="text-sm font-medium text-foreground">{displayName}</div>
             <div className="text-xs text-muted-foreground">
-              {isGroup ? '群聊' : '私聊'} · {new Date(binding.createdAt).toLocaleDateString('zh-CN')}
+              {isGroup ? '群聊' : '私聊'} · 最近 {new Date(lastUsedAt).toLocaleDateString('zh-CN')}
+              {binding.source === 'session-mirror' && ' · Session 镜像'}
             </div>
           </div>
         </div>
 
-        <AlertDialog>
-          <AlertDialogTrigger asChild>
-            <Button size="icon" variant="ghost" className="h-7 w-7 text-muted-foreground hover:text-destructive">
-              <Trash2 size={14} />
-            </Button>
-          </AlertDialogTrigger>
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>解除绑定</AlertDialogTitle>
-              <AlertDialogDescription>
-                确定要解除「{displayName}」的飞书聊天绑定吗？解除后下次在飞书发消息会自动创建新绑定。
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel>取消</AlertDialogCancel>
-              <AlertDialogAction onClick={() => onRemove(binding.chatId)}>
-                确认解除
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
+        <div className="flex items-center gap-1">
+          <Button
+            size="icon"
+            variant="ghost"
+            className="h-7 w-7 text-muted-foreground"
+            onClick={() => onArchive(binding.chatId, !isArchived)}
+            title={isArchived ? '取消归档' : '归档'}
+          >
+            {isArchived ? <ArchiveRestore size={14} /> : <Archive size={14} />}
+          </Button>
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button size="icon" variant="ghost" className="h-7 w-7 text-muted-foreground hover:text-destructive">
+                <Trash2 size={14} />
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>解除绑定</AlertDialogTitle>
+                <AlertDialogDescription>
+                  确定要解除「{displayName}」的飞书聊天绑定吗？解除后下次在飞书发消息会自动创建新绑定。
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>取消</AlertDialogCancel>
+                <AlertDialogAction onClick={() => onRemove(binding.chatId)}>
+                  确认解除
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
       </div>
 
       {/* 工作区选择 */}
@@ -465,6 +501,8 @@ function FeishuBindingCard({ binding, onUpdate, onRemove }: FeishuBindingCardPro
         <span className="text-muted-foreground">工作区</span>
         <Select
           value={binding.workspaceId}
+          open={workspaceSelectOpen}
+          onOpenChange={setWorkspaceSelectOpen}
           onValueChange={(value) => onUpdate(binding.chatId, { workspaceId: value })}
         >
           <SelectTrigger className="h-8 text-xs">
@@ -473,16 +511,17 @@ function FeishuBindingCard({ binding, onUpdate, onRemove }: FeishuBindingCardPro
             </SelectValue>
           </SelectTrigger>
           <SelectContent>
-            {workspaces.map((w) => (
+            {workspaceSelectOpen && workspaces.map((w) => (
               <SelectItem key={w.id} value={w.id}>{w.name}</SelectItem>
             ))}
           </SelectContent>
         </Select>
 
-        {/* 会话显示 */}
         <span className="text-muted-foreground">会话</span>
         <Select
           value={binding.sessionId}
+          open={sessionSelectOpen}
+          onOpenChange={setSessionSelectOpen}
           onValueChange={(value) => onUpdate(binding.chatId, { sessionId: value })}
         >
           <SelectTrigger className="h-8 text-xs">
@@ -491,7 +530,7 @@ function FeishuBindingCard({ binding, onUpdate, onRemove }: FeishuBindingCardPro
             </SelectValue>
           </SelectTrigger>
           <SelectContent>
-            {workspaceSessions.map((s) => (
+            {sessionSelectOpen && workspaceSessions.map((s) => (
               <SelectItem key={s.id} value={s.id}>
                 {s.title}
               </SelectItem>
@@ -501,17 +540,75 @@ function FeishuBindingCard({ binding, onUpdate, onRemove }: FeishuBindingCardPro
       </div>
     </div>
   )
-}
+})
 
 // ===== 绑定管理 Tab =====
 
 function FeishuBindingsTab(): React.ReactElement {
   const bindings = useAtomValue(feishuBindingsAtom)
   const setBindings = useSetAtom(feishuBindingsAtom)
-  const botStates = useAtomValue(feishuBotStatesAtom)
+  const workspaces = useAtomValue(agentWorkspacesAtom)
+  const sessions = useAtomValue(agentSessionsAtom)
   const [refreshing, setRefreshing] = React.useState(false)
+  const [viewMode, setViewMode] = React.useState<FeishuBindingViewMode>('active')
+  const [query, setQuery] = React.useState('')
+  const [chatTypeFilter, setChatTypeFilter] = React.useState<FeishuBindingTypeFilter>('all')
+  const [sourceFilter, setSourceFilter] = React.useState<FeishuBindingSourceFilter>('all')
+  const [visibleLimit, setVisibleLimit] = React.useState(FEISHU_BINDING_PAGE_SIZE)
 
-  const anyConnected = Object.values(botStates).some((b) => b.status === 'connected')
+  const activeCount = React.useMemo(
+    () => bindings.filter((binding) => !binding.archived).length,
+    [bindings],
+  )
+  const archivedCount = React.useMemo(
+    () => bindings.filter((binding) => binding.archived).length,
+    [bindings],
+  )
+
+  const workspaceById = React.useMemo(
+    () => new Map(workspaces.map((workspace) => [workspace.id, workspace])),
+    [workspaces],
+  )
+  const sessionById = React.useMemo(
+    () => new Map(sessions.map((session) => [session.id, session])),
+    [sessions],
+  )
+  const sessionsByWorkspaceId = React.useMemo(() => {
+    const grouped = new Map<string, AgentSessionMeta[]>()
+    for (const session of sessions) {
+      if (!session.workspaceId) continue
+      const list = grouped.get(session.workspaceId) ?? []
+      list.push(session)
+      grouped.set(session.workspaceId, list)
+    }
+    for (const list of grouped.values()) {
+      list.sort((a, b) => b.updatedAt - a.updatedAt)
+    }
+    return grouped
+  }, [sessions])
+
+  const filteredBindings = React.useMemo(
+    () => filterFeishuBindings(bindings, {
+      viewMode,
+      chatType: chatTypeFilter,
+      source: sourceFilter,
+      query,
+    }),
+    [bindings, chatTypeFilter, query, sourceFilter, viewMode],
+  )
+
+  const visibleBindings = React.useMemo(
+    () => filteredBindings.slice(0, visibleLimit),
+    [filteredBindings, visibleLimit],
+  )
+  const { groupBindings, p2pBindings } = React.useMemo(
+    () => groupFeishuBindings(visibleBindings),
+    [visibleBindings],
+  )
+
+  React.useEffect(() => {
+    setVisibleLimit(FEISHU_BINDING_PAGE_SIZE)
+  }, [chatTypeFilter, query, sourceFilter, viewMode])
 
   // 刷新绑定列表
   const refreshBindings = React.useCallback(async () => {
@@ -531,13 +628,6 @@ function FeishuBindingsTab(): React.ReactElement {
     refreshBindings()
   }, [refreshBindings])
 
-  // 有 Bot 连接时刷新
-  React.useEffect(() => {
-    if (anyConnected) {
-      refreshBindings()
-    }
-  }, [anyConnected, refreshBindings])
-
   // 更新绑定
   const handleUpdate = React.useCallback(async (chatId: string, updates: { workspaceId?: string; sessionId?: string }) => {
     try {
@@ -548,6 +638,19 @@ function FeishuBindingsTab(): React.ReactElement {
       }
     } catch {
       toast.error('更新绑定失败')
+    }
+  }, [setBindings])
+
+  // 归档 / 恢复绑定
+  const handleArchive = React.useCallback(async (chatId: string, archived: boolean) => {
+    try {
+      const result = await window.electronAPI.updateFeishuBinding({ chatId, archived })
+      if (result) {
+        setBindings((prev) => prev.map((binding) => binding.chatId === chatId ? result : binding))
+        toast.success(archived ? '绑定已归档' : '绑定已恢复')
+      }
+    } catch {
+      toast.error(archived ? '归档绑定失败' : '恢复绑定失败')
     }
   }, [setBindings])
 
@@ -564,15 +667,11 @@ function FeishuBindingsTab(): React.ReactElement {
     }
   }, [setBindings])
 
-  // 按类型分组：群聊 + 单聊
-  const groupBindings = bindings.filter((b) => b.chatType === 'group')
-  const p2pBindings = bindings.filter((b) => b.chatType !== 'group')
-
   return (
     <div className="space-y-8">
       <SettingsSection
         title="绑定管理"
-        description="查看和管理飞书聊天与 Proma 工作区/会话的绑定关系"
+        description={`${activeCount} 个活跃绑定，${archivedCount} 个已归档绑定`}
         action={
           <Button
             size="sm"
@@ -585,10 +684,78 @@ function FeishuBindingsTab(): React.ReactElement {
           </Button>
         }
       >
+        <SettingsCard divided={false}>
+          <div className="px-4 py-3 space-y-3">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
+              <div className="inline-flex rounded-lg bg-muted p-1 gap-0.5">
+                <button
+                  type="button"
+                  onClick={() => setViewMode('active')}
+                  className={cn(
+                    'px-3 py-1.5 rounded-md text-sm font-medium transition-colors',
+                    viewMode === 'active' ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground',
+                  )}
+                >
+                  活跃 ({activeCount})
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setViewMode('archived')}
+                  className={cn(
+                    'px-3 py-1.5 rounded-md text-sm font-medium transition-colors',
+                    viewMode === 'archived' ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground',
+                  )}
+                >
+                  已归档 ({archivedCount})
+                </button>
+              </div>
+
+              <div className="relative min-w-0 flex-1">
+                <Search size={14} className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  placeholder="搜索群名、chat_id、session"
+                  className="h-9 pl-8 text-sm"
+                />
+              </div>
+
+              <div className="grid grid-cols-2 gap-2 sm:flex sm:items-center">
+                <Select value={chatTypeFilter} onValueChange={(value) => setChatTypeFilter(value as FeishuBindingTypeFilter)}>
+                  <SelectTrigger className="h-9 w-full sm:w-[118px] text-xs">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">全部类型</SelectItem>
+                    <SelectItem value="group">群聊</SelectItem>
+                    <SelectItem value="p2p">单聊</SelectItem>
+                  </SelectContent>
+                </Select>
+                <Select value={sourceFilter} onValueChange={(value) => setSourceFilter(value as FeishuBindingSourceFilter)}>
+                  <SelectTrigger className="h-9 w-full sm:w-[138px] text-xs">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">全部来源</SelectItem>
+                    <SelectItem value="feishu">飞书主动</SelectItem>
+                    <SelectItem value="session-mirror">Session 镜像</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          </div>
+        </SettingsCard>
+
         {bindings.length === 0 ? (
           <SettingsCard divided={false}>
             <div className="px-4 py-8 text-center text-sm text-muted-foreground">
-              暂无活跃绑定。启动 Bridge 后在飞书中发消息即可自动创建绑定。
+              暂无绑定。启动 Bridge 后在飞书中发消息即可自动创建绑定。
+            </div>
+          </SettingsCard>
+        ) : filteredBindings.length === 0 ? (
+          <SettingsCard divided={false}>
+            <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+              没有匹配的绑定。
             </div>
           </SettingsCard>
         ) : (
@@ -604,7 +771,12 @@ function FeishuBindingsTab(): React.ReactElement {
                     <FeishuBindingCard
                       key={binding.chatId}
                       binding={binding}
+                      workspaces={workspaces}
+                      workspaceById={workspaceById}
+                      sessionById={sessionById}
+                      sessionsByWorkspaceId={sessionsByWorkspaceId}
                       onUpdate={handleUpdate}
+                      onArchive={handleArchive}
                       onRemove={handleRemove}
                     />
                   ))}
@@ -623,11 +795,28 @@ function FeishuBindingsTab(): React.ReactElement {
                     <FeishuBindingCard
                       key={binding.chatId}
                       binding={binding}
+                      workspaces={workspaces}
+                      workspaceById={workspaceById}
+                      sessionById={sessionById}
+                      sessionsByWorkspaceId={sessionsByWorkspaceId}
                       onUpdate={handleUpdate}
+                      onArchive={handleArchive}
                       onRemove={handleRemove}
                     />
                   ))}
                 </SettingsCard>
+              </div>
+            )}
+
+            {visibleBindings.length < filteredBindings.length && (
+              <div className="flex justify-center">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setVisibleLimit((limit) => limit + FEISHU_BINDING_PAGE_SIZE)}
+                >
+                  加载更多（{visibleBindings.length}/{filteredBindings.length}）
+                </Button>
               </div>
             )}
           </div>
@@ -862,7 +1051,7 @@ function SessionMirrorSection({ bots }: { bots: FeishuBotConfig[] }): React.Reac
   )
   const selectedBotHasBinding = React.useMemo(
     () => Boolean(settings.botId && bindings.some((binding) =>
-      binding.botId === settings.botId && binding.userId && binding.userId !== 'unknown'
+      !binding.archived && binding.botId === settings.botId && binding.userId && binding.userId !== 'unknown'
     )),
     [bindings, settings.botId],
   )

--- a/apps/electron/src/renderer/lib/feishu-bindings.test.ts
+++ b/apps/electron/src/renderer/lib/feishu-bindings.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'bun:test'
+import type { FeishuChatBinding } from '@proma/shared'
+import { filterFeishuBindings, groupFeishuBindings } from './feishu-bindings'
+
+function makeBinding(
+  chatId: string,
+  extra: Partial<FeishuChatBinding> = {},
+): FeishuChatBinding {
+  return {
+    chatId,
+    botId: 'bot-1',
+    userId: 'user-1',
+    sessionId: `session-${chatId}`,
+    workspaceId: 'workspace-1',
+    channelId: 'channel-1',
+    source: 'feishu',
+    chatType: 'p2p',
+    createdAt: 1,
+    ...extra,
+  }
+}
+
+describe('filterFeishuBindings', () => {
+  test('Given 活跃和已归档绑定 When 查看活跃视图 Then 只返回未归档绑定', () => {
+    const result = filterFeishuBindings([
+      makeBinding('active'),
+      makeBinding('archived', { archived: true, archivedAt: 9 }),
+    ], {
+      viewMode: 'active',
+      chatType: 'all',
+      source: 'all',
+      query: '',
+    })
+
+    expect(result.map((binding) => binding.chatId)).toEqual(['active'])
+  })
+
+  test('Given 绑定有最近使用时间 When 筛选 Then 按 lastUsedAt 优先降序排列', () => {
+    const result = filterFeishuBindings([
+      makeBinding('old', { createdAt: 10 }),
+      makeBinding('recent', { createdAt: 1, lastUsedAt: 30 }),
+      makeBinding('middle', { createdAt: 20 }),
+    ], {
+      viewMode: 'active',
+      chatType: 'all',
+      source: 'all',
+      query: '',
+    })
+
+    expect(result.map((binding) => binding.chatId)).toEqual(['recent', 'middle', 'old'])
+  })
+
+  test('Given 已归档群聊绑定 When 在归档视图搜索群名 Then 返回匹配绑定', () => {
+    const result = filterFeishuBindings([
+      makeBinding('chat-a', { archived: true, chatType: 'group', groupName: '研发群' }),
+      makeBinding('chat-b', { archived: true, chatType: 'group', groupName: '设计群' }),
+    ], {
+      viewMode: 'archived',
+      chatType: 'group',
+      source: 'all',
+      query: '研发',
+    })
+
+    expect(result.map((binding) => binding.chatId)).toEqual(['chat-a'])
+  })
+})
+
+describe('groupFeishuBindings', () => {
+  test('Given 群聊和单聊绑定 When 分组 Then 分别进入群聊和单聊列表', () => {
+    const result = groupFeishuBindings([
+      makeBinding('group', { chatType: 'group' }),
+      makeBinding('p2p', { chatType: 'p2p' }),
+    ])
+
+    expect(result.groupBindings.map((binding) => binding.chatId)).toEqual(['group'])
+    expect(result.p2pBindings.map((binding) => binding.chatId)).toEqual(['p2p'])
+  })
+})

--- a/apps/electron/src/renderer/lib/feishu-bindings.ts
+++ b/apps/electron/src/renderer/lib/feishu-bindings.ts
@@ -1,0 +1,56 @@
+import type { FeishuChatBinding } from '@proma/shared'
+
+export type FeishuBindingViewMode = 'active' | 'archived'
+export type FeishuBindingTypeFilter = 'all' | 'group' | 'p2p'
+export type FeishuBindingSourceFilter = 'all' | 'feishu' | 'session-mirror'
+
+export interface FeishuBindingFilters {
+  viewMode: FeishuBindingViewMode
+  chatType: FeishuBindingTypeFilter
+  source: FeishuBindingSourceFilter
+  query: string
+}
+
+export interface GroupedFeishuBindings {
+  groupBindings: FeishuChatBinding[]
+  p2pBindings: FeishuChatBinding[]
+}
+
+export const FEISHU_BINDING_PAGE_SIZE = 30
+
+function getBindingSearchText(binding: FeishuChatBinding): string {
+  return [
+    binding.groupName,
+    binding.chatId,
+    binding.userId,
+    binding.sessionId,
+    binding.workspaceId,
+    binding.source,
+  ].filter(Boolean).join(' ').toLowerCase()
+}
+
+function getBindingTime(binding: FeishuChatBinding): number {
+  return binding.lastUsedAt ?? binding.createdAt
+}
+
+export function filterFeishuBindings(
+  bindings: FeishuChatBinding[],
+  filters: FeishuBindingFilters,
+): FeishuChatBinding[] {
+  const query = filters.query.trim().toLowerCase()
+  const archived = filters.viewMode === 'archived'
+
+  return bindings
+    .filter((binding) => !!binding.archived === archived)
+    .filter((binding) => filters.chatType === 'all' || (binding.chatType ?? 'p2p') === filters.chatType)
+    .filter((binding) => filters.source === 'all' || binding.source === filters.source)
+    .filter((binding) => !query || getBindingSearchText(binding).includes(query))
+    .sort((a, b) => getBindingTime(b) - getBindingTime(a))
+}
+
+export function groupFeishuBindings(bindings: FeishuChatBinding[]): GroupedFeishuBindings {
+  return {
+    groupBindings: bindings.filter((binding) => binding.chatType === 'group'),
+    p2pBindings: bindings.filter((binding) => binding.chatType !== 'group'),
+  }
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/shared",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "license": "AGPL-3.0-only",
   "description": "Shared types, configs and utilities for proma",
   "type": "module",

--- a/packages/shared/src/types/feishu.ts
+++ b/packages/shared/src/types/feishu.ts
@@ -129,9 +129,11 @@ export interface FeishuUpdateBindingInput {
   workspaceId?: string
   /** 新的会话 ID（不传则不修改） */
   sessionId?: string
+  /** 是否归档该绑定（不传则不修改） */
+  archived?: boolean
 }
 
-/** 飞书聊天 → Proma 会话绑定（内存态，不持久化） */
+/** 飞书聊天 → Proma 会话绑定（由各 Bot 绑定文件持久化） */
 export interface FeishuChatBinding {
   /** 飞书 chat_id（单聊或群聊） */
   chatId: string
@@ -149,6 +151,12 @@ export interface FeishuChatBinding {
   modelId?: string
   /** 绑定来源：飞书主动绑定或 Proma 桌面 Session 镜像 */
   source?: 'feishu' | 'session-mirror'
+  /** 是否已归档 */
+  archived?: boolean
+  /** 归档时间 */
+  archivedAt?: number
+  /** 最近一次收到该聊天消息的时间 */
+  lastUsedAt?: number
   /** 聊天类型（单聊或群聊） */
   chatType?: 'p2p' | 'group'
   /** 群名称（群聊时） */


### PR DESCRIPTION
## Summary
- Optimize Feishu binding management so large binding sets render incrementally with search, filters, and active/archive views.
- Persist binding archive metadata, keep active binding counts accurate, and auto-restore archived bindings when a Feishu chat is used again.
- Filter archived bindings out of automation notification targets and Session mirror binding checks.

## Validation
- bun test apps/electron/src/renderer/lib/feishu-bindings.test.ts
- bun run --filter='@proma/shared' typecheck
- bun run --filter='@proma/electron' typecheck
- bun run --filter='@proma/electron' build:renderer
- bun run --filter='@proma/electron' build:main
- bun run --filter='@proma/electron' build:preload
- git diff --check