### PR TITLE
feat(image): 图片预览支持多图翻页

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -2512,17 +2512,28 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
             {/* 附件 + 引用选中文本 Chip（同排并排） */}
             {(pendingFiles.length > 0 || currentQuotedSelection) && (
               <div className="flex flex-wrap gap-2 px-3 pt-2.5 pb-1.5">
-                {pendingFiles.map((file) => (
-                  <AttachmentPreviewItem
-                    key={file.id}
-                    filename={file.filename}
-                    mediaType={file.mediaType}
-                    previewUrl={file.previewUrl}
-                    onRemove={() => handleRemoveFile(file.id)}
-                    onClick={file.filename.startsWith('clipboard-') ? () => handleClipboardPreview(file) : undefined}
-                    onEditComplete={(editedDataUrl) => handleAttachmentEditComplete(file.id, editedDataUrl)}
-                  />
-                ))}
+                {(() => {
+                  // 同批图片附件 — 用于大图预览时左右翻页
+                  const imageFiles = pendingFiles.filter((f) => f.mediaType.startsWith('image/') && !!f.previewUrl)
+                  const imageSiblings = imageFiles.map((f) => ({
+                    previewUrl: f.previewUrl as string,
+                    filename: f.filename,
+                    onEditComplete: (editedDataUrl: string) => handleAttachmentEditComplete(f.id, editedDataUrl),
+                  }))
+                  return pendingFiles.map((file) => (
+                    <AttachmentPreviewItem
+                      key={file.id}
+                      filename={file.filename}
+                      mediaType={file.mediaType}
+                      previewUrl={file.previewUrl}
+                      onRemove={() => handleRemoveFile(file.id)}
+                      onClick={file.filename.startsWith('clipboard-') ? () => handleClipboardPreview(file) : undefined}
+                      onEditComplete={(editedDataUrl) => handleAttachmentEditComplete(file.id, editedDataUrl)}
+                      imageSiblings={imageSiblings}
+                      siblingIndex={imageFiles.findIndex((f) => f.id === file.id)}
+                    />
+                  ))
+                })()}
                 {currentQuotedSelection && (
                   <QuotedSelectionChip
                     text={currentQuotedSelection.text}

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -2444,6 +2444,20 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     </Button>
   )
 
+  // 同批图片附件 — 用于大图预览时左右翻页（提取到 useMemo 避免每次渲染重建）
+  const pendingImageFiles = React.useMemo(
+    () => pendingFiles.filter((f) => f.mediaType.startsWith('image/') && !!f.previewUrl),
+    [pendingFiles]
+  )
+  const imageSiblingsForPending = React.useMemo(
+    () => pendingImageFiles.map((f) => ({
+      previewUrl: f.previewUrl as string,
+      filename: f.filename,
+      onEditComplete: (editedDataUrl: string) => handleAttachmentEditComplete(f.id, editedDataUrl),
+    })),
+    [pendingImageFiles, handleAttachmentEditComplete]
+  )
+
   return (
     <>
     <AgentSessionProvider sessionId={sessionId}>
@@ -2512,15 +2526,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
             {/* 附件 + 引用选中文本 Chip（同排并排） */}
             {(pendingFiles.length > 0 || currentQuotedSelection) && (
               <div className="flex flex-wrap gap-2 px-3 pt-2.5 pb-1.5">
-                {(() => {
-                  // 同批图片附件 — 用于大图预览时左右翻页
-                  const imageFiles = pendingFiles.filter((f) => f.mediaType.startsWith('image/') && !!f.previewUrl)
-                  const imageSiblings = imageFiles.map((f) => ({
-                    previewUrl: f.previewUrl as string,
-                    filename: f.filename,
-                    onEditComplete: (editedDataUrl: string) => handleAttachmentEditComplete(f.id, editedDataUrl),
-                  }))
-                  return pendingFiles.map((file) => (
+                {pendingFiles.map((file) => (
                     <AttachmentPreviewItem
                       key={file.id}
                       filename={file.filename}
@@ -2529,11 +2535,10 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
                       onRemove={() => handleRemoveFile(file.id)}
                       onClick={file.filename.startsWith('clipboard-') ? () => handleClipboardPreview(file) : undefined}
                       onEditComplete={(editedDataUrl) => handleAttachmentEditComplete(file.id, editedDataUrl)}
-                      imageSiblings={imageSiblings}
-                      siblingIndex={imageFiles.findIndex((f) => f.id === file.id)}
+                      imageSiblings={imageSiblingsForPending}
+                      siblingIndex={pendingImageFiles.findIndex((f) => f.id === file.id)}
                     />
-                  ))
-                })()}
+                  ))}
                 {currentQuotedSelection && (
                   <QuotedSelectionChip
                     text={currentQuotedSelection.text}

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -15,7 +15,7 @@ import * as React from 'react'
 import { Bot, Loader2, AlertTriangle, FileText, FileImage, Download, Split, Undo2, RotateCw, Plus, Minimize2, Wrench, Settings, Cpu, ExternalLink, Quote, Clock } from 'lucide-react'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { cn } from '@/lib/utils'
-import { ImageLightbox } from '@/components/ui/image-lightbox'
+import { ImageLightbox, type LightboxImage } from '@/components/ui/image-lightbox'
 import { ContentBlock } from './ContentBlock'
 import { TaskProgressCard } from './TaskProgressCard'
 import { TurnFileChangesSummary } from './TurnFileChangesSummary'
@@ -756,9 +756,16 @@ export function isImageFile(filename: string): boolean {
 }
 
 /** 图片附件缩略图，点击可预览大图 */
-function AttachedImageThumb({ file, onEditComplete }: { file: AttachedFileRef; onEditComplete?: (editedDataUrl: string) => void }): React.ReactElement {
+function AttachedImageThumb({ file, index, onOpen, onLoaded }: {
+  file: AttachedFileRef
+  /** 该图在同批图片中的索引 */
+  index: number
+  /** 点击缩略图打开大图预览（第 index 张） */
+  onOpen: (index: number) => void
+  /** 图片 src 加载完成上报父组件（供共享 lightbox 翻页使用） */
+  onLoaded: (path: string, src: string) => void
+}): React.ReactElement {
   const [imageSrc, setImageSrc] = React.useState<string | null>(null)
-  const [lightboxOpen, setLightboxOpen] = React.useState(false)
 
   React.useEffect(() => {
     const ext = file.filename.split('.').pop()?.toLowerCase() ?? 'png'
@@ -770,9 +777,13 @@ function AttachedImageThumb({ file, onEditComplete }: { file: AttachedFileRef; o
 
     window.electronAPI
       .readAttachment(file.path)
-      .then((base64) => setImageSrc(`data:${mediaType};base64,${base64}`))
+      .then((base64) => {
+        const src = `data:${mediaType};base64,${base64}`
+        setImageSrc(src)
+        onLoaded(file.path, src)
+      })
       .catch((err) => console.error('[AttachedImageThumb] 读取附件失败:', err))
-  }, [file.path, file.filename])
+  }, [file.path, file.filename, onLoaded])
 
   const handleSave = React.useCallback((): void => {
     window.electronAPI.saveImageAs(file.path, file.filename)
@@ -788,7 +799,7 @@ function AttachedImageThumb({ file, onEditComplete }: { file: AttachedFileRef; o
         src={imageSrc}
         alt={file.filename}
         className="max-w-[300px] max-h-[200px] rounded-lg object-contain cursor-pointer"
-        onClick={() => setLightboxOpen(true)}
+        onClick={() => onOpen(index)}
       />
       <button
         type="button"
@@ -798,14 +809,6 @@ function AttachedImageThumb({ file, onEditComplete }: { file: AttachedFileRef; o
       >
         <Download className="size-4" />
       </button>
-      <ImageLightbox
-        src={imageSrc}
-        alt={file.filename}
-        open={lightboxOpen}
-        onOpenChange={setLightboxOpen}
-        onSave={handleSave}
-        onEditComplete={onEditComplete}
-      />
     </div>
   )
 }
@@ -934,6 +937,32 @@ function UserInputMessage({ message }: { message: SDKUserMessage }): React.React
     })
   }, [activeSessionId, setSessionPendingFiles])
 
+  // 共享大图预览状态（多图可左右翻页）
+  const [lightboxOpen, setLightboxOpen] = React.useState(false)
+  const [lightboxIndex, setLightboxIndex] = React.useState(0)
+  // 各图加载好的 src（key = file.path）——缩略图渲染时已加载，翻页复用不再触发 IO
+  const [loadedSrcs, setLoadedSrcs] = React.useState<Record<string, string>>({})
+
+  const handleImageLoaded = React.useCallback((path: string, src: string): void => {
+    setLoadedSrcs((prev) => (prev[path] ? prev : { ...prev, [path]: src }))
+  }, [])
+
+  const openLightbox = React.useCallback((index: number): void => {
+    setLightboxIndex(index)
+    setLightboxOpen(true)
+  }, [])
+
+  // lightbox 图片列表（索引与 imageFiles 对齐，每张带自己的保存回调）
+  const lightboxImages = React.useMemo<LightboxImage[]>(
+    () => imageFiles.map((file) => ({
+      src: loadedSrcs[file.path] ?? '',
+      alt: file.filename,
+      onSave: () => window.electronAPI.saveImageAs(file.path, file.filename),
+      onEditComplete: handleImageEditComplete,
+    })),
+    [imageFiles, loadedSrcs, handleImageEditComplete]
+  )
+
   return (
     <Message from="user">
       <div className="flex items-start gap-2.5 mb-2.5">
@@ -964,8 +993,14 @@ function UserInputMessage({ message }: { message: SDKUserMessage }): React.React
         {/* 图片缩略图 */}
         {imageFiles.length > 0 && (
           <div className="flex flex-wrap gap-2.5 mb-2">
-            {imageFiles.map((file) => (
-              <AttachedImageThumb key={file.path} file={file} onEditComplete={handleImageEditComplete} />
+            {imageFiles.map((file, index) => (
+              <AttachedImageThumb
+                key={file.path}
+                file={file}
+                index={index}
+                onOpen={openLightbox}
+                onLoaded={handleImageLoaded}
+              />
             ))}
           </div>
         )}
@@ -979,6 +1014,16 @@ function UserInputMessage({ message }: { message: SDKUserMessage }): React.React
         )}
         {text && <UserMessageContent>{text}</UserMessageContent>}
       </MessageContent>
+      {/* 共享大图预览 — 单图时无翻页，行为同以前 */}
+      {imageFiles.length > 0 && (
+        <ImageLightbox
+          open={lightboxOpen}
+          onOpenChange={setLightboxOpen}
+          images={lightboxImages}
+          index={lightboxIndex}
+          onIndexChange={setLightboxIndex}
+        />
+      )}
       {text && (
         <MessageActions className="pl-[46px] mt-0.5">
           <CopyButton content={text} />

--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -27,7 +27,7 @@ import { cn } from '@/lib/utils'
 import { shouldInspectMermaidCodeBlock, shouldRenderMermaidCodeBlock } from '@/lib/mermaid-detection'
 import { normalizeLatexDelimiters } from '@/lib/normalize-latex'
 import { Button } from '@/components/ui/button'
-import { ImageLightbox } from '@/components/ui/image-lightbox'
+import { ImageLightbox, type LightboxImage } from '@/components/ui/image-lightbox'
 import {
   Tooltip,
   TooltipContent,
@@ -712,13 +712,46 @@ export function MessageAttachments({
   const fileAttachments = attachments.filter((att) => !att.mediaType.startsWith('image/'))
   const isSingleImage = imageAttachments.length === 1 && fileAttachments.length === 0
 
+  // 共享大图预览状态（多图可左右翻页）
+  const [lightboxOpen, setLightboxOpen] = React.useState(false)
+  const [lightboxIndex, setLightboxIndex] = React.useState(0)
+  // 各图加载好的 src（key = attachment.id）——缩略图渲染时已加载，翻页复用不再触发 IO
+  const [loadedSrcs, setLoadedSrcs] = React.useState<Record<string, string>>({})
+
+  const handleLoaded = React.useCallback((id: string, src: string): void => {
+    setLoadedSrcs((prev) => (prev[id] ? prev : { ...prev, [id]: src }))
+  }, [])
+
+  const openLightbox = React.useCallback((index: number): void => {
+    setLightboxIndex(index)
+    setLightboxOpen(true)
+  }, [])
+
+  // lightbox 图片列表（索引与 imageAttachments 对齐，每张带自己的保存/编辑回调）
+  const lightboxImages = React.useMemo<LightboxImage[]>(
+    () => imageAttachments.map((att) => ({
+      src: loadedSrcs[att.id] ?? '',
+      alt: att.filename,
+      onSave: () => window.electronAPI.saveImageAs(att.localPath, att.filename),
+      onEditComplete: onImageEditComplete,
+    })),
+    [imageAttachments, loadedSrcs, onImageEditComplete]
+  )
+
   return (
     <div className={cn('flex flex-col gap-2 mb-2', className)} {...props}>
       {/* 图片附件 */}
       {imageAttachments.length > 0 && (
         <div className="flex flex-wrap gap-2.5">
-          {imageAttachments.map((att) => (
-            <MessageAttachmentImage key={att.id} attachment={att} isSingle={isSingleImage} onEditComplete={onImageEditComplete} />
+          {imageAttachments.map((att, index) => (
+            <MessageAttachmentImage
+              key={att.id}
+              attachment={att}
+              isSingle={isSingleImage}
+              index={index}
+              onOpen={openLightbox}
+              onLoaded={handleLoaded}
+            />
           ))}
         </div>
       )}
@@ -730,6 +763,16 @@ export function MessageAttachments({
           ))}
         </div>
       )}
+      {/* 共享大图预览 — 单图时无翻页，行为同以前 */}
+      {imageAttachments.length > 0 && (
+        <ImageLightbox
+          open={lightboxOpen}
+          onOpenChange={setLightboxOpen}
+          images={lightboxImages}
+          index={lightboxIndex}
+          onIndexChange={setLightboxIndex}
+        />
+      )}
     </div>
   )
 }
@@ -740,25 +783,30 @@ interface MessageAttachmentImageProps {
   attachment: FileAttachment
   /** 是否为唯一附件（单图模式） */
   isSingle?: boolean
-  /** 编辑完成回调 */
-  onEditComplete?: (editedDataUrl: string) => void
+  /** 该图在同批图片中的索引 */
+  index: number
+  /** 点击缩略图打开大图预览（第 index 张） */
+  onOpen: (index: number) => void
+  /** 图片 src 加载完成上报父组件（供共享 lightbox 翻页使用） */
+  onLoaded: (id: string, src: string) => void
 }
 
 /** 图片附件展示（单图: max 500px，多图: 280px 方块），点击可预览大图 */
-function MessageAttachmentImage({ attachment, isSingle = false, onEditComplete }: MessageAttachmentImageProps): React.ReactElement {
+function MessageAttachmentImage({ attachment, isSingle = false, index, onOpen, onLoaded }: MessageAttachmentImageProps): React.ReactElement {
   const [imageSrc, setImageSrc] = React.useState<string | null>(null)
-  const [lightboxOpen, setLightboxOpen] = React.useState(false)
 
   React.useEffect(() => {
     window.electronAPI
       .readAttachment(attachment.localPath)
       .then((base64) => {
-        setImageSrc(`data:${attachment.mediaType};base64,${base64}`)
+        const src = `data:${attachment.mediaType};base64,${base64}`
+        setImageSrc(src)
+        onLoaded(attachment.id, src)
       })
       .catch((error) => {
         console.error('[MessageAttachmentImage] 读取附件失败:', error)
       })
-  }, [attachment.localPath, attachment.mediaType])
+  }, [attachment.id, attachment.localPath, attachment.mediaType, onLoaded])
 
   /** 保存图片到本地 */
   const handleSave = React.useCallback((): void => {
@@ -779,14 +827,14 @@ function MessageAttachmentImage({ attachment, isSingle = false, onEditComplete }
       src={imageSrc}
       alt={attachment.filename}
       className="max-w-[500px] max-h-[min(500px,50vh)] rounded-lg object-contain cursor-pointer"
-      onClick={() => setLightboxOpen(true)}
+      onClick={() => onOpen(index)}
     />
   ) : (
     <img
       src={imageSrc}
       alt={attachment.filename}
       className="size-[280px] rounded-lg object-cover shrink-0 cursor-pointer"
-      onClick={() => setLightboxOpen(true)}
+      onClick={() => onOpen(index)}
     />
   )
 
@@ -801,14 +849,6 @@ function MessageAttachmentImage({ attachment, isSingle = false, onEditComplete }
       >
         <Download className="size-4" />
       </button>
-      <ImageLightbox
-        src={imageSrc}
-        alt={attachment.filename}
-        open={lightboxOpen}
-        onOpenChange={setLightboxOpen}
-        onSave={handleSave}
-        onEditComplete={onEditComplete}
-      />
     </div>
   )
 }

--- a/apps/electron/src/renderer/components/chat/AttachmentPreviewItem.tsx
+++ b/apps/electron/src/renderer/components/chat/AttachmentPreviewItem.tsx
@@ -10,7 +10,17 @@
 import * as React from 'react'
 import { X, Paperclip } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import { ImageLightbox } from '@/components/ui/image-lightbox'
+import { ImageLightbox, type LightboxImage } from '@/components/ui/image-lightbox'
+
+/** 同批图片附件（用于大图预览时左右翻页） */
+export interface AttachmentSibling {
+  /** 本地预览 URL */
+  previewUrl: string
+  /** 文件名 */
+  filename: string
+  /** 该图的编辑完成回调（可选） */
+  onEditComplete?: (editedDataUrl: string) => void
+}
 
 interface AttachmentPreviewItemProps {
   /** 原始文件名 */
@@ -25,6 +35,10 @@ interface AttachmentPreviewItemProps {
   onClick?: () => void
   /** 编辑完成回调 — 提供则启用图片编辑功能 */
   onEditComplete?: (editedDataUrl: string) => void
+  /** 同批图片列表（可选）— 提供则大图预览时可左右翻页 */
+  imageSiblings?: AttachmentSibling[]
+  /** 当前图片在同批列表中的索引（可选） */
+  siblingIndex?: number
   className?: string
 }
 
@@ -45,9 +59,29 @@ export function AttachmentPreviewItem({
   onRemove,
   onClick,
   onEditComplete,
+  imageSiblings,
+  siblingIndex,
   className,
 }: AttachmentPreviewItemProps): React.ReactElement {
   const [lightboxOpen, setLightboxOpen] = React.useState(false)
+  // 大图预览当前索引（多图翻页时受控）
+  const [lightboxIndex, setLightboxIndex] = React.useState(0)
+
+  // 同批图片映射成 lightbox 的 images（每张带自己的编辑回调）
+  const hasSiblings = Array.isArray(imageSiblings) && imageSiblings.length > 1
+  const lightboxImages = React.useMemo<LightboxImage[] | undefined>(() => {
+    if (!hasSiblings) return undefined
+    return imageSiblings!.map((sib) => ({
+      src: sib.previewUrl,
+      alt: sib.filename,
+      onEditComplete: sib.onEditComplete,
+    }))
+  }, [hasSiblings, imageSiblings])
+
+  const openLightbox = React.useCallback(() => {
+    setLightboxIndex(hasSiblings ? (siblingIndex ?? 0) : 0)
+    setLightboxOpen(true)
+  }, [hasSiblings, siblingIndex])
   const handleRemoveClick = React.useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation()
     onRemove()
@@ -69,7 +103,7 @@ export function AttachmentPreviewItem({
           src={previewUrl}
           alt={filename}
           className="size-full object-cover cursor-pointer"
-          onClick={() => setLightboxOpen(true)}
+          onClick={openLightbox}
           onError={(e) => { (e.target as HTMLImageElement).style.display = 'none' }}
         />
         {/* hover 关闭按钮 */}
@@ -93,6 +127,9 @@ export function AttachmentPreviewItem({
           open={lightboxOpen}
           onOpenChange={setLightboxOpen}
           onEditComplete={onEditComplete}
+          images={lightboxImages}
+          index={lightboxIndex}
+          onIndexChange={setLightboxIndex}
         />
       </div>
     )

--- a/apps/electron/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatInput.tsx
@@ -402,6 +402,20 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
     </Button>
   )
 
+  // 同批图片附件 — 用于大图预览时左右翻页（提取到 useMemo 避免每次渲染重建）
+  const imageAttachmentsList = React.useMemo(
+    () => pendingAttachments.filter((a) => a.mediaType.startsWith('image/') && !!a.previewUrl),
+    [pendingAttachments]
+  )
+  const imageSiblings = React.useMemo(
+    () => imageAttachmentsList.map((a) => ({
+      previewUrl: a.previewUrl as string,
+      filename: a.filename,
+      onEditComplete: (editedDataUrl: string) => handleEditComplete(a.id, editedDataUrl),
+    })),
+    [imageAttachmentsList, handleEditComplete]
+  )
+
   return (
     <div className="px-2.5 pb-2.5 md:px-[18px] md:pb-[18px]" data-input-mode="chat">
         {/* 卡片式输入容器 — 对标 Cherry Studio: border-radius 17px, 0.5px border */}
@@ -418,27 +432,18 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
           {/* 附件 + 引用选中文本 Chip（与 Agent 输入框保持一致） */}
           {(pendingAttachments.length > 0 || currentQuotedSelection) && (
             <div className="flex flex-wrap gap-2 px-3 pt-2.5 pb-1.5">
-              {(() => {
-                // 同批图片附件 — 用于大图预览时左右翻页
-                const imageAttachments = pendingAttachments.filter((a) => a.mediaType.startsWith('image/') && !!a.previewUrl)
-                const imageSiblings = imageAttachments.map((a) => ({
-                  previewUrl: a.previewUrl as string,
-                  filename: a.filename,
-                  onEditComplete: (editedDataUrl: string) => handleEditComplete(a.id, editedDataUrl),
-                }))
-                return pendingAttachments.map((att) => (
-                  <AttachmentPreviewItem
-                    key={att.id}
-                    filename={att.filename}
-                    mediaType={att.mediaType}
-                    previewUrl={att.previewUrl}
-                    onRemove={() => handleRemoveAttachment(att.id)}
-                    onEditComplete={(editedDataUrl) => handleEditComplete(att.id, editedDataUrl)}
-                    imageSiblings={imageSiblings}
-                    siblingIndex={imageAttachments.findIndex((a) => a.id === att.id)}
-                  />
-                ))
-              })()}
+              {pendingAttachments.map((att) => (
+                <AttachmentPreviewItem
+                  key={att.id}
+                  filename={att.filename}
+                  mediaType={att.mediaType}
+                  previewUrl={att.previewUrl}
+                  onRemove={() => handleRemoveAttachment(att.id)}
+                  onEditComplete={(editedDataUrl) => handleEditComplete(att.id, editedDataUrl)}
+                  imageSiblings={imageSiblings}
+                  siblingIndex={imageAttachmentsList.findIndex((a) => a.id === att.id)}
+                />
+              ))}
               {currentQuotedSelection && (
                 <QuotedSelectionChip
                   text={currentQuotedSelection.text}

--- a/apps/electron/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatInput.tsx
@@ -418,16 +418,27 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
           {/* 附件 + 引用选中文本 Chip（与 Agent 输入框保持一致） */}
           {(pendingAttachments.length > 0 || currentQuotedSelection) && (
             <div className="flex flex-wrap gap-2 px-3 pt-2.5 pb-1.5">
-              {pendingAttachments.map((att) => (
-                <AttachmentPreviewItem
-                  key={att.id}
-                  filename={att.filename}
-                  mediaType={att.mediaType}
-                  previewUrl={att.previewUrl}
-                  onRemove={() => handleRemoveAttachment(att.id)}
-                  onEditComplete={(editedDataUrl) => handleEditComplete(att.id, editedDataUrl)}
-                />
-              ))}
+              {(() => {
+                // 同批图片附件 — 用于大图预览时左右翻页
+                const imageAttachments = pendingAttachments.filter((a) => a.mediaType.startsWith('image/') && !!a.previewUrl)
+                const imageSiblings = imageAttachments.map((a) => ({
+                  previewUrl: a.previewUrl as string,
+                  filename: a.filename,
+                  onEditComplete: (editedDataUrl: string) => handleEditComplete(a.id, editedDataUrl),
+                }))
+                return pendingAttachments.map((att) => (
+                  <AttachmentPreviewItem
+                    key={att.id}
+                    filename={att.filename}
+                    mediaType={att.mediaType}
+                    previewUrl={att.previewUrl}
+                    onRemove={() => handleRemoveAttachment(att.id)}
+                    onEditComplete={(editedDataUrl) => handleEditComplete(att.id, editedDataUrl)}
+                    imageSiblings={imageSiblings}
+                    siblingIndex={imageAttachments.findIndex((a) => a.id === att.id)}
+                  />
+                ))
+              })()}
               {currentQuotedSelection && (
                 <QuotedSelectionChip
                   text={currentQuotedSelection.text}

--- a/apps/electron/src/renderer/components/chat/InlineEditForm.tsx
+++ b/apps/electron/src/renderer/components/chat/InlineEditForm.tsx
@@ -238,15 +238,25 @@ export function InlineEditForm({ message, onSubmit, onCancel }: InlineEditFormPr
     >
       {editableAttachments.length > 0 && (
         <div className="flex flex-wrap gap-1">
-          {editableAttachments.map((item) => (
-            <AttachmentPreviewItem
-              key={item.id}
-              filename={item.attachment.filename}
-              mediaType={item.attachment.mediaType}
-              previewUrl={item.previewUrl}
-              onRemove={() => removeEditableAttachment(item.id)}
-            />
-          ))}
+          {(() => {
+            // 同批图片附件 — 用于大图预览时左右翻页（内联编辑为只读预览，无编辑回调）
+            const imageItems = editableAttachments.filter((it) => it.attachment.mediaType.startsWith('image/') && !!it.previewUrl)
+            const imageSiblings = imageItems.map((it) => ({
+              previewUrl: it.previewUrl as string,
+              filename: it.attachment.filename,
+            }))
+            return editableAttachments.map((item) => (
+              <AttachmentPreviewItem
+                key={item.id}
+                filename={item.attachment.filename}
+                mediaType={item.attachment.mediaType}
+                previewUrl={item.previewUrl}
+                onRemove={() => removeEditableAttachment(item.id)}
+                imageSiblings={imageSiblings}
+                siblingIndex={imageItems.findIndex((it) => it.id === item.id)}
+              />
+            ))
+          })()}
         </div>
       )}
       <textarea

--- a/apps/electron/src/renderer/components/chat/InlineEditForm.tsx
+++ b/apps/electron/src/renderer/components/chat/InlineEditForm.tsx
@@ -210,6 +210,19 @@ export function InlineEditForm({ message, onSubmit, onCancel }: InlineEditFormPr
     onSubmit(buildPayload())
   }, [canSubmit, onSubmit, buildPayload])
 
+  // 同批图片附件 — 用于大图预览时左右翻页（提取到 useMemo 避免每次渲染重建）
+  const editImageItems = React.useMemo(
+    () => editableAttachments.filter((it) => it.attachment.mediaType.startsWith('image/') && !!it.previewUrl),
+    [editableAttachments]
+  )
+  const editImageSiblings = React.useMemo(
+    () => editImageItems.map((it) => ({
+      previewUrl: it.previewUrl as string,
+      filename: it.attachment.filename,
+    })),
+    [editImageItems]
+  )
+
   return (
     <div
       className={cn(
@@ -238,25 +251,17 @@ export function InlineEditForm({ message, onSubmit, onCancel }: InlineEditFormPr
     >
       {editableAttachments.length > 0 && (
         <div className="flex flex-wrap gap-1">
-          {(() => {
-            // 同批图片附件 — 用于大图预览时左右翻页（内联编辑为只读预览，无编辑回调）
-            const imageItems = editableAttachments.filter((it) => it.attachment.mediaType.startsWith('image/') && !!it.previewUrl)
-            const imageSiblings = imageItems.map((it) => ({
-              previewUrl: it.previewUrl as string,
-              filename: it.attachment.filename,
-            }))
-            return editableAttachments.map((item) => (
+          {editableAttachments.map((item) => (
               <AttachmentPreviewItem
                 key={item.id}
                 filename={item.attachment.filename}
                 mediaType={item.attachment.mediaType}
                 previewUrl={item.previewUrl}
                 onRemove={() => removeEditableAttachment(item.id)}
-                imageSiblings={imageSiblings}
-                siblingIndex={imageItems.findIndex((it) => it.id === item.id)}
+                imageSiblings={editImageSiblings}
+                siblingIndex={editImageItems.findIndex((it) => it.id === item.id)}
               />
-            ))
-          })()}
+            ))}
         </div>
       )}
       <textarea

--- a/apps/electron/src/renderer/components/ui/image-lightbox.tsx
+++ b/apps/electron/src/renderer/components/ui/image-lightbox.tsx
@@ -4,27 +4,49 @@
  * 全屏图片预览：点击图片打开，点击遮罩层或按 Esc 关闭。
  * 遮罩层与 Dialog 完全统一，操作按钮收拢到图片正下方的悬浮岛。
  * 支持编辑模式（裁剪/旋转/绘制），编辑后可发送到对话。
+ *
+ * 多图导航（可选）：传入 images + index + onIndexChange 后，可在同一批图片间
+ * 左右翻页（‹ › 按钮 / 方向键，首尾循环）。不传 images 时回退为单图行为，
+ * 完全向后兼容。
  */
 
 import * as React from 'react'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
-import { Download, Pencil, X } from 'lucide-react'
+import { ChevronLeft, ChevronRight, Download, Pencil, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { ImageEditor } from '@/components/ui/image-editor'
 
-interface ImageLightboxProps {
+/** 单张图片描述（多图导航时使用） */
+export interface LightboxImage {
   /** 图片 src（data URL 或普通 URL） */
-  src: string | null
+  src: string
+  /** 图片 alt / 文件名 */
+  alt?: string
+  /** 下载回调（可选） */
+  onSave?: () => void
+  /** 编辑完成回调 — 提供则显示编辑按钮 */
+  onEditComplete?: (editedDataUrl: string) => void
+}
+
+interface ImageLightboxProps {
+  /** 图片 src（data URL 或普通 URL）— 单图模式使用 */
+  src?: string | null
   /** 图片 alt / 文件名 */
   alt?: string
   /** 是否打开 */
   open: boolean
   /** 关闭回调 */
   onOpenChange: (open: boolean) => void
-  /** 下载回调（可选） */
+  /** 下载回调（可选，单图模式） */
   onSave?: () => void
-  /** 编辑完成回调 — 提供则显示编辑按钮 */
+  /** 编辑完成回调 — 提供则显示编辑按钮（单图模式） */
   onEditComplete?: (editedDataUrl: string) => void
+  /** 多图列表（可选）— 提供则启用左右翻页 */
+  images?: LightboxImage[]
+  /** 当前展示的图片索引（多图模式，受控） */
+  index?: number
+  /** 翻页回调（多图模式） */
+  onIndexChange?: (nextIndex: number) => void
 }
 
 export function ImageLightbox({
@@ -34,28 +56,67 @@ export function ImageLightbox({
   onOpenChange,
   onSave,
   onEditComplete,
+  images,
+  index,
+  onIndexChange,
 }: ImageLightboxProps): React.ReactElement | null {
   const [mode, setMode] = React.useState<'preview' | 'editing'>('preview')
+
+  const hasImages = Array.isArray(images) && images.length > 0
+  const total = hasImages ? images!.length : 0
+  const hasMultiple = total > 1
+  const safeIndex = hasImages ? Math.min(Math.max(index ?? 0, 0), total - 1) : 0
 
   // 关闭时重置模式
   React.useEffect(() => {
     if (!open) setMode('preview')
   }, [open])
 
-  // hooks 必须在条件 return 前声明，以遵守 React 规则（src 为 prop，值在渲染间不变）
-  if (!src) return null
+  // 多图模式下监听方向键翻页（编辑模式禁用）
+  React.useEffect(() => {
+    if (!open || mode !== 'preview' || !hasMultiple || !onIndexChange) return
+    const handler = (event: KeyboardEvent): void => {
+      if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+        event.preventDefault()
+        onIndexChange((safeIndex - 1 + total) % total)
+      } else if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+        event.preventDefault()
+        onIndexChange((safeIndex + 1) % total)
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [open, mode, hasMultiple, onIndexChange, safeIndex, total])
 
-  const handleEditSave = (editedDataUrl: string) => {
-    onEditComplete?.(editedDataUrl)
+  // 当前展示的图片：多图取 images[index]，否则回退单图 src（值在渲染间不变，hooks 已在前声明）
+  const current: LightboxImage | null = hasImages
+    ? images![safeIndex] ?? null
+    : src
+      ? { src, alt, onSave, onEditComplete }
+      : null
+  if (!current) return null
+
+  const handleEditSave = (editedDataUrl: string): void => {
+    current.onEditComplete?.(editedDataUrl)
     onOpenChange(false)
     setMode('preview')
   }
 
-  const handleEditCancel = () => {
+  const handleEditCancel = (): void => {
     setMode('preview')
   }
 
-  const showEdit = !!onEditComplete
+  const goPrev = (): void => onIndexChange?.((safeIndex - 1 + total) % total)
+  const goNext = (): void => onIndexChange?.((safeIndex + 1) % total)
+
+  const showEdit = !!current.onEditComplete
+  const showNav = mode === 'preview' && hasMultiple
+  const navBtn = cn(
+    'absolute top-1/2 -translate-y-1/2 z-10 rounded-full p-2',
+    'bg-black/50 text-white/80 backdrop-blur-md shadow-lg transition-colors duration-150',
+    'hover:bg-black/70 hover:text-white',
+    'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:ring-offset-2 focus-visible:ring-offset-black'
+  )
 
   return (
     <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
@@ -81,11 +142,26 @@ export function ImageLightbox({
           }}
         >
           <DialogPrimitive.Title className="sr-only">
-            {alt || '图片预览'}
+            {current.alt || '图片预览'}
           </DialogPrimitive.Title>
           <DialogPrimitive.Description className="sr-only">
-            预览图片：{alt || '图片'}
+            预览图片：{current.alt || '图片'}
           </DialogPrimitive.Description>
+
+          {/* 翻页按钮（多图，预览模式） */}
+          {showNav && (
+            <>
+              <button type="button" onClick={goPrev} className={cn(navBtn, 'left-4')} title="上一张">
+                <ChevronLeft className="size-6" /><span className="sr-only">上一张</span>
+              </button>
+              <button type="button" onClick={goNext} className={cn(navBtn, 'right-4')} title="下一张">
+                <ChevronRight className="size-6" /><span className="sr-only">下一张</span>
+              </button>
+              <div className="absolute top-4 left-1/2 -translate-x-1/2 z-10 rounded-full bg-black/50 px-3 py-1 text-xs text-white/90 backdrop-blur-md">
+                {safeIndex + 1} / {total}
+              </div>
+            </>
+          )}
 
           {/* 双层都占位 — visibility 切换，无 unmount，Grid 单格叠加 */}
           <div className="grid" style={{ gridTemplate: '"layer" 1fr / 1fr' }}>
@@ -93,8 +169,8 @@ export function ImageLightbox({
             <div style={{ gridArea: 'layer', visibility: mode === 'editing' ? 'hidden' : 'visible' }}>
               <div className="flex flex-col items-center">
               <img
-                src={src}
-                alt={alt}
+                src={current.src}
+                alt={current.alt}
                 className="max-w-[90vw] max-h-[85vh] rounded-lg object-contain shadow-2xl select-none"
                 draggable={false}
               />
@@ -107,14 +183,14 @@ export function ImageLightbox({
                   <X className="size-5" /><span className="sr-only">关闭</span>
                 </DialogPrimitive.Close>
                 {showEdit && (<><div className="mx-1.5 h-5 w-px bg-white/20" aria-hidden /><button type="button" onClick={() => setMode('editing')} className={cn('rounded-full p-1.5 text-white/80 transition-colors duration-150', 'hover:bg-white/15 hover:text-white', 'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:ring-offset-2 focus-visible:ring-offset-black')} title="编辑图片"><Pencil className="size-5" /></button></>)}
-                {onSave && (<><div className="mx-1.5 h-5 w-px bg-white/20" aria-hidden /><button type="button" onClick={onSave} className={cn('rounded-full p-1.5 text-white/80 transition-colors duration-150', 'hover:bg-white/15 hover:text-white', 'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:ring-offset-2 focus-visible:ring-offset-black')} title="保存图片"><Download className="size-5" /></button></>)}
+                {current.onSave && (<><div className="mx-1.5 h-5 w-px bg-white/20" aria-hidden /><button type="button" onClick={current.onSave} className={cn('rounded-full p-1.5 text-white/80 transition-colors duration-150', 'hover:bg-white/15 hover:text-white', 'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:ring-offset-2 focus-visible:ring-offset-black')} title="保存图片"><Download className="size-5" /></button></>)}
               </div>
               </div>
             </div>
 
             {/* 编辑层 */}
             <div style={{ gridArea: 'layer', visibility: mode === 'preview' ? 'hidden' : 'visible' }}>
-              <ImageEditor src={src} onSave={handleEditSave} onCancel={handleEditCancel} />
+              <ImageEditor src={current.src} onSave={handleEditSave} onCancel={handleEditCancel} />
             </div>
           </div>
         </DialogPrimitive.Content>


### PR DESCRIPTION
## 概述

图片预览（ImageLightbox）在存在多张图片时支持左右翻页，覆盖输入框和消息气泡两个场景、Chat 和 Agent 两种模式。此前只能单张预览，多图时无法在预览态切换上一张/下一张。

## 交互

- ‹ › 按钮 + 键盘方向键翻页，首尾循环
- 顶部显示「当前 / 总数」角标
- 单图时保持原行为：无翻页按钮、无角标

## 改动范围（7 个文件）

**核心组件**
- `ui/image-lightbox.tsx`：扩展 `images` / `index` / `onIndexChange` 能力，支持受控翻页

**输入框场景（收集待发送图片列表共享同一个 lightbox）**
- `chat/ChatInput.tsx`
- `chat/AttachmentPreviewItem.tsx`
- `chat/InlineEditForm.tsx`
- `agent/AgentView.tsx`

**消息气泡场景（发出后的历史消息）**
- `ai-elements/message.tsx`：`MessageAttachments` 将 lightbox 状态从子缩略图上提到父组件，父组件收集图片 src 成列表，渲染单个共享 lightbox
- `agent/SDKMessageRenderer.tsx`：`UserInputMessage` 对称改法

## 设计要点

- 缩略图渲染时本就要加载全尺寸图，翻页复用这批已加载的 src（`onLoaded` 上报父组件），不触发额外 IO
- 每张图带自己的 `onSave`，编辑回调沿用消息级统一回调
- 气泡翻页范围限定当前消息，符合微信/Slack 的交互习惯

## 测试

- `bun run typecheck` 通过，改动文件无类型错误
- 本地实测输入框多图翻页（Chat / Agent 均正常）
- 消息气泡翻页、单图回归待 reviewer 实机复核

🤖 Generated with [Claude Code](https://claude.com/claude-code)