### PR TITLE
chore: remove unused revealSelect prop and update stale comments

### DIFF
--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -428,9 +428,9 @@ export const currentSessionSidePanelOpenAtom = atom<boolean>((get) => {
 export const agentSessionPathMapAtom = atom<Map<string, string>>(new Map())
 
 /**
- * 文件浏览器自动定位信号：当 Agent 调用写入类工具（Write/Edit/MultiEdit/NotebookEdit）时，
- * 设置该 atom；FileBrowser 实例订阅后，若路径落在自身 rootPath 下则展开祖先 + 滚动 + 高亮。
- * `ts` 用于触发同路径的二次脉冲（atom 比对引用）。
+ * 文件浏览器自动定位信号：当用户通过文件搜索点击结果时设置该 atom；
+ * FileBrowser 实例订阅后，若路径落在自身 rootPath 下则展开祖先 + 滚动定位。
+ * `ts` 用于触发同路径的二次定位（atom 比对引用）。
  */
 export interface FileBrowserAutoReveal {
   sessionId: string

--- a/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
@@ -151,7 +151,6 @@ export function FileBrowser({ rootPath, roots, hideToolbar, embedded, hideEmpty,
   )
   const revealTarget = revealForThisRoot?.path ?? null
   const revealTs = revealForThisRoot?.ts ?? 0
-  const revealSelect = revealForThisRoot?.select ?? false
 
   // ===== autoReveal 带 select 标记时，将目标文件加入选中态 =====
   const consumedSelectTsRef = React.useRef(0)
@@ -386,7 +385,6 @@ export function FileBrowser({ rootPath, roots, hideToolbar, embedded, hideEmpty,
           revealAncestors={revealAncestors}
           revealTarget={revealTarget}
           revealTs={revealTs}
-          revealSelect={revealSelect}
           recentlyModifiedSet={recentlyModifiedSet}
           onSelect={handleSelect}
           onShowInFolder={handleShowInFolder}
@@ -490,13 +488,10 @@ interface FileTreeItemProps {
   refreshVersion: number
   /** 自动定位：祖先目录路径集合（命中则自动展开） */
   revealAncestors: Set<string>
-  /** 自动定位：目标文件路径（命中则滚动 + 高亮脉冲） */
+  /** 自动定位：目标文件路径 */
   revealTarget: string | null
-  /** 自动定位脉冲时间戳，变化时重新触发 */
+  /** 自动定位时间戳，变化时重新触发 */
   revealTs: number
-  /** 本次 reveal 是否带 select 标记（来源于用户搜索点击）；为 true 时跳过 flash 高亮，避免覆盖选中色 */
-  revealSelect: boolean
-  /** 最近修改的路径集合（命中则在行左侧显示竖条标记） */
   recentlyModifiedSet: Set<string>
   onSelect: (entry: FileEntry, event: React.MouseEvent) => void
   onShowInFolder: (entry: FileEntry) => void
@@ -525,7 +520,6 @@ function FileTreeItem({
   revealAncestors,
   revealTarget,
   revealTs,
-  revealSelect,
   recentlyModifiedSet,
   onSelect,
   onShowInFolder,
@@ -556,7 +550,7 @@ function FileTreeItem({
     }
   }, [refreshVersion]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // ===== Agent 自动定位：祖先目录自动展开 + 目标行滚动到中心 + 0.8s 高亮脉冲 =====
+  // ===== 文件搜索 reveal：祖先目录自动展开 + 目标行滚动到中心 =====
   React.useEffect(() => {
     if (revealTs === 0) return
 
@@ -969,7 +963,6 @@ function FileTreeItem({
               revealAncestors={revealAncestors}
               revealTarget={revealTarget}
               revealTs={revealTs}
-              revealSelect={revealSelect}
               recentlyModifiedSet={recentlyModifiedSet}
               onSelect={onSelect}
               onShowInFolder={onShowInFolder}


### PR DESCRIPTION
## Summary

修复 PR #1335 审查中提出的两个 low 级建议：

### 1. 清理无用的 `revealSelect` prop
`FileBrowser.tsx` 中 `revealSelect` 变量及 prop 在删除 flash 高亮脉冲后不再参与任何运行时行为，已移除：
- 局部变量 `revealSelect`
- `FileTreeItemProps` 中的 prop 定义
- `FileTreeItem` 的 destructuring 与两处递归传递

### 2. 更新过期注释
- `agent-atoms.ts`: `FileBrowserAutoReveal` 注释从"Agent 调用写入工具触发"改为"用户通过文件搜索点击结果触发"
- `FileBrowser.tsx`: revealTarget/revealTs prop 注释移除"高亮脉冲"，FileTreeItem 内部注释从"Agent 自动定位"改为"文件搜索 reveal"

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)