### PR TITLE
fix(agent): 引用选区后直达目标 Agent 输入框【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffTabContent.tsx
@@ -27,6 +27,7 @@ import {
   selectedModelAtom,
 } from '@/atoms/chat-atoms'
 import { markdownTocOpenAtom } from '@/atoms/markdown-toc'
+import { useFocusAgentSessionInput } from '@/hooks/useFocusAgentSessionInput'
 import { useShortcut } from '@/hooks/useShortcut'
 import { initShortcutRegistry } from '@/lib/shortcut-registry'
 import { DiffView } from './DiffView'
@@ -333,6 +334,7 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
   const setSideChatMap = useSetAtom(agentSideChatMapAtom)
   const setSidePanelOpen = useSetAtom(agentSidePanelOpenAtom)
   const setSidePanelTabMap = useSetAtom(agentDiffPanelTabAtom)
+  const focusAgentSessionInput = useFocusAgentSessionInput()
   const [previewSelection, setPreviewSelection] = React.useState<PreviewTextSelection | null>(null)
   const filePathRef = React.useRef(filePath)
   filePathRef.current = filePath
@@ -986,8 +988,8 @@ export function DiffTabContent({ filePath, dirPath, sessionId, gitRoot, previewO
     })
     window.getSelection()?.removeAllRanges()
     clearPreviewSelection()
-    toast.success('已添加到 Agent 引用')
-  }, [clearPreviewSelection, previewSelection, sessionId, setQuotedSelectionMap])
+    focusAgentSessionInput(sessionId)
+  }, [clearPreviewSelection, focusAgentSessionInput, previewSelection, sessionId, setQuotedSelectionMap])
 
   const handleOpenSelectionChat = React.useCallback(async (): Promise<void> => {
     if (!previewSelection) return

--- a/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
+++ b/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
@@ -26,6 +26,7 @@ import {
 import { agentSideChatMapAtom, conversationsAtom, conversationDraftsAtom, selectedModelAtom } from '@/atoms/chat-atoms'
 import { appModeAtom } from '@/atoms/app-mode'
 import { quotedSelectionMapAtom } from '@/atoms/preview-atoms'
+import { useFocusAgentSessionInput } from '@/hooks/useFocusAgentSessionInput'
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -152,6 +153,7 @@ function ScratchPadEditor({ variant }: ScratchPadEditorProps): React.ReactElemen
   const setAgentSidePanelTabMap = useSetAtom(agentDiffPanelTabAtom)
   const setCurrentAgentSessionId = useSetAtom(currentAgentSessionIdAtom)
   const setAppMode = useSetAtom(appModeAtom)
+  const focusAgentSessionInput = useFocusAgentSessionInput()
 
   const extensions = React.useMemo(() => [
     StarterKit.configure({
@@ -398,8 +400,8 @@ function ScratchPadEditor({ variant }: ScratchPadEditorProps): React.ReactElemen
     })
     window.getSelection()?.removeAllRanges()
     clearSelection()
-    toast.success('已添加到 Agent 引用')
-  }, [clearSelection, getTargetAgentSessionId, selection, setQuotedSelectionMap])
+    focusAgentSessionInput(sessionId)
+  }, [clearSelection, focusAgentSessionInput, getTargetAgentSessionId, selection, setQuotedSelectionMap])
 
   const handleOpenSideChat = React.useCallback(async (): Promise<void> => {
     if (!selection) return

--- a/apps/electron/src/renderer/hooks/useFocusAgentSessionInput.ts
+++ b/apps/electron/src/renderer/hooks/useFocusAgentSessionInput.ts
@@ -1,0 +1,73 @@
+/**
+ * 聚焦已有 Agent Tab，并把输入焦点交给该会话。
+ *
+ * 仅切换 activeTabId，不重建、关闭或改变预览 Tab / 分屏状态。
+ */
+
+import * as React from 'react'
+import { useAtomValue, useSetAtom, useStore } from 'jotai'
+import { appModeAtom } from '@/atoms/app-mode'
+import { currentConversationIdAtom } from '@/atoms/chat-atoms'
+import {
+  agentSessionsAtom,
+  currentAgentSessionIdAtom,
+  currentAgentWorkspaceIdAtom,
+  unviewedCompletedSessionIdsAtom,
+} from '@/atoms/agent-atoms'
+import { activeTabIdAtom, tabsAtom } from '@/atoms/tab-atoms'
+
+type FocusAgentSessionInput = (sessionId: string) => boolean
+
+export function useFocusAgentSessionInput(): FocusAgentSessionInput {
+  const store = useStore()
+  const tabs = useAtomValue(tabsAtom)
+  const agentSessions = useAtomValue(agentSessionsAtom)
+  const setActiveTabId = useSetAtom(activeTabIdAtom)
+  const setAppMode = useSetAtom(appModeAtom)
+  const setCurrentConversationId = useSetAtom(currentConversationIdAtom)
+  const setCurrentAgentSessionId = useSetAtom(currentAgentSessionIdAtom)
+  const setCurrentAgentWorkspaceId = useSetAtom(currentAgentWorkspaceIdAtom)
+  const setUnviewedCompleted = useSetAtom(unviewedCompletedSessionIdsAtom)
+
+  return React.useCallback((sessionId: string): boolean => {
+    const agentTab = tabs.find((tab) => tab.type === 'agent' && tab.sessionId === sessionId)
+    if (!agentTab) return false
+
+    setActiveTabId(agentTab.id)
+    setAppMode('agent')
+    setCurrentConversationId(null)
+    setCurrentAgentSessionId(sessionId)
+    setUnviewedCompleted((prev) => {
+      if (!prev.has(sessionId)) return prev
+      const next = new Set(prev)
+      next.delete(sessionId)
+      return next
+    })
+
+    const session = agentSessions.find((item) => item.id === sessionId)
+    if (session?.workspaceId) {
+      setCurrentAgentWorkspaceId(session.workspaceId)
+      window.electronAPI.updateSettings({ agentWorkspaceId: session.workspaceId }).catch(console.error)
+    }
+
+    // 等待 AgentView 成为当前内容，再复用其既有输入框聚焦事件。
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        if (store.get(activeTabIdAtom) !== agentTab.id) return
+        window.dispatchEvent(new CustomEvent('proma:focus-input'))
+      })
+    })
+
+    return true
+  }, [
+    agentSessions,
+    setActiveTabId,
+    setAppMode,
+    setCurrentAgentSessionId,
+    setCurrentAgentWorkspaceId,
+    setCurrentConversationId,
+    setUnviewedCompleted,
+    store,
+    tabs,
+  ])
+}


### PR DESCRIPTION
## 概述

文件预览或草稿中的选区被引用给 Agent 后，界面现在会直接定位到对应 Agent 会话并聚焦输入框，减少用户在预览、草稿与会话之间手动切换的步骤。

## 改动

- `apps/electron/src/renderer/hooks/useFocusAgentSessionInput.ts` — 新增会话聚焦 Hook：复用现有会话状态与输入聚焦事件，只切换激活 Tab，不重建、关闭或修改预览 Tab / 分屏状态。
- `apps/electron/src/renderer/components/diff/DiffTabContent.tsx` — 文件预览选区写入引用后调用该 Hook，移除跳转后的冗余成功提示。
- `apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx` — 草稿选区采用同一跳转逻辑，保持与文件预览一致。

## 测试方法

1. 运行 `bun run typecheck`，全部 workspace package 通过。
2. 运行 `bun run --filter='@proma/electron' build:renderer`，renderer 构建通过。
3. 运行 `bun test`：474 项通过；2 项既有失败来自 Bun 直接加载 Electron 模块时缺少 `dialog` / `shell` 导出，和本 PR 无关。

## 备注

- 预览 Tab 与右侧分屏状态不会被本改动关闭或转换。
- 独立弹出的预览窗口没有共享主窗口 Jotai store；跨窗口引用与跳转不在本 PR 范围内。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)