### PR TITLE
Fix DingTalk bot ID update

### DIFF
--- a/apps/electron/src/main/lib/dingtalk-config.test.ts
+++ b/apps/electron/src/main/lib/dingtalk-config.test.ts
@@ -143,4 +143,44 @@ describe('钉钉 Bot 配置迁移', () => {
     const shared = merged.find((b: { chatId: string }) => b.chatId === 'chat-shared')
     expect(shared.sessionId).toBe('new-session')
   })
+
+  test('Given 已有 Bot 修改 Client ID When 保存配置 Then 立即返回新稳定 Bot ID 并迁移绑定文件', () => {
+    const oldClientId = 'ding-old-app-key'
+    const nextClientId = 'ding-next-app-key'
+    const oldBotId = createStableDingTalkBotId(oldClientId)!
+    const nextBotId = createStableDingTalkBotId(nextClientId)!
+    const bindings = [
+      { chatId: 'chat-existing', sessionId: 'session-existing', workspaceId: 'ws-1', channelId: 'ch-1' },
+    ]
+
+    writeFileSync(configPaths.getDingTalkConfigPath(), JSON.stringify({
+      version: 2,
+      bots: [
+        {
+          id: oldBotId,
+          name: '钉钉助手',
+          enabled: true,
+          clientId: oldClientId,
+          clientSecret: 'secret',
+          defaultWorkspaceId: 'ws-1',
+        },
+      ],
+    }, null, 2), 'utf-8')
+    writeFileSync(configPaths.getDingTalkBotBindingsPath(oldBotId), JSON.stringify(bindings, null, 2), 'utf-8')
+
+    const saved = dingtalkConfig.saveDingTalkBotConfig({
+      id: oldBotId,
+      name: '钉钉助手',
+      enabled: true,
+      clientId: nextClientId,
+      clientSecret: '',
+      defaultWorkspaceId: 'ws-1',
+    })
+
+    expect(saved.id).toBe(nextBotId)
+    expect(dingtalkConfig.getDingTalkBotById(nextBotId)?.clientId).toBe(nextClientId)
+    expect(dingtalkConfig.getDingTalkBotById(oldBotId)).toBeUndefined()
+    expect(existsSync(configPaths.getDingTalkBotBindingsPath(oldBotId))).toBe(false)
+    expect(JSON.parse(readFileSync(configPaths.getDingTalkBotBindingsPath(nextBotId), 'utf-8'))).toEqual(bindings)
+  })
 })

--- a/apps/electron/src/main/lib/dingtalk-config.ts
+++ b/apps/electron/src/main/lib/dingtalk-config.ts
@@ -199,11 +199,19 @@ export function saveDingTalkBotConfig(input: DingTalkBotConfigInput): DingTalkBo
       throw new Error(`Bot ${input.id} 不存在`)
     }
     const existing = config.bots[idx]!
+    const clientId = input.clientId.trim()
+    const resolvedId = resolveBotId(clientId, input.id)
+    const nextId = config.bots.some((b, i) => i !== idx && b.id === resolvedId)
+      ? input.id
+      : resolvedId
+    if (nextId !== input.id) {
+      migrateDingTalkBindingFile(input.id, nextId)
+    }
     const updated: DingTalkBotConfig = {
-      id: input.id,
+      id: nextId,
       name: input.name,
       enabled: input.enabled,
-      clientId: input.clientId.trim(),
+      clientId,
       clientSecret: input.clientSecret ? encryptSecret(input.clientSecret) : existing.clientSecret,
       defaultWorkspaceId: input.defaultWorkspaceId,
       defaultChannelId: input.defaultChannelId,


### PR DESCRIPTION
## Summary

- Resolve the stable DingTalk Bot ID immediately when saving an existing Bot whose Client ID changes.
- Migrate the Bot binding file during that save path so chat/session bindings follow the new stable ID.
- Add a regression test for editing an existing Bot Client ID.

## Root Cause

#1129 normalized DingTalk Bot IDs when reading config and when creating new Bots, but the existing-Bot update path still wrote and returned `input.id`. The settings IPC immediately calls `restartBot(saved.id)` after save. If the Client ID changed, the next config read normalizes the Bot to a different stable ID, so restart looks up the old ID and fails with `Bot <old id> 不存在`.

## Validation

- `bun test apps/electron/src/main/lib/dingtalk-config.test.ts apps/electron/src/main/lib/bridge-binding-store.test.ts`
- `bun run --cwd apps/electron typecheck`
- `bun test packages/shared/src/utils/context-window.test.ts packages/session-core/src/session-core.test.ts apps/electron/src/main/lib/agent-run-message-visibility.test.ts apps/electron/src/main/lib/agent-model-routing.test.ts apps/electron/src/main/lib/agent-session-manager.test.ts`
- `git diff --check`
