### PR TITLE
fix(agent): silence delegated completion notifications

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.15.7",
+  "version": "0.15.8",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/agent-completion-payload.test.ts
+++ b/apps/electron/src/main/lib/agent-completion-payload.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'bun:test'
-import { buildAgentStreamCompletePayload } from './agent-completion-payload'
+import { AGENT_IPC_CHANNELS } from '@proma/shared'
+import type { AgentStreamCompletePayload } from '@proma/shared'
+import {
+  buildAgentStreamCompletePayload,
+  sendAgentStreamComplete,
+} from './agent-completion-payload'
 
 describe('Agent 完成载荷来源', () => {
   test('Given 委派子会话 When 构建完成载荷 Then 保留 delegation 来源', () => {
@@ -24,6 +29,66 @@ describe('Agent 完成载荷来源', () => {
       ),
     ).toEqual({
       sessionId: 'parent-1',
+      triggeredBy: undefined,
+      messages: [],
+    })
+  })
+})
+
+describe('Agent 完成 IPC sender', () => {
+  function createTarget(): {
+    sent: Array<{ channel: string; payload: AgentStreamCompletePayload }>
+    target: { send: (channel: string, payload: AgentStreamCompletePayload) => void }
+  } {
+    const sent: Array<{ channel: string; payload: AgentStreamCompletePayload }> = []
+    return {
+      sent,
+      target: {
+        send: (channel, payload) => { sent.push({ channel, payload }) },
+      },
+    }
+  }
+
+  test('Given 委派正常完成 When 发送完成 IPC Then 使用正确 channel 并保留 delegation 来源', () => {
+    const { sent, target } = createTarget()
+
+    sendAgentStreamComplete(
+      target,
+      { sessionId: 'child-normal', triggeredBy: 'delegation' },
+      { messages: [], stoppedByUser: false },
+    )
+
+    expect(sent).toEqual([{
+      channel: AGENT_IPC_CHANNELS.STREAM_COMPLETE,
+      payload: {
+        sessionId: 'child-normal',
+        triggeredBy: 'delegation',
+        messages: [],
+        stoppedByUser: false,
+      },
+    }])
+  })
+
+  test('Given 委派 defensive/catch 完成 When 发送完成 IPC Then 仍保留 delegation 来源', () => {
+    const { sent, target } = createTarget()
+
+    sendAgentStreamComplete(
+      target,
+      { sessionId: 'child-catch', triggeredBy: 'delegation' },
+      { messages: [], stoppedByUser: false, startedAt: 100 },
+    )
+
+    expect(sent[0]?.channel).toBe(AGENT_IPC_CHANNELS.STREAM_COMPLETE)
+    expect(sent[0]?.payload.triggeredBy).toBe('delegation')
+  })
+
+  test('Given 历史调用未提供来源 When 发送完成 IPC Then undefined 来源保持兼容', () => {
+    const { sent, target } = createTarget()
+
+    sendAgentStreamComplete(target, { sessionId: 'parent-legacy' }, { messages: [] })
+
+    expect(sent[0]?.payload).toEqual({
+      sessionId: 'parent-legacy',
       triggeredBy: undefined,
       messages: [],
     })

--- a/apps/electron/src/main/lib/agent-completion-payload.test.ts
+++ b/apps/electron/src/main/lib/agent-completion-payload.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test'
+import { buildAgentStreamCompletePayload } from './agent-completion-payload'
+
+describe('Agent 完成载荷来源', () => {
+  test('Given 委派子会话 When 构建完成载荷 Then 保留 delegation 来源', () => {
+    expect(
+      buildAgentStreamCompletePayload(
+        { sessionId: 'child-1', triggeredBy: 'delegation' },
+        { stoppedByUser: false, startedAt: 100 },
+      ),
+    ).toEqual({
+      sessionId: 'child-1',
+      triggeredBy: 'delegation',
+      stoppedByUser: false,
+      startedAt: 100,
+    })
+  })
+
+  test('Given 普通历史调用未提供来源 When 构建完成载荷 Then 保持字段可选', () => {
+    expect(
+      buildAgentStreamCompletePayload(
+        { sessionId: 'parent-1' },
+        { messages: [] },
+      ),
+    ).toEqual({
+      sessionId: 'parent-1',
+      triggeredBy: undefined,
+      messages: [],
+    })
+  })
+})

--- a/apps/electron/src/main/lib/agent-completion-payload.ts
+++ b/apps/electron/src/main/lib/agent-completion-payload.ts
@@ -1,3 +1,4 @@
+import { AGENT_IPC_CHANNELS } from '@proma/shared'
 import type {
   AgentSendInput,
   AgentStreamCompletePayload,
@@ -8,8 +9,12 @@ export type AgentStreamCompletionDetails = Omit<
   'sessionId' | 'triggeredBy'
 >
 
+export interface AgentStreamCompleteTarget {
+  send(channel: string, payload: AgentStreamCompletePayload): void
+}
+
 export function buildAgentStreamCompletePayload(
-  run: Pick<AgentSendInput, 'sessionId' | 'triggeredBy'>,
+  run: Readonly<Pick<AgentSendInput, 'sessionId' | 'triggeredBy'>>,
   details: AgentStreamCompletionDetails = {},
 ): AgentStreamCompletePayload {
   return {
@@ -17,4 +22,15 @@ export function buildAgentStreamCompletePayload(
     triggeredBy: run.triggeredBy,
     ...details,
   }
+}
+
+export function sendAgentStreamComplete(
+  target: AgentStreamCompleteTarget,
+  run: Readonly<Pick<AgentSendInput, 'sessionId' | 'triggeredBy'>>,
+  details: AgentStreamCompletionDetails = {},
+): void {
+  target.send(
+    AGENT_IPC_CHANNELS.STREAM_COMPLETE,
+    buildAgentStreamCompletePayload(run, details),
+  )
 }

--- a/apps/electron/src/main/lib/agent-completion-payload.ts
+++ b/apps/electron/src/main/lib/agent-completion-payload.ts
@@ -1,0 +1,20 @@
+import type {
+  AgentSendInput,
+  AgentStreamCompletePayload,
+} from '@proma/shared'
+
+export type AgentStreamCompletionDetails = Omit<
+  AgentStreamCompletePayload,
+  'sessionId' | 'triggeredBy'
+>
+
+export function buildAgentStreamCompletePayload(
+  run: Pick<AgentSendInput, 'sessionId' | 'triggeredBy'>,
+  details: AgentStreamCompletionDetails = {},
+): AgentStreamCompletePayload {
+  return {
+    sessionId: run.sessionId,
+    triggeredBy: run.triggeredBy,
+    ...details,
+  }
+}

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -36,6 +36,7 @@ import { AgentOrchestrator } from './agent-orchestrator'
 import { getAgentSessionWorkspacePath, getWorkspaceFilesDir } from './config-paths'
 import { getAgentSessionMeta, updateAgentSessionMeta } from './agent-session-manager'
 import { setAgentStopper, setHeadlessAgentRunner } from './agent-headless-runner-registry'
+import { buildAgentStreamCompletePayload } from './agent-completion-payload'
 
 // ===== 实例创建 =====
 
@@ -163,15 +164,17 @@ export async function runAgent(
       },
       onComplete: (messages, opts) => {
         if (!webContents.isDestroyed()) {
-          webContents.send(AGENT_IPC_CHANNELS.STREAM_COMPLETE, {
-            sessionId: input.sessionId,
-            messages,
-            stoppedByUser: opts?.stoppedByUser ?? false,
-            startedAt: opts?.startedAt,
-            resultSubtype: opts?.resultSubtype,
-            resultErrors: opts?.resultErrors,
-            backgroundTasksPending: opts?.backgroundTasksPending,
-          })
+          webContents.send(
+            AGENT_IPC_CHANNELS.STREAM_COMPLETE,
+            buildAgentStreamCompletePayload(input, {
+              messages,
+              stoppedByUser: opts?.stoppedByUser ?? false,
+              startedAt: opts?.startedAt,
+              resultSubtype: opts?.resultSubtype,
+              resultErrors: opts?.resultErrors,
+              backgroundTasksPending: opts?.backgroundTasksPending,
+            }),
+          )
         }
       },
       onTitleUpdated: (title) => {
@@ -195,11 +198,13 @@ export async function runAgent(
         sessionId: input.sessionId,
         error: errorMessage,
       })
-      webContents.send(AGENT_IPC_CHANNELS.STREAM_COMPLETE, {
-        sessionId: input.sessionId,
-        messages: [],
-        stoppedByUser: false,
-      })
+      webContents.send(
+        AGENT_IPC_CHANNELS.STREAM_COMPLETE,
+        buildAgentStreamCompletePayload(input, {
+          messages: [],
+          stoppedByUser: false,
+        }),
+      )
     }
   } finally {
     // 仅在 orchestrator 已完成此会话时清理映射
@@ -249,15 +254,17 @@ export async function runAgentHeadless(
         callbacks.onComplete(messages)
         // 同步到渲染进程
         if (wc && !wc.isDestroyed()) {
-          wc.send(AGENT_IPC_CHANNELS.STREAM_COMPLETE, {
-            sessionId: runInput.sessionId,
-            messages,
-            stoppedByUser: opts?.stoppedByUser ?? false,
-            startedAt: opts?.startedAt,
-            resultSubtype: opts?.resultSubtype,
-            resultErrors: opts?.resultErrors,
-            backgroundTasksPending: opts?.backgroundTasksPending,
-          })
+          wc.send(
+            AGENT_IPC_CHANNELS.STREAM_COMPLETE,
+            buildAgentStreamCompletePayload(runInput, {
+              messages,
+              stoppedByUser: opts?.stoppedByUser ?? false,
+              startedAt: opts?.startedAt,
+              resultSubtype: opts?.resultSubtype,
+              resultErrors: opts?.resultErrors,
+              backgroundTasksPending: opts?.backgroundTasksPending,
+            }),
+          )
         }
       },
       onTitleUpdated: (title) => {
@@ -297,7 +304,14 @@ export async function runAgentHeadless(
     callbacks.onComplete()
     if (wc && !wc.isDestroyed()) {
       wc.send(AGENT_IPC_CHANNELS.STREAM_ERROR, { sessionId: runInput.sessionId, error: errorMessage })
-      wc.send(AGENT_IPC_CHANNELS.STREAM_COMPLETE, { sessionId: runInput.sessionId, messages: [], stoppedByUser: false, startedAt })
+      wc.send(
+        AGENT_IPC_CHANNELS.STREAM_COMPLETE,
+        buildAgentStreamCompletePayload(runInput, {
+          messages: [],
+          stoppedByUser: false,
+          startedAt,
+        }),
+      )
     }
   } finally {
     if (!orchestrator.isActive(runInput.sessionId)) {

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -36,7 +36,7 @@ import { AgentOrchestrator } from './agent-orchestrator'
 import { getAgentSessionWorkspacePath, getWorkspaceFilesDir } from './config-paths'
 import { getAgentSessionMeta, updateAgentSessionMeta } from './agent-session-manager'
 import { setAgentStopper, setHeadlessAgentRunner } from './agent-headless-runner-registry'
-import { buildAgentStreamCompletePayload } from './agent-completion-payload'
+import { sendAgentStreamComplete } from './agent-completion-payload'
 
 // ===== 实例创建 =====
 
@@ -164,17 +164,14 @@ export async function runAgent(
       },
       onComplete: (messages, opts) => {
         if (!webContents.isDestroyed()) {
-          webContents.send(
-            AGENT_IPC_CHANNELS.STREAM_COMPLETE,
-            buildAgentStreamCompletePayload(input, {
-              messages,
-              stoppedByUser: opts?.stoppedByUser ?? false,
-              startedAt: opts?.startedAt,
-              resultSubtype: opts?.resultSubtype,
-              resultErrors: opts?.resultErrors,
-              backgroundTasksPending: opts?.backgroundTasksPending,
-            }),
-          )
+          sendAgentStreamComplete(webContents, input, {
+            messages,
+            stoppedByUser: opts?.stoppedByUser ?? false,
+            startedAt: opts?.startedAt,
+            resultSubtype: opts?.resultSubtype,
+            resultErrors: opts?.resultErrors,
+            backgroundTasksPending: opts?.backgroundTasksPending,
+          })
         }
       },
       onTitleUpdated: (title) => {
@@ -198,13 +195,10 @@ export async function runAgent(
         sessionId: input.sessionId,
         error: errorMessage,
       })
-      webContents.send(
-        AGENT_IPC_CHANNELS.STREAM_COMPLETE,
-        buildAgentStreamCompletePayload(input, {
-          messages: [],
-          stoppedByUser: false,
-        }),
-      )
+      sendAgentStreamComplete(webContents, input, {
+        messages: [],
+        stoppedByUser: false,
+      })
     }
   } finally {
     // 仅在 orchestrator 已完成此会话时清理映射
@@ -254,17 +248,14 @@ export async function runAgentHeadless(
         callbacks.onComplete(messages)
         // 同步到渲染进程
         if (wc && !wc.isDestroyed()) {
-          wc.send(
-            AGENT_IPC_CHANNELS.STREAM_COMPLETE,
-            buildAgentStreamCompletePayload(runInput, {
-              messages,
-              stoppedByUser: opts?.stoppedByUser ?? false,
-              startedAt: opts?.startedAt,
-              resultSubtype: opts?.resultSubtype,
-              resultErrors: opts?.resultErrors,
-              backgroundTasksPending: opts?.backgroundTasksPending,
-            }),
-          )
+          sendAgentStreamComplete(wc, runInput, {
+            messages,
+            stoppedByUser: opts?.stoppedByUser ?? false,
+            startedAt: opts?.startedAt,
+            resultSubtype: opts?.resultSubtype,
+            resultErrors: opts?.resultErrors,
+            backgroundTasksPending: opts?.backgroundTasksPending,
+          })
         }
       },
       onTitleUpdated: (title) => {
@@ -304,14 +295,11 @@ export async function runAgentHeadless(
     callbacks.onComplete()
     if (wc && !wc.isDestroyed()) {
       wc.send(AGENT_IPC_CHANNELS.STREAM_ERROR, { sessionId: runInput.sessionId, error: errorMessage })
-      wc.send(
-        AGENT_IPC_CHANNELS.STREAM_COMPLETE,
-        buildAgentStreamCompletePayload(runInput, {
-          messages: [],
-          stoppedByUser: false,
-          startedAt,
-        }),
-      )
+      sendAgentStreamComplete(wc, runInput, {
+        messages: [],
+        stoppedByUser: false,
+        startedAt,
+      })
     }
   } finally {
     if (!orchestrator.isActive(runInput.sessionId)) {

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -63,7 +63,10 @@ import type { AgentStreamEvent, AgentStreamCompletePayload, AgentEvent, AgentStr
 import { inferAgentSdkContextWindow, inferContextWindow } from '@proma/shared'
 import { buildExternalAgentRunActivation } from '@/lib/external-agent-run'
 import { upsertAgentSession, mergeFetchedAgentSessions } from '@/lib/agent-session-list'
-import { getAgentCompletionMarkers } from '@/lib/agent-completion-presence'
+import {
+  getAgentCompletionMarkers,
+  shouldNotifyAgentCompletion,
+} from '@/lib/agent-completion-presence'
 import { getPlanModeChangeFromToolName, updatePlanModeSessionSet } from '@/lib/agent-plan-mode'
 
 /** 触发右侧文件浏览器自动定位的写入类工具集合 */
@@ -974,11 +977,17 @@ export function useGlobalAgentListeners(): void {
           (!data.resultSubtype || data.resultSubtype === 'success')
 
         // 发送桌面通知（仅真正成功完成时播放提示音，错误/中断/异常完成不伪装成完成）
+        const completionSession = store.get(agentSessionsAtom)
+          .find((session) => session.id === data.sessionId)
+        const shouldNotifyCompletion = shouldNotifyAgentCompletion({
+          completion: data,
+          session: completionSession,
+        })
         const enabled = store.get(notificationsEnabledAtom)
         const soundEnabled = store.get(notificationSoundEnabledAtom)
         const sounds = store.get(notificationSoundsAtom)
         const sessionTitle = getSessionTitle(data.sessionId)
-        if (!backgroundTasksPending && isSuccessfulCompletion) {
+        if (!backgroundTasksPending && isSuccessfulCompletion && shouldNotifyCompletion) {
           sendDesktopNotification(
             'Agent 任务完成',
             `[${sessionTitle}] 任务已完成`,

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -65,7 +65,7 @@ import { buildExternalAgentRunActivation } from '@/lib/external-agent-run'
 import { upsertAgentSession, mergeFetchedAgentSessions } from '@/lib/agent-session-list'
 import {
   getAgentCompletionMarkers,
-  shouldNotifyAgentCompletion,
+  notifyAgentCompletion,
 } from '@/lib/agent-completion-presence'
 import { getPlanModeChangeFromToolName, updatePlanModeSessionSet } from '@/lib/agent-plan-mode'
 
@@ -972,34 +972,32 @@ export function useGlobalAgentListeners(): void {
         // 等后台任务完成时 Agent 会自动唤醒续轮。
         const backgroundTasksPending = data.backgroundTasksPending === true
         const hasStreamError = store.get(agentStreamErrorsAtom).has(data.sessionId)
-        const isSuccessfulCompletion = !data.stoppedByUser &&
-          !hasStreamError &&
-          (!data.resultSubtype || data.resultSubtype === 'success')
 
         // 发送桌面通知（仅真正成功完成时播放提示音，错误/中断/异常完成不伪装成完成）
         const completionSession = store.get(agentSessionsAtom)
           .find((session) => session.id === data.sessionId)
-        const shouldNotifyCompletion = shouldNotifyAgentCompletion({
-          completion: data,
-          session: completionSession,
-        })
         const enabled = store.get(notificationsEnabledAtom)
         const soundEnabled = store.get(notificationSoundEnabledAtom)
         const sounds = store.get(notificationSoundsAtom)
         const sessionTitle = getSessionTitle(data.sessionId)
-        if (!backgroundTasksPending && isSuccessfulCompletion && shouldNotifyCompletion) {
-          sendDesktopNotification(
-            'Agent 任务完成',
-            `[${sessionTitle}] 任务已完成`,
-            enabled,
-            {
-              playSound: enabled && soundEnabled,
-              soundType: 'taskComplete',
-              sounds,
-              onNavigate: makeNavigateToSession(data.sessionId, sessionTitle),
-            }
-          )
-        }
+        notifyAgentCompletion({
+          completion: data,
+          session: completionSession,
+          hasStreamError,
+          notify: () => {
+            sendDesktopNotification(
+              'Agent 任务完成',
+              `[${sessionTitle}] 任务已完成`,
+              enabled,
+              {
+                playSound: enabled && soundEnabled,
+                soundType: 'taskComplete',
+                sounds,
+                onNavigate: makeNavigateToSession(data.sessionId, sessionTitle),
+              }
+            )
+          },
+        })
 
         // STREAM_COMPLETE 表示后端已完全结束 — 立即标记 running: false
         // 同时将所有未完成的工具活动标记为已完成，防止 subagent spinner 继续转动

--- a/apps/electron/src/renderer/lib/agent-completion-presence.test.ts
+++ b/apps/electron/src/renderer/lib/agent-completion-presence.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'bun:test'
-import { getAgentCompletionMarkers, isAgentSessionActiveForCompletion } from './agent-completion-presence'
+import {
+  getAgentCompletionMarkers,
+  isAgentSessionActiveForCompletion,
+  shouldNotifyAgentCompletion,
+} from './agent-completion-presence'
 import type { TabItem } from '@/atoms/tab-atoms'
 
 describe('Agent 完成归属判断', () => {
@@ -68,5 +72,32 @@ describe('Agent 完成归属判断', () => {
     expect(getAgentCompletionMarkers(input)).toEqual({
       markUnviewedCompleted: true,
     })
+  })
+})
+
+describe('Agent 完成通知边界', () => {
+  test('Given 顶层会话成功完成 When 判断通知资格 Then 允许提醒', () => {
+    expect(shouldNotifyAgentCompletion({
+      completion: { sessionId: 'parent-1', triggeredBy: 'user' },
+    })).toBe(true)
+  })
+
+  test('Given 委派子会话快速完成且 metadata 尚未加载 When 判断通知资格 Then 完全静默', () => {
+    expect(shouldNotifyAgentCompletion({
+      completion: { sessionId: 'child-1', triggeredBy: 'delegation' },
+    })).toBe(false)
+  })
+
+  test('Given 旧完成载荷缺少来源但 metadata 标记为委派 When 判断通知资格 Then 完全静默', () => {
+    expect(shouldNotifyAgentCompletion({
+      completion: { sessionId: 'child-legacy' },
+      session: { sourceDelegationId: 'delegation-1' },
+    })).toBe(false)
+  })
+
+  test('Given 自动任务完成 When 判断通知资格 Then 不误判为委派', () => {
+    expect(shouldNotifyAgentCompletion({
+      completion: { sessionId: 'automation-1', triggeredBy: 'automation' },
+    })).toBe(true)
   })
 })

--- a/apps/electron/src/renderer/lib/agent-completion-presence.test.ts
+++ b/apps/electron/src/renderer/lib/agent-completion-presence.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import {
   getAgentCompletionMarkers,
   isAgentSessionActiveForCompletion,
+  notifyAgentCompletion,
   shouldNotifyAgentCompletion,
 } from './agent-completion-presence'
 import type { TabItem } from '@/atoms/tab-atoms'
@@ -76,28 +77,65 @@ describe('Agent 完成归属判断', () => {
 })
 
 describe('Agent 完成通知边界', () => {
+  test('Given 顶层会话成功完成 When 执行完成通知 Then callback 恰好调用一次', () => {
+    let calls = 0
+    notifyAgentCompletion({
+      completion: { sessionId: 'parent-1', triggeredBy: 'user' },
+      hasStreamError: false,
+      notify: () => { calls += 1 },
+    })
+    expect(calls).toBe(1)
+  })
+
+  test('Given 自动任务成功完成 When 执行完成通知 Then callback 恰好调用一次', () => {
+    let calls = 0
+    notifyAgentCompletion({
+      completion: { sessionId: 'automation-1', triggeredBy: 'automation' },
+      hasStreamError: false,
+      notify: () => { calls += 1 },
+    })
+    expect(calls).toBe(1)
+  })
+
+  test('Given 委派子会话成功完成且 metadata 尚未加载 When 执行完成通知 Then callback 不调用', () => {
+    let calls = 0
+    notifyAgentCompletion({
+      completion: { sessionId: 'child-1', triggeredBy: 'delegation' },
+      hasStreamError: false,
+      notify: () => { calls += 1 },
+    })
+    expect(calls).toBe(0)
+  })
+
+  test.each([
+    ['stream error', { sessionId: 'error-1' }, true],
+    ['stoppedByUser', { sessionId: 'stopped-1', stoppedByUser: true }, false],
+    ['abnormal subtype', { sessionId: 'abnormal-1', resultSubtype: 'error_max_turns' }, false],
+    ['backgroundTasksPending', { sessionId: 'background-1', backgroundTasksPending: true }, false],
+  ] as const)('Given %s When 执行完成通知 Then callback 不调用', (_caseName, completion, hasStreamError) => {
+    let calls = 0
+    notifyAgentCompletion({
+      completion,
+      hasStreamError,
+      notify: () => { calls += 1 },
+    })
+    expect(calls).toBe(0)
+  })
+
+  test('Given 旧完成载荷缺少来源但 metadata 标记为委派 When 执行完成通知 Then callback 不调用', () => {
+    let calls = 0
+    notifyAgentCompletion({
+      completion: { sessionId: 'child-legacy' },
+      session: { sourceDelegationId: 'delegation-1' },
+      hasStreamError: false,
+      notify: () => { calls += 1 },
+    })
+    expect(calls).toBe(0)
+  })
+
   test('Given 顶层会话成功完成 When 判断通知资格 Then 允许提醒', () => {
     expect(shouldNotifyAgentCompletion({
       completion: { sessionId: 'parent-1', triggeredBy: 'user' },
-    })).toBe(true)
-  })
-
-  test('Given 委派子会话快速完成且 metadata 尚未加载 When 判断通知资格 Then 完全静默', () => {
-    expect(shouldNotifyAgentCompletion({
-      completion: { sessionId: 'child-1', triggeredBy: 'delegation' },
-    })).toBe(false)
-  })
-
-  test('Given 旧完成载荷缺少来源但 metadata 标记为委派 When 判断通知资格 Then 完全静默', () => {
-    expect(shouldNotifyAgentCompletion({
-      completion: { sessionId: 'child-legacy' },
-      session: { sourceDelegationId: 'delegation-1' },
-    })).toBe(false)
-  })
-
-  test('Given 自动任务完成 When 判断通知资格 Then 不误判为委派', () => {
-    expect(shouldNotifyAgentCompletion({
-      completion: { sessionId: 'automation-1', triggeredBy: 'automation' },
     })).toBe(true)
   })
 })

--- a/apps/electron/src/renderer/lib/agent-completion-presence.ts
+++ b/apps/electron/src/renderer/lib/agent-completion-presence.ts
@@ -19,12 +19,35 @@ export interface AgentCompletionNotificationInput {
   session?: Pick<AgentSessionMeta, 'sourceDelegationId'>
 }
 
+export interface NotifyAgentCompletionInput extends AgentCompletionNotificationInput {
+  hasStreamError: boolean
+  notify: () => void
+}
+
 /** 仅顶层 Agent 会话完成属于用户级任务完成提醒边界 */
 export function shouldNotifyAgentCompletion({
   completion,
   session,
 }: AgentCompletionNotificationInput): boolean {
   return completion.triggeredBy !== 'delegation' && !session?.sourceDelegationId
+}
+
+/** 仅在真正成功且无需等待后台任务时调用完成通知 callback */
+export function notifyAgentCompletion({
+  completion,
+  session,
+  hasStreamError,
+  notify,
+}: NotifyAgentCompletionInput): void {
+  const isSuccessfulCompletion = !completion.stoppedByUser &&
+    !hasStreamError &&
+    (!completion.resultSubtype || completion.resultSubtype === 'success')
+
+  if (!completion.backgroundTasksPending &&
+    isSuccessfulCompletion &&
+    shouldNotifyAgentCompletion({ completion, session })) {
+    notify()
+  }
 }
 
 /** 判断 Agent 完成时用户是否仍停留在该会话入口 */

--- a/apps/electron/src/renderer/lib/agent-completion-presence.ts
+++ b/apps/electron/src/renderer/lib/agent-completion-presence.ts
@@ -1,3 +1,4 @@
+import type { AgentSessionMeta, AgentStreamCompletePayload } from '@proma/shared'
 import type { TabItem } from '@/atoms/tab-atoms'
 
 export interface AgentCompletionPresenceInput {
@@ -11,6 +12,19 @@ export interface AgentCompletionPresenceInput {
 
 export interface AgentCompletionMarkers {
   markUnviewedCompleted: boolean
+}
+
+export interface AgentCompletionNotificationInput {
+  completion: AgentStreamCompletePayload
+  session?: Pick<AgentSessionMeta, 'sourceDelegationId'>
+}
+
+/** 仅顶层 Agent 会话完成属于用户级任务完成提醒边界 */
+export function shouldNotifyAgentCompletion({
+  completion,
+  session,
+}: AgentCompletionNotificationInput): boolean {
+  return completion.triggeredBy !== 'delegation' && !session?.sourceDelegationId
 }
 
 /** 判断 Agent 完成时用户是否仍停留在该会话入口 */

--- a/docs/superpowers/plans/2026-07-21-delegation-completion-notification.md
+++ b/docs/superpowers/plans/2026-07-21-delegation-completion-notification.md
@@ -1,0 +1,529 @@
+# Delegation Completion Notification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep delegated child Agent completions completely silent while preserving one existing completion notification and sound for an eligible top-level parent conversation.
+
+**Architecture:** Reuse `AgentSendInput.triggeredBy` as the authoritative run origin, propagate it through every `STREAM_COMPLETE` payload, and centralize the renderer notification decision in a pure helper with a `sourceDelegationId` compatibility fallback. Leave all non-notification stream finalization paths unchanged so child state and parent result delivery continue normally.
+
+**Tech Stack:** TypeScript, Electron IPC, React/Jotai renderer state, Bun test runner, Bun workspace scripts.
+
+## Global Constraints
+
+- Delegated child completion must produce neither a desktop completion notification nor a task-complete sound.
+- Parent completion retains the existing success, error, stop, and `backgroundTasksPending` behavior.
+- Claude and Pi runtimes must share the same result because the fix belongs above both adapters.
+- Preserve child streaming state, persisted messages, sidebar state, completion markers, and delegation result delivery.
+- Add no dependency, setting, IPC channel, unrelated refactor, or README/AGENTS change.
+- Increment `@proma/shared` from `0.1.42` to `0.1.43` and `@proma/electron` from `0.15.7` to `0.15.8`.
+- Work only in `/Users/rongyulin/Desktop/vibe_projects/Proma/.worktrees/delegation-completion-notification` on `fix/delegation-completion-notification`.
+
+---
+
+## File map
+
+- `packages/shared/src/types/agent.ts`: extend the existing completion IPC contract with the optional run origin.
+- `packages/shared/package.json`: patch-version bump for the shared IPC type change.
+- `apps/electron/src/main/lib/agent-completion-payload.ts`: pure builder that attaches `sessionId` and `triggeredBy` consistently to completion payloads.
+- `apps/electron/src/main/lib/agent-completion-payload.test.ts`: BDD regression coverage for authoritative run-origin propagation.
+- `apps/electron/src/main/lib/agent-service.ts`: route all normal and defensive `STREAM_COMPLETE` sends through the builder.
+- `apps/electron/src/renderer/lib/agent-completion-presence.ts`: pure user-facing completion-notification policy alongside existing completion-presence policy.
+- `apps/electron/src/renderer/lib/agent-completion-presence.test.ts`: BDD coverage for delegation silence and compatibility fallback.
+- `apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts`: apply notification eligibility without changing the remaining completion flow.
+- `apps/electron/package.json`: patch-version bump for the Electron behavior fix.
+
+---
+
+### Task 1: Preserve run origin in every completion IPC payload
+
+**Files:**
+- Create: `apps/electron/src/main/lib/agent-completion-payload.ts`
+- Create: `apps/electron/src/main/lib/agent-completion-payload.test.ts`
+- Modify: `packages/shared/src/types/agent.ts:1106-1120`
+- Modify: `packages/shared/package.json:2-4`
+- Modify: `apps/electron/src/main/lib/agent-service.ts:150-300`
+
+**Interfaces:**
+- Consumes: `AgentSendInput.triggeredBy?: 'user' | 'automation' | 'delegation'`.
+- Produces: `AgentStreamCompletePayload.triggeredBy?: AgentSendInput['triggeredBy']`.
+- Produces: `buildAgentStreamCompletePayload(run, details): AgentStreamCompletePayload`.
+
+- [ ] **Step 1: Write the failing origin-propagation test**
+
+Create `apps/electron/src/main/lib/agent-completion-payload.test.ts`:
+
+```ts
+import { describe, expect, test } from 'bun:test'
+import { buildAgentStreamCompletePayload } from './agent-completion-payload'
+
+describe('Agent 完成载荷来源', () => {
+  test('Given 委派子会话 When 构建完成载荷 Then 保留 delegation 来源', () => {
+    expect(buildAgentStreamCompletePayload(
+      { sessionId: 'child-1', triggeredBy: 'delegation' },
+      { stoppedByUser: false, startedAt: 100 },
+    )).toEqual({
+      sessionId: 'child-1',
+      triggeredBy: 'delegation',
+      stoppedByUser: false,
+      startedAt: 100,
+    })
+  })
+
+  test('Given 普通历史调用未提供来源 When 构建完成载荷 Then 保持字段可选', () => {
+    expect(buildAgentStreamCompletePayload(
+      { sessionId: 'parent-1' },
+      { messages: [] },
+    )).toEqual({
+      sessionId: 'parent-1',
+      triggeredBy: undefined,
+      messages: [],
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+cd /Users/rongyulin/Desktop/vibe_projects/Proma/.worktrees/delegation-completion-notification
+bun test apps/electron/src/main/lib/agent-completion-payload.test.ts
+```
+
+Expected: FAIL because `./agent-completion-payload` does not exist.
+
+- [ ] **Step 3: Extend the shared completion payload type**
+
+Add this field to `AgentStreamCompletePayload` immediately after `sessionId`:
+
+```ts
+  /** 触发来源：用于区分顶层会话与父 Agent 委派的子会话完成 */
+  triggeredBy?: AgentSendInput['triggeredBy']
+```
+
+- [ ] **Step 4: Implement the pure payload builder**
+
+Create `apps/electron/src/main/lib/agent-completion-payload.ts`:
+
+```ts
+import type {
+  AgentSendInput,
+  AgentStreamCompletePayload,
+} from '@proma/shared'
+
+export type AgentStreamCompletionDetails = Omit<
+  AgentStreamCompletePayload,
+  'sessionId' | 'triggeredBy'
+>
+
+export function buildAgentStreamCompletePayload(
+  run: Pick<AgentSendInput, 'sessionId' | 'triggeredBy'>,
+  details: AgentStreamCompletionDetails = {},
+): AgentStreamCompletePayload {
+  return {
+    sessionId: run.sessionId,
+    triggeredBy: run.triggeredBy,
+    ...details,
+  }
+}
+```
+
+- [ ] **Step 5: Route every service completion send through the builder**
+
+Import the helper in `apps/electron/src/main/lib/agent-service.ts`:
+
+```ts
+import { buildAgentStreamCompletePayload } from './agent-completion-payload'
+```
+
+Replace the normal interactive completion payload with:
+
+```ts
+webContents.send(
+  AGENT_IPC_CHANNELS.STREAM_COMPLETE,
+  buildAgentStreamCompletePayload(input, {
+    messages,
+    stoppedByUser: opts?.stoppedByUser ?? false,
+    startedAt: opts?.startedAt,
+    resultSubtype: opts?.resultSubtype,
+    resultErrors: opts?.resultErrors,
+    backgroundTasksPending: opts?.backgroundTasksPending,
+  }),
+)
+```
+
+Replace the interactive catch payload with:
+
+```ts
+webContents.send(
+  AGENT_IPC_CHANNELS.STREAM_COMPLETE,
+  buildAgentStreamCompletePayload(input, {
+    messages: [],
+    stoppedByUser: false,
+  }),
+)
+```
+
+Replace the normal headless completion payload with:
+
+```ts
+wc.send(
+  AGENT_IPC_CHANNELS.STREAM_COMPLETE,
+  buildAgentStreamCompletePayload(runInput, {
+    messages,
+    stoppedByUser: opts?.stoppedByUser ?? false,
+    startedAt: opts?.startedAt,
+    resultSubtype: opts?.resultSubtype,
+    resultErrors: opts?.resultErrors,
+    backgroundTasksPending: opts?.backgroundTasksPending,
+  }),
+)
+```
+
+Replace the headless catch payload with:
+
+```ts
+wc.send(
+  AGENT_IPC_CHANNELS.STREAM_COMPLETE,
+  buildAgentStreamCompletePayload(runInput, {
+    messages: [],
+    stoppedByUser: false,
+    startedAt,
+  }),
+)
+```
+
+- [ ] **Step 6: Verify GREEN and type safety**
+
+Run:
+
+```bash
+bun test apps/electron/src/main/lib/agent-completion-payload.test.ts
+bun run --filter='@proma/shared' typecheck
+bun run --filter='@proma/electron' typecheck
+```
+
+Expected: both tests pass; both typechecks exit 0.
+
+- [ ] **Step 7: Bump the shared package patch version and commit**
+
+Change `packages/shared/package.json`:
+
+```json
+"version": "0.1.43"
+```
+
+Then run and commit:
+
+```bash
+git diff --check
+git add packages/shared/src/types/agent.ts packages/shared/package.json \
+  apps/electron/src/main/lib/agent-completion-payload.ts \
+  apps/electron/src/main/lib/agent-completion-payload.test.ts \
+  apps/electron/src/main/lib/agent-service.ts
+git commit -m "fix(agent): preserve completion run origin"
+```
+
+Expected: one focused commit with no renderer behavior change yet.
+
+---
+
+### Task 2: Suppress delegated child completion notifications
+
+**Files:**
+- Modify: `apps/electron/src/renderer/lib/agent-completion-presence.ts`
+- Modify: `apps/electron/src/renderer/lib/agent-completion-presence.test.ts`
+- Modify: `apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts:962-993`
+- Modify: `apps/electron/package.json:2-4`
+
+**Interfaces:**
+- Consumes: `AgentStreamCompletePayload.triggeredBy` from Task 1.
+- Consumes: optional `Pick<AgentSessionMeta, 'sourceDelegationId'>` compatibility metadata.
+- Produces: `shouldNotifyAgentCompletion(input): boolean`.
+
+- [ ] **Step 1: Add failing BDD tests for the notification boundary**
+
+Extend imports in `apps/electron/src/renderer/lib/agent-completion-presence.test.ts`:
+
+```ts
+import {
+  getAgentCompletionMarkers,
+  isAgentSessionActiveForCompletion,
+  shouldNotifyAgentCompletion,
+} from './agent-completion-presence'
+```
+
+Append:
+
+```ts
+describe('Agent 完成通知边界', () => {
+  test('Given 顶层会话成功完成 When 判断通知资格 Then 允许提醒', () => {
+    expect(shouldNotifyAgentCompletion({
+      completion: { sessionId: 'parent-1', triggeredBy: 'user' },
+    })).toBe(true)
+  })
+
+  test('Given 委派子会话快速完成且 metadata 尚未加载 When 判断通知资格 Then 完全静默', () => {
+    expect(shouldNotifyAgentCompletion({
+      completion: { sessionId: 'child-1', triggeredBy: 'delegation' },
+    })).toBe(false)
+  })
+
+  test('Given 旧完成载荷缺少来源但 metadata 标记为委派 When 判断通知资格 Then 完全静默', () => {
+    expect(shouldNotifyAgentCompletion({
+      completion: { sessionId: 'child-legacy' },
+      session: { sourceDelegationId: 'delegation-1' },
+    })).toBe(false)
+  })
+
+  test('Given 自动任务完成 When 判断通知资格 Then 不误判为委派', () => {
+    expect(shouldNotifyAgentCompletion({
+      completion: { sessionId: 'automation-1', triggeredBy: 'automation' },
+    })).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+bun test apps/electron/src/renderer/lib/agent-completion-presence.test.ts
+```
+
+Expected: FAIL because `shouldNotifyAgentCompletion` is not exported.
+
+- [ ] **Step 3: Implement the minimum pure notification policy**
+
+Add the shared type imports and policy to `agent-completion-presence.ts`:
+
+```ts
+import type {
+  AgentSessionMeta,
+  AgentStreamCompletePayload,
+} from '@proma/shared'
+
+export interface AgentCompletionNotificationInput {
+  completion: AgentStreamCompletePayload
+  session?: Pick<AgentSessionMeta, 'sourceDelegationId'>
+}
+
+/** 仅顶层 Agent 会话完成属于用户级任务完成提醒边界 */
+export function shouldNotifyAgentCompletion({
+  completion,
+  session,
+}: AgentCompletionNotificationInput): boolean {
+  return completion.triggeredBy !== 'delegation' && !session?.sourceDelegationId
+}
+```
+
+Keep the existing `TabItem` import and completion-marker functions unchanged.
+
+- [ ] **Step 4: Apply the policy only to the desktop-notification branch**
+
+Update the helper import in `useGlobalAgentListeners.ts`:
+
+```ts
+import {
+  getAgentCompletionMarkers,
+  shouldNotifyAgentCompletion,
+} from '@/lib/agent-completion-presence'
+```
+
+Before the existing notification `if`, resolve the current metadata and eligibility:
+
+```ts
+const completionSession = store.get(agentSessionsAtom)
+  .find((session) => session.id === data.sessionId)
+const shouldNotifyCompletion = shouldNotifyAgentCompletion({
+  completion: data,
+  session: completionSession,
+})
+```
+
+Change only the notification guard:
+
+```ts
+if (!backgroundTasksPending && isSuccessfulCompletion && shouldNotifyCompletion) {
+```
+
+Do not place the remaining stream finalization, completion-marker, message-refresh, or sidebar logic inside this guard.
+
+- [ ] **Step 5: Verify GREEN and focused behavior**
+
+Run:
+
+```bash
+bun test \
+  apps/electron/src/main/lib/agent-completion-payload.test.ts \
+  apps/electron/src/renderer/lib/agent-completion-presence.test.ts
+bun run --filter='@proma/electron' typecheck
+```
+
+Expected: all tests in both focused files pass with 0 failures; typecheck exits 0.
+
+- [ ] **Step 6: Bump the Electron package patch version and commit**
+
+Change `apps/electron/package.json`:
+
+```json
+"version": "0.15.8"
+```
+
+Then run and commit:
+
+```bash
+git diff --check
+git add apps/electron/package.json \
+  apps/electron/src/renderer/lib/agent-completion-presence.ts \
+  apps/electron/src/renderer/lib/agent-completion-presence.test.ts \
+  apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+git commit -m "fix(agent): silence delegated completion notifications"
+```
+
+Expected: one renderer-policy commit; no change to child completion state handling.
+
+---
+
+### Task 3: Verify, independently review, and prepare the upstream PR
+
+**Files:**
+- Review only: all files changed since `origin/main`
+- Create outside Git history: `/tmp/proma-delegation-completion-pr-body.md`
+- Create outside Git history: session-scoped developer/QA evidence artifacts
+
+**Interfaces:**
+- Consumes: the two implementation commits from Tasks 1 and 2.
+- Produces: fresh verification evidence, independent review disposition, revision-pinned QA result, pushed fork branch, and upstream PR URL.
+
+- [ ] **Step 1: Run focused regression tests**
+
+```bash
+bun test \
+  apps/electron/src/main/lib/agent-completion-payload.test.ts \
+  apps/electron/src/renderer/lib/agent-completion-presence.test.ts
+```
+
+Expected: all tests pass with 0 failures.
+
+- [ ] **Step 2: Run package typechecks and the Electron build**
+
+```bash
+bun run --filter='@proma/shared' typecheck
+bun run --filter='@proma/electron' typecheck
+bun run electron:build
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 3: Run the repository-wide Bun test suite**
+
+```bash
+bun test
+```
+
+Expected: 0 failures. If a pre-existing environment-dependent failure appears, record the exact test and prove it is unchanged from `origin/main`; do not call the suite passing.
+
+- [ ] **Step 4: Inspect the complete diff and version scope**
+
+```bash
+git diff --check origin/main...HEAD
+git diff --stat origin/main...HEAD
+git diff origin/main...HEAD -- \
+  packages/shared/src/types/agent.ts \
+  packages/shared/package.json \
+  apps/electron/package.json \
+  apps/electron/src/main/lib/agent-completion-payload.ts \
+  apps/electron/src/main/lib/agent-completion-payload.test.ts \
+  apps/electron/src/main/lib/agent-service.ts \
+  apps/electron/src/renderer/lib/agent-completion-presence.ts \
+  apps/electron/src/renderer/lib/agent-completion-presence.test.ts \
+  apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+```
+
+Expected: only the approved design document, plan, shared payload contract/builder, renderer notification policy, service wiring, tests, and two patch version bumps appear.
+
+- [ ] **Step 5: Request independent code review and resolve findings**
+
+Give the reviewer:
+
+```text
+Requirement: delegated child completions must emit no desktop completion notification or sound; eligible top-level parent completions retain existing behavior.
+Base: origin/main
+Head: current HEAD
+Review priorities: every STREAM_COMPLETE exit preserves triggeredBy; metadata race is covered; no child state/finalization path is skipped; automation/bridge sessions are not silenced; tests genuinely cover the regression.
+```
+
+Expected: no unresolved Critical or Important finding. Any code change made for a finding must receive a focused failing test when it changes behavior, then repeat Steps 1-4.
+
+- [ ] **Step 6: Perform revision-pinned independent QA**
+
+QA acceptance criteria:
+
+```text
+1. A synthetic/controlled completion with triggeredBy=delegation produces no completion notification call.
+2. A top-level successful completion remains eligible for exactly one notification call.
+3. Delegated child completion still finalizes stream state and completion markers outside the notification guard.
+4. The tested revision equals the final pushed revision.
+```
+
+Expected: QA accepts the same revision that will be pushed. If desktop runtime instrumentation is unavailable, mark runtime sound playback as unverified rather than substituting developer confidence; retain unit-level evidence for the notification-call boundary.
+
+- [ ] **Step 7: Create or reuse the authenticated fork and push the branch**
+
+```bash
+gh repo view rongyulin3/Proma >/dev/null 2>&1 || gh repo fork proma-ai/Proma --clone=false
+if ! git remote get-url fork >/dev/null 2>&1; then
+  git remote add fork https://github.com/rongyulin3/Proma.git
+fi
+git push -u fork fix/delegation-completion-notification
+```
+
+Expected: branch is available as `rongyulin3:fix/delegation-completion-notification`; no force push.
+
+- [ ] **Step 8: Create the upstream PR**
+
+Write `/tmp/proma-delegation-completion-pr-body.md`:
+
+```markdown
+## Summary
+
+- preserve each Agent run's `triggeredBy` origin in completion IPC payloads
+- keep delegated child completions completely silent while retaining their normal state/message finalization
+- add race-safe BDD coverage with a `sourceDelegationId` compatibility fallback
+
+## Root cause
+
+Visible collaboration children complete through the same global `STREAM_COMPLETE` handler as top-level conversations, but the completion payload dropped `triggeredBy`. The renderer therefore treated child milestones as user-level task completion and played the configured completion sound.
+
+## Test plan
+
+- `bun test apps/electron/src/main/lib/agent-completion-payload.test.ts apps/electron/src/renderer/lib/agent-completion-presence.test.ts`
+- `bun run --filter='@proma/shared' typecheck`
+- `bun run --filter='@proma/electron' typecheck`
+- `bun run electron:build`
+- `bun test`
+```
+
+Create the PR:
+
+```bash
+gh pr create \
+  --repo proma-ai/Proma \
+  --base main \
+  --head rongyulin3:fix/delegation-completion-notification \
+  --title "fix(agent): silence delegated completion notifications" \
+  --body-file /tmp/proma-delegation-completion-pr-body.md
+```
+
+Expected: an open PR URL targeting `proma-ai/Proma:main`.
+
+- [ ] **Step 9: Check upstream CI and report exact status**
+
+```bash
+gh pr checks --repo proma-ai/Proma --watch
+```
+
+Expected: report every check result. If checks are still pending at the bounded wait limit or fail for an upstream/environmental reason, leave the PR open and report the exact state without claiming merge readiness.

--- a/docs/superpowers/specs/2026-07-21-delegation-completion-notification-design.md
+++ b/docs/superpowers/specs/2026-07-21-delegation-completion-notification-design.md
@@ -1,0 +1,108 @@
+# Delegation Completion Notification Design
+
+Date: 2026-07-21
+Status: design approved; awaiting written-spec review
+
+## Problem
+
+Proma sends every Agent run through the same renderer-level `STREAM_COMPLETE` handler. Visible collaboration children run through `runAgentHeadless()` with `AgentSendInput.triggeredBy = 'delegation'`, but the completion IPC payload does not preserve that origin. The renderer therefore treats both a delegated child finishing and the parent conversation finishing as a user-level task completion, producing a desktop notification and playing the configured `taskComplete` sound for each child.
+
+This is a lifecycle-boundary bug: a delegated child completion is an internal milestone of the parent conversation, not the user-facing completion boundary.
+
+## Goals
+
+1. Play the task-complete sound only for a successful top-level Agent conversation completion.
+2. Keep delegated child completions completely silent: no task-complete sound and no desktop completion notification.
+3. Preserve child-session streaming state, persisted messages, sidebar status, completion markers, delegation result delivery, and parent wake-up behavior.
+4. Use authoritative run-origin data so fast child completions cannot race asynchronous session metadata loading.
+5. Apply the same behavior to Claude and Pi runtimes because both share the Agent service and renderer completion path.
+
+## Non-goals
+
+- Aggregate all child results into a new main-process lifecycle state machine.
+- Change permission, AskUser, or ExitPlanMode notifications.
+- Change task-complete sound settings or add a new preference.
+- Silence independent automation, Feishu, DingTalk, WeChat, or bridge-triggered Agent sessions.
+- Refactor unrelated completion, sidebar, or notification code.
+
+## Behavior contract
+
+- A completion whose run origin is `delegation` does not send a desktop completion notification and does not play a completion sound.
+- The rule covers initial delegation, continued delegation, and retried delegation runs.
+- A successful top-level parent completion continues to notify once when `backgroundTasksPending !== true`.
+- Errors, user stops, abnormal result subtypes, and background-task waiting retain their current behavior.
+- Delegated child sessions still transition to their terminal UI state and remain inspectable.
+- If an old or incomplete completion payload lacks the run origin, a session carrying `sourceDelegationId` is still treated as a delegated child.
+
+## Architecture
+
+### Authoritative origin propagation
+
+Reuse the existing `AgentSendInput.triggeredBy` union (`user | automation | delegation`). Add an optional field with the same semantics to `AgentStreamCompletePayload` and populate it at every `STREAM_COMPLETE` send site in `runAgent()` and `runAgentHeadless()`, including defensive catch paths.
+
+The origin is captured from the immutable run input rather than inferred from renderer timing. No new IPC channel or persistent setting is required.
+
+### Central completion-notification policy
+
+Add a small pure function near the existing Agent completion-presence helpers. It receives the completion payload plus optional session metadata and returns whether a user-facing task-complete notification is allowed.
+
+The policy rejects completion notification when either condition is true:
+
+1. `payload.triggeredBy === 'delegation'`; or
+2. the session metadata has `sourceDelegationId`.
+
+The metadata check is a compatibility fallback. The IPC origin is the primary source of truth and eliminates the race in which a child finishes before `agentSessionsAtom` has refreshed.
+
+The existing success checks remain separate and unchanged: a notification is sent only when the completion is successful and no background tasks remain. All non-notification completion handling continues to run for delegated children.
+
+## Data flow
+
+```text
+parent Agent delegates work
+→ collaboration tool creates child session with sourceDelegationId
+→ child run starts with triggeredBy = delegation
+→ shared Agent service streams and persists child output
+→ child run emits STREAM_COMPLETE(triggeredBy = delegation)
+→ renderer notification policy rejects user-facing completion notice
+→ renderer still finalizes child state and refreshes messages/sidebar
+→ parent receives/waits for child result and continues
+→ parent emits top-level STREAM_COMPLETE
+→ existing success/background checks pass
+→ one desktop notification and configured task-complete sound are emitted
+```
+
+## Error handling and compatibility
+
+- Defensive completion payloads emitted from service catch blocks must preserve `triggeredBy`; otherwise an exceptional child run could regress to a false completion notification.
+- `triggeredBy` remains optional for compatibility with older callers and stored type consumers.
+- `sourceDelegationId` provides a renderer-side fallback when origin is absent.
+- No notification-policy failure may block stream finalization, message refresh, or delegation bookkeeping.
+- Existing suppression for stream errors, user stops, abnormal result subtypes, and `backgroundTasksPending` remains authoritative.
+
+## Tests
+
+BDD-focused tests will cover:
+
+1. a normal top-level completion is eligible for notification;
+2. a payload with `triggeredBy = delegation` is ineligible even if metadata has not loaded;
+3. a payload without origin is ineligible when session metadata has `sourceDelegationId`;
+4. automation and other non-delegation origins remain eligible for the existing completion policy;
+5. the renderer combines origin policy with existing success and background-task conditions;
+6. focused tests, affected package typechecks, the Electron build, and the relevant broader Bun test suite pass.
+
+The regression test must be observed failing before production logic is changed, then passing after the minimum fix.
+
+## Versioning and documentation
+
+The change affects shared IPC types and the Electron application, so patch versions for `@proma/shared` and `@proma/electron` will be incremented according to repository policy. No dependency is added.
+
+README and AGENTS documentation will not be changed: this is a bug fix restoring the existing user-facing meaning of “Agent task complete,” not a new setting, feature, or public workflow.
+
+## Acceptance criteria
+
+- Delegated child completion produces neither a desktop completion notification nor a task-complete sound.
+- Parent conversation completion still produces exactly one configured completion notification/sound when currently eligible.
+- Child session state, messages, sidebar status, and parent result flow remain intact.
+- The implementation is race-safe when renderer session metadata is unavailable.
+- Focused regression tests, typechecks, Electron build, independent code review, and PR checks pass.
+- The PR contains no dependency change, unrelated refactor, or current-branch work from `fix/pi-context-compaction-recovery`.

--- a/docs/superpowers/specs/2026-07-21-delegation-completion-notification-design.md
+++ b/docs/superpowers/specs/2026-07-21-delegation-completion-notification-design.md
@@ -1,7 +1,7 @@
 # Delegation Completion Notification Design
 
 Date: 2026-07-21
-Status: design approved; awaiting written-spec review
+Status: approved for implementation
 
 ## Problem
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/shared",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "license": "AGPL-3.0-only",
   "description": "Shared types, configs and utilities for proma",
   "type": "module",

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1105,6 +1105,8 @@ export interface AgentStreamEvent {
  */
 export interface AgentStreamCompletePayload {
   sessionId: string
+  /** 触发来源：用于区分顶层会话与父 Agent 委派的子会话完成 */
+  triggeredBy?: AgentSendInput['triggeredBy']
   /** 已持久化的完整消息列表 */
   messages?: AgentMessage[]
   /** 是否由用户手动中止 */


### PR DESCRIPTION
## Summary

- preserve each Agent run's `triggeredBy` origin in every `STREAM_COMPLETE` path
- keep delegated child completions completely silent while retaining their normal state/message/sidebar finalization
- centralize and regression-test both the main-process IPC sender and renderer notification callback boundary

## Root cause

Visible collaboration children finish through the same global `STREAM_COMPLETE` handler as top-level conversations, but the completion payload dropped `triggeredBy`. The renderer therefore treated each delegated child milestone as a user-level task completion and played the configured completion sound.

## Behavior after this change

- delegated child completion: no desktop completion notification and no `taskComplete` sound
- eligible top-level parent completion: existing notification and sound behavior remains
- automation/bridge sessions: unchanged unless the session itself is a delegated child
- child stream finalization, messages, completion markers, and sidebar state: unchanged

## Verification

- `bun test apps/electron/src/main/lib/agent-completion-payload.test.ts apps/electron/src/renderer/lib/agent-completion-presence.test.ts` — **18 pass, 0 fail**
- `bun run --filter='@proma/shared' typecheck` — pass
- `bun run --filter='@proma/electron' typecheck` — pass
- `bun run electron:build` — pass (existing Vite chunk-size warning only)
- independent whole-branch review — **Ready to merge: Yes**, no unresolved findings
- revision-pinned QA — **conditional-go**, no product defects in tested scope

### Existing full-suite issue

`bun test` reports **412 pass / 2 fail** on this branch. The same two failures reproduce on clean `origin/main` (**398 pass / 2 fail**) and are caused by full-suite Bun mock ordering around Electron named exports (`BrowserWindow` / `shell`). Both affected test files pass together in isolation (**10 pass / 0 fail**) on both revisions. This PR does not modify those tests or modules.

## Residual scope

The real macOS notification center and physical `taskComplete` audio output were not exercised end-to-end; the notification-call boundary, origin propagation, success/error/background conditions, and all four normal/catch completion exits are covered by focused tests and independent static review.
