### PR TITLE
fix(agent): move delegated sessions with parent

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.14.10",
+  "version": "0.14.11",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -512,11 +512,67 @@ export function deleteAgentSession(id: string): void {
 }
 
 /**
+ * 收集会话及其全部委派子会话。
+ */
+function collectSessionTreeIds(sessions: AgentSessionMeta[], sessionId: string): Set<string> {
+  const ids = new Set<string>([sessionId])
+  let changed = true
+
+  while (changed) {
+    changed = false
+    for (const session of sessions) {
+      if (ids.has(session.id)) continue
+      // 仅收集协作委派子会话。parent/root 负责维护树结构，sourceDelegationId 负责限定来源。
+      if (!session.sourceDelegationId) continue
+      if (session.parentSessionId && ids.has(session.parentSessionId)) {
+        ids.add(session.id)
+        changed = true
+        continue
+      }
+      if (session.rootSessionId === sessionId) {
+        ids.add(session.id)
+        changed = true
+      }
+    }
+  }
+
+  return ids
+}
+
+function moveSessionWorkspaceDir(session: AgentSessionMeta, targetWorkspaceSlug: string): void {
+  if (!session.workspaceId) return
+
+  const sourceWs = getAgentWorkspace(session.workspaceId)
+  if (!sourceWs || sourceWs.slug === targetWorkspaceSlug) return
+
+  const srcDir = join(getAgentWorkspacePath(sourceWs.slug), session.id)
+  if (!existsSync(srcDir)) return
+
+  const destDir = join(getAgentWorkspacePath(targetWorkspaceSlug), session.id)
+  // 清理已存在的目标目录，防止 renameSync 抛出 ENOTEMPTY/EEXIST。
+  if (existsSync(destDir)) {
+    try {
+      const contents = readdirSync(destDir)
+      rmSyncWithRetry(destDir, { recursive: true, force: true })
+      const reason = contents.length === 0 ? '空目标目录' : '非空目标目录（以源目录为准）'
+      console.log(`[Agent 会话] 已清理${reason}: ${destDir}`)
+    } catch (cleanupError) {
+      console.warn('[Agent 会话] 清理目标目录失败，跳过目录迁移:', cleanupError)
+      throw cleanupError
+    }
+  }
+
+  // renameWithRetry：优先 renameSync（原子），跨设备或句柄占用时自动降级 cpSync + rmSyncWithRetry。
+  renameWithRetry(srcDir, destDir)
+  console.log(`[Agent 会话] 已移动工作目录: ${srcDir} → ${destDir}`)
+}
+
+/**
  * 迁移 Agent 会话到另一个工作区
  *
  * 操作步骤：
  * 1. 验证会话和目标工作区存在
- * 2. 源 == 目标 → no-op
+ * 2. 收集目标会话及其委派子会话
  * 3. 移动会话工作目录到目标工作区
  * 4. 更新元数据（workspaceId + 清空 sdkSessionId）
  * 5. JSONL 消息文件保持原位（全局目录）
@@ -530,61 +586,43 @@ export function moveSessionToWorkspace(sessionId: string, targetWorkspaceId: str
 
   const session = index.sessions[idx]!
 
-  // 源 == 目标 → 直接返回
-  if (session.workspaceId === targetWorkspaceId) return session
-
   const targetWs = getAgentWorkspace(targetWorkspaceId)
   if (!targetWs) {
     throw new Error(`目标工作区不存在: ${targetWorkspaceId}`)
   }
 
-  // 移动工作目录（如果源工作区存在）
-  if (session.workspaceId) {
-    const sourceWs = getAgentWorkspace(session.workspaceId)
-    if (sourceWs) {
-      const srcDir = join(getAgentWorkspacePath(sourceWs.slug), sessionId)
-      if (existsSync(srcDir)) {
-        const destDir = join(getAgentWorkspacePath(targetWs.slug), sessionId)
-        // 清理已存在的空目标目录，防止 renameSync 抛出 ENOTEMPTY/EEXIST
-        if (existsSync(destDir)) {
-          try {
-            const contents = readdirSync(destDir)
-            if (contents.length === 0) {
-              rmSyncWithRetry(destDir, { recursive: true, force: true })
-              console.log(`[Agent 会话] 已清理空目标目录: ${destDir}`)
-            } else {
-              // 目标目录非空，合并：先移除目标，再移动源
-              rmSyncWithRetry(destDir, { recursive: true, force: true })
-              console.log(`[Agent 会话] 已清理非空目标目录（以源目录为准）: ${destDir}`)
-            }
-          } catch (cleanupError) {
-            console.warn(`[Agent 会话] 清理目标目录失败，跳过目录迁移:`, cleanupError)
-            // 清理失败时不可继续 cpSync，否则会与残留目录混合
-            throw cleanupError
-          }
-        }
-        // renameWithRetry：优先 renameSync（原子），跨设备或句柄占用时自动降级 cpSync + rmSyncWithRetry
-        renameWithRetry(srcDir, destDir)
-        console.log(`[Agent 会话] 已移动工作目录: ${srcDir} → ${destDir}`)
-      }
+  const sessionTreeIds = collectSessionTreeIds(index.sessions, sessionId)
+  const sessionsToMove = index.sessions.filter((item) => sessionTreeIds.has(item.id) && item.workspaceId !== targetWorkspaceId)
+  if (sessionsToMove.length === 0) return session
+
+  const now = Date.now()
+  let updatedRoot = session
+  let movedCount = 0
+
+  for (let i = 0; i < index.sessions.length; i++) {
+    const current = index.sessions[i]!
+    if (!sessionTreeIds.has(current.id) || current.workspaceId === targetWorkspaceId) continue
+
+    moveSessionWorkspaceDir(current, targetWs.slug)
+    // 确保目标工作区下有 session 目录。
+    getAgentSessionWorkspacePath(targetWs.slug, current.id)
+
+    const updated: AgentSessionMeta = {
+      ...current,
+      workspaceId: targetWorkspaceId,
+      sdkSessionId: undefined, // SDK 上下文与工作区 cwd 绑定，必须清空
+      updatedAt: now,
+    }
+    index.sessions[i] = updated
+    writeIndex(index)
+    movedCount++
+    if (current.id === sessionId) {
+      updatedRoot = updated
     }
   }
 
-  // 确保目标工作区下有 session 目录
-  getAgentSessionWorkspacePath(targetWs.slug, sessionId)
-
-  // 更新元数据
-  const updated: AgentSessionMeta = {
-    ...session,
-    workspaceId: targetWorkspaceId,
-    sdkSessionId: undefined, // SDK 上下文与工作区 cwd 绑定，必须清空
-    updatedAt: Date.now(),
-  }
-  index.sessions[idx] = updated
-  writeIndex(index)
-
-  console.log(`[Agent 会话] 已迁移会话到工作区: ${updated.title} → ${targetWs.name}`)
-  return updated
+  console.log(`[Agent 会话] 已迁移会话及子会话到工作区: ${updatedRoot.title}（${movedCount} 个）→ ${targetWs.name}`)
+  return updatedRoot
 }
 
 /**

--- a/apps/electron/src/renderer/components/agent/MoveSessionDialog.tsx
+++ b/apps/electron/src/renderer/components/agent/MoveSessionDialog.tsx
@@ -28,7 +28,7 @@ interface MoveSessionDialogProps {
   sessionId: string
   sourceWorkspaceId: string | undefined
   workspaces: AgentWorkspace[]
-  onMoved: (updatedSession: AgentSessionMeta, targetWorkspaceName: string) => void
+  onMoved: (updatedSession: AgentSessionMeta, targetWorkspaceName: string) => void | Promise<void>
 }
 
 export function MoveSessionDialog({
@@ -66,7 +66,7 @@ export function MoveSessionDialog({
         sessionId,
         targetWorkspaceId: selectedWorkspaceId,
       })
-      onMoved(updated, targetWs?.name ?? '未知工作区')
+      await onMoved(updated, targetWs?.name ?? '未知工作区')
       onOpenChange(false)
     } catch (error) {
       console.error('[迁移会话] 迁移失败:', error)

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -481,6 +481,29 @@ function getDirectDelegatedChildren(
   ))
 }
 
+function collectDelegatedSessionTreeIds(sessions: AgentSessionMeta[], rootSessionId: string): Set<string> {
+  const ids = new Set<string>([rootSessionId])
+  let changed = true
+
+  while (changed) {
+    changed = false
+    for (const session of sessions) {
+      if (ids.has(session.id)) continue
+      // 与主进程迁移逻辑保持一致：只处理协作委派子会话。
+      if (!session.sourceDelegationId) continue
+      if (
+        (session.parentSessionId && ids.has(session.parentSessionId))
+        || session.rootSessionId === rootSessionId
+      ) {
+        ids.add(session.id)
+        changed = true
+      }
+    }
+  }
+
+  return ids
+}
+
 function hasPinnedVisibleParent(session: AgentSessionMeta, sessions: AgentSessionMeta[]): boolean {
   if (!isDelegatedChildSession(session) || !session.parentSessionId) return false
   const parent = sessions.find((item) => item.id === session.parentSessionId)
@@ -1764,18 +1787,38 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
   }, [agentSessions])
 
   /** 迁移会话到另一个项目后的回调 */
-  const handleSessionMoved = (updatedSession: AgentSessionMeta, targetWorkspaceName: string): void => {
-    setAgentSessions((prev) => replaceAgentSessionInFreshnessOrder(prev, updatedSession))
-    // 如果迁移的是当前选中的会话，取消选中并关闭标签页
-    if (currentAgentSessionId === updatedSession.id) {
-      const tabResult = closeTab(tabs, activeTabId, updatedSession.id)
+  const handleSessionMoved = async (updatedSession: AgentSessionMeta, targetWorkspaceName: string): Promise<void> => {
+    const movedSessionIds = collectDelegatedSessionTreeIds(store.get(agentSessionsAtom), updatedSession.id)
+    try {
+      const sessions = await window.electronAPI.listAgentSessions()
+      setAgentSessions(sessions)
+    } catch (error) {
+      console.error('[侧边栏] 迁移后刷新 Agent 会话列表失败:', error)
+      setAgentSessions((prev) => replaceAgentSessionInFreshnessOrder(prev, updatedSession))
+    }
+    const hasMovedOpenTab = tabs.some((tab) => (
+      (tab.type === 'agent' || tab.type === 'preview')
+      && movedSessionIds.has(tab.sessionId)
+    ))
+    if (hasMovedOpenTab) {
+      let tabResult = { tabs, activeTabId }
+      for (const sessionId of movedSessionIds) {
+        tabResult = closeTab(tabResult.tabs, tabResult.activeTabId, sessionId)
+        cleanupMapAtoms(sessionId)
+      }
       setTabs(tabResult.tabs)
       setActiveTabId(tabResult.activeTabId)
+      const nextActiveTab = tabResult.activeTabId
+        ? tabResult.tabs.find((tab) => tab.id === tabResult.activeTabId) ?? null
+        : null
+      syncActiveTabSideEffects(nextActiveTab)
+    }
+    if (currentAgentSessionId && movedSessionIds.has(currentAgentSessionId)) {
       setCurrentAgentSessionId(null)
     }
     setMoveTargetId(null)
     toast.success('会话已迁移', {
-      description: `已迁移到「${targetWorkspaceName}」，请切换项目查看`,
+      description: `已迁移到「${targetWorkspaceName}」，子会话会一起移动`,
     })
   }
 

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.14.10",
+      "version": "0.14.11",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.201",
         "@anthropic-ai/sdk": "^0.93.0",


### PR DESCRIPTION
## Summary
- Move delegated child sessions together when an Agent session is migrated to another workspace.
- Refresh renderer session state after migration so child sessions no longer remain visually attached to the old workspace.
- Close migrated parent/child session tabs and clear per-session UI state to avoid stale workspace context.
- Bump `@proma/electron` to `0.14.11`.

## Root Cause
The main-process migration path only updated the selected parent session. Even after backend support was added, the renderer still replaced only the returned parent session in `agentSessionsAtom`, leaving delegated child sessions with stale workspace metadata in the sidebar until a full reload.

## What Changed
- `moveSessionToWorkspace()` now collects the selected session and its delegated descendant sessions, moves each session workspace directory, updates each `workspaceId`, and clears each moved session's `sdkSessionId` because SDK context is tied to cwd.
- Main and renderer session-tree collection now use the same delegated-session predicate: `sourceDelegationId` limits the scope, while `parentSessionId` / `rootSessionId` define the tree.
- Multi-session migration now writes the session index after each successfully moved session, reducing the partial-failure window where directories have moved but metadata still points to the old workspace.
- `MoveSessionDialog` now awaits the post-move callback.
- `LeftSidebar` refreshes the full Agent session list after migration and closes any open migrated parent/child tabs.

## Validation
- `bun run --cwd apps/electron typecheck`
- `bun run --cwd apps/electron build:main`
- `bun run --cwd apps/electron build:renderer`
- `git diff --check`

Note: the temporary regression test changes were removed before publishing per request.
