### PR TITLE
feat(agent): expand session reference list to 200

### DIFF
--- a/apps/electron/src/main/lib/agent-session-manager.test.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.test.ts
@@ -53,6 +53,28 @@ function writeSdkSessionJsonl(sdkSessionId: string, rows: string[]): void {
   writeFileSync(join(dir, `${sdkSessionId}.jsonl`), jsonl(rows), 'utf-8')
 }
 
+function writeAgentSessionsIndex(sessions: Array<{
+  id: string
+  title: string
+  workspaceId: string
+  createdAt: number
+  updatedAt: number
+}>): void {
+  const dir = join(tempHome, '.proma')
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'agent-sessions.json'), JSON.stringify({ version: 1, sessions }), 'utf-8')
+}
+
+function createIndexedSessions(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `session-${index}`,
+    title: `会话 ${index}`,
+    workspaceId: 'workspace-a',
+    createdAt: index,
+    updatedAt: index,
+  }))
+}
+
 beforeAll(async () => {
   tempHome = mkdtempSync(join(os.tmpdir(), 'proma-agent-session-manager-'))
   process.env.HOME = tempHome
@@ -125,5 +147,32 @@ describe('Agent 会话 JSONL 读取', () => {
 
     expect(() => manager.truncateSDKMessages('session-truncate-bad-line', 'assistant-1'))
       .toThrow('JSONL 第 2 行解析失败')
+  })
+})
+
+describe('Agent 会话引用搜索', () => {
+  test('Given 工作区有超过 20 个会话 When 请求最近 200 条 Then 按更新时间返回 200 条', () => {
+    writeAgentSessionsIndex(createIndexedSessions(220))
+
+    const results = manager.searchAgentSessionReferences({
+      workspaceId: 'workspace-a',
+      limit: 200,
+    })
+
+    expect(results).toHaveLength(200)
+    expect(results[0]?.sessionId).toBe('session-219')
+    expect(results.at(-1)?.sessionId).toBe('session-20')
+    expect(results.every((result) => result.matchSource === 'recent')).toBe(true)
+  })
+
+  test('Given 请求数量超过性能上限 When 搜索可引用会话 Then 最多返回 200 条', () => {
+    writeAgentSessionsIndex(createIndexedSessions(220))
+
+    const results = manager.searchAgentSessionReferences({
+      workspaceId: 'workspace-a',
+      limit: 500,
+    })
+
+    expect(results).toHaveLength(200)
   })
 })

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -59,6 +59,14 @@ interface AgentSessionsIndex {
 /** 当前索引版本 */
 const INDEX_VERSION = 1
 
+/**
+ * 会话引用最大返回数。
+ *
+ * 无搜索词时只返回索引中的轻量元数据，200 条可以显著扩大可选范围，
+ * 同时避免极端会话数量下向渲染进程传输过大列表。
+ */
+const MAX_SESSION_REFERENCE_LIMIT = 200
+
 interface JsonlParseError {
   lineNumber: number
   message: string
@@ -1712,7 +1720,7 @@ export function searchAgentSessionReferences(input: AgentSessionReferenceSearchI
   const query = (input?.query ?? '').trim()
   const queryLower = query.toLowerCase()
   const requestedLimit = Number.isFinite(input?.limit) ? input.limit! : 20
-  const limit = Math.min(Math.max(requestedLimit, 1), 50)
+  const limit = Math.min(Math.max(requestedLimit, 1), MAX_SESSION_REFERENCE_LIMIT)
 
   const candidates = listAgentSessions()
     .filter((session) => session.workspaceId === workspaceId)

--- a/apps/electron/src/renderer/components/agent/mention-suggestions.tsx
+++ b/apps/electron/src/renderer/components/agent/mention-suggestions.tsx
@@ -231,6 +231,10 @@ export function createMcpMentionSuggestion(
 
 export type SessionMentionItem = AgentSessionReferenceSearchResult
 
+// 空查询只读会话索引，可安全展示更多；搜索会读取 JSONL 消息，保持较小上限避免阻塞主进程。
+const RECENT_SESSION_MENTION_LIMIT = 200
+const SEARCHED_SESSION_MENTION_LIMIT = 20
+
 export function createSessionMentionSuggestion(
   workspaceIdRef: React.RefObject<string | null>,
   currentSessionIdRef: React.RefObject<string | null>,
@@ -249,7 +253,7 @@ export function createSessionMentionSuggestion(
           workspaceId,
           excludeSessionId: currentSessionIdRef.current ?? undefined,
           query: q,
-          limit: 20,
+          limit: q ? SEARCHED_SESSION_MENTION_LIMIT : RECENT_SESSION_MENTION_LIMIT,
         })
       },
       keyExtractor: (item) => item.sessionId,


### PR DESCRIPTION
## What changed

- Show up to 200 recent sessions when the user opens the `&` session-reference menu.
- Keep keyword-search results at 20 because content search reads session JSONL files synchronously.
- Add a backend hard cap of 200 results to bound IPC payload and renderer work.
- Add BDD coverage for the expanded result set and hard cap.

## Why

The previous 20-session window made older but still relevant Agent sessions difficult to reference. The adaptive limits expand the fast metadata-only path by 10x without increasing the expensive message-content search path.

## User impact

Users can browse many more recent sessions directly after typing `&`. Sessions outside that window remain discoverable with a specific title or content query.

## Validation

- `bun test apps/electron/src/main/lib/agent-session-manager.test.ts`
- `cd apps/electron && bun run typecheck`
- `git diff --check`
