### PR TITLE
fix(agent): default Windows shell to Git Bash

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.15.10",
+  "version": "0.15.11",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/adapters/pi-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/pi-agent-adapter.ts
@@ -1077,7 +1077,7 @@ function shellQuote(value: string): string {
   return `'${value.replace(/'/g, String.raw`'\''`)}'`
 }
 
-function windowsPathToWslPath(value: string): string {
+export function windowsPathToWslPath(value: string): string {
   const driveMatch = value.match(/^([A-Za-z]):[\\/](.*)$/)
   if (!driveMatch) return value
   const drive = driveMatch[1]!.toLowerCase()
@@ -1099,20 +1099,29 @@ function buildWslCommand(command: string, env: NodeJS.ProcessEnv | undefined): s
     : command
 }
 
+export function buildWslBashArgs(
+  runtimeEnv: Pick<AgentRuntimeEnv, 'wslDistro'>,
+  cwd: string,
+  command: string,
+  env: NodeJS.ProcessEnv | undefined,
+): string[] {
+  return [
+    ...(runtimeEnv.wslDistro ? ['--distribution', runtimeEnv.wslDistro] : []),
+    '--cd',
+    windowsPathToWslPath(cwd),
+    '--exec',
+    'bash',
+    '-lc',
+    buildWslCommand(command, env),
+  ]
+}
+
 function createWslBashOperations(runtimeEnv: AgentRuntimeEnv): BashOperations {
   return {
     exec(command, cwd, options) {
       return new Promise((resolve, reject) => {
         const mergedEnv = mergeRuntimeEnv(process.env, options.env)
-        const args = [
-          ...(runtimeEnv.wslDistro ? ['--distribution', runtimeEnv.wslDistro] : []),
-          '--cd',
-          cwd,
-          '--exec',
-          'bash',
-          '-lc',
-          buildWslCommand(command, mergedEnv),
-        ]
+        const args = buildWslBashArgs(runtimeEnv, cwd, command, mergedEnv)
         const child = spawn(runtimeEnv.wslCommand ?? 'wsl.exe', args, {
           env: mergedEnv,
           stdio: ['ignore', 'pipe', 'pipe'],

--- a/apps/electron/src/main/lib/adapters/pi-agent-bash.test.ts
+++ b/apps/electron/src/main/lib/adapters/pi-agent-bash.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'bun:test'
+import { buildWslBashArgs, windowsPathToWslPath } from './pi-agent-adapter'
+
+describe('Pi WSL Bash', () => {
+  test('Given a Windows workspace path When building WSL Bash arguments Then uses its mounted Linux path', () => {
+    expect(buildWslBashArgs(
+      { wslDistro: 'Ubuntu-24.04' },
+      'C:\\Users\\alice\\Workspace\\project',
+      'pwd',
+      undefined,
+    )).toEqual([
+      '--distribution',
+      'Ubuntu-24.04',
+      '--cd',
+      '/mnt/c/Users/alice/Workspace/project',
+      '--exec',
+      'bash',
+      '-lc',
+      'pwd',
+    ])
+  })
+
+  test('Given a Linux path When converting for WSL Then leaves it unchanged', () => {
+    expect(windowsPathToWslPath('/home/alice/project')).toBe('/home/alice/project')
+  })
+})

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -46,7 +46,7 @@ import { getFetchFn } from './proxy-fetch'
 import { getEffectiveProxyUrl } from './proxy-settings-service'
 import { appendSDKMessages, updateAgentSessionMeta, getAgentSessionMeta, getAgentSessionMessages, truncateSDKMessages, removeSDKErrorMessage, resolveUserUuidFromSDK, rewindFilesFromSnapshot, rewindPiAgentSession } from './agent-session-manager'
 import { getAgentWorkspace, getWorkspaceMcpConfig, ensurePluginManifest, getWorkspaceAutoMemoryDir, getWorkspaceAttachedDirectories, getWorkspaceAttachedFiles } from './agent-workspace-manager'
-import { getAgentWorkspacePath, getAgentSessionWorkspacePath, getSdkConfigDir, getWorkspaceFilesDir, getBundledCliPath, getWorkspaceSkillsDir } from './config-paths'
+import { getAgentWorkspacePath, getAgentSessionWorkspacePath, getSdkConfigDir, getWorkspaceFilesDir, getWorkspaceSkillsDir } from './config-paths'
 import { getRuntimeStatus } from './runtime-init'
 import { getSettings } from './settings-service'
 import { buildSystemPrompt, buildDynamicContext } from './agent-prompt-builder'
@@ -63,7 +63,7 @@ import { injectChromeDevtoolsMcpServer } from './builtin-mcp/chrome-devtools'
 import { isBuiltinMcpUserEnabled } from './builtin-mcp/settings'
 import { buildPiBuiltinTools } from './adapters/pi-builtin-tools'
 import { buildPiMcpTools } from './adapters/pi-mcp-tools'
-import type { AgentRuntimeEnv } from './agent-runtime-env'
+import { buildAgentRuntimeEnv, mergeRuntimeEnv, type AgentRuntimeEnv } from './agent-runtime-env'
 import { isVisibleRunMessage } from './agent-run-message-visibility'
 import { applyAgentSdkAuthEnv } from './agent-sdk-auth-env'
 import { getAgentSdkMaxOutputTokens } from './agent-sdk-output-limits'
@@ -104,14 +104,6 @@ function sdkPermissionModeForPromaMode(mode: PromaPermissionMode): PromaPermissi
 
 function normalizeAgentRuntime(value: unknown): AgentRuntime {
   return value === 'pi' ? 'pi' : 'claude'
-}
-
-function buildPiRuntimeEnv(env: Record<string, string | undefined>): AgentRuntimeEnv {
-  const cleanEnv: Record<string, string> = {}
-  for (const [key, value] of Object.entries(env)) {
-    if (value !== undefined) cleanEnv[key] = value
-  }
-  return { env: cleanEnv }
 }
 
 const EMPTY_RESPONSE_RESULT_SUBTYPE = 'empty_response'
@@ -424,12 +416,13 @@ export class AgentOrchestrator {
    * 注入 API Key、Base URL、代理、Shell 配置等。
    * 对 Kimi Coding Plan / MiniMax Coding Plan：使用 Bearer 认证（ANTHROPIC_AUTH_TOKEN）。
    */
-  private async buildSdkEnv(
+  private buildSdkRuntimeEnv(
     apiKey: string,
     baseUrl: string | undefined,
     provider: ProviderType,
     modelId: string | undefined,
-  ): Promise<Record<string, string | undefined>> {
+    proxyUrl: string | undefined,
+  ): AgentRuntimeEnv {
     const DEFAULT_ANTHROPIC_URL = 'https://api.anthropic.com'
 
     // 从 process.env 继承系统变量，但清理所有 ANTHROPIC_ 前缀的变量，
@@ -450,15 +443,6 @@ export class AgentOrchestrator {
       ...cleanEnv,
       // 仅 Claude 模型显式提高输出上限；其它兼容模型不注入 max_tokens 覆盖。
       ...(maxOutputTokens ? { CLAUDE_CODE_MAX_OUTPUT_TOKENS: maxOutputTokens } : {}),
-      // 暴露打包进 App 的 proma CLI 路径，供 session-cleaner 等 skill / Agent 调用
-      // （开发模式无编译二进制，getBundledCliPath 返回 undefined，此处不注入，
-      //   skill 回退到源码运行 bun apps/cli/src/index.ts）。
-      ...(getBundledCliPath()
-        ? {
-            PROMA_CLI: getBundledCliPath(),
-            PATH: `${dirname(getBundledCliPath()!)}${process.platform === 'win32' ? ';' : ':'}${cleanEnv.PATH ?? ''}`,
-          }
-        : {}),
       // 启用 Tasks 功能
       CLAUDE_CODE_ENABLE_TASKS: 'true',
       // 禁用 SDK 内置 Workflows，避免每轮注入 workflow 相关提示词。
@@ -502,29 +486,22 @@ export class AgentOrchestrator {
       sdkEnv.ANTHROPIC_BASE_URL = normalizeAnthropicBaseUrlForSdk(baseUrl)
     }
 
-    const proxyUrl = await getEffectiveProxyUrl()
-    if (proxyUrl) {
-      sdkEnv.HTTPS_PROXY = proxyUrl
-      sdkEnv.HTTP_PROXY = proxyUrl
-    }
+    const runtimeEnv = buildAgentRuntimeEnv({
+      proxyUrl,
+      runtimeStatus: getRuntimeStatus(),
+      windowsShellPreference: getSettings().windowsShellPreference,
+      processEnv: sdkEnv,
+    })
 
-    // Windows 平台：配置 Shell 环境
     if (process.platform === 'win32') {
-      const runtimeStatus = getRuntimeStatus()
-      const shellStatus = runtimeStatus?.shell
-
-      if (shellStatus) {
-        if (shellStatus.gitBash?.available && shellStatus.gitBash.path) {
-          sdkEnv.CLAUDE_CODE_SHELL = shellStatus.gitBash.path
-          console.log(`[Agent 编排] 配置 Shell 环境: Git Bash (${shellStatus.gitBash.path})`)
-        } else if (shellStatus.wsl?.available) {
-          sdkEnv.CLAUDE_CODE_SHELL = 'wsl'
-          console.log(`[Agent 编排] 配置 Shell 环境: WSL ${shellStatus.wsl.version} (${shellStatus.wsl.defaultDistro})`)
-        } else {
-          console.warn('[Agent 编排] Windows 平台未检测到可用的 Shell 环境（Git Bash / WSL）')
-        }
-        sdkEnv.CLAUDE_BASH_NO_LOGIN = '1'
+      if (runtimeEnv.shellKind === 'wsl') {
+        console.log(`[Agent 编排] 配置 Shell 环境: WSL (${runtimeEnv.wslDistro ?? '默认发行版'})`)
+      } else if (runtimeEnv.shellKind === 'git-bash') {
+        console.log(`[Agent 编排] 配置 Shell 环境: Git Bash (${runtimeEnv.shellPath})`)
+      } else {
+        console.warn('[Agent 编排] Windows 平台未检测到可用的 Shell 环境（Git Bash / WSL）')
       }
+      sdkEnv.CLAUDE_BASH_NO_LOGIN = '1'
     }
 
     // 针对 claude-agent-sdk 0.2.111+ 的 options.env 叠加语义加固：
@@ -538,7 +515,10 @@ export class AgentOrchestrator {
       }
     }
 
-    return sdkEnv
+    return {
+      ...runtimeEnv,
+      env: mergeRuntimeEnv(sdkEnv, runtimeEnv.env),
+    }
   }
 
   /**
@@ -1110,7 +1090,14 @@ export class AgentOrchestrator {
     }
 
     const proxyUrl = await getEffectiveProxyUrl()
-    const sdkEnv = await this.buildSdkEnv(apiKey, channel.baseUrl, channel.provider, modelId || DEFAULT_MODEL_ID)
+    const runtimeEnv = this.buildSdkRuntimeEnv(
+      apiKey,
+      channel.baseUrl,
+      channel.provider,
+      modelId || DEFAULT_MODEL_ID,
+      proxyUrl,
+    )
+    const sdkEnv = runtimeEnv.env
 
     // 4. 读取已有的 SDK session ID（用于 resume）
     let existingSdkSessionId = sessionMeta?.sdkSessionId
@@ -1641,7 +1628,7 @@ export class AgentOrchestrator {
         provider: channel.provider,
         channelName: channel.name,
         proxyUrl,
-        runtimeEnv: buildPiRuntimeEnv(sdkEnv),
+        runtimeEnv,
         ...(maxTurns != null && { maxTurns }),
         permissionMode: initialPermissionMode,
         canUseTool,

--- a/apps/electron/src/main/lib/agent-runtime-env.test.ts
+++ b/apps/electron/src/main/lib/agent-runtime-env.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'bun:test'
+import type { GitBashStatus, RuntimeStatus, ShellEnvironmentStatus, WslStatus } from '@proma/shared'
+import { buildAgentRuntimeEnv, mergeRuntimeEnv } from './agent-runtime-env'
+
+function runtimeStatus(shell: ShellEnvironmentStatus): RuntimeStatus {
+  return { shell } as RuntimeStatus
+}
+
+const gitBash: GitBashStatus = {
+  available: true,
+  path: 'C:\\Program Files\\Git\\bin\\bash.exe',
+  version: '5.2.37',
+  error: null,
+}
+
+const wsl: WslStatus = {
+  available: true,
+  version: 2,
+  defaultDistro: 'Ubuntu-24.04',
+  distros: ['Ubuntu-24.04'],
+  error: null,
+}
+
+const bothShells = runtimeStatus({ gitBash, wsl, recommended: 'git-bash' })
+
+describe('Agent Windows Shell 运行环境', () => {
+  test('Given Git Bash 与 WSL 均可用 When 使用默认策略 Then 优先使用 Git Bash', () => {
+    const result = buildAgentRuntimeEnv({
+      bundledCliPath: '',
+      platform: 'win32',
+      processEnv: {},
+      runtimeStatus: bothShells,
+    })
+
+    expect(result).toMatchObject({
+      shellKind: 'git-bash',
+      shellPath: gitBash.path,
+      env: {
+        PROMA_WINDOWS_SHELL: 'git-bash',
+        CLAUDE_CODE_SHELL: gitBash.path,
+      },
+    })
+  })
+
+  test('Given Git Bash 与 WSL 均可用 When 用户显式选择 WSL Then 使用 WSL', () => {
+    const result = buildAgentRuntimeEnv({
+      bundledCliPath: '',
+      platform: 'win32',
+      processEnv: {},
+      runtimeStatus: bothShells,
+      windowsShellPreference: 'wsl',
+    })
+
+    expect(result).toMatchObject({
+      shellKind: 'wsl',
+      wslCommand: 'wsl.exe',
+      wslDistro: 'Ubuntu-24.04',
+      env: {
+        PROMA_WINDOWS_SHELL: 'wsl',
+        PROMA_WSL_DISTRO: 'Ubuntu-24.04',
+        CLAUDE_CODE_SHELL: 'wsl.exe',
+      },
+    })
+  })
+
+  test('Given WSL 首选项不可用 When Git Bash 可用 Then 回退到 Git Bash', () => {
+    const result = buildAgentRuntimeEnv({
+      bundledCliPath: '',
+      platform: 'win32',
+      processEnv: {},
+      windowsShellPreference: 'wsl',
+      runtimeStatus: runtimeStatus({
+        gitBash,
+        wsl: { ...wsl, available: false, version: null, defaultDistro: null, distros: [], error: '未安装' },
+        recommended: 'git-bash',
+      }),
+    })
+
+    expect(result.shellKind).toBe('git-bash')
+    expect(result.shellPath).toBe(gitBash.path!)
+  })
+
+  test('Given Windows Path 大小写不同 When 合并运行环境 Then 仅保留覆盖后的 PATH', () => {
+    const result = mergeRuntimeEnv(
+      { Path: 'C:\\Windows\\System32' },
+      { PATH: 'C:\\Proma;C:\\Windows\\System32' },
+    )
+
+    expect(result).toEqual({ PATH: 'C:\\Proma;C:\\Windows\\System32' })
+  })
+})

--- a/apps/electron/src/main/lib/agent-runtime-env.ts
+++ b/apps/electron/src/main/lib/agent-runtime-env.ts
@@ -1,9 +1,10 @@
 import { existsSync } from 'node:fs'
 import { delimiter, dirname, join, win32 } from 'node:path'
-import type { RuntimeStatus } from '@proma/shared'
+import type { RuntimeStatus, WindowsShellPreference } from '@proma/shared'
 import { getBundledCliPath } from './config-paths'
+import { selectWindowsShell, type WindowsShellKind } from './windows-shell-selection'
 
-export type AgentRuntimeShellKind = 'git-bash' | 'wsl'
+export type AgentRuntimeShellKind = WindowsShellKind
 
 export interface AgentRuntimeEnv {
   env: Record<string, string>
@@ -16,6 +17,7 @@ export interface AgentRuntimeEnv {
 export interface BuildAgentRuntimeEnvOptions {
   proxyUrl?: string
   runtimeStatus?: RuntimeStatus | null
+  windowsShellPreference?: WindowsShellPreference
   bundledCliPath?: string
   processEnv?: NodeJS.ProcessEnv
   platform?: NodeJS.Platform
@@ -115,25 +117,15 @@ function getWslCommandPath(
 
 function collectWindowsShellEnv(
   runtimeStatus: RuntimeStatus | null | undefined,
+  preference: WindowsShellPreference | undefined,
   processEnv: NodeJS.ProcessEnv,
   pathExists: (path: string) => boolean,
 ): Omit<AgentRuntimeEnv, 'env'> & { env: Record<string, string> } {
   const shellStatus = runtimeStatus?.shell
   const env: Record<string, string> = {}
+  const shellKind = selectWindowsShell(shellStatus, preference)
 
-  if (shellStatus?.gitBash.available && shellStatus.gitBash.path) {
-    const shellPath = shellStatus.gitBash.path
-    env.PROMA_WINDOWS_SHELL = 'git-bash'
-    env.CLAUDE_CODE_SHELL = shellPath
-    env.SHELL = shellPath
-    return {
-      env,
-      shellKind: 'git-bash',
-      shellPath,
-    }
-  }
-
-  if (shellStatus?.wsl.available) {
+  if (shellKind === 'wsl' && shellStatus?.wsl.available) {
     const wslCommand = getWslCommandPath(processEnv, pathExists)
     env.PROMA_WINDOWS_SHELL = 'wsl'
     env.CLAUDE_CODE_SHELL = wslCommand
@@ -146,6 +138,18 @@ function collectWindowsShellEnv(
       shellKind: 'wsl',
       wslCommand,
       ...(shellStatus.wsl.defaultDistro && { wslDistro: shellStatus.wsl.defaultDistro }),
+    }
+  }
+
+  if (shellKind === 'git-bash' && shellStatus?.gitBash.path) {
+    const shellPath = shellStatus.gitBash.path
+    env.PROMA_WINDOWS_SHELL = 'git-bash'
+    env.CLAUDE_CODE_SHELL = shellPath
+    env.SHELL = shellPath
+    return {
+      env,
+      shellKind: 'git-bash',
+      shellPath,
     }
   }
 
@@ -204,7 +208,12 @@ export function buildAgentRuntimeEnv(options: BuildAgentRuntimeEnvOptions = {}):
   Object.assign(env, collectProxyEnv(options.proxyUrl, processEnv))
 
   if (platform === 'win32') {
-    const shellRuntimeEnv = collectWindowsShellEnv(options.runtimeStatus, processEnv, pathExists)
+    const shellRuntimeEnv = collectWindowsShellEnv(
+      options.runtimeStatus,
+      options.windowsShellPreference,
+      processEnv,
+      pathExists,
+    )
     Object.assign(env, shellRuntimeEnv.env)
     return {
       env,

--- a/apps/electron/src/main/lib/runtime-init.ts
+++ b/apps/electron/src/main/lib/runtime-init.ts
@@ -16,6 +16,7 @@ import { detectBunRuntime } from './bun-finder'
 import { detectGitRuntime, getGitRepoStatus } from './git-detector'
 import { detectGitBash } from './git-bash-detector'
 import { detectWsl } from './wsl-detector'
+import { selectWindowsShell } from './windows-shell-selection'
 
 /** 运行时状态缓存 */
 let runtimeStatusCache: RuntimeStatus | null = null
@@ -92,13 +93,7 @@ export async function initializeRuntime(options: RuntimeInitOptions = {}): Promi
       const gitBashStatus = await detectGitBash()
       const wslStatus = await detectWsl()
 
-      // 推荐策略：优先 Git Bash > WSL 2 > WSL 1
-      let recommended: 'git-bash' | 'wsl' | null = null
-      if (gitBashStatus.available) {
-        recommended = 'git-bash'
-      } else if (wslStatus.available) {
-        recommended = 'wsl'
-      }
+      const recommended = selectWindowsShell({ gitBash: gitBashStatus, wsl: wslStatus })
 
       shellEnvironmentStatus = {
         gitBash: gitBashStatus,

--- a/apps/electron/src/main/lib/settings-service.ts
+++ b/apps/electron/src/main/lib/settings-service.ts
@@ -30,6 +30,7 @@ export function getSettings(): AppSettings {
       feishuSessionMirror: { mode: 'off' },
       builtinMcpDisabledIds: [],
       agentRuntime: DEFAULT_AGENT_RUNTIME,
+      windowsShellPreference: 'auto',
       agentThinking: { type: 'adaptive' },
     }
   }
@@ -51,6 +52,7 @@ export function getSettings(): AppSettings {
       feishuSessionMirror: data.feishuSessionMirror ?? { mode: 'off' },
       builtinMcpDisabledIds: settings.builtinMcpDisabledIds ?? [],
       agentRuntime: settings.agentRuntime ?? DEFAULT_AGENT_RUNTIME,
+      windowsShellPreference: settings.windowsShellPreference ?? 'auto',
       agentThinking: settings.agentThinking ?? { type: 'adaptive' },
     }
   } catch (error) {
@@ -66,6 +68,7 @@ export function getSettings(): AppSettings {
       feishuSessionMirror: { mode: 'off' },
       builtinMcpDisabledIds: [],
       agentRuntime: DEFAULT_AGENT_RUNTIME,
+      windowsShellPreference: 'auto',
       agentThinking: { type: 'adaptive' },
     }
   }

--- a/apps/electron/src/main/lib/windows-shell-selection.ts
+++ b/apps/electron/src/main/lib/windows-shell-selection.ts
@@ -1,0 +1,23 @@
+import type { ShellEnvironmentStatus, WindowsShellPreference } from '@proma/shared'
+
+export type WindowsShellKind = 'git-bash' | 'wsl'
+
+/**
+ * 解析 Windows Agent Shell。
+ *
+ * 默认策略优先 Git Bash，确保 Electron、工作区与 Bash 工具都使用 Windows 路径；
+ * WSL 仅在用户明确选择时启用。任何首选项不可用时，都会安全回退到另一可用 Shell。
+ */
+export function selectWindowsShell(
+  shellStatus: Pick<ShellEnvironmentStatus, 'gitBash' | 'wsl'> | null | undefined,
+  preference: WindowsShellPreference = 'auto',
+): WindowsShellKind | null {
+  const hasGitBash = Boolean(shellStatus?.gitBash.available && shellStatus.gitBash.path)
+  const hasWsl = Boolean(shellStatus?.wsl.available)
+
+  if (preference === 'wsl' && hasWsl) return 'wsl'
+  if (preference === 'git-bash' && hasGitBash) return 'git-bash'
+  if (hasGitBash) return 'git-bash'
+  if (hasWsl) return 'wsl'
+  return null
+}

--- a/apps/electron/src/renderer/components/settings/AboutSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AboutSettings.tsx
@@ -8,11 +8,12 @@
 import * as React from 'react'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { RefreshCw, Loader2, CheckCircle2, AlertCircle, Info, Terminal, ChevronDown, ChevronUp, ExternalLink, RotateCw } from 'lucide-react'
-import type { EnvironmentCheckResult, RuntimeStatus } from '@proma/shared'
+import type { EnvironmentCheckResult, RuntimeStatus, WindowsShellPreference } from '@proma/shared'
 import {
   SettingsSection,
   SettingsCard,
   SettingsRow,
+  SettingsSelect,
 } from './primitives'
 import { updateStatusAtom, updaterAvailableAtom, checkForUpdates } from '@/atoms/updater'
 import {
@@ -322,13 +323,17 @@ function EnvironmentCard(): React.ReactElement {
 /** Shell 环境卡片（Windows 平台）*/
 function ShellEnvironmentCard(): React.ReactElement | null {
   const [runtimeStatus, setRuntimeStatus] = React.useState<RuntimeStatus | null>(null)
+  const [shellPreference, setShellPreference] = React.useState<WindowsShellPreference>('auto')
   const [isChecking, setIsChecking] = React.useState(false)
 
-  // 初始化时加载运行时状态
+  // 初始化时加载运行时状态与用户偏好
   React.useEffect(() => {
-    window.electronAPI.getRuntimeStatus().then((status) => {
-      setRuntimeStatus(status)
-    })
+    Promise.all([window.electronAPI.getRuntimeStatus(), window.electronAPI.getSettings()])
+      .then(([status, settings]) => {
+        setRuntimeStatus(status)
+        setShellPreference(settings.windowsShellPreference ?? 'auto')
+      })
+      .catch((error) => console.error('[Shell 环境检测] 读取设置失败:', error))
   }, [])
 
   // 重新检测
@@ -345,6 +350,13 @@ function ShellEnvironmentCard(): React.ReactElement | null {
     }
   }
 
+  const handlePreferenceChange = async (value: string): Promise<void> => {
+    if (value !== 'auto' && value !== 'git-bash' && value !== 'wsl') return
+    const preference = value as WindowsShellPreference
+    await window.electronAPI.updateSettings({ windowsShellPreference: preference })
+    setShellPreference(preference)
+  }
+
   // 非 Windows 平台不显示
   if (!runtimeStatus || !runtimeStatus.shell) {
     return null
@@ -352,6 +364,12 @@ function ShellEnvironmentCard(): React.ReactElement | null {
 
   const { shell } = runtimeStatus
   const hasShell = shell.gitBash?.available || shell.wsl?.available
+  const resolvedShell = shellPreference === 'wsl' && shell.wsl.available
+    ? 'wsl'
+    : shellPreference === 'git-bash' && shell.gitBash.available
+      ? 'git-bash'
+      : shell.recommended
+  const resolvedShellLabel = resolvedShell === 'git-bash' ? 'Git Bash' : resolvedShell === 'wsl' ? 'WSL' : '无可用 Shell'
 
   return (
     <SettingsCard>
@@ -381,6 +399,20 @@ function ShellEnvironmentCard(): React.ReactElement | null {
       </div>
 
       <div className="p-4 space-y-3">
+        <SettingsSelect
+          label="Agent Shell"
+          description="默认使用 Git Bash，确保 Windows 工作区与 Agent 工具使用同一套路径；选择 WSL 后，WSL 不可用时会回退到 Git Bash。"
+          value={shellPreference}
+          onValueChange={(value) => {
+            void handlePreferenceChange(value).catch((error) => console.error('[Shell 环境检测] 保存偏好失败:', error))
+          }}
+          options={[
+            { value: 'auto', label: '自动（推荐：Git Bash 优先）' },
+            { value: 'git-bash', label: 'Git Bash' },
+            { value: 'wsl', label: 'WSL（实验性）' },
+          ]}
+        />
+
         {/* Git Bash 检测卡片 */}
         <EnvironmentCheckCard
           name="Git Bash"
@@ -412,16 +444,14 @@ function ShellEnvironmentCard(): React.ReactElement | null {
           }
         />
 
-        {/* 推荐环境提示 */}
-        {shell.recommended && (
-          <Alert>
-            <Info className="h-4 w-4" />
-            <AlertDescription className="text-xs">
-              <strong>当前使用：</strong>
-              {shell.recommended === 'git-bash' ? 'Git Bash（推荐）' : 'WSL'}
-            </AlertDescription>
-          </Alert>
-        )}
+        <Alert>
+          <Info className="h-4 w-4" />
+          <AlertDescription className="text-xs">
+            <strong>Agent 将使用：</strong>{resolvedShellLabel}
+            {shellPreference === 'wsl' && resolvedShell !== 'wsl' && '（WSL 不可用，已回退）'}
+            {shellPreference === 'git-bash' && resolvedShell !== 'git-bash' && '（Git Bash 不可用，已回退）'}
+          </AlertDescription>
+        </Alert>
 
         {/* 无可用环境警告 */}
         {!hasShell && (

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -4,7 +4,7 @@
  * 主题模式、IPC 通道等设置相关定义。
  */
 
-import type { AgentRuntime, EnvironmentCheckResult, ThinkingConfig, AgentEffort, FeishuSessionMirrorSettings } from '@proma/shared'
+import type { AgentRuntime, EnvironmentCheckResult, ThinkingConfig, AgentEffort, FeishuSessionMirrorSettings, WindowsShellPreference } from '@proma/shared'
 
 /** 通知音场景类型 */
 export type NotificationSoundType = 'taskComplete' | 'permissionRequest' | 'exitPlanMode'
@@ -207,6 +207,8 @@ export interface AppSettings {
   agentWorkspaceId?: string
   /** 新 Agent 会话默认使用的 runtime；历史会话缺省仍按 claude 兼容。 */
   agentRuntime?: AgentRuntime
+  /** Windows 上 Agent Bash 工具的运行环境；默认自动选择 Git Bash，WSL 需用户显式启用。 */
+  windowsShellPreference?: WindowsShellPreference
   /** 侧栏「自动任务」合成项目组在项目列表中的位置索引（默认 0 = 最靠前；可拖拽调整） */
   agentAutomationGroupOrder?: number
   /** 是否已完成 Onboarding 流程 */

--- a/packages/shared/src/types/runtime.ts
+++ b/packages/shared/src/types/runtime.ts
@@ -257,6 +257,9 @@ export interface DefaultAppInfo {
   iconDataUrl: string
 }
 
+/** Windows Agent Shell 偏好：默认自动选择 Git Bash，用户可显式改用 WSL。 */
+export type WindowsShellPreference = 'auto' | 'git-bash' | 'wsl'
+
 /**
  * WSL 运行时状态（Windows 平台）
  */


### PR DESCRIPTION
## Summary

- Default Windows Agent Bash execution to Git Bash so Electron, the workspace, and Bash tools share Windows path semantics.
- Add an explicit Agent Shell setting that permits opting into WSL, with fallback to the other available shell.
- Pass the unified runtime environment to both Claude and Pi; Pi now converts Windows working directories to `/mnt/<drive>/...` for WSL.

## Test plan

- `bun test apps/electron/src/main/lib/agent-runtime-env.test.ts apps/electron/src/main/lib/adapters/pi-agent-bash.test.ts`
- `bun run typecheck`
- `bun run --filter="@proma/electron" build:main`
- `bun run --filter="@proma/electron" build:renderer`
- `git diff --check`

## Windows manual verification

- On a machine with Git Bash and WSL, verify Auto uses Git Bash and explicit WSL uses Linux.
- Verify a workspace under a Windows path with spaces resolves to `/mnt/<drive>/...` in WSL.