### PR TITLE
fix(agent): harden skill scanning around broken symlinks

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.14.20",
+  "version": "0.14.21",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/agent-workspace-manager.test.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.test.ts
@@ -1,9 +1,70 @@
-import { describe, expect, test } from 'bun:test'
-import { normalizeWorkspaceMcpConfig } from './agent-workspace-manager'
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import * as os from 'node:os'
+import { join } from 'node:path'
+
+type AgentWorkspaceManager = typeof import('./agent-workspace-manager')
+type ConfigPathsModule = typeof import('./config-paths')
+
+let manager: AgentWorkspaceManager
+let configPaths: ConfigPathsModule
+let tempHome: string
+const originalHome = process.env.HOME
+const originalPromaDev = process.env.PROMA_DEV
+
+mock.module('electron', () => ({
+  app: {
+    isPackaged: true,
+    getPath: () => join(process.env.HOME ?? tempHome, 'Library', 'Application Support'),
+  },
+  safeStorage: {
+    isEncryptionAvailable: () => false,
+    encryptString: (value: string) => Buffer.from(value),
+    decryptString: (value: Buffer) => value.toString('utf-8'),
+  },
+}))
+
+mock.module('node:os', () => ({
+  ...os,
+  homedir: () => tempHome,
+}))
+
+beforeAll(async () => {
+  tempHome = mkdtempSync(join(os.tmpdir(), 'proma-agent-workspace-manager-'))
+  process.env.HOME = tempHome
+  process.env.PROMA_DEV = '0'
+  configPaths = await import('./config-paths')
+  manager = await import('./agent-workspace-manager')
+})
+
+beforeEach(() => {
+  rmSync(join(tempHome, '.proma'), { recursive: true, force: true })
+  mkdirSync(join(tempHome, '.proma'), { recursive: true })
+})
+
+afterAll(() => {
+  if (originalHome === undefined) {
+    delete process.env.HOME
+  } else {
+    process.env.HOME = originalHome
+  }
+  if (originalPromaDev === undefined) {
+    delete process.env.PROMA_DEV
+  } else {
+    process.env.PROMA_DEV = originalPromaDev
+  }
+  rmSync(tempHome, { recursive: true, force: true })
+})
+
+function writeWorkspaceSkill(workspaceSlug: string, skillSlug: string, name: string): void {
+  const skillDir = join(configPaths.getWorkspaceSkillsDir(workspaceSlug), skillSlug)
+  mkdirSync(skillDir, { recursive: true })
+  writeFileSync(join(skillDir, 'SKILL.md'), `---\nname: ${name}\n---\n`, 'utf-8')
+}
 
 describe('Agent 工作区 MCP 配置', () => {
   test('Given 工作区 MCP 包含内置保留名 When 归一化配置 Then 剔除冲突项并保留普通服务器', () => {
-    const normalized = normalizeWorkspaceMcpConfig({
+    const normalized = manager.normalizeWorkspaceMcpConfig({
       servers: {
         automation: {
           type: 'stdio',
@@ -25,5 +86,36 @@ describe('Agent 工作区 MCP 配置', () => {
 
     expect(Object.keys(normalized.servers).sort()).toEqual(['github'])
     expect(normalized.servers.github?.command).toBe('github-mcp')
+  })
+})
+
+describe('Agent 工作区 Skill 扫描', () => {
+  test('Given Skills 目录包含 broken symlink When 获取工作区 Skills Then 跳过坏条目并继续扫描后续 Skill', () => {
+    const workspaceSlug = 'workspace-a'
+    const skillsDir = configPaths.getWorkspaceSkillsDir(workspaceSlug)
+
+    writeWorkspaceSkill(workspaceSlug, 'alpha', 'Alpha')
+    symlinkSync(join(skillsDir, 'missing-target'), join(skillsDir, 'broken-link'), 'dir')
+    writeWorkspaceSkill(workspaceSlug, 'zeta', 'Zeta')
+
+    for (let i = 0; i < 20; i++) {
+      const entryNames = readdirSync(skillsDir)
+      const brokenIndex = entryNames.indexOf('broken-link')
+      const hasSkillAfterBroken = entryNames.slice(brokenIndex + 1).some((name) => name !== 'missing-target')
+      if (brokenIndex !== -1 && hasSkillAfterBroken) break
+      writeWorkspaceSkill(workspaceSlug, `tail-${i}`, `Tail ${i}`)
+    }
+
+    const finalEntryNames = readdirSync(skillsDir)
+    const finalBrokenIndex = finalEntryNames.indexOf('broken-link')
+    expect(finalBrokenIndex).not.toBe(-1)
+    expect(finalEntryNames.slice(finalBrokenIndex + 1).some((name) => name !== 'missing-target')).toBe(true)
+
+    const expectedSlugs = finalEntryNames
+      .filter((name) => name !== 'broken-link')
+      .sort()
+    const skills = manager.getWorkspaceSkills(workspaceSlug)
+
+    expect(skills.map((skill) => skill.slug).sort()).toEqual(expectedSlugs)
   })
 })

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -7,6 +7,7 @@
  */
 
 import { readFileSync, writeFileSync, existsSync, readdirSync, cpSync, mkdirSync, statSync, openSync, readSync, closeSync, realpathSync } from 'node:fs'
+import type { Dirent } from 'node:fs'
 import { rmSyncWithRetry, renameWithRetry } from './fs-retry'
 import { writeJsonFileAtomic, readJsonFileSafe } from './safe-file'
 import { randomUUID } from 'node:crypto'
@@ -629,6 +630,17 @@ export function deleteWorkspaceSkill(workspaceSlug: string, skillSlug: string): 
 }
 
 /** 扫描指定目录下的 Skills，供 getWorkspaceSkills 和 getAllWorkspaceSkills 复用 */
+function isSkillDirectoryEntry(dir: string, entry: Dirent): boolean {
+  if (entry.isDirectory()) return true
+  if (!entry.isSymbolicLink()) return false
+
+  try {
+    return statSync(join(dir, entry.name)).isDirectory()
+  } catch {
+    return false
+  }
+}
+
 function scanSkillsInDir(dir: string, enabled: boolean): SkillMeta[] {
   const skills: SkillMeta[] = []
 
@@ -636,15 +648,7 @@ function scanSkillsInDir(dir: string, enabled: boolean): SkillMeta[] {
     const entries = readdirSync(dir, { withFileTypes: true })
 
     for (const entry of entries) {
-      // 单个条目（含 dangling/broken symlink）解析失败时跳过该条目继续扫描，
-      // 不能让坏条目逃逸到 outer catch 终止整个扫描，导致后续 Skill 全部丢失。
-      let isDir: boolean
-      try {
-        isDir = entry.isDirectory() || (entry.isSymbolicLink() && statSync(join(dir, entry.name)).isDirectory())
-      } catch {
-        continue
-      }
-      if (!isDir) continue
+      if (!isSkillDirectoryEntry(dir, entry)) continue
 
       const skillMdPath = join(dir, entry.name, 'SKILL.md')
       if (!existsSync(skillMdPath)) continue

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -636,7 +636,14 @@ function scanSkillsInDir(dir: string, enabled: boolean): SkillMeta[] {
     const entries = readdirSync(dir, { withFileTypes: true })
 
     for (const entry of entries) {
-      const isDir = entry.isDirectory() || (entry.isSymbolicLink() && statSync(join(dir, entry.name)).isDirectory())
+      // 单个条目（含 dangling/broken symlink）解析失败时跳过该条目继续扫描，
+      // 不能让坏条目逃逸到 outer catch 终止整个扫描，导致后续 Skill 全部丢失。
+      let isDir: boolean
+      try {
+        isDir = entry.isDirectory() || (entry.isSymbolicLink() && statSync(join(dir, entry.name)).isDirectory())
+      } catch {
+        continue
+      }
       if (!isDir) continue
 
       const skillMdPath = join(dir, entry.name, 'SKILL.md')


### PR DESCRIPTION
## Summary

This builds on and credits the fix in #1147 by @david188888. The root cause and repair direction there are correct: a dangling/broken symlink under `skills/` should not let `statSync(...)` escape to the outer scan catch and stop discovery of later skills.

This follow-up tightens the implementation and adds regression coverage:

- keeps the broken-symlink behavior but moves the directory decision into `isSkillDirectoryEntry(...)`
- treats an unreadable or dangling symlink as “not a skill directory” instead of a reason to abort the scan
- adds a regression test that creates a temporary workspace with a broken symlink and verifies subsequent valid skills are still returned
- keeps the scope limited to the documented single-level `skills/<name>/SKILL.md` layout; no nested skill scanning is introduced

## Validation

- `bun test apps/electron/src/main/lib/agent-workspace-manager.test.ts`
- `git diff --check`

`bun run --cwd apps/electron typecheck` is currently blocked on unrelated pre-existing provider type errors in this branch/base:

- `src/main/lib/agent-model-routing.ts(40,38): error TS2554: Expected 2 arguments, but got 1.`
- `src/main/lib/agent-orchestrator.ts(1401,16): error TS2554: Expected 2 arguments, but got 1.`
- `src/renderer/lib/model-logo.ts(237,7): error TS2741: Property '"zhipu-coding-team"' is missing ...`
