### PR TITLE
fix(preview): add code wrap toggle

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.14.19",
+  "version": "0.14.20",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/atoms/preview-atoms.ts
+++ b/apps/electron/src/renderer/atoms/preview-atoms.ts
@@ -53,6 +53,14 @@ export const previewModePreferenceAtom = atomWithStorage<PreviewModePreference>(
   { getOnInit: true },
 )
 
+/** 代码预览换行偏好（默认不换行，保持现有横向滚动行为） */
+export const previewCodeWrapAtom = atomWithStorage<boolean>(
+  'proma-preview-code-wrap',
+  false,
+  undefined,
+  { getOnInit: true },
+)
+
 /** 当前会话的预览面板是否打开（derived） */
 export const currentSessionPreviewOpenAtom = atom<boolean>((get) => {
   const sessionId = get(currentAgentSessionIdAtom)

--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -6,7 +6,7 @@
  */
 
 import * as React from 'react'
-import { ChevronRight, Code2, Copy, Check, Eye, List, Pencil, RefreshCw, Save, X } from 'lucide-react'
+import { ChevronRight, Code2, Copy, Check, Eye, List, Pencil, RefreshCw, Save, WrapText, X } from 'lucide-react'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import DOMPurify from 'dompurify'
 import { File as PierreFile } from '@pierre/diffs/react'
@@ -19,7 +19,7 @@ import {
   agentSidePanelOpenAtom,
 } from '@/atoms/agent-atoms'
 import { resolvedThemeAtom } from '@/atoms/theme'
-import { quotedSelectionMapAtom } from '@/atoms/preview-atoms'
+import { previewCodeWrapAtom, quotedSelectionMapAtom } from '@/atoms/preview-atoms'
 import {
   agentSideChatMapAtom,
   conversationsAtom,
@@ -266,6 +266,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   const refreshVersion = refreshVersionMap.get(sessionId) ?? 0
   const previewContentVersion = previewOnly ? refreshVersion : 0
   const theme = useAtomValue(resolvedThemeAtom)
+  const [codeWrap, setCodeWrap] = useAtom(previewCodeWrapAtom)
   const [tocOpen, setTocOpen] = useAtom(markdownTocOpenAtom)
 
   const ext = getExtension(filePath)
@@ -277,6 +278,20 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   const isOfficePreview = previewOnly && OFFICE_PREVIEW_EXTS.has(ext)
   const isLegacyOffice = previewOnly && LEGACY_OFFICE_EXTS.has(ext)
   const isImage = previewOnly && IMAGE_EXTS.has(ext)
+  const canTogglePreviewWrap =
+    previewOnly &&
+    !markdownEditing &&
+    !isMarkdown &&
+    !isPdf &&
+    !isImage &&
+    !isDocx &&
+    !isOfficePreview &&
+    !isLegacyOffice &&
+    newContent.length > 0 &&
+    newContent.length <= MAX_PREVIEW_CHARS
+  const previewWrapLabel = codeWrap
+    ? '当前为自动换行，点击改为横向滚动'
+    : '当前为横向滚动，点击改为自动换行'
 
   React.useEffect(() => {
     initShortcutRegistry()
@@ -489,10 +504,10 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   const pierreOptions = React.useMemo(() => ({
     theme: { dark: 'one-dark-pro' as const, light: 'one-light' as const },
     disableFileHeader: true,
-    overflow: 'scroll' as const,
+    overflow: codeWrap ? 'wrap' as const : 'scroll' as const,
     themeType: theme as 'light' | 'dark' | 'system',
     unsafeCSS: PIERRE_FILE_CSS,
-  }), [theme])
+  }), [theme, codeWrap])
   const markdownFileAccess = React.useMemo(() => {
     const candidateBasePaths: string[] = []
     const slash = filePath.lastIndexOf('/')
@@ -1188,6 +1203,27 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
         >
           <RefreshCw className="size-3.5" />
         </button>
+
+        {canTogglePreviewWrap && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => setCodeWrap((v) => !v)}
+                className={cn(
+                  'p-1 rounded hover:bg-foreground/[0.06] shrink-0',
+                  codeWrap ? 'text-foreground/70' : 'text-foreground/40 hover:text-foreground/60',
+                )}
+                aria-label={previewWrapLabel}
+              >
+                <WrapText className="size-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              <p>{previewWrapLabel}</p>
+            </TooltipContent>
+          </Tooltip>
+        )}
 
         {isMarkdown && !markdownEditing && (
           <button


### PR DESCRIPTION
## Summary

- add a persisted preview code-wrap preference for file previews
- expose a wrap/scroll toggle inside the shared DiffTabContent preview toolbar
- keep diff, Markdown, PDF, image, Office, and large-file fallback previews unchanged
- bump @proma/electron to 0.14.20

Closes #1056

## Testing

- bun run typecheck
- git diff --check origin/main...HEAD