### PR TITLE
Fix Agent history scrolling

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.14.9",
+  "version": "0.14.10",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -623,7 +623,7 @@ export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persi
 
   return (
     <BasePathsProvider basePaths={attachedDirs}>
-    <div ref={historySelectionRootRef} className="relative min-h-0 flex-1">
+    <div ref={historySelectionRootRef} className="relative flex min-h-0 flex-1 flex-col">
       <Conversation resize={ready && !transitioning ? 'smooth' : 'instant'} className={ready ? (skipFadeIn ? 'opacity-100' : 'opacity-100 transition-opacity duration-200') : 'opacity-0'}>
         <ScrollPositionManager id={sessionId} ready={ready} />
         <ConversationContent>

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -2364,7 +2364,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   return (
     <>
     <AgentSessionProvider sessionId={sessionId}>
-      <div className="flex flex-col h-full flex-1 min-w-0 max-w-[min(72rem,100%)] mx-auto">
+      <div className="flex h-full min-h-0 flex-1 min-w-0 max-w-[min(72rem,100%)] flex-col overflow-hidden mx-auto">
         {/* Agent Header */}
         <AgentHeader sessionId={sessionId} />
 

--- a/apps/electron/src/renderer/components/ai-elements/conversation.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/conversation.tsx
@@ -25,7 +25,7 @@ export type ConversationProps = ComponentProps<typeof StickToBottom>
 export function Conversation({ className, ...props }: ConversationProps): React.ReactElement {
   return (
     <StickToBottom
-      className={cn('relative flex-1 overflow-y-hidden scrollbar-none', className)}
+      className={cn('relative min-h-0 flex-1 overflow-y-hidden scrollbar-none', className)}
       initial="instant"
       resize="smooth"
       role="log"

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.14.9",
+      "version": "0.14.10",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.201",
         "@anthropic-ai/sdk": "^0.93.0",


### PR DESCRIPTION
Fixes the Agent history panel becoming non-scrollable after the selectable history wrapper was added.

The wrapper now participates in the flex column layout, the Agent view clamps its height chain, and the shared Conversation root has min-h-0 so StickToBottom receives a bounded scroll area.

Also bumps @proma/electron and bun.lock to 0.14.10.

Checks: bun install --frozen-lockfile; bun run --filter="@proma/electron" typecheck; bun run --filter="@proma/electron" build:renderer; git diff --check.