### PR TITLE
fix(preview): add TTL to default app cache and context menu

### DIFF
--- a/apps/electron/src/main/lib/default-app-cache.ts
+++ b/apps/electron/src/main/lib/default-app-cache.ts
@@ -20,6 +20,7 @@ interface DefaultAppCacheFile {
 
 const CACHE_VERSION = 1
 const MAX_CACHE_ENTRIES = 80
+const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000
 
 let loaded = false
 let entries = new Map<string, DefaultAppCacheEntry>()
@@ -89,6 +90,10 @@ export function getCachedDefaultAppInfo(cacheKey: string): DefaultAppInfo | null
   loadCache()
   const entry = entries.get(cacheKey)
   if (!entry) return null
+  if (Date.now() - entry.updatedAt > CACHE_TTL_MS) {
+    entries.delete(cacheKey)
+    return null
+  }
   return {
     name: entry.name,
     appPath: entry.appPath,

--- a/apps/electron/src/renderer/components/diff/DefaultAppOpenButton.tsx
+++ b/apps/electron/src/renderer/components/diff/DefaultAppOpenButton.tsx
@@ -3,12 +3,19 @@
  *
  * 通过 useDefaultAppForFile 拿到本机为该文件类型注册的默认 App（含图标），
  * 渲染一个按钮；点击调用 systemOpenFile 让系统按默认 App 打开。
+ * 右键弹出菜单：用默认 App 打开 / 在 Finder 中显示。
  * 探测失败或图标读取失败时不渲染。
  */
 
 import * as React from 'react'
 import type { FileAccessOptions } from '@proma/shared'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { FolderOpen } from 'lucide-react'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from '@/components/ui/context-menu'
 import { useDefaultAppForFile } from '@/hooks/useDefaultAppForFile'
 import { cn } from '@/lib/utils'
 
@@ -35,16 +42,23 @@ export function DefaultAppOpenButton({
     })
   }, [filePath, access])
 
+  const handleShowInFolder = React.useCallback(() => {
+    window.electronAPI.showInFolder(filePath).catch((err) => {
+      console.error('[DefaultAppOpenButton] 在文件夹中显示失败:', err)
+    })
+  }, [filePath])
+
   if (!info) return null
 
   const labeled = variant === 'labeled'
 
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
         <button
           type="button"
           onClick={handleClick}
+          title={`用 ${info.name} 打开编辑`}
           className={cn(
             'flex items-center shrink-0 text-muted-foreground hover:text-foreground hover:bg-muted/50 rounded transition-colors',
             labeled ? 'gap-1 h-6 px-1.5 max-w-[140px]' : 'justify-center size-6',
@@ -62,10 +76,17 @@ export function DefaultAppOpenButton({
             <span className="text-[11px] leading-none truncate">{info.name}</span>
           )}
         </button>
-      </TooltipTrigger>
-      <TooltipContent side="bottom">
-        <p>用 {info.name} 打开编辑</p>
-      </TooltipContent>
-    </Tooltip>
+      </ContextMenuTrigger>
+      <ContextMenuContent className="z-[9999] min-w-0 p-0.5">
+        <ContextMenuItem onSelect={handleClick}>
+          <img src={info.iconDataUrl} alt="" className="size-4 shrink-0" draggable={false} />
+          用 {info.name} 打开
+        </ContextMenuItem>
+        <ContextMenuItem onSelect={handleShowInFolder}>
+          <FolderOpen className="size-4 shrink-0" />
+          在 Finder 中显示
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   )
 }


### PR DESCRIPTION
## Summary

- 默认 App 缓存增加 7 天 TTL，过期后自动重新探测系统默认打开方式，解决用户修改系统文件关联后 Proma 无法同步的问题
- 预览面板"用 XXX 打开"按钮新增右键菜单：用默认 App 打开 / 在 Finder 中显示

## 改动文件

- `apps/electron/src/main/lib/default-app-cache.ts` — 新增 TTL 常量和过期检查
- `apps/electron/src/renderer/components/diff/DefaultAppOpenButton.tsx` — 替换 Tooltip 为 ContextMenu，新增右键菜单

## Test plan

- [x] 删除 `~/.proma-dev/default-apps.json` 后重启，验证默认 App 重新探测正确
- [x] 右键按钮弹出菜单，"用 Cursor 打开"和"在 Finder 中显示"均正常工作
- [x] TypeScript 编译通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)