### PR TITLE
feat: add session quick switch shortcuts

### DIFF
--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -13,7 +13,7 @@
  * - 自动扩高
  */
 
-import { useState, useEffect, useRef, useMemo } from 'react'
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react'
 import { useAtomValue } from 'jotai'
 import { useEditor, EditorContent } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
@@ -38,6 +38,29 @@ import {
 } from '@/lib/voice-input-focus'
 
 // ===== 行数计算 =====
+
+const SESSION_QUICK_SWITCH_KEYDOWN_EVENT = 'proma:session-quick-switch-keydown'
+const SESSION_QUICK_SWITCH_KEYUP_EVENT = 'proma:session-quick-switch-keyup'
+
+function isMacPlatform(): boolean {
+  return typeof navigator !== 'undefined' && /mac/i.test(navigator.platform || '')
+}
+
+function isPrimaryModifierEvent(event: KeyboardEvent, isMac: boolean): boolean {
+  if (isMac) {
+    return event.key === 'Meta' || event.key === 'OS' || event.code === 'MetaLeft' || event.code === 'MetaRight'
+  }
+  return event.key === 'Control' || event.code === 'ControlLeft' || event.code === 'ControlRight'
+}
+
+function shouldForwardSessionQuickSwitchEvent(event: KeyboardEvent, isMac: boolean): boolean {
+  if (isPrimaryModifierEvent(event, isMac)) return true
+  if (!/^[1-9]$/.test(event.key)) return false
+  if (isMac) {
+    return event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey
+  }
+  return event.ctrlKey && !event.metaKey && !event.shiftKey && !event.altKey
+}
 
 /** 计算编辑器内容的行数 */
 function countEditorLines(editor: ReturnType<typeof useEditor>): number {
@@ -207,6 +230,16 @@ export function RichTextInput({
   const richTextEnabled = useAtomValue(richTextRenderingEnabledAtom)
   const richTextEnabledRef = useRef(richTextEnabled)
   richTextEnabledRef.current = richTextEnabled
+  const isMac = useMemo(() => isMacPlatform(), [])
+
+  const forwardSessionQuickSwitchKeyEvent = useCallback((event: React.KeyboardEvent<HTMLDivElement>, type: 'keydown' | 'keyup'): void => {
+    const nativeEvent = event.nativeEvent
+    if (!shouldForwardSessionQuickSwitchEvent(nativeEvent, isMac)) return
+    window.dispatchEvent(new CustomEvent(
+      type === 'keydown' ? SESSION_QUICK_SWITCH_KEYDOWN_EVENT : SESSION_QUICK_SWITCH_KEYUP_EVENT,
+      { detail: { event: nativeEvent } },
+    ))
+  }, [isMac])
 
   // Mention Suggestion 配置（稳定引用，不随 workspacePath 变化重建）
   const mentionSuggestion = useMemo(
@@ -666,6 +699,8 @@ export function RichTextInput({
 
   return (
     <div
+      onKeyDownCapture={(event) => forwardSessionQuickSwitchKeyEvent(event, 'keydown')}
+      onKeyUpCapture={(event) => forwardSessionQuickSwitchKeyEvent(event, 'keyup')}
       className={cn(
         'rich-text-input relative w-full overflow-y-auto scrollbar-thin transition-[max-height] duration-200 ease-in-out',
         isManuallyCollapsed

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -326,6 +326,8 @@ const PINNED_SESSION_ROW_HEIGHT_PX = 32
 const PINNED_SESSION_MAX_HEIGHT = PINNED_SESSION_VISIBLE_LIMIT * PINNED_SESSION_ROW_HEIGHT_PX
 const SESSION_QUICK_SWITCH_HINT_DELAY_MS = 1000
 const SESSION_QUICK_SWITCH_LIMIT = 9
+const SESSION_QUICK_SWITCH_KEYDOWN_EVENT = 'proma:session-quick-switch-keydown'
+const SESSION_QUICK_SWITCH_KEYUP_EVENT = 'proma:session-quick-switch-keyup'
 
 const ACTIVE_SESSION_STATUSES: ReadonlySet<SessionIndicatorStatus> = new Set([
   'blocked',
@@ -404,7 +406,7 @@ interface QuickSwitchTarget {
 }
 
 function getPrimaryModifierLabel(isMac: boolean): string {
-  return isMac ? '⌘' : 'Ctrl+'
+  return isMac ? '⌘' : 'Ctrl'
 }
 
 function isPrimaryModifierKey(event: KeyboardEvent, isMac: boolean): boolean {
@@ -446,6 +448,15 @@ function isQuickSwitchRowVisible(row: HTMLElement, root: HTMLElement): boolean {
   }
 
   return true
+}
+
+function SessionQuickSwitchKeycap(): React.ReactElement {
+  return (
+    <span className="session-quick-switch-keycap" aria-hidden="true">
+      <span className="session-quick-switch-modifier" />
+      <span className="session-quick-switch-number" />
+    </span>
+  )
 }
 
 function getRailInitial(title: string): string {
@@ -618,15 +629,11 @@ function RailRecentButton({
           <button
             ref={preview.setAnchorRef}
             type="button"
-            data-session-switch-id={item.id}
-            data-session-switch-title={item.title}
-            data-session-switch-type={item.type}
             aria-label={`打开${item.type === 'agent' ? 'Agent 会话' : 'Chat 对话'}：${item.title}`}
             onClick={() => onSelect(item)}
             onMouseEnter={preview.handleMouseEnter}
             onMouseLeave={preview.handleMouseLeave}
             className={cn(
-              'session-quick-switch-row',
               'relative size-10 flex items-center justify-center overflow-hidden rounded-[12px] transition-colors titlebar-no-drag',
               item.active
                 ? 'bg-primary/10 text-foreground shadow-[0_1px_2px_0_rgba(0,0,0,0.05)]'
@@ -783,6 +790,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
   const sidebarRootRef = React.useRef<HTMLDivElement>(null)
   const quickSwitchTargetsRef = React.useRef<QuickSwitchTarget[]>([])
   const quickSwitchHintTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+  const processedQuickSwitchEventsRef = React.useRef<WeakSet<KeyboardEvent>>(new WeakSet())
   const [quickSwitchHintsVisible, setQuickSwitchHintsVisible] = React.useState(false)
 
   // 归档 & 搜索状态
@@ -1689,6 +1697,8 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     for (const row of rows) {
       delete row.dataset.quickSwitchLabel
       delete row.dataset.quickSwitchIndex
+      row.querySelector<HTMLElement>('.session-quick-switch-modifier')?.replaceChildren()
+      row.querySelector<HTMLElement>('.session-quick-switch-number')?.replaceChildren()
     }
 
     const targets: QuickSwitchTarget[] = []
@@ -1709,6 +1719,10 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       const index = targets.length + 1
       row.dataset.quickSwitchIndex = String(index)
       row.dataset.quickSwitchLabel = `${modifierLabel}${index}`
+      const modifier = row.querySelector<HTMLElement>('.session-quick-switch-modifier')
+      const number = row.querySelector<HTMLElement>('.session-quick-switch-number')
+      if (modifier) modifier.textContent = modifierLabel
+      if (number) number.textContent = String(index)
       targets.push({
         id: sessionSwitchId,
         title: sessionSwitchTitle,
@@ -1729,6 +1743,8 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       for (const row of rows) {
         delete row.dataset.quickSwitchLabel
         delete row.dataset.quickSwitchIndex
+        row.querySelector<HTMLElement>('.session-quick-switch-modifier')?.replaceChildren()
+        row.querySelector<HTMLElement>('.session-quick-switch-number')?.replaceChildren()
       }
       quickSwitchTargetsRef.current = []
       return
@@ -1776,6 +1792,8 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     }
 
     const handleKeyDown = (event: KeyboardEvent): void => {
+      if (processedQuickSwitchEventsRef.current.has(event)) return
+      processedQuickSwitchEventsRef.current.add(event)
       if (event.isComposing) return
       if (settingsOpen || searchDialogOpen) return
 
@@ -1805,18 +1823,36 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     }
 
     const handleKeyUp = (event: KeyboardEvent): void => {
+      if (processedQuickSwitchEventsRef.current.has(event)) return
+      processedQuickSwitchEventsRef.current.add(event)
       if (isPrimaryModifierKey(event, isMac)) {
         hideHints()
       }
     }
 
+    const handleForwardedKeyDown = (event: Event): void => {
+      const forwarded = event as CustomEvent<{ event?: KeyboardEvent }>
+      const originalEvent = forwarded.detail?.event
+      if (originalEvent) handleKeyDown(originalEvent)
+    }
+
+    const handleForwardedKeyUp = (event: Event): void => {
+      const forwarded = event as CustomEvent<{ event?: KeyboardEvent }>
+      const originalEvent = forwarded.detail?.event
+      if (originalEvent) handleKeyUp(originalEvent)
+    }
+
     window.addEventListener('keydown', handleKeyDown, true)
     window.addEventListener('keyup', handleKeyUp, true)
+    window.addEventListener(SESSION_QUICK_SWITCH_KEYDOWN_EVENT, handleForwardedKeyDown)
+    window.addEventListener(SESSION_QUICK_SWITCH_KEYUP_EVENT, handleForwardedKeyUp)
     window.addEventListener('blur', hideHints)
     document.addEventListener('visibilitychange', hideHints)
     return () => {
       window.removeEventListener('keydown', handleKeyDown, true)
       window.removeEventListener('keyup', handleKeyUp, true)
+      window.removeEventListener(SESSION_QUICK_SWITCH_KEYDOWN_EVENT, handleForwardedKeyDown)
+      window.removeEventListener(SESSION_QUICK_SWITCH_KEYUP_EVENT, handleForwardedKeyUp)
       window.removeEventListener('blur', hideHints)
       document.removeEventListener('visibilitychange', hideHints)
       clearHintTimer()
@@ -3213,7 +3249,7 @@ function SessionItemActions({
 
   return (
     <div
-      className="relative flex-shrink-0 h-[18px] w-[58px]"
+      className="session-item-actions relative flex-shrink-0 h-[18px] w-[58px]"
       onClick={(e) => e.stopPropagation()}
     >
       <span
@@ -3403,8 +3439,7 @@ const ConversationItem = React.memo(function ConversationItem({
             startEdit()
           }}
           className={cn(
-            'session-quick-switch-row',
-            'group relative w-full flex items-center gap-1.5 rounded-md py-1 pl-2.5 pr-1.5 transition-colors duration-100 titlebar-no-drag text-left',
+            'session-quick-switch-row group relative w-full flex items-center gap-1.5 rounded-md py-1 pl-2.5 pr-1.5 transition-colors duration-100 titlebar-no-drag text-left',
             active && 'session-item-selected',
             streaming
               ? 'text-foreground font-medium hover:bg-foreground/[0.03]'
@@ -3460,6 +3495,7 @@ const ConversationItem = React.memo(function ConversationItem({
               menuItems={menuItems}
             />
           )}
+          <SessionQuickSwitchKeycap />
         </div>
       </ContextMenuTrigger>
       <ContextMenuContent className="w-40 z-[9999] min-w-0 p-0.5">
@@ -3663,8 +3699,7 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
           onMouseEnter={preview.handleMouseEnter}
           onMouseLeave={preview.handleMouseLeave}
           className={cn(
-            'session-quick-switch-row',
-            'group relative w-full flex items-center gap-1.5 rounded-md py-1 pl-2.5 pr-1.5 transition-colors duration-100 titlebar-no-drag text-left',
+            'session-quick-switch-row group relative w-full flex items-center gap-1.5 rounded-md py-1 pl-2.5 pr-1.5 transition-colors duration-100 titlebar-no-drag text-left',
             active && 'agent-session-item-active',
             leftAccent
               ? SESSION_ACCENT_ROW_CLASS[leftAccent]
@@ -3753,7 +3788,7 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
                       event.stopPropagation()
                       preview.closeNow()
                     }}
-                    className="flex-shrink-0 inline-flex size-6 -my-1 items-center justify-center rounded text-foreground/45 hover:bg-foreground/[0.055] hover:text-foreground/70 transition-colors"
+                    className="session-delegation-toggle flex-shrink-0 inline-flex size-6 -my-1 items-center justify-center rounded text-foreground/45 hover:bg-foreground/[0.055] hover:text-foreground/70 transition-colors"
                   >
                     <ChevronRight
                       size={11}
@@ -3775,6 +3810,7 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
                 onMenuOpenChange={setMenuOpen}
                 menuItems={menuItems}
               />
+              <SessionQuickSwitchKeycap />
             </>
           )}
         </div>

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -1315,35 +1315,56 @@
 .spinner-cube:nth-child(9) { animation-delay: 0.2s; }
 
 /* ===== Session 快速切换提示 ===== */
-.session-quick-switch-row[data-quick-switch-label]::after {
-  content: attr(data-quick-switch-label);
+.session-quick-switch-keycap {
   position: absolute;
   top: 50%;
-  right: 6px;
+  right: 7px;
   z-index: 8;
-  min-width: 24px;
-  height: 18px;
-  padding: 0 5px;
+  display: inline-flex;
+  height: 17px;
+  width: max-content;
+  align-items: center;
+  gap: 1px;
+  padding: 0 4px;
   transform: translateY(-50%) scale(0.96);
-  border: 1px solid hsl(var(--border) / 0.72);
-  border-radius: 6px;
-  background: hsl(var(--popover) / 0.96);
-  color: hsl(var(--popover-foreground) / 0.78);
-  box-shadow: 0 4px 14px hsl(var(--foreground) / 0.10);
+  border: 1px solid hsl(var(--primary) / 0.28);
+  border-radius: 5px;
+  background: hsl(var(--primary) / 0.10);
+  color: hsl(var(--primary) / 0.92);
+  box-shadow: 0 2px 6px hsl(var(--primary) / 0.10);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
-  font-size: 10px;
-  font-weight: 600;
-  line-height: 16px;
-  text-align: center;
+  font-weight: 400;
   white-space: nowrap;
   pointer-events: none;
   opacity: 0;
   transition: opacity 120ms ease, transform 120ms ease;
 }
 
-[data-session-switch-hints="true"] .session-quick-switch-row[data-quick-switch-label]::after {
+.session-quick-switch-modifier {
+  font-size: 16px;
+  line-height: 15px;
+  font-weight: 400;
+}
+
+.session-quick-switch-number {
+  font-size: 9px;
+  line-height: 11px;
+  font-weight: 400;
+}
+
+[data-session-switch-hints="true"] .session-quick-switch-row[data-quick-switch-label] .session-quick-switch-keycap {
   opacity: 1;
   transform: translateY(-50%) scale(1);
+}
+
+[data-session-switch-hints="true"] .session-quick-switch-row[data-quick-switch-label] {
+  padding-right: 44px;
+}
+
+[data-session-switch-hints="true"] .session-quick-switch-row[data-quick-switch-label] .session-item-actions,
+[data-session-switch-hints="true"] .session-quick-switch-row[data-quick-switch-label] .session-delegation-toggle {
+  opacity: 0;
+  pointer-events: none;
 }
 
 /* ===== 深色主题：迷你导航当前可见范围指示器 — 加亮 ===== */


### PR DESCRIPTION
## Summary

- Add long-press primary modifier hints for visible sidebar sessions, using Command on macOS and Ctrl on Windows/Linux.
- Support quick switching with primary modifier + number even when focus is inside the rich text input.
- Render a compact themed shortcut badge on the right side of session rows while hiding right-side row actions during hints.

## Validation

- git diff --check
- bun run --filter='@proma/electron' typecheck