### PR TITLE
fix(skills): load PDF skill frontmatter

### DIFF
--- a/apps/electron/default-skills/pdf/SKILL.md
+++ b/apps/electron/default-skills/pdf/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: pdf
-description: Use this skill whenever the user mentions a PDF file or asks to produce/edit one. For read-only tasks such as reading, summarizing, extracting plain text, or answering questions from a PDF, follow this skill's read-only routing rules: use the built-in Read tool first, do not write code or scripts, and prefer markitdown for PDFs over 100 pages. Use PDF processing libraries/scripts only for modification tasks such as merging, splitting, rotating, watermarking, filling forms, encrypting/decrypting, extracting images, OCR, or creating PDFs.
+description: "Use this skill whenever the user mentions a PDF file or asks to produce/edit one. For read-only tasks such as reading, summarizing, extracting plain text, or answering questions from a PDF, follow this skill's read-only routing rules: use the built-in Read tool first, do not write code or scripts, and prefer markitdown for PDFs over 100 pages. Use PDF processing libraries/scripts only for modification tasks such as merging, splitting, rotating, watermarking, filling forms, encrypting/decrypting, extracting images, OCR, or creating PDFs."
 license: Proprietary. LICENSE.txt has complete terms
-version: "1.0.4"
+version: "1.0.5"
 ---
 
 # PDF Processing Guide


### PR DESCRIPTION
## Summary
- Quote the PDF Skill description so Pi's strict YAML parser loads it.
- Bump the bundled skill version to propagate the corrected default Skill to existing installations.

## Validation
- Loaded the bundled default-skills directory through Pi's `loadSkillsFromDir`.
- Confirmed `pdf` is included and no diagnostics are emitted.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
