### PR TITLE
fix(sidebar): 对齐项目分区布局【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -2686,7 +2686,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
         <div className="flex-1 flex flex-col min-h-0">
           {pinnedConversations.length > 0 && (
             <div className="pt-2 pb-1 flex-shrink-0 titlebar-no-drag">
-              <div className="px-3.5 pb-1 text-[11px] font-medium text-foreground/40 select-none">
+              <div className="pl-[18px] pr-3.5 pb-1 text-[13px] font-medium leading-[18px] text-foreground/40 select-none">
                 置顶
               </div>
               <div
@@ -2751,7 +2751,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
         <div className="flex-1 flex flex-col min-h-0">
           {pinnedAgentSessions.length > 0 && (
             <div className="pt-2 pb-1 flex-shrink-0 titlebar-no-drag">
-              <div className="px-3.5 pb-1 text-[11px] font-medium text-foreground/40 select-none">
+              <div className="pl-[18px] pr-3.5 pb-1 text-[13px] font-medium leading-[18px] text-foreground/40 select-none">
                 置顶
               </div>
               <div
@@ -2827,16 +2827,16 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
 
           {/* 下区标题：项目历史 */}
           <div className="px-2 pt-2 pb-1 flex items-center justify-between flex-shrink-0">
-            <span className="px-1.5 text-[11px] font-medium text-foreground/40 select-none">项目</span>
+            <span className="ml-[4px] px-1.5 text-[13px] font-medium leading-[18px] text-foreground/40 select-none">项目</span>
             <Tooltip>
               <TooltipTrigger asChild>
                 <button
                   type="button"
                   onClick={handleStartCreateProject}
-                  className="size-6 flex items-center justify-center rounded-md text-foreground/35 hover:bg-foreground/[0.06] hover:text-foreground/60 transition-colors titlebar-no-drag"
+                  className="size-6 flex items-center justify-center rounded-md text-foreground/40 hover:bg-foreground/[0.06] hover:text-foreground/60 transition-colors titlebar-no-drag"
                   aria-label="新建项目"
                 >
-                  <Plus size={13} />
+                  <Plus size={16} />
                 </button>
               </TooltipTrigger>
               <TooltipContent side="top">新建项目</TooltipContent>
@@ -4115,10 +4115,10 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
       className={cn('relative py-0.5 rounded-md transition-opacity', dragging && 'opacity-45')}
     >
       {dropPosition === 'before' && (
-        <div className="absolute -top-0.5 left-3 right-3 h-0.5 rounded-full bg-primary z-10" />
+        <div className="absolute -top-0.5 left-3 right-3 h-0.5 translate-x-[2px] rounded-full bg-primary z-10" />
       )}
 
-      <div className="group/project relative flex items-center">
+      <div className="group/project relative flex translate-x-[2px] items-center">
         <span
           draggable
           onDragStart={(e) => onDragStart(e, group.workspace.id)}
@@ -4132,7 +4132,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
         {renamingWorkspace ? (
           <div
             className={cn(
-              'relative flex-1 min-w-0 flex items-center gap-1 px-1 py-1 rounded-md text-left titlebar-no-drag group-hover/project:pl-4 group-hover/project:pr-11',
+              'relative flex-1 min-w-0 flex items-center gap-1 pl-[9px] pr-1 py-1 rounded-md text-left titlebar-no-drag group-hover/project:pl-4 group-hover/project:pr-11',
               isCurrent
                 ? 'agent-project-item-current text-foreground'
                 : 'text-foreground/65',
@@ -4159,7 +4159,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
               onSelectProject(group.workspace.id)
             }}
             className={cn(
-              'relative flex-1 min-w-0 flex items-center gap-1 px-1 py-1 rounded-md text-left transition-[padding,color,background-color] titlebar-no-drag group-hover/project:pl-4 group-hover/project:pr-11 hover:bg-foreground/[0.025]',
+              'relative flex-1 min-w-0 flex items-center gap-1 pl-[9px] pr-1 py-1 rounded-md text-left transition-[padding,color,background-color] titlebar-no-drag group-hover/project:pl-4 group-hover/project:pr-11 hover:bg-foreground/[0.025]',
               isCurrent
                 ? 'agent-project-item-current text-foreground'
                 : 'text-foreground/65 hover:text-foreground/88',

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -2689,7 +2689,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
           <div className="flex-1 overflow-y-auto px-2 pb-3 scrollbar-thin min-h-0 titlebar-no-drag">
             {conversationGroups.map((group) => (
               <div key={group.label} className="mb-1">
-                <div className="px-1.5 pt-2 pb-1 text-[11px] font-medium text-foreground/40 select-none">
+                <div className="ml-[4px] px-1.5 pt-2 pb-1 text-[11px] font-medium text-foreground/40 select-none">
                   {group.label}
                 </div>
                 <div className="flex flex-col gap-0.5">

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -2660,7 +2660,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
           )}
 
           <div className="group/chat-section relative flex items-center px-2 pt-2 pb-1 flex-shrink-0">
-            <span className="px-1.5 text-[11px] font-medium text-foreground/40 select-none">对话</span>
+            <span className="ml-[4px] px-1.5 text-[13px] font-medium leading-[18px] text-foreground/40 select-none">对话</span>
             {newChatShortcutLabel && (
               <span
                 aria-hidden="true"


### PR DESCRIPTION
## 概述

统一 Agent 左侧栏中“置顶”和“项目”分级标题的字级与水平对齐，并微调项目组及其拖拽排序指示线的位置，使项目区域在常态和拖拽反馈中保持一致。

## 改动

- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 将 Chat 与 Agent 模式的“置顶”标题调整为与项目标题一致的 `13px / font-medium / 18px` 文字规格，并微调左侧偏移。
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 将“项目”标题按设计位置微调，并将新建项目加号调整为 `16px`，其常态色与项目标题一致。
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 调整自动任务与项目组标题行的水平偏移，同时让拖拽排序插入指示线使用同样的位移，避免拖拽反馈与标题行错位。

## 测试方法

1. 执行 `bun run typecheck`，确认 monorepo 所有包通过类型检查。
2. 启动 Electron 开发环境，确认 `LeftSidebar.tsx` 的 HMR 更新成功加载。
3. 在 Agent 左侧栏检查“置顶”“项目”、自动任务和项目组的文字规格与水平对齐。
4. 拖拽项目排序，确认插入指示线与项目组标题行保持对齐。

## 备注

- 已执行代码审查与 Windows 兼容性静态扫描；本 PR 仅涉及 renderer 样式 class，不包含路径、平台 API、依赖或构建配置改动。
- 上游仓库不允许当前账号直接推送，分支托管于 `Andreaseszhang/Proma`。