### PR TITLE
Fix compatible provider channel testing and model discovery

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.14.18",
+  "version": "0.14.19",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -31,6 +31,7 @@ import type {
   ChannelCreateInput,
   ChannelUpdateInput,
   ChannelTestResult,
+  ChannelDirectTestInput,
   FetchModelsInput,
   FetchModelsResult,
   ConversationMeta,
@@ -1138,7 +1139,7 @@ export function registerIpcHandlers(): void {
   // 直接测试连接（无需已保存渠道，传入明文凭证）
   ipcMain.handle(
     CHANNEL_IPC_CHANNELS.TEST_DIRECT,
-    async (_, input: FetchModelsInput): Promise<ChannelTestResult> => {
+    async (_, input: ChannelDirectTestInput): Promise<ChannelTestResult> => {
       return testChannelDirect(input)
     }
   )

--- a/apps/electron/src/main/lib/channel-manager.ts
+++ b/apps/electron/src/main/lib/channel-manager.ts
@@ -16,6 +16,7 @@ import type {
   ChannelUpdateInput,
   ChannelsConfig,
   ChannelTestResult,
+  ChannelDirectTestInput,
   ChannelModel,
   FetchModelsInput,
   FetchModelsResult,
@@ -40,6 +41,20 @@ const CONFIG_VERSION = 2
 /** 连接测试 / 模型拉取的统一超时时间 */
 const CHANNEL_TEST_TIMEOUT_MS = 15_000
 const ARK_CODING_PLAN_TEST_MODEL = 'doubao-seed-2.0-code'
+const DEEPSEEK_PRESET_MODELS: ChannelModel[] = [
+  { id: 'deepseek-v4-pro', name: 'DeepSeek V4 Pro', enabled: true },
+  { id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash', enabled: true },
+]
+const KIMI_PRESET_MODELS: ChannelModel[] = [
+  { id: 'kimi-k2.6', name: 'Kimi K2.6', enabled: true },
+]
+const XIAOMI_PRESET_MODELS: ChannelModel[] = [
+  { id: 'mimo-v2.5-pro', name: 'MiMo V2.5 Pro', enabled: true },
+  { id: 'mimo-v2-pro', name: 'MiMo V2 Pro', enabled: true },
+  { id: 'mimo-v2.5', name: 'MiMo V2.5', enabled: true },
+  { id: 'mimo-v2-omni', name: 'MiMo V2 Omni', enabled: true },
+  { id: 'mimo-v2-flash', name: 'MiMo V2 Flash', enabled: true },
+]
 const ARK_CODING_PLAN_MODELS: ChannelModel[] = [
   { id: 'doubao-seed-2.0-code', name: 'Doubao Seed 2.0 Code', enabled: true },
   { id: 'doubao-seed-2.0-pro', name: 'Doubao Seed 2.0 Pro', enabled: true },
@@ -57,6 +72,67 @@ const ARK_CODING_PLAN_MODELS: ChannelModel[] = [
  */
 function withTimeout(init: RequestInit): RequestInit {
   return { ...init, signal: AbortSignal.timeout(CHANNEL_TEST_TIMEOUT_MS) }
+}
+
+function cloneModels(models: ChannelModel[]): ChannelModel[] {
+  return models.map((model) => ({ ...model }))
+}
+
+function createPresetModelsResult(providerName: string, models: ChannelModel[]): FetchModelsResult {
+  return {
+    success: true,
+    message: `${providerName} 未开放模型列表端点，已加载 ${models.length} 个预设模型`,
+    models: cloneModels(models),
+  }
+}
+
+function resolveFirstTestModelId(models?: ChannelModel[]): string | undefined {
+  return models?.find((model) => model.enabled)?.id ?? models?.[0]?.id
+}
+
+function resolveDeepSeekTestModelId(modelId?: string, models?: ChannelModel[]): string {
+  const explicitModelId = modelId?.trim()
+  if (explicitModelId) return explicitModelId
+  return resolveFirstTestModelId(models) ?? DEEPSEEK_PRESET_MODELS[0]!.id
+}
+
+function resolveKimiTestModelId(modelId?: string, models?: ChannelModel[]): string {
+  const explicitModelId = modelId?.trim()
+  if (explicitModelId) return explicitModelId
+  return resolveFirstTestModelId(models) ?? KIMI_PRESET_MODELS[0]!.id
+}
+
+function resolveXiaomiTestModelId(modelId?: string, models?: ChannelModel[]): string {
+  const explicitModelId = modelId?.trim()
+  if (explicitModelId) return explicitModelId
+  return resolveFirstTestModelId(models) ?? XIAOMI_PRESET_MODELS[0]!.id
+}
+
+function resolveDeepSeekModelsUrl(baseUrl: string): string {
+  return `${new URL(baseUrl.trim()).origin}/models`
+}
+
+function resolveKimiModelsUrl(baseUrl: string): string {
+  const origin = new URL(baseUrl.trim()).origin
+  return `${origin}/v1/models`
+}
+
+function inferProviderFromBaseUrl(provider: ProviderType, baseUrl: string): ProviderType {
+  try {
+    const hostname = new URL(baseUrl.trim()).hostname
+    if (hostname.startsWith('token-plan-') && hostname.endsWith('.xiaomimimo.com')) {
+      return 'xiaomi-token-plan'
+    }
+    if (hostname === 'api.xiaomimimo.com') {
+      return 'xiaomi'
+    }
+    if (hostname === 'api.moonshot.cn' || hostname === 'api.moonshot.ai') {
+      return 'kimi-api'
+    }
+    return provider
+  } catch {
+    return provider
+  }
 }
 
 /**
@@ -196,10 +272,7 @@ export function listChannels(): Channel[] {
       provider: 'deepseek',
       baseUrl: PROVIDER_DEFAULT_URLS.deepseek,
       apiKey: encryptApiKey(''),
-      models: [
-        { id: 'deepseek-v4-pro', name: 'DeepSeek V4 Pro', enabled: true },
-        { id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash', enabled: true },
-      ],
+      models: cloneModels(DEEPSEEK_PRESET_MODELS),
       enabled: false,
       createdAt: now,
       updatedAt: now,
@@ -335,9 +408,10 @@ export async function testChannel(channelId: string): Promise<ChannelTestResult>
 
   const apiKey = decryptKey(channel.apiKey)
   const proxyUrl = await getEffectiveProxyUrl()
+  const provider = inferProviderFromBaseUrl(channel.provider, channel.baseUrl)
 
   try {
-    switch (channel.provider) {
+    switch (provider) {
       case 'anthropic':
       case 'anthropic-compatible':
       case 'deepseek':
@@ -349,20 +423,54 @@ export async function testChannel(channelId: string): Promise<ChannelTestResult>
       case 'xiaomi':
       case 'xiaomi-token-plan':
       case 'qwen-anthropic':
-        if (channel.provider === 'ark-coding-plan') {
+        if (provider === 'deepseek') {
+          return await testDeepSeekMessages(
+            channel.baseUrl,
+            apiKey,
+            resolveDeepSeekTestModelId(undefined, channel.models),
+            proxyUrl,
+          )
+        }
+        if (provider === 'kimi-api') {
+          return await testKimiMessages(
+            channel.baseUrl,
+            apiKey,
+            resolveKimiTestModelId(undefined, channel.models),
+            proxyUrl,
+          )
+        }
+        if (provider === 'xiaomi') {
+          return await testXiaomiMessages(
+            channel.baseUrl,
+            apiKey,
+            resolveXiaomiTestModelId(undefined, channel.models),
+            'xiaomi',
+            proxyUrl,
+          )
+        }
+        if (provider === 'xiaomi-token-plan') {
+          return await testXiaomiMessages(
+            channel.baseUrl,
+            apiKey,
+            resolveXiaomiTestModelId(undefined, channel.models),
+            'xiaomi-token-plan',
+            proxyUrl,
+          )
+        }
+        if (provider === 'ark-coding-plan') {
           return await testArkCodingPlan(channel.baseUrl, apiKey, proxyUrl)
         }
-        return await testAnthropicCompatible(channel.baseUrl, apiKey, proxyUrl, channel.provider)
+        return await testAnthropicCompatible(channel.baseUrl, apiKey, proxyUrl, provider)
       case 'openai':
       case 'zhipu':
       case 'doubao':
       case 'qwen':
       case 'custom':
-        return await testOpenAICompatible(channel.baseUrl, apiKey, proxyUrl, channel.provider)
+        return await testOpenAICompatible(channel.baseUrl, apiKey, proxyUrl, provider)
       case 'google':
         return await testGoogle(channel.baseUrl, apiKey, proxyUrl)
       default:
-        return { success: false, message: `不支持的供应商: ${channel.provider}。你可能过去使用的是 Proma 商业版，请重新下载商业版覆盖安装，当前版本为开源版本。` }
+        return { success: false, message: `不支持的供应商: ${provider}。你可能过去使用的是 Proma 商业版，请重新下载商业版覆盖安装，当前版本为开源版本。` }
     }
   } catch (error) {
     return normalizeRequestError(error)
@@ -404,6 +512,99 @@ async function testAnthropicCompatible(
   const response = await fetchFn(url, withTimeout({
     method: 'GET',
     headers,
+  }))
+
+  return normalizeHttpResponse(response)
+}
+
+/**
+ * DeepSeek 的 /models 端点可用性与具体模型可用性不完全等价。
+ * 连接测试使用渠道第一个可用模型发极小 messages 请求，更贴近真实使用路径。
+ */
+async function testDeepSeekMessages(
+  baseUrl: string,
+  apiKey: string,
+  modelId: string,
+  proxyUrl?: string,
+): Promise<ChannelTestResult> {
+  const url = resolveAnthropicMessagesUrl(baseUrl, 'deepseek')
+  const fetchFn = getFetchFn(proxyUrl)
+
+  const response = await fetchFn(url, withTimeout({
+    method: 'POST',
+    headers: {
+      'anthropic-version': '2023-06-01',
+      'content-type': 'application/json',
+      'x-api-key': apiKey,
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: modelId,
+      max_tokens: 8,
+      messages: [{ role: 'user', content: 'ping' }],
+    }),
+  }))
+
+  return normalizeHttpResponse(response)
+}
+
+/**
+ * Kimi API 的连接测试使用 Anthropic messages 端点和第一个可用模型。
+ */
+async function testKimiMessages(
+  baseUrl: string,
+  apiKey: string,
+  modelId: string,
+  proxyUrl?: string,
+): Promise<ChannelTestResult> {
+  const url = resolveAnthropicMessagesUrl(baseUrl, 'kimi-api')
+  const fetchFn = getFetchFn(proxyUrl)
+
+  const response = await fetchFn(url, withTimeout({
+    method: 'POST',
+    headers: {
+      'anthropic-version': '2023-06-01',
+      'content-type': 'application/json',
+      'x-api-key': apiKey,
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: modelId,
+      max_tokens: 8,
+      messages: [{ role: 'user', content: 'ping' }],
+    }),
+  }))
+
+  return normalizeHttpResponse(response)
+}
+
+/**
+ * 小米 API 的模型可用性需要走真实 messages 请求验证。
+ */
+async function testXiaomiMessages(
+  baseUrl: string,
+  apiKey: string,
+  modelId: string,
+  provider: 'xiaomi' | 'xiaomi-token-plan',
+  proxyUrl?: string,
+): Promise<ChannelTestResult> {
+  const url = resolveAnthropicMessagesUrl(baseUrl, provider)
+  const fetchFn = getFetchFn(proxyUrl)
+
+  const headers: Record<string, string> = {
+    'anthropic-version': '2023-06-01',
+    'content-type': 'application/json',
+    'api-key': apiKey,
+  }
+
+  const response = await fetchFn(url, withTimeout({
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      model: modelId,
+      max_tokens: 8,
+      messages: [{ role: 'user', content: 'ping' }],
+    }),
   }))
 
   return normalizeHttpResponse(response)
@@ -482,11 +683,12 @@ async function testGoogle(baseUrl: string, apiKey: string, proxyUrl?: string): P
  * 使用传入的明文凭证直接向提供商发送测试请求。
  * 适用于创建/编辑渠道时用户在保存前先验证连接。
  */
-export async function testChannelDirect(input: FetchModelsInput): Promise<ChannelTestResult> {
+export async function testChannelDirect(input: ChannelDirectTestInput): Promise<ChannelTestResult> {
   const proxyUrl = await getEffectiveProxyUrl()
+  const provider = inferProviderFromBaseUrl(input.provider, input.baseUrl)
 
   try {
-    switch (input.provider) {
+    switch (provider) {
       case 'anthropic':
       case 'anthropic-compatible':
       case 'deepseek':
@@ -498,20 +700,54 @@ export async function testChannelDirect(input: FetchModelsInput): Promise<Channe
       case 'xiaomi':
       case 'xiaomi-token-plan':
       case 'qwen-anthropic':
-        if (input.provider === 'ark-coding-plan') {
+        if (provider === 'deepseek') {
+          return await testDeepSeekMessages(
+            input.baseUrl,
+            input.apiKey,
+            resolveDeepSeekTestModelId(input.modelId),
+            proxyUrl,
+          )
+        }
+        if (provider === 'kimi-api') {
+          return await testKimiMessages(
+            input.baseUrl,
+            input.apiKey,
+            resolveKimiTestModelId(input.modelId),
+            proxyUrl,
+          )
+        }
+        if (provider === 'xiaomi') {
+          return await testXiaomiMessages(
+            input.baseUrl,
+            input.apiKey,
+            resolveXiaomiTestModelId(input.modelId),
+            'xiaomi',
+            proxyUrl,
+          )
+        }
+        if (provider === 'xiaomi-token-plan') {
+          return await testXiaomiMessages(
+            input.baseUrl,
+            input.apiKey,
+            resolveXiaomiTestModelId(input.modelId),
+            'xiaomi-token-plan',
+            proxyUrl,
+          )
+        }
+        if (provider === 'ark-coding-plan') {
           return await testArkCodingPlan(input.baseUrl, input.apiKey, proxyUrl)
         }
-        return await testAnthropicCompatible(input.baseUrl, input.apiKey, proxyUrl, input.provider)
+        return await testAnthropicCompatible(input.baseUrl, input.apiKey, proxyUrl, provider)
       case 'openai':
       case 'zhipu':
       case 'doubao':
       case 'qwen':
       case 'custom':
-        return await testOpenAICompatible(input.baseUrl, input.apiKey, proxyUrl, input.provider)
+        return await testOpenAICompatible(input.baseUrl, input.apiKey, proxyUrl, provider)
       case 'google':
         return await testGoogle(input.baseUrl, input.apiKey, proxyUrl)
       default:
-        return { success: false, message: `不支持的提供商: ${input.provider}` }
+        return { success: false, message: `不支持的提供商: ${provider}` }
     }
   } catch (error) {
     return normalizeRequestError(error)
@@ -528,9 +764,10 @@ export async function testChannelDirect(input: FetchModelsInput): Promise<Channe
  */
 export async function fetchModels(input: FetchModelsInput): Promise<FetchModelsResult> {
   const proxyUrl = await getEffectiveProxyUrl()
+  const provider = inferProviderFromBaseUrl(input.provider, input.baseUrl)
 
   try {
-    switch (input.provider) {
+    switch (provider) {
       case 'anthropic':
       case 'anthropic-compatible':
       case 'deepseek':
@@ -542,29 +779,129 @@ export async function fetchModels(input: FetchModelsInput): Promise<FetchModelsR
       case 'xiaomi':
       case 'xiaomi-token-plan':
       case 'qwen-anthropic':
-        if (input.provider === 'ark-coding-plan') {
+        if (provider === 'deepseek') {
+          return await fetchDeepSeekModels(input.baseUrl, input.apiKey, proxyUrl)
+        }
+        if (provider === 'kimi-api') {
+          return await fetchKimiModels(input.baseUrl, input.apiKey, proxyUrl)
+        }
+        if (provider === 'xiaomi') {
+          return createPresetModelsResult('小米 API', XIAOMI_PRESET_MODELS)
+        }
+        if (provider === 'xiaomi-token-plan') {
+          return createPresetModelsResult('小米 Token Plan', XIAOMI_PRESET_MODELS)
+        }
+        if (provider === 'ark-coding-plan') {
           return {
             success: true,
             message: `火山方舟 Coding Plan 未开放模型列表端点，已加载 ${ARK_CODING_PLAN_MODELS.length} 个预设模型`,
             models: ARK_CODING_PLAN_MODELS,
           }
         }
-        return await fetchAnthropicCompatibleModels(input.baseUrl, input.apiKey, proxyUrl, input.provider)
+        return await fetchAnthropicCompatibleModels(input.baseUrl, input.apiKey, proxyUrl, provider)
       case 'openai':
       case 'zhipu':
       case 'doubao':
       case 'qwen':
       case 'custom':
-        return await fetchOpenAICompatibleModels(input.baseUrl, input.apiKey, proxyUrl, input.provider)
+        return await fetchOpenAICompatibleModels(input.baseUrl, input.apiKey, proxyUrl, provider)
       case 'google':
         return await fetchGoogleModels(input.baseUrl, input.apiKey, proxyUrl)
       default:
-        return { success: false, message: `不支持的供应商: ${input.provider}`, models: [] }
+        return { success: false, message: `不支持的供应商: ${provider}`, models: [] }
     }
   } catch (error) {
     console.error('[渠道管理] 拉取模型列表失败:', error)
     const result = normalizeRequestError(error)
     return { success: false, message: result.message, models: [] }
+  }
+}
+
+/**
+ * 从 DeepSeek 原生模型 API 拉取模型列表。
+ *
+ * DeepSeek 的 Anthropic 对话端点是 /anthropic/v1/messages，但模型列表端点固定在 /models。
+ */
+async function fetchDeepSeekModels(
+  baseUrl: string,
+  apiKey: string,
+  proxyUrl?: string,
+): Promise<FetchModelsResult> {
+  const url = resolveDeepSeekModelsUrl(baseUrl)
+  const fetchFn = getFetchFn(proxyUrl)
+
+  const response = await fetchFn(url, withTimeout({
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+  }))
+
+  if (!response.ok) {
+    const result = await normalizeHttpResponse(response)
+    return { success: false, message: result.message, models: [] }
+  }
+
+  const data = await response.json() as { data?: OpenAIModelItem[] }
+  const items = data.data ?? []
+
+  const models: ChannelModel[] = items.map((item) => ({
+    id: item.id,
+    name: item.id,
+    enabled: true,
+  }))
+
+  models.sort((a, b) => a.id.localeCompare(b.id))
+
+  return {
+    success: true,
+    message: `成功获取 ${models.length} 个模型`,
+    models,
+  }
+}
+
+/**
+ * 从 Kimi OpenAI-compatible 模型列表端点拉取模型。
+ *
+ * Kimi 的 Anthropic 对话端点保留 /anthropic/v1/messages；模型列表使用官方 /v1/models。
+ */
+async function fetchKimiModels(
+  baseUrl: string,
+  apiKey: string,
+  proxyUrl?: string,
+): Promise<FetchModelsResult> {
+  const url = resolveKimiModelsUrl(baseUrl)
+  const fetchFn = getFetchFn(proxyUrl)
+
+  const response = await fetchFn(url, withTimeout({
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+  }))
+
+  if (!response.ok) {
+    const result = await normalizeHttpResponse(response)
+    return { success: false, message: result.message, models: [] }
+  }
+
+  const data = await response.json() as { data?: OpenAIModelItem[] }
+  const items = data.data ?? []
+
+  const models: ChannelModel[] = items.map((item) => ({
+    id: item.id,
+    name: item.id,
+    enabled: true,
+  }))
+
+  models.sort((a, b) => a.id.localeCompare(b.id))
+
+  return {
+    success: true,
+    message: `成功获取 ${models.length} 个模型`,
+    models,
   }
 }
 

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -15,6 +15,7 @@ import type {
   ChannelCreateInput,
   ChannelUpdateInput,
   ChannelTestResult,
+  ChannelDirectTestInput,
   FetchModelsInput,
   FetchModelsResult,
   ConversationMeta,
@@ -210,7 +211,7 @@ export interface ElectronAPI {
   testChannel: (channelId: string) => Promise<ChannelTestResult>
 
   /** 直接测试连接（无需已保存渠道，传入明文凭证） */
-  testChannelDirect: (input: FetchModelsInput) => Promise<ChannelTestResult>
+  testChannelDirect: (input: ChannelDirectTestInput) => Promise<ChannelTestResult>
 
   /** 从供应商拉取可用模型列表（直接传入凭证，无需已保存渠道） */
   fetchModels: (input: FetchModelsInput) => Promise<FetchModelsResult>
@@ -1151,7 +1152,7 @@ const electronAPI: ElectronAPI = {
     return ipcRenderer.invoke(CHANNEL_IPC_CHANNELS.TEST, channelId)
   },
 
-  testChannelDirect: (input: FetchModelsInput) => {
+  testChannelDirect: (input: ChannelDirectTestInput) => {
     return ipcRenderer.invoke(CHANNEL_IPC_CHANNELS.TEST_DIRECT, input)
   },
 

--- a/apps/electron/src/renderer/components/settings/ChannelForm.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelForm.tsx
@@ -74,12 +74,27 @@ interface ChannelFormProps {
 /** 所有可选供应商 */
 const PROVIDER_OPTIONS: ProviderType[] = ['anthropic', 'anthropic-compatible', 'openai', 'deepseek', 'google', 'kimi-api', 'kimi-coding', 'zhipu', 'zhipu-coding', 'ark-coding-plan', 'minimax', 'doubao', 'qwen', 'qwen-anthropic', 'xiaomi', 'xiaomi-token-plan', 'custom']
 
+/** 需要用 messages 端点测试的供应商预设模型 */
+const PROVIDER_TEST_MODEL_PRESETS: Partial<Record<ProviderType, string[]>> = {
+  deepseek: ['deepseek-v4-pro', 'deepseek-v4-flash'],
+  'kimi-api': ['kimi-k2.6'],
+  xiaomi: ['mimo-v2.5-pro', 'mimo-v2-pro', 'mimo-v2.5', 'mimo-v2-omni', 'mimo-v2-flash'],
+  'xiaomi-token-plan': ['mimo-v2.5-pro', 'mimo-v2-pro', 'mimo-v2.5', 'mimo-v2-omni', 'mimo-v2-flash'],
+}
+
 /** 供应商选项（用于 SettingsSelect） */
 const PROVIDER_SELECT_OPTIONS = PROVIDER_OPTIONS.map((p) => ({
   value: p,
   label: PROVIDER_LABELS[p],
   icon: getProviderLogo(p),
 }))
+
+function resolveDirectTestModelId(provider: ProviderType, models: ChannelModel[]): string | undefined {
+  if (!PROVIDER_TEST_MODEL_PRESETS[provider]) return undefined
+  const configuredModelId = models.find((model) => model.enabled)?.id ?? models[0]?.id
+  if (configuredModelId) return configuredModelId
+  return PROVIDER_TEST_MODEL_PRESETS[provider]?.[0]
+}
 
 /** 走 Anthropic 协议的供应商集合（共用 /v1/messages 端点） */
 const ANTHROPIC_PROTOCOL_PROVIDERS: ReadonlySet<ProviderType> = new Set<ProviderType>([
@@ -386,10 +401,12 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
     setTestResult(null)
 
     try {
+      const modelId = resolveDirectTestModelId(provider, models)
       const result = await window.electronAPI.testChannelDirect({
         provider,
         baseUrl,
         apiKey,
+        ...(modelId ? { modelId } : {}),
       })
       setTestResult(result)
     } catch (error) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/core",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "license": "AGPL-3.0-only",
   "description": "proma core types,storage and core logic with agents",
   "type": "module",

--- a/packages/core/src/providers/anthropic-adapter.ts
+++ b/packages/core/src/providers/anthropic-adapter.ts
@@ -6,7 +6,7 @@
  * - 角色：user / assistant（不支持 system 角色，system 通过 body.system 传递）
  * - 图片格式：{ type: 'image', source: { type: 'base64', media_type, data } }
  * - SSE 解析：content_block_delta → text，thinking_delta → reasoning，tool_use 支持
- * - 认证：x-api-key + Authorization: Bearer（Kimi Coding Plan 只用 Bearer）
+ * - 认证：按供应商差异发送 api-key / x-api-key / Authorization
  * - 同时适配 Anthropic 原生 API、DeepSeek、Kimi API、Kimi Coding Plan、MiniMax
  *
  * 思考模式按模型能力分支（见 thinking-capability.ts）：
@@ -283,13 +283,12 @@ export class AnthropicAdapter implements ProviderAdapter {
       base['User-Agent'] = getPromaUserAgent()
       return base
     }
-    if (this.providerType === 'xiaomi-token-plan') {
-      base['Authorization'] = `Bearer ${apiKey}`
-      base['User-Agent'] = getPromaUserAgent()
-      return base
-    }
     if (this.providerType === 'minimax' || this.providerType === 'qwen-anthropic') {
       base['Authorization'] = `Bearer ${apiKey}`
+      return base
+    }
+    if (this.providerType === 'xiaomi' || this.providerType === 'xiaomi-token-plan') {
+      base['api-key'] = apiKey
       return base
     }
     // 其它渠道：保持双认证头（Anthropic 原生 + Bearer 兼容）

--- a/packages/core/src/providers/url-utils.test.ts
+++ b/packages/core/src/providers/url-utils.test.ts
@@ -243,6 +243,18 @@ describe('resolveAnthropicMessagesUrl', () => {
     )
   })
 
+  test('小米 Token Plan 从 OpenAI Base URL 纠正到 Anthropic messages 端点', () => {
+    expect(resolveAnthropicMessagesUrl('https://token-plan-cn.xiaomimimo.com/v1', 'xiaomi-token-plan')).toBe(
+      'https://token-plan-cn.xiaomimimo.com/anthropic/v1/messages',
+    )
+  })
+
+  test('小米 API 从 OpenAI Base URL 纠正到 Anthropic messages 端点', () => {
+    expect(resolveAnthropicMessagesUrl('https://api.xiaomimimo.com/v1', 'xiaomi')).toBe(
+      'https://api.xiaomimimo.com/anthropic/v1/messages',
+    )
+  })
+
   test('内置 anthropic 已是完整端点不重复追加', () => {
     expect(resolveAnthropicMessagesUrl('https://api.anthropic.com/v1/messages', 'anthropic')).toBe(
       'https://api.anthropic.com/v1/messages',

--- a/packages/core/src/providers/url-utils.ts
+++ b/packages/core/src/providers/url-utils.ts
@@ -196,6 +196,9 @@ export function resolveAnthropicMessagesUrl(baseUrl: string, provider: ProviderT
   if (provider === 'anthropic-compatible') {
     return trimTrailingUrlPathSlash(baseUrl)
   }
+  if (provider === 'xiaomi' || provider === 'xiaomi-token-plan') {
+    return `${new URL(baseUrl.trim()).origin}/anthropic/v1/messages`
+  }
   if (hasPathSuffix(baseUrl, '/messages')) {
     return trimTrailingUrlPathSlash(baseUrl)
   }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/shared",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "license": "AGPL-3.0-only",
   "description": "Shared types, configs and utilities for proma",
   "type": "module",

--- a/packages/shared/src/types/channel.ts
+++ b/packages/shared/src/types/channel.ts
@@ -221,6 +221,18 @@ export interface FetchModelsInput {
 }
 
 /**
+ * 直接测试渠道连接的输入参数（无需已保存的渠道，直接传入凭证）
+ */
+export interface ChannelDirectTestInput {
+  provider: ProviderType
+  baseUrl: string
+  /** 明文 API Key */
+  apiKey: string
+  /** 用于 messages 端点测试的模型 ID；不需要模型的供应商可忽略 */
+  modelId?: string
+}
+
+/**
  * 拉取模型的结果
  */
 export interface FetchModelsResult {


### PR DESCRIPTION
## Summary
- use real minimal messages requests for DeepSeek, Kimi, and Xiaomi channel connection tests with provider-specific fallback models
- route DeepSeek and Kimi model discovery to their provider-specific models endpoints, and use local presets for Xiaomi MiMo where remote model listing returns 404
- infer Kimi and Xiaomi provider behavior from known base URLs to avoid stale or generic provider configs hitting invalid paths
- update affected package patch versions

## Validation
- bun test packages/core/src/providers/url-utils.test.ts
- bun run typecheck
- cd apps/electron && bun run build:main && bun run build:preload