### PR TITLE
fix(agent): render local Markdown file links as chips

### DIFF
--- a/apps/electron/src/renderer/components/ai-elements/message.test.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MessageResponse } from './message'
+
+function renderMessage(markdown: string): string {
+  return renderToStaticMarkup(<MessageResponse>{markdown}</MessageResponse>)
+}
+
+describe('MessageResponse local file Markdown links', () => {
+  test('renders the reported absolute path with a line suffix as a file chip', () => {
+    const href = '/Users/bigmouth/Workspace/Project/Proma/apps/electron/src/renderer/components/agent/ContextUsageBadge.tsx:247'
+    const html = renderMessage(`[ContextUsageBadge.tsx](${href})`)
+
+    expect(html).toContain('<button')
+    expect(html).toContain('ContextUsageBadge.tsx:247')
+    expect(html).not.toContain(`<a href="${href}"`)
+  })
+
+  test('keeps Windows absolute file paths through URL sanitization and renders a file chip', () => {
+    const href = 'C:/Workspace/Proma/apps/electron/src/message.tsx:247'
+    const html = renderMessage(`[message.tsx](${href})`)
+
+    expect(html).toContain('<button')
+    expect(html).toContain('message.tsx:247')
+    expect(html).not.toContain('<a')
+  })
+
+  test('keeps HTTP links as external links', () => {
+    const html = renderMessage('[Proma](https://proma.ai)')
+
+    expect(html).toContain('href="https://proma.ai"')
+    expect(html).not.toContain('<button')
+  })
+
+  test('keeps mention links as mention chips', () => {
+    const html = renderMessage('[file](mention://file/%2Ftmp%2Fexample.ts)')
+
+    expect(html).toContain('example.ts')
+    expect(html).not.toContain('<a')
+    expect(html).not.toContain('<button')
+  })
+})

--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -401,9 +401,9 @@ interface MessageResponseProps {
 const REMARK_PLUGINS = [remarkGfm, remarkMath]
 const REHYPE_PLUGINS = [rehypeKatex]
 
-/** 允许 mention:// 协议通过 URL 清洗（react-markdown 默认只放行 http/https） */
+/** 允许 mention:// 和本地绝对路径通过 URL 清洗 */
 function mentionUrlTransform(url: string): string {
-  if (url.startsWith('mention://')) return url
+  if (url.startsWith('mention://') || isAbsoluteFilePath(safeDecode(url))) return url
   return defaultUrlTransform(url)
 }
 
@@ -423,6 +423,11 @@ const MarkdownLink = React.memo(function MarkdownLink({
     const mentionMatch = MENTION_URL_RE.exec(href)
     if (mentionMatch) {
       return <MentionChip type={mentionMatch[1] as MentionType} value={mentionMatch[2] ?? ''} />
+    }
+
+    const filePath = safeDecode(href)
+    if (isAbsoluteFilePath(filePath)) {
+      return <FilePathChip filePath={filePath} />
     }
   }
 


### PR DESCRIPTION
## Summary
- Render absolute local file paths in Agent Markdown links as the existing FilePathChip.
- Preserve HTTP(S), mention, anchor, and unsafe-link behavior.
- Cover macOS paths, Windows paths, HTTP links, and mention links with MessageResponse rendering tests.

## Verification
- bun test apps/electron/src/renderer/components/ai-elements/message.test.tsx
- bun run --cwd apps/electron typecheck
- bun run --cwd apps/electron build:renderer