### PR TITLE
feat: show stop control while agent has draft

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -2859,7 +2859,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     handleCompact,
   ])
 
-  const sendControl = streaming && !hasTextInput ? (
+  const stopControl = (
     <Tooltip>
       <TooltipTrigger asChild>
         <Button
@@ -2876,7 +2876,9 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         <p>停止 Agent ({getAcceleratorDisplay(getActiveAccelerator('stop-generation'))})</p>
       </TooltipContent>
     </Tooltip>
-  ) : (
+  )
+
+  const sendButton = (
     <Button
       type="button"
       variant="ghost"
@@ -2890,6 +2892,13 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       <CornerDownLeft className="size-[22px]" />
     </Button>
   )
+
+  const sendControl = streaming ? (
+    <>
+      {hasTextInput && sendButton}
+      {stopControl}
+    </>
+  ) : sendButton
 
   const inputTrailingNode = (
     <>


### PR DESCRIPTION
## Summary

- Show both Send and Stop controls while an Agent is running and the composer contains text.
- Preserve Enter submission and existing queued-message behavior.

## Test plan

- [x] `bun run --filter='@proma/electron' typecheck`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)