### PR TITLE
Fix Ark GLM-5.2 output token cap

### DIFF
--- a/apps/electron/src/main/lib/adapters/pi-model-registry.test.ts
+++ b/apps/electron/src/main/lib/adapters/pi-model-registry.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test'
+import { buildModel } from './pi-model-registry'
+
+describe('Pi runtime 火山方舟 GLM-5.2 输出限制', () => {
+  test.each([
+    ['doubao', 'https://ark.cn-beijing.volces.com/api/v3'],
+    ['ark-coding-plan', 'https://ark.cn-beijing.volces.com/api/plan'],
+  ] as const)(
+    'Given %s 的 GLM-5.2 When buildModel Then 使用 128000 输出上限',
+    async (provider, baseUrl) => {
+      const sdk = await import('@earendil-works/pi-coding-agent')
+      const result = await buildModel(sdk, {
+        sessionId: `session-${provider}-glm-52`,
+        prompt: 'hi',
+        apiKey: 'test-key',
+        provider,
+        baseUrl,
+        model: 'glm-5.2',
+        permissionMode: 'plan',
+        systemPrompt: 'system',
+        piAgentDir: '/tmp/pi-agent',
+        piSessionDir: '/tmp/pi-session',
+      })
+
+      expect(result.model.maxTokens).toBe(128_000)
+    },
+  )
+})

--- a/apps/electron/src/main/lib/adapters/pi-model-registry.ts
+++ b/apps/electron/src/main/lib/adapters/pi-model-registry.ts
@@ -239,7 +239,8 @@ async function findPiCatalogModel(provider: ProviderType, modelId: string): Prom
 
 async function resolvePiModelDefaults(input: PiAgentQueryOptions): Promise<PiModelDefaults> {
   const catalogModel = input.model ? await findPiCatalogModel(input.provider, input.model) : undefined
-  const isVolcengineGlm52 = input.provider === 'doubao' && input.model?.toLowerCase() === 'glm-5.2'
+  const isVolcengineGlm52 = (input.provider === 'doubao' || input.provider === 'ark-coding-plan')
+    && input.model?.toLowerCase() === 'glm-5.2'
   const catalogContextWindow = catalogModel?.contextWindow ?? DEFAULT_CONTEXT_WINDOW
   const inferredContextWindow = inferAgentSdkContextWindow(input.model, input.provider) ?? DEFAULT_CONTEXT_WINDOW
   return {


### PR DESCRIPTION
## Summary

- c6c52e12 fix(agent): cap Ark GLM-5.2 output tokens

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归