### PR TITLE
fix(agent): restore progress after Pi context compaction

### DIFF
--- a/apps/electron/src/renderer/atoms/agent-atoms.test.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.test.ts
@@ -123,4 +123,38 @@ describe('Agent 上下文压缩状态', () => {
     })
     expect(result.contextUsageIsEstimated).toBeUndefined()
   })
+
+  test('given 压缩成功 when 同一流开始下一项工具工作 then 清除压缩终态并恢复正常进度', () => {
+    const compacting = applyAgentEvent(createStreamState(), { type: 'compacting' })
+    const compacted = applyAgentEvent(compacting, { type: 'compact_complete', status: 'success' })
+    const resumed = applyAgentEvent(compacted, {
+      type: 'tool_start',
+      toolName: 'TaskCreate',
+      toolUseId: 'resume-task',
+      input: {},
+    })
+
+    expect(compacted).toMatchObject({
+      isCompacting: false,
+      compactInFlight: true,
+      contextCompaction: { status: 'success' },
+    })
+    expect(resumed.contextCompaction).toBeUndefined()
+    expect(resumed.compactInFlight).toBe(false)
+    expect(resumed.toolActivities).toContainEqual(expect.objectContaining({
+      toolUseId: 'resume-task',
+      done: false,
+    }))
+  })
+
+  test('given 压缩成功 when 当前流直接结束 then 保留终态反馈给短时完成提示', () => {
+    const compacting = applyAgentEvent(createStreamState(), { type: 'compacting' })
+    const compacted = applyAgentEvent(compacting, { type: 'compact_complete', status: 'success' })
+    const result = applyAgentEvent(compacted, { type: 'complete' })
+
+    expect(result).toMatchObject({
+      compactInFlight: true,
+      contextCompaction: { status: 'success' },
+    })
+  })
 })

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -92,12 +92,12 @@ export interface AgentStreamState {
   thinkingEstimatedTokens?: number
   /** 是否正在压缩上下文 */
   isCompacting?: boolean
-  /** 当前或最近一次压缩状态，保留到实时消息清理完成后供底部进度区展示。 */
+  /** 当前或最近一次压缩状态，保留到实时消息清理或同一流恢复正常工作后供底部进度区展示。 */
   contextCompaction?: ContextCompactionState
   /**
    * 压缩流程是否进行中（含收尾窗口）。
-   * 从用户点击压缩 / SDK compacting 事件开始 → 到整个 stream 结束（state 被删除）前一直为 true。
-   * 用于抑制压缩分隔符切换期间 AgentRunningIndicator 的短暂闪烁。
+   * 从用户点击压缩 / SDK compacting 事件开始；若同一流在压缩后恢复正常工作则立即清除，
+   * 否则保留到整个 stream 结束（state 被删除）。用于抑制压缩分隔符切换期间 AgentRunningIndicator 的短暂闪烁。
    */
   compactInFlight?: boolean
   /** 流式开始时间戳（用于思考计时持久化） */
@@ -112,6 +112,20 @@ export interface AgentStreamState {
     history: RetryAttempt[]
     /** 是否已失败 */
     failed: boolean
+  }
+}
+
+/**
+ * 成功或无需压缩后，Pi 可能在同一个 stream 内自动续跑原任务。
+ * 一旦收到新的正常 Agent 活动，终态压缩提示不应继续抢占底部进度区。
+ */
+function clearFinishedCompactionForResumedWork(prev: AgentStreamState): AgentStreamState {
+  const status = prev.contextCompaction?.status
+  if (status !== 'success' && status !== 'noop') return prev
+  return {
+    ...prev,
+    compactInFlight: false,
+    contextCompaction: undefined,
   }
 }
 
@@ -626,20 +640,25 @@ export function applyAgentEvent(
   event: AgentEvent,
 ): AgentStreamState {
   switch (event.type) {
-    case 'text_delta':
+    case 'text_delta': {
       // 开始接收文本 - 清除重试状态（重试成功）
-      return { ...prev, content: prev.content + event.text, retrying: undefined }
+      const resumed = clearFinishedCompactionForResumedWork(prev)
+      return { ...resumed, content: resumed.content + event.text, retrying: undefined }
+    }
 
-    case 'text_complete':
+    case 'text_complete': {
       // 用完整文本替换增量累积的文本（用于回放场景：只需 text_complete 即可重建文本状态）
-      return { ...prev, content: event.text }
+      const resumed = clearFinishedCompactionForResumedWork(prev)
+      return { ...resumed, content: event.text }
+    }
 
     case 'tool_start': {
-      const existing = prev.toolActivities.find((t) => t.toolUseId === event.toolUseId)
+      const resumed = clearFinishedCompactionForResumedWork(prev)
+      const existing = resumed.toolActivities.find((t) => t.toolUseId === event.toolUseId)
       if (existing) {
         return {
-          ...prev,
-          toolActivities: prev.toolActivities.map((t) =>
+          ...resumed,
+          toolActivities: resumed.toolActivities.map((t) =>
             t.toolUseId === event.toolUseId
               ? { ...t, input: event.input, intent: event.intent || t.intent, displayName: event.displayName || t.displayName }
               : t
@@ -649,8 +668,8 @@ export function applyAgentEvent(
         }
       }
       return {
-        ...prev,
-        toolActivities: [...prev.toolActivities, {
+        ...resumed,
+        toolActivities: [...resumed.toolActivities, {
           toolUseId: event.toolUseId,
           toolName: event.toolName,
           input: event.input,
@@ -664,76 +683,87 @@ export function applyAgentEvent(
       }
     }
 
-    case 'tool_result':
+    case 'tool_result': {
+      const resumed = clearFinishedCompactionForResumedWork(prev)
       return {
-        ...prev,
-        toolActivities: prev.toolActivities.map((t) =>
+        ...resumed,
+        toolActivities: resumed.toolActivities.map((t) =>
           t.toolUseId === event.toolUseId
             ? { ...t, result: event.result, isError: event.isError, done: true, imageAttachments: event.imageAttachments }
             : t
         ),
       }
+    }
 
-    case 'task_backgrounded':
+    case 'task_backgrounded': {
+      const resumed = clearFinishedCompactionForResumedWork(prev)
       return {
-        ...prev,
-        toolActivities: prev.toolActivities.map((t) =>
+        ...resumed,
+        toolActivities: resumed.toolActivities.map((t) =>
           t.toolUseId === event.toolUseId
             ? { ...t, isBackground: true, taskId: event.taskId, done: true }
             : t
         ),
       }
+    }
 
-    case 'task_progress':
+    case 'task_progress': {
+      const resumed = clearFinishedCompactionForResumedWork(prev)
       // 普通 tool 计时语义（仅当有真实 elapsedSeconds 时更新）
       if (event.elapsedSeconds != null) {
         return {
-          ...prev,
-          toolActivities: prev.toolActivities.map((t) =>
+          ...resumed,
+          toolActivities: resumed.toolActivities.map((t) =>
             t.toolUseId === event.toolUseId
               ? { ...t, elapsedSeconds: event.elapsedSeconds! }
               : t
           ),
         }
       }
-      return prev
+      return resumed
+    }
 
     case 'task_started': {
+      const resumed = clearFinishedCompactionForResumedWork(prev)
       // 查找匹配 toolUseId 的 ToolActivity，更新 intent 和 taskId
-      let nextActivities = prev.toolActivities
+      let nextActivities = resumed.toolActivities
       if (event.toolUseId) {
-        if (prev.toolActivities.some((t) => t.toolUseId === event.toolUseId)) {
-          nextActivities = prev.toolActivities.map((t) =>
+        if (resumed.toolActivities.some((t) => t.toolUseId === event.toolUseId)) {
+          nextActivities = resumed.toolActivities.map((t) =>
             t.toolUseId === event.toolUseId
               ? { ...t, intent: event.description, taskId: event.taskId }
               : t
           )
         }
       }
-      return { ...prev, toolActivities: nextActivities }
+      return { ...resumed, toolActivities: nextActivities }
     }
 
-    case 'shell_backgrounded':
+    case 'shell_backgrounded': {
+      const resumed = clearFinishedCompactionForResumedWork(prev)
       return {
-        ...prev,
-        toolActivities: prev.toolActivities.map((t) =>
+        ...resumed,
+        toolActivities: resumed.toolActivities.map((t) =>
           t.toolUseId === event.toolUseId
             ? { ...t, isBackground: true, shellId: event.shellId, done: true }
             : t
         ),
       }
+    }
 
     case 'shell_killed':
-      return prev
+      return clearFinishedCompactionForResumedWork(prev)
 
     case 'task_notification':
-      return prev
+      return clearFinishedCompactionForResumedWork(prev)
 
-    case 'thinking_tokens':
+    case 'thinking_tokens': {
+      const resumed = clearFinishedCompactionForResumedWork(prev)
       return {
-        ...prev,
+        ...resumed,
         thinkingEstimatedTokens: event.estimatedTokens,
       }
+    }
 
     case 'tool_use_summary':
       // 工具使用摘要 — 目前不影响流式状态，仅用于 UI 展示
@@ -785,9 +815,11 @@ export function applyAgentEvent(
       }
     }
 
-    case 'run_resumed':
+    case 'run_resumed': {
       // 后台任务完成自动唤醒：从"空闲可输入"恢复到运行态（防御性，监听器已显式处理）。
-      return { ...prev, running: true, backgroundWaiting: false }
+      const resumed = clearFinishedCompactionForResumedWork(prev)
+      return { ...resumed, running: true, backgroundWaiting: false }
+    }
 
     case 'typed_error':
       // 处理类型化错误（TypedError）
@@ -799,9 +831,10 @@ export function applyAgentEvent(
       // retrying 状态由专用事件控制
       return { ...prev, running: false }
 
-    case 'usage_update':
+    case 'usage_update': {
+      const resumed = clearFinishedCompactionForResumedWork(prev)
       return {
-        ...prev,
+        ...resumed,
         ...(event.usage.inputTokens != null && {
           inputTokens: event.usage.inputTokens,
           contextUsageIsEstimated: false,
@@ -815,9 +848,10 @@ export function applyAgentEvent(
         // 模型窗口在同一会话内不会缩小，取更大值可兼顾两类端点——既不会让推断偏小的
         // 端点（如 GLM 剥掉 [1m] 后缀）挡住真实的 1M，也不会让回报偏小的端点覆盖正确的 1M。
         ...(event.usage.contextWindow && {
-          contextWindow: Math.max(prev.contextWindow ?? 0, event.usage.contextWindow),
+          contextWindow: Math.max(resumed.contextWindow ?? 0, event.usage.contextWindow),
         }),
       }
+    }
 
     case 'compacting':
       return {

--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -98,6 +98,21 @@ export function getContextCompactionProgress(
   isCompacting: boolean | undefined,
   streamCompaction: AgentStreamState['contextCompaction'] | undefined,
 ): ContextCompactionProgress | undefined {
+  const latestStatusIndex = messages.findLastIndex((message) =>
+    message.type === 'system' && getSDKCompactStatus(message as SDKSystemMessage) != null,
+  )
+  const latestStatus = latestStatusIndex >= 0
+    ? messages[latestStatusIndex] as SDKSystemMessage
+    : undefined
+  const status = latestStatus ? getSDKCompactStatus(latestStatus) : undefined
+  // Pi 会在同一个 stream 内续跑压缩前的任务。压缩边界后的 assistant、user 或普通系统消息都属于新工作，
+  // 终态状态（无论来自 atom 还是 liveMessages）都不能继续抢占新的正常进度。
+  const hasResumedWork = latestStatusIndex >= 0
+    && messages.slice(latestStatusIndex + 1).some((message) => {
+      if (message.type === 'assistant' || message.type === 'user') return true
+      return message.type === 'system' && getSDKCompactStatus(message as SDKSystemMessage) == null
+    })
+
   if (streamCompaction?.status === 'running') {
     return {
       status: 'running',
@@ -105,7 +120,7 @@ export function getContextCompactionProgress(
       detail: '正在生成会话摘要，完成后可继续当前任务。',
     }
   }
-  if (streamCompaction?.status === 'success') {
+  if (streamCompaction?.status === 'success' && !hasResumedWork) {
     return {
       status: 'success',
       label: '上下文已压缩',
@@ -113,7 +128,7 @@ export function getContextCompactionProgress(
       summary: streamCompaction.summary,
     }
   }
-  if (streamCompaction?.status === 'noop') {
+  if (streamCompaction?.status === 'noop' && !hasResumedWork) {
     return {
       status: 'noop',
       label: '当前上下文无需压缩',
@@ -127,11 +142,7 @@ export function getContextCompactionProgress(
       detail: streamCompaction.message ?? '请检查模型连接后重试。',
     }
   }
-
-  const latestStatus = [...messages].reverse().find((message) =>
-    message.type === 'system' && getSDKCompactStatus(message as SDKSystemMessage) != null,
-  ) as SDKSystemMessage | undefined
-  const status = latestStatus ? getSDKCompactStatus(latestStatus) : undefined
+  if (hasResumedWork) return undefined
 
   if (status === 'success' && latestStatus) {
     return {
@@ -620,15 +631,16 @@ export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persi
     return currentTurn ? buildTaskProgressDataForTurn(currentTurn).taskActivities : []
   }, [liveMessages, sessionModelId])
 
-  // 压缩流程进行中（含收尾窗口：compact_boundary 已到但 result 未到）
-  // → 一律抑制 AgentRunningIndicator，避免压缩分隔符切换期间闪烁。
-  // compactInFlight 从点击压缩 / SDK compacting 事件开始为 true，
-  // 直到整个 stream 结束（state 被删除）才消失。
-  const suppressAgentRunning = streamState?.isCompacting || streamState?.compactInFlight
   const contextCompaction = React.useMemo(
     () => getContextCompactionProgress(liveMessages ?? [], streamState?.isCompacting, streamState?.contextCompaction),
     [liveMessages, streamState?.isCompacting, streamState?.contextCompaction],
   )
+  // 压缩流程进行中（含收尾窗口：compact_boundary 已到但 result 未到）
+  // → 抑制 AgentRunningIndicator，避免压缩分隔符切换期间闪烁。
+  // Pi 同一 stream 续跑后，getContextCompactionProgress 会清除终态反馈；此时即使旧标记尚未刷新，
+  // 也必须恢复正常运行指示器。
+  const suppressAgentRunning = streamState?.isCompacting
+    || (streamState?.compactInFlight && contextCompaction != null)
 
   // 统一分组：将持久化 + 实时消息合并后再分组，确保 system 消息（如压缩分割线）出现在正确位置
   const allGroups = React.useMemo(() => {

--- a/apps/electron/src/renderer/components/agent/TaskProgressOverlay.tsx
+++ b/apps/electron/src/renderer/components/agent/TaskProgressOverlay.tsx
@@ -45,6 +45,18 @@ export function shouldRestoreCompactionProgress(signature: string, dismissedSign
   return signature !== dismissedSignature
 }
 
+/**
+ * 压缩成功后，如果同一个 stream 已恢复正常工作，保留的终态反馈不能继续覆盖新的任务进度。
+ * 手动压缩直接结束时 streaming 会变为 false，因此仍可保留短时成功反馈。
+ */
+export function shouldClearRetainedCompactionForResumedStream(
+  streaming: boolean,
+  contextCompaction: ContextCompactionProgress | undefined,
+  retainedCompaction: ContextCompactionProgress | undefined,
+): boolean {
+  return streaming && !contextCompaction && !!retainedCompaction
+}
+
 function CompactionProgressDetails({ progress }: { progress: ContextCompactionProgress }): React.ReactElement {
   const isRunning = progress.status === 'running'
   const isFailed = progress.status === 'failed'
@@ -120,11 +132,12 @@ export function TaskProgressOverlay({ activities, streaming, contextCompaction }
   }, [contextCompaction, dismissedCompactionSignature, liveCompactionSignature, retainedCompactionSignature])
 
   React.useEffect(() => {
-    if (!streaming || contextCompaction || retainedCompaction?.status !== 'failed') return
+    if (!shouldClearRetainedCompactionForResumedStream(streaming, contextCompaction, retainedCompaction)) return
     setRetainedCompaction(undefined)
     setRetainedCompactionSignature('')
-    setVisible(false)
-  }, [streaming, contextCompaction, retainedCompaction?.status])
+    setFading(false)
+    setVisible(hasLiveTasks)
+  }, [streaming, contextCompaction, retainedCompaction, hasLiveTasks])
 
   const displayActivities = hasLiveTasks ? activities : retainedActivities
   const displayItems = hasLiveTasks
@@ -132,14 +145,16 @@ export function TaskProgressOverlay({ activities, streaming, contextCompaction }
     : aggregateTaskItems(retainedActivities, false)
   const displaySignature = hasLiveTasks ? liveSignature : retainedSignature
   const displayCompaction = contextCompaction ?? retainedCompaction
+  // 上游每次 liveMessages 更新都会重建 progress 对象；超时 effect 必须依赖稳定签名，不能依赖对象引用。
+  const displayCompactionSignature = displayCompaction ? compactionSignature(displayCompaction) : ''
   const hasDisplayTasks = displayItems.length > 0
   const compactionIsRunning = displayCompaction?.status === 'running'
   const shouldRetainFinishedProgress = displayCompaction
     ? !compactionIsRunning && displayCompaction.status !== 'failed'
     : hasDisplayTasks && (!streaming || !hasLiveActiveTask)
   const hideKey = shouldRetainFinishedProgress
-    ? displayCompaction
-      ? `${compactionSignature(displayCompaction)}:${streaming}`
+    ? displayCompactionSignature
+      ? `${displayCompactionSignature}:${streaming}`
       : `${displaySignature}:${streaming}`
     : null
 
@@ -156,8 +171,8 @@ export function TaskProgressOverlay({ activities, streaming, contextCompaction }
       setFading(true)
     }, FINISH_RETENTION_MS - FADE_OUT_DURATION_MS)
     const hideTimer = window.setTimeout(() => {
-      if (displayCompaction) {
-        setDismissedCompactionSignature(compactionSignature(displayCompaction))
+      if (displayCompactionSignature) {
+        setDismissedCompactionSignature(displayCompactionSignature)
       }
       setVisible(false)
       setOpen(false)
@@ -170,7 +185,7 @@ export function TaskProgressOverlay({ activities, streaming, contextCompaction }
       window.clearTimeout(fadeTimer)
       window.clearTimeout(hideTimer)
     }
-  }, [hasDisplayTasks, displayCompaction, hideKey])
+  }, [hasDisplayTasks, displayCompactionSignature, hideKey])
 
   const completedCount = displayItems.filter((item) => isTerminalTaskStatus(item.status)).length
   const currentTask = getCurrentTask(displayItems)

--- a/apps/electron/src/renderer/components/agent/compaction-progress.test.ts
+++ b/apps/electron/src/renderer/components/agent/compaction-progress.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, test } from 'bun:test'
 import type { SDKMessage } from '@proma/shared'
 import { getContextCompactionProgress, isCompactionControlHistoryGroup } from './AgentMessages'
-import { shouldRestoreCompactionProgress } from './TaskProgressOverlay'
+import { shouldClearRetainedCompactionForResumedStream, shouldRestoreCompactionProgress } from './TaskProgressOverlay'
 
 function systemMessage(fields: Record<string, unknown>): SDKMessage {
   return { type: 'system', ...fields } as unknown as SDKMessage
+}
+
+function assistantMessage(): SDKMessage {
+  return { type: 'assistant', message: { content: [] } } as unknown as SDKMessage
 }
 
 describe('context compaction progress overlay state', () => {
@@ -47,6 +51,15 @@ describe('context compaction progress overlay state', () => {
     expect(shouldRestoreCompactionProgress('running:正在整理上下文::', 'noop:当前上下文无需压缩::')).toBe(true)
   })
 
+  test('clears retained compaction feedback when the same stream resumes normal work', () => {
+    const completed = { status: 'success' as const, label: '上下文已压缩' }
+
+    expect(shouldClearRetainedCompactionForResumedStream(true, undefined, completed)).toBe(true)
+    expect(shouldClearRetainedCompactionForResumedStream(false, undefined, completed)).toBe(false)
+    expect(shouldClearRetainedCompactionForResumedStream(true, completed, completed)).toBe(false)
+    expect(shouldClearRetainedCompactionForResumedStream(true, undefined, undefined)).toBe(false)
+  })
+
   test('maps successful compaction to a terminal state', () => {
     expect(getContextCompactionProgress([
       systemMessage({ subtype: 'compact_boundary', summary: '已完成的工作已整理。' }),
@@ -55,6 +68,19 @@ describe('context compaction progress overlay state', () => {
       label: '上下文已压缩',
       summary: '已完成的工作已整理。',
     })
+  })
+
+  test('does not revive an old compaction boundary after Pi continues with assistant or task work', () => {
+    const compactionBoundary = systemMessage({ subtype: 'compact_boundary', summary: '已完成的工作已整理。' })
+
+    expect(getContextCompactionProgress([
+      compactionBoundary,
+      assistantMessage(),
+    ], false, { status: 'success' })).toBeUndefined()
+    expect(getContextCompactionProgress([
+      compactionBoundary,
+      systemMessage({ subtype: 'task_started', task_id: 'continued-task' }),
+    ], false, { status: 'success' })).toBeUndefined()
   })
 
   test('maps a no-op result to a clear terminal state', () => {


### PR DESCRIPTION
## Summary

- Clear Pi compaction terminal UI state as soon as the same stream resumes normal Agent work.
- Prevent stale `compact_boundary` messages from reviving the old success indicator.
- Keep terminal feedback for a directly finished compaction, while making its timeout independent of transient object identities.

## Test plan

- [x] `bun test apps/electron/src/renderer/atoms/agent-atoms.test.ts apps/electron/src/renderer/components/agent/compaction-progress.test.ts`
- [x] `bun run build:renderer`
- [x] Manual development-environment verification
- [ ] `bun run typecheck` — blocked by pre-existing, unchanged `pi-agent-adapter.ts` `streamFunction` typing errors

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
