### PR TITLE
【已审核】feat(agent): 会话标题自动跟随话题更新

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -186,7 +186,7 @@ import {
   searchAgentSessionMessages,
   searchAgentSessionReferences,
 } from './lib/agent-session-manager'
-import { runAgent, stopAgent, generateAgentTitle, saveFilesToAgentSession, saveFilesToWorkspaceFiles, isAgentSessionActive, queueAgentMessage, updateAgentPermissionMode, rewindAgentSession } from './lib/agent-service'
+import { runAgent, stopAgent, generateAgentTitle, regenerateAgentTitle, saveFilesToAgentSession, saveFilesToWorkspaceFiles, isAgentSessionActive, queueAgentMessage, updateAgentPermissionMode, rewindAgentSession } from './lib/agent-service'
 import { permissionService } from './lib/agent-permission-service'
 import { askUserService } from './lib/agent-ask-user-service'
 import { exitPlanService } from './lib/agent-exit-plan-service'
@@ -1777,7 +1777,7 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(
     AGENT_IPC_CHANNELS.UPDATE_TITLE,
     async (_, id: string, title: string): Promise<AgentSessionMeta> => {
-      return updateAgentSessionMeta(id, { title })
+      return updateAgentSessionMeta(id, { title, titleManualOverride: true })
     }
   )
 
@@ -1786,6 +1786,24 @@ export function registerIpcHandlers(): void {
     AGENT_IPC_CHANNELS.GENERATE_TITLE,
     async (_, input: AgentGenerateTitleInput): Promise<string | null> => {
       return generateAgentTitle(input)
+    }
+  )
+
+  // 手动重新生成 Agent 会话标题（基于最近消息摘要，跳过节流）
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.REGENERATE_TITLE,
+    async (event, id: string): Promise<import('@proma/shared').RegenerateTitleResult> => {
+      const result = await regenerateAgentTitle(id)
+      if (result.ok && result.title) {
+        // 广播 TITLE_UPDATED 到所有窗口（与 agent-service 的 onTitleUpdated 行为一致），
+        // 避免多窗口场景下仅请求窗口收到标题更新
+        for (const win of BrowserWindow.getAllWindows()) {
+          if (!win.isDestroyed()) {
+            win.webContents.send(AGENT_IPC_CHANNELS.TITLE_UPDATED, { sessionId: id, title: result.title })
+          }
+        }
+      }
+      return result
     }
   )
 

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -20,7 +20,7 @@ import { join, dirname } from 'node:path'
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { app } from 'electron'
-import type { AgentSendInput, AgentMessage, AgentGenerateTitleInput, AgentProviderAdapter, AgentSessionMeta, TypedError, RetryAttempt, SDKMessage, SDKAssistantMessage, AgentStreamPayload, RewindSessionResult, ProviderType } from '@proma/shared'
+import type { AgentSendInput, AgentMessage, AgentGenerateTitleInput, RegenerateTitleResult, AgentProviderAdapter, AgentSessionMeta, TypedError, RetryAttempt, SDKMessage, SDKAssistantMessage, AgentStreamPayload, RewindSessionResult, ProviderType } from '@proma/shared'
 import {
   PROMA_DEFAULT_PERMISSION_MODE,
   PROMA_PERMISSION_MODE_CONFIG,
@@ -41,7 +41,7 @@ import { getAdapter, fetchTitle, normalizeAnthropicBaseUrlForSdk, getPromaUserAg
 import pkg from '../../../package.json' with { type: 'json' }
 import { getFetchFn } from './proxy-fetch'
 import { getEffectiveProxyUrl } from './proxy-settings-service'
-import { appendSDKMessages, updateAgentSessionMeta, getAgentSessionMeta, getAgentSessionMessages, truncateSDKMessages, resolveUserUuidFromSDK, rewindFilesFromSnapshot } from './agent-session-manager'
+import { appendSDKMessages, updateAgentSessionMeta, getAgentSessionMeta, getAgentSessionMessages, getAgentSessionSDKMessages, truncateSDKMessages, resolveUserUuidFromSDK, rewindFilesFromSnapshot } from './agent-session-manager'
 import { getAgentWorkspace, getWorkspaceMcpConfig, ensurePluginManifest, getWorkspaceAutoMemoryDir, getWorkspaceAttachedDirectories, getWorkspaceAttachedFiles } from './agent-workspace-manager'
 import { getAgentWorkspacePath, getAgentSessionWorkspacePath, getSdkConfigDir, getWorkspaceFilesDir, getBundledCliPath } from './config-paths'
 import { getRuntimeStatus } from './runtime-init'
@@ -73,7 +73,7 @@ export interface SessionCallbacks {
   /** 发送流式完成（携带已持久化的消息列表） */
   onComplete: (messages?: AgentMessage[], opts?: { stoppedByUser?: boolean; startedAt?: number; resultSubtype?: string; resultErrors?: string[]; backgroundTasksPending?: boolean }) => void
   /** 发送标题更新 */
-  onTitleUpdated: (title: string) => void
+  onTitleUpdated: (title: string, isAuto?: boolean) => void
   /** 用户消息已持久化，外部入口可据此通知前端切到实时会话 */
   onRunStarted?: (opts: { startedAt: number }) => void
 }
@@ -295,8 +295,182 @@ const MAX_TITLE_LENGTH = 20
 /** 默认会话标题（用于判断是否需要自动生成） */
 const DEFAULT_SESSION_TITLE = '新 Agent 会话'
 
+/** 渐进式标题更新：漂移检测取最近 N 条 user/assistant 文本消息做摘要 */
+const DRIFT_MESSAGE_COUNT = 12
+
+/** 渐进式标题更新：距上次生成标题的轮次间隔（基于真实会话轮次分布校准，N=5 覆盖 64% 会话） */
+const DRIFT_INTERVAL_TURNS = 5
+
+/** 渐进式标题更新：每条消息摘要截断长度 */
+const DRIFT_MESSAGE_EXCERPT_LEN = 400
+
+/** 渐进式标题更新：漂移检测 Prompt */
+const DRIFT_TITLE_PROMPT = '标题「{currentTitle}」\n\n最近对话：\n{digest}\n\n若主题已变，给一个新标题（≤10字）。若未变，复制原标题。只输出标题本身。'
+
+/** 渐进式标题更新：手动重生成 Prompt（强制生成新标题，不回退原标题） */
+const REGENERATE_TITLE_PROMPT = '为以下对话起一个简短标题（≤10字），只输出标题本身。\n\n{digest}'
+
+/** 渐进式标题更新：极简重试 Prompt（sanitize 失败时用，无否定指令防学舌） */
+const FALLBACK_TITLE_PROMPT = '为以下对话生成一个简短标题\n{digest}'
+
 /** 默认模型 ID */
 const DEFAULT_MODEL_ID = 'claude-sonnet-5'
+
+/**
+ * 渐进式标题更新：判断 SDK user 消息是否含 text 块（即真实用户输入，非 tool_result 续接）
+ */
+function isUserTextMessage(m: SDKMessage): boolean {
+  if (m.type !== 'user') return false
+  const content = (m as unknown as { message?: { content?: unknown } }).message?.content
+  if (Array.isArray(content)) {
+    return content.some((b) => typeof b === 'object' && b !== null && (b as { type: string }).type === 'text')
+  }
+  return typeof content === 'string'
+}
+
+/**
+ * 渐进式标题更新：从 SDK 消息列表中提取纯文本消息（user 文本 / assistant 含文本），
+ * 跳过 tool_result / tool_use / 系统消息 / 空文本 assistant 消息，与实时流过滤逻辑保持一致。
+ */
+function extractTextMessages(messages: SDKMessage[]): SDKMessage[] {
+  return messages.filter((m) => {
+    if (m.type === 'user') return isUserTextMessage(m)
+    if (m.type === 'assistant') return extractMessageText(m).length > 0
+    return false
+  })
+}
+
+/**
+ * 渐进式标题更新：统计用户轮次（user 文本消息数，与首条标题生成口径一致）
+ */
+function countUserTurns(messages: SDKMessage[]): number {
+  return messages.filter(isUserTextMessage).length
+}
+
+/**
+ * 渐进式标题更新：取最近 N 条 user/assistant 文本消息（正序）
+ */
+function pickRecentTextMessages(messages: SDKMessage[], n: number): SDKMessage[] {
+  const textMsgs = extractTextMessages(messages)
+  return textMsgs.slice(-n)
+}
+
+/**
+ * 渐进式标题更新：把最近消息拼成摘要文本（每条截断到 DRIFT_MESSAGE_EXCERPT_LEN 字）
+ */
+function buildRecentMessagesDigest(messages: SDKMessage[]): string {
+  return messages.map((m) => {
+    const role = m.type === 'user' ? '用户' : '助手'
+    const text = extractMessageText(m)
+    const excerpt = text.length > DRIFT_MESSAGE_EXCERPT_LEN
+      ? text.slice(0, DRIFT_MESSAGE_EXCERPT_LEN) + '…'
+      : text
+    return `- ${role}：${excerpt}`
+  }).join('\n')
+}
+
+/**
+ * 渐进式标题更新：从 SDK 消息中提取纯文本内容
+ */
+function extractMessageText(message: SDKMessage): string {
+  const content = (message as unknown as { message?: { content?: unknown } }).message?.content
+  if (typeof content === 'string') return content
+  if (Array.isArray(content)) {
+    return content
+      .filter((b): b is { type: 'text'; text: string } =>
+        typeof b === 'object' && b !== null && (b as { type: string }).type === 'text' && typeof (b as { text?: unknown }).text === 'string')
+      .map((b) => b.text)
+      .join('')
+  }
+  return ''
+}
+
+/**
+ * 渐进式标题更新：归一化标题用于漂移判定
+ *
+ * 模型输出常有空格/全半角/标点细微差异，严格 === 会把「未漂移」误判为漂移。
+ * 归一化：trim + 折叠连续空白 + 全角转半角（字母数字），然后比较。
+ */
+function normalizeTitle(title: string): string {
+  return title
+    .trim()
+    .replace(/\s+/g, ' ')
+    .replace(/[Ａ-Ｚａ-ｚ０-９]/g, (ch) => String.fromCharCode(ch.charCodeAt(0) - 0xFEE0))
+    .replace(/　/g, ' ')                          // 全角空格 → 半角
+    .replace(/[，、。！？；：""''「」『』《》（）【】]/g, '')  // 全角标点 → 空
+    .replace(/[.,!?;:()"'\-_]/g, '')                   // 半角标点 → 空
+    .trim()
+}
+
+/**
+ * 渐进式标题更新：清洗模型输出，滤除 prompt 指令回显
+ *
+ * 弱模型可能把 prompt 中的指令文字鹦鹉学舌回来。此函数检测并过滤这些碎片，
+ * 返回真正的标题文本。若整个输出都是指令碎片则返回 null。
+ */
+function sanitizeTitleOutput(raw: string): string | null {
+  // 1. 基础清理
+  let cleaned = raw.trim().replace(/^["'""''「《]+|["'""''」》]+$/g, '').trim()
+
+  // 2. 滤除常见 prompt 指令碎片（弱模型鹦鹉学舌）
+  const instructionFragments = [
+    '只输出标题', '不要有任何其他', '标点符号', '不要输出任何', '输出标题本身',
+    '以下对话', '对话摘要', '最近对话', '当前会话标题',
+    '请基于此', '请判断', '若已偏离', '若未偏离', '复制原标题',
+    '请生成', '起一个', '为主题起', '请为主题',
+  ]
+  for (const frag of instructionFragments) {
+    if (cleaned.includes(frag)) {
+      // 尝试从输出中提取可能被夹杂的真实标题
+      // 策略：移除指令行，取第一行纯文本
+      const lines = cleaned.split(/[\n\r]+/).map((l) => l.trim()).filter((l) => l.length > 0)
+      for (const line of lines) {
+        const isInstruction = instructionFragments.some((f) => line.includes(f))
+        if (!isInstruction && line.length <= MAX_TITLE_LENGTH * 2) {
+          cleaned = line
+          break
+        }
+      }
+      // 若所有行都含指令碎片，放弃
+      if (instructionFragments.some((f) => cleaned.includes(f))) {
+        return null
+      }
+    }
+  }
+
+  // 3. 超长标题大概率是模型胡言乱语
+  if (cleaned.length > MAX_TITLE_LENGTH * 2) return null
+
+  // 4. 截断到允许长度
+  return cleaned.slice(0, MAX_TITLE_LENGTH) || null
+}
+
+/**
+ * 渐进式标题更新：判断候选标题与当前标题是否等价（未漂移）
+ */
+function isSameTitle(a: string, b: string): boolean {
+  return normalizeTitle(a) === normalizeTitle(b)
+}
+
+/**
+ * 渐进式标题更新：解析漂移检测/手动重生成所用模型
+ *
+ * 优先用设置中配置的 titleModelChannelId/titleModelId，未配置则回退到当前会话的 channelId/modelId。
+ */
+function resolveTitleModel(
+  meta: AgentSessionMeta,
+  settings: { titleModelChannelId?: string; titleModelId?: string },
+): { channelId: string; modelId: string } {
+  const settingsChannel = settings.titleModelChannelId
+  const settingsModel = settings.titleModelId
+  if (settingsChannel && settingsModel) {
+    return { channelId: settingsChannel, modelId: settingsModel }
+  }
+  return {
+    channelId: meta.channelId ?? '',
+    modelId: meta.modelId ?? '',
+  }
+}
 
 /**
  * 聚合一次 SDK 调用涉及的所有附加目录（去重，保持插入顺序）。
@@ -544,44 +718,119 @@ export class AgentOrchestrator {
    *
    * 使用 Provider 适配器系统，支持所有渠道。任何错误返回 null。
    */
+  /**
+   * 生成 Agent 会话标题
+   *
+   * 使用 Provider 适配器系统，支持所有渠道。任何错误返回 null。
+   *
+   * 两种模式：
+   * - 首条生成：传 `userMessage`，用 `TITLE_PROMPT`
+   * - 漂移检测/手动重生成：传 `messages` + `currentTitle`，用 `DRIFT_TITLE_PROMPT`，
+   *   模型返回与 `currentTitle` 相同则视为未漂移（调用方比对决定是否写回）
+   */
   async generateTitle(input: AgentGenerateTitleInput): Promise<string | null> {
-    const { userMessage, channelId, modelId } = input
-    console.log('[Agent 标题生成] 开始生成标题:', { channelId, modelId, userMessage: userMessage.slice(0, 50) })
+    const { userMessage, messages, currentTitle, channelId, modelId, isManualRegen } = input
 
-    try {
-      const channels = listChannels()
-      const channel = channels.find((c) => c.id === channelId)
-      if (!channel) {
-        console.warn('[Agent 标题生成] 渠道不存在:', channelId)
+    // 漂移检测/手动重生成分支
+    if (messages && messages.length > 0) {
+      const digest = buildRecentMessagesDigest(messages)
+      // 手动重生成用强制生成 prompt（总是给新标题），自动漂移检测用对比 prompt
+      const prompt = isManualRegen
+        ? REGENERATE_TITLE_PROMPT.split('{digest}').join(digest)
+        : DRIFT_TITLE_PROMPT
+            .split('{currentTitle}').join(currentTitle ?? DEFAULT_SESSION_TITLE)
+            .split('{digest}').join(digest)
+      const modeLabel = isManualRegen ? '手动重生成' : '漂移检测'
+      console.log(`[Agent 标题${modeLabel}] 开始:`, { channelId, modelId, currentTitle, messageCount: messages.length })
+      try {
+        const title = await this.requestTitle(channelId, modelId, prompt)
+        if (!title) {
+          console.warn(`[Agent 标题${modeLabel}] API 返回空标题`)
+          return null
+        }
+        let result = sanitizeTitleOutput(title)
+        // 静默重试：sanitize 返回 null 时，用极简 prompt 重拉一次（弱模型学舌概率低）
+        if (!result) {
+          const fallbackPrompt = FALLBACK_TITLE_PROMPT.split('{digest}').join(digest)
+          console.log(`[Agent 标题${modeLabel}] sanitize 返回 null，静默重试极简 prompt`)
+          const retry = await this.requestTitle(channelId, modelId, fallbackPrompt)
+          if (!retry) {
+            console.warn(`[Agent 标题${modeLabel}] 静默重试 API 返回空`)
+            return null
+          }
+          result = sanitizeTitleOutput(retry)
+          if (!result) {
+            console.warn(`[Agent 标题${modeLabel}] 两次尝试均 sanitize 失败`)
+            return null
+          }
+          console.log(`[Agent 标题${modeLabel}] 静默重试成功: "${result}"`)
+        }
+        console.log(`[Agent 标题${modeLabel}] 候选标题: "${result}"`)
+        return result
+      } catch (error) {
+        console.warn(`[Agent 标题${modeLabel}] 生成失败:`, error)
         return null
       }
+    }
 
-      const apiKey = decryptApiKey(channelId)
-      const providerAdapter = getAdapter(channel.provider)
-      const request = providerAdapter.buildTitleRequest({
-        baseUrl: channel.baseUrl,
-        apiKey,
-        modelId,
-        prompt: TITLE_PROMPT + userMessage,
-      })
-
-      const proxyUrl = await getEffectiveProxyUrl()
-      const fetchFn = getFetchFn(proxyUrl)
-      const title = await fetchTitle(request, providerAdapter, fetchFn)
+    // 首条生成分支（原逻辑）
+    const msg = userMessage ?? ''
+    console.log('[Agent 标题生成] 开始生成标题:', { channelId, modelId, userMessage: msg.slice(0, 50) })
+    try {
+      const title = await this.requestTitle(channelId, modelId, TITLE_PROMPT + msg)
       if (!title) {
         console.warn('[Agent 标题生成] API 返回空标题')
         return null
       }
-
-      const cleaned = title.trim().replace(/^["'""''「《]+|["'""''」》]+$/g, '').trim()
-      const result = cleaned.slice(0, MAX_TITLE_LENGTH) || null
-
+      let result = sanitizeTitleOutput(title)
+      if (!result) {
+        const fallbackPrompt = FALLBACK_TITLE_PROMPT.split('{digest}').join(msg.slice(0, DRIFT_MESSAGE_EXCERPT_LEN))
+        console.log('[Agent 标题生成] sanitize 返回 null，静默重试极简 prompt')
+        const retry = await this.requestTitle(channelId, modelId, fallbackPrompt)
+        if (!retry) {
+          console.warn('[Agent 标题生成] 静默重试 API 返回空')
+          return null
+        }
+        result = sanitizeTitleOutput(retry)
+        if (!result) {
+          console.warn('[Agent 标题生成] 两次尝试均 sanitize 失败')
+          return null
+        }
+        console.log(`[Agent 标题生成] 静默重试成功: "${result}"`)
+      }
       console.log(`[Agent 标题生成] 生成标题成功: "${result}"`)
       return result
     } catch (error) {
       console.warn('[Agent 标题生成] 生成失败:', error)
       return null
     }
+  }
+
+  /**
+   * 调用渠道 adapter 构建并发送标题生成请求，返回模型输出的标题文本
+   *
+   * `generateTitle` 的内部共用方法，封装渠道查找 + API Key 解密 + 代理 + fetchTitle。
+   */
+  private async requestTitle(channelId: string, modelId: string, prompt: string): Promise<string | null> {
+    const channels = listChannels()
+    const channel = channels.find((c) => c.id === channelId)
+    if (!channel) {
+      console.warn('[Agent 标题生成] 渠道不存在:', channelId)
+      return null
+    }
+
+    const apiKey = decryptApiKey(channelId)
+    const providerAdapter = getAdapter(channel.provider)
+    const request = providerAdapter.buildTitleRequest({
+      baseUrl: channel.baseUrl,
+      apiKey,
+      modelId,
+      prompt,
+    })
+
+    const proxyUrl = await getEffectiveProxyUrl()
+    const fetchFn = getFetchFn(proxyUrl)
+    return fetchTitle(request, providerAdapter, fetchFn)
   }
 
   /**
@@ -600,14 +849,204 @@ export class AgentOrchestrator {
       const meta = getAgentSessionMeta(sessionId)
       if (!meta || meta.title !== DEFAULT_SESSION_TITLE) return
 
-      const title = await this.generateTitle({ userMessage, channelId, modelId })
+      // 首条标题也用 resolveTitleModel 统一模型解析路径，与后续漂移检测一致：
+      // 用户在设置中配了标题专用模型 → 首条就用，否则回退到会话模型
+      const settings = getSettings()
+      const { channelId: titleChannelId, modelId: titleModelId } = resolveTitleModel(meta, settings)
+      const effectiveChannelId = titleChannelId || channelId
+      const effectiveModelId = titleModelId || modelId
+
+      const title = await this.generateTitle({
+        userMessage,
+        channelId: effectiveChannelId,
+        modelId: effectiveModelId,
+      })
       if (!title) return
 
-      updateAgentSessionMeta(sessionId, { title })
+      // CAS：生成期间 maybeRefreshTitle 可能已完成并写入标题（首条消息较长 + 工具调用多轮）。
+      // 若标题已非默认值，放弃覆盖，避免竞态下 autoGenerateTitle 的过时结果盖掉漂移检测结果。
+      const latestMeta = getAgentSessionMeta(sessionId)
+      if (!latestMeta || latestMeta.title !== DEFAULT_SESSION_TITLE) return
+
+      // 记录当前实际用户轮次，而非硬编码 1（首条消息后可能已累积多轮 SDK 往返）
+      const turns = countUserTurns(getAgentSessionSDKMessages(sessionId))
+      updateAgentSessionMeta(sessionId, { title, lastTitleTurn: Math.max(turns, 1) })
       callbacks.onTitleUpdated(title)
       console.log(`[Agent 编排] 自动标题生成完成: "${title}"`)
     } catch (error) {
       console.warn('[Agent 编排] 自动标题生成失败:', error)
+    }
+  }
+
+  /**
+   * 渐进式标题更新：流成功完成后检测话题是否漂移，漂移则重新生成标题
+   *
+   * 三道闸门（顺序）：
+   * 1. 会话类型：仅普通主会话参与，排除一切子会话/定时会话
+   * 2. 设置开关：progressiveTitleUpdateEnabled
+   * 3. 节流：距上次标题生成（lastTitleTurn）≥ DRIFT_INTERVAL_TURNS
+   *
+   * 通过「候选标题 vs 当前标题不同 = 漂移」判定，相同则不写回（锚点稳住）。
+   * 失败静默，不影响主流程。
+   */
+  private async maybeRefreshTitle(
+    sessionId: string,
+    callbacks: SessionCallbacks,
+  ): Promise<void> {
+    try {
+      const meta = getAgentSessionMeta(sessionId)
+      if (!meta) return
+
+      // 闸门 1：仅普通主会话（排除协作子会话/定时会话，不论毕业与否）
+      if (meta.parentSessionId || meta.sourceDelegationId || meta.delegationDepth || meta.sourceAutomationId) {
+        return
+      }
+
+      // 闸门 2：设置开关
+      const settings = getSettings()
+      if (settings.progressiveTitleUpdateEnabled === false) return
+
+      // 闸门 2.5：用户手动编辑标题后跳过自动漂移（尊重用户意图，不被覆盖）。
+      // 手动编辑会置 titleManualOverride=true，直到用户手动重生成后清除。
+      if (meta.titleManualOverride) {
+        console.log('[Agent 标题漂移检测] 用户已手动编辑标题，跳过自动更新')
+        // 仍推进节流轮次，避免每轮都进来检查 manualOverride
+        const currentTurns = countUserTurns(getAgentSessionSDKMessages(sessionId))
+        if (meta.lastTitleTurn !== undefined) {
+          updateAgentSessionMeta(sessionId, { lastTitleTurn: currentTurns })
+        }
+        return
+      }
+
+      // 闸门 3：节流
+      // 老会话升级（lastTitleTurn 未初始化）：写入当前轮次后跳过本轮检测，
+      // 避免大轮次差（undefined→0→穿透节流）导致无意义的 LLM 调用。
+      const messages = getAgentSessionSDKMessages(sessionId)
+      const currentTurns = countUserTurns(messages)
+      if (meta.lastTitleTurn === undefined) {
+        updateAgentSessionMeta(sessionId, { lastTitleTurn: currentTurns })
+        return
+      }
+      const lastTurn = meta.lastTitleTurn
+      if (currentTurns - lastTurn < DRIFT_INTERVAL_TURNS) return
+
+      // 取最近 K 条消息摘要
+      const recent = pickRecentTextMessages(messages, DRIFT_MESSAGE_COUNT)
+      if (recent.length === 0) return
+
+      // 解析漂移检测所用模型（设置优先，回退会话模型）
+      const { channelId, modelId } = resolveTitleModel(meta, settings)
+      if (!channelId || !modelId) return
+
+      // 透传守卫：maybeRefreshTitle 被 completeRun 同步调用时 active slot 已释放，
+      // 本守卫不会触发；仅防御 future refactor 中 completeRun 改为异步调用后
+      // 与用户秒发的下一条消息并发——届时让新一轮完成后再判断。
+      const runGeneration = this.activeSessions.get(sessionId)
+      if (runGeneration !== undefined) return
+
+      const currentTitle = meta.title ?? DEFAULT_SESSION_TITLE
+      const candidate = await this.generateTitle({
+        messages: recent,
+        currentTitle,
+        channelId,
+        modelId,
+      })
+      if (!candidate) return
+
+      // CAS 校验：await generateTitle 期间用户可能已进入新一轮并推进 lastTitleTurn。
+      // 重新读取最新 meta，若 lastTitleTurn 已变化则放弃写回，交给新一轮完成后重新判断。
+      const latestMeta = getAgentSessionMeta(sessionId)
+      if (!latestMeta || (latestMeta.lastTitleTurn ?? 0) !== lastTurn) {
+        console.log('[Agent 标题漂移检测] 检测期间会话已进入新一轮，放弃写回')
+        return
+      }
+
+      // 与当前标题相同/等价则视为未漂移。仍推进 lastTitleTurn 到当前轮次，
+      // 否则节流闸门失效——每轮 currentTurns - lastTurn 都会 ≥ 阈值，退化成每轮都调 LLM。
+      if (isSameTitle(candidate, currentTitle) || candidate === DEFAULT_SESSION_TITLE) {
+        console.log(`[Agent 标题漂移检测] 未漂移，保持标题: "${currentTitle}"`)
+        updateAgentSessionMeta(sessionId, { lastTitleTurn: currentTurns })
+        return
+      }
+
+      updateAgentSessionMeta(sessionId, { title: candidate, lastTitleTurn: currentTurns })
+      callbacks.onTitleUpdated(candidate, true)
+      console.log(`[Agent 标题漂移检测] 话题漂移，标题更新: "${currentTitle}" → "${candidate}"`)
+    } catch (error) {
+      console.warn('[Agent 编排] 渐进式标题更新失败:', error)
+    }
+  }
+
+  /**
+   * 手动重新生成会话标题（用户从 AgentHeader 触发）
+   *
+   * 与 `maybeRefreshTitle` 的区别：
+   * - 跳过节流闸门（用户主动操作不受轮次限制）
+   * - 使用专用 prompt（REGENERATE_TITLE_PROMPT），不强求「未偏离则输出原标题」，
+   *   确保用户每次手动操作都能得到新鲜标题
+   * - 清除 titleManualOverride 标记，恢复自动漂移检测
+   *
+   * @returns 结构化结果，区分「未调 LLM 因故放弃」与「调了 LLM 但未漂移」
+   */
+  async regenerateTitle(sessionId: string): Promise<RegenerateTitleResult> {
+    try {
+      const meta = getAgentSessionMeta(sessionId)
+      if (!meta) {
+        console.warn('[Agent 标题手动重生成] meta 不存在:', sessionId)
+        return { ok: false, reason: 'error' }
+      }
+
+      // 仅普通主会话（排除协作子会话/定时会话，不论毕业与否）
+      if (meta.parentSessionId || meta.sourceDelegationId || meta.delegationDepth || meta.sourceAutomationId) {
+        return { ok: false, reason: 'not-main-session' }
+      }
+
+      const messages = getAgentSessionSDKMessages(sessionId)
+      const recent = pickRecentTextMessages(messages, DRIFT_MESSAGE_COUNT)
+      if (recent.length === 0) return { ok: false, reason: 'no-messages' }
+
+      const settings = getSettings()
+      const { channelId, modelId } = resolveTitleModel(meta, settings)
+      if (!channelId || !modelId) return { ok: false, reason: 'no-model' }
+
+      // CAS：保存当前 lastTitleTurn，写入前校验是否被并发 maybeRefreshTitle 推进
+      const lastTurn = meta.lastTitleTurn
+
+      const currentTitle = meta.title ?? DEFAULT_SESSION_TITLE
+      const candidate = await this.generateTitle({
+        messages: recent,
+        currentTitle,
+        channelId,
+        modelId,
+        isManualRegen: true,  // 使用强制生成 prompt，总是返回新标题
+      })
+      if (!candidate) {
+        console.log(`[Agent 标题手动重生成] generateTitle 返回 null，调用失败`)
+        return { ok: false, reason: 'error' }
+      }
+
+      // 手动重生成不检查 isSameTitle——用户主动操作期待新标题，即使是同一主题的不同表述也好。
+      // 唯一拒绝：候选为空字符串或仍为默认标题
+      if (!candidate || candidate === DEFAULT_SESSION_TITLE) {
+        console.log(`[Agent 标题手动重生成] 候选无效，保持标题: "${currentTitle}"`)
+        return { ok: false, reason: 'same' }
+      }
+
+      // CAS 校验：await generateTitle 期间 maybeRefreshTitle 可能已完成并推进 lastTitleTurn
+      const latestMeta = getAgentSessionMeta(sessionId)
+      if (!latestMeta || (latestMeta.lastTitleTurn ?? 0) !== (lastTurn ?? 0)) {
+        console.log('[Agent 标题手动重生成] 检测期间自动漂移更新已推进标题，放弃写回')
+        return { ok: false, reason: 'stale' }
+      }
+
+      const currentTurns = countUserTurns(messages)
+      // 清除 titleManualOverride：用户主动重生成表示接受 AI 管理标题
+      updateAgentSessionMeta(sessionId, { title: candidate, lastTitleTurn: currentTurns, titleManualOverride: false })
+      console.log(`[Agent 标题手动重生成] 标题更新: "${currentTitle}" → "${candidate}"`)
+      return { ok: true, title: candidate }
+    } catch (error) {
+      console.warn('[Agent 编排] 手动重生成标题失败:', error)
+      return { ok: false, reason: 'error' }
     }
   }
 
@@ -824,6 +1263,19 @@ export class AgentOrchestrator {
     // 0.5 清除上一轮中断标记
     try { updateAgentSessionMeta(sessionId, { stoppedByUser: false }) } catch { /* 会话可能已删除 */ }
 
+    // 0.6 持久化本次运行所用渠道/模型到 meta
+    // 用途：标题漂移检测/手动重生成回退解析模型（resolveTitleModel），老会话首次发消息后即补齐。
+    // modelId 回退到 DEFAULT_MODEL_ID，与 SDK 实际运行模型（line 1235 resolvedModel）保持一致，
+    // 避免调用方未传 modelId 时 meta 仍空、resolveTitleModel 落到 'no-model'。
+    if (channelId) {
+      try {
+        updateAgentSessionMeta(sessionId, {
+          channelId,
+          modelId: modelId || DEFAULT_MODEL_ID,
+        })
+      } catch { /* 会话可能已删除 */ }
+    }
+
     // 环境 / 配置类错误的统一上报：持久化为 TypedError 消息，由 SDKMessageRenderer 渲染
     const reportPreflightError = (typedError: TypedError) => {
       const errorContent = typedError.title
@@ -922,10 +1374,15 @@ export class AgentOrchestrator {
     }
     const completeRun = (
       messages?: AgentMessage[],
-      opts?: { stoppedByUser?: boolean; startedAt?: number; resultSubtype?: string; resultErrors?: string[] },
+      opts?: { stoppedByUser?: boolean; startedAt?: number; resultSubtype?: string; resultErrors?: string[]; terminatedWithError?: boolean },
     ): void => {
       releaseActiveRun()
       callbacks.onComplete(messages, opts)
+      // 渐进式标题更新：仅成功完成（非用户中断、非错误终止）时触发，fire-and-forget
+      if (!opts?.stoppedByUser && !opts?.terminatedWithError) {
+        this.maybeRefreshTitle(sessionId, callbacks)
+          .catch((err) => console.error('[Agent 编排] 渐进式标题更新未捕获异常:', err))
+      }
     }
     // 轻量完成：turn 主体结束但仍有后台任务在飞行。
     // 关键区别——不调用 releaseActiveRun，保留 activeSessions/activeChannels/sessionPermissionModes，
@@ -1789,7 +2246,7 @@ export class AgentOrchestrator {
                 // 透传归一化后的错误消息到前端，避免 SDK 原始 API Error 直接暴露给用户。
                 this.eventBus.emit(sessionId, { kind: 'sdk_message', message: errorSDKMsg })
                 try { updateAgentSessionMeta(sessionId, {}) } catch { /* 忽略 */ }
-                completeRun(getAgentSessionMessages(sessionId), { startedAt: streamStartedAt })
+                completeRun(getAgentSessionMessages(sessionId), { startedAt: streamStartedAt, terminatedWithError: true })
                 return
               }
             }

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -18,6 +18,7 @@ import { AGENT_IPC_CHANNELS, MAX_ATTACHMENT_SIZE } from '@proma/shared'
 import type {
   AgentSendInput,
   AgentGenerateTitleInput,
+  RegenerateTitleResult,
   AgentSaveFilesInput,
   AgentSaveWorkspaceFilesInput,
   AgentSavedFile,
@@ -169,7 +170,7 @@ export async function runAgent(
           })
         }
       },
-      onTitleUpdated: (title) => {
+      onTitleUpdated: (title, isAuto) => {
         eventBus.emit(input.sessionId, {
           kind: 'proma_event',
           event: { type: 'title_updated', title },
@@ -178,6 +179,7 @@ export async function runAgent(
           webContents.send(AGENT_IPC_CHANNELS.TITLE_UPDATED, {
             sessionId: input.sessionId,
             title,
+            isAuto: isAuto ?? false,
           })
         }
       },
@@ -266,6 +268,7 @@ export async function runAgentHeadless(
           wc.send(AGENT_IPC_CHANNELS.TITLE_UPDATED, {
             sessionId: runInput.sessionId,
             title,
+            isAuto: false,
           })
         }
       },
@@ -306,6 +309,13 @@ export async function runAgentHeadless(
  */
 export async function generateAgentTitle(input: AgentGenerateTitleInput): Promise<string | null> {
   return orchestrator.generateTitle(input)
+}
+
+/**
+ * 手动重新生成 Agent 会话标题（基于最近消息摘要，跳过节流）
+ */
+export async function regenerateAgentTitle(sessionId: string): Promise<RegenerateTitleResult> {
+  return orchestrator.regenerateTitle(sessionId)
 }
 
 /**

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -403,7 +403,7 @@ export function getAgentSessionSDKMessages(id: string): SDKMessage[] {
  */
 export function updateAgentSessionMeta(
   id: string,
-  updates: Partial<Pick<AgentSessionMeta, 'title' | 'channelId' | 'modelId' | 'sdkSessionId' | 'workspaceId' | 'pinned' | 'archived' | 'attachedDirectories' | 'attachedFiles' | 'forkSourceDir' | 'forkSourceSdkSessionId' | 'resumeAtMessageUuid' | 'stoppedByUser' | 'permissionMode' | 'completedButUnconfirmed' | 'sourceAutomationId' | 'automationGraduated' | 'parentSessionId' | 'rootSessionId' | 'sourceDelegationId' | 'delegationRole' | 'delegationStatus' | 'delegationDepth' | 'delegationGoal'>>,
+  updates: Partial<Pick<AgentSessionMeta, 'title' | 'channelId' | 'modelId' | 'sdkSessionId' | 'workspaceId' | 'pinned' | 'archived' | 'attachedDirectories' | 'attachedFiles' | 'forkSourceDir' | 'forkSourceSdkSessionId' | 'resumeAtMessageUuid' | 'stoppedByUser' | 'permissionMode' | 'completedButUnconfirmed' | 'sourceAutomationId' | 'automationGraduated' | 'parentSessionId' | 'rootSessionId' | 'sourceDelegationId' | 'delegationRole' | 'delegationStatus' | 'delegationDepth' | 'delegationGoal' | 'lastTitleTurn' | 'titleManualOverride'>>,
 ): AgentSessionMeta {
   const index = readIndex()
   const idx = index.sessions.findIndex((s) => s.id === id)

--- a/apps/electron/src/main/lib/settings-service.ts
+++ b/apps/electron/src/main/lib/settings-service.ts
@@ -27,6 +27,7 @@ export function getSettings(): AppSettings {
       notificationsEnabled: true,
       longTextPasteAsAttachmentEnabled: false,
       richTextRenderingEnabled: false,
+      progressiveTitleUpdateEnabled: true,
       feishuSessionMirror: { mode: 'off' },
       builtinMcpDisabledIds: [],
     }
@@ -44,6 +45,7 @@ export function getSettings(): AppSettings {
       notificationsEnabled: data.notificationsEnabled ?? true,
       longTextPasteAsAttachmentEnabled: data.longTextPasteAsAttachmentEnabled ?? false,
       richTextRenderingEnabled: data.richTextRenderingEnabled ?? false,
+      progressiveTitleUpdateEnabled: data.progressiveTitleUpdateEnabled ?? true,
       feishuSessionMirror: data.feishuSessionMirror ?? { mode: 'off' },
       builtinMcpDisabledIds: data.builtinMcpDisabledIds ?? [],
     }
@@ -57,6 +59,7 @@ export function getSettings(): AppSettings {
       notificationsEnabled: true,
       longTextPasteAsAttachmentEnabled: false,
       richTextRenderingEnabled: false,
+      progressiveTitleUpdateEnabled: true,
       feishuSessionMirror: { mode: 'off' },
       builtinMcpDisabledIds: [],
     }

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -455,6 +455,9 @@ export interface ElectronAPI {
   /** 生成 Agent 会话标题 */
   generateAgentTitle: (input: AgentGenerateTitleInput) => Promise<string | null>
 
+  /** 手动重新生成 Agent 会话标题（基于最近消息摘要，跳过节流） */
+  regenerateAgentTitle: (id: string) => Promise<import('@proma/shared').RegenerateTitleResult>
+
   /** 发送 Agent 消息 */
   sendAgentMessage: (input: AgentSendInput) => Promise<void>
 
@@ -584,7 +587,7 @@ export interface ElectronAPI {
   onAgentStreamError: (callback: (data: { sessionId: string; error: string }) => void) => () => void
 
   /** 订阅 Agent 标题自动更新事件 */
-  onAgentTitleUpdated: (callback: (data: { sessionId: string; title: string }) => void) => () => void
+  onAgentTitleUpdated: (callback: (data: { sessionId: string; title: string; isAuto?: boolean }) => void) => () => void
 
   // ===== Agent 权限系统 =====
 
@@ -1469,6 +1472,10 @@ const electronAPI: ElectronAPI = {
 
   generateAgentTitle: (input: AgentGenerateTitleInput) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.GENERATE_TITLE, input)
+  },
+
+  regenerateAgentTitle: (id: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.REGENERATE_TITLE, id)
   },
 
   sendAgentMessage: (input: AgentSendInput) => {

--- a/apps/electron/src/renderer/atoms/ui-preferences.ts
+++ b/apps/electron/src/renderer/atoms/ui-preferences.ts
@@ -16,6 +16,14 @@ export const longTextPasteAsAttachmentEnabledAtom = atom<boolean>(false)
 
 /** 输入框是否渲染 Markdown 富文本格式（默认关闭，纯文本模式；开启后渲染富文本，仍保留 Mention 引用） */
 export const richTextRenderingEnabledAtom = atom<boolean>(false)
+/** 渐进式更新会话标题（话题偏移时自动重新生成，仅普通主会话生效） */
+export const progressiveTitleUpdateEnabledAtom = atom<boolean>(true)
+
+/** 渐进式标题更新/手动重生成所用模型渠道 ID（空 = 跟随当前会话渠道） */
+export const titleModelChannelIdAtom = atom<string>('')
+
+/** 渐进式标题更新/手动重生成所用模型 ID（空 = 跟随当前会话模型） */
+export const titleModelIdAtom = atom<string>('')
 
 // ===== 初始化 =====
 
@@ -25,13 +33,19 @@ export const richTextRenderingEnabledAtom = atom<boolean>(false)
 export async function initializeUiPreferences(
   setStickyUserMessageEnabled: (enabled: boolean) => void,
   setLongTextPasteAsAttachmentEnabled?: (enabled: boolean) => void,
-  setRichTextRenderingEnabled?: (enabled: boolean) => void
+  setRichTextRenderingEnabled?: (enabled: boolean) => void,
+  setProgressiveTitleUpdateEnabled?: (enabled: boolean) => void,
+  setTitleModelChannelId?: (channelId: string) => void,
+  setTitleModelId?: (modelId: string) => void,
 ): Promise<void> {
   try {
     const settings = await window.electronAPI.getSettings()
     setStickyUserMessageEnabled(settings.stickyUserMessageEnabled ?? true)
     setLongTextPasteAsAttachmentEnabled?.(settings.longTextPasteAsAttachmentEnabled ?? false)
     setRichTextRenderingEnabled?.(settings.richTextRenderingEnabled ?? false)
+    setProgressiveTitleUpdateEnabled?.(settings.progressiveTitleUpdateEnabled ?? true)
+    setTitleModelChannelId?.(settings.titleModelChannelId ?? '')
+    setTitleModelId?.(settings.titleModelId ?? '')
   } catch (error) {
     console.error('[UI偏好] 初始化失败:', error)
   }
@@ -69,5 +83,33 @@ export async function updateRichTextRenderingEnabled(enabled: boolean): Promise<
     await window.electronAPI.updateSettings({ richTextRenderingEnabled: enabled })
   } catch (error) {
     console.error('[UI偏好] 更新输入框 Markdown 渲染设置失败:', error)
+  }
+}
+
+/**
+ * 更新渐进式标题更新开关并持久化
+ */
+export async function updateProgressiveTitleUpdateEnabled(enabled: boolean): Promise<void> {
+  try {
+    await window.electronAPI.updateSettings({ progressiveTitleUpdateEnabled: enabled })
+  } catch (error) {
+    console.error('[UI偏好] 更新渐进式标题更新设置失败:', error)
+  }
+}
+
+/**
+ * 更新渐进式标题更新所用模型并持久化
+ *
+ * @param channelId 渠道 ID，空字符串表示清除（跟随会话渠道）
+ * @param modelId 模型 ID，空字符串表示清除（跟随会话模型）
+ */
+export async function updateTitleModel(channelId: string, modelId: string): Promise<void> {
+  try {
+    await window.electronAPI.updateSettings({
+      titleModelChannelId: channelId,
+      titleModelId: modelId,
+    })
+  } catch (error) {
+    console.error('[UI偏好] 更新标题模型设置失败:', error)
   }
 }

--- a/apps/electron/src/renderer/components/agent/AgentHeader.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentHeader.tsx
@@ -7,7 +7,8 @@
 
 import * as React from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
-import { Pencil, Check, X } from 'lucide-react'
+import { Pencil, Check, X, Sparkles, Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
 import { agentSessionsAtom } from '@/atoms/agent-atoms'
 import { tabsAtom, updateTabTitle } from '@/atoms/tab-atoms'
 import { replaceAgentSessionInFreshnessOrder } from '@/lib/agent-session-list'
@@ -27,15 +28,82 @@ export function AgentHeader({ sessionId }: AgentHeaderProps): React.ReactElement
   const setTabs = useSetAtom(tabsAtom)
   const [editing, setEditing] = React.useState(false)
   const [editTitle, setEditTitle] = React.useState('')
+  const [regenerating, setRegenerating] = React.useState(false)
   const inputRef = React.useRef<HTMLInputElement>(null)
 
   if (!session) return null
+
+  // 仅普通主会话（排除协作子会话/定时会话）才显示重生成按钮；
+  // 与 orchestrator.regenerateTitle 的会话类型闸门对齐，避免按钮出现却秒退 null。
+  const isPlainMainSession =
+    !session.parentSessionId &&
+    !session.sourceDelegationId &&
+    !session.delegationDepth &&
+    !session.sourceAutomationId
 
   /** 进入编辑模式 */
   const startEdit = (): void => {
     setEditTitle(session.title)
     setEditing(true)
     requestAnimationFrame(() => inputRef.current?.focus())
+  }
+
+  /** 手动重新生成标题（基于最近消息摘要，跳过节流） */
+  const regenerateTitle = async (): Promise<void> => {
+    if (regenerating) return
+    const previousTitle = session.title  // 保存旧标题用于 undo
+    setRegenerating(true)
+    try {
+      const result = await window.electronAPI.regenerateAgentTitle(session.id)
+      if (result.ok && result.title) {
+        // 标题更新由全局 onAgentTitleUpdated 监听（useGlobalAgentListeners）统一同步
+        // tabs / agentSessions / 侧边栏均由该监听刷新，这里不手动更新避免竞态
+        toast.success(`标题已更新：${result.title}`, {
+          action: {
+            label: '撤销',
+            onClick: async () => {
+              try {
+                // 撤销：写回原标题，同时置 titleManualOverride=true 停止自动漂移覆盖
+                const restored = await window.electronAPI.updateAgentSessionTitle(session.id, previousTitle)
+                setTabs((prev) => updateTabTitle(prev, restored.id, restored.title))
+                setAgentSessions((prev) => replaceAgentSessionInFreshnessOrder(prev, restored))
+                toast.success(`已撤销：${previousTitle}`)
+              } catch (err) {
+                console.error('[AgentHeader] 撤销标题失败:', err)
+                toast.error('撤销失败，请手动编辑标题')
+              }
+            },
+          },
+        })
+        return
+      }
+      // 按 reason 给准确提示，不再一刀切"未偏离"
+      switch (result.reason) {
+        case 'no-model':
+          toast.error('未配置标题模型，请在设置中绑定渠道与模型，或在该会话发送一条消息后重试')
+          break
+        case 'no-messages':
+          toast.warning('当前会话没有可参考的对话内容')
+          break
+        case 'not-main-session':
+          toast.warning('该会话类型不支持重新生成标题')
+          break
+        case 'same':
+          toast.warning('AI 无法生成有效标题，请手动编辑')
+          break
+        case 'stale':
+          toast('标题刚刚已被自动更新，请再次点击重试')
+          break
+        default:
+          toast.error('重新生成标题失败')
+          break
+      }
+    } catch (error) {
+      console.error('[AgentHeader] 重新生成标题失败:', error)
+      toast.error('重新生成标题失败')
+    } finally {
+      setRegenerating(false)
+    }
   }
 
   /** 保存标题 */
@@ -114,6 +182,21 @@ export function AgentHeader({ sessionId }: AgentHeaderProps): React.ReactElement
           >
             <Pencil className="size-3.5" />
           </button>
+          {isPlainMainSession && (
+            <button
+              type="button"
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={regenerateTitle}
+              disabled={regenerating}
+              className="titlebar-no-drag p-1 text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
+              aria-label="重新生成标题"
+              title="基于最近对话重新生成标题"
+            >
+              {regenerating
+                ? <Loader2 className="size-3.5 animate-spin" />
+                : <Sparkles className="size-3.5" />}
+            </button>
+          )}
         </div>
       )}
     </div>

--- a/apps/electron/src/renderer/components/settings/GeneralSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/GeneralSettings.tsx
@@ -15,6 +15,7 @@ import {
   SettingsCard,
   SettingsRow,
   SettingsToggle,
+  SettingsSegmentedControl,
 } from './primitives'
 import { Popover, PopoverTrigger, PopoverContent } from '../ui/popover'
 import {
@@ -41,12 +42,18 @@ import {
   longTextPasteAsAttachmentEnabledAtom,
   richTextRenderingEnabledAtom,
   stickyUserMessageEnabledAtom,
+  progressiveTitleUpdateEnabledAtom,
+  titleModelChannelIdAtom,
+  titleModelIdAtom,
   updateLongTextPasteAsAttachmentEnabled,
   updateRichTextRenderingEnabled,
   updateStickyUserMessageEnabled,
+  updateProgressiveTitleUpdateEnabled,
+  updateTitleModel,
 } from '@/atoms/ui-preferences'
 import { cn } from '@/lib/utils'
 import { Button } from '../ui/button'
+import { ModelSelector } from '../chat/ModelSelector'
 import type { NotificationSoundId, NotificationSoundType, NotificationSoundSettings } from '@/types/settings'
 
 /** emoji-mart 选择回调的 emoji 对象类型 */
@@ -67,6 +74,9 @@ export function GeneralSettings(): React.ReactElement {
   const [stickyUserMessageEnabled, setStickyUserMessageEnabled] = useAtom(stickyUserMessageEnabledAtom)
   const [longTextPasteAsAttachmentEnabled, setLongTextPasteAsAttachmentEnabled] = useAtom(longTextPasteAsAttachmentEnabledAtom)
   const [richTextRenderingEnabled, setRichTextRenderingEnabled] = useAtom(richTextRenderingEnabledAtom)
+  const [progressiveTitleUpdateEnabled, setProgressiveTitleUpdateEnabled] = useAtom(progressiveTitleUpdateEnabledAtom)
+  const [titleModelChannelId, setTitleModelChannelId] = useAtom(titleModelChannelIdAtom)
+  const [titleModelId, setTitleModelId] = useAtom(titleModelIdAtom)
   const [isEditingName, setIsEditingName] = React.useState(false)
   const [nameInput, setNameInput] = React.useState(userProfile.userName)
   const [showEmojiPicker, setShowEmojiPicker] = React.useState(false)
@@ -343,6 +353,50 @@ export function GeneralSettings(): React.ReactElement {
               updateRichTextRenderingEnabled(checked)
             }}
           />
+          <SettingsSegmentedControl
+            label="会话标题更新"
+            description="自动：话题显著偏移时自动重新生成；仅手动：仅在点击 ✨ 按钮时生成"
+            options={[
+              { label: '渐进+手动', value: 'true' },
+              { label: '仅手动', value: 'false' },
+            ]}
+            value={progressiveTitleUpdateEnabled ? 'true' : 'false'}
+            onValueChange={(value) => {
+              const enabled = value === 'true'
+              setProgressiveTitleUpdateEnabled(enabled)
+              updateProgressiveTitleUpdateEnabled(enabled)
+            }}
+          />
+          <SettingsRow label="标题更新所用模型" description="漂移检测与手动重新生成所用模型，留空则跟随当前会话模型">
+            <div className="flex items-center gap-2">
+              <ModelSelector
+                externalSelectedModel={
+                  titleModelChannelId && titleModelId
+                    ? { channelId: titleModelChannelId, modelId: titleModelId }
+                    : null
+                }
+                onModelSelect={(option) => {
+                  setTitleModelChannelId(option.channelId)
+                  setTitleModelId(option.modelId)
+                  updateTitleModel(option.channelId, option.modelId)
+                }}
+                showChannelInTrigger
+              />
+              {titleModelChannelId && titleModelId && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    setTitleModelChannelId('')
+                    setTitleModelId('')
+                    updateTitleModel('', '')
+                  }}
+                >
+                  清除
+                </Button>
+              )}
+            </div>
+          </SettingsRow>
         </SettingsCard>
       </SettingsSection>
     </div>

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -1123,7 +1123,7 @@ export function useGlobalAgentListeners(): void {
     )
 
     // ===== 4. 标题更新 =====
-    const cleanupTitleUpdated = window.electronAPI.onAgentTitleUpdated(({ sessionId, title }) => {
+    const cleanupTitleUpdated = window.electronAPI.onAgentTitleUpdated(({ sessionId, title, isAuto }) => {
       // 先使用事件 payload 立即同步标签页，避免依赖会话列表旧快照比较。
       store.set(tabsAtom, (tabs) => updateTabTitle(tabs, sessionId, title))
       store.set(agentSessionsAtom, (prev) =>
@@ -1136,6 +1136,10 @@ export function useGlobalAgentListeners(): void {
           store.set(agentSessionsAtom, (prev) => mergeFetchedAgentSessions(prev, sessions))
         })
         .catch(console.error)
+      // 自动漂移更新静默 toast，不标绿色（非「成功操作」），低打扰
+      if (isAuto) {
+        toast(`标题已自动更新为：${title}`, { duration: 4000 })
+      }
     })
 
     // 定期清理 60s 前的「最近修改」标记，避免 atom 无限增长

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -54,6 +54,9 @@ import {
   stickyUserMessageEnabledAtom,
   longTextPasteAsAttachmentEnabledAtom,
   richTextRenderingEnabledAtom,
+  progressiveTitleUpdateEnabledAtom,
+  titleModelChannelIdAtom,
+  titleModelIdAtom,
   initializeUiPreferences,
 } from './atoms/ui-preferences'
 import {
@@ -433,14 +436,27 @@ function UiPreferencesInitializer(): null {
   const setStickyUserMessageEnabled = useSetAtom(stickyUserMessageEnabledAtom)
   const setLongTextPasteAsAttachmentEnabled = useSetAtom(longTextPasteAsAttachmentEnabledAtom)
   const setRichTextRenderingEnabled = useSetAtom(richTextRenderingEnabledAtom)
+  const setProgressiveTitleUpdateEnabled = useSetAtom(progressiveTitleUpdateEnabledAtom)
+  const setTitleModelChannelId = useSetAtom(titleModelChannelIdAtom)
+  const setTitleModelId = useSetAtom(titleModelIdAtom)
 
   useEffect(() => {
     initializeUiPreferences(
       setStickyUserMessageEnabled,
       setLongTextPasteAsAttachmentEnabled,
-      setRichTextRenderingEnabled
+      setRichTextRenderingEnabled,
+      setProgressiveTitleUpdateEnabled,
+      setTitleModelChannelId,
+      setTitleModelId,
     )
-  }, [setStickyUserMessageEnabled, setLongTextPasteAsAttachmentEnabled, setRichTextRenderingEnabled])
+  }, [
+    setStickyUserMessageEnabled,
+    setLongTextPasteAsAttachmentEnabled,
+    setRichTextRenderingEnabled,
+    setProgressiveTitleUpdateEnabled,
+    setTitleModelChannelId,
+    setTitleModelId,
+  ])
 
   return null
 }

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -240,6 +240,12 @@ export interface AppSettings {
   longTextPasteAsAttachmentEnabled?: boolean
   /** 输入框是否渲染 Markdown 富文本格式（默认 false，关闭后为纯文本模式，仍保留 Mention 引用） */
   richTextRenderingEnabled?: boolean
+  /** 渐进式更新会话标题：话题偏移时自动重新生成（默认 true，仅普通主会话生效） */
+  progressiveTitleUpdateEnabled?: boolean
+  /** 渐进式标题更新/手动重生成所用模型的渠道 ID（未设置则跟随当前会话渠道） */
+  titleModelChannelId?: string
+  /** 渐进式标题更新/手动重生成所用模型 ID（未设置则跟随当前会话模型） */
+  titleModelId?: string
   /** Markdown 预览字号档位（默认 'medium'，对应 15px） */
   markdownFontSize?: MarkdownFontSize
   /** 上次是否在 Scratch Pad 页（用于重启恢复） */

--- a/packages/core/src/providers/anthropic-adapter.ts
+++ b/packages/core/src/providers/anthropic-adapter.ts
@@ -441,7 +441,6 @@ export class AnthropicAdapter implements ProviderAdapter {
 
   buildTitleRequest(input: TitleRequestInput): ProviderRequest {
     const url = this.resolveMessagesUrl(input.baseUrl)
-    const capability = detectThinkingCapability(this.providerType, input.modelId)
 
     const body: Record<string, unknown> = {
       model: input.modelId,
@@ -449,12 +448,8 @@ export class AnthropicAdapter implements ProviderAdapter {
       messages: [{ role: 'user', content: input.prompt }],
     }
 
-    // 标题生成不需要思考：按模型能力选择禁用方式
-    // - Mythos Preview 不接受 disabled，省略字段即可
-    // - 其它 Claude 显式 disabled（对 manual / adaptive 模型都有效）
-    if (capability.disableStrategy === 'explicit-disabled') {
-      body.thinking = { type: 'disabled' }
-    }
+    // 标题生成强制禁用 thinking，避免模型输出思维链污染标题文本
+    body.thinking = { type: 'disabled' }
 
     return {
       url,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/shared",
-  "version": "0.1.41",
+  "version": "0.1.43",
   "license": "AGPL-3.0-only",
   "description": "Shared types, configs and utilities for proma",
   "type": "module",

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -612,6 +612,10 @@ export interface AgentSessionMeta {
   delegationDepth?: number
   /** 委派目标摘要，便于 UI 展示和追溯 */
   delegationGoal?: string
+  /** 渐进式标题更新：上次（自动或手动）生成标题时的累计用户轮次，用于节流判定 */
+  lastTitleTurn?: number
+  /** 渐进式标题更新：用户手动编辑标题后置 true，自动漂移检测跳过（尊重用户意图，不被覆盖） */
+  titleManualOverride?: boolean
   /** 创建时间戳 */
   createdAt: number
   /** 更新时间戳 */
@@ -718,12 +722,39 @@ export interface AgentSessionReferenceSearchResult {
 
 /** Agent 标题生成输入 */
 export interface AgentGenerateTitleInput {
-  /** 用户第一条消息内容 */
-  userMessage: string
+  /** 用户第一条消息内容（首条标题生成时使用） */
+  userMessage?: string
+  /** 渐进式标题更新/手动重生成时，传入最近若干条 SDK 消息，与 userMessage 二选一 */
+  messages?: SDKMessage[]
+  /** 当前标题（漂移检测时用于比对，模型返回与当前相同则视为未漂移） */
+  currentTitle?: string
+  /** 手动重生成模式：使用不同 prompt（总是生成新标题），跳过他 same-title 比较 */
+  isManualRegen?: boolean
   /** 渠道 ID（用于获取 API Key） */
   channelId: string
   /** 模型 ID */
   modelId: string
+}
+
+/**
+ * 手动重生成标题的结果
+ *
+ * 区分「没调 LLM 因故放弃」与「调了 LLM 但未漂移」两种 null 语义，
+ * 让前端能给出准确提示，避免把"未配置模型"误报成"主题未偏离"。
+ */
+export interface RegenerateTitleResult {
+  /** 是否成功生成并写回新标题 */
+  ok: boolean
+  /** 失败/未漂移原因；ok=true 时为 undefined */
+  reason?:
+    | 'not-main-session' // 子会话/定时会话，不参与手动重生成
+    | 'no-messages'      // 取不到最近文本消息
+    | 'no-model'         // 解析不到渠道/模型（设置未配 + meta 空）
+    | 'same'             // 调了 LLM，返回无效标题（空或默认标题）
+    | 'stale'            // CAS 校验失败：并发自动漂移检测已推进标题
+    | 'error'            // 调用异常
+  /** 新标题；仅 ok=true 时有值 */
+  title?: string
 }
 
 // ===== MCP 服务器配置 =====
@@ -1400,6 +1431,8 @@ export const AGENT_IPC_CHANNELS = {
   // 标题生成
   /** 生成 Agent 会话标题 */
   GENERATE_TITLE: 'agent:generate-title',
+  /** 手动重新生成 Agent 会话标题（基于最近消息摘要，触发漂移检测逻辑） */
+  REGENERATE_TITLE: 'agent:regenerate-title',
 
   // 消息发送
   /** 发送消息（触发 Agent 流式响应） */


### PR DESCRIPTION
## 概述

让会话标题"活"起来——当你的对话悄悄换了话题，标题会自动跟上，不用手动改。

### 场景

你跟 Agent 聊着聊着，话题漂移了——从"怎么写这个 API"滑到了"数据库索引怎么优化"。再看侧边栏，标题还停在最初的"帮我写 API"，已经和对话内容脱节了。

这个 PR 解决的问题就是：**让标题自己去追对话**。

### 怎么运作的

不是每轮都检测（那样太吵），而是设了四道闸门，过了才查：

```
第 1 关：是普通会话吗？（子会话/定时任务不参与）
第 2 关：用户在设置里开了吗？
第 3 关：用户手动改过标题吗？（尊重用户意图，手动改的标题不覆盖）
第 4 关：至少聊了 5 轮以上，值得看一眼了
     ↓ 全部通过
  取最近 12 条对话，生成摘要 → 发给 LLM
     ↓
  标题一样？→ 静默跳过
  标题变了？→ 自动更新 ✨
```

**防误判**：标题比对前会 `normalizeTitle` — 全角半角统一、空白折叠、标点全删。比如「帮我写 API！」和「帮我写API」不会因为一个叹号和空格就被判成"漂移"。更新后的标题还会过一道 `sanitizeTitleOutput`，防止弱模型把 prompt 指令（「只输出标题」「不要废话」之类）当标题吐出来。

**防竞态**：LLM 调用期间如果你又发了新消息，旧的标题结果会自动作废（CAS 机制）——不会拿过期的标题覆盖你正在进行的新话题。

### 怎么用

**自动模式**（默认开启）：什么也不用做。聊着聊着话题变了，标题自己更新，侧边栏会弹一个安静的 toast「标题已自动更新为：…」。

**手动触发**：顶栏 AgentHeader 右边多了个 ✨ 按钮。点一下就立即检测——如果标题已经准确，会告诉你「标题已反映当前话题」；如果需要更新，即刻重生成。重生成后还有撤销按钮，万一不满意一键回退。

**个性化设置**：
- 不想自动更新？设置页关掉开关
- 想用特定模型写标题？可以指定标题专用模型（渠道 + 模型独立选），和对话用的模型分开

**手动改标题的尊重**：如果你自己点击标题编辑，系统会记住"这是用户亲手改的"，不再自动覆盖——直到你主动点 ✨ 重生成，才算"重新交给系统"。

### 其他细节

- 流以错误终止时不触发漂移检测（都崩了就别折腾标题了）
- 每轮对话自动记下当前渠道/模型到元数据，保证老会话首次发消息后也能正确解析标题模型
- 标题生成时强制关闭 thinking/思维链（避免模型把推理过程写进标题）

## 改动

| 文件 | 增/删 | 说明 |
|------|-------|------|
| `packages/shared/src/types/agent.ts` | +37 | `AgentGenerateTitleInput` 扩展（messages / currentTitle / isManualRegen）、`RegenerateTitleResult` 类型、`lastTitleTurn` / `titleManualOverride` 元数据字段、`REGENERATE_TITLE` 通道常量 |
| `packages/shared/package.json` | +1/-1 | 版本 0.1.41 → 0.1.43 |
| `apps/electron/src/main/lib/agent-orchestrator.ts` | +403 | 核心引擎：漂移常量、消息提取/计数/摘要构建、normalizeTitle / sanitizeTitleOutput、标题模型解析、双模式 generateTitle、四道闸门 maybeRefreshTitle、CAS 并发安全、手动 regenerateTitle（6 种终止原因）、autoGenerateTitle 防护、completedWithError 守卫、runAgent 元数据持久化 |
| `apps/electron/src/main/lib/agent-service.ts` | +12 | `regenerateAgentTitle` 导出；`onTitleUpdated` 新增 `isAuto` 参数 |
| `apps/electron/src/main/lib/agent-session-manager.ts` | +2 | meta 更新 Pick 追加 `lastTitleTurn` / `titleManualOverride` |
| `apps/electron/src/main/lib/settings-service.ts` | +3 | `progressiveTitleUpdateEnabled` 默认 true |
| `apps/electron/src/main/ipc.ts` | +22 | `REGENERATE_TITLE` handler + 全窗口广播 + `UPDATE_TITLE` 追加 manual override 标记 |
| `apps/electron/src/preload/index.ts` | +9 | `regenerateAgentTitle` 桥接；`onAgentTitleUpdated` 签名扩展 |
| `apps/electron/src/types/settings.ts` | +6 | 3 个新设置字段类型 |
| `apps/electron/src/renderer/atoms/ui-preferences.ts` | +44 | 3 个持久化 atom + 初始化函数 |
| `apps/electron/src/renderer/components/agent/AgentHeader.tsx` | +85 | ✨ 重生成按钮（6 种 toast + 撤销 action）+ regenerating 期间禁用编辑 + 会话类型闸门 |
| `apps/electron/src/renderer/components/settings/GeneralSettings.tsx` | +50 | 开关 + 标题专用模型选择器 |
| `apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts` | +6 | 自动漂移低打扰 toast |
| `apps/electron/src/renderer/main.tsx` | +20 | UiPreferencesInitializer 扩展 |
| `packages/core/src/providers/anthropic-adapter.ts` | +6/-5 | 标题生成无条件禁用 thinking（`body.thinking = { type: 'disabled' }`），避免思维链污染标题 |

## 测试

- [x] TypeCheck 全包通过（6/6）
- [x] BDD 自审查通过（4 视角并行审查：核心逻辑 / IPC 通道 / UI 状态管理 / 架构一致性）
- [x] 体验完整性审查通过（7 条旅程：新会话首条标题、话题漂移自动更新、手动重生成、老会话升级兼容、设置开关交互、并发竞态、多窗口同步）

## 紧急度

常规

## 备注

Closes #1079