### PR TITLE
Fix default application menu fallback

### DIFF
--- a/apps/electron/src/renderer/components/diff/DefaultAppOpenButton.tsx
+++ b/apps/electron/src/renderer/components/diff/DefaultAppOpenButton.tsx
@@ -3,13 +3,15 @@
  *
  * 通过 useDefaultAppForFile 拿到本机为该文件类型注册的默认 App（含图标），
  * 渲染一个按钮；点击调用 systemOpenFile 让系统按默认 App 打开。
- * 探测失败或图标读取失败时不渲染。
+ * 探测未完成或失败时，使用通用图标和文案保留打开入口。
  */
 
 import * as React from 'react'
+import { ExternalLink } from 'lucide-react'
 import type { FileAccessOptions } from '@proma/shared'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useDefaultAppForFile } from '@/hooks/useDefaultAppForFile'
+import { getDefaultAppOpenLabel } from '@/lib/default-app-open-label'
 import { cn } from '@/lib/utils'
 
 interface DefaultAppOpenButtonProps {
@@ -35,9 +37,8 @@ export function DefaultAppOpenButton({
     })
   }, [filePath, access])
 
-  if (!info) return null
-
   const labeled = variant === 'labeled'
+  const label = getDefaultAppOpenLabel(info)
 
   return (
     <Tooltip>
@@ -50,21 +51,25 @@ export function DefaultAppOpenButton({
             labeled ? 'gap-1 h-6 px-1.5 max-w-[140px]' : 'justify-center size-6',
             className,
           )}
-          aria-label={`用 ${info.name} 打开`}
+          aria-label={label}
         >
-          <img
-            src={info.iconDataUrl}
-            alt=""
-            className={cn('shrink-0', labeled ? 'size-4' : 'size-3.5')}
-            draggable={false}
-          />
+          {info ? (
+            <img
+              src={info.iconDataUrl}
+              alt=""
+              className={cn('shrink-0', labeled ? 'size-4' : 'size-3.5')}
+              draggable={false}
+            />
+          ) : (
+            <ExternalLink className={cn('shrink-0', labeled ? 'size-4' : 'size-3.5')} />
+          )}
           {labeled && (
-            <span className="text-[11px] leading-none truncate">{info.name}</span>
+            <span className="text-[11px] leading-none truncate">{info?.name ?? '系统默认应用'}</span>
           )}
         </button>
       </TooltipTrigger>
       <TooltipContent side="bottom">
-        <p>用 {info.name} 打开编辑</p>
+        <p>{info ? `用 ${info.name} 打开编辑` : '用系统默认应用打开'}</p>
       </TooltipContent>
     </Tooltip>
   )

--- a/apps/electron/src/renderer/components/file-browser/DefaultAppMenuItem.test.tsx
+++ b/apps/electron/src/renderer/components/file-browser/DefaultAppMenuItem.test.tsx
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'bun:test'
+import { getDefaultAppOpenLabel } from '@/lib/default-app-open-label'
+
+describe('默认应用打开文案', () => {
+  test('given 默认应用探测失败 when 生成打开文案 then 保留系统默认应用入口', () => {
+    expect(getDefaultAppOpenLabel(null)).toBe('用系统默认应用打开')
+  })
+
+  test('given 默认应用探测成功 when 生成打开文案 then 显示已探测的应用名称', () => {
+    expect(getDefaultAppOpenLabel({
+      name: 'Preview',
+      appPath: '/System/Applications/Preview.app',
+      iconDataUrl: 'data:image/png;base64,icon',
+    })).toBe('用 Preview 打开')
+  })
+})

--- a/apps/electron/src/renderer/components/file-browser/DefaultAppMenuItem.tsx
+++ b/apps/electron/src/renderer/components/file-browser/DefaultAppMenuItem.tsx
@@ -1,13 +1,15 @@
 /**
  * DefaultAppMenuItem — DropdownMenuItem 形式的"用默认 App 打开"。
  *
- * 探测本机为该文件类型注册的默认 App，菜单项文案动态显示「用 XX 打开」并带 App Logo。
- * 探测失败（图标读取失败、文件类型未注册默认 App、平台不支持）时整个菜单项不渲染。
+ * 探测本机为该文件类型注册的默认 App，成功时显示「用 XX 打开」并带 App Logo。
+ * 探测尚未完成或失败时，仍保留系统默认应用打开入口。
  */
 
 import * as React from 'react'
+import { ExternalLink } from 'lucide-react'
 import { DropdownMenuItem } from '@/components/ui/dropdown-menu'
 import { useDefaultAppForFile } from '@/hooks/useDefaultAppForFile'
+import { getDefaultAppOpenLabel } from '@/lib/default-app-open-label'
 
 interface DefaultAppMenuItemProps {
   filePath: string
@@ -17,10 +19,8 @@ interface DefaultAppMenuItemProps {
 export function DefaultAppMenuItem({
   filePath,
   className,
-}: DefaultAppMenuItemProps): React.ReactElement | null {
+}: DefaultAppMenuItemProps): React.ReactElement {
   const info = useDefaultAppForFile(filePath)
-
-  if (!info) return null
 
   return (
     <DropdownMenuItem
@@ -31,13 +31,17 @@ export function DefaultAppMenuItem({
         })
       }}
     >
-      <img
-        src={info.iconDataUrl}
-        alt=""
-        className="size-3.5 shrink-0"
-        draggable={false}
-      />
-      <span className="truncate">用 {info.name} 打开</span>
+      {info ? (
+        <img
+          src={info.iconDataUrl}
+          alt=""
+          className="size-3.5 shrink-0"
+          draggable={false}
+        />
+      ) : (
+        <ExternalLink />
+      )}
+      <span className="truncate">{getDefaultAppOpenLabel(info)}</span>
     </DropdownMenuItem>
   )
 }

--- a/apps/electron/src/renderer/hooks/useDefaultAppForFile.ts
+++ b/apps/electron/src/renderer/hooks/useDefaultAppForFile.ts
@@ -2,13 +2,13 @@
  * useDefaultAppForFile — 探测本机为文件类型注册的默认 App，并缓存。
  *
  * 跨组件共用：预览面板顶栏按钮、文件浏览器三点菜单等都通过此 hook 拿到 App 信息。
- * 缓存按文件后缀维度，进程内一直有效——切换默认 App 后下次启动 dev/window 生效。
+ * 成功结果按文件后缀缓存；探测失败不缓存，避免临时系统异常长期隐藏打开入口。
  */
 
 import * as React from 'react'
 import type { DefaultAppInfo, FileAccessOptions } from '@proma/shared'
 
-const rendererCache = new Map<string, DefaultAppInfo | null>()
+const rendererCache = new Map<string, DefaultAppInfo>()
 
 function extKeyOf(filePath: string): string {
   const base = filePath.split(/[\\/]/).pop() ?? ''
@@ -42,14 +42,12 @@ export function useDefaultAppForFile(
       .then((result) => {
         if (cancelled) return
         console.log('[useDefaultAppForFile] IPC 返回:', filePath, result ? `name=${result.name}` : 'null')
-        // 带访问上下文时，null 可能来自路径授权失败，不能污染按后缀共享的默认 App 缓存。
-        if (result || !access) rendererCache.set(key, result)
+        if (result) rendererCache.set(key, result)
         setInfo(result)
       })
       .catch((err) => {
         if (cancelled) return
         console.warn('[useDefaultAppForFile] IPC 报错:', filePath, err)
-        rendererCache.set(key, null)
         setInfo(null)
       })
     return () => {

--- a/apps/electron/src/renderer/lib/default-app-open-label.ts
+++ b/apps/electron/src/renderer/lib/default-app-open-label.ts
@@ -1,0 +1,5 @@
+import type { DefaultAppInfo } from '@proma/shared'
+
+export function getDefaultAppOpenLabel(info: DefaultAppInfo | null): string {
+  return info ? `用 ${info.name} 打开` : '用系统默认应用打开'
+}


### PR DESCRIPTION
## Summary

- Always render the system default application action in file menus and preview toolbars.
- Use the detected application name and icon only as progressive enhancement; Swift, LaunchServices, or icon lookup failures no longer hide the action.
- Cache only successful renderer-side lookups, so a transient failure cannot suppress the entry for the rest of the session.
- Add BDD coverage for generic and enriched open labels.

Closes #1242

## Validation

- [x] `bun test apps/electron/src/renderer/components/file-browser/DefaultAppMenuItem.test.tsx`
- [x] `bun run typecheck`
- [x] `bun run build:renderer`
- [ ] `bun test` has 438 passing tests and 2 existing failures because Bun's Electron stub lacks `BrowserWindow` / `shell` exports for two main-process test files.