### PR TITLE
【已审核】fix(preview): 代码预览添加自动换行切换按钮

### DIFF
--- a/apps/electron/src/renderer/atoms/preview-atoms.ts
+++ b/apps/electron/src/renderer/atoms/preview-atoms.ts
@@ -53,6 +53,9 @@ export const previewModePreferenceAtom = atomWithStorage<PreviewModePreference>(
   { getOnInit: true },
 )
 
+/** 代码预览换行偏好（默认 false = 不换行，保持现有行为） */
+export const previewCodeWrapAtom = atomWithStorage<boolean>('proma-preview-code-wrap', false, undefined, { getOnInit: true })
+
 /** 当前会话的预览面板是否打开（derived） */
 export const currentSessionPreviewOpenAtom = atom<boolean>((get) => {
   const sessionId = get(currentAgentSessionIdAtom)

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -6,7 +6,7 @@
  */
 
 import * as React from 'react'
-import { ChevronRight, Code2, Copy, Check, Eye, List, Pencil, RefreshCw, Save, X } from 'lucide-react'
+import { ChevronRight, Code2, Copy, Check, Eye, List, Pencil, RefreshCw, Save, WrapText, X } from 'lucide-react'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import DOMPurify from 'dompurify'
 import { File as PierreFile } from '@pierre/diffs/react'
@@ -19,7 +19,7 @@ import {
   agentSidePanelOpenAtom,
 } from '@/atoms/agent-atoms'
 import { resolvedThemeAtom } from '@/atoms/theme'
-import { quotedSelectionMapAtom } from '@/atoms/preview-atoms'
+import { previewCodeWrapAtom, quotedSelectionMapAtom } from '@/atoms/preview-atoms'
 import {
   agentSideChatMapAtom,
   conversationsAtom,
@@ -266,6 +266,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   const refreshVersion = refreshVersionMap.get(sessionId) ?? 0
   const previewContentVersion = previewOnly ? refreshVersion : 0
   const theme = useAtomValue(resolvedThemeAtom)
+  const [codeWrap, setCodeWrap] = useAtom(previewCodeWrapAtom)
   const [tocOpen, setTocOpen] = useAtom(markdownTocOpenAtom)
 
   const ext = getExtension(filePath)
@@ -489,10 +490,10 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   const pierreOptions = React.useMemo(() => ({
     theme: { dark: 'one-dark-pro' as const, light: 'one-light' as const },
     disableFileHeader: true,
-    overflow: 'scroll' as const,
+    overflow: (codeWrap ? 'wrap' : 'scroll') as 'scroll' | 'wrap',
     themeType: theme as 'light' | 'dark' | 'system',
     unsafeCSS: PIERRE_FILE_CSS,
-  }), [theme])
+  }), [theme, codeWrap])
   const markdownFileAccess = React.useMemo(() => {
     const candidateBasePaths: string[] = []
     const slash = filePath.lastIndexOf('/')
@@ -1188,6 +1189,20 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
         >
           <RefreshCw className="size-3.5" />
         </button>
+
+        {previewOnly && !isMarkdown && !isPdf && !isImage && !isDocx && !isOfficePreview && !isLegacyOffice && (
+          <button
+            type="button"
+            onClick={() => setCodeWrap((v) => !v)}
+            className={cn(
+              'p-1 rounded hover:bg-foreground/[0.06] shrink-0',
+              codeWrap ? 'text-foreground/70' : 'text-foreground/40 hover:text-foreground/60',
+            )}
+            title={codeWrap ? '当前为自动换行，点击改为横向滚动' : '当前为横向滚动，点击改为自动换行'}
+          >
+            <WrapText className="size-3.5" />
+          </button>
+        )}
 
         {isMarkdown && !markdownEditing && (
           <button

--- a/apps/electron/src/renderer/components/diff/PreviewPanel.tsx
+++ b/apps/electron/src/renderer/components/diff/PreviewPanel.tsx
@@ -7,11 +7,12 @@
 
 import * as React from 'react'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
-import { Maximize2, PanelRight, X } from 'lucide-react'
+import { Maximize2, PanelRight, WrapText, X } from 'lucide-react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import {
   previewPanelOpenMapAtom,
   previewFileMapAtom,
+  previewCodeWrapAtom,
   previewModePreferenceAtom,
 } from '@/atoms/preview-atoms'
 import {
@@ -45,6 +46,7 @@ export function PreviewPanel({ sessionId }: PreviewPanelProps): React.ReactEleme
   const setActiveTabId = useSetAtom(activeTabIdAtom)
   const isSidePanelOpen = useAtomValue(currentSessionSidePanelOpenAtom)
   const [previewModePref, setPreviewModePref] = useAtom(previewModePreferenceAtom)
+  const [codeWrap, setCodeWrap] = useAtom(previewCodeWrapAtom)
 
   const currentFile = fileMap.get(sessionId) ?? null
 
@@ -125,6 +127,28 @@ export function PreviewPanel({ sessionId }: PreviewPanelProps): React.ReactEleme
           </TooltipTrigger>
           <TooltipContent side="bottom">
             <p>作为标签页打开预览</p>
+          </TooltipContent>
+        </Tooltip>
+      )}
+      {currentFile && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={() => setCodeWrap((v) => !v)}
+              className={cn(
+                'flex items-center justify-center size-6 shrink-0 rounded transition-colors',
+                codeWrap
+                  ? 'text-primary bg-primary/10'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
+              )}
+              aria-label={codeWrap ? '代码自动换行，点击改为横向滚动' : '代码横向滚动，点击改为自动换行'}
+            >
+              <WrapText className="size-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            <p>{codeWrap ? '自动换行已开启，点击改为横向滚动' : '自动换行已关闭，点击改为自动换行'}</p>
           </TooltipContent>
         </Tooltip>
       )}


### PR DESCRIPTION
## 概述

为代码文件预览面板添加自动换行/横向滚动切换按钮。此前 @pierre/diffs 的 overflow 参数被硬编码为 scroll，长行代码只能横向滚动查看。现在通过工具栏 WrapText 按钮一键切换，偏好通过 atomWithStorage 持久化到 localStorage。

关联 issue：proma-ai/Proma#1056

## 改动

| 文件 | 说明 |
|------|------|
| atoms/preview-atoms.ts | 新增 previewCodeWrapAtom（atomWithStorage<boolean>，默认 false 保持现有行为） |
| components/diff/DiffTabContent.tsx | pierreOptions.overflow 从硬编码 scroll 改为读 atom 值动态切换；工具栏加换行按钮（仅代码文件预览显示） |
| components/diff/PreviewPanel.tsx | 外层工具栏加换行切换按钮 |

3 文件，+47/-5 行。

## 测试

- TypeCheck 0 错误
- bun run dev 实时测试：打开代码文件预览 → 工具栏出现 WrapText 按钮 → 点击切换换行/横向滚动 → 切换后刷新/重新打开记忆偏好

## 紧急度

常规

## 备注

Closes #1056