### PR TITLE
feat(channel): add OpenCode Go subscription

### DIFF
--- a/apps/electron/src/main/lib/adapters/pi-model-registry.ts
+++ b/apps/electron/src/main/lib/adapters/pi-model-registry.ts
@@ -185,6 +185,7 @@ function loadPiAiCompat(): Promise<PiAiCompat> {
 function normalizePiApi(provider: ProviderType): Api {
   switch (provider) {
     case 'openai':
+    case 'opencode-go-openai':
     case 'zhipu':
     case 'doubao':
     case 'qwen':

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -641,12 +641,12 @@ export class AgentOrchestrator {
       const proxyUrl = await getEffectiveProxyUrl()
       const fetchFn = getFetchFn(proxyUrl)
       const title = await fetchTitle(request, providerAdapter, fetchFn)
-      if (!title) {
-        console.warn('[Agent 标题生成] API 返回空标题')
-        return null
+      const result = title ? sanitizeGeneratedTitle(title) : null
+      if (!result) {
+        console.warn('[Agent 标题生成] API 未返回可用标题')
+        // OpenCode Go 的服务端偶发返回空标题时，仍要完成重命名，避免会话长期停在默认标题。
+        return channel.provider === 'opencode-go-openai' ? createFallbackTitle(userMessage) : null
       }
-
-      const result = sanitizeGeneratedTitle(title)
 
       console.log(`[Agent 标题生成] 生成标题成功: "${result}"`)
       return result

--- a/apps/electron/src/main/lib/channel-manager.ts
+++ b/apps/electron/src/main/lib/channel-manager.ts
@@ -595,6 +595,7 @@ export async function testChannel(channelId: string): Promise<ChannelTestResult>
         return await testAnthropicCompatible(channel.baseUrl, apiKey, proxyUrl, provider)
       case 'openai':
       case 'openai-responses':
+      case 'opencode-go-openai':
       case 'zhipu':
       case 'doubao':
       case 'qwen':
@@ -1569,6 +1570,7 @@ export async function testChannelDirect(input: ChannelDirectTestInput): Promise<
         return await testAnthropicCompatible(input.baseUrl, input.apiKey, proxyUrl, provider)
       case 'openai':
       case 'openai-responses':
+      case 'opencode-go-openai':
       case 'zhipu':
       case 'doubao':
       case 'qwen':
@@ -1646,6 +1648,7 @@ export async function fetchModels(input: FetchModelsInput): Promise<FetchModelsR
         return await fetchAnthropicCompatibleModels(input.baseUrl, input.apiKey, proxyUrl, provider)
       case 'openai':
       case 'openai-responses':
+      case 'opencode-go-openai':
       case 'zhipu':
       case 'doubao':
       case 'qwen':

--- a/apps/electron/src/main/lib/chat-service.ts
+++ b/apps/electron/src/main/lib/chat-service.ts
@@ -626,13 +626,13 @@ export async function generateTitle(input: GenerateTitleInput): Promise<string |
     const proxyUrl = await getEffectiveProxyUrl()
     const fetchFn = getFetchFn(proxyUrl)
     const title = await fetchTitle(request, adapter, fetchFn)
-    if (!title) {
-      console.warn('[标题生成] API 返回空标题')
-      return null
+    const result = title ? sanitizeGeneratedTitle(title) : null
+    if (!result) {
+      console.warn('[标题生成] API 未返回可用标题')
+      // OpenCode Go 的服务端偶发返回空标题时，仍要完成重命名，避免对话长期停在默认标题。
+      return channel.provider === 'opencode-go-openai' ? createFallbackTitle(userMessage) : null
     }
 
-    // 截断到最大长度并清理引号
-    const result = sanitizeGeneratedTitle(title)
     console.log('[标题生成] 成功生成标题:', result)
     return result
   } catch (error) {

--- a/apps/electron/src/renderer/components/settings/ChannelForm.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelForm.tsx
@@ -79,12 +79,13 @@ interface ChannelFormProps {
 }
 
 /** 所有可选供应商 */
-const PROVIDER_OPTIONS: ProviderType[] = ['anthropic', 'anthropic-compatible', 'openai', 'openai-responses', 'openai-codex', 'deepseek', 'google', 'kimi-api', 'kimi-coding', 'zhipu', 'zhipu-coding', 'zhipu-coding-team', 'ark-coding-plan', 'minimax', 'doubao', 'qwen', 'qwen-anthropic', 'qwen-token-plan', 'xiaomi', 'xiaomi-token-plan', 'custom']
+const PROVIDER_OPTIONS: ProviderType[] = ['anthropic', 'anthropic-compatible', 'openai', 'openai-responses', 'openai-codex', 'deepseek', 'google', 'kimi-api', 'kimi-coding', 'opencode-go-openai', 'zhipu', 'zhipu-coding', 'zhipu-coding-team', 'ark-coding-plan', 'minimax', 'doubao', 'qwen', 'qwen-anthropic', 'qwen-token-plan', 'xiaomi', 'xiaomi-token-plan', 'custom']
 
 /** 需要用 messages 端点测试的供应商预设模型 */
 const PROVIDER_TEST_MODEL_PRESETS: Partial<Record<ProviderType, string[]>> = {
   deepseek: ['deepseek-v4-pro', 'deepseek-v4-flash'],
   'kimi-api': ['k3', 'kimi-k2.6'],
+  'opencode-go-openai': ['grok-4.5', 'glm-5.2', 'kimi-k3'],
   xiaomi: ['mimo-v2.5-pro', 'mimo-v2-pro', 'mimo-v2.5', 'mimo-v2-omni', 'mimo-v2-flash'],
   'xiaomi-token-plan': ['mimo-v2.5-pro', 'mimo-v2-pro', 'mimo-v2.5', 'mimo-v2-omni', 'mimo-v2-flash'],
   'qwen-token-plan': ['qwen3.8-max-preview', 'qwen3.7-max', 'qwen3.6-flash'],
@@ -395,6 +396,19 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
         setModels([
           { id: 'k3', name: 'Kimi K3', enabled: true },
           { id: 'kimi-for-coding', name: 'Kimi for Coding', enabled: true },
+        ])
+      } else if (p === 'opencode-go-openai') {
+        setModels([
+          { id: 'grok-4.5', name: 'Grok 4.5', enabled: true },
+          { id: 'glm-5.2', name: 'GLM-5.2', enabled: true },
+          { id: 'glm-5.1', name: 'GLM-5.1', enabled: true },
+          { id: 'kimi-k3', name: 'Kimi K3', enabled: true },
+          { id: 'kimi-k2.7-code', name: 'Kimi K2.7 Code', enabled: true },
+          { id: 'kimi-k2.6', name: 'Kimi K2.6', enabled: true },
+          { id: 'deepseek-v4-pro', name: 'DeepSeek V4 Pro', enabled: true },
+          { id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash', enabled: true },
+          { id: 'mimo-v2.5', name: 'MiMo V2.5', enabled: true },
+          { id: 'mimo-v2.5-pro', name: 'MiMo V2.5 Pro', enabled: true },
         ])
       } else if (p === 'zhipu' || p === 'zhipu-coding' || p === 'zhipu-coding-team') {
         setModels([

--- a/apps/electron/src/renderer/lib/model-logo.ts
+++ b/apps/electron/src/renderer/lib/model-logo.ts
@@ -243,6 +243,7 @@ const PROVIDER_LOGO_MAP: Record<ProviderType, string> = {
   google: GeminiLogo,
   'kimi-api': KimiLogo,
   'kimi-coding': KimiLogo,
+  'opencode-go-openai': DefaultLogo,
   zhipu: ZhipuLogo,
   'zhipu-coding': ZhipuLogo,
   'zhipu-coding-team': ZhipuLogo,

--- a/packages/core/src/providers/index.ts
+++ b/packages/core/src/providers/index.ts
@@ -34,6 +34,7 @@ const adapterRegistry = new Map<ProviderType, ProviderAdapter>([
   ['deepseek', new AnthropicAdapter('deepseek')],   // DeepSeek 使用 Anthropic 兼容协议
   ['kimi-api', new AnthropicAdapter('kimi-api')],       // Kimi API 的 Anthropic 协议端点
   ['kimi-coding', new AnthropicAdapter('kimi-coding')], // Kimi Coding Plan 订阅制（强制 User-Agent）
+  ['opencode-go-openai', new OpenAIAdapter('opencode-go-openai')], // OpenCode Go 的 OpenAI 兼容端点
   ['zhipu', new OpenAIAdapter()],         // 智谱 AI 使用 OpenAI 兼容协议
   ['zhipu-coding', new AnthropicAdapter('zhipu-coding')], // 智谱 Coding Plan 订阅制（强制 User-Agent）
   ['zhipu-coding-team', new AnthropicAdapter('zhipu-coding-team')], // 智谱 Coding Plan 团队版

--- a/packages/core/src/providers/openai-adapter.test.ts
+++ b/packages/core/src/providers/openai-adapter.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test'
+import { OpenAIAdapter } from './openai-adapter.ts'
+
+function buildTitleBody(provider: 'openai' | 'opencode-go-openai'): Record<string, unknown> {
+  const request = new OpenAIAdapter(provider).buildTitleRequest({
+    baseUrl: provider === 'opencode-go-openai'
+      ? 'https://opencode.ai/zen/go/v1'
+      : 'https://api.openai.com/v1',
+    apiKey: 'test-key',
+    modelId: 'glm-5.2',
+    prompt: '生成标题',
+  })
+
+  return JSON.parse(request.body) as Record<string, unknown>
+}
+
+describe('OpenAIAdapter 标题生成请求', () => {
+  test('Given OpenCode Go 的推理模型 When 生成标题 Then 预留足够的输出预算', () => {
+    expect(buildTitleBody('opencode-go-openai').max_tokens).toBe(512)
+  })
+
+  test('Given 标准 OpenAI 渠道 When 生成标题 Then 保持原有的小输出预算', () => {
+    expect(buildTitleBody('openai').max_tokens).toBe(50)
+  })
+})

--- a/packages/core/src/providers/openai-adapter.ts
+++ b/packages/core/src/providers/openai-adapter.ts
@@ -273,6 +273,9 @@ export class OpenAIAdapter implements ProviderAdapter {
 
   buildTitleRequest(input: TitleRequestInput): ProviderRequest {
     const url = resolveOpenAIChatCompletionsUrl(input.baseUrl, this.providerType)
+    // OpenCode Go 的编程模型会将一部分输出预算用于推理；通用标题请求的
+    // 50 tokens 不足以稳定产出可见正文，导致自动重命名收到空标题。
+    const maxTokens = this.providerType === 'opencode-go-openai' ? 512 : 50
 
     return {
       url,
@@ -283,7 +286,7 @@ export class OpenAIAdapter implements ProviderAdapter {
       body: JSON.stringify({
         model: input.modelId,
         messages: [{ role: 'user', content: input.prompt }],
-        max_tokens: 50,
+        max_tokens: maxTokens,
       }),
     }
   }

--- a/packages/core/src/providers/url-utils.test.ts
+++ b/packages/core/src/providers/url-utils.test.ts
@@ -205,6 +205,12 @@ describe('resolveOpenAIChatCompletionsUrl', () => {
     )
   })
 
+  test('OpenCode Go OpenAI 协议根地址补全 chat completions 端点', () => {
+    expect(resolveOpenAIChatCompletionsUrl('https://opencode.ai/zen/go/v1', 'opencode-go-openai')).toBe(
+      'https://opencode.ai/zen/go/v1/chat/completions',
+    )
+  })
+
   test('保留查询参数', () => {
     expect(resolveOpenAIChatCompletionsUrl('https://api.example.com/v1/chat/completions?api-version=2024', 'custom')).toBe(
       'https://api.example.com/v1/chat/completions?api-version=2024',

--- a/packages/shared/src/types/channel.test.ts
+++ b/packages/shared/src/types/channel.test.ts
@@ -10,6 +10,10 @@ describe('Agent 渠道协议兼容性', () => {
     expect(isAgentCompatibleProvider('anthropic-compatible')).toBe(true)
   })
 
+  test('Given OpenCode Go 的 OpenAI 兼容渠道 When 判断 Claude Agent 兼容性 Then 不加入白名单', () => {
+    expect(isAgentCompatibleProvider('opencode-go-openai')).toBe(false)
+  })
+
   test.each(['openai-responses', 'openai-codex'] as const)(
     'Given %s When 判断 Claude Agent 兼容性 Then 不加入白名单',
     (provider) => {

--- a/packages/shared/src/types/channel.ts
+++ b/packages/shared/src/types/channel.ts
@@ -17,6 +17,7 @@ export type ProviderType =
   | 'google'
   | 'kimi-api'
   | 'kimi-coding'
+  | 'opencode-go-openai'
   | 'zhipu'
   | 'zhipu-coding'
   | 'zhipu-coding-team'
@@ -49,6 +50,7 @@ export const PROVIDER_DEFAULT_URLS: Record<ProviderType, string> = {
   google: 'https://generativelanguage.googleapis.com',
   'kimi-api': 'https://api.moonshot.cn/anthropic',
   'kimi-coding': 'https://api.kimi.com/coding/v1',
+  'opencode-go-openai': 'https://opencode.ai/zen/go/v1',
   zhipu: 'https://open.bigmodel.cn/api/paas/v4',
   'zhipu-coding': 'https://open.bigmodel.cn/api/anthropic',
   'zhipu-coding-team': 'https://open.bigmodel.cn/api/anthropic',
@@ -78,6 +80,7 @@ export const PROVIDER_LABELS: Record<ProviderType, string> = {
   google: 'Google',
   'kimi-api': 'Kimi API (Anthropic 协议)',
   'kimi-coding': 'Kimi Coding Plan',
+  'opencode-go-openai': 'OpenCode Go (OpenAI 协议)',
   zhipu: '智谱 AI',
   'zhipu-coding': '智谱 Coding Plan',
   'zhipu-coding-team': '智谱 Coding Plan 团队版',


### PR DESCRIPTION
## Summary
- Add the OpenCode Go OpenAI-compatible subscription channel and official model presets.
- Route connection tests, model discovery, Chat, and Pi Agent runtime through its Chat Completions endpoint.
- Make automatic Chat and Agent titles reliable for reasoning models with a larger title budget and local fallback.

## Validation
- `bun test packages/shared/src/types/channel.test.ts packages/core/src/providers/url-utils.test.ts packages/core/src/providers/openai-adapter.test.ts apps/electron/src/main/lib/title-generation.test.ts`
- `bun run typecheck`