### PR TITLE
fix(input): 修复 Windows 复制时段落空行【测试中】

### DIFF
--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -26,7 +26,7 @@ import { ChevronsDownUp, ChevronsUpDown } from 'lucide-react'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { lowlight } from '@/lib/lowlight'
-import { htmlToMarkdown } from '@/lib/markdown-rich-text'
+import { htmlToClipboardText, htmlToMarkdown } from '@/lib/markdown-rich-text'
 import { richTextRenderingEnabledAtom } from '@/atoms/ui-preferences'
 import { createFileMentionSuggestion } from '@/components/file-browser/file-mention-suggestion'
 import { createSkillMentionSuggestion, createMcpMentionSuggestion, createSessionMentionSuggestion } from '@/components/agent/mention-suggestions'
@@ -390,7 +390,7 @@ export function RichTextInput({
           const fragment = range.cloneContents()
           const tempDiv = document.createElement('div')
           tempDiv.appendChild(fragment)
-          const text = htmlToMarkdown(tempDiv.innerHTML, { skipMarkdownEscape: !richTextEnabledRef.current }) || selection.toString()
+          const text = htmlToClipboardText(tempDiv.innerHTML, { skipMarkdownEscape: !richTextEnabledRef.current }) || selection.toString().replace(/\r\n?/g, '\n')
           event.preventDefault()
           event.clipboardData.setData('text/plain', text)
           event.clipboardData.setData('text/html', '')

--- a/apps/electron/src/renderer/lib/markdown-rich-text.test.ts
+++ b/apps/electron/src/renderer/lib/markdown-rich-text.test.ts
@@ -1,5 +1,38 @@
 import { describe, expect, test } from 'bun:test'
-import { markdownToHtml } from './markdown-rich-text'
+import { DOMParser } from '@xmldom/xmldom'
+import { htmlToClipboardText, htmlToMarkdown, markdownToHtml } from './markdown-rich-text'
+
+function withHtmlDocument<T>(run: () => T): T {
+  const originalDocument = globalThis.document
+  const originalNode = globalThis.Node
+  const parser = new DOMParser()
+
+  Object.assign(globalThis, {
+    document: {
+      createElement: () => {
+        let root: Element | null = null
+        return {
+          nodeType: 1,
+          tagName: 'DIV',
+          getAttribute: () => null,
+          set innerHTML(html: string) {
+            root = parser.parseFromString(`<div>${html}</div>`, 'text/html').documentElement
+          },
+          get childNodes() {
+            return root?.childNodes ?? []
+          },
+        }
+      },
+    },
+    Node: { TEXT_NODE: 3, ELEMENT_NODE: 1 },
+  })
+
+  try {
+    return run()
+  } finally {
+    Object.assign(globalThis, { document: originalDocument, Node: originalNode })
+  }
+}
 
 describe('markdownToHtml rich preview blocks', () => {
   test('renders leading yaml frontmatter as a collapsible metadata block', () => {
@@ -110,6 +143,26 @@ describe('markdownToHtml rich preview blocks', () => {
     expect(html).toContain('&lt;img src=&quot;晨光.jpg&quot;&gt;')
     expect(html).toContain('### Agent 模式')
     expect(html).not.toContain('<h3>Agent 模式</h3>')
+  })
+})
+
+describe('Clipboard 纯文本序列化', () => {
+  test('不改变 Markdown 持久化使用的段落分隔', () => {
+    const markdown = withHtmlDocument(() => htmlToMarkdown('<p>第一段</p><p>第二段</p>'))
+
+    expect(markdown).toBe('第一段\n\n第二段')
+  })
+
+  test('相邻段落复制为单换行，不带 Markdown 的空段落分隔', () => {
+    const text = withHtmlDocument(() => htmlToClipboardText('<p>第一段</p><p>第二段</p>'))
+
+    expect(text).toBe('第一段\n第二段')
+  })
+
+  test('显式空段落保留一个空行，Windows 换行统一为 LF', () => {
+    const text = withHtmlDocument(() => htmlToClipboardText('<p>第一行\r\n内容</p><p></p><p>第三段</p>'))
+
+    expect(text).toBe('第一行\n内容\n\n第三段')
   })
 })
 

--- a/apps/electron/src/renderer/lib/markdown-rich-text.ts
+++ b/apps/electron/src/renderer/lib/markdown-rich-text.ts
@@ -362,7 +362,10 @@ export function markdownToHtml(markdown: string): string {
 }
 
 /** 将 TipTap 输出的 HTML 转换为 Markdown 格式 */
-export function htmlToMarkdown(html: string, options?: { skipMarkdownEscape?: boolean }): string {
+export function htmlToMarkdown(
+  html: string,
+  options?: { skipMarkdownEscape?: boolean; paragraphSeparator?: string },
+): string {
   if (!html || html === '<p></p>') return ''
 
   const div = document.createElement('div')
@@ -408,7 +411,7 @@ export function htmlToMarkdown(html: string, options?: { skipMarkdownEscape?: bo
         return `<video controls src="${escapeAttr(src)}"${title ? ` title="${escapeAttr(title)}"` : ''}></video>\n`
       }
       case 'p':
-        return children + '\n\n'
+        return children + (options?.paragraphSeparator ?? '\n\n')
       case 'br':
         return '\n'
       case 'strong':
@@ -512,4 +515,18 @@ export function htmlToMarkdown(html: string, options?: { skipMarkdownEscape?: bo
   }
 
   return processNode(div).trim()
+}
+
+/**
+ * 将编辑器选区导出为系统剪贴板的纯文本。
+ *
+ * Markdown 持久化需要用空行区分段落；普通剪贴板文本只需要单个换行。
+ * 这个专用出口避免把 Markdown 的段落分隔符带入其他编辑器，同时保留
+ * 选区内显式空段落和全部内联 Markdown 语义。
+ */
+export function htmlToClipboardText(html: string, options?: { skipMarkdownEscape?: boolean }): string {
+  return htmlToMarkdown(html, {
+    ...options,
+    paragraphSeparator: '\n',
+  }).replace(/\r\n?/g, '\n')
 }


### PR DESCRIPTION
## 概述
修复 Chat 与 Agent 输入框在 Windows 等环境复制多段内容时，把 Markdown 持久化用的双换行写入系统剪贴板，导致粘贴到其他编辑器后出现额外段落空白的问题。改动仅覆盖输入框复制出口，不改变 TipTap 编辑行为、草稿持久化或 Markdown 文件读写。

## 改动
- `apps/electron/src/renderer/lib/markdown-rich-text.ts` — 为 `htmlToMarkdown` 增加可配置段落分隔符，并新增 `htmlToClipboardText` 专用出口：剪贴板采用单换行分隔相邻段落，统一 `CRLF`/`CR` 为 `LF`；默认 Markdown 持久化仍保持双换行语义。
- `apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx` — 输入框复制事件改用 Clipboard 专用序列化器，仍写入 `text/plain` 并清空 `text/html`，保留既有纯文本复制与 Markdown 转义策略。
- `apps/electron/src/renderer/lib/markdown-rich-text.test.ts` — 覆盖 Markdown 持久化段落分隔不变、相邻段落复制、显式空段落保留及 Windows 换行归一化。

## 测试方法
1. 运行 `bun test apps/electron/src/renderer/lib/markdown-rich-text.test.ts`，16 项测试通过。
2. 在 `apps/electron` 目录运行 `bun run typecheck`，通过。
3. 在 `apps/electron` 目录运行 `bun run build:renderer`，通过。
4. 手动验证建议：在 Chat 或 Agent 输入框复制多段文本，粘贴到草稿、Markdown 编辑器及外部应用，确认相邻段落不再额外增殖空行。

## 备注
- 上游仓库不允许当前账号直接推送，分支已推送至 `Andreaseszhang/Proma` fork，并以该 fork 分支向 `ErlichLiu/Proma:main` 发起 PR。
- 草稿本与 Markdown 富编辑器未在本 PR 中改动；若 Windows 实测仍有独立复现，将根据实际 Clipboard payload 单独处理。
