### PR TITLE
fix(renderer): contain nested scrolling

### DIFF
--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -702,7 +702,7 @@ export function RichTextInput({
       onKeyDownCapture={(event) => forwardSessionQuickSwitchKeyEvent(event, 'keydown')}
       onKeyUpCapture={(event) => forwardSessionQuickSwitchKeyEvent(event, 'keyup')}
       className={cn(
-        'rich-text-input relative w-full overflow-y-auto scrollbar-thin transition-[max-height] duration-200 ease-in-out',
+        'rich-text-input relative w-full overflow-y-auto overscroll-contain scrollbar-thin transition-[max-height] duration-200 ease-in-out',
         isManuallyCollapsed
           ? 'max-h-[101px]'
           : isExpanded ? 'max-h-[500px]' : 'max-h-[200px]',

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -87,6 +87,12 @@ import 'katex/dist/katex.min.css'
 const isQuickTaskWindow = new URLSearchParams(window.location.search).get('window') === 'quick-task'
 const isVoiceDictationWindow = new URLSearchParams(window.location.search).get('window') === 'voice-dictation'
 const isDetachedPreviewWindow = new URLSearchParams(window.location.search).get('window') === 'detached-preview'
+const isMainWindow = !isQuickTaskWindow && !isVoiceDictationWindow && !isDetachedPreviewWindow
+
+// 仅主窗口禁用页面级滚动；独立浮窗各自管理自己的内容高度和滚动。
+if (isMainWindow) {
+  document.documentElement.classList.add('proma-main-window')
+}
 
 /**
  * 主题初始化组件

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -516,9 +516,9 @@
 
 @layer base {
   /* Electron 主窗口不应成为滚动容器；所有滚动必须停留在各自面板内。 */
-  html,
-  body,
-  #root {
+  html.proma-main-window,
+  html.proma-main-window body,
+  html.proma-main-window #root {
     width: 100%;
     height: 100%;
     overflow: hidden;

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -515,6 +515,16 @@
 }
 
 @layer base {
+  /* Electron 主窗口不应成为滚动容器；所有滚动必须停留在各自面板内。 */
+  html,
+  body,
+  #root {
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    overscroll-behavior: none;
+  }
+
   * {
     @apply border-border;
   }


### PR DESCRIPTION
## Summary
- prevent scroll chaining from nested panes to the Electron window
- contain long rich-text input scrolling

## Validation
- bun run --filter='@proma/electron' typecheck
- bun run --filter='@proma/electron' build:renderer

Verified manually in Agent mode: sidebar, file panel, and long input no longer move the app shell.