### PR TITLE
【已审核】fix(diff): 预览面板仅在所预览文件被写时刷新，保留无关文件的滚动位置

### DIFF
--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -334,8 +334,37 @@ export const agentDiffPanelTabAtom = atom<Map<string, AgentSidePanelTab>>(new Ma
 /** Diff 视图模式：'split' | 'unified'，默认使用统一预览 */
 export const agentDiffViewModeAtom = atom<'split' | 'unified'>('unified')
 
-/** Diff 刷新版本号 — 按 session 隔离，Agent 写工具完成时递增 */
-export const agentDiffRefreshVersionAtom = atom(new Map<string, number>())
+/**
+ * Diff 刷新版本号 — 按 session 隔离，Agent 写工具完成时递增。
+ *
+ * value 为 `AgentDiffRefreshVersion`：
+ * - `writtenPath` 缺省 = 全域刷新（git 突变 / revert / 手动刷新 / 窗口聚焦外部改动），
+ *   所有依赖该 atom 的面板都需重新读盘。
+ * - `writtenPath` 给定 = 定向失效，仅所预览文件路径命中该路径的面板需要刷新；
+ *   其他无关面板应跳过重读并保留滚动位置（修复预览面板在 AI 写无关文件时跳回顶部的问题）。
+ */
+export interface AgentDiffRefreshVersion {
+  version: number
+  /** 触发本次刷新的被写文件绝对路径；undefined 表示全域刷新 */
+  writtenPath?: string
+}
+export const agentDiffRefreshVersionAtom = atom(new Map<string, AgentDiffRefreshVersion>())
+
+/**
+ * 统一 bump 入口：在 atom 的 per-session Map 上递增 version，可选附带 writtenPath 做定向失效。
+ * - 写类工具完成时传 writtenPath（工具 input 里的绝对路径）
+ * - git 突变 / revert / 手动刷新 / 窗口聚焦等"全域"场景省略 writtenPath
+ */
+export function bumpDiffRefreshVersion(
+  prev: Map<string, AgentDiffRefreshVersion>,
+  sessionId: string,
+  writtenPath?: string,
+): Map<string, AgentDiffRefreshVersion> {
+  const m = new Map(prev)
+  const cur = prev.get(sessionId)
+  m.set(sessionId, { version: (cur?.version ?? 0) + 1, writtenPath })
+  return m
+}
 
 /** 当前会话选中的 worktree 路径，null = 默认行为（显示 session 改动） */
 export const agentSelectedWorktreeAtom = atom(new Map<string, string | null>())

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -82,6 +82,7 @@ import {
   agentSDKMessagesCacheAtom,
   setSessionMessagesCache,
   agentDiffRefreshVersionAtom,
+  bumpDiffRefreshVersion,
   agentSessionsAtom,
   agentAttachedDirectoriesMapAtom,
   agentAttachedFilesMapAtom,
@@ -2041,9 +2042,9 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       })
 
       // 刷新预览面板的 diff（文件已被回退，当前显示的内容已过期）
-      store.set(agentDiffRefreshVersionAtom, (prev) => {
-        const m = new Map(prev); m.set(sessionId, (prev.get(sessionId) ?? 0) + 1); return m
-      })
+      // revert 可能影响多文件，保持全域刷新
+      store.set(agentDiffRefreshVersionAtom, (prev) =>
+        bumpDiffRefreshVersion(prev, sessionId))
 
       if (result.fileRewind?.canRewind) {
         const fileCount = result.fileRewind.filesChanged?.length ?? 0

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -113,7 +113,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   const filesVersion = useAtomValue(workspaceFilesVersionAtom)
   const setFilesVersion = useSetAtom(workspaceFilesVersionAtom)
   const diffRefreshVersionMap = useAtomValue(agentDiffRefreshVersionAtom)
-  const diffRefreshVersion = diffRefreshVersionMap.get(sessionId) ?? 0
+  const diffRefreshVersion = diffRefreshVersionMap.get(sessionId)?.version ?? 0
   const hasFileChanges = filesVersion > 0
 
   // 派生当前工作区 slug（用于 FileDropZone IPC 调用）

--- a/apps/electron/src/renderer/components/diff/DetachedPreviewApp.tsx
+++ b/apps/electron/src/renderer/components/diff/DetachedPreviewApp.tsx
@@ -8,7 +8,7 @@ import * as React from 'react'
 import { AlertCircle, RefreshCw } from 'lucide-react'
 import { useSetAtom } from 'jotai'
 import type { DetachedPreviewWindowData } from '@proma/shared'
-import { agentDiffRefreshVersionAtom } from '@/atoms/agent-atoms'
+import { agentDiffRefreshVersionAtom, bumpDiffRefreshVersion } from '@/atoms/agent-atoms'
 import { cn } from '@/lib/utils'
 import { DiffTabContent } from './DiffTabContent'
 import { DefaultAppOpenButton } from './DefaultAppOpenButton'
@@ -54,11 +54,8 @@ export function DetachedPreviewApp(): React.ReactElement {
 
   const handleRefresh = React.useCallback(() => {
     if (!data) return
-    setRefreshVersionMap((prev) => {
-      const map = new Map(prev)
-      map.set(data.sessionId, (prev.get(data.sessionId) ?? 0) + 1)
-      return map
-    })
+    // 手动刷新：用户主动行为，全域刷新所有预览面板
+    setRefreshVersionMap((prev) => bumpDiffRefreshVersion(prev, data.sessionId))
   }, [data, setRefreshVersionMap])
 
   if (loading) {

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -17,6 +17,7 @@ import {
   agentDiffViewModeAtom,
   agentDiffRefreshVersionAtom,
   agentSidePanelOpenAtom,
+  bumpDiffRefreshVersion,
 } from '@/atoms/agent-atoms'
 import { resolvedThemeAtom } from '@/atoms/theme'
 import { quotedSelectionMapAtom } from '@/atoms/preview-atoms'
@@ -90,6 +91,29 @@ const MAX_QUOTED_CHARS = 2000
 
 /** 滚动位置持久化：key = `${sessionId}:${filePath}` */
 const scrollPositionCache = new Map<string, { top: number; left: number }>()
+
+/**
+ * 判断定向刷新的 writtenPath 是否指向当前预览文件 filePath。
+ * - writtenPath 通常为工具 input 给的绝对路径
+ * - filePath 可能是相对路径（来自 previewFileMap）
+ *
+ * 比较策略：统一为正斜杠 + 小写后，判断任一方以"对方 + /"结尾（包含关系），
+ * 或两者完全相等。覆盖 Windows 大小写不敏感与绝对/相对路径形态差异。
+ *
+ * 注意：endsWith 包含判断在极端情况下可能误判（如 /other/src/a.ts 包含 src/a.ts），
+ * 误判方向为"认为相关 → 不冻结 → 会刷新"，等价于修复前的全域行为，不会导致漏刷新。
+ */
+function isSamePreviewFile(writtenPath: string, filePath: string): boolean {
+  const norm = (p: string) => p.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase()
+  const a = norm(writtenPath)
+  const b = norm(filePath)
+  if (!a || !b) return false
+  if (a === b) return true
+  // writtenPath 是绝对路径、filePath 是相对路径时，writtenPath 以 "/filePath" 结尾
+  if (a.endsWith('/' + b)) return true
+  if (b.endsWith('/' + a)) return true
+  return false
+}
 
 function scrollCacheKey(sessionId: string, filePath: string): string {
   return `${sessionId}:${filePath}`
@@ -263,8 +287,20 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   const [copied, setCopied] = React.useState(false)
   const refreshVersionMap = useAtomValue(agentDiffRefreshVersionAtom)
   const setRefreshVersionMap = useSetAtom(agentDiffRefreshVersionAtom)
-  const refreshVersion = refreshVersionMap.get(sessionId) ?? 0
-  const previewContentVersion = previewOnly ? refreshVersion : 0
+  const refreshEntry = refreshVersionMap.get(sessionId)
+  const refreshVersion = refreshEntry?.version ?? 0
+  // 定向失效：writtenPath 给定且与当前预览文件不同 → 无关刷新，跳过重读保留滚动
+  const isUnrelatedRefresh = previewOnly
+    ? (refreshEntry?.writtenPath !== undefined && !isSamePreviewFile(refreshEntry.writtenPath, filePath))
+    : false
+  // 无关 bump 时冻结 previewContentVersion，避免 cacheKey/PierreFile 误判内容变化重算。
+  // 渲染期写 ref 在此安全：isUnrelatedRefresh 由 atom 派生，同次渲染内 Jotai 快照一致，
+  // 并发渲染两次读到的值相同，ref 最终值稳定。
+  const effectivePreviewVersionRef = React.useRef(0)
+  if (!isUnrelatedRefresh) {
+    effectivePreviewVersionRef.current = previewOnly ? refreshVersion : 0
+  }
+  const previewContentVersion = effectivePreviewVersionRef.current
   const theme = useAtomValue(resolvedThemeAtom)
   const [tocOpen, setTocOpen] = useAtom(markdownTocOpenAtom)
 
@@ -560,6 +596,8 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   // 纯预览模式也跟随 refreshVersion 失效，保证同一文件二次写入后重新读盘。
   // 命中缓存时跳过 loading 闪烁直接渲染；未命中走 IPC 拉取
   React.useEffect(() => {
+    // 定向失效：本次 bump 由其他文件触发，当前预览面板无需重读，保留滚动与内容
+    if (isUnrelatedRefresh) return
     let cancelled = false
 
     // 所有文件类型均可缓存（含 PDF/DOCX/Office/Image）
@@ -689,7 +727,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     load()
     return () => { cancelled = true }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filePath, dirPath, gitRoot, previewOnly, previewContentVersion, fileAccess, isPdf, isDocx, isOfficePreview, isLegacyOffice, isImage, sessionId, ext, getContentCacheKey])
+  }, [filePath, dirPath, gitRoot, previewOnly, previewContentVersion, fileAccess, isPdf, isDocx, isOfficePreview, isLegacyOffice, isImage, sessionId, ext, getContentCacheKey, isUnrelatedRefresh])
 
   // refreshVersion 触发的静默刷新：仅 diff 模式、内容有变化时才更新 state
   const prevRefreshRef = React.useRef(-1)
@@ -723,7 +761,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     }
     refresh()
     return () => { cancelled = true }
-  }, [refreshVersion, previewOnly, filePath, dirPath, gitRoot, sessionId, getContentCacheKey])
+  }, [refreshVersion, previewOnly, filePath, dirPath, gitRoot, sessionId, getContentCacheKey, isUnrelatedRefresh])
 
   // diff 模式：内容加载完成后若新旧一致（无差异），通知父组件关闭预览面板
   const emptyDiffFiredRef = React.useRef(false)
@@ -770,15 +808,18 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   const restoreRafRef = React.useRef(0)
 
   // WHEN content version changes (refreshVersion bump): delete stored scroll position
-  // 只在内容变化时清除，切换文件时保留位置以支持返回导航
+  // 只在内容变化时清除，切换文件时保留位置以支持返回导航。
+  // 无关 bump（写的是其他文件）：跳过删除，保留当前预览面板的滚动位置
   React.useEffect(() => {
     if (loading) return // still loading, don't clear yet
     if (prevRefreshVersionRef.current !== refreshVersion) {
-      scrollPositionCache.delete(scrollKey)
-      restoreScrollRef.current = false
+      if (!isUnrelatedRefresh) {
+        scrollPositionCache.delete(scrollKey)
+        restoreScrollRef.current = false
+      }
       prevRefreshVersionRef.current = refreshVersion
     }
-  }, [scrollKey, refreshVersion, loading])
+  }, [scrollKey, refreshVersion, loading, isUnrelatedRefresh])
 
   // RESTORE scroll position after cached content renders.
   // 等待滚动容器内容高度连续 3 帧稳定后再恢复，避免异步渲染
@@ -910,11 +951,8 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
         setOldContent('')
         setNewContent(draft)
         cacheSet(getContentCacheKey('preview', refreshVersion + 1), { oldContent: '', newContent: draft })
-        setRefreshVersionMap((prev) => {
-          const m = new Map(prev)
-          m.set(sessionId, (prev.get(sessionId) ?? 0) + 1)
-          return m
-        })
+        // 定向失效：自保存只刷新当前预览文件，避免误伤其他打开的无关预览面板
+        setRefreshVersionMap((prev) => bumpDiffRefreshVersion(prev, sessionId, fp))
         setAutosaveStatus('saved')
       }
       return true
@@ -946,12 +984,9 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   }, [fileAccess, filePath, isEditableText, markdownDraft, markdownSaving, persistMarkdownDraft])
 
   const handleManualRefresh = React.useCallback(() => {
-    setRefreshVersionMap((prev) => {
-      const m = new Map(prev)
-      m.set(sessionId, (prev.get(sessionId) ?? 0) + 1)
-      return m
-    })
-  }, [sessionId, setRefreshVersionMap])
+    // 手动刷新当前预览文件：定向失效，避免误伤其他无关预览面板
+    setRefreshVersionMap((prev) => bumpDiffRefreshVersion(prev, sessionId, filePath))
+  }, [sessionId, filePath, setRefreshVersionMap])
 
   const handleAddSelectionToAgent = React.useCallback(() => {
     if (!previewSelection) return

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -41,6 +41,7 @@ import {
   unviewedCompletedSessionIdsAtom,
   agentSessionPathMapAtom,
   agentDiffRefreshVersionAtom,
+  bumpDiffRefreshVersion,
   askUserDraftsAtom,
 } from '@/atoms/agent-atoms'
 import {
@@ -765,9 +766,9 @@ export function useGlobalAgentListeners(): void {
               const entry = pendingWriteTools.get(event.toolUseId)!
               const writtenPath = entry.path
               pendingWriteTools.delete(event.toolUseId)
-              store.set(agentDiffRefreshVersionAtom, (prev) => {
-                const m = new Map(prev); m.set(sessionId, (prev.get(sessionId) ?? 0) + 1); return m
-              })
+              // 定向失效：仅命中该路径的预览面板需要重读，其他无关面板保留滚动
+              store.set(agentDiffRefreshVersionAtom, (prev) =>
+                bumpDiffRefreshVersion(prev, sessionId, writtenPath || undefined))
               if (writtenPath) {
                 buildWrittenFilePreviewInfo(sessionId, writtenPath).then((previewFile) => {
                   if (!previewFile || previewFile.previewOnly || !previewFile.inDiffScope) return
@@ -789,9 +790,9 @@ export function useGlobalAgentListeners(): void {
             // Bash git 突变命令完成时，仅刷新 diff 列表（不标记 unseen，避免红点）
             if (pendingGitMutateTools.has(event.toolUseId)) {
               pendingGitMutateTools.delete(event.toolUseId)
-              store.set(agentDiffRefreshVersionAtom, (prev) => {
-                const m = new Map(prev); m.set(sessionId, (prev.get(sessionId) ?? 0) + 1); return m
-              })
+              // git 突变可能影响多文件，保持全域刷新
+              store.set(agentDiffRefreshVersionAtom, (prev) =>
+                bumpDiffRefreshVersion(prev, sessionId))
             }
           } else if (event.type === 'shell_killed') {
             store.set(backgroundTasksAtomFamily(sessionId), (prev) => {
@@ -1156,12 +1157,9 @@ export function useGlobalAgentListeners(): void {
     const fileContentHashMap = new Map<string, string>()
     const HASH_MAX = 100
     let focusCheckSeq = 0
-    const bumpDiffRefresh = (sessionId: string) => {
-      store.set(agentDiffRefreshVersionAtom, (prev) => {
-        const m = new Map(prev)
-        m.set(sessionId, (prev.get(sessionId) ?? 0) + 1)
-        return m
-      })
+    const bumpDiffRefresh = (sessionId: string, writtenPath?: string) => {
+      store.set(agentDiffRefreshVersionAtom, (prev) =>
+        bumpDiffRefreshVersion(prev, sessionId, writtenPath))
     }
 
     const onWindowFocus = async () => {
@@ -1170,6 +1168,7 @@ export function useGlobalAgentListeners(): void {
 
       const previewFile = store.get(previewFileMapAtom).get(activeSessionId)
       if (!previewFile || previewFile.previewOnly !== true) {
+        // 非预览模式：全域刷新 diff 列表
         bumpDiffRefresh(activeSessionId)
         return
       }
@@ -1200,7 +1199,8 @@ export function useGlobalAgentListeners(): void {
 
         if (prevHash === undefined || prevHash !== hash) {
           // 首次建立 hash 基准时也刷新一次，避免用户离开窗口后首次外部修改被吞掉。
-          bumpDiffRefresh(activeSessionId)
+          // 定向到当前预览文件路径，避免误伤其他打开的无关预览面板。
+          bumpDiffRefresh(activeSessionId, previewFile.filePath)
         }
         fileContentHashMap.set(hashKey, hash)
 
@@ -1212,7 +1212,7 @@ export function useGlobalAgentListeners(): void {
       } catch {
         // 读取失败时删除旧 hash，并触发一次刷新让预览进入真实失败/空状态。
         fileContentHashMap.delete(hashKey)
-        bumpDiffRefresh(activeSessionId)
+        bumpDiffRefresh(activeSessionId, previewFile.filePath)
       }
     }
     window.addEventListener('focus', onWindowFocus)


### PR DESCRIPTION
## 概述

Agent 写工具完成时无条件递增 session 级全局刷新版本号，导致所有已打开的预览面板（分屏/预览标签页/独立窗口，均复用 DiffTabContent）无论是否相关都重新读盘并跳回顶部。本 PR 将 agentDiffRefreshVersionAtom 的值从 number 扩展为 { version, writtenPath? } 对象，写工具完成时传入被写文件路径做定向失效，DiffTabContent 判断 unrelated 时短路跳过重读并保留滚动位置。

## 改动

- agent-atoms.ts — 新增 AgentDiffRefreshVersion 接口 + 统一 bump 入口 bumpDiffRefreshVersion，消除 6 处重复 inline 逻辑
- DiffTabContent.tsx — 新增 isSamePreviewFile 跨平台路径比较 + isUnrelatedRefresh 派生判断，无关 bump 时短路 3 个 effect 并跳过 scroll cache 删除
- useGlobalAgentListeners.ts — 写工具完成传 writtenPath（定向），git 突变保持全域刷新，窗口聚焦外部修改传当前预览文件路径
- AgentView.tsx — revert 文件后迁移至 bumpDiffRefreshVersion（全域，revert 可能影响多文件）
- DetachedPreviewApp.tsx — 手动刷新迁移至统一 bump 入口（全域，用户主动行为）
- SidePanel.tsx — 类型适配：?? 0 改为 ?.version ?? 0

## 测试

1. 打开长文档预览面板，滚动到中段
2. 让 AI 流式写另一个无关文件 → 预览面板滚动位置保持不变
3. 让 AI 写当前预览文件 → 正常刷新并重新读盘
4. git revert、手动刷新按钮、窗口聚焦检测外部修改 → 全域刷新行为不变

## 紧急度

常规

## 备注

Closes #1059

替代此前被关闭的 #1061。