### PR TITLE
fix(scratch-pad): improve image UX and markdown persistence

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -4,7 +4,7 @@
  * 负责注册主进程和渲染进程之间的通信处理器
  */
 
-import { ipcMain, nativeTheme, shell, dialog, BrowserWindow, app } from 'electron'
+import { ipcMain, nativeTheme, shell, dialog, BrowserWindow, app, clipboard, nativeImage } from 'electron'
 import { join, resolve, sep, dirname } from 'node:path'
 import { existsSync, realpathSync, rmSync, readFileSync, writeFileSync, mkdirSync, statSync } from 'node:fs'
 import { writeFile } from 'node:fs/promises'
@@ -1660,6 +1660,27 @@ export function registerIpcHandlers(): void {
         ],
       })
       return result.canceled ? null : result.filePath
+    }
+  )
+
+  // 将图片 data URL 写入系统剪贴板
+  ipcMain.handle(
+    SCRATCH_PAD_IPC_CHANNELS.COPY_IMAGE,
+    async (_, dataUrl: string): Promise<{ success: boolean; message?: string }> => {
+      try {
+        if (!dataUrl || typeof dataUrl !== 'string') {
+          return { success: false, message: '无效的图片数据' }
+        }
+        const img = nativeImage.createFromDataURL(dataUrl)
+        if (img.isEmpty()) {
+          return { success: false, message: '该格式图片暂不支持复制' }
+        }
+        clipboard.writeImage(img)
+        return { success: true }
+      } catch (err) {
+        console.error('[ScratchPad] 复制图片到剪贴板失败:', err)
+        return { success: false, message: '复制失败' }
+      }
     }
   )
 

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -361,6 +361,9 @@ export interface ElectronAPI {
   /** 打开原生保存对话框，返回用户选择的路径 */
   chooseExportPath: (defaultName: string) => Promise<string | null>
 
+  /** 将图片 data URL 写入系统剪贴板 */
+  copyImageToClipboard: (dataUrl: string) => Promise<{ success: boolean; message?: string }>
+
   // ===== 应用图标切换 =====
 
   /** 设置应用图标变体（传入 variant ID，如 'blue'、'cyberpunk'，'default' 恢复默认） */
@@ -1373,6 +1376,10 @@ const electronAPI: ElectronAPI = {
 
   chooseExportPath: (defaultName: string) => {
     return ipcRenderer.invoke(SCRATCH_PAD_IPC_CHANNELS.CHOOSE_EXPORT_PATH, defaultName)
+  },
+
+  copyImageToClipboard: (dataUrl: string) => {
+    return ipcRenderer.invoke(SCRATCH_PAD_IPC_CHANNELS.COPY_IMAGE, dataUrl)
   },
 
   // 应用图标切换

--- a/apps/electron/src/renderer/components/diff/markdown-preview-extensions.tsx
+++ b/apps/electron/src/renderer/components/diff/markdown-preview-extensions.tsx
@@ -1,4 +1,4 @@
-import { Node, mergeAttributes, nodeInputRule } from '@tiptap/core'
+import { Node, mergeAttributes, nodeInputRule, ResizableNodeView } from '@tiptap/core'
 import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
 import { Fragment } from '@tiptap/pm/model'
 import { Plugin, PluginKey } from '@tiptap/pm/state'
@@ -76,7 +76,17 @@ function serializeMarkdownImage(state: MarkdownSerializerLike, node: ProseMirror
   const src = escapeMarkdownLinkTarget(stringAttr(node, 'src'))
   const alt = state.esc(stringAttr(node, 'alt'))
   const title = stringAttr(node, 'title').replace(/"/g, '\\"')
-  state.write(`![${alt}](${src}${title ? ` "${title}"` : ''})`)
+  const width = node.attrs.width as number | null
+  if (width) {
+    const escapedSrc = escapeHtmlAttr(stringAttr(node, 'src'))
+    const escapedAlt = escapeHtmlAttr(stringAttr(node, 'alt'))
+    const escapedTitle = escapeHtmlAttr(stringAttr(node, 'title'))
+    state.write(`<img src="${escapedSrc}" alt="${escapedAlt}" width="${width}"${escapedTitle ? ` title="${escapedTitle}"` : ''}>`)
+  } else {
+    state.write(`![${alt}](${src}${title ? ` "${title}"` : ''})`)
+  }
+  state.ensureNewLine()
+  state.closeBlock(node)
 }
 
 function serializeMarkdownVideo(state: MarkdownSerializerLike, node: ProseMirrorNode): void {
@@ -460,10 +470,10 @@ function createStaticHtmlView(
   }
 }
 
-function createMarkdownImageView(initialNode: ProseMirrorNode, fileAccessRef: FileAccessRefOrNull) {
+function createMarkdownImageView(initialNode: ProseMirrorNode, fileAccessRef: FileAccessRefOrNull, editor: any, getPos: (() => number | undefined) | boolean) {
   const figure = document.createElement('figure')
   figure.contentEditable = 'false'
-  setClass(figure, 'not-prose my-3')
+  setClass(figure, 'not-prose my-3 group relative w-fit')
 
   const img = document.createElement('img')
   img.draggable = false
@@ -473,6 +483,73 @@ function createMarkdownImageView(initialNode: ProseMirrorNode, fileAccessRef: Fi
   const caption = document.createElement('figcaption')
   setClass(caption, 'mt-1 text-center text-xs text-muted-foreground')
 
+  // Toolbar (copy / edit / delete)
+  const toolbar = document.createElement('div')
+  setClass(toolbar, 'absolute top-2 right-2 hidden group-hover:flex items-center gap-1 bg-background/90 backdrop-blur-sm border border-border rounded-md p-1 shadow-sm z-10')
+
+  const createBtn = (title: string, svgPath: string, onClick: () => void) => {
+    const btn = document.createElement('button')
+    setClass(btn, 'p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors')
+    btn.title = title
+    btn.innerHTML = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">${svgPath}</svg>`
+    btn.addEventListener('click', (e) => { e.stopPropagation(); onClick() })
+    return btn
+  }
+
+  const copyBtn = createBtn('复制图片', '<rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>', async () => {
+    const src = img.src
+    if (!src) return
+    let dataUrl = src
+    if (!src.startsWith('data:')) {
+      try {
+        const resp = await fetch(src)
+        const blob = await resp.blob()
+        dataUrl = await new Promise<string>((resolve) => {
+          const reader = new FileReader()
+          reader.onload = () => resolve(reader.result as string)
+          reader.readAsDataURL(blob)
+        })
+      } catch { return }
+    }
+    const result = await window.electronAPI.copyImageToClipboard(dataUrl)
+    const { toast } = await import('sonner')
+    if (result.success) {
+      toast.success('已复制到剪贴板')
+    } else if (result.message) {
+      toast.error(result.message)
+    }
+  })
+
+  const editBtn = createBtn('编辑图片', '<path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>', () => {
+    figure.dispatchEvent(new CustomEvent('scratch-pad-edit-image', {
+      bubbles: true,
+      detail: { src: img.src, getPos, nodeType: initialNode.type, mode: 'editing' },
+    }))
+  })
+
+  // 单击图片打开预览
+  img.style.cursor = 'pointer'
+  img.addEventListener('click', (e) => {
+    e.stopPropagation()
+    figure.dispatchEvent(new CustomEvent('scratch-pad-edit-image', {
+      bubbles: true,
+      detail: { src: img.src, getPos, nodeType: initialNode.type, mode: 'preview' },
+    }))
+  })
+
+  const deleteBtn = createBtn('删除图片', '<path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/>', () => {
+    if (typeof getPos === 'function') {
+      const pos = getPos()
+      if (pos == null) return
+      editor.chain().focus().deleteRange({ from: pos, to: pos + initialNode.nodeSize }).run()
+    }
+  })
+
+  toolbar.appendChild(copyBtn)
+  toolbar.appendChild(editBtn)
+  toolbar.appendChild(deleteBtn)
+  figure.appendChild(toolbar)
+
   let cleanup = () => {}
 
   const render = (node: ProseMirrorNode) => {
@@ -480,8 +557,15 @@ function createMarkdownImageView(initialNode: ProseMirrorNode, fileAccessRef: Fi
     const src = String(node.attrs.src ?? '')
     const alt = String(node.attrs.alt ?? '')
     const title = String(node.attrs.title ?? '')
+    const width = node.attrs.width as number | null
     img.alt = alt
     img.title = title
+    if (width) {
+      img.style.width = `${width}px`
+      img.style.maxWidth = '100%'
+    } else {
+      img.style.width = ''
+    }
     cleanup = resolveMediaSrc(src, fileAccessRef, (resolvedSrc) => { img.src = resolvedSrc })
 
     if (title) {
@@ -494,10 +578,53 @@ function createMarkdownImageView(initialNode: ProseMirrorNode, fileAccessRef: Fi
 
   render(initialNode)
 
+  // Use ResizableNodeView for resize capability (only in editable mode)
+  if (editor.isEditable) {
+    const resizable = new ResizableNodeView({
+      node: initialNode,
+      editor,
+      element: figure,
+      getPos: getPos as () => number | undefined,
+      onResize: (w: number, _h: number) => {
+        img.style.width = `${w}px`
+        img.style.maxWidth = '100%'
+      },
+      onCommit: (w: number, _h: number) => {
+        if (typeof getPos === 'function') {
+          editor.chain().focus()
+            .command(({ tr }: { tr: any }) => {
+              tr.setNodeMarkup(getPos(), undefined, { ...initialNode.attrs, width: w })
+              return true
+            })
+            .run()
+        }
+      },
+      onUpdate: (node: ProseMirrorNode) => {
+        if (node.type !== initialNode.type) return false
+        initialNode = node
+        render(node)
+        return true
+      },
+      options: {
+        directions: ['bottom-right'],
+        preserveAspectRatio: true,
+        min: { width: 50, height: 50 },
+        className: {
+          container: 'scratch-pad-image-resize-container',
+          wrapper: 'scratch-pad-image-resize-wrapper',
+          handle: 'scratch-pad-image-resize-handle',
+          resizing: 'scratch-pad-image-resizing',
+        },
+      },
+    })
+    return resizable
+  }
+
   return {
     dom: figure,
     update(nextNode: ProseMirrorNode) {
       if (nextNode.type !== initialNode.type) return false
+      initialNode = nextNode
       render(nextNode)
       return true
     },
@@ -690,6 +817,17 @@ export function createMarkdownImage(fileAccessRef: FileAccessRefOrNull): Node {
         src: { default: '' },
         alt: { default: '' },
         title: { default: '' },
+        width: {
+          default: null,
+          parseHTML: (el) => {
+            const w = el.getAttribute('width')
+            return w ? parseInt(w, 10) || null : null
+          },
+          renderHTML: (attrs) => {
+            if (!attrs.width) return {}
+            return { width: attrs.width }
+          },
+        },
       }
     },
 
@@ -698,10 +836,12 @@ export function createMarkdownImage(fileAccessRef: FileAccessRefOrNull): Node {
         tag: 'img[src]',
         getAttrs: (node) => {
           if (!(node instanceof HTMLElement)) return false
+          const width = node.getAttribute('width')
           return {
             src: node.getAttribute('src') || '',
             alt: node.getAttribute('alt') || '',
             title: node.getAttribute('title') || '',
+            width: width ? parseInt(width, 10) || null : null,
           }
         },
       }]
@@ -720,7 +860,7 @@ export function createMarkdownImage(fileAccessRef: FileAccessRefOrNull): Node {
     },
 
     addNodeView() {
-      return ({ node }) => createMarkdownImageView(node, fileAccessRef)
+      return ({ node, editor, getPos }) => createMarkdownImageView(node, fileAccessRef, editor, getPos)
     },
   })
 }

--- a/apps/electron/src/renderer/components/diff/markdown-preview-extensions.tsx
+++ b/apps/electron/src/renderer/components/diff/markdown-preview-extensions.tsx
@@ -18,7 +18,8 @@ import { highlightCode, highlightToTokens, getDisplayName } from '@proma/core'
 import { MermaidBlock } from '@proma/ui'
 import type { HighlightTokensResult } from '@proma/core'
 import type { FileAccessOptions } from '@proma/shared'
-import { extractCodeText } from '../../lib/markdown-rich-text'
+import { copyImageSourceToClipboard } from '../../lib/image-clipboard'
+import { extractCodeText, parseImageWidth } from '../../lib/markdown-rich-text'
 import { shouldRenderMermaidCodeBlock } from '../../lib/mermaid-detection'
 
 type FileAccessRef = { current: FileAccessOptions | undefined }
@@ -76,7 +77,7 @@ function serializeMarkdownImage(state: MarkdownSerializerLike, node: ProseMirror
   const src = escapeMarkdownLinkTarget(stringAttr(node, 'src'))
   const alt = state.esc(stringAttr(node, 'alt'))
   const title = stringAttr(node, 'title').replace(/"/g, '\\"')
-  const width = node.attrs.width as number | null
+  const width = parseImageWidth(node.attrs.width)
   if (width) {
     const escapedSrc = escapeHtmlAttr(stringAttr(node, 'src'))
     const escapedAlt = escapeHtmlAttr(stringAttr(node, 'alt'))
@@ -482,6 +483,7 @@ function createMarkdownImageView(initialNode: ProseMirrorNode, fileAccessRef: Fi
 
   const caption = document.createElement('figcaption')
   setClass(caption, 'mt-1 text-center text-xs text-muted-foreground')
+  const isScratchPad = fileAccessRef === null
 
   // Toolbar (copy / edit / delete)
   const toolbar = document.createElement('div')
@@ -497,26 +499,12 @@ function createMarkdownImageView(initialNode: ProseMirrorNode, fileAccessRef: Fi
   }
 
   const copyBtn = createBtn('复制图片', '<rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>', async () => {
-    const src = img.src
-    if (!src) return
-    let dataUrl = src
-    if (!src.startsWith('data:')) {
-      try {
-        const resp = await fetch(src)
-        const blob = await resp.blob()
-        dataUrl = await new Promise<string>((resolve) => {
-          const reader = new FileReader()
-          reader.onload = () => resolve(reader.result as string)
-          reader.readAsDataURL(blob)
-        })
-      } catch { return }
-    }
-    const result = await window.electronAPI.copyImageToClipboard(dataUrl)
+    const result = await copyImageSourceToClipboard(img.src, window.electronAPI.copyImageToClipboard)
     const { toast } = await import('sonner')
     if (result.success) {
       toast.success('已复制到剪贴板')
-    } else if (result.message) {
-      toast.error(result.message)
+    } else {
+      toast.error(result.message ?? '复制失败')
     }
   })
 
@@ -527,15 +515,17 @@ function createMarkdownImageView(initialNode: ProseMirrorNode, fileAccessRef: Fi
     }))
   })
 
-  // 单击图片打开预览
-  img.style.cursor = 'pointer'
-  img.addEventListener('click', (e) => {
-    e.stopPropagation()
-    figure.dispatchEvent(new CustomEvent('scratch-pad-edit-image', {
-      bubbles: true,
-      detail: { src: img.src, getPos, nodeType: initialNode.type, mode: 'preview' },
-    }))
-  })
+  // 单击图片打开预览（仅 Scratch Pad 监听该事件）
+  if (isScratchPad) {
+    img.style.cursor = 'pointer'
+    img.addEventListener('click', (e) => {
+      e.stopPropagation()
+      figure.dispatchEvent(new CustomEvent('scratch-pad-edit-image', {
+        bubbles: true,
+        detail: { src: img.src, getPos, nodeType: initialNode.type, mode: 'preview' },
+      }))
+    })
+  }
 
   const deleteBtn = createBtn('删除图片', '<path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/>', () => {
     if (typeof getPos === 'function') {
@@ -545,10 +535,12 @@ function createMarkdownImageView(initialNode: ProseMirrorNode, fileAccessRef: Fi
     }
   })
 
-  toolbar.appendChild(copyBtn)
-  toolbar.appendChild(editBtn)
-  toolbar.appendChild(deleteBtn)
-  figure.appendChild(toolbar)
+  if (isScratchPad) {
+    toolbar.appendChild(copyBtn)
+    toolbar.appendChild(editBtn)
+    toolbar.appendChild(deleteBtn)
+    figure.appendChild(toolbar)
+  }
 
   let cleanup = () => {}
 
@@ -557,7 +549,7 @@ function createMarkdownImageView(initialNode: ProseMirrorNode, fileAccessRef: Fi
     const src = String(node.attrs.src ?? '')
     const alt = String(node.attrs.alt ?? '')
     const title = String(node.attrs.title ?? '')
-    const width = node.attrs.width as number | null
+    const width = parseImageWidth(node.attrs.width)
     img.alt = alt
     img.title = title
     if (width) {
@@ -819,13 +811,10 @@ export function createMarkdownImage(fileAccessRef: FileAccessRefOrNull): Node {
         title: { default: '' },
         width: {
           default: null,
-          parseHTML: (el) => {
-            const w = el.getAttribute('width')
-            return w ? parseInt(w, 10) || null : null
-          },
+          parseHTML: (el) => parseImageWidth(el.getAttribute('width')),
           renderHTML: (attrs) => {
-            if (!attrs.width) return {}
-            return { width: attrs.width }
+            const width = parseImageWidth(attrs.width)
+            return width ? { width } : {}
           },
         },
       }
@@ -836,12 +825,11 @@ export function createMarkdownImage(fileAccessRef: FileAccessRefOrNull): Node {
         tag: 'img[src]',
         getAttrs: (node) => {
           if (!(node instanceof HTMLElement)) return false
-          const width = node.getAttribute('width')
           return {
             src: node.getAttribute('src') || '',
             alt: node.getAttribute('alt') || '',
             title: node.getAttribute('title') || '',
-            width: width ? parseInt(width, 10) || null : null,
+            width: parseImageWidth(node.getAttribute('width')),
           }
         },
       }]

--- a/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
+++ b/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
@@ -58,6 +58,7 @@ import {
 import { SelectionActionPopover } from '@/components/selection/SelectionActionPopover'
 import { SELECTION_ACTION_POPOVER_SELECTOR } from '@/lib/quoted-selection'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { ImageLightbox } from '@/components/ui/image-lightbox'
 import { openScratchInSplit } from './scratch-pad-opener'
 
 const MAX_SCRATCH_PAD_QUOTED_CHARS = 2000
@@ -133,6 +134,11 @@ function ScratchPadEditor({ variant }: ScratchPadEditorProps): React.ReactElemen
   const captureTimerRef = React.useRef<number | null>(null)
   const openSideChatPendingRef = React.useRef(false)
 
+  // Image lightbox state for edit functionality
+  const [lightboxSrc, setLightboxSrc] = React.useState<string | null>(null)
+  const [lightboxMode, setLightboxMode] = React.useState<'preview' | 'editing'>('preview')
+  const lightboxGetPosRef = React.useRef<(() => number) | null>(null)
+
   // 用 ref 追踪最新内容，避免在 useEffect deps 里包含 content 导致循环
   const contentRef = React.useRef(content)
   contentRef.current = content
@@ -195,6 +201,39 @@ function ScratchPadEditor({ variant }: ScratchPadEditorProps): React.ReactElemen
     },
     immediatelyRender: false,
   })
+
+  // ===== 图片编辑 =====
+
+  React.useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+    const handler = (e: Event) => {
+      const { src, getPos, mode } = (e as CustomEvent).detail
+      setLightboxSrc(src)
+      setLightboxMode(mode || 'preview')
+      lightboxGetPosRef.current = typeof getPos === 'function' ? getPos : null
+    }
+    container.addEventListener('scratch-pad-edit-image', handler)
+    return () => container.removeEventListener('scratch-pad-edit-image', handler)
+  }, [])
+
+  const handleImageEditComplete = React.useCallback((editedDataUrl: string) => {
+    const getPos = lightboxGetPosRef.current
+    if (editor && getPos) {
+      const pos = getPos()
+      editor.chain().focus()
+        .command(({ tr }) => {
+          const node = tr.doc.nodeAt(pos)
+          if (node) {
+            tr.setNodeMarkup(pos, undefined, { ...node.attrs, src: editedDataUrl, width: null })
+          }
+          return true
+        })
+        .run()
+    }
+    setLightboxSrc(null)
+    lightboxGetPosRef.current = null
+  }, [editor])
 
   // ===== 导出 =====
 
@@ -713,6 +752,13 @@ function ScratchPadEditor({ variant }: ScratchPadEditorProps): React.ReactElemen
           </DropdownMenuPortal>
         </DropdownMenu>
       </div>
+      <ImageLightbox
+        src={lightboxSrc}
+        open={!!lightboxSrc}
+        onOpenChange={(open) => { if (!open) setLightboxSrc(null) }}
+        onEditComplete={handleImageEditComplete}
+        initialMode={lightboxMode}
+      />
     </div>
   )
 }

--- a/apps/electron/src/renderer/components/ui/image-lightbox.tsx
+++ b/apps/electron/src/renderer/components/ui/image-lightbox.tsx
@@ -47,6 +47,8 @@ interface ImageLightboxProps {
   index?: number
   /** 翻页回调（多图模式） */
   onIndexChange?: (nextIndex: number) => void
+  /** 打开时的初始模式（默认 'preview'） */
+  initialMode?: 'preview' | 'editing'
 }
 
 export function ImageLightbox({
@@ -59,6 +61,7 @@ export function ImageLightbox({
   images,
   index,
   onIndexChange,
+  initialMode = 'preview',
 }: ImageLightboxProps): React.ReactElement | null {
   const [mode, setMode] = React.useState<'preview' | 'editing'>('preview')
 
@@ -67,10 +70,10 @@ export function ImageLightbox({
   const hasMultiple = total > 1
   const safeIndex = hasImages ? Math.min(Math.max(index ?? 0, 0), total - 1) : 0
 
-  // 关闭时重置模式
   React.useEffect(() => {
-    if (!open) setMode('preview')
-  }, [open])
+    if (open) setMode(initialMode)
+    else setMode('preview')
+  }, [open, initialMode])
 
   // 多图模式下监听方向键翻页（编辑模式禁用）
   React.useEffect(() => {
@@ -103,7 +106,11 @@ export function ImageLightbox({
   }
 
   const handleEditCancel = (): void => {
-    setMode('preview')
+    if (initialMode === 'editing') {
+      onOpenChange(false)
+    } else {
+      setMode('preview')
+    }
   }
 
   const goPrev = (): void => onIndexChange?.((safeIndex - 1 + total) % total)

--- a/apps/electron/src/renderer/lib/image-clipboard.test.ts
+++ b/apps/electron/src/renderer/lib/image-clipboard.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test'
+import { copyImageSourceToClipboard } from './image-clipboard'
+
+describe('图片复制', () => {
+  test('data URL 直接交给主进程复制', async () => {
+    const source = 'data:image/png;base64,AAAA'
+    const copied: string[] = []
+
+    const result = await copyImageSourceToClipboard(source, async (dataUrl) => {
+      copied.push(dataUrl)
+      return { success: true }
+    })
+
+    expect(result).toEqual({ success: true })
+    expect(copied).toEqual([source])
+  })
+
+  test('图片读取失败时返回用户可见错误', async () => {
+    const result = await copyImageSourceToClipboard(
+      'file:///missing.png',
+      async () => ({ success: true }),
+      async () => { throw new Error('missing') },
+    )
+
+    expect(result).toEqual({ success: false, message: '复制失败，请检查图片是否可访问' })
+  })
+
+  test('IPC 拒绝时返回用户可见错误', async () => {
+    const result = await copyImageSourceToClipboard(
+      'data:image/png;base64,AAAA',
+      async () => { throw new Error('clipboard denied') },
+    )
+
+    expect(result).toEqual({ success: false, message: '复制失败，请检查图片是否可访问' })
+  })
+
+  test('主进程失败且未提供原因时使用默认错误', async () => {
+    const result = await copyImageSourceToClipboard(
+      'data:image/png;base64,AAAA',
+      async () => ({ success: false }),
+    )
+
+    expect(result).toEqual({ success: false, message: '复制失败' })
+  })
+})

--- a/apps/electron/src/renderer/lib/image-clipboard.ts
+++ b/apps/electron/src/renderer/lib/image-clipboard.ts
@@ -1,0 +1,40 @@
+export interface ImageClipboardResult {
+  success: boolean
+  message?: string
+}
+
+type ImageClipboardWriter = (dataUrl: string) => Promise<ImageClipboardResult>
+type ImageDataUrlLoader = (src: string) => Promise<string>
+
+async function fetchImageAsDataUrl(src: string): Promise<string> {
+  const response = await fetch(src)
+  if (!response.ok) throw new Error(`图片读取失败（${response.status}）`)
+
+  const blob = await response.blob()
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader()
+    reader.addEventListener('load', () => {
+      if (typeof reader.result === 'string') resolve(reader.result)
+      else reject(new Error('图片转换失败'))
+    }, { once: true })
+    reader.addEventListener('error', () => reject(new Error('图片转换失败')), { once: true })
+    reader.addEventListener('abort', () => reject(new Error('图片转换已取消')), { once: true })
+    reader.readAsDataURL(blob)
+  })
+}
+
+export async function copyImageSourceToClipboard(
+  src: string,
+  writeImage: ImageClipboardWriter,
+  loadDataUrl: ImageDataUrlLoader = fetchImageAsDataUrl,
+): Promise<ImageClipboardResult> {
+  if (!src) return { success: false, message: '无效的图片数据' }
+
+  try {
+    const dataUrl = src.startsWith('data:') ? src : await loadDataUrl(src)
+    const result = await writeImage(dataUrl)
+    return result.success ? result : { success: false, message: result.message ?? '复制失败' }
+  } catch {
+    return { success: false, message: '复制失败，请检查图片是否可访问' }
+  }
+}

--- a/apps/electron/src/renderer/lib/markdown-rich-text.test.ts
+++ b/apps/electron/src/renderer/lib/markdown-rich-text.test.ts
@@ -166,6 +166,23 @@ describe('Clipboard 纯文本序列化', () => {
   })
 })
 
+describe('图片 Markdown 持久化', () => {
+  test('保留合法宽度，并与后续块级内容分隔', () => {
+    const markdown = withHtmlDocument(() => htmlToMarkdown('<img src="image.png" alt="截图" width="240"><p>后续内容</p>'))
+
+    expect(markdown).toBe('<img src="image.png" alt="截图" width="240">\n\n后续内容')
+    const html = markdownToHtml(markdown)
+    expect(html).toContain('width=&quot;240&quot;')
+    expect(html).toContain('<p>后续内容</p>')
+  })
+
+  test('丢弃非法图片宽度', () => {
+    const markdown = withHtmlDocument(() => htmlToMarkdown('<img src="image.png" alt="截图" width="-20">'))
+
+    expect(markdown).toBe('![截图](<image.png>)')
+  })
+})
+
 describe('linkify 合成链接防护', () => {
   test('markdownToHtml 不把 SKILL.md 文件名误判为 URL 链接', () => {
     const html = markdownToHtml('请查看 SKILL.md 了解更多')

--- a/apps/electron/src/renderer/lib/markdown-rich-text.ts
+++ b/apps/electron/src/renderer/lib/markdown-rich-text.ts
@@ -337,12 +337,23 @@ function enhanceMarkdownHtml(html: string): string {
   root.innerHTML = html
 
   for (const li of Array.from(root.querySelectorAll('li'))) {
-    const first = li.firstChild
-    const textNode = first?.nodeType === Node.TEXT_NODE
-      ? first
-      : first instanceof HTMLElement && first.tagName.toLowerCase() === 'p' && first.firstChild?.nodeType === Node.TEXT_NODE
-        ? first.firstChild
-        : null
+    let textNode: ChildNode | null = null
+    let first = li.firstChild
+    // Skip whitespace-only text nodes to find the meaningful first child
+    while (first && first.nodeType === Node.TEXT_NODE && !first.textContent?.trim()) {
+      first = first.nextSibling
+    }
+    if (first?.nodeType === Node.TEXT_NODE) {
+      textNode = first
+    } else if (first instanceof HTMLElement && first.tagName.toLowerCase() === 'p') {
+      let pChild = first.firstChild
+      while (pChild && pChild.nodeType === Node.TEXT_NODE && !pChild.textContent?.trim()) {
+        pChild = pChild.nextSibling
+      }
+      if (pChild?.nodeType === Node.TEXT_NODE) {
+        textNode = pChild
+      }
+    }
     const text = textNode?.textContent ?? ''
     const match = text.match(/^\s*\[([ xX])\]\s*/)
     if (!match || !textNode) continue
@@ -403,7 +414,11 @@ export function htmlToMarkdown(
         const src = el.getAttribute('src') || ''
         const alt = el.getAttribute('alt') || ''
         const title = el.getAttribute('title') || ''
-        return `![${escapeMarkdownText(alt)}](${escapeMarkdownLinkTarget(src)}${title ? ` "${title.replace(/"/g, '\\"')}"` : ''})`
+        const width = el.getAttribute('width')
+        if (width) {
+          return `<img src="${escapeAttr(src)}" alt="${escapeAttr(alt)}" width="${width}"${title ? ` title="${escapeAttr(title)}"` : ''}>\n\n`
+        }
+        return `![${escapeMarkdownText(alt)}](${escapeMarkdownLinkTarget(src)}${title ? ` "${title.replace(/"/g, '\\"')}"` : ''})\n\n`
       }
       case 'video': {
         const src = el.getAttribute('src') || el.querySelector('source')?.getAttribute('src') || ''

--- a/apps/electron/src/renderer/lib/markdown-rich-text.ts
+++ b/apps/electron/src/renderer/lib/markdown-rich-text.ts
@@ -38,6 +38,12 @@ function escapeAttr(value: string): string {
     .replace(/\n/g, '&#10;')
 }
 
+export function parseImageWidth(value: unknown): number | null {
+  if (typeof value === 'string' && !/^\d+$/.test(value)) return null
+  const width = typeof value === 'number' || typeof value === 'string' ? Number(value) : NaN
+  return Number.isSafeInteger(width) && width > 0 && width <= 10_000 ? width : null
+}
+
 export function extractCodeText(codeEl: Element): string {
   const parts: string[] = []
   for (const child of Array.from(codeEl.childNodes)) {
@@ -414,7 +420,7 @@ export function htmlToMarkdown(
         const src = el.getAttribute('src') || ''
         const alt = el.getAttribute('alt') || ''
         const title = el.getAttribute('title') || ''
-        const width = el.getAttribute('width')
+        const width = parseImageWidth(el.getAttribute('width'))
         if (width) {
           return `<img src="${escapeAttr(src)}" alt="${escapeAttr(alt)}" width="${width}"${title ? ` title="${escapeAttr(title)}"` : ''}>\n\n`
         }

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -2404,3 +2404,52 @@
 .scratch-pad-editor .ProseMirror ul[data-type="taskList"] > li > label > input {
   cursor: pointer;
 }
+
+/* Scratch Pad 图片 resize handle */
+.scratch-pad-image-resize-container {
+  display: inline-flex;
+  max-width: 100%;
+}
+.scratch-pad-image-resize-wrapper {
+  position: relative;
+  display: inline-block;
+  max-width: 100%;
+}
+.scratch-pad-image-resize-handle {
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+  background: hsl(var(--primary));
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  cursor: nwse-resize;
+}
+.scratch-pad-image-resize-wrapper:hover .scratch-pad-image-resize-handle,
+.scratch-pad-image-resizing .scratch-pad-image-resize-handle {
+  opacity: 1;
+}
+.scratch-pad-image-resizing {
+  user-select: none;
+}
+
+/* Gapcursor: 在 atom block 节点前后显示光标 */
+.ProseMirror-gapcursor {
+  display: none;
+  pointer-events: none;
+  position: relative;
+}
+.ProseMirror-gapcursor::after {
+  content: '';
+  display: block;
+  position: absolute;
+  top: -2px;
+  width: 20px;
+  border-top: 1px solid currentColor;
+  animation: ProseMirror-cursor-blink 1.1s steps(2, start) infinite;
+}
+@keyframes ProseMirror-cursor-blink {
+  to { visibility: hidden; }
+}
+.ProseMirror-focused .ProseMirror-gapcursor {
+  display: block;
+}

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -309,6 +309,8 @@ export const SCRATCH_PAD_IPC_CHANNELS = {
   EXPORT: 'scratch-pad:export',
   /** 打开保存对话框选择导出路径 */
   CHOOSE_EXPORT_PATH: 'scratch-pad:choose-export-path',
+  /** 将图片写入系统剪贴板 */
+  COPY_IMAGE: 'scratch-pad:copy-image',
 } as const
 
 /** 应用图标 IPC 通道 */


### PR DESCRIPTION
## Summary

- 复制按钮点击后显示 toast 提示（成功/失败）
- 单击图片打开预览，编辑按钮直接进入编辑模式（原来需要两步）
- 图片 width 属性在 markdown 序列化/反序列化中正确持久化，重启后尺寸不丢失
- 修复图片下一行内容合并到同一行的 bug（block-level 节点缺少尾部换行）
- 添加 Gapcursor CSS 样式，改善 block 节点间的光标可见性
- 图片 resize 仅保留右下角拖拽手柄（标准行为）

## 改动文件

- `apps/electron/src/main/ipc.ts` — 剪贴板 IPC 处理
- `apps/electron/src/preload/index.ts` — preload bridge
- `apps/electron/src/renderer/components/diff/markdown-preview-extensions.tsx` — 图片 NodeView（toast、点击预览、编辑按钮）
- `apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx` — lightbox mode 状态管理
- `apps/electron/src/renderer/components/ui/image-lightbox.tsx` — 支持 initialMode prop
- `apps/electron/src/renderer/lib/markdown-rich-text.ts` — htmlToMarkdown 保留 img width、修复换行
- `apps/electron/src/renderer/styles/globals.css` — Gapcursor 样式
- `apps/electron/src/types/settings.ts` — 类型定义

## Test plan

- [x] 插入图片 → resize → 关闭重启 → 图片尺寸保持
- [x] 复制按钮 → 显示 toast
- [x] 单击图片 → 打开预览 lightbox
- [x] 编辑按钮 → 直接进入编辑模式
- [x] 图片下方有文字/列表/todo → 重启后不合并到同一行

🤖 Generated with [Claude Code](https://claude.com/claude-code)