### PR TITLE
fix(main-area): 条件化 mr-0.5，消除无预览时主区域与右侧面板之间的白条缝隙【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/tabs/MainArea.tsx
+++ b/apps/electron/src/renderer/components/tabs/MainArea.tsx
@@ -154,7 +154,7 @@ export function MainArea(): React.ReactElement {
               视觉上像"内容从右向左推送"。让左侧瞬间变宽，由右侧 absolute 滑出动画
               覆盖期内呈现"被剥离"的视觉效果。 */}
           <div
-            className="flex flex-col min-w-0 h-full relative mr-0.5"
+            className={cn('flex flex-col min-w-0 h-full relative', showPreview && 'mr-0.5')}
             style={leftFlexStyle}
           >
             {activeView === 'automations' ? (


### PR DESCRIPTION
## 概述

修复主内容区域（MainArea）上方 TabBar 与右侧会话文件面板之间的可见白条缝隙。该缝隙由左侧容器的无条件 `mr-0.5`（2px 右边距）引起——这个 margin 的原始用途是为预览分屏面板的拖拽手柄留呼吸空间，但它始终生效，即使预览关闭时也存在。

当预览关闭、右侧文件面板打开时，这 2px 空隙加上右侧面板左边缘的 1px border 分隔线，在视觉上形成了一条明显的白条，破坏了界面的一体感。

## 改动

- `apps/electron/src/renderer/components/tabs/MainArea.tsx` — 将左侧容器的 `mr-0.5` 从无条件 className 改为 `cn(..., showPreview && 'mr-0.5')`，仅在预览分屏面板打开时生效

## 测试方法

1. 启动 Proma（`bun run dev`）
2. 打开一个 Agent 会话，确认右侧文件面板打开（快捷键 `⌘⇧B`）
3. 观察主 TabBar 和右侧「会话文件」Tab 之间——应无可见白条
4. 在会话中打开一个文件的预览分屏，确认预览面板与主内容区域之间间距正常
5. 关闭预览面板，确认间隙消失

## 备注

- 仅 CSS class 级别改动，不涉及状态管理、IPC 或数据持久化
- 所有 6 个包 `bun run typecheck` 零错误
- Windows 兼容性扫描无问题
- 预览关闭动画期间 `showPreview` 仍为 true，`mr-0.5` 保留，动画不受影响