### PR TITLE
feat(agent): default new sessions to pi runtime

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -1805,7 +1805,7 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(
     AGENT_IPC_CHANNELS.CREATE_SESSION,
     async (_, title?: string, channelId?: string, workspaceId?: string, modelId?: string): Promise<AgentSessionMeta> => {
-      const session = createAgentSession(title, channelId, workspaceId, modelId, getSettings().agentRuntime ?? 'claude')
+      const session = createAgentSession(title, channelId, workspaceId, modelId, getSettings().agentRuntime ?? 'pi')
       feishuBridgeManager.ensureSessionMirror(session).catch((error) => {
         console.error('[飞书 Session 镜像] 新会话建群失败:', error)
       })
@@ -4423,7 +4423,8 @@ export function registerIpcHandlers(): void {
     input: Partial<CreateAutomationInput | UpdateAutomationInput>,
     existing?: Automation,
   ): void => {
-    const finalRuntime: AgentRuntime = input.agentRuntime ?? existing?.agentRuntime ?? 'claude'
+    // 更新历史任务时，缺失的持久化 runtime 仍按 Claude 解释；仅新建任务使用 Pi 默认值。
+    const finalRuntime: AgentRuntime = input.agentRuntime ?? existing?.agentRuntime ?? (existing ? 'claude' : 'pi')
     const finalChannelId = input.channelId !== undefined ? input.channelId : existing?.channelId
     if (finalRuntime === 'claude' && finalChannelId) {
       const agentChannelIds = getSettings().agentChannelIds ?? []

--- a/apps/electron/src/main/lib/agent-session-manager.test.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.test.ts
@@ -151,15 +151,15 @@ describe('Agent 会话 JSONL 读取', () => {
 })
 
 describe('Agent 会话 runtime 元数据', () => {
-  test('Given 新建会话 When 指定或省略 runtime Then 持久化指定值并默认 Claude', () => {
+  test('Given 新建会话 When 指定或省略 runtime Then 持久化指定值并默认 Pi', () => {
     const defaultRuntimeSession = manager.createAgentSession('默认内核会话')
-    const piRuntimeSession = manager.createAgentSession('Pi 内核会话', undefined, undefined, undefined, 'pi')
+    const claudeRuntimeSession = manager.createAgentSession('Claude 内核会话', undefined, undefined, undefined, 'claude')
 
-    expect(defaultRuntimeSession.agentRuntime).toBe('claude')
-    expect(piRuntimeSession.agentRuntime).toBe('pi')
-    expect(manager.getAgentSessionMeta(defaultRuntimeSession.id)?.agentRuntime).toBe('claude')
-    expect(manager.getAgentSessionMeta(piRuntimeSession.id)?.agentRuntime).toBe('pi')
-    expect(defaultRuntimeSession.openAIThinkingLevel).toBe('off')
+    expect(defaultRuntimeSession.agentRuntime).toBe('pi')
+    expect(claudeRuntimeSession.agentRuntime).toBe('claude')
+    expect(manager.getAgentSessionMeta(defaultRuntimeSession.id)?.agentRuntime).toBe('pi')
+    expect(manager.getAgentSessionMeta(claudeRuntimeSession.id)?.agentRuntime).toBe('claude')
+    expect(defaultRuntimeSession.openAIThinkingLevel).toBe('high')
   })
 
   test('Given Codex session settings When updating Then persists depth per session', () => {

--- a/apps/electron/src/main/lib/agent-session-manager.test.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.test.ts
@@ -151,15 +151,15 @@ describe('Agent 会话 JSONL 读取', () => {
 })
 
 describe('Agent 会话 runtime 元数据', () => {
-  test('Given 新建会话 When 指定或省略 runtime Then 持久化指定值并默认 Pi', () => {
+  test('Given 新建会话 When 指定或省略 runtime Then 持久化指定值并默认 Claude', () => {
     const defaultRuntimeSession = manager.createAgentSession('默认内核会话')
-    const claudeRuntimeSession = manager.createAgentSession('Claude 内核会话', undefined, undefined, undefined, 'claude')
+    const piRuntimeSession = manager.createAgentSession('Pi 内核会话', undefined, undefined, undefined, 'pi')
 
-    expect(defaultRuntimeSession.agentRuntime).toBe('pi')
-    expect(claudeRuntimeSession.agentRuntime).toBe('claude')
-    expect(manager.getAgentSessionMeta(defaultRuntimeSession.id)?.agentRuntime).toBe('pi')
-    expect(manager.getAgentSessionMeta(claudeRuntimeSession.id)?.agentRuntime).toBe('claude')
-    expect(defaultRuntimeSession.openAIThinkingLevel).toBe('high')
+    expect(defaultRuntimeSession.agentRuntime).toBe('claude')
+    expect(piRuntimeSession.agentRuntime).toBe('pi')
+    expect(manager.getAgentSessionMeta(defaultRuntimeSession.id)?.agentRuntime).toBe('claude')
+    expect(manager.getAgentSessionMeta(piRuntimeSession.id)?.agentRuntime).toBe('pi')
+    expect(defaultRuntimeSession.openAIThinkingLevel).toBe('off')
   })
 
   test('Given Codex session settings When updating Then persists depth per session', () => {

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -216,7 +216,7 @@ export function createAgentSession(
   channelId?: string,
   workspaceId?: string,
   modelId?: string,
-  agentRuntime: AgentRuntime = 'claude',
+  agentRuntime: AgentRuntime = 'pi',
 ): AgentSessionMeta {
   const index = readIndex()
   const now = Date.now()

--- a/apps/electron/src/main/lib/automation-manager.ts
+++ b/apps/electron/src/main/lib/automation-manager.ts
@@ -272,7 +272,8 @@ export function createAutomation(input: CreateAutomationInput): Automation {
     dayOfMonth: input.dayOfMonth,
     scheduledAt: input.scheduledAt,
     maxRuns: normalizeMaxRuns(input.maxRuns),
-    agentRuntime: input.agentRuntime,
+    // 新建任务未指定 runtime 时默认 Pi；已有历史任务的缺省值由读取/调度路径继续按 Claude 处理。
+    agentRuntime: input.agentRuntime ?? 'pi',
     channelId: input.channelId,
     modelId: input.modelId,
     workspaceId: input.workspaceId,

--- a/apps/electron/src/main/lib/bridge-command-handler.ts
+++ b/apps/electron/src/main/lib/bridge-command-handler.ts
@@ -139,7 +139,7 @@ export class BridgeCommandHandler {
       channelId,
       workspaceId || undefined,
       undefined,
-      settings.agentRuntime ?? 'claude',
+      settings.agentRuntime ?? 'pi',
     )
 
     const binding: BridgeChatBinding = {
@@ -303,7 +303,7 @@ export class BridgeCommandHandler {
       channelId,
       workspaceId || undefined,
       undefined,
-      settings.agentRuntime ?? 'claude',
+      settings.agentRuntime ?? 'pi',
     )
 
     // 清理旧绑定

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -213,7 +213,7 @@ export const agentModelIdAtom = atom<string | null>(null)
 /** Agent 启用的渠道 ID 列表（多选，设置页 Switch 开关控制） */
 export const agentChannelIdsAtom = atom<string[]>([])
 /** 新 Agent 会话默认 runtime */
-export const agentRuntimeAtom = atom<'claude' | 'pi'>('claude')
+export const agentRuntimeAtom = atom<'claude' | 'pi'>('pi')
 
 /** Per-session 渠道 ID Map — sessionId → channelId */
 export const agentSessionChannelMapAtom = atom<Map<string, string>>(new Map())

--- a/apps/electron/src/renderer/atoms/automation-atoms.ts
+++ b/apps/electron/src/renderer/atoms/automation-atoms.ts
@@ -70,7 +70,7 @@ export function createEmptyDraft(): AutomationDraft {
     timeOfDay: '09:00',
     dayOfWeek: 1,
     dayOfMonth: 1,
-    agentRuntime: 'claude',
+    agentRuntime: 'pi',
     channelId: '',
     permissionMode: AUTOMATION_DEFAULT_PERMISSION_MODE,
     sessionMode: AUTOMATION_DEFAULT_SESSION_MODE,

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -209,7 +209,7 @@ function AgentSettingsInitializer(): null {
         store.set(selectedModelAtom, null)
       }
 
-      const defaultAgentRuntime = settings.agentRuntime ?? 'claude'
+      const defaultAgentRuntime = settings.agentRuntime ?? 'pi'
       setAgentRuntime(defaultAgentRuntime)
 
       // 渠道的启用状态是唯一开关：启动时也必须从实际渠道派生 Claude 白名单，

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -180,8 +180,8 @@ export type InterfaceVariant = 'classic' | 'modern'
 /** 默认界面风格 */
 export const DEFAULT_INTERFACE_VARIANT: InterfaceVariant = 'modern'
 
-/** 默认 Agent runtime；历史配置缺省继续使用 Claude */
-export const DEFAULT_AGENT_RUNTIME: AgentRuntime = 'claude'
+/** 新建 Agent 会话与自动任务的默认 runtime。历史持久化记录缺失 runtime 时仍按 Claude 兼容。 */
+export const DEFAULT_AGENT_RUNTIME: AgentRuntime = 'pi'
 
 /** Markdown 预览字号档位 */
 export type MarkdownFontSize = 'small' | 'medium' | 'large'
@@ -205,7 +205,7 @@ export interface AppSettings {
   agentChannelIds?: string[]
   /** Agent 当前工作区 ID */
   agentWorkspaceId?: string
-  /** 新 Agent 会话默认使用的 runtime；历史会话缺省为 claude */
+  /** 新 Agent 会话默认使用的 runtime；历史会话缺省仍按 claude 兼容。 */
   agentRuntime?: AgentRuntime
   /** 侧栏「自动任务」合成项目组在项目列表中的位置索引（默认 0 = 最靠前；可拖拽调整） */
   agentAutomationGroupOrder?: number

--- a/packages/shared/src/types/automation.ts
+++ b/packages/shared/src/types/automation.ts
@@ -89,7 +89,7 @@ export interface Automation {
    * 与 scheduleType 正交——任意循环模式都可叠加；once 模式语义上等价于 maxRuns=1。
    */
   maxRuns?: number
-  /** 本任务运行时使用的 Agent runtime；历史任务缺省为 claude */
+  /** 本任务运行时使用的 Agent runtime；新任务默认 pi，历史任务缺省仍按 claude 兼容。 */
   agentRuntime?: import('./agent-provider').AgentRuntime
   /** AI 渠道 ID */
   channelId: string
@@ -148,7 +148,7 @@ export interface CreateAutomationInput {
   scheduledAt?: number
   /** 最大运行次数上限（实际执行次数），达到后自动停用；不传 = 不限次 */
   maxRuns?: number
-  /** 本任务运行时使用的 Agent runtime；不传则为 claude */
+  /** 本任务运行时使用的 Agent runtime；新建任务不传则为 pi。 */
   agentRuntime?: import('./agent-provider').AgentRuntime
   channelId: string
   modelId?: string


### PR DESCRIPTION
## Summary

- 4018ec99 test: remove runtime default assertion update
- ac0edb68 feat(agent): default new sessions to pi runtime

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归