### PR TITLE
fix(agent): prevent silent message loss

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.14.13",
+  "version": "0.14.16",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -82,6 +82,50 @@ function sdkPermissionModeForPromaMode(mode: PromaPermissionMode): PromaPermissi
   return PROMA_PERMISSION_MODE_CONFIG[mode].sdkMode
 }
 
+const EMPTY_RESPONSE_RESULT_SUBTYPE = 'empty_response'
+
+function isNonEmptyString(value: unknown): boolean {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function errorMessageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function isMissingActiveQueueChannelError(error: unknown): boolean {
+  return errorMessageOf(error).includes('无活跃消息通道可注入队列消息')
+}
+
+function isVisibleRunMessage(message: SDKMessage): boolean {
+  const msgRecord = message as Record<string, unknown>
+  if (msgRecord.isReplay) return false
+
+  if (message.type === 'assistant') {
+    const assistantMsg = message as SDKAssistantMessage
+    if (assistantMsg.error) return true
+    const content = assistantMsg.message?.content
+    if (!Array.isArray(content)) return false
+    return content.some((block) => {
+      if (block.type === 'text') return isNonEmptyString((block as { text?: unknown }).text)
+      if (block.type === 'thinking') return isNonEmptyString((block as { thinking?: unknown }).thinking)
+      if (block.type === 'tool_use') return true
+      return Object.keys(block).length > 1
+    })
+  }
+
+  if (message.type === 'user') {
+    const content = (message as { message?: { content?: Array<{ type: string }> } }).message?.content
+    return Array.isArray(content) && content.some((block) => block.type === 'tool_result')
+  }
+
+  if (message.type === 'system') {
+    const subtype = (message as SDKSystemMessage).subtype
+    return subtype === 'task_started' || subtype === 'task_progress' || subtype === 'task_notification'
+  }
+
+  return false
+}
+
 /**
  * 从 stderr 中提取 API 错误信息
  *
@@ -722,6 +766,51 @@ export class AgentOrchestrator {
     appendSDKMessages(sessionId, withTimestamps)
   }
 
+  private persistUserMessage(sessionId: string, userMessage: string, createdAt = Date.now()): void {
+    const userSDKMsg: SDKMessage = {
+      type: 'user',
+      message: {
+        content: [{ type: 'text', text: userMessage }],
+      },
+      parent_tool_use_id: null,
+      _createdAt: createdAt,
+    } as unknown as SDKMessage
+    appendSDKMessages(sessionId, [userSDKMsg])
+  }
+
+  private persistEmptyResponseError(
+    sessionId: string,
+    resultSubtype: string | undefined,
+    resultErrors: string[] | undefined,
+  ): string {
+    const detail = resultErrors?.find((error) => error.trim().length > 0)?.trim()
+    const subtype = resultSubtype ?? 'unknown'
+    const errorContent = detail
+      ? `Agent 本轮结束了，但没有返回任何可展示内容。错误详情：${detail}`
+      : resultSubtype === 'success'
+        ? 'Agent 本轮结束了，但没有返回任何可展示内容。你的消息已保留，可以直接重试或切换模型。'
+        : `Agent 本轮异常结束（${subtype}），但没有返回任何可展示内容。你的消息已保留，可以直接重试或切换模型。`
+    const errorSDKMsg: SDKMessage = {
+      type: 'assistant',
+      message: {
+        content: [{ type: 'text', text: errorContent }],
+      },
+      parent_tool_use_id: null,
+      error: { message: errorContent, errorType: EMPTY_RESPONSE_RESULT_SUBTYPE },
+      _createdAt: Date.now(),
+      _errorCode: 'unknown_error',
+      _errorTitle: '没有收到模型回复',
+      _errorCanRetry: true,
+      _errorActions: [
+        { key: 'r', label: '重试', action: 'retry' },
+        { key: 'm', label: '重新选择模型', action: 'select_model' },
+      ],
+    } as unknown as SDKMessage
+    appendSDKMessages(sessionId, [errorSDKMsg])
+    console.warn(`[Agent 编排] 本轮没有收到可展示内容: sessionId=${sessionId}, resultSubtype=${subtype}`)
+    return errorContent
+  }
+
   /**
    * 发送消息并流式推送事件
    *
@@ -731,12 +820,36 @@ export class AgentOrchestrator {
   async sendMessage(input: AgentSendInput, callbacks: SessionCallbacks): Promise<void> {
     const { sessionId, userMessage, channelId, modelId, workspaceId, additionalDirectories, customMcpServers, permissionModeOverride, mentionedSkills, mentionedMcpServers, mentionedSessionIds, automationContext } = input
     const stderrChunks: string[] = []
+    const streamStartedAt = input.startedAt ?? Date.now()
+    let userMessagePersisted = false
+
+    const persistInitialUserMessage = (): void => {
+      if (userMessagePersisted) return
+      this.persistUserMessage(sessionId, userMessage)
+      userMessagePersisted = true
+      callbacks.onRunStarted?.({ startedAt: streamStartedAt })
+    }
 
     // 0. 并发保护
     if (this.activeSessions.has(sessionId)) {
       console.warn(`[Agent 编排] 会话 ${sessionId} 正在处理中，拒绝新请求`)
+      try {
+        persistInitialUserMessage()
+      } catch (error) {
+        console.error('[Agent 编排] 持久化被拒绝的用户消息失败:', error)
+      }
       callbacks.onError('上一条消息仍在处理中，请稍候再试')
-      callbacks.onComplete([], { startedAt: input.startedAt })
+      callbacks.onComplete([], { startedAt: streamStartedAt })
+      return
+    }
+
+    try {
+      persistInitialUserMessage()
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      console.error('[Agent 编排] 持久化用户消息失败:', error)
+      callbacks.onError(`消息保存失败：${message}`)
+      callbacks.onComplete([], { startedAt: streamStartedAt })
       return
     }
 
@@ -766,7 +879,7 @@ export class AgentOrchestrator {
         console.error('[Agent 编排] 持久化 preflight error 失败:', e)
       }
       callbacks.onError(errorContent)
-      callbacks.onComplete([], { startedAt: input.startedAt })
+      callbacks.onComplete([], { startedAt: streamStartedAt })
     }
 
     // 1. Windows 平台：检查 Shell 环境可用性
@@ -829,9 +942,6 @@ export class AgentOrchestrator {
     // 防止 buildSdkEnv 等 await 期间并发调用绕过上方的检查，导致多条重复消息写入 JSONL
     // finally 块会通过 generation 匹配来安全清理，不影响正常流程
     const runGeneration = Date.now()
-    // 优先使用渲染进程传来的 startedAt（确保 STREAM_COMPLETE 竞态保护比较的是同一个值），
-    // 否则用本地 runGeneration 作为回退（headless 模式等无渲染进程场景）
-    const streamStartedAt = input.startedAt ?? runGeneration
     this.activeSessions.set(sessionId, runGeneration)
 
     const releaseActiveRun = (): void => {
@@ -914,19 +1024,7 @@ export class AgentOrchestrator {
 
     console.log(`[Agent 编排] Resume 状态: sdkSessionId=${existingSdkSessionId || '无'}, proma sessionId=${sessionId}`)
 
-    // 5. 持久化用户消息（SDKMessage 格式）
-    const userSDKMsg: SDKMessage = {
-      type: 'user',
-      message: {
-        content: [{ type: 'text', text: userMessage }],
-      },
-      parent_tool_use_id: null,
-      _createdAt: Date.now(),
-    } as unknown as SDKMessage
-    appendSDKMessages(sessionId, [userSDKMsg])
-    callbacks.onRunStarted?.({ startedAt: streamStartedAt })
-
-    // 6. 状态初始化
+    // 5. 状态初始化
     const accumulatedMessages: SDKMessage[] = []
     let resolvedModel = modelId || DEFAULT_MODEL_ID
     let titleGenerationStarted = false
@@ -1531,6 +1629,7 @@ export class AgentOrchestrator {
           // 后台任务等待态：result 走轻量完成后置 true，下一轮真正开始（收到 assistant/user/task 消息）时
           // 置回 false 并发 run_resumed，让 UI 从空闲态恢复运行态。
           let awaitingBackgroundWake = false
+          let visibleRunMessageCount = 0
 
           while (true) {
             if (!pendingNext) {
@@ -1560,6 +1659,9 @@ export class AgentOrchestrator {
 
             pendingNext = null
             const msg = iterResult.value
+            if (isVisibleRunMessage(msg)) {
+              visibleRunMessageCount += 1
+            }
 
             // 后台任务唤醒：轻量完成后处于等待态，收到新一轮的首条实质消息时
             // 发 run_resumed，让 UI 从"空闲可输入"恢复到"运行中"。
@@ -1862,6 +1964,16 @@ export class AgentOrchestrator {
           this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
 
           try { updateAgentSessionMeta(sessionId, wasStoppedByUser ? { stoppedByUser: true } : {}) } catch { /* 忽略 */ }
+
+          if (!wasStoppedByUser && visibleRunMessageCount === 0) {
+            const errorContent = this.persistEmptyResponseError(sessionId, capturedResultSubtype, capturedResultErrors)
+            failRun(errorContent, getAgentSessionMessages(sessionId), {
+              startedAt: streamStartedAt,
+              resultSubtype: EMPTY_RESPONSE_RESULT_SUBTYPE,
+              resultErrors: [errorContent],
+            })
+            return
+          }
 
           // Plan 模式：Agent 完成规划后注入"接受计划"建议
           if (initialPermissionMode === 'plan' && planModeEntered && this.activeSessions.has(sessionId)) {
@@ -2358,6 +2470,12 @@ export class AgentOrchestrator {
       appendSDKMessages(sessionId, [persistMsg])
     } catch (error) {
       uuids.delete(uuid)
+      if (isMissingActiveQueueChannelError(error)) {
+        console.warn(`[Agent 编排] 队列注入失败且消息通道已失效，释放陈旧运行状态: sessionId=${sessionId}`)
+        this.activeSessions.delete(sessionId)
+        this.sessionPermissionModes.delete(sessionId)
+        this.queuedMessageUuids.delete(sessionId)
+      }
       throw error
     }
 

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -187,6 +187,16 @@ function getUserTextFromSDKMessage(message: SDKMessage): string | null {
   return texts.length > 0 ? texts.join('\n') : null
 }
 
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function isStaleAgentQueueError(error: unknown): boolean {
+  const message = getErrorMessage(error)
+  return message.includes('会话未运行，无法追加消息') ||
+    message.includes('无活跃消息通道可注入队列消息')
+}
+
 // ===== 思考模式 Hover Popover =====
 
 interface AgentThinkingPopoverProps {
@@ -839,7 +849,16 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     // - backgroundWaiting（软空闲，无活跃 turn）：直接注入，无需中断
     // 避免"外层判定 streaming、内层已结束"两个快照不一致导致的竞态。
     if (streaming || backgroundWaiting) {
-      await queueMessageIntoActiveAgent(message, payload.rawText, payload.sdkText, payload.mentions, streaming)
+      try {
+        await queueMessageIntoActiveAgent(message, payload.rawText, payload.sdkText, payload.mentions, streaming)
+      } catch (error) {
+        if (isStaleAgentQueueError(error)) {
+          console.warn('[AgentView] 检测到陈旧的 Agent 追加通道，改为启动新一轮运行:', error)
+          await startQueuedMessageRun(payload.rawText, payload.mentions, agentChannelId, message.additionalDirectories)
+          return
+        }
+        throw error
+      }
       return
     }
 

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -925,12 +925,17 @@ export function useGlobalAgentListeners(): void {
         // 不发"任务已完成"通知（任务并未真正完成）、不清后台任务列表、不重载消息——
         // 等后台任务完成时 Agent 会自动唤醒续轮。
         const backgroundTasksPending = data.backgroundTasksPending === true
-        // 发送桌面通知（任务完成，始终播放提示音）
+        const hasStreamError = store.get(agentStreamErrorsAtom).has(data.sessionId)
+        const isSuccessfulCompletion = !data.stoppedByUser &&
+          !hasStreamError &&
+          (!data.resultSubtype || data.resultSubtype === 'success')
+
+        // 发送桌面通知（仅真正成功完成时播放提示音，错误/中断/异常完成不伪装成完成）
         const enabled = store.get(notificationsEnabledAtom)
         const soundEnabled = store.get(notificationSoundEnabledAtom)
         const sounds = store.get(notificationSoundsAtom)
         const sessionTitle = getSessionTitle(data.sessionId)
-        if (!backgroundTasksPending) {
+        if (!backgroundTasksPending && isSuccessfulCompletion) {
           sendDesktopNotification(
             'Agent 任务完成',
             `[${sessionTitle}] 任务已完成`,
@@ -1003,6 +1008,7 @@ export function useGlobalAgentListeners(): void {
             error_max_turns: '任务被中断：已达到轮次上限。继续对话可让 Agent 接着完成。',
             error_max_budget_usd: '任务被中断：已达到预算上限。',
             error_during_execution: '任务执行过程中发生错误。',
+            empty_response: 'Agent 本轮结束了，但没有返回任何可展示内容。你的消息已保留，可以直接重试或切换模型。',
           }
           // error_during_execution 等执行期错误：优先展示 SDK result.errors[] 携带的真实原因，
           // 让用户能据此判断重试 / 改提问 / 报 bug，而非只看到泛泛的兜底文案。


### PR DESCRIPTION
Fixes Agent send flows so user prompts are persisted before preflight/model checks, empty SDK completions become visible errors, and stale queue channels fall back to a fresh run instead of trapping the next message.

The root cause was that several failure paths could complete before a user message or assistant error was written, while completion notifications still treated those turns as successful.

This also suppresses success completion sounds for error or interrupted completions and bumps @proma/electron to 0.14.16.

Validated with `cd apps/electron && bun run typecheck`, `bun test`, and `git diff --check`.