### PR TITLE
fix agent 1m model suffix routing

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -29,6 +29,7 @@ import {
   THINKING_SIGNATURE_ERROR_TITLE,
   isPersistableSDKSystemMessage,
   normalizeMcpTransportType,
+  inferAgentSdkContextWindow,
   resolveAgentSdkModelId,
 } from '@proma/shared'
 import type { PromaPermissionMode, AskUserRequest, ExitPlanModeRequest, SDKSystemMessage } from '@proma/shared'
@@ -1477,12 +1478,14 @@ export class AgentOrchestrator {
           this.eventBus.emit(sessionId, { kind: 'proma_event', event: { type: 'model_resolved', model: resolvedModel } })
         },
         onContextWindow: (cw: number) => {
-          console.log(`[Agent 编排] 缓存 contextWindow: ${cw}`)
+          const inferredWindow = inferAgentSdkContextWindow(modelId, channel.provider)
+          const contextWindow = Math.max(cw, inferredWindow ?? 0) || cw
+          console.log(`[Agent 编排] 缓存 contextWindow: ${contextWindow}`)
           // result 消息里的真实 contextWindow 透传到 renderer，
           // 覆盖流式过程中按模型名推断的 fallback 值（智谱等端点会把 [1m] 等后缀剥掉，导致 fallback 不准）
           this.eventBus.emit(sessionId, {
             kind: 'proma_event',
-            event: { type: 'context_window', contextWindow: cw },
+            event: { type: 'context_window', contextWindow },
           })
         },
       }

--- a/apps/electron/src/main/lib/agent-session-usage.ts
+++ b/apps/electron/src/main/lib/agent-session-usage.ts
@@ -107,10 +107,11 @@ function pickResultContextWindow(result: SDKResultMessage): number | undefined {
   if (!result.modelUsage) return undefined
   let best: number | undefined
   for (const [modelId, info] of Object.entries(result.modelUsage)) {
+    const fallbackModelId = result._channelModelId ?? modelId
     const fallbackWindow = result._channelProvider
-      ? inferAgentSdkContextWindow(modelId, result._channelProvider)
-      : inferContextWindow(modelId)
-    const win = info?.contextWindow ?? fallbackWindow
+      ? inferAgentSdkContextWindow(fallbackModelId, result._channelProvider)
+      : inferContextWindow(fallbackModelId)
+    const win = Math.max(info?.contextWindow ?? 0, fallbackWindow ?? 0) || undefined
     if (win === undefined) continue
     if (best === undefined || win > best) best = win
   }

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -81,6 +81,8 @@ import type {
 import type { AgentPendingFile } from '@proma/shared'
 import {
   getSDKCompactStatus,
+  inferAgentSdkContextWindow,
+  inferContextWindow,
   THINKING_SIGNATURE_ERROR_CODE,
   THINKING_SIGNATURE_ERROR_TITLE,
   THINKING_SIGNATURE_ERROR_MESSAGE,
@@ -216,11 +218,20 @@ function extractTurnUsage(turnMessages: SDKMessage[]): { durationMs?: number; us
     // 多 entry 场景（Task 子 Agent 等）：取最大 contextWindow
     let contextWindow: number | undefined
     if (resultMsg.modelUsage) {
-      for (const info of Object.values(resultMsg.modelUsage)) {
-        if (info?.contextWindow && (contextWindow === undefined || info.contextWindow > contextWindow)) {
-          contextWindow = info.contextWindow
+      for (const [modelId, info] of Object.entries(resultMsg.modelUsage)) {
+        const fallbackModelId = resultMsg._channelModelId ?? modelId
+        const fallbackWindow = resultMsg._channelProvider
+          ? inferAgentSdkContextWindow(fallbackModelId, resultMsg._channelProvider)
+          : inferContextWindow(fallbackModelId)
+        const candidate = Math.max(info?.contextWindow ?? 0, fallbackWindow ?? 0) || undefined
+        if (candidate && (contextWindow === undefined || candidate > contextWindow)) {
+          contextWindow = candidate
         }
       }
+    } else {
+      contextWindow = resultMsg._channelProvider
+        ? inferAgentSdkContextWindow(resultMsg._channelModelId, resultMsg._channelProvider)
+        : inferContextWindow(resultMsg._channelModelId)
     }
     return {
       durationMs,

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -248,16 +248,27 @@ function payloadToLegacyEvents(payload: AgentStreamPayload): AgentEvent[] {
         total_cost_usd?: number
         modelUsage?: Record<string, { contextWindow?: number }>
         usage?: { input_tokens: number; output_tokens: number; cache_read_input_tokens: number; cache_creation_input_tokens: number }
+        _channelModelId?: string
+        _channelProvider?: ProviderType
       }
       // 多 entry 场景（Task 子 Agent 等）：取最大 contextWindow，
       // 避免子 Agent 的小窗口覆盖主模型的大窗口、导致指示器飘忽。
       let contextWindow: number | undefined
+      const fallbackWindow = rMsg._channelProvider
+        ? inferAgentSdkContextWindow(rMsg._channelModelId, rMsg._channelProvider)
+        : inferContextWindow(rMsg._channelModelId)
       if (rMsg.modelUsage) {
-        for (const info of Object.values(rMsg.modelUsage)) {
-          if (info?.contextWindow && (contextWindow === undefined || info.contextWindow > contextWindow)) {
-            contextWindow = info.contextWindow
+        for (const [modelId, info] of Object.entries(rMsg.modelUsage)) {
+          const modelFallbackWindow = rMsg._channelProvider
+            ? inferAgentSdkContextWindow(rMsg._channelModelId ?? modelId, rMsg._channelProvider)
+            : inferContextWindow(rMsg._channelModelId ?? modelId)
+          const candidate = Math.max(info?.contextWindow ?? 0, modelFallbackWindow ?? 0) || undefined
+          if (candidate && (contextWindow === undefined || candidate > contextWindow)) {
+            contextWindow = candidate
           }
         }
+      } else {
+        contextWindow = fallbackWindow
       }
       // result.usage 是整个 query 内所有模型调用的累计求和，不能当成当前上下文占用，
       // 否则进度环会虚高、冲破 100%（PR #821 修的正是这个问题）。

--- a/packages/shared/src/utils/context-window.test.ts
+++ b/packages/shared/src/utils/context-window.test.ts
@@ -63,11 +63,12 @@ describe('模型上下文窗口', () => {
     expect(resolveAgentSdkModelId('glm-5.2', 'anthropic-compatible')).toBe('glm-5.2')
   })
 
-  test('Given Agent SDK 运行窗口推断 When 通用兼容端点模型名命中 1M 规则 Then 仍按 200K 处理', () => {
+  test('Given Agent SDK 运行窗口推断 When 模型名命中 1M 规则 Then 按模型能力返回 1M', () => {
     expect(inferAgentSdkContextWindow('glm-5.2', 'zhipu-coding')).toBe(ONE_MILLION_CONTEXT_WINDOW)
-    expect(inferAgentSdkContextWindow('glm-5.2', 'anthropic-compatible')).toBe(DEFAULT_CONTEXT_WINDOW)
+    expect(inferAgentSdkContextWindow('glm-5.2', 'anthropic-compatible')).toBe(ONE_MILLION_CONTEXT_WINDOW)
     expect(inferAgentSdkContextWindow('deepseek-v4-pro', 'deepseek')).toBe(ONE_MILLION_CONTEXT_WINDOW)
-    expect(inferAgentSdkContextWindow('deepseek-v4-pro', 'anthropic-compatible')).toBe(DEFAULT_CONTEXT_WINDOW)
-    expect(inferAgentSdkContextWindow('qwen3.7-plus', 'qwen-anthropic')).toBe(DEFAULT_CONTEXT_WINDOW)
+    expect(inferAgentSdkContextWindow('deepseek-v4-pro', 'anthropic-compatible')).toBe(ONE_MILLION_CONTEXT_WINDOW)
+    expect(inferAgentSdkContextWindow('qwen3.7-plus', 'qwen-anthropic')).toBe(ONE_MILLION_CONTEXT_WINDOW)
+    expect(inferAgentSdkContextWindow('claude-sonnet-5', 'anthropic-compatible')).toBe(ONE_MILLION_CONTEXT_WINDOW)
   })
 })

--- a/packages/shared/src/utils/context-window.ts
+++ b/packages/shared/src/utils/context-window.ts
@@ -108,12 +108,14 @@ export function inferContextWindow(model?: string): number | undefined {
 /**
  * 按 Agent SDK 实际启用的窗口推断 contextWindow。
  *
- * 与 inferContextWindow 不同，这里必须同时看 provider：通用 Anthropic-compatible
- * 端点即便模型名命中 1M 家族，也不一定能安全使用 SDK `[1m]` 变体。
+ * 与 resolveAgentSdkModelId 不同，这里只判断模型窗口能力，不判断是否要把
+ * `[1m]` 后缀传给 SDK。通用 Anthropic-compatible 端点可能不接受带后缀的
+ * 模型名，但这不应把已知 1M 模型的上下文分母降级为 200K。
  */
 export function inferAgentSdkContextWindow(modelId: string | undefined, provider: ProviderType): number | undefined {
   if (!modelId) return undefined
-  return resolveAgentSdkModelId(modelId, provider) !== modelId
+  return supports1MContext(modelId)
+    || resolveAgentSdkModelId(modelId, provider) !== modelId
     || /\[1m\]$/i.test(modelId)
     ? ONE_MILLION_CONTEXT_WINDOW
     : DEFAULT_CONTEXT_WINDOW


### PR DESCRIPTION
## Summary

Fixes Agent-mode model routing so SDK-only `[1m]` suffixes are only applied for provider/model combinations we explicitly trust.

## Root Cause

`resolveAgentSdkModelId()` previously decided whether to append `[1m]` from the model name alone. That meant user-configured Anthropic-compatible endpoints and Qwen Anthropic-compatible channels could receive model IDs such as `qwen3.7-plus[1m]`, which some compatible providers validate as a non-existent model.

## Changes

- Make Agent SDK `[1m]` model selection provider-aware.
- Keep generic `anthropic-compatible` and `qwen-anthropic` channels on the exact configured model ID.
- Preserve 1M display inference separately from the Agent SDK runtime window.
- Persist channel provider metadata on Agent messages/results so usage fallback and compression thresholds use the SDK runtime window, not just model-name inference.
- Update SubAgent model routing to avoid injecting `[1m]` for generic compatible endpoints.

## Validation

- `bun test apps/electron/src/main/lib/agent-model-routing.test.ts packages/shared/src/utils/context-window.test.ts`
- `bun run typecheck`
- `git diff --check`
