### PR TITLE
fix(pi): 修复 Responses 流终态事件中断未自动重试【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.15.11",
+  "version": "0.15.12",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/lib/adapters/pi-native-retry.test.ts
+++ b/apps/electron/src/main/lib/adapters/pi-native-retry.test.ts
@@ -11,10 +11,11 @@ function failedAssistant(errorMessage: string): AssistantMessage {
 }
 
 describe('Pi native retry classifier', () => {
-  test('classifies an OpenAI Responses terminal-event stream interruption as retryable', () => {
-    expect(isRetryableAssistantError(
-      failedAssistant('OpenAI Responses stream ended before a terminal response event'),
-    )).toBe(true)
+  test.each([
+    'OpenAI Responses stream ended before a terminal response event',
+    'Upstream Responses stream ended before a terminal event',
+  ])('classifies Responses terminal-event stream interruption "%s" as retryable', (errorMessage) => {
+    expect(isRetryableAssistantError(failedAssistant(errorMessage))).toBe(true)
   })
 
   test.each([

--- a/apps/electron/src/main/lib/error-patterns.test.ts
+++ b/apps/electron/src/main/lib/error-patterns.test.ts
@@ -17,6 +17,7 @@ describe('isTransientNetworkError', () => {
     'stream closed prematurely',
     'premature close',
     'OpenAI Responses stream ended before a terminal response event',
+    'Upstream Responses stream ended before a terminal event',
     'Anthropic stream ended before message_stop',
     'peer closed connection',
     'incomplete chunked read',

--- a/apps/electron/src/main/lib/error-patterns.ts
+++ b/apps/electron/src/main/lib/error-patterns.ts
@@ -14,7 +14,7 @@
  * 这些都是 provider 连接被 CDN/网关切断的同类瞬时错误，与 ECONNRESET 性质一致。
  */
 export const TRANSIENT_NETWORK_PATTERN =
-  /terminated|socket hang up|ECONNRESET|ETIMEDOUT|ECONNABORTED|EPIPE|ENOTFOUND|EAI_AGAIN|ECONNREFUSED|fetch failed|network error|peer closed connection|connection (?:error|closed|reset)|other side closed|incomplete chunked read|AbortError|(?:operation|request) was aborted|(?:request )?timed out|stream (?:closed|ended|disconnected) prematurely|premature close|stream ended before (?:a )?(?:terminal response event|message_stop)/i
+  /terminated|socket hang up|ECONNRESET|ETIMEDOUT|ECONNABORTED|EPIPE|ENOTFOUND|EAI_AGAIN|ECONNREFUSED|fetch failed|network error|peer closed connection|connection (?:error|closed|reset)|other side closed|incomplete chunked read|AbortError|(?:operation|request) was aborted|(?:request )?timed out|stream (?:closed|ended|disconnected) prematurely|premature close|stream ended before (?:a )?(?:terminal (?:response )?event|message_stop)/i
 
 /** 判断错误消息/stderr 是否为瞬时网络错误 */
 export function isTransientNetworkError(message?: string, stderr?: string): boolean {

--- a/patches/@earendil-works%2Fpi-ai@0.80.9.patch
+++ b/patches/@earendil-works%2Fpi-ai@0.80.9.patch
@@ -7,7 +7,7 @@ index b3c27c8d5fb9a77c117af7ab8f789170903d5252..42b41a67c5607ef605fba6340882db6f
      // (#4433); Bedrock/Smithy can throw an HTTP/2 no-response error (#3594).
      "ended without",
 +    // OpenAI Responses can close an SSE stream before sending its terminal event.
-+    "stream ended before (?:a )?terminal response event",
++    "stream ended before (?:a )?terminal (?:response )?event",
 +    // HTTP chunked/SSE transports can close before the complete body arrives.
 +    // Match both phrases because proxy implementations may retain only one.
 +    "peer closed connection",


### PR DESCRIPTION
## 概述

修复部分上游 Responses SSE 流在终态事件前中断时无法触发 Pi 原生自动重试的问题。实际错误文案为 `Upstream Responses stream ended before a terminal event`，与既有规则中的 `terminal response event` 少了 `response`，导致未被归类为可恢复断流。

## 改动

- `patches/@earendil-works%2Fpi-ai@0.80.9.patch` — 将 Pi 原生 retry pattern 扩展为同时识别 `terminal event` 与 `terminal response event`，使其在同一 transcript 内自动恢复。
- `apps/electron/src/main/lib/error-patterns.ts` — 同步扩展 Proma 主进程的瞬时网络错误分类；原生重试耗尽后，该错误仍会作为 `network_error` 进入外层重试与 UI。
- `apps/electron/src/main/lib/adapters/pi-native-retry.test.ts` — 添加截图中 `Upstream Responses stream ended before a terminal event` 的原生重试回归测试。
- `apps/electron/src/main/lib/error-patterns.test.ts` — 添加同一错误文案的主进程网络错误分类回归测试。
- `apps/electron/package.json` — 将 `@proma/electron` 版本从 `0.15.11` 升至 `0.15.12`。

## 测试方法

1. 执行 `bun test apps/electron/src/main/lib/adapters/pi-native-retry.test.ts apps/electron/src/main/lib/error-patterns.test.ts`。
2. 确认 45 个测试全部通过，其中包括截图错误文本的 Pi 原生重试与 `network_error` 分类。
3. 执行 `bun run typecheck`，确认所有 workspace package 类型检查通过。

## 备注

- 审查已覆盖 Windows 兼容性；本 PR 不含路径、Shell、平台分支、构建脚本或原生依赖变更。
- 匹配范围仍限定在明确的终态事件断流措辞，不会将任意 `stream ended` 错误误判为可重试。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)