### PR TITLE
fix(tutorial): 修复跨视图打开教程【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.15.7",
+  "version": "0.15.8",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
+++ b/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
@@ -28,6 +28,8 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { settingsTabAtom, channelFormDirtyAtom, settingsCloseRequestedAtom, settingsOpenAtom } from "@/atoms/settings-tab";
 import type { SettingsTab } from "@/atoms/settings-tab";
 import { appModeAtom } from "@/atoms/app-mode";
+import { activeViewAtom } from "@/atoms/active-view";
+import { automationFormAtom } from "@/atoms/automation-atoms";
 import { hasUpdateAtom } from "@/atoms/updater";
 import { tabsAtom, activeTabIdAtom, openTab, TUTORIAL_TAB_ID } from "@/atoms/tab-atoms";
 import { hasEnvironmentIssuesAtom } from "@/atoms/environment";
@@ -147,6 +149,8 @@ export function SettingsPanel({
   const channelFormDirty = useAtomValue(channelFormDirtyAtom);
   const [closeRequested, setCloseRequested] = useAtom(settingsCloseRequestedAtom);
   const setSettingsOpen = useSetAtom(settingsOpenAtom);
+  const setActiveView = useSetAtom(activeViewAtom);
+  const setAutomationForm = useSetAtom(automationFormAtom);
   const appMode = useAtomValue(appModeAtom);
   const hasUpdate = useAtomValue(hasUpdateAtom);
   const hasEnvironmentIssues = useAtomValue(hasEnvironmentIssuesAtom);
@@ -180,6 +184,9 @@ export function SettingsPanel({
       const result = openTab(mainTabs, { type: 'tutorial', sessionId: TUTORIAL_TAB_ID, title: 'Proma 使用教程' })
       setMainTabs(result.tabs)
       setMainActiveTabId(result.activeTabId)
+      // Skills/Automations 会全屏覆盖 TabContent；打开教程时先清理表单并回到会话视图。
+      setAutomationForm({ open: false, draft: null })
+      setActiveView('conversations')
       setSettingsOpen(false)
       return
     }


### PR DESCRIPTION
## 概述
修复从 Agent 技能、定时任务等全屏特殊视图进入设置后点击「Proma 教程」时，教程 Tab 已创建却被原视图或定时任务编辑表单遮住的问题。现在教程入口会统一关闭定时任务编辑表单，并切回会话主视图后展示教程。

## 改动
- `apps/electron/src/renderer/components/settings/SettingsPanel.tsx` — 教程入口新增 `activeViewAtom` 与 `automationFormAtom` 状态复位：关闭可能覆盖内容区的任务编辑表单，并切换至 `conversations`，确保教程 Tab 在 Agent Skills、定时任务列表和任务编辑态均可展示。
- `apps/electron/package.json` — Electron 客户端 patch 版本从 `0.15.7` 升至 `0.15.8`。

## 测试方法
1. 执行 `bun run typecheck`，确认 shared、session-core、core、cli、ui 与 electron 包均通过类型检查。
2. 在普通会话、Agent 技能页和定时任务列表中分别打开设置，点击「Proma 教程」，确认进入教程 Tab。
3. 在定时任务新建或编辑表单中打开设置，点击「Proma 教程」，确认任务表单关闭且教程 Tab 正常展示。

## 备注
- 已审查该修复的跨平台影响；改动仅涉及渲染层 Jotai 状态，不包含路径、Shell 命令或平台特定逻辑。
- 打开教程时清理任务草稿，与现有会话/Tab 导航关闭任务表单的行为保持一致。