### PR TITLE
fix(agent): 安全恢复 Pi 终态流中断【已审核 PR】

### DIFF
--- a/apps/electron/src/main/lib/adapters/pi-message-adapter.test.ts
+++ b/apps/electron/src/main/lib/adapters/pi-message-adapter.test.ts
@@ -43,4 +43,17 @@ describe('convertPiMessage', () => {
     })
     expect(JSON.stringify(message).length).toBeGreaterThan(content.length)
   })
+
+  test('only persists provider errors for terminal Pi failures', () => {
+    const providerError = 'stream ended before a terminal response event'
+    const partialStop = convertPiMessage({
+      role: 'assistant', content: [], stopReason: 'stop', errorMessage: providerError,
+    } as unknown as AssistantMessage, 'session-1') as { error?: unknown }
+    const terminalError = convertPiMessage({
+      role: 'assistant', content: [], stopReason: 'error', errorMessage: providerError,
+    } as unknown as AssistantMessage, 'session-1') as { error?: { message?: string } }
+
+    expect(partialStop.error).toBeUndefined()
+    expect(terminalError.error?.message).toBe(providerError)
+  })
 })

--- a/apps/electron/src/main/lib/adapters/pi-message-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/pi-message-adapter.ts
@@ -208,6 +208,17 @@ export function convertPiMessage(
 
   if (message.role === 'assistant') {
     const assistant = message as AssistantMessage
+    // 只有 stopReason === 'error' 时才把 errorMessage 提升为终态 error 字段。
+    // - 'aborted' 属于用户/系统主动中断，不是失败，弹「服务繁忙 + 重试」在语义上完全错误。
+    // - 'stop' / 'length' / 'toolUse' 即使带 errorMessage 也只是 provider 中途抖动，
+    //   Pi SDK 认定本轮已成功，不应在渲染层误导用户。
+    // 上述非终态情况的 errorMessage 只写主进程 console，供开发排查；用户侧完全无感知。
+    const isTerminalError = assistant.stopReason === 'error'
+    if (assistant.errorMessage && !isTerminalError && final) {
+      console.warn(
+        `[pi-adapter] 忽略非终态 errorMessage（stopReason=${assistant.stopReason}）: ${assistant.errorMessage}`,
+      )
+    }
     return {
       type: 'assistant',
       message: {
@@ -234,7 +245,9 @@ export function convertPiMessage(
       session_id: sessionId,
       uuid: options.uuid ?? randomUUID(),
       ...(!final && { _partial: true }),
-      ...(assistant.errorMessage && { error: { message: assistant.errorMessage, errorType: 'provider_error' } }),
+      ...(assistant.errorMessage && isTerminalError && {
+        error: { message: assistant.errorMessage, errorType: 'provider_error' },
+      }),
       ...(channelModelId && { _channelModelId: channelModelId }),
     } as unknown as SDKMessage
   }

--- a/apps/electron/src/main/lib/adapters/pi-native-retry.test.ts
+++ b/apps/electron/src/main/lib/adapters/pi-native-retry.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test'
+import { isRetryableAssistantError, type AssistantMessage } from '@earendil-works/pi-ai/compat'
+
+function failedAssistant(errorMessage: string): AssistantMessage {
+  return {
+    role: 'assistant',
+    content: [],
+    stopReason: 'error',
+    errorMessage,
+  } as unknown as AssistantMessage
+}
+
+describe('Pi native retry classifier', () => {
+  test('classifies an OpenAI Responses terminal-event stream interruption as retryable', () => {
+    expect(isRetryableAssistantError(
+      failedAssistant('OpenAI Responses stream ended before a terminal response event'),
+    )).toBe(true)
+  })
+
+  test('does not broadly retry unrelated stream-ended errors', () => {
+    expect(isRetryableAssistantError(
+      failedAssistant('stream ended before the model emitted a local marker'),
+    )).toBe(false)
+  })
+
+  test('keeps non-transient quota failures non-retryable', () => {
+    expect(isRetryableAssistantError(
+      failedAssistant('429 insufficient_quota: billing limit reached'),
+    )).toBe(false)
+  })
+})

--- a/apps/electron/src/main/lib/error-patterns.test.ts
+++ b/apps/electron/src/main/lib/error-patterns.test.ts
@@ -16,6 +16,8 @@ describe('isTransientNetworkError', () => {
     'network error',
     'stream closed prematurely',
     'premature close',
+    'OpenAI Responses stream ended before a terminal response event',
+    'Anthropic stream ended before message_stop',
   ])('Given 已知瞬时网络错误 "%s" Then 判定为可重试', (msg) => {
     expect(isTransientNetworkError(msg)).toBe(true)
   })
@@ -43,6 +45,7 @@ describe('isTransientNetworkError', () => {
   test('Given 普通业务错误 Then 不判定为瞬时网络错误', () => {
     expect(isTransientNetworkError('invalid api key')).toBe(false)
     expect(isTransientNetworkError('400 Bad Request: model not found')).toBe(false)
+    expect(isTransientNetworkError('stream ended before an unrelated local marker')).toBe(false)
     expect(isTransientNetworkError()).toBe(false)
   })
 })

--- a/apps/electron/src/main/lib/error-patterns.ts
+++ b/apps/electron/src/main/lib/error-patterns.ts
@@ -6,9 +6,14 @@
  * AbortError）、对端提前关闭等。这些错误无 HTTP 状态码，SDK HTTP 客户端层
  * 内置的 2 次重试无法完全消化时，会穿透到 Orchestrator 应用层兜底。
  * 命中此模式的错误会走「保留 resume 的自动重试」，不会清除 sdkSessionId（#903）。
+ *
+ * 同时覆盖 OpenAI/Anthropic provider 的流中断错误：
+ * - "stream ended before a terminal response event"（OpenAI Responses API）
+ * - "stream ended before message_stop"（Anthropic Messages API）
+ * 这两种是 provider 连接被 CDN/网关切断的同类瞬时错误，与 ECONNRESET 性质一致。
  */
 export const TRANSIENT_NETWORK_PATTERN =
-  /terminated|socket hang up|ECONNRESET|ETIMEDOUT|ECONNABORTED|EPIPE|ENOTFOUND|EAI_AGAIN|ECONNREFUSED|fetch failed|network error|connection (?:error|closed|reset)|other side closed|AbortError|(?:operation|request) was aborted|(?:request )?timed out|stream (?:closed|ended|disconnected) prematurely|premature close/i
+  /terminated|socket hang up|ECONNRESET|ETIMEDOUT|ECONNABORTED|EPIPE|ENOTFOUND|EAI_AGAIN|ECONNREFUSED|fetch failed|network error|connection (?:error|closed|reset)|other side closed|AbortError|(?:operation|request) was aborted|(?:request )?timed out|stream (?:closed|ended|disconnected) prematurely|premature close|stream ended before (?:a )?(?:terminal response event|message_stop)/i
 
 /** 判断错误消息/stderr 是否为瞬时网络错误 */
 export function isTransientNetworkError(message?: string, stderr?: string): boolean {

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -168,8 +168,10 @@ function resolveRunContextWindow(
 
 interface SDKMessageRecord {
   type?: string
+  uuid?: string
   parent_tool_use_id?: string | null
   isSynthetic?: boolean
+  error?: unknown
   message?: {
     content?: unknown
   }
@@ -194,6 +196,15 @@ function getUserTextFromSDKMessage(message: SDKMessage): string | null {
     .map((block) => (block as { text: string }).text)
 
   return texts.length > 0 ? texts.join('\n') : null
+}
+
+function removeRetriedErrorSDKMessage(messages: SDKMessage[], errorUuid: string | undefined): SDKMessage[] {
+  if (!errorUuid) return messages
+  const next = messages.filter((message) => {
+    const record = message as unknown as SDKMessageRecord
+    return !(record.type === 'assistant' && record.uuid === errorUuid && record.error !== undefined && record.error !== null)
+  })
+  return next.length === messages.length ? messages : next
 }
 
 function getErrorMessage(error: unknown): string {
@@ -2209,6 +2220,15 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       .find((text): text is string => text !== null)
     if (!lastUserMessage) return
 
+    // 与主进程按 UUID 的原子删除同步更新当前 React 状态和 LRU cache，避免旧错误
+    // 在下一轮回复开始前仍被页面渲染。旧会话没有 UUID 时保留历史，由主进程幂等处理。
+    const messagesAfterCleanup = removeRetriedErrorSDKMessage(persistedSDKMessages, retryOfErrorUuid)
+    if (messagesAfterCleanup !== persistedSDKMessages) {
+      persistedSDKMessagesRef.current = messagesAfterCleanup
+      setPersistedSDKMessages(messagesAfterCleanup)
+      setMessagesCache((prev) => setSessionMessagesCache(prev, sessionId, messagesAfterCleanup))
+    }
+
     // 清除错误状态
     setAgentStreamErrors((prev) => {
       if (!prev.has(sessionId)) return prev
@@ -2245,7 +2265,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       permissionModeOverride: permissionMode,
       ...(retryOfErrorUuid && { retryOfErrorUuid }),
     }).catch(console.error)
-  }, [persistedSDKMessages, sessionId, agentChannelId, agentModelId, sessionAgentRuntime, agentChannelProvider, currentWorkspaceId, streaming, setAgentStreamErrors, setStreamingStates, permissionMode])
+  }, [persistedSDKMessages, sessionId, agentChannelId, agentModelId, sessionAgentRuntime, agentChannelProvider, currentWorkspaceId, streaming, setAgentStreamErrors, setStreamingStates, setMessagesCache, permissionMode])
 
   /** 在新对话继续：创建新会话 + 切换 tab + 使用 &session 引用旧会话 */
   const handleRetryInNewSession = React.useCallback(async (): Promise<void> => {

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -410,10 +410,17 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, onR
   let errorContent: SDKAssistantMessage | null = null
 
   for (const aMsg of turn.assistantMessages) {
+    const msgAny = aMsg as unknown as Record<string, unknown>
+    // 区分两种错误消息：
+    // 1. Orchestrator 造的纯错误消息（带 _errorCode）：content 里的 text 就是错误摘要，不当正文渲染
+    // 2. Pi 混合消息（只带 error、无 _errorCode）：provider 已吐完正文后收尾报错，content 是真正的 assistant 正文
+    const isPureErrorSummary = typeof msgAny._errorCode === 'string'
     if (aMsg.error) {
       hasError = true
       errorContent = aMsg
-      continue
+      // 纯错误消息的 content 不当正文渲染（避免错误摘要重复出现两次）
+      if (isPureErrorSummary) continue
+      // Pi 混合消息：继续向下把 content 收集进 enrichedBlocks，保留真正的助手正文
     }
     const blocks = aMsg.message?.content
     if (Array.isArray(blocks)) {
@@ -552,13 +559,14 @@ export function AssistantTurnRenderer({ turn, allMessages, basePath, onFork, onR
             )
           })}
         </div>
-        {/* 如果有错误但也有内容块，在末尾显示错误 */}
+        {/* 如果有错误但也有内容块，在末尾以 tail 形式挂错误横幅附错误提示 + 重试按钮，保留正文本身的 markdown 排版 */}
         {hasError && errorContent && topLevelBlocks.length > 0 && (
-          <div className="mt-3 text-sm text-destructive">
-            {isThinkingSignatureError(errorContent.error?.message)
-              ? `${THINKING_SIGNATURE_ERROR_TITLE}：${THINKING_SIGNATURE_ERROR_MESSAGE}`
-              : (errorContent.error?.message ?? '未知错误')}
-          </div>
+          <AssistantErrorTail
+            message={errorContent}
+            onRetry={onRetry}
+            onRetryInNewSession={onRetryInNewSession}
+            onCompact={onCompact}
+          />
         )}
         </TurnFileMapProvider>
       </MessageContent>
@@ -627,15 +635,30 @@ export function SDKMessageRenderer({
     // 跳过重放消息
     if (aMsg.isReplay) return null
 
-    // 错误消息
+    // 错误消息分发：
+    // - Orchestrator 造的纯错误消息（带 _errorCode）：直接走 ErrorMessage 组件
+    // - Pi 混合消息（只带 error、无 _errorCode）：走下方正常渲染 + 末尾挂 tail
+    //   与 AssistantTurnRenderer 对齐：不检查 hasRenderableContent，有 blocks 就正常渲染正文，
+    //   没有 blocks 才回退到 ErrorMessage
     if (aMsg.error) {
-      return <ErrorMessage message={aMsg} />
+      const msgAny = aMsg as unknown as Record<string, unknown>
+      const isPureErrorSummary = typeof msgAny._errorCode === 'string'
+      if (isPureErrorSummary) {
+        return <ErrorMessage message={aMsg} />
+      }
+      // Pi 混合消息：下面按正常路径收集 content blocks，末尾挂 AssistantErrorTail
     }
 
     const rawBlocks = aMsg.message?.content
-    if (!Array.isArray(rawBlocks) || rawBlocks.length === 0) return null
+    if (!Array.isArray(rawBlocks) || rawBlocks.length === 0) {
+      if (aMsg.error) return <ErrorMessage message={aMsg} />
+      return null
+    }
     const blocks = normalizeThinkTagsInContentBlocks(rawBlocks)
-    if (blocks.length === 0) return null
+    if (blocks.length === 0) {
+      if (aMsg.error) return <ErrorMessage message={aMsg} />
+      return null
+    }
 
     const model = aMsg._channelModelId || aMsg.message?.model || sessionModelId
     const meta = extractMeta(message)
@@ -667,6 +690,10 @@ export function SDKMessageRenderer({
               />
             ))}
           </div>
+          {/* Pi runtime 下「provider 已吐正文 + 收尾报错」的混合消息：末尾挂错误横幅 */}
+          {aMsg.error && (
+            <AssistantErrorTail message={aMsg} />
+          )}
         </MessageContent>
       </Message>
     )
@@ -1028,8 +1055,39 @@ interface ErrorMessageProps {
   onCompact?: () => void
 }
 
-function ErrorMessage({ message, onRetry, onRetryInNewSession, onCompact }: ErrorMessageProps): React.ReactElement {
-  const meta = extractMeta(message as unknown as SDKMessage)
+interface AssistantErrorTailProps {
+  message: SDKAssistantMessage
+  /** 重试回调（在当前会话内重试） */
+  onRetry?: (errorUuid?: string) => void
+  /** 在新会话中重试回调（创建新会话并引用当前会话继续） */
+  onRetryInNewSession?: () => void
+  /** 压缩上下文回调（仅 prompt_too_long 错误使用） */
+  onCompact?: () => void
+  /**
+   * 以「独立错误消息」形式渲染：正文用红色 MessageResponse 展示（用于 ErrorMessage 主体）。
+   *
+   * 以 tail 形式（默认 false）渲染时：正文本身已在上层用普通 MessageResponse 展示，这里只输出
+   * 错误标题 + 简短描述 + 诊断详情 + recovery 按钮，附一条分隔线。
+   */
+  standalone?: boolean
+}
+
+/**
+ * 助手消息的错误尾部（诊断详情 + recovery 按钮 + 简短错误描述）。
+ *
+ * 抽出这个组件是为了让「Pi runtime 已经吐了正文，但收尾时上游报错」这种混合消息
+ * 也能保留正文的 markdown 排版，同时把错误提示以尾部 banner 形式挂在最下面。
+ *
+ * standalone=true 时兼容旧 ErrorMessage 的行为：把 error.message / content 里的所有 text
+ * 一并作为红色 MessageResponse 渲染出来，用于「没有正文，只有错误」的场景。
+ */
+export function AssistantErrorTail({
+  message,
+  onRetry,
+  onRetryInNewSession,
+  onCompact,
+  standalone = false,
+}: AssistantErrorTailProps): React.ReactElement | null {
   const errorText = message.error?.message ?? '未知错误'
 
   const msgAny = message as unknown as Record<string, unknown>
@@ -1049,14 +1107,18 @@ function ErrorMessage({ message, onRetry, onRetryInNewSession, onCompact }: Erro
   const setModelSelectorOpen = useSetAtom(modelSelectorOpenAtom)
   const [detailsOpen, setDetailsOpen] = React.useState(false)
 
-  const contentText = message.message?.content
-    ?.filter((b) => b.type === 'text' && 'text' in b)
-    .map((b) => (b as { text: string }).text)
-    .join('\n') ?? errorText
+  // standalone 模式（纯错误消息）：把 content 里所有 text 用双换行拼起来一并渲染，保留 markdown 段落结构。
+  // tail 模式（混合消息）：正文已由上层渲染，这里只用 error.message 作为简短提示。
+  const bodyText = standalone
+    ? (message.message?.content
+        ?.filter((b) => b.type === 'text' && 'text' in b)
+        .map((b) => (b as { text: string }).text)
+        .join('\n\n') || errorText)
+    : errorText
   const isThinkingSignature = errorCode === THINKING_SIGNATURE_ERROR_CODE ||
-    isThinkingSignatureError(contentText, errorText)
+    isThinkingSignatureError(bodyText, errorText)
   const displayTitle = errorTitle ?? (isThinkingSignature ? THINKING_SIGNATURE_ERROR_TITLE : undefined)
-  const displayContentText = isThinkingSignature ? THINKING_SIGNATURE_ERROR_MESSAGE : contentText
+  const displayContentText = isThinkingSignature ? THINKING_SIGNATURE_ERROR_MESSAGE : bodyText
   const displayedErrorActions = (errorActions ?? []).filter((action) => {
     if (action.action === 'retry' && !onRetry) return false
     if (action.action === 'compact' && !onCompact) return false
@@ -1124,6 +1186,110 @@ function ErrorMessage({ message, onRetry, onRetryInNewSession, onCompact }: Erro
   const hasLegacyActions = !!(onRetry || onRetryInNewSession || (isPromptTooLong && onCompact))
   const hasActions = hasStructuredActions || hasLegacyActions
 
+  // tail 模式：给出上边距 + 顶部细边分隔线，让它视觉上是「正文之后的一段警告」而不是「消息本身」
+  const rootClass = standalone
+    ? undefined
+    : 'mt-3 pt-3 border-t border-destructive/20'
+
+  return (
+    <div className={rootClass}>
+      {displayTitle && (
+        <div className="text-sm font-medium text-destructive mb-1 flex items-center gap-1.5">
+          {!standalone && <AlertTriangle size={14} className="shrink-0" />}
+          {displayTitle}
+        </div>
+      )}
+      {standalone ? (
+        <div className="text-destructive">
+          <MessageResponse>{displayContentText}</MessageResponse>
+        </div>
+      ) : (
+        displayContentText && (
+          <div className="text-sm text-destructive/90 whitespace-pre-wrap break-words">
+            {displayContentText}
+          </div>
+        )
+      )}
+      {errorDetails && errorDetails.length > 0 && (
+        <div className="mt-2 text-[11px] text-muted-foreground">
+          <button
+            type="button"
+            onClick={() => setDetailsOpen((v) => !v)}
+            className="underline-offset-2 hover:underline"
+          >
+            {detailsOpen ? '收起诊断详情' : '查看诊断详情'}
+          </button>
+          {detailsOpen && (
+            <ul className="mt-1.5 space-y-0.5 list-disc list-inside">
+              {errorDetails.map((d, i) => (
+                <li key={i}>{d}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+      {hasActions && (
+        <div className="flex items-center flex-wrap gap-2 mt-3">
+          {hasStructuredActions &&
+            displayedErrorActions.map((a, i) => (
+              <Button
+                key={`${a.action}-${i}`}
+                size="sm"
+                variant={i === 0 ? 'default' : 'outline'}
+                onClick={() => handleRecoveryAction(a)}
+              >
+                {iconForAction(a.action)}
+                {a.label}
+              </Button>
+            ))}
+          {!hasStructuredActions && isPromptTooLong && onCompact && (
+            <Button size="sm" onClick={onCompact}>
+              <Minimize2 className="size-3.5 mr-1.5" />
+              压缩上下文
+            </Button>
+          )}
+          {!hasStructuredActions && isThinkingSignature && onRetryInNewSession && (
+            <Button
+              size="sm"
+              onClick={onRetryInNewSession}
+              title="新建对话并引用当前会话继续"
+            >
+              <Plus className="size-3.5 mr-1.5" />
+              在新对话继续
+            </Button>
+          )}
+          {!hasStructuredActions && onRetry && (
+            <Button size="sm" variant={isPromptTooLong || isThinkingSignature ? 'outline' : 'default'} onClick={() => onRetry(typeof message.uuid === 'string' ? message.uuid : undefined)}>
+              <RotateCw className="size-3.5 mr-1.5" />
+              重试
+            </Button>
+          )}
+          {!hasStructuredActions && !isThinkingSignature && onRetryInNewSession && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={onRetryInNewSession}
+              title="如遇到未知错误，可点此按钮在新会话中尝试解决"
+            >
+              <Plus className="size-3.5 mr-1.5" />
+              在新会话中重试
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ErrorMessage({ message, onRetry, onRetryInNewSession, onCompact }: ErrorMessageProps): React.ReactElement {
+  const meta = extractMeta(message as unknown as SDKMessage)
+
+  // 复用 AssistantErrorTail 的正文/详情/按钮逻辑，只在这里补上「独立错误消息」的 Message 外壳。
+  const copyText = message.message?.content
+    ?.filter((b) => b.type === 'text' && 'text' in b)
+    .map((b) => (b as { text: string }).text)
+    .join('\n\n') || (message.error?.message ?? '未知错误')
+
   return (
     <Message from="assistant">
       <MessageHeader
@@ -1136,86 +1302,16 @@ function ErrorMessage({ message, onRetry, onRetryInNewSession, onCompact }: Erro
         }
       />
       <MessageContent>
-        {displayTitle && (
-          <div className="text-sm font-medium text-destructive mb-1">{displayTitle}</div>
-        )}
-        <div className="text-destructive">
-          <MessageResponse>{displayContentText}</MessageResponse>
-        </div>
-        {errorDetails && errorDetails.length > 0 && (
-          <div className="mt-2 text-[11px] text-muted-foreground">
-            <button
-              type="button"
-              onClick={() => setDetailsOpen((v) => !v)}
-              className="underline-offset-2 hover:underline"
-            >
-              {detailsOpen ? '收起诊断详情' : '查看诊断详情'}
-            </button>
-            {detailsOpen && (
-              <ul className="mt-1.5 space-y-0.5 list-disc list-inside">
-                {errorDetails.map((d, i) => (
-                  <li key={i}>{d}</li>
-                ))}
-              </ul>
-            )}
-          </div>
-        )}
-        {hasActions && (
-          <div className="flex items-center flex-wrap gap-2 mt-3">
-            {hasStructuredActions &&
-              displayedErrorActions.map((a, i) => (
-                <Button
-                  key={`${a.action}-${i}`}
-                  size="sm"
-                  variant={i === 0 ? 'default' : 'outline'}
-                  onClick={() => handleRecoveryAction(a)}
-                >
-                  {iconForAction(a.action)}
-                  {a.label}
-                </Button>
-              ))}
-            {!hasStructuredActions && isPromptTooLong && onCompact && (
-              <Button size="sm" onClick={onCompact}>
-                <Minimize2 className="size-3.5 mr-1.5" />
-                压缩上下文
-              </Button>
-            )}
-            {!hasStructuredActions && isThinkingSignature && onRetryInNewSession && (
-              <Button
-                size="sm"
-                onClick={onRetryInNewSession}
-                title="新建对话并引用当前会话继续"
-              >
-                <Plus className="size-3.5 mr-1.5" />
-                在新对话继续
-              </Button>
-            )}
-            {!hasStructuredActions && onRetry && (
-              <Button
-                size="sm"
-                variant={isPromptTooLong || isThinkingSignature ? 'outline' : 'default'}
-                onClick={() => onRetry(typeof message.uuid === 'string' ? message.uuid : undefined)}
-              >
-                <RotateCw className="size-3.5 mr-1.5" />
-                重试
-              </Button>
-            )}
-            {!hasStructuredActions && !isThinkingSignature && onRetryInNewSession && (
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={onRetryInNewSession}
-                title="如遇到未知错误，可点此按钮在新会话中尝试解决"
-              >
-                <Plus className="size-3.5 mr-1.5" />
-                在新会话中重试
-              </Button>
-            )}
-          </div>
-        )}
+        <AssistantErrorTail
+          message={message}
+          onRetry={onRetry}
+          onRetryInNewSession={onRetryInNewSession}
+          onCompact={onCompact}
+          standalone
+        />
       </MessageContent>
       <MessageActions className="pl-[46px] mt-0.5">
-        <CopyButton content={displayContentText} />
+        <CopyButton content={copyText} />
       </MessageActions>
     </Message>
   )

--- a/bun.lock
+++ b/bun.lock
@@ -211,6 +211,9 @@
       },
     },
   },
+  "patchedDependencies": {
+    "@earendil-works/pi-ai@0.80.9": "patches/@earendil-works%2Fpi-ai@0.80.9.patch",
+  },
   "overrides": {
     "@anthropic-ai/claude-agent-sdk": "0.3.201",
     "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.201",

--- a/package.json
+++ b/package.json
@@ -44,5 +44,6 @@
     "@earendil-works/pi-tui": "0.80.9"
   },
   "patchedDependencies": {
-  }
+  "@earendil-works/pi-ai@0.80.9": "patches/@earendil-works%2Fpi-ai@0.80.9.patch"
+}
 }

--- a/patches/@earendil-works%2Fpi-ai@0.80.9.patch
+++ b/patches/@earendil-works%2Fpi-ai@0.80.9.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/utils/retry.js b/dist/utils/retry.js
+index b3c27c8d5fb9a77c117af7ab8f789170903d5252..42b41a67c5607ef605fba6340882db6fecac0c49 100644
+--- a/dist/utils/retry.js
++++ b/dist/utils/retry.js
+@@ -57,6 +57,8 @@ const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
+     // "stream ended without ..." and "Anthropic stream ended before message_stop"
+     // (#4433); Bedrock/Smithy can throw an HTTP/2 no-response error (#3594).
+     "ended without",
++    // OpenAI Responses can close an SSE stream before sending its terminal event.
++    "stream ended before (?:a )?terminal response event",
+     "stream ended before message_stop",
+     "http2 request did not get a response",
+     // Provider-requested retry delay cap failures should flow through the outer


### PR DESCRIPTION
## 概述
修复 Pi runtime 在 OpenAI Responses SSE 流未发送 terminal event 时的恢复路径。该错误现在由 Pi session 内部的 native retry 识别并通过 `agent.continue()` 续跑，不会由 Proma 编排层重放原始用户 prompt，因此不会重复已经完成的工具副作用。

## 改动
- `patches/@earendil-works%2Fpi-ai@0.80.9.patch`、`package.json`、`bun.lock` — 为上游当前锁定的 `pi-ai@0.80.9` 增加精确的 OpenAI Responses terminal-event retry matcher；以 Bun patched dependency 方式持久化。
- `apps/electron/src/main/lib/adapters/pi-native-retry.test.ts` — 覆盖该错误可重试、无关 stream-ended 文本不误判、quota/billing 错误不重试。
- `apps/electron/src/main/lib/error-patterns.ts` 与测试 — 收紧外层断流识别，仅覆盖 OpenAI terminal event 和 Anthropic `message_stop` 两个已知文本。
- `apps/electron/src/main/lib/adapters/pi-message-adapter.ts` 与测试 — 仅将 `stopReason: error` 的 provider error 持久化为终态错误，避免 aborted/stop 等非终态消息出现误导性的失败 banner。
- `apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx` — 区分 orchestrator 纯错误与 Pi“正文 + provider error”混合消息；保留已输出正文，并在末尾显示带恢复操作的错误提示。
- `apps/electron/src/renderer/components/agent/AgentView.tsx` — 手动重试时按 upstream 的错误 UUID 同步更新 React/LRU cache；主进程仍使用 upstream 已有的原子 JSONL 删除机制。

## 测试方法
1. 运行 `bun test apps/electron/src/main/lib/error-patterns.test.ts apps/electron/src/main/lib/adapters/pi-message-adapter.test.ts apps/electron/src/main/lib/adapters/pi-native-retry.test.ts`，共 40 项断言通过。
2. 运行 `bun run typecheck`，所有 workspace 包通过。
3. 运行 `bun install --force --frozen-lockfile`，确认 `pi-ai@0.80.9` patch 被重新应用；随后运行 native retry 测试通过。
4. 对最终 diff 执行 Windows 兼容性静态扫描：未新增 POSIX 路径、Unix-only shell 调用、平台分支、macOS 专用快捷键或不兼容打包脚本。

## 备注
- PR 基于最新 `main` (`97313483`) 重建，合并了 upstream 已有的“按错误 UUID 原子删除历史错误”机制，未保留旧分支中重复的 IPC/非原子 JSONL 重写实现。
- Pi 不再允许进入 Proma orchestrator 的 prompt-replay retry；若 Pi native retry 耗尽，错误将作为最终失败展示。