### PR TITLE
fix: avoid black screen when closing fullscreen mac window

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.14.12",
+  "version": "0.14.13",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -104,6 +104,7 @@ import { startScheduler, stopScheduler } from './lib/automation-scheduler'
 import { feishuBridgeManager } from './lib/feishu-bridge-manager'
 import { getFeishuMultiBotConfig } from './lib/feishu-config'
 import { stopFeishuSyncSleepBlocker, syncFeishuSyncSleepBlocker } from './lib/feishu-sleep-blocker'
+import { getPersistableMainWindowState, hideMacMainWindowAfterClose } from './lib/main-window-lifecycle'
 import { dingtalkBridgeManager } from './lib/dingtalk-bridge-manager'
 import { getDingTalkMultiBotConfig } from './lib/dingtalk-config'
 import { wechatBridge } from './lib/wechat-bridge'
@@ -305,17 +306,10 @@ function getIconPath(): string {
 
 function saveMainWindowState(): void {
   if (!mainWindow || mainWindow.isDestroyed()) return
-  const isMaximized = mainWindow.isMaximized()
-  // 最大化时用恢复尺寸（unmaximize 后的尺寸），避免记录最大化的全屏 bounds
-  const bounds = isMaximized ? mainWindow.getNormalBounds() : mainWindow.getBounds()
+  const mainWindowState = getPersistableMainWindowState(mainWindow)
+  if (!mainWindowState) return
   updateSettings({
-    mainWindowState: {
-      width: bounds.width,
-      height: bounds.height,
-      x: bounds.x,
-      y: bounds.y,
-      isMaximized,
-    },
+    mainWindowState,
   })
 }
 
@@ -423,8 +417,9 @@ function createWindow(): void {
         }
         saveMainWindowState()
         event.preventDefault()
-        mainWindow?.hide()
-        app.hide()
+        if (mainWindow && !mainWindow.isDestroyed()) {
+          hideMacMainWindowAfterClose(mainWindow, app)
+        }
       }
     })
   }

--- a/apps/electron/src/main/lib/main-window-lifecycle.ts
+++ b/apps/electron/src/main/lib/main-window-lifecycle.ts
@@ -1,0 +1,76 @@
+import type { MainWindowState } from '../../types'
+
+interface WindowBounds {
+  width: number
+  height: number
+  x: number
+  y: number
+}
+
+export interface MainWindowStateReadable {
+  isDestroyed(): boolean
+  isMaximized(): boolean
+  isFullScreen(): boolean
+  getBounds(): WindowBounds
+  getNormalBounds(): WindowBounds
+}
+
+export interface MacCloseWindowController {
+  isDestroyed(): boolean
+  isFullScreen(): boolean
+  setFullScreen(flag: boolean): void
+  once(event: 'leave-full-screen', listener: () => void): void
+  hide(): void
+}
+
+export interface MacCloseAppController {
+  hide(): void
+}
+
+export type ScheduleFn = (callback: () => void, delayMs: number) => unknown
+
+const FULL_SCREEN_HIDE_DELAY_MS = 160
+const FULL_SCREEN_HIDE_FALLBACK_DELAY_MS = 1000
+
+/**
+ * 全屏/最大化状态下只保存普通窗口 bounds，避免把全屏 Space 尺寸写入配置。
+ */
+export function getPersistableMainWindowState(win: MainWindowStateReadable): MainWindowState | null {
+  if (win.isDestroyed()) return null
+
+  const isMaximized = win.isMaximized()
+  const bounds = (isMaximized || win.isFullScreen()) ? win.getNormalBounds() : win.getBounds()
+  return {
+    width: bounds.width,
+    height: bounds.height,
+    x: bounds.x,
+    y: bounds.y,
+    isMaximized,
+  }
+}
+
+export function hideMacMainWindowAfterClose(
+  win: MacCloseWindowController,
+  app: MacCloseAppController,
+  schedule: ScheduleFn = setTimeout,
+): void {
+  let didHide = false
+  const hideWindowAndApp = (): void => {
+    if (didHide) return
+    if (win.isDestroyed()) return
+    didHide = true
+    win.hide()
+    app.hide()
+  }
+
+  if (!win.isFullScreen()) {
+    hideWindowAndApp()
+    return
+  }
+
+  win.once('leave-full-screen', () => {
+    schedule(hideWindowAndApp, FULL_SCREEN_HIDE_DELAY_MS)
+  })
+  win.setFullScreen(false)
+  schedule(hideWindowAndApp, FULL_SCREEN_HIDE_FALLBACK_DELAY_MS)
+}


### PR DESCRIPTION
## Summary
- exit macOS fullscreen before hiding the main window on close
- persist normal window bounds while fullscreen or maximized instead of fullscreen Space bounds
- bump `@proma/electron` patch version to `0.14.13`

## Root Cause
The macOS close handler prevented the native close event and immediately called `hide()` plus `app.hide()`. When the window was in fullscreen, that could race with macOS Spaces/fullscreen teardown and leave a black fullscreen Space behind.

## Validation
- `git diff --check`
- `bun run --filter='@proma/electron' typecheck`
- `bun run --filter='@proma/electron' build:main`
