### PR TITLE
feat(agent): 强化 Pi 内核推荐与 Claude 下线提示

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -374,9 +374,32 @@ function AgentThinkingPopover({ agentThinking, onToggle, codexConfig }: AgentThi
   )
 }
 
-const AGENT_RUNTIME_OPTIONS: Array<{ value: AgentRuntime; label: string; description: string }> = [
-  { value: 'claude', label: 'Claude', description: '使用 Claude Agent SDK' },
-  { value: 'pi', label: 'Pi', description: '使用 Pi Agent SDK' },
+interface AgentRuntimeOption {
+  value: AgentRuntime
+  label: string
+  description: string
+  badge?: string
+  badgeTone?: 'recommended' | 'deprecated'
+  notice?: string
+}
+
+// Pi 为默认与推荐内核，Claude Agent SDK 计划于 2026 年 8 月中旬彻底下线
+const AGENT_RUNTIME_OPTIONS: AgentRuntimeOption[] = [
+  {
+    value: 'pi',
+    label: 'Pi',
+    description: 'Pi Agent SDK，Proma 默认内核，新功能仅在 Pi 上提供',
+    badge: '推荐',
+    badgeTone: 'recommended',
+  },
+  {
+    value: 'claude',
+    label: 'Claude',
+    description: 'Claude Agent SDK',
+    badge: '即将下线',
+    badgeTone: 'deprecated',
+    notice: '新功能已不再支持，将于 8 月中旬彻底下线，建议尽快切换到 Pi',
+  },
 ]
 
 interface AgentRuntimeSelectorProps {
@@ -420,8 +443,9 @@ function AgentRuntimeSelector({ runtime, disabled = false, onChange }: AgentRunt
             </Button>
           </PopoverTrigger>
         </TooltipTrigger>
-        <TooltipContent side="top" className="max-w-[220px]">
+        <TooltipContent side="top" className="max-w-[240px]">
           <p className="font-medium">{current.description}</p>
+          {current.notice && <p className="mt-0.5 text-xs text-amber-600 dark:text-amber-400">{current.notice}</p>}
           <p className="mt-0.5 text-xs text-muted-foreground">
             {disabled ? 'Agent 运行中，完成后可切换' : '切换当前会话下一轮使用的内核'}
           </p>
@@ -431,7 +455,7 @@ function AgentRuntimeSelector({ runtime, disabled = false, onChange }: AgentRunt
         side="top"
         align="start"
         sideOffset={8}
-        className="w-[180px] p-1.5"
+        className="w-[248px] p-1.5"
         onOpenAutoFocus={(e) => e.preventDefault()}
       >
         <div className="flex flex-col gap-1">
@@ -452,12 +476,31 @@ function AgentRuntimeSelector({ runtime, disabled = false, onChange }: AgentRunt
                 <div className="flex w-full items-center gap-2">
                   <Box className="size-4 shrink-0 text-muted-foreground" />
                   <div className="min-w-0 flex-1">
-                    <div className="text-xs font-medium">{option.label}</div>
-                    <div className="mt-0.5 truncate text-[11px] font-normal text-muted-foreground">
+                    <div className="flex items-center gap-1.5">
+                      <span className="text-xs font-medium">{option.label}</span>
+                      {option.badge && (
+                        <span
+                          className={cn(
+                            'rounded-sm px-1 py-px text-[10px] font-medium leading-tight',
+                            option.badgeTone === 'deprecated'
+                              ? 'bg-amber-500/15 text-amber-700 dark:text-amber-400'
+                              : 'bg-primary/10 text-primary'
+                          )}
+                        >
+                          {option.badge}
+                        </span>
+                      )}
+                    </div>
+                    <div className="mt-0.5 whitespace-normal text-[11px] font-normal leading-snug text-muted-foreground">
                       {option.description}
                     </div>
+                    {option.notice && (
+                      <div className="mt-0.5 whitespace-normal text-[11px] font-normal leading-snug text-amber-600 dark:text-amber-400">
+                        {option.notice}
+                      </div>
+                    )}
                   </div>
-                  {active && <Check className="size-3.5 shrink-0" />}
+                  {active && <Check className="size-3.5 shrink-0 self-start" />}
                 </div>
               </Button>
             )

--- a/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
+++ b/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
@@ -279,9 +279,30 @@ function SaveStatusBadge({
   )
 }
 
-const AGENT_RUNTIME_OPTIONS: Array<{ value: AgentRuntime; label: string; description: string }> = [
-  { value: 'claude', label: 'Claude', description: '使用 Claude Agent SDK；模型仅限已标记为 Agent 兼容的渠道' },
-  { value: 'pi', label: 'Pi', description: '使用 Pi Agent SDK；可选择任意已启用模型渠道' },
+// Pi 为默认与推荐内核，Claude Agent SDK 计划于 2026 年 8 月中旬彻底下线
+const AGENT_RUNTIME_OPTIONS: Array<{
+  value: AgentRuntime
+  label: string
+  description: string
+  badge?: string
+  badgeTone?: 'recommended' | 'deprecated'
+  notice?: string
+}> = [
+  {
+    value: 'pi',
+    label: 'Pi',
+    description: 'Pi Agent SDK，Proma 默认内核，新功能仅在 Pi 上提供；可选择任意已启用模型渠道',
+    badge: '推荐',
+    badgeTone: 'recommended',
+  },
+  {
+    value: 'claude',
+    label: 'Claude',
+    description: 'Claude Agent SDK；模型仅限已标记为 Agent 兼容的渠道',
+    badge: '即将下线',
+    badgeTone: 'deprecated',
+    notice: '新功能已不再支持，将于 8 月中旬彻底下线，建议尽快切换到 Pi',
+  },
 ]
 
 function AutomationRuntimeSelector({
@@ -331,8 +352,27 @@ function AutomationRuntimeSelector({
               >
                 <Box className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
                 <span className="min-w-0 flex-1">
-                  <span className="block text-xs font-medium">{option.label}</span>
+                  <span className="flex items-center gap-1.5">
+                    <span className="text-xs font-medium">{option.label}</span>
+                    {option.badge && (
+                      <span
+                        className={cn(
+                          'rounded-sm px-1 py-px text-[10px] font-medium leading-tight',
+                          option.badgeTone === 'deprecated'
+                            ? 'bg-amber-500/15 text-amber-700 dark:text-amber-400'
+                            : 'bg-primary/10 text-primary',
+                        )}
+                      >
+                        {option.badge}
+                      </span>
+                    )}
+                  </span>
                   <span className="mt-0.5 block text-[11px] leading-relaxed text-muted-foreground">{option.description}</span>
+                  {option.notice && (
+                    <span className="mt-0.5 block text-[11px] leading-relaxed text-amber-600 dark:text-amber-400">
+                      {option.notice}
+                    </span>
+                  )}
                 </span>
                 {active && <Check className="mt-0.5 size-3.5 shrink-0" />}
               </button>

--- a/apps/electron/src/renderer/components/settings/ChannelSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelSettings.tsx
@@ -326,7 +326,7 @@ function AgentCoreChips({ provider }: Pick<Channel, 'provider'>): React.ReactEle
         <Badge
           variant="outline"
           className="px-1.5 py-0 text-[10px] font-medium leading-5"
-          title="Claude Agent SDK"
+          title="Claude Agent SDK（新功能不再支持，将于 8 月中旬彻底下线）"
         >
           Claude
         </Badge>
@@ -334,7 +334,7 @@ function AgentCoreChips({ provider }: Pick<Channel, 'provider'>): React.ReactEle
       <Badge
         variant="outline"
         className="px-1.5 py-0 text-[10px] font-medium leading-5"
-        title="Pi Agent SDK"
+        title="Pi Agent SDK（推荐，新功能仅在 Pi 上提供）"
       >
         Pi
       </Badge>


### PR DESCRIPTION
## 变更

Agent 输入框的内核选择器、定时任务内核选择器和渠道设置的 Agent Core 徽章统一文案，明确 Pi 是默认与推荐内核，Claude Agent SDK 即将下线。

- 选项顺序调整为 Pi 在前，与 `DEFAULT_AGENT_RUNTIME = 'pi'` 一致
- Pi 加「推荐」徽章，描述补充「新功能仅在 Pi 上提供」
- Claude 加「即将下线」徽章，提示「新功能已不再支持，将于 8 月中旬彻底下线，建议尽快切换到 Pi」
- 下拉宽度 180px → 248px，描述由 `truncate` 改为可换行，避免长文案截断
- 渠道设置徽章 hover title 同步说明

## 测试

- `tsc --noEmit`（apps/electron）通过，0 报错
- 纯文案与展示层改动，没有触及 runtime 选择逻辑

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)