### PR TITLE
Fix: exclude completed todos from counts

### DIFF
--- a/apps/electron/src/renderer/components/planning/PlanningGroupManager.tsx
+++ b/apps/electron/src/renderer/components/planning/PlanningGroupManager.tsx
@@ -14,6 +14,8 @@ interface PlanningGroupManagerProps {
   trigger: React.ReactElement
   itemLabel: string
   getUsageCount: (groupId: string) => number
+  hasAssociatedItems?: (groupId: string) => boolean
+  showDeletionCount?: boolean
   onCreate: (name: string) => Promise<PlanningGroup | undefined>
   onRename: (group: PlanningGroup, name: string) => Promise<PlanningGroup | undefined>
   onDelete: (group: PlanningGroup) => Promise<boolean>
@@ -24,7 +26,7 @@ interface PlanningGroupManagerProps {
  * 轻量分组管理器：不单独占用页面，只在当前工作流中提供新建、重命名与删除。
  * 删除操作仅解除关联，目标 Todo 或日程本身不会被删除。
  */
-export function PlanningGroupManager({ scope, groups, trigger, itemLabel, getUsageCount, onCreate, onRename, onDelete, onCreated }: PlanningGroupManagerProps): React.ReactElement {
+export function PlanningGroupManager({ scope, groups, trigger, itemLabel, getUsageCount, hasAssociatedItems, showDeletionCount = true, onCreate, onRename, onDelete, onCreated }: PlanningGroupManagerProps): React.ReactElement {
   const [open, setOpen] = React.useState(false)
   const [creating, setCreating] = React.useState(false)
   const [newName, setNewName] = React.useState('')
@@ -103,6 +105,7 @@ export function PlanningGroupManager({ scope, groups, trigger, itemLabel, getUsa
   }
 
   const deletionCount = pendingDeletion ? getUsageCount(pendingDeletion.id) : 0
+  const deletionHasAssociatedItems = pendingDeletion ? (hasAssociatedItems?.(pendingDeletion.id) ?? deletionCount > 0) : false
   return <>
     <Popover open={open} onOpenChange={closeManager}>
       <PopoverTrigger asChild>{trigger}</PopoverTrigger>
@@ -152,7 +155,7 @@ export function PlanningGroupManager({ scope, groups, trigger, itemLabel, getUsa
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>确认删除分组</AlertDialogTitle>
-          <AlertDialogDescription>{deletionCount > 0 ? `删除「${pendingDeletion?.name}」后，${deletionCount} 个${itemLabel}会变为未分组，内容不会删除。` : `删除「${pendingDeletion?.name}」后无法恢复。`}</AlertDialogDescription>
+          <AlertDialogDescription>{deletionHasAssociatedItems ? `删除「${pendingDeletion?.name}」后，${showDeletionCount ? `${deletionCount} 个` : '关联的'}${itemLabel}会变为未分组，内容不会删除。` : `删除「${pendingDeletion?.name}」后无法恢复。`}</AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel disabled={savingAction === 'delete'}>取消</AlertDialogCancel>

--- a/apps/electron/src/renderer/components/planning/PlanningView.tsx
+++ b/apps/electron/src/renderer/components/planning/PlanningView.tsx
@@ -361,9 +361,10 @@ function TodoWorkspace({ standalone = false }: { standalone?: boolean } = {}): R
   const openTodos = todos.filter((todo) => todo.status === 'open')
   const todoGroupUsageCounts = React.useMemo(() => {
     const counts = new Map<string, number>()
-    for (const todo of todos) if (todo.groupId) counts.set(todo.groupId, (counts.get(todo.groupId) ?? 0) + 1)
+    for (const todo of todos) if (todo.status === 'open' && todo.groupId) counts.set(todo.groupId, (counts.get(todo.groupId) ?? 0) + 1)
     return counts
   }, [todos])
+  const todoGroupHasAssociatedItems = React.useMemo(() => new Set(todos.flatMap((todo) => todo.groupId ? [todo.groupId] : [])), [todos])
   const todayEnd = React.useMemo(() => endOfToday(dayVersion), [dayVersion])
   const weekEnd = React.useMemo(() => endOfToday(addLocalDays(dayVersion, 7)), [dayVersion])
   const visibleTodos = view === 'all' ? openTodos
@@ -374,11 +375,11 @@ function TodoWorkspace({ standalone = false }: { standalone?: boolean } = {}): R
   const viewTitle = view === 'all' ? '全部任务' : view === 'today' ? '今天' : view === 'upcoming' ? '未来 7 天' : view === 'completed' ? '已完成' : groups.find((group) => `group:${group.id}` === view)?.name ?? '分组'
   const count = (predicate: (todo: Todo) => boolean): number => openTodos.filter(predicate).length
 
-  const navItems: Array<{ id: TodoListView; label: string; icon: React.ReactNode; count: number }> = [
+  const navItems: Array<{ id: TodoListView; label: string; icon: React.ReactNode; count?: number }> = [
     { id: 'all', label: '全部任务', icon: <ListTodo size={15} />, count: openTodos.length },
     { id: 'today', label: '今天', icon: <CalendarDays size={15} />, count: count((todo) => todo.dueAt !== undefined && todo.dueAt <= todayEnd) },
     { id: 'upcoming', label: '未来 7 天', icon: <ChevronRight size={15} />, count: count((todo) => todo.dueAt !== undefined && todo.dueAt > todayEnd && todo.dueAt <= weekEnd) },
-    { id: 'completed', label: '已完成', icon: <Check size={15} />, count: todos.filter((todo) => todo.status === 'completed').length },
+    { id: 'completed', label: '已完成', icon: <Check size={15} /> },
   ]
 
   return (
@@ -387,14 +388,14 @@ function TodoWorkspace({ standalone = false }: { standalone?: boolean } = {}): R
         <aside className="flex min-h-0 flex-col overflow-y-auto border-r border-border/60 bg-muted/15 p-3 scrollbar-thin">
           <div className="px-2 pb-3 pt-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">Todo</div>
           <nav className="space-y-1" aria-label="Todo 清单">
-            {navItems.map((item) => <button key={item.id} type="button" onClick={() => { setView(item.id); setSelectedId(null) }} className={cn('flex h-9 w-full items-center gap-2 rounded-md px-2 text-sm transition-colors', view === item.id ? 'bg-background font-medium text-foreground shadow-sm' : 'text-muted-foreground hover:bg-muted/70 hover:text-foreground')}><span className="text-muted-foreground">{item.icon}</span><span className="flex-1 text-left">{item.label}</span><span className="text-xs tabular-nums text-muted-foreground">{item.count}</span></button>)}
+            {navItems.map((item) => <button key={item.id} type="button" onClick={() => { setView(item.id); setSelectedId(null) }} className={cn('flex h-9 w-full items-center gap-2 rounded-md px-2 text-sm transition-colors', view === item.id ? 'bg-background font-medium text-foreground shadow-sm' : 'text-muted-foreground hover:bg-muted/70 hover:text-foreground')}><span className="text-muted-foreground">{item.icon}</span><span className="flex-1 text-left">{item.label}</span>{item.count !== undefined && <span className="text-xs tabular-nums text-muted-foreground">{item.count}</span>}</button>)}
           </nav>
-          <div className="mt-7"><div className="flex items-center justify-between px-2 pb-2"><span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Todo 分组</span><PlanningGroupManager scope="todo" groups={groups} itemLabel="Todo" getUsageCount={(groupId) => todoGroupUsageCounts.get(groupId) ?? 0} onCreate={createTodoGroup} onRename={renameTodoGroup} onDelete={deleteTodoGroup} onCreated={(group) => { setView(`group:${group.id}`); setSelectedId(null) }} trigger={<button type="button" className="min-h-10 px-1 text-xs text-muted-foreground transition-colors hover:text-foreground">管理</button>} /></div><div className="space-y-1">{groups.map((group) => { const id = `group:${group.id}` as TodoListView; return <button key={group.id} type="button" onClick={() => { setView(id); setSelectedId(null) }} className={cn('flex h-9 w-full items-center gap-2 rounded-md px-2 text-sm transition-colors', view === id ? 'bg-background font-medium text-foreground shadow-sm' : 'text-muted-foreground hover:bg-muted/70 hover:text-foreground')}><span className="size-2 rounded-full" style={{ backgroundColor: group.color ?? 'currentColor' }} /><span className="flex-1 truncate text-left">{group.name}</span><span className="text-xs tabular-nums text-muted-foreground">{todoGroupUsageCounts.get(group.id) ?? 0}</span></button> })}</div></div>
+          <div className="mt-7"><div className="flex items-center justify-between px-2 pb-2"><span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Todo 分组</span><PlanningGroupManager scope="todo" groups={groups} itemLabel="Todo" getUsageCount={(groupId) => todoGroupUsageCounts.get(groupId) ?? 0} hasAssociatedItems={(groupId) => todoGroupHasAssociatedItems.has(groupId)} showDeletionCount={false} onCreate={createTodoGroup} onRename={renameTodoGroup} onDelete={deleteTodoGroup} onCreated={(group) => { setView(`group:${group.id}`); setSelectedId(null) }} trigger={<button type="button" className="min-h-10 px-1 text-xs text-muted-foreground transition-colors hover:text-foreground">管理</button>} /></div><div className="space-y-1">{groups.map((group) => { const id = `group:${group.id}` as TodoListView; return <button key={group.id} type="button" onClick={() => { setView(id); setSelectedId(null) }} className={cn('flex h-9 w-full items-center gap-2 rounded-md px-2 text-sm transition-colors', view === id ? 'bg-background font-medium text-foreground shadow-sm' : 'text-muted-foreground hover:bg-muted/70 hover:text-foreground')}><span className="size-2 rounded-full" style={{ backgroundColor: group.color ?? 'currentColor' }} /><span className="flex-1 truncate text-left">{group.name}</span><span className="text-xs tabular-nums text-muted-foreground">{todoGroupUsageCounts.get(group.id) ?? 0}</span></button> })}</div></div>
         </aside>
 
         <div className="flex min-h-0 min-w-0 flex-col overflow-hidden border-r border-border/60">
           <div className="border-b border-border/60 px-5 py-4">
-            <div className="flex items-center justify-between"><h2 className="text-base font-semibold">{viewTitle}</h2><span className="text-xs tabular-nums text-muted-foreground">{visibleTodos.length} 项</span></div>
+            <div className="flex items-center justify-between"><h2 className="text-base font-semibold">{viewTitle}</h2>{view !== 'completed' && <span className="text-xs tabular-nums text-muted-foreground">{visibleTodos.length} 项</span>}</div>
           </div>
           <div className="min-h-0 flex-1 overflow-y-auto">{visibleTodos.length ? visibleTodos.map((todo) => <TodoListItem key={todo.id} todo={todo} selected={selectedId === todo.id} todayEnd={todayEnd} onSelect={() => setSelectedId(todo.id)} onToggle={() => void completeTodo(todo)} onDelete={() => setTodoPendingDeletion(todo)} />) : <div className="flex h-full min-h-56 items-center justify-center px-8 text-center text-sm text-muted-foreground">这里还没有任务。点击右上角“新建 Todo”或按 ⌘N 即可添加。</div>}</div>
         </div>


### PR DESCRIPTION
## Summary

- Exclude completed Todo items from group and sidebar counts.
- Keep completed Todo history accessible without exposing its count.

## Test plan

- [x] `bun run --filter='@proma/electron' typecheck`
- [x] `bun test apps/electron/src/main/lib/planning-manager.test.ts`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)