### PR TITLE
fix(agent): gate 64K output cap on Claude family name

### DIFF
--- a/apps/electron/src/main/lib/agent-sdk-output-limits.test.ts
+++ b/apps/electron/src/main/lib/agent-sdk-output-limits.test.ts
@@ -13,49 +13,4 @@ describe('Agent SDK 输出 token 上限', () => {
       expect(getAgentSdkMaxOutputTokens(modelId)).toBeUndefined()
     },
   )
-
-  // issue #1159：模型名仅**包含** claude 子串时不应命中
-  test.each([
-    // 用户自定义模型名，并非 Claude
-    'my-not-claude-fork',
-    // 第三方网关别名，实际后端并非 Claude
-    'gateway/claude-proxy',
-    'claude-proxy',
-    // 仅有 claude 字样、不带任何系列名
-    'claude',
-    'my-claude',
-    'claude-mini',
-  ] as const)(
-    'Given 模型名仅包含 claude 子串但无系列名 %s When 构建 SDK env Then 不注入 max output token 覆盖',
-    (modelId) => {
-      expect(getAgentSdkMaxOutputTokens(modelId)).toBeUndefined()
-    },
-  )
-
-  // 真实 Claude 模型的各种别名形态必须继续命中（避免修复过度收窄）
-  test.each([
-    // 系列名在前（4.x 起的命名）
-    'claude-sonnet-4-6',
-    'claude-opus-4-8',
-    'claude-haiku-4-5',
-    'claude-fable-5',
-    'claude-mythos-preview',
-    // 厂商前缀 / provider 作用域形态
-    'vendor/Claude-Opus-4-8',
-    'anthropic.claude-opus-4-6-v1',
-    // Agent SDK 的 [1m] 扩展上下文后缀
-    'claude-sonnet-4-6[1m]',
-    // 版本号在前的 3.x 旧命名
-    'claude-3-opus-20240229',
-    'claude-3-5-sonnet-20241022',
-  ] as const)(
-    'Given 真实 Claude 模型 %s When 构建 SDK env Then 注入 64K 输出上限',
-    (modelId) => {
-      expect(getAgentSdkMaxOutputTokens(modelId)).toBe('64000')
-    },
-  )
-
-  test('Given 空模型名 When 构建 SDK env Then 不注入 max output token 覆盖', () => {
-    expect(getAgentSdkMaxOutputTokens('')).toBeUndefined()
-  })
 })

--- a/apps/electron/src/main/lib/agent-sdk-output-limits.test.ts
+++ b/apps/electron/src/main/lib/agent-sdk-output-limits.test.ts
@@ -13,4 +13,49 @@ describe('Agent SDK 输出 token 上限', () => {
       expect(getAgentSdkMaxOutputTokens(modelId)).toBeUndefined()
     },
   )
+
+  // issue #1159：模型名仅**包含** claude 子串时不应命中
+  test.each([
+    // 用户自定义模型名，并非 Claude
+    'my-not-claude-fork',
+    // 第三方网关别名，实际后端并非 Claude
+    'gateway/claude-proxy',
+    'claude-proxy',
+    // 仅有 claude 字样、不带任何系列名
+    'claude',
+    'my-claude',
+    'claude-mini',
+  ] as const)(
+    'Given 模型名仅包含 claude 子串但无系列名 %s When 构建 SDK env Then 不注入 max output token 覆盖',
+    (modelId) => {
+      expect(getAgentSdkMaxOutputTokens(modelId)).toBeUndefined()
+    },
+  )
+
+  // 真实 Claude 模型的各种别名形态必须继续命中（避免修复过度收窄）
+  test.each([
+    // 系列名在前（4.x 起的命名）
+    'claude-sonnet-4-6',
+    'claude-opus-4-8',
+    'claude-haiku-4-5',
+    'claude-fable-5',
+    'claude-mythos-preview',
+    // 厂商前缀 / provider 作用域形态
+    'vendor/Claude-Opus-4-8',
+    'anthropic.claude-opus-4-6-v1',
+    // Agent SDK 的 [1m] 扩展上下文后缀
+    'claude-sonnet-4-6[1m]',
+    // 版本号在前的 3.x 旧命名
+    'claude-3-opus-20240229',
+    'claude-3-5-sonnet-20241022',
+  ] as const)(
+    'Given 真实 Claude 模型 %s When 构建 SDK env Then 注入 64K 输出上限',
+    (modelId) => {
+      expect(getAgentSdkMaxOutputTokens(modelId)).toBe('64000')
+    },
+  )
+
+  test('Given 空模型名 When 构建 SDK env Then 不注入 max output token 覆盖', () => {
+    expect(getAgentSdkMaxOutputTokens('')).toBeUndefined()
+  })
 })

--- a/apps/electron/src/main/lib/agent-sdk-output-limits.ts
+++ b/apps/electron/src/main/lib/agent-sdk-output-limits.ts
@@ -1,3 +1,25 @@
+/**
+ * Agent SDK 输出 token 上限判定。
+ *
+ * 只有真正的 Claude 模型才应注入 `CLAUDE_CODE_MAX_OUTPUT_TOKENS=64000`。此前用
+ * `modelId.includes('claude')` 判断，任何仅**包含** "claude" 子串的 ID 都会误命中：
+ * - 用户自定义模型名 `my-not-claude-fork`
+ * - 第三方网关别名 `gateway/claude-proxy`（实际后端并非 Claude）
+ *
+ * 判定沿用仓库既有的模型识别惯例：真实 Claude 模型 ID 一定带**系列名**，而网关别名
+ * 与自定义分支不带。参见 `adapters/pi-model-registry.ts` 的 `getClaudeFamilyKey`
+ * （同样要求 `claude` + 系列名，并使用同一套分隔符类以兼容
+ * `anthropic.claude-opus-4-6-v1`、`vendor/Claude-Opus-4-8`、`claude-sonnet-4-6[1m]`
+ * 等别名形态）；`mythos` 系列见 `packages/core/src/providers/thinking-capability.ts`
+ * 对 `claude-mythos-preview` 的处理。
+ *
+ * 两种命名形态都要覆盖，避免收窄现有行为：
+ * - 系列名在前（4.x 起）：`claude-sonnet-4-6`、`claude-opus-4-8`、`claude-haiku-4-5`
+ * - 版本号在前（3.x 旧命名）：`claude-3-opus-20240229`、`claude-3-5-sonnet-20241022`
+ */
+const CLAUDE_MODEL_PATTERN =
+  /claude[\s._:/-]+(?:(?:opus|sonnet|haiku|fable|mythos)\b|\d+(?:[\s._:/-]+\d+)?[\s._:/-]+(?:opus|sonnet|haiku)\b)/i
+
 export function getAgentSdkMaxOutputTokens(modelId: string | undefined): string | undefined {
-  return modelId?.toLowerCase().includes('claude') ? '64000' : undefined
+  return modelId && CLAUDE_MODEL_PATTERN.test(modelId) ? '64000' : undefined
 }


### PR DESCRIPTION
## Summary

`getAgentSdkMaxOutputTokens` gated on `modelId?.toLowerCase().includes('claude')`, so any model id
merely *containing* the substring got `CLAUDE_CODE_MAX_OUTPUT_TOKENS=64000` injected into the Agent
SDK env at `agent-orchestrator.ts:479-484`. Reproduced on `main` (`e81e666`) before the change:

```
claude-sonnet-4-6          -> 64000
vendor/Claude-Opus-4-8     -> 64000
claude-sonnet-4-6[1m]      -> 64000
my-not-claude-fork         -> 64000   <-- 误命中
gateway/claude-proxy       -> 64000   <-- 误命中
claude-haiku-4-5           -> 64000
glm-5.2                    -> undefined
undefined                  -> undefined
```

Fixes #1159.

## 关于 issue 里给的两个修复方向

issue 建议「前缀匹配 `/^claude-/i`，或与 `AGENT_SDK_1M_CONTEXT_RULES.claude` 的模型列表保持一致」。
两个都验证过，这里都没有直接采用，原因如下：

- **`/^claude-/i` 会让仓库现有测试失败。** `agent-sdk-output-limits.test.ts:7` 已经固定了
  `getAgentSdkMaxOutputTokens('vendor/Claude-Opus-4-8')` → `'64000'`，而 `vendor/Claude-Opus-4-8`
  并不以 `claude-` 开头。带厂商前缀的真实 Claude 模型会被一起误杀。
- **绑定 `AGENT_SDK_1M_CONTEXT_RULES.claude` 会收窄现有行为。** 那份列表的语义是「已确认需要显式选择
  `[1m]` 变体的模型」，只有 7 项；改用它之后 `claude-haiku-4-5`、`claude-mythos-preview`、
  `claude-sonnet-4-5-20250929`、`claude-3-*` 等真实 Claude 模型都会不再注入 64K。这是把「1M 上下文」
  和「64K 输出上限」两个不同的判定耦合到一起，属于产品决策，不在本 PR 范围内。

改用的判定是**仓库自己已有的做法**：真实 Claude 模型 ID 一定带**系列名**，而网关别名 / 自定义分支
不带。`adapters/pi-model-registry.ts` 的 `getClaudeFamilyKey` 就是这么做的（`claude` + 系列名 +
版本号，注释里明确写了要兼容 `anthropic.claude-opus-4-6-v1` 这类形态），本 PR 复用它的系列名集合和
分隔符类 `[\s._:/-]`；`mythos` 取自 `packages/core/src/providers/thinking-capability.ts` 对
`claude-mythos-preview` 的处理。

两种命名形态都覆盖，避免修复过度收窄：

- 系列名在前（4.x 起）：`claude-sonnet-4-6`、`claude-opus-4-8`、`claude-haiku-4-5`
- 版本号在前（3.x 旧命名）：`claude-3-opus-20240229`、`claude-3-5-sonnet-20241022`

**唯一的行为变化就是 issue 报告的那一类**：ID 里带 `claude` 字样但不含任何系列名的，不再注入。

## Test plan

`bun test apps/electron/src/main/lib/agent-sdk-output-limits.test.ts`

| | 结果 |
|---|---|
| 修复前（pristine `e81e666`） | **6 pass / 0 fail** |
| 修复后 | **23 pass / 0 fail**（+17 新增用例） |
| 负向对照（只回滚 `agent-sdk-output-limits.ts`，保留新测试） | **17 pass / 6 fail** |

负向对照失败的正好是 6 条误命中断言（`my-not-claude-fork`、`gateway/claude-proxy`、`claude-proxy`、
`claude`、`my-claude`、`claude-mini`），说明新测试确实钉住了这个 bug 而不是别的东西。

`bun run typecheck`（root，全部 workspace）：6 个包全部 `Exited with code 0`。

`bun test`（全仓库）：

| | 结果 |
|---|---|
| pristine `e81e666` | 457 pass / 15 fail / 472 tests across 67 files |
| 本分支 | 474 pass / 15 fail / 489 tests across 67 files |

`+17 pass / +17 tests` 正好等于新增用例数，**15 条失败两边完全一致**（去掉耗时后集合相等，7 个
唯一用例名）。这 15 条在 pristine `main` 上同样失败，都是 Windows 环境问题，与本改动无关：工作区
Windows 保留设备名、broken symlink 扫描、planning sqlite 库、MCP 保留名归一化。

## 已知局限

- 验证环境是 **Windows + bun 1.3.13**，没有跑 Electron 端到端；改动是一个纯函数 + 它的单测。
- 无法穷尽区分「真 Claude」与「借 Claude 命名的网关别名」：例如
  `gateway/claude-sonnet-proxy` 这种既带系列名又是代理的 ID 仍会命中。要完全消除只能维护精确模型
  白名单（即 issue 的第二个方向），代价是上面说的收窄。如果你们更希望走白名单那条路（或者希望为输出
  上限单独建一份列表、与 1M 上下文解耦），我可以按那个方向改。
- `claude-3-*` 这类老模型的真实输出上限远低于 64K，注入 64000 本身是否合适可能值得单独看；本 PR
  保持现状不动，只修 issue 报告的问题。
