### PR TITLE
Add scratch side pane support

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.14.16",
+  "version": "0.14.17",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/atoms/tab-atoms.ts
+++ b/apps/electron/src/renderer/atoms/tab-atoms.ts
@@ -117,6 +117,15 @@ export const tabMinimapCacheAtom = atom<Map<string, TabMinimapItem[]>>(new Map()
 export const scratchPadContentAtom = atom<string>('')
 /** Scratch Pad 内容是否已从磁盘加载 */
 export const scratchPadLoadedAtom = atom<boolean>(false)
+/** Scratch Pad 是否固定在 Agent 右侧分屏；通过拖出 Scratch Tab 打开 */
+export const scratchPadPanelOpenAtom = atom<boolean>(false)
+/** 右侧工作区中 Preview 与 Scratch 并排时，Preview 占比 */
+export const rightWorkspaceSplitRatioAtom = atomWithStorage<number>(
+  'proma-right-workspace-split-ratio',
+  0.58,
+  undefined,
+  { getOnInit: true },
+)
 
 // ===== 派生 Atoms =====
 

--- a/apps/electron/src/renderer/components/diff/preview-opener.ts
+++ b/apps/electron/src/renderer/components/diff/preview-opener.ts
@@ -113,4 +113,3 @@ export function tearOffPreviewToSplit(store: JotaiStore, tabId: string): void {
     return m
   })
 }
-

--- a/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
+++ b/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
@@ -12,8 +12,8 @@ import { useEditor, EditorContent } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import Placeholder from '@tiptap/extension-placeholder'
 import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
-import { useAtom, useAtomValue, useSetAtom } from 'jotai'
-import { FileDown } from 'lucide-react'
+import { useAtom, useAtomValue, useSetAtom, useStore } from 'jotai'
+import { FileDown, PanelRight, X } from 'lucide-react'
 import { toast } from 'sonner'
 import { scratchPadContentAtom, scratchPadLoadedAtom, tabsAtom, activeTabIdAtom } from '@/atoms/tab-atoms'
 import {
@@ -57,6 +57,8 @@ import {
 } from '@/lib/voice-input-focus'
 import { SelectionActionPopover } from '@/components/selection/SelectionActionPopover'
 import { SELECTION_ACTION_POPOVER_SELECTOR } from '@/lib/quoted-selection'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { openScratchInSplit } from './scratch-pad-opener'
 
 const MAX_SCRATCH_PAD_QUOTED_CHARS = 2000
 
@@ -64,6 +66,14 @@ interface ScratchPadSelection {
   text: string
   x: number
   y: number
+}
+
+interface ScratchPadPaneProps {
+  onClose: () => void
+}
+
+interface ScratchPadEditorProps {
+  variant: 'page' | 'pane'
 }
 
 function normalizeSelectionText(text: string): string {
@@ -76,8 +86,47 @@ function getElementFromNode(node: Node | null): Element | null {
 }
 
 export function ScratchPadView(): React.ReactElement {
+  return <ScratchPadEditor variant="page" />
+}
+
+export function ScratchPadPane({ onClose }: ScratchPadPaneProps): React.ReactElement {
+  return (
+    <div className="flex h-full flex-col overflow-hidden bg-content-area titlebar-no-drag">
+      <div className="flex-shrink-0 border-b border-border/30 titlebar-no-drag">
+        <div className="flex h-[34px] items-center px-3">
+          <span className="truncate text-xs text-muted-foreground">
+            草稿
+          </span>
+          <div className="ml-auto flex shrink-0 items-center gap-0.5">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+                  aria-label="关闭草稿分屏"
+                >
+                  <X className="size-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                <p>关闭草稿分屏</p>
+              </TooltipContent>
+            </Tooltip>
+          </div>
+        </div>
+      </div>
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <ScratchPadEditor variant="pane" />
+      </div>
+    </div>
+  )
+}
+
+function ScratchPadEditor({ variant }: ScratchPadEditorProps): React.ReactElement {
   const [content, setContent] = useAtom(scratchPadContentAtom)
   const loaded = useAtomValue(scratchPadLoadedAtom)
+  const store = useStore()
   const containerRef = React.useRef<HTMLDivElement>(null)
   const [selection, setSelection] = React.useState<ScratchPadSelection | null>(null)
   const pointerSelectingRef = React.useRef(false)
@@ -152,6 +201,13 @@ export function ScratchPadView(): React.ReactElement {
     const agentTab = tabs.find((t) => t.sessionId === activeSessionId && t.type === 'agent')
     return agentTab?.title ?? null
   }, [tabs, activeSessionId])
+
+  const handleOpenScratchPanel = React.useCallback((): void => {
+    const opened = openScratchInSplit(store)
+    if (!opened) {
+      toast.info('先打开一个 Agent 会话，再把草稿放到右侧。')
+    }
+  }, [store])
 
   const clearSelection = React.useCallback((): void => {
     setSelection(null)
@@ -496,23 +552,56 @@ export function ScratchPadView(): React.ReactElement {
     return () => el.removeEventListener('paste', handlePaste, true)
   }, [editor])
 
+  const isPane = variant === 'pane'
+  const scrollClassName = isPane
+    ? 'flex-1 overflow-auto scrollbar-thin px-4 pt-4 pb-20'
+    : 'flex-1 overflow-auto scrollbar-thin px-8 pt-6 pb-20'
+  const contentClassName = isPane ? 'h-full max-w-none' : 'max-w-3xl mx-auto h-full'
+  const speechWrapperClassName = isPane
+    ? 'absolute left-1/2 -translate-x-1/2 bottom-9 z-20'
+    : 'absolute left-1/2 -translate-x-1/2 bottom-10 z-20'
+  const speechButtonClassName = isPane
+    ? 'size-9 rounded-full bg-background/95 border border-border/60 shadow-md backdrop-blur hover:bg-accent text-foreground/80'
+    : 'size-11 rounded-full bg-background/95 border border-border/60 shadow-md backdrop-blur hover:bg-accent text-foreground/80'
+
   return (
     <div ref={containerRef} className="relative flex flex-col h-full">
-      <div className="flex-1 overflow-auto scrollbar-thin px-8 pt-6 pb-20">
-        <div className="max-w-3xl mx-auto h-full">
-          <div className="mb-5 flex flex-col gap-2">
-            <div>
-              <h1 className="text-xl font-semibold tracking-normal text-foreground">草稿页</h1>
-              <p className="mt-1 text-[13px] leading-5 text-muted-foreground">
-                临时记录内容、整理 Todo、暂存剪贴板文本，稍后再导出到会话或工作区。
-              </p>
+      <div className={scrollClassName}>
+        <div className={contentClassName}>
+          {isPane ? (
+            <div className="mb-3 text-[11px] text-muted-foreground">自动保存到本地</div>
+          ) : (
+            <div className="mb-5 flex flex-col gap-2">
+              <div className="flex items-start gap-3">
+                <div className="min-w-0 flex-1">
+                  <h1 className="text-xl font-semibold tracking-normal text-foreground">草稿页</h1>
+                  <p className="mt-1 text-[13px] leading-5 text-muted-foreground">
+                    临时记录内容、整理 Todo、暂存剪贴板文本，稍后再导出到会话或工作区。
+                  </p>
+                </div>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={handleOpenScratchPanel}
+                      className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+                      aria-label="在右侧边栏打开草稿"
+                    >
+                      <PanelRight className="size-4" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    <p>在右侧边栏打开草稿（也可将草稿 Tab 拖出标签栏）</p>
+                  </TooltipContent>
+                </Tooltip>
+              </div>
+              <div className="flex flex-wrap gap-1.5 text-[11px] text-muted-foreground/80">
+                <span className="rounded-md bg-muted px-2 py-1">临时笔记</span>
+                <span className="rounded-md bg-muted px-2 py-1">Todo 草稿</span>
+                <span className="rounded-md bg-muted px-2 py-1">剪贴板暂存</span>
+              </div>
             </div>
-            <div className="flex flex-wrap gap-1.5 text-[11px] text-muted-foreground/80">
-              <span className="rounded-md bg-muted px-2 py-1">临时笔记</span>
-              <span className="rounded-md bg-muted px-2 py-1">Todo 草稿</span>
-              <span className="rounded-md bg-muted px-2 py-1">剪贴板暂存</span>
-            </div>
-          </div>
+          )}
           {loaded ? (
             <EditorContent
               editor={editor}
@@ -534,12 +623,12 @@ export function ScratchPadView(): React.ReactElement {
         />
       )}
       {/* 底部居中悬浮：圆形语音输入按钮 */}
-      <div className="absolute left-1/2 -translate-x-1/2 bottom-10 z-20">
-        <SpeechButton className="size-11 rounded-full bg-background/95 border border-border/60 shadow-md backdrop-blur hover:bg-accent text-foreground/80" />
+      <div className={speechWrapperClassName}>
+        <SpeechButton className={speechButtonClassName} />
       </div>
       <div className="h-[28px] border-t border-border/40 px-4 flex items-center justify-between">
         <span className="text-[11px] text-muted-foreground/60">
-          Scratch Pad — 内容自动保存到本地
+          {isPane ? '草稿自动保存' : 'Scratch Pad — 内容自动保存到本地'}
         </span>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>

--- a/apps/electron/src/renderer/components/scratch-pad/scratch-pad-opener.ts
+++ b/apps/electron/src/renderer/components/scratch-pad/scratch-pad-opener.ts
@@ -59,8 +59,8 @@ export function openScratchInSplit(store: JotaiStore): boolean {
   const agentTab = findTargetAgentTab(tabs, sessions, currentSessionId)
   if (!agentTab) return false
 
-  const scratch = tabs.find((tab) => tab.id === SCRATCH_PAD_ID) ?? scratchTab
-  const nextTabs = [scratch, agentTab]
+  const hasAgentTab = tabs.some((tab) => tab.id === agentTab.id)
+  const nextTabs = hasAgentTab ? tabs : [...tabs, agentTab]
   store.set(tabsAtom, nextTabs)
   store.set(activeTabIdAtom, agentTab.id)
   store.set(appModeAtom, 'agent')

--- a/apps/electron/src/renderer/components/scratch-pad/scratch-pad-opener.ts
+++ b/apps/electron/src/renderer/components/scratch-pad/scratch-pad-opener.ts
@@ -10,6 +10,7 @@ import {
   activeTabIdAtom,
   scratchPadPanelOpenAtom,
   SCRATCH_PAD_ID,
+  SCRATCH_PAD_TITLE,
   tabsAtom,
   type TabItem,
 } from '@/atoms/tab-atoms'
@@ -29,6 +30,15 @@ interface ScratchPadAgentSession {
 }
 
 type JotaiStore = ReturnType<typeof useStore>
+
+function createScratchTab(): TabItem {
+  return {
+    id: SCRATCH_PAD_ID,
+    type: 'scratch',
+    sessionId: SCRATCH_PAD_ID,
+    title: SCRATCH_PAD_TITLE,
+  }
+}
 
 function findTargetAgentTab(
   tabs: TabItem[],
@@ -82,4 +92,12 @@ export function openScratchInSplit(store: JotaiStore): boolean {
 
 export function tearOffScratchToSplit(store: JotaiStore): void {
   openScratchInSplit(store)
+}
+
+export function closeScratchInSplit(store: JotaiStore): void {
+  const tabs = store.get(tabsAtom)
+  store.set(scratchPadPanelOpenAtom, false)
+
+  if (tabs.some((tab) => tab.id === SCRATCH_PAD_ID)) return
+  store.set(tabsAtom, [createScratchTab(), ...tabs])
 }

--- a/apps/electron/src/renderer/components/scratch-pad/scratch-pad-opener.ts
+++ b/apps/electron/src/renderer/components/scratch-pad/scratch-pad-opener.ts
@@ -1,0 +1,84 @@
+/**
+ * Scratch Pad 侧边分屏入口。
+ *
+ * 与 Preview tear-off 保持同一交互：回到最近的 Agent 会话，
+ * 并把草稿固定到右侧分屏。
+ */
+
+import type { useStore } from 'jotai'
+import {
+  activeTabIdAtom,
+  scratchPadPanelOpenAtom,
+  SCRATCH_PAD_ID,
+  tabsAtom,
+  type TabItem,
+} from '@/atoms/tab-atoms'
+import {
+  agentSessionsAtom,
+  currentAgentSessionIdAtom,
+  currentAgentWorkspaceIdAtom,
+} from '@/atoms/agent-atoms'
+import { appModeAtom } from '@/atoms/app-mode'
+import { currentConversationIdAtom } from '@/atoms/chat-atoms'
+
+interface ScratchPadAgentSession {
+  id: string
+  title: string
+  archived?: boolean
+  workspaceId?: string
+}
+
+type JotaiStore = ReturnType<typeof useStore>
+
+function findTargetAgentTab(
+  tabs: TabItem[],
+  sessions: ScratchPadAgentSession[],
+  currentSessionId: string | null,
+): TabItem | null {
+  const existingAgentTab = [...tabs].reverse().find((tab) => tab.type === 'agent')
+  if (existingAgentTab) return existingAgentTab
+  if (!currentSessionId) return null
+
+  const session = sessions?.find((item) => item.id === currentSessionId && !item.archived)
+  if (!session) return null
+  return {
+    id: session.id,
+    type: 'agent',
+    sessionId: session.id,
+    title: session.title || 'Agent 会话',
+  }
+}
+
+export function openScratchInSplit(store: JotaiStore): boolean {
+  const tabs = store.get(tabsAtom)
+  const scratchTab = tabs.find((tab) => tab.id === SCRATCH_PAD_ID && tab.type === 'scratch')
+  if (!scratchTab) return false
+
+  const sessions = store.get(agentSessionsAtom)
+  const currentSessionId = store.get(currentAgentSessionIdAtom)
+  const agentTab = findTargetAgentTab(tabs, sessions, currentSessionId)
+  if (!agentTab) return false
+
+  const scratch = tabs.find((tab) => tab.id === SCRATCH_PAD_ID) ?? scratchTab
+  const nextTabs = [scratch, agentTab]
+  store.set(tabsAtom, nextTabs)
+  store.set(activeTabIdAtom, agentTab.id)
+  store.set(appModeAtom, 'agent')
+  store.set(currentConversationIdAtom, null)
+  store.set(currentAgentSessionIdAtom, agentTab.sessionId)
+
+  const session = sessions.find((item) => item.id === agentTab.sessionId)
+  if (session?.workspaceId) {
+    store.set(currentAgentWorkspaceIdAtom, session.workspaceId)
+    window.electronAPI.updateSettings({
+      agentWorkspaceId: session.workspaceId,
+    }).catch(console.error)
+  }
+
+  store.set(scratchPadPanelOpenAtom, true)
+  return true
+}
+
+export function tearOffScratchToSplit(store: JotaiStore): void {
+  openScratchInSplit(store)
+}

--- a/apps/electron/src/renderer/components/scratch-pad/scratch-pad-opener.ts
+++ b/apps/electron/src/renderer/components/scratch-pad/scratch-pad-opener.ts
@@ -59,8 +59,9 @@ export function openScratchInSplit(store: JotaiStore): boolean {
   const agentTab = findTargetAgentTab(tabs, sessions, currentSessionId)
   if (!agentTab) return false
 
-  const hasAgentTab = tabs.some((tab) => tab.id === agentTab.id)
-  const nextTabs = hasAgentTab ? tabs : [...tabs, agentTab]
+  const baseTabs = tabs.filter((tab) => tab.id !== SCRATCH_PAD_ID)
+  const hasAgentTab = baseTabs.some((tab) => tab.id === agentTab.id)
+  const nextTabs = hasAgentTab ? baseTabs : [...baseTabs, agentTab]
   store.set(tabsAtom, nextTabs)
   store.set(activeTabIdAtom, agentTab.id)
   store.set(appModeAtom, 'agent')

--- a/apps/electron/src/renderer/components/tabs/MainArea.tsx
+++ b/apps/electron/src/renderer/components/tabs/MainArea.tsx
@@ -8,11 +8,18 @@
 
 import * as React from 'react'
 import { useAtomValue, useSetAtom, useAtom } from 'jotai'
-import { tabsAtom, activeTabIdAtom, activeTabAtom } from '@/atoms/tab-atoms'
+import {
+  tabsAtom,
+  activeTabIdAtom,
+  activeTabAtom,
+  scratchPadPanelOpenAtom,
+  rightWorkspaceSplitRatioAtom,
+} from '@/atoms/tab-atoms'
 import { Panel } from '@/components/app-shell/Panel'
 import { WelcomeView } from '@/components/welcome/WelcomeView'
 import { previewPanelOpenMapAtom, previewSplitRatioAtom } from '@/atoms/preview-atoms'
 import { PreviewPanel } from '@/components/diff/PreviewPanel'
+import { ScratchPadPane } from '@/components/scratch-pad/ScratchPadView'
 import { useTrackSessionView } from '@/hooks/useTrackSessionView'
 import { TabBar } from './TabBar'
 import { TabContent } from './TabContent'
@@ -44,11 +51,16 @@ export function MainArea(): React.ReactElement {
 
   const previewOpenMap = useAtomValue(previewPanelOpenMapAtom)
   const [splitRatio, setSplitRatio] = useAtom(previewSplitRatioAtom)
+  const [rightWorkspaceRatio, setRightWorkspaceRatio] = useAtom(rightWorkspaceSplitRatioAtom)
   const previewDragging = React.useRef(false)
+  const rightWorkspaceDragging = React.useRef(false)
 
   const previewOpen =
     activeTab?.type === 'agent' && (previewOpenMap.get(activeTab.sessionId) ?? false)
   const previewSessionId = activeTab?.type === 'agent' ? activeTab.sessionId : null
+  const [scratchPanelOpen, setScratchPanelOpen] = useAtom(scratchPadPanelOpenAtom)
+  const showScratchPanel =
+    activeTab?.type === 'agent' && scratchPanelOpen && activeView === 'conversations'
 
   // 关闭动画状态：当 previewOpen 从 true → false 时，播放退出动画再移除 DOM
   // 在 render 阶段同步派生 closing，避免中间帧出现 flex: 1 1 auto 导致左侧瞬间跳到 100% 宽
@@ -73,6 +85,9 @@ export function MainArea(): React.ReactElement {
   }, [previewOpen, previewSessionId])
 
   const showPreview = (previewOpen || closing) && previewSessionId && activeView === 'conversations'
+  const showPreviewClosingOnly = closing && !previewOpen
+  const showPreviewPane = !!showPreview && !(showPreviewClosingOnly && showScratchPanel)
+  const showBothRightPanels = showPreviewPane && showScratchPanel
 
   const handlePreviewDragStart = React.useCallback((e: React.MouseEvent) => {
     e.preventDefault()
@@ -110,6 +125,42 @@ export function MainArea(): React.ReactElement {
     document.addEventListener('mouseup', onMouseUp)
   }, [splitRatio, setSplitRatio])
 
+  const handleRightWorkspaceDragStart = React.useCallback((e: React.MouseEvent) => {
+    e.preventDefault()
+    rightWorkspaceDragging.current = true
+    const startX = e.clientX
+    const startRatio = rightWorkspaceRatio
+    const containerEl = (e.currentTarget as HTMLElement).closest('[data-right-workspace]') as HTMLElement | null
+    const containerWidth = containerEl?.clientWidth ?? 1
+    let rafId = 0
+
+    document.body.style.userSelect = 'none'
+    document.body.style.cursor = 'col-resize'
+    document.querySelectorAll('iframe').forEach((f) => { (f as HTMLElement).style.pointerEvents = 'none' })
+
+    const onMouseMove = (ev: MouseEvent) => {
+      if (!rightWorkspaceDragging.current) return
+      if (rafId) return
+      rafId = requestAnimationFrame(() => {
+        rafId = 0
+        const delta = ev.clientX - startX
+        const newRatio = Math.max(0.3, Math.min(0.7, startRatio + delta / containerWidth))
+        setRightWorkspaceRatio(newRatio)
+      })
+    }
+    const onMouseUp = () => {
+      rightWorkspaceDragging.current = false
+      if (rafId) cancelAnimationFrame(rafId)
+      document.body.style.userSelect = ''
+      document.body.style.cursor = ''
+      document.querySelectorAll('iframe').forEach((f) => { (f as HTMLElement).style.pointerEvents = '' })
+      document.removeEventListener('mousemove', onMouseMove)
+      document.removeEventListener('mouseup', onMouseUp)
+    }
+    document.addEventListener('mousemove', onMouseMove)
+    document.addEventListener('mouseup', onMouseUp)
+  }, [rightWorkspaceRatio, setRightWorkspaceRatio])
+
   React.useEffect(() => {
     if (tabs.length === 0) {
       console.warn('[FLASH-DEBUG] MainArea: tabs.length === 0, showing WelcomeView!', new Error().stack)
@@ -136,10 +187,17 @@ export function MainArea(): React.ReactElement {
       }
     : undefined
 
-  // 左侧容器宽度：预览打开时固定占 splitRatio；其他情况（含 closing 动画期间）
+  // 左侧容器宽度：右侧工作区打开时固定占 splitRatio；其他情况（含 closing 动画期间）
   // 直接 1 1 auto 占满——closing 时右侧 absolute 脱离 flex 流，所以左侧自然占 100%。
-  const leftFlexStyle: React.CSSProperties = (previewOpen && previewSessionId && activeView === 'conversations')
+  const showRightPanel = showScratchPanel || showPreviewPane
+  const leftFlexStyle: React.CSSProperties = showRightPanel
     ? { flex: `0 0 calc(${splitRatio * 100}% - 6px)` }
+    : { flex: '1 1 auto' }
+  const previewPaneStyle: React.CSSProperties = showBothRightPanels
+    ? { flex: `0 0 calc(${rightWorkspaceRatio * 100}% - 4px)` }
+    : { flex: '1 1 auto' }
+  const scratchPaneStyle: React.CSSProperties = showBothRightPanels
+    ? { flex: `0 0 calc(${(1 - rightWorkspaceRatio) * 100}% - 4px)` }
     : { flex: '1 1 auto' }
 
   return (
@@ -185,23 +243,38 @@ export function MainArea(): React.ReactElement {
             )}
           </div>
 
-          {/* 右侧：预览面板。关闭动画期间脱离 flex 流，向右滑出 */}
-          {showPreview && (
+          {/* 右侧：预览/草稿工作区。Preview 和草稿可在同一右侧槽位内并排显示。 */}
+          {showRightPanel && (
             <div
-              className={closing ? 'animate-preview-slide-out' : 'flex flex-1 min-w-0'}
-              style={closingOverlayStyle}
+              className={cn(closing && !showScratchPanel ? 'animate-preview-slide-out' : 'flex flex-1 min-w-0')}
+              style={closing && !showScratchPanel ? closingOverlayStyle : undefined}
               onAnimationEnd={(e) => {
                 if (closing && e.target === e.currentTarget) setClosingState(false)
               }}
             >
-              {!closing && (
+              {!(closing && !showScratchPanel) && (
                 <div
                   className="w-[8px] cursor-col-resize bg-border/40 hover:bg-primary/30 active:bg-primary/50 transition-colors flex-shrink-0 self-stretch"
                   onMouseDown={handlePreviewDragStart}
                 />
               )}
-              <div className="flex-1 min-w-0 h-full overflow-hidden">
-                <PreviewPanel sessionId={previewSessionId} />
+              <div className="flex flex-1 min-w-0 h-full overflow-hidden" data-right-workspace>
+                {showPreviewPane && previewSessionId && (
+                  <div className="min-w-[260px] h-full overflow-hidden" style={previewPaneStyle}>
+                    <PreviewPanel sessionId={previewSessionId} />
+                  </div>
+                )}
+                {showBothRightPanels && (
+                  <div
+                    className="w-[8px] cursor-col-resize bg-border/40 hover:bg-primary/30 active:bg-primary/50 transition-colors flex-shrink-0 self-stretch"
+                    onMouseDown={handleRightWorkspaceDragStart}
+                  />
+                )}
+                {showScratchPanel && (
+                  <div className="min-w-[260px] h-full overflow-hidden" style={scratchPaneStyle}>
+                    <ScratchPadPane onClose={() => setScratchPanelOpen(false)} />
+                  </div>
+                )}
               </div>
             </div>
           )}

--- a/apps/electron/src/renderer/components/tabs/MainArea.tsx
+++ b/apps/electron/src/renderer/components/tabs/MainArea.tsx
@@ -161,6 +161,10 @@ export function MainArea(): React.ReactElement {
     document.addEventListener('mouseup', onMouseUp)
   }, [rightWorkspaceRatio, setRightWorkspaceRatio])
 
+  const handleCloseScratchPanel = React.useCallback(() => {
+    setScratchPanelOpen(false)
+  }, [setScratchPanelOpen])
+
   React.useEffect(() => {
     if (tabs.length === 0) {
       console.warn('[FLASH-DEBUG] MainArea: tabs.length === 0, showing WelcomeView!', new Error().stack)
@@ -272,7 +276,7 @@ export function MainArea(): React.ReactElement {
                 )}
                 {showScratchPanel && (
                   <div className="min-w-[260px] h-full overflow-hidden" style={scratchPaneStyle}>
-                    <ScratchPadPane onClose={() => setScratchPanelOpen(false)} />
+                    <ScratchPadPane onClose={handleCloseScratchPanel} />
                   </div>
                 )}
               </div>

--- a/apps/electron/src/renderer/components/tabs/MainArea.tsx
+++ b/apps/electron/src/renderer/components/tabs/MainArea.tsx
@@ -7,7 +7,7 @@
  */
 
 import * as React from 'react'
-import { useAtomValue, useSetAtom, useAtom } from 'jotai'
+import { useAtomValue, useSetAtom, useAtom, useStore } from 'jotai'
 import {
   tabsAtom,
   activeTabIdAtom,
@@ -20,6 +20,7 @@ import { WelcomeView } from '@/components/welcome/WelcomeView'
 import { previewPanelOpenMapAtom, previewSplitRatioAtom } from '@/atoms/preview-atoms'
 import { PreviewPanel } from '@/components/diff/PreviewPanel'
 import { ScratchPadPane } from '@/components/scratch-pad/ScratchPadView'
+import { closeScratchInSplit } from '@/components/scratch-pad/scratch-pad-opener'
 import { useTrackSessionView } from '@/hooks/useTrackSessionView'
 import { TabBar } from './TabBar'
 import { TabContent } from './TabContent'
@@ -43,6 +44,7 @@ export function MainArea(): React.ReactElement {
   const activeView = useAtomValue(activeViewAtom)
   const interfaceVariant = useAtomValue(interfaceVariantAtom)
   const isClassic = interfaceVariant === 'classic'
+  const store = useStore()
 
   // Tab 内容渲染降级为非紧急：TabBar 立即高亮新 tab，主区域昂贵渲染（含 PreviewPanel 中
   // DiffTabContent → ProseMirror editor mount + Shiki tokenize）让出主线程，避免点击 tab
@@ -58,7 +60,7 @@ export function MainArea(): React.ReactElement {
   const previewOpen =
     activeTab?.type === 'agent' && (previewOpenMap.get(activeTab.sessionId) ?? false)
   const previewSessionId = activeTab?.type === 'agent' ? activeTab.sessionId : null
-  const [scratchPanelOpen, setScratchPanelOpen] = useAtom(scratchPadPanelOpenAtom)
+  const scratchPanelOpen = useAtomValue(scratchPadPanelOpenAtom)
   const showScratchPanel =
     activeTab?.type === 'agent' && scratchPanelOpen && activeView === 'conversations'
 
@@ -162,8 +164,8 @@ export function MainArea(): React.ReactElement {
   }, [rightWorkspaceRatio, setRightWorkspaceRatio])
 
   const handleCloseScratchPanel = React.useCallback(() => {
-    setScratchPanelOpen(false)
-  }, [setScratchPanelOpen])
+    closeScratchInSplit(store)
+  }, [store])
 
   React.useEffect(() => {
     if (tabs.length === 0) {

--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -30,6 +30,7 @@ import {
 import { appModeAtom } from '@/atoms/app-mode'
 import { automationFormAtom } from '@/atoms/automation-atoms'
 import { tearOffPreviewToSplit } from '@/components/diff/preview-opener'
+import { tearOffScratchToSplit } from '@/components/scratch-pad/scratch-pad-opener'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { TabBarItem } from './TabBarItem'
@@ -59,12 +60,19 @@ export function TabBar(): React.ReactElement {
   const store = useStore()
 
   /**
-   * Tear-off：把 preview Tab 拖出 TabBar 时，转成右侧分屏预览。
-   * 公共实现在 preview-opener.ts，PreviewTabContent 顶栏切换按钮共用同一份逻辑。
+   * Tear-off：把 preview/scratch Tab 拖出 TabBar 时，转成 Agent 右侧分屏。
+   * preview 公共实现在 preview-opener.ts，PreviewTabContent 顶栏切换按钮共用同一份逻辑。
    */
   const handleTearOff = React.useCallback((tabId: string) => {
-    tearOffPreviewToSplit(store, tabId)
-  }, [store])
+    const tab = tabs.find((item) => item.id === tabId)
+    if (tab?.type === 'preview') {
+      tearOffPreviewToSplit(store, tabId)
+      return
+    }
+    if (tab?.type === 'scratch') {
+      tearOffScratchToSplit(store)
+    }
+  }, [store, tabs])
 
   const workspaceNameBySessionId = React.useMemo(() => {
     const workspaceNameMap = new Map(agentWorkspaces.map((workspace) => [workspace.id, workspace.name]))
@@ -240,14 +248,14 @@ function TabBarInner({
   // 整条 TabBar 容器 ref，用于拖拽 tear-off 时检测鼠标是否离开 TabBar 区域
   const barRef = React.useRef<HTMLDivElement>(null)
 
-  // 拖出 TabBar 区域时给出视觉提示（仅 preview Tab 可 tear-off）
+  // 拖出 TabBar 区域时给出视觉提示（preview/scratch Tab 可 tear-off）
   const [tearingOff, setTearingOff] = React.useState<string | null>(null)
 
-  // 拦截外层 handleDragStart：若拖出 TabBar 区域且是 preview Tab，触发 tear-off
+  // 拦截外层 handleDragStart：若拖出 TabBar 区域且是 preview/scratch Tab，触发 tear-off
   const handleDragStartWithTearOff = React.useCallback((tabId: string, e: React.PointerEvent) => {
     const tab = tabs.find((t) => t.id === tabId)
-    // 仅 preview Tab 支持拖出转分屏
-    if (!tab || tab.type !== 'preview') {
+    // 仅 preview / scratch Tab 支持拖出转分屏
+    if (!tab || (tab.type !== 'preview' && tab.type !== 'scratch')) {
       onDragStart(tabId, e)
       return
     }


### PR DESCRIPTION
## Summary

Adds a Scratch side pane that can be opened from the Scratch page or by dragging the Scratch tab out of the tab bar. Preview and Scratch can now stay open together in the Agent right workspace with an adjustable split. The Scratch pane header and close behavior are aligned with Preview, and @proma/electron is bumped to 0.14.17.

## Validation

- bun run --filter='@proma/electron' typecheck\n- git diff --check\n- bun run --filter='@proma/electron' build:renderer