### PR TITLE
fix(sidebar): 归档视图补回排序确保按最近更新排列

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -1833,7 +1833,9 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
 
   /** Agent 归档会话按日期分组（跨项目），含委派树 */
   const archivedAgentSessionTrees = React.useMemo(() => {
-    const archived = agentSessions.filter((s) => s.archived && !draftSessionIds.has(s.id))
+    const archived = sortAgentSessionsByUpdatedAtDesc(
+      agentSessions.filter((s) => s.archived && !draftSessionIds.has(s.id))
+    )
     const trees = buildAgentSessionTrees(archived)
     // groupByDate 要求 T extends { updatedAt: number }，AgentSessionTreeItem 不直接满足
     const wrapped = trees.map((tree) => ({ updatedAt: tree.session.updatedAt, tree }))


### PR DESCRIPTION
## Summary

- PR #1096 引入树形归档渲染时遗漏了 `sortAgentSessionsByUpdatedAtDesc` 调用，导致归档视图同一日期分组内会话顺序不确定
- 补回排序，确保归档视图与活跃视图行为一致：最近更新的会话排在前面

## Test plan

- [ ] 打开归档视图，确认同一日期分组（今天/昨天/更早）内会话按最近更新时间倒序排列
- [ ] 对比活跃视图的排序行为，确认两者一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)