### PR TITLE
[codex] Fix DingTalk bot session binding migration

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.14.17",
+  "version": "0.14.18",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/dingtalk-bot-identity.ts
+++ b/apps/electron/src/main/lib/dingtalk-bot-identity.ts
@@ -1,0 +1,17 @@
+import { createHash } from 'node:crypto'
+
+const DINGTALK_BOT_ID_PREFIX = 'dingtalk-bot-'
+
+/**
+ * 基于钉钉 Client ID 生成稳定 Bot ID。
+ *
+ * Bot ID 会参与绑定文件路径，不能使用升级/迁移时重新生成的随机值，
+ * 否则同一个钉钉群会读不到旧的 chatId -> sessionId 绑定。
+ */
+export function createStableDingTalkBotId(clientId: string): string | undefined {
+  const normalized = clientId.trim()
+  if (!normalized) return undefined
+
+  const digest = createHash('sha256').update(normalized).digest('hex').slice(0, 16)
+  return `${DINGTALK_BOT_ID_PREFIX}${digest}`
+}

--- a/apps/electron/src/main/lib/dingtalk-config.test.ts
+++ b/apps/electron/src/main/lib/dingtalk-config.test.ts
@@ -100,4 +100,47 @@ describe('钉钉 Bot 配置迁移', () => {
     expect(existsSync(configPaths.getDingTalkBotBindingsPath(legacyBotId))).toBe(false)
     expect(JSON.parse(readFileSync(configPaths.getDingTalkBotBindingsPath(stableBotId), 'utf-8'))).toEqual(bindings)
   })
+
+  test('Given 旧绑定文件与稳定路径绑定文件同时存在 When 迁移 Then 按 chatId 去重合并', () => {
+    const legacyBotId = 'legacy-random-bot-id-2'
+    const clientId = 'ding-app-key-2'
+    const stableBotId = createStableDingTalkBotId(clientId)!
+
+    const oldBindings = [
+      { chatId: 'chat-shared', sessionId: 'old-session', workspaceId: 'ws-1', channelId: 'ch-1' },
+      { chatId: 'chat-only-old', sessionId: 'session-old', workspaceId: 'ws-1', channelId: 'ch-2' },
+    ]
+    const existingBindings = [
+      { chatId: 'chat-shared', sessionId: 'new-session', workspaceId: 'ws-1', channelId: 'ch-1' },
+      { chatId: 'chat-only-new', sessionId: 'session-new', workspaceId: 'ws-1', channelId: 'ch-3' },
+    ]
+
+    writeFileSync(configPaths.getDingTalkConfigPath(), JSON.stringify({
+      version: 2,
+      bots: [
+        {
+          id: legacyBotId,
+          name: '钉钉助手',
+          enabled: true,
+          clientId,
+          clientSecret: 'secret',
+          defaultWorkspaceId: 'ws-1',
+        },
+      ],
+    }, null, 2), 'utf-8')
+    writeFileSync(configPaths.getDingTalkBotBindingsPath(legacyBotId), JSON.stringify(oldBindings, null, 2), 'utf-8')
+    writeFileSync(configPaths.getDingTalkBotBindingsPath(stableBotId), JSON.stringify(existingBindings, null, 2), 'utf-8')
+
+    const config = dingtalkConfig.getDingTalkMultiBotConfig()
+
+    expect(config.bots[0]?.id).toBe(stableBotId)
+    expect(existsSync(configPaths.getDingTalkBotBindingsPath(legacyBotId))).toBe(false)
+
+    const merged = JSON.parse(readFileSync(configPaths.getDingTalkBotBindingsPath(stableBotId), 'utf-8'))
+    const chatIds = merged.map((b: { chatId: string }) => b.chatId).sort()
+    expect(chatIds).toEqual(['chat-only-new', 'chat-only-old', 'chat-shared'])
+    // target（稳定路径）的条目优先
+    const shared = merged.find((b: { chatId: string }) => b.chatId === 'chat-shared')
+    expect(shared.sessionId).toBe('new-session')
+  })
 })

--- a/apps/electron/src/main/lib/dingtalk-config.test.ts
+++ b/apps/electron/src/main/lib/dingtalk-config.test.ts
@@ -1,0 +1,103 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import * as os from 'node:os'
+import { join } from 'node:path'
+import { createStableDingTalkBotId } from './dingtalk-bot-identity'
+
+type DingTalkConfigModule = typeof import('./dingtalk-config')
+type ConfigPathsModule = typeof import('./config-paths')
+
+let dingtalkConfig: DingTalkConfigModule
+let configPaths: ConfigPathsModule
+let tempHome: string
+const originalHome = process.env.HOME
+const originalPromaDev = process.env.PROMA_DEV
+
+mock.module('electron', () => ({
+  app: {
+    isPackaged: true,
+    getPath: () => join(process.env.HOME ?? tempHome, 'Library', 'Application Support'),
+  },
+  safeStorage: {
+    isEncryptionAvailable: () => false,
+    encryptString: (value: string) => Buffer.from(value),
+    decryptString: (value: Buffer) => value.toString('utf-8'),
+  },
+}))
+
+mock.module('node:os', () => ({
+  ...os,
+  homedir: () => tempHome,
+}))
+
+beforeAll(async () => {
+  tempHome = mkdtempSync(join(os.tmpdir(), 'proma-dingtalk-config-'))
+  process.env.HOME = tempHome
+  process.env.PROMA_DEV = '0'
+  configPaths = await import('./config-paths')
+  dingtalkConfig = await import('./dingtalk-config')
+})
+
+beforeEach(() => {
+  rmSync(join(tempHome, '.proma'), { recursive: true, force: true })
+  mkdirSync(join(tempHome, '.proma'), { recursive: true })
+})
+
+afterAll(() => {
+  if (originalHome === undefined) {
+    delete process.env.HOME
+  } else {
+    process.env.HOME = originalHome
+  }
+  if (originalPromaDev === undefined) {
+    delete process.env.PROMA_DEV
+  } else {
+    process.env.PROMA_DEV = originalPromaDev
+  }
+  rmSync(tempHome, { recursive: true, force: true })
+})
+
+describe('钉钉 Bot 配置迁移', () => {
+  test('Given 相同 Client ID When 生成 Bot ID Then 返回稳定值', () => {
+    const first = createStableDingTalkBotId('ding-app-key')
+    const second = createStableDingTalkBotId('  ding-app-key  ')
+
+    expect(first).toBe(second)
+    expect(first).toStartWith('dingtalk-bot-')
+  })
+
+  test('Given v2 配置仍使用旧随机 Bot ID When 读取配置 Then 稳定 Bot ID 并迁移绑定文件', () => {
+    const legacyBotId = 'legacy-random-bot-id'
+    const clientId = 'ding-app-key'
+    const stableBotId = createStableDingTalkBotId(clientId)!
+    const bindings = [
+      {
+        chatId: 'ding-conversation-1',
+        sessionId: 'session-1',
+        workspaceId: 'workspace-1',
+        channelId: 'channel-1',
+      },
+    ]
+
+    writeFileSync(configPaths.getDingTalkConfigPath(), JSON.stringify({
+      version: 2,
+      bots: [
+        {
+          id: legacyBotId,
+          name: '钉钉助手',
+          enabled: true,
+          clientId,
+          clientSecret: 'secret',
+          defaultWorkspaceId: 'workspace-1',
+        },
+      ],
+    }, null, 2), 'utf-8')
+    writeFileSync(configPaths.getDingTalkBotBindingsPath(legacyBotId), JSON.stringify(bindings, null, 2), 'utf-8')
+
+    const config = dingtalkConfig.getDingTalkMultiBotConfig()
+
+    expect(config.bots[0]?.id).toBe(stableBotId)
+    expect(existsSync(configPaths.getDingTalkBotBindingsPath(legacyBotId))).toBe(false)
+    expect(JSON.parse(readFileSync(configPaths.getDingTalkBotBindingsPath(stableBotId), 'utf-8'))).toEqual(bindings)
+  })
+})

--- a/apps/electron/src/main/lib/dingtalk-config.ts
+++ b/apps/electron/src/main/lib/dingtalk-config.ts
@@ -9,9 +9,10 @@
  */
 
 import { randomUUID } from 'node:crypto'
-import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { readFileSync, writeFileSync, existsSync, renameSync, unlinkSync } from 'node:fs'
 import { safeStorage } from 'electron'
-import { getDingTalkConfigPath } from './config-paths'
+import { getDingTalkConfigPath, getDingTalkBotBindingsPath } from './config-paths'
+import { createStableDingTalkBotId } from './dingtalk-bot-identity'
 import type {
   DingTalkConfig,
   DingTalkConfigInput,
@@ -50,13 +51,83 @@ function decryptSecret(encryptedSecret: string): string {
 /** 默认空多 Bot 配置 */
 const EMPTY_MULTI_CONFIG: DingTalkMultiBotConfig = { version: 2, bots: [] }
 
+function resolveBotId(clientId: string, fallbackId?: string): string {
+  return createStableDingTalkBotId(clientId) ?? fallbackId ?? randomUUID()
+}
+
+function readJsonArrayFile(filePath: string): unknown[] {
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, 'utf-8')) as unknown
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+function mergeJsonArrayFiles(sourcePath: string, targetPath: string): void {
+  const source = readJsonArrayFile(sourcePath)
+  const target = existsSync(targetPath) ? readJsonArrayFile(targetPath) : []
+
+  const byChatId = new Map<string, unknown>()
+  for (const item of [...source, ...target]) {
+    if (!item || typeof item !== 'object') continue
+    const chatId = (item as Record<string, unknown>).chatId
+    if (typeof chatId !== 'string') continue
+    byChatId.set(chatId, item)
+  }
+
+  writeFileSync(targetPath, JSON.stringify(Array.from(byChatId.values()), null, 2), 'utf-8')
+}
+
+function migrateDingTalkBindingFile(oldBotId: string, nextBotId: string): void {
+  if (oldBotId === nextBotId) return
+
+  const oldPath = getDingTalkBotBindingsPath(oldBotId)
+  if (!existsSync(oldPath)) return
+
+  const nextPath = getDingTalkBotBindingsPath(nextBotId)
+  try {
+    if (existsSync(nextPath)) {
+      mergeJsonArrayFiles(oldPath, nextPath)
+      unlinkSync(oldPath)
+    } else {
+      renameSync(oldPath, nextPath)
+    }
+    console.log(`[钉钉配置] 已迁移 Bot 绑定文件: ${oldBotId} → ${nextBotId}`)
+  } catch (error) {
+    console.warn('[钉钉配置] 迁移 Bot 绑定文件失败:', error)
+  }
+}
+
+function normalizeBotIds(config: DingTalkMultiBotConfig): boolean {
+  let changed = false
+  const usedIds = new Set<string>()
+
+  for (const bot of config.bots) {
+    const nextId = resolveBotId(bot.clientId, bot.id)
+    if (usedIds.has(nextId)) {
+      usedIds.add(bot.id)
+      continue
+    }
+
+    usedIds.add(nextId)
+    if (bot.id !== nextId) {
+      migrateDingTalkBindingFile(bot.id, nextId)
+      bot.id = nextId
+      changed = true
+    }
+  }
+
+  return changed
+}
+
 /** 从旧单 Bot 格式迁移到多 Bot 格式 */
 function migrateV1ToV2(v1: DingTalkConfig): DingTalkMultiBotConfig {
   if (!v1.clientId) {
     return { ...EMPTY_MULTI_CONFIG }
   }
   const bot: DingTalkBotConfig = {
-    id: randomUUID(),
+    id: resolveBotId(v1.clientId),
     name: '钉钉助手',
     enabled: v1.enabled,
     clientId: v1.clientId,
@@ -78,7 +149,12 @@ function readRawConfig(): DingTalkMultiBotConfig {
 
     // v2 格式
     if (data.version === 2 && Array.isArray(data.bots)) {
-      return data as unknown as DingTalkMultiBotConfig
+      const config = data as unknown as DingTalkMultiBotConfig
+      if (normalizeBotIds(config)) {
+        writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8')
+        console.log('[钉钉配置] 已稳定 Bot ID 并迁移绑定文件')
+      }
+      return config
     }
 
     // v1 格式 → 迁移
@@ -141,7 +217,7 @@ export function saveDingTalkBotConfig(input: DingTalkBotConfigInput): DingTalkBo
 
   // 新建 Bot
   const bot: DingTalkBotConfig = {
-    id: randomUUID(),
+    id: resolveBotId(input.clientId),
     name: input.name,
     enabled: input.enabled,
     clientId: input.clientId.trim(),

--- a/apps/electron/src/main/lib/dingtalk-config.ts
+++ b/apps/electron/src/main/lib/dingtalk-config.ts
@@ -9,9 +9,10 @@
  */
 
 import { randomUUID } from 'node:crypto'
-import { readFileSync, writeFileSync, existsSync, renameSync, unlinkSync } from 'node:fs'
+import { readFileSync, existsSync, renameSync, unlinkSync } from 'node:fs'
 import { safeStorage } from 'electron'
 import { getDingTalkConfigPath, getDingTalkBotBindingsPath } from './config-paths'
+import { writeJsonFileAtomic } from './safe-file'
 import { createStableDingTalkBotId } from './dingtalk-bot-identity'
 import type {
   DingTalkConfig,
@@ -76,7 +77,7 @@ function mergeJsonArrayFiles(sourcePath: string, targetPath: string): void {
     byChatId.set(chatId, item)
   }
 
-  writeFileSync(targetPath, JSON.stringify(Array.from(byChatId.values()), null, 2), 'utf-8')
+  writeJsonFileAtomic(targetPath, Array.from(byChatId.values()))
 }
 
 function migrateDingTalkBindingFile(oldBotId: string, nextBotId: string): void {
@@ -151,7 +152,7 @@ function readRawConfig(): DingTalkMultiBotConfig {
     if (data.version === 2 && Array.isArray(data.bots)) {
       const config = data as unknown as DingTalkMultiBotConfig
       if (normalizeBotIds(config)) {
-        writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8')
+        writeJsonFileAtomic(configPath, config)
         console.log('[钉钉配置] 已稳定 Bot ID 并迁移绑定文件')
       }
       return config
@@ -160,8 +161,7 @@ function readRawConfig(): DingTalkMultiBotConfig {
     // v1 格式 → 迁移
     const v1 = data as unknown as DingTalkConfig
     const v2 = migrateV1ToV2(v1)
-    // 写回迁移后的新格式
-    writeFileSync(configPath, JSON.stringify(v2, null, 2), 'utf-8')
+    writeJsonFileAtomic(configPath, v2)
     console.log('[钉钉配置] 已从 v1 迁移到 v2 多 Bot 格式')
     return v2
   } catch (error) {
@@ -172,7 +172,7 @@ function readRawConfig(): DingTalkMultiBotConfig {
 
 function writeMultiConfig(config: DingTalkMultiBotConfig): void {
   const configPath = getDingTalkConfigPath()
-  writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8')
+  writeJsonFileAtomic(configPath, config)
 }
 
 // ===== 多 Bot API =====


### PR DESCRIPTION
## Summary

Fixes DingTalk bot session loss after upgrades by making DingTalk bot IDs stable for the same Client ID and migrating existing per-bot binding files to the stable path.

## Root Cause

DingTalk chat bindings are persisted as `chatId -> sessionId` files keyed by `bot.id`. During the older single-bot to multi-bot migration, the bot ID was generated randomly. If that ID changed across an upgrade or config migration, Proma could no longer load the existing binding file, so the next group mention created a new Agent Session and lost context.

## Changes

- Added stable DingTalk bot ID generation from the trimmed Client ID.
- Normalized existing v2 DingTalk configs to the stable ID during config load.
- Migrated old random-ID binding files to the stable binding path, merging by `chatId` when both files exist.
- Added BDD-style tests covering stable ID generation and binding-file migration.
- Bumped `@proma/electron` patch version to `0.14.18`.

## Validation

- `bun test apps/electron/src/main/lib/dingtalk-config.test.ts apps/electron/src/main/lib/bridge-binding-store.test.ts`
- `bun run --filter='@proma/electron' typecheck`
- `git diff --check`
