### PR TITLE
fix(agent): show estimated context after Pi compaction

### DIFF
--- a/apps/electron/src/main/lib/adapters/pi-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/pi-agent-adapter.ts
@@ -1574,6 +1574,10 @@ export class PiAgentAdapter implements AgentProviderAdapter {
                   subtype: 'compact_boundary',
                   session_id: session.sessionId,
                   summary: event.result.summary,
+                  // 仅手动压缩展示 Pi 的压缩后预估值，自动压缩保持既有行为。
+                  ...(event.reason === 'manual' && event.result.estimatedTokensAfter != null && {
+                    compactionEstimatedTokensAfter: event.result.estimatedTokensAfter,
+                  }),
                 } as unknown as SDKMessage)
               } else if (event.aborted) {
                 queue.push({
@@ -1610,6 +1614,7 @@ export class PiAgentAdapter implements AgentProviderAdapter {
               subtype: 'success',
               usage: { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
               terminal_reason: 'completed',
+              isSyntheticCompactionResult: true,
               session_id: session.sessionId,
             } as unknown as SDKMessage)
             queue.close()
@@ -1625,6 +1630,7 @@ export class PiAgentAdapter implements AgentProviderAdapter {
                 subtype: 'success',
                 usage: { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
                 terminal_reason: 'completed',
+                isSyntheticCompactionResult: true,
                 session_id: session.sessionId,
               } as unknown as SDKMessage)
               queue.close()

--- a/apps/electron/src/renderer/atoms/agent-atoms.test.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from 'bun:test'
+import { applyAgentEvent, type AgentStreamState } from './agent-atoms'
+
+function createStreamState(overrides: Partial<AgentStreamState> = {}): AgentStreamState {
+  return {
+    running: true,
+    content: '',
+    toolActivities: [],
+    inputTokens: 180_000,
+    outputTokens: 2_000,
+    cacheReadTokens: 160_000,
+    cacheCreationTokens: 18_000,
+    contextWindow: 200_000,
+    ...overrides,
+  }
+}
+
+describe('Agent 上下文压缩状态', () => {
+  test('given Pi 手动压缩提供预估 token when 压缩完成 then 显示预估值并清除旧明细', () => {
+    const result = applyAgentEvent(createStreamState(), {
+      type: 'compact_complete',
+      status: 'success',
+      estimatedTokensAfter: 32_000,
+    })
+
+    expect(result).toMatchObject({
+      isCompacting: false,
+      inputTokens: 32_000,
+      contextWindow: 200_000,
+      contextUsageIsEstimated: true,
+    })
+    expect(result.outputTokens).toBeUndefined()
+    expect(result.cacheReadTokens).toBeUndefined()
+    expect(result.cacheCreationTokens).toBeUndefined()
+  })
+
+  test('given 压缩后的预估值 when 当前压缩操作的收尾 result 没有 usage then 保留预估状态', () => {
+    const compacted = applyAgentEvent(createStreamState(), {
+      type: 'compact_complete',
+      status: 'success',
+      estimatedTokensAfter: 32_000,
+    })
+    const result = applyAgentEvent(compacted, { type: 'complete' })
+
+    expect(result).toMatchObject({
+      inputTokens: 32_000,
+      contextUsageIsEstimated: true,
+    })
+  })
+
+  test('given 压缩后的预估值 when 收到零 token result then 保留预估状态', () => {
+    const compacted = applyAgentEvent(createStreamState(), {
+      type: 'compact_complete',
+      status: 'success',
+      estimatedTokensAfter: 32_000,
+    })
+    const result = applyAgentEvent(compacted, {
+      type: 'complete',
+      usage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      },
+    })
+
+    expect(result).toMatchObject({
+      inputTokens: 32_000,
+      contextUsageIsEstimated: true,
+    })
+  })
+
+  test('given 压缩后的预估值 when 下一轮收到真实 usage then 用真实值覆盖预估状态', () => {
+    const compacted = applyAgentEvent(createStreamState(), {
+      type: 'compact_complete',
+      status: 'success',
+      estimatedTokensAfter: 32_000,
+    })
+    const result = applyAgentEvent(compacted, {
+      type: 'usage_update',
+      usage: {
+        inputTokens: 36_000,
+        cacheReadTokens: 30_000,
+        outputTokens: 800,
+      },
+    })
+
+    expect(result).toMatchObject({
+      inputTokens: 36_000,
+      cacheReadTokens: 30_000,
+      outputTokens: 800,
+      contextUsageIsEstimated: false,
+    })
+  })
+
+  test('given 压缩后的预估值 when 下一轮仅在 result 返回 usage then 用真实值覆盖预估状态', () => {
+    const compacted = applyAgentEvent(createStreamState(), {
+      type: 'compact_complete',
+      status: 'success',
+      estimatedTokensAfter: 32_000,
+    })
+    const result = applyAgentEvent(compacted, {
+      type: 'complete',
+      usage: {
+        inputTokens: 40_000,
+        cacheReadTokens: 34_000,
+      },
+    })
+
+    expect(result).toMatchObject({
+      inputTokens: 40_000,
+      cacheReadTokens: 34_000,
+      contextUsageIsEstimated: false,
+    })
+  })
+
+  test('given 没有 Pi 预估 token 的压缩完成事件 when 处理 then 保持既有上下文用量', () => {
+    const result = applyAgentEvent(createStreamState(), { type: 'compact_complete', status: 'success' })
+
+    expect(result).toMatchObject({
+      isCompacting: false,
+      inputTokens: 180_000,
+    })
+    expect(result.contextUsageIsEstimated).toBeUndefined()
+  })
+})

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -86,6 +86,8 @@ export interface AgentStreamState {
   costUsd?: number
   /** 模型上下文窗口大小 */
   contextWindow?: number
+  /** 当前上下文 token 是 Pi 手动压缩后的预估值 */
+  contextUsageIsEstimated?: boolean
   /** 当前 thinking block 的 token 估算值（SDK 实时估算，非计费值） */
   thinkingEstimatedTokens?: number
   /** 是否正在压缩上下文 */
@@ -757,7 +759,10 @@ export function applyAgentEvent(
       // - contextWindow：取流式与 result 的较大值（result 未必更权威——多 entry 时
       //   子 Agent 的小窗口可能拉低值，Fix 1/2 已从源头取 max，此处作为安全网）。
       // - costUsd：始终覆盖（本就该是整轮累计成本）
-      const needResultFallback = !prev.inputTokens || prev.inputTokens <= 0
+      const needResultFallback = !prev.inputTokens || prev.inputTokens <= 0 || prev.contextUsageIsEstimated === true
+      const shouldUseResultUsage = needResultFallback
+        && event.usage?.inputTokens != null
+        && (event.usage.inputTokens > 0 || prev.contextUsageIsEstimated !== true)
       return {
         ...prev,
         ...(event.usage ? {
@@ -767,10 +772,13 @@ export function applyAgentEvent(
               ? Math.max(prev.contextWindow, event.usage.contextWindow)
               : event.usage.contextWindow,
           }),
-          ...(needResultFallback && event.usage.inputTokens != null && { inputTokens: event.usage.inputTokens }),
-          ...(needResultFallback && event.usage.outputTokens != null && { outputTokens: event.usage.outputTokens }),
-          ...(needResultFallback && event.usage.cacheReadTokens != null && { cacheReadTokens: event.usage.cacheReadTokens }),
-          ...(needResultFallback && event.usage.cacheCreationTokens != null && { cacheCreationTokens: event.usage.cacheCreationTokens }),
+          ...(shouldUseResultUsage && {
+            inputTokens: event.usage.inputTokens,
+            outputTokens: event.usage.outputTokens,
+            cacheReadTokens: event.usage.cacheReadTokens,
+            cacheCreationTokens: event.usage.cacheCreationTokens,
+            contextUsageIsEstimated: false,
+          }),
         } : {}),
         retrying: undefined,
         ...finalizeStreamingActivities(prev.toolActivities),
@@ -794,7 +802,10 @@ export function applyAgentEvent(
     case 'usage_update':
       return {
         ...prev,
-        ...(event.usage.inputTokens != null && { inputTokens: event.usage.inputTokens }),
+        ...(event.usage.inputTokens != null && {
+          inputTokens: event.usage.inputTokens,
+          contextUsageIsEstimated: false,
+        }),
         ...(event.usage.outputTokens != null && { outputTokens: event.usage.outputTokens }),
         ...(event.usage.cacheReadTokens != null && { cacheReadTokens: event.usage.cacheReadTokens }),
         ...(event.usage.cacheCreationTokens != null && { cacheCreationTokens: event.usage.cacheCreationTokens }),
@@ -816,16 +827,26 @@ export function applyAgentEvent(
         contextCompaction: { status: 'running' },
       }
 
-    case 'compact_complete':
+    case 'compact_complete': {
+      const contextCompaction = {
+        status: event.status,
+        summary: event.summary,
+        message: event.message,
+      }
+      if (event.estimatedTokensAfter == null) {
+        return { ...prev, isCompacting: false, contextCompaction }
+      }
       return {
         ...prev,
         isCompacting: false,
-        contextCompaction: {
-          status: event.status,
-          summary: event.summary,
-          message: event.message,
-        },
+        contextCompaction,
+        inputTokens: event.estimatedTokensAfter,
+        outputTokens: undefined,
+        cacheReadTokens: undefined,
+        cacheCreationTokens: undefined,
+        contextUsageIsEstimated: true,
       }
+    }
 
     case 'model_resolved':
       // 不用 SDK 返回的实际模型名覆盖，保持用户选择的 modelId
@@ -911,6 +932,8 @@ export interface AgentContextStatus {
   cacheCreationTokens?: number
   costUsd?: number
   contextWindow?: number
+  /** 当前上下文 token 是否为 Pi 手动压缩后的预估值 */
+  contextUsageIsEstimated?: boolean
 }
 
 /** 当前会话的上下文使用量派生 atom */
@@ -926,6 +949,7 @@ export const agentContextStatusAtom = atom<AgentContextStatus>((get) => {
     cacheCreationTokens: state?.cacheCreationTokens,
     costUsd: state?.costUsd,
     contextWindow: state?.contextWindow,
+    contextUsageIsEstimated: state?.contextUsageIsEstimated,
   }
 })
 

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -547,6 +547,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     isCompacting: streamState?.isCompacting ?? false,
     inputTokens: streamState?.inputTokens,
     contextWindow: streamState?.contextWindow,
+    contextUsageIsEstimated: streamState?.contextUsageIsEstimated,
   }
   const setAgentStreamErrors = useSetAtom(agentStreamErrorsAtom)
   const streamErrors = useAtomValue(agentStreamErrorsAtom)
@@ -1094,6 +1095,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
                 cacheReadTokens: state.cacheReadTokens,
                 cacheCreationTokens: state.cacheCreationTokens,
                 contextWindow: state.contextWindow,
+                contextUsageIsEstimated: state.contextUsageIsEstimated,
                 model: state.model,
                 contextCompaction: state.contextCompaction,
               })
@@ -2685,6 +2687,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           cacheReadTokens={contextStatus.cacheReadTokens}
           cacheCreationTokens={contextStatus.cacheCreationTokens}
           contextWindow={contextStatus.contextWindow}
+          isEstimated={contextStatus.contextUsageIsEstimated === true}
           isCompacting={contextStatus.isCompacting}
           isProcessing={streaming}
           sessionId={sessionId}

--- a/apps/electron/src/renderer/components/agent/ContextUsageBadge.tsx
+++ b/apps/electron/src/renderer/components/agent/ContextUsageBadge.tsx
@@ -33,6 +33,8 @@ interface ContextUsageBadgeProps {
   cacheCreationTokens?: number
   costUsd?: number
   contextWindow?: number
+  /** 当前上下文 token 是否为 Pi 手动压缩后的预估值 */
+  isEstimated: boolean
   isCompacting: boolean
   isProcessing: boolean
   onCompact: () => void
@@ -164,6 +166,7 @@ export function ContextUsageBadge({
   cacheReadTokens,
   cacheCreationTokens,
   contextWindow,
+  isEstimated,
   isCompacting,
   isProcessing,
   onCompact,
@@ -308,26 +311,36 @@ export function ContextUsageBadge({
         onOpenAutoFocus={(e) => e.preventDefault()}
       >
         <div className="flex flex-col gap-1.5">
-          {displayOutput ? <DetailRow label="输出" value={displayOutput.toLocaleString()} /> : null}
-          {displayCacheCreation ? <DetailRow label="缓存写入" value={displayCacheCreation.toLocaleString()} /> : null}
-          {displayCacheRead ? <DetailRow label="缓存读取" value={displayCacheRead.toLocaleString()} /> : null}
-
-          {displayWindow ? (
+          {isEstimated ? (
+            <DetailRow
+              label="压缩后"
+              value={`预估 ${formatTokens(displayTokens)} tokens${percent != null ? `（${percent}%）` : ''}`}
+              emphasized
+            />
+          ) : (
             <>
-              <DetailRow
-                label="上下文"
-                value={`${formatTokens(displayTokens)} / ${formatTokens(displayWindow)}`}
-                emphasized
-              />
-              {percent != null && (
-                <DetailRow
-                  label="占用"
-                  value={`${percent}%`}
-                  emphasized={isWarning}
-                />
-              )}
+              {displayOutput ? <DetailRow label="输出" value={displayOutput.toLocaleString()} /> : null}
+              {displayCacheCreation ? <DetailRow label="缓存写入" value={displayCacheCreation.toLocaleString()} /> : null}
+              {displayCacheRead ? <DetailRow label="缓存读取" value={displayCacheRead.toLocaleString()} /> : null}
+
+              {displayWindow ? (
+                <>
+                  <DetailRow
+                    label="上下文"
+                    value={`${formatTokens(displayTokens)} / ${formatTokens(displayWindow)}`}
+                    emphasized
+                  />
+                  {percent != null && (
+                    <DetailRow
+                      label="占用"
+                      value={`${percent}%`}
+                      emphasized={isWarning}
+                    />
+                  )}
+                </>
+              ) : null}
             </>
-          ) : null}
+          )}
 
           {shouldShowPlanQuota ? (
             <>

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -251,8 +251,15 @@ function payloadToLegacyEvents(payload: AgentStreamPayload): AgentEvent[] {
         total_cost_usd?: number
         modelUsage?: Record<string, { contextWindow?: number }>
         usage?: { input_tokens: number; output_tokens: number; cache_read_input_tokens: number; cache_creation_input_tokens: number }
+        isSyntheticCompactionResult?: boolean
         _channelModelId?: string
         _channelProvider?: ProviderType
+      }
+      if (rMsg.isSyntheticCompactionResult) {
+        return [{
+          type: 'complete',
+          stopReason: rMsg.subtype === 'success' ? 'end_turn' : 'error',
+        }]
       }
       // 多 entry 场景（Task 子 Agent 等）：取最大 contextWindow，
       // 避免子 Agent 的小窗口覆盖主模型的大窗口、导致指示器飘忽。
@@ -300,7 +307,13 @@ function payloadToLegacyEvents(payload: AgentStreamPayload): AgentEvent[] {
     case 'system': {
       const sMsg = msg as SDKSystemMessage
       if (sMsg.subtype === 'compact_boundary') {
-        return [{ type: 'compact_complete', status: 'success', summary: sMsg.summary }]
+        const estimatedTokensAfter = sMsg.compactionEstimatedTokensAfter
+        return [{
+          type: 'compact_complete',
+          status: 'success',
+          summary: sMsg.summary,
+          ...(typeof estimatedTokensAfter === 'number' && estimatedTokensAfter > 0 && { estimatedTokensAfter }),
+        }]
       }
       if (sMsg.subtype === 'compacting') return [{ type: 'compacting' }]
       if (sMsg.subtype === 'status') {

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -250,6 +250,8 @@ export interface SDKResultMessage {
   modelUsage?: Record<string, { contextWindow?: number }>
   errors?: string[]
   terminal_reason?: string
+  /** Pi 手动压缩用于收束流的内部 result，不代表真实模型 usage */
+  isSyntheticCompactionResult?: boolean
   background_tasks?: SDKBackgroundTaskSummary[]
   session_crons?: SDKSessionCronSummary[]
   session_id?: string
@@ -276,6 +278,8 @@ export interface SDKSystemMessage {
   compact_result?: 'success' | 'failed' | 'noop'
   /** SDK status: 上下文压缩失败原因 */
   compact_error?: string
+  /** Pi 手动压缩后的上下文 token 预估值 */
+  compactionEstimatedTokensAfter?: number
   summary?: string
   output_file?: string
   last_tool_name?: string
@@ -539,7 +543,13 @@ export type AgentEvent =
   | { type: 'usage_update'; usage: AgentEventUsage }
   // 上下文压缩
   | { type: 'compacting' }
-  | { type: 'compact_complete'; status: 'success' | 'noop' | 'failed'; summary?: string; message?: string }
+  | {
+    type: 'compact_complete'
+    status: 'success' | 'noop' | 'failed'
+    summary?: string
+    message?: string
+    estimatedTokensAfter?: number
+  }
   // 权限请求
   | { type: 'permission_request'; request: PermissionRequest }
   | { type: 'permission_resolved'; requestId: string; behavior: 'allow' | 'deny' }


### PR DESCRIPTION
## Summary

- Show Pi manual compaction's estimated post-compaction token count and context ratio in the input context badge.
- Preserve the estimate until the next real usage update, then restore the normal exact usage display.
- Ignore the Pi internal compaction completion result so its zero usage cannot replace the estimate.
- Keep Claude runtime and Pi automatic compaction behavior unchanged.

## Test plan

- [x] `bun test ./apps/electron/src/renderer/atoms/agent-atoms.test.ts`
- [x] `bun run typecheck`