### PR TITLE
fix(agent): keep Pi channels out of Claude whitelist

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -55,6 +55,7 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import { cn } from '@/lib/utils'
+import { nextAgentChannelIdsAfterModelSelect } from '@/lib/agent-channel-selection'
 import { getActiveAccelerator, getAcceleratorDisplay } from '@/lib/shortcut-registry'
 import { registerShortcut } from '@/lib/shortcut-registry'
 import { supportsChannelPlanQuota } from '@/lib/channel-plan-quota'
@@ -1761,10 +1762,11 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       return map
     })
 
-    // 自动将选中的渠道加入 Agent 可用渠道白名单
-    const updatedChannelIds = agentChannelIds.includes(option.channelId)
-      ? agentChannelIds
-      : [...agentChannelIds, option.channelId]
+    const updatedChannelIds = nextAgentChannelIdsAfterModelSelect(
+      agentChannelIds,
+      option.channelId,
+      sessionAgentRuntime,
+    )
     if (updatedChannelIds !== agentChannelIds) {
       setAgentChannelIds(updatedChannelIds)
     }
@@ -1787,7 +1789,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         )))
       })
       .catch(console.error)
-  }, [sessionId, setSessionChannelMap, setSessionModelMap, setDefaultChannelId, setDefaultModelId, agentChannelIds, setAgentChannelIds, setAgentSessions])
+  }, [sessionId, setSessionChannelMap, setSessionModelMap, setDefaultChannelId, setDefaultModelId, agentChannelIds, sessionAgentRuntime, setAgentChannelIds, setAgentSessions])
 
   const handleAgentRuntimeChange = React.useCallback(async (runtime: AgentRuntime): Promise<void> => {
     if (runtime === sessionAgentRuntime) {

--- a/apps/electron/src/renderer/lib/agent-channel-selection.test.ts
+++ b/apps/electron/src/renderer/lib/agent-channel-selection.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test'
+import { nextAgentChannelIdsAfterModelSelect } from './agent-channel-selection'
+
+describe('nextAgentChannelIdsAfterModelSelect', () => {
+  test('adds the selected channel for Claude runtime', () => {
+    expect(nextAgentChannelIdsAfterModelSelect(['anthropic'], 'kimi', 'claude')).toEqual(['anthropic', 'kimi'])
+  })
+
+  test('keeps the list unchanged when Claude channel is already present', () => {
+    const channelIds = ['anthropic', 'kimi']
+    expect(nextAgentChannelIdsAfterModelSelect(channelIds, 'kimi', 'claude')).toBe(channelIds)
+  })
+
+  test('does not mark Pi-selected channels as Claude-compatible', () => {
+    const channelIds = ['anthropic']
+    expect(nextAgentChannelIdsAfterModelSelect(channelIds, 'openai-responses', 'pi')).toBe(channelIds)
+  })
+
+  test('does not migrate a Pi default channel into the Claude whitelist', () => {
+    const channelIds: string[] = []
+    expect(nextAgentChannelIdsAfterModelSelect(channelIds, 'openai-responses', 'pi')).toBe(channelIds)
+  })
+})

--- a/apps/electron/src/renderer/lib/agent-channel-selection.ts
+++ b/apps/electron/src/renderer/lib/agent-channel-selection.ts
@@ -1,0 +1,12 @@
+import type { AgentRuntime } from '@proma/shared'
+
+export function nextAgentChannelIdsAfterModelSelect(
+  currentChannelIds: string[],
+  selectedChannelId: string,
+  runtime: AgentRuntime,
+): string[] {
+  if (runtime !== 'claude') return currentChannelIds
+  return currentChannelIds.includes(selectedChannelId)
+    ? currentChannelIds
+    : [...currentChannelIds, selectedChannelId]
+}

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -79,6 +79,7 @@ import { showCapabilityChangeToasts } from './lib/capabilities-toast'
 import { GlobalShortcuts } from './components/shortcuts/GlobalShortcuts'
 import { TabSwitcher } from './components/tabs/TabSwitcher'
 import { htmlToMarkdown, markdownToHtml } from './lib/markdown-rich-text'
+import { nextAgentChannelIdsAfterModelSelect } from './lib/agent-channel-selection'
 import './styles/globals.css'
 import 'katex/dist/katex.min.css'
 
@@ -213,7 +214,8 @@ function AgentSettingsInitializer(): null {
       if (settings.agentModelId && (!settings.agentChannelId || channelIds.has(settings.agentChannelId))) {
         setAgentModelId(settings.agentModelId)
       }
-      setAgentRuntime(settings.agentRuntime ?? 'claude')
+      const defaultAgentRuntime = settings.agentRuntime ?? 'claude'
+      setAgentRuntime(defaultAgentRuntime)
 
       // 加载 Agent 启用渠道列表，过滤已删除的渠道
       if (settings.agentChannelIds && settings.agentChannelIds.length > 0) {
@@ -226,16 +228,18 @@ function AgentSettingsInitializer(): null {
         }
       } else if (settings.agentChannelId && channelIds.has(settings.agentChannelId)) {
         // 迁移：旧版本只有 agentChannelId，自动转为数组
-        const migrated = [settings.agentChannelId]
-        setAgentChannelIds(migrated)
-        window.electronAPI.updateSettings({ agentChannelIds: migrated }).catch(console.error)
+        const migrated = nextAgentChannelIdsAfterModelSelect([], settings.agentChannelId, defaultAgentRuntime)
+        if (migrated.length > 0) {
+          setAgentChannelIds(migrated)
+          window.electronAPI.updateSettings({ agentChannelIds: migrated }).catch(console.error)
+        }
       }
 
       // 兜底：agentChannelId 存在但不在 agentChannelIds 白名单中，自动修复不一致
       if (settings.agentChannelId && channelIds.has(settings.agentChannelId)) {
         const currentIds = settings.agentChannelIds?.filter((id) => channelIds.has(id)) ?? []
-        if (!currentIds.includes(settings.agentChannelId)) {
-          const fixedIds = [...currentIds, settings.agentChannelId]
+        const fixedIds = nextAgentChannelIdsAfterModelSelect(currentIds, settings.agentChannelId, defaultAgentRuntime)
+        if (fixedIds !== currentIds) {
           setAgentChannelIds(fixedIds)
           window.electronAPI.updateSettings({ agentChannelIds: fixedIds }).catch(console.error)
         }


### PR DESCRIPTION
## Summary

- Keep channels selected with the Pi runtime out of the Claude Agent SDK channel whitelist.
- Make settings migration and consistency repair runtime-aware, so a Pi default channel is not persisted as Claude-compatible.
- Add unit coverage for Claude and Pi channel-selection behavior.

## Test plan

- [x] `bun test apps/electron/src/renderer/lib/agent-channel-selection.test.ts`
- [ ] `bun run typecheck` *(not runnable in this fresh worktree: `tsc: command not found`)*