### PR TITLE
fix(agent): Skill 扫描对 dangling/broken symlink 容错，避免坏条目终止整个扫描

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.14.20",
+  "version": "0.14.21",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -636,7 +636,14 @@ function scanSkillsInDir(dir: string, enabled: boolean): SkillMeta[] {
     const entries = readdirSync(dir, { withFileTypes: true })
 
     for (const entry of entries) {
-      const isDir = entry.isDirectory() || (entry.isSymbolicLink() && statSync(join(dir, entry.name)).isDirectory())
+      // 单个条目（含 dangling/broken symlink）解析失败时跳过该条目继续扫描，
+      // 不能让坏条目逃逸到 outer catch 终止整个扫描，导致后续 Skill 全部丢失。
+      let isDir: boolean
+      try {
+        isDir = entry.isDirectory() || (entry.isSymbolicLink() && statSync(join(dir, entry.name)).isDirectory())
+      } catch {
+        continue
+      }
       if (!isDir) continue
 
       const skillMdPath = join(dir, entry.name, 'SKILL.md')


### PR DESCRIPTION
## 关联 Issue
Closes #1134

## 根因
`scanSkillsInDir`（`agent-workspace-manager.ts:639`）中 `statSync(join(dir, entry.name))` 的 symlink 目录判断位于 inner per-entry `try` 块**之外**。当遇到 dangling/broken symlink 时，`statSync` 抛错会逃逸到 outer catch，**终止整个 `readdirSync` for 循环**，导致排在坏 symlink 之后的 Skill 全部丢失（实测 22 个只显示 13 个，丢 9 个）。

## 修复
将 symlink 目录判断（`statSync`）移入 per-entry `try/catch`，单个条目解析失败时 `continue` 跳过该条目，不再让坏条目终止整体扫描。一个目录扫描器在遇到单个坏条目时应当跳过继续，而不是整体中止。

嵌套扫描（`skills/<x>/skills/<x>/SKILL.md`）经查证未实施：SDK 通过 `plugins: [{type:'local', path: workspacePath}]` 把工作区注册为 local plugin，按文档化的单层布局 `skills/<name>/SKILL.md` 发现 Skill，嵌套布局属用户误配。

## 验证
- `bun run typecheck`：通过
- `bun test`：通过（1 个 pre-existing flake `agent-session-manager.test.ts` 在 main 基线同样复现，单独运行 5 pass，与本次改动无关）
- `bun run build:renderer`（vite 构建）：通过

## 改动范围
- `apps/electron/src/main/lib/agent-workspace-manager.ts`：+7 行（per-entry try/catch）
- `apps/electron/package.json`：patch 版本递增
