### PR TITLE
fix(core): omit thinking field for qwen/xiaomi token plan in title generation

### DIFF
--- a/packages/core/src/providers/thinking-capability.ts
+++ b/packages/core/src/providers/thinking-capability.ts
@@ -73,8 +73,10 @@ export function detectThinkingCapability(
     return { mode: 'manual-only', disableStrategy: 'explicit-disabled' }
   }
 
-  // Kimi / 智谱 / MiniMax 的 Anthropic 协议渠道：
+  // Kimi / 智谱 / MiniMax / Token Plan 的 Anthropic 协议渠道：
   // 这些供应商的 thinking 请求参数存在兼容差异，这里直接省略以保持连接稳定。
+  // Token Plan（qwen-token-plan / xiaomi-token-plan）端点不接受 thinking 字段，
+  // 发送 `thinking: {type:'disabled'}` 会导致请求失败（标题生成等场景）。
   if (
     providerType === 'kimi-api'
     || providerType === 'kimi-coding'
@@ -82,6 +84,8 @@ export function detectThinkingCapability(
     || providerType === 'zhipu-coding-team'
     || providerType === 'ark-coding-plan'
     || providerType === 'minimax'
+    || providerType === 'qwen-token-plan'
+    || providerType === 'xiaomi-token-plan'
   ) {
     return { mode: 'none', disableStrategy: 'omit-field' }
   }


### PR DESCRIPTION
## 问题

千问 Token Plan（qwen-token-plan）渠道下无法正常生成会话标题，标题始终停留在默认值。

## 根因

`detectThinkingCapability` 中 `qwen-token-plan` 未被列入不支持 thinking 字段的供应商白名单，落入了通用「非 Anthropic 供应商」分支，返回 `disableStrategy: 'explicit-disabled'`。

这导致 `buildTitleRequest` 在构造标题生成请求时往 body 里加了 `thinking: { type: 'disabled' }`，而千问 Token Plan 端点不接受该字段，请求直接失败，标题生成静默返回 null。

## 修复

将 `qwen-token-plan` 和 `xiaomi-token-plan`（同样的问题模式）加入排除列表，使其返回 `mode: 'none'` + `disableStrategy: 'omit-field'`，标题生成请求不再携带 `thinking` 字段，与 kimi、智谱、MiniMax 等渠道行为一致。

## 测试

- [x] 千问 Token Plan 渠道新建会话，标题正常生成