### PR TITLE
fix(sidebar): 强化当前项目选中指示【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.14.8",
+  "version": "0.14.9",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -3808,9 +3808,15 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
               ? <Clock size={13} className="flex-shrink-0 text-foreground/40" />
               : <FolderOpen size={13} className="flex-shrink-0 text-foreground/40" />
             }
-            <span className="flex-1 min-w-0 truncate text-[13px] font-medium leading-[18px]">
-              {group.workspace.name}
+            <span className="flex min-w-0 items-center">
+              <span className="min-w-0 truncate text-[13px] font-medium leading-[18px]">
+                {group.workspace.name}
+              </span>
+              {isCurrent && (
+                <span className="workspace-selected-triangle flex-shrink-0" aria-hidden="true" />
+              )}
             </span>
+            <span className="min-w-[4px] flex-1" aria-hidden="true" />
             <ChevronRight
               size={12}
               className={cn(

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -549,6 +549,16 @@
   background-color: hsl(var(--sidebar-control-surface-hover));
 }
 
+/* 当前工作区选中指示：纯三角，颜色跟随工作区文字色 */
+.workspace-selected-triangle {
+  width: 0;
+  height: 0;
+  margin-left: 5px;
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+  border-right: 7px solid currentColor;
+}
+
 /* Windows 自定义窗口控制按钮
  *
  * 可点击性关键点（解决 Windows 用户点击失效 / 需要双击的 bug）：

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.14.8",
+      "version": "0.14.9",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.201",
         "@anthropic-ai/sdk": "^0.93.0",


### PR DESCRIPTION
## 概述
这个 PR 为左侧栏当前选中的项目名称后添加一个纯 CSS 左指三角，用更明确的视觉提示强化“当前项目/工作区”的选中感。之前在项目列表里很多时候不容易看清当前究竟处在哪个工作区，尤其在「旧屏微光」主题下，现有选中态几乎无法被稳定识别。

三角不引入额外背景高亮，颜色跟随现有选中项目文字色，避免破坏各主题下原有的侧边栏视觉层级。

## 改动
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 将项目标题拆成“标题文本 + 选中三角 + 右侧弹性占位”的结构，让三角贴近项目名称末尾，同时保留右侧折叠箭头的布局。
- `apps/electron/src/renderer/styles/globals.css` — 新增 `.workspace-selected-triangle`，使用 CSS border 绘制纯三角，并通过 `currentColor` 继承当前主题下的项目文字颜色。
- `apps/electron/package.json` — 按项目约定将 `@proma/electron` patch 版本递增到 `0.14.9`。
- `bun.lock` — 同步更新 workspace 包版本记录。

## 测试方法
1. 运行 `bun run typecheck`，确认所有 workspace 包类型检查通过。
2. 运行 `git diff --check`，确认没有空白或补丁格式问题。
3. 在 Agent 左侧栏中切换不同项目，确认当前项目名称右侧显示左指三角，且没有额外选中背景高亮。
4. 切换到「旧屏微光」主题，确认当前工作区能通过三角被清楚识别。

## 备注
- 该改动仅影响渲染层 UI 与 CSS，不涉及 IPC、主进程、持久化或跨平台路径逻辑。
- 三角使用 `currentColor`，因此会自然跟随各主题现有的项目文字颜色。