### PR TITLE
support Kimi K3 context

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.14.22",
+  "version": "0.14.23",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/channel-manager.ts
+++ b/apps/electron/src/main/lib/channel-manager.ts
@@ -48,6 +48,7 @@ const DEEPSEEK_PRESET_MODELS: ChannelModel[] = [
   { id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash', enabled: true },
 ]
 const KIMI_PRESET_MODELS: ChannelModel[] = [
+  { id: 'k3', name: 'Kimi K3', enabled: true },
   { id: 'kimi-k2.6', name: 'Kimi K2.6', enabled: true },
 ]
 const XIAOMI_PRESET_MODELS: ChannelModel[] = [
@@ -62,6 +63,7 @@ const ARK_CODING_PLAN_MODELS: ChannelModel[] = [
   { id: 'doubao-seed-2.0-pro', name: 'Doubao Seed 2.0 Pro', enabled: true },
   { id: 'doubao-seed-2.0-lite', name: 'Doubao Seed 2.0 Lite', enabled: true },
   { id: 'glm-5.2', name: 'GLM-5.2', enabled: true },
+  { id: 'k3', name: 'Kimi K3', enabled: true },
   { id: 'kimi-k2.7-code', name: 'Kimi K2.7 Code', enabled: true },
   { id: 'minimax-m3', name: 'MiniMax M3', enabled: true },
   { id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash', enabled: true },

--- a/apps/electron/src/renderer/components/settings/ChannelForm.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelForm.tsx
@@ -78,7 +78,7 @@ const PROVIDER_OPTIONS: ProviderType[] = ['anthropic', 'anthropic-compatible', '
 /** 需要用 messages 端点测试的供应商预设模型 */
 const PROVIDER_TEST_MODEL_PRESETS: Partial<Record<ProviderType, string[]>> = {
   deepseek: ['deepseek-v4-pro', 'deepseek-v4-flash'],
-  'kimi-api': ['kimi-k2.6'],
+  'kimi-api': ['k3', 'kimi-k2.6'],
   xiaomi: ['mimo-v2.5-pro', 'mimo-v2-pro', 'mimo-v2.5', 'mimo-v2-omni', 'mimo-v2-flash'],
   'xiaomi-token-plan': ['mimo-v2.5-pro', 'mimo-v2-pro', 'mimo-v2.5', 'mimo-v2-omni', 'mimo-v2-flash'],
 }
@@ -348,6 +348,7 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
         ])
       } else if (p === 'kimi-api') {
         setModels([
+          { id: 'k3', name: 'Kimi K3', enabled: true },
           { id: 'kimi-k2.6', name: 'Kimi K2.6', enabled: true },
         ])
       } else if (p === 'kimi-coding') {
@@ -365,6 +366,7 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
           { id: 'doubao-seed-2.0-pro', name: 'Doubao Seed 2.0 Pro', enabled: true },
           { id: 'doubao-seed-2.0-lite', name: 'Doubao Seed 2.0 Lite', enabled: true },
           { id: 'glm-5.2', name: 'GLM-5.2', enabled: true },
+          { id: 'k3', name: 'Kimi K3', enabled: true },
           { id: 'kimi-k2.7-code', name: 'Kimi K2.7 Code', enabled: true },
           { id: 'minimax-m3', name: 'MiniMax M3', enabled: true },
           { id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash', enabled: true },

--- a/apps/electron/src/renderer/components/settings/ChannelForm.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelForm.tsx
@@ -353,6 +353,7 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
         ])
       } else if (p === 'kimi-coding') {
         setModels([
+          { id: 'k3', name: 'Kimi K3', enabled: true },
           { id: 'kimi-for-coding', name: 'Kimi for Coding', enabled: true },
         ])
       } else if (p === 'zhipu' || p === 'zhipu-coding' || p === 'zhipu-coding-team') {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/shared",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "license": "AGPL-3.0-only",
   "description": "Shared types, configs and utilities for proma",
   "type": "module",

--- a/packages/shared/src/utils/context-window.test.ts
+++ b/packages/shared/src/utils/context-window.test.ts
@@ -33,6 +33,7 @@ describe('模型上下文窗口', () => {
     expect(resolveAgentSdkModelId('mimo-v2.5', 'xiaomi-token-plan')).toBe('mimo-v2.5[1m]')
     expect(resolveAgentSdkModelId('MiniMax-M3', 'minimax')).toBe('MiniMax-M3[1m]')
     expect(resolveAgentSdkModelId('k3', 'kimi-api')).toBe('k3[1m]')
+    expect(resolveAgentSdkModelId('k3', 'kimi-coding')).toBe('k3[1m]')
     expect(resolveAgentSdkModelId('k3', 'ark-coding-plan')).toBe('k3[1m]')
   })
 

--- a/packages/shared/src/utils/context-window.test.ts
+++ b/packages/shared/src/utils/context-window.test.ts
@@ -32,6 +32,8 @@ describe('模型上下文窗口', () => {
     expect(resolveAgentSdkModelId('mimo-v2.5-pro', 'xiaomi')).toBe('mimo-v2.5-pro[1m]')
     expect(resolveAgentSdkModelId('mimo-v2.5', 'xiaomi-token-plan')).toBe('mimo-v2.5[1m]')
     expect(resolveAgentSdkModelId('MiniMax-M3', 'minimax')).toBe('MiniMax-M3[1m]')
+    expect(resolveAgentSdkModelId('k3', 'kimi-api')).toBe('k3[1m]')
+    expect(resolveAgentSdkModelId('k3', 'ark-coding-plan')).toBe('k3[1m]')
   })
 
   test('Given 已带后缀或未纳入 SDK 1M 的模型 When 解析 SDK 模型 Then 保持原值', () => {
@@ -40,6 +42,8 @@ describe('模型上下文窗口', () => {
     expect(resolveAgentSdkModelId('claude-haiku-4-5-20251001', 'anthropic')).toBe('claude-haiku-4-5-20251001')
     expect(resolveAgentSdkModelId('mimo-v2-pro', 'xiaomi')).toBe('mimo-v2-pro')
     expect(resolveAgentSdkModelId('MiniMax-M2.7', 'minimax')).toBe('MiniMax-M2.7')
+    expect(resolveAgentSdkModelId('kimi-k2.6', 'kimi-api')).toBe('kimi-k2.6')
+    expect(resolveAgentSdkModelId('not-k3-compatible', 'kimi-api')).toBe('not-k3-compatible')
     expect(resolveAgentSdkModelId('qwen3-max', 'qwen-anthropic')).toBe('qwen3-max')
     expect(resolveAgentSdkModelId('qwen3.6-max-preview', 'qwen-anthropic')).toBe('qwen3.6-max-preview')
     expect(resolveAgentSdkModelId('qwen3.5-397b-a17b', 'qwen-anthropic')).toBe('qwen3.5-397b-a17b')
@@ -61,6 +65,7 @@ describe('模型上下文窗口', () => {
     expect(resolveAgentSdkModelId('qwen3.7-plus', 'anthropic-compatible')).toBe('qwen3.7-plus')
     expect(resolveAgentSdkModelId('deepseek-v4-pro', 'anthropic-compatible')).toBe('deepseek-v4-pro')
     expect(resolveAgentSdkModelId('glm-5.2', 'anthropic-compatible')).toBe('glm-5.2')
+    expect(resolveAgentSdkModelId('k3', 'anthropic-compatible')).toBe('k3')
   })
 
   test('Given Agent SDK 运行窗口推断 When 模型名命中 1M 规则 Then 按模型能力返回 1M', () => {
@@ -70,5 +75,7 @@ describe('模型上下文窗口', () => {
     expect(inferAgentSdkContextWindow('deepseek-v4-pro', 'anthropic-compatible')).toBe(ONE_MILLION_CONTEXT_WINDOW)
     expect(inferAgentSdkContextWindow('qwen3.7-plus', 'qwen-anthropic')).toBe(ONE_MILLION_CONTEXT_WINDOW)
     expect(inferAgentSdkContextWindow('claude-sonnet-5', 'anthropic-compatible')).toBe(ONE_MILLION_CONTEXT_WINDOW)
+    expect(inferAgentSdkContextWindow('k3', 'kimi-api')).toBe(ONE_MILLION_CONTEXT_WINDOW)
+    expect(inferAgentSdkContextWindow('k3', 'anthropic-compatible')).toBe(ONE_MILLION_CONTEXT_WINDOW)
   })
 })

--- a/packages/shared/src/utils/context-window.ts
+++ b/packages/shared/src/utils/context-window.ts
@@ -63,6 +63,7 @@ const AGENT_SDK_1M_CONTEXT_PROVIDER_RULES: Partial<Record<ProviderType, readonly
     ...AGENT_SDK_1M_CONTEXT_RULES.minimax,
   ],
   'kimi-api': AGENT_SDK_1M_CONTEXT_RULES.kimi,
+  'kimi-coding': AGENT_SDK_1M_CONTEXT_RULES.kimi,
 }
 
 const AGENT_SDK_1M_CONTEXT_DISPLAY_RULES = Object.values(AGENT_SDK_1M_CONTEXT_RULES).flat()

--- a/packages/shared/src/utils/context-window.ts
+++ b/packages/shared/src/utils/context-window.ts
@@ -35,6 +35,8 @@ const AGENT_SDK_1M_CONTEXT_RULES = {
   mimo: ['mimo-v2.5'],
   // MiniMax
   minimax: ['minimax-m3'],
+  // Kimi
+  kimi: ['k3'],
   // 通义千问
   qwen: [
     'qwen3.7',
@@ -57,11 +59,20 @@ const AGENT_SDK_1M_CONTEXT_PROVIDER_RULES: Partial<Record<ProviderType, readonly
   'ark-coding-plan': [
     ...AGENT_SDK_1M_CONTEXT_RULES.deepseek,
     ...AGENT_SDK_1M_CONTEXT_RULES.glm,
+    ...AGENT_SDK_1M_CONTEXT_RULES.kimi,
     ...AGENT_SDK_1M_CONTEXT_RULES.minimax,
   ],
+  'kimi-api': AGENT_SDK_1M_CONTEXT_RULES.kimi,
 }
 
 const AGENT_SDK_1M_CONTEXT_DISPLAY_RULES = Object.values(AGENT_SDK_1M_CONTEXT_RULES).flat()
+
+function matchesContextRule(model: string, pattern: string): boolean {
+  if (pattern.length <= 3) {
+    return model === pattern || model.startsWith(`${pattern}[`)
+  }
+  return model.includes(pattern)
+}
 
 /**
  * 上下文窗口配置表。仅影响显示推断的模型加在 rules；已实测 Agent SDK 1M
@@ -91,7 +102,7 @@ export function supports1MContext(modelId: string): boolean {
   if (!modelId) return false
   const m = modelId.toLowerCase()
   if (CONTEXT_WINDOW_CONFIG.exclude.some((p) => m.includes(p))) return false
-  return CONTEXT_WINDOW_CONFIG.rules.some((p) => m.includes(p))
+  return CONTEXT_WINDOW_CONFIG.rules.some((p) => matchesContextRule(m, p))
 }
 
 /**
@@ -134,6 +145,6 @@ export function resolveAgentSdkModelId(modelId: string, provider: ProviderType):
   }
   const model = modelId.toLowerCase()
   const rules = AGENT_SDK_1M_CONTEXT_PROVIDER_RULES[provider]
-  if (!rules?.some((pattern) => model.includes(pattern))) return modelId
+  if (!rules?.some((pattern) => matchesContextRule(model, pattern))) return modelId
   return `${modelId}[1m]`
 }


### PR DESCRIPTION
## Summary

- add Kimi K3 (`k3`) to the Kimi API preset model list and the Ark Coding Plan preset list
- include `k3` in the Kimi API direct-test preset order
- treat `k3` as a 1M-context model for usage inference and Agent SDK model selection while keeping short model-name matching exact
- bump `@proma/shared` to `0.1.42` and `@proma/electron` to `0.14.23`

## Validation

- `bun test packages/shared/src/utils/context-window.test.ts`
- `cd packages/shared && bun run typecheck`
- `cd apps/electron && bun run typecheck`
- `cd apps/electron && bun run build:main`
- `cd apps/electron && bun run build:preload`
- `cd apps/electron && bun run build:renderer`
- `git diff --check`
