### PR TITLE
fix: serialize Codex title generation

### DIFF
--- a/apps/electron/src/main/lib/adapters/pi-codex-title-generator.test.ts
+++ b/apps/electron/src/main/lib/adapters/pi-codex-title-generator.test.ts
@@ -42,7 +42,7 @@ describe('Codex OAuth 标题生成', () => {
       async complete(_model, context, options) {
         receivedPrompt = context.messages[0]?.role === 'user' ? context.messages[0].content as string : undefined
         receivedOptions = options
-        return { content: [{ type: 'text', text: 'OAuth 标题修复' }] }
+        return { content: [{ type: 'text', text: 'OAuth 标题修复' }], stopReason: 'stop' }
       },
     }
     const dispatcher = {} as Dispatcher
@@ -53,7 +53,7 @@ describe('Codex OAuth 标题生成', () => {
     expect(receivedOptions).toEqual({
       transport: 'sse',
       maxTokens: 40,
-      timeoutMs: 15_000,
+      timeoutMs: 30_000,
       maxRetries: 0,
       reasoningEffort: 'none',
       reasoningSummary: 'off',

--- a/apps/electron/src/main/lib/adapters/pi-codex-title-generator.ts
+++ b/apps/electron/src/main/lib/adapters/pi-codex-title-generator.ts
@@ -21,13 +21,14 @@ type PiSdk = typeof import('@earendil-works/pi-coding-agent')
 type CodexModel = Model<'openai-codex-responses'>
 
 const TITLE_MAX_OUTPUT_TOKENS = 40
-const TITLE_REQUEST_TIMEOUT_MS = 15_000
+const TITLE_REQUEST_TIMEOUT_MS = 30_000
 
 export interface CodexTitleGenerationInput {
   modelId: string
   prompt: string
   credentials: CodexOAuthCredentials
   proxyUrl?: string
+  signal?: AbortSignal
   onCredentialsRefreshed?: (credentials: CodexOAuthCredentials) => void | Promise<void>
 }
 
@@ -36,7 +37,7 @@ export interface CodexTitleRuntime {
     model: CodexModel,
     context: Context,
     options: OpenAICodexResponsesOptions,
-  ) => Promise<Pick<AssistantMessage, 'content'>>
+  ) => Promise<Pick<AssistantMessage, 'content' | 'stopReason' | 'errorMessage'>>
 }
 
 export interface CodexTitleRequestEnvironment {
@@ -62,6 +63,7 @@ export async function completeCodexTitleRequest(
   model: CodexModel,
   prompt: string,
   environment: CodexTitleRequestEnvironment,
+  signal?: AbortSignal,
 ): Promise<string | null> {
   try {
     environment.installRequestProxyFetch()
@@ -72,6 +74,7 @@ export async function completeCodexTitleRequest(
       },
       {
         transport: 'sse',
+        ...(signal && { signal }),
         maxTokens: TITLE_MAX_OUTPUT_TOKENS,
         timeoutMs: TITLE_REQUEST_TIMEOUT_MS,
         maxRetries: 0,
@@ -81,6 +84,10 @@ export async function completeCodexTitleRequest(
         toolChoice: 'none',
       } satisfies OpenAICodexResponsesOptions,
     ))
+
+    if (response.stopReason === 'error' || response.stopReason === 'aborted') {
+      throw new Error(response.errorMessage?.trim() || 'Codex 标题请求未完成')
+    }
 
     return extractCodexResponseText(response.content).trim() || null
   } finally {
@@ -111,5 +118,6 @@ export async function generateCodexTitle(input: CodexTitleGenerationInput): Prom
       runWithRequestProxy: runWithPiRequestProxy,
       closeRequestProxyDispatcher: closePiRequestProxyDispatcher,
     },
+    input.signal,
   )
 }

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -75,6 +75,7 @@ import { getAgentSdkMaxOutputTokens } from './agent-sdk-output-limits'
 import { resolvePiThinkingLevel } from './agent-thinking-level'
 import { resolvePiReasoningCapability } from './adapters/pi-model-registry'
 import { generateCodexTitle } from './adapters/pi-codex-title-generator'
+import { CodexTitleRequestCoordinator } from './codex-title-request-coordinator'
 import { createFallbackTitle, sanitizeGeneratedTitle, TITLE_PROMPT } from './title-generation'
 
 // ===== 类型定义 =====
@@ -389,6 +390,7 @@ export class AgentOrchestrator {
   private adapter: AgentProviderAdapter
   private eventBus: AgentEventBus
   private activeSessions = new Map<string, number>()
+  private codexTitleRequestCoordinator = new CodexTitleRequestCoordinator()
 
   /** 队列消息本地记录（sessionId → UUID 集合，用于防重） */
   private queuedMessageUuids = new Map<string, Set<string>>()
@@ -577,8 +579,9 @@ export class AgentOrchestrator {
    *
    * 使用 Provider 适配器系统，支持所有渠道。任何错误返回 null。
    */
-  async generateTitle(input: AgentGenerateTitleInput): Promise<string | null> {
+  async generateTitle(input: AgentGenerateTitleInput, signal?: AbortSignal): Promise<string | null> {
     const { userMessage, channelId, modelId } = input
+    if (signal?.aborted) return null
     console.log('[Agent 标题生成] 开始生成标题:', { channelId, modelId, userMessage: userMessage.slice(0, 50) })
 
     try {
@@ -596,13 +599,16 @@ export class AgentOrchestrator {
             resolveCodexOAuthCredentials(channelId),
             getEffectiveProxyUrl(),
           ])
+          if (signal?.aborted) return null
           const generatedTitle = await generateCodexTitle({
             modelId,
             prompt: TITLE_PROMPT + userMessage,
             credentials,
             proxyUrl,
+            signal,
             onCredentialsRefreshed: (refreshed) => persistCodexOAuthCredentials(channelId, refreshed),
           })
+          if (signal?.aborted) return null
           const title = generatedTitle ? sanitizeGeneratedTitle(generatedTitle) : null
           if (title) {
             console.log(`[Agent 标题生成] ChatGPT OAuth 语义标题生成成功: "${title}"`)
@@ -610,6 +616,7 @@ export class AgentOrchestrator {
           }
           console.warn('[Agent 标题生成] ChatGPT OAuth 返回空标题，使用本地兜底')
         } catch (error) {
+          if (signal?.aborted) return null
           console.warn('[Agent 标题生成] ChatGPT OAuth 语义标题生成失败，使用本地兜底:', error)
         }
         return fallbackTitle
@@ -653,18 +660,25 @@ export class AgentOrchestrator {
     channelId: string,
     modelId: string,
     callbacks: SessionCallbacks,
+    signal?: AbortSignal,
   ): Promise<void> {
+    if (signal?.aborted) return
     try {
       const meta = getAgentSessionMeta(sessionId)
       if (!meta || meta.title !== DEFAULT_SESSION_TITLE) return
 
-      const title = await this.generateTitle({ userMessage, channelId, modelId })
-      if (!title) return
+      const title = await this.generateTitle({ userMessage, channelId, modelId }, signal)
+      if (!title || signal?.aborted) return
+
+      // 标题请求是异步的；请求期间用户可能已手动重命名，不能用旧结果覆盖。
+      const latestMeta = getAgentSessionMeta(sessionId)
+      if (!latestMeta || latestMeta.title !== DEFAULT_SESSION_TITLE) return
 
       updateAgentSessionMeta(sessionId, { title })
       callbacks.onTitleUpdated(title)
       console.log(`[Agent 编排] 自动标题生成完成: "${title}"`)
     } catch (error) {
+      if (signal?.aborted) return
       console.warn('[Agent 编排] 自动标题生成失败:', error)
     }
   }
@@ -1045,14 +1059,22 @@ export class AgentOrchestrator {
     // finally 块会通过 generation 匹配来安全清理，不影响正常流程
     const runGeneration = Date.now()
     this.activeSessions.set(sessionId, runGeneration)
+    const usesCodexOAuth = channel.provider === 'openai-codex'
+    let codexForegroundRunActive = false
 
     const releaseActiveRun = (): void => {
       // 在发送 STREAM_COMPLETE 前释放 active slot，避免渲染进程已进入空闲态、
       // 主进程仍在 finally 前短暂拒绝下一条消息。
-      if (this.activeSessions.get(sessionId) !== runGeneration) return
-      this.activeSessions.delete(sessionId)
-      this.sessionPermissionModes.delete(sessionId)
-      this.queuedMessageUuids.delete(sessionId)
+      const ownsActiveRun = this.activeSessions.get(sessionId) === runGeneration
+      if (ownsActiveRun) {
+        this.activeSessions.delete(sessionId)
+        this.sessionPermissionModes.delete(sessionId)
+        this.queuedMessageUuids.delete(sessionId)
+      }
+      if (codexForegroundRunActive) {
+        codexForegroundRunActive = false
+        this.codexTitleRequestCoordinator.endForeground(channelId)
+      }
     }
     const completeRun = (
       messages?: AgentMessage[],
@@ -1132,6 +1154,12 @@ export class AgentOrchestrator {
     let workspace: import('@proma/shared').AgentWorkspace | undefined
 
     try {
+      if (usesCodexOAuth) {
+        codexForegroundRunActive = true
+        await this.codexTitleRequestCoordinator.beginForeground(channelId)
+        if (this.activeSessions.get(sessionId) !== runGeneration) return
+      }
+
       const sdk = agentRuntime === 'claude' ? await import('@anthropic-ai/claude-agent-sdk') : undefined
       const cliPath = agentRuntime === 'claude' ? resolveSDKCliPath() : undefined
 
@@ -1623,6 +1651,20 @@ export class AgentOrchestrator {
         collaborationAvailable,
         currentModelId: selectedModelId,
       }) + (automationContext ? `\n\n## 定时任务执行上下文\n\n${automationContext}` : '')
+      const startAutoTitleGeneration = (): void => {
+        if (titleGenerationStarted) return
+        titleGenerationStarted = true
+
+        if (channel.provider === 'openai-codex') {
+          this.codexTitleRequestCoordinator.enqueue(channelId, (signal) =>
+            this.autoGenerateTitle(sessionId, userMessage, channelId, resolvedModel, callbacks, signal),
+          )
+          return
+        }
+
+        this.autoGenerateTitle(sessionId, userMessage, channelId, resolvedModel, callbacks)
+          .catch((err) => console.error('[Agent 编排] 标题生成未捕获异常:', err))
+      }
       const handleSessionId = (sdkSessionId: string, piSessionFile?: string): void => {
         // 仅在 session_id 真正变化时才持久化。SDK v2 几乎每条消息都会回调 onSessionId，
         // capturedSdkSessionId 已初始化为 existingSdkSessionId，并在 recovery 时同步重置。
@@ -1641,10 +1683,10 @@ export class AgentOrchestrator {
           }
         }
 
-        if (!titleGenerationStarted) {
-          titleGenerationStarted = true
-          this.autoGenerateTitle(sessionId, userMessage, channelId, resolvedModel, callbacks)
-            .catch((err) => console.error('[Agent 编排] 标题生成未捕获异常:', err))
+        // Codex OAuth 标题会额外占用订阅请求通道，等待主 Agent 请求结束再发起，
+        // 避免在 session.prompt() 前与主请求竞争同一通道。
+        if (channel.provider !== 'openai-codex') {
+          startAutoTitleGeneration()
         }
       }
       const handleModelResolved = (model: string): void => {
@@ -2270,6 +2312,10 @@ export class AgentOrchestrator {
           // 发送完成信号
           completeRun(getAgentSessionMessages(sessionId), { stoppedByUser: wasStoppedByUser, startedAt: streamStartedAt, resultSubtype: capturedResultSubtype, resultErrors: capturedResultErrors })
 
+          if (!wasStoppedByUser && channel.provider === 'openai-codex') {
+            startAutoTitleGeneration()
+          }
+
           break  // 成功完成，退出重试循环
 
         } catch (error) {
@@ -2664,6 +2710,7 @@ export class AgentOrchestrator {
       console.log(`[Agent 编排] 正在中止所有活跃会话 (${this.activeSessions.size} 个)...`)
     }
     // 即便 activeSessions 为空，也要调 dispose 清理可能残留的 pidMap / 子进程
+    this.codexTitleRequestCoordinator.dispose()
     this.adapter.dispose()
     this.activeSessions.clear()
     this.sessionPermissionModes.clear()

--- a/apps/electron/src/main/lib/codex-title-request-coordinator.ts
+++ b/apps/electron/src/main/lib/codex-title-request-coordinator.ts
@@ -1,0 +1,86 @@
+export type CodexTitleJob = (signal: AbortSignal) => Promise<void>
+
+interface ActiveCodexTitleJob {
+  controller: AbortController
+  completion: Promise<void>
+}
+
+/**
+ * Keeps low-priority title requests out of the way of foreground Codex runs.
+ * Requests are serialized per configured OAuth channel.
+ */
+export class CodexTitleRequestCoordinator {
+  private readonly foregroundRuns = new Map<string, number>()
+  private readonly queuedJobs = new Map<string, CodexTitleJob[]>()
+  private readonly activeJobs = new Map<string, ActiveCodexTitleJob>()
+
+  async beginForeground(channelId: string): Promise<void> {
+    this.foregroundRuns.set(channelId, (this.foregroundRuns.get(channelId) ?? 0) + 1)
+
+    const active = this.activeJobs.get(channelId)
+    if (!active) return
+
+    active.controller.abort()
+    await active.completion
+  }
+
+  endForeground(channelId: string): void {
+    const current = this.foregroundRuns.get(channelId)
+    if (!current) return
+
+    if (current === 1) {
+      this.foregroundRuns.delete(channelId)
+      this.startNext(channelId)
+      return
+    }
+
+    this.foregroundRuns.set(channelId, current - 1)
+  }
+
+  enqueue(channelId: string, job: CodexTitleJob): void {
+    const queue = this.queuedJobs.get(channelId) ?? []
+    queue.push(job)
+    this.queuedJobs.set(channelId, queue)
+    this.startNext(channelId)
+  }
+
+  dispose(): void {
+    for (const active of this.activeJobs.values()) {
+      active.controller.abort()
+    }
+    this.activeJobs.clear()
+    this.queuedJobs.clear()
+    this.foregroundRuns.clear()
+  }
+
+  private startNext(channelId: string): void {
+    if (this.foregroundRuns.has(channelId) || this.activeJobs.has(channelId)) return
+
+    const queue = this.queuedJobs.get(channelId)
+    const job = queue?.shift()
+    if (!job) {
+      this.queuedJobs.delete(channelId)
+      return
+    }
+    if (!queue?.length) this.queuedJobs.delete(channelId)
+
+    const controller = new AbortController()
+    let active: ActiveCodexTitleJob
+    const completion = Promise.resolve()
+      .then(() => job(controller.signal))
+      .catch((error: unknown) => {
+        if (!controller.signal.aborted) {
+          console.warn('[Codex 标题] 低优先级请求失败:', error)
+        }
+      })
+      .finally(() => {
+        if (this.activeJobs.get(channelId) === active) {
+          this.activeJobs.delete(channelId)
+          this.startNext(channelId)
+        }
+      })
+
+    active = { controller, completion }
+    this.activeJobs.set(channelId, active)
+  }
+}


### PR DESCRIPTION
## Summary

- Defer Codex title generation until the foreground run has completed.
- Serialize low-priority title requests per Codex OAuth channel and cancel them when a foreground request begins.
- Surface structured Pi failures and avoid title writes after cancellation or manual renames.

## Validation

- Not run per request.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)