### PR TITLE
Fix Codex OAuth refresh lifecycle

### DIFF
--- a/apps/electron/src/main/lib/adapters/pi-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/pi-agent-adapter.ts
@@ -13,6 +13,7 @@ import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:pat
 import type {
   AgentThinkingLevel,
   AgentProviderAdapter,
+  CodexOAuthCredentials,
   AgentQueryInput,
   ErrorCode,
   JsonSchemaOutputFormat,
@@ -125,6 +126,10 @@ export interface PiAgentQueryOptions extends AgentQueryInput {
   compactRequest?: boolean
   /** ChatGPT Codex Fast Mode；仅 openai-codex 的受支持模型实际注入 priority service tier。 */
   codexFastMode?: boolean
+  /** Pi 的 OAuth credential store 使用真实 expires 和 refresh，不读取 ~/.pi。 */
+  codexOAuthCredentials?: CodexOAuthCredentials
+  /** Pi 运行中刷新 OAuth 后，将新凭据回写到 Proma 渠道存储。 */
+  onCodexOAuthCredentialsRefreshed?: (credentials: CodexOAuthCredentials) => void | Promise<void>
   /** 会话级 OpenAI（Codex OAuth / Responses API）思考深度。 */
   openAIThinkingLevel?: AgentThinkingLevel
 }

--- a/apps/electron/src/main/lib/adapters/pi-model-registry.ts
+++ b/apps/electron/src/main/lib/adapters/pi-model-registry.ts
@@ -5,7 +5,12 @@
  * ProviderType 到 Pi API 协议、baseUrl、认证头和模型 catalog 默认值的映射。
  */
 
-import { extractZhipuCodingTeamApiToken, inferAgentSdkContextWindow, type ProviderType } from '@proma/shared'
+import {
+  extractZhipuCodingTeamApiToken,
+  inferAgentSdkContextWindow,
+  type CodexOAuthCredentials,
+  type ProviderType,
+} from '@proma/shared'
 import {
   getPromaUserAgent,
   normalizeAnthropicBaseUrlForSdk,
@@ -40,22 +45,16 @@ const CODEX_54_MINI_CONTEXT_WINDOW = 400_000
 const CODEX_56_CONTEXT_WINDOW = 1_050_000
 const CODEX_THINKING_LEVEL_MAP = { xhigh: 'xhigh', minimal: 'low' } as const
 
-type CodexRuntimeCredential = {
+type CodexRuntimeCredential = CodexOAuthCredentials & {
   type: 'oauth'
-  access: string
-  refresh: string
-  expires: number
+  [key: string]: unknown
 }
 
-function createCodexRuntimeCredentialStore(access: string) {
-  let credential: CodexRuntimeCredential | undefined = {
-    type: 'oauth',
-    access,
-    // Proma refreshes the persisted credential before each agent execution.
-    // Keep this one-run store valid so Pi never tries to write or refresh ~/.pi.
-    refresh: '',
-    expires: Number.MAX_SAFE_INTEGER,
-  }
+function createCodexRuntimeCredentialStore(
+  initial: CodexOAuthCredentials,
+  onRefreshed?: PiAgentQueryOptions['onCodexOAuthCredentialsRefreshed'],
+) {
+  let credential: CodexRuntimeCredential | undefined = { type: 'oauth', ...initial }
 
   return {
     async read(providerId: string): Promise<CodexRuntimeCredential | undefined> {
@@ -69,7 +68,21 @@ function createCodexRuntimeCredentialStore(access: string) {
       fn: (current: CodexRuntimeCredential | undefined) => Promise<CodexRuntimeCredential | undefined>,
     ): Promise<CodexRuntimeCredential | undefined> {
       if (providerId !== 'openai-codex') return undefined
+      const previous = credential
       credential = await fn(credential)
+
+      if (credential && (
+        previous?.access !== credential.access
+        || previous?.refresh !== credential.refresh
+        || previous?.expires !== credential.expires
+        || previous?.accountId !== credential.accountId
+      )) {
+        try {
+          await onRefreshed?.(credential)
+        } catch (error) {
+          console.warn('[Pi Codex OAuth] 刷新后的凭据回写失败，将在下次执行前重试:', error)
+        }
+      }
       return credential
     },
     async delete(providerId: string): Promise<void> {
@@ -341,15 +354,19 @@ export async function getCodexCatalogModels(): Promise<PiCatalogModel[]> {
  * openai-codex 是 Pi SDK 的内置 KnownProvider：模型目录、baseUrl 和
  * `openai-codex-responses` 协议全部内置，无需（也不能）手工构造 models 或 baseUrl。
  * Pi 0.80.10 将它声明为 OAuth-only provider；runtime API key 不会参与其认证解析。
- * 因此将 Proma 已刷新过的 access token 放入一次性内存 OAuth credential store，
- * 避免 Pi 读取或写入全局 ~/.pi 认证文件。
- *
- * 注意：这里的 input.apiKey 必须是编排层用 resolveCodexAccessToken 解析并按需
- * 刷新后的 access token，而不是存储的凭据 JSON。
+ * 因此将 Proma 已刷新过的完整凭据放入一次性内存 OAuth credential store，
+ * 按真实 expires 刷新并回写 Proma，避免读写全局 ~/.pi 认证文件。
  */
 async function buildCodexModel(sdk: PiSdk, input: PiAgentQueryOptions) {
+  if (!input.codexOAuthCredentials) {
+    throw new Error('ChatGPT (Codex) OAuth 凭据缺失，请重新登录')
+  }
+
   const modelRuntime = await sdk.ModelRuntime.create({
-    credentials: createCodexRuntimeCredentialStore(input.apiKey),
+    credentials: createCodexRuntimeCredentialStore(
+      input.codexOAuthCredentials,
+      input.onCodexOAuthCredentialsRefreshed,
+    ),
     allowModelNetwork: false,
   })
 

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -20,7 +20,7 @@ import { join, dirname } from 'node:path'
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { app } from 'electron'
-import type { AgentRuntime, AgentSendInput, AgentMessage, AgentGenerateTitleInput, AgentProviderAdapter, AgentSessionMeta, TypedError, RetryAttempt, SDKMessage, SDKAssistantMessage, AgentStreamPayload, RewindSessionResult, ProviderType } from '@proma/shared'
+import type { AgentRuntime, AgentSendInput, AgentMessage, AgentGenerateTitleInput, AgentProviderAdapter, AgentSessionMeta, CodexOAuthCredentials, TypedError, RetryAttempt, SDKMessage, SDKAssistantMessage, AgentStreamPayload, RewindSessionResult, ProviderType } from '@proma/shared'
 import {
   PROMA_DEFAULT_PERMISSION_MODE,
   PROMA_PERMISSION_MODE_CONFIG,
@@ -39,7 +39,7 @@ import { isPromptTooLongError, isThinkingSignatureError, friendlyErrorMessage, m
 import type { PiAgentQueryOptions } from './adapters/pi-agent-adapter'
 import { isTransientNetworkError, isMalformedResponseError, isSessionNotFoundError } from './error-patterns'
 import { AgentEventBus } from './agent-event-bus'
-import { decryptApiKey, getChannelById, listChannels, resolveChannelRuntimeApiKey, resolveCodexAccessToken } from './channel-manager'
+import { decryptApiKey, getChannelById, listChannels, persistCodexOAuthCredentials, resolveChannelRuntimeApiKey, resolveCodexOAuthCredentials } from './channel-manager'
 import { getAdapter, fetchTitle, normalizeAnthropicBaseUrlForSdk, getPromaUserAgent } from '@proma/core'
 import pkg from '../../../package.json' with { type: 'json' }
 import { getFetchFn } from './proxy-fetch'
@@ -943,12 +943,16 @@ export class AgentOrchestrator {
     }
 
     let apiKey: string
+    let codexOAuthCredentials: CodexOAuthCredentials | undefined
     try {
-      // ChatGPT (Codex) OAuth 渠道：apiKey 字段存的是加密凭据 JSON，需解析并按需刷新，
-      // 取出可用的 access token 传给 pi runtime；其余渠道直接解密 API Key。
-      apiKey = channel.provider === 'openai-codex'
-        ? await resolveCodexAccessToken(channelId)
-        : decryptApiKey(channelId)
+      // ChatGPT (Codex) OAuth 渠道必须保留完整凭据给 Pi runtime，才能按真实
+      // expires 刷新；其余渠道只需解密 API Key。
+      if (channel.provider === 'openai-codex') {
+        codexOAuthCredentials = await resolveCodexOAuthCredentials(channelId)
+        apiKey = codexOAuthCredentials.access
+      } else {
+        apiKey = decryptApiKey(channelId)
+      }
     } catch (err) {
       if (channel.provider === 'openai-codex') {
         reportPreflightError({
@@ -1617,6 +1621,12 @@ export class AgentOrchestrator {
         ...(mentionedSkills?.length ? { skillMentions: mentionedSkills } : {}),
         ...(isCompactCommand ? { compactRequest: true } : {}),
         ...(sessionMeta?.codexFastMode && channel.provider === 'openai-codex' ? { codexFastMode: true } : {}),
+        ...(codexOAuthCredentials && {
+          codexOAuthCredentials,
+          onCodexOAuthCredentialsRefreshed: (credentials: CodexOAuthCredentials) => {
+            persistCodexOAuthCredentials(channelId, credentials)
+          },
+        }),
         ...((channel.provider === 'openai-codex' || channel.provider === 'openai-responses')
           && isOpenAIReasoningSupportedModel(selectedModelId) && {
             openAIThinkingLevel: resolvePiThinkingLevel(appSettings, sessionMeta, channel.provider),

--- a/apps/electron/src/main/lib/channel-manager.ts
+++ b/apps/electron/src/main/lib/channel-manager.ts
@@ -20,6 +20,7 @@ import type {
   ChannelModel,
   ChannelPlanQuotaResult,
   ChannelPlanQuotaWindow,
+  CodexOAuthCredentials,
   FetchModelsInput,
   FetchModelsResult,
   ProviderType,
@@ -431,19 +432,28 @@ export function decryptApiKey(channelId: string): string {
  * 只有一次刷新在飞行，其余调用复用同一 Promise。对应 memory 里记过的
  * 「OAuth 刷新需并发锁」经验。
  */
-const inflightCodexRefresh = new Map<string, Promise<string>>()
+const inflightCodexRefresh = new Map<string, Promise<CodexOAuthCredentials>>()
+
+/** 保存 Pi 或 Proma 刷新后的完整 Codex OAuth 凭据。 */
+export function persistCodexOAuthCredentials(channelId: string, credentials: CodexOAuthCredentials): void {
+  const channel = getChannelById(channelId)
+  if (!channel || channel.provider !== 'openai-codex') {
+    throw new Error(`Codex 渠道不存在或类型不匹配: ${channelId}`)
+  }
+
+  const existing = parseCodexCredentials(decryptKey(channel.apiKey))
+  const merged = {
+    ...credentials,
+    accountId: credentials.accountId ?? existing?.accountId,
+  }
+  updateChannel(channelId, { apiKey: serializeCodexCredentials(merged) })
+}
 
 /**
- * 解析渠道存储的 ChatGPT (Codex) OAuth 凭据，按需刷新并回写，返回可用的 access token。
- *
- * - 渠道 apiKey 字段存的是加密后的凭据 JSON（access/refresh/expires）。
- * - access token 未过期：直接返回。
- * - 已过期或即将过期：用 refresh token 换新，加密回写渠道，返回新的 access token。
- *
- * 仅用于 provider === 'openai-codex' 的渠道。刷新失败时抛错，交由上层映射为
- * expired_oauth_token 并引导用户重新登录。
+ * 解析渠道存储的 ChatGPT (Codex) OAuth 凭据，按需刷新并回写。
+ * Pi runtime 必须接收完整 credential，才能在长时间运行时按真实 expires 刷新 token。
  */
-export async function resolveCodexAccessToken(channelId: string): Promise<string> {
+export async function resolveCodexOAuthCredentials(channelId: string): Promise<CodexOAuthCredentials> {
   const config = readConfig()
   const channel = config.channels.find((c) => c.id === channelId)
   if (!channel) {
@@ -456,23 +466,21 @@ export async function resolveCodexAccessToken(channelId: string): Promise<string
   }
 
   if (!isCodexCredentialExpired(credentials)) {
-    return credentials.access
+    return credentials
   }
 
-  // 过期：去重刷新。同一渠道并发调用复用同一个刷新 Promise。
   const existing = inflightCodexRefresh.get(channelId)
   if (existing) return existing
 
-  const refreshPromise = (async (): Promise<string> => {
+  const refreshPromise = (async (): Promise<CodexOAuthCredentials> => {
     try {
       const refreshed = await refreshCodexOAuth(credentials.refresh)
-      // 回写加密凭据（保留刚拿到的 accountId，缺省沿用旧值）。
       const merged = {
         ...refreshed,
         accountId: refreshed.accountId ?? credentials.accountId,
       }
-      updateChannel(channelId, { apiKey: serializeCodexCredentials(merged) })
-      return refreshed.access
+      persistCodexOAuthCredentials(channelId, merged)
+      return merged
     } finally {
       inflightCodexRefresh.delete(channelId)
     }
@@ -480,6 +488,11 @@ export async function resolveCodexAccessToken(channelId: string): Promise<string
 
   inflightCodexRefresh.set(channelId, refreshPromise)
   return refreshPromise
+}
+
+/** 返回当前有效的 Codex access token，兼容只需要 bearer token 的调用方。 */
+export async function resolveCodexAccessToken(channelId: string): Promise<string> {
+  return (await resolveCodexOAuthCredentials(channelId)).access
 }
 
 /**


### PR DESCRIPTION
## Summary
- pass complete Codex OAuth credentials into the Pi runtime
- persist Pi runtime token refreshes back to Proma channel storage
- retain real token expiry instead of an unbounded in-memory expiry

## Validation
- bun run --filter=@proma/electron typecheck
- bun run build:main
- bun test packages/shared/src/types/channel.codex.test.ts apps/electron/src/main/lib/codex-plan-quota.test.ts apps/electron/src/main/lib/adapters/pi-codex-fast-mode.test.ts

## Notes
- follows merged PR #1213
- does not write Pi global auth storage (~/.pi)