### PR TITLE
Fix Feishu session mirror for new bots

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -2041,7 +2041,13 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(
     AGENT_IPC_CHANNELS.FORK_SESSION,
     async (_, input: ForkSessionInput): Promise<AgentSessionMeta> => {
-      return forkAgentSession(input)
+      const session = await forkAgentSession(input)
+      // Fork 直接在 session manager 内创建元数据，绕过 CREATE_SESSION 的镜像生命周期。
+      // 将它作为新的桌面会话处理，确保 Pi fork 也会立即获得可双向续聊的飞书群。
+      feishuBridgeManager.ensureSessionMirror(session).catch((error) => {
+        console.error('[飞书 Session 镜像] 分叉会话建群失败:', error)
+      })
+      return session
     }
   )
 
@@ -3859,6 +3865,7 @@ export function registerIpcHandlers(): void {
     FEISHU_IPC_CHANNELS.SAVE_BOT_CONFIG,
     async (_, input: import('@proma/shared').FeishuBotConfigInput) => {
       const saved = saveFeishuBotConfig(input)
+      feishuBridgeManager.setSessionMirrorOperator(saved.id, input.operatorOpenId)
       // 配置变更后自动重启或停止（不阻塞保存结果）
       if (saved.enabled && saved.appId && saved.appSecret) {
         feishuBridgeManager.restartBot(saved.id).catch((err) => {

--- a/apps/electron/src/main/lib/feishu-bridge-manager.ts
+++ b/apps/electron/src/main/lib/feishu-bridge-manager.ts
@@ -18,10 +18,11 @@ import type {
 import { FeishuBridge } from './feishu-bridge'
 import { redactSensitiveLogValue } from './bridge-log-redaction'
 import { getFeishuMultiBotConfig, getFeishuBotById } from './feishu-config'
-import { getFeishuBotBindingsPath } from './config-paths'
+import { getFeishuBotBindingsPath, getFeishuBotMetadataPath } from './config-paths'
+import { writeJsonFileAtomic } from './safe-file'
 import { isBindingForDeletedWorkspace } from './bridge-binding-store'
 import { getSettings } from './settings-service'
-import { resolveSessionMirrorBot } from './feishu/session-mirror'
+import { resolveSessionMirrorBot, normalizeSessionMirrorUserOpenId } from './feishu/session-mirror'
 
 class FeishuBridgeManager {
   /** botId → Bridge 实例 */
@@ -95,6 +96,24 @@ class FeishuBridgeManager {
   async restartBot(botId: string): Promise<void> {
     this.stopBot(botId)
     await this.startBot(botId)
+  }
+
+  /** 为新建或重配的 Bot 记录扫码操作人的当前组织身份，供 Session 镜像立即建群。 */
+  setSessionMirrorOperator(botId: string, operatorOpenId: string | undefined): void {
+    const userOpenId = normalizeSessionMirrorUserOpenId(operatorOpenId)
+    if (!userOpenId) return
+
+    const bridge = this.bridges.get(botId)
+    if (bridge) {
+      bridge.setSessionMirrorUserOpenId(userOpenId)
+      return
+    }
+
+    try {
+      writeJsonFileAtomic(getFeishuBotMetadataPath(botId), { lastInteractedUserOpenId: userOpenId })
+    } catch (error) {
+      console.error(`[飞书 BridgeManager] 保存 Bot ${botId} 的镜像用户身份失败:`, redactSensitiveLogValue(error))
+    }
   }
 
   // ===== 状态查询 =====

--- a/apps/electron/src/main/lib/feishu-bridge.ts
+++ b/apps/electron/src/main/lib/feishu-bridge.ts
@@ -39,6 +39,7 @@ import {
 } from './agent-workspace-manager'
 import { getFeishuBotBindingsPath, getFeishuBotMetadataPath } from './config-paths'
 import { writeFileSync, readFileSync, existsSync } from 'node:fs'
+import { readJsonFileSafe, writeJsonFileAtomic } from './safe-file'
 import {
   inferImageMediaType as inferImageMediaTypeShared,
   saveImageToSession as saveImageToSessionShared,
@@ -79,7 +80,7 @@ import {
   type RunState,
 } from './feishu/card-run-state'
 import { renderCard as renderRunCard } from './feishu/card-renderer-v2'
-import { buildSessionMirrorGroupName } from './feishu/session-mirror'
+import { buildSessionMirrorGroupName, normalizeSessionMirrorUserOpenId } from './feishu/session-mirror'
 import { resolveGroupMessageAccess } from './feishu/group-message-policy'
 import { ScopedQueue } from './feishu/scoped-queue'
 import { RunCoordinator } from './feishu/run-coordinator'
@@ -416,32 +417,30 @@ class FeishuBridge {
    */
   private loadMetadata(): void {
     const metaPath = getFeishuBotMetadataPath(this.botConfig.id)
-    if (!existsSync(metaPath)) return
-
-    try {
-      const raw = readFileSync(metaPath, 'utf-8')
-      const data = JSON.parse(raw) as { lastInteractedUserOpenId?: string }
-      if (data.lastInteractedUserOpenId && data.lastInteractedUserOpenId !== 'unknown') {
-        this.lastInteractedUserOpenId = data.lastInteractedUserOpenId
-      }
-    } catch (error) {
-      console.error('[飞书 Bridge] 加载元数据失败:', redactSensitiveLogValue(error))
-    }
+    const data = readJsonFileSafe<{ lastInteractedUserOpenId?: string }>(metaPath)
+    const userOpenId = normalizeSessionMirrorUserOpenId(data?.lastInteractedUserOpenId)
+    if (userOpenId) this.lastInteractedUserOpenId = userOpenId
   }
 
   private saveMetadata(): void {
     try {
-      const metaPath = getFeishuBotMetadataPath(this.botConfig.id)
-      const data = { lastInteractedUserOpenId: this.lastInteractedUserOpenId }
-      writeFileSync(metaPath, JSON.stringify(data, null, 2), 'utf-8')
+      writeJsonFileAtomic(getFeishuBotMetadataPath(this.botConfig.id), {
+        lastInteractedUserOpenId: this.lastInteractedUserOpenId,
+      })
     } catch (error) {
       console.error('[飞书 Bridge] 保存元数据失败:', redactSensitiveLogValue(error))
     }
   }
 
+  /** 将扫码创建该 Bot 的当前组织用户设为 Session 镜像目标。 */
+  setSessionMirrorUserOpenId(openId: string): void {
+    this.setLastInteractedUserOpenId(openId)
+  }
+
   private setLastInteractedUserOpenId(openId: string | null): void {
-    if (this.lastInteractedUserOpenId === openId) return
-    this.lastInteractedUserOpenId = openId
+    const normalized = normalizeSessionMirrorUserOpenId(openId)
+    if (!normalized || this.lastInteractedUserOpenId === normalized) return
+    this.lastInteractedUserOpenId = normalized
     this.saveMetadata()
   }
 

--- a/apps/electron/src/main/lib/feishu/session-mirror.ts
+++ b/apps/electron/src/main/lib/feishu/session-mirror.ts
@@ -34,6 +34,11 @@ export function buildSessionMirrorGroupName(session: Pick<AgentSessionMeta, 'id'
   return truncateGroupName(`Proma - ${title}`)
 }
 
+export function normalizeSessionMirrorUserOpenId(openId: string | null | undefined): string | undefined {
+  const normalized = openId?.trim()
+  return normalized && normalized !== 'unknown' ? normalized : undefined
+}
+
 function truncateGroupName(name: string): string {
   return name.length > 60 ? `${name.slice(0, 57)}...` : name
 }

--- a/apps/electron/src/renderer/components/settings/FeishuSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/FeishuSettings.tsx
@@ -882,8 +882,8 @@ function CliRecommendationCard(): React.ReactElement {
 interface RegisterFeishuDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
-  /** 注册成功后回调，返回主进程拿到的 App ID/Secret；上层应在此处保存配置并启动 Bot */
-  onSuccess: (result: { appId: string; appSecret: string }) => void
+  /** 注册成功后回调，返回主进程拿到的 App ID/Secret 与扫码用户身份；上层应在此处保存配置并启动 Bot */
+  onSuccess: (result: { appId: string; appSecret: string; operatorOpenId?: string }) => void
 }
 
 /** 扫码注册飞书 Bot：弹窗内全程引导，扫码成功后自动保存配置并启动 Bot */
@@ -922,7 +922,11 @@ function RegisterFeishuDialog({ open, onOpenChange, onSuccess }: RegisterFeishuD
       .then((result) => {
         if (cancelled) return
         setPhase('success')
-        onSuccessRef.current({ appId: result.appId, appSecret: result.appSecret })
+        onSuccessRef.current({
+          appId: result.appId,
+          appSecret: result.appSecret,
+          operatorOpenId: result.operatorOpenId,
+        })
       })
       .catch((err: unknown) => {
         if (cancelled) return
@@ -1179,7 +1183,7 @@ function SessionMirrorSection({ bots }: { bots: FeishuBotConfig[] }): React.Reac
             <div className="flex items-start gap-2 rounded-lg bg-amber-500/10 px-3 py-3 text-xs text-amber-800 dark:text-amber-300">
               <AlertTriangle size={15} className="mt-0.5 flex-shrink-0" />
               <div className="leading-relaxed">
-                当前同步 Bot 还没有绑定记录。请先在飞书里向「{selectedBot?.name ?? '该 Bot'}」发送一条消息，Proma 记录你的 open_id 后才能自动为新 Session 建群。
+                当前同步 Bot 还没有历史聊天绑定。通过 Proma「扫码创建」的 Bot 已保存扫码账号的当前组织身份，可直接为新 Session 建群；手动填写 App ID/Secret 添加的 Bot，请先在飞书里向「{selectedBot?.name ?? '该 Bot'}」发送一条消息，让 Proma 记录当前组织的 open_id。
               </div>
             </div>
           )}
@@ -1491,7 +1495,7 @@ function FeishuConfigTab(): React.ReactElement {
   const [registerOpen, setRegisterOpen] = React.useState(false)
 
   /** 扫码成功后：保存配置 + 自动启动 Bot */
-  const handleRegisterSuccess = React.useCallback(async (result: { appId: string; appSecret: string }) => {
+  const handleRegisterSuccess = React.useCallback(async (result: { appId: string; appSecret: string; operatorOpenId?: string }) => {
     try {
       const saved = await window.electronAPI.saveFeishuBotConfig({
         name: defaultBotName(bots.length),
@@ -1501,6 +1505,7 @@ function FeishuConfigTab(): React.ReactElement {
         defaultWorkspaceId: undefined,
         defaultChannelId: undefined,
         defaultModelId: undefined,
+        operatorOpenId: result.operatorOpenId,
       })
       setBots((prev) => [...prev, saved])
       toast.success(`Bot "${saved.name}" 已创建`)

--- a/packages/shared/src/types/feishu.ts
+++ b/packages/shared/src/types/feishu.ts
@@ -74,6 +74,8 @@ export interface FeishuBotConfigInput {
   defaultChannelId?: string
   /** 默认模型 ID */
   defaultModelId?: string
+  /** 扫码创建此应用的当前组织用户 open_id，仅用于初始化 Session 镜像目标。 */
+  operatorOpenId?: string
 }
 
 // ===== Session 镜像 =====


### PR DESCRIPTION
## Summary

- Restore Feishu session-mirror binding creation for forked desktop sessions.
- Persist the current tenant's scanned operator open_id for each newly configured Feishu Bot, so session mirroring survives Bot and organization changes.
- Keep manual Bot setup explicit: the user must first message the Bot to establish its organization-scoped open_id.

## Test plan

- [x] `bun run --filter='@proma/electron' typecheck`
- [x] `bun test apps/electron/src/main/lib/feishu/session-mirror.test.ts apps/electron/src/main/lib/adapters/pi-message-adapter.test.ts apps/electron/src/main/lib/adapters/pi-agent-retry-policy.test.ts`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)