### PR TITLE
[codex] Fix storage cleanup memory safeguards

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.14.10",
+  "version": "0.14.11",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/storage-service.ts
+++ b/apps/electron/src/main/lib/storage-service.ts
@@ -8,7 +8,7 @@
 import { existsSync, statSync, unlinkSync } from 'node:fs'
 import { rmSyncWithRetry } from './fs-retry'
 import { promises as fsPromises } from 'node:fs'
-import { join, basename } from 'node:path'
+import { join, basename, relative, isAbsolute } from 'node:path'
 import { tmpdir } from 'node:os'
 import { app } from 'electron'
 import {
@@ -40,6 +40,15 @@ export interface StorageCategory {
   hasOrphans: boolean
   orphanBytes: number
   orphanCount: number
+  orphanItems: StorageOrphanItem[]
+  orphanItemsTruncated: boolean
+}
+
+export interface StorageOrphanItem {
+  kind: 'file' | 'directory'
+  path: string
+  bytes: number
+  count: number
 }
 
 export interface StorageStats {
@@ -71,8 +80,43 @@ const SKIP_DIRS = new Set([
 
 // 单次扫描最大文件数上限，防止超大工作区导致无限递归
 const MAX_FILE_SCAN = 100_000
+const MAX_ORPHAN_ITEM_PREVIEW = 80
 
-async function getDirSize(dirPath: string): Promise<{ bytes: number; count: number }> {
+const WORKSPACE_METADATA_DIRS = new Set([
+  'workspace-files',
+  'skills',
+  'skills-inactive',
+  '.claude',
+  '.claude-plugin',
+])
+
+const PRESERVED_ORPHAN_SESSION_DIRS = new Set([
+  '.context',
+])
+
+function isWorkspaceMetadataDir(entryName: string): boolean {
+  return WORKSPACE_METADATA_DIRS.has(entryName)
+}
+
+function displayStoragePath(filePath: string): string {
+  const configDir = getConfigDir()
+  const rel = relative(configDir, filePath)
+  if (!rel.startsWith('..') && !isAbsolute(rel)) {
+    return `~/${basename(configDir)}/${rel.split(/[\\/]/).join('/')}`
+  }
+  return filePath
+}
+
+function addOrphanItem(items: StorageOrphanItem[], item: StorageOrphanItem): boolean {
+  if (items.length >= MAX_ORPHAN_ITEM_PREVIEW) return true
+  items.push(item)
+  return false
+}
+
+async function getDirSize(
+  dirPath: string,
+  options: { skipTopLevelDirs?: Set<string> } = {}
+): Promise<{ bytes: number; count: number }> {
   let bytes = 0
   let count = 0
   if (!existsSync(dirPath)) return { bytes, count }
@@ -80,7 +124,7 @@ async function getDirSize(dirPath: string): Promise<{ bytes: number; count: numb
   // limit 对象通过闭包在整个递归树内共享，作为全局文件计数上限
   const limit = { remaining: MAX_FILE_SCAN }
 
-  async function walk(dir: string): Promise<void> {
+  async function walk(dir: string, depth: number): Promise<void> {
     try {
       const entries = await fsPromises.readdir(dir, { withFileTypes: true })
       for (const entry of entries) {
@@ -88,8 +132,9 @@ async function getDirSize(dirPath: string): Promise<{ bytes: number; count: numb
         const fullPath = join(dir, entry.name)
         try {
           if (entry.isDirectory()) {
+            if (depth === 0 && options.skipTopLevelDirs?.has(entry.name)) continue
             if (SKIP_DIRS.has(entry.name)) continue
-            await walk(fullPath)
+            await walk(fullPath, depth + 1)
           } else if (entry.isFile()) {
             const stat = await fsPromises.stat(fullPath)
             bytes += stat.size
@@ -101,7 +146,7 @@ async function getDirSize(dirPath: string): Promise<{ bytes: number; count: numb
     } catch { /* skip inaccessible dir */ }
   }
 
-  await walk(dirPath)
+  await walk(dirPath, 0)
   return { bytes, count }
 }
 
@@ -123,6 +168,39 @@ async function safeRmDir(dirPath: string): Promise<number> {
   } catch {
     return 0
   }
+}
+
+async function cleanupOrphanSessionWorkspaceDir(sessionDir: string): Promise<number> {
+  let freedBytes = 0
+  let deletedAny = false
+
+  try {
+    const entries = await fsPromises.readdir(sessionDir)
+    for (const entry of entries) {
+      if (PRESERVED_ORPHAN_SESSION_DIRS.has(entry)) continue
+      const entryPath = join(sessionDir, entry)
+      try {
+        const stat = await fsPromises.lstat(entryPath)
+        if (stat.isDirectory()) {
+          freedBytes += await safeRmDir(entryPath)
+          deletedAny = true
+        } else if (stat.isFile()) {
+          const freed = safeUnlink(entryPath)
+          freedBytes += freed
+          deletedAny = true
+        }
+      } catch { /* skip */ }
+    }
+
+    const remaining = await fsPromises.readdir(sessionDir)
+    if (remaining.length === 0) {
+      rmSyncWithRetry(sessionDir, { recursive: true, force: true })
+    }
+  } catch {
+    return 0
+  }
+
+  return deletedAny ? freedBytes : 0
 }
 
 // ─── 统计 ───
@@ -148,6 +226,8 @@ async function calcAgentSessionsCategory(): Promise<StorageCategory> {
   const dir = getAgentSessionsDir()
   const activeIds = getActiveSessionIds()
   let bytes = 0, count = 0, orphanBytes = 0, orphanCount = 0
+  const orphanItems: StorageOrphanItem[] = []
+  let orphanItemsTruncated = false
 
   if (existsSync(dir)) {
     try {
@@ -163,6 +243,12 @@ async function calcAgentSessionsCategory(): Promise<StorageCategory> {
           if (!activeIds.has(id)) {
             orphanBytes += stat.size
             orphanCount++
+            orphanItemsTruncated = addOrphanItem(orphanItems, {
+              kind: 'file',
+              path: displayStoragePath(fullPath),
+              bytes: stat.size,
+              count: 1,
+            }) || orphanItemsTruncated
           }
         } catch { /* skip */ }
       }
@@ -175,6 +261,7 @@ async function calcAgentSessionsCategory(): Promise<StorageCategory> {
     bytes, count,
     hasOrphans: orphanCount > 0,
     orphanBytes, orphanCount,
+    orphanItems, orphanItemsTruncated,
   }
 }
 
@@ -182,6 +269,8 @@ async function calcSdkConfigCategory(): Promise<StorageCategory> {
   const sdkDir = getSdkConfigDir()
   const activeSdkIds = getActiveSdkSessionIds()
   let bytes = 0, count = 0, orphanBytes = 0, orphanCount = 0
+  const orphanItems: StorageOrphanItem[] = []
+  let orphanItemsTruncated = false
 
   const projectsDir = join(sdkDir, 'projects')
   if (existsSync(projectsDir)) {
@@ -203,6 +292,12 @@ async function calcSdkConfigCategory(): Promise<StorageCategory> {
               if (!activeSdkIds.has(sdkId)) {
                 orphanBytes += stat.size
                 orphanCount++
+                orphanItemsTruncated = addOrphanItem(orphanItems, {
+                  kind: 'file',
+                  path: displayStoragePath(fullPath),
+                  bytes: stat.size,
+                  count: 1,
+                }) || orphanItemsTruncated
               }
             } catch { /* skip */ }
           }
@@ -225,6 +320,12 @@ async function calcSdkConfigCategory(): Promise<StorageCategory> {
           if (!activeSdkIds.has(sdkId)) {
             orphanBytes += sub.bytes
             orphanCount += sub.count
+            orphanItemsTruncated = addOrphanItem(orphanItems, {
+              kind: 'directory',
+              path: displayStoragePath(histPath),
+              bytes: sub.bytes,
+              count: sub.count,
+            }) || orphanItemsTruncated
           }
         } catch { /* skip */ }
       }
@@ -259,6 +360,7 @@ async function calcSdkConfigCategory(): Promise<StorageCategory> {
     bytes, count,
     hasOrphans: orphanCount > 0,
     orphanBytes, orphanCount,
+    orphanItems, orphanItemsTruncated,
   }
 }
 
@@ -267,6 +369,8 @@ async function calcWorkspacesCategory(): Promise<StorageCategory> {
   const activeIds = getActiveSessionIds()
   const activeSlugs = getActiveWorkspaceSlugs()
   let bytes = 0, count = 0, orphanBytes = 0, orphanCount = 0
+  const orphanItems: StorageOrphanItem[] = []
+  let orphanItemsTruncated = false
 
   if (existsSync(wsDir)) {
     try {
@@ -279,9 +383,16 @@ async function calcWorkspacesCategory(): Promise<StorageCategory> {
           for (const entry of entries) {
             const entryPath = join(slugDir, entry)
             try {
-              if (!(await fsPromises.lstat(entryPath)).isDirectory()) continue
-              // workspace-files, skills, skills-inactive 等元目录不算孤儿
-              if (['workspace-files', 'skills', 'skills-inactive', '.claude-plugin'].includes(entry)) {
+              const stat = await fsPromises.lstat(entryPath)
+              if (!stat.isDirectory()) {
+                if (stat.isFile()) {
+                  bytes += stat.size
+                  count++
+                }
+                continue
+              }
+              // 工作区级元目录不属于会话目录，不能按 orphan session 清理。
+              if (isWorkspaceMetadataDir(entry)) {
                 const sub = await getDirSize(entryPath)
                 bytes += sub.bytes
                 count += sub.count
@@ -292,8 +403,17 @@ async function calcWorkspacesCategory(): Promise<StorageCategory> {
               count += sub.count
               // session 目录的 ID 不在活跃列表中 → 孤儿
               if (!activeIds.has(entry) && !activeSlugs.has(entry)) {
-                orphanBytes += sub.bytes
-                orphanCount++
+                const cleanable = await getDirSize(entryPath, { skipTopLevelDirs: PRESERVED_ORPHAN_SESSION_DIRS })
+                if (cleanable.count > 0) {
+                  orphanBytes += cleanable.bytes
+                  orphanCount++
+                  orphanItemsTruncated = addOrphanItem(orphanItems, {
+                    kind: 'directory',
+                    path: displayStoragePath(entryPath),
+                    bytes: cleanable.bytes,
+                    count: cleanable.count,
+                  }) || orphanItemsTruncated
+                }
               }
             } catch { /* skip */ }
           }
@@ -308,6 +428,7 @@ async function calcWorkspacesCategory(): Promise<StorageCategory> {
     bytes, count,
     hasOrphans: orphanCount > 0,
     orphanBytes, orphanCount,
+    orphanItems, orphanItemsTruncated,
   }
 }
 
@@ -320,6 +441,7 @@ async function calcConversationsCategory(): Promise<StorageCategory> {
     bytes, count,
     hasOrphans: false,
     orphanBytes: 0, orphanCount: 0,
+    orphanItems: [], orphanItemsTruncated: false,
   }
 }
 
@@ -332,6 +454,7 @@ async function calcAttachmentsCategory(): Promise<StorageCategory> {
     bytes, count,
     hasOrphans: false,
     orphanBytes: 0, orphanCount: 0,
+    orphanItems: [], orphanItemsTruncated: false,
   }
 }
 
@@ -349,6 +472,7 @@ async function calcTempFilesCategory(): Promise<StorageCategory> {
     count: preview.count + installer.count,
     hasOrphans: false,
     orphanBytes: 0, orphanCount: 0,
+    orphanItems: [], orphanItemsTruncated: false,
   }
 }
 
@@ -502,12 +626,12 @@ async function cleanupOrphanWorkspaces(): Promise<CleanupResult> {
         if (!(await fsPromises.lstat(slugDir)).isDirectory()) continue
         const entries = await fsPromises.readdir(slugDir)
         for (const entry of entries) {
-          if (['workspace-files', 'skills', 'skills-inactive', '.claude-plugin'].includes(entry)) continue
+          if (isWorkspaceMetadataDir(entry)) continue
           const entryPath = join(slugDir, entry)
           try {
             if (!(await fsPromises.lstat(entryPath)).isDirectory()) continue
             if (activeIds.has(entry) || activeSlugs.has(entry)) continue
-            const freed = await safeRmDir(entryPath)
+            const freed = await cleanupOrphanSessionWorkspaceDir(entryPath)
             if (freed > 0) { freedBytes += freed; deletedCount++ }
           } catch { /* skip */ }
         }

--- a/apps/electron/src/renderer/components/settings/StorageSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/StorageSettings.tsx
@@ -20,7 +20,24 @@ import {
   SelectValue,
 } from '../ui/select'
 import { Button } from '../ui/button'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '../ui/alert-dialog'
 import { cn } from '@/lib/utils'
+
+interface StorageOrphanItem {
+  kind: 'file' | 'directory'
+  path: string
+  bytes: number
+  count: number
+}
 
 interface StorageCategory {
   label: string
@@ -30,6 +47,8 @@ interface StorageCategory {
   hasOrphans: boolean
   orphanBytes: number
   orphanCount: number
+  orphanItems: StorageOrphanItem[]
+  orphanItemsTruncated: boolean
 }
 
 interface StorageStats {
@@ -42,6 +61,12 @@ interface CleanupResult {
   freedBytes: number
   deletedCount: number
   errors: string[]
+}
+
+interface PendingCleanup {
+  label: string
+  cleaningKey: string
+  categories: string[]
 }
 
 function formatBytes(bytes: number): string {
@@ -90,6 +115,7 @@ export function StorageSettings(): React.ReactElement {
   const [lastResult, setLastResult] = React.useState<CleanupResult | null>(null)
   const [autoCleanupTemp, setAutoCleanupTemp] = React.useState(true)
   const [autoCleanupDays, setAutoCleanupDays] = React.useState(0)
+  const [pendingCleanup, setPendingCleanup] = React.useState<PendingCleanup | null>(null)
 
   const loadStats = React.useCallback(async () => {
     setLoading(true)
@@ -111,13 +137,13 @@ export function StorageSettings(): React.ReactElement {
     }).catch(console.error)
   }, [loadStats])
 
-  const handleCleanCategory = async (key: string, orphansOnly: boolean): Promise<void> => {
-    setCleaningKey(key)
+  const handleCleanOrphans = async (target: PendingCleanup): Promise<void> => {
+    setCleaningKey(target.cleaningKey)
     setLastResult(null)
     try {
       const result = await window.electronAPI.cleanupStorage({
-        categories: [key],
-        orphansOnly,
+        categories: target.categories,
+        orphansOnly: true,
         archivedBeforeDays: 0,
       }) as CleanupResult
       setLastResult(result)
@@ -143,22 +169,20 @@ export function StorageSettings(): React.ReactElement {
     }
   }
 
-  const handleCleanAllOrphans = async (): Promise<void> => {
-    setCleaningKey('all-orphans')
-    setLastResult(null)
-    try {
-      const result = await window.electronAPI.cleanupStorage({
-        categories: ['agent-sessions', 'sdk-config', 'workspaces'],
-        orphansOnly: true,
-        archivedBeforeDays: 0,
-      }) as CleanupResult
-      setLastResult(result)
-      await loadStats()
-    } catch (e) {
-      console.error('[存储管理] 清理孤儿数据失败:', e)
-    } finally {
-      setCleaningKey(null)
-    }
+  const requestCleanCategory = (category: StorageCategory): void => {
+    setPendingCleanup({
+      label: category.label,
+      cleaningKey: category.key,
+      categories: [category.key],
+    })
+  }
+
+  const requestCleanAllOrphans = (): void => {
+    setPendingCleanup({
+      label: '全部孤儿数据',
+      cleaningKey: 'all-orphans',
+      categories: ['agent-sessions', 'sdk-config', 'workspaces'],
+    })
   }
 
   const handleAutoCleanupTempChange = async (enabled: boolean): Promise<void> => {
@@ -182,6 +206,15 @@ export function StorageSettings(): React.ReactElement {
 
   const totalOrphanBytes = stats?.categories.reduce((sum, c) => sum + c.orphanBytes, 0) ?? 0
   const hasOrphans = totalOrphanBytes > 0
+  const pendingCategories = React.useMemo(() => {
+    if (!pendingCleanup || !stats) return []
+    const keys = new Set(pendingCleanup.categories)
+    return stats.categories.filter((category) => keys.has(category.key) && category.hasOrphans)
+  }, [pendingCleanup, stats])
+  const pendingOrphanItems = pendingCategories.flatMap((category) => category.orphanItems)
+  const pendingOrphanBytes = pendingCategories.reduce((sum, category) => sum + category.orphanBytes, 0)
+  const pendingOrphanCount = pendingCategories.reduce((sum, category) => sum + category.orphanCount, 0)
+  const pendingOrphanItemsTruncated = pendingCategories.some((category) => category.orphanItemsTruncated)
 
   return (
     <div className="space-y-6">
@@ -240,7 +273,7 @@ export function StorageSettings(): React.ReactElement {
                   <Button
                     variant="ghost"
                     size="sm"
-                    onClick={() => handleCleanCategory(cat.key, true)}
+                    onClick={() => requestCleanCategory(cat)}
                     disabled={cleaningKey !== null}
                     className="h-7 gap-1 text-xs"
                   >
@@ -302,7 +335,7 @@ export function StorageSettings(): React.ReactElement {
               <Button
                 variant={hasOrphans ? 'default' : 'ghost'}
                 size="sm"
-                onClick={handleCleanAllOrphans}
+                onClick={requestCleanAllOrphans}
                 disabled={cleaningKey !== null || !hasOrphans}
                 className="gap-1.5"
               >
@@ -331,6 +364,55 @@ export function StorageSettings(): React.ReactElement {
           )}
         </div>
       )}
+
+      <AlertDialog
+        open={pendingCleanup !== null}
+        onOpenChange={(open) => { if (!open) setPendingCleanup(null) }}
+      >
+        <AlertDialogContent className="max-w-2xl">
+          <AlertDialogHeader>
+            <AlertDialogTitle>确认清理{pendingCleanup?.label}？</AlertDialogTitle>
+            <AlertDialogDescription>
+              将删除 {pendingOrphanCount} 项孤儿数据，预计释放 {formatBytes(pendingOrphanBytes)}。请确认下面的路径都不再需要。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <div className="max-h-72 overflow-auto rounded-md bg-muted/50 p-2">
+            {pendingOrphanItems.length > 0 ? (
+              <div className="space-y-1">
+                {pendingOrphanItems.map((item) => (
+                  <div key={`${item.kind}:${item.path}`} className="flex items-start justify-between gap-3 rounded-sm px-2 py-1.5 text-xs">
+                    <div className="min-w-0">
+                      <div className="break-all font-mono text-foreground">{item.path}</div>
+                      <div className="mt-0.5 text-muted-foreground">
+                        {item.kind === 'directory' ? '目录' : '文件'} · {item.count} 个文件
+                      </div>
+                    </div>
+                    <span className="shrink-0 tabular-nums text-muted-foreground">{formatBytes(item.bytes)}</span>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="px-2 py-6 text-center text-sm text-muted-foreground">没有可展示的孤儿路径</div>
+            )}
+          </div>
+          {pendingOrphanItemsTruncated && (
+            <div className="text-xs text-amber-500">列表较长，仅展示前 80 项；确认后会清理当前分类下全部孤儿数据。</div>
+          )}
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => setPendingCleanup(null)}>取消</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/92"
+              onClick={() => {
+                const target = pendingCleanup
+                setPendingCleanup(null)
+                if (target) void handleCleanOrphans(target)
+              }}
+            >
+              确认清理
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.14.10",
+      "version": "0.14.11",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.201",
         "@anthropic-ai/sdk": "^0.93.0",


### PR DESCRIPTION
## Summary
- Protect workspace metadata directories, including .claude, from orphan workspace cleanup.
- Preserve orphan session .context directories while cleaning only the removable contents around them.
- Add a confirmation dialog that lists orphan paths before cleanup runs.
- Bump @proma/electron to 0.14.11.

## Root Cause
Workspace orphan cleanup treated any workspace-root directory that was not an active session id as removable. That included durable workspace memory under .claude/memory. The cleanup UI also only showed aggregate size, so users could not verify the exact paths before deleting.

## Validation
- bun test apps/electron/src/main/lib/storage-service.test.ts (run before removing the temporary regression test file per request)
- bun run --filter='@proma/electron' typecheck
- bun run --filter='@proma/electron' build:main
- bun run --filter='@proma/electron' build:renderer
- git diff --check