### PR TITLE
feat(agent): identify Skill reads in tool activity

### DIFF
--- a/apps/electron/src/renderer/components/agent/tool-phrase.ts
+++ b/apps/electron/src/renderer/components/agent/tool-phrase.ts
@@ -22,6 +22,18 @@ function filename(path: string): string {
   return path.split(/[/\\]/).pop() || path
 }
 
+/**
+ * 从 Proma Skill 入口文件路径中提取 Skill 名称。
+ *
+ * Pi Agent 以普通 Read 工具加载 Skill，因此需在展示层识别
+ * `<workspace>/skills/<skill-name>/SKILL.md`，避免标题只显示泛化的 SKILL.md。
+ */
+function skillNameFromEntryPath(path: string): string | null {
+  const normalizedPath = path.replace(/\\/g, '/')
+  const match = normalizedPath.match(/(?:^|\/)skills\/([^/]+)\/SKILL\.md$/i)
+  return match?.[1] ?? null
+}
+
 /** 截断文本 */
 function truncate(text: string, max: number): string {
   return text.length > max ? text.slice(0, max) + '…' : text
@@ -37,6 +49,9 @@ export function getToolPhrase(toolName: string, input: Record<string, unknown>):
     case 'Read': {
       const fp = input.file_path ?? input.filePath
       if (typeof fp === 'string') {
+        const skillName = skillNameFromEntryPath(fp)
+        if (skillName) return phrase(`读取技能 ${skillName}`)
+
         const name = filename(fp)
         const offset = typeof input.offset === 'number' ? input.offset : undefined
         const limit = typeof input.limit === 'number' ? input.limit : undefined


### PR DESCRIPTION
## Summary

- a9468616 feat(agent): identify Skill reads in tool activity

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)