### PR TITLE
fix(file-browser): 默认应用探测失败时保留系统打开入口【已审核 PR】

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -800,9 +800,12 @@ if let appUrl = NSWorkspace.shared.urlForApplication(toOpen: url) {
 
   const iconDataUrl = await getAppIconDataUrl(appPath).catch((e) => { console.warn('[DefaultApp] getAppIconDataUrl 失败:', e); return '' })
   console.log('[DefaultApp] iconDataUrl 长度:', iconDataUrl?.length)
-  if (!iconDataUrl) return cacheNull(cacheKey)
 
-  const info: import('@proma/shared').DefaultAppInfo = { name: appName, appPath, iconDataUrl }
+  const info: import('@proma/shared').DefaultAppInfo = {
+    name: appName,
+    appPath,
+    ...(iconDataUrl ? { iconDataUrl } : {}),
+  }
   defaultAppCache.set(cacheKey, info)
   defaultAppFailureCache.delete(cacheKey)
   saveCachedDefaultAppInfo(cacheKey, info)

--- a/apps/electron/src/main/lib/default-app-cache.ts
+++ b/apps/electron/src/main/lib/default-app-cache.ts
@@ -34,13 +34,18 @@ function normalizeEntry(value: unknown): DefaultAppCacheEntry | null {
   if (
     typeof name !== 'string' ||
     typeof appPath !== 'string' ||
-    typeof iconDataUrl !== 'string' ||
+    (iconDataUrl !== undefined && typeof iconDataUrl !== 'string') ||
     typeof updatedAt !== 'number'
   ) {
     return null
   }
-  if (!name || !appPath || !iconDataUrl) return null
-  return { name, appPath, iconDataUrl, updatedAt }
+  if (!name || !appPath) return null
+  return {
+    name,
+    appPath,
+    ...(iconDataUrl ? { iconDataUrl } : {}),
+    updatedAt,
+  }
 }
 
 function loadCache(): void {
@@ -92,7 +97,7 @@ export function getCachedDefaultAppInfo(cacheKey: string): DefaultAppInfo | null
   return {
     name: entry.name,
     appPath: entry.appPath,
-    iconDataUrl: entry.iconDataUrl,
+    ...(entry.iconDataUrl ? { iconDataUrl: entry.iconDataUrl } : {}),
   }
 }
 

--- a/apps/electron/src/renderer/components/diff/DefaultAppOpenButton.tsx
+++ b/apps/electron/src/renderer/components/diff/DefaultAppOpenButton.tsx
@@ -3,10 +3,11 @@
  *
  * 通过 useDefaultAppForFile 拿到本机为该文件类型注册的默认 App（含图标），
  * 渲染一个按钮；点击调用 systemOpenFile 让系统按默认 App 打开。
- * 探测失败或图标读取失败时不渲染。
+ * 探测失败时不渲染；图标读取失败时使用通用图标。
  */
 
 import * as React from 'react'
+import { ExternalLink } from 'lucide-react'
 import type { FileAccessOptions } from '@proma/shared'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useDefaultAppForFile } from '@/hooks/useDefaultAppForFile'
@@ -52,12 +53,16 @@ export function DefaultAppOpenButton({
           )}
           aria-label={`用 ${info.name} 打开`}
         >
-          <img
-            src={info.iconDataUrl}
-            alt=""
-            className={cn('shrink-0', labeled ? 'size-4' : 'size-3.5')}
-            draggable={false}
-          />
+          {info.iconDataUrl ? (
+            <img
+              src={info.iconDataUrl}
+              alt=""
+              className={cn('shrink-0', labeled ? 'size-4' : 'size-3.5')}
+              draggable={false}
+            />
+          ) : (
+            <ExternalLink className={cn('shrink-0', labeled ? 'size-4' : 'size-3.5')} />
+          )}
           {labeled && (
             <span className="text-[11px] leading-none truncate">{info.name}</span>
           )}

--- a/apps/electron/src/renderer/components/file-browser/DefaultAppMenuItem.test.tsx
+++ b/apps/electron/src/renderer/components/file-browser/DefaultAppMenuItem.test.tsx
@@ -1,0 +1,16 @@
+import { expect, test } from 'bun:test'
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { DefaultAppMenuItem } from './DefaultAppMenuItem'
+
+test('renders the system default open command when default app discovery is unavailable', () => {
+  const markup = renderToStaticMarkup(
+    <DropdownMenuPrimitive.Root open>
+      <DropdownMenuPrimitive.Content forceMount>
+        <DefaultAppMenuItem filePath="/tmp/report.md" />
+      </DropdownMenuPrimitive.Content>
+    </DropdownMenuPrimitive.Root>,
+  )
+
+  expect(markup).toContain('用系统默认应用打开')
+})

--- a/apps/electron/src/renderer/components/file-browser/DefaultAppMenuItem.tsx
+++ b/apps/electron/src/renderer/components/file-browser/DefaultAppMenuItem.tsx
@@ -1,11 +1,12 @@
 /**
  * DefaultAppMenuItem — DropdownMenuItem 形式的"用默认 App 打开"。
  *
- * 探测本机为该文件类型注册的默认 App，菜单项文案动态显示「用 XX 打开」并带 App Logo。
- * 探测失败（图标读取失败、文件类型未注册默认 App、平台不支持）时整个菜单项不渲染。
+ * 探测本机为该文件类型注册的默认 App，成功时显示「用 XX 打开」并带 App Logo。
+ * 探测失败时保留「用系统默认应用打开」命令，保证系统打开能力不依赖显示元数据。
  */
 
 import * as React from 'react'
+import { ExternalLink } from 'lucide-react'
 import { DropdownMenuItem } from '@/components/ui/dropdown-menu'
 import { useDefaultAppForFile } from '@/hooks/useDefaultAppForFile'
 
@@ -17,10 +18,8 @@ interface DefaultAppMenuItemProps {
 export function DefaultAppMenuItem({
   filePath,
   className,
-}: DefaultAppMenuItemProps): React.ReactElement | null {
+}: DefaultAppMenuItemProps): React.ReactElement {
   const info = useDefaultAppForFile(filePath)
-
-  if (!info) return null
 
   return (
     <DropdownMenuItem
@@ -31,13 +30,19 @@ export function DefaultAppMenuItem({
         })
       }}
     >
-      <img
-        src={info.iconDataUrl}
-        alt=""
-        className="size-3.5 shrink-0"
-        draggable={false}
-      />
-      <span className="truncate">用 {info.name} 打开</span>
+      {info?.iconDataUrl ? (
+        <img
+          src={info.iconDataUrl}
+          alt=""
+          className="size-3.5 shrink-0"
+          draggable={false}
+        />
+      ) : (
+        <ExternalLink className="size-3.5 shrink-0" />
+      )}
+      <span className="truncate">
+        {info?.name ? `用 ${info.name} 打开` : '用系统默认应用打开'}
+      </span>
     </DropdownMenuItem>
   )
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/shared",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "license": "AGPL-3.0-only",
   "description": "Shared types, configs and utilities for proma",
   "type": "module",

--- a/packages/shared/src/types/runtime.ts
+++ b/packages/shared/src/types/runtime.ts
@@ -253,8 +253,8 @@ export interface DefaultAppInfo {
   name: string
   /** 应用绝对路径（macOS 为 .app bundle，Windows 为 .exe），用于点击打开/调试 */
   appPath: string
-  /** App 图标的 PNG dataURL；通过 Electron app.getFileIcon 抓取 */
-  iconDataUrl: string
+  /** App 图标的 PNG dataURL；通过 Electron app.getFileIcon 抓取。图标读取失败时可省略。 */
+  iconDataUrl?: string
 }
 
 /**


### PR DESCRIPTION
## 概述

工作区文件的三点菜单此前将“系统默认应用打开”命令与默认应用名称、图标探测绑定。macOS 的 LaunchServices、Swift 调用或图标转换任一失败时，菜单项会被整体隐藏。本 PR 将系统打开命令与展示元数据解耦，确保用户始终可以尝试交由操作系统打开单个文件。

## 改动

- `apps/electron/src/renderer/components/file-browser/DefaultAppMenuItem.tsx` — 对单文件始终渲染系统打开命令；探测成功时显示具体 App 名称和图标，探测失败时显示“用系统默认应用打开”及通用图标。
- `apps/electron/src/main/ipc.ts` — 默认 App 已识别但图标提取失败时仍返回名称和路径，不再将其视为探测失败。
- `packages/shared/src/types/runtime.ts` — 将 `DefaultAppInfo.iconDataUrl` 调整为可选字段，表达“有默认应用、无可用图标”的合法状态。
- `apps/electron/src/main/lib/default-app-cache.ts` — 缓存读写兼容无图标的默认 App 信息，同时保持对已有缓存的兼容。
- `apps/electron/src/renderer/components/diff/DefaultAppOpenButton.tsx` — 预览面板的默认 App 按钮在缺少图标时改用通用图标。
- `apps/electron/src/renderer/components/file-browser/DefaultAppMenuItem.test.tsx` — 新增回归测试，验证探测无结果时仍显示系统默认应用打开命令。
- `packages/shared/package.json` — 按共享包版本规范递增 patch 版本至 `0.1.43`。

## 测试方法

1. 执行 `bun run typecheck`，确认全部 workspace package 类型检查通过。
2. 执行 `bun test apps/electron/src/renderer/components/file-browser/DefaultAppMenuItem.test.tsx`，确认默认应用信息为空时仍输出通用菜单命令。
3. 执行 `bun run --filter='@proma/electron' build:main` 和 `bun run --filter='@proma/electron' build:renderer`，确认主进程与 renderer 均可构建。
4. 在 macOS 开发版的工作区文件面板中，对单个文件打开三点菜单：无论默认 App 元数据是否探测成功，均应保留系统打开入口；点击后交由系统按文件关联处理。

## 备注

- 本 PR 不改变 `systemOpenFile` 的访问控制与平台分支；macOS 继续使用 `open`，Windows/Linux 继续使用 Electron `shell.openPath`。
- 若系统没有关联应用，系统可能提示选择应用或返回无法打开；本 PR 解决的是 Proma 不应预先隐藏该命令。