### PR TITLE
fix(agent): UI 渲染修复：保留 Pi 断流前正文并分离错误展示【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.15.10",
+  "version": "0.15.11",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/adapters/pi-message-adapter.test.ts
+++ b/apps/electron/src/main/lib/adapters/pi-message-adapter.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from 'bun:test'
 import type { AssistantMessage } from '@earendil-works/pi-ai/compat'
-import { convertPiMessage, convertResultMessage } from './pi-message-adapter'
+import type { SDKAssistantMessage } from '@proma/shared'
+import {
+  convertPiMessage,
+  convertResultMessage,
+  getPiAssistantErrorDetails,
+  hasPiAssistantTextContent,
+  stripPiAssistantError,
+} from './pi-message-adapter'
 
 function writeToolCall(content: string): AssistantMessage {
   return {
@@ -78,6 +85,26 @@ describe('convertPiMessage', () => {
     } as unknown as AssistantMessage, 'session-1') as { error?: { message?: string; errorType?: string } }
 
     expect(terminalError.error).toEqual({ message: errorMessage, errorType: 'network_error' })
+  })
+
+  test('keeps generated text separate from a terminal transport error', () => {
+    const body = 'Generated assistant output must not appear inside the error card.'
+    const transportError = 'peer closed connection without sending complete message body (incomplete chunked read)'
+    const terminalError = convertPiMessage({
+      role: 'assistant',
+      content: [{ type: 'text', text: body }],
+      stopReason: 'error',
+      errorMessage: transportError,
+    } as unknown as AssistantMessage, 'session-1') as SDKAssistantMessage
+
+    expect(getPiAssistantErrorDetails(terminalError)).toEqual({
+      detailedMessage: transportError,
+      originalError: transportError,
+    })
+    expect(hasPiAssistantTextContent(terminalError)).toBe(true)
+    expect(stripPiAssistantError(terminalError).error).toBeUndefined()
+    expect(terminalError.message.content).toEqual([{ type: 'text', text: body }])
+    expect(terminalError.error).toEqual({ message: transportError, errorType: 'network_error' })
   })
 
   test('only reports result errors for terminal Pi failures', () => {

--- a/apps/electron/src/main/lib/adapters/pi-message-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/pi-message-adapter.ts
@@ -8,7 +8,7 @@
 import { randomUUID } from 'node:crypto'
 import type { AgentMessage } from '@earendil-works/pi-agent-core'
 import type { AssistantMessage, ToolResultMessage, UserMessage } from '@earendil-works/pi-ai/compat'
-import type { SDKMessage } from '@proma/shared'
+import type { SDKAssistantMessage, SDKMessage } from '@proma/shared'
 import type { RuntimeGuardResultOverride } from '../agent-runtime-guards'
 import { isTransientNetworkError } from '../error-patterns'
 
@@ -155,6 +155,29 @@ function contentToText(content: unknown): string {
 
 export function isAssistantPiMessage(message: AgentMessage): message is AssistantMessage {
   return !!message && typeof message === 'object' && 'role' in message && message.role === 'assistant'
+}
+
+/** Pi's terminal error and any generated assistant content are independent fields. */
+export function getPiAssistantErrorDetails(message: SDKAssistantMessage): {
+  detailedMessage: string
+  originalError: string
+} {
+  const errorMessage = message.error?.message?.trim() || 'Unknown error'
+  return { detailedMessage: errorMessage, originalError: errorMessage }
+}
+
+/** Pi can generate text before a stream failure; preserve it as normal assistant output. */
+export function hasPiAssistantTextContent(message: SDKAssistantMessage): boolean {
+  return message.message.content.some(
+    (block) => block.type === 'text' && 'text' in block && typeof block.text === 'string' && block.text.trim().length > 0,
+  )
+}
+
+/** Copy Pi's generated output without the terminal transport/provider failure. */
+export function stripPiAssistantError(message: SDKAssistantMessage): SDKAssistantMessage {
+  const contentMessage = { ...message }
+  delete contentMessage.error
+  return contentMessage
 }
 
 export function isAbortedAssistantMessage(message: AgentMessage): message is AssistantMessage {

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -37,6 +37,7 @@ import type { PromaPermissionMode, AskUserRequest, ExitPlanModeRequest, SDKSyste
 import type { ClaudeAgentQueryOptions } from './adapters/claude-agent-adapter'
 import { isPromptTooLongError, isThinkingSignatureError, friendlyErrorMessage, mapSDKErrorToTypedError, extractErrorDetails, shouldKeepChannelOpen } from './adapters/claude-agent-adapter'
 import type { PiAgentQueryOptions } from './adapters/pi-agent-adapter'
+import { getPiAssistantErrorDetails, hasPiAssistantTextContent, stripPiAssistantError } from './adapters/pi-message-adapter'
 import { isTransientNetworkError, isMalformedResponseError, isSessionNotFoundError } from './error-patterns'
 import { AgentEventBus } from './agent-event-bus'
 import { decryptApiKey, getChannelById, listChannels, persistCodexOAuthCredentials, resolveChannelRuntimeApiKey, resolveCodexOAuthCredentials } from './channel-manager'
@@ -1904,7 +1905,11 @@ export class AgentOrchestrator {
             if (msg.type === 'assistant' && !isPartialMessage) {
               const assistantMsg = msg as SDKAssistantMessage
               if (assistantMsg.error) {
-                const { detailedMessage, originalError } = extractErrorDetails(assistantMsg as unknown as Parameters<typeof extractErrorDetails>[0])
+                // Pi keeps generated text and the transport failure in separate fields. Claude's
+                // content-first extractor would otherwise promote the text to error details.
+                const { detailedMessage, originalError } = agentRuntime === 'pi'
+                  ? getPiAssistantErrorDetails(assistantMsg)
+                  : extractErrorDetails(assistantMsg as unknown as Parameters<typeof extractErrorDetails>[0])
                 let errorCode = assistantMsg.error.errorType || 'unknown_error'
                 if (isPromptTooLongError(detailedMessage, originalError)) {
                   errorCode = 'prompt_too_long'
@@ -1995,7 +2000,17 @@ export class AgentOrchestrator {
                 }
 
                 // 不可重试 → 终止
+                const hasPiPartialOutput = agentRuntime === 'pi' && hasPiAssistantTextContent(assistantMsg)
+                if (hasPiPartialOutput) {
+                  const partialOutput = stripPiAssistantError(assistantMsg)
+                  if (modelId) partialOutput._channelModelId = modelId
+                  partialOutput._channelProvider = channel.provider
+                  accumulatedMessages.push(partialOutput)
+                  // Reuse the Pi UUID to replace the latest partial frame with normal markdown output.
+                  this.eventBus.emit(sessionId, { kind: 'sdk_message', message: partialOutput })
+                }
                 this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
+                accumulatedMessages.length = 0
                 if (typedError.code === 'prompt_too_long') {
                   try { updateAgentSessionMeta(sessionId, { sdkSessionId: undefined }) } catch { /* 忽略 */ }
                 }

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -1104,14 +1104,9 @@ export function AssistantErrorTail({
   const setModelSelectorOpen = useSetAtom(modelSelectorOpenAtom)
   const [detailsOpen, setDetailsOpen] = React.useState(false)
 
-  // standalone 模式（纯错误消息）：把 content 里所有 text 用双换行拼起来一并渲染，保留 markdown 段落结构。
-  // tail 模式（混合消息）：正文已由上层渲染，这里只用 error.message 作为简短提示。
-  const bodyText = standalone
-    ? (message.message?.content
-        ?.filter((b) => b.type === 'text' && 'text' in b)
-        .map((b) => (b as { text: string }).text)
-        .join('\n\n') || errorText)
-    : errorText
+  // Error presentation always uses error.message. Assistant content is not error detail:
+  // Pi may have generated it before a stream failure.
+  const bodyText = errorText
   const isThinkingSignature = errorCode === THINKING_SIGNATURE_ERROR_CODE ||
     isThinkingSignatureError(bodyText, errorText)
   const displayTitle = errorTitle ?? (isThinkingSignature ? THINKING_SIGNATURE_ERROR_TITLE : undefined)
@@ -1281,11 +1276,8 @@ export function AssistantErrorTail({
 function ErrorMessage({ message, onRetry, onRetryInNewSession, onCompact }: ErrorMessageProps): React.ReactElement {
   const meta = extractMeta(message as unknown as SDKMessage)
 
-  // 复用 AssistantErrorTail 的正文/详情/按钮逻辑，只在这里补上「独立错误消息」的 Message 外壳。
-  const copyText = message.message?.content
-    ?.filter((b) => b.type === 'text' && 'text' in b)
-    .map((b) => (b as { text: string }).text)
-    .join('\n\n') || (message.error?.message ?? '未知错误')
+  // Do not copy assistant content carried by an error record.
+  const copyText = message.error?.message ?? 'Unknown error'
 
   return (
     <Message from="assistant">


### PR DESCRIPTION
## 概述

Pi runtime 在 HTTP chunked/SSE 流收尾中断时，可能已经生成 assistant 正文，同时返回独立的传输错误。此前编排层复用 Claude 的 content-first 错误解析，会把正文写入 typed error，导致 renderer 在“服务繁忙/网络异常”错误卡片中把整段正文渲染为红色。

本 PR 保留断流前已生成的正文为正常 assistant 消息，并将终态 transport/provider error 作为独立摘要显示在正文尾部。`#1267` 已负责 Pi native retry 和网络错误分类；本 PR 补全正文与错误的消息边界。

## 改动

- `apps/electron/src/main/lib/adapters/pi-message-adapter.ts` — 新增 Pi 专用错误详情、正文检测和移除 error 字段的 helper；Pi 不再按 Claude 的 content-first 语义解析错误。
- `apps/electron/src/main/lib/agent-orchestrator.ts` — Pi 终态错误有正文时，先持久化并推送不带 `error` 的正文消息，再生成短错误摘要；复用 UUID 覆盖流式 partial frame，并补齐渠道元数据。
- `apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx` — 错误卡片只显示 `error.message`，不再将错误记录附带的 assistant content 当作错误详情或复制内容。
- `apps/electron/src/main/lib/adapters/pi-message-adapter.test.ts` — 覆盖“已有 assistant 正文 + `peer closed connection ... incomplete chunked read`”的真实 Pi 终态消息，验证正文、错误详情与 `network_error` 分类保持分离。
- `apps/electron/package.json` — Electron patch 版本从 `0.15.10` 升至 `0.15.11`。

## 测试方法

1. `bun test apps/electron/src/main/lib/adapters/pi-message-adapter.test.ts apps/electron/src/main/lib/adapters/pi-native-retry.test.ts apps/electron/src/main/lib/adapters/pi-retry-control.test.ts apps/electron/src/main/lib/error-patterns.test.ts` — 56 pass / 0 fail。
2. `bun run typecheck` — 全部 workspace package 通过。
3. `git diff --check` — 通过。

## 备注

- #1267 已合入 `main`，本 PR 从合并后的 `a8ccf12b` 独立切出，不携带 #1267 的重复 diff。
- 未做真实网络断流的 Electron UI E2E；单测覆盖了导致历史错误卡片正文污染的实际 Pi 消息形态。
- Windows 静态扫描未发现路径、Shell、平台分支、快捷键、原生依赖或打包兼容性风险。