### PR TITLE
fix: cap Volcengine GLM-5.2 output tokens

### DIFF
--- a/apps/electron/src/main/lib/adapters/pi-model-registry.test.ts
+++ b/apps/electron/src/main/lib/adapters/pi-model-registry.test.ts
@@ -94,6 +94,26 @@ describe('Pi runtime OpenAI Responses 渠道', () => {
   })
 })
 
+describe('Pi runtime 火山方舟模型限制', () => {
+  test('Given 火山方舟的 GLM-5.2 When buildModel Then 使用其 128000 输出上限', async () => {
+    const sdk = await import('@earendil-works/pi-coding-agent')
+    const result = await buildModel(sdk, {
+      sessionId: 'session-volcengine-glm-52',
+      prompt: 'hi',
+      apiKey: 'test-key',
+      provider: 'doubao',
+      baseUrl: 'https://ark.cn-beijing.volces.com/api/v3',
+      model: 'glm-5.2',
+      permissionMode: 'plan',
+      systemPrompt: 'system',
+      piAgentDir: '/tmp/pi-agent',
+      piSessionDir: '/tmp/pi-session',
+    })
+
+    expect(result.model.maxTokens).toBe(128_000)
+  })
+})
+
 describe('ChatGPT Codex 模型目录补丁', () => {
   test('Given Pi SDK 内置目录缺少 5.6 When listCodexModels Then 补齐 5.6 系列', async () => {
     const models = await listCodexModels()

--- a/apps/electron/src/main/lib/adapters/pi-model-registry.ts
+++ b/apps/electron/src/main/lib/adapters/pi-model-registry.ts
@@ -33,6 +33,7 @@ interface PiModelDefaults {
 const ZERO_MODEL_COST: PiModelCost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
 export const DEFAULT_CONTEXT_WINDOW = 200_000
 const DEFAULT_MAX_TOKENS = 64_000
+const VOLCENGINE_GLM_52_MAX_TOKENS = 128_000
 const CODEX_BASE_URL = 'https://chatgpt.com/backend-api'
 const CODEX_MAX_TOKENS = 128_000
 const CODEX_54_MINI_CONTEXT_WINDOW = 400_000
@@ -182,12 +183,16 @@ async function findPiCatalogModel(provider: ProviderType, modelId: string): Prom
 
 async function resolvePiModelDefaults(input: PiAgentQueryOptions): Promise<PiModelDefaults> {
   const catalogModel = input.model ? await findPiCatalogModel(input.provider, input.model) : undefined
+  const isVolcengineGlm52 = input.provider === 'doubao' && input.model?.toLowerCase() === 'glm-5.2'
   return {
     reasoning: catalogModel?.reasoning ?? true,
     input: catalogModel ? [...catalogModel.input] : ['text', 'image'],
     cost: catalogModel ? { ...catalogModel.cost } : { ...ZERO_MODEL_COST },
     contextWindow: catalogModel?.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
-    maxTokens: catalogModel?.maxTokens ?? DEFAULT_MAX_TOKENS,
+    // Pi 的智谱目录将 GLM-5.2 标为 131072，但火山方舟兼容端点上限为 128000。
+    maxTokens: isVolcengineGlm52
+      ? VOLCENGINE_GLM_52_MAX_TOKENS
+      : (catalogModel?.maxTokens ?? DEFAULT_MAX_TOKENS),
   }
 }
 


### PR DESCRIPTION
## Summary

- 245d5181 fix: cap Volcengine GLM-5.2 output tokens

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归