### PR TITLE
fix(scratch): 修复复制时段落空行【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
+++ b/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
@@ -36,7 +36,7 @@ import {
   DropdownMenuSeparator,
 } from '@/components/ui/dropdown-menu'
 import { lowlight } from '@/lib/lowlight'
-import { htmlToMarkdown, markdownToHtml } from '@/lib/markdown-rich-text'
+import { htmlToClipboardText, htmlToMarkdown, markdownToHtml } from '@/lib/markdown-rich-text'
 import {
   MathBlock,
   MathInline,
@@ -171,6 +171,25 @@ function ScratchPadEditor({ variant }: ScratchPadEditorProps): React.ReactElemen
   const editor = useEditor({
     extensions,
     content: content || '',
+    editorProps: {
+      handleDOMEvents: {
+        // 草稿保存为 Markdown 时段落必须以空行分隔；复制到系统剪贴板时只保留普通文本换行，
+        // 避免 Windows/外部编辑器再次将 Markdown 段落间隔渲染为额外空白。
+        copy: (_view, event) => {
+          const selection = window.getSelection()
+          if (!selection || selection.isCollapsed || !event.clipboardData) return false
+          const range = selection.getRangeAt(0)
+          const fragment = range.cloneContents()
+          const tempDiv = document.createElement('div')
+          tempDiv.appendChild(fragment)
+          const text = htmlToClipboardText(tempDiv.innerHTML) || selection.toString().replace(/\r\n?/g, '\n')
+          event.preventDefault()
+          event.clipboardData.setData('text/plain', text)
+          event.clipboardData.setData('text/html', '')
+          return true
+        },
+      },
+    },
     onUpdate: ({ editor }) => {
       setContent(editor.getHTML())
     },

--- a/apps/electron/src/renderer/lib/markdown-rich-text.test.ts
+++ b/apps/electron/src/renderer/lib/markdown-rich-text.test.ts
@@ -1,5 +1,38 @@
 import { describe, expect, test } from 'bun:test'
-import { markdownToHtml } from './markdown-rich-text'
+import { DOMParser } from '@xmldom/xmldom'
+import { htmlToClipboardText, htmlToMarkdown, markdownToHtml } from './markdown-rich-text'
+
+function withHtmlDocument<T>(run: () => T): T {
+  const originalDocument = globalThis.document
+  const originalNode = globalThis.Node
+  const parser = new DOMParser()
+
+  Object.assign(globalThis, {
+    document: {
+      createElement: () => {
+        let root: Element | null = null
+        return {
+          nodeType: 1,
+          tagName: 'DIV',
+          getAttribute: () => null,
+          set innerHTML(html: string) {
+            root = parser.parseFromString(`<div>${html}</div>`, 'text/html').documentElement
+          },
+          get childNodes() {
+            return root?.childNodes ?? []
+          },
+        }
+      },
+    },
+    Node: { TEXT_NODE: 3, ELEMENT_NODE: 1 },
+  })
+
+  try {
+    return run()
+  } finally {
+    Object.assign(globalThis, { document: originalDocument, Node: originalNode })
+  }
+}
 
 describe('markdownToHtml rich preview blocks', () => {
   test('renders leading yaml frontmatter as a collapsible metadata block', () => {
@@ -110,6 +143,26 @@ describe('markdownToHtml rich preview blocks', () => {
     expect(html).toContain('&lt;img src=&quot;晨光.jpg&quot;&gt;')
     expect(html).toContain('### Agent 模式')
     expect(html).not.toContain('<h3>Agent 模式</h3>')
+  })
+})
+
+describe('Clipboard 纯文本序列化', () => {
+  test('不改变 Markdown 持久化使用的段落分隔', () => {
+    const markdown = withHtmlDocument(() => htmlToMarkdown('<p>第一段</p><p>第二段</p>'))
+
+    expect(markdown).toBe('第一段\n\n第二段')
+  })
+
+  test('相邻段落复制为单换行，不带 Markdown 的空段落分隔', () => {
+    const text = withHtmlDocument(() => htmlToClipboardText('<p>第一段</p><p>第二段</p>'))
+
+    expect(text).toBe('第一段\n第二段')
+  })
+
+  test('显式空段落保留一个空行，Windows 换行统一为 LF', () => {
+    const text = withHtmlDocument(() => htmlToClipboardText('<p>第一行\r\n内容</p><p></p><p>第三段</p>'))
+
+    expect(text).toBe('第一行\n内容\n\n第三段')
   })
 })
 

--- a/apps/electron/src/renderer/lib/markdown-rich-text.ts
+++ b/apps/electron/src/renderer/lib/markdown-rich-text.ts
@@ -362,7 +362,10 @@ export function markdownToHtml(markdown: string): string {
 }
 
 /** 将 TipTap 输出的 HTML 转换为 Markdown 格式 */
-export function htmlToMarkdown(html: string, options?: { skipMarkdownEscape?: boolean }): string {
+export function htmlToMarkdown(
+  html: string,
+  options?: { skipMarkdownEscape?: boolean; paragraphSeparator?: string },
+): string {
   if (!html || html === '<p></p>') return ''
 
   const div = document.createElement('div')
@@ -408,7 +411,7 @@ export function htmlToMarkdown(html: string, options?: { skipMarkdownEscape?: bo
         return `<video controls src="${escapeAttr(src)}"${title ? ` title="${escapeAttr(title)}"` : ''}></video>\n`
       }
       case 'p':
-        return children + '\n\n'
+        return children + (options?.paragraphSeparator ?? '\n\n')
       case 'br':
         return '\n'
       case 'strong':
@@ -512,4 +515,18 @@ export function htmlToMarkdown(html: string, options?: { skipMarkdownEscape?: bo
   }
 
   return processNode(div).trim()
+}
+
+/**
+ * 将编辑器选区导出为系统剪贴板的纯文本。
+ *
+ * Markdown 持久化需要用空行区分段落；普通剪贴板文本只需要单个换行。
+ * 这个专用出口避免把 Markdown 的段落分隔符带入其他编辑器，同时保留
+ * 选区内显式空段落和全部内联 Markdown 语义。
+ */
+export function htmlToClipboardText(html: string, options?: { skipMarkdownEscape?: boolean }): string {
+  return htmlToMarkdown(html, {
+    ...options,
+    paragraphSeparator: '\n',
+  }).replace(/\r\n?/g, '\n')
 }


### PR DESCRIPTION
## 概述
修复草稿编辑器将多段内容复制到 Windows 或其他外部编辑器时出现额外空白行的问题。草稿保存为 Markdown 仍使用空行表达段落；仅在复制到系统剪贴板时使用普通文本段落换行，避免外部编辑器重复渲染段落间距。

## 改动
- `apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx` — 为草稿 TipTap 编辑器增加专用复制事件处理：将选区写入规范化的 `text/plain`，清空 `text/html`，避免富文本段落语义被目标编辑器再次放大。
- `apps/electron/src/renderer/lib/markdown-rich-text.ts` — 增加 Clipboard 专用 HTML 序列化入口；默认 Markdown 持久化继续使用双换行段落分隔，Clipboard 改用单换行并统一 CRLF/CR 为 LF。
- `apps/electron/src/renderer/lib/markdown-rich-text.test.ts` — 覆盖 Markdown 持久化不变、相邻段落复制、显式空段落与 Windows 换行归一化。

## 测试方法
1. 运行 `bun test apps/electron/src/renderer/lib/markdown-rich-text.test.ts`，16 项测试通过。
2. 在 `apps/electron` 目录运行 `bun run typecheck`，通过。
3. 在 `apps/electron` 目录运行 `bun run build:renderer`，通过。
4. 手动验证：从草稿中复制多段内容并粘贴到 Windows 外部编辑器，确认相邻段落不再生成额外空白。

## 备注
- 此 PR 仅处理草稿复制出口；Chat / Agent 输入框没有改动。
- 先前定位到输入框的 PR #1273 已关闭并删除对应分支。
