### PR TITLE
Fix Codex GPT-5.6 context window to 372K

### DIFF
--- a/apps/electron/src/main/lib/adapters/pi-model-registry.ts
+++ b/apps/electron/src/main/lib/adapters/pi-model-registry.ts
@@ -43,9 +43,9 @@ const VOLCENGINE_GLM_52_MAX_TOKENS = 128_000
 const CODEX_BASE_URL = 'https://chatgpt.com/backend-api'
 const CODEX_MAX_TOKENS = 128_000
 const CODEX_54_MINI_CONTEXT_WINDOW = 400_000
-// ChatGPT Codex OAuth currently exposes a 272K context window for GPT-5.6 models.
+// ChatGPT Codex OAuth currently exposes a 372K context window for GPT-5.6 models.
 // This differs from the 1.05M API model specification.
-const CODEX_56_CONTEXT_WINDOW = 272_000
+const CODEX_56_CONTEXT_WINDOW = 372_000
 const CODEX_THINKING_LEVEL_MAP = { xhigh: 'xhigh', minimal: 'low' } as const
 
 type CodexRuntimeCredential = CodexOAuthCredentials & {


### PR DESCRIPTION
## Summary

- c4c90d19 fix(codex): use 372K GPT-5.6 context window

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归