### PR TITLE
feat(sidebar): 将会话创建入口收敛至项目层【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -24,7 +24,6 @@ import { settingsOpenAtom, settingsTabAtom } from '@/atoms/settings-tab'
 import {
   conversationsAtom,
   currentConversationIdAtom,
-  selectedModelAtom,
   streamingConversationIdsAtom,
   conversationModelsAtom,
   conversationContextLengthAtom,
@@ -81,7 +80,7 @@ import { searchDialogOpenAtom } from '@/atoms/search-atoms'
 import { hasUpdateAtom, updateStatusAtom, type UpdateStatus } from '@/atoms/updater'
 import { draftSessionIdsAtom } from '@/atoms/draft-session-atoms'
 import { hasEnvironmentIssuesAtom } from '@/atoms/environment'
-import { promptConfigAtom, selectedPromptIdAtom, conversationPromptIdAtom } from '@/atoms/system-prompt-atoms'
+import { conversationPromptIdAtom } from '@/atoms/system-prompt-atoms'
 import { interfaceVariantAtom } from '@/atoms/theme'
 import { useOpenSession } from '@/hooks/useOpenSession'
 import { useSyncActiveTabSideEffects } from '@/hooks/useSyncActiveTabSideEffects'
@@ -747,15 +746,12 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
   const newProjectInputRef = React.useRef<HTMLInputElement>(null)
   const [relativeTimeNow, setRelativeTimeNow] = React.useState(() => Date.now())
   const [userProfile, setUserProfile] = useAtom(userProfileAtom)
-  const selectedModel = useAtomValue(selectedModelAtom)
   const streamingIds = useAtomValue(streamingConversationIdsAtom)
   const mode = useAtomValue(appModeAtom)
   const isMac = React.useMemo(() => detectIsMac(), [])
   const hasUpdate = useAtomValue(hasUpdateAtom)
   const updateStatus = useAtomValue(updateStatusAtom)
   const hasEnvironmentIssues = useAtomValue(hasEnvironmentIssuesAtom)
-  const promptConfig = useAtomValue(promptConfigAtom)
-  const setSelectedPromptId = useSetAtom(selectedPromptIdAtom)
   const interfaceVariant = useAtomValue(interfaceVariantAtom)
   const isClassic = interfaceVariant === 'classic'
 
@@ -1064,29 +1060,6 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     setViewMode('active')
   }, [mode, setViewMode])
 
-  /** 创建新对话（继承当前选中的模型/渠道） */
-  const handleNewConversation = async (): Promise<void> => {
-    setActiveView('conversations')
-    try {
-      const meta = await window.electronAPI.createConversation(
-        undefined,
-        selectedModel?.modelId,
-        selectedModel?.channelId,
-      )
-      setConversations((prev) => [meta, ...prev])
-      // 打开新标签页
-      openSession('chat', meta.id, meta.title)
-      // 确保在对话视图
-      setActiveView('conversations')
-      // 根据默认提示词重置选中
-      if (promptConfig.defaultPromptId) {
-        setSelectedPromptId(promptConfig.defaultPromptId)
-      }
-    } catch (error) {
-      console.error('[侧边栏] 创建对话失败:', error)
-    }
-  }
-
   /** 选择对话（打开或聚焦标签页） */
   const handleSelectConversation = React.useCallback((id: string, title: string): void => {
     openSession('chat', id, title)
@@ -1307,12 +1280,6 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       console.error('[侧边栏] 创建 Agent 会话失败:', error)
     }
   }, [agentChannelId, agentModelId, currentWorkspaceId, openSession, setActiveView, setAgentSessions, setCurrentWorkspaceId, setSessionChannelMap, setSessionModelMap])
-
-  /** 创建新 Agent 会话 */
-  const handleNewAgentSession = React.useCallback(async (): Promise<void> => {
-    setActiveView('conversations')
-    await createAgentSessionInWorkspace()
-  }, [createAgentSessionInWorkspace, setActiveView])
 
   /** 切换当前项目；点击当前已选中工作区标题时则折叠/展开其会话列表 */
   const handleSelectProject = React.useCallback((workspaceId: string): void => {
@@ -2455,22 +2422,6 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
             <TooltipTrigger asChild>
               <button
                 type="button"
-                aria-label={mode === 'agent' ? '新建 Agent 会话' : '新建 Chat 对话'}
-                onClick={mode === 'agent' ? handleNewAgentSession : handleNewConversation}
-                className="size-10 flex items-center justify-center rounded-[12px] text-foreground/70 sidebar-control-surface hover:text-foreground transition-[background-color,color] duration-150 titlebar-no-drag"
-              >
-                <Plus size={16} />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="right">
-              {mode === 'agent' ? '新会话' : '新对话'}
-            </TooltipContent>
-          </Tooltip>
-
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
                 aria-label="搜索"
                 onClick={() => setSearchDialogOpen(true)}
                 className="size-10 flex items-center justify-center rounded-[12px] text-foreground/45 sidebar-control-surface hover:text-foreground/70 transition-[background-color,color] duration-150 titlebar-no-drag"
@@ -2618,11 +2569,22 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       {/* macOS 需要避开左上角红绿灯；边栏覆盖全局标题栏拖拽层，因此留白自身也要可拖拽。 */}
       <div className={cn('w-full flex-shrink-0 titlebar-drag-region', isMac ? 'h-[30px]' : 'h-1')} />
 
-      {/* 模式切换器 + 折叠按钮 */}
+      {/* 模式切换器 + 搜索 + 折叠按钮 */}
       <div className="titlebar-drag-region flex items-start gap-1.5 px-3">
         <div className="flex-1 min-w-0">
           <ModeSwitcher />
         </div>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={() => setSearchDialogOpen(true)}
+              className="mt-2 size-10 flex-shrink-0 flex items-center justify-center rounded-[10px] text-foreground/40 sidebar-control-surface hover:text-foreground/60 transition-[background-color,color] duration-150 titlebar-no-drag"
+            >
+              <Search size={14} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">搜索 ({getAcceleratorDisplay(getActiveAccelerator('global-search'))})</TooltipContent>
+        </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>
             <button
@@ -2635,28 +2597,6 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
             </button>
           </TooltipTrigger>
           <TooltipContent side="right">收起侧边栏 ({navigator.platform.includes('Mac') ? '⌘B' : 'Ctrl+B'})</TooltipContent>
-        </Tooltip>
-      </div>
-
-      {/* 新对话/新会话按钮 + 搜索按钮 */}
-      <div className="px-3 pt-2 flex items-center gap-1.5">
-        <button
-          onClick={mode === 'agent' ? handleNewAgentSession : handleNewConversation}
-          className="flex-1 flex items-center gap-2 h-10 px-3 rounded-[10px] text-[13px] font-medium text-foreground/70 sidebar-control-surface hover:text-foreground transition-[background-color,color] duration-150 titlebar-no-drag"
-        >
-          <Plus size={14} />
-          <span>{mode === 'agent' ? '新会话' : '新对话'}</span>
-        </button>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              onClick={() => setSearchDialogOpen(true)}
-              className="flex-shrink-0 size-10 flex items-center justify-center rounded-[10px] text-foreground/40 sidebar-control-surface hover:text-foreground/60 transition-[background-color,color] duration-150 titlebar-no-drag"
-            >
-              <Search size={14} />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">搜索 ({getAcceleratorDisplay(getActiveAccelerator('global-search'))})</TooltipContent>
         </Tooltip>
       </div>
 
@@ -4016,8 +3956,10 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
   onToggleDelegationParent,
 }: AgentProjectGroupItemProps): React.ReactElement {
   const isCurrent = group.workspace.id === currentWorkspaceId
+  const newSessionShortcutLabel = getAcceleratorDisplay(getActiveAccelerator('new-session'))
 
   const [renamingWorkspace, setRenamingWorkspace] = React.useState(false)
+  const [projectMenuOpen, setProjectMenuOpen] = React.useState(false)
   const [workspaceEditName, setWorkspaceEditName] = React.useState('')
   const workspaceEditRef = React.useRef<HTMLInputElement>(null)
   const justStartedRenamingRef = React.useRef(false)
@@ -4159,16 +4101,26 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
               onSelectProject(group.workspace.id)
             }}
             className={cn(
-              'relative flex-1 min-w-0 flex items-center gap-1 px-1 py-1 rounded-md text-left transition-[padding,color,background-color] titlebar-no-drag group-hover/project:pl-4 group-hover/project:pr-11 hover:bg-foreground/[0.025]',
+              'relative flex-1 min-w-0 flex items-center gap-1 px-1 py-1 pr-12 rounded-md text-left transition-[padding,color,background-color] titlebar-no-drag group-hover/project:pl-4 hover:bg-foreground/[0.025]',
               isCurrent
-                ? 'agent-project-item-current text-foreground'
+                ? 'agent-project-item-current pr-32 text-foreground'
                 : 'text-foreground/65 hover:text-foreground/88',
             )}
           >
-            {isAutomationGroup
-              ? <Clock size={13} className="flex-shrink-0 text-foreground/40" />
-              : <FolderOpen size={13} className="flex-shrink-0 text-foreground/40" />
-            }
+            {isAutomationGroup ? (
+              <Clock size={13} className="flex-shrink-0 text-foreground/40" />
+            ) : (
+              <>
+                <FolderOpen size={13} className="flex-shrink-0 text-foreground/40 group-hover/project:hidden" />
+                <ChevronRight
+                  size={13}
+                  className={cn(
+                    'hidden flex-shrink-0 text-foreground/40 transition-transform duration-150 group-hover/project:block',
+                    collapsed ? '-rotate-90' : 'rotate-90',
+                  )}
+                />
+              </>
+            )}
             <span className="flex min-w-0 items-center">
               <span className="min-w-0 truncate text-[13px] font-medium leading-[18px]">
                 {group.workspace.name}
@@ -4178,14 +4130,25 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
               )}
             </span>
             <span className="min-w-[4px] flex-1" aria-hidden="true" />
-            <ChevronRight
-              size={12}
-              className={cn(
-                'flex-shrink-0 text-foreground/30 transition-transform duration-150',
-                collapsed ? '-rotate-90' : 'rotate-90',
-              )}
-            />
+            {isAutomationGroup && (
+              <ChevronRight
+                size={12}
+                className={cn(
+                  'flex-shrink-0 text-foreground/30 transition-transform duration-150',
+                  collapsed ? '-rotate-90' : 'rotate-90',
+                )}
+              />
+            )}
           </button>
+        )}
+
+        {isCurrent && !isAutomationGroup && newSessionShortcutLabel && !projectMenuOpen && (
+          <span
+            aria-hidden="true"
+            className="pointer-events-none absolute right-6 top-1/2 -translate-y-1/2 whitespace-nowrap text-[10px] font-medium text-foreground/35 transition-opacity group-hover/project:opacity-0"
+          >
+            {newSessionShortcutLabel} 新建项目内会话
+          </span>
         )}
 
         {!isAutomationGroup && (
@@ -4198,22 +4161,24 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
                 e.stopPropagation()
                 void onNewSession(group.workspace.id)
               }}
-              className="absolute right-5 top-1/2 flex size-5 -translate-y-1/2 items-center justify-center rounded-md text-foreground/30 opacity-0 transition-colors hover:bg-foreground/[0.055] hover:text-foreground/65 group-hover/project:opacity-100 titlebar-no-drag"
+              className="absolute right-0 top-1/2 flex size-5 -translate-y-1/2 items-center justify-center rounded-md text-foreground/30 transition-colors hover:bg-foreground/[0.055] hover:text-foreground/65 titlebar-no-drag"
             >
               <Plus size={13} />
             </button>
           </TooltipTrigger>
-          <TooltipContent side="top">在此项目中新建会话</TooltipContent>
+          <TooltipContent side="top">
+            {`在此项目中新建会话${newSessionShortcutLabel ? ` (${newSessionShortcutLabel})` : ''}`}
+          </TooltipContent>
         </Tooltip>
         )}
 
         {!isAutomationGroup && (
-        <DropdownMenu>
+        <DropdownMenu onOpenChange={setProjectMenuOpen}>
           <DropdownMenuTrigger asChild>
             <button
               type="button"
               aria-label="项目菜单"
-              className="absolute right-0 top-1/2 flex size-5 -translate-y-1/2 items-center justify-center rounded-md text-foreground/30 opacity-0 transition-colors hover:bg-foreground/[0.055] hover:text-foreground/60 group-hover/project:opacity-100 data-[state=open]:opacity-100 titlebar-no-drag"
+              className="absolute right-5 top-1/2 flex size-5 -translate-y-1/2 items-center justify-center rounded-md text-foreground/30 opacity-0 transition-colors hover:bg-foreground/[0.055] hover:text-foreground/60 group-hover/project:opacity-100 data-[state=open]:opacity-100 titlebar-no-drag"
             >
               <MoreHorizontal size={13} />
             </button>

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -82,6 +82,7 @@ import { draftSessionIdsAtom } from '@/atoms/draft-session-atoms'
 import { hasEnvironmentIssuesAtom } from '@/atoms/environment'
 import { conversationPromptIdAtom } from '@/atoms/system-prompt-atoms'
 import { interfaceVariantAtom } from '@/atoms/theme'
+import { useCreateSession } from '@/hooks/useCreateSession'
 import { useOpenSession } from '@/hooks/useOpenSession'
 import { useSyncActiveTabSideEffects } from '@/hooks/useSyncActiveTabSideEffects'
 import { CollapsedWorkspacePopover } from '@/components/agent/CollapsedWorkspacePopover'
@@ -780,6 +781,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
   // 会话高亮按"激活 Tab 所属会话"判定：预览 Tab 激活时其 owner 会话仍保持高亮
   const activeSessionId = useAtomValue(activeSessionIdAtom)
   const [sidebarCollapsed, setSidebarCollapsed] = useAtom(sidebarCollapsedAtom)
+  const { createChat } = useCreateSession()
   const openSession = useOpenSession()
   const syncActiveTabSideEffects = useSyncActiveTabSideEffects()
   const store = useStore()
@@ -793,6 +795,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
   const [viewMode, setViewMode] = useAtom(sidebarViewModeAtom)
   const searchDialogOpen = useAtomValue(searchDialogOpenAtom)
   const setSearchDialogOpen = useSetAtom(searchDialogOpenAtom)
+  const newChatShortcutLabel = getAcceleratorDisplay(getActiveAccelerator('new-session'))
 
   const handleOpenSettings = React.useCallback((): void => {
     setSettingsOpen(true)
@@ -2656,8 +2659,31 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
             </div>
           )}
 
-          <div className="px-2 pt-2 pb-1 flex-shrink-0">
+          <div className="group/chat-section relative flex items-center px-2 pt-2 pb-1 flex-shrink-0">
             <span className="px-1.5 text-[11px] font-medium text-foreground/40 select-none">对话</span>
+            {newChatShortcutLabel && (
+              <span
+                aria-hidden="true"
+                className="pointer-events-none absolute right-9 top-1/2 -translate-y-1/2 whitespace-nowrap text-[10px] font-medium text-foreground/35 transition-opacity group-hover/chat-section:opacity-0"
+              >
+                {newChatShortcutLabel} 新建对话
+              </span>
+            )}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-label="新建对话"
+                  onClick={() => { void createChat() }}
+                  className="absolute right-2 top-1/2 flex size-5 -translate-y-1/2 items-center justify-center rounded-md text-foreground/30 transition-colors hover:bg-foreground/[0.055] hover:text-foreground/65 titlebar-no-drag"
+                >
+                  <Plus size={13} />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top">
+                {`新建对话${newChatShortcutLabel ? ` (${newChatShortcutLabel})` : ''}`}
+              </TooltipContent>
+            </Tooltip>
           </div>
 
           <div className="flex-1 overflow-y-auto px-2 pb-3 scrollbar-thin min-h-0 titlebar-no-drag">


### PR DESCRIPTION
## 概述
将左侧栏原先不明确归属的全局新建入口收敛到 Agent 项目行，使用户可以直接在目标项目中创建会话；同时压缩顶部控制区并保留搜索与侧栏收起能力。

## 改动
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 移除展开态和收起态的全局新建入口，将搜索按钮移动到 ModeSwitcher 与收起侧栏按钮之间。
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 普通项目行常驻显示项目内新建会话加号；hover 时切换为展开状态图标并显示项目菜单。
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 为当前项目展示新建会话快捷键和说明；菜单打开时隐藏该说明，避免与三点按钮重叠。

## 测试方法
1. 执行 `bun run typecheck`，确认所有 workspace 包通过类型检查。
2. 执行 `bun run --filter='@proma/electron' build:renderer`，确认 renderer 构建成功。
3. 手动验证项目行默认、hover、项目菜单打开和侧栏折叠状态下的操作布局。

## 备注
- 默认快捷键由现有 registry 提供：macOS 为 `⌘N`，Windows 为 `Ctrl+N`。
- 本 PR 已完成静态 Windows 兼容性扫描；未引入平台路径、Shell 命令或打包配置改动。