### PR TITLE
feat(agent): 会话列表新增星标标记，未星标时仅 hover 显示【已审核 PR】

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -1888,6 +1888,17 @@ export function registerIpcHandlers(): void {
     }
   )
 
+  // 切换 Agent 会话星标状态
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.TOGGLE_STAR,
+    async (_, id: string): Promise<AgentSessionMeta> => {
+      const sessions = listAgentSessions()
+      const current = sessions.find((s) => s.id === id)
+      if (!current) throw new Error(`Agent session not found: ${id}`)
+      return updateAgentSessionMeta(id, { starred: !current.starred })
+    }
+  )
+
   // 清除 Agent 会话完成状态（兼容清除旧版 manualWorking）
   ipcMain.handle(
     AGENT_IPC_CHANNELS.CLEAR_COMPLETION_STATE,

--- a/apps/electron/src/main/lib/agent-session-manager.test.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.test.ts
@@ -170,6 +170,17 @@ describe('Agent 会话 runtime 元数据', () => {
     expect(updated.openAIThinkingLevel).toBe('xhigh')
     expect(manager.getAgentSessionMeta(session.id)).toMatchObject({ openAIThinkingLevel: 'xhigh' })
   })
+
+  test('Given a session When star state is updated Then it persists without changing freshness or archive state', () => {
+    const session = manager.createAgentSession('星标会话')
+    const archived = manager.updateAgentSessionMeta(session.id, { archived: true })
+
+    const updated = manager.updateAgentSessionMeta(session.id, { starred: true })
+
+    expect(updated).toMatchObject({ starred: true, archived: true })
+    expect(updated.updatedAt).toBe(archived.updatedAt)
+    expect(manager.getAgentSessionMeta(session.id)).toMatchObject({ starred: true, archived: true })
+  })
 })
 
 describe('Agent 会话引用搜索', () => {

--- a/apps/electron/src/main/lib/agent-session-manager.test.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.test.ts
@@ -151,15 +151,15 @@ describe('Agent 会话 JSONL 读取', () => {
 })
 
 describe('Agent 会话 runtime 元数据', () => {
-  test('Given 新建会话 When 指定或省略 runtime Then 持久化指定值并默认 Claude', () => {
+  test('Given 新建会话 When 指定或省略 runtime Then 持久化指定值并默认 Pi', () => {
     const defaultRuntimeSession = manager.createAgentSession('默认内核会话')
-    const piRuntimeSession = manager.createAgentSession('Pi 内核会话', undefined, undefined, undefined, 'pi')
+    const claudeRuntimeSession = manager.createAgentSession('Claude 内核会话', undefined, undefined, undefined, 'claude')
 
-    expect(defaultRuntimeSession.agentRuntime).toBe('claude')
-    expect(piRuntimeSession.agentRuntime).toBe('pi')
-    expect(manager.getAgentSessionMeta(defaultRuntimeSession.id)?.agentRuntime).toBe('claude')
-    expect(manager.getAgentSessionMeta(piRuntimeSession.id)?.agentRuntime).toBe('pi')
-    expect(defaultRuntimeSession.openAIThinkingLevel).toBe('off')
+    expect(defaultRuntimeSession.agentRuntime).toBe('pi')
+    expect(claudeRuntimeSession.agentRuntime).toBe('claude')
+    expect(manager.getAgentSessionMeta(defaultRuntimeSession.id)?.agentRuntime).toBe('pi')
+    expect(manager.getAgentSessionMeta(claudeRuntimeSession.id)?.agentRuntime).toBe('claude')
+    expect(defaultRuntimeSession.openAIThinkingLevel).toBe('high')
   })
 
   test('Given Codex session settings When updating Then persists depth per session', () => {

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -433,7 +433,7 @@ export function getAgentSessionSDKMessages(id: string): SDKMessage[] {
  */
 export function updateAgentSessionMeta(
   id: string,
-  updates: Partial<Pick<AgentSessionMeta, 'title' | 'channelId' | 'modelId' | 'sdkSessionId' | 'piSessionFile' | 'piEntryBindings' | 'agentRuntime' | 'codexFastMode' | 'openAIThinkingLevel' | 'workspaceId' | 'pinned' | 'archived' | 'attachedDirectories' | 'attachedFiles' | 'forkSourceDir' | 'forkSourceSdkSessionId' | 'resumeAtMessageUuid' | 'stoppedByUser' | 'permissionMode' | 'completedButUnconfirmed' | 'sourceAutomationId' | 'automationGraduated' | 'parentSessionId' | 'rootSessionId' | 'sourceDelegationId' | 'delegationRole' | 'delegationStatus' | 'delegationDepth' | 'delegationGoal'>>,
+  updates: Partial<Pick<AgentSessionMeta, 'title' | 'channelId' | 'modelId' | 'sdkSessionId' | 'piSessionFile' | 'piEntryBindings' | 'agentRuntime' | 'codexFastMode' | 'openAIThinkingLevel' | 'workspaceId' | 'pinned' | 'starred' | 'archived' | 'attachedDirectories' | 'attachedFiles' | 'forkSourceDir' | 'forkSourceSdkSessionId' | 'resumeAtMessageUuid' | 'stoppedByUser' | 'permissionMode' | 'completedButUnconfirmed' | 'sourceAutomationId' | 'automationGraduated' | 'parentSessionId' | 'rootSessionId' | 'sourceDelegationId' | 'delegationRole' | 'delegationStatus' | 'delegationDepth' | 'delegationGoal'>>,
 ): AgentSessionMeta {
   const index = readIndex()
   const idx = index.sessions.findIndex((s) => s.id === id)
@@ -443,14 +443,17 @@ export function updateAgentSessionMeta(
   }
 
   const existing = index.sessions[idx]!
-  // 非手动归档操作时，若会话已归档则自动恢复为活跃（仅更新 stoppedByUser 不触发解归档）
-  const isStoppedByUserOnly = Object.keys(updates).every((k) => k === 'stoppedByUser')
-  const autoUnarchive = existing.archived && !('archived' in updates) && !isStoppedByUserOnly
+  const updateKeys = Object.keys(updates)
+  // 星标只是侧栏的视觉标记，不应改变会话的新鲜度或归档状态。
+  const isStarredOnly = updateKeys.every((key) => key === 'starred')
+  // 非手动归档操作时，若会话已归档则自动恢复为活跃（仅更新 stoppedByUser 或 starred 不触发解归档）
+  const isStoppedByUserOnly = updateKeys.every((key) => key === 'stoppedByUser')
+  const autoUnarchive = existing.archived && !('archived' in updates) && !isStoppedByUserOnly && !isStarredOnly
   const updated: AgentSessionMeta = {
     ...existing,
     ...updates,
     ...(autoUnarchive ? { archived: false } : {}),
-    updatedAt: Date.now(),
+    updatedAt: isStarredOnly ? existing.updatedAt : Date.now(),
   }
 
   index.sessions[idx] = updated

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -456,6 +456,9 @@ export interface ElectronAPI {
   /** 切换 Agent 会话置顶状态 */
   togglePinAgentSession: (id: string) => Promise<AgentSessionMeta>
 
+  /** 切换 Agent 会话星标状态 */
+  toggleStarAgentSession: (id: string) => Promise<AgentSessionMeta>
+
   /** 清除 Agent 会话完成状态（兼容清除旧版 manualWorking） */
   clearAgentCompletionState: (id: string) => Promise<AgentSessionMeta>
 
@@ -1490,6 +1493,10 @@ const electronAPI: ElectronAPI = {
 
   togglePinAgentSession: (id: string) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.TOGGLE_PIN, id)
+  },
+
+  toggleStarAgentSession: (id: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.TOGGLE_STAR, id)
   },
 
   clearAgentCompletionState: (id: string) => {

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -11,7 +11,7 @@
 import * as React from 'react'
 import { useAtom, useSetAtom, useAtomValue, useStore } from 'jotai'
 import { toast } from 'sonner'
-import { Pin, PinOff, Settings, Plus, Trash2, Pencil, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, GripVertical, Clock, AlarmClock, ChevronRight, Blocks, GitBranch, Download, Loader2, RotateCw } from 'lucide-react'
+import { Pin, PinOff, Star, Settings, Plus, Trash2, Pencil, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, GripVertical, Clock, AlarmClock, ChevronRight, Blocks, GitBranch, Download, Loader2, RotateCw } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { ModeSwitcher } from './ModeSwitcher'
@@ -1963,6 +1963,16 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     }
   }, [draftSessionIds, store, setAgentSessions])
 
+  /** 切换 Agent 会话星标状态 */
+  const handleToggleStarAgent = React.useCallback(async (id: string): Promise<void> => {
+    try {
+      const updated = await window.electronAPI.toggleStarAgentSession(id)
+      setAgentSessions((prev) => replaceAgentSessionInFreshnessOrder(prev, updated))
+    } catch (error) {
+      console.error('[侧边栏] 切换 Agent 会话星标失败:', error)
+    }
+  }, [setAgentSessions])
+
   /** 切换 Agent 会话归档状态 */
   const handleToggleArchiveAgent = React.useCallback(async (id: string): Promise<void> => {
     const sessions = store.get(agentSessionsAtom)
@@ -2781,6 +2791,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
                             onRequestMove={handleRequestMove}
                             onRename={handleAgentRename}
                             onTogglePin={handleTogglePinAgent}
+                            onToggleStar={handleToggleStarAgent}
                             onToggleArchive={handleToggleArchiveAgent}
                           />
 
@@ -2799,6 +2810,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
                                   onRequestMove={handleRequestMove}
                                   onRename={handleAgentRename}
                                   onTogglePin={handleTogglePinAgent}
+                                  onToggleStar={handleToggleStarAgent}
                                   onToggleArchive={handleToggleArchiveAgent}
                                 />
                               ))}
@@ -2893,6 +2905,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
                     onRequestMove={handleRequestMove}
                     onRename={handleAgentRename}
                     onTogglePin={handleTogglePinAgent}
+                    onToggleStar={handleToggleStarAgent}
                     onToggleArchive={handleToggleArchiveAgent}
                     onToggleDelegationParent={handleToggleDelegationParent}
                   />
@@ -2979,6 +2992,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
                             onRequestMove={handleRequestMove}
                             onRename={handleAgentRename}
                             onTogglePin={handleTogglePinAgent}
+                            onToggleStar={handleToggleStarAgent}
                             onToggleArchive={handleToggleArchiveAgent}
                           />
 
@@ -2997,6 +3011,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
                                   onRequestMove={handleRequestMove}
                                   onRename={handleAgentRename}
                                   onTogglePin={handleTogglePinAgent}
+                                  onToggleStar={handleToggleStarAgent}
                                   onToggleArchive={handleToggleArchiveAgent}
                                 />
                               ))}
@@ -3571,6 +3586,7 @@ interface AgentSessionItemProps {
   onRequestMove: (id: string) => void
   onRename: (id: string, newTitle: string) => Promise<void>
   onTogglePin: (id: string, cascade: boolean) => Promise<void>
+  onToggleStar: (id: string) => Promise<void>
   onToggleArchive: (id: string) => Promise<void>
 }
 
@@ -3589,11 +3605,13 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
   onRequestMove,
   onRename,
   onTogglePin,
+  onToggleStar,
   onToggleArchive,
 }: AgentSessionItemProps): React.ReactElement {
   const [editing, setEditing] = React.useState(false)
   const [editTitle, setEditTitle] = React.useState('')
   const [menuOpen, setMenuOpen] = React.useState(false)
+  const [rowHovered, setRowHovered] = React.useState(false)
   const inputRef = React.useRef<HTMLInputElement>(null)
   const justStartedEditing = React.useRef(false)
   // 菜单打开时关闭迷你地图预览，避免预览面板盖住菜单项导致点不动
@@ -3696,8 +3714,8 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
           data-session-switch-title={session.title}
           data-session-switch-type="agent"
           onClick={() => onSelect(session.id, session.title)}
-          onMouseEnter={preview.handleMouseEnter}
-          onMouseLeave={preview.handleMouseLeave}
+          onMouseEnter={() => { setRowHovered(true); preview.handleMouseEnter() }}
+          onMouseLeave={() => { setRowHovered(false); preview.handleMouseLeave() }}
           className={cn(
             'session-quick-switch-row group relative w-full flex items-center gap-1.5 rounded-md py-1 pl-2.5 pr-1.5 transition-colors duration-100 titlebar-no-drag text-left',
             active && 'agent-session-item-active',
@@ -3752,6 +3770,37 @@ const AgentSessionItem = React.memo(function AgentSessionItem({
                 >
                   {session.title}
                 </span>
+                <SafeTooltip content={session.starred ? '取消星标' : '添加星标'} side="top">
+                  <button
+                    type="button"
+                    aria-label={session.starred ? '取消星标' : '添加星标'}
+                    aria-pressed={!!session.starred}
+                    onMouseEnter={preview.closeNow}
+                    onFocus={preview.closeNow}
+                    onMouseDown={(event) => {
+                      event.stopPropagation()
+                      preview.closeNow()
+                    }}
+                    onClick={(event) => {
+                      event.stopPropagation()
+                      preview.closeNow()
+                      if (event.detail > 1) return
+                      void onToggleStar(session.id)
+                    }}
+                    onDoubleClick={(event) => {
+                      event.stopPropagation()
+                      preview.closeNow()
+                    }}
+                    className={cn(
+                      'flex-shrink-0 inline-flex size-6 -my-1 items-center justify-center rounded transition-colors',
+                      session.starred
+                        ? 'text-amber-500 hover:text-amber-500'
+                        : cn('text-foreground/45 hover:bg-foreground/[0.055] hover:text-foreground/70', rowHovered ? 'opacity-100' : 'opacity-0'),
+                    )}
+                  >
+                    <Star size={13} fill={session.starred ? 'currentColor' : 'none'} />
+                  </button>
+                </SafeTooltip>
                 {workspaceName && (
                   <span className="flex-shrink-0 px-1.5 py-0 rounded-full bg-primary/10 text-[10px] leading-4 workspace-badge font-medium truncate max-w-[80px]">
                     {workspaceName}
@@ -3848,6 +3897,7 @@ interface DelegatedChildSessionItemProps {
   onRequestMove: (id: string) => void
   onRename: (id: string, newTitle: string) => Promise<void>
   onTogglePin: (id: string, cascade: boolean) => Promise<void>
+  onToggleStar: (id: string) => Promise<void>
   onToggleArchive: (id: string) => Promise<void>
 }
 
@@ -3862,6 +3912,7 @@ const DelegatedChildSessionItem = React.memo(function DelegatedChildSessionItem(
   onRequestMove,
   onRename,
   onTogglePin,
+  onToggleStar,
   onToggleArchive,
 }: DelegatedChildSessionItemProps): React.ReactElement {
   const status = getDelegatedChildStatus(session, agentIndicatorMap)
@@ -3878,6 +3929,7 @@ const DelegatedChildSessionItem = React.memo(function DelegatedChildSessionItem(
       onRequestMove={onRequestMove}
       onRename={onRename}
       onTogglePin={onTogglePin}
+      onToggleStar={onToggleStar}
       onToggleArchive={onToggleArchive}
     />
   )
@@ -3921,6 +3973,7 @@ interface AgentProjectGroupItemProps {
   onRequestMove: (id: string) => void
   onRename: (id: string, newTitle: string) => Promise<void>
   onTogglePin: (id: string, cascade: boolean) => Promise<void>
+  onToggleStar: (id: string) => Promise<void>
   onToggleArchive: (id: string) => Promise<void>
   onToggleDelegationParent: (id: string, expanded: boolean) => void
 }
@@ -3958,6 +4011,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
   onRequestMove,
   onRename,
   onTogglePin,
+  onToggleStar,
   onToggleArchive,
   onToggleDelegationParent,
 }: AgentProjectGroupItemProps): React.ReactElement {
@@ -4238,6 +4292,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
                       onRequestMove={onRequestMove}
                       onRename={onRename}
                       onTogglePin={onTogglePin}
+                      onToggleStar={onToggleStar}
                       onToggleArchive={onToggleArchive}
                     />
 
@@ -4256,6 +4311,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
                             onRequestMove={onRequestMove}
                             onRename={onRename}
                             onTogglePin={onTogglePin}
+                            onToggleStar={onToggleStar}
                             onToggleArchive={onToggleArchive}
                           />
                         ))}

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -619,6 +619,8 @@ export interface AgentSessionMeta {
   workspaceId?: string
   /** 是否置顶 */
   pinned?: boolean
+  /** 是否已星标（仅用于侧栏快速识别，不影响排序或置顶） */
+  starred?: boolean
   /** 是否已归档 */
   archived?: boolean
   /** 附加的外部目录路径列表（绝对路径，作为 SDK additionalDirectories 传递） */
@@ -1424,6 +1426,8 @@ export const AGENT_IPC_CHANNELS = {
   MIGRATE_CHAT_TO_AGENT: 'agent:migrate-chat-to-agent',
   /** 切换会话置顶状态 */
   TOGGLE_PIN: 'agent:toggle-pin',
+  /** 切换会话星标状态 */
+  TOGGLE_STAR: 'agent:toggle-star',
   /** 清除会话完成状态（兼容清除旧版 manualWorking）。channel 值保留旧名以兼容已缓存的 preload */
   CLEAR_COMPLETION_STATE: 'agent:confirm-working-done',
   /** 切换会话归档状态 */


### PR DESCRIPTION
## 概述

在左侧会话列表中每个 Agent 会话标题右侧新增可持久化的星标标记。已星标的会话始终显示琥珀色填充五角星，未星标的会话仅在鼠标悬停行时显示空心五角星。方便用户在大量会话中快速定位 actively 使用的几个。

## 改动

- `packages/shared/src/types/agent.ts` — AgentSessionMeta 新增 `starred?: boolean` 字段；AGENT_IPC_CHANNELS 新增 `TOGGLE_STAR` channel
- `apps/electron/src/main/lib/agent-session-manager.ts` — updateAgentSessionMeta 支持更新 `starred` 字段；纯星标更新不改变 `updatedAt`（不干扰排序）、不触发已归档会话解归档
- `apps/electron/src/main/lib/agent-session-manager.test.ts` — 新增单元测试：验证星标持久化且不改 freshness 和归档状态
- `apps/electron/src/main/ipc.ts` — 注册 `TOGGLE_STAR` IPC handler
- `apps/electron/src/preload/index.ts` — 暴露 `toggleStarAgentSession` 到渲染进程
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — AgentSessionItem 组件新增星标按钮 UI；使用 React state（rowHovered）而非 CSS group-hover 控制未星标星星的可见性，避免点击后浏览器 :hover 粘滞 bug；onToggleStar prop 逐层透传到 DelegatedChildSessionItem 和 AgentProjectGroupItem

## 测试方法

1. 在左侧栏任意 Agent 会话标题右侧 hover，应出现空心五角星
2. 点击空心五角星 → 变为琥珀色实心五角星，始终可见
3. 再次点击实心五角星 → 恢复空心，会话行失焦后消失
4. 关闭并重启 App → 星标状态保持不变
5. 已归档会话的星标切换不应自动解归档
6. 委派子会话也应显示星标按钮且功能正常

## 备注

- 星标是纯视觉标记，不影响会话排序、置顶或归档逻辑
- 使用 React state 驱动可见性而非 CSS :hover，避免了 Chrome 在点击触发 DOM 变更后 :hover 粘滞的已知 bug
- 已通过 TypeScript typecheck，零错误
- Windows 兼容性扫描无问题