### PR TITLE
Add Ark Coding Plan channel preset

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.14.11",
+  "version": "0.14.12",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/channel-manager.ts
+++ b/apps/electron/src/main/lib/channel-manager.ts
@@ -28,6 +28,7 @@ import {
   getPromaUserAgent,
   migrateCompatibleChannelBaseUrl,
   normalizeBaseUrl,
+  resolveAnthropicMessagesUrl,
   resolveAnthropicModelsUrl,
   resolveOpenAIModelsUrl,
 } from '@proma/core'
@@ -38,6 +39,17 @@ import pkg from '../../../package.json' with { type: 'json' }
 const CONFIG_VERSION = 2
 /** 连接测试 / 模型拉取的统一超时时间 */
 const CHANNEL_TEST_TIMEOUT_MS = 15_000
+const ARK_CODING_PLAN_TEST_MODEL = 'doubao-seed-2.0-code'
+const ARK_CODING_PLAN_MODELS: ChannelModel[] = [
+  { id: 'doubao-seed-2.0-code', name: 'Doubao Seed 2.0 Code', enabled: true },
+  { id: 'doubao-seed-2.0-pro', name: 'Doubao Seed 2.0 Pro', enabled: true },
+  { id: 'doubao-seed-2.0-lite', name: 'Doubao Seed 2.0 Lite', enabled: true },
+  { id: 'glm-5.2', name: 'GLM-5.2', enabled: true },
+  { id: 'kimi-k2.7-code', name: 'Kimi K2.7 Code', enabled: true },
+  { id: 'minimax-m3', name: 'MiniMax M3', enabled: true },
+  { id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash', enabled: true },
+  { id: 'deepseek-v4-pro', name: 'DeepSeek V4 Pro', enabled: true },
+]
 
 /**
  * 为连接测试 / 模型拉取请求统一附加超时信号。
@@ -332,10 +344,14 @@ export async function testChannel(channelId: string): Promise<ChannelTestResult>
       case 'kimi-api':
       case 'kimi-coding':
       case 'zhipu-coding':
+      case 'ark-coding-plan':
       case 'minimax':
       case 'xiaomi':
       case 'xiaomi-token-plan':
       case 'qwen-anthropic':
+        if (channel.provider === 'ark-coding-plan') {
+          return await testArkCodingPlan(channel.baseUrl, apiKey, proxyUrl)
+        }
         return await testAnthropicCompatible(channel.baseUrl, apiKey, proxyUrl, channel.provider)
       case 'openai':
       case 'zhipu':
@@ -388,6 +404,35 @@ async function testAnthropicCompatible(
   const response = await fetchFn(url, withTimeout({
     method: 'GET',
     headers,
+  }))
+
+  return normalizeHttpResponse(response)
+}
+
+/**
+ * 火山方舟 Coding Plan 当前没有可用的模型列表端点，连接测试改用极小的 messages 请求。
+ */
+async function testArkCodingPlan(
+  baseUrl: string,
+  apiKey: string,
+  proxyUrl?: string,
+): Promise<ChannelTestResult> {
+  const url = resolveAnthropicMessagesUrl(baseUrl, 'ark-coding-plan')
+  const fetchFn = getFetchFn(proxyUrl)
+
+  const response = await fetchFn(url, withTimeout({
+    method: 'POST',
+    headers: {
+      'anthropic-version': '2023-06-01',
+      'content-type': 'application/json',
+      'x-api-key': apiKey,
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: ARK_CODING_PLAN_TEST_MODEL,
+      max_tokens: 8,
+      messages: [{ role: 'user', content: 'ping' }],
+    }),
   }))
 
   return normalizeHttpResponse(response)
@@ -448,10 +493,14 @@ export async function testChannelDirect(input: FetchModelsInput): Promise<Channe
       case 'kimi-api':
       case 'kimi-coding':
       case 'zhipu-coding':
+      case 'ark-coding-plan':
       case 'minimax':
       case 'xiaomi':
       case 'xiaomi-token-plan':
       case 'qwen-anthropic':
+        if (input.provider === 'ark-coding-plan') {
+          return await testArkCodingPlan(input.baseUrl, input.apiKey, proxyUrl)
+        }
         return await testAnthropicCompatible(input.baseUrl, input.apiKey, proxyUrl, input.provider)
       case 'openai':
       case 'zhipu':
@@ -488,10 +537,18 @@ export async function fetchModels(input: FetchModelsInput): Promise<FetchModelsR
       case 'kimi-api':
       case 'kimi-coding':
       case 'zhipu-coding':
+      case 'ark-coding-plan':
       case 'minimax':
       case 'xiaomi':
       case 'xiaomi-token-plan':
       case 'qwen-anthropic':
+        if (input.provider === 'ark-coding-plan') {
+          return {
+            success: true,
+            message: `火山方舟 Coding Plan 未开放模型列表端点，已加载 ${ARK_CODING_PLAN_MODELS.length} 个预设模型`,
+            models: ARK_CODING_PLAN_MODELS,
+          }
+        }
         return await fetchAnthropicCompatibleModels(input.baseUrl, input.apiKey, proxyUrl, input.provider)
       case 'openai':
       case 'zhipu':

--- a/apps/electron/src/renderer/components/settings/ChannelForm.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelForm.tsx
@@ -72,7 +72,7 @@ interface ChannelFormProps {
 }
 
 /** 所有可选供应商 */
-const PROVIDER_OPTIONS: ProviderType[] = ['anthropic', 'anthropic-compatible', 'openai', 'deepseek', 'google', 'kimi-api', 'kimi-coding', 'zhipu', 'zhipu-coding', 'minimax', 'doubao', 'qwen', 'qwen-anthropic', 'xiaomi', 'xiaomi-token-plan', 'custom']
+const PROVIDER_OPTIONS: ProviderType[] = ['anthropic', 'anthropic-compatible', 'openai', 'deepseek', 'google', 'kimi-api', 'kimi-coding', 'zhipu', 'zhipu-coding', 'ark-coding-plan', 'minimax', 'doubao', 'qwen', 'qwen-anthropic', 'xiaomi', 'xiaomi-token-plan', 'custom']
 
 /** 供应商选项（用于 SettingsSelect） */
 const PROVIDER_SELECT_OPTIONS = PROVIDER_OPTIONS.map((p) => ({
@@ -89,6 +89,7 @@ const ANTHROPIC_PROTOCOL_PROVIDERS: ReadonlySet<ProviderType> = new Set<Provider
   'kimi-api',
   'kimi-coding',
   'zhipu-coding',
+  'ark-coding-plan',
   'minimax',
   'xiaomi',
   'xiaomi-token-plan',
@@ -275,6 +276,17 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
         setModels([
           { id: 'glm-5.2', name: 'GLM-5.2', enabled: true },
           { id: 'glm-5.1', name: 'GLM-5.1', enabled: false },
+        ])
+      } else if (p === 'ark-coding-plan') {
+        setModels([
+          { id: 'doubao-seed-2.0-code', name: 'Doubao Seed 2.0 Code', enabled: true },
+          { id: 'doubao-seed-2.0-pro', name: 'Doubao Seed 2.0 Pro', enabled: true },
+          { id: 'doubao-seed-2.0-lite', name: 'Doubao Seed 2.0 Lite', enabled: true },
+          { id: 'glm-5.2', name: 'GLM-5.2', enabled: true },
+          { id: 'kimi-k2.7-code', name: 'Kimi K2.7 Code', enabled: true },
+          { id: 'minimax-m3', name: 'MiniMax M3', enabled: true },
+          { id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash', enabled: true },
+          { id: 'deepseek-v4-pro', name: 'DeepSeek V4 Pro', enabled: true },
         ])
       } else if (p === 'minimax') {
         setModels([

--- a/apps/electron/src/renderer/lib/model-logo.ts
+++ b/apps/electron/src/renderer/lib/model-logo.ts
@@ -244,6 +244,7 @@ const PROVIDER_LOGO_MAP: Record<ProviderType, string> = {
   'kimi-coding': KimiLogo,
   zhipu: ZhipuLogo,
   'zhipu-coding': ZhipuLogo,
+  'ark-coding-plan': DoubaoLogo,
   minimax: MiniMaxLogo,
   doubao: DoubaoLogo,
   qwen: QwenLogo,

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "apps/electron": {
       "name": "@proma/electron",
-      "version": "0.14.11",
+      "version": "0.14.12",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.201",
         "@anthropic-ai/sdk": "^0.93.0",
@@ -154,7 +154,7 @@
     },
     "packages/core": {
       "name": "@proma/core",
-      "version": "0.2.13",
+      "version": "0.2.14",
       "dependencies": {
         "@proma/shared": "workspace:*",
         "highlight.js": "^11.11.1",
@@ -182,7 +182,7 @@
     },
     "packages/shared": {
       "name": "@proma/shared",
-      "version": "0.1.37",
+      "version": "0.1.39",
       "devDependencies": {
         "typescript": "^5.0.0",
       },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/core",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "license": "AGPL-3.0-only",
   "description": "proma core types,storage and core logic with agents",
   "type": "module",

--- a/packages/core/src/providers/index.ts
+++ b/packages/core/src/providers/index.ts
@@ -33,6 +33,7 @@ const adapterRegistry = new Map<ProviderType, ProviderAdapter>([
   ['kimi-coding', new AnthropicAdapter('kimi-coding')], // Kimi Coding Plan 订阅制（强制 User-Agent）
   ['zhipu', new OpenAIAdapter()],         // 智谱 AI 使用 OpenAI 兼容协议
   ['zhipu-coding', new AnthropicAdapter('zhipu-coding')], // 智谱 Coding Plan 订阅制（强制 User-Agent）
+  ['ark-coding-plan', new AnthropicAdapter('ark-coding-plan')], // 火山方舟 Coding Plan 使用 Anthropic 兼容协议
   ['minimax', new AnthropicAdapter('minimax')], // MiniMax 使用 Anthropic 兼容协议
   ['doubao', new OpenAIAdapter()],        // 豆包使用 OpenAI 兼容协议
   ['qwen', new OpenAIAdapter()],          // 通义千问使用 OpenAI 兼容协议

--- a/packages/core/src/providers/thinking-capability.ts
+++ b/packages/core/src/providers/thinking-capability.ts
@@ -75,7 +75,13 @@ export function detectThinkingCapability(
 
   // Kimi / 智谱 / MiniMax 的 Anthropic 协议渠道：
   // 这些供应商的 thinking 请求参数存在兼容差异，这里直接省略以保持连接稳定。
-  if (providerType === 'kimi-api' || providerType === 'kimi-coding' || providerType === 'zhipu-coding' || providerType === 'minimax') {
+  if (
+    providerType === 'kimi-api'
+    || providerType === 'kimi-coding'
+    || providerType === 'zhipu-coding'
+    || providerType === 'ark-coding-plan'
+    || providerType === 'minimax'
+  ) {
     return { mode: 'none', disableStrategy: 'omit-field' }
   }
 

--- a/packages/core/src/providers/url-utils.test.ts
+++ b/packages/core/src/providers/url-utils.test.ts
@@ -149,6 +149,12 @@ describe('normalizeAnthropicProviderUrl', () => {
     )
   })
 
+  test('ark-coding-plan 补全 /v1', () => {
+    expect(normalizeAnthropicProviderUrl('https://ark.cn-beijing.volces.com/api/plan', 'ark-coding-plan')).toBe(
+      'https://ark.cn-beijing.volces.com/api/plan/v1',
+    )
+  })
+
   test('原生 anthropic 纯域名补全 /v1', () => {
     expect(normalizeAnthropicProviderUrl('https://api.anthropic.com', 'anthropic')).toBe('https://api.anthropic.com/v1')
   })
@@ -231,6 +237,12 @@ describe('resolveAnthropicMessagesUrl', () => {
     )
   })
 
+  test('火山方舟 Coding Plan 协议根地址补全 /v1/messages', () => {
+    expect(resolveAnthropicMessagesUrl('https://ark.cn-beijing.volces.com/api/plan', 'ark-coding-plan')).toBe(
+      'https://ark.cn-beijing.volces.com/api/plan/v1/messages',
+    )
+  })
+
   test('内置 anthropic 已是完整端点不重复追加', () => {
     expect(resolveAnthropicMessagesUrl('https://api.anthropic.com/v1/messages', 'anthropic')).toBe(
       'https://api.anthropic.com/v1/messages',
@@ -266,6 +278,12 @@ describe('resolveAnthropicModelsUrl', () => {
   test('内置协议根地址推导 /models', () => {
     expect(resolveAnthropicModelsUrl('https://api.minimaxi.com/anthropic', 'minimax')).toBe(
       'https://api.minimaxi.com/anthropic/v1/models',
+    )
+  })
+
+  test('火山方舟 Coding Plan 协议根地址推导 /v1/models', () => {
+    expect(resolveAnthropicModelsUrl('https://ark.cn-beijing.volces.com/api/plan', 'ark-coding-plan')).toBe(
+      'https://ark.cn-beijing.volces.com/api/plan/v1/models',
     )
   })
 })

--- a/packages/core/src/providers/url-utils.ts
+++ b/packages/core/src/providers/url-utils.ts
@@ -174,6 +174,7 @@ export function normalizeAnthropicProviderUrl(baseUrl: string, provider: Provide
     || provider === 'xiaomi-token-plan'
     || provider === 'qwen-anthropic'
     || provider === 'zhipu-coding'
+    || provider === 'ark-coding-plan'
     || provider === 'deepseek'
     || provider === 'kimi-api'
     || provider === 'kimi-coding'

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/shared",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "license": "AGPL-3.0-only",
   "description": "Shared types, configs and utilities for proma",
   "type": "module",

--- a/packages/shared/src/types/channel.ts
+++ b/packages/shared/src/types/channel.ts
@@ -18,6 +18,7 @@ export type ProviderType =
   | 'kimi-coding'
   | 'zhipu'
   | 'zhipu-coding'
+  | 'ark-coding-plan'
   | 'minimax'
   | 'doubao'
   | 'qwen'
@@ -39,6 +40,7 @@ export const PROVIDER_DEFAULT_URLS: Record<ProviderType, string> = {
   'kimi-coding': 'https://api.kimi.com/coding/v1',
   zhipu: 'https://open.bigmodel.cn/api/paas/v4',
   'zhipu-coding': 'https://open.bigmodel.cn/api/anthropic',
+  'ark-coding-plan': 'https://ark.cn-beijing.volces.com/api/plan',
   minimax: 'https://api.minimaxi.com/anthropic',
   doubao: 'https://ark.cn-beijing.volces.com/api/v3',
   qwen: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
@@ -61,6 +63,7 @@ export const PROVIDER_LABELS: Record<ProviderType, string> = {
   'kimi-coding': 'Kimi Coding Plan',
   zhipu: '智谱 AI',
   'zhipu-coding': '智谱 Coding Plan',
+  'ark-coding-plan': '火山方舟 Coding Plan',
   minimax: 'MiniMax (API&编程包)',
   doubao: '豆包',
   qwen: '通义千问',
@@ -83,6 +86,7 @@ export const AGENT_COMPATIBLE_PROVIDERS: ReadonlySet<ProviderType> = new Set<Pro
   'kimi-api',
   'kimi-coding',
   'zhipu-coding',
+  'ark-coding-plan',
   'minimax',
   'xiaomi',
   'xiaomi-token-plan',


### PR DESCRIPTION
Adds a 火山方舟 Coding Plan provider preset with the requested default Base URL and model list.
Routes it through the Anthropic-compatible adapter, including settings preview, provider logo fallback, URL normalization tests, and package version bumps.
Because the live Coding Plan gateway returns 404 for model-list endpoints while `/api/plan/v1/messages` succeeds, the fetch-models action loads the bundled preset list and connection testing uses a tiny messages request.

Validation: `bun run typecheck`, `bun test packages/core/src/providers/url-utils.test.ts`, and `git diff --check`.