### PR TITLE
feat(agent): generate Codex OAuth semantic titles

### DIFF
--- a/apps/electron/src/main/lib/adapters/pi-codex-title-generator.test.ts
+++ b/apps/electron/src/main/lib/adapters/pi-codex-title-generator.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'bun:test'
+import type { Model, OpenAICodexResponsesOptions } from '@earendil-works/pi-ai/compat'
+import type { Dispatcher } from 'undici'
+import {
+  completeCodexTitleRequest,
+  extractCodexResponseText,
+  type CodexTitleRequestEnvironment,
+  type CodexTitleRuntime,
+} from './pi-codex-title-generator'
+
+const model = {} as Model<'openai-codex-responses'>
+
+function createEnvironment(dispatcher?: Dispatcher): CodexTitleRequestEnvironment & { closed: Dispatcher | undefined; installed: boolean } {
+  return {
+    dispatcher,
+    closed: undefined,
+    installed: false,
+    installRequestProxyFetch() { this.installed = true },
+    runWithRequestProxy(_dispatcher, operation) { return operation() },
+    async closeRequestProxyDispatcher(closed) { this.closed = closed },
+  }
+}
+
+describe('Codex OAuth 标题生成', () => {
+  test('Given Pi response with reasoning and text When extracting title Then returns visible text only', () => {
+    expect(extractCodexResponseText([
+      { type: 'thinking', text: '先理解用户意图' },
+      { type: 'text', text: '修复 OAuth 登录' },
+      { type: 'toolCall', text: 'ignored' },
+      { type: 'text', text: '问题' },
+    ])).toBe('修复 OAuth 登录问题')
+  })
+
+  test('Given Pi response without text When extracting title Then returns an empty string', () => {
+    expect(extractCodexResponseText([{ type: 'thinking', text: '不应显示' }])).toBe('')
+  })
+
+  test('Given Codex runtime When requesting title Then uses a small non-reasoning SSE request and closes its proxy', async () => {
+    let receivedOptions: OpenAICodexResponsesOptions | undefined
+    let receivedPrompt: string | undefined
+    const runtime: CodexTitleRuntime = {
+      async complete(_model, context, options) {
+        receivedPrompt = context.messages[0]?.role === 'user' ? context.messages[0].content as string : undefined
+        receivedOptions = options
+        return { content: [{ type: 'text', text: 'OAuth 标题修复' }] }
+      },
+    }
+    const dispatcher = {} as Dispatcher
+    const environment = createEnvironment(dispatcher)
+
+    await expect(completeCodexTitleRequest(runtime, model, '生成标题', environment)).resolves.toBe('OAuth 标题修复')
+    expect(receivedPrompt).toBe('生成标题')
+    expect(receivedOptions).toEqual({
+      transport: 'sse',
+      maxTokens: 40,
+      timeoutMs: 15_000,
+      maxRetries: 0,
+      reasoningEffort: 'none',
+      reasoningSummary: 'off',
+      textVerbosity: 'low',
+      toolChoice: 'none',
+    })
+    expect(environment.installed).toBe(true)
+    expect(environment.closed).toBe(dispatcher)
+  })
+
+  test('Given Codex request failure When completing title Then still closes its proxy', async () => {
+    const runtime: CodexTitleRuntime = {
+      async complete() { throw new Error('quota exceeded') },
+    }
+    const dispatcher = {} as Dispatcher
+    const environment = createEnvironment(dispatcher)
+
+    await expect(completeCodexTitleRequest(runtime, model, '生成标题', environment)).rejects.toThrow('quota exceeded')
+    expect(environment.closed).toBe(dispatcher)
+  })
+})

--- a/apps/electron/src/main/lib/adapters/pi-codex-title-generator.ts
+++ b/apps/electron/src/main/lib/adapters/pi-codex-title-generator.ts
@@ -1,0 +1,115 @@
+/**
+ * 通过 Pi 的 ChatGPT Codex OAuth runtime 发起轻量文本请求。
+ *
+ * 标题生成不能复用 @proma/core 的 Chat Completions / Messages 请求：
+ * Codex OAuth 只支持 Pi 管理的 Responses 协议、认证头和账号路由。此模块复用
+ * 相同的 ModelRuntime/credential store，且不写入 Pi 的全局认证目录。
+ */
+
+import type { CodexOAuthCredentials } from '@proma/shared'
+import type { AssistantMessage, Context, Model, OpenAICodexResponsesOptions } from '@earendil-works/pi-ai/compat'
+import type { Dispatcher } from 'undici'
+import { buildCodexModel } from './pi-model-registry'
+import {
+  closePiRequestProxyDispatcher,
+  createPiRequestProxyDispatcher,
+  installPiRequestProxyFetch,
+  runWithPiRequestProxy,
+} from './pi-request-proxy'
+
+type PiSdk = typeof import('@earendil-works/pi-coding-agent')
+type CodexModel = Model<'openai-codex-responses'>
+
+const TITLE_MAX_OUTPUT_TOKENS = 40
+const TITLE_REQUEST_TIMEOUT_MS = 15_000
+
+export interface CodexTitleGenerationInput {
+  modelId: string
+  prompt: string
+  credentials: CodexOAuthCredentials
+  proxyUrl?: string
+  onCredentialsRefreshed?: (credentials: CodexOAuthCredentials) => void | Promise<void>
+}
+
+export interface CodexTitleRuntime {
+  complete: (
+    model: CodexModel,
+    context: Context,
+    options: OpenAICodexResponsesOptions,
+  ) => Promise<Pick<AssistantMessage, 'content'>>
+}
+
+export interface CodexTitleRequestEnvironment {
+  dispatcher?: Dispatcher
+  installRequestProxyFetch: () => void
+  runWithRequestProxy: <T>(dispatcher: Dispatcher | undefined, operation: () => T) => T
+  closeRequestProxyDispatcher: (dispatcher: Dispatcher | undefined) => Promise<void>
+}
+
+/** 从 Pi 响应中抽取可见文本，忽略 reasoning/tool content。 */
+export function extractCodexResponseText(content: Array<{ type: string; text?: string }>): string {
+  return content
+    .filter((block) => block.type === 'text' && typeof block.text === 'string')
+    .map((block) => block.text)
+    .join('')
+}
+
+/**
+ * 完成单次短标题请求。抽出运行环境以便验证请求参数、代理作用域与异常清理。
+ */
+export async function completeCodexTitleRequest(
+  runtime: CodexTitleRuntime,
+  model: CodexModel,
+  prompt: string,
+  environment: CodexTitleRequestEnvironment,
+): Promise<string | null> {
+  try {
+    environment.installRequestProxyFetch()
+    const response = await environment.runWithRequestProxy(environment.dispatcher, () => runtime.complete(
+      model,
+      {
+        messages: [{ role: 'user', content: prompt, timestamp: Date.now() }],
+      },
+      {
+        transport: 'sse',
+        maxTokens: TITLE_MAX_OUTPUT_TOKENS,
+        timeoutMs: TITLE_REQUEST_TIMEOUT_MS,
+        maxRetries: 0,
+        reasoningEffort: 'none',
+        reasoningSummary: 'off',
+        textVerbosity: 'low',
+        toolChoice: 'none',
+      } satisfies OpenAICodexResponsesOptions,
+    ))
+
+    return extractCodexResponseText(response.content).trim() || null
+  } finally {
+    await environment.closeRequestProxyDispatcher(environment.dispatcher)
+  }
+}
+
+/**
+ * 使用已登录的 ChatGPT Codex 模型生成一个短文本。请求固定使用 SSE，避免一次标题
+ * 生成额外创建 WebSocket；请求失败由调用方按产品语义决定降级方式。
+ */
+export async function generateCodexTitle(input: CodexTitleGenerationInput): Promise<string | null> {
+  const sdk: PiSdk = await import('@earendil-works/pi-coding-agent')
+  const { modelRuntime, model } = await buildCodexModel(sdk, {
+    model: input.modelId,
+    codexOAuthCredentials: input.credentials,
+    onCodexOAuthCredentialsRefreshed: input.onCredentialsRefreshed,
+  })
+  const dispatcher = createPiRequestProxyDispatcher({ proxyUrl: input.proxyUrl, httpIdleTimeoutMs: TITLE_REQUEST_TIMEOUT_MS })
+
+  return completeCodexTitleRequest(
+    modelRuntime as CodexTitleRuntime,
+    model as CodexModel,
+    input.prompt,
+    {
+      dispatcher,
+      installRequestProxyFetch: installPiRequestProxyFetch,
+      runWithRequestProxy: runWithPiRequestProxy,
+      closeRequestProxyDispatcher: closePiRequestProxyDispatcher,
+    },
+  )
+}

--- a/apps/electron/src/main/lib/adapters/pi-model-registry.ts
+++ b/apps/electron/src/main/lib/adapters/pi-model-registry.ts
@@ -55,6 +55,13 @@ type CodexRuntimeCredential = CodexOAuthCredentials & {
   [key: string]: unknown
 }
 
+/** Pi 内置 Codex provider 所需的最小模型与 OAuth 输入。 */
+export interface CodexModelInput {
+  model?: string
+  codexOAuthCredentials?: CodexOAuthCredentials
+  onCodexOAuthCredentialsRefreshed?: (credentials: CodexOAuthCredentials) => void | Promise<void>
+}
+
 function createCodexRuntimeCredentialStore(
   initial: CodexOAuthCredentials,
   onRefreshed?: PiAgentQueryOptions['onCodexOAuthCredentialsRefreshed'],
@@ -362,7 +369,7 @@ export async function getCodexCatalogModels(): Promise<PiCatalogModel[]> {
  * 因此将 Proma 已刷新过的完整凭据放入一次性内存 OAuth credential store，
  * 按真实 expires 刷新并回写 Proma，避免读写全局 ~/.pi 认证文件。
  */
-async function buildCodexModel(sdk: PiSdk, input: PiAgentQueryOptions) {
+export async function buildCodexModel(sdk: PiSdk, input: CodexModelInput) {
   if (!input.codexOAuthCredentials) {
     throw new Error('ChatGPT (Codex) OAuth 凭据缺失，请重新登录')
   }

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -68,6 +68,7 @@ import { isVisibleRunMessage } from './agent-run-message-visibility'
 import { applyAgentSdkAuthEnv } from './agent-sdk-auth-env'
 import { getAgentSdkMaxOutputTokens } from './agent-sdk-output-limits'
 import { resolvePiThinkingLevel } from './agent-thinking-level'
+import { generateCodexTitle } from './adapters/pi-codex-title-generator'
 import { createFallbackTitle, sanitizeGeneratedTitle, TITLE_PROMPT } from './title-generation'
 
 // ===== 类型定义 =====
@@ -604,7 +605,27 @@ export class AgentOrchestrator {
 
       if (channel.provider === 'openai-codex') {
         const fallbackTitle = createFallbackTitle(userMessage)
-        console.log('[Agent 标题生成] ChatGPT OAuth 渠道使用本地标题:', fallbackTitle)
+        try {
+          const [credentials, proxyUrl] = await Promise.all([
+            resolveCodexOAuthCredentials(channelId),
+            getEffectiveProxyUrl(),
+          ])
+          const generatedTitle = await generateCodexTitle({
+            modelId,
+            prompt: TITLE_PROMPT + userMessage,
+            credentials,
+            proxyUrl,
+            onCredentialsRefreshed: (refreshed) => persistCodexOAuthCredentials(channelId, refreshed),
+          })
+          const title = generatedTitle ? sanitizeGeneratedTitle(generatedTitle) : null
+          if (title) {
+            console.log(`[Agent 标题生成] ChatGPT OAuth 语义标题生成成功: "${title}"`)
+            return title
+          }
+          console.warn('[Agent 标题生成] ChatGPT OAuth 返回空标题，使用本地兜底')
+        } catch (error) {
+          console.warn('[Agent 标题生成] ChatGPT OAuth 语义标题生成失败，使用本地兜底:', error)
+        }
         return fallbackTitle
       }
 


### PR DESCRIPTION
## Summary

- a09088cf feat(agent): generate Codex OAuth semantic titles

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归