### PR TITLE
Fix Agent compact provider window handling

### DIFF
--- a/apps/electron/src/main/lib/agent-model-routing.test.ts
+++ b/apps/electron/src/main/lib/agent-model-routing.test.ts
@@ -35,7 +35,7 @@ describe('Agent 辅助模型路由', () => {
       modelId: 'claude-sonnet-4-6',
       provider: 'anthropic',
     })
-    applyAgentModelRoutingToEnv(env, policy)
+    applyAgentModelRoutingToEnv(env, policy, 'anthropic')
 
     expect(policy.deepSeekFamily).toBe(false)
     expect(env.CLAUDE_CODE_SUBAGENT_MODEL).toBeUndefined()
@@ -47,8 +47,19 @@ describe('Agent 辅助模型路由', () => {
     applyAgentModelRoutingToEnv(env, resolveAgentModelRouting({
       modelId: 'deepseek-v4-flash',
       provider: 'deepseek',
-    }))
+    }), 'deepseek')
 
     expect(env.CLAUDE_CODE_SUBAGENT_MODEL).toBe(`${DEEPSEEK_SUBAGENT_MODEL_ID}[1m]`)
+  })
+
+  test('Given 通用 Anthropic-compatible DeepSeek 模型 When 应用模型路由 Then SubAgent 模型不追加 SDK 后缀', () => {
+    const env: Record<string, string | undefined> = {}
+
+    applyAgentModelRoutingToEnv(env, resolveAgentModelRouting({
+      modelId: 'gateway/deepseek-v4-pro',
+      provider: 'anthropic-compatible',
+    }), 'anthropic-compatible')
+
+    expect(env.CLAUDE_CODE_SUBAGENT_MODEL).toBe(DEEPSEEK_SUBAGENT_MODEL_ID)
   })
 })

--- a/apps/electron/src/main/lib/agent-model-routing.ts
+++ b/apps/electron/src/main/lib/agent-model-routing.ts
@@ -35,9 +35,10 @@ export function resolveAgentModelRouting(input: AgentModelRoutingInput): AgentMo
 export function applyAgentModelRoutingToEnv(
   env: Record<string, string | undefined>,
   policy: AgentModelRoutingPolicy,
+  provider: ProviderType,
 ): void {
   if (policy.subagentModel) {
-    env.CLAUDE_CODE_SUBAGENT_MODEL = resolveAgentSdkModelId(policy.subagentModel)
+    env.CLAUDE_CODE_SUBAGENT_MODEL = resolveAgentSdkModelId(policy.subagentModel, provider)
   } else {
     delete env.CLAUDE_CODE_SUBAGENT_MODEL
   }

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -58,6 +58,7 @@ import { validateToolInput } from './agent-tool-input-validator'
 import { estimateTokenCount, WRITE_CONTENT_TOKEN_THRESHOLD } from './agent-tool-token-estimator'
 import { injectBuiltinMcpServers } from './builtin-mcp/registry'
 import { isVisibleRunMessage } from './agent-run-message-visibility'
+import { applyAgentSdkAuthEnv } from './agent-sdk-auth-env'
 
 // ===== 类型定义 =====
 
@@ -428,19 +429,14 @@ export class AgentOrchestrator {
     }
 
     // 认证方式按 provider 分支
-    // - Kimi Coding Plan：只认 Bearer，通过 ANTHROPIC_CUSTOM_HEADERS 注入 Proma UA
+    // - Coding Plan / Token Plan：只认 Bearer，通过 ANTHROPIC_CUSTOM_HEADERS 注入 Proma UA
     // - MiniMax Coding Plan：Claude Code 场景使用 Bearer（ANTHROPIC_AUTH_TOKEN）
     // - 通过 ANTHROPIC_AUTH_TOKEN 让 SDK 发 Authorization: Bearer
     // - 其它：ANTHROPIC_API_KEY（SDK 内部会同时带上 x-api-key 和 Bearer）
-    if (provider === 'kimi-coding' || provider === 'zhipu-coding' || provider === 'xiaomi-token-plan') {
-      sdkEnv.ANTHROPIC_AUTH_TOKEN = apiKey
-      sdkEnv.ANTHROPIC_CUSTOM_HEADERS = `User-Agent: ${getPromaUserAgent(pkg.version)}`
-    } else if (provider === 'minimax') {
-      sdkEnv.ANTHROPIC_AUTH_TOKEN = apiKey
+    applyAgentSdkAuthEnv(sdkEnv, provider, apiKey, getPromaUserAgent(pkg.version))
+    if (provider === 'minimax') {
       sdkEnv.API_TIMEOUT_MS = '3000000'
       sdkEnv.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC = '1'
-    } else {
-      sdkEnv.ANTHROPIC_API_KEY = apiKey
     }
 
     // 全局 API 超时保护：防止网络环境变化（代理断开/WiFi 切换等）导致 SDK 子进程的
@@ -954,20 +950,7 @@ export class AgentOrchestrator {
     delete process.env.ANTHROPIC_AUTH_TOKEN
     delete process.env.ANTHROPIC_BASE_URL
     delete process.env.ANTHROPIC_CUSTOM_HEADERS
-    if (channel.provider === 'kimi-coding') {
-      // Kimi Coding Plan：只用 Bearer + 必须带 User-Agent
-      process.env.ANTHROPIC_AUTH_TOKEN = apiKey
-      process.env.ANTHROPIC_CUSTOM_HEADERS = `User-Agent: ${getPromaUserAgent(pkg.version)}`
-    } else if (channel.provider === 'xiaomi-token-plan') {
-      // 小米 Token Plan：Bearer + 必须带 User-Agent
-      process.env.ANTHROPIC_AUTH_TOKEN = apiKey
-      process.env.ANTHROPIC_CUSTOM_HEADERS = `User-Agent: ${getPromaUserAgent(pkg.version)}`
-    } else if (channel.provider === 'minimax') {
-      // MiniMax Coding Plan：Claude Code 兼容配置使用 Bearer
-      process.env.ANTHROPIC_AUTH_TOKEN = apiKey
-    } else {
-      process.env.ANTHROPIC_API_KEY = apiKey
-    }
+    applyAgentSdkAuthEnv(process.env, channel.provider, apiKey, getPromaUserAgent(pkg.version))
     // 使用与 buildSdkEnv 相同的规范化逻辑，确保 process.env 和 sdkEnv 中的 URL 一致
     if (channel.baseUrl && channel.baseUrl !== 'https://api.anthropic.com') {
       process.env.ANTHROPIC_BASE_URL = normalizeAnthropicBaseUrlForSdk(channel.baseUrl)
@@ -975,7 +958,7 @@ export class AgentOrchestrator {
 
     const modelRouting = resolveAgentModelRouting({ modelId: modelId || DEFAULT_MODEL_ID, provider: channel.provider })
     const sdkEnv = await this.buildSdkEnv(apiKey, channel.baseUrl, channel.provider)
-    applyAgentModelRoutingToEnv(sdkEnv, modelRouting)
+    applyAgentModelRoutingToEnv(sdkEnv, modelRouting, channel.provider)
 
     // 4. 读取已有的 SDK session ID（用于 resume）
     const sessionMeta = getAgentSessionMeta(sessionId)
@@ -1397,8 +1380,8 @@ export class AgentOrchestrator {
       const queryOptions: ClaudeAgentQueryOptions = {
         sessionId,
         prompt: finalPrompt,
-        // SDK 需要 `[1m]` 显式选择扩展上下文；发送给提供商前会自动剥离后缀。
-        model: resolveAgentSdkModelId(selectedModelId),
+        // 已验证的内置供应商可用 `[1m]` 选择扩展上下文；通用兼容端点保持原始模型 ID。
+        model: resolveAgentSdkModelId(selectedModelId, channel.provider),
         cwd: agentCwd,
         sdkCliPath: cliPath,
         env: sdkEnv,
@@ -1767,6 +1750,8 @@ export class AgentOrchestrator {
                     content: [{ type: 'text', text: errorContent }],
                   },
                   parent_tool_use_id: null,
+                  _channelModelId: modelId,
+                  _channelProvider: channel.provider,
                   error: { message: typedError.message, errorType: typedError.code },
                   _createdAt: Date.now(),
                   _errorCode: typedError.code,
@@ -1809,9 +1794,19 @@ export class AgentOrchestrator {
                     accumulatedMessages.push(msg)
                   }
                 } else {
-                  // 为 assistant 消息注入渠道 modelId，确保持久化后能正确匹配模型显示名
-                  if (msg.type === 'assistant' && modelId) {
-                    (msg as Record<string, unknown>)._channelModelId = modelId
+                  // 为结果消息注入渠道信息，确保持久化后能按 Agent SDK 运行窗口计算压缩阈值
+                  if (msg.type === 'result') {
+                    if (modelId) {
+                      (msg as Record<string, unknown>)._channelModelId = modelId
+                    }
+                    ;(msg as Record<string, unknown>)._channelProvider = channel.provider
+                  }
+                  // 为 assistant 消息注入渠道信息，确保持久化后能正确匹配模型显示名与 Agent SDK 窗口
+                  if (msg.type === 'assistant') {
+                    if (modelId) {
+                      (msg as Record<string, unknown>)._channelModelId = modelId
+                    }
+                    ;(msg as Record<string, unknown>)._channelProvider = channel.provider
                   }
                   accumulatedMessages.push(msg)
                 }

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -381,6 +381,7 @@ export class AgentOrchestrator {
     apiKey: string,
     baseUrl: string | undefined,
     provider: ProviderType,
+    modelId: string | undefined,
   ): Promise<Record<string, string | undefined>> {
     const DEFAULT_ANTHROPIC_URL = 'https://api.anthropic.com'
 
@@ -391,15 +392,17 @@ export class AgentOrchestrator {
     // loadShellEnv() 可能从 shell 配置文件（~/.zshrc 等）重新注入这些变量。
     const cleanEnv: Record<string, string | undefined> = {}
     for (const [key, value] of Object.entries(process.env)) {
-      if (!key.startsWith('ANTHROPIC_')) {
+      if (!key.startsWith('ANTHROPIC_') && key !== 'CLAUDE_CODE_MAX_OUTPUT_TOKENS') {
         cleanEnv[key] = value
       }
     }
 
+    const maxOutputTokens = getAgentSdkMaxOutputTokens(modelId)
+
     const sdkEnv: Record<string, string | undefined> = {
       ...cleanEnv,
-      // Claude 原生可提高输出上限；兼容渠道常见上限为 32768，不能全局下发 64000。
-      CLAUDE_CODE_MAX_OUTPUT_TOKENS: getAgentSdkMaxOutputTokens(provider),
+      // 仅 Claude 模型显式提高输出上限；其它兼容模型不注入 max_tokens 覆盖。
+      ...(maxOutputTokens ? { CLAUDE_CODE_MAX_OUTPUT_TOKENS: maxOutputTokens } : {}),
       // 暴露打包进 App 的 proma CLI 路径，供 session-cleaner 等 skill / Agent 调用
       // （开发模式无编译二进制，getBundledCliPath 返回 undefined，此处不注入，
       //   skill 回退到源码运行 bun apps/cli/src/index.ts）。
@@ -951,6 +954,7 @@ export class AgentOrchestrator {
     delete process.env.ANTHROPIC_AUTH_TOKEN
     delete process.env.ANTHROPIC_BASE_URL
     delete process.env.ANTHROPIC_CUSTOM_HEADERS
+    delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS
     applyAgentSdkAuthEnv(process.env, channel.provider, apiKey, getPromaUserAgent(pkg.version))
     // 使用与 buildSdkEnv 相同的规范化逻辑，确保 process.env 和 sdkEnv 中的 URL 一致
     if (channel.baseUrl && channel.baseUrl !== 'https://api.anthropic.com') {
@@ -958,7 +962,7 @@ export class AgentOrchestrator {
     }
 
     const modelRouting = resolveAgentModelRouting({ modelId: modelId || DEFAULT_MODEL_ID, provider: channel.provider })
-    const sdkEnv = await this.buildSdkEnv(apiKey, channel.baseUrl, channel.provider)
+    const sdkEnv = await this.buildSdkEnv(apiKey, channel.baseUrl, channel.provider, modelId || DEFAULT_MODEL_ID)
     applyAgentModelRoutingToEnv(sdkEnv, modelRouting, channel.provider)
 
     // 4. 读取已有的 SDK session ID（用于 resume）

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -59,6 +59,7 @@ import { estimateTokenCount, WRITE_CONTENT_TOKEN_THRESHOLD } from './agent-tool-
 import { injectBuiltinMcpServers } from './builtin-mcp/registry'
 import { isVisibleRunMessage } from './agent-run-message-visibility'
 import { applyAgentSdkAuthEnv } from './agent-sdk-auth-env'
+import { getAgentSdkMaxOutputTokens } from './agent-sdk-output-limits'
 
 // ===== 类型定义 =====
 
@@ -397,8 +398,8 @@ export class AgentOrchestrator {
 
     const sdkEnv: Record<string, string | undefined> = {
       ...cleanEnv,
-      // 提升输出 token 上限，避免 "exceeded 32000 output token maximum" 错误
-      CLAUDE_CODE_MAX_OUTPUT_TOKENS: '64000',
+      // Claude 原生可提高输出上限；兼容渠道常见上限为 32768，不能全局下发 64000。
+      CLAUDE_CODE_MAX_OUTPUT_TOKENS: getAgentSdkMaxOutputTokens(provider),
       // 暴露打包进 App 的 proma CLI 路径，供 session-cleaner 等 skill / Agent 调用
       // （开发模式无编译二进制，getBundledCliPath 返回 undefined，此处不注入，
       //   skill 回退到源码运行 bun apps/cli/src/index.ts）。

--- a/apps/electron/src/main/lib/agent-sdk-auth-env.test.ts
+++ b/apps/electron/src/main/lib/agent-sdk-auth-env.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test'
+import { applyAgentSdkAuthEnv, usesAgentSdkBearerWithUserAgent } from './agent-sdk-auth-env'
+
+describe('Agent SDK 认证环境变量', () => {
+  test.each(['kimi-coding', 'zhipu-coding', 'xiaomi-token-plan'] as const)(
+    'Given %s When 写入 SDK 认证 env Then 使用 Bearer 与 Proma User-Agent',
+    (provider) => {
+      const env: Record<string, string | undefined> = {}
+
+      applyAgentSdkAuthEnv(env, provider, 'test-key', 'Proma/test')
+
+      expect(usesAgentSdkBearerWithUserAgent(provider)).toBe(true)
+      expect(env.ANTHROPIC_AUTH_TOKEN).toBe('test-key')
+      expect(env.ANTHROPIC_CUSTOM_HEADERS).toBe('User-Agent: Proma/test')
+      expect(env.ANTHROPIC_API_KEY).toBeUndefined()
+    },
+  )
+
+  test('Given 普通 Anthropic 渠道 When 写入 SDK 认证 env Then 使用 API Key', () => {
+    const env: Record<string, string | undefined> = {}
+
+    applyAgentSdkAuthEnv(env, 'anthropic', 'test-key', 'Proma/test')
+
+    expect(env.ANTHROPIC_API_KEY).toBe('test-key')
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBeUndefined()
+    expect(env.ANTHROPIC_CUSTOM_HEADERS).toBeUndefined()
+  })
+})

--- a/apps/electron/src/main/lib/agent-sdk-auth-env.ts
+++ b/apps/electron/src/main/lib/agent-sdk-auth-env.ts
@@ -1,0 +1,27 @@
+import type { ProviderType } from '@proma/shared'
+
+export function usesAgentSdkBearerWithUserAgent(provider: ProviderType): boolean {
+  return provider === 'kimi-coding'
+    || provider === 'zhipu-coding'
+    || provider === 'xiaomi-token-plan'
+}
+
+export function applyAgentSdkAuthEnv(
+  target: Record<string, string | undefined>,
+  provider: ProviderType,
+  apiKey: string,
+  userAgent: string,
+): void {
+  if (usesAgentSdkBearerWithUserAgent(provider)) {
+    target.ANTHROPIC_AUTH_TOKEN = apiKey
+    target.ANTHROPIC_CUSTOM_HEADERS = `User-Agent: ${userAgent}`
+    return
+  }
+
+  if (provider === 'minimax') {
+    target.ANTHROPIC_AUTH_TOKEN = apiKey
+    return
+  }
+
+  target.ANTHROPIC_API_KEY = apiKey
+}

--- a/apps/electron/src/main/lib/agent-sdk-output-limits.test.ts
+++ b/apps/electron/src/main/lib/agent-sdk-output-limits.test.ts
@@ -2,14 +2,15 @@ import { describe, expect, test } from 'bun:test'
 import { getAgentSdkMaxOutputTokens } from './agent-sdk-output-limits'
 
 describe('Agent SDK 输出 token 上限', () => {
-  test('Given Anthropic 原生渠道 When 构建 SDK env Then 保留 Claude 64K 输出上限', () => {
-    expect(getAgentSdkMaxOutputTokens('anthropic')).toBe('64000')
+  test('Given 模型名包含 claude When 构建 SDK env Then 注入 64K 输出上限', () => {
+    expect(getAgentSdkMaxOutputTokens('claude-sonnet-4-6')).toBe('64000')
+    expect(getAgentSdkMaxOutputTokens('vendor/Claude-Opus-4-8')).toBe('64000')
   })
 
-  test.each(['kimi-coding', 'zhipu-coding', 'ark-coding-plan', 'qwen-anthropic', 'anthropic-compatible'] as const)(
-    'Given 非 Claude 兼容渠道 %s When 构建 SDK env Then 不超过常见 32768 max_tokens 限制',
-    (provider) => {
-      expect(getAgentSdkMaxOutputTokens(provider)).toBe('32768')
+  test.each(['glm-5.2', 'kimi-k2.7-code', 'deepseek-v4-pro', 'qwen3.7-plus', undefined] as const)(
+    'Given 非 Claude 模型 %s When 构建 SDK env Then 不注入 max output token 覆盖',
+    (modelId) => {
+      expect(getAgentSdkMaxOutputTokens(modelId)).toBeUndefined()
     },
   )
 })

--- a/apps/electron/src/main/lib/agent-sdk-output-limits.test.ts
+++ b/apps/electron/src/main/lib/agent-sdk-output-limits.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'bun:test'
+import { getAgentSdkMaxOutputTokens } from './agent-sdk-output-limits'
+
+describe('Agent SDK 输出 token 上限', () => {
+  test('Given Anthropic 原生渠道 When 构建 SDK env Then 保留 Claude 64K 输出上限', () => {
+    expect(getAgentSdkMaxOutputTokens('anthropic')).toBe('64000')
+  })
+
+  test.each(['kimi-coding', 'zhipu-coding', 'ark-coding-plan', 'qwen-anthropic', 'anthropic-compatible'] as const)(
+    'Given 非 Claude 兼容渠道 %s When 构建 SDK env Then 不超过常见 32768 max_tokens 限制',
+    (provider) => {
+      expect(getAgentSdkMaxOutputTokens(provider)).toBe('32768')
+    },
+  )
+})

--- a/apps/electron/src/main/lib/agent-sdk-output-limits.ts
+++ b/apps/electron/src/main/lib/agent-sdk-output-limits.ts
@@ -1,5 +1,3 @@
-import type { ProviderType } from '@proma/shared'
-
-export function getAgentSdkMaxOutputTokens(provider: ProviderType): string {
-  return provider === 'anthropic' ? '64000' : '32768'
+export function getAgentSdkMaxOutputTokens(modelId: string | undefined): string | undefined {
+  return modelId?.toLowerCase().includes('claude') ? '64000' : undefined
 }

--- a/apps/electron/src/main/lib/agent-sdk-output-limits.ts
+++ b/apps/electron/src/main/lib/agent-sdk-output-limits.ts
@@ -1,0 +1,5 @@
+import type { ProviderType } from '@proma/shared'
+
+export function getAgentSdkMaxOutputTokens(provider: ProviderType): string {
+  return provider === 'anthropic' ? '64000' : '32768'
+}

--- a/apps/electron/src/main/lib/agent-session-usage.ts
+++ b/apps/electron/src/main/lib/agent-session-usage.ts
@@ -20,7 +20,7 @@
  * 避免对整份会话 JSONL 全量 JSON.parse（高频 daily 任务一天可触发数百次）。
  */
 
-import { calculateContextUsageRatio, inferContextWindow } from '@proma/shared'
+import { calculateContextUsageRatio, inferAgentSdkContextWindow, inferContextWindow } from '@proma/shared'
 import type { SDKAssistantMessage, SDKResultMessage } from '@proma/shared'
 import { existsSync, readFileSync } from 'node:fs'
 import { getAgentSessionMessagesPath } from './config-paths'
@@ -81,7 +81,10 @@ export function getSessionContextUsageRatio(sessionId: string): number | undefin
       const usage = asst.message?.usage
       if (!usage) continue
       const usedTokens = sumUsedTokens(usage)
-      const contextWindow = inferContextWindow(asst.message?.model)
+      const modelId = asst._channelModelId ?? asst.message?.model
+      const contextWindow = asst._channelProvider
+        ? inferAgentSdkContextWindow(modelId, asst._channelProvider)
+        : inferContextWindow(modelId)
       return calculateContextUsageRatio(usedTokens, contextWindow)
     }
   }
@@ -98,13 +101,16 @@ export function getSessionContextUsageRatio(sessionId: string): number | undefin
  *   - 单 entry（常态）：行为与从前一致
  *   - 多 entry：避免被子 agent 的小窗口拉低、过早误触发 daily 切换阈值
  *
- * 每个 entry 优先用 SDK 实测的 contextWindow，缺失时按 modelId 推断。
+ * 每个 entry 优先用 SDK 实测的 contextWindow，缺失时按本次 Agent provider 的运行窗口推断。
  */
 function pickResultContextWindow(result: SDKResultMessage): number | undefined {
   if (!result.modelUsage) return undefined
   let best: number | undefined
   for (const [modelId, info] of Object.entries(result.modelUsage)) {
-    const win = info?.contextWindow ?? inferContextWindow(modelId)
+    const fallbackWindow = result._channelProvider
+      ? inferAgentSdkContextWindow(modelId, result._channelProvider)
+      : inferContextWindow(modelId)
+    const win = info?.contextWindow ?? fallbackWindow
     if (win === undefined) continue
     if (best === undefined || win > best) best = win
   }

--- a/apps/electron/src/main/lib/channel-manager.ts
+++ b/apps/electron/src/main/lib/channel-manager.ts
@@ -594,7 +594,12 @@ async function testXiaomiMessages(
   const headers: Record<string, string> = {
     'anthropic-version': '2023-06-01',
     'content-type': 'application/json',
-    'api-key': apiKey,
+  }
+  if (provider === 'xiaomi-token-plan') {
+    headers.Authorization = `Bearer ${apiKey}`
+    headers['User-Agent'] = getPromaUserAgent(pkg.version)
+  } else {
+    headers['api-key'] = apiKey
   }
 
   const response = await fetchFn(url, withTimeout({

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -110,8 +110,8 @@ import { AgentSessionProvider } from '@/contexts/session-context'
 import { draftSessionIdsAtom } from '@/atoms/draft-session-atoms'
 import { sendWithCmdEnterAtom } from '@/atoms/shortcut-atoms'
 import { useOpenPreview } from '@/components/diff/preview-opener'
-import type { AgentSendInput, AgentPendingFile, FileDialogLargeFile, ModelOption, SDKMessage, SDKUserMessage } from '@proma/shared'
-import { inferContextWindow, MAX_ATTACHMENT_SIZE } from '@proma/shared'
+import type { AgentSendInput, AgentPendingFile, FileDialogLargeFile, ModelOption, SDKMessage, SDKUserMessage, ProviderType } from '@proma/shared'
+import { inferAgentSdkContextWindow, inferContextWindow, MAX_ATTACHMENT_SIZE } from '@proma/shared'
 import { fileToBase64, formatFileNames, getFileParentPath } from '@/lib/file-utils'
 import { buildQuotedSelectionBlock } from '@/lib/quoted-selection'
 import { createClipboardPendingFile, createClipboardTextDraft, makeUniqueAttachmentName } from '@/lib/clipboard-text-attachment'
@@ -153,8 +153,14 @@ function createUserSDKMessage(text: string, uuid?: string, createdAt = Date.now(
   return message
 }
 
-function resolveRunContextWindow(modelId: string | undefined, previous: number | undefined): number | undefined {
-  return inferContextWindow(modelId) ?? previous
+function resolveRunContextWindow(
+  modelId: string | undefined,
+  provider: ProviderType | undefined,
+  previous: number | undefined,
+): number | undefined {
+  return provider
+    ? inferAgentSdkContextWindow(modelId, provider) ?? previous
+    : inferContextWindow(modelId) ?? previous
 }
 
 interface SDKMessageRecord {
@@ -535,6 +541,10 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
 
   // 渠道已选但模型未选时，自动选择第一个可用模型
   const globalChannels = useAtomValue(channelsAtom)
+  const agentChannelProvider = React.useMemo(
+    () => globalChannels.find((c) => c.id === agentChannelId)?.provider,
+    [globalChannels, agentChannelId],
+  )
 
   // 检查 Agent 渠道列表中是否存在可用的模型（渠道 enabled + 模型 enabled）
   const hasAvailableModel = React.useMemo(() => {
@@ -1035,7 +1045,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           model: snapshot.modelId,
           startedAt: streamStartedAt,
           inputTokens: existing?.inputTokens,
-          contextWindow: resolveRunContextWindow(snapshot.modelId, existing?.contextWindow),
+          contextWindow: resolveRunContextWindow(snapshot.modelId, agentChannelProvider, existing?.contextWindow),
         })
         return map
       })
@@ -1075,7 +1085,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         })
       })
     })
-  }, [messagesLoaded, pendingPrompt, sessionId, agentChannelId, agentModelId, currentWorkspaceId, streaming, setPendingPrompt, setStreamingStates, permissionMode, attachedDirs, attachedFileDirectories])
+  }, [messagesLoaded, pendingPrompt, sessionId, agentChannelId, agentModelId, agentChannelProvider, currentWorkspaceId, streaming, setPendingPrompt, setStreamingStates, permissionMode, attachedDirs, attachedFileDirectories])
   // ===== 附件处理 =====
 
   /** 为文件生成唯一文件名（避免粘贴多张图片时文件名重复导致覆盖） */
@@ -1813,7 +1823,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         model: agentModelId || undefined,
         startedAt: streamStartedAt,
         inputTokens: existing?.inputTokens,
-        contextWindow: resolveRunContextWindow(agentModelId || undefined, existing?.contextWindow),
+        contextWindow: resolveRunContextWindow(agentModelId || undefined, agentChannelProvider, existing?.contextWindow),
       })
       return map
     })
@@ -1861,7 +1871,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         return map
       })
     })
-  }, [inputContent, createBaseAdditionalDirectories, preparePendingFilesForSend, restoreQueuedAttachmentsToPending, sessionId, agentChannelId, agentModelId, currentWorkspaceId, streaming, backgroundWaiting, suggestion, hasAvailableModel, store, consumeQuotedSelection, setStreamingStates, setAgentStreamErrors, setPromptSuggestions, setInputContent, setLiveMessagesMap, permissionMode, messagesLoaded, setQueuedMessages, setQuotedSelectionMap, sendPlainTextAgentMessage])
+  }, [inputContent, createBaseAdditionalDirectories, preparePendingFilesForSend, restoreQueuedAttachmentsToPending, sessionId, agentChannelId, agentModelId, agentChannelProvider, currentWorkspaceId, streaming, backgroundWaiting, suggestion, hasAvailableModel, store, consumeQuotedSelection, setStreamingStates, setAgentStreamErrors, setPromptSuggestions, setInputContent, setLiveMessagesMap, permissionMode, messagesLoaded, setQueuedMessages, setQuotedSelectionMap, sendPlainTextAgentMessage])
 
   /** 停止生成 */
   const handleStop = React.useCallback((): void => {
@@ -1998,7 +2008,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         model: agentModelId || undefined,
         startedAt: streamStartedAt,
         inputTokens: existing?.inputTokens,
-        contextWindow: resolveRunContextWindow(agentModelId || undefined, existing?.contextWindow),
+        contextWindow: resolveRunContextWindow(agentModelId || undefined, agentChannelProvider, existing?.contextWindow),
       })
       return map
     })
@@ -2012,7 +2022,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       startedAt: streamStartedAt,
       permissionModeOverride: permissionMode,
     }).catch(console.error)
-  }, [persistedSDKMessages, sessionId, agentChannelId, agentModelId, currentWorkspaceId, streaming, setAgentStreamErrors, setStreamingStates, permissionMode])
+  }, [persistedSDKMessages, sessionId, agentChannelId, agentModelId, agentChannelProvider, currentWorkspaceId, streaming, setAgentStreamErrors, setStreamingStates, permissionMode])
 
   /** 在新对话继续：创建新会话 + 切换 tab + 使用 &session 引用旧会话 */
   const handleRetryInNewSession = React.useCallback(async (): Promise<void> => {

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -26,7 +26,9 @@ import {
   applyAgentEvent,
   liveMessagesMapAtom,
   agentSessionModelMapAtom,
+  agentSessionChannelMapAtom,
   agentModelIdAtom,
+  agentChannelIdAtom,
   agentPermissionModeMapAtom,
   stoppedByUserSessionsAtom,
   agentPlanModeSessionsAtom,
@@ -53,11 +55,12 @@ import { appModeAtom } from '@/atoms/app-mode'
 import { tabsAtom, activeTabIdAtom, openTab, updateTabTitle } from '@/atoms/tab-atoms'
 import type { AgentStreamState } from '@/atoms/agent-atoms'
 import { agentDiffUnseenChangesAtom, agentDiffUnseenFilesAtom } from '@/atoms/agent-atoms'
+import { channelsAtom } from '@/atoms/chat-atoms'
 import { previewFileMapAtom } from '@/atoms/preview-atoms'
 import type { NotificationSoundType } from '@/types/settings'
 import { toast } from 'sonner'
-import type { AgentStreamEvent, AgentStreamCompletePayload, AgentEvent, AgentStreamPayload, SDKAssistantMessage, SDKUserMessage, SDKSystemMessage, SDKContentBlock, SDKUserContentBlock, PromaEvent, AgentSessionMeta } from '@proma/shared'
-import { inferContextWindow } from '@proma/shared'
+import type { AgentStreamEvent, AgentStreamCompletePayload, AgentEvent, AgentStreamPayload, SDKAssistantMessage, SDKUserMessage, SDKSystemMessage, SDKContentBlock, SDKUserContentBlock, PromaEvent, AgentSessionMeta, ProviderType } from '@proma/shared'
+import { inferAgentSdkContextWindow, inferContextWindow } from '@proma/shared'
 import { buildExternalAgentRunActivation } from '@/lib/external-agent-run'
 import { upsertAgentSession, mergeFetchedAgentSessions } from '@/lib/agent-session-list'
 import { getAgentCompletionMarkers } from '@/lib/agent-completion-presence'
@@ -200,7 +203,10 @@ function payloadToLegacyEvents(payload: AgentStreamPayload): AgentEvent[] {
         // 因为部分端点（如智谱）会在 message.model 里剥掉 [1m] 等规格后缀，
         // 导致 glm-x-preview[1m] 被识别成 glm-x-preview（200K）。
         const modelName = aMsg._channelModelId ?? aMsg.message.model
-        const fallbackWindow = inferContextWindow(modelName)
+        const provider = aMsg._channelProvider
+        const fallbackWindow = provider
+          ? inferAgentSdkContextWindow(modelName, provider)
+          : inferContextWindow(modelName)
         events.push({
           type: 'usage_update',
           usage: {
@@ -630,11 +636,21 @@ export function useGlobalAgentListeners(): void {
               msgRecord._createdAt = Date.now()
             }
 
-            // 为 assistant 消息注入渠道 modelId，确保流式期间就绑定正确模型
+            // 为 assistant 消息注入渠道信息，确保流式期间就绑定正确模型与 Agent SDK 窗口
             if (msgRecord.type === 'assistant' && !msgRecord._channelModelId) {
               const sessionModelMap = store.get(agentSessionModelMapAtom)
               const defaultModelId = store.get(agentModelIdAtom)
               msgRecord._channelModelId = sessionModelMap.get(sessionId) ?? defaultModelId ?? undefined
+            }
+            if (msgRecord.type === 'assistant' && !msgRecord._channelProvider) {
+              const sessionChannelMap = store.get(agentSessionChannelMapAtom)
+              const defaultChannelId = store.get(agentChannelIdAtom)
+              const channelId = sessionChannelMap.get(sessionId) ?? defaultChannelId ?? undefined
+              const channels = store.get(channelsAtom)
+              const provider = channels.find((c) => c.id === channelId)?.provider
+              if (provider) {
+                msgRecord._channelProvider = provider as ProviderType
+              }
             }
 
             store.set(liveMessagesMapAtom, (prev) => {

--- a/packages/core/src/providers/anthropic-adapter.test.ts
+++ b/packages/core/src/providers/anthropic-adapter.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'bun:test'
+import type { ProviderType } from '@proma/shared'
+import { AnthropicAdapter } from './anthropic-adapter.ts'
+import { setPromaVersion } from './user-agent.ts'
+
+function buildRequest(provider: ProviderType) {
+  const adapter = new AnthropicAdapter(provider)
+  const baseUrl = provider === 'xiaomi-token-plan'
+    ? 'https://token-plan-cn.xiaomimimo.com/anthropic'
+    : 'https://api.xiaomimimo.com/anthropic'
+
+  return adapter.buildStreamRequest({
+    baseUrl,
+    apiKey: 'test-key',
+    modelId: 'mimo-v2.5-pro',
+    history: [],
+    userMessage: 'ping',
+    readImageAttachments: () => [],
+  })
+}
+
+describe('AnthropicAdapter headers', () => {
+  test('xiaomi API uses api-key authentication', () => {
+    const request = buildRequest('xiaomi')
+
+    expect(request.headers['api-key']).toBe('test-key')
+    expect(request.headers.Authorization).toBeUndefined()
+    expect(request.headers['User-Agent']).toBeUndefined()
+  })
+
+  test('xiaomi token plan keeps bearer authentication with Proma User-Agent', () => {
+    setPromaVersion('9.9.9')
+
+    const request = buildRequest('xiaomi-token-plan')
+
+    expect(request.headers.Authorization).toBe('Bearer test-key')
+    expect(request.headers['User-Agent']).toBe('Proma/9.9.9 (+https://github.com/ErlichLiu/Proma)')
+    expect(request.headers['api-key']).toBeUndefined()
+  })
+})

--- a/packages/core/src/providers/anthropic-adapter.ts
+++ b/packages/core/src/providers/anthropic-adapter.ts
@@ -283,11 +283,16 @@ export class AnthropicAdapter implements ProviderAdapter {
       base['User-Agent'] = getPromaUserAgent()
       return base
     }
+    if (this.providerType === 'xiaomi-token-plan') {
+      base['Authorization'] = `Bearer ${apiKey}`
+      base['User-Agent'] = getPromaUserAgent()
+      return base
+    }
     if (this.providerType === 'minimax' || this.providerType === 'qwen-anthropic') {
       base['Authorization'] = `Bearer ${apiKey}`
       return base
     }
-    if (this.providerType === 'xiaomi' || this.providerType === 'xiaomi-token-plan') {
+    if (this.providerType === 'xiaomi') {
       base['api-key'] = apiKey
       return base
     }

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1,3 +1,5 @@
+import type { ProviderType } from './channel'
+
 /**
  * Agent 相关类型定义
  *
@@ -182,6 +184,8 @@ export interface SDKAssistantMessage {
   isReplay?: boolean
   /** 渠道配置的模型 ID，持久化/流式期间注入，用于正确匹配模型显示名 */
   _channelModelId?: string
+  /** 渠道 provider，用于按 Agent SDK 实际运行窗口计算压缩阈值 */
+  _channelProvider?: ProviderType
 }
 
 /** SDK user 消息 */
@@ -217,6 +221,10 @@ export interface SDKResultMessage {
   background_tasks?: SDKBackgroundTaskSummary[]
   session_crons?: SDKSessionCronSummary[]
   session_id?: string
+  /** 渠道配置的模型 ID，用于缺失 modelUsage.contextWindow 时按 Agent SDK 运行窗口兜底 */
+  _channelModelId?: string
+  /** 渠道 provider，用于按 Agent SDK 实际运行窗口计算压缩阈值 */
+  _channelProvider?: ProviderType
 }
 
 /** SDK system 消息（init / compact_boundary / permission_denied / task_started / task_progress / task_notification） */

--- a/packages/shared/src/utils/context-window.test.ts
+++ b/packages/shared/src/utils/context-window.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import {
   DEFAULT_CONTEXT_WINDOW,
   ONE_MILLION_CONTEXT_WINDOW,
+  inferAgentSdkContextWindow,
   inferContextWindow,
   resolveAgentSdkModelId,
   supports1MContext,
@@ -22,34 +23,51 @@ describe('模型上下文窗口', () => {
   })
 
   test('Given 支持 1M 的 Agent 模型 When 解析 SDK 模型 Then 追加扩展上下文后缀', () => {
-    expect(resolveAgentSdkModelId('claude-opus-4-8-promo-3')).toBe('claude-opus-4-8-promo-3[1m]')
-    expect(resolveAgentSdkModelId('claude-sonnet-5')).toBe('claude-sonnet-5[1m]')
-    expect(resolveAgentSdkModelId('claude-fable-5')).toBe('claude-fable-5[1m]')
-    expect(resolveAgentSdkModelId('deepseek-v4-pro')).toBe('deepseek-v4-pro[1m]')
-    expect(resolveAgentSdkModelId('deepseek-v4-flash')).toBe('deepseek-v4-flash[1m]')
-    expect(resolveAgentSdkModelId('glm-5.2')).toBe('glm-5.2[1m]')
-    expect(resolveAgentSdkModelId('mimo-v2.5-pro')).toBe('mimo-v2.5-pro[1m]')
-    expect(resolveAgentSdkModelId('mimo-v2.5')).toBe('mimo-v2.5[1m]')
-    expect(resolveAgentSdkModelId('MiniMax-M3')).toBe('MiniMax-M3[1m]')
-    expect(resolveAgentSdkModelId('qwen3.7-max')).toBe('qwen3.7-max[1m]')
-    expect(resolveAgentSdkModelId('qwen3.7-plus')).toBe('qwen3.7-plus[1m]')
-    expect(resolveAgentSdkModelId('qwen3.6-plus')).toBe('qwen3.6-plus[1m]')
-    expect(resolveAgentSdkModelId('qwen3.6-flash')).toBe('qwen3.6-flash[1m]')
-    expect(resolveAgentSdkModelId('qwen3.5-plus')).toBe('qwen3.5-plus[1m]')
-    expect(resolveAgentSdkModelId('qwen3.5-flash')).toBe('qwen3.5-flash[1m]')
-    expect(resolveAgentSdkModelId('qwen3-coder-plus')).toBe('qwen3-coder-plus[1m]')
+    expect(resolveAgentSdkModelId('claude-opus-4-8-promo-3', 'anthropic')).toBe('claude-opus-4-8-promo-3[1m]')
+    expect(resolveAgentSdkModelId('claude-sonnet-5', 'anthropic')).toBe('claude-sonnet-5[1m]')
+    expect(resolveAgentSdkModelId('claude-fable-5', 'anthropic')).toBe('claude-fable-5[1m]')
+    expect(resolveAgentSdkModelId('deepseek-v4-pro', 'deepseek')).toBe('deepseek-v4-pro[1m]')
+    expect(resolveAgentSdkModelId('deepseek-v4-flash', 'deepseek')).toBe('deepseek-v4-flash[1m]')
+    expect(resolveAgentSdkModelId('glm-5.2', 'zhipu-coding')).toBe('glm-5.2[1m]')
+    expect(resolveAgentSdkModelId('mimo-v2.5-pro', 'xiaomi')).toBe('mimo-v2.5-pro[1m]')
+    expect(resolveAgentSdkModelId('mimo-v2.5', 'xiaomi-token-plan')).toBe('mimo-v2.5[1m]')
+    expect(resolveAgentSdkModelId('MiniMax-M3', 'minimax')).toBe('MiniMax-M3[1m]')
   })
 
   test('Given 已带后缀或未纳入 SDK 1M 的模型 When 解析 SDK 模型 Then 保持原值', () => {
-    expect(resolveAgentSdkModelId('claude-opus-4-8[1m]')).toBe('claude-opus-4-8[1m]')
-    expect(resolveAgentSdkModelId('claude-sonnet-4-5')).toBe('claude-sonnet-4-5')
-    expect(resolveAgentSdkModelId('claude-haiku-4-5-20251001')).toBe('claude-haiku-4-5-20251001')
-    expect(resolveAgentSdkModelId('mimo-v2-pro')).toBe('mimo-v2-pro')
-    expect(resolveAgentSdkModelId('MiniMax-M2.7')).toBe('MiniMax-M2.7')
-    expect(resolveAgentSdkModelId('qwen3-max')).toBe('qwen3-max')
-    expect(resolveAgentSdkModelId('qwen3.6-max-preview')).toBe('qwen3.6-max-preview')
-    expect(resolveAgentSdkModelId('qwen3.5-397b-a17b')).toBe('qwen3.5-397b-a17b')
-    expect(resolveAgentSdkModelId('qwen3-coder-next')).toBe('qwen3-coder-next')
-    expect(resolveAgentSdkModelId('unknown-model')).toBe('unknown-model')
+    expect(resolveAgentSdkModelId('claude-opus-4-8[1m]', 'anthropic')).toBe('claude-opus-4-8[1m]')
+    expect(resolveAgentSdkModelId('claude-sonnet-4-5', 'anthropic')).toBe('claude-sonnet-4-5')
+    expect(resolveAgentSdkModelId('claude-haiku-4-5-20251001', 'anthropic')).toBe('claude-haiku-4-5-20251001')
+    expect(resolveAgentSdkModelId('mimo-v2-pro', 'xiaomi')).toBe('mimo-v2-pro')
+    expect(resolveAgentSdkModelId('MiniMax-M2.7', 'minimax')).toBe('MiniMax-M2.7')
+    expect(resolveAgentSdkModelId('qwen3-max', 'qwen-anthropic')).toBe('qwen3-max')
+    expect(resolveAgentSdkModelId('qwen3.6-max-preview', 'qwen-anthropic')).toBe('qwen3.6-max-preview')
+    expect(resolveAgentSdkModelId('qwen3.5-397b-a17b', 'qwen-anthropic')).toBe('qwen3.5-397b-a17b')
+    expect(resolveAgentSdkModelId('qwen3-coder-next', 'qwen-anthropic')).toBe('qwen3-coder-next')
+    expect(resolveAgentSdkModelId('unknown-model', 'anthropic')).toBe('unknown-model')
+  })
+
+  test('Given Qwen Anthropic 协议渠道 When 模型名命中 1M 规则 Then 保持真实模型 ID', () => {
+    expect(resolveAgentSdkModelId('qwen3.7-max', 'qwen-anthropic')).toBe('qwen3.7-max')
+    expect(resolveAgentSdkModelId('qwen3.7-plus', 'qwen-anthropic')).toBe('qwen3.7-plus')
+    expect(resolveAgentSdkModelId('qwen3.6-plus', 'qwen-anthropic')).toBe('qwen3.6-plus')
+    expect(resolveAgentSdkModelId('qwen3.6-flash', 'qwen-anthropic')).toBe('qwen3.6-flash')
+    expect(resolveAgentSdkModelId('qwen3.5-plus', 'qwen-anthropic')).toBe('qwen3.5-plus')
+    expect(resolveAgentSdkModelId('qwen3.5-flash', 'qwen-anthropic')).toBe('qwen3.5-flash')
+    expect(resolveAgentSdkModelId('qwen3-coder-plus', 'qwen-anthropic')).toBe('qwen3-coder-plus')
+  })
+
+  test('Given 通用 Anthropic-compatible 端点 When 模型名命中 1M 规则 Then 保持真实模型 ID', () => {
+    expect(resolveAgentSdkModelId('qwen3.7-plus', 'anthropic-compatible')).toBe('qwen3.7-plus')
+    expect(resolveAgentSdkModelId('deepseek-v4-pro', 'anthropic-compatible')).toBe('deepseek-v4-pro')
+    expect(resolveAgentSdkModelId('glm-5.2', 'anthropic-compatible')).toBe('glm-5.2')
+  })
+
+  test('Given Agent SDK 运行窗口推断 When 通用兼容端点模型名命中 1M 规则 Then 仍按 200K 处理', () => {
+    expect(inferAgentSdkContextWindow('glm-5.2', 'zhipu-coding')).toBe(ONE_MILLION_CONTEXT_WINDOW)
+    expect(inferAgentSdkContextWindow('glm-5.2', 'anthropic-compatible')).toBe(DEFAULT_CONTEXT_WINDOW)
+    expect(inferAgentSdkContextWindow('deepseek-v4-pro', 'deepseek')).toBe(ONE_MILLION_CONTEXT_WINDOW)
+    expect(inferAgentSdkContextWindow('deepseek-v4-pro', 'anthropic-compatible')).toBe(DEFAULT_CONTEXT_WINDOW)
+    expect(inferAgentSdkContextWindow('qwen3.7-plus', 'qwen-anthropic')).toBe(DEFAULT_CONTEXT_WINDOW)
   })
 })

--- a/packages/shared/src/utils/context-window.ts
+++ b/packages/shared/src/utils/context-window.ts
@@ -1,3 +1,5 @@
+import type { ProviderType } from '../types/channel'
+
 /**
  * 模型上下文窗口推断 — 单一 source of truth。
  *
@@ -15,30 +17,50 @@ export const DEFAULT_CONTEXT_WINDOW = 200_000
 export const ONE_MILLION_CONTEXT_WINDOW = 1_000_000
 
 /** 已确认需要显式选择 Claude Agent SDK `[1m]` 变体的模型。 */
-const AGENT_SDK_1M_CONTEXT_RULES = [
+const AGENT_SDK_1M_CONTEXT_RULES = {
   // Claude 系列
-  'claude-sonnet-4-6',
-  'claude-sonnet-5',
-  'claude-opus-4-6',
-  'claude-opus-4-7',
-  'claude-opus-4-8',
-  'claude-fable-5',
+  claude: [
+    'claude-sonnet-4-6',
+    'claude-sonnet-5',
+    'claude-opus-4-6',
+    'claude-opus-4-7',
+    'claude-opus-4-8',
+    'claude-fable-5',
+  ],
   // DeepSeek
-  'deepseek-v4',
+  deepseek: ['deepseek-v4'],
   // 智谱 GLM
-  'glm-5.2',
+  glm: ['glm-5.2'],
   // 小米 MiMo
-  'mimo-v2.5',
+  mimo: ['mimo-v2.5'],
   // MiniMax
-  'minimax-m3',
+  minimax: ['minimax-m3'],
   // 通义千问
-  'qwen3.7',
-  'qwen3.6-plus',
-  'qwen3.6-flash',
-  'qwen3.5-plus',
-  'qwen3.5-flash',
-  'qwen3-coder-plus',
-] as const
+  qwen: [
+    'qwen3.7',
+    'qwen3.6-plus',
+    'qwen3.6-flash',
+    'qwen3.5-plus',
+    'qwen3.5-flash',
+    'qwen3-coder-plus',
+  ],
+} as const
+
+const AGENT_SDK_1M_CONTEXT_PROVIDER_RULES: Partial<Record<ProviderType, readonly string[]>> = {
+  anthropic: AGENT_SDK_1M_CONTEXT_RULES.claude,
+  deepseek: AGENT_SDK_1M_CONTEXT_RULES.deepseek,
+  'zhipu-coding': AGENT_SDK_1M_CONTEXT_RULES.glm,
+  minimax: AGENT_SDK_1M_CONTEXT_RULES.minimax,
+  xiaomi: AGENT_SDK_1M_CONTEXT_RULES.mimo,
+  'xiaomi-token-plan': AGENT_SDK_1M_CONTEXT_RULES.mimo,
+  'ark-coding-plan': [
+    ...AGENT_SDK_1M_CONTEXT_RULES.deepseek,
+    ...AGENT_SDK_1M_CONTEXT_RULES.glm,
+    ...AGENT_SDK_1M_CONTEXT_RULES.minimax,
+  ],
+}
+
+const AGENT_SDK_1M_CONTEXT_DISPLAY_RULES = Object.values(AGENT_SDK_1M_CONTEXT_RULES).flat()
 
 /**
  * 上下文窗口配置表。仅影响显示推断的模型加在 rules；已实测 Agent SDK 1M
@@ -55,7 +77,7 @@ const CONTEXT_WINDOW_CONFIG = {
 
   /** 1M 上下文模型匹配规则 */
   rules: [
-    ...AGENT_SDK_1M_CONTEXT_RULES,
+    ...AGENT_SDK_1M_CONTEXT_DISPLAY_RULES,
     // 已废弃的 MiMo V2 Pro 仅保留历史显示推断，不主动启用 SDK 1M 变体
     'mimo-v2-pro',
   ] as const,
@@ -84,16 +106,31 @@ export function inferContextWindow(model?: string): number | undefined {
 }
 
 /**
+ * 按 Agent SDK 实际启用的窗口推断 contextWindow。
+ *
+ * 与 inferContextWindow 不同，这里必须同时看 provider：通用 Anthropic-compatible
+ * 端点即便模型名命中 1M 家族，也不一定能安全使用 SDK `[1m]` 变体。
+ */
+export function inferAgentSdkContextWindow(modelId: string | undefined, provider: ProviderType): number | undefined {
+  if (!modelId) return undefined
+  return resolveAgentSdkModelId(modelId, provider) !== modelId
+    || /\[1m\]$/i.test(modelId)
+    ? ONE_MILLION_CONTEXT_WINDOW
+    : DEFAULT_CONTEXT_WINDOW
+}
+
+/**
  * 将已确认的 1M Agent 模型转换为 Claude Agent SDK 的扩展上下文变体。
  *
- * `[1m]` 仅影响 SDK 的窗口与自动压缩判定；SDK 发给提供商前会自动剥离该后缀，
- * 因此不会改变 Proma 渠道路由使用的真实模型 ID。
+ * `[1m]` 仅用于已验证的内置供应商组合。泛化的 Anthropic-compatible
+ * 端点无法保证 SDK 会在请求前剥离后缀，因此必须保留用户配置的真实模型 ID。
  */
-export function resolveAgentSdkModelId(modelId: string): string {
+export function resolveAgentSdkModelId(modelId: string, provider: ProviderType): string {
   if (!modelId || /\[1m\]$/i.test(modelId)) {
     return modelId
   }
   const model = modelId.toLowerCase()
-  if (!AGENT_SDK_1M_CONTEXT_RULES.some((pattern) => model.includes(pattern))) return modelId
+  const rules = AGENT_SDK_1M_CONTEXT_PROVIDER_RULES[provider]
+  if (!rules?.some((pattern) => model.includes(pattern))) return modelId
   return `${modelId}[1m]`
 }

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -14,6 +14,7 @@ export {
   ONE_MILLION_CONTEXT_WINDOW,
   supports1MContext,
   inferContextWindow,
+  inferAgentSdkContextWindow,
   resolveAgentSdkModelId,
 } from './context-window'
 export { calculateContextUsageRatio } from './context-usage'


### PR DESCRIPTION
## Summary

- unify Agent SDK auth env handling for Coding Plan / Token Plan providers so buildSdkEnv and process.env use the same Bearer + Proma User-Agent rules
- make Agent SDK [1m] model-id selection provider-aware, keeping generic Anthropic-compatible endpoints on the user-configured model ID
- carry channel provider metadata through live and persisted SDK messages so UI usage badges and automation context reuse calculate compaction thresholds from the actual Agent SDK runtime window
- only set CLAUDE_CODE_MAX_OUTPUT_TOKENS for Agent models whose model ID contains claude; non-Claude compatible models no longer receive a max_tokens override

## Root Cause

Manual /compact and context-window fallback logic had provider-specific drift. zhipu-coding was handled correctly in buildSdkEnv but not in the process-level env sync, and the 1M context fallback was based on model name alone even when the runtime path intentionally should not append the SDK [1m] suffix for generic compatible endpoints.

Separately, Proma globally set CLAUDE_CODE_MAX_OUTPUT_TOKENS=64000 for the Claude Agent SDK. The SDK turns that into request max_tokens, which is valid for Claude models but exceeds the limit enforced by some non-Claude compatible providers. The override is now model-name gated and omitted for non-Claude models.

## Validation

- bun test packages/shared/src/utils/context-window.test.ts apps/electron/src/main/lib/agent-model-routing.test.ts apps/electron/src/main/lib/agent-sdk-auth-env.test.ts apps/electron/src/main/lib/agent-run-message-visibility.test.ts
- bun test apps/electron/src/main/lib/agent-sdk-output-limits.test.ts apps/electron/src/main/lib/agent-sdk-auth-env.test.ts
- bun run --cwd apps/electron typecheck
- git diff --check