### PR TITLE
feat: add session hover preview toggle and remove auto file reveal

### DIFF
--- a/apps/electron/src/renderer/atoms/ui-preferences.ts
+++ b/apps/electron/src/renderer/atoms/ui-preferences.ts
@@ -17,6 +17,9 @@ export const longTextPasteAsAttachmentEnabledAtom = atom<boolean>(false)
 /** 输入框是否渲染 Markdown 富文本格式（默认关闭，纯文本模式；开启后渲染富文本，仍保留 Mention 引用） */
 export const richTextRenderingEnabledAtom = atom<boolean>(false)
 
+/** 左侧会话列表悬浮预览迷你地图（默认关闭，需手动开启） */
+export const sessionHoverPreviewEnabledAtom = atom<boolean>(false)
+
 // ===== 初始化 =====
 
 /**
@@ -25,13 +28,15 @@ export const richTextRenderingEnabledAtom = atom<boolean>(false)
 export async function initializeUiPreferences(
   setStickyUserMessageEnabled: (enabled: boolean) => void,
   setLongTextPasteAsAttachmentEnabled?: (enabled: boolean) => void,
-  setRichTextRenderingEnabled?: (enabled: boolean) => void
+  setRichTextRenderingEnabled?: (enabled: boolean) => void,
+  setSessionHoverPreviewEnabled?: (enabled: boolean) => void
 ): Promise<void> {
   try {
     const settings = await window.electronAPI.getSettings()
     setStickyUserMessageEnabled(settings.stickyUserMessageEnabled ?? true)
     setLongTextPasteAsAttachmentEnabled?.(settings.longTextPasteAsAttachmentEnabled ?? false)
     setRichTextRenderingEnabled?.(settings.richTextRenderingEnabled ?? false)
+    setSessionHoverPreviewEnabled?.(settings.sessionHoverPreviewEnabled ?? false)
   } catch (error) {
     console.error('[UI偏好] 初始化失败:', error)
   }
@@ -69,5 +74,16 @@ export async function updateRichTextRenderingEnabled(enabled: boolean): Promise<
     await window.electronAPI.updateSettings({ richTextRenderingEnabled: enabled })
   } catch (error) {
     console.error('[UI偏好] 更新输入框 Markdown 渲染设置失败:', error)
+  }
+}
+
+/**
+ * 更新左侧会话悬浮预览开关并持久化
+ */
+export async function updateSessionHoverPreviewEnabled(enabled: boolean): Promise<void> {
+  try {
+    await window.electronAPI.updateSettings({ sessionHoverPreviewEnabled: enabled })
+  } catch (error) {
+    console.error('[UI偏好] 更新会话悬浮预览设置失败:', error)
   }
 }

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -361,42 +361,6 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   // Files 将会话与项目文件放在同一视图；FileBrowser 自己处理对应根目录的自动定位。
   // RightSidePanel 完全由用户控制，不因 Agent 文件变更自动打开。
 
-  // Agent 写文件时把已打开的侧栏切回文件视图，让 FileBrowser 消费定位/高亮信号。
-  // 用户从搜索结果选择文件时不抢占当前视图，也不重新打开用户主动关闭的侧栏。
-  const autoRevealSignal = useAtomValue(fileBrowserAutoRevealAtom)
-  const consumedTabRevealTsRef = React.useRef(0)
-  React.useEffect(() => {
-    if (!isOpen || !autoRevealSignal || autoRevealSignal.select) return
-    if (autoRevealSignal.sessionId !== sessionId) return
-    if (autoRevealSignal.ts <= consumedTabRevealTsRef.current) return
-
-    const targetPath = autoRevealSignal.path
-    const belongsToSession =
-      (!!sessionPath && (targetPath === sessionPath || isPathUnderRoot(sessionPath, targetPath)))
-      || attachedDirs.some((dir) => isPathUnderRoot(dir, targetPath))
-      || attachedFiles.includes(targetPath)
-    const belongsToProject =
-      (!!workspaceFilesPath && (targetPath === workspaceFilesPath || isPathUnderRoot(workspaceFilesPath, targetPath)))
-      || wsAttachedDirs.some((dir) => isPathUnderRoot(dir, targetPath))
-      || wsAttachedFiles.includes(targetPath)
-    if (!belongsToSession && !belongsToProject) return
-
-    consumedTabRevealTsRef.current = autoRevealSignal.ts
-    if (activeTab !== 'files') onTabChange('files')
-  }, [
-    activeTab,
-    attachedDirs,
-    attachedFiles,
-    autoRevealSignal,
-    isOpen,
-    onTabChange,
-    sessionId,
-    sessionPath,
-    workspaceFilesPath,
-    wsAttachedDirs,
-    wsAttachedFiles,
-  ])
-
   // 同步 basePaths ref（供 handleFilePreview 使用，避免 hooks 声明顺序问题）
   basePathsRef.current = [sessionPath, workspaceFilesPath, ...fileAccessPathsMemo].filter(Boolean) as string[]
   const hasSessionAttachedItems = attachedDirs.length > 0 || attachedFiles.length > 0

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -85,6 +85,7 @@ import { interfaceVariantAtom } from '@/atoms/theme'
 import { useCreateSession } from '@/hooks/useCreateSession'
 import { useOpenSession } from '@/hooks/useOpenSession'
 import { useSyncActiveTabSideEffects } from '@/hooks/useSyncActiveTabSideEffects'
+import { sessionHoverPreviewEnabledAtom } from '@/atoms/ui-preferences'
 import { CollapsedWorkspacePopover } from '@/components/agent/CollapsedWorkspacePopover'
 import { LocalProjectBadge } from '@/components/agent/LocalProjectBadge'
 import { MoveSessionDialog } from '@/components/agent/MoveSessionDialog'
@@ -613,11 +614,13 @@ interface RailRecentItem {
 function RailRecentButton({
   item,
   onSelect,
+  miniMapDisabled,
 }: {
   item: RailRecentItem
   onSelect: (item: RailRecentItem) => void
+  miniMapDisabled?: boolean
 }): React.ReactElement {
-  const preview = useSessionMiniMapHover()
+  const preview = useSessionMiniMapHover(600, miniMapDisabled)
 
   return (
     <>
@@ -755,6 +758,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
   const hasEnvironmentIssues = useAtomValue(hasEnvironmentIssuesAtom)
   const interfaceVariant = useAtomValue(interfaceVariantAtom)
   const isClassic = interfaceVariant === 'classic'
+  const sessionHoverPreviewEnabled = useAtomValue(sessionHoverPreviewEnabledAtom)
 
   // Agent 模式状态
   const [agentSessions, setAgentSessions] = useAtom(agentSessionsAtom)
@@ -2599,6 +2603,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
               <RailRecentButton
                 key={`${item.type}-${item.id}`}
                 item={item}
+                miniMapDisabled={!sessionHoverPreviewEnabled}
                 onSelect={(selected) => {
                   if (selected.type === 'agent') {
                     handleSelectAgentSession(selected.id, selected.title)
@@ -2833,6 +2838,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
                             active={treeActive}
                             indicatorStatus={rowStatus}
                             showPinIcon={false}
+                            disableMiniMap={!sessionHoverPreviewEnabled}
                             delegationSummary={childCount > 0
                               ? {
                                 total: childCount,
@@ -3051,6 +3057,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
                             active={treeActive}
                             indicatorStatus={rowStatus}
                             showPinIcon={!!item.session.pinned}
+                            disableMiniMap={!sessionHoverPreviewEnabled}
                             delegationSummary={childCount > 0
                               ? {
                                 total: childCount,
@@ -3439,13 +3446,14 @@ const ConversationItem = React.memo(function ConversationItem({
   onTogglePin,
   onToggleArchive,
 }: ConversationItemProps): React.ReactElement {
+  const sessionHoverPreviewEnabled = useAtomValue(sessionHoverPreviewEnabledAtom)
   const [editing, setEditing] = React.useState(false)
   const [editTitle, setEditTitle] = React.useState('')
   const [menuOpen, setMenuOpen] = React.useState(false)
   const inputRef = React.useRef<HTMLInputElement>(null)
   const justStartedEditing = React.useRef(false)
   // 菜单打开时关闭迷你地图预览，避免预览面板盖住菜单项导致点不动
-  const preview = useSessionMiniMapHover(600, menuOpen)
+  const preview = useSessionMiniMapHover(600, !sessionHoverPreviewEnabled || menuOpen)
   const interfaceVariant = useAtomValue(interfaceVariantAtom)
   const isClassic = interfaceVariant === 'classic'
 
@@ -3592,18 +3600,20 @@ const ConversationItem = React.memo(function ConversationItem({
       <ContextMenuContent className="w-40 z-[9999] min-w-0 p-0.5">
         {menuItems(ContextMenuItem, ContextMenuSeparator)}
       </ContextMenuContent>
-      <SessionMiniMapPopover
-        target={{
-          type: 'chat',
-          sessionId: conversation.id,
-          title: conversation.title,
-        }}
-        anchorRef={preview.anchorRef}
-        open={preview.isOpen}
-        isLeaving={preview.isLeaving}
-        onMouseEnter={preview.handlePanelMouseEnter}
-        onMouseLeave={preview.handlePanelMouseLeave}
-      />
+      {sessionHoverPreviewEnabled && (
+        <SessionMiniMapPopover
+          target={{
+            type: 'chat',
+            sessionId: conversation.id,
+            title: conversation.title,
+          }}
+          anchorRef={preview.anchorRef}
+          open={preview.isOpen}
+          isLeaving={preview.isLeaving}
+          onMouseEnter={preview.handlePanelMouseEnter}
+          onMouseLeave={preview.handlePanelMouseLeave}
+        />
+      )}
     </ContextMenu>
   )
 })
@@ -3991,6 +4001,7 @@ const DelegatedChildSessionItem = React.memo(function DelegatedChildSessionItem(
   onToggleStar,
   onToggleArchive,
 }: DelegatedChildSessionItemProps): React.ReactElement {
+  const sessionHoverPreviewEnabled = useAtomValue(sessionHoverPreviewEnabledAtom)
   const status = getDelegatedChildStatus(session, agentIndicatorMap)
 
   return (
@@ -3998,6 +4009,7 @@ const DelegatedChildSessionItem = React.memo(function DelegatedChildSessionItem(
       session={session}
       active={session.id === activeSessionId}
       indicatorStatus={status}
+      disableMiniMap={!sessionHoverPreviewEnabled}
       relativeTimeNow={relativeTimeNow}
       workspaceName={workspaceName}
       onSelect={onSelect}
@@ -4097,6 +4109,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
 }: AgentProjectGroupItemProps): React.ReactElement {
   const isCurrent = group.workspace.id === currentWorkspaceId
   const newSessionShortcutLabel = getAcceleratorDisplay(getActiveAccelerator('new-session'))
+  const sessionHoverPreviewEnabled = useAtomValue(sessionHoverPreviewEnabledAtom)
   const hasUnavailableProjectRoot = Boolean(
     group.workspace.projectRootPath
     && group.workspace.projectRootStatus
@@ -4411,6 +4424,7 @@ const AgentProjectGroupItem = React.memo(function AgentProjectGroupItem({
                       active={treeActive}
                       indicatorStatus={rowStatus}
                       showPinIcon={!!item.session.pinned}
+                      disableMiniMap={!sessionHoverPreviewEnabled}
                       delegationSummary={childCount > 0
                         ? {
                           total: childCount,

--- a/apps/electron/src/renderer/components/app-shell/SearchDialog.tsx
+++ b/apps/electron/src/renderer/components/app-shell/SearchDialog.tsx
@@ -31,6 +31,7 @@ import {
 import { activeViewAtom } from '@/atoms/active-view'
 import { useOpenSession } from '@/hooks/useOpenSession'
 import { useCreateSession } from '@/hooks/useCreateSession'
+import { sessionHoverPreviewEnabledAtom } from '@/atoms/ui-preferences'
 import {
   SessionMiniMapPopover,
   useSessionMiniMapHover,
@@ -131,6 +132,7 @@ interface SearchResultRowProps {
   index: number
   isSelected: boolean
   committedQuery: string
+  miniMapDisabled?: boolean
   getAgentWorkspaceName: (sessionId: string) => string | undefined
   onSelect: (result: SearchResult) => void
   onHover: (index: number) => void
@@ -141,11 +143,12 @@ function SearchResultRow({
   index,
   isSelected,
   committedQuery,
+  miniMapDisabled,
   getAgentWorkspaceName,
   onSelect,
   onHover,
 }: SearchResultRowProps): React.ReactElement {
-  const preview = useSessionMiniMapHover(400)
+  const preview = useSessionMiniMapHover(400, miniMapDisabled)
   const isContent = isContentResult(result)
   const wsName = result.type === 'agent' ? getAgentWorkspaceName(result.id) : undefined
 
@@ -214,6 +217,7 @@ export function SearchDialog(): React.ReactElement {
   const [open, setOpen] = useAtom(searchDialogOpenAtom)
   const conversations = useAtomValue(conversationsAtom)
   const agentSessions = useAtomValue(agentSessionsAtom)
+  const sessionHoverPreviewEnabled = useAtomValue(sessionHoverPreviewEnabledAtom)
   const agentWorkspaces = useAtomValue(agentWorkspacesAtom)
   const channels = useAtomValue(channelsAtom)
   const currentAgentChannelId = useAtomValue(agentChannelIdAtom)
@@ -577,6 +581,7 @@ export function SearchDialog(): React.ReactElement {
                   index={idx}
                   isSelected={selectedIndex === idx}
                   committedQuery={committedQuery}
+                  miniMapDisabled={!sessionHoverPreviewEnabled}
                   getAgentWorkspaceName={getAgentWorkspaceName}
                   onSelect={navigateToResult}
                   onHover={setSelectedIndex}
@@ -599,6 +604,7 @@ export function SearchDialog(): React.ReactElement {
                   index={titleResults.length + i}
                   isSelected={selectedIndex === titleResults.length + i}
                   committedQuery={committedQuery}
+                  miniMapDisabled={!sessionHoverPreviewEnabled}
                   getAgentWorkspaceName={getAgentWorkspaceName}
                   onSelect={navigateToResult}
                   onHover={setSelectedIndex}

--- a/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
@@ -544,7 +544,6 @@ function FileTreeItem({
   const [expanded, setExpanded] = React.useState(false)
   const [children, setChildren] = React.useState<ScopedFileEntry[]>([])
   const [childrenLoaded, setChildrenLoaded] = React.useState(false)
-  const [flash, setFlash] = React.useState(false)
   const rowRef = React.useRef<HTMLDivElement>(null)
   const supportsTerminalFolderOpen = typeof navigator !== 'undefined' && navigator.userAgent.includes('Mac')
 
@@ -598,20 +597,10 @@ function FileTreeItem({
       cleanups.push(() => { cancelled = true })
     }
 
-    // 目标行：滚动到可视区中心 + 高亮脉冲
+    // 目标行：滚动到可视区中心
     if (isTarget) {
       // 仅在不会通过展开分支异步滚动时立即滚动（即：目标是文件，或已展开的目录）
       if (!willExpand) scrollToTarget()
-      // 用户搜索点击场景（revealSelect=true）会同步把目标置为选中态，
-      // flash 动画末关键帧的 transparent 背景会盖掉 bg-accent，造成"先闪一下再变选中"的视觉断层，
-      // 因此该路径跳过 flash，仅保留滚动 + 选中态。Agent 自动定位（无 select）仍走 flash。
-      // 注意：不要改 globals.css 里 .file-browser-row-flash 末关键帧的 transparent，那是 Agent
-      // 路径下"动画结束行恢复无背景"的预期行为；选中态冲突应由本分支跳过 class 解决。
-      if (!revealSelect) {
-        setFlash(true)
-        const t = setTimeout(() => setFlash(false), 1200)
-        cleanups.push(() => clearTimeout(t))
-      }
     }
 
     if (cleanups.length > 0) return () => { for (const c of cleanups) c() }
@@ -778,7 +767,6 @@ function FileTreeItem({
               : isSticky
                 ? 'group-hover:bg-accent'
                 : 'group-hover:bg-accent/50',
-            flash && 'file-browser-row-flash',
           )}
         />
         {/* sticky 行祖先链竖线，逻辑见 tree-row-layout.tsx 的 AncestorGuides */}

--- a/apps/electron/src/renderer/components/settings/GeneralSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/GeneralSettings.tsx
@@ -41,9 +41,11 @@ import {
   longTextPasteAsAttachmentEnabledAtom,
   richTextRenderingEnabledAtom,
   stickyUserMessageEnabledAtom,
+  sessionHoverPreviewEnabledAtom,
   updateLongTextPasteAsAttachmentEnabled,
   updateRichTextRenderingEnabled,
   updateStickyUserMessageEnabled,
+  updateSessionHoverPreviewEnabled,
 } from '@/atoms/ui-preferences'
 import { cn } from '@/lib/utils'
 import { Button } from '../ui/button'
@@ -67,6 +69,7 @@ export function GeneralSettings(): React.ReactElement {
   const [stickyUserMessageEnabled, setStickyUserMessageEnabled] = useAtom(stickyUserMessageEnabledAtom)
   const [longTextPasteAsAttachmentEnabled, setLongTextPasteAsAttachmentEnabled] = useAtom(longTextPasteAsAttachmentEnabledAtom)
   const [richTextRenderingEnabled, setRichTextRenderingEnabled] = useAtom(richTextRenderingEnabledAtom)
+  const [sessionHoverPreviewEnabled, setSessionHoverPreviewEnabled] = useAtom(sessionHoverPreviewEnabledAtom)
   const [isEditingName, setIsEditingName] = React.useState(false)
   const [nameInput, setNameInput] = React.useState(userProfile.userName)
   const [showEmojiPicker, setShowEmojiPicker] = React.useState(false)
@@ -365,6 +368,15 @@ export function GeneralSettings(): React.ReactElement {
             onCheckedChange={(checked) => {
               setRichTextRenderingEnabled(checked)
               updateRichTextRenderingEnabled(checked)
+            }}
+          />
+          <SettingsToggle
+            label="会话悬浮预览"
+            description="鼠标悬停在左侧会话列表项上时，弹出会话内容迷你地图预览"
+            checked={sessionHoverPreviewEnabled}
+            onCheckedChange={(checked) => {
+              setSessionHoverPreviewEnabled(checked)
+              updateSessionHoverPreviewEnabled(checked)
             }}
           />
           <SettingsToggle

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -20,7 +20,6 @@ import {
   allPendingExitPlanRequestsAtom,
   agentPromptSuggestionsAtom,
   backgroundTasksAtomFamily,
-  fileBrowserAutoRevealAtom,
   recentlyModifiedPathsAtom,
   RECENTLY_MODIFIED_TTL_MS,
   applyAgentEvent,
@@ -833,7 +832,7 @@ export function useGlobalAgentListeners(): void {
 
           // RightSidePanel 由用户完全控制，Agent 行为不影响其开关状态
 
-          // Agent 修改文件时，触发右侧文件浏览器自动定位（展开父目录 + 滚动 + 高亮）
+          // Agent 修改文件时，记入「最近修改」状态，用于 60s 内左侧竖条标记
           if (event.type === 'tool_start' && WRITE_TOOLS.has(event.toolName)) {
             const input = event.input as Record<string, unknown> | undefined
             const targetPath =
@@ -843,8 +842,7 @@ export function useGlobalAgentListeners(): void {
             pendingWriteTools.set(event.toolUseId, { path: targetPath || '', sessionId })
             if (typeof targetPath === 'string' && targetPath.length > 0) {
               const now = Date.now()
-              store.set(fileBrowserAutoRevealAtom, { sessionId, path: targetPath, ts: now })
-              // 同时记入「最近修改」状态，用于 60s 内左侧竖条标记
+              // 记入「最近修改」状态，用于 60s 内左侧竖条标记
               store.set(recentlyModifiedPathsAtom, (prev) => {
                 const map = new Map(prev)
                 const inner = new Map(map.get(sessionId) ?? new Map())

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -56,6 +56,7 @@ import {
   stickyUserMessageEnabledAtom,
   longTextPasteAsAttachmentEnabledAtom,
   richTextRenderingEnabledAtom,
+  sessionHoverPreviewEnabledAtom,
   initializeUiPreferences,
 } from './atoms/ui-preferences'
 import {
@@ -514,14 +515,16 @@ function UiPreferencesInitializer(): null {
   const setStickyUserMessageEnabled = useSetAtom(stickyUserMessageEnabledAtom)
   const setLongTextPasteAsAttachmentEnabled = useSetAtom(longTextPasteAsAttachmentEnabledAtom)
   const setRichTextRenderingEnabled = useSetAtom(richTextRenderingEnabledAtom)
+  const setSessionHoverPreviewEnabled = useSetAtom(sessionHoverPreviewEnabledAtom)
 
   useEffect(() => {
     initializeUiPreferences(
       setStickyUserMessageEnabled,
       setLongTextPasteAsAttachmentEnabled,
-      setRichTextRenderingEnabled
+      setRichTextRenderingEnabled,
+      setSessionHoverPreviewEnabled
     )
-  }, [setStickyUserMessageEnabled, setLongTextPasteAsAttachmentEnabled, setRichTextRenderingEnabled])
+  }, [setStickyUserMessageEnabled, setLongTextPasteAsAttachmentEnabled, setRichTextRenderingEnabled, setSessionHoverPreviewEnabled])
 
   return null
 }

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -1556,24 +1556,6 @@
   content: none;
 }
 
-/* ===== FileBrowser 自动定位的高亮脉冲 =====
- * 末关键帧用 transparent 是故意的：Agent 自动 reveal（select=false）一行不进入选中态，
- * 动画结束后行需要恢复无背景色。如果改成 hsl(--accent) 等不透明色，那一行会一直停留
- * 在高亮色直到下次重渲染。
- *
- * 副作用：当 reveal 同时把目标置为选中态（用户搜索点击，select=true）时，
- * animation 在 1.2s 内会盖掉 .bg-accent，造成"先闪→变透明→才出现选中色"的视觉断层。
- * 因此 FileTreeItem 在 select=true 路径下跳过 .file-browser-row-flash class，
- * 直接呈现选中态，避开此冲突。详见 FileBrowser.tsx 中 reveal 分支的注释。
- */
-@keyframes file-browser-flash {
-  0%   { background-color: hsl(var(--primary) / 0.18); }
-  50%  { background-color: hsl(var(--primary) / 0.22); }
-  100% { background-color: transparent; }
-}
-.file-browser-row-flash {
-  animation: file-browser-flash 1.2s ease-out;
-}
 
 /* ===== FileBrowser 层级引导线：默认隐藏，鼠标悬浮文件树时显示（VS Code 风格） ===== */
 .file-tree-guide {

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -247,6 +247,8 @@ export interface AppSettings {
   shortcutOverrides?: ShortcutOverrides
   /** 是否显示用户消息悬浮置顶条（默认 true） */
   stickyUserMessageEnabled?: boolean
+  /** 左侧会话列表悬浮预览迷你地图（默认 false，需手动开启） */
+  sessionHoverPreviewEnabled?: boolean
   /** 粘贴超过阈值的长文本时是否自动转为附件（默认 false） */
   longTextPasteAsAttachmentEnabled?: boolean
   /** 输入框是否渲染 Markdown 富文本格式（默认 false，关闭后为纯文本模式，仍保留 Mention 引用） */


### PR DESCRIPTION
## Summary

两个 UI 行为优化：

### 1. 新增设置项「会话悬浮预览」（默认关闭）

鼠标悬停左侧会话列表项时弹出的迷你地图预览，现在可以通过 **设置 → 通用 → 会话悬浮预览** 开关控制，默认关闭，用户需手动开启。

- 新增 `sessionHoverPreviewEnabled` 设置字段和 atom
- 覆盖场景：置顶列表、项目分组、委派子会话、折叠侧栏（Rail）、搜索对话框

### 2. 删除 Agent 编辑文件时文件树自动跳转

Agent 写文件时右侧文件树自动展开父目录、滚动定位、高亮脉冲的行为已删除。

- 移除 `useGlobalAgentListeners` 中对 `fileBrowserAutoRevealAtom` 的触发
- 移除 `SidePanel` 中切回文件视图的 effect
- 移除 `FileBrowser` 中 flash 高亮脉冲逻辑和 CSS 动画
- 保留：搜索点击文件 reveal、左侧竖条 recentlyModified 标记

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)