### PR TITLE
fix(agent): synchronize delegated session UI lifecycle

### DIFF
--- a/apps/electron/src/main/lib/agent-collaboration-tools.ts
+++ b/apps/electron/src/main/lib/agent-collaboration-tools.ts
@@ -711,6 +711,7 @@ function startDelegation(
     },
     {
       source: 'delegation',
+      originSessionId: ctx.sessionId,
       onError: (error) => {
         markDelegationFinished(record, 'failed', { error })
       },
@@ -1037,6 +1038,7 @@ export async function injectAgentCollaborationMcpServer(
             },
             {
               source: 'delegation',
+              originSessionId: ctx.sessionId,
               onError: (error) => {
                 markDelegationFinished(record, 'failed', { error })
               },
@@ -1391,6 +1393,7 @@ export function buildPiCollaborationTools(
           },
           {
             source: 'delegation',
+            originSessionId: ctx.sessionId,
             onError: (error) => {
               markDelegationFinished(record, 'failed', { error })
             },

--- a/apps/electron/src/main/lib/agent-headless-run-target.test.ts
+++ b/apps/electron/src/main/lib/agent-headless-run-target.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'bun:test'
+import { getHeadlessAgentRunTarget } from './agent-headless-run-target'
+
+interface FakeWebContents {
+  id: string
+  destroyed: boolean
+  isDestroyed(): boolean
+}
+
+function createWebContents(id: string, destroyed = false): FakeWebContents {
+  return {
+    id,
+    destroyed,
+    isDestroyed() {
+      return this.destroyed
+    },
+  }
+}
+
+describe('headless Agent renderer routing', () => {
+  test('uses the originating session renderer before the generic main-window fallback', () => {
+    const origin = createWebContents('origin')
+    const fallback = createWebContents('fallback')
+
+    const target = getHeadlessAgentRunTarget(
+      new Map([['parent-session', origin]]),
+      'parent-session',
+      () => fallback,
+    )
+
+    expect(target).toBe(origin)
+  })
+
+  test('falls back when the originating renderer has been destroyed', () => {
+    const origin = createWebContents('origin', true)
+    const fallback = createWebContents('fallback')
+
+    const target = getHeadlessAgentRunTarget(
+      new Map([['parent-session', origin]]),
+      'parent-session',
+      () => fallback,
+    )
+
+    expect(target).toBe(fallback)
+  })
+
+  test('returns null when neither renderer can receive events', () => {
+    const target = getHeadlessAgentRunTarget(
+      new Map<string, FakeWebContents>(),
+      'parent-session',
+      () => null,
+    )
+
+    expect(target).toBeNull()
+  })
+})

--- a/apps/electron/src/main/lib/agent-headless-run-target.ts
+++ b/apps/electron/src/main/lib/agent-headless-run-target.ts
@@ -1,0 +1,21 @@
+/**
+ * 选择 headless Agent 运行应接收事件的 renderer。
+ *
+ * 委派子会话优先复用父会话所在窗口；没有可用父窗口时才回退通用主窗口。
+ */
+export interface HeadlessAgentRunTarget {
+  isDestroyed(): boolean
+}
+
+export function getHeadlessAgentRunTarget<T extends HeadlessAgentRunTarget>(
+  sessionTargets: ReadonlyMap<string, T>,
+  originSessionId: string | undefined,
+  getFallbackTarget: () => T | null,
+): T | null {
+  const originTarget = originSessionId ? sessionTargets.get(originSessionId) : undefined
+  if (originTarget && !originTarget.isDestroyed()) {
+    return originTarget
+  }
+
+  return getFallbackTarget()
+}

--- a/apps/electron/src/main/lib/agent-headless-runner-registry.ts
+++ b/apps/electron/src/main/lib/agent-headless-runner-registry.ts
@@ -16,6 +16,8 @@ export interface HeadlessAgentRunCallbacks {
   onComplete: (messages?: AgentMessage[]) => void
   onTitleUpdated: (title: string) => void
   source?: AgentExternalRunSource
+  /** 发起此次 headless 运行的可见会话，用于将事件路由回其 renderer。 */
+  originSessionId?: string
 }
 
 export type HeadlessAgentRunner = (

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -37,6 +37,7 @@ import { getAgentSessionWorkspacePath } from './config-paths'
 import { getAgentWorkspaceBySlug, getLocalProjectRootStatus, getProjectFilesPath } from './agent-workspace-manager'
 import { getAgentSessionMeta, updateAgentSessionMeta } from './agent-session-manager'
 import { setAgentStopper, setHeadlessAgentRunner } from './agent-headless-runner-registry'
+import { getHeadlessAgentRunTarget } from './agent-headless-run-target'
 import { sendAgentStreamComplete } from './agent-completion-payload'
 
 // ===== 实例创建 =====
@@ -223,10 +224,15 @@ export async function runAgentHeadless(
     onComplete: (messages?: AgentMessage[]) => void
     onTitleUpdated: (title: string) => void
     source?: AgentExternalRunSource
+    originSessionId?: string
   },
 ): Promise<void> {
-  // 尝试注册主窗口 webContents，让流式事件同步推送到桌面端
-  const wc = getMainRendererWebContents()
+  // 委派子会话优先回到父会话所在 renderer，外部无界面运行才回退任意主窗口。
+  const wc = getHeadlessAgentRunTarget(
+    sessionWebContents,
+    callbacks.originSessionId,
+    getMainRendererWebContents,
+  )
   const runInput: AgentSendInput = input.startedAt != null ? input : { ...input, startedAt: Date.now() }
   const startedAt = runInput.startedAt!
   if (wc) {
@@ -285,6 +291,7 @@ export async function runAgentHeadless(
             workspaceId: runInput.workspaceId ?? session?.workspaceId,
             modelId: runInput.modelId,
             startedAt: persistedStartedAt,
+            ...(session ? { session } : {}),
           },
         })
       },

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -62,7 +62,7 @@ import type { NotificationSoundType } from '@/types/settings'
 import { toast } from 'sonner'
 import type { AgentStreamEvent, AgentStreamCompletePayload, AgentEvent, AgentStreamPayload, SDKAssistantMessage, SDKUserMessage, SDKSystemMessage, SDKContentBlock, SDKUserContentBlock, PromaEvent, AgentSessionMeta, ProviderType } from '@proma/shared'
 import { inferAgentSdkContextWindow, inferContextWindow } from '@proma/shared'
-import { buildExternalAgentRunActivation } from '@/lib/external-agent-run'
+import { buildExternalAgentRunActivation, shouldActivateExternalAgentRun } from '@/lib/external-agent-run'
 import { upsertAgentSession, mergeFetchedAgentSessions } from '@/lib/agent-session-list'
 import {
   getAgentCompletionMarkers,
@@ -479,15 +479,22 @@ export function useGlobalAgentListeners(): void {
 
     const activateExternalAgentRun = (event: Extract<PromaEvent, { type: 'external_run_started' }>): void => {
       const applyActivation = (sessions: AgentSessionMeta[]): void => {
+        const currentStreamState = store.get(agentStreamingStatesAtom).get(event.sessionId)
+        if (!shouldActivateExternalAgentRun(currentStreamState, event.startedAt)) {
+          return
+        }
+
+        const eventSession = event.session
+        const activationSessions = eventSession ? [eventSession] : sessions
         const activation = buildExternalAgentRunActivation({
           tabs: store.get(tabsAtom),
-          sessions,
+          sessions: activationSessions,
           sessionId: event.sessionId,
           title: event.title,
           workspaceId: event.workspaceId,
           modelId: event.modelId,
           startedAt: event.startedAt,
-          currentStreamState: store.get(agentStreamingStatesAtom).get(event.sessionId),
+          currentStreamState,
         })
 
         // 外部来源（飞书/钉钉/微信/bridge）唤起的 run 不抢占前台：
@@ -503,7 +510,7 @@ export function useGlobalAgentListeners(): void {
         // turn 的父会话的快照，把父会话冲掉——父会话从列表消失后，其子会话
         // 因找不到父而从树形子节点变成根节点直接显示（用户观察到的现象）。
         // 改为单条 upsert 后，每个回调只负责自己那一个会话，互不干扰。
-        const sessionMeta = sessions.find((item) => item.id === event.sessionId)
+        const sessionMeta = eventSession ?? sessions.find((item) => item.id === event.sessionId)
         const upserted: AgentSessionMeta = sessionMeta ?? {
           id: event.sessionId,
           title: activation.title,
@@ -532,6 +539,11 @@ export function useGlobalAgentListeners(): void {
           map.set(event.sessionId, activation.streamState)
           return map
         })
+      }
+
+      if (event.session) {
+        applyActivation([event.session])
+        return
       }
 
       const knownSessions = store.get(agentSessionsAtom)

--- a/apps/electron/src/renderer/lib/external-agent-run.test.ts
+++ b/apps/electron/src/renderer/lib/external-agent-run.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import type { AgentSessionMeta } from '@proma/shared'
-import { buildExternalAgentRunActivation } from './external-agent-run'
+import { buildExternalAgentRunActivation, shouldActivateExternalAgentRun } from './external-agent-run'
 import type { ExternalAgentRunTab } from './external-agent-run'
 
 const session: AgentSessionMeta = {
@@ -77,6 +77,44 @@ describe('外部 Agent 运行激活', () => {
     expect(result.tabs[0]!.title).toBe('新 Agent 会话')
     expect(result.activeTabId).toBe('unknown-session')
     expect(result.workspaceId).toBeUndefined()
+  })
+
+  test('Given 事件携带完整会话元数据 When 本地列表尚未刷新 Then 立即使用该元数据激活流状态', () => {
+    const delegatedSession: AgentSessionMeta = {
+      ...session,
+      id: 'delegated-agent',
+      parentSessionId: 'parent-agent',
+      sourceDelegationId: 'delegation-1',
+    }
+
+    const result = buildExternalAgentRunActivation({
+      tabs: [],
+      sessions: [delegatedSession],
+      sessionId: delegatedSession.id,
+      startedAt: 350,
+    })
+
+    expect(result.title).toBe(delegatedSession.title)
+    expect(result.workspaceId).toBe(delegatedSession.workspaceId)
+    expect(result.streamState.running).toBeTrue()
+  })
+
+  test('Given the same run has already completed When a delayed start event arrives Then keep it terminal', () => {
+    expect(shouldActivateExternalAgentRun({
+      running: false,
+      content: 'completed',
+      toolActivities: [],
+      startedAt: 500,
+    }, 500)).toBeFalse()
+  })
+
+  test('Given a newer run is active When an older start event arrives Then ignore the old event', () => {
+    expect(shouldActivateExternalAgentRun({
+      running: true,
+      content: 'newer run',
+      toolActivities: [],
+      startedAt: 700,
+    }, 600)).toBeFalse()
   })
 
   test('Given 无 currentStreamState When 激活 Then streamState 使用空默认值', () => {

--- a/apps/electron/src/renderer/lib/external-agent-run.ts
+++ b/apps/electron/src/renderer/lib/external-agent-run.ts
@@ -28,6 +28,19 @@ export interface ExternalAgentRunActivation {
   streamState: AgentStreamState
 }
 
+/** 迟到的启动事件不得复活已结束运行，或覆盖同一会话的更新运行。 */
+export function shouldActivateExternalAgentRun(
+  currentStreamState: AgentStreamState | undefined,
+  startedAt: number,
+): boolean {
+  if (!currentStreamState || currentStreamState.startedAt == null) return true
+  if (currentStreamState.startedAt > startedAt) return false
+  if (currentStreamState.startedAt === startedAt) {
+    return currentStreamState.running && !currentStreamState.backgroundWaiting
+  }
+  return true
+}
+
 export function buildExternalAgentRunActivation(
   input: ExternalAgentRunActivationInput,
 ): ExternalAgentRunActivation {

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -606,7 +606,7 @@ export type PromaEvent =
   | { type: 'context_window'; contextWindow: number }
   | { type: 'permission_mode_changed'; mode: PromaPermissionMode }
   | { type: 'title_updated'; title: string }
-  | { type: 'external_run_started'; source: AgentExternalRunSource; sessionId: string; title?: string; workspaceId?: string; modelId?: string; startedAt: number }
+  | { type: 'external_run_started'; source: AgentExternalRunSource; sessionId: string; title?: string; workspaceId?: string; modelId?: string; startedAt: number; session?: AgentSessionMeta }
   | { type: 'run_resumed'; sessionId: string }
   // 协作子会话阻塞事件上浮
   | { type: 'delegation_blocked'; delegationId: string; blockedEvent: unknown }


### PR DESCRIPTION
## Summary

- Route delegated headless runs back to the renderer that owns the parent session.
- Include child session metadata in external run start events so the sidebar upserts immediately.
- Ignore stale start events that could restore a completed child run to running.

## Test plan

- [x] `bun test apps/electron/src/main/lib/agent-headless-run-target.test.ts apps/electron/src/renderer/lib/external-agent-run.test.ts apps/electron/src/renderer/lib/agent-session-list.test.ts`
- [x] `bun run typecheck`
- [x] Manual development-build validation of delegated session lifecycle

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)