### PR TITLE
fix(electron): harden Windows project creation

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.14.21",
+  "version": "0.14.22",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/agent-workspace-manager.test.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test'
-import { mkdirSync, mkdtempSync, readdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import * as os from 'node:os'
 import { join } from 'node:path'
 
@@ -86,6 +86,31 @@ describe('Agent 工作区 MCP 配置', () => {
 
     expect(Object.keys(normalized.servers).sort()).toEqual(['github'])
     expect(normalized.servers.github?.command).toBe('github-mcp')
+  })
+})
+
+describe('Agent 工作区创建', () => {
+  test('Given 项目名称是 Windows 保留设备名 When 创建工作区 Then slug 避免直接使用保留名', () => {
+    const workspace = manager.createAgentWorkspace('CON')
+
+    expect(workspace.slug).toBe('workspace-con')
+    expect(existsSync(configPaths.getAgentWorkspacePath(workspace.slug))).toBe(true)
+  })
+
+  test('Given 默认 Skill 包含 blocklist 目录 When 创建工作区 Then 初始化 Skills 时跳过高风险目录', () => {
+    const defaultSkillDir = join(configPaths.getDefaultSkillsDir(), 'sample-skill')
+    mkdirSync(join(defaultSkillDir, '.git', 'objects'), { recursive: true })
+    mkdirSync(join(defaultSkillDir, 'node_modules', 'pkg'), { recursive: true })
+    writeFileSync(join(defaultSkillDir, 'SKILL.md'), '---\nname: Sample\n---\n', 'utf-8')
+    writeFileSync(join(defaultSkillDir, '.git', 'objects', 'locked'), 'skip', 'utf-8')
+    writeFileSync(join(defaultSkillDir, 'node_modules', 'pkg', 'index.js'), 'skip', 'utf-8')
+
+    const workspace = manager.createAgentWorkspace('Filtered Copy')
+    const copiedSkillDir = join(configPaths.getWorkspaceSkillsDir(workspace.slug), 'sample-skill')
+
+    expect(existsSync(join(copiedSkillDir, 'SKILL.md'))).toBe(true)
+    expect(existsSync(join(copiedSkillDir, '.git'))).toBe(false)
+    expect(existsSync(join(copiedSkillDir, 'node_modules'))).toBe(false)
   })
 })
 

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -34,6 +34,30 @@ interface AgentWorkspacesIndex {
 }
 
 const INDEX_VERSION = 2
+const WINDOWS_RESERVED_SLUGS = new Set([
+  'con',
+  'prn',
+  'aux',
+  'nul',
+  'com1',
+  'com2',
+  'com3',
+  'com4',
+  'com5',
+  'com6',
+  'com7',
+  'com8',
+  'com9',
+  'lpt1',
+  'lpt2',
+  'lpt3',
+  'lpt4',
+  'lpt5',
+  'lpt6',
+  'lpt7',
+  'lpt8',
+  'lpt9',
+])
 
 /** 读取工作区索引文件，自动执行版本迁移 */
 function readIndex(): AgentWorkspacesIndex {
@@ -108,6 +132,9 @@ function slugify(name: string, existingSlugs: Set<string>): string {
   if (!base) {
     base = `workspace-${Date.now()}`
   }
+  if (WINDOWS_RESERVED_SLUGS.has(base)) {
+    base = `workspace-${base}`
+  }
 
   let slug = base
   let counter = 1
@@ -156,7 +183,7 @@ export function getAgentWorkspace(id: string): AgentWorkspace | undefined {
 }
 
 /** 将 ~/.proma/default-skills/ 的内容逐个复制到工作区 skills/ 目录 */
-function copyDefaultSkills(workspaceSlug: string): void {
+function copyDefaultSkills(workspaceSlug: string, options: { throwOnError?: boolean } = {}): void {
   const defaultDir = getDefaultSkillsDir()
   const targetDir = getWorkspaceSkillsDir(workspaceSlug)
 
@@ -171,11 +198,17 @@ function copyDefaultSkills(workspaceSlug: string): void {
       if (!entry.isDirectory()) continue
       const source = join(defaultDir, entry.name)
       const target = join(targetDir, entry.name)
-      cpSync(source, target, { recursive: true })
+      try {
+        cpSync(source, target, { recursive: true, filter: skillCopyFilter })
+      } catch (err) {
+        console.warn(`[Agent 工作区] 复制默认 Skill 失败 (${workspaceSlug}/${entry.name}):`, err)
+        if (options.throwOnError) throw err
+      }
     }
     console.log(`[Agent 工作区] 已复制默认 Skills 到: ${workspaceSlug}`)
   } catch (err) {
     console.error(`[Agent 工作区] 复制默认 Skills 失败 (${workspaceSlug}):`, err)
+    if (options.throwOnError) throw err
   }
 }
 
@@ -199,9 +232,24 @@ export function createAgentWorkspace(name: string): AgentWorkspace {
     updatedAt: now,
   }
 
-  getAgentWorkspacePath(slug)
-  ensurePluginManifest(slug, name)
-  copyDefaultSkills(slug)
+  try {
+    getAgentWorkspacePath(slug)
+    ensurePluginManifest(slug, name)
+    copyDefaultSkills(slug, { throwOnError: true })
+  } catch (error) {
+    const workspacesRoot = resolve(getAgentWorkspacesDir())
+    const workspaceDir = resolve(join(workspacesRoot, slug))
+    const relativePath = relative(workspacesRoot, workspaceDir)
+    if (relativePath && !relativePath.startsWith('..') && !isAbsolute(relativePath) && existsSync(workspaceDir)) {
+      try {
+        rmSyncWithRetry(workspaceDir, { recursive: true, force: true })
+      } catch (cleanupError) {
+        console.warn(`[Agent 工作区] 创建失败后清理目录失败 (${slug}):`, cleanupError)
+      }
+    }
+    console.error(`[Agent 工作区] 创建工作区失败 (${name}, slug: ${slug}):`, error)
+    throw new Error(`创建项目失败: ${(error as Error)?.message ?? '初始化项目目录失败'}`)
+  }
 
   index.workspaces.unshift(workspace)
   writeIndex(index)


### PR DESCRIPTION
## Summary
- avoid Windows reserved device names when deriving project workspace slugs
- copy default Skills during project creation with the existing blocklist filter
- roll back partially created project directories when initialization fails
- add regression coverage for reserved names and filtered Skill copy

## Validation
- bun test apps/electron/src/main/lib/agent-workspace-manager.test.ts
- bun run --cwd apps/electron typecheck
- bun run --cwd apps/electron build:main
- git diff --check

## Notes
This targets the Windows crash path reported when pressing Enter to save a newly created project name. The likely failure area is the main-process project creation path, especially synchronous default Skill copying and Windows filesystem edge cases.