### PR TITLE
fix(mermaid): 修复 mermaid 超宽图左侧内容不可滚动【已审核 PR】

### DIFF
--- a/packages/ui/src/mermaid-block/MermaidBlock.tsx
+++ b/packages/ui/src/mermaid-block/MermaidBlock.tsx
@@ -231,12 +231,10 @@ export function MermaidBlock({ code }: MermaidBlockProps): React.ReactElement {
           </pre>
         ) : (
           <div className="mermaid-block-scroll bg-background overflow-auto min-h-[180px]">
-            <div
-              className="flex justify-center items-center p-4 min-h-[180px] origin-center"
-              style={{ transform: `scale(${scale})` }}
-            >
+            <div className="flex w-max min-w-full items-center justify-start p-4 min-h-[180px]">
               <div
-                className="mermaid-svg [&>svg]:max-w-full [&>svg]:h-auto"
+                className="mermaid-svg inline-block [&>svg]:block [&>svg]:h-auto"
+                style={{ zoom: scale }}
                 dangerouslySetInnerHTML={{ __html: renderedSvg }}
               />
             </div>


### PR DESCRIPTION
## 概述
修复 Agent 与 Chat 中超宽 Mermaid 图表在横向滚动到最左端后，左侧参与者、标签或箭头仍被裁剪的问题。此前容器将 SVG 居中放置；当 SVG 宽度超过可视区域时，居中会让左侧内容落到负坐标，浏览器的 `scrollLeft = 0` 无法访问该区域。原实现还用 `transform: scale()` 缩放，缩放结果不参与滚动尺寸计算，放大后也可能出现可滚动范围不足。

## 改动
- `packages/ui/src/mermaid-block/MermaidBlock.tsx` — 将 SVG 内容层改为 `w-max min-w-full`，基于 Mermaid SVG 的真实宽度建立横向滚动范围。
- `packages/ui/src/mermaid-block/MermaidBlock.tsx` — 将超宽图从居中改为左对齐，避免生成位于滚动起点之前的负向溢出内容。
- `packages/ui/src/mermaid-block/MermaidBlock.tsx` — 移除 SVG 的 `max-w-full` 约束，并以 Chromium/Electron 支持且参与布局计算的 `zoom` 代替 `transform: scale()`，确保缩放后滚动边界同步更新。
- 渲染器选择保持不变：继续优先使用 `beautiful-mermaid`，仅在其渲染失败时使用既有官方 Mermaid 兜底。

## 测试方法
1. 执行 `bun run typecheck`，确认所有 workspace 包类型检查通过。
2. 执行 `bun run --filter='@proma/electron' build`，确认 Electron renderer 与 Mermaid 动态导入可成功构建。
3. 在 Agent 或 Chat 中渲染包含多个参与者的超宽 Mermaid sequence diagram。
4. 将横向滚动条拖到最左和最右，确认两端内容都可见；分别测试 25%、100% 和 300% 缩放，确认滚动范围随缩放更新。

## 备注
- 修改已完成代码审查：未发现 TypeScript、路径处理、Shell 调用或 Windows 平台兼容性问题。
- `beautiful-mermaid` 输出包含数值化 SVG 宽高，因此内容层可可靠地使用其原生宽度计算滚动范围。