### PR TITLE
fix(channel): 允许手动填写模型 contextWindow 修正第三方兼容渠道圆环分母

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.14.20",
+  "version": "0.14.21",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/agent-session-usage.ts
+++ b/apps/electron/src/main/lib/agent-session-usage.ts
@@ -20,10 +20,15 @@
  * 避免对整份会话 JSONL 全量 JSON.parse（高频 daily 任务一天可触发数百次）。
  */
 
-import { calculateContextUsageRatio, inferContextWindow } from '@proma/shared'
+import {
+  calculateContextUsageRatio,
+  resolveDisplayContextWindow,
+} from '@proma/shared'
 import type { SDKAssistantMessage, SDKResultMessage } from '@proma/shared'
 import { existsSync, readFileSync } from 'node:fs'
 import { getAgentSessionMessagesPath } from './config-paths'
+import { getAgentSessionMeta } from './agent-session-manager'
+import { getChannelById } from './channel-manager'
 
 interface UsageTokens {
   input_tokens: number
@@ -40,6 +45,29 @@ function sumUsedTokens(usage: UsageTokens): number {
     (usage.cache_read_input_tokens ?? 0) +
     (usage.cache_creation_input_tokens ?? 0)
   )
+}
+
+/**
+ * 从会话对应渠道的模型配置中读取用户手动填写的 contextWindow 覆盖值。
+ *
+ * 主进程 daily 用量统计路径：第三方兼容渠道改写 modelId 后按 modelId 推断可能不准，
+ * 优先采用用户在渠道模型配置中填写的 contextWindow。SDK result 的 modelUsage[].contextWindow
+ * 仍为最高优先级（在 pickResultContextWindow 内部处理）。
+ */
+function resolveSessionUserContextWindow(
+  sessionId: string,
+  modelId?: string,
+): number | undefined {
+  const meta = getAgentSessionMeta(sessionId)
+  const channelId = meta?.channelId
+  if (!channelId) return undefined
+  const channel = getChannelById(channelId)
+  if (!channel) return undefined
+  // 优先匹配会话记录的 modelId，其次取任一配置了 contextWindow 的模型
+  const byModel = channel.models.find((m) => m.id === modelId)
+  if (byModel?.contextWindow != null) return byModel.contextWindow
+  const anyOverride = channel.models.find((m) => m.contextWindow != null)
+  return anyOverride?.contextWindow
 }
 
 export function getSessionContextUsageRatio(sessionId: string): number | undefined {
@@ -72,7 +100,8 @@ export function getSessionContextUsageRatio(sessionId: string): number | undefin
       const result = parsed as SDKResultMessage
       if (!result.usage) continue
       const usedTokens = sumUsedTokens(result.usage)
-      const contextWindow = pickResultContextWindow(result)
+      const userContextWindow = resolveSessionUserContextWindow(sessionId)
+      const contextWindow = pickResultContextWindow(result, userContextWindow)
       return calculateContextUsageRatio(usedTokens, contextWindow)
     }
 
@@ -81,7 +110,11 @@ export function getSessionContextUsageRatio(sessionId: string): number | undefin
       const usage = asst.message?.usage
       if (!usage) continue
       const usedTokens = sumUsedTokens(usage)
-      const contextWindow = inferContextWindow(asst.message?.model)
+      const userContextWindow = resolveSessionUserContextWindow(sessionId, asst.message?.model)
+      const contextWindow = resolveDisplayContextWindow({
+        userContextWindow,
+        modelId: asst.message?.model,
+      })
       return calculateContextUsageRatio(usedTokens, contextWindow)
     }
   }
@@ -100,12 +133,19 @@ export function getSessionContextUsageRatio(sessionId: string): number | undefin
  *
  * 每个 entry 优先用 SDK 实测的 contextWindow，缺失时按 modelId 推断。
  */
-function pickResultContextWindow(result: SDKResultMessage): number | undefined {
+function pickResultContextWindow(
+  result: SDKResultMessage,
+  userContextWindow?: number,
+): number | undefined {
   if (!result.modelUsage) return undefined
   let best: number | undefined
   for (const [modelId, info] of Object.entries(result.modelUsage)) {
-    const win = info?.contextWindow ?? inferContextWindow(modelId)
-    if (win === undefined) continue
+    // SDK 实测 contextWindow 为最高优先级，缺失时回退到用户覆盖值 / modelId 推断
+    const win = resolveDisplayContextWindow({
+      sdkContextWindow: info?.contextWindow,
+      userContextWindow,
+      modelId,
+    })
     if (best === undefined || win > best) best = win
   }
   return best

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -153,7 +153,14 @@ function createUserSDKMessage(text: string, uuid?: string, createdAt = Date.now(
   return message
 }
 
-function resolveRunContextWindow(modelId: string | undefined, previous: number | undefined): number | undefined {
+function resolveRunContextWindow(
+  modelId: string | undefined,
+  previous: number | undefined,
+  userContextWindow?: number,
+): number | undefined {
+  // 优先用用户手动填写的 contextWindow，其次 modelId 推断，最后沿用 previous。
+  // SDK result 的真实 contextWindow 会通过 context_window 事件覆盖。
+  if (typeof userContextWindow === 'number' && userContextWindow > 0) return userContextWindow
   return inferContextWindow(modelId) ?? previous
 }
 
@@ -535,6 +542,15 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
 
   // 渠道已选但模型未选时，自动选择第一个可用模型
   const globalChannels = useAtomValue(channelsAtom)
+
+  // 当前渠道模型上用户手动填写的 contextWindow 覆盖值（仅第三方兼容渠道有）
+  const currentUserContextWindow = React.useMemo(() => {
+    if (!agentChannelId) return undefined
+    const channel = globalChannels.find((c) => c.id === agentChannelId)
+    if (!channel) return undefined
+    const model = channel.models.find((m) => m.id === agentModelId)
+    return model?.contextWindow
+  }, [globalChannels, agentChannelId, agentModelId])
 
   // 检查 Agent 渠道列表中是否存在可用的模型（渠道 enabled + 模型 enabled）
   const hasAvailableModel = React.useMemo(() => {
@@ -1035,7 +1051,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           model: snapshot.modelId,
           startedAt: streamStartedAt,
           inputTokens: existing?.inputTokens,
-          contextWindow: resolveRunContextWindow(snapshot.modelId, existing?.contextWindow),
+          contextWindow: resolveRunContextWindow(snapshot.modelId, existing?.contextWindow, currentUserContextWindow),
         })
         return map
       })
@@ -1813,7 +1829,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         model: agentModelId || undefined,
         startedAt: streamStartedAt,
         inputTokens: existing?.inputTokens,
-        contextWindow: resolveRunContextWindow(agentModelId || undefined, existing?.contextWindow),
+        contextWindow: resolveRunContextWindow(agentModelId || undefined, existing?.contextWindow, currentUserContextWindow),
       })
       return map
     })
@@ -1998,7 +2014,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         model: agentModelId || undefined,
         startedAt: streamStartedAt,
         inputTokens: existing?.inputTokens,
-        contextWindow: resolveRunContextWindow(agentModelId || undefined, existing?.contextWindow),
+        contextWindow: resolveRunContextWindow(agentModelId || undefined, existing?.contextWindow, currentUserContextWindow),
       })
       return map
     })

--- a/apps/electron/src/renderer/components/settings/ChannelForm.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelForm.tsx
@@ -353,6 +353,23 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
     )
   }
 
+  /** 更新模型的用户手动 contextWindow 覆盖值（仅第三方兼容渠道可填） */
+  const handleModelContextWindowChange = (modelId: string, value: string): void => {
+    const trimmed = value.trim()
+    const parsed = trimmed === '' ? undefined : Number(trimmed)
+    setModels((prev) =>
+      prev.map((m) =>
+        m.id === modelId
+          ? {
+              ...m,
+              contextWindow:
+                parsed != null && Number.isFinite(parsed) && parsed > 0 ? parsed : undefined,
+            }
+          : m
+      )
+    )
+  }
+
   /** 从供应商 API 拉取可用模型列表 */
   const handleFetchModels = async (): Promise<void> => {
     if (!apiKey.trim() || !baseUrl.trim()) return
@@ -382,7 +399,14 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
         const manualKept = prev.filter((m) => m.source === 'manual' && !fetchedById.has(m.id))
         const merged = fetchedModels.map((m) => {
           const old = prev.find((p) => p.id === m.id)
-          return old ? { ...m, enabled: old.enabled } : { ...m, enabled: false }
+          // 重新拉取时保留旧的 enabled 状态与用户手动填写的 contextWindow 覆盖值，
+          // 避免刷新模型列表覆盖用户已填的上下文窗口配置
+          if (!old) return { ...m, enabled: false }
+          return {
+            ...m,
+            enabled: old.enabled,
+            ...(old.contextWindow != null && { contextWindow: old.contextWindow }),
+          }
         })
         return [...manualKept, ...merged]
       })
@@ -650,6 +674,20 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
                       <span className="text-muted-foreground ml-1">({model.id})</span>
                     )}
                   </span>
+                  {provider === 'anthropic-compatible' || provider === 'custom' ? (
+                    <div className="flex items-center gap-1.5" title="手动指定上下文窗口（token 数），仅影响用量圆环显示">
+                      <span className="text-xs text-muted-foreground whitespace-nowrap">上下文窗口</span>
+                      <Input
+                        type="number"
+                        min={1}
+                        inputMode="numeric"
+                        value={model.contextWindow ?? ''}
+                        onChange={(e) => handleModelContextWindowChange(model.id, e.target.value)}
+                        placeholder="自动"
+                        className="h-7 w-28 text-xs"
+                      />
+                    </div>
+                  ) : null}
                   <button
                     type="button"
                     onClick={() => handleToggleModel(model.id)}

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -26,6 +26,7 @@ import {
   applyAgentEvent,
   liveMessagesMapAtom,
   agentSessionModelMapAtom,
+  agentSessionChannelMapAtom,
   agentModelIdAtom,
   agentPermissionModeMapAtom,
   stoppedByUserSessionsAtom,
@@ -43,6 +44,7 @@ import {
   agentDiffRefreshVersionAtom,
   askUserDraftsAtom,
 } from '@/atoms/agent-atoms'
+import { channelsAtom } from '@/atoms/chat-atoms'
 import {
   notificationsEnabledAtom,
   notificationSoundEnabledAtom,
@@ -56,8 +58,8 @@ import { agentDiffUnseenChangesAtom, agentDiffUnseenFilesAtom } from '@/atoms/ag
 import { previewFileMapAtom } from '@/atoms/preview-atoms'
 import type { NotificationSoundType } from '@/types/settings'
 import { toast } from 'sonner'
-import type { AgentStreamEvent, AgentStreamCompletePayload, AgentEvent, AgentStreamPayload, SDKAssistantMessage, SDKUserMessage, SDKSystemMessage, SDKContentBlock, SDKUserContentBlock, PromaEvent, AgentSessionMeta } from '@proma/shared'
-import { inferContextWindow } from '@proma/shared'
+import type { AgentStreamEvent, AgentStreamCompletePayload, AgentEvent, AgentStreamPayload, SDKAssistantMessage, SDKUserMessage, SDKSystemMessage, SDKContentBlock, SDKUserContentBlock, PromaEvent, AgentSessionMeta, Channel, ChannelModel } from '@proma/shared'
+import { resolveDisplayContextWindow } from '@proma/shared'
 import { buildExternalAgentRunActivation } from '@/lib/external-agent-run'
 import { upsertAgentSession, mergeFetchedAgentSessions } from '@/lib/agent-session-list'
 import { getAgentCompletionMarkers } from '@/lib/agent-completion-presence'
@@ -103,7 +105,30 @@ function uniqueTruthyPaths(paths: Array<string | null | undefined>): string[] {
 // Phase 2 将移除此转换，直接使用 SDKMessage 渲染
 // ============================================================================
 
-function payloadToLegacyEvents(payload: AgentStreamPayload): AgentEvent[] {
+/**
+ * 解析当前会话渠道模型上用户手动填写的 contextWindow 覆盖值。
+ *
+ * 用于流式 fallback 的圆环分母：第三方兼容渠道改写 modelId 后按 modelId 推断
+ * 可能不准，优先采用用户在渠道模型配置中填写的 contextWindow。SDK result 的
+ * 真实 contextWindow 会通过 context_window 事件覆盖此 fallback。
+ */
+function resolveUserContextWindow(store: ReturnType<typeof useStore>, sessionId: string): number | undefined {
+  const channelId = store.get(agentSessionChannelMapAtom).get(sessionId)
+  if (!channelId) return undefined
+  const channel = store.get(channelsAtom).find((c: Channel) => c.id === channelId)
+  if (!channel) return undefined
+  // 优先用会话记录的 modelId 匹配，其次退到第一个配置了 contextWindow 的模型
+  const sessionModelId = store.get(agentSessionModelMapAtom).get(sessionId)
+  const model = channel.models.find((m: ChannelModel) => m.id === sessionModelId)
+  if (model?.contextWindow != null) return model.contextWindow
+  const anyOverride = channel.models.find((m: ChannelModel) => m.contextWindow != null)
+  return anyOverride?.contextWindow
+}
+
+function payloadToLegacyEvents(
+  payload: AgentStreamPayload,
+  userContextWindow?: number,
+): AgentEvent[] {
   if (payload.kind === 'proma_event') {
     const evt = payload.event
     switch (evt.type) {
@@ -200,7 +225,12 @@ function payloadToLegacyEvents(payload: AgentStreamPayload): AgentEvent[] {
         // 因为部分端点（如智谱）会在 message.model 里剥掉 [1m] 等规格后缀，
         // 导致 glm-x-preview[1m] 被识别成 glm-x-preview（200K）。
         const modelName = aMsg._channelModelId ?? aMsg.message.model
-        const fallbackWindow = inferContextWindow(modelName)
+        // 流式 fallback：优先用用户手动填写的 contextWindow，其次按 modelId 推断。
+        // SDK result 的真实 contextWindow 会通过 context_window 事件覆盖，此处只是流式过程中的临时分母。
+        const fallbackWindow = resolveDisplayContextWindow({
+          userContextWindow,
+          modelId: modelName,
+        })
         events.push({
           type: 'usage_update',
           usage: {
@@ -208,7 +238,7 @@ function payloadToLegacyEvents(payload: AgentStreamPayload): AgentEvent[] {
             outputTokens: u.output_tokens,
             cacheReadTokens: u.cache_read_input_tokens,
             cacheCreationTokens: u.cache_creation_input_tokens,
-            ...(fallbackWindow ? { contextWindow: fallbackWindow } : {}),
+            contextWindow: fallbackWindow,
           },
         })
       }
@@ -654,7 +684,9 @@ export function useGlobalAgentListeners(): void {
         }
 
         // Phase 1 兼容：将新 AgentStreamPayload 转换为旧 AgentEvent[]
-        const legacyEvents = payloadToLegacyEvents(payload)
+        // 解析当前会话渠道模型上用户手动填写的 contextWindow 覆盖值，传入用于流式 fallback 分母
+        const userContextWindow = resolveUserContextWindow(store, sessionId)
+        const legacyEvents = payloadToLegacyEvents(payload, userContextWindow)
 
         for (const event of legacyEvents) {
           // 会话首次进入 running 时，清除旧的完成提醒状态

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/shared",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "license": "AGPL-3.0-only",
   "description": "Shared types, configs and utilities for proma",
   "type": "module",

--- a/packages/shared/src/types/channel.ts
+++ b/packages/shared/src/types/channel.ts
@@ -112,6 +112,14 @@ export interface ChannelModel {
   enabled: boolean
   /** 来源标记：手动添加的模型在拉取供应商列表时保留，不会被覆盖清除 */
   source?: 'manual' | 'fetched'
+  /**
+   * 用户手动指定的上下文窗口（token 数）。
+   *
+   * 仅用于显示推断（圆环分母），不影响 Agent SDK 的 [1m] 模型选择路径。
+   * 第三方兼容渠道改写 modelId 后，按 modelId 推断可能拿不到正确窗口，
+   * 允许用户在此覆盖。未填写时由 resolveDisplayContextWindow 回退到推断逻辑。
+   */
+  contextWindow?: number
 }
 
 /**

--- a/packages/shared/src/utils/context-window.ts
+++ b/packages/shared/src/utils/context-window.ts
@@ -6,6 +6,9 @@
  * 故不再下发任何 beta。Claude Agent SDK 仍要求通过 `[1m]` 模型后缀显式选择
  * 扩展上下文（发送请求前会自动剥离），因此前端推断、后端用量统计和 SDK 模型
  * 选择必须共用同一份判定，否则会出现"UI 显示 1M 但实际只 200K"的不一致。
+ * 注意：SDK [1m] 模型选择路径（resolveAgentSdkModelId）有意不读取用户手动填写的
+ * contextWindow 覆盖字段。该字段仅参与显示推断（resolveDisplayContextWindow），
+ * 用于第三方兼容渠道改写 modelId 后修正圆环分母，绝不污染 SDK 路由决策。
  */
 
 /** 默认上下文窗口（无法识别模型时使用） */
@@ -96,4 +99,28 @@ export function resolveAgentSdkModelId(modelId: string): string {
   const model = modelId.toLowerCase()
   if (!AGENT_SDK_1M_CONTEXT_RULES.some((pattern) => model.includes(pattern))) return modelId
   return `${modelId}[1m]`
+}
+
+/** resolveDisplayContextWindow 入参 */
+export interface ResolveDisplayContextWindowOptions {
+  /** SDK result 携带的 contextWindow（最高优先级，部分渠道不返回） */
+  sdkContextWindow?: number
+  /** 用户手动填写的 contextWindow 覆盖值（来自渠道模型配置） */
+  userContextWindow?: number
+  /** 模型 ID，用于回退推断 */
+  modelId?: string
+}
+
+/**
+ * 解析用于显示的 contextWindow（圆环分母）。
+ *
+ * 优先级：sdkContextWindow > userContextWindow > inferContextWindow(modelId) > DEFAULT_CONTEXT_WINDOW。
+ * 该函数仅用于 UI 显示与用量统计的圆环分母，绝不参与 Agent SDK 的 [1m] 模型选择路径。
+ */
+export function resolveDisplayContextWindow(opts: ResolveDisplayContextWindowOptions): number {
+  const { sdkContextWindow, userContextWindow, modelId } = opts
+  if (typeof sdkContextWindow === 'number' && sdkContextWindow > 0) return sdkContextWindow
+  if (typeof userContextWindow === 'number' && userContextWindow > 0) return userContextWindow
+  const inferred = inferContextWindow(modelId)
+  return inferred ?? DEFAULT_CONTEXT_WINDOW
 }

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -15,6 +15,8 @@ export {
   supports1MContext,
   inferContextWindow,
   resolveAgentSdkModelId,
+  resolveDisplayContextWindow,
+  type ResolveDisplayContextWindowOptions,
 } from './context-window'
 export { calculateContextUsageRatio } from './context-usage'
 export {


### PR DESCRIPTION
## 关联 Issue
Closes #1024

## 根因
`ChannelModel`（`packages/shared/src/types/channel.ts:106`）没有 `contextWindow` 字段。第三方兼容渠道（anthropic-compatible）改写 modelId 后，`inferContextWindow` 的 modelId 子串匹配必然落空，回退到默认 200K，导致圆环分母错误显示 200K（实际 1M），百分比偏高约 5 倍，警告色早约 5 倍出现。

## 修复（4 层，SDK `[1m]` 路径保持纯净）

**关键安全设计**：SDK `[1m]` 模型选择由独立的 `resolveAgentSdkModelId` 读 `AGENT_SDK_1M_CONTEXT_RULES` 决定，**不调用** `inferContextWindow`。新增的用户 `contextWindow` 字段仅参与显示推断，绝不污染 SDK 路由决策。

1. **shared 类型**：`ChannelModel` 新增可选 `contextWindow?: number`（JSDoc 标注仅显示用）
2. **shared 工具**：新增 `resolveDisplayContextWindow({ sdkContextWindow?, userContextWindow?, modelId? })`，优先级 `sdk > user > inferContextWindow(modelId) > DEFAULT_CONTEXT_WINDOW`。未改动 `inferContextWindow` / `supports1MContext` / `resolveAgentSdkModelId` / `AGENT_SDK_1M_CONTEXT_RULES`
3. **ChannelForm**：已启用模型行新增可选 contextWindow 数字输入（仅 `anthropic-compatible` / `custom` provider 显示，placeholder "自动"）。修复 `handleFetchModels` merge 逻辑，重新拉取模型时保留 `old.contextWindow`，避免刷新覆盖用户填写值
4. **圆环消费点**改用 `resolveDisplayContextWindow`：
   - `useGlobalAgentListeners.ts`：流式 fallback（新增 `resolveUserContextWindow` 辅助函数查渠道模型）
   - `AgentView.tsx`：`resolveRunContextWindow` 加 `userContextWindow` 参数（3 个调用点传入）
   - `agent-session-usage.ts`：主进程 daily 统计（新增 `resolveSessionUserContextWindow` 辅助函数，SDK result contextWindow 仍最高优先）

`resolveAgentSdkModelId` 调用点（`agent-orchestrator.ts:1401`、`agent-model-routing.ts:40`）**未改动**。

## 验证
- `bun run typecheck`：全部包通过（@proma/cli, electron, session-core, shared, core, ui）
- `bun test`：298 pass / 1 fail（pre-existing flake 同 #1134 说明）
- `bun run build:renderer`：通过（9.4s）

## 改动范围
- `packages/shared/src/types/channel.ts`：+8 行
- `packages/shared/src/utils/context-window.ts`：+27 行（新函数）
- `packages/shared/src/utils/index.ts`：+2 行（导出）
- `apps/electron/src/renderer/components/settings/ChannelForm.tsx`：+40 行
- `apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts`：+44 行
- `apps/electron/src/renderer/components/agent/AgentView.tsx`：+24 行
- `apps/electron/src/main/lib/agent-session-usage.ts`：+52 行
- `packages/shared/package.json`：patch 0.1.41 -> 0.1.42
- `apps/electron/package.json`：patch 递增

## 备注
4 个并行 PR 均递增 `apps/electron` patch 版本，若合并时存在版本号冲突请维护者取较高值。
