### PR TITLE
feat(files): 支持在终端打开会话与工作区文件夹【已审核 PR】

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -2985,6 +2985,34 @@ export function registerIpcHandlers(): void {
     }
   )
 
+  // 使用 macOS 系统 Terminal 在指定工作目录打开会话/工作区文件夹
+  ipcMain.handle(
+    AGENT_IPC_CHANNELS.OPEN_FOLDER_IN_TERMINAL,
+    async (_, folderPath: string): Promise<void> => {
+      if (process.platform !== 'darwin') {
+        throw new Error('当前仅支持在 macOS 终端中打开文件夹')
+      }
+      if (!isPathAllowed(folderPath)) {
+        throw new Error('访问路径超出 Agent 工作区范围')
+      }
+
+      const safePath = realpathSync(resolve(folderPath))
+      if (!statSync(safePath).isDirectory()) {
+        throw new Error('只能在终端中打开文件夹')
+      }
+
+      const { spawn } = await import('node:child_process')
+      await new Promise<void>((resolvePromise, reject) => {
+        const child = spawn('open', ['-a', 'Terminal', safePath], { detached: true, stdio: 'ignore' })
+        child.once('error', reject)
+        child.once('spawn', () => {
+          child.unref()
+          resolvePromise()
+        })
+      })
+    }
+  )
+
   // 在系统文件管理器中显示任意路径（无工作区限制，用户主动点击触发）
   ipcMain.handle(
     IPC_CHANNELS.SHOW_ITEM_IN_FOLDER,

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -740,6 +740,9 @@ export interface ElectronAPI {
   /** 在系统文件管理器中显示文件 */
   showInFolder: (filePath: string) => Promise<void>
 
+  /** 使用系统终端打开文件夹 */
+  openFolderInTerminal: (folderPath: string) => Promise<void>
+
   /** 在系统文件管理器中显示文件（无工作区限制，支持候选基础目录） */
   showItemInFolder: (filePath: string, candidateBasePaths?: string[]) => Promise<boolean>
 
@@ -1902,6 +1905,10 @@ const electronAPI: ElectronAPI = {
 
   showInFolder: (filePath: string) => {
     return ipcRenderer.invoke(AGENT_IPC_CHANNELS.SHOW_IN_FOLDER, filePath)
+  },
+
+  openFolderInTerminal: (folderPath: string) => {
+    return ipcRenderer.invoke(AGENT_IPC_CHANNELS.OPEN_FOLDER_IN_TERMINAL, folderPath)
   },
 
   /** 在系统文件管理器中显示文件（无工作区限制，支持候选基础目录） */

--- a/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
@@ -18,6 +18,7 @@ import {
   RefreshCw,
   ExternalLink,
   FolderSearch,
+  Terminal,
   MoreHorizontal,
   FolderInput,
   Pencil,
@@ -208,6 +209,11 @@ export function FileBrowser({ rootPath, hideToolbar, embedded, hideEmpty, onAddT
     window.electronAPI.showInFolder(entry.path).catch(console.error)
   }, [])
 
+  /** 在系统终端中打开文件夹 */
+  const handleOpenInTerminal = React.useCallback((entry: FileEntry) => {
+    window.electronAPI.openFolderInTerminal(entry.path).catch(console.error)
+  }, [])
+
   /** 开始重命名 */
   const handleStartRename = React.useCallback((entry: FileEntry) => {
     setRenamingPath(entry.path)
@@ -325,6 +331,7 @@ export function FileBrowser({ rootPath, hideToolbar, embedded, hideEmpty, onAddT
           recentlyModifiedSet={recentlyModifiedSet}
           onSelect={handleSelect}
           onShowInFolder={handleShowInFolder}
+          onOpenInTerminal={handleOpenInTerminal}
           onStartRename={handleStartRename}
           onCancelRename={handleCancelRename}
           onRename={handleRename}
@@ -429,6 +436,7 @@ interface FileTreeItemProps {
   recentlyModifiedSet: Set<string>
   onSelect: (entry: FileEntry, event: React.MouseEvent) => void
   onShowInFolder: (entry: FileEntry) => void
+  onOpenInTerminal: (entry: FileEntry) => void
   onStartRename: (entry: FileEntry) => void
   onCancelRename: () => void
   onRename: (filePath: string, newName: string) => Promise<string | null>
@@ -455,6 +463,7 @@ function FileTreeItem({
   recentlyModifiedSet,
   onSelect,
   onShowInFolder,
+  onOpenInTerminal,
   onStartRename,
   onCancelRename,
   onRename,
@@ -470,6 +479,7 @@ function FileTreeItem({
   const [childrenLoaded, setChildrenLoaded] = React.useState(false)
   const [flash, setFlash] = React.useState(false)
   const rowRef = React.useRef<HTMLDivElement>(null)
+  const supportsTerminalFolderOpen = typeof navigator !== 'undefined' && navigator.userAgent.includes('Mac')
 
   // 当 refreshVersion 变化时，已展开的文件夹自动重新加载子项
   React.useEffect(() => {
@@ -803,6 +813,15 @@ function FileTreeItem({
                     在文件夹中显示
                   </DropdownMenuItem>
                 )}
+                {supportsTerminalFolderOpen && menuSelectedCount === 1 && entry.isDirectory && (
+                  <DropdownMenuItem
+                    className="text-xs py-1 [&>svg]:size-3.5"
+                    onSelect={() => onOpenInTerminal(entry)}
+                  >
+                    <Terminal />
+                    在终端中打开此文件夹
+                  </DropdownMenuItem>
+                )}
                 {menuSelectedCount === 1 && !entry.isDirectory && (
                   <DefaultAppMenuItem
                     filePath={entry.path}
@@ -873,6 +892,7 @@ function FileTreeItem({
               recentlyModifiedSet={recentlyModifiedSet}
               onSelect={onSelect}
               onShowInFolder={onShowInFolder}
+              onOpenInTerminal={onOpenInTerminal}
               onStartRename={onStartRename}
               onCancelRename={onCancelRename}
               onRename={onRename}

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1590,6 +1590,8 @@ export const AGENT_IPC_CHANNELS = {
   OPEN_FILE: 'agent:open-file',
   /** 在系统文件管理器中显示文件 */
   SHOW_IN_FOLDER: 'agent:show-in-folder',
+  /** 使用系统终端打开文件夹 */
+  OPEN_FOLDER_IN_TERMINAL: 'agent:open-folder-in-terminal',
   /** 重命名文件/目录 */
   RENAME_FILE: 'agent:rename-file',
   /** 移动文件/目录到目标目录 */


### PR DESCRIPTION
## 概述

在会话文件和工作区文件的文件夹三点菜单中新增“在终端中打开此文件夹”。macOS 上会使用系统自带 Terminal 并以所选文件夹作为工作目录；Windows/Linux 不显示该项，避免呈现不可用操作。

## 改动

- `apps/electron/src/renderer/components/file-browser/FileBrowser.tsx` — 为目录菜单增加 Terminal 图标与操作入口，并仅在 macOS 显示。
- `apps/electron/src/preload/index.ts` — 暴露受限的 `openFolderInTerminal` 预加载 API。
- `apps/electron/src/main/ipc.ts` — 新增 macOS Terminal IPC，验证调用路径属于 Agent 工作区、目标真实存在且为目录，再以参数数组调用系统 `open` 命令。
- `packages/shared/src/types/agent.ts` — 新增对应的 Agent IPC channel。

## 测试方法

1. 执行 `bun run typecheck`，确认 monorepo 全部 package 通过 TypeScript 检查。
2. 在 macOS 的会话文件或工作区文件页，对任意文件夹打开三点菜单并点击“在终端中打开此文件夹”。
3. 确认系统 Terminal 打开，工作目录为所选文件夹。
4. 在 Windows/Linux 确认该菜单项不显示。

## 备注

- 主进程保留 macOS 与目录授权校验，避免 renderer 异常调用执行平台专属命令。
- 该 PR 基于最新 upstream `main` 创建。