### PR TITLE
feat(agent): 统一输入框命令菜单与跨工作区会话引用【已审核 PR】

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -1962,7 +1962,7 @@ export function registerIpcHandlers(): void {
     }
   )
 
-  // 搜索当前工作区可引用的 Agent 会话
+  // 搜索可引用的 Agent 会话；省略 workspaceId 时跨工作区搜索。
   ipcMain.handle(
     AGENT_IPC_CHANNELS.SEARCH_SESSION_REFERENCES,
     async (_, input: AgentSessionReferenceSearchInput) => {

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -1311,7 +1311,7 @@ export class AgentOrchestrator {
 
       // 11.5 注入 mention 引用指令（Skill/MCP/会话）— 仅影响 prompt，不影响持久化
       let enrichedMessage = userMessage
-      const referencedSessionsBlock = buildReferencedSessionsPrompt(sessionId, mentionedSessionIds, workspaceId, workspaceSlug)
+      const referencedSessionsBlock = buildReferencedSessionsPrompt(sessionId, mentionedSessionIds, workspaceSlug)
       if (referencedSessionsBlock) {
         enrichedMessage = `${referencedSessionsBlock}\n\n${enrichedMessage}`
         console.log(`[Agent 编排] 注入 referenced_sessions: ${mentionedSessionIds?.length ?? 0} sessions`)
@@ -2674,7 +2674,7 @@ export class AgentOrchestrator {
       : undefined
 
     let enrichedText = text
-    const referencedSessionsBlock = buildReferencedSessionsPrompt(sessionId, mentionedSessionIds, meta?.workspaceId, workspaceSlug)
+    const referencedSessionsBlock = buildReferencedSessionsPrompt(sessionId, mentionedSessionIds, workspaceSlug)
     if (referencedSessionsBlock) {
       enrichedText = `${referencedSessionsBlock}\n\n${enrichedText}`
     }

--- a/apps/electron/src/main/lib/agent-session-context-prompt.ts
+++ b/apps/electron/src/main/lib/agent-session-context-prompt.ts
@@ -183,13 +183,11 @@ function escapeContextAttr(value: string): string {
 export function buildReferencedSessionsPrompt(
   currentSessionId: string,
   mentionedSessionIds?: string[],
-  workspaceId?: string,
   workspaceSlug?: string,
 ): string {
   const uniqueIds = [...new Set((mentionedSessionIds ?? []).filter(Boolean))]
   if (uniqueIds.length === 0) return ''
 
-  const currentWorkspaceId = workspaceId ?? getAgentSessionMeta(currentSessionId)?.workspaceId
   const sessionBlocks: string[] = []
 
   for (const referencedSessionId of uniqueIds) {
@@ -197,7 +195,6 @@ export function buildReferencedSessionsPrompt(
 
     const meta = getAgentSessionMeta(referencedSessionId)
     if (!meta || meta.archived) continue
-    if (currentWorkspaceId && meta.workspaceId !== currentWorkspaceId) continue
 
     const title = escapeContextAttr(meta.title)
     const historyPath = getSessionHistoryPath(referencedSessionId)
@@ -211,5 +208,5 @@ export function buildReferencedSessionsPrompt(
 
   if (sessionBlocks.length === 0) return ''
 
-  return `<referenced_sessions>\n用户在消息中明确引用了以下同工作区 Agent 会话。${buildReferencedSessionsHistoryInstruction(workspaceSlug)}\n${sessionBlocks.join('\n\n')}\n</referenced_sessions>`
+  return `<referenced_sessions>\n用户在消息中明确引用了以下 Agent 会话。${buildReferencedSessionsHistoryInstruction(workspaceSlug)}\n${sessionBlocks.join('\n\n')}\n</referenced_sessions>`
 }

--- a/apps/electron/src/main/lib/agent-session-manager.test.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.test.ts
@@ -4,8 +4,10 @@ import * as os from 'node:os'
 import { join } from 'node:path'
 
 type AgentSessionManager = typeof import('./agent-session-manager')
+type AgentSessionContextPrompt = typeof import('./agent-session-context-prompt')
 
 let manager: AgentSessionManager
+let contextPrompt: AgentSessionContextPrompt
 let tempHome: string
 const originalHome = process.env.HOME
 const originalPromaDev = process.env.PROMA_DEV
@@ -81,6 +83,7 @@ beforeAll(async () => {
   process.env.PROMA_DEV = '0'
   delete process.env.CLAUDE_CONFIG_DIR
   manager = await import('./agent-session-manager')
+  contextPrompt = await import('./agent-session-context-prompt')
 })
 
 afterAll(() => {
@@ -225,10 +228,10 @@ describe('Agent 会话 runtime 元数据', () => {
 })
 
 describe('Agent 会话引用搜索', () => {
-  test('Given 工作区有超过 20 个会话 When 请求最近 200 条 Then 按更新时间返回 200 条', () => {
+  test('Given 工作区有超过 20 个会话 When 请求最近 200 条 Then 按更新时间返回 200 条', async () => {
     writeAgentSessionsIndex(createIndexedSessions(220))
 
-    const results = manager.searchAgentSessionReferences({
+    const results = await manager.searchAgentSessionReferences({
       workspaceId: 'workspace-a',
       limit: 200,
     })
@@ -239,14 +242,76 @@ describe('Agent 会话引用搜索', () => {
     expect(results.every((result) => result.matchSource === 'recent')).toBe(true)
   })
 
-  test('Given 请求数量超过性能上限 When 搜索可引用会话 Then 最多返回 200 条', () => {
+  test('Given 请求数量超过性能上限 When 搜索可引用会话 Then 最多返回 200 条', async () => {
     writeAgentSessionsIndex(createIndexedSessions(220))
 
-    const results = manager.searchAgentSessionReferences({
+    const results = await manager.searchAgentSessionReferences({
       workspaceId: 'workspace-a',
       limit: 500,
     })
 
     expect(results).toHaveLength(200)
+  })
+
+  test('Given 未指定工作区 When 搜索可引用会话 Then 返回全部工作区的最近会话并排除当前会话', async () => {
+    writeAgentSessionsIndex([
+      { id: 'workspace-a-session', title: '工作区 A', workspaceId: 'workspace-a', createdAt: 1, updatedAt: 1 },
+      { id: 'workspace-b-session', title: '工作区 B', workspaceId: 'workspace-b', createdAt: 2, updatedAt: 2 },
+      { id: 'current-session', title: '当前会话', workspaceId: 'workspace-c', createdAt: 3, updatedAt: 3 },
+    ])
+
+    const results = await manager.searchAgentSessionReferences({
+      excludeSessionId: 'current-session',
+      limit: 200,
+    })
+
+    expect(results.map((result) => result.sessionId)).toEqual(['workspace-b-session', 'workspace-a-session'])
+  })
+
+  test('Given 消息内容命中 When 搜索可引用会话 Then 异步返回匹配片段', async () => {
+    writeAgentSessionsIndex([
+      { id: 'message-session', title: '项目讨论', workspaceId: 'workspace-b', createdAt: 1, updatedAt: 1 },
+    ])
+    writeAgentSessionJsonl('message-session', [
+      JSON.stringify({ type: 'user', message: { content: [{ type: 'text', text: '需要核对跨工作区的会话引用。' }] } }),
+    ])
+
+    const results = await manager.searchAgentSessionReferences({ query: '跨工作区' })
+
+    expect(results).toHaveLength(1)
+    expect(results[0]).toMatchObject({
+      sessionId: 'message-session',
+      matchSource: 'message',
+      snippet: expect.stringContaining('跨工作区'),
+    })
+  })
+})
+
+describe('Agent 会话引用 prompt', () => {
+  test('Given 用户显式引用跨工作区会话 When 构建发送 prompt Then 保留该会话上下文', () => {
+    writeAgentSessionsIndex([
+      { id: 'current-session', title: '当前工作区会话', workspaceId: 'workspace-a', createdAt: 1, updatedAt: 1 },
+      { id: 'other-workspace-session', title: '其他工作区会话', workspaceId: 'workspace-b', createdAt: 2, updatedAt: 2 },
+    ])
+
+    const processWithResourcesPath = process as NodeJS.Process & { resourcesPath?: string }
+    const originalResourcesPath = processWithResourcesPath.resourcesPath
+    processWithResourcesPath.resourcesPath = tempHome
+    try {
+      const prompt = contextPrompt.buildReferencedSessionsPrompt(
+        'current-session',
+        ['other-workspace-session'],
+      )
+
+      expect(prompt).toContain('id="other-workspace-session"')
+      expect(prompt).toContain('title="其他工作区会话"')
+      expect(prompt).not.toContain('同工作区')
+    } finally {
+      Object.defineProperty(processWithResourcesPath, 'resourcesPath', {
+        value: originalResourcesPath,
+        configurable: true,
+        writable: true,
+      })
+    }
   })
 })

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -1815,77 +1815,27 @@ async function findFirstMatchInAgentJsonl(
   }
 }
 
-function extractTextFromPersistedMessage(parsed: unknown): string {
-  if (!parsed || typeof parsed !== 'object') return ''
-  const record = parsed as {
-    content?: unknown
-    message?: { content?: Array<{ type: string; text?: string }> }
-  }
-
-  if (typeof record.content === 'string') {
-    return record.content
-  }
-
-  if (Array.isArray(record.message?.content)) {
-    return record.message.content
-      .filter((b) => b.type === 'text' && b.text)
-      .map((b) => b.text!)
-      .join('\n')
-  }
-
-  return ''
-}
-
-function createSnippet(text: string, matchIndex: number, matchLength: number): string {
-  const snippetStart = Math.max(0, matchIndex - 48)
-  const snippetEnd = Math.min(text.length, matchIndex + matchLength + 48)
-  return (snippetStart > 0 ? '...' : '') +
-    text.slice(snippetStart, snippetEnd) +
-    (snippetEnd < text.length ? '...' : '')
-}
-
-function findSessionMessageSnippet(sessionId: string, query: string): string | undefined {
+async function findSessionMessageSnippet(sessionId: string, query: string): Promise<string | undefined> {
   if (!query || query.length < 2) return undefined
 
   const filePath = getAgentSessionMessagesPath(sessionId)
   if (!existsSync(filePath)) return undefined
 
-  const queryLower = query.toLowerCase()
   try {
-    const raw = readFileSync(filePath, 'utf-8')
-    const lines = raw.split('\n').filter((line) => line.trim())
-
-    for (const line of lines) {
-      let parsed: unknown
-      try {
-        parsed = JSON.parse(line)
-      } catch (error) {
-        console.warn(`[Agent 会话] 会话引用摘要跳过无法解析的 JSONL 行 (${sessionId}):`, error)
-        continue
-      }
-      const textContent = extractTextFromPersistedMessage(parsed)
-      if (!textContent) continue
-
-      const matchIndex = textContent.toLowerCase().indexOf(queryLower)
-      if (matchIndex === -1) continue
-
-      return createSnippet(textContent, matchIndex, query.length)
-    }
+    const hit = await findFirstMatchInAgentJsonl(filePath, query.toLowerCase(), query.length)
+    return hit?.snippet
   } catch {
     return undefined
   }
-
-  return undefined
 }
 
 /**
- * 搜索当前工作区可引用的 Agent 会话。
+ * 搜索可引用的 Agent 会话。
  *
- * 仅返回当前工作区、未归档、非当前会话的结果；无关键词时返回最近更新的会话。
+ * 指定工作区时仅返回该工作区；省略工作区时跨工作区搜索。两种模式都排除已归档和当前会话；无关键词时返回最近更新的会话。
  */
-export function searchAgentSessionReferences(input: AgentSessionReferenceSearchInput): AgentSessionReferenceSearchResult[] {
+export async function searchAgentSessionReferences(input: AgentSessionReferenceSearchInput): Promise<AgentSessionReferenceSearchResult[]> {
   const workspaceId = input?.workspaceId?.trim()
-  if (!workspaceId) return []
 
   const query = (input?.query ?? '').trim()
   const queryLower = query.toLowerCase()
@@ -1893,7 +1843,7 @@ export function searchAgentSessionReferences(input: AgentSessionReferenceSearchI
   const limit = Math.min(Math.max(requestedLimit, 1), MAX_SESSION_REFERENCE_LIMIT)
 
   const candidates = listAgentSessions()
-    .filter((session) => session.workspaceId === workspaceId)
+    .filter((session) => !workspaceId || session.workspaceId === workspaceId)
     .filter((session) => !session.archived)
     .filter((session) => session.id !== input?.excludeSessionId)
 
@@ -1922,7 +1872,7 @@ export function searchAgentSessionReferences(input: AgentSessionReferenceSearchI
       continue
     }
 
-    const snippet = findSessionMessageSnippet(session.id, query)
+    const snippet = await findSessionMessageSnippet(session.id, query)
     if (snippet) {
       results.push({
         sessionId: session.id,

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -474,7 +474,7 @@ export interface ElectronAPI {
   /** 搜索 Agent 会话消息内容 */
   searchAgentSessionMessages: (query: string) => Promise<AgentMessageSearchResult[]>
 
-  /** 搜索当前工作区可引用的 Agent 会话 */
+  /** 搜索可引用的 Agent 会话；省略 workspaceId 时跨工作区搜索。 */
   searchAgentSessionReferences: (input: AgentSessionReferenceSearchInput) => Promise<AgentSessionReferenceSearchResult[]>
 
   /** 迁移 Agent 会话到另一个工作区 */

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -17,7 +17,7 @@ import * as React from 'react'
 import { unstable_batchedUpdates } from 'react-dom'
 import { useAtom, useAtomValue, useSetAtom, useStore } from 'jotai'
 import { toast } from 'sonner'
-import { Box, CornerDownLeft, Square, Settings, Paperclip, FolderPlus, X, Copy, Check, Brain, Sparkles, ChevronDown } from 'lucide-react'
+import { Box, CornerDownLeft, Square, Settings, X, Copy, Check, Brain, Sparkles, ChevronDown } from 'lucide-react'
 import { AgentMessages } from './AgentMessages'
 import { AgentHeader } from './AgentHeader'
 import { AgentMessageQueue } from './AgentMessageQueue'
@@ -2614,17 +2614,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const canSend = messagesLoaded && (streaming || !messagesRefreshing) && (hasTextInput || pendingFiles.length > 0 || !!suggestion) && agentChannelId !== null && hasAvailableModel && (!streaming || hasTextInput)
 
   const inputToolbarItems = React.useMemo<ToolbarItem[]>(() => [
-    {
-      key: 'model',
-      node: (
-        <ModelSelector
-          filterChannelIds={sessionAgentRuntime === 'pi' ? undefined : agentChannelIds}
-          externalSelectedModel={externalSelectedModel}
-          onModelSelect={handleModelSelect}
-          useSharedOpenState
-        />
-      ),
-    },
     ...(isCodexFastModeAvailable ? [{
       key: 'codex-fast-mode',
       node: (
@@ -2647,16 +2636,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         </Tooltip>
       ),
     }] : []),
-    {
-      key: 'runtime',
-      node: (
-        <AgentRuntimeSelector
-          runtime={sessionAgentRuntime}
-          disabled={streaming || backgroundWaiting}
-          onChange={handleAgentRuntimeChange}
-        />
-      ),
-    },
     { key: 'permission-mode', node: <PermissionModeSelector sessionId={sessionId} /> },
     {
       key: 'thinking',
@@ -2681,48 +2660,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     },
     { key: 'speech', node: <SpeechButton className={inputToolbarButtonClass} /> },
     {
-      key: 'attach-file',
-      node: (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className={inputToolbarButtonClass}
-              onClick={handleOpenFileDialog}
-            >
-              <Paperclip className="size-5" />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="top">
-            <p>添加附件</p>
-          </TooltipContent>
-        </Tooltip>
-      ),
-    },
-    {
-      key: 'attach-folder',
-      node: (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className={inputToolbarButtonClass}
-              onClick={handleAttachFolder}
-            >
-              <FolderPlus className="size-5" />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="top">
-            <p>附加文件夹</p>
-          </TooltipContent>
-        </Tooltip>
-      ),
-    },
-    {
       key: 'context-usage',
       node: (
         <ContextUsageBadge
@@ -2742,8 +2679,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       ),
     },
   ], [
-    agentChannelIds,
-    agentChannelId,
     planQuotaChannelId,
     planQuotaChannelUpdatedAt,
     isCodexFastModeAvailable,
@@ -2753,16 +2688,11 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     openAIThinkingLevel,
     openAIThinkingLevels,
     updateReasoningLevel,
-    agentModelId,
-    handleModelSelect,
     sessionAgentRuntime,
     backgroundWaiting,
-    handleAgentRuntimeChange,
     sessionId,
     agentThinking,
     setAgentThinking,
-    handleOpenFileDialog,
-    handleAttachFolder,
     contextStatus.inputTokens,
     contextStatus.outputTokens,
     contextStatus.cacheReadTokens,
@@ -2773,7 +2703,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     handleCompact,
   ])
 
-  const inputTrailingNode = streaming && !hasTextInput ? (
+  const sendControl = streaming && !hasTextInput ? (
     <Tooltip>
       <TooltipTrigger asChild>
         <Button
@@ -2803,6 +2733,26 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     >
       <CornerDownLeft className="size-[22px]" />
     </Button>
+  )
+
+  const inputTrailingNode = (
+    <>
+      <div className="flex min-w-0 items-center gap-1 [&_.model-selector-trigger>span]:max-w-[min(12rem,30vw)]">
+        <ModelSelector
+          filterChannelIds={sessionAgentRuntime === 'pi' ? undefined : agentChannelIds}
+          externalSelectedModel={externalSelectedModel}
+          onModelSelect={handleModelSelect}
+          showChannelInTrigger
+          useSharedOpenState
+        />
+        <AgentRuntimeSelector
+          runtime={sessionAgentRuntime}
+          disabled={streaming || backgroundWaiting}
+          onChange={handleAgentRuntimeChange}
+        />
+      </div>
+      {sendControl}
+    </>
   )
 
   // 同批图片附件 — 用于大图预览时左右翻页（提取到 useMemo 避免每次渲染重建）
@@ -2956,8 +2906,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
               placeholder={
                 agentChannelId && hasAvailableModel
                   ? sendWithCmdEnter
-                    ? '输入消息... (⌘/Ctrl+Enter 发送，Enter 换行，@ 引用文件，/ 调用 Skill，# 调用 MCP，& 引用会话)'
-                    : '输入消息... (Enter 发送，Shift+Enter 换行，@ 引用文件，/ 调用 Skill，# 调用 MCP，& 引用会话)'
+                    ? '输入消息... (输入 / 打开菜单，⌘/Ctrl+Enter 发送)'
+                    : '输入消息... (输入 / 打开菜单，Enter 发送)'
                   : !agentChannelId
                     ? '请先在设置中选择 Agent 供应商'
                     : '暂无可用模型，请先在设置中启用渠道'
@@ -2967,7 +2917,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
               collapsible
               enableMentions
               workspacePath={sessionPath}
-              workspaceId={currentWorkspaceId}
               workspaceSlug={workspaceSlug}
               sessionId={sessionId}
               attachedDirs={workspaceMentionPaths}
@@ -2975,6 +2924,10 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
               htmlValue={inputHtmlContent}
               onHtmlChange={setInputHtmlContent}
               sendWithCmdEnter={sendWithCmdEnter}
+              commandActions={{
+                onAttachFile: handleOpenFileDialog,
+                onAttachFolder: handleAttachFolder,
+              }}
             />
 
             {/* Footer 工具栏 — 容器变窄时尾部按钮自动折叠进「更多」Popover */}

--- a/apps/electron/src/renderer/components/agent/agent-command-menu-state.test.ts
+++ b/apps/electron/src/renderer/components/agent/agent-command-menu-state.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  filterCommandMenuItems,
+  getNextCommandMenuIndex,
+  shouldOpenSlashCommandMenu,
+} from './agent-command-menu-state'
+
+describe('Agent command menu navigation', () => {
+  test('wraps keyboard navigation at both ends of a menu', () => {
+    expect(getNextCommandMenuIndex(0, -1, 4)).toBe(3)
+    expect(getNextCommandMenuIndex(3, 1, 4)).toBe(0)
+    expect(getNextCommandMenuIndex(1, 1, 4)).toBe(2)
+  })
+
+  test('keeps the selection at zero when there are no choices', () => {
+    expect(getNextCommandMenuIndex(0, 1, 0)).toBe(0)
+  })
+
+  test('filters entries by their label or supporting description', () => {
+    const items = [
+      { id: 'file', label: '引用文件', description: '会话文件和工作区文件' },
+      { id: 'session', label: '引用会话', description: '选择历史 Agent 会话' },
+      { id: 'compact', label: '压缩上下文', description: '释放上下文空间' },
+    ]
+
+    expect(filterCommandMenuItems(items, '工作区')).toEqual([items[0]!])
+    expect(filterCommandMenuItems(items, '会话')).toEqual([items[0]!, items[1]!])
+    expect(filterCommandMenuItems(items, '')).toEqual(items)
+  })
+
+  test('only opens the slash menu for a clean command prefix', () => {
+    expect(shouldOpenSlashCommandMenu('/')).toBe(true)
+    expect(shouldOpenSlashCommandMenu('/引')).toBe(true)
+    expect(shouldOpenSlashCommandMenu('先说 /')).toBe(false)
+    expect(shouldOpenSlashCommandMenu('/tmp/file')).toBe(false)
+    expect(shouldOpenSlashCommandMenu('')).toBe(false)
+  })
+})

--- a/apps/electron/src/renderer/components/agent/agent-command-menu-state.ts
+++ b/apps/electron/src/renderer/components/agent/agent-command-menu-state.ts
@@ -1,0 +1,27 @@
+export interface CommandMenuSearchItem {
+  label: string
+  description?: string
+}
+
+export function getNextCommandMenuIndex(current: number, direction: 1 | -1, itemCount: number): number {
+  if (itemCount <= 0) return 0
+  return (current + direction + itemCount) % itemCount
+}
+
+export function filterCommandMenuItems<T extends CommandMenuSearchItem>(items: T[], query: string): T[] {
+  const normalizedQuery = query.trim().toLocaleLowerCase()
+  if (!normalizedQuery) return items
+
+  return items.filter((item) => (
+    item.label.toLocaleLowerCase().includes(normalizedQuery) ||
+    item.description?.toLocaleLowerCase().includes(normalizedQuery)
+  ))
+}
+
+/**
+ * The root palette owns only a standalone command prefix. This keeps literal
+ * paths and Markdown such as /tmp/file from being intercepted as commands.
+ */
+export function shouldOpenSlashCommandMenu(text: string): boolean {
+  return /^\/[^/\s]*$/.test(text)
+}

--- a/apps/electron/src/renderer/components/agent/agent-command-suggestion.tsx
+++ b/apps/electron/src/renderer/components/agent/agent-command-suggestion.tsx
@@ -1,0 +1,644 @@
+import * as React from "react";
+import { ReactRenderer } from "@tiptap/react";
+import type { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
+import {
+  ChevronLeft,
+  ChevronRight,
+  FileText,
+  FolderPlus,
+  LoaderCircle,
+  MessageSquareText,
+  Paperclip,
+  Sparkles,
+  Wrench,
+} from "lucide-react";
+import type {
+  FileIndexEntry,
+  FileSearchResult,
+  AgentSessionReferenceSearchResult,
+} from "@proma/shared";
+import { FileMentionList } from "@/components/file-browser/FileMentionList";
+import type { FileMentionRef } from "@/components/file-browser/FileMentionList";
+import { cn } from "@/lib/utils";
+import {
+  createMentionPopup,
+  isSuggestionTriggerPresent,
+  positionPopup,
+} from "./mention-popup-utils";
+import {
+  filterCommandMenuItems,
+  getNextCommandMenuIndex,
+  shouldOpenSlashCommandMenu,
+} from "./agent-command-menu-state";
+
+type CommandPage = "root" | "skills" | "tools" | "sessions" | "files";
+type MentionCharacter = "@" | "/" | "&" | "#";
+
+type CommandAction = "attach-file" | "attach-folder";
+
+interface RootMenuItem {
+  id: CommandPage | CommandAction;
+  label: string;
+  description: string;
+  icon: React.ComponentType<{ className?: string }>;
+  kind: "page" | "action";
+  disabled?: boolean;
+}
+
+interface ReferenceMenuItem {
+  id: string;
+  label: string;
+  description?: string;
+}
+
+export interface AgentCommandActions {
+  onAttachFile?: () => void;
+  onAttachFolder?: () => void;
+}
+
+interface AgentCommandMenuProps {
+  query: string;
+  workspacePathRef: React.RefObject<string | null>;
+  currentSessionIdRef: React.RefObject<string | null>;
+  workspaceSlugRef: React.RefObject<string | null>;
+  attachedDirsRef: React.RefObject<string[]>;
+  sessionAttachedDirsRef: React.RefObject<string[]>;
+  actionsRef: React.RefObject<AgentCommandActions>;
+  onInsertMention: (
+    character: MentionCharacter,
+    id: string,
+    label: string,
+  ) => void;
+  onRunAction: (action: CommandAction) => void;
+}
+
+export interface AgentCommandMenuRef {
+  onKeyDown: (props: { event: KeyboardEvent }) => boolean;
+}
+
+const EMPTY_FILE_RESULT: FileSearchResult = {
+  entries: [],
+  total: 0,
+  sessionEntries: [],
+  workspaceEntries: [],
+};
+
+function getRootMenuItems(): RootMenuItem[] {
+  return [
+    {
+      id: "skills",
+      label: "调用 Skill",
+      description: "选择当前工作区已启用的 Skill",
+      icon: Sparkles,
+      kind: "page",
+    },
+    {
+      id: "sessions",
+      label: "引用会话",
+      description: "引用其他 Agent 会话",
+      icon: MessageSquareText,
+      kind: "page",
+    },
+    {
+      id: "files",
+      label: "引用文件",
+      description: "选择会话文件或工作区文件",
+      icon: FileText,
+      kind: "page",
+    },
+    {
+      id: "attach-file",
+      label: "添加附件",
+      description: "从本机选择文件附加到消息",
+      icon: Paperclip,
+      kind: "action",
+    },
+    {
+      id: "attach-folder",
+      label: "附加文件夹",
+      description: "授权 Agent 访问一个文件夹",
+      icon: FolderPlus,
+      kind: "action",
+    },
+    {
+      id: "tools",
+      label: "MCP 工具",
+      description: "选择当前 Agent 可用的 MCP 工具",
+      icon: Wrench,
+      kind: "page",
+    },
+  ];
+}
+
+function menuTitle(page: CommandPage): string {
+  switch (page) {
+    case "skills":
+      return "Skills";
+    case "tools":
+      return "MCP 工具";
+    case "sessions":
+      return "引用会话";
+    case "files":
+      return "引用文件";
+    default:
+      return "命令";
+  }
+}
+
+function menuHint(page: CommandPage): string {
+  return page === "root"
+    ? "↑ ↓ 选择  ·  → 或 Enter 进入  ·  Esc 关闭"
+    : "↑ ↓ 选择  ·  ← 返回  ·  Enter 确认  ·  Esc 关闭";
+}
+
+function menuEmptyText(page: CommandPage, loading: boolean): string {
+  if (loading) return "正在加载…";
+  switch (page) {
+    case "skills":
+      return "没有已启用的 Skill";
+    case "tools":
+      return "没有可用的 MCP 工具";
+    case "sessions":
+      return "没有可引用的会话";
+    case "files":
+      return "没有可引用的文件";
+    default:
+      return "没有匹配的命令";
+  }
+}
+
+const AgentCommandMenu = React.forwardRef<
+  AgentCommandMenuRef,
+  AgentCommandMenuProps
+>(function AgentCommandMenu(
+  {
+    query,
+    workspacePathRef,
+    currentSessionIdRef,
+    workspaceSlugRef,
+    attachedDirsRef,
+    sessionAttachedDirsRef,
+    actionsRef,
+    onInsertMention,
+    onRunAction,
+  },
+  ref,
+) {
+  const [page, setPage] = React.useState<CommandPage>("root");
+  const [selectedIndex, setSelectedIndex] = React.useState(0);
+  const [loading, setLoading] = React.useState(false);
+  const [skills, setSkills] = React.useState<ReferenceMenuItem[]>([]);
+  const [tools, setTools] = React.useState<ReferenceMenuItem[]>([]);
+  const [sessions, setSessions] = React.useState<ReferenceMenuItem[]>([]);
+  const [fileResult, setFileResult] =
+    React.useState<FileSearchResult>(EMPTY_FILE_RESULT);
+  const [sessionSearchQuery, setSessionSearchQuery] = React.useState(query);
+  const fileListRef = React.useRef<FileMentionRef>(null);
+  const menuScrollRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    setSelectedIndex(0);
+  }, [page, query]);
+
+  React.useEffect(() => {
+    if (page !== "sessions") return;
+
+    const timer = window.setTimeout(() => {
+      setSessionSearchQuery(query.trim());
+    }, 250);
+    return () => window.clearTimeout(timer);
+  }, [page, query]);
+
+  React.useEffect(() => {
+    let disposed = false;
+
+    const loadPage = async (): Promise<void> => {
+      if (page === "root") return;
+      setLoading(true);
+      try {
+        if (page === "skills" || page === "tools") {
+          const slug = workspaceSlugRef.current;
+          if (!slug) return;
+          const capabilities =
+            await window.electronAPI.getWorkspaceCapabilities(slug);
+          if (disposed) return;
+          if (page === "skills") {
+            setSkills(
+              capabilities.skills
+                .filter((skill) => skill.enabled)
+                .map((skill) => ({
+                  id: skill.slug,
+                  label: skill.name,
+                  description: skill.description,
+                })),
+            );
+          } else {
+            setTools(
+              capabilities.mcpServers
+                .filter((server) => server.enabled)
+                .map((server) => ({
+                  id: server.name,
+                  label: server.name,
+                  description: server.type,
+                })),
+            );
+          }
+          return;
+        }
+
+        if (page === "sessions") {
+          const result = await window.electronAPI.searchAgentSessionReferences({
+            excludeSessionId: currentSessionIdRef.current ?? undefined,
+            query: sessionSearchQuery || undefined,
+            limit: sessionSearchQuery ? 20 : 200,
+          });
+          if (disposed) return;
+          setSessions(
+            result.map((session: AgentSessionReferenceSearchResult) => ({
+              id: session.sessionId,
+              label: session.title,
+              description: session.snippet,
+            })),
+          );
+          return;
+        }
+
+        const workspacePath = workspacePathRef.current;
+        if (!workspacePath) return;
+        const attachedDirs = attachedDirsRef.current ?? [];
+        const sessionAttachedDirs = sessionAttachedDirsRef.current ?? [];
+        const result = await window.electronAPI.searchWorkspaceFiles(
+          workspacePath,
+          "",
+          200,
+          attachedDirs.length > 0 ? attachedDirs : undefined,
+          sessionAttachedDirs.length > 0 ? sessionAttachedDirs : undefined,
+        );
+        if (!disposed) setFileResult(result);
+      } catch (error) {
+        console.error("[AgentCommandMenu] 加载菜单数据失败:", error);
+        if (!disposed) {
+          setSkills([]);
+          setTools([]);
+          setSessions([]);
+          setFileResult(EMPTY_FILE_RESULT);
+        }
+      } finally {
+        if (!disposed) setLoading(false);
+      }
+    };
+
+    void loadPage();
+    return () => {
+      disposed = true;
+    };
+  }, [
+    page,
+    sessionSearchQuery,
+    workspacePathRef,
+    currentSessionIdRef,
+    workspaceSlugRef,
+    attachedDirsRef,
+    sessionAttachedDirsRef,
+  ]);
+
+  const rootItems = React.useMemo(
+    () => filterCommandMenuItems(getRootMenuItems(), query),
+    [actionsRef, query],
+  );
+  const referenceItems = React.useMemo(() => {
+    const source =
+      page === "skills" ? skills : page === "tools" ? tools : sessions;
+    return filterCommandMenuItems(source, query);
+  }, [page, skills, tools, sessions, query]);
+
+  const selectRootItem = React.useCallback(
+    (item: RootMenuItem): void => {
+      if (item.disabled) return;
+      if (item.kind === "page") {
+        setPage(item.id as CommandPage);
+        return;
+      }
+      onRunAction(item.id as CommandAction);
+    },
+    [onRunAction],
+  );
+
+  const selectReferenceItem = React.useCallback(
+    (item: ReferenceMenuItem): void => {
+      const character: MentionCharacter =
+        page === "skills" ? "/" : page === "tools" ? "#" : "&";
+      onInsertMention(character, item.id, item.label);
+    },
+    [onInsertMention, page],
+  );
+
+  React.useImperativeHandle(
+    ref,
+    () => ({
+      onKeyDown: ({ event }) => {
+        if (page === "files") {
+          return fileListRef.current?.onKeyDown({ event }) ?? false;
+        }
+
+        const items = page === "root" ? rootItems : referenceItems;
+        if (event.key === "ArrowUp") {
+          setSelectedIndex((current) =>
+            getNextCommandMenuIndex(current, -1, items.length),
+          );
+          return true;
+        }
+        if (event.key === "ArrowDown") {
+          setSelectedIndex((current) =>
+            getNextCommandMenuIndex(current, 1, items.length),
+          );
+          return true;
+        }
+        if (event.key === "ArrowLeft") {
+          if (page !== "root") {
+            setPage("root");
+            return true;
+          }
+          return false;
+        }
+        if (event.key === "ArrowRight" || event.key === "Enter") {
+          const item = items[selectedIndex];
+          if (!item) return true;
+          if (page === "root") selectRootItem(item as RootMenuItem);
+          else selectReferenceItem(item);
+          return true;
+        }
+        return false;
+      },
+    }),
+    [
+      page,
+      rootItems,
+      referenceItems,
+      selectedIndex,
+      selectRootItem,
+      selectReferenceItem,
+    ],
+  );
+
+  const isFilePage = page === "files";
+  const hasItems = isFilePage
+    ? fileResult.sessionEntries.length > 0 ||
+      fileResult.workspaceEntries.length > 0
+    : (page === "root" ? rootItems.length : referenceItems.length) > 0;
+
+  React.useEffect(() => {
+    if (isFilePage) return;
+    const container = menuScrollRef.current;
+    if (!container) return;
+    const selected = container.querySelector<HTMLElement>(
+      `[data-command-menu-index="${selectedIndex}"]`,
+    );
+    selected?.scrollIntoView({ block: "nearest" });
+  }, [
+    isFilePage,
+    page,
+    selectedIndex,
+    rootItems.length,
+    referenceItems.length,
+  ]);
+
+  return (
+    <div
+      className="w-[min(25rem,calc(100vw-2rem))] overflow-hidden rounded-lg bg-popover shadow-xl"
+      role="dialog"
+      aria-label="Agent 命令菜单"
+    >
+      <div className="flex items-center gap-2 border-b border-border/50 bg-muted/40 px-3 py-2">
+        {page !== "root" && (
+          <ChevronLeft className="size-3.5 text-muted-foreground" />
+        )}
+        <span className="text-xs font-semibold text-foreground">
+          {menuTitle(page)}
+        </span>
+        {page === "skills" && (
+          <span className="text-[11px] text-muted-foreground">
+            继续输入以搜索
+          </span>
+        )}
+        {loading && (
+          <LoaderCircle className="ml-auto size-3.5 animate-spin text-muted-foreground" />
+        )}
+      </div>
+      <div ref={menuScrollRef} className="h-[22rem] overflow-y-auto p-1.5">
+        {isFilePage ? (
+          hasItems ? (
+            <FileMentionList
+              ref={fileListRef}
+              sessionEntries={fileResult.sessionEntries}
+              workspaceEntries={fileResult.workspaceEntries}
+              onSelect={(file: Pick<FileIndexEntry, "name" | "path">) =>
+                onInsertMention("@", file.path, file.name)
+              }
+              onBack={() => setPage("root")}
+              embedded
+            />
+          ) : (
+            <MenuEmpty text={menuEmptyText(page, loading)} />
+          )
+        ) : hasItems ? (
+          <div role="listbox" aria-label={menuTitle(page)}>
+            {(page === "root" ? rootItems : referenceItems).map(
+              (item, index) => {
+                const rootItem = item as RootMenuItem;
+                const Icon =
+                  page === "root"
+                    ? rootItem.icon
+                    : page === "skills"
+                      ? Sparkles
+                      : page === "tools"
+                        ? Wrench
+                        : MessageSquareText;
+                const selected = index === selectedIndex;
+                const disabled = page === "root" && rootItem.disabled;
+                return (
+                  <button
+                    key={item.id}
+                    type="button"
+                    role="option"
+                    aria-selected={selected}
+                    data-command-menu-index={index}
+                    disabled={disabled}
+                    className={cn(
+                      "flex w-full items-center gap-3 rounded-md px-2.5 py-2 text-left transition-colors",
+                      selected && "bg-accent text-accent-foreground",
+                      !selected && !disabled && "hover:bg-accent/60",
+                      disabled && "cursor-not-allowed opacity-45",
+                    )}
+                    onMouseEnter={() => setSelectedIndex(index)}
+                    onMouseDown={(event) => {
+                      event.preventDefault();
+                      if (page === "root") selectRootItem(rootItem);
+                      else selectReferenceItem(item as ReferenceMenuItem);
+                    }}
+                  >
+                    <Icon className="size-4 shrink-0 text-primary" />
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-sm font-medium">
+                        {item.label}
+                      </span>
+                      {item.description && (
+                        <span className="block truncate text-xs text-muted-foreground">
+                          {item.description}
+                        </span>
+                      )}
+                    </span>
+                    {page === "root" && rootItem.kind === "page" && (
+                      <ChevronRight className="size-4 shrink-0 text-muted-foreground" />
+                    )}
+                  </button>
+                );
+              },
+            )}
+          </div>
+        ) : (
+          <MenuEmpty text={menuEmptyText(page, loading)} />
+        )}
+      </div>
+      <div className="border-t border-border/50 px-3 py-1.5 text-[11px] text-muted-foreground">
+        {menuHint(page)}
+      </div>
+    </div>
+  );
+});
+
+function MenuEmpty({ text }: { text: string }): React.ReactElement {
+  return (
+    <div className="px-2.5 py-5 text-center text-xs text-muted-foreground">
+      {text}
+    </div>
+  );
+}
+
+interface SlashSuggestionItem {
+  id: string;
+}
+
+export function createAgentCommandSuggestion(
+  workspacePathRef: React.RefObject<string | null>,
+  currentSessionIdRef: React.RefObject<string | null>,
+  workspaceSlugRef: React.RefObject<string | null>,
+  attachedDirsRef: React.RefObject<string[]>,
+  sessionAttachedDirsRef: React.RefObject<string[]>,
+  actionsRef: React.RefObject<AgentCommandActions>,
+): Omit<SuggestionOptions<SlashSuggestionItem>, "editor"> {
+  return {
+    char: "/",
+    allowSpaces: false,
+    allowedPrefixes: null,
+    items: () => [{ id: "agent-command-root" }],
+    allow: ({ state }) => shouldOpenSlashCommandMenu(state.doc.textContent),
+    command: ({ editor, range, props }) => {
+      editor
+        .chain()
+        .focus()
+        .insertContentAt(range, [
+          { type: "mention", attrs: props },
+          { type: "text", text: " " },
+        ])
+        .run();
+    },
+    render: () => {
+      let renderer: ReactRenderer<AgentCommandMenuRef> | null = null;
+      let popup: HTMLDivElement | null = null;
+      let blurHandler: (() => void) | null = null;
+      let editorDom: HTMLElement | null = null;
+      let activeProps: SuggestionProps<SlashSuggestionItem> | null = null;
+
+      const removeTrigger = (): void => {
+        const props = activeProps;
+        if (!props) return;
+        props.editor.chain().focus().deleteRange(props.range).run();
+      };
+
+      const insertMention = (
+        character: MentionCharacter,
+        id: string,
+        label: string,
+      ): void => {
+        activeProps?.command({
+          id,
+          label,
+          mentionSuggestionChar: character,
+          commandMenuMention: true,
+        });
+      };
+
+      const runAction = (action: CommandAction): void => {
+        const actions = actionsRef.current ?? {};
+        removeTrigger();
+        requestAnimationFrame(() => {
+          if (action === "attach-file") actions.onAttachFile?.();
+          if (action === "attach-folder") actions.onAttachFolder?.();
+        });
+      };
+
+      const cleanup = (): void => {
+        if (blurHandler && editorDom) {
+          editorDom.removeEventListener("blur", blurHandler, true);
+          blurHandler = null;
+        }
+        editorDom = null;
+        activeProps = null;
+        popup?.remove();
+        popup = null;
+        renderer?.destroy();
+        renderer = null;
+      };
+
+      const getRendererProps = (
+        props: SuggestionProps<SlashSuggestionItem>,
+      ) => ({
+        query: props.query,
+        workspacePathRef,
+        currentSessionIdRef,
+        workspaceSlugRef,
+        attachedDirsRef,
+        sessionAttachedDirsRef,
+        actionsRef,
+        onInsertMention: insertMention,
+        onRunAction: runAction,
+      });
+
+      return {
+        onStart(props) {
+          if (popup || renderer) cleanup();
+          if (!isSuggestionTriggerPresent(props.editor, props.range, "/"))
+            return;
+
+          activeProps = props;
+          editorDom = props.editor.view.dom;
+          renderer = new ReactRenderer(AgentCommandMenu, {
+            props: getRendererProps(props),
+            editor: props.editor,
+          });
+          popup = createMentionPopup(renderer.element);
+          positionPopup(popup, props.clientRect?.());
+
+          blurHandler = () => {
+            setTimeout(() => {
+              if (!props.editor.view.hasFocus() && popup) cleanup();
+            }, 100);
+          };
+          editorDom.addEventListener("blur", blurHandler, true);
+        },
+        onUpdate(props) {
+          activeProps = props;
+          renderer?.updateProps(getRendererProps(props));
+          positionPopup(popup, props.clientRect?.());
+        },
+        onKeyDown(props) {
+          return renderer?.ref?.onKeyDown({ event: props.event }) ?? false;
+        },
+        onExit() {
+          cleanup();
+        },
+      };
+    },
+  };
+}

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -28,8 +28,7 @@ import { cn } from '@/lib/utils'
 import { lowlight } from '@/lib/lowlight'
 import { htmlToMarkdown } from '@/lib/markdown-rich-text'
 import { richTextRenderingEnabledAtom } from '@/atoms/ui-preferences'
-import { createFileMentionSuggestion } from '@/components/file-browser/file-mention-suggestion'
-import { createSkillMentionSuggestion, createMcpMentionSuggestion, createSessionMentionSuggestion } from '@/components/agent/mention-suggestions'
+import { createAgentCommandSuggestion, type AgentCommandActions } from '@/components/agent/agent-command-suggestion'
 import { shouldConvertClipboardTextToAttachment } from '@/lib/clipboard-text-attachment'
 import {
   VOICE_DICTATION_INSERT_EVENT,
@@ -118,15 +117,13 @@ interface RichTextInputProps {
   autoFocusTrigger?: string | null
   /** 是否支持手动折叠（内容较长时显示折叠按钮） */
   collapsible?: boolean
-  /** 是否启用 Mention 功能（@ 文件、/ Skill、# MCP、& 会话） */
+  /** 是否启用 / 命令菜单和引用 chip。 */
   enableMentions?: boolean
-  /** 工作区根路径（启用 @ 引用文件功能时需要） */
+  /** 工作区根路径（启用 / 文件引用功能时需要） */
   workspacePath?: string | null
-  /** 工作区 ID（启用 & 引用 Agent 会话功能时需要） */
-  workspaceId?: string | null
-  /** 工作区 slug（启用 / Skill 和 # MCP 功能时需要） */
+  /** 工作区 slug（启用 / Skill 和 MCP 功能时需要） */
   workspaceSlug?: string | null
-  /** 当前 Agent 会话 ID（启用 & 引用 Agent 会话功能时用于排除自身） */
+  /** 当前 Agent 会话 ID（用于在 / 会话引用中排除自身） */
   sessionId?: string | null
   /** 附加目录路径列表（工作区级，@ 引用时标记为工作区文件） */
   attachedDirs?: string[]
@@ -138,6 +135,8 @@ interface RichTextInputProps {
   onHtmlChange?: (html: string) => void
   /** 是否使用 Cmd/Ctrl+Enter 发送（而非 Enter） */
   sendWithCmdEnter?: boolean
+  /** / 命令菜单可调用的输入框外部动作。 */
+  commandActions?: AgentCommandActions
   className?: string
 }
 
@@ -162,7 +161,6 @@ export function RichTextInput({
   collapsible = false,
   enableMentions,
   workspacePath,
-  workspaceId,
   workspaceSlug,
   sessionId,
   attachedDirs = [],
@@ -170,6 +168,7 @@ export function RichTextInput({
   htmlValue,
   onHtmlChange,
   sendWithCmdEnter = false,
+  commandActions,
 }: RichTextInputProps): React.ReactElement {
   const [isExpanded, setIsExpanded] = useState(false)
   const inputIdRef = useRef(`rich-text-input-${Math.random().toString(36).slice(2)}`)
@@ -200,31 +199,27 @@ export function RichTextInput({
   // 发送模式引用
   const sendWithCmdEnterRef = useRef(sendWithCmdEnter)
   sendWithCmdEnterRef.current = sendWithCmdEnter
-  // Mention 活跃状态（阻止 Enter 发送消息）
-  const mentionActiveRef = useRef(false)
-  // Mention 弹窗中的可选项数量（0 时 Enter 不阻塞发送）
-  const mentionItemCountRef = useRef(0)
-  // 工作区路径引用（给 Suggestion 使用）
+  // 工作区路径引用（给 / 命令菜单使用）
   const workspacePathRef = useRef<string | null>(workspacePath ?? null)
   workspacePathRef.current = workspacePath ?? null
-  // 工作区 ID 引用（给会话引用 Suggestion 使用）
-  const workspaceIdRef = useRef<string | null>(workspaceId ?? null)
-  workspaceIdRef.current = workspaceId ?? null
-  // 当前会话 ID 引用（给会话引用 Suggestion 使用）
+  // 当前会话 ID 引用（给 / 会话引用使用）
   const currentSessionIdRef = useRef<string | null>(sessionId ?? null)
   currentSessionIdRef.current = sessionId ?? null
-  // 工作区级附加目录路径引用（给 Suggestion 使用，标记为 workspace）
+  // 工作区级附加目录路径引用（给 / 文件引用使用，标记为 workspace）
   const attachedDirsRef = useRef<string[]>(attachedDirs)
   attachedDirsRef.current = attachedDirs
-  // 会话级附加目录路径引用（给 Suggestion 使用，标记为 session）
+  // 会话级附加目录路径引用（给 / 文件引用使用，标记为 session）
   const sessionAttachedDirsRef = useRef<string[]>(sessionAttachedDirs)
   sessionAttachedDirsRef.current = sessionAttachedDirs
-  // 工作区 slug 引用（给 Skill/MCP Suggestion 使用）
+  // 工作区 slug 引用（给统一命令菜单和 MCP Suggestion 使用）
   const workspaceSlugRef = useRef<string | null>(workspaceSlug ?? null)
   workspaceSlugRef.current = workspaceSlug ?? null
+  // / 菜单中的回调必须始终指向当前 Agent 会话，避免切换会话后执行旧闭包。
+  const commandActionsRef = useRef<AgentCommandActions>(commandActions ?? {})
+  commandActionsRef.current = commandActions ?? {}
 
   // 是否启用 Mention 功能：Agent 首帧可能尚未拿到路径/slug/id，但扩展必须先注册。
-  const hasMentionSupport = enableMentions ?? (workspacePath !== undefined || workspaceSlug !== undefined || workspaceId !== undefined)
+  const hasMentionSupport = enableMentions ?? (workspacePath !== undefined || workspaceSlug !== undefined)
 
   // 输入框 Markdown 渲染开关：关闭后为纯文本模式（禁用格式化扩展 + 粘贴跳过 HTML 解析），Mention 仍保留
   const richTextEnabled = useAtomValue(richTextRenderingEnabledAtom)
@@ -241,27 +236,16 @@ export function RichTextInput({
     ))
   }, [isMac])
 
-  // Mention Suggestion 配置（稳定引用，不随 workspacePath 变化重建）
-  const mentionSuggestion = useMemo(
-    () => createFileMentionSuggestion(workspacePathRef, mentionActiveRef, attachedDirsRef, mentionItemCountRef, sessionAttachedDirsRef),
-    [],
-  )
-
-  // Skill Suggestion 配置（/ 触发）
-  const skillSuggestion = useMemo(
-    () => createSkillMentionSuggestion(workspaceSlugRef, mentionActiveRef, mentionItemCountRef),
-    [],
-  )
-
-  // MCP Suggestion 配置（# 触发）
-  const mcpSuggestion = useMemo(
-    () => createMcpMentionSuggestion(workspaceSlugRef, mentionActiveRef, mentionItemCountRef),
-    [],
-  )
-
-  // Agent 会话引用 Suggestion（& 触发）
-  const sessionSuggestion = useMemo(
-    () => createSessionMentionSuggestion(workspaceIdRef, currentSessionIdRef, mentionActiveRef, mentionItemCountRef),
+  // / 统一命令菜单配置。它复用 TipTap Suggestion 生命周期，确保 Esc、焦点和异步清理与原有 mention 一致。
+  const commandSuggestion = useMemo(
+    () => createAgentCommandSuggestion(
+      workspacePathRef,
+      currentSessionIdRef,
+      workspaceSlugRef,
+      attachedDirsRef,
+      sessionAttachedDirsRef,
+      commandActionsRef,
+    ),
     [],
   )
 
@@ -309,7 +293,7 @@ export function RichTextInput({
         emptyEditorClass: 'is-editor-empty',
       }),
       // Mention 扩展：启用时注册，路径/slug 后续通过 ref 异步更新
-      // @ 引用文件、/ 触发 Skill、# 触发 MCP
+      // Mention 节点只由 / 统一命令菜单插入；历史草稿中的旧 token 继续渲染。
       // 纯文本模式下仍然保留，确保引用功能可用
       ...(hasMentionSupport ? [
         Mention.extend({
@@ -323,12 +307,22 @@ export function RichTextInput({
                   'data-mention-suggestion-char': attrs.mentionSuggestionChar,
                 }),
               },
+              // / 命令菜单在一个 Slash suggestion 内插入多种引用，需按节点自身类型渲染 Chip。
+              commandMenuMention: {
+                default: false,
+                parseHTML: (el: HTMLElement) => el.getAttribute('data-command-menu-mention') === 'true',
+                renderHTML: (attrs: Record<string, unknown>) => attrs.commandMenuMention
+                  ? { 'data-command-menu-mention': 'true' }
+                  : {},
+              },
             }
           },
         }).configure({
           HTMLAttributes: {},
           renderHTML({ node, suggestion }) {
-            const char = suggestion?.char ?? node.attrs.mentionSuggestionChar ?? '@'
+            const char = node.attrs.commandMenuMention
+              ? node.attrs.mentionSuggestionChar ?? '@'
+              : suggestion?.char ?? node.attrs.mentionSuggestionChar ?? '@'
             const label = node.attrs.label ?? node.attrs.id
             let chipClass = 'mention-chip'
             if (char === '/') chipClass = 'skill-mention-chip'
@@ -341,17 +335,13 @@ export function RichTextInput({
                 'data-id': node.attrs.id,
                 'data-label': node.attrs.label,
                 'data-mention-suggestion-char': char,
+                ...(node.attrs.commandMenuMention ? { 'data-command-menu-mention': 'true' } : {}),
                 class: chipClass,
               },
               `${char === '@' ? '@' : ''}${label}`,
             ]
           },
-          suggestions: [
-            mentionSuggestion,
-            skillSuggestion,
-            mcpSuggestion,
-            sessionSuggestion,
-          ],
+          suggestions: [commandSuggestion],
         }),
       ] : []),
     ],

--- a/apps/electron/src/renderer/components/file-browser/FileMentionList.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileMentionList.tsx
@@ -65,6 +65,10 @@ export interface FileMentionListProps {
   sessionEntries: FileIndexEntry[]
   workspaceEntries: FileIndexEntry[]
   onSelect: (item: { name: string; path: string; type: 'file' | 'dir' }) => void
+  /** 作为统一命令菜单子层时，← 可返回命令根层。 */
+  onBack?: () => void
+  /** 嵌入另一个弹层时，移除自身的卡片容器样式。 */
+  embedded?: boolean
 }
 
 export interface FileMentionRef {
@@ -143,7 +147,7 @@ function flattenVisible(nodes: FileTreeNode[]): FileTreeNode[] {
 // ===== 组件 =====
 
 export const FileMentionList = React.forwardRef<FileMentionRef, FileMentionListProps>(
-  function FileMentionList({ sessionEntries, workspaceEntries, onSelect }, ref) {
+  function FileMentionList({ sessionEntries, workspaceEntries, onSelect, onBack, embedded = false }, ref) {
     // 构建树（仅在条目变化时重建）
     const sessionTree = React.useMemo(
       () => buildTree(sessionEntries),
@@ -276,6 +280,8 @@ export const FileMentionList = React.forwardRef<FileMentionRef, FileMentionListP
           const node = getNodeAt(selectedIndex)
           if (node && node.type === 'dir' && node.expanded) {
             toggleExpand(node.path)
+          } else {
+            onBack?.()
           }
           return true
         }
@@ -301,7 +307,7 @@ export const FileMentionList = React.forwardRef<FileMentionRef, FileMentionListP
     // 无匹配结果
     if (!hasResults) {
       return (
-        <div className="rounded-lg border bg-popover shadow-lg overflow-hidden min-w-[260px]">
+        <div className={cn(!embedded && 'rounded-lg border bg-popover shadow-lg', 'overflow-hidden min-w-[260px]')}>
           <div className="flex items-center justify-between gap-2 px-2.5 py-1.5 text-[11px] font-medium bg-primary/10 text-primary border-b border-border/50">
             <span>文件</span>
             <span className="font-normal text-muted-foreground">Esc 关闭 · Enter 选中</span>
@@ -316,7 +322,11 @@ export const FileMentionList = React.forwardRef<FileMentionRef, FileMentionListP
         <MentionErrorBoundary>
       <div
         ref={containerRef}
-        className="rounded-lg border bg-popover shadow-lg overflow-y-auto max-h-[360px] min-w-[260px]"
+        className={cn(
+          !embedded && 'rounded-lg border bg-popover shadow-lg',
+          embedded ? 'max-h-none min-w-0' : 'max-h-[360px] min-w-[260px]',
+          'overflow-y-auto',
+        )}
       >
         {/* 会话文件 */}
         {hasSession && (

--- a/apps/electron/src/renderer/lib/markdown-rich-text.test.ts
+++ b/apps/electron/src/renderer/lib/markdown-rich-text.test.ts
@@ -146,6 +146,21 @@ describe('markdownToHtml rich preview blocks', () => {
   })
 })
 
+describe('Agent command menu mention serialization', () => {
+  test('preserves the existing file, Skill, MCP, and session reference protocols', () => {
+    const markdown = withHtmlDocument(() => htmlToMarkdown([
+      '<p>',
+      '<span data-type="mention" data-id="notes/brief.md" data-mention-suggestion-char="@">brief.md</span> ',
+      '<span data-type="mention" data-id="brainstorming" data-mention-suggestion-char="/">brainstorming</span> ',
+      '<span data-type="mention" data-id="playwright" data-mention-suggestion-char="#">playwright</span> ',
+      '<span data-type="mention" data-id="session-123" data-mention-suggestion-char="&">Current session</span>',
+      '</p>',
+    ].join('')))
+
+    expect(markdown).toBe('@file:notes/brief.md /skill:brainstorming #mcp:playwright &session:session-123')
+  })
+})
+
 describe('Clipboard 纯文本序列化', () => {
   test('不改变 Markdown 持久化使用的段落分隔', () => {
     const markdown = withHtmlDocument(() => htmlToMarkdown('<p>第一段</p><p>第二段</p>'))

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -743,8 +743,8 @@ export interface AgentMessageSearchResult {
  * Agent 会话引用搜索输入
  */
 export interface AgentSessionReferenceSearchInput {
-  /** 当前工作区 ID，仅搜索该工作区下的会话 */
-  workspaceId: string
+  /** 可选工作区 ID；省略时搜索全部工作区中的会话。 */
+  workspaceId?: string
   /** 搜索关键词，匹配标题或消息内容 */
   query?: string
   /** 排除当前会话，避免引用自己 */


### PR DESCRIPTION
## 概述

将 Agent 输入框中分散的文件、Skill、MCP、会话与附件入口统一为键盘优先的 `/` 分层命令菜单，并修复跨工作区会话可选但发送时未注入上下文的问题。菜单保留既有 Mention 序列化协议，同时将会话正文搜索从同步输入热路径迁移为防抖后的异步 JSONL 流式检索。

## 改动

- `apps/electron/src/renderer/components/agent/agent-command-suggestion.tsx` — 新增 `/` 命令菜单，实现根级入口、Skill/MCP/会话/文件子层、键盘导航、自动滚动、文件树返回及会话搜索防抖。
- `apps/electron/src/renderer/components/agent/agent-command-menu-state.ts` 与测试 — 提供并覆盖菜单筛选、循环焦点和 slash 触发判定。
- `apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx` — 仅注册统一 slash Suggestion；为命令菜单插入的 Mention 保存类型来源，确保文件、Skill、MCP、会话 Chip 使用正确样式。
- `apps/electron/src/renderer/components/agent/AgentView.tsx` — 将模型/渠道、运行内核和发送控件固定在输入栏右侧；把附件与目录入口交由命令菜单；保留 ContextUsageBadge。
- `apps/electron/src/renderer/components/file-browser/FileMentionList.tsx` — 支持嵌入命令菜单及 ArrowLeft 返回上级。
- `apps/electron/src/main/lib/agent-session-manager.ts`、`packages/shared/src/types/agent.ts`、IPC/preload — 支持省略 workspaceId 的全局会话搜索，并将消息片段匹配改为异步 JSONL 流式读取。
- `apps/electron/src/main/lib/agent-session-context-prompt.ts` 与 `agent-orchestrator.ts` — 允许用户显式选择的跨工作区会话进入最终 referenced_sessions prompt，不再被当前工作区过滤。
- `apps/electron/src/main/lib/agent-session-manager.test.ts` 与 `markdown-rich-text.test.ts` — 覆盖跨工作区检索、prompt 注入、异步消息片段与四类 Mention 协议序列化。

## 测试方法

1. 运行 `bun test ./apps/electron/src/main/lib/agent-session-manager.test.ts ./apps/electron/src/renderer/lib/markdown-rich-text.test.ts ./apps/electron/src/renderer/components/agent/agent-command-menu-state.test.ts`。
2. 运行 `bun run --filter='@proma/electron' typecheck`。
3. 运行 `bun run --filter='@proma/electron' build`。
4. 运行 `git diff --check`。

## 备注

- 会话搜索对连续输入使用 250ms 防抖，搜索请求不会在每次按键时同步读取会话 JSONL。
- 引用格式继续使用 `@file:`、`/skill:`、`#mcp:` 和 `&session:`，不改变现有发送解析协议。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)