### PR TITLE
feat(scratch): 草稿区支持待办清单与无序列表

### DIFF
--- a/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
+++ b/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
@@ -13,7 +13,7 @@ import StarterKit from '@tiptap/starter-kit'
 import Placeholder from '@tiptap/extension-placeholder'
 import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
 import { useAtom, useAtomValue, useSetAtom, useStore } from 'jotai'
-import { FileDown, PanelRight, X } from 'lucide-react'
+import { FileDown, List, ListTodo, PanelRight, X } from 'lucide-react'
 import { toast } from 'sonner'
 import { scratchPadContentAtom, scratchPadLoadedAtom, tabsAtom, activeTabIdAtom } from '@/atoms/tab-atoms'
 import {
@@ -605,7 +605,7 @@ function ScratchPadEditor({ variant }: ScratchPadEditorProps): React.ReactElemen
           {loaded ? (
             <EditorContent
               editor={editor}
-              className="prose prose-sm dark:prose-invert max-w-none h-full [&_.ProseMirror]:min-h-full [&_.ProseMirror]:outline-none [&_.ProseMirror]:text-sm [&_.ProseMirror_p.is-editor-empty:first-child::before]:text-muted-foreground/50 [&_.ProseMirror_p.is-editor-empty:first-child::before]:content-[attr(data-placeholder)] [&_.ProseMirror_p.is-editor-empty:first-child::before]:float-left [&_.ProseMirror_p.is-editor-empty:first-child::before]:pointer-events-none [&_.ProseMirror_p.is-editor-empty:first-child::before]:h-0"
+              className="scratch-pad-editor prose prose-sm dark:prose-invert max-w-none h-full [&_.ProseMirror]:min-h-full [&_.ProseMirror]:outline-none [&_.ProseMirror]:text-sm [&_.ProseMirror_p.is-editor-empty:first-child::before]:text-muted-foreground/50 [&_.ProseMirror_p.is-editor-empty:first-child::before]:content-[attr(data-placeholder)] [&_.ProseMirror_p.is-editor-empty:first-child::before]:float-left [&_.ProseMirror_p.is-editor-empty:first-child::before]:pointer-events-none [&_.ProseMirror_p.is-editor-empty:first-child::before]:h-0"
             />
           ) : (
             <div className="min-h-[200px] flex items-center justify-center">
@@ -627,9 +627,29 @@ function ScratchPadEditor({ variant }: ScratchPadEditorProps): React.ReactElemen
         <SpeechButton className={speechButtonClassName} />
       </div>
       <div className="h-[28px] border-t border-border/40 px-4 flex items-center justify-between">
-        <span className="text-[11px] text-muted-foreground/60">
-          {isPane ? '草稿自动保存' : 'Scratch Pad — 内容自动保存到本地'}
-        </span>
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={() => editor?.chain().focus().toggleTaskList().run()}
+            className="text-[11px] text-muted-foreground/60 hover:text-foreground flex items-center gap-1 transition-colors"
+            title="插入 / 切换待办清单（也可在行首输入 [ ] 加空格）"
+          >
+            <ListTodo className="w-3 h-3" />
+            待办清单
+          </button>
+          <button
+            type="button"
+            onClick={() => editor?.chain().focus().toggleBulletList().run()}
+            className="text-[11px] text-muted-foreground/60 hover:text-foreground flex items-center gap-1 transition-colors"
+            title="插入 / 切换无序列表（也可在行首输入 - 加空格）"
+          >
+            <List className="w-3 h-3" />
+            无序列表
+          </button>
+          <span className="text-[11px] text-muted-foreground/60">
+            {isPane ? '草稿自动保存' : 'Scratch Pad — 内容自动保存到本地'}
+          </span>
+        </div>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <button

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -2298,3 +2298,46 @@
 .theme-terminal-dark [class*="rounded"] {
   border-radius: 0 !important;
 }
+
+/* ===== 草稿区：待办清单排版 =====
+ * TaskList/TaskItem 扩展带 not-prose，默认丢失了 prose 的行距/间距，且 flex 布局下
+ * 空待办项的正文 div 会塌缩到 0 宽导致光标无处落脚。以下规则仅作用于草稿区
+ * （.scratch-pad-editor），把待办项的行距、间距、字号对齐到正文与无序列表，
+ * 并保证空项也能落下光标。不改共享的扩展配置，故不影响 diff 预览等其它用到该扩展处。
+ */
+.scratch-pad-editor .ProseMirror ul[data-type="taskList"] {
+  margin: 0.75em 0;
+  padding-left: 0;
+  list-style: none;
+}
+.scratch-pad-editor .ProseMirror ul[data-type="taskList"] > li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5em;
+  margin: 0.25em 0;
+}
+/* 正文撑开：空待办项也有宽度，光标可正常显示与闪烁 */
+.scratch-pad-editor .ProseMirror ul[data-type="taskList"] > li > div {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+/* 待办项段落行距对齐正文（prose-sm 约 1.71） */
+.scratch-pad-editor .ProseMirror ul[data-type="taskList"] > li > div > p {
+  margin: 0;
+  line-height: 1.7142857;
+}
+/* 勾选后置灰划线 —— 用语义色，跟随各主题 */
+.scratch-pad-editor .ProseMirror ul[data-type="taskList"] > li[data-checked="true"] > div {
+  text-decoration: line-through;
+  color: hsl(var(--muted-foreground) / 0.6);
+  transition: color 0.15s ease, text-decoration-color 0.15s ease;
+}
+/* 复选框与首行文字对齐 */
+.scratch-pad-editor .ProseMirror ul[data-type="taskList"] > li > label {
+  flex: 0 0 auto;
+  margin-top: 0.28em;
+  user-select: none;
+}
+.scratch-pad-editor .ProseMirror ul[data-type="taskList"] > li > label > input {
+  cursor: pointer;
+}


### PR DESCRIPTION
## 概述

为草稿区（Scratch Pad）补齐待办清单与无序列表的编辑能力与排版，让 TaskList/TaskItem 从「底层可用但体验粗糙」变为「开箱好用」。

## 改动

- **底部工具栏新增两个入口**：「待办清单」（`toggleTaskList`）、「无序列表」（`toggleBulletList`），一键插入/切换；同时保留行首 `[ ]`+空格 / `- `+空格 的 Markdown 快捷输入。
- **修复空待办项光标不显示**：TaskItem 的 flex 布局下，空待办项正文 `div` 会塌缩到 0 宽，导致光标无处落脚。给正文 div 加 `flex:1 1 auto; min-width:0` 撑开。
- **统一排版**：待办项的 `ul`/`li`/`div`/`p` 的 margin、line-height 对齐正文与无序列表，行高统一到 prose-sm 节奏，消除待办项与普通段落行距差异过大的问题。
- **勾选后置灰划线**：已勾选项正文 `line-through` + 语义色 `--muted-foreground`，跟随各外观主题（含深色 / ocean / forest / slate / terminal）。

## 实现方式

排版样式集中在 `globals.css` 中一段**作用域限定于 `.scratch-pad-editor`** 的普通 CSS，不改共享的 TaskList/TaskItem 扩展配置，因此不影响 diff 预览等其它用到该扩展的地方。

## 涉及文件

- `apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx`
- `apps/electron/src/renderer/styles/globals.css`

共 2 文件，+68 / -5。

## 测试

- `tsc --noEmit` 类型检查通过
- `vite build` 构建通过，确认新 CSS 规则正确生成
- 本地实测：插入/切换待办与无序列表、空项光标正常闪动、勾选置灰划线、行距与正文一致、各主题下颜色正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)