### PR TITLE
fix(markdown): avoid fuzzy linkify for file-like text

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.14.20",
+  "version": "0.14.21",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.14.21",
+  "version": "0.14.20",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/lib/markdown-rich-text.test.ts
+++ b/apps/electron/src/renderer/lib/markdown-rich-text.test.ts
@@ -129,4 +129,14 @@ describe('linkify 合成链接防护', () => {
     const html = markdownToHtml('访问 google.com 搜索')
     expect(html).not.toContain('<a')
   })
+
+  test('markdownToHtml 不把 .md 结尾的文件名误判为合成链接', () => {
+    // 这是 htmlToMarkdown 序列化乱码的根源：linkify 若把 SKILL.md 合成为
+    // <a href="http://SKILL.md">SKILL.md</a>，<a> case 会序列化为
+    // [SKILL.md](<http://SKILL.md>)。这里从 markdownToHtml 侧断言不合成。
+    const html = markdownToHtml('请查看 SKILL.md 了解更多')
+    expect(html).not.toContain('http://SKILL.md')
+    expect(html).not.toContain('<a')
+    expect(html).toContain('SKILL.md')
+  })
 })

--- a/apps/electron/src/renderer/lib/markdown-rich-text.test.ts
+++ b/apps/electron/src/renderer/lib/markdown-rich-text.test.ts
@@ -112,3 +112,21 @@ describe('markdownToHtml rich preview blocks', () => {
     expect(html).not.toContain('<h3>Agent 模式</h3>')
   })
 })
+
+describe('linkify 合成链接防护', () => {
+  test('markdownToHtml 不把 SKILL.md 文件名误判为 URL 链接', () => {
+    const html = markdownToHtml('请查看 SKILL.md 了解更多')
+    expect(html).not.toContain('http://SKILL.md')
+    expect(html).not.toContain('<a')
+  })
+
+  test('markdownToHtml 仍对带 scheme 的真实 URL 自动链接', () => {
+    const html = markdownToHtml('访问 https://example.com 了解更多')
+    expect(html).toContain('<a href="https://example.com">')
+  })
+
+  test('markdownToHtml 不把裸域名 google.com 误判为链接', () => {
+    const html = markdownToHtml('访问 google.com 搜索')
+    expect(html).not.toContain('<a')
+  })
+})

--- a/apps/electron/src/renderer/lib/markdown-rich-text.test.ts
+++ b/apps/electron/src/renderer/lib/markdown-rich-text.test.ts
@@ -130,13 +130,10 @@ describe('linkify 合成链接防护', () => {
     expect(html).not.toContain('<a')
   })
 
-  test('markdownToHtml 不把 .md 结尾的文件名误判为合成链接', () => {
-    // 这是 htmlToMarkdown 序列化乱码的根源：linkify 若把 SKILL.md 合成为
-    // <a href="http://SKILL.md">SKILL.md</a>，<a> case 会序列化为
-    // [SKILL.md](<http://SKILL.md>)。这里从 markdownToHtml 侧断言不合成。
-    const html = markdownToHtml('请查看 SKILL.md 了解更多')
-    expect(html).not.toContain('http://SKILL.md')
+  test('markdownToHtml 不把裸邮箱 foo@bar.com 误判为 mailto 链接', () => {
+    const html = markdownToHtml('联系 foo@bar.com')
+    expect(html).not.toContain('mailto:')
     expect(html).not.toContain('<a')
-    expect(html).toContain('SKILL.md')
+    expect(html).toContain('foo@bar.com')
   })
 })

--- a/apps/electron/src/renderer/lib/markdown-rich-text.ts
+++ b/apps/electron/src/renderer/lib/markdown-rich-text.ts
@@ -152,6 +152,11 @@ const markdownIt = new MarkdownIt({
   breaks: false,
 })
 
+// 关闭 linkify 的模糊匹配：避免把形如 SKILL.md 的文件名（.md 被误判为摩尔多瓦 TLD）
+// 自动包装成 http://SKILL.md 这样的合成链接。带 scheme 的真实 URL（http(s)://...）
+// 仍会被正常链接。fuzzyEmail 同理关闭，防止 foo@bar.com 被误判。
+markdownIt.linkify.set({ fuzzyLink: false, fuzzyEmail: false })
+
 addMathSupport(markdownIt)
 
 markdownIt.core.ruler.after('inline', 'emoji_shortcode', (state: any) => {


### PR DESCRIPTION
## Summary

This builds on and credits #1148 by @david188888. The root cause and fix direction there are correct: markdown-it linkify fuzzy matching turns file-like text such as `SKILL.md` into a synthetic `http://SKILL.md` link, which later serializes back to noisy markdown link syntax.

This follow-up keeps that fix and tightens the PR:

- disables `fuzzyLink` and `fuzzyEmail` while preserving scheme-based URL linking
- adds regression coverage for:
  - `SKILL.md` not becoming `http://SKILL.md`
  - `https://example.com` still becoming a link
  - `google.com` not becoming a fuzzy bare-domain link
  - `foo@bar.com` not becoming a fuzzy `mailto:` link
- removes the `apps/electron/package.json` version bump from the final diff so this does not conflict with adjacent patch-version PRs such as #1147/#1161

## Validation

- `bun test apps/electron/src/renderer/lib/markdown-rich-text.test.ts`
- `git diff --check`

`bun run --cwd apps/electron typecheck` is currently blocked on unrelated pre-existing provider type errors in this branch/base:

- `src/main/lib/agent-model-routing.ts(40,38): error TS2554: Expected 2 arguments, but got 1.`
- `src/main/lib/agent-orchestrator.ts(1401,16): error TS2554: Expected 2 arguments, but got 1.`
- `src/renderer/lib/model-logo.ts(237,7): error TS2741: Property '"zhipu-coding-team"' is missing ...`
