### PR TITLE
fix(agent): remember the default reasoning effort

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.15.7",
+  "version": "0.15.8",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/agent-session-manager.test.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.test.ts
@@ -151,15 +151,55 @@ describe('Agent 会话 JSONL 读取', () => {
 })
 
 describe('Agent 会话 runtime 元数据', () => {
-  test('Given 新建会话 When 指定或省略 runtime Then 持久化指定值并默认 Pi', () => {
-    const defaultRuntimeSession = manager.createAgentSession('默认内核会话')
-    const claudeRuntimeSession = manager.createAgentSession('Claude 内核会话', undefined, undefined, undefined, 'claude')
+  test('Given 已保存 OpenAI medium 默认值 When 新建 Pi 或 Claude 会话 Then 默认并持久化 medium', () => {
+    const settingsPath = join(tempHome, '.proma', 'settings.json')
+    mkdirSync(join(tempHome, '.proma'), { recursive: true })
+    writeFileSync(settingsPath, JSON.stringify({
+      agentThinking: { type: 'adaptive' },
+      agentEffort: 'max',
+      defaultOpenAIThinkingLevel: 'medium',
+    }), 'utf-8')
 
-    expect(defaultRuntimeSession.agentRuntime).toBe('pi')
-    expect(claudeRuntimeSession.agentRuntime).toBe('claude')
-    expect(manager.getAgentSessionMeta(defaultRuntimeSession.id)?.agentRuntime).toBe('pi')
-    expect(manager.getAgentSessionMeta(claudeRuntimeSession.id)?.agentRuntime).toBe('claude')
-    expect(defaultRuntimeSession.openAIThinkingLevel).toBe('high')
+    try {
+      const defaultRuntimeSession = manager.createAgentSession('默认内核会话')
+      const claudeRuntimeSession = manager.createAgentSession('Claude 内核会话', undefined, undefined, undefined, 'claude')
+
+      expect(defaultRuntimeSession.agentRuntime).toBe('pi')
+      expect(claudeRuntimeSession.agentRuntime).toBe('claude')
+      expect(manager.getAgentSessionMeta(defaultRuntimeSession.id)?.agentRuntime).toBe('pi')
+      expect(manager.getAgentSessionMeta(claudeRuntimeSession.id)?.agentRuntime).toBe('claude')
+      expect(defaultRuntimeSession.openAIThinkingLevel).toBe('medium')
+      expect(claudeRuntimeSession.openAIThinkingLevel).toBe('medium')
+      expect(manager.getAgentSessionMeta(defaultRuntimeSession.id)?.openAIThinkingLevel).toBe('medium')
+      expect(manager.getAgentSessionMeta(claudeRuntimeSession.id)?.openAIThinkingLevel).toBe('medium')
+    } finally {
+      rmSync(settingsPath, { force: true })
+    }
+  })
+
+  test('Given 新安装用户保存关闭思考 When 连续新建会话 Then 不被旧版迁移改回 high', () => {
+    const settingsPath = join(tempHome, '.proma', 'settings.json')
+    const indexPath = join(tempHome, '.proma', 'agent-sessions.json')
+    const indexBackupPath = `${indexPath}.bak`
+    rmSync(indexPath, { force: true })
+    rmSync(indexBackupPath, { force: true })
+    writeFileSync(settingsPath, JSON.stringify({
+      agentThinking: { type: 'adaptive' },
+      agentEffort: 'medium',
+      defaultOpenAIThinkingLevel: 'off',
+    }), 'utf-8')
+
+    try {
+      const firstSession = manager.createAgentSession('关闭思考会话一')
+      const secondSession = manager.createAgentSession('关闭思考会话二')
+
+      expect(manager.getAgentSessionMeta(firstSession.id)?.openAIThinkingLevel).toBe('off')
+      expect(manager.getAgentSessionMeta(secondSession.id)?.openAIThinkingLevel).toBe('off')
+    } finally {
+      rmSync(settingsPath, { force: true })
+      rmSync(indexPath, { force: true })
+      rmSync(indexBackupPath, { force: true })
+    }
   })
 
   test('Given Codex session settings When updating Then persists depth per session', () => {

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -23,6 +23,8 @@ import {
   getSdkConfigDir,
 } from './config-paths'
 import { getAgentWorkspace, getWorkspaceAutoMemoryDir } from './agent-workspace-manager'
+import { resolvePiThinkingLevel } from './agent-thinking-level'
+import { getSettings } from './settings-service'
 
 // 在模块加载时一次性设置 SDK 配置目录，避免在 forkSession 等异步调用中临时修改/恢复
 // process.env 导致的并发安全问题（异步操作的 await 间隙其他代码可能读到错误值）
@@ -175,7 +177,11 @@ function readIndex(): AgentSessionsIndex {
     }
     return data
   }
-  return { version: INDEX_VERSION, sessions: [] }
+  return {
+    version: INDEX_VERSION,
+    sessions: [],
+    openAIThinkingDefaultEnabledMigrationCompleted: true,
+  }
 }
 
 /**
@@ -221,6 +227,9 @@ export function createAgentSession(
   const index = readIndex()
   const now = Date.now()
 
+  const settings = getSettings()
+  const defaultThinkingLevel = settings.defaultOpenAIThinkingLevel
+    ?? resolvePiThinkingLevel(settings, undefined, 'openai-codex')
   const meta: AgentSessionMeta = {
     id: randomUUID(),
     title: title || '新 Agent 会话',
@@ -228,8 +237,8 @@ export function createAgentSession(
     modelId,
     workspaceId,
     agentRuntime,
-    // OpenAI 推理配置从创建起归属于会话；默认启用高思考深度。
-    openAIThinkingLevel: 'high',
+    // 新会话继承已持久化的全局思考偏好，之后仍可按会话单独调整。
+    openAIThinkingLevel: defaultThinkingLevel,
     createdAt: now,
     updatedAt: now,
   }

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -1874,6 +1874,13 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     try {
       const updated = await window.electronAPI.updateSessionOpenAIThinkingLevel(sessionId, thinkingLevel)
       setAgentSessions((prev) => prev.map((item) => item.id === sessionId ? updated : item))
+
+      try {
+        await window.electronAPI.updateSettings({ defaultOpenAIThinkingLevel: thinkingLevel })
+      } catch (error) {
+        console.error('[AgentView] 保存 OpenAI 默认思考深度失败:', error)
+        toast.error('默认思考深度保存失败', { description: getErrorMessage(error) })
+      }
     } catch (error) {
       console.error('[AgentView] 更新 OpenAI 思考深度失败:', error)
       setAgentSessions((prev) => prev.map((item) => item.id === sessionId ? previousSessionMeta : item))

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -4,7 +4,7 @@
  * 主题模式、IPC 通道等设置相关定义。
  */
 
-import type { AgentRuntime, EnvironmentCheckResult, ThinkingConfig, AgentEffort, FeishuSessionMirrorSettings } from '@proma/shared'
+import type { AgentRuntime, EnvironmentCheckResult, ThinkingConfig, AgentEffort, AgentThinkingLevel, FeishuSessionMirrorSettings } from '@proma/shared'
 
 /** 通知音场景类型 */
 export type NotificationSoundType = 'taskComplete' | 'permissionRequest' | 'exitPlanMode'
@@ -227,6 +227,8 @@ export interface AppSettings {
   agentThinking?: ThinkingConfig
   /** Agent 推理深度 */
   agentEffort?: AgentEffort
+  /** OpenAI 新会话默认思考深度 */
+  defaultOpenAIThinkingLevel?: AgentThinkingLevel
   /** Agent 最大预算（美元/次） */
   agentMaxBudgetUsd?: number
   /** Agent 最大轮次（0 或 undefined = SDK 默认） */


### PR DESCRIPTION
## Summary

- remember the last OpenAI/Codex reasoning level selected in the Agent thinking control
- initialize every new Agent session from that persisted default, including automation, collaboration, bridge, and fork flows that share `createAgentSession()`
- keep the OpenAI default separate from the generic Claude/Pi `agentThinking` and `agentEffort` settings
- preserve existing per-session overrides and legacy-setting fallback behavior

## Problem

`createAgentSession()` currently persists `openAIThinkingLevel: 'high'` for every new session. This overrides the saved global preference and makes users re-select Medium (or another level) in each new conversation.

## Implementation

- add `AppSettings.defaultOpenAIThinkingLevel`
- persist the selected OpenAI level after the current session update succeeds
- make `createAgentSession()` prefer the dedicated saved default, falling back to the existing global resolver for backward compatibility
- mark fresh session indexes as having completed the legacy `off -> high` migration, so a newly selected `off` default is not rewritten on the next session creation

## Verification

- focused Bun tests: **12 passed, 0 failed**
- workspace typecheck: **passed**
- renderer build: **passed**
- Electron main build: **passed**
- independent review: **approved**

The repository-wide `bun test` result is **398 passed / 2 failed** on both this branch and `origin/main`. The same pre-existing Electron mock isolation failures (`BrowserWindow` / `shell` named exports) reproduce on the baseline, so this change introduces no additional test failure.
