### PR TITLE
Fix planning auto mode deletions

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -56,6 +56,7 @@ import { buildSystemPrompt, buildDynamicContext } from './agent-prompt-builder'
 import { MAX_CONTEXT_MESSAGES, buildContextPrompt, buildRecoveryPrompt, buildReferencedSessionsPrompt } from './agent-session-context-prompt'
 import { permissionService } from './agent-permission-service'
 import type { PermissionResult, CanUseToolOptions } from './agent-permission-service'
+import { resolvePlanningDeletionPermission } from './planning-permission-policy'
 import { askUserService } from './agent-ask-user-service'
 import { exitPlanService, type ExitPlanPermissionResult } from './agent-exit-plan-service'
 import { removePromaAutoCompactSettings } from './agent-auto-compact-settings'
@@ -1434,14 +1435,6 @@ export class AgentOrchestrator {
         'mcp__planning__list_groups', 'mcp__planning__list_tags',
         'mcp__planning__list_active_reminders',
       ])
-      // 即使会话已启用 bypassPermissions，本地规划删除仍必须每次由用户确认。
-      const DESTRUCTIVE_PLANNING_TOOLS = new Set([
-        'mcp__planning__delete_todo',
-        'mcp__planning__delete_calendar_event',
-        'mcp__planning__delete_group',
-        'mcp__planning__delete_tag',
-        'mcp__planning__delete_reminder',
-      ])
       const runTriggeredBy = input.triggeredBy
 
       /** Plan 模式是否已被 Agent 进入（初始 plan 模式时天然为 true，其他模式需 EnterPlanMode 触发） */
@@ -1536,12 +1529,18 @@ export class AgentOrchestrator {
           )
         }
 
-        // 自动任务/协作子 Agent 没有可靠的本地确认界面，不能发起删除。
-        if (DESTRUCTIVE_PLANNING_TOOLS.has(toolName) && (runTriggeredBy === 'automation' || runTriggeredBy === 'delegation')) {
+        const planningDeletionPermission = resolvePlanningDeletionPermission(
+          toolName,
+          currentMode,
+          runTriggeredBy,
+        )
+        if (planningDeletionPermission === 'deny-unattended') {
           return { behavior: 'deny' as const, message: '定时任务和协作子 Agent 不能删除本地规划数据，请由用户主会话发起并确认。' }
         }
-        // 规划删除会移除用户本地数据；不纳入 bypassPermissions 的白名单语义。
-        if (currentMode !== 'plan' && DESTRUCTIVE_PLANNING_TOOLS.has(toolName)) {
+        if (planningDeletionPermission === 'allow') {
+          return { behavior: 'allow' as const, updatedInput: input }
+        }
+        if (planningDeletionPermission === 'require-single-approval') {
           return permissionService.requestSingleApproval(sessionId, toolName, input, options, (request) => {
             this.eventBus.emit(sessionId, { kind: 'proma_event', event: { type: 'permission_request', request } })
           })

--- a/apps/electron/src/main/lib/agent-permission-service.test.ts
+++ b/apps/electron/src/main/lib/agent-permission-service.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from 'bun:test'
 import { AgentPermissionService, type CanUseToolOptions } from './agent-permission-service'
 
 function permissionOptions(signal: AbortSignal, toolUseID: string): CanUseToolOptions {
-  return { signal, toolUseID, displayName: '删除 Todo', description: '删除本地 Todo' }
+  return { signal, toolUseID, displayName: '删除分组', description: '删除 Todo 分组' }
 }
 
 test('Given a destructive planning request When it is approved Then approval is single-use and cannot create a session whitelist', async () => {
@@ -12,8 +12,8 @@ test('Given a destructive planning request When it is approved Then approval is 
 
   const firstResult = service.requestSingleApproval(
     'session-1',
-    'mcp__planning__delete_todo',
-    { id: 'todo-1' },
+    'mcp__planning__delete_group',
+    { id: 'group-1', scope: 'todo' },
     permissionOptions(controller.signal, 'tool-1'),
     (request) => { firstRequest = request },
   )
@@ -24,8 +24,8 @@ test('Given a destructive planning request When it is approved Then approval is 
 
   let secondRequest: { requestId: string } | undefined
   const secondResult = service.createCanUseTool('session-1', (request) => { secondRequest = request })(
-    'mcp__planning__delete_todo',
-    { id: 'todo-2' },
+    'mcp__planning__delete_group',
+    { id: 'group-2', scope: 'todo' },
     permissionOptions(controller.signal, 'tool-2'),
   )
 

--- a/apps/electron/src/main/lib/planning-permission-policy.ts
+++ b/apps/electron/src/main/lib/planning-permission-policy.ts
@@ -1,0 +1,44 @@
+import type { AgentSendInput, PromaPermissionMode } from '@proma/shared'
+
+const PLANNING_DELETION_TOOLS = new Set([
+  'mcp__planning__delete_todo',
+  'mcp__planning__delete_calendar_event',
+  'mcp__planning__delete_group',
+  'mcp__planning__delete_tag',
+  'mcp__planning__delete_reminder',
+])
+
+// Todo 与日程条目属于用户明确指定的删除目标，完全自动模式下不再额外弹出权限审核。
+const FULLY_AUTOMATIC_PLANNING_DELETION_TOOLS = new Set([
+  'mcp__planning__delete_todo',
+  'mcp__planning__delete_calendar_event',
+])
+
+export type PlanningDeletionPermissionDecision =
+  | 'not-planning-deletion'
+  | 'allow'
+  | 'require-single-approval'
+  | 'deny-unattended'
+  | 'defer-to-plan-mode'
+
+/**
+ * 将 Planning 删除操作映射为编排层可执行的权限决策。
+ * 自动任务与协作子会话始终不能删除；计划模式则继续由只读策略拒绝。
+ */
+export function resolvePlanningDeletionPermission(
+  toolName: string,
+  permissionMode: PromaPermissionMode,
+  triggeredBy: AgentSendInput['triggeredBy'],
+): PlanningDeletionPermissionDecision {
+  if (!PLANNING_DELETION_TOOLS.has(toolName)) return 'not-planning-deletion'
+
+  if (triggeredBy === 'automation' || triggeredBy === 'delegation') {
+    return 'deny-unattended'
+  }
+
+  if (permissionMode === 'plan') return 'defer-to-plan-mode'
+
+  return FULLY_AUTOMATIC_PLANNING_DELETION_TOOLS.has(toolName)
+    ? 'allow'
+    : 'require-single-approval'
+}


### PR DESCRIPTION
## Summary

- b502e361 fix(planning): honor auto mode for todo and calendar deletions

## Test plan

- [x] `bun test apps/electron/src/main/lib/agent-permission-service.test.ts apps/electron/src/main/lib/planning-manager.test.ts`
- [x] `bun run build:main`
- [ ] 完整 typecheck（与 `origin/main` 存在相同的既有 Pi SDK 类型错误）

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)