### PR TITLE
fix(automation): 独立窗口编辑界面增加顶部间距避免与红绿灯冲突

### DIFF
--- a/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
+++ b/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
@@ -384,7 +384,7 @@ function AutomationRuntimeSelector({
   )
 }
 
-export function AutomationFormView(): React.ReactElement | null {
+export function AutomationFormView({ standalone = false }: { standalone?: boolean } = {}): React.ReactElement | null {
   const isWindows = React.useMemo(() => detectIsWindows(), [])
   const [formState, setFormState] = useAtom(automationFormAtom)
   const setAutomations = useSetAtom(automationsAtom)
@@ -717,7 +717,7 @@ export function AutomationFormView(): React.ReactElement | null {
     <div className="titlebar-no-drag absolute inset-0 z-10 bg-content-area flex animate-in fade-in duration-200">
       {/* 左栏：自然语言任务描述（主角） */}
       <div className="flex-1 min-w-0 flex flex-col">
-        <div className="flex items-center gap-2 px-6 py-4 flex-shrink-0">
+        <div className={cn('flex items-center gap-2 px-6 flex-shrink-0', standalone ? 'titlebar-drag-region pt-8 pb-4' : 'py-4')}>
           <button
             type="button"
             onClick={close}
@@ -729,7 +729,7 @@ export function AutomationFormView(): React.ReactElement | null {
           </button>
           <Clock className="size-4 text-primary flex-shrink-0" />
           {editingName ? (
-            <div className="flex items-center gap-1.5 flex-1 min-w-0">
+            <div className="titlebar-no-drag flex items-center gap-1.5 flex-1 min-w-0">
               <input
                 ref={nameInputRef}
                 value={form.name}
@@ -750,7 +750,7 @@ export function AutomationFormView(): React.ReactElement | null {
               </button>
             </div>
           ) : (
-            <div className="flex items-center gap-1.5 flex-1 min-w-0">
+            <div className="titlebar-no-drag flex items-center gap-1.5 flex-1 min-w-0">
               <span className="truncate text-sm font-semibold text-foreground">
                 {form.name.trim() || (isEdit ? '未命名任务' : '新建定时任务')}
               </span>
@@ -795,7 +795,7 @@ export function AutomationFormView(): React.ReactElement | null {
 
       {/* 右栏：配置 sidebar */}
       <div className="w-[340px] flex-shrink-0 border-l border-border/50 flex flex-col bg-content-area">
-        <div className="flex items-center justify-between gap-2 px-4 py-4 flex-shrink-0">
+        <div className={cn('flex items-center justify-between gap-2 px-4 flex-shrink-0', standalone ? 'titlebar-drag-region pt-8 pb-4' : 'py-4')}>
           <span className="text-sm font-semibold text-foreground">配置</span>
           <div className="flex items-center gap-1">
             {!isWindows && (

--- a/apps/electron/src/renderer/components/planning/PlanningWindowApp.tsx
+++ b/apps/electron/src/renderer/components/planning/PlanningWindowApp.tsx
@@ -13,5 +13,5 @@ export function PlanningWindowApp(): React.ReactElement {
     document.title = 'Proma · 规划中心'
   }, [])
 
-  return <TooltipProvider delayDuration={200}><div className="h-screen overflow-hidden bg-content-area">{automationFormOpen ? <AutomationFormView /> : <PlanningView standalone />}</div></TooltipProvider>
+  return <TooltipProvider delayDuration={200}><div className="h-screen overflow-hidden bg-content-area">{automationFormOpen ? <AutomationFormView standalone /> : <PlanningView standalone />}</div></TooltipProvider>
 }


### PR DESCRIPTION
## 问题

定时任务在独立窗口（规划中心）中打开编辑界面时，左右两栏的顶部内容只有 `py-4`（16px）的间距，与 macOS 窗口红绿灯按钮（位于 y=18，延伸至约 y=36）发生重叠。Windows 上 hidden titlebar 同样需要顶部空间。

## 修复

为 `AutomationFormView` 添加 `standalone` prop（默认 `false`，不影响主窗口）：

- **standalone 模式下**，左右栏 header 从 `py-4` 改为 `pt-8 pb-4`（32px 顶部间距），与 `PlanningView` standalone 模式一致
- 添加 `titlebar-drag-region` 使顶部区域可拖拽移动窗口
- 为 header 内的交互元素（任务名称编辑/显示容器）添加 `titlebar-no-drag`，确保拖拽区域内按钮/输入框仍可正常点击

## 改动文件

- `AutomationFormView.tsx`：添加 `standalone` prop + 条件 padding 和 drag region
- `PlanningWindowApp.tsx`：传递 `standalone` prop

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)