### PR TITLE
fix(pi): 为 HTTP chunked/SSE 流式中断增加原生重试与网络异常分类【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.15.9",
+  "version": "0.15.10",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/adapters/pi-message-adapter.test.ts
+++ b/apps/electron/src/main/lib/adapters/pi-message-adapter.test.ts
@@ -44,17 +44,40 @@ describe('convertPiMessage', () => {
     expect(JSON.stringify(message).length).toBeGreaterThan(content.length)
   })
 
-  test('only persists provider errors for terminal Pi failures', () => {
+  test('only persists errors for terminal Pi failures', () => {
     const providerError = 'stream ended before a terminal response event'
     const partialStop = convertPiMessage({
       role: 'assistant', content: [], stopReason: 'stop', errorMessage: providerError,
     } as unknown as AssistantMessage, 'session-1') as { error?: unknown }
     const terminalError = convertPiMessage({
       role: 'assistant', content: [], stopReason: 'error', errorMessage: providerError,
-    } as unknown as AssistantMessage, 'session-1') as { error?: { message?: string } }
+    } as unknown as AssistantMessage, 'session-1') as { error?: { message?: string; errorType?: string } }
 
     expect(partialStop.error).toBeUndefined()
-    expect(terminalError.error?.message).toBe(providerError)
+    expect(terminalError.error).toEqual({
+      message: providerError,
+      errorType: 'network_error',
+    })
+  })
+
+  test('keeps non-network terminal Pi errors as provider_error', () => {
+    const terminalError = convertPiMessage({
+      role: 'assistant', content: [], stopReason: 'error', errorMessage: '529 overloaded',
+    } as unknown as AssistantMessage, 'session-1') as { error?: { message?: string; errorType?: string } }
+
+    expect(terminalError.error).toEqual({ message: '529 overloaded', errorType: 'provider_error' })
+  })
+
+  test.each([
+    'peer closed connection',
+    'incomplete chunked read',
+    'peer closed connection without sending complete message body (incomplete chunked read)',
+  ])('classifies terminal Pi transport error "%s" as network_error', (errorMessage) => {
+    const terminalError = convertPiMessage({
+      role: 'assistant', content: [], stopReason: 'error', errorMessage,
+    } as unknown as AssistantMessage, 'session-1') as { error?: { message?: string; errorType?: string } }
+
+    expect(terminalError.error).toEqual({ message: errorMessage, errorType: 'network_error' })
   })
 
   test('only reports result errors for terminal Pi failures', () => {

--- a/apps/electron/src/main/lib/adapters/pi-message-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/pi-message-adapter.ts
@@ -10,6 +10,7 @@ import type { AgentMessage } from '@earendil-works/pi-agent-core'
 import type { AssistantMessage, ToolResultMessage, UserMessage } from '@earendil-works/pi-ai/compat'
 import type { SDKMessage } from '@proma/shared'
 import type { RuntimeGuardResultOverride } from '../agent-runtime-guards'
+import { isTransientNetworkError } from '../error-patterns'
 
 function getPiEditItems(input: Record<string, unknown>): Array<Record<string, unknown>> {
   return Array.isArray(input.edits)
@@ -214,6 +215,9 @@ export function convertPiMessage(
     //   Pi SDK 认定本轮已成功，不应在渲染层误导用户。
     // 上述非终态情况的 errorMessage 只写主进程 console，供开发排查；用户侧完全无感知。
     const isTerminalError = assistant.stopReason === 'error'
+    const errorType = assistant.errorMessage && isTransientNetworkError(assistant.errorMessage)
+      ? 'network_error'
+      : 'provider_error'
     if (assistant.errorMessage && !isTerminalError && final) {
       console.warn(
         `[pi-adapter] 忽略非终态 errorMessage（stopReason=${assistant.stopReason}）: ${assistant.errorMessage}`,
@@ -246,7 +250,7 @@ export function convertPiMessage(
       uuid: options.uuid ?? randomUUID(),
       ...(!final && { _partial: true }),
       ...(assistant.errorMessage && isTerminalError && {
-        error: { message: assistant.errorMessage, errorType: 'provider_error' },
+        error: { message: assistant.errorMessage, errorType },
       }),
       ...(channelModelId && { _channelModelId: channelModelId }),
     } as unknown as SDKMessage

--- a/apps/electron/src/main/lib/adapters/pi-native-retry.test.ts
+++ b/apps/electron/src/main/lib/adapters/pi-native-retry.test.ts
@@ -17,6 +17,14 @@ describe('Pi native retry classifier', () => {
     )).toBe(true)
   })
 
+  test.each([
+    'peer closed connection',
+    'incomplete chunked read',
+    'peer closed connection without sending complete message body (incomplete chunked read)',
+  ])('classifies chunked stream interruption "%s" as retryable', (errorMessage) => {
+    expect(isRetryableAssistantError(failedAssistant(errorMessage))).toBe(true)
+  })
+
   test('does not broadly retry unrelated stream-ended errors', () => {
     expect(isRetryableAssistantError(
       failedAssistant('stream ended before the model emitted a local marker'),

--- a/apps/electron/src/main/lib/error-patterns.test.ts
+++ b/apps/electron/src/main/lib/error-patterns.test.ts
@@ -18,6 +18,9 @@ describe('isTransientNetworkError', () => {
     'premature close',
     'OpenAI Responses stream ended before a terminal response event',
     'Anthropic stream ended before message_stop',
+    'peer closed connection',
+    'incomplete chunked read',
+    'peer closed connection without sending complete message body (incomplete chunked read)',
   ])('Given 已知瞬时网络错误 "%s" Then 判定为可重试', (msg) => {
     expect(isTransientNetworkError(msg)).toBe(true)
   })

--- a/apps/electron/src/main/lib/error-patterns.ts
+++ b/apps/electron/src/main/lib/error-patterns.ts
@@ -10,10 +10,11 @@
  * 同时覆盖 OpenAI/Anthropic provider 的流中断错误：
  * - "stream ended before a terminal response event"（OpenAI Responses API）
  * - "stream ended before message_stop"（Anthropic Messages API）
- * 这两种是 provider 连接被 CDN/网关切断的同类瞬时错误，与 ECONNRESET 性质一致。
+ * - "peer closed connection ... (incomplete chunked read)"（HTTP chunked/SSE 响应中断）
+ * 这些都是 provider 连接被 CDN/网关切断的同类瞬时错误，与 ECONNRESET 性质一致。
  */
 export const TRANSIENT_NETWORK_PATTERN =
-  /terminated|socket hang up|ECONNRESET|ETIMEDOUT|ECONNABORTED|EPIPE|ENOTFOUND|EAI_AGAIN|ECONNREFUSED|fetch failed|network error|connection (?:error|closed|reset)|other side closed|AbortError|(?:operation|request) was aborted|(?:request )?timed out|stream (?:closed|ended|disconnected) prematurely|premature close|stream ended before (?:a )?(?:terminal response event|message_stop)/i
+  /terminated|socket hang up|ECONNRESET|ETIMEDOUT|ECONNABORTED|EPIPE|ENOTFOUND|EAI_AGAIN|ECONNREFUSED|fetch failed|network error|peer closed connection|connection (?:error|closed|reset)|other side closed|incomplete chunked read|AbortError|(?:operation|request) was aborted|(?:request )?timed out|stream (?:closed|ended|disconnected) prematurely|premature close|stream ended before (?:a )?(?:terminal response event|message_stop)/i
 
 /** 判断错误消息/stderr 是否为瞬时网络错误 */
 export function isTransientNetworkError(message?: string, stderr?: string): boolean {

--- a/patches/@earendil-works%2Fpi-ai@0.80.9.patch
+++ b/patches/@earendil-works%2Fpi-ai@0.80.9.patch
@@ -2,12 +2,16 @@ diff --git a/dist/utils/retry.js b/dist/utils/retry.js
 index b3c27c8d5fb9a77c117af7ab8f789170903d5252..42b41a67c5607ef605fba6340882db6fecac0c49 100644
 --- a/dist/utils/retry.js
 +++ b/dist/utils/retry.js
-@@ -57,6 +57,8 @@ const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
+@@ -57,6 +57,12 @@ const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
      // "stream ended without ..." and "Anthropic stream ended before message_stop"
      // (#4433); Bedrock/Smithy can throw an HTTP/2 no-response error (#3594).
      "ended without",
 +    // OpenAI Responses can close an SSE stream before sending its terminal event.
 +    "stream ended before (?:a )?terminal response event",
++    // HTTP chunked/SSE transports can close before the complete body arrives.
++    // Match both phrases because proxy implementations may retain only one.
++    "peer closed connection",
++    "incomplete chunked read",
      "stream ended before message_stop",
      "http2 request did not get a response",
      // Provider-requested retry delay cap failures should flow through the outer


### PR DESCRIPTION
## 概述

Proma 使用 GPT 模型、Pi runtime 时偶发 `peer closed connection without sending complete message body (incomplete chunked read)`，当前表现为终端报错且 UI 固定显示「服务繁忙」。该错误是传输层断流（上游/CDN/代理提前关闭 HTTP chunked/SSE 连接），并非真正的 provider 过载。

此 PR 完成三层修复：

1. **Pi 原生重试（P0）** — 在 `@earendil-works/pi-ai` 依赖 patch 的 retry pattern 中增加 `peer closed connection` 和 `incomplete chunked read`，命中后 Pi 通过同一 transcript 的 `agent.continue()` 自动恢复，不重放原 prompt、不重复执行工具。
2. **Proma 通用网络错误识别（P1）** — 在 `TRANSIENT_NETWORK_PATTERN` 同步扩展上述模式，覆盖 adapter queue 异常等其他路径。
3. **终态错误分类修正** — 当 Pi native retry 耗尽时，`pi-message-adapter` 现在依据 `isTransientNetworkError()` 将此类断流写为 `network_error` 而非硬编码的 `provider_error`，UI 会准确显示「网络异常」。

关联背景：
- 提交 `346623be fix(agent): recover Pi terminal stream interruptions safely (#1236)` 已修复这些混合消息的“正文整段红色渲染”问题，但未补重试和错误类型分类。
- 外层 Orchestrator 已正确禁止 Pi 的 prompt replay 重试，依赖 Pi native retry。

## 改动

- `patches/@earendil-works%2Fpi-ai@0.80.9.patch` — 在 Pi SDK retry classifier 中新增 `peer closed connection` 和 `incomplete chunked read` 两个模式，两个短语均匹配以覆盖不同代理层保留的文本
- `apps/electron/src/main/lib/error-patterns.ts` — 在 `TRANSIENT_NETWORK_PATTERN` 注释和正�`中同步增加上述模式
- `apps/electron/src/main/lib/adapters/pi-message-adapter.ts` — 终端 assistant error 现在调用 `isTransientNetworkError` 决定 `errorType`，传输断流写入 `network_error`，真正的 provider 过载保持 `provider_error`
- `apps/electron/src/main/lib/adapters/pi-message-adapter.test.ts` — 覆盖 `peer closed connection`、`incomplete chunked read` 和完整报错文本的 `network_error` 分类，并验证 `529 overloaded` 仍保持 `provider_error`
- `apps/electron/src/main/lib/adapters/pi-native-retry.test.ts` — 三条 chunked transport 文本的 retryable 分类回归
- `apps/electron/src/main/lib/error-patterns.test.ts` — 三条瞬时网络错误文本的识别回归
- `apps/electron/package.json` — 版本递增 `0.15.9 → 0.15.10`

## 测试方法

1. `bun run typecheck` — 全仓类型检查通过
2. `bun test apps/electron/src/main/lib/adapters/pi-native-retry.test.ts` — 6 pass，覆盖 retryable/非 retryable 分类
3. `bun test apps/electron/src/main/lib/adapters/pi-message-adapter.test.ts` — 9 pass，覆盖 network_error/provider_error 分类和 result errors
4. `bun test apps/electron/src/main/lib/error-patterns.test.ts` — 37 pass，含三条新增 transient 文本和原有回归
5. `bun test apps/electron/src/main/lib/adapters/pi-retry-control.test.ts` — 4 pass，retry gate 逻辑

线下验证：使用含 `peer closed connection ... (incomplete chunked read)` 的终端日志，确认 Pi native retry 触发 2–3 次 `auto_retry_start` 并在第 2 次恢复。

## 备注

- 当前代码不包含 P2 renderer 变更，P2 的“正文整段红色”修复已在 `346623be` 中完成。
- Windows 兼容性静态扫描通过，本次没有引入平台相关代码。