### PR TITLE
fix(agent): Windows 环境优先使用 WSL

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.15.10",
+  "version": "0.15.11",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -46,7 +46,7 @@ import { getFetchFn } from './proxy-fetch'
 import { getEffectiveProxyUrl } from './proxy-settings-service'
 import { appendSDKMessages, updateAgentSessionMeta, getAgentSessionMeta, getAgentSessionMessages, truncateSDKMessages, removeSDKErrorMessage, resolveUserUuidFromSDK, rewindFilesFromSnapshot, rewindPiAgentSession } from './agent-session-manager'
 import { getAgentWorkspace, getWorkspaceMcpConfig, ensurePluginManifest, getWorkspaceAutoMemoryDir, getWorkspaceAttachedDirectories, getWorkspaceAttachedFiles } from './agent-workspace-manager'
-import { getAgentWorkspacePath, getAgentSessionWorkspacePath, getSdkConfigDir, getWorkspaceFilesDir, getBundledCliPath, getWorkspaceSkillsDir } from './config-paths'
+import { getAgentWorkspacePath, getAgentSessionWorkspacePath, getSdkConfigDir, getWorkspaceFilesDir, getWorkspaceSkillsDir } from './config-paths'
 import { getRuntimeStatus } from './runtime-init'
 import { getSettings } from './settings-service'
 import { buildSystemPrompt, buildDynamicContext } from './agent-prompt-builder'
@@ -63,7 +63,7 @@ import { injectChromeDevtoolsMcpServer } from './builtin-mcp/chrome-devtools'
 import { isBuiltinMcpUserEnabled } from './builtin-mcp/settings'
 import { buildPiBuiltinTools } from './adapters/pi-builtin-tools'
 import { buildPiMcpTools } from './adapters/pi-mcp-tools'
-import type { AgentRuntimeEnv } from './agent-runtime-env'
+import { buildAgentRuntimeEnv, mergeRuntimeEnv, type AgentRuntimeEnv } from './agent-runtime-env'
 import { isVisibleRunMessage } from './agent-run-message-visibility'
 import { applyAgentSdkAuthEnv } from './agent-sdk-auth-env'
 import { getAgentSdkMaxOutputTokens } from './agent-sdk-output-limits'
@@ -104,14 +104,6 @@ function sdkPermissionModeForPromaMode(mode: PromaPermissionMode): PromaPermissi
 
 function normalizeAgentRuntime(value: unknown): AgentRuntime {
   return value === 'pi' ? 'pi' : 'claude'
-}
-
-function buildPiRuntimeEnv(env: Record<string, string | undefined>): AgentRuntimeEnv {
-  const cleanEnv: Record<string, string> = {}
-  for (const [key, value] of Object.entries(env)) {
-    if (value !== undefined) cleanEnv[key] = value
-  }
-  return { env: cleanEnv }
 }
 
 const EMPTY_RESPONSE_RESULT_SUBTYPE = 'empty_response'
@@ -424,12 +416,13 @@ export class AgentOrchestrator {
    * 注入 API Key、Base URL、代理、Shell 配置等。
    * 对 Kimi Coding Plan / MiniMax Coding Plan：使用 Bearer 认证（ANTHROPIC_AUTH_TOKEN）。
    */
-  private async buildSdkEnv(
+  private buildSdkRuntimeEnv(
     apiKey: string,
     baseUrl: string | undefined,
     provider: ProviderType,
     modelId: string | undefined,
-  ): Promise<Record<string, string | undefined>> {
+    proxyUrl: string | undefined,
+  ): AgentRuntimeEnv {
     const DEFAULT_ANTHROPIC_URL = 'https://api.anthropic.com'
 
     // 从 process.env 继承系统变量，但清理所有 ANTHROPIC_ 前缀的变量，
@@ -450,15 +443,6 @@ export class AgentOrchestrator {
       ...cleanEnv,
       // 仅 Claude 模型显式提高输出上限；其它兼容模型不注入 max_tokens 覆盖。
       ...(maxOutputTokens ? { CLAUDE_CODE_MAX_OUTPUT_TOKENS: maxOutputTokens } : {}),
-      // 暴露打包进 App 的 proma CLI 路径，供 session-cleaner 等 skill / Agent 调用
-      // （开发模式无编译二进制，getBundledCliPath 返回 undefined，此处不注入，
-      //   skill 回退到源码运行 bun apps/cli/src/index.ts）。
-      ...(getBundledCliPath()
-        ? {
-            PROMA_CLI: getBundledCliPath(),
-            PATH: `${dirname(getBundledCliPath()!)}${process.platform === 'win32' ? ';' : ':'}${cleanEnv.PATH ?? ''}`,
-          }
-        : {}),
       // 启用 Tasks 功能
       CLAUDE_CODE_ENABLE_TASKS: 'true',
       // 禁用 SDK 内置 Workflows，避免每轮注入 workflow 相关提示词。
@@ -502,29 +486,21 @@ export class AgentOrchestrator {
       sdkEnv.ANTHROPIC_BASE_URL = normalizeAnthropicBaseUrlForSdk(baseUrl)
     }
 
-    const proxyUrl = await getEffectiveProxyUrl()
-    if (proxyUrl) {
-      sdkEnv.HTTPS_PROXY = proxyUrl
-      sdkEnv.HTTP_PROXY = proxyUrl
-    }
+    const runtimeEnv = buildAgentRuntimeEnv({
+      proxyUrl,
+      runtimeStatus: getRuntimeStatus(),
+      processEnv: sdkEnv,
+    })
 
-    // Windows 平台：配置 Shell 环境
     if (process.platform === 'win32') {
-      const runtimeStatus = getRuntimeStatus()
-      const shellStatus = runtimeStatus?.shell
-
-      if (shellStatus) {
-        if (shellStatus.gitBash?.available && shellStatus.gitBash.path) {
-          sdkEnv.CLAUDE_CODE_SHELL = shellStatus.gitBash.path
-          console.log(`[Agent 编排] 配置 Shell 环境: Git Bash (${shellStatus.gitBash.path})`)
-        } else if (shellStatus.wsl?.available) {
-          sdkEnv.CLAUDE_CODE_SHELL = 'wsl'
-          console.log(`[Agent 编排] 配置 Shell 环境: WSL ${shellStatus.wsl.version} (${shellStatus.wsl.defaultDistro})`)
-        } else {
-          console.warn('[Agent 编排] Windows 平台未检测到可用的 Shell 环境（Git Bash / WSL）')
-        }
-        sdkEnv.CLAUDE_BASH_NO_LOGIN = '1'
+      if (runtimeEnv.shellKind === 'wsl') {
+        console.log(`[Agent 编排] 配置 Shell 环境: WSL (${runtimeEnv.wslDistro ?? '默认发行版'})`)
+      } else if (runtimeEnv.shellKind === 'git-bash') {
+        console.log(`[Agent 编排] 配置 Shell 环境: Git Bash (${runtimeEnv.shellPath})`)
+      } else {
+        console.warn('[Agent 编排] Windows 平台未检测到可用的 Shell 环境（Git Bash / WSL）')
       }
+      sdkEnv.CLAUDE_BASH_NO_LOGIN = '1'
     }
 
     // 针对 claude-agent-sdk 0.2.111+ 的 options.env 叠加语义加固：
@@ -538,7 +514,10 @@ export class AgentOrchestrator {
       }
     }
 
-    return sdkEnv
+    return {
+      ...runtimeEnv,
+      env: mergeRuntimeEnv(sdkEnv, runtimeEnv.env),
+    }
   }
 
   /**
@@ -1110,7 +1089,14 @@ export class AgentOrchestrator {
     }
 
     const proxyUrl = await getEffectiveProxyUrl()
-    const sdkEnv = await this.buildSdkEnv(apiKey, channel.baseUrl, channel.provider, modelId || DEFAULT_MODEL_ID)
+    const runtimeEnv = this.buildSdkRuntimeEnv(
+      apiKey,
+      channel.baseUrl,
+      channel.provider,
+      modelId || DEFAULT_MODEL_ID,
+      proxyUrl,
+    )
+    const sdkEnv = runtimeEnv.env
 
     // 4. 读取已有的 SDK session ID（用于 resume）
     let existingSdkSessionId = sessionMeta?.sdkSessionId
@@ -1641,7 +1627,7 @@ export class AgentOrchestrator {
         provider: channel.provider,
         channelName: channel.name,
         proxyUrl,
-        runtimeEnv: buildPiRuntimeEnv(sdkEnv),
+        runtimeEnv,
         ...(maxTurns != null && { maxTurns }),
         permissionMode: initialPermissionMode,
         canUseTool,

--- a/apps/electron/src/main/lib/agent-runtime-env.test.ts
+++ b/apps/electron/src/main/lib/agent-runtime-env.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'bun:test'
+import type { GitBashStatus, RuntimeStatus, ShellEnvironmentStatus, WslStatus } from '@proma/shared'
+import { buildAgentRuntimeEnv, mergeRuntimeEnv } from './agent-runtime-env'
+
+function runtimeStatus(shell: ShellEnvironmentStatus): RuntimeStatus {
+  return { shell } as RuntimeStatus
+}
+
+const gitBash: GitBashStatus = {
+  available: true,
+  path: 'C:\\Program Files\\Git\\bin\\bash.exe',
+  version: '5.2.37',
+  error: null,
+}
+
+const wsl: WslStatus = {
+  available: true,
+  version: 2,
+  defaultDistro: 'Ubuntu-24.04',
+  distros: ['Ubuntu-24.04'],
+  error: null,
+}
+
+describe('Agent Windows Shell 运行环境', () => {
+  test('Given Git Bash 与 WSL 均可用 When 构建运行环境 Then 优先使用 WSL', () => {
+    const result = buildAgentRuntimeEnv({
+      bundledCliPath: '',
+      platform: 'win32',
+      processEnv: {},
+      runtimeStatus: runtimeStatus({ gitBash, wsl, recommended: 'wsl' }),
+    })
+
+    expect(result).toMatchObject({
+      shellKind: 'wsl',
+      wslCommand: 'wsl.exe',
+      wslDistro: 'Ubuntu-24.04',
+      env: {
+        PROMA_WINDOWS_SHELL: 'wsl',
+        PROMA_WSL_DISTRO: 'Ubuntu-24.04',
+        CLAUDE_CODE_SHELL: 'wsl.exe',
+      },
+    })
+  })
+
+  test('Given 仅 Git Bash 可用 When 构建运行环境 Then 回退到 Git Bash', () => {
+    const result = buildAgentRuntimeEnv({
+      bundledCliPath: '',
+      platform: 'win32',
+      processEnv: {},
+      runtimeStatus: runtimeStatus({
+        gitBash,
+        wsl: { ...wsl, available: false, version: null, defaultDistro: null, distros: [], error: '未安装' },
+        recommended: 'git-bash',
+      }),
+    })
+
+    expect(result).toMatchObject({
+      shellKind: 'git-bash',
+      shellPath: gitBash.path,
+      env: {
+        PROMA_WINDOWS_SHELL: 'git-bash',
+        CLAUDE_CODE_SHELL: gitBash.path,
+      },
+    })
+  })
+
+  test('Given Windows Path 大小写不同 When 合并运行环境 Then 仅保留覆盖后的 PATH', () => {
+    const result = mergeRuntimeEnv(
+      { Path: 'C:\\Windows\\System32' },
+      { PATH: 'C:\\Proma;C:\\Windows\\System32' },
+    )
+
+    expect(result).toEqual({ PATH: 'C:\\Proma;C:\\Windows\\System32' })
+  })
+})

--- a/apps/electron/src/main/lib/agent-runtime-env.ts
+++ b/apps/electron/src/main/lib/agent-runtime-env.ts
@@ -2,8 +2,9 @@ import { existsSync } from 'node:fs'
 import { delimiter, dirname, join, win32 } from 'node:path'
 import type { RuntimeStatus } from '@proma/shared'
 import { getBundledCliPath } from './config-paths'
+import { selectWindowsShell, type WindowsShellKind } from './windows-shell-selection'
 
-export type AgentRuntimeShellKind = 'git-bash' | 'wsl'
+export type AgentRuntimeShellKind = WindowsShellKind
 
 export interface AgentRuntimeEnv {
   env: Record<string, string>
@@ -120,20 +121,9 @@ function collectWindowsShellEnv(
 ): Omit<AgentRuntimeEnv, 'env'> & { env: Record<string, string> } {
   const shellStatus = runtimeStatus?.shell
   const env: Record<string, string> = {}
+  const shellKind = selectWindowsShell(shellStatus)
 
-  if (shellStatus?.gitBash.available && shellStatus.gitBash.path) {
-    const shellPath = shellStatus.gitBash.path
-    env.PROMA_WINDOWS_SHELL = 'git-bash'
-    env.CLAUDE_CODE_SHELL = shellPath
-    env.SHELL = shellPath
-    return {
-      env,
-      shellKind: 'git-bash',
-      shellPath,
-    }
-  }
-
-  if (shellStatus?.wsl.available) {
+  if (shellKind === 'wsl' && shellStatus?.wsl.available) {
     const wslCommand = getWslCommandPath(processEnv, pathExists)
     env.PROMA_WINDOWS_SHELL = 'wsl'
     env.CLAUDE_CODE_SHELL = wslCommand
@@ -146,6 +136,18 @@ function collectWindowsShellEnv(
       shellKind: 'wsl',
       wslCommand,
       ...(shellStatus.wsl.defaultDistro && { wslDistro: shellStatus.wsl.defaultDistro }),
+    }
+  }
+
+  if (shellKind === 'git-bash' && shellStatus?.gitBash.path) {
+    const shellPath = shellStatus.gitBash.path
+    env.PROMA_WINDOWS_SHELL = 'git-bash'
+    env.CLAUDE_CODE_SHELL = shellPath
+    env.SHELL = shellPath
+    return {
+      env,
+      shellKind: 'git-bash',
+      shellPath,
     }
   }
 

--- a/apps/electron/src/main/lib/runtime-init.ts
+++ b/apps/electron/src/main/lib/runtime-init.ts
@@ -16,6 +16,7 @@ import { detectBunRuntime } from './bun-finder'
 import { detectGitRuntime, getGitRepoStatus } from './git-detector'
 import { detectGitBash } from './git-bash-detector'
 import { detectWsl } from './wsl-detector'
+import { selectWindowsShell } from './windows-shell-selection'
 
 /** 运行时状态缓存 */
 let runtimeStatusCache: RuntimeStatus | null = null
@@ -92,13 +93,7 @@ export async function initializeRuntime(options: RuntimeInitOptions = {}): Promi
       const gitBashStatus = await detectGitBash()
       const wslStatus = await detectWsl()
 
-      // 推荐策略：优先 Git Bash > WSL 2 > WSL 1
-      let recommended: 'git-bash' | 'wsl' | null = null
-      if (gitBashStatus.available) {
-        recommended = 'git-bash'
-      } else if (wslStatus.available) {
-        recommended = 'wsl'
-      }
+      const recommended = selectWindowsShell({ gitBash: gitBashStatus, wsl: wslStatus })
 
       shellEnvironmentStatus = {
         gitBash: gitBashStatus,

--- a/apps/electron/src/main/lib/windows-shell-selection.ts
+++ b/apps/electron/src/main/lib/windows-shell-selection.ts
@@ -1,0 +1,11 @@
+import type { ShellEnvironmentStatus } from '@proma/shared'
+
+export type WindowsShellKind = 'git-bash' | 'wsl'
+
+export function selectWindowsShell(
+  shellStatus: Pick<ShellEnvironmentStatus, 'gitBash' | 'wsl'> | null | undefined,
+): WindowsShellKind | null {
+  if (shellStatus?.wsl.available) return 'wsl'
+  if (shellStatus?.gitBash.available && shellStatus.gitBash.path) return 'git-bash'
+  return null
+}


### PR DESCRIPTION
## Summary

Windows 同时安装 Git Bash 与 WSL 时，Proma 现在会优先使用 WSL，并在 WSL 不可用时继续回退到 Git Bash。

此前 Shell 检测与 Agent 编排都固定优先 Git Bash；同时 Pi Runtime 只接收了环境变量，没有收到 `shellKind`、`wslCommand` 和 `wslDistro`，因此已有的 WSL Bash operations 分支无法生效。本次修复统一了 Shell 选择策略，并让 Claude 与 Pi 共用完整的运行环境描述。

## Behavior

- Windows Shell 推荐项与实际 Agent 路由统一为 WSL first、Git Bash fallback。
- Pi Runtime 会保留 WSL 命令和发行版元数据，从而通过 `wsl.exe` 执行 Bash 工具。
- CLI 路径、代理变量和 Shell 变量由同一个环境构建器合并，避免 Windows `Path` / `PATH` 大小写冲突导致系统路径丢失。

## Test plan

- `bun test apps/electron/src/main/lib/agent-runtime-env.test.ts apps/electron/src/main/lib/adapters/pi-*.test.ts` — 60 passed
- `bun run typecheck` — 6 workspace packages passed
- `bun run --filter='@proma/electron' build:main` — passed
- `git diff --check` — passed

补充：WSL 中一次全量并行测试为 465/466，唯一失败是 Electron `BrowserWindow` 的跨文件模块加载顺序问题；失败文件在 `origin/main` 和本分支中单独运行均为 8/8 passed。

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.6--sol-000000)
