### PR TITLE
Revert Codex GPT-5.6 context indicator

### DIFF
--- a/packages/shared/src/utils/context-window.ts
+++ b/packages/shared/src/utils/context-window.ts
@@ -27,8 +27,6 @@ const AGENT_SDK_1M_CONTEXT_RULES = {
     'claude-opus-4-8',
     'claude-fable-5',
   ],
-  // OpenAI ChatGPT (Codex OAuth)：GPT-5.6 系列均为 1M。
-  gpt: ['gpt-5.6'],
   // DeepSeek
   deepseek: ['deepseek-v4'],
   // 智谱 GLM


### PR DESCRIPTION
## Summary

- 4f09a2a2 Revert "fix(agent): show 1M context for Codex GPT-5.6 (#1222)"

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归