### PR TITLE
Support 1M context for Agent models

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.14.17",
+  "version": "0.14.18",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/agent-model-routing.test.ts
+++ b/apps/electron/src/main/lib/agent-model-routing.test.ts
@@ -49,6 +49,6 @@ describe('Agent 辅助模型路由', () => {
       provider: 'deepseek',
     }))
 
-    expect(env.CLAUDE_CODE_SUBAGENT_MODEL).toBe(DEEPSEEK_SUBAGENT_MODEL_ID)
+    expect(env.CLAUDE_CODE_SUBAGENT_MODEL).toBe(`${DEEPSEEK_SUBAGENT_MODEL_ID}[1m]`)
   })
 })

--- a/apps/electron/src/main/lib/agent-model-routing.ts
+++ b/apps/electron/src/main/lib/agent-model-routing.ts
@@ -1,4 +1,4 @@
-import type { ProviderType } from '@proma/shared'
+import { resolveAgentSdkModelId, type ProviderType } from '@proma/shared'
 
 export const DEEPSEEK_SUBAGENT_MODEL_ID = 'deepseek-v4-flash'
 export interface AgentModelRoutingInput {
@@ -37,7 +37,7 @@ export function applyAgentModelRoutingToEnv(
   policy: AgentModelRoutingPolicy,
 ): void {
   if (policy.subagentModel) {
-    env.CLAUDE_CODE_SUBAGENT_MODEL = policy.subagentModel
+    env.CLAUDE_CODE_SUBAGENT_MODEL = resolveAgentSdkModelId(policy.subagentModel)
   } else {
     delete env.CLAUDE_CODE_SUBAGENT_MODEL
   }

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -57,6 +57,7 @@ import { applyAgentModelRoutingToEnv, resolveAgentModelRouting } from './agent-m
 import { validateToolInput } from './agent-tool-input-validator'
 import { estimateTokenCount, WRITE_CONTENT_TOKEN_THRESHOLD } from './agent-tool-token-estimator'
 import { injectBuiltinMcpServers } from './builtin-mcp/registry'
+import { isVisibleRunMessage } from './agent-run-message-visibility'
 
 // ===== 类型定义 =====
 
@@ -85,46 +86,12 @@ function sdkPermissionModeForPromaMode(mode: PromaPermissionMode): PromaPermissi
 
 const EMPTY_RESPONSE_RESULT_SUBTYPE = 'empty_response'
 
-function isNonEmptyString(value: unknown): boolean {
-  return typeof value === 'string' && value.trim().length > 0
-}
-
 function errorMessageOf(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
 function isMissingActiveQueueChannelError(error: unknown): boolean {
   return errorMessageOf(error).includes('无活跃消息通道可注入队列消息')
-}
-
-function isVisibleRunMessage(message: SDKMessage): boolean {
-  const msgRecord = message as Record<string, unknown>
-  if (msgRecord.isReplay) return false
-
-  if (message.type === 'assistant') {
-    const assistantMsg = message as SDKAssistantMessage
-    if (assistantMsg.error) return true
-    const content = assistantMsg.message?.content
-    if (!Array.isArray(content)) return false
-    return content.some((block) => {
-      if (block.type === 'text') return isNonEmptyString((block as { text?: unknown }).text)
-      if (block.type === 'thinking') return isNonEmptyString((block as { thinking?: unknown }).thinking)
-      if (block.type === 'tool_use') return true
-      return Object.keys(block).length > 1
-    })
-  }
-
-  if (message.type === 'user') {
-    const content = (message as { message?: { content?: Array<{ type: string }> } }).message?.content
-    return Array.isArray(content) && content.some((block) => block.type === 'tool_result')
-  }
-
-  if (message.type === 'system') {
-    const subtype = (message as SDKSystemMessage).subtype
-    return subtype === 'task_started' || subtype === 'task_progress' || subtype === 'task_notification'
-  }
-
-  return false
 }
 
 /**

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -29,6 +29,7 @@ import {
   THINKING_SIGNATURE_ERROR_TITLE,
   isPersistableSDKSystemMessage,
   normalizeMcpTransportType,
+  resolveAgentSdkModelId,
 } from '@proma/shared'
 import type { PromaPermissionMode, AskUserRequest, ExitPlanModeRequest, SDKSystemMessage } from '@proma/shared'
 import type { ClaudeAgentQueryOptions } from './adapters/claude-agent-adapter'
@@ -1421,14 +1422,16 @@ export class AgentOrchestrator {
 
       // 13. 构建 Adapter 查询选项
       // 检测用户选用的模型是否为 Claude 系列，决定 SubAgent 是否使用独立模型分层
-      const claudeAvailable = (modelId || DEFAULT_MODEL_ID).toLowerCase().includes('claude')
+      const selectedModelId = modelId || DEFAULT_MODEL_ID
+      const claudeAvailable = selectedModelId.toLowerCase().includes('claude')
       const maxTurns = appSettings.agentMaxTurns && appSettings.agentMaxTurns > 0
         ? appSettings.agentMaxTurns
         : undefined
       const queryOptions: ClaudeAgentQueryOptions = {
         sessionId,
         prompt: finalPrompt,
-        model: modelId || DEFAULT_MODEL_ID,
+        // SDK 需要 `[1m]` 显式选择扩展上下文；发送给提供商前会自动剥离后缀。
+        model: resolveAgentSdkModelId(selectedModelId),
         cwd: agentCwd,
         sdkCliPath: cliPath,
         env: sdkEnv,
@@ -1512,10 +1515,11 @@ export class AgentOrchestrator {
           }
         },
         onModelResolved: (model: string) => {
-          resolvedModel = model
+          // `[1m]` 是 SDK 内部上下文变体，不应泄漏到标题生成或用户可见的模型名。
+          resolvedModel = model.replace(/\[1m\]$/i, '')
           console.log(`[Agent 编排] SDK 确认模型: ${resolvedModel}`)
           // 通知渲染进程更新流式状态中的模型信息
-          this.eventBus.emit(sessionId, { kind: 'proma_event', event: { type: 'model_resolved', model } })
+          this.eventBus.emit(sessionId, { kind: 'proma_event', event: { type: 'model_resolved', model: resolvedModel } })
         },
         onContextWindow: (cw: number) => {
           console.log(`[Agent 编排] 缓存 contextWindow: ${cw}`)

--- a/apps/electron/src/main/lib/agent-run-message-visibility.test.ts
+++ b/apps/electron/src/main/lib/agent-run-message-visibility.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'bun:test'
+import type { SDKMessage } from '@proma/shared'
+import { isVisibleRunMessage } from './agent-run-message-visibility'
+
+describe('Agent 本轮可见消息判定', () => {
+  test.each([
+    { type: 'system', subtype: 'compacting' },
+    { type: 'system', subtype: 'compact_boundary' },
+    { type: 'system', subtype: 'status', compact_result: 'success' },
+  ] as SDKMessage[])('Given /compact 返回压缩状态 %# When 判断本轮是否有可见内容 Then 不误报空回复', (message) => {
+    expect(isVisibleRunMessage(message)).toBe(true)
+  })
+
+  test('Given SDK 仅返回不可展示的 init 和 result When 判断本轮是否有可见内容 Then 仍允许空回复保护接管', () => {
+    expect(isVisibleRunMessage({ type: 'system', subtype: 'init' } as SDKMessage)).toBe(false)
+    expect(isVisibleRunMessage({ type: 'result', subtype: 'success' } as SDKMessage)).toBe(false)
+  })
+})

--- a/apps/electron/src/main/lib/agent-run-message-visibility.ts
+++ b/apps/electron/src/main/lib/agent-run-message-visibility.ts
@@ -1,0 +1,40 @@
+import type { SDKAssistantMessage, SDKMessage, SDKSystemMessage } from '@proma/shared'
+import { isPersistableSDKSystemMessage } from '@proma/shared'
+
+function isNonEmptyString(value: unknown): boolean {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+/** 判断本轮 SDK 消息中是否包含用户最终能看到的内容。 */
+export function isVisibleRunMessage(message: SDKMessage): boolean {
+  const msgRecord = message as Record<string, unknown>
+  if (msgRecord.isReplay) return false
+
+  if (message.type === 'assistant') {
+    const assistantMsg = message as SDKAssistantMessage
+    if (assistantMsg.error) return true
+    const content = assistantMsg.message?.content
+    if (!Array.isArray(content)) return false
+    return content.some((block) => {
+      if (block.type === 'text') return isNonEmptyString((block as { text?: unknown }).text)
+      if (block.type === 'thinking') return isNonEmptyString((block as { thinking?: unknown }).thinking)
+      if (block.type === 'tool_use') return true
+      return Object.keys(block).length > 1
+    })
+  }
+
+  if (message.type === 'user') {
+    const content = (message as { message?: { content?: Array<{ type: string }> } }).message?.content
+    return Array.isArray(content) && content.some((block) => block.type === 'tool_result')
+  }
+
+  if (message.type === 'system') {
+    const systemMessage = message as SDKSystemMessage
+    return isPersistableSDKSystemMessage(systemMessage)
+      || systemMessage.subtype === 'task_started'
+      || systemMessage.subtype === 'task_progress'
+      || systemMessage.subtype === 'task_notification'
+  }
+
+  return false
+}

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -1281,10 +1281,10 @@ export function getGroupId(group: MessageGroup): string {
     return messageIdCache.get(group.message)!
   }
   if (group.type === 'system') {
-    if (!messageIdCache.has(group.message)) {
-      messageIdCache.set(group.message, `system-${group.message.subtype ?? 'unknown'}-${++fallbackIdCounter}`)
+    if (!messageIdCache.has(group.identityMessage)) {
+      messageIdCache.set(group.identityMessage, `system-${group.identityMessage.subtype ?? 'unknown'}-${++fallbackIdCounter}`)
     }
-    return messageIdCache.get(group.message)!
+    return messageIdCache.get(group.identityMessage)!
   }
   // assistant-turn：取首条 assistant 消息的 uuid
   const first = group.assistantMessages[0]

--- a/packages/session-core/src/group.ts
+++ b/packages/session-core/src/group.ts
@@ -79,7 +79,13 @@ export interface AssistantTurn {
 
 export type MessageGroup =
   | { type: 'user'; message: SDKUserMessage }
-  | { type: 'system'; message: SDKSystemMessage }
+  | {
+      type: 'system'
+      /** 当前需要渲染的最新状态。 */
+      message: SDKSystemMessage
+      /** 首次创建该 group 的消息，用于压缩状态原位更新时保持稳定身份。 */
+      identityMessage: SDKSystemMessage
+    }
   | AssistantTurn
 
 /**
@@ -95,9 +101,6 @@ export type MessageGroup =
 export function groupIntoTurns(messages: SDKMessage[], sessionModelId?: string): MessageGroup[] {
   const groups: MessageGroup[] = []
   let currentTurn: AssistantTurn | null = null
-  const hasCompactBoundary = messages.some((msg) => {
-    return msg.type === 'system' && (msg as SDKSystemMessage).subtype === 'compact_boundary'
-  })
   // 收到后台任务完成通知（task_notification）后，若没有用户输入就直接出现新的 assistant 输出，
   // 说明这是自动唤醒的新一轮，应另起独立消息块，而不是续接上一轮。
   // 注意：不能用 result 做信号——正常对话每轮也以 result 结束，会误伤普通回复。
@@ -149,14 +152,30 @@ export function groupIntoTurns(messages: SDKMessage[], sessionModelId?: string):
       }
     } else if (msg.type === 'system') {
       const sysMsg = msg as SDKSystemMessage
-      if (hasCompactBoundary && sysMsg.subtype === 'status' && sysMsg.compact_result === 'success') {
-        continue
-      }
       // 仅需要独立渲染的 system 消息才中断 turn（压缩状态 / permission_denied）
       // 其他 system 消息（如 init、task_started、task_progress）归入当前 turn，不中断分组
       if (isPersistableSDKSystemMessage(sysMsg)) {
         flushTurn()
-        groups.push({ type: 'system', message: sysMsg })
+        const previousGroup = groups.at(-1)
+        const compactStatus = getSDKCompactStatus(sysMsg)
+        const previousCompactStatus = previousGroup?.type === 'system'
+          ? getSDKCompactStatus(previousGroup.message)
+          : undefined
+        const startsNewCompactLifecycle = compactStatus === 'compacting'
+          && previousCompactStatus !== undefined
+          && previousCompactStatus !== 'compacting'
+        // 同一次压缩会依次产生 compacting、status success/failed、compact_boundary。
+        // 这些事件共同更新一个 group，避免界面为一个压缩生命周期渲染多条分界线。
+        if (
+          compactStatus
+          && previousGroup?.type === 'system'
+          && previousCompactStatus
+          && !startsNewCompactLifecycle
+        ) {
+          previousGroup.message = sysMsg
+        } else {
+          groups.push({ type: 'system', message: sysMsg, identityMessage: sysMsg })
+        }
       } else if (sysMsg.subtype === 'task_notification') {
         // 后台任务完成通知：仅在没有进行中的 turn 时标记唤醒边界（真正的唤醒场景）。
         // 若当前有 turn 正在进行，归入当前 turn 不截断。

--- a/packages/session-core/src/session-core.test.ts
+++ b/packages/session-core/src/session-core.test.ts
@@ -67,7 +67,7 @@ describe('工具折叠 ×N', () => {
 })
 
 describe('SDK 压缩状态分组', () => {
-  test('status 压缩事件独立成组并生成预览', () => {
+  test('Given 压缩从进行中变为失败 When 分组 Then 原位更新同一个状态组', () => {
     const raw = jsonl([
       { type: 'user', message: { content: [{ type: 'text', text: '压缩测试' }] }, parent_tool_use_id: null },
       { type: 'assistant', message: { id: 'a1', content: [{ type: 'text', text: '准备压缩' }] }, parent_tool_use_id: null },
@@ -77,9 +77,47 @@ describe('SDK 压缩状态分组', () => {
 
     const groups = groupIntoTurns(readSessionMessagesFromString(raw))
 
-    expect(groups.map((g) => g.type)).toEqual(['user', 'assistant-turn', 'system', 'system'])
-    expect(getGroupPreview(groups[2]!)).toBe('正在压缩上下文...')
-    expect(getGroupPreview(groups[3]!)).toBe('上下文压缩失败')
+    expect(groups.map((g) => g.type)).toEqual(['user', 'assistant-turn', 'system'])
+    expect(getGroupPreview(groups[2]!)).toBe('上下文压缩失败')
+    expect(groups[2]).toMatchObject({
+      type: 'system',
+      identityMessage: { status: 'compacting' },
+      message: { compact_result: 'failed' },
+    })
+  })
+
+  test('Given 压缩产生多个成功事件 When 分组 Then 只保留一条已完成分界线', () => {
+    const raw = jsonl([
+      { type: 'user', message: { content: [{ type: 'text', text: '/compact' }] }, parent_tool_use_id: null },
+      { type: 'system', subtype: 'compacting' },
+      { type: 'system', subtype: 'status', compact_result: 'success' },
+      { type: 'system', subtype: 'compact_boundary' },
+      { type: 'result', subtype: 'success' },
+    ])
+
+    const groups = groupIntoTurns(readSessionMessagesFromString(raw))
+
+    expect(groups.map((g) => g.type)).toEqual(['user', 'system'])
+    expect(getGroupPreview(groups[1]!)).toBe('上下文已压缩')
+    expect(groups[1]).toMatchObject({
+      type: 'system',
+      identityMessage: { subtype: 'compacting' },
+      message: { subtype: 'compact_boundary' },
+    })
+  })
+
+  test('Given 上一次压缩已结束且下一次立即开始 When 分组 Then 保留两个压缩周期', () => {
+    const raw = jsonl([
+      { type: 'system', subtype: 'compacting' },
+      { type: 'system', subtype: 'compact_boundary' },
+      { type: 'system', subtype: 'compacting' },
+    ])
+
+    const groups = groupIntoTurns(readSessionMessagesFromString(raw))
+
+    expect(groups).toHaveLength(2)
+    expect(getGroupPreview(groups[0]!)).toBe('上下文已压缩')
+    expect(getGroupPreview(groups[1]!)).toBe('正在压缩上下文...')
   })
 })
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/shared",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "license": "AGPL-3.0-only",
   "description": "Shared types, configs and utilities for proma",
   "type": "module",

--- a/packages/shared/src/utils/context-window.test.ts
+++ b/packages/shared/src/utils/context-window.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  DEFAULT_CONTEXT_WINDOW,
+  ONE_MILLION_CONTEXT_WINDOW,
+  inferContextWindow,
+  resolveAgentSdkModelId,
+  supports1MContext,
+} from './context-window'
+
+describe('模型上下文窗口', () => {
+  test('Given 当前 1M Claude 模型 When 推断窗口 Then 返回 1M', () => {
+    expect(inferContextWindow('claude-opus-4-8-promo-3')).toBe(ONE_MILLION_CONTEXT_WINDOW)
+    expect(inferContextWindow('claude-sonnet-4-6')).toBe(ONE_MILLION_CONTEXT_WINDOW)
+    expect(inferContextWindow('claude-sonnet-5')).toBe(ONE_MILLION_CONTEXT_WINDOW)
+  })
+
+  test('Given 旧版 Claude 或 Haiku When 推断窗口 Then 保持 200K', () => {
+    expect(supports1MContext('claude-sonnet-4-5')).toBe(false)
+    expect(inferContextWindow('claude-sonnet-4-5')).toBe(DEFAULT_CONTEXT_WINDOW)
+    expect(inferContextWindow('claude-opus-4-5')).toBe(DEFAULT_CONTEXT_WINDOW)
+    expect(inferContextWindow('claude-haiku-4-5-20251001')).toBe(DEFAULT_CONTEXT_WINDOW)
+  })
+
+  test('Given 支持 1M 的 Agent 模型 When 解析 SDK 模型 Then 追加扩展上下文后缀', () => {
+    expect(resolveAgentSdkModelId('claude-opus-4-8-promo-3')).toBe('claude-opus-4-8-promo-3[1m]')
+    expect(resolveAgentSdkModelId('claude-sonnet-5')).toBe('claude-sonnet-5[1m]')
+    expect(resolveAgentSdkModelId('claude-fable-5')).toBe('claude-fable-5[1m]')
+    expect(resolveAgentSdkModelId('deepseek-v4-pro')).toBe('deepseek-v4-pro[1m]')
+    expect(resolveAgentSdkModelId('deepseek-v4-flash')).toBe('deepseek-v4-flash[1m]')
+    expect(resolveAgentSdkModelId('glm-5.2')).toBe('glm-5.2[1m]')
+    expect(resolveAgentSdkModelId('mimo-v2.5-pro')).toBe('mimo-v2.5-pro[1m]')
+    expect(resolveAgentSdkModelId('mimo-v2.5')).toBe('mimo-v2.5[1m]')
+    expect(resolveAgentSdkModelId('MiniMax-M3')).toBe('MiniMax-M3[1m]')
+    expect(resolveAgentSdkModelId('qwen3.7-max')).toBe('qwen3.7-max[1m]')
+    expect(resolveAgentSdkModelId('qwen3.7-plus')).toBe('qwen3.7-plus[1m]')
+    expect(resolveAgentSdkModelId('qwen3.6-plus')).toBe('qwen3.6-plus[1m]')
+    expect(resolveAgentSdkModelId('qwen3.6-flash')).toBe('qwen3.6-flash[1m]')
+    expect(resolveAgentSdkModelId('qwen3.5-plus')).toBe('qwen3.5-plus[1m]')
+    expect(resolveAgentSdkModelId('qwen3.5-flash')).toBe('qwen3.5-flash[1m]')
+    expect(resolveAgentSdkModelId('qwen3-coder-plus')).toBe('qwen3-coder-plus[1m]')
+  })
+
+  test('Given 已带后缀或未纳入 SDK 1M 的模型 When 解析 SDK 模型 Then 保持原值', () => {
+    expect(resolveAgentSdkModelId('claude-opus-4-8[1m]')).toBe('claude-opus-4-8[1m]')
+    expect(resolveAgentSdkModelId('claude-sonnet-4-5')).toBe('claude-sonnet-4-5')
+    expect(resolveAgentSdkModelId('claude-haiku-4-5-20251001')).toBe('claude-haiku-4-5-20251001')
+    expect(resolveAgentSdkModelId('mimo-v2-pro')).toBe('mimo-v2-pro')
+    expect(resolveAgentSdkModelId('MiniMax-M2.7')).toBe('MiniMax-M2.7')
+    expect(resolveAgentSdkModelId('qwen3-max')).toBe('qwen3-max')
+    expect(resolveAgentSdkModelId('qwen3.6-max-preview')).toBe('qwen3.6-max-preview')
+    expect(resolveAgentSdkModelId('qwen3.5-397b-a17b')).toBe('qwen3.5-397b-a17b')
+    expect(resolveAgentSdkModelId('qwen3-coder-next')).toBe('qwen3-coder-next')
+    expect(resolveAgentSdkModelId('unknown-model')).toBe('unknown-model')
+  })
+})

--- a/packages/shared/src/utils/context-window.ts
+++ b/packages/shared/src/utils/context-window.ts
@@ -3,9 +3,9 @@
  *
  * 1M 上下文已随各家模型转正为默认能力（Anthropic 于 2026-03 对 Opus 4.6 /
  * Sonnet 4.6 起 GA，无需 context-1m beta header；Sonnet 5 / Opus 4.7+ 延续），
- * 故不再下发任何 beta。本文件仅用于「按模型名推断上下文窗口大小」，供前端
- * ContextUsageBadge 进度环分母 fallback 与后端用量统计共用同一份判定，
- * 否则会出现"UI 显示 1M 但实际只 200K"或反过来的不一致。
+ * 故不再下发任何 beta。Claude Agent SDK 仍要求通过 `[1m]` 模型后缀显式选择
+ * 扩展上下文（发送请求前会自动剥离），因此前端推断、后端用量统计和 SDK 模型
+ * 选择必须共用同一份判定，否则会出现"UI 显示 1M 但实际只 200K"的不一致。
  */
 
 /** 默认上下文窗口（无法识别模型时使用） */
@@ -14,8 +14,35 @@ export const DEFAULT_CONTEXT_WINDOW = 200_000
 /** 1M 上下文窗口 */
 export const ONE_MILLION_CONTEXT_WINDOW = 1_000_000
 
+/** 已确认需要显式选择 Claude Agent SDK `[1m]` 变体的模型。 */
+const AGENT_SDK_1M_CONTEXT_RULES = [
+  // Claude 系列
+  'claude-sonnet-4-6',
+  'claude-sonnet-5',
+  'claude-opus-4-6',
+  'claude-opus-4-7',
+  'claude-opus-4-8',
+  'claude-fable-5',
+  // DeepSeek
+  'deepseek-v4',
+  // 智谱 GLM
+  'glm-5.2',
+  // 小米 MiMo
+  'mimo-v2.5',
+  // MiniMax
+  'minimax-m3',
+  // 通义千问
+  'qwen3.7',
+  'qwen3.6-plus',
+  'qwen3.6-flash',
+  'qwen3.5-plus',
+  'qwen3.5-flash',
+  'qwen3-coder-plus',
+] as const
+
 /**
- * 上下文窗口配置表 — 新增模型只需在此处加一行。
+ * 上下文窗口配置表。仅影响显示推断的模型加在 rules；已实测 Agent SDK 1M
+ * 行为的模型加在上方 AGENT_SDK_1M_CONTEXT_RULES，并自动复用于 rules。
  *
  * 匹配规则：modelId.toLowerCase() 包含 pattern 即命中（substring match）。
  * exclude 列表优先级最高：命中 exclude 的模型始终返回 DEFAULT_CONTEXT_WINDOW。
@@ -28,24 +55,9 @@ const CONTEXT_WINDOW_CONFIG = {
 
   /** 1M 上下文模型匹配规则 */
   rules: [
-    // Claude 系列
-    'claude-sonnet-4',
-    'claude-sonnet-5',
-    'claude-opus-4-6',
-    'claude-opus-4-7',
-    'claude-opus-4-8',
-    'claude-fable-5',
-    // DeepSeek
-    'deepseek-v4',
-    // 小米 MiMo
-    'mimo-v2.5',
+    ...AGENT_SDK_1M_CONTEXT_RULES,
+    // 已废弃的 MiMo V2 Pro 仅保留历史显示推断，不主动启用 SDK 1M 变体
     'mimo-v2-pro',
-    // 智谱 GLM
-    'glm-5.2',
-    // MiniMax
-    'minimax-m3',
-    // Qwen3.7（DashScope Anthropic 兼容端点默认 1M，无需 context-1m beta header）
-    'qwen3.7',
   ] as const,
 } as const
 
@@ -69,4 +81,19 @@ export function inferContextWindow(model?: string): number | undefined {
   if (!model) return undefined
   if (supports1MContext(model)) return ONE_MILLION_CONTEXT_WINDOW
   return DEFAULT_CONTEXT_WINDOW
+}
+
+/**
+ * 将已确认的 1M Agent 模型转换为 Claude Agent SDK 的扩展上下文变体。
+ *
+ * `[1m]` 仅影响 SDK 的窗口与自动压缩判定；SDK 发给提供商前会自动剥离该后缀，
+ * 因此不会改变 Proma 渠道路由使用的真实模型 ID。
+ */
+export function resolveAgentSdkModelId(modelId: string): string {
+  if (!modelId || /\[1m\]$/i.test(modelId)) {
+    return modelId
+  }
+  const model = modelId.toLowerCase()
+  if (!AGENT_SDK_1M_CONTEXT_RULES.some((pattern) => model.includes(pattern))) return modelId
+  return `${modelId}[1m]`
 }

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -14,6 +14,7 @@ export {
   ONE_MILLION_CONTEXT_WINDOW,
   supports1MContext,
   inferContextWindow,
+  resolveAgentSdkModelId,
 } from './context-window'
 export { calculateContextUsageRatio } from './context-usage'
 export {


### PR DESCRIPTION
## Summary

- enable Claude Agent SDK's explicit `[1m]` model variant for confirmed 1M-context models
- cover Claude, DeepSeek V4, GLM 5.2, MiMo V2.5, MiniMax M3, and supported Qwen model families
- keep SDK-only suffixes out of user-visible model names and session metadata
- apply the same routing to the fixed DeepSeek subagent model

## Root cause

Proma inferred a 1M context window for display and usage accounting, but passed the raw model ID to Claude Agent SDK. The SDK therefore continued using its default 200K compression threshold unless the `[1m]` model variant was selected explicitly.

## Changes

- centralize confirmed Agent SDK 1M model rules in the shared context-window utility
- add an idempotent `resolveAgentSdkModelId()` helper
- resolve main-agent and subagent model IDs before starting SDK queries
- strip the internal `[1m]` suffix from resolved model events
- narrow older Claude matching so unsupported variants remain on the default context window
- add BDD coverage for supported and excluded model families
- bump Electron and shared package patch versions

## Validation

- native Claude Agent SDK mock transport: confirmed `contextWindow: 1000000` and provider-facing suffix stripping for all included model families
- `bun test` — 289 passed, 0 failed
- `bun run typecheck`
- `bun run --cwd apps/electron build:main`
- `git diff --check`
