### PR TITLE
fix opencode kimi k3 context window

### DIFF
--- a/packages/shared/src/utils/context-window.test.ts
+++ b/packages/shared/src/utils/context-window.test.ts
@@ -63,11 +63,13 @@ describe('模型上下文窗口', () => {
     expect(resolveAgentSdkModelId('MiniMax-M2.7', 'minimax')).toBe('MiniMax-M2.7')
     expect(resolveAgentSdkModelId('kimi-k2.6', 'kimi-api')).toBe('kimi-k2.6')
     expect(resolveAgentSdkModelId('not-k3-compatible', 'kimi-api')).toBe('not-k3-compatible')
+    expect(resolveAgentSdkModelId('kimi-k3', 'opencode-go-openai')).toBe('kimi-k3')
     expect(resolveAgentSdkModelId('qwen3-max', 'qwen-anthropic')).toBe('qwen3-max')
     expect(resolveAgentSdkModelId('qwen3.6-max-preview', 'qwen-anthropic')).toBe('qwen3.6-max-preview')
     expect(resolveAgentSdkModelId('qwen3.5-397b-a17b', 'qwen-anthropic')).toBe('qwen3.5-397b-a17b')
     expect(resolveAgentSdkModelId('qwen3-coder-next', 'qwen-anthropic')).toBe('qwen3-coder-next')
     expect(resolveAgentSdkModelId('unknown-model', 'anthropic')).toBe('unknown-model')
+    expect(supports1MContext('not-kimi-k3-compatible')).toBe(false)
   })
 
   test('Given Qwen Anthropic 协议渠道 When 模型名命中 1M 规则 Then 保持真实模型 ID', () => {
@@ -102,5 +104,6 @@ describe('模型上下文窗口', () => {
     expect(inferAgentSdkContextWindow('claude-sonnet-5', 'anthropic-compatible')).toBe(ONE_MILLION_CONTEXT_WINDOW)
     expect(inferAgentSdkContextWindow('k3', 'kimi-api')).toBe(ONE_MILLION_CONTEXT_WINDOW)
     expect(inferAgentSdkContextWindow('k3', 'anthropic-compatible')).toBe(ONE_MILLION_CONTEXT_WINDOW)
+    expect(inferAgentSdkContextWindow('kimi-k3', 'opencode-go-openai')).toBe(ONE_MILLION_CONTEXT_WINDOW)
   })
 })

--- a/packages/shared/src/utils/context-window.ts
+++ b/packages/shared/src/utils/context-window.ts
@@ -93,9 +93,10 @@ const AGENT_SDK_1M_CONTEXT_PROVIDER_RULES: Partial<Record<ProviderType, readonly
 }
 
 const AGENT_SDK_1M_CONTEXT_DISPLAY_RULES = Object.values(AGENT_SDK_1M_CONTEXT_RULES).flat()
+const EXACT_CONTEXT_RULES = new Set(['k3', 'kimi-k3'])
 
 function matchesContextRule(model: string, pattern: string): boolean {
-  if (pattern.length <= 3) {
+  if (EXACT_CONTEXT_RULES.has(pattern)) {
     return model === pattern || model.startsWith(`${pattern}[`)
   }
   return model.includes(pattern)
@@ -117,6 +118,8 @@ const CONTEXT_WINDOW_CONFIG = {
   /** 1M 上下文模型匹配规则 */
   rules: [
     ...AGENT_SDK_1M_CONTEXT_DISPLAY_RULES,
+    // OpenAI 协议渠道（如 OpenCode Go）使用该真实模型 ID，不应追加 Claude SDK `[1m]` 后缀。
+    'kimi-k3',
     // 已废弃的 MiMo V2 Pro 仅保留历史显示推断，不主动启用 SDK 1M 变体
     'mimo-v2-pro',
   ] as const,


### PR DESCRIPTION
## Summary

- Treat OpenCode Go's `kimi-k3` model ID as Kimi K3's 1M context variant for display and runtime window inference.
- Keep the OpenCode Go model ID unchanged instead of adding the Claude Agent SDK `[1m]` suffix.
- Add focused regression coverage for the OpenCode Go `kimi-k3` path and the exact-match guard.

## Root Cause

PR #1263 added the OpenCode Go preset model `kimi-k3`, but the shared context-window rules only recognized exact `k3` as Kimi K3. As a result, `supports1MContext('kimi-k3')`, `inferContextWindow('kimi-k3')`, and `inferAgentSdkContextWindow('kimi-k3', 'opencode-go-openai')` fell back to 200K.

## Validation

- `bun test packages/shared/src/utils/context-window.test.ts`
- `bun test packages/shared/src/utils/context-window.test.ts apps/electron/src/main/lib/adapters/pi-model-registry.test.ts`
- `bun run --filter='@proma/shared' typecheck`
- `bun run --filter='@proma/electron' typecheck`
- `git diff --check`

Regression check now returns `{"supports":true,"inferred":1000000,"display":1000000,"sdk":"kimi-k3"}`.
