### PR TITLE
fix: preserve side chat workspace on agent migration

### DIFF
--- a/apps/electron/src/renderer/atoms/chat-atoms.test.ts
+++ b/apps/electron/src/renderer/atoms/chat-atoms.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test'
+import type { AgentSessionMeta } from '@proma/shared'
+import { resolveSideChatWorkspaceId } from './chat-atoms'
+
+function makeSession(id: string, workspaceId?: string): AgentSessionMeta {
+  return {
+    id,
+    title: id,
+    createdAt: 0,
+    updatedAt: 0,
+    workspaceId,
+  }
+}
+
+describe('resolveSideChatWorkspaceId', () => {
+  test('Given 右侧问答关联源会话 When 解析工作区 Then 返回源会话的工作区', () => {
+    const workspaceId = resolveSideChatWorkspaceId(
+      'conversation-side',
+      new Map([['session-a', 'conversation-side']]),
+      [makeSession('session-a', 'workspace-b')],
+    )
+
+    expect(workspaceId).toBe('workspace-b')
+  })
+
+  test('Given 对话没有右侧问答关联 When 解析工作区 Then 返回 undefined', () => {
+    const workspaceId = resolveSideChatWorkspaceId(
+      'conversation-chat',
+      new Map([['session-a', 'conversation-side']]),
+      [makeSession('session-a', 'workspace-a')],
+    )
+
+    expect(workspaceId).toBeUndefined()
+  })
+
+  test('Given 右侧问答关联的源会话已不存在 When 解析工作区 Then 返回 undefined', () => {
+    const workspaceId = resolveSideChatWorkspaceId(
+      'conversation-side',
+      new Map([['session-missing', 'conversation-side']]),
+      [makeSession('session-a', 'workspace-a')],
+    )
+
+    expect(workspaceId).toBeUndefined()
+  })
+})

--- a/apps/electron/src/renderer/atoms/chat-atoms.ts
+++ b/apps/electron/src/renderer/atoms/chat-atoms.ts
@@ -7,7 +7,7 @@
 
 import { atom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
-import type { ConversationMeta, ChatMessage, FileAttachment, ChatToolActivity, Channel } from '@proma/shared'
+import type { AgentSessionMeta, ConversationMeta, ChatMessage, FileAttachment, ChatToolActivity, Channel } from '@proma/shared'
 
 /** 全局渠道列表缓存（启动时加载一次，设置变更时刷新） */
 export const channelsAtom = atom<Channel[]>([])
@@ -38,6 +38,19 @@ export const currentConversationIdAtom = atom<string | null>(null)
 
 /** Agent 会话右侧 Chat 面板，key 为 Agent sessionId，value 为 Chat conversationId */
 export const agentSideChatMapAtom = atom<Map<string, string>>(new Map())
+
+/** 根据右侧问答对话反查其源 Agent 会话所属工作区。 */
+export function resolveSideChatWorkspaceId(
+  conversationId: string,
+  sideChatMap: ReadonlyMap<string, string>,
+  sessions: readonly AgentSessionMeta[],
+): string | undefined {
+  for (const [sessionId, sideChatConversationId] of sideChatMap) {
+    if (sideChatConversationId !== conversationId) continue
+    return sessions.find((session) => session.id === sessionId)?.workspaceId
+  }
+  return undefined
+}
 
 /** 当前对话的消息列表 */
 export const currentMessagesAtom = atom<ChatMessage[]>([])

--- a/apps/electron/src/renderer/components/chat/AgentRecommendBanner.tsx
+++ b/apps/electron/src/renderer/components/chat/AgentRecommendBanner.tsx
@@ -18,7 +18,7 @@ import { useAtom, useStore } from 'jotai'
 import { toast } from 'sonner'
 import { Sparkles, X, ArrowRight } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { pendingAgentRecommendationAtom } from '@/atoms/chat-atoms'
+import { agentSideChatMapAtom, pendingAgentRecommendationAtom, resolveSideChatWorkspaceId } from '@/atoms/chat-atoms'
 import {
   agentChannelIdAtom,
   agentModelIdAtom,
@@ -59,13 +59,20 @@ export function AgentRecommendBanner(): React.ReactElement | null {
     setMigrating(true)
     try {
       const workspaces = store.get(agentWorkspacesAtom)
-      const defaultWorkspaceId = workspaces[0]?.id ?? null
+      const sourceWorkspaceId = resolveSideChatWorkspaceId(
+        conversationId,
+        store.get(agentSideChatMapAtom),
+        store.get(agentSessionsAtom),
+      )
+      const targetWorkspaceId = workspaces.some((workspace) => workspace.id === sourceWorkspaceId)
+        ? sourceWorkspaceId
+        : workspaces[0]?.id ?? null
 
       // 1. 创建 Agent 会话
       const session = await window.electronAPI.createAgentSession(
         undefined,
         agentChannelId,
-        defaultWorkspaceId ?? undefined,
+        targetWorkspaceId ?? undefined,
         store.get(agentModelIdAtom) || undefined,
       )
 
@@ -76,11 +83,11 @@ export function AgentRecommendBanner(): React.ReactElement | null {
       const sessions = await window.electronAPI.listAgentSessions()
       store.set(agentSessionsAtom, sessions)
 
-      // 4. 切换到默认工作区（确保 AgentView 能正确显示新会话）
-      if (defaultWorkspaceId) {
-        store.set(currentAgentWorkspaceIdAtom, defaultWorkspaceId)
+      // 4. 切换到目标工作区（确保 AgentView 能正确显示新会话）
+      if (targetWorkspaceId) {
+        store.set(currentAgentWorkspaceIdAtom, targetWorkspaceId)
         window.electronAPI.updateSettings({
-          agentWorkspaceId: defaultWorkspaceId,
+          agentWorkspaceId: targetWorkspaceId,
         }).catch(console.error)
       }
 


### PR DESCRIPTION
## Summary
- resolve the source workspace from the existing Agent side-chat mapping before migrating from the recommendation banner
- retain the existing default-workspace fallback when the source session or workspace is unavailable
- add regression coverage for source workspace resolution

## Validation
- bun test apps/electron/src/renderer/atoms/chat-atoms.test.ts
- bun run --filter='@proma/electron' typecheck\n- bun run --filter='@proma/electron' build:renderer