### PR TITLE
feat(agent): defer runtime and thinking changes

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -2572,9 +2572,7 @@ export function registerIpcHandlers(): void {
       if (!getAgentSessionMeta(sessionId)) {
         throw new Error(`Agent 会话不存在: ${sessionId}`)
       }
-      if (isAgentSessionActive(sessionId)) {
-        throw new Error('Agent 正在运行，完成后再切换思考深度')
-      }
+      // 当前运行已在启动时读取推理深度；此处只更新会话的下一轮配置。
       return updateAgentSessionMeta(sessionId, { reasoningLevel: thinkingLevel })
     }
   )
@@ -2590,17 +2588,18 @@ export function registerIpcHandlers(): void {
         throw new Error(`Agent 会话不存在: ${sessionId}`)
       }
 
-      if (isAgentSessionActive(sessionId)) {
-        throw new Error('Agent 正在运行，完成后再切换内核')
-      }
+      // 当前运行持有其启动时的 runtime；此处只更新会话的下一轮配置。
 
       // 历史会话缺失 runtime 时按 Claude 处理，避免将 Claude SDK 会话 ID 交给 Pi 恢复。
       const previousRuntime: AgentRuntime = isAgentRuntime(current.agentRuntime) ? current.agentRuntime : 'claude'
-      const updates: Partial<Pick<AgentSessionMeta, 'agentRuntime' | 'sdkSessionId'>> = {
+      const updates: Partial<Pick<AgentSessionMeta, 'agentRuntime' | 'sdkSessionId' | 'piSessionFile' | 'piEntryBindings'>> = {
         agentRuntime: runtime,
       }
       if (previousRuntime !== runtime) {
+        // 两套 runtime 的会话 artifact 不可互用；下一轮从 Proma 已持久化的转录恢复。
         updates.sdkSessionId = undefined
+        updates.piSessionFile = undefined
+        updates.piEntryBindings = undefined
       }
 
       return updateAgentSessionMeta(sessionId, updates)

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -1725,11 +1725,17 @@ export class AgentOrchestrator {
         capturedSdkSessionId = sdkSessionId
         if (isNewSessionId || needsPiSessionFile) {
           try {
-            updateAgentSessionMeta(sessionId, {
-              sdkSessionId,
-              ...(agentRuntime === 'pi' && piSessionFile ? { piSessionFile } : {}),
-            })
-            console.log(`[Agent 编排] 已保存 SDK session_id: ${sdkSessionId}`)
+            // 用户可在本轮运行中改选下一轮内核；不能让旧 runtime 回填不兼容的 session artifact。
+            const latestSessionMeta = getAgentSessionMeta(sessionId)
+            if (latestSessionMeta?.agentRuntime !== agentRuntime) {
+              console.log(`[Agent 编排] 忽略已切换 runtime 的 session artifact: ${sdkSessionId}`)
+            } else {
+              updateAgentSessionMeta(sessionId, {
+                sdkSessionId,
+                ...(agentRuntime === 'pi' && piSessionFile ? { piSessionFile } : {}),
+              })
+              console.log(`[Agent 编排] 已保存 SDK session_id: ${sdkSessionId}`)
+            }
           } catch (err) {
             console.error(`[Agent 编排] 保存 SDK session_id 失败:`, err)
           }
@@ -1811,8 +1817,10 @@ export class AgentOrchestrator {
         onSessionId: handleSessionId,
         onPiEntryBindings: (bindings) => {
           const latest = getAgentSessionMeta(sessionId)
+          // 运行中切到其他内核后，保留旧 turn 展示但不再写入 Pi 专用恢复 artifact。
+          if (latest?.agentRuntime !== 'pi') return
           updateAgentSessionMeta(sessionId, {
-            piEntryBindings: { ...(latest?.piEntryBindings ?? {}), ...bindings },
+            piEntryBindings: { ...(latest.piEntryBindings ?? {}), ...bindings },
           })
         },
         onModelResolved: handleModelResolved,

--- a/apps/electron/src/renderer/atoms/chat-atoms.ts
+++ b/apps/electron/src/renderer/atoms/chat-atoms.ts
@@ -267,9 +267,3 @@ export const conversationThinkingEnabledAtom = atom<Map<string, boolean>>(new Ma
 
 /** 每个对话的并排模式 */
 export const conversationParallelModeAtom = atom<Map<string, boolean>>(new Map())
-
-/** 思考块默认展开偏好（持久化到 localStorage） */
-export const thinkingExpandedAtom = atomWithStorage<boolean>(
-  'proma-thinking-expanded',
-  false,
-)

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -109,7 +109,7 @@ import {
 import type { AgentContextStatus } from '@/atoms/agent-atoms'
 import { settingsOpenAtom } from '@/atoms/settings-tab'
 import { longTextPasteAsAttachmentEnabledAtom } from '@/atoms/ui-preferences'
-import { channelsAtom, thinkingExpandedAtom } from '@/atoms/chat-atoms'
+import { channelsAtom } from '@/atoms/chat-atoms'
 import { todoPlanningGroupsAtom } from '@/atoms/planning-atoms'
 import { useOpenSession } from '@/hooks/useOpenSession'
 import { AgentSessionProvider } from '@/contexts/session-context'
@@ -254,7 +254,6 @@ function normalizeOpenAIThinkingLevel(
 interface CodexThinkingConfig {
   thinkingLevel: AgentThinkingLevel
   levels: readonly OpenAIThinkingLevel[]
-  disabled: boolean
   onThinkingLevelChange: (level: AgentThinkingLevel) => void
 }
 
@@ -265,7 +264,6 @@ interface AgentThinkingPopoverProps {
 }
 
 function AgentThinkingPopover({ agentThinking, onToggle, codexConfig }: AgentThinkingPopoverProps): React.ReactElement {
-  const [thinkingExpanded, setThinkingExpanded] = useAtom(thinkingExpandedAtom)
   const [open, setOpen] = React.useState(false)
   const hoverTimeout = React.useRef<ReturnType<typeof setTimeout> | null>(null)
   const isCodex = Boolean(codexConfig)
@@ -311,7 +309,6 @@ function AgentThinkingPopover({ agentThinking, onToggle, codexConfig }: AgentThi
           onClick={handleButtonClick}
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
-          disabled={codexConfig?.disabled}
         >
           <Brain className="size-5" />
         </Button>
@@ -341,7 +338,6 @@ function AgentThinkingPopover({ agentThinking, onToggle, codexConfig }: AgentThi
                   min={0}
                   max={thinkingLevels.length - 1}
                   step={1}
-                  disabled={codexConfig.disabled}
                   aria-label="思考深度"
                 />
                 <div className="flex justify-between text-[10px] text-muted-foreground">
@@ -359,15 +355,6 @@ function AgentThinkingPopover({ agentThinking, onToggle, codexConfig }: AgentThi
               />
             </div>
           )}
-          <div className="h-px bg-border" />
-          <div className="flex items-center justify-between gap-4">
-            <span className="text-xs text-foreground/70">展开思考</span>
-            <Switch
-              checked={thinkingExpanded}
-              onCheckedChange={setThinkingExpanded}
-              className="h-4 w-7 [&>span]:size-3 [&>span]:data-[state=checked]:translate-x-3"
-            />
-          </div>
         </div>
       </PopoverContent>
     </Popover>
@@ -404,18 +391,12 @@ const AGENT_RUNTIME_OPTIONS: AgentRuntimeOption[] = [
 
 interface AgentRuntimeSelectorProps {
   runtime: AgentRuntime
-  disabled?: boolean
   onChange: (runtime: AgentRuntime) => void
 }
 
-function AgentRuntimeSelector({ runtime, disabled = false, onChange }: AgentRuntimeSelectorProps): React.ReactElement {
+function AgentRuntimeSelector({ runtime, onChange }: AgentRuntimeSelectorProps): React.ReactElement {
   const [open, setOpen] = React.useState(false)
   const current = AGENT_RUNTIME_OPTIONS.find((option) => option.value === runtime) ?? AGENT_RUNTIME_OPTIONS[0]!
-
-  const handleOpenChange = (nextOpen: boolean): void => {
-    if (disabled && nextOpen) return
-    setOpen(nextOpen)
-  }
 
   const handleSelect = (nextRuntime: AgentRuntime): void => {
     onChange(nextRuntime)
@@ -423,19 +404,15 @@ function AgentRuntimeSelector({ runtime, disabled = false, onChange }: AgentRunt
   }
 
   return (
-    <Popover open={open} onOpenChange={handleOpenChange}>
+    <Popover open={open} onOpenChange={setOpen}>
       <Tooltip>
         <TooltipTrigger asChild>
           <PopoverTrigger asChild>
             <Button
               type="button"
               variant="ghost"
-              disabled={disabled}
               aria-label={`Agent 内核：${current.label}`}
-              className={cn(
-                'model-selector-trigger flex h-8 shrink-0 items-center gap-1.5 rounded-md px-2 text-xs font-medium text-muted-foreground hover:bg-accent hover:text-foreground',
-                disabled && 'cursor-not-allowed opacity-60 hover:bg-transparent hover:text-muted-foreground'
-              )}
+              className="model-selector-trigger flex h-8 shrink-0 items-center gap-1.5 rounded-md px-2 text-xs font-medium text-muted-foreground hover:bg-accent hover:text-foreground"
             >
               <Box className="size-3.5" />
               <span>{current.label}</span>
@@ -446,9 +423,7 @@ function AgentRuntimeSelector({ runtime, disabled = false, onChange }: AgentRunt
         <TooltipContent side="top" className="max-w-[240px]">
           <p className="font-medium">{current.description}</p>
           {current.notice && <p className="mt-0.5 text-xs text-amber-600 dark:text-amber-400">{current.notice}</p>}
-          <p className="mt-0.5 text-xs text-muted-foreground">
-            {disabled ? 'Agent 运行中，完成后可切换' : '切换当前会话下一轮使用的内核'}
-          </p>
+          <p className="mt-0.5 text-xs text-muted-foreground">切换当前会话下一轮使用的内核</p>
         </TooltipContent>
       </Tooltip>
       <PopoverContent
@@ -1992,18 +1967,22 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       requestAnimationFrame(() => document.querySelector<HTMLElement>('[data-input-mode="agent"] .ProseMirror')?.focus())
       return
     }
-    if (streaming || backgroundWaiting) {
-      toast.info('Agent 运行中，完成后再切换内核')
-      return
-    }
 
+    const runtimeSwitchDeferred = streaming || backgroundWaiting
     const previousDefaultRuntime = agentRuntime
     const previousSessionMeta = sessionMeta
     setAgentRuntime(runtime)
     if (sessionMeta) {
       setAgentSessions((prev) => prev.map((item) =>
         item.id === sessionId
-          ? { ...item, agentRuntime: runtime, sdkSessionId: undefined, updatedAt: Date.now() }
+          ? {
+            ...item,
+            agentRuntime: runtime,
+            sdkSessionId: undefined,
+            piSessionFile: undefined,
+            piEntryBindings: undefined,
+            updatedAt: Date.now(),
+          }
           : item
       ))
     }
@@ -2014,6 +1993,9 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       window.electronAPI.updateSettings({ agentRuntime: runtime }).catch((error) => {
         console.error('[AgentView] 保存 Agent Runtime 默认值失败:', error)
       })
+      if (runtimeSwitchDeferred) {
+        toast.info('Agent 内核已切换，本轮结束后生效')
+      }
     } catch (error) {
       console.error('[AgentView] 切换 Agent Runtime 失败:', error)
       setAgentRuntime(previousDefaultRuntime)
@@ -2055,8 +2037,9 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   }, [backgroundWaiting, codexFastModeEnabled, isCodexFastModeAvailable, sessionId, sessionMeta, setAgentSessions, streaming])
 
   const updateReasoningLevel = React.useCallback(async (thinkingLevel: AgentThinkingLevel): Promise<void> => {
-    if (!isSessionThinkingAvailable || streaming || backgroundWaiting || !sessionMeta) return
+    if (!isSessionThinkingAvailable || !sessionMeta) return
 
+    const reasoningLevelSwitchDeferred = streaming || backgroundWaiting
     const previousSessionMeta = sessionMeta
     setAgentSessions((prev) => prev.map((item) => (
       item.id === sessionId ? { ...item, reasoningLevel: thinkingLevel, updatedAt: Date.now() } : item
@@ -2071,6 +2054,9 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       } catch (error) {
         console.error('[AgentView] 保存 OpenAI 默认思考深度失败:', error)
         toast.error('默认思考深度保存失败', { description: getErrorMessage(error) })
+      }
+      if (reasoningLevelSwitchDeferred) {
+        toast.info('思考强度已切换，本轮结束后生效', { id: `agent-reasoning-level-deferred-${sessionId}` })
       }
     } catch (error) {
       console.error('[AgentView] 更新 OpenAI 思考深度失败:', error)
@@ -2822,7 +2808,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           codexConfig={isSessionThinkingAvailable ? {
             thinkingLevel: openAIThinkingLevel,
             levels: openAIThinkingLevels,
-            disabled: streaming || backgroundWaiting,
             onThinkingLevelChange: (level) => { void updateReasoningLevel(level) },
           } : undefined}
         />
@@ -2918,7 +2903,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         />
         <AgentRuntimeSelector
           runtime={sessionAgentRuntime}
-          disabled={streaming || backgroundWaiting}
           onChange={handleAgentRuntimeChange}
         />
       </div>

--- a/apps/electron/src/renderer/components/agent/ContentBlock.tsx
+++ b/apps/electron/src/renderer/components/agent/ContentBlock.tsx
@@ -4,7 +4,7 @@
  * 支持三种内容块类型：
  * - text: 通过 MessageResponse 渲染 Markdown
  * - tool_use: 语义化短语行（如 "读取 foo.ts 第 10-60 行"），展开显示结构化结果
- * - thinking: 默认展开，左上角 "Thinking" 标签 + 虚线边框内容区
+ * - thinking: 默认折叠，左上角 "Thinking" 标签 + 虚线边框内容区
  */
 
 import * as React from 'react'
@@ -17,8 +17,6 @@ import {
   Brain,
   MessageSquareText,
 } from 'lucide-react'
-import { useAtomValue } from 'jotai'
-import { thinkingExpandedAtom } from '@/atoms/chat-atoms'
 import { cn } from '@/lib/utils'
 import { MessageResponse } from '@/components/ai-elements/message'
 import { getToolIcon, extractFilePath } from './tool-utils'
@@ -553,7 +551,7 @@ function ToolUseBlock({ block, allMessages, animate = false, index = 0, dimmed =
   )
 }
 
-// ===== 思考块（默认展开，Thinking 标签 + 虚线边框） =====
+// ===== 思考块（默认折叠，Thinking 标签 + 虚线边框） =====
 
 interface ThinkingBlockProps {
   block: SDKThinkingBlock
@@ -564,8 +562,7 @@ interface ThinkingBlockProps {
 const THINKING_COLLAPSE_LINE_THRESHOLD = 4
 
 function ThinkingBlock({ block, dimmed = false }: ThinkingBlockProps): React.ReactElement {
-  const thinkingExpanded = useAtomValue(thinkingExpandedAtom)
-  const [isExpanded, setIsExpanded] = React.useState(thinkingExpanded)
+  const [isExpanded, setIsExpanded] = React.useState(false)
   const [shouldCollapse, setShouldCollapse] = React.useState(false)
   const contentRef = React.useRef<HTMLDivElement>(null)
 
@@ -577,11 +574,6 @@ function ThinkingBlock({ block, dimmed = false }: ThinkingBlockProps): React.Rea
     const maxHeight = lineHeight * THINKING_COLLAPSE_LINE_THRESHOLD
     setShouldCollapse(el.scrollHeight > maxHeight + 10)
   }, [block.thinking])
-
-  // 当全局偏好变更时同步（仅在"应折叠"时生效）
-  React.useEffect(() => {
-    setIsExpanded(thinkingExpanded)
-  }, [thinkingExpanded])
 
   const toggleExpand = React.useCallback(() => {
     setIsExpanded((prev) => !prev)


### PR DESCRIPTION
## Summary

- Keep thinking blocks collapsed by default and remove the expansion preference.
- Allow runtime and reasoning-strength changes while an Agent run is active; apply them on the next turn.
- Prevent a previous runtime from persisting incompatible session artifacts after a deferred switch.

## Test plan

- [x] `bun run --filter='@proma/electron' typecheck`
- [x] `bun run --filter='@proma/electron' build:renderer`
- [x] `bun test apps/electron/src/main/lib/agent-thinking-level.test.ts`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)