### PR TITLE
Add selectable references for Agent context

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.14.7",
+  "version": "0.14.8",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -326,8 +326,10 @@ export const agentSidePanelWidthAtom = atomWithStorage<number>('proma-agent-side
 /** @deprecated 保留以兼容旧代码，但实际所有 session 都读全局 atom */
 export const agentSidePanelOpenMapAtom = atom<Map<string, boolean>>(new Map())
 
-/** 侧面板当前 Tab：'session' | 'workspace' | 'changes'（per-session Map） */
-export const agentDiffPanelTabAtom = atom<Map<string, 'session' | 'workspace' | 'changes'>>(new Map())
+export type AgentSidePanelTab = 'session' | 'workspace' | 'changes' | 'chat'
+
+/** 侧面板当前 Tab：会话文件 / 工作区文件 / 文件改动 / Chat（per-session Map） */
+export const agentDiffPanelTabAtom = atom<Map<string, AgentSidePanelTab>>(new Map())
 
 /** Diff 视图模式：'split' | 'unified'，默认使用统一预览 */
 export const agentDiffViewModeAtom = atom<'split' | 'unified'>('unified')

--- a/apps/electron/src/renderer/atoms/chat-atoms.ts
+++ b/apps/electron/src/renderer/atoms/chat-atoms.ts
@@ -36,6 +36,9 @@ export const conversationsAtom = atom<ConversationMeta[]>([])
 /** 当前对话 ID */
 export const currentConversationIdAtom = atom<string | null>(null)
 
+/** Agent 会话右侧 Chat 面板，key 为 Agent sessionId，value 为 Chat conversationId */
+export const agentSideChatMapAtom = atom<Map<string, string>>(new Map())
+
 /** 当前对话的消息列表 */
 export const currentMessagesAtom = atom<ChatMessage[]>([])
 

--- a/apps/electron/src/renderer/atoms/preview-atoms.ts
+++ b/apps/electron/src/renderer/atoms/preview-atoms.ts
@@ -62,12 +62,23 @@ export const currentSessionPreviewOpenAtom = atom<boolean>((get) => {
 
 // ===== 引用选中文本（Quoted Selection）=====
 
-/** 从预览面板中选中的文本引用 */
+/** 选中文本引用的来源 */
+export type QuotedSelectionSourceType = 'file' | 'agent-history' | 'scratch-pad'
+
+/** 从预览面板或 Agent 历史中选中的文本引用 */
 export interface QuotedSelection {
   /** 选中的文本内容 */
   text: string
-  /** 来源文件路径 */
+  /** 来源文件路径；历史引用时作为兼容展示字段 */
   filePath: string
+  /** 引用来源类型 */
+  sourceType?: QuotedSelectionSourceType
+  /** 面向用户展示的来源名称 */
+  sourceLabel?: string
+  /** Agent 历史消息 ID */
+  messageId?: string
+  /** Agent 历史消息角色 */
+  messageRole?: 'user' | 'assistant' | 'system'
   /** 起始行号（1-based，代码文件可计算，markdown 等无法计算时为 undefined） */
   startLine?: number
   /** 结束行号（1-based） */

--- a/apps/electron/src/renderer/components/agent/AgentHistorySelectionLayer.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentHistorySelectionLayer.tsx
@@ -65,6 +65,7 @@ export function AgentHistorySelectionLayer({
   const [selection, setSelection] = React.useState<AgentHistorySelection | null>(null)
   const pointerSelectingRef = React.useRef(false)
   const captureTimerRef = React.useRef<number | null>(null)
+  const openChatPendingRef = React.useRef(false)
 
   const clearSelection = React.useCallback((): void => {
     setSelection(null)
@@ -212,6 +213,8 @@ export function AgentHistorySelectionLayer({
 
   const handleOpenChatTab = React.useCallback(async (): Promise<void> => {
     if (!selection) return
+    if (openChatPendingRef.current) return
+    openChatPendingRef.current = true
     try {
       const conversation = await window.electronAPI.createConversation(
         '历史选区问答',
@@ -256,6 +259,8 @@ export function AgentHistorySelectionLayer({
     } catch (error) {
       console.error('[AgentMessages] 打开历史选区聊天标签失败:', error)
       toast.error('打开聊天标签失败')
+    } finally {
+      openChatPendingRef.current = false
     }
   }, [
     clearSelection,

--- a/apps/electron/src/renderer/components/agent/AgentHistorySelectionLayer.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentHistorySelectionLayer.tsx
@@ -8,7 +8,6 @@
 
 import * as React from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
-import { Bot, MessageCircle } from 'lucide-react'
 import { toast } from 'sonner'
 import {
   agentSideChatMapAtom,
@@ -18,6 +17,8 @@ import {
 } from '@/atoms/chat-atoms'
 import { quotedSelectionMapAtom } from '@/atoms/preview-atoms'
 import { agentDiffPanelTabAtom, agentSidePanelOpenAtom } from '@/atoms/agent-atoms'
+import { SelectionActionPopover } from '@/components/selection/SelectionActionPopover'
+import { SELECTION_ACTION_POPOVER_SELECTOR } from '@/lib/quoted-selection'
 
 const MAX_AGENT_HISTORY_QUOTED_CHARS = 2000
 
@@ -75,7 +76,7 @@ export function AgentHistorySelectionLayer({
     const root = rootRef.current
     if (!root) return
     const activeEl = document.activeElement
-    if (activeEl?.closest?.('.ProseMirror, [data-input-mode], [data-agent-history-selection-popover]')) return
+    if (activeEl?.closest?.(`.ProseMirror, [data-input-mode], ${SELECTION_ACTION_POPOVER_SELECTOR}`)) return
 
     const sel = window.getSelection()
     if (!sel || sel.rangeCount === 0 || sel.isCollapsed) {
@@ -152,7 +153,7 @@ export function AgentHistorySelectionLayer({
     }
     const onPointerDown = (event: PointerEvent): void => {
       const target = event.target
-      if (target instanceof Element && target.closest('[data-agent-history-selection-popover]')) return
+      if (target instanceof Element && target.closest(SELECTION_ACTION_POPOVER_SELECTOR)) return
       if (target instanceof Element && rootRef.current?.contains(target)) {
         pointerSelectingRef.current = true
         clearSelection()
@@ -278,33 +279,12 @@ export function AgentHistorySelectionLayer({
   return (
     <>
       {selection && (
-        <div
-          data-agent-history-selection-popover
-          className="fixed z-[90] -translate-x-1/2 -translate-y-full rounded-xl bg-popover/95 px-2 py-1.5 text-popover-foreground shadow-xl ring-1 ring-border/40 backdrop-blur"
-          style={{ left: selection.x, top: selection.y }}
-          onMouseDown={(event) => event.preventDefault()}
-        >
-          <div className="flex items-center gap-1">
-            <button
-              type="button"
-              className="inline-flex h-8 items-center gap-1.5 rounded-lg px-2.5 text-[13px] font-medium transition-colors hover:bg-muted"
-              onClick={handleAddToAgent}
-            >
-              <Bot className="size-4" />
-              为 Agent 引用
-            </button>
-            <button
-              type="button"
-              className="inline-flex h-8 items-center gap-1.5 rounded-lg px-2.5 text-[13px] font-medium transition-colors hover:bg-muted"
-              onClick={() => {
-                void handleOpenChatTab()
-              }}
-            >
-              <MessageCircle className="size-4" />
-              打开右侧问答
-            </button>
-          </div>
-        </div>
+        <SelectionActionPopover
+          x={selection.x}
+          y={selection.y}
+          onAddToAgent={handleAddToAgent}
+          onOpenChat={handleOpenChatTab}
+        />
       )}
     </>
   )

--- a/apps/electron/src/renderer/components/agent/AgentHistorySelectionLayer.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentHistorySelectionLayer.tsx
@@ -1,0 +1,306 @@
+/**
+ * AgentHistorySelectionLayer — Agent 历史选区引用入口
+ *
+ * 在 Agent 历史消息里划选文本后，提供两个轻量动作：
+ * 1. 添加到当前 Agent 输入框引用
+ * 2. 打开 Agent 右侧问答 Tab，用选区作为上下文提问
+ */
+
+import * as React from 'react'
+import { useAtomValue, useSetAtom } from 'jotai'
+import { Bot, MessageCircle } from 'lucide-react'
+import { toast } from 'sonner'
+import {
+  agentSideChatMapAtom,
+  conversationsAtom,
+  conversationDraftsAtom,
+  selectedModelAtom,
+} from '@/atoms/chat-atoms'
+import { quotedSelectionMapAtom } from '@/atoms/preview-atoms'
+import { agentDiffPanelTabAtom, agentSidePanelOpenAtom } from '@/atoms/agent-atoms'
+
+const MAX_AGENT_HISTORY_QUOTED_CHARS = 2000
+
+interface AgentHistorySelection {
+  text: string
+  x: number
+  y: number
+  sourceLabel: string
+  messageId?: string
+  messageRole?: 'user' | 'assistant' | 'system'
+}
+
+interface AgentHistorySelectionLayerProps {
+  sessionId: string
+  rootRef: React.RefObject<HTMLDivElement>
+}
+
+function getElementFromNode(node: Node | null): Element | null {
+  if (!node) return null
+  return node instanceof Element ? node : node.parentElement
+}
+
+function normalizeSelectedText(text: string): string {
+  return text.replace(/\s+\n/g, '\n').replace(/\n\s+/g, '\n').trim()
+}
+
+function getRoleLabel(role?: string): string {
+  if (role === 'user') return 'Agent 历史 · 用户消息'
+  if (role === 'assistant') return 'Agent 历史 · Agent 回复'
+  if (role === 'system') return 'Agent 历史 · 系统消息'
+  return 'Agent 历史'
+}
+
+export function AgentHistorySelectionLayer({
+  sessionId,
+  rootRef,
+}: AgentHistorySelectionLayerProps): React.ReactElement {
+  const setQuotedSelectionMap = useSetAtom(quotedSelectionMapAtom)
+  const selectedChatModel = useAtomValue(selectedModelAtom)
+  const setConversations = useSetAtom(conversationsAtom)
+  const setConversationDrafts = useSetAtom(conversationDraftsAtom)
+  const setSideChatMap = useSetAtom(agentSideChatMapAtom)
+  const setSidePanelOpen = useSetAtom(agentSidePanelOpenAtom)
+  const setSidePanelTabMap = useSetAtom(agentDiffPanelTabAtom)
+  const [selection, setSelection] = React.useState<AgentHistorySelection | null>(null)
+  const pointerSelectingRef = React.useRef(false)
+  const captureTimerRef = React.useRef<number | null>(null)
+
+  const clearSelection = React.useCallback((): void => {
+    setSelection(null)
+  }, [])
+
+  const captureSelection = React.useCallback((): void => {
+    const root = rootRef.current
+    if (!root) return
+    const activeEl = document.activeElement
+    if (activeEl?.closest?.('.ProseMirror, [data-input-mode], [data-agent-history-selection-popover]')) return
+
+    const sel = window.getSelection()
+    if (!sel || sel.rangeCount === 0 || sel.isCollapsed) {
+      clearSelection()
+      return
+    }
+
+    const range = sel.getRangeAt(0)
+    const startEl = getElementFromNode(range.startContainer)
+    const endEl = getElementFromNode(range.endContainer)
+    if (!startEl || !endEl || !root.contains(startEl) || !root.contains(endEl)) {
+      clearSelection()
+      return
+    }
+
+    const startMessageEl = startEl.closest('[data-message-id]')
+    const endMessageEl = endEl.closest('[data-message-id]')
+    if (!startMessageEl || !endMessageEl) {
+      clearSelection()
+      return
+    }
+
+    const rawText = normalizeSelectedText(sel.toString())
+    if (!rawText) {
+      clearSelection()
+      return
+    }
+
+    const truncated = rawText.length > MAX_AGENT_HISTORY_QUOTED_CHARS
+    const text = truncated ? rawText.slice(0, MAX_AGENT_HISTORY_QUOTED_CHARS) : rawText
+    const rect = range.getBoundingClientRect()
+    const firstRect = range.getClientRects()[0]
+    const anchorRect = rect.width > 0 || rect.height > 0 ? rect : firstRect
+    if (!anchorRect) return
+
+    const sameMessage = startMessageEl === endMessageEl
+    const role = sameMessage
+      ? (startMessageEl.getAttribute('data-message-role') as AgentHistorySelection['messageRole'] | null)
+      : null
+    const messageId = sameMessage ? startMessageEl.getAttribute('data-message-id') ?? undefined : undefined
+
+    setSelection({
+      text,
+      x: anchorRect.left + anchorRect.width / 2,
+      y: Math.max(12, anchorRect.top - 12),
+      sourceLabel: sameMessage ? getRoleLabel(role ?? undefined) : 'Agent 历史 · 多条消息',
+      messageId,
+      messageRole: role ?? undefined,
+    })
+
+    if (truncated) {
+      toast.warning(`已选中超过 ${MAX_AGENT_HISTORY_QUOTED_CHARS} 字符，仅引用前 ${MAX_AGENT_HISTORY_QUOTED_CHARS} 字符`, {
+        id: `agent-history-selection-cap:${sessionId}`,
+        duration: 3000,
+      })
+    }
+  }, [clearSelection, rootRef, sessionId])
+
+  const scheduleCaptureSelection = React.useCallback((): void => {
+    if (captureTimerRef.current != null) {
+      window.clearTimeout(captureTimerRef.current)
+    }
+    captureTimerRef.current = window.setTimeout(() => {
+      captureTimerRef.current = null
+      captureSelection()
+    }, 80)
+  }, [captureSelection])
+
+  React.useEffect(() => {
+    const onSelectionChange = (): void => {
+      if (pointerSelectingRef.current) return
+      const sel = window.getSelection()
+      if (!sel || sel.isCollapsed) clearSelection()
+    }
+    const onPointerDown = (event: PointerEvent): void => {
+      const target = event.target
+      if (target instanceof Element && target.closest('[data-agent-history-selection-popover]')) return
+      if (target instanceof Element && rootRef.current?.contains(target)) {
+        pointerSelectingRef.current = true
+        clearSelection()
+        return
+      }
+      clearSelection()
+    }
+    const onPointerUp = (): void => {
+      if (!pointerSelectingRef.current) return
+      pointerSelectingRef.current = false
+      scheduleCaptureSelection()
+    }
+    const onPointerCancel = (): void => {
+      pointerSelectingRef.current = false
+    }
+    const onKeyUp = (event: KeyboardEvent): void => {
+      if (!event.shiftKey && !['Shift', 'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End', 'PageUp', 'PageDown'].includes(event.key)) return
+      scheduleCaptureSelection()
+    }
+
+    document.addEventListener('selectionchange', onSelectionChange)
+    document.addEventListener('pointerdown', onPointerDown, true)
+    document.addEventListener('pointerup', onPointerUp, true)
+    document.addEventListener('pointercancel', onPointerCancel, true)
+    document.addEventListener('keyup', onKeyUp, true)
+    return () => {
+      if (captureTimerRef.current != null) {
+        window.clearTimeout(captureTimerRef.current)
+        captureTimerRef.current = null
+      }
+      document.removeEventListener('selectionchange', onSelectionChange)
+      document.removeEventListener('pointerdown', onPointerDown, true)
+      document.removeEventListener('pointerup', onPointerUp, true)
+      document.removeEventListener('pointercancel', onPointerCancel, true)
+      document.removeEventListener('keyup', onKeyUp, true)
+    }
+  }, [clearSelection, rootRef, scheduleCaptureSelection])
+
+  const handleAddToAgent = React.useCallback((): void => {
+    if (!selection) return
+    setQuotedSelectionMap((prev) => {
+      const next = new Map(prev)
+      next.set(sessionId, {
+        text: selection.text,
+        filePath: selection.sourceLabel,
+        sourceType: 'agent-history',
+        sourceLabel: selection.sourceLabel,
+        messageId: selection.messageId,
+        messageRole: selection.messageRole,
+        capturedAt: Date.now(),
+      })
+      return next
+    })
+    window.getSelection()?.removeAllRanges()
+    clearSelection()
+    toast.success('已添加到 Agent 引用')
+  }, [clearSelection, selection, sessionId, setQuotedSelectionMap])
+
+  const handleOpenChatTab = React.useCallback(async (): Promise<void> => {
+    if (!selection) return
+    try {
+      const conversation = await window.electronAPI.createConversation(
+        '历史选区问答',
+        selectedChatModel?.modelId,
+        selectedChatModel?.channelId,
+      )
+      setConversations((prev) => {
+        if (prev.some((item) => item.id === conversation.id)) return prev
+        return [conversation, ...prev]
+      })
+      setConversationDrafts((prev) => {
+        const next = new Map(prev)
+        next.set(conversation.id, '我的问题：')
+        return next
+      })
+      setQuotedSelectionMap((prev) => {
+        const next = new Map(prev)
+        next.set(conversation.id, {
+          text: selection.text,
+          filePath: selection.sourceLabel,
+          sourceType: 'agent-history',
+          sourceLabel: selection.sourceLabel,
+          messageId: selection.messageId,
+          messageRole: selection.messageRole,
+          capturedAt: Date.now(),
+        })
+        return next
+      })
+      setSideChatMap((prev) => {
+        const next = new Map(prev)
+        next.set(sessionId, conversation.id)
+        return next
+      })
+      setSidePanelOpen(true)
+      setSidePanelTabMap((prev) => {
+        const next = new Map(prev)
+        next.set(sessionId, 'chat')
+        return next
+      })
+      window.getSelection()?.removeAllRanges()
+      clearSelection()
+    } catch (error) {
+      console.error('[AgentMessages] 打开历史选区聊天标签失败:', error)
+      toast.error('打开聊天标签失败')
+    }
+  }, [
+    clearSelection,
+    selectedChatModel,
+    selection,
+    sessionId,
+    setConversationDrafts,
+    setConversations,
+    setQuotedSelectionMap,
+    setSideChatMap,
+    setSidePanelOpen,
+    setSidePanelTabMap,
+  ])
+
+  return (
+    <>
+      {selection && (
+        <div
+          data-agent-history-selection-popover
+          className="fixed z-[90] -translate-x-1/2 -translate-y-full rounded-xl bg-popover/95 px-2 py-1.5 text-popover-foreground shadow-xl ring-1 ring-border/40 backdrop-blur"
+          style={{ left: selection.x, top: selection.y }}
+          onMouseDown={(event) => event.preventDefault()}
+        >
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              className="inline-flex h-8 items-center gap-1.5 rounded-lg px-2.5 text-[13px] font-medium transition-colors hover:bg-muted"
+              onClick={handleAddToAgent}
+            >
+              <Bot className="size-4" />
+              为 Agent 引用
+            </button>
+            <button
+              type="button"
+              className="inline-flex h-8 items-center gap-1.5 rounded-lg px-2.5 text-[13px] font-medium transition-colors hover:bg-muted"
+              onClick={() => {
+                void handleOpenChatTab()
+              }}
+            >
+              <MessageCircle className="size-4" />
+              打开右侧问答
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -37,6 +37,7 @@ import { groupIntoTurns, MessageGroupRenderer, getGroupId, getGroupPreview, extr
 import { buildLiveGroupSet } from './live-group-set'
 import { ContentBlock } from './ContentBlock'
 import { parseThinkTagsFromText } from './thinking-tag-parser'
+import { AgentHistorySelectionLayer } from './AgentHistorySelectionLayer'
 import type { AgentEventUsage, RetryAttempt, SDKMessage, SDKSystemMessage } from '@proma/shared'
 import { getSDKCompactStatus } from '@proma/shared'
 import type { AgentStreamState } from '@/atoms/agent-atoms'
@@ -406,6 +407,7 @@ export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persi
   const userProfile = useAtomValue(userProfileAtom)
   const setMinimapCache = useSetAtom(tabMinimapCacheAtom)
   const channels = useAtomValue(channelsAtom)
+  const historySelectionRootRef = React.useRef<HTMLDivElement>(null)
   /** 淡入控制：切换会话时先隐藏，等布局完成后再显示。 */
   const [ready, setReady] = React.useState(false)
   // 空会话无需淡入过渡（无消息则无滚动位置问题）
@@ -621,101 +623,104 @@ export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persi
 
   return (
     <BasePathsProvider basePaths={attachedDirs}>
-    <Conversation resize={ready && !transitioning ? 'smooth' : 'instant'} className={ready ? (skipFadeIn ? 'opacity-100' : 'opacity-100 transition-opacity duration-200') : 'opacity-0'}>
-      <ScrollPositionManager id={sessionId} ready={ready} />
-      <ConversationContent>
-        {!hasContent && !streaming ? (
-          <EmptyState />
-        ) : (
-          <>
-            {/* 统一消息渲染（持久化 + 实时合并为一个列表，确保 system 消息位置正确） */}
-            {allGroups.map((group, idx) => {
-              const isLive = liveGroupSet.has(group)
-              const isErrorGroup = group.type === 'assistant-turn'
-                && group.assistantMessages.some((m) => !!m.error)
-              const shouldDisableActions = isLive && !isErrorGroup
-              // 仅在最后一个 assistant-turn 上显示"已被用户中断" badge
-              const isLastAssistantTurn = !streaming && stoppedByUser
-                && group.type === 'assistant-turn'
-                && idx === allGroups.findLastIndex((g) => g.type === 'assistant-turn')
-              return (
-                <MessageGroupRenderer
-                  key={getGroupId(group)}
-                  group={group}
-                  allMessages={allSDKMessages}
-                  historicalTaskSubjects={historicalTaskSubjects}
-                  basePath={sessionPath || undefined}
-                  onFork={shouldDisableActions ? undefined : onFork}
-                  onRewind={shouldDisableActions ? undefined : onRewind}
-                  onRetry={shouldDisableActions ? undefined : onRetry}
-                  onRetryInNewSession={shouldDisableActions ? undefined : onRetryInNewSession}
-                  onCompact={shouldDisableActions ? undefined : onCompact}
-                  isStreaming={isLive || undefined}
-                  stoppedByUser={isLastAssistantTurn || undefined}
-                  sessionModelId={sessionModelId}
-                />
-              )
-            })}
+    <div ref={historySelectionRootRef} className="relative min-h-0 flex-1">
+      <Conversation resize={ready && !transitioning ? 'smooth' : 'instant'} className={ready ? (skipFadeIn ? 'opacity-100' : 'opacity-100 transition-opacity duration-200') : 'opacity-0'}>
+        <ScrollPositionManager id={sessionId} ready={ready} />
+        <ConversationContent>
+          {!hasContent && !streaming ? (
+            <EmptyState />
+          ) : (
+            <>
+              {/* 统一消息渲染（持久化 + 实时合并为一个列表，确保 system 消息位置正确） */}
+              {allGroups.map((group, idx) => {
+                const isLive = liveGroupSet.has(group)
+                const isErrorGroup = group.type === 'assistant-turn'
+                  && group.assistantMessages.some((m) => !!m.error)
+                const shouldDisableActions = isLive && !isErrorGroup
+                // 仅在最后一个 assistant-turn 上显示"已被用户中断" badge
+                const isLastAssistantTurn = !streaming && stoppedByUser
+                  && group.type === 'assistant-turn'
+                  && idx === allGroups.findLastIndex((g) => g.type === 'assistant-turn')
+                return (
+                  <MessageGroupRenderer
+                    key={getGroupId(group)}
+                    group={group}
+                    allMessages={allSDKMessages}
+                    historicalTaskSubjects={historicalTaskSubjects}
+                    basePath={sessionPath || undefined}
+                    onFork={shouldDisableActions ? undefined : onFork}
+                    onRewind={shouldDisableActions ? undefined : onRewind}
+                    onRetry={shouldDisableActions ? undefined : onRetry}
+                    onRetryInNewSession={shouldDisableActions ? undefined : onRetryInNewSession}
+                    onCompact={shouldDisableActions ? undefined : onCompact}
+                    isStreaming={isLive || undefined}
+                    stoppedByUser={isLastAssistantTurn || undefined}
+                    sessionModelId={sessionModelId}
+                  />
+                )
+              })}
 
-            {/* 有实时助手内容时：显示运行指示器或占位（防止 streaming 结束到 Actions Bar 出现之间的高度跳动） */}
-            {/* 不使用 mt：ConversationContent 的 gap-1(4px) 已提供间距，
-                匹配内部 MessageActions 的 gap-0.5(2px)+mt-0.5(2px)=4px 间距 */}
-            {hasLiveAssistantContent && !suppressAgentRunning && (
-              <div className="pl-[56px] min-h-[28px]">
-                {retrying && <RetryingNotice retrying={retrying} />}
-                {streaming && <AgentRunningIndicator startedAt={startedAt} />}
-              </div>
-            )}
-
-            {/* 无实时助手内容时：显示完整气泡（含头像/名称/时间） */}
-            {/* 注意：工具活动已通过 SDK 渲染路径（liveGroups）展示 */}
-            {!hasLiveAssistantContent && !suppressAgentRunning && (streaming || smoothContent || retrying) && (
-              <Message from="assistant">
-                <MessageHeader
-                  model={agentStreamingModel}
-                  time={formatMessageTime(Date.now())}
-                  logo={<AssistantLogo model={streamingModelId} />}
-                />
-                <MessageContent>
+              {/* 有实时助手内容时：显示运行指示器或占位（防止 streaming 结束到 Actions Bar 出现之间的高度跳动） */}
+              {/* 不使用 mt：ConversationContent 的 gap-1(4px) 已提供间距，
+                  匹配内部 MessageActions 的 gap-0.5(2px)+mt-0.5(2px)=4px 间距 */}
+              {hasLiveAssistantContent && !suppressAgentRunning && (
+                <div className="pl-[56px] min-h-[28px]">
                   {retrying && <RetryingNotice retrying={retrying} />}
-                  {smoothContent ? (
-                    <>
-                      <div className={cn('space-y-2')}>
-                        {smoothContentBlocks.map((block, index) => (
-                          <ContentBlock
-                            key={index}
-                            block={block}
-                            allMessages={allSDKMessages}
-                            basePath={sessionPath || undefined}
-                            basePaths={attachedDirs}
-                            index={index}
-                            dimmed={hasSmoothTextContent && block.type !== 'text'}
-                            isStreaming={streaming}
-                          />
-                        ))}
-                      </div>
-                      {streaming && <AgentRunningIndicator startedAt={startedAt} />}
-                    </>
-                  ) : (
-                    streaming && <AgentRunningIndicator startedAt={startedAt} />
-                  )}
-                </MessageContent>
-              </Message>
-            )}
+                  {streaming && <AgentRunningIndicator startedAt={startedAt} />}
+                </div>
+              )}
 
-            {/* 压缩中指示器：由 isCompacting flag 驱动的尾部元素，compact_boundary 到达时 flag 翻 false 自然消失，
-                视觉上被流中新出现的"上下文已压缩"分隔符无缝替换 */}
-            {streamState?.isCompacting && !compactStatusInLiveMessages && <CompactingIndicator />}
+              {/* 无实时助手内容时：显示完整气泡（含头像/名称/时间） */}
+              {/* 注意：工具活动已通过 SDK 渲染路径（liveGroups）展示 */}
+              {!hasLiveAssistantContent && !suppressAgentRunning && (streaming || smoothContent || retrying) && (
+                <Message from="assistant">
+                  <MessageHeader
+                    model={agentStreamingModel}
+                    time={formatMessageTime(Date.now())}
+                    logo={<AssistantLogo model={streamingModelId} />}
+                  />
+                  <MessageContent>
+                    {retrying && <RetryingNotice retrying={retrying} />}
+                    {smoothContent ? (
+                      <>
+                        <div className={cn('space-y-2')}>
+                          {smoothContentBlocks.map((block, index) => (
+                            <ContentBlock
+                              key={index}
+                              block={block}
+                              allMessages={allSDKMessages}
+                              basePath={sessionPath || undefined}
+                              basePaths={attachedDirs}
+                              index={index}
+                              dimmed={hasSmoothTextContent && block.type !== 'text'}
+                              isStreaming={streaming}
+                            />
+                          ))}
+                        </div>
+                        {streaming && <AgentRunningIndicator startedAt={startedAt} />}
+                      </>
+                    ) : (
+                      streaming && <AgentRunningIndicator startedAt={startedAt} />
+                    )}
+                  </MessageContent>
+                </Message>
+              )}
 
-          </>
+              {/* 压缩中指示器：由 isCompacting flag 驱动的尾部元素，compact_boundary 到达时 flag 翻 false 自然消失，
+                  视觉上被流中新出现的"上下文已压缩"分隔符无缝替换 */}
+              {streamState?.isCompacting && !compactStatusInLiveMessages && <CompactingIndicator />}
+
+            </>
+          )}
+        </ConversationContent>
+        <ScrollMinimap items={minimapItems} />
+        <ConversationScrollButton />
+        {allUserMessagesData.length > 0 && (
+          <StickyUserMessage userMessages={allUserMessagesData} />
         )}
-      </ConversationContent>
-      <ScrollMinimap items={minimapItems} />
-      <ConversationScrollButton />
-      {allUserMessagesData.length > 0 && (
-        <StickyUserMessage userMessages={allUserMessagesData} />
-      )}
-    </Conversation>
+      </Conversation>
+      <AgentHistorySelectionLayer sessionId={sessionId} rootRef={historySelectionRootRef} />
+    </div>
     </BasePathsProvider>
   )
 }

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -112,6 +112,7 @@ import { useOpenPreview } from '@/components/diff/preview-opener'
 import type { AgentSendInput, AgentPendingFile, FileDialogLargeFile, ModelOption, SDKMessage, SDKUserMessage } from '@proma/shared'
 import { inferContextWindow, MAX_ATTACHMENT_SIZE } from '@proma/shared'
 import { fileToBase64, formatFileNames, getFileParentPath } from '@/lib/file-utils'
+import { buildQuotedSelectionBlock } from '@/lib/quoted-selection'
 import { createClipboardPendingFile, createClipboardTextDraft, makeUniqueAttachmentName } from '@/lib/clipboard-text-attachment'
 import {
   createAgentQueuedMessage,
@@ -1666,31 +1667,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     const quotedSelection = store.get(quotedSelectionMapAtom).get(sessionId)
     if (quotedSelection) {
       const capturedAt = quotedSelection.capturedAt
-      // XML 转义：path 走完整实体编码（&, <, >, "），text 仅需防误闭合外层标签
-      const safePath = quotedSelection.filePath
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-      const safeLabel = (quotedSelection.sourceLabel ?? quotedSelection.filePath)
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-      const safeMessageId = (quotedSelection.messageId ?? '')
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-      const safeRole = quotedSelection.messageRole ?? ''
-      const safeText = quotedSelection.text
-        .replace(/<\/quoted_file>/gi, '</quoted_file_>')
-        .replace(/<\/quoted_context>/gi, '</quoted_context_>')
-      const safeSource = quotedSelection.sourceType ?? 'file'
-      const quotedBlock = safeSource === 'file'
-        ? `<quoted_file path="${safePath}">\n${safeText}\n</quoted_file>\n\n`
-        : `<quoted_context source="${safeSource}" label="${safeLabel}" message_id="${safeMessageId}" role="${safeRole}">\n${safeText}\n</quoted_context>\n\n`
-      fileReferences = fileReferences + quotedBlock
+      fileReferences = fileReferences + buildQuotedSelectionBlock(quotedSelection)
 
       store.set(quotedSelectionMapAtom, (prev) => {
         const m = new Map(prev)

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -1672,8 +1672,24 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')
         .replace(/"/g, '&quot;')
-      const safeText = quotedSelection.text.replace(/<\/quoted_file>/gi, '</quoted_file_>')
-      const quotedBlock = `<quoted_file path="${safePath}">\n${safeText}\n</quoted_file>\n\n`
+      const safeLabel = (quotedSelection.sourceLabel ?? quotedSelection.filePath)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+      const safeMessageId = (quotedSelection.messageId ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+      const safeRole = quotedSelection.messageRole ?? ''
+      const safeText = quotedSelection.text
+        .replace(/<\/quoted_file>/gi, '</quoted_file_>')
+        .replace(/<\/quoted_context>/gi, '</quoted_context_>')
+      const safeSource = quotedSelection.sourceType ?? 'file'
+      const quotedBlock = safeSource === 'file'
+        ? `<quoted_file path="${safePath}">\n${safeText}\n</quoted_file>\n\n`
+        : `<quoted_context source="${safeSource}" label="${safeLabel}" message_id="${safeMessageId}" role="${safeRole}">\n${safeText}\n</quoted_context>\n\n`
       fileReferences = fileReferences + quotedBlock
 
       store.set(quotedSelectionMapAtom, (prev) => {
@@ -2421,6 +2437,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
                   <QuotedSelectionChip
                     text={currentQuotedSelection.text}
                     filePath={currentQuotedSelection.filePath}
+                    sourceLabel={currentQuotedSelection.sourceLabel}
                     onRemove={handleRemoveQuotedSelection}
                   />
                 )}

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -727,30 +727,51 @@ export interface QuotedFileRef {
   path: string
   /** 源文件名 */
   filename: string
+  /** 引用来源类型 */
+  sourceType?: 'file' | 'agent-history'
+  /** 面向用户展示的来源名称 */
+  label?: string
 }
 
-/** 解析消息中的 <attached_files> 块和 <quoted_file> 块，返回文件列表、引用列表和剩余文本 */
+function decodeXmlAttribute(value: string): string {
+  return value
+    .replace(/&quot;/g, '"')
+    .replace(/&gt;/g, '>')
+    .replace(/&lt;/g, '<')
+    .replace(/&amp;/g, '&')
+}
+
+/** 解析消息中的 <attached_files>、<quoted_file> 和 <quoted_context> 块，返回文件列表、引用列表和剩余文本 */
 export function parseAttachedFiles(content: string): { files: AttachedFileRef[]; quotes: QuotedFileRef[]; text: string } {
   const quoteRegex = /<quoted_file[^>]*>[\s\S]*?<\/quoted_file>\n*/g
+  const contextQuoteRegex = /<quoted_context[^>]*>[\s\S]*?<\/quoted_context>\n*/g
   const quotes: QuotedFileRef[] = []
   let quoteMatch: RegExpExecArray | null
   while ((quoteMatch = quoteRegex.exec(content)) !== null) {
     const pathMatch = quoteMatch[0].match(/path="([^"]*)"/)
     if (pathMatch) {
-      // 反解 XML 实体：&amp; 必须最后做，否则会被先一步解出的 & 误伤
-      const filePath = pathMatch[1]!
-        .replace(/&quot;/g, '"')
-        .replace(/&gt;/g, '>')
-        .replace(/&lt;/g, '<')
-        .replace(/&amp;/g, '&')
+      const filePath = decodeXmlAttribute(pathMatch[1]!)
       quotes.push({ path: filePath, filename: filePath.split('/').pop() ?? filePath })
     }
+  }
+  while ((quoteMatch = contextQuoteRegex.exec(content)) !== null) {
+    const labelMatch = quoteMatch[0].match(/label="([^"]*)"/)
+    const label = labelMatch ? decodeXmlAttribute(labelMatch[1]!) : 'Agent 历史'
+    quotes.push({
+      path: label,
+      filename: label,
+      sourceType: 'agent-history',
+      label,
+    })
   }
 
   const regex = /<attached_files>\n?([\s\S]*?)\n?<\/attached_files>\n*/
   const match = content.match(regex)
   if (!match) {
-    const cleanText = content.replace(/<quoted_file[^>]*>[\s\S]*?<\/quoted_file>\n*/g, '').trim()
+    const cleanText = content
+      .replace(/<quoted_file[^>]*>[\s\S]*?<\/quoted_file>\n*/g, '')
+      .replace(/<quoted_context[^>]*>[\s\S]*?<\/quoted_context>\n*/g, '')
+      .trim()
     return { files: [], quotes, text: cleanText }
   }
 
@@ -765,6 +786,7 @@ export function parseAttachedFiles(content: string): { files: AttachedFileRef[];
 
   let text = content.replace(regex, '')
   text = text.replace(/<quoted_file[^>]*>[\s\S]*?<\/quoted_file>\n*/g, '')
+  text = text.replace(/<quoted_context[^>]*>[\s\S]*?<\/quoted_context>\n*/g, '')
   text = text.trim()
   return { files, quotes, text }
 }
@@ -866,10 +888,11 @@ function AttachedFileChip({ file }: { file: AttachedFileRef }): React.ReactEleme
 
 /** 引用文件 Chip（显示在用户消息中，表示该消息引用了某个文件的选中内容） */
 function QuoteChip({ quote }: { quote: QuotedFileRef }): React.ReactElement {
+  const label = quote.label ?? quote.filename
   return (
     <div className="inline-flex items-center gap-1.5 rounded-md bg-primary/8 border border-primary/20 px-2.5 py-1 text-[12px] text-muted-foreground">
       <Quote className="size-3.5 shrink-0 text-primary/60" />
-      <span className="truncate max-w-[200px]">{quote.filename}</span>
+      <span className="truncate max-w-[200px]">{label}</span>
     </div>
   )
 }

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -63,6 +63,7 @@ import { environmentCheckDialogOpenAtom } from '@/atoms/environment'
 import { settingsOpenAtom, settingsTabAtom } from '@/atoms/settings-tab'
 import { useOpenPreview } from '@/components/diff/preview-opener'
 import { getFileParentPath } from '@/lib/file-utils'
+import { decodeXmlAttribute } from '@/lib/quoted-selection'
 import type {
   SDKMessage,
   SDKAssistantMessage,
@@ -728,17 +729,9 @@ export interface QuotedFileRef {
   /** 源文件名 */
   filename: string
   /** 引用来源类型 */
-  sourceType?: 'file' | 'agent-history'
+  sourceType?: 'file' | 'agent-history' | 'scratch-pad'
   /** 面向用户展示的来源名称 */
   label?: string
-}
-
-function decodeXmlAttribute(value: string): string {
-  return value
-    .replace(/&quot;/g, '"')
-    .replace(/&gt;/g, '>')
-    .replace(/&lt;/g, '<')
-    .replace(/&amp;/g, '&')
 }
 
 /** 解析消息中的 <attached_files>、<quoted_file> 和 <quoted_context> 块，返回文件列表、引用列表和剩余文本 */
@@ -757,10 +750,12 @@ export function parseAttachedFiles(content: string): { files: AttachedFileRef[];
   while ((quoteMatch = contextQuoteRegex.exec(content)) !== null) {
     const labelMatch = quoteMatch[0].match(/label="([^"]*)"/)
     const label = labelMatch ? decodeXmlAttribute(labelMatch[1]!) : 'Agent 历史'
+    const sourceMatch = quoteMatch[0].match(/source="([^"]*)"/)
+    const sourceType = sourceMatch ? decodeXmlAttribute(sourceMatch[1]!) : 'agent-history'
     quotes.push({
       path: label,
       filename: label,
-      sourceType: 'agent-history',
+      sourceType: sourceType === 'scratch-pad' ? 'scratch-pad' : 'agent-history',
       label,
     })
   }

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -63,7 +63,8 @@ import { environmentCheckDialogOpenAtom } from '@/atoms/environment'
 import { settingsOpenAtom, settingsTabAtom } from '@/atoms/settings-tab'
 import { useOpenPreview } from '@/components/diff/preview-opener'
 import { getFileParentPath } from '@/lib/file-utils'
-import { decodeXmlAttribute } from '@/lib/quoted-selection'
+import { parseQuotedSelectionRefs } from '@/lib/quoted-selection'
+import type { ParsedQuotedSelectionRef } from '@/lib/quoted-selection'
 import type {
   SDKMessage,
   SDKAssistantMessage,
@@ -723,51 +724,17 @@ export interface AttachedFileRef {
 }
 
 /** 解析的引用文件 */
-export interface QuotedFileRef {
-  /** 源文件路径 */
-  path: string
-  /** 源文件名 */
-  filename: string
-  /** 引用来源类型 */
-  sourceType?: 'file' | 'agent-history' | 'scratch-pad'
-  /** 面向用户展示的来源名称 */
-  label?: string
-}
+export type QuotedFileRef = ParsedQuotedSelectionRef
 
 /** 解析消息中的 <attached_files>、<quoted_file> 和 <quoted_context> 块，返回文件列表、引用列表和剩余文本 */
 export function parseAttachedFiles(content: string): { files: AttachedFileRef[]; quotes: QuotedFileRef[]; text: string } {
-  const quoteRegex = /<quoted_file[^>]*>[\s\S]*?<\/quoted_file>\n*/g
-  const contextQuoteRegex = /<quoted_context[^>]*>[\s\S]*?<\/quoted_context>\n*/g
-  const quotes: QuotedFileRef[] = []
-  let quoteMatch: RegExpExecArray | null
-  while ((quoteMatch = quoteRegex.exec(content)) !== null) {
-    const pathMatch = quoteMatch[0].match(/path="([^"]*)"/)
-    if (pathMatch) {
-      const filePath = decodeXmlAttribute(pathMatch[1]!)
-      quotes.push({ path: filePath, filename: filePath.split('/').pop() ?? filePath })
-    }
-  }
-  while ((quoteMatch = contextQuoteRegex.exec(content)) !== null) {
-    const labelMatch = quoteMatch[0].match(/label="([^"]*)"/)
-    const label = labelMatch ? decodeXmlAttribute(labelMatch[1]!) : 'Agent 历史'
-    const sourceMatch = quoteMatch[0].match(/source="([^"]*)"/)
-    const sourceType = sourceMatch ? decodeXmlAttribute(sourceMatch[1]!) : 'agent-history'
-    quotes.push({
-      path: label,
-      filename: label,
-      sourceType: sourceType === 'scratch-pad' ? 'scratch-pad' : 'agent-history',
-      label,
-    })
-  }
+  const parsedQuotes = parseQuotedSelectionRefs(content)
+  const quotes: QuotedFileRef[] = parsedQuotes.quotes
 
   const regex = /<attached_files>\n?([\s\S]*?)\n?<\/attached_files>\n*/
   const match = content.match(regex)
   if (!match) {
-    const cleanText = content
-      .replace(/<quoted_file[^>]*>[\s\S]*?<\/quoted_file>\n*/g, '')
-      .replace(/<quoted_context[^>]*>[\s\S]*?<\/quoted_context>\n*/g, '')
-      .trim()
-    return { files: [], quotes, text: cleanText }
+    return { files: [], quotes, text: parsedQuotes.text }
   }
 
   const files: AttachedFileRef[] = []
@@ -779,10 +746,7 @@ export function parseAttachedFiles(content: string): { files: AttachedFileRef[];
     }
   }
 
-  let text = content.replace(regex, '')
-  text = text.replace(/<quoted_file[^>]*>[\s\S]*?<\/quoted_file>\n*/g, '')
-  text = text.replace(/<quoted_context[^>]*>[\s\S]*?<\/quoted_context>\n*/g, '')
-  text = text.trim()
+  const text = parsedQuotes.text.replace(regex, '').trim()
   return { files, quotes, text }
 }
 

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -20,6 +20,7 @@ import { cn } from '@/lib/utils'
 import { FileBrowser, FileDropZone, FileTypeIcon, FileSearchBar, computeRevealAncestors, isPathUnderRoot, computeTreeRowLayout, AncestorGuides, STICKY_ROW_BASE_CLASS, canBeSticky } from '@/components/file-browser'
 import { DiffPanelTabBar } from '@/components/diff/DiffPanelTabBar'
 import { DiffChangesList } from '@/components/diff/DiffChangesList'
+import { ChatView } from '@/components/chat/ChatView'
 import {
   agentSidePanelOpenAtom,
   workspaceFilesVersionAtom,
@@ -34,6 +35,8 @@ import {
   fileBrowserAutoRevealAtom,
   agentSelectedWorktreeAtom,
 } from '@/atoms/agent-atoms'
+import type { AgentSidePanelTab } from '@/atoms/agent-atoms'
+import { agentSideChatMapAtom } from '@/atoms/chat-atoms'
 import { interfaceVariantAtom } from '@/atoms/theme'
 import { previewFileMapAtom } from '@/atoms/preview-atoms'
 import { useOpenPreview } from '@/components/diff/preview-opener'
@@ -55,8 +58,8 @@ function getMediaTypeFromFilename(filename: string): string {
 interface SidePanelProps {
   sessionId: string
   sessionPath: string | null
-  activeTab: 'session' | 'workspace' | 'changes'
-  onTabChange: (tab: 'session' | 'workspace' | 'changes') => void
+  activeTab: AgentSidePanelTab
+  onTabChange: (tab: AgentSidePanelTab) => void
   width?: number
 }
 
@@ -396,6 +399,24 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   const hasWorkspaceAttachedItems = wsAttachedDirs.length > 0 || wsAttachedFiles.length > 0
   const interfaceVariant = useAtomValue(interfaceVariantAtom)
   const isClassic = interfaceVariant === 'classic'
+  const sideChatMap = useAtomValue(agentSideChatMapAtom)
+  const setSideChatMap = useSetAtom(agentSideChatMapAtom)
+  const sideChatConversationId = sideChatMap.get(sessionId) ?? null
+  const effectiveActiveTab: AgentSidePanelTab = activeTab === 'chat' && !sideChatConversationId
+    ? 'session'
+    : activeTab
+
+  const handleCloseChatTab = React.useCallback(() => {
+    setSideChatMap((prev) => {
+      if (!prev.has(sessionId)) return prev
+      const next = new Map(prev)
+      next.delete(sessionId)
+      return next
+    })
+    if (activeTab === 'chat') {
+      onTabChange('session')
+    }
+  }, [activeTab, onTabChange, sessionId, setSideChatMap])
 
   return (
     <div
@@ -416,9 +437,24 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
           isOpen ? 'opacity-100' : 'opacity-0 pointer-events-none',
         )}
         >
-          <DiffPanelTabBar activeTab={activeTab} onTabChange={onTabChange} onClose={() => setIsOpen(false)} isWindows={isWindows} />
+          <DiffPanelTabBar
+            activeTab={effectiveActiveTab}
+            onTabChange={onTabChange}
+            onClose={() => setIsOpen(false)}
+            onCloseChat={handleCloseChatTab}
+            showChatTab={Boolean(sideChatConversationId)}
+            isWindows={isWindows}
+          />
 
-          {activeTab === 'changes' ? (
+          {effectiveActiveTab === 'chat' ? (
+            sideChatConversationId ? (
+              <div className="min-h-0 flex-1 overflow-hidden">
+                <ChatView conversationId={sideChatConversationId} />
+              </div>
+            ) : (
+              <div className="flex-1 flex items-center justify-center text-muted-foreground text-xs">暂无问答会话</div>
+            )
+          ) : effectiveActiveTab === 'changes' ? (
             sessionPath ? (
               <DiffChangesList
                 key={sessionId}
@@ -436,7 +472,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
             ) : (
               <div className="flex-1 flex items-center justify-center text-muted-foreground text-xs">等待会话初始化...</div>
             )
-          ) : activeTab === 'session' ? (
+          ) : effectiveActiveTab === 'session' ? (
             <div className="flex-1 min-h-0 flex flex-col pt-0.5 mx-2 mb-2">
               {sessionPath ? (
                 <>

--- a/apps/electron/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/electron/src/renderer/components/app-shell/AppShell.tsx
@@ -22,7 +22,7 @@ import { detectIsWindows, WINDOW_CONTROLS_INSET_RIGHT } from '@/lib/platform'
 import { cn } from '@/lib/utils'
 
 const MIN_RIGHT_PANEL_WIDTH = 300
-const MAX_RIGHT_PANEL_WIDTH = 420
+const MAX_RIGHT_PANEL_WIDTH = 560
 
 function clampRightPanelWidth(width: number): number {
   return Math.max(MIN_RIGHT_PANEL_WIDTH, Math.min(MAX_RIGHT_PANEL_WIDTH, width))

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -30,6 +30,7 @@ import {
   conversationContextLengthAtom,
   conversationThinkingEnabledAtom,
   conversationParallelModeAtom,
+  agentSideChatMapAtom,
 } from '@/atoms/chat-atoms'
 import {
   agentSessionsAtom,
@@ -739,6 +740,7 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
   const setConvPromptId = useSetAtom(conversationPromptIdAtom)
   const setPreviewPanelOpen = useSetAtom(previewPanelOpenMapAtom)
   const setPreviewFile = useSetAtom(previewFileMapAtom)
+  const setAgentSideChatMap = useSetAtom(agentSideChatMapAtom)
   const setDiffPanelTab = useSetAtom(agentDiffPanelTabAtom)
   const setDiffRefreshVersion = useSetAtom(agentDiffRefreshVersionAtom)
   const setDiffUnseen = useSetAtom(agentDiffUnseenChangesAtom)
@@ -764,6 +766,18 @@ export function LeftSidebar({ width }: LeftSidebarProps): React.ReactElement {
     setConvPromptId(deleteKey)
     setPreviewPanelOpen(deleteKey)
     setPreviewFile(deleteKey)
+    setAgentSideChatMap((prev) => {
+      let changed = false
+      const map = new Map(prev)
+      if (map.delete(id)) changed = true
+      for (const [sessionId, conversationId] of map) {
+        if (conversationId === id) {
+          map.delete(sessionId)
+          changed = true
+        }
+      }
+      return changed ? map : prev
+    })
     setDiffPanelTab(deleteKey)
     setDiffRefreshVersion(deleteKey)
     setDiffUnseen(deleteKey)

--- a/apps/electron/src/renderer/components/app-shell/RightSidePanel.tsx
+++ b/apps/electron/src/renderer/components/app-shell/RightSidePanel.tsx
@@ -14,6 +14,7 @@ import {
   agentSessionPathMapAtom,
   agentDiffPanelTabAtom,
 } from '@/atoms/agent-atoms'
+import type { AgentSidePanelTab } from '@/atoms/agent-atoms'
 import { SidePanel } from '@/components/agent/SidePanel'
 
 export function RightSidePanel({ width }: { width?: number }): React.ReactElement | null {
@@ -23,7 +24,7 @@ export function RightSidePanel({ width }: { width?: number }): React.ReactElemen
   const diffPanelTabMap = useAtomValue(agentDiffPanelTabAtom)
   const setDiffPanelTabMap = useSetAtom(agentDiffPanelTabAtom)
 
-  const setActiveTab = React.useCallback((tab: 'session' | 'workspace' | 'changes') => {
+  const setActiveTab = React.useCallback((tab: AgentSidePanelTab) => {
     if (!currentSessionId) return
     setDiffPanelTabMap((prev) => {
       const map = new Map(prev)

--- a/apps/electron/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatInput.tsx
@@ -20,6 +20,7 @@ import { ClearContextButton } from './ClearContextButton'
 import { ContextSettingsPopover } from './ContextSettingsPopover'
 import { ToolSelectorPopover } from './ToolSelectorPopover'
 import { AttachmentPreviewItem } from './AttachmentPreviewItem'
+import { QuotedSelectionChip } from '@/components/diff/QuotedSelectionChip'
 import { RichTextInput } from '@/components/ai-elements/rich-text-input'
 import { SpeechButton } from '@/components/ai-elements/speech-button'
 import { InputToolbarOverflow, type ToolbarItem } from '@/components/ai-elements/InputToolbarOverflow'
@@ -41,6 +42,7 @@ import {
   conversationDraftsAtom,
 } from '@/atoms/chat-atoms'
 import type { PendingAttachment } from '@/atoms/chat-atoms'
+import { quotedSelectionMapAtom } from '@/atoms/preview-atoms'
 import {
   useConversationModel,
   useConversationThinkingEnabled,
@@ -73,6 +75,9 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
   // 从 Map atom 读写草稿
   const draftsMap = useAtomValue(conversationDraftsAtom)
   const setDraftsMap = useSetAtom(conversationDraftsAtom)
+  const quotedSelectionMap = useAtomValue(quotedSelectionMapAtom)
+  const setQuotedSelectionMap = useSetAtom(quotedSelectionMapAtom)
+  const currentQuotedSelection = quotedSelectionMap.get(conversationId) ?? null
   const content = draftsMap.get(conversationId) ?? ''
   const setContent = React.useCallback((value: string) => {
     setDraftsMap((prev) => {
@@ -212,6 +217,16 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
       return prev.filter((a) => a.id !== id)
     })
   }, [setPendingAttachments])
+
+  /** 移除当前引用选中文本 */
+  const handleRemoveQuotedSelection = React.useCallback((): void => {
+    setQuotedSelectionMap((prev) => {
+      if (!prev.has(conversationId)) return prev
+      const next = new Map(prev)
+      next.delete(conversationId)
+      return next
+    })
+  }, [conversationId, setQuotedSelectionMap])
 
   /** 编辑完成 — 用编辑后的图片替换原 pending 附件 */
   const handleEditComplete = React.useCallback((attachmentId: string, editedDataUrl: string): void => {
@@ -400,9 +415,9 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
           onDragLeave={handleDragLeave}
           onDrop={handleDrop}
         >
-          {/* 附件预览区域 — Cherry Studio: padding 5px 15px, flex-wrap, gap 4px */}
-          {pendingAttachments.length > 0 && (
-            <div className="flex flex-wrap gap-1 px-[15px] pt-[10px] pb-[15px]">
+          {/* 附件 + 引用选中文本 Chip（与 Agent 输入框保持一致） */}
+          {(pendingAttachments.length > 0 || currentQuotedSelection) && (
+            <div className="flex flex-wrap gap-2 px-3 pt-2.5 pb-1.5">
               {pendingAttachments.map((att) => (
                 <AttachmentPreviewItem
                   key={att.id}
@@ -413,6 +428,14 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
                   onEditComplete={(editedDataUrl) => handleEditComplete(att.id, editedDataUrl)}
                 />
               ))}
+              {currentQuotedSelection && (
+                <QuotedSelectionChip
+                  text={currentQuotedSelection.text}
+                  filePath={currentQuotedSelection.filePath}
+                  sourceLabel={currentQuotedSelection.sourceLabel}
+                  onRemove={handleRemoveQuotedSelection}
+                />
+              )}
             </div>
           )}
 

--- a/apps/electron/src/renderer/components/chat/ChatMessageItem.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessageItem.tsx
@@ -11,7 +11,7 @@
 
 import * as React from 'react'
 import { useAtomValue } from 'jotai'
-import { AlertCircle, Pencil, RotateCcw, Trash2 } from 'lucide-react'
+import { AlertCircle, Pencil, Quote, RotateCcw, Trash2 } from 'lucide-react'
 import {
   Message,
   MessageHeader,
@@ -43,6 +43,55 @@ import { ChatToolActivityIndicator } from './ChatToolActivityIndicator'
 
 // 重导出供外部使用
 export type { InlineEditSubmitPayload } from './InlineEditForm'
+
+interface QuotedMessageContext {
+  label: string
+}
+
+function decodeXmlAttribute(value: string): string {
+  return value
+    .replace(/&quot;/g, '"')
+    .replace(/&gt;/g, '>')
+    .replace(/&lt;/g, '<')
+    .replace(/&amp;/g, '&')
+}
+
+function parseQuotedMessageContent(content: string): { quotes: QuotedMessageContext[]; text: string } {
+  const quotes: QuotedMessageContext[] = []
+  let text = content
+
+  const quotedFileRegex = /<quoted_file[^>]*>[\s\S]*?<\/quoted_file>\n*/g
+  const quotedContextRegex = /<quoted_context[^>]*>[\s\S]*?<\/quoted_context>\n*/g
+
+  let match: RegExpExecArray | null
+  while ((match = quotedFileRegex.exec(content)) !== null) {
+    const pathMatch = match[0].match(/path="([^"]*)"/)
+    if (!pathMatch) continue
+    const filePath = decodeXmlAttribute(pathMatch[1]!)
+    quotes.push({ label: filePath.split('/').pop() ?? filePath })
+  }
+
+  while ((match = quotedContextRegex.exec(content)) !== null) {
+    const labelMatch = match[0].match(/label="([^"]*)"/)
+    quotes.push({ label: labelMatch ? decodeXmlAttribute(labelMatch[1]!) : 'Agent 历史' })
+  }
+
+  text = text
+    .replace(quotedFileRegex, '')
+    .replace(quotedContextRegex, '')
+    .trim()
+
+  return { quotes, text }
+}
+
+function QuoteChip({ quote }: { quote: QuotedMessageContext }): React.ReactElement {
+  return (
+    <div className="inline-flex max-w-full min-w-0 items-center gap-1.5 rounded-md bg-primary/8 border border-primary/20 px-2.5 py-1 text-[12px] text-muted-foreground">
+      <Quote className="size-3.5 shrink-0 text-primary/60" />
+      <span className="min-w-0 max-w-full truncate">{quote.label}</span>
+    </div>
+  )
+}
 
 /**
  * 格式化消息时间（简略写法）
@@ -115,6 +164,10 @@ export const ChatMessageItem = React.memo(function ChatMessageItem({
   const [isDeleting, setIsDeleting] = React.useState(false)
   const userProfile = useAtomValue(userProfileAtom)
   const channels = useAtomValue(channelsAtom)
+  const parsedUserContent = React.useMemo(
+    () => message.role === 'user' ? parseQuotedMessageContent(message.content) : { quotes: [], text: message.content },
+    [message.content, message.role],
+  )
 
   /** 确认删除消息 */
   const handleDeleteConfirm = async (): Promise<void> => {
@@ -222,14 +275,21 @@ export const ChatMessageItem = React.memo(function ChatMessageItem({
               {!isInlineEditing && message.attachments && message.attachments.length > 0 && (
                 <MessageAttachments attachments={message.attachments} onImageEditComplete={onImageEditComplete} />
               )}
+              {!isInlineEditing && parsedUserContent.quotes.length > 0 && (
+                <div className="flex flex-wrap gap-1.5 mb-2">
+                  {parsedUserContent.quotes.map((quote, index) => (
+                    <QuoteChip key={`${quote.label}:${index}`} quote={quote} />
+                  ))}
+                </div>
+              )}
               {isInlineEditing ? (
                 <InlineEditForm
                   message={message}
                   onSubmit={handleInlineEditSubmit}
                   onCancel={() => onCancelInlineEdit?.()}
                 />
-              ) : message.content && (
-                <UserMessageContent>{message.content}</UserMessageContent>
+              ) : parsedUserContent.text && (
+                <UserMessageContent>{parsedUserContent.text}</UserMessageContent>
               )}
             </>
           )}
@@ -238,7 +298,7 @@ export const ChatMessageItem = React.memo(function ChatMessageItem({
         {/* 操作按钮（非 streaming 时显示，hover 时可见） */}
         {(message.content || message.error || (message.attachments && message.attachments.length > 0)) && !isStreaming && !isInlineEditing && (
           <MessageActions className="pl-[46px] mt-0.5 min-h-[28px]">
-            <CopyButton content={message.content} />
+            <CopyButton content={message.role === 'user' ? parsedUserContent.text : message.content} />
             {message.role === 'assistant' && conversationId && (
               <MigrateToAgentButton conversationId={conversationId} />
             )}

--- a/apps/electron/src/renderer/components/chat/ChatMessageItem.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessageItem.tsx
@@ -40,20 +40,13 @@ import { channelsAtom } from '@/atoms/chat-atoms'
 import type { ChatMessage } from '@proma/shared'
 import type { InlineEditSubmitPayload } from './InlineEditForm'
 import { ChatToolActivityIndicator } from './ChatToolActivityIndicator'
+import { decodeXmlAttribute } from '@/lib/quoted-selection'
 
 // 重导出供外部使用
 export type { InlineEditSubmitPayload } from './InlineEditForm'
 
 interface QuotedMessageContext {
   label: string
-}
-
-function decodeXmlAttribute(value: string): string {
-  return value
-    .replace(/&quot;/g, '"')
-    .replace(/&gt;/g, '>')
-    .replace(/&lt;/g, '<')
-    .replace(/&amp;/g, '&')
 }
 
 function parseQuotedMessageContent(content: string): { quotes: QuotedMessageContext[]; text: string } {

--- a/apps/electron/src/renderer/components/chat/ChatMessageItem.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatMessageItem.tsx
@@ -40,7 +40,7 @@ import { channelsAtom } from '@/atoms/chat-atoms'
 import type { ChatMessage } from '@proma/shared'
 import type { InlineEditSubmitPayload } from './InlineEditForm'
 import { ChatToolActivityIndicator } from './ChatToolActivityIndicator'
-import { decodeXmlAttribute } from '@/lib/quoted-selection'
+import { parseQuotedSelectionRefs } from '@/lib/quoted-selection'
 
 // 重导出供外部使用
 export type { InlineEditSubmitPayload } from './InlineEditForm'
@@ -50,30 +50,8 @@ interface QuotedMessageContext {
 }
 
 function parseQuotedMessageContent(content: string): { quotes: QuotedMessageContext[]; text: string } {
-  const quotes: QuotedMessageContext[] = []
-  let text = content
-
-  const quotedFileRegex = /<quoted_file[^>]*>[\s\S]*?<\/quoted_file>\n*/g
-  const quotedContextRegex = /<quoted_context[^>]*>[\s\S]*?<\/quoted_context>\n*/g
-
-  let match: RegExpExecArray | null
-  while ((match = quotedFileRegex.exec(content)) !== null) {
-    const pathMatch = match[0].match(/path="([^"]*)"/)
-    if (!pathMatch) continue
-    const filePath = decodeXmlAttribute(pathMatch[1]!)
-    quotes.push({ label: filePath.split('/').pop() ?? filePath })
-  }
-
-  while ((match = quotedContextRegex.exec(content)) !== null) {
-    const labelMatch = match[0].match(/label="([^"]*)"/)
-    quotes.push({ label: labelMatch ? decodeXmlAttribute(labelMatch[1]!) : 'Agent 历史' })
-  }
-
-  text = text
-    .replace(quotedFileRegex, '')
-    .replace(quotedContextRegex, '')
-    .trim()
-
+  const { quotes: parsedQuotes, text } = parseQuotedSelectionRefs(content)
+  const quotes = parsedQuotes.map((quote) => ({ label: quote.label ?? quote.filename }))
   return { quotes, text }
 }
 

--- a/apps/electron/src/renderer/components/chat/ChatView.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatView.tsx
@@ -14,7 +14,7 @@
  */
 
 import * as React from 'react'
-import { useAtomValue, useSetAtom } from 'jotai'
+import { useAtomValue, useSetAtom, useStore } from 'jotai'
 import { AlertCircle, X } from 'lucide-react'
 import { ChatHeader } from './ChatHeader'
 import { ChatMessages } from './ChatMessages'
@@ -33,6 +33,8 @@ import {
   INITIAL_MESSAGE_LIMIT,
 } from '@/atoms/chat-atoms'
 import type { PendingAttachment, ChatPendingMessage } from '@/atoms/chat-atoms'
+import { quotedSelectionMapAtom } from '@/atoms/preview-atoms'
+import type { QuotedSelection } from '@/atoms/preview-atoms'
 import { promptConfigAtom, promptSidebarOpenAtom, conversationPromptIdAtom, resolveSystemMessage, selectedPromptIdAtom } from '@/atoms/system-prompt-atoms'
 import { activeToolIdsAtom } from '@/atoms/chat-tool-atoms'
 import { userProfileAtom } from '@/atoms/user-profile'
@@ -55,6 +57,31 @@ import type {
 
 interface ChatViewProps {
   conversationId: string
+}
+
+function escapeXmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+function buildQuotedSelectionBlock(quotedSelection: QuotedSelection): string {
+  const safeText = quotedSelection.text
+    .replace(/<\/quoted_file>/gi, '</quoted_file_>')
+    .replace(/<\/quoted_context>/gi, '</quoted_context_>')
+
+  if (quotedSelection.sourceType && quotedSelection.sourceType !== 'file') {
+    const safeLabel = escapeXmlAttribute(quotedSelection.sourceLabel ?? quotedSelection.filePath)
+    const safeMessageId = escapeXmlAttribute(quotedSelection.messageId ?? '')
+    const safeRole = quotedSelection.messageRole ?? ''
+    const safeSource = escapeXmlAttribute(quotedSelection.sourceType)
+    return `<quoted_context source="${safeSource}" label="${safeLabel}" message_id="${safeMessageId}" role="${safeRole}">\n${safeText}\n</quoted_context>\n\n`
+  }
+
+  const safePath = escapeXmlAttribute(quotedSelection.filePath)
+  return `<quoted_file path="${safePath}">\n${safeText}\n</quoted_file>\n\n`
 }
 
 function cleanupPendingAttachments(attachments: PendingAttachment[]): void {
@@ -83,6 +110,7 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
   const [hasMoreMessages, setHasMoreMessages] = React.useState(false)
   const [messagesLoaded, setMessagesLoaded] = React.useState(false)
   const [inlineEditingMessageId, setInlineEditingMessageId] = React.useState<string | null>(null)
+  const store = useStore()
 
   // ===== Per-conversation hooks（分屏独立） =====
   const [selectedModel, setSelectedModel] = useConversationModel()
@@ -290,6 +318,22 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
       setPendingAttachments([])
     }
 
+    const quotedSelection = store.get(quotedSelectionMapAtom).get(conversationId)
+    const finalContent = quotedSelection
+      ? buildQuotedSelectionBlock(quotedSelection) + content
+      : content
+
+    if (quotedSelection) {
+      const capturedAt = quotedSelection.capturedAt
+      store.set(quotedSelectionMapAtom, (prev) => {
+        const current = prev.get(conversationId)
+        if (!current || current.capturedAt !== capturedAt) return prev
+        const next = new Map(prev)
+        next.delete(conversationId)
+        return next
+      })
+    }
+
     // 初始化当前对话的流式状态
     setStreamingStates((prev) => {
       const map = new Map(prev)
@@ -319,7 +363,7 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
 
     const input: ChatSendInput = {
       conversationId,
-      userMessage: content,
+      userMessage: finalContent,
       messageHistory: [], // 后端已改为从磁盘读取完整历史，无需前端传入
       channelId: selectedModel.channelId,
       modelId: selectedModel.modelId,
@@ -337,7 +381,7 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
       {
         id: `temp-${Date.now()}`,
         role: 'user',
-        content,
+        content: finalContent,
         createdAt: Date.now(),
         attachments: savedAttachments.length > 0 ? savedAttachments : undefined,
       },
@@ -373,6 +417,7 @@ function ChatViewInner({ conversationId }: ChatViewProps): React.ReactElement {
     setChatStreamErrors,
     setStreamingStates,
     setConversations,
+    store,
   ])
 
   // ===== 自动发送快速任务消息 =====

--- a/apps/electron/src/renderer/components/chat/ChatView.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatView.tsx
@@ -34,7 +34,6 @@ import {
 } from '@/atoms/chat-atoms'
 import type { PendingAttachment, ChatPendingMessage } from '@/atoms/chat-atoms'
 import { quotedSelectionMapAtom } from '@/atoms/preview-atoms'
-import type { QuotedSelection } from '@/atoms/preview-atoms'
 import { promptConfigAtom, promptSidebarOpenAtom, conversationPromptIdAtom, resolveSystemMessage, selectedPromptIdAtom } from '@/atoms/system-prompt-atoms'
 import { activeToolIdsAtom } from '@/atoms/chat-tool-atoms'
 import { userProfileAtom } from '@/atoms/user-profile'
@@ -48,6 +47,7 @@ import {
 import { registerPendingTitle } from '@/hooks/useGlobalChatListeners'
 import { draftSessionIdsAtom } from '@/atoms/draft-session-atoms'
 import { cn } from '@/lib/utils'
+import { buildQuotedSelectionBlock } from '@/lib/quoted-selection'
 import type {
   ChatMessage,
   ChatSendInput,
@@ -57,31 +57,6 @@ import type {
 
 interface ChatViewProps {
   conversationId: string
-}
-
-function escapeXmlAttribute(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-}
-
-function buildQuotedSelectionBlock(quotedSelection: QuotedSelection): string {
-  const safeText = quotedSelection.text
-    .replace(/<\/quoted_file>/gi, '</quoted_file_>')
-    .replace(/<\/quoted_context>/gi, '</quoted_context_>')
-
-  if (quotedSelection.sourceType && quotedSelection.sourceType !== 'file') {
-    const safeLabel = escapeXmlAttribute(quotedSelection.sourceLabel ?? quotedSelection.filePath)
-    const safeMessageId = escapeXmlAttribute(quotedSelection.messageId ?? '')
-    const safeRole = quotedSelection.messageRole ?? ''
-    const safeSource = escapeXmlAttribute(quotedSelection.sourceType)
-    return `<quoted_context source="${safeSource}" label="${safeLabel}" message_id="${safeMessageId}" role="${safeRole}">\n${safeText}\n</quoted_context>\n\n`
-  }
-
-  const safePath = escapeXmlAttribute(quotedSelection.filePath)
-  return `<quoted_file path="${safePath}">\n${safeText}\n</quoted_file>\n\n`
 }
 
 function cleanupPendingAttachments(attachments: PendingAttachment[]): void {

--- a/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffPanelTabBar.tsx
@@ -6,28 +6,36 @@
 
 import * as React from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
-import { PanelRightClose } from 'lucide-react'
+import { PanelRightClose, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { WINDOW_CONTROLS_INSET_RIGHT } from '@/lib/platform'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { agentDiffUnseenChangesAtom, currentAgentSessionIdAtom } from '@/atoms/agent-atoms'
+import type { AgentSidePanelTab } from '@/atoms/agent-atoms'
 import { interfaceVariantAtom } from '@/atoms/theme'
 
-type DiffPanelTab = 'session' | 'workspace' | 'changes'
-
 interface DiffPanelTabBarProps {
-  activeTab: DiffPanelTab
-  onTabChange: (tab: DiffPanelTab) => void
+  activeTab: AgentSidePanelTab
+  onTabChange: (tab: AgentSidePanelTab) => void
   onClose?: () => void
+  onCloseChat?: () => void
+  showChatTab?: boolean
   isWindows?: boolean
 }
 
 interface PreviousTabState {
   sessionId: string | null
-  activeTab: DiffPanelTab
+  activeTab: AgentSidePanelTab
 }
 
-export function DiffPanelTabBar({ activeTab, onTabChange, onClose, isWindows = false }: DiffPanelTabBarProps): React.ReactElement {
+export function DiffPanelTabBar({
+  activeTab,
+  onTabChange,
+  onClose,
+  onCloseChat,
+  showChatTab = false,
+  isWindows = false,
+}: DiffPanelTabBarProps): React.ReactElement {
   const unseenMap = useAtomValue(agentDiffUnseenChangesAtom)
   const setUnseenMap = useSetAtom(agentDiffUnseenChangesAtom)
   const currentSessionId = useAtomValue(currentAgentSessionIdAtom)
@@ -125,6 +133,42 @@ export function DiffPanelTabBar({ activeTab, onTabChange, onClose, isWindows = f
             文件改动
           </span>
         </button>
+        {showChatTab && (
+          <div
+            className={cn(
+              'flex-1 h-[34px] text-xs transition-colors select-none relative whitespace-nowrap overflow-hidden',
+              isClassic ? 'rounded-t-lg' : 'rounded-none',
+              'border-t border-l border-r',
+              activeTab === 'chat'
+                ? isClassic
+                  ? 'bg-content-area text-foreground border-border/50'
+                  : 'app-tab-active text-foreground border-border/80'
+                : isClassic
+                  ? 'text-muted-foreground border-transparent hover:text-foreground hover:bg-muted/50'
+                  : 'app-tab-inactive text-muted-foreground border-transparent hover:text-foreground',
+            )}
+          >
+            <div className="flex h-full items-center">
+              <button
+                type="button"
+                onClick={() => onTabChange('chat')}
+                className="min-w-0 flex-1 self-stretch px-2 text-left"
+              >
+                <span className="block truncate text-center">问答</span>
+              </button>
+              {onCloseChat && (
+                <button
+                  type="button"
+                  className="mr-1 inline-flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted/70 hover:text-foreground"
+                  aria-label="关闭问答 Tab"
+                  onClick={onCloseChat}
+                >
+                  <X className="size-3" />
+                </button>
+              )}
+            </div>
+          </div>
+        )}
         {/* 右侧关闭按钮（常驻，三个 tab 下都可见） */}
         {onClose && (
           <Tooltip>

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -6,15 +6,26 @@
  */
 
 import * as React from 'react'
-import { ChevronRight, Code2, Copy, Check, Eye, List, Pencil, RefreshCw, Save, X } from 'lucide-react'
+import { ChevronRight, Code2, Copy, Check, Eye, List, Bot, MessageCircle, Pencil, RefreshCw, Save, X } from 'lucide-react'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import DOMPurify from 'dompurify'
 import { File as PierreFile } from '@pierre/diffs/react'
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
-import { agentDiffViewModeAtom, agentDiffRefreshVersionAtom } from '@/atoms/agent-atoms'
+import {
+  agentDiffPanelTabAtom,
+  agentDiffViewModeAtom,
+  agentDiffRefreshVersionAtom,
+  agentSidePanelOpenAtom,
+} from '@/atoms/agent-atoms'
 import { resolvedThemeAtom } from '@/atoms/theme'
 import { quotedSelectionMapAtom } from '@/atoms/preview-atoms'
+import {
+  agentSideChatMapAtom,
+  conversationsAtom,
+  conversationDraftsAtom,
+  selectedModelAtom,
+} from '@/atoms/chat-atoms'
 import { markdownTocOpenAtom } from '@/atoms/markdown-toc'
 import { useShortcut } from '@/hooks/useShortcut'
 import { initShortcutRegistry } from '@/lib/shortcut-registry'
@@ -53,6 +64,19 @@ type CacheEntry = {
   officeHtml?: string
   officeText?: string
 }
+
+interface DeepSelection {
+  text: string
+  rect: DOMRect | null
+}
+
+interface PreviewTextSelection {
+  text: string
+  x: number
+  y: number
+  filePath: string
+}
+
 const CACHE_MAX = 50
 const contentCache = new Map<string, CacheEntry>()
 
@@ -127,13 +151,21 @@ function isSelectionInside(container: HTMLElement, selection: Selection): boolea
   return false
 }
 
+function getSelectionAnchorRect(selection: Selection): DOMRect | null {
+  if (selection.rangeCount === 0) return null
+  const range = selection.getRangeAt(0)
+  const rect = range.getBoundingClientRect()
+  if (rect.width > 0 || rect.height > 0) return rect
+  return range.getClientRects()[0] ?? null
+}
+
 /** 获取容器内的选区：先查光 DOM，再遍历缓存的 ShadowRoot 集合 */
-function getDeepSelection(container: HTMLElement, shadowRoots?: Set<ShadowRoot> | null): { text: string } | null {
+function getDeepSelection(container: HTMLElement, shadowRoots?: Set<ShadowRoot> | null): DeepSelection | null {
   const docSel = document.getSelection()
   if (docSel && !docSel.isCollapsed && docSel.rangeCount > 0) {
     if (isSelectionInside(container, docSel)) {
       const text = docSel.toString().trim()
-      if (text) return { text }
+      if (text) return { text, rect: getSelectionAnchorRect(docSel) }
     }
   }
 
@@ -145,19 +177,19 @@ function getDeepSelection(container: HTMLElement, shadowRoots?: Set<ShadowRoot> 
       const shadowSel = (sr as { getSelection?: () => Selection | null }).getSelection?.()
       if (shadowSel && !shadowSel.isCollapsed && shadowSel.rangeCount > 0) {
         const text = shadowSel.toString().trim()
-        if (text) return { text }
+        if (text) return { text, rect: getSelectionAnchorRect(shadowSel) }
       }
     }
     return null
   }
 
   // 兜底：无缓存时递归遍历（组件初始化瞬间可能命中一次）
-  function walk(node: Node): { text: string } | null {
+  function walk(node: Node): DeepSelection | null {
     if (node instanceof HTMLElement && node.shadowRoot) {
       const shadowSel = (node.shadowRoot as { getSelection?: () => Selection | null }).getSelection?.()
       if (shadowSel && !shadowSel.isCollapsed && shadowSel.rangeCount > 0) {
         const text = shadowSel.toString().trim()
-        if (text) return { text }
+        if (text) return { text, rect: getSelectionAnchorRect(shadowSel) }
       }
       const result = walk(node.shadowRoot)
       if (result) return result
@@ -277,9 +309,18 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   // ===== 选中文本引用（Quoted Selection）=====
 
   const setQuotedSelectionMap = useSetAtom(quotedSelectionMapAtom)
+  const selectedChatModel = useAtomValue(selectedModelAtom)
+  const setConversations = useSetAtom(conversationsAtom)
+  const setConversationDrafts = useSetAtom(conversationDraftsAtom)
+  const setSideChatMap = useSetAtom(agentSideChatMapAtom)
+  const setSidePanelOpen = useSetAtom(agentSidePanelOpenAtom)
+  const setSidePanelTabMap = useSetAtom(agentDiffPanelTabAtom)
+  const [previewSelection, setPreviewSelection] = React.useState<PreviewTextSelection | null>(null)
   const filePathRef = React.useRef(filePath)
   filePathRef.current = filePath
   const shadowRootsRef = React.useRef<Set<ShadowRoot>>(new Set())
+  const pointerSelectingRef = React.useRef(false)
+  const captureTimerRef = React.useRef<number | null>(null)
   /** 当前正在展示的截断 toast id；选中回落到上限内或选区消失时主动 dismiss */
   const lastToastIdRef = React.useRef<string | null>(null)
 
@@ -290,46 +331,36 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     }
   }, [])
 
-  /** 捕获预览面板中的文本选中，写入 quotedSelectionMapAtom */
+  const clearPreviewSelection = React.useCallback(() => {
+    setPreviewSelection(null)
+  }, [])
+
+  /** 捕获预览面板中的文本选中，显示动作弹层 */
   const handleSelectionCapture = React.useCallback(() => {
     if (!previewOnly) return
+    if (markdownEditing) return
     const container = scrollContainerRef.current
     if (!container) return
 
     const deepSel = getDeepSelection(container, shadowRootsRef.current)
     if (!deepSel) {
-      // 选区消失：先撤掉截断 toast，再判断是否清 Chip
-      dismissTruncationToast()
-      // 若焦点在 ProseMirror 编辑器（输入框），保留 Chip；否则清除
-      const activeEl = document.activeElement
-      if (activeEl && (activeEl.closest?.('.ProseMirror') || activeEl.closest?.('[data-input-mode]'))) return
-      setQuotedSelectionMap((prev) => {
-        const m = new Map(prev)
-        if (!m.has(sessionId)) return prev
-        m.delete(sessionId)
-        return m
-      })
+      clearPreviewSelection()
       return
     }
 
-    // 实时更新只存文本 + 路径，不计算行号
     const truncated = deepSel.text.length > MAX_QUOTED_CHARS
     const newText = truncated ? deepSel.text.slice(0, MAX_QUOTED_CHARS) : deepSel.text
     const newFilePath = filePathRef.current
-    setQuotedSelectionMap((prev) => {
-      const existing = prev.get(sessionId)
-      // 选区文本与路径都未变 → 跳过 atom 写入，避免触发 AgentView 整树重渲染
-      if (existing && existing.text === newText && existing.filePath === newFilePath) {
-        return prev
-      }
-      const m = new Map(prev)
-      m.set(sessionId, {
-        text: newText,
-        filePath: newFilePath,
-        capturedAt: Date.now(),
-      })
-      return m
+    const anchorRect = deepSel.rect
+    if (!anchorRect) return
+
+    setPreviewSelection({
+      text: newText,
+      x: anchorRect.left + anchorRect.width / 2,
+      y: Math.max(12, anchorRect.top - 12),
+      filePath: newFilePath,
     })
+
     // 超过上限时按千位分档 toast；跨档时撤掉上一档，回到上限内则全部撤掉
     if (truncated) {
       const k = Math.floor(deepSel.text.length / 1000) * 1000
@@ -345,7 +376,17 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     } else {
       dismissTruncationToast()
     }
-  }, [previewOnly, sessionId, setQuotedSelectionMap, dismissTruncationToast])
+  }, [clearPreviewSelection, dismissTruncationToast, markdownEditing, previewOnly, sessionId])
+
+  const scheduleSelectionCapture = React.useCallback((): void => {
+    if (captureTimerRef.current != null) {
+      window.clearTimeout(captureTimerRef.current)
+    }
+    captureTimerRef.current = window.setTimeout(() => {
+      captureTimerRef.current = null
+      handleSelectionCapture()
+    }, 80)
+  }, [handleSelectionCapture])
 
   // 监听选区变化：document selectionchange + 容器内鼠标拖拽轮询
   React.useEffect(() => {
@@ -377,58 +418,48 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     })
     mo.observe(container, { childList: true, subtree: true })
 
-    let tracking = false
-    let rafId = 0
-
-    const scheduleCapture = () => {
-      // 快速路径：非拖拽时若 document 选区已折叠（输入框打字/点击），跳过昂贵的树遍历。
-      // @pierre/diffs 使用 open Shadow DOM，Chrome/Electron 会将 shadow 内选区反映到
-      // document.getSelection()，因此键盘选区（Shift+Arrow）也能通过此检查。
-      if (!tracking) {
-        const docSel = document.getSelection()
-        if (!docSel || docSel.isCollapsed) return
-        // 光 DOM 快速检查：选区不在预览容器内也跳过
-        if (!isSelectionInside(container, docSel)) return
-      }
-      if (rafId) return
-      rafId = requestAnimationFrame(() => {
-        rafId = 0
-        handleSelectionCapture()
-      })
-    }
-
     const onMouseDown = (e: MouseEvent) => {
-      if (e.button === 0) tracking = true
-    }
-    const onMouseMove = () => {
-      if (tracking) scheduleCapture()
+      const target = e.target
+      if (target instanceof Element && target.closest('[data-preview-selection-popover]')) return
+      if (e.button === 0) {
+        pointerSelectingRef.current = true
+        clearPreviewSelection()
+      }
     }
     const onMouseUp = () => {
-      if (tracking) {
-        tracking = false
-        scheduleCapture()
-      }
+      if (!pointerSelectingRef.current) return
+      pointerSelectingRef.current = false
+      scheduleSelectionCapture()
     }
     const onSelectionChange = () => {
-      scheduleCapture()
+      if (pointerSelectingRef.current) return
+      const docSel = document.getSelection()
+      if (!docSel || docSel.isCollapsed) {
+        clearPreviewSelection()
+        return
+      }
+      if (isSelectionInside(container, docSel)) {
+        scheduleSelectionCapture()
+      }
     }
 
     container.addEventListener('mousedown', onMouseDown)
-    document.addEventListener('mousemove', onMouseMove)
     document.addEventListener('mouseup', onMouseUp)
     document.addEventListener('selectionchange', onSelectionChange)
     return () => {
-      if (rafId) cancelAnimationFrame(rafId)
+      if (captureTimerRef.current != null) {
+        window.clearTimeout(captureTimerRef.current)
+        captureTimerRef.current = null
+      }
       mo.disconnect()
       shadowRoots.clear()
       container.removeEventListener('mousedown', onMouseDown)
-      document.removeEventListener('mousemove', onMouseMove)
       document.removeEventListener('mouseup', onMouseUp)
       document.removeEventListener('selectionchange', onSelectionChange)
       // unmount / 切预览 / 切 session 时撤掉残留的截断 toast，避免贴脸 3 秒
       dismissTruncationToast()
     }
-  }, [previewOnly, handleSelectionCapture, dismissTruncationToast])
+  }, [previewOnly, clearPreviewSelection, dismissTruncationToast, scheduleSelectionCapture])
 
   const fileAccess = React.useMemo(() => ({
     sessionId,
@@ -919,6 +950,82 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     })
   }, [sessionId, setRefreshVersionMap])
 
+  const handleAddSelectionToAgent = React.useCallback(() => {
+    if (!previewSelection) return
+    setQuotedSelectionMap((prev) => {
+      const next = new Map(prev)
+      next.set(sessionId, {
+        text: previewSelection.text,
+        filePath: previewSelection.filePath,
+        sourceType: 'file',
+        sourceLabel: previewSelection.filePath,
+        capturedAt: Date.now(),
+      })
+      return next
+    })
+    window.getSelection()?.removeAllRanges()
+    clearPreviewSelection()
+    toast.success('已添加到 Agent 引用')
+  }, [clearPreviewSelection, previewSelection, sessionId, setQuotedSelectionMap])
+
+  const handleOpenSelectionChat = React.useCallback(async (): Promise<void> => {
+    if (!previewSelection) return
+    try {
+      const conversation = await window.electronAPI.createConversation(
+        '预览选区问答',
+        selectedChatModel?.modelId,
+        selectedChatModel?.channelId,
+      )
+      setConversations((prev) => {
+        if (prev.some((item) => item.id === conversation.id)) return prev
+        return [conversation, ...prev]
+      })
+      setConversationDrafts((prev) => {
+        const next = new Map(prev)
+        next.set(conversation.id, '我的问题：')
+        return next
+      })
+      setQuotedSelectionMap((prev) => {
+        const next = new Map(prev)
+        next.set(conversation.id, {
+          text: previewSelection.text,
+          filePath: previewSelection.filePath,
+          sourceType: 'file',
+          sourceLabel: previewSelection.filePath,
+          capturedAt: Date.now(),
+        })
+        return next
+      })
+      setSideChatMap((prev) => {
+        const next = new Map(prev)
+        next.set(sessionId, conversation.id)
+        return next
+      })
+      setSidePanelOpen(true)
+      setSidePanelTabMap((prev) => {
+        const next = new Map(prev)
+        next.set(sessionId, 'chat')
+        return next
+      })
+      window.getSelection()?.removeAllRanges()
+      clearPreviewSelection()
+    } catch (error) {
+      console.error('[DiffTabContent] 打开预览选区聊天标签失败:', error)
+      toast.error('打开聊天标签失败')
+    }
+  }, [
+    clearPreviewSelection,
+    previewSelection,
+    selectedChatModel,
+    sessionId,
+    setConversationDrafts,
+    setConversations,
+    setQuotedSelectionMap,
+    setSideChatMap,
+    setSidePanelOpen,
+    setSidePanelTabMap,
+  ])
+
   // persistRef 始终持有最新 persistMarkdownDraft，供 setTimeout / unmount cleanup 调用。
   // 用 effect 而非渲染期赋值，避免 React 19 严格模式下并发渲染中途读到中间态。
   React.useEffect(() => {
@@ -1291,6 +1398,35 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
             <DiffView oldContent={oldContent} newContent={newContent} filePath={filePath} viewMode={viewMode} />
           )}
         </div>
+        {previewSelection && (
+          <div
+            data-preview-selection-popover
+            className="fixed z-[90] -translate-x-1/2 -translate-y-full rounded-xl bg-popover/95 px-2 py-1.5 text-popover-foreground shadow-xl ring-1 ring-border/40 backdrop-blur"
+            style={{ left: previewSelection.x, top: previewSelection.y }}
+            onMouseDown={(event) => event.preventDefault()}
+          >
+            <div className="flex items-center gap-1">
+              <button
+                type="button"
+                className="inline-flex h-8 items-center gap-1.5 rounded-lg px-2.5 text-[13px] font-medium transition-colors hover:bg-muted"
+                onClick={handleAddSelectionToAgent}
+              >
+                <Bot className="size-4" />
+                为 Agent 引用
+              </button>
+              <button
+                type="button"
+                className="inline-flex h-8 items-center gap-1.5 rounded-lg px-2.5 text-[13px] font-medium transition-colors hover:bg-muted"
+                onClick={() => {
+                  void handleOpenSelectionChat()
+                }}
+              >
+                <MessageCircle className="size-4" />
+                打开右侧问答
+              </button>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -321,6 +321,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   const shadowRootsRef = React.useRef<Set<ShadowRoot>>(new Set())
   const pointerSelectingRef = React.useRef(false)
   const captureTimerRef = React.useRef<number | null>(null)
+  const openSelectionChatPendingRef = React.useRef(false)
   /** 当前正在展示的截断 toast id；选中回落到上限内或选区消失时主动 dismiss */
   const lastToastIdRef = React.useRef<string | null>(null)
 
@@ -970,6 +971,8 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
 
   const handleOpenSelectionChat = React.useCallback(async (): Promise<void> => {
     if (!previewSelection) return
+    if (openSelectionChatPendingRef.current) return
+    openSelectionChatPendingRef.current = true
     try {
       const conversation = await window.electronAPI.createConversation(
         '预览选区问答',
@@ -1012,6 +1015,8 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     } catch (error) {
       console.error('[DiffTabContent] 打开预览选区聊天标签失败:', error)
       toast.error('打开聊天标签失败')
+    } finally {
+      openSelectionChatPendingRef.current = false
     }
   }, [
     clearPreviewSelection,

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -6,7 +6,7 @@
  */
 
 import * as React from 'react'
-import { ChevronRight, Code2, Copy, Check, Eye, List, Bot, MessageCircle, Pencil, RefreshCw, Save, X } from 'lucide-react'
+import { ChevronRight, Code2, Copy, Check, Eye, List, Pencil, RefreshCw, Save, X } from 'lucide-react'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import DOMPurify from 'dompurify'
 import { File as PierreFile } from '@pierre/diffs/react'
@@ -35,6 +35,8 @@ import { PreviewFindBar } from './PreviewFindBar'
 import { MarkdownToc } from './MarkdownToc'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { PIERRE_FILE_CSS } from '@/components/agent/tool-result-renderers/pierre-styles'
+import { SelectionActionPopover } from '@/components/selection/SelectionActionPopover'
+import { SELECTION_ACTION_POPOVER_SELECTOR } from '@/lib/quoted-selection'
 
 const MD_EXTS = new Set(['.md', '.markdown'])
 const PLAIN_TEXT_EDIT_EXTS = new Set(['.txt', '.text', '.log'])
@@ -421,7 +423,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
 
     const onMouseDown = (e: MouseEvent) => {
       const target = e.target
-      if (target instanceof Element && target.closest('[data-preview-selection-popover]')) return
+      if (target instanceof Element && target.closest(SELECTION_ACTION_POPOVER_SELECTOR)) return
       if (e.button === 0) {
         pointerSelectingRef.current = true
         clearPreviewSelection()
@@ -1404,33 +1406,12 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
           )}
         </div>
         {previewSelection && (
-          <div
-            data-preview-selection-popover
-            className="fixed z-[90] -translate-x-1/2 -translate-y-full rounded-xl bg-popover/95 px-2 py-1.5 text-popover-foreground shadow-xl ring-1 ring-border/40 backdrop-blur"
-            style={{ left: previewSelection.x, top: previewSelection.y }}
-            onMouseDown={(event) => event.preventDefault()}
-          >
-            <div className="flex items-center gap-1">
-              <button
-                type="button"
-                className="inline-flex h-8 items-center gap-1.5 rounded-lg px-2.5 text-[13px] font-medium transition-colors hover:bg-muted"
-                onClick={handleAddSelectionToAgent}
-              >
-                <Bot className="size-4" />
-                为 Agent 引用
-              </button>
-              <button
-                type="button"
-                className="inline-flex h-8 items-center gap-1.5 rounded-lg px-2.5 text-[13px] font-medium transition-colors hover:bg-muted"
-                onClick={() => {
-                  void handleOpenSelectionChat()
-                }}
-              >
-                <MessageCircle className="size-4" />
-                打开右侧问答
-              </button>
-            </div>
-          </div>
+          <SelectionActionPopover
+            x={previewSelection.x}
+            y={previewSelection.y}
+            onAddToAgent={handleAddSelectionToAgent}
+            onOpenChat={handleOpenSelectionChat}
+          />
         )}
       </div>
     </div>

--- a/apps/electron/src/renderer/components/diff/QuotedSelectionChip.tsx
+++ b/apps/electron/src/renderer/components/diff/QuotedSelectionChip.tsx
@@ -14,6 +14,8 @@ interface QuotedSelectionChipProps {
   text: string
   /** 来源文件路径（截断显示） */
   filePath: string
+  /** 来源展示名称 */
+  sourceLabel?: string
   /** 移除回调 */
   onRemove: () => void
   className?: string
@@ -35,6 +37,7 @@ function truncatePath(filePath: string, maxLen: number = 40): string {
 export function QuotedSelectionChip({
   text,
   filePath,
+  sourceLabel,
   onRemove,
   className,
 }: QuotedSelectionChipProps): React.ReactElement {
@@ -46,7 +49,7 @@ export function QuotedSelectionChip({
   return (
     <div
       className={cn(
-        'group/chip relative flex items-start gap-2 shrink-0 max-w-[33%]',
+        'group/chip relative flex min-w-0 max-w-full items-start gap-2',
         'rounded-lg bg-primary/8 border border-primary/20',
         'pl-2.5 pr-7 py-1.5 text-[13px]',
         'transition-colors hover:bg-primary/12',
@@ -55,11 +58,11 @@ export function QuotedSelectionChip({
     >
       <Quote className="size-4 shrink-0 mt-0.5 text-primary/60" />
       <div className="flex flex-col min-w-0">
-        <span className="text-foreground/80 line-clamp-2 leading-snug">
+        <span className="text-foreground/80 line-clamp-2 leading-snug break-words [overflow-wrap:anywhere]">
           {truncateText(text)}
         </span>
-        <span className="text-[11px] text-muted-foreground/60 mt-0.5">
-          {truncatePath(filePath)}
+        <span className="text-[11px] text-muted-foreground/60 mt-0.5 break-words [overflow-wrap:anywhere]">
+          {sourceLabel ?? truncatePath(filePath)}
         </span>
       </div>
       <button

--- a/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
+++ b/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
@@ -80,6 +80,7 @@ export function ScratchPadView(): React.ReactElement {
   const [selection, setSelection] = React.useState<ScratchPadSelection | null>(null)
   const pointerSelectingRef = React.useRef(false)
   const captureTimerRef = React.useRef<number | null>(null)
+  const openSideChatPendingRef = React.useRef(false)
 
   // 用 ref 追踪最新内容，避免在 useEffect deps 里包含 content 导致循环
   const contentRef = React.useRef(content)
@@ -286,9 +287,11 @@ export function ScratchPadView(): React.ReactElement {
 
   const handleOpenSideChat = React.useCallback(async (): Promise<void> => {
     if (!selection) return
+    if (openSideChatPendingRef.current) return
     const sessionId = getTargetAgentSessionId()
     if (!sessionId) return
 
+    openSideChatPendingRef.current = true
     try {
       const conversation = await window.electronAPI.createConversation(
         '草稿选区问答',
@@ -333,6 +336,8 @@ export function ScratchPadView(): React.ReactElement {
     } catch (error) {
       console.error('[ScratchPad] 打开草稿选区右侧问答失败:', error)
       toast.error('打开右侧问答失败')
+    } finally {
+      openSideChatPendingRef.current = false
     }
   }, [
     clearSelection,

--- a/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
+++ b/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
@@ -12,10 +12,20 @@ import { useEditor, EditorContent } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import Placeholder from '@tiptap/extension-placeholder'
 import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
-import { useAtom, useAtomValue } from 'jotai'
-import { FileDown } from 'lucide-react'
+import { useAtom, useAtomValue, useSetAtom } from 'jotai'
+import { FileDown, Bot, MessageCircle } from 'lucide-react'
+import { toast } from 'sonner'
 import { scratchPadContentAtom, scratchPadLoadedAtom, tabsAtom, activeTabIdAtom } from '@/atoms/tab-atoms'
-import { currentAgentWorkspaceIdAtom, agentWorkspacesAtom } from '@/atoms/agent-atoms'
+import {
+  agentDiffPanelTabAtom,
+  agentSidePanelOpenAtom,
+  currentAgentSessionIdAtom,
+  currentAgentWorkspaceIdAtom,
+  agentWorkspacesAtom,
+} from '@/atoms/agent-atoms'
+import { agentSideChatMapAtom, conversationsAtom, conversationDraftsAtom, selectedModelAtom } from '@/atoms/chat-atoms'
+import { appModeAtom } from '@/atoms/app-mode'
+import { quotedSelectionMapAtom } from '@/atoms/preview-atoms'
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -46,14 +56,44 @@ import {
   setLastFocusedVoiceInputId,
 } from '@/lib/voice-input-focus'
 
+const MAX_SCRATCH_PAD_QUOTED_CHARS = 2000
+
+interface ScratchPadSelection {
+  text: string
+  x: number
+  y: number
+}
+
+function normalizeSelectionText(text: string): string {
+  return text.replace(/\s+\n/g, '\n').replace(/\n\s+/g, '\n').trim()
+}
+
+function getElementFromNode(node: Node | null): Element | null {
+  if (!node) return null
+  return node instanceof Element ? node : node.parentElement
+}
+
 export function ScratchPadView(): React.ReactElement {
   const [content, setContent] = useAtom(scratchPadContentAtom)
   const loaded = useAtomValue(scratchPadLoadedAtom)
   const containerRef = React.useRef<HTMLDivElement>(null)
+  const [selection, setSelection] = React.useState<ScratchPadSelection | null>(null)
+  const pointerSelectingRef = React.useRef(false)
+  const captureTimerRef = React.useRef<number | null>(null)
 
   // 用 ref 追踪最新内容，避免在 useEffect deps 里包含 content 导致循环
   const contentRef = React.useRef(content)
   contentRef.current = content
+
+  const setQuotedSelectionMap = useSetAtom(quotedSelectionMapAtom)
+  const selectedChatModel = useAtomValue(selectedModelAtom)
+  const setConversations = useSetAtom(conversationsAtom)
+  const setConversationDrafts = useSetAtom(conversationDraftsAtom)
+  const setAgentSideChatMap = useSetAtom(agentSideChatMapAtom)
+  const setAgentSidePanelOpen = useSetAtom(agentSidePanelOpenAtom)
+  const setAgentSidePanelTabMap = useSetAtom(agentDiffPanelTabAtom)
+  const setCurrentAgentSessionId = useSetAtom(currentAgentSessionIdAtom)
+  const setAppMode = useSetAtom(appModeAtom)
 
   const extensions = React.useMemo(() => [
     StarterKit.configure({
@@ -109,6 +149,205 @@ export function ScratchPadView(): React.ReactElement {
     const agentTab = tabs.find((t) => t.sessionId === activeSessionId && t.type === 'agent')
     return agentTab?.title ?? null
   }, [tabs, activeSessionId])
+
+  const clearSelection = React.useCallback((): void => {
+    setSelection(null)
+  }, [])
+
+  const captureSelection = React.useCallback((): void => {
+    const editorRoot = editor?.view.dom
+    if (!editorRoot) return
+
+    const sel = window.getSelection()
+    if (!sel || sel.rangeCount === 0 || sel.isCollapsed) {
+      clearSelection()
+      return
+    }
+
+    const range = sel.getRangeAt(0)
+    const startEl = getElementFromNode(range.startContainer)
+    const endEl = getElementFromNode(range.endContainer)
+    if (!startEl || !endEl || !editorRoot.contains(startEl) || !editorRoot.contains(endEl)) {
+      clearSelection()
+      return
+    }
+
+    const rawText = normalizeSelectionText(sel.toString())
+    if (!rawText) {
+      clearSelection()
+      return
+    }
+
+    const truncated = rawText.length > MAX_SCRATCH_PAD_QUOTED_CHARS
+    const text = truncated ? rawText.slice(0, MAX_SCRATCH_PAD_QUOTED_CHARS) : rawText
+    const rect = range.getBoundingClientRect()
+    const firstRect = range.getClientRects()[0]
+    const anchorRect = rect.width > 0 || rect.height > 0 ? rect : firstRect
+    if (!anchorRect) return
+
+    setSelection({
+      text,
+      x: anchorRect.left + anchorRect.width / 2,
+      y: Math.max(12, anchorRect.top - 12),
+    })
+
+    if (truncated) {
+      toast.warning(`已选中超过 ${MAX_SCRATCH_PAD_QUOTED_CHARS} 字符，仅引用前 ${MAX_SCRATCH_PAD_QUOTED_CHARS} 字符`, {
+        id: 'scratch-pad-selection-cap',
+        duration: 3000,
+      })
+    }
+  }, [clearSelection, editor])
+
+  const scheduleCaptureSelection = React.useCallback((): void => {
+    if (captureTimerRef.current != null) {
+      window.clearTimeout(captureTimerRef.current)
+    }
+    captureTimerRef.current = window.setTimeout(() => {
+      captureTimerRef.current = null
+      captureSelection()
+    }, 80)
+  }, [captureSelection])
+
+  React.useEffect(() => {
+    const editorRoot = editor?.view.dom
+    if (!editorRoot) return
+
+    const onPointerDown = (event: PointerEvent): void => {
+      const target = event.target
+      if (target instanceof Element && target.closest('[data-scratch-pad-selection-popover]')) return
+      if (target instanceof Element && editorRoot.contains(target)) {
+        pointerSelectingRef.current = true
+        clearSelection()
+        return
+      }
+      clearSelection()
+    }
+    const onPointerUp = (): void => {
+      if (!pointerSelectingRef.current) return
+      pointerSelectingRef.current = false
+      scheduleCaptureSelection()
+    }
+    const onPointerCancel = (): void => {
+      pointerSelectingRef.current = false
+    }
+    const onSelectionChange = (): void => {
+      if (pointerSelectingRef.current) return
+      const sel = window.getSelection()
+      if (!sel || sel.isCollapsed) {
+        clearSelection()
+        return
+      }
+      scheduleCaptureSelection()
+    }
+
+    document.addEventListener('pointerdown', onPointerDown, true)
+    document.addEventListener('pointerup', onPointerUp, true)
+    document.addEventListener('pointercancel', onPointerCancel, true)
+    document.addEventListener('selectionchange', onSelectionChange)
+    return () => {
+      if (captureTimerRef.current != null) {
+        window.clearTimeout(captureTimerRef.current)
+        captureTimerRef.current = null
+      }
+      document.removeEventListener('pointerdown', onPointerDown, true)
+      document.removeEventListener('pointerup', onPointerUp, true)
+      document.removeEventListener('pointercancel', onPointerCancel, true)
+      document.removeEventListener('selectionchange', onSelectionChange)
+    }
+  }, [clearSelection, editor, scheduleCaptureSelection])
+
+  const getTargetAgentSessionId = React.useCallback((): string | null => {
+    if (activeSessionId) return activeSessionId
+    toast.warning('请先打开一个 Agent 会话，再引用草稿选区')
+    return null
+  }, [activeSessionId])
+
+  const handleAddToAgent = React.useCallback((): void => {
+    if (!selection) return
+    const sessionId = getTargetAgentSessionId()
+    if (!sessionId) return
+
+    setQuotedSelectionMap((prev) => {
+      const next = new Map(prev)
+      next.set(sessionId, {
+        text: selection.text,
+        filePath: '草稿页',
+        sourceType: 'scratch-pad',
+        sourceLabel: '草稿页',
+        capturedAt: Date.now(),
+      })
+      return next
+    })
+    window.getSelection()?.removeAllRanges()
+    clearSelection()
+    toast.success('已添加到 Agent 引用')
+  }, [clearSelection, getTargetAgentSessionId, selection, setQuotedSelectionMap])
+
+  const handleOpenSideChat = React.useCallback(async (): Promise<void> => {
+    if (!selection) return
+    const sessionId = getTargetAgentSessionId()
+    if (!sessionId) return
+
+    try {
+      const conversation = await window.electronAPI.createConversation(
+        '草稿选区问答',
+        selectedChatModel?.modelId,
+        selectedChatModel?.channelId,
+      )
+      setConversations((prev) => {
+        if (prev.some((item) => item.id === conversation.id)) return prev
+        return [conversation, ...prev]
+      })
+      setConversationDrafts((prev) => {
+        const next = new Map(prev)
+        next.set(conversation.id, '我的问题：')
+        return next
+      })
+      setQuotedSelectionMap((prev) => {
+        const next = new Map(prev)
+        next.set(conversation.id, {
+          text: selection.text,
+          filePath: '草稿页',
+          sourceType: 'scratch-pad',
+          sourceLabel: '草稿页',
+          capturedAt: Date.now(),
+        })
+        return next
+      })
+      setCurrentAgentSessionId(sessionId)
+      setAppMode('agent')
+      setAgentSideChatMap((prev) => {
+        const next = new Map(prev)
+        next.set(sessionId, conversation.id)
+        return next
+      })
+      setAgentSidePanelOpen(true)
+      setAgentSidePanelTabMap((prev) => {
+        const next = new Map(prev)
+        next.set(sessionId, 'chat')
+        return next
+      })
+      window.getSelection()?.removeAllRanges()
+      clearSelection()
+    } catch (error) {
+      console.error('[ScratchPad] 打开草稿选区右侧问答失败:', error)
+      toast.error('打开右侧问答失败')
+    }
+  }, [
+    clearSelection,
+    getTargetAgentSessionId,
+    selectedChatModel,
+    selection,
+    setAgentSideChatMap,
+    setAgentSidePanelOpen,
+    setAgentSidePanelTabMap,
+    setAppMode,
+    setConversationDrafts,
+    setConversations,
+    setCurrentAgentSessionId,
+    setQuotedSelectionMap,
+  ])
 
   const makeFilename = () => {
     const now = new Date()
@@ -279,6 +518,35 @@ export function ScratchPadView(): React.ReactElement {
           )}
         </div>
       </div>
+      {selection && (
+        <div
+          data-scratch-pad-selection-popover
+          className="fixed z-[90] -translate-x-1/2 -translate-y-full rounded-xl bg-popover/95 px-2 py-1.5 text-popover-foreground shadow-xl ring-1 ring-border/40 backdrop-blur"
+          style={{ left: selection.x, top: selection.y }}
+          onMouseDown={(event) => event.preventDefault()}
+        >
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              className="inline-flex h-8 items-center gap-1.5 rounded-lg px-2.5 text-[13px] font-medium transition-colors hover:bg-muted"
+              onClick={handleAddToAgent}
+            >
+              <Bot className="size-4" />
+              为 Agent 引用
+            </button>
+            <button
+              type="button"
+              className="inline-flex h-8 items-center gap-1.5 rounded-lg px-2.5 text-[13px] font-medium transition-colors hover:bg-muted"
+              onClick={() => {
+                void handleOpenSideChat()
+              }}
+            >
+              <MessageCircle className="size-4" />
+              打开右侧问答
+            </button>
+          </div>
+        </div>
+      )}
       {/* 底部居中悬浮：圆形语音输入按钮 */}
       <div className="absolute left-1/2 -translate-x-1/2 bottom-10 z-20">
         <SpeechButton className="size-11 rounded-full bg-background/95 border border-border/60 shadow-md backdrop-blur hover:bg-accent text-foreground/80" />

--- a/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
+++ b/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
@@ -13,7 +13,7 @@ import StarterKit from '@tiptap/starter-kit'
 import Placeholder from '@tiptap/extension-placeholder'
 import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
-import { FileDown, Bot, MessageCircle } from 'lucide-react'
+import { FileDown } from 'lucide-react'
 import { toast } from 'sonner'
 import { scratchPadContentAtom, scratchPadLoadedAtom, tabsAtom, activeTabIdAtom } from '@/atoms/tab-atoms'
 import {
@@ -55,6 +55,8 @@ import {
   getLastFocusedVoiceInputId,
   setLastFocusedVoiceInputId,
 } from '@/lib/voice-input-focus'
+import { SelectionActionPopover } from '@/components/selection/SelectionActionPopover'
+import { SELECTION_ACTION_POPOVER_SELECTOR } from '@/lib/quoted-selection'
 
 const MAX_SCRATCH_PAD_QUOTED_CHARS = 2000
 
@@ -216,7 +218,7 @@ export function ScratchPadView(): React.ReactElement {
 
     const onPointerDown = (event: PointerEvent): void => {
       const target = event.target
-      if (target instanceof Element && target.closest('[data-scratch-pad-selection-popover]')) return
+      if (target instanceof Element && target.closest(SELECTION_ACTION_POPOVER_SELECTOR)) return
       if (target instanceof Element && editorRoot.contains(target)) {
         pointerSelectingRef.current = true
         clearSelection()
@@ -524,33 +526,12 @@ export function ScratchPadView(): React.ReactElement {
         </div>
       </div>
       {selection && (
-        <div
-          data-scratch-pad-selection-popover
-          className="fixed z-[90] -translate-x-1/2 -translate-y-full rounded-xl bg-popover/95 px-2 py-1.5 text-popover-foreground shadow-xl ring-1 ring-border/40 backdrop-blur"
-          style={{ left: selection.x, top: selection.y }}
-          onMouseDown={(event) => event.preventDefault()}
-        >
-          <div className="flex items-center gap-1">
-            <button
-              type="button"
-              className="inline-flex h-8 items-center gap-1.5 rounded-lg px-2.5 text-[13px] font-medium transition-colors hover:bg-muted"
-              onClick={handleAddToAgent}
-            >
-              <Bot className="size-4" />
-              为 Agent 引用
-            </button>
-            <button
-              type="button"
-              className="inline-flex h-8 items-center gap-1.5 rounded-lg px-2.5 text-[13px] font-medium transition-colors hover:bg-muted"
-              onClick={() => {
-                void handleOpenSideChat()
-              }}
-            >
-              <MessageCircle className="size-4" />
-              打开右侧问答
-            </button>
-          </div>
-        </div>
+        <SelectionActionPopover
+          x={selection.x}
+          y={selection.y}
+          onAddToAgent={handleAddToAgent}
+          onOpenChat={handleOpenSideChat}
+        />
       )}
       {/* 底部居中悬浮：圆形语音输入按钮 */}
       <div className="absolute left-1/2 -translate-x-1/2 bottom-10 z-20">

--- a/apps/electron/src/renderer/components/selection/SelectionActionPopover.tsx
+++ b/apps/electron/src/renderer/components/selection/SelectionActionPopover.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react'
+import { Bot, MessageCircle } from 'lucide-react'
+
+interface SelectionActionPopoverProps {
+  x: number
+  y: number
+  onAddToAgent: () => void
+  onOpenChat: () => void | Promise<void>
+}
+
+export function SelectionActionPopover({
+  x,
+  y,
+  onAddToAgent,
+  onOpenChat,
+}: SelectionActionPopoverProps): React.ReactElement {
+  return (
+    <div
+      data-selection-action-popover
+      className="fixed z-[90] -translate-x-1/2 -translate-y-full rounded-xl bg-popover/95 px-2 py-1.5 text-popover-foreground shadow-xl ring-1 ring-border/40 backdrop-blur"
+      style={{ left: x, top: y }}
+      onMouseDown={(event) => event.preventDefault()}
+    >
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          className="inline-flex h-8 items-center gap-1.5 rounded-lg px-2.5 text-[13px] font-medium transition-colors hover:bg-muted"
+          onClick={onAddToAgent}
+        >
+          <Bot className="size-4" />
+          为 Agent 引用
+        </button>
+        <button
+          type="button"
+          className="inline-flex h-8 items-center gap-1.5 rounded-lg px-2.5 text-[13px] font-medium transition-colors hover:bg-muted"
+          onClick={() => {
+            void onOpenChat()
+          }}
+        >
+          <MessageCircle className="size-4" />
+          打开右侧问答
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/session-preview/SessionMiniMapPopover.tsx
+++ b/apps/electron/src/renderer/components/session-preview/SessionMiniMapPopover.tsx
@@ -158,6 +158,7 @@ function normalizePreviewText(text: string): string {
   return text
     .replace(/<attached_files>[\s\S]*?<\/attached_files>\n*/g, '')
     .replace(/<quoted_file[^>]*>[\s\S]*?<\/quoted_file>\n*/g, '')
+    .replace(/<quoted_context[^>]*>[\s\S]*?<\/quoted_context>\n*/g, '')
     .replace(/\r\n/g, '\n')
     .replace(/\n{3,}/g, '\n\n')
     .trim()

--- a/apps/electron/src/renderer/hooks/useCloseTab.tsx
+++ b/apps/electron/src/renderer/hooks/useCloseTab.tsx
@@ -25,6 +25,7 @@ import {
   agentSessionIndicatorMapAtom,
   unviewedCompletedSessionIdsAtom,
 } from '@/atoms/agent-atoms'
+import { agentSideChatMapAtom } from '@/atoms/chat-atoms'
 import { useSyncActiveTabSideEffects } from '@/hooks/useSyncActiveTabSideEffects'
 
 interface UseCloseTabReturn {
@@ -42,6 +43,7 @@ export function useCloseTab(): UseCloseTabReturn {
   const setUnviewedCompleted = useSetAtom(unviewedCompletedSessionIdsAtom)
   const setAgentSessions = useSetAtom(agentSessionsAtom)
   const setViewStateMap = useSetAtom(sessionViewStateMapAtom)
+  const setSideChatMap = useSetAtom(agentSideChatMapAtom)
 
   const clearIdleAgentCompletionNotice = React.useCallback((sessionId: string) => {
     const indicatorMap = store.get(agentSessionIndicatorMapAtom)
@@ -93,6 +95,27 @@ export function useCloseTab(): UseCloseTabReturn {
           return next
         })
       }
+
+      if (closingTab.type === 'agent') {
+        setSideChatMap((prev) => {
+          if (!prev.has(closingTab.sessionId)) return prev
+          const next = new Map(prev)
+          next.delete(closingTab.sessionId)
+          return next
+        })
+      } else if (closingTab.type === 'chat') {
+        setSideChatMap((prev) => {
+          let changed = false
+          const next = new Map(prev)
+          for (const [ownerSessionId, conversationId] of next) {
+            if (conversationId === closingTab.sessionId) {
+              next.delete(ownerSessionId)
+              changed = true
+            }
+          }
+          return changed ? next : prev
+        })
+      }
     }
 
     if (wasActive) {
@@ -106,7 +129,7 @@ export function useCloseTab(): UseCloseTabReturn {
     if (closingTab && closingTab.type === 'agent') {
       clearIdleAgentCompletionNotice(closingTab.sessionId)
     }
-  }, [tabs, activeTabId, setTabs, setActiveTabId, setViewStateMap, syncActiveTabSideEffects, clearIdleAgentCompletionNotice])
+  }, [tabs, activeTabId, setTabs, setActiveTabId, setViewStateMap, setSideChatMap, syncActiveTabSideEffects, clearIdleAgentCompletionNotice])
 
   const requestClose = React.useCallback((tabId: string) => {
     executeClose(tabId)

--- a/apps/electron/src/renderer/lib/quoted-selection.test.ts
+++ b/apps/electron/src/renderer/lib/quoted-selection.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'bun:test'
+import { buildQuotedSelectionBlock, parseQuotedSelectionRefs } from './quoted-selection'
+
+describe('quoted selection XML', () => {
+  test('Given 文件引用 When 构建并解析引用块 Then 保留文件名并移除隐藏 XML', () => {
+    const block = buildQuotedSelectionBlock({
+      text: '引用内容</quoted_file>',
+      filePath: '/tmp/demo & draft.md',
+      sourceType: 'file',
+      capturedAt: 1,
+    })
+    const parsed = parseQuotedSelectionRefs(`${block}我的问题：`)
+
+    expect(block).toContain('path="/tmp/demo &amp; draft.md"')
+    expect(block).toContain('</quoted_file_>')
+    expect(parsed.quotes).toEqual([
+      {
+        path: '/tmp/demo & draft.md',
+        filename: 'demo & draft.md',
+        sourceType: 'file',
+      },
+    ])
+    expect(parsed.text).toBe('我的问题：')
+  })
+
+  test('Given Agent 和草稿引用 When 解析引用块 Then 区分来源类型并使用展示标签', () => {
+    const content = [
+      '<quoted_context source="agent-history" label="Agent 历史 · Agent 回复" message_id="m1" role="assistant">',
+      '历史内容',
+      '</quoted_context>',
+      '<quoted_context source="scratch-pad" label="草稿页" message_id="" role="">',
+      '草稿内容',
+      '</quoted_context>',
+      '继续提问',
+    ].join('\n')
+
+    const parsed = parseQuotedSelectionRefs(content)
+
+    expect(parsed.quotes).toEqual([
+      {
+        path: 'Agent 历史 · Agent 回复',
+        filename: 'Agent 历史 · Agent 回复',
+        sourceType: 'agent-history',
+        label: 'Agent 历史 · Agent 回复',
+      },
+      {
+        path: '草稿页',
+        filename: '草稿页',
+        sourceType: 'scratch-pad',
+        label: '草稿页',
+      },
+    ])
+    expect(parsed.text).toBe('继续提问')
+  })
+})

--- a/apps/electron/src/renderer/lib/quoted-selection.ts
+++ b/apps/electron/src/renderer/lib/quoted-selection.ts
@@ -1,4 +1,17 @@
 import type { QuotedSelection } from '@/atoms/preview-atoms'
+import type { QuotedSelectionSourceType } from '@/atoms/preview-atoms'
+
+export interface ParsedQuotedSelectionRef {
+  path: string
+  filename: string
+  sourceType: QuotedSelectionSourceType
+  label?: string
+}
+
+export const SELECTION_ACTION_POPOVER_SELECTOR = '[data-selection-action-popover]'
+
+const QUOTED_FILE_REGEX = /<quoted_file[^>]*>[\s\S]*?<\/quoted_file>\n*/g
+const QUOTED_CONTEXT_REGEX = /<quoted_context[^>]*>[\s\S]*?<\/quoted_context>\n*/g
 
 export function escapeXmlAttribute(value: string): string {
   return value
@@ -35,4 +48,47 @@ export function buildQuotedSelectionBlock(quotedSelection: QuotedSelection): str
 
   const safePath = escapeXmlAttribute(quotedSelection.filePath)
   return `<quoted_file path="${safePath}">\n${safeText}\n</quoted_file>\n\n`
+}
+
+function normalizeContextSourceType(value: string | undefined): QuotedSelectionSourceType {
+  if (value === 'scratch-pad') return 'scratch-pad'
+  return 'agent-history'
+}
+
+export function parseQuotedSelectionRefs(content: string): { quotes: ParsedQuotedSelectionRef[]; text: string } {
+  const quotes: ParsedQuotedSelectionRef[] = []
+
+  let quoteMatch: RegExpExecArray | null
+  QUOTED_FILE_REGEX.lastIndex = 0
+  while ((quoteMatch = QUOTED_FILE_REGEX.exec(content)) !== null) {
+    const pathMatch = quoteMatch[0].match(/path="([^"]*)"/)
+    if (!pathMatch) continue
+    const filePath = decodeXmlAttribute(pathMatch[1]!)
+    quotes.push({
+      path: filePath,
+      filename: filePath.split('/').pop() ?? filePath,
+      sourceType: 'file',
+    })
+  }
+
+  QUOTED_CONTEXT_REGEX.lastIndex = 0
+  while ((quoteMatch = QUOTED_CONTEXT_REGEX.exec(content)) !== null) {
+    const labelMatch = quoteMatch[0].match(/label="([^"]*)"/)
+    const sourceMatch = quoteMatch[0].match(/source="([^"]*)"/)
+    const label = labelMatch ? decodeXmlAttribute(labelMatch[1]!) : 'Agent 历史'
+    const sourceType = normalizeContextSourceType(sourceMatch ? decodeXmlAttribute(sourceMatch[1]!) : 'agent-history')
+    quotes.push({
+      path: label,
+      filename: label,
+      sourceType,
+      label,
+    })
+  }
+
+  const text = content
+    .replace(QUOTED_FILE_REGEX, '')
+    .replace(QUOTED_CONTEXT_REGEX, '')
+    .trim()
+
+  return { quotes, text }
 }

--- a/apps/electron/src/renderer/lib/quoted-selection.ts
+++ b/apps/electron/src/renderer/lib/quoted-selection.ts
@@ -1,0 +1,38 @@
+import type { QuotedSelection } from '@/atoms/preview-atoms'
+
+export function escapeXmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+export function decodeXmlAttribute(value: string): string {
+  return value
+    .replace(/&quot;/g, '"')
+    .replace(/&gt;/g, '>')
+    .replace(/&lt;/g, '<')
+    .replace(/&amp;/g, '&')
+}
+
+function sanitizeQuotedText(value: string): string {
+  return value
+    .replace(/<\/quoted_file>/gi, '</quoted_file_>')
+    .replace(/<\/quoted_context>/gi, '</quoted_context_>')
+}
+
+export function buildQuotedSelectionBlock(quotedSelection: QuotedSelection): string {
+  const safeText = sanitizeQuotedText(quotedSelection.text)
+
+  if (quotedSelection.sourceType && quotedSelection.sourceType !== 'file') {
+    const safeSource = escapeXmlAttribute(quotedSelection.sourceType)
+    const safeLabel = escapeXmlAttribute(quotedSelection.sourceLabel ?? quotedSelection.filePath)
+    const safeMessageId = escapeXmlAttribute(quotedSelection.messageId ?? '')
+    const safeRole = escapeXmlAttribute(quotedSelection.messageRole ?? '')
+    return `<quoted_context source="${safeSource}" label="${safeLabel}" message_id="${safeMessageId}" role="${safeRole}">\n${safeText}\n</quoted_context>\n\n`
+  }
+
+  const safePath = escapeXmlAttribute(quotedSelection.filePath)
+  return `<quoted_file path="${safePath}">\n${safeText}\n</quoted_file>\n\n`
+}

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.14.7",
+      "version": "0.14.8",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.201",
         "@anthropic-ai/sdk": "^0.93.0",

--- a/packages/session-core/src/group.ts
+++ b/packages/session-core/src/group.ts
@@ -251,6 +251,7 @@ export function getGroupPreview(group: MessageGroup): string {
     return stripScheduledRunMarker(extractUserText(group.message) ?? '')
       .replace(/<attached_files>[\s\S]*?<\/attached_files>\n*/, '')
       .replace(/<quoted_file[^>]*>[\s\S]*?<\/quoted_file>\n*/g, '')
+      .replace(/<quoted_context[^>]*>[\s\S]*?<\/quoted_context>\n*/g, '')
       .slice(0, 200)
   }
   if (group.type === 'system') {

--- a/packages/session-core/src/transcript.ts
+++ b/packages/session-core/src/transcript.ts
@@ -102,6 +102,7 @@ export function toTranscript(groups: MessageGroup[]): TranscriptTurn[] {
       const text = stripScheduledRunMarker(extractUserText(group.message) ?? '')
         .replace(/<attached_files>[\s\S]*?<\/attached_files>\n*/g, '')
         .replace(/<quoted_file[^>]*>[\s\S]*?<\/quoted_file>\n*/g, '')
+        .replace(/<quoted_context[^>]*>[\s\S]*?<\/quoted_context>\n*/g, '')
         .trim()
       return {
         index,


### PR DESCRIPTION
Adds selection popovers for Agent history, file previews, and Scratch Pad so selected text can become an Agent quote or open a right-side Chat question.
Unifies quote metadata/rendering across Agent and Chat, supports file/history/scratch sources, and keeps quote chips from overflowing.
Moves contextual Chat into the Agent right-side `问答` tab with cleanup for closed/deleted sessions, and widens that panel for the workflow.

Validation:
- `bun run typecheck`
- `bun run --cwd apps/electron build:renderer`
- `git diff --check`
