### PR TITLE
Move toast notifications to bottom right

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.14.8",
+  "version": "0.14.9",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -893,7 +893,7 @@ if (isQuickTaskWindow) {
       <React.StrictMode>
         <ThemeInitializer />
         <VoiceDictationApp />
-        <Toaster position="top-right" />
+        <Toaster position="bottom-right" />
       </React.StrictMode>
     )
   })
@@ -904,7 +904,7 @@ if (isQuickTaskWindow) {
         <ThemeInitializer />
         <MarkdownFontSizeInitializer />
         <DetachedPreviewApp />
-        <Toaster position="top-right" />
+        <Toaster position="bottom-right" />
       </React.StrictMode>
     )
   })
@@ -930,7 +930,7 @@ if (isQuickTaskWindow) {
       <GlobalShortcuts />
       <TabSwitcher />
       <App />
-      <Toaster position="top-right" />
+      <Toaster position="bottom-right" />
     </React.StrictMode>
   )
 }

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.14.8",
+      "version": "0.14.9",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.201",
         "@anthropic-ai/sdk": "^0.93.0",


### PR DESCRIPTION
Moves Sonner toast placement from the top right to the bottom right in the main, detached preview, and voice dictation windows.

This avoids covering the top tab bar and toolbar areas when notifications stack.

Also bumps @proma/electron to 0.14.9 and syncs bun.lock.

Validation: bun install --frozen-lockfile, bun run --filter='@proma/electron' typecheck, git diff --check.