### PR TITLE
fix(agent): preserve queued quote selections

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.14.8",
+  "version": "0.14.9",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/agent/AgentMessageQueue.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessageQueue.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Clock3, CornerDownLeft, GripVertical, Trash2, Undo2 } from 'lucide-react'
+import { Clock3, CornerDownLeft, GripVertical, Quote, Trash2, Undo2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
@@ -105,8 +105,16 @@ export function AgentMessageQueue({
               {isDropBefore && <div className="absolute left-2 right-2 top-0 h-0.5 rounded-full bg-primary" />}
               {isDropAfter && <div className="absolute left-2 right-2 bottom-0 h-0.5 rounded-full bg-primary" />}
               <GripVertical className="size-4 shrink-0 cursor-grab text-muted-foreground/55 active:cursor-grabbing" />
-              <div className="min-w-0 flex-1 text-[13px] leading-5 text-foreground/80 line-clamp-2">
-                {item.text}
+              <div className="min-w-0 flex-1 text-[13px] leading-5 text-foreground/80">
+                {item.quotedSelection && (
+                  <div className="mb-0.5 flex min-w-0 items-center gap-1 text-[11px] leading-4 text-muted-foreground">
+                    <Quote className="size-3 shrink-0" />
+                    <span className="truncate">
+                      引用：{item.quotedSelection.sourceLabel ?? item.quotedSelection.filePath}
+                    </span>
+                  </div>
+                )}
+                <div className="line-clamp-2">{item.text}</div>
               </div>
               <div className="flex shrink-0 items-center gap-0.5">
                 <QueueIconButton

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -58,6 +58,7 @@ import { cn } from '@/lib/utils'
 import { getActiveAccelerator, getAcceleratorDisplay } from '@/lib/shortcut-registry'
 import { registerShortcut } from '@/lib/shortcut-registry'
 import { previewPanelOpenMapAtom, quotedSelectionMapAtom, currentQuotedSelectionAtom } from '@/atoms/preview-atoms'
+import type { QuotedSelection } from '@/atoms/preview-atoms'
 import {
   agentStreamingStatesAtom,
   agentSessionStreamingStateAtomFamily,
@@ -115,6 +116,7 @@ import { fileToBase64, formatFileNames, getFileParentPath } from '@/lib/file-uti
 import { buildQuotedSelectionBlock } from '@/lib/quoted-selection'
 import { createClipboardPendingFile, createClipboardTextDraft, makeUniqueAttachmentName } from '@/lib/clipboard-text-attachment'
 import {
+  buildQueuedMessageSendPayload,
   createAgentQueuedMessage,
   moveQueuedMessage,
   parseQueuedMessageMentions,
@@ -442,6 +444,21 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     })
   }, [sessionId, setQuotedSelectionMap])
 
+  /** 消费当前引用选区，用于把引用快照固定到本次发送/队列消息中 */
+  const consumeQuotedSelection = React.useCallback((): QuotedSelection | null => {
+    const quotedSelection = store.get(quotedSelectionMapAtom).get(sessionId) ?? null
+    if (!quotedSelection) return null
+
+    const capturedAt = quotedSelection.capturedAt
+    store.set(quotedSelectionMapAtom, (prev) => {
+      const m = new Map(prev)
+      const current = m.get(sessionId)
+      if (current && current.capturedAt === capturedAt) m.delete(sessionId)
+      return m
+    })
+    return quotedSelection
+  }, [sessionId, store])
+
   const suggestionsMap = useAtomValue(agentPromptSuggestionsAtom)
   const suggestion = suggestionsMap.get(sessionId) ?? null
   const setPromptSuggestions = useSetAtom(agentPromptSuggestionsAtom)
@@ -709,20 +726,21 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
 
   const queueMessageIntoActiveAgent = React.useCallback(async (
     message: AgentQueuedMessage,
-    text: string,
+    rawText: string,
+    sdkText: string,
     mentions: ReturnType<typeof parseQueuedMessageMentions>,
     interruptCurrentTurn: boolean,
   ): Promise<void> => {
     // 气泡显示用原文 text（保留 /skill: #mcp: &session: 语法），
     // 让 message.tsx 的 remarkMentions 立即渲染出引用芯片；
-    // 剥离后的 cleanedText 仅用于传给 SDK，不作为展示文本。
-    appendLiveUserMessage(createUserSDKMessage(text, message.id, Date.now()))
+    // 剥离后的 sdkText 仅用于传给 SDK，不作为展示文本。
+    appendLiveUserMessage(createUserSDKMessage(rawText, message.id, Date.now()))
 
     try {
       await window.electronAPI.queueAgentMessage({
         sessionId,
-        userMessage: mentions.cleanedText,
-        rawUserMessage: text,
+        userMessage: sdkText,
+        rawUserMessage: rawText,
         uuid: message.id,
         interrupt: interruptCurrentTurn,
         ...(mentions.mentionedSkills.length > 0 && { mentionedSkills: mentions.mentionedSkills }),
@@ -798,10 +816,12 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const sendPlainTextAgentMessage = React.useCallback(async (
     message: AgentQueuedMessage,
   ): Promise<void> => {
-    const text = message.text.trim()
-    if (!text || !agentChannelId || !hasAvailableModel) return
+    const quotedSelectionBlock = message.quotedSelection
+      ? buildQuotedSelectionBlock(message.quotedSelection)
+      : ''
+    const payload = buildQueuedMessageSendPayload(message, quotedSelectionBlock)
+    if (!payload.rawText || !agentChannelId || !hasAvailableModel) return
 
-    const mentions = parseQueuedMessageMentions(text)
     clearStoppedByUser()
 
     // interrupt 由本函数读到的实时 streaming 决定，而非调用方传入的快照：
@@ -809,11 +829,11 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     // - backgroundWaiting（软空闲，无活跃 turn）：直接注入，无需中断
     // 避免"外层判定 streaming、内层已结束"两个快照不一致导致的竞态。
     if (streaming || backgroundWaiting) {
-      await queueMessageIntoActiveAgent(message, text, mentions, streaming)
+      await queueMessageIntoActiveAgent(message, payload.rawText, payload.sdkText, payload.mentions, streaming)
       return
     }
 
-    await startQueuedMessageRun(text, mentions, agentChannelId)
+    await startQueuedMessageRun(payload.rawText, payload.mentions, agentChannelId)
   }, [
     agentChannelId,
     backgroundWaiting,
@@ -1482,9 +1502,10 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         return
       }
 
+      const quotedSelection = consumeQuotedSelection()
       setQueuedMessages((prev) => [
         ...prev,
-        createAgentQueuedMessage(effectiveText, crypto.randomUUID(), Date.now()),
+        createAgentQueuedMessage(effectiveText, crypto.randomUUID(), Date.now(), quotedSelection),
       ])
       if (overrideText === undefined) {
         setInputContent('')
@@ -1509,7 +1530,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         return
       }
 
-      const message = createAgentQueuedMessage(effectiveText, crypto.randomUUID(), Date.now())
+      const quotedSelection = consumeQuotedSelection()
+      const message = createAgentQueuedMessage(effectiveText, crypto.randomUUID(), Date.now(), quotedSelection)
       if (overrideText === undefined) {
         setInputContent('')
         setInputHtmlContent('')
@@ -1535,6 +1557,14 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           }
           return map
         })
+        const failedQuotedSelection = message.quotedSelection
+        if (failedQuotedSelection) {
+          setQuotedSelectionMap((prev) => {
+            const map = new Map(prev)
+            map.set(sessionId, failedQuotedSelection)
+            return map
+          })
+        }
       })
       return
     }
@@ -1664,17 +1694,9 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     }
 
     // 构建引用选中文本：内联 XML 拼入 prompt，对话框不展示（parseAttachedFiles 剥离）
-    const quotedSelection = store.get(quotedSelectionMapAtom).get(sessionId)
+    const quotedSelection = consumeQuotedSelection()
     if (quotedSelection) {
-      const capturedAt = quotedSelection.capturedAt
       fileReferences = fileReferences + buildQuotedSelectionBlock(quotedSelection)
-
-      store.set(quotedSelectionMapAtom, (prev) => {
-        const m = new Map(prev)
-        const current = m.get(sessionId)
-        if (current && current.capturedAt === capturedAt) m.delete(sessionId)
-        return m
-      })
     }
 
     // 2. 构建最终消息
@@ -1757,7 +1779,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         return map
       })
     })
-  }, [inputContent, createBaseAdditionalDirectories, sessionId, agentChannelId, agentModelId, currentWorkspaceId, workspaces, streaming, backgroundWaiting, suggestion, hasAvailableModel, store, setStreamingStates, setPendingFiles, setAgentStreamErrors, setPromptSuggestions, setInputContent, setLiveMessagesMap, permissionMode, messagesLoaded, setQueuedMessages, sendPlainTextAgentMessage])
+  }, [inputContent, createBaseAdditionalDirectories, sessionId, agentChannelId, agentModelId, currentWorkspaceId, workspaces, streaming, backgroundWaiting, suggestion, hasAvailableModel, store, consumeQuotedSelection, setStreamingStates, setPendingFiles, setAgentStreamErrors, setPromptSuggestions, setInputContent, setLiveMessagesMap, permissionMode, messagesLoaded, setQueuedMessages, setQuotedSelectionMap, sendPlainTextAgentMessage])
 
   /** 停止生成 */
   const handleStop = React.useCallback((): void => {
@@ -2101,6 +2123,14 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     if (!message) return
 
     setQueuedMessages((prev) => removeQueuedMessage(prev, messageId))
+    const recalledQuotedSelection = message.quotedSelection
+    if (recalledQuotedSelection) {
+      setQuotedSelectionMap((prev) => {
+        const map = new Map(prev)
+        map.set(sessionId, recalledQuotedSelection)
+        return map
+      })
+    }
 
     const hasDraft = inputContent.trim().length > 0
     const nextDraft = hasDraft
@@ -2118,7 +2148,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     } else {
       setInputHtmlContent('')
     }
-  }, [inputContent, inputHtmlContent, queuedMessages, setInputContent, setInputHtmlContent, setQueuedMessages])
+  }, [inputContent, inputHtmlContent, queuedMessages, sessionId, setInputContent, setInputHtmlContent, setQueuedMessages, setQuotedSelectionMap])
 
   const handleRemoveQueuedMessage = React.useCallback((messageId: string): void => {
     setQueuedMessages((prev) => removeQueuedMessage(prev, messageId))

--- a/apps/electron/src/renderer/lib/agent-message-queue.test.ts
+++ b/apps/electron/src/renderer/lib/agent-message-queue.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test'
+import { createAgentQueuedMessage, buildQueuedMessageSendPayload } from './agent-message-queue'
+import { buildQuotedSelectionBlock } from './quoted-selection'
+import type { QuotedSelection } from '@/atoms/preview-atoms'
+
+describe('agent-message-queue', () => {
+  test('Given 带引用选区的队列消息 When 构建发送 payload Then 保留引用并剥离 mention 语法', () => {
+    const quotedSelection: QuotedSelection = {
+      text: '被引用的内容',
+      filePath: '/tmp/demo.md',
+      capturedAt: 123,
+    }
+
+    const message = createAgentQueuedMessage(
+      '继续解释 /skill:writer #mcp:docs &session:abc',
+      'queued-1',
+      456,
+      quotedSelection,
+    )
+    const payload = buildQueuedMessageSendPayload(message, buildQuotedSelectionBlock(quotedSelection))
+
+    expect(payload.rawText).toContain('<quoted_file path="/tmp/demo.md">')
+    expect(payload.rawText).toContain('被引用的内容')
+    expect(payload.rawText).toContain('继续解释 /skill:writer #mcp:docs &session:abc')
+    expect(payload.sdkText).toContain('<quoted_file path="/tmp/demo.md">')
+    expect(payload.sdkText).toContain('继续解释')
+    expect(payload.sdkText).not.toContain('/skill:writer')
+    expect(payload.mentions).toEqual({
+      cleanedText: '继续解释',
+      mentionedSkills: ['writer'],
+      mentionedMcpServers: ['docs'],
+      mentionedSessionIds: ['abc'],
+    })
+  })
+})

--- a/apps/electron/src/renderer/lib/agent-message-queue.ts
+++ b/apps/electron/src/renderer/lib/agent-message-queue.ts
@@ -1,21 +1,27 @@
+import type { QuotedSelection } from '@/atoms/preview-atoms'
+
 export type QueueDropPlacement = 'before' | 'after'
 
 export interface AgentQueuedMessage {
   id: string
   text: string
   createdAt: number
+  quotedSelection?: QuotedSelection
 }
 
 export function createAgentQueuedMessage(
   text: string,
   id: string,
   createdAt: number,
+  quotedSelection?: QuotedSelection | null,
 ): AgentQueuedMessage {
-  return {
+  const message: AgentQueuedMessage = {
     id,
     text: text.trim(),
     createdAt,
   }
+  if (quotedSelection) message.quotedSelection = quotedSelection
+  return message
 }
 
 export function removeQueuedMessage(
@@ -63,6 +69,12 @@ export interface ParsedQueuedMessageMentions {
   mentionedSessionIds: string[]
 }
 
+export interface QueuedMessageSendPayload {
+  rawText: string
+  sdkText: string
+  mentions: ParsedQueuedMessageMentions
+}
+
 function escapeHtml(text: string): string {
   return text
     .replace(/&/g, '&amp;')
@@ -104,5 +116,22 @@ export function parseQueuedMessageMentions(text: string): ParsedQueuedMessageMen
     mentionedSkills,
     mentionedMcpServers,
     mentionedSessionIds,
+  }
+}
+
+export function buildQueuedMessageSendPayload(
+  message: AgentQueuedMessage,
+  quotedSelectionBlock = '',
+): QueuedMessageSendPayload {
+  const text = message.text.trim()
+  const mentions = parseQueuedMessageMentions(text)
+  const prefix = quotedSelectionBlock.trim().length > 0
+    ? `${quotedSelectionBlock.trimEnd()}\n\n`
+    : ''
+
+  return {
+    rawText: `${prefix}${text}`.trim(),
+    sdkText: `${prefix}${mentions.cleanedText}`.trim(),
+    mentions,
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.14.8",
+      "version": "0.14.9",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.201",
         "@anthropic-ai/sdk": "^0.93.0",


### PR DESCRIPTION
Fixes queued Agent messages losing their selected quote context when they are sent while the Agent is still running.

The queued message now snapshots the quoted selection, rebuilds raw/display text separately from SDK-safe text, and restores the quote if the queued message is recalled or a background send fails.
The queue UI also shows when a queued message carries a quote, and a focused BDD test covers quote preservation alongside mention stripping.
Validated with targeted Bun tests, Electron typecheck, and git diff whitespace checks.
