### PR TITLE
feat(files): 支持按会话筛选文件来源【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -387,6 +387,15 @@ export const agentSidePanelOpenAtom = atomWithStorage<boolean>('proma-agent-side
 /** 侧面板宽度（全局共享，用户拖拽后持久化） */
 export const agentSidePanelWidthAtom = atomWithStorage<number>('proma-agent-sidepanel-width', 280)
 
+/** 文件来源选择：按会话持久化，未存储的会话默认显示会话文件。 */
+export type AgentFileSourceFilter = 'session' | 'project'
+export const agentFileSourceFilterMapAtom = atomWithStorage<Record<string, AgentFileSourceFilter>>(
+  'proma-agent-file-source-filter-map',
+  {},
+  undefined,
+  { getOnInit: true },
+)
+
 /** @deprecated 保留以兼容旧代码，但实际所有 session 都读全局 atom */
 export const agentSidePanelOpenMapAtom = atom<Map<string, boolean>>(new Map())
 

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -23,6 +23,7 @@ import { DiffChangesList } from '@/components/diff/DiffChangesList'
 import { ChatView } from '@/components/chat/ChatView'
 import {
   agentSidePanelOpenAtom,
+  agentFileSourceFilterMapAtom,
   workspaceFilesVersionAtom,
   currentAgentWorkspaceIdAtom,
   agentWorkspacesAtom,
@@ -36,7 +37,7 @@ import {
   fileBrowserAutoRevealAtom,
   agentSelectedWorktreeAtom,
 } from '@/atoms/agent-atoms'
-import type { AgentSidePanelTab } from '@/atoms/agent-atoms'
+import type { AgentSidePanelTab, AgentFileSourceFilter } from '@/atoms/agent-atoms'
 import { agentSideChatMapAtom } from '@/atoms/chat-atoms'
 import { interfaceVariantAtom } from '@/atoms/theme'
 import { previewFileMapAtom } from '@/atoms/preview-atoms'
@@ -74,7 +75,6 @@ interface SidePanelProps {
   onTabChange: (tab: AgentSidePanelTab) => void
   width?: number
 }
-
 
 export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, width = 280 }: SidePanelProps): React.ReactElement {
   // per-session 侧面板状态（默认打开）
@@ -353,10 +353,22 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
     [sessionPath, workspaceFilesPath, extraPathsMemo]
   )
 
+  const fileSourceFilterMap = useAtomValue(agentFileSourceFilterMapAtom)
+  const setFileSourceFilterMap = useSetAtom(agentFileSourceFilterMapAtom)
+  const fileSourceFilter = fileSourceFilterMap[sessionId] ?? 'session'
+  const setFileSourceFilter = React.useCallback((source: AgentFileSourceFilter) => {
+    setFileSourceFilterMap((prev) => {
+      if (prev[sessionId] === source) return prev
+      return { ...prev, [sessionId]: source }
+    })
+  }, [sessionId, setFileSourceFilterMap])
+  const showSessionFiles = fileSourceFilter === 'session'
+  const showProjectFiles = fileSourceFilter === 'project'
+
   const visibleFileRoots = React.useMemo(() => [
-    ...(workspaceFilesPath && !isProjectRootUnavailable ? [{ path: workspaceFilesPath, scope: 'project' as const }] : []),
-    ...(sessionPath ? [{ path: sessionPath, scope: 'session' as const }] : []),
-  ], [workspaceFilesPath, isProjectRootUnavailable, sessionPath])
+    ...(showProjectFiles && workspaceFilesPath && !isProjectRootUnavailable ? [{ path: workspaceFilesPath, scope: 'project' as const }] : []),
+    ...(showSessionFiles && sessionPath ? [{ path: sessionPath, scope: 'session' as const }] : []),
+  ], [showProjectFiles, workspaceFilesPath, isProjectRootUnavailable, showSessionFiles, sessionPath])
 
   // Files 将会话与项目文件放在同一视图；FileBrowser 自己处理对应根目录的自动定位。
   // RightSidePanel 完全由用户控制，不因 Agent 文件变更自动打开。
@@ -365,6 +377,8 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   basePathsRef.current = [sessionPath, workspaceFilesPath, ...fileAccessPathsMemo].filter(Boolean) as string[]
   const hasSessionAttachedItems = attachedDirs.length > 0 || attachedFiles.length > 0
   const hasWorkspaceAttachedItems = wsAttachedDirs.length > 0 || wsAttachedFiles.length > 0
+  const hasVisibleSessionAttachedItems = showSessionFiles && hasSessionAttachedItems
+  const hasVisibleWorkspaceAttachedItems = showProjectFiles && hasWorkspaceAttachedItems
   const interfaceVariant = useAtomValue(interfaceVariantAtom)
   const isClassic = interfaceVariant === 'classic'
   const sideChatMap = useAtomValue(agentSideChatMapAtom)
@@ -450,12 +464,45 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
                     sessionPath={sessionPath}
                     sessionAttachedDirs={attachedDirs}
                     workspaceAttachedDirs={wsAttachedDirs}
+                    sourceFilter={fileSourceFilter}
+                    showSessionBadge={false}
                     placeholder="搜索文件..."
                     sessionId={sessionId}
                     onFilePreview={handleFilePreview}
-                  />
-                  <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin">
-                    {wsAttachedFiles.length > 0 && (
+                  >
+                    <div className="file-source-tabbar main-tabbar mt-1.5 flex h-7 border-b border-border/80" role="tablist" aria-label="文件来源">
+                      <button
+                        type="button"
+                        role="tab"
+                        className={cn(
+                          'relative flex-1 h-7 px-2 text-[11px] transition-colors select-none',
+                          fileSourceFilter === 'session'
+                            ? 'app-tab-active text-foreground'
+                            : 'app-tab-inactive text-muted-foreground hover:text-foreground',
+                        )}
+                        aria-selected={fileSourceFilter === 'session'}
+                        onClick={() => setFileSourceFilter('session')}
+                      >
+                        会话文件
+                      </button>
+                      <button
+                        type="button"
+                        role="tab"
+                        className={cn(
+                          'relative flex-1 h-7 px-2 text-[11px] transition-colors select-none',
+                          fileSourceFilter === 'project'
+                            ? 'app-tab-active text-foreground'
+                            : 'app-tab-inactive text-muted-foreground hover:text-foreground',
+                        )}
+                        aria-selected={fileSourceFilter === 'project'}
+                        onClick={() => setFileSourceFilter('project')}
+                      >
+                        项目文件
+                      </button>
+                    </div>
+                  </FileSearchBar>
+                  <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin pt-1">
+                    {showProjectFiles && wsAttachedFiles.length > 0 && (
                       <AttachedFilesSection
                         scope="project"
                         attachedFiles={wsAttachedFiles}
@@ -466,7 +513,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
                         sessionId={sessionId}
                       />
                     )}
-                    {wsAttachedDirs.length > 0 && (
+                    {showProjectFiles && wsAttachedDirs.length > 0 && (
                       <AttachedDirsSection
                         scope="project"
                         attachedDirs={wsAttachedDirs}
@@ -478,9 +525,10 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
                         sessionId={sessionId}
                       />
                     )}
-                    {attachedFiles.length > 0 && (
+                    {showSessionFiles && attachedFiles.length > 0 && (
                       <AttachedFilesSection
                         scope="session"
+                        showSessionBadge={false}
                         attachedFiles={attachedFiles}
                         onDetach={handleDetachFile}
                         onAddToChat={handleAddToChat}
@@ -489,9 +537,10 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
                         sessionId={sessionId}
                       />
                     )}
-                    {attachedDirs.length > 0 && (
+                    {showSessionFiles && attachedDirs.length > 0 && (
                       <AttachedDirsSection
                         scope="session"
+                        showSessionBadge={false}
                         attachedDirs={attachedDirs}
                         onDetach={handleDetachDirectory}
                         refreshVersion={filesVersion}
@@ -501,7 +550,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
                         sessionId={sessionId}
                       />
                     )}
-                    {isProjectRootUnavailable && (
+                    {showProjectFiles && isProjectRootUnavailable && (
                       <div className="mx-2 my-2 px-3 py-2 text-xs text-destructive bg-destructive/10 rounded-md">
                         本地项目根目录不可用；当前会话文件仍可访问。
                       </div>
@@ -510,13 +559,14 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
                       roots={visibleFileRoots}
                       access={fileAccess}
                       projectRootPath={isProjectRootUnavailable ? null : workspaceFilesPath}
+                      showSessionBadge={false}
                       hideToolbar
                       embedded
-                      hideEmpty={hasSessionAttachedItems || hasWorkspaceAttachedItems}
+                      hideEmpty={hasVisibleSessionAttachedItems || hasVisibleWorkspaceAttachedItems}
                       onAddToChat={handleAddToChat}
                       onFilePreview={handleFilePreview}
                     />
-                    {!isProjectRootUnavailable && workspaceSlug && (
+                    {showProjectFiles && !isProjectRootUnavailable && workspaceSlug && (
                       <FileDropZone
                         workspaceSlug={workspaceSlug}
                         target="workspace"
@@ -543,6 +593,7 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
 interface AttachedFilesSectionProps {
   title?: string
   scope?: 'project' | 'session'
+  showSessionBadge?: boolean
   attachedFiles: string[]
   onDetach: (filePath: string) => void
   onAddToChat?: (entry: FileEntry) => void
@@ -551,7 +602,7 @@ interface AttachedFilesSectionProps {
   sessionId: string
 }
 
-function AttachedFilesSection({ title, scope = 'project', attachedFiles, onDetach, onAddToChat, onFilePreview, allowedPaths, sessionId }: AttachedFilesSectionProps): React.ReactElement {
+function AttachedFilesSection({ title, scope = 'project', showSessionBadge = true, attachedFiles, onDetach, onAddToChat, onFilePreview, allowedPaths, sessionId }: AttachedFilesSectionProps): React.ReactElement {
   return (
     <div className="pt-1 pb-0 flex-shrink-0">
       {title && <div className="text-[11px] font-medium text-muted-foreground mb-1 px-3">{title}</div>}
@@ -567,7 +618,7 @@ function AttachedFilesSection({ title, scope = 'project', attachedFiles, onDetac
             <span className="w-3.5 flex-shrink-0" />
             <FileTypeIcon name={name} isDirectory={false} />
             <span className="text-xs truncate flex-1" title={filePath}>{name}</span>
-            {scope === 'session' && (
+            {showSessionBadge && scope === 'session' && (
               <span className="flex-shrink-0 rounded-md bg-muted px-1.5 py-0.5 text-[10px] leading-none text-muted-foreground">会话文件</span>
             )}
             <div
@@ -634,6 +685,7 @@ function AttachedFilesSection({ title, scope = 'project', attachedFiles, onDetac
 interface AttachedDirsSectionProps {
   title?: string
   scope?: 'project' | 'session'
+  showSessionBadge?: boolean
   attachedDirs: string[]
   onDetach: (dirPath: string) => void
   /** 文件版本号，用于自动刷新已展开的目录 */
@@ -646,7 +698,7 @@ interface AttachedDirsSectionProps {
 }
 
 /** 附加目录区域：统一管理所有子项的选中状态 */
-function AttachedDirsSection({ title, scope = 'project', attachedDirs, onDetach, refreshVersion, onAddToChat, onFilePreview, allowedPaths, sessionId }: AttachedDirsSectionProps): React.ReactElement {
+function AttachedDirsSection({ title, scope = 'project', showSessionBadge = true, attachedDirs, onDetach, refreshVersion, onAddToChat, onFilePreview, allowedPaths, sessionId }: AttachedDirsSectionProps): React.ReactElement {
   const [selectedPaths, setSelectedPaths] = React.useState<Set<string>>(new Set())
 
   // ===== 接入搜索点击触发的 reveal：附加目录文件搜到后，需要展开/选中目标 =====
@@ -710,6 +762,7 @@ function AttachedDirsSection({ title, scope = 'project', attachedDirs, onDetach,
             allowedPaths={allowedPaths}
             sessionId={sessionId}
             scope={scope}
+            showSessionBadge={showSessionBadge}
             revealTarget={isRevealRoot ? revealTarget : null}
             revealTs={isRevealRoot ? revealTs : 0}
           />
@@ -732,13 +785,14 @@ interface AttachedDirTreeProps {
   allowedPaths?: string[]
   sessionId: string
   scope: 'project' | 'session'
+  showSessionBadge: boolean
   /** 自动定位目标（仅当落在此 dirPath 之下时由父级传入，否则为 null） */
   revealTarget?: string | null
   /** 自动定位脉冲时间戳，变化时重新触发 */
   revealTs?: number
 }
 
-function AttachedDirTree({ dirPath, onDetach, selectedPaths, onSelect, refreshVersion, onAddToChat, onFilePreview, allowedPaths, sessionId, scope, revealTarget = null, revealTs = 0 }: AttachedDirTreeProps): React.ReactElement {
+function AttachedDirTree({ dirPath, onDetach, selectedPaths, onSelect, refreshVersion, onAddToChat, onFilePreview, allowedPaths, sessionId, scope, showSessionBadge, revealTarget = null, revealTs = 0 }: AttachedDirTreeProps): React.ReactElement {
   const [expanded, setExpanded] = React.useState(false)
   const [children, setChildren] = React.useState<FileEntry[]>([])
   const [loaded, setLoaded] = React.useState(false)
@@ -829,7 +883,7 @@ function AttachedDirTree({ dirPath, onDetach, selectedPaths, onSelect, refreshVe
         <span className="relative z-10 text-xs truncate flex-1" title={dirPath}>
           {dirName}
         </span>
-        {scope === 'session' && (
+        {showSessionBadge && scope === 'session' && (
           <span className="relative z-10 flex-shrink-0 rounded-md bg-muted px-1.5 py-0.5 text-[10px] leading-none text-muted-foreground">会话文件</span>
         )}
         <Button

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -225,6 +225,49 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
     }
   }, [sessionId, setAttachedFilesMap])
 
+  const attachSessionDir = React.useCallback(async (dirPath: string) => {
+    const updated = await window.electronAPI.attachDirectory({ sessionId, directoryPath: dirPath })
+    setAttachedDirsMap((prev) => {
+      const map = new Map(prev)
+      map.set(sessionId, updated)
+      return map
+    })
+  }, [sessionId, setAttachedDirsMap])
+
+  const handleAttachSessionFolder = React.useCallback(async () => {
+    try {
+      const result = await window.electronAPI.openFolderDialog()
+      if (result) await attachSessionDir(result.path)
+    } catch (error) {
+      console.error('[SidePanel] 附加会话文件夹失败:', error)
+    }
+  }, [attachSessionDir])
+
+  const handleSessionFoldersDropped = React.useCallback(async (folderPaths: string[]) => {
+    for (const dirPath of folderPaths) {
+      try { await attachSessionDir(dirPath) } catch (error) {
+        console.error('[SidePanel] 拖拽附加会话文件夹失败:', error)
+      }
+    }
+  }, [attachSessionDir])
+
+  const attachSessionFile = React.useCallback(async (filePath: string) => {
+    const updated = await window.electronAPI.attachFile({ sessionId, filePath })
+    setAttachedFilesMap((prev) => {
+      const map = new Map(prev)
+      map.set(sessionId, updated)
+      return map
+    })
+  }, [sessionId, setAttachedFilesMap])
+
+  const handleSessionFilesAttached = React.useCallback(async (filePaths: string[]) => {
+    for (const filePath of filePaths) {
+      try { await attachSessionFile(filePath) } catch (error) {
+        console.error('[SidePanel] 附加会话文件失败:', error)
+      }
+    }
+  }, [attachSessionFile])
+
   // === 工作区级：附加/移除目录 ===
 
   const attachWorkspaceDir = React.useCallback(async (dirPath: string) => {
@@ -566,6 +609,17 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
                       onAddToChat={handleAddToChat}
                       onFilePreview={handleFilePreview}
                     />
+                    {showSessionFiles && workspaceSlug && (
+                      <FileDropZone
+                        workspaceSlug={workspaceSlug}
+                        sessionId={sessionId}
+                        target="session"
+                        onFilesUploaded={handleFilesUploaded}
+                        onFilesAttached={handleSessionFilesAttached}
+                        onAttachFolder={handleAttachSessionFolder}
+                        onFoldersDropped={handleSessionFoldersDropped}
+                      />
+                    )}
                     {showProjectFiles && !isProjectRootUnavailable && workspaceSlug && (
                       <FileDropZone
                         workspaceSlug={workspaceSlug}

--- a/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
@@ -113,6 +113,8 @@ interface FileBrowserProps {
   access?: FileAccessOptions
   /** 当前项目共享文件根；存在时，会话文件可移入此目录。 */
   projectRootPath?: string | null
+  /** 混合来源时用 badge 标记会话文件。 */
+  showSessionBadge?: boolean
   /** 点击添加到聊天（在文件操作菜单中显示） */
   onAddToChat?: (entry: FileEntry) => void
   /** 单击文件时在内联预览面板中显示（替代外部窗口预览） */
@@ -126,7 +128,7 @@ function sortEntries(entries: ScopedFileEntry[]): ScopedFileEntry[] {
   })
 }
 
-export function FileBrowser({ rootPath, roots, hideToolbar, embedded, hideEmpty, access, projectRootPath, onAddToChat, onFilePreview }: FileBrowserProps): React.ReactElement {
+export function FileBrowser({ rootPath, roots, hideToolbar, embedded, hideEmpty, access, projectRootPath, showSessionBadge = true, onAddToChat, onFilePreview }: FileBrowserProps): React.ReactElement {
   const browserRoots = React.useMemo<FileBrowserRoot[]>(() => {
     if (roots && roots.length > 0) return roots.filter((root) => Boolean(root.path))
     return rootPath ? [{ path: rootPath, scope: 'project' }] : []
@@ -395,6 +397,7 @@ export function FileBrowser({ rootPath, roots, hideToolbar, embedded, hideEmpty,
           onDelete={handleRequestDelete}
           onMove={handleMove}
           onPromoteToProject={projectRootPath ? handlePromoteToProject : undefined}
+          showSessionBadge={showSessionBadge}
           onRefresh={loadRoot}
           onClearSelection={() => setSelectedPaths(new Set())}
           onAddToChat={onAddToChat}
@@ -502,6 +505,7 @@ interface FileTreeItemProps {
   onDelete: (entry: FileEntry) => void
   onMove: (entry: FileEntry) => void
   onPromoteToProject?: (entry: ScopedFileEntry) => void
+  showSessionBadge: boolean
   onRefresh: () => Promise<void>
   onClearSelection: () => void
   onAddToChat?: (entry: FileEntry) => void
@@ -530,6 +534,7 @@ function FileTreeItem({
   onDelete,
   onMove,
   onPromoteToProject,
+  showSessionBadge,
   onRefresh,
   onClearSelection,
   onAddToChat,
@@ -817,7 +822,7 @@ function FileTreeItem({
         ) : (
           <>
             <span className="relative z-10 truncate text-xs flex-1">{entry.name}</span>
-            {entry.scope === 'session' && (
+            {showSessionBadge && entry.scope === 'session' && (
               <span className="relative z-10 flex-shrink-0 rounded-md bg-muted px-1.5 py-0.5 text-[10px] leading-none text-muted-foreground">
                 会话文件
               </span>
@@ -973,6 +978,7 @@ function FileTreeItem({
               onDelete={onDelete}
               onMove={onMove}
               onPromoteToProject={onPromoteToProject}
+              showSessionBadge={showSessionBadge}
               onRefresh={handleRefreshAfterDelete}
               onClearSelection={onClearSelection}
               onAddToChat={onAddToChat}

--- a/apps/electron/src/renderer/components/file-browser/FileSearchBar.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileSearchBar.tsx
@@ -19,6 +19,12 @@ interface FileSearchBarProps {
   sessionPath: string | null
   sessionAttachedDirs: string[]
   workspaceAttachedDirs: string[]
+  /** 限定搜索范围；默认同时搜索项目和会话文件。 */
+  sourceFilter?: 'all' | 'session' | 'project'
+  /** 混合来源时用 badge 标记会话文件。 */
+  showSessionBadge?: boolean
+  /** 显示在搜索框下方的控制区；搜索结果将自动避开该区域。 */
+  children?: React.ReactNode
   placeholder?: string
   /** 当前 session ID，用于文件自动定位 */
   sessionId?: string
@@ -46,6 +52,9 @@ export function FileSearchBar({
   sessionPath,
   sessionAttachedDirs,
   workspaceAttachedDirs,
+  sourceFilter = 'all',
+  showSessionBadge = true,
+  children,
   placeholder = '搜索文件...',
   sessionId,
   onFilePreview,
@@ -68,7 +77,8 @@ export function FileSearchBar({
 
   const setAutoReveal = useSetAtom(fileBrowserAutoRevealAtom)
 
-  const hasAnyRoot = !!workspaceFilesPath || !!sessionPath
+  const hasAnyRoot = (sourceFilter !== 'session' && !!workspaceFilesPath)
+    || (sourceFilter !== 'project' && !!sessionPath)
 
   /** 将搜索结果的相对路径转为绝对路径，供 FileBrowser 自动定位使用 */
   const resolveAbsolutePath = React.useCallback((entry: FileIndexEntry): string => {
@@ -115,7 +125,7 @@ export function FileSearchBar({
         // 分别搜索项目文件和会话文件，确保两边都用相对路径
         const searches: Promise<FileIndexEntry[]>[] = []
 
-        if (workspaceFilesPath) {
+        if (workspaceFilesPath && sourceFilter !== 'session') {
           searches.push(
             window.electronAPI.searchWorkspaceFiles(
               workspaceFilesPath,
@@ -127,7 +137,7 @@ export function FileSearchBar({
           )
         }
 
-        if (sessionPath) {
+        if (sessionPath && sourceFilter !== 'project') {
           searches.push(
             window.electronAPI.searchWorkspaceFiles(
               sessionPath,
@@ -169,7 +179,7 @@ export function FileSearchBar({
       if (debounceRef.current) clearTimeout(debounceRef.current)
       abortRef.current?.abort()
     }
-  }, [query, workspaceFilesPath, sessionPath, sessionAttachedDirs, workspaceAttachedDirs, hasAnyRoot])
+  }, [query, workspaceFilesPath, sessionPath, sessionAttachedDirs, workspaceAttachedDirs, sourceFilter, hasAnyRoot])
 
   // 点击外部关闭
   React.useEffect(() => {
@@ -230,7 +240,9 @@ export function FileSearchBar({
   }, [onFilePreview, sessionId, setAutoReveal, resolveAbsolutePath])
 
 
-  if (!hasAnyRoot) return null
+  if (!hasAnyRoot) {
+    return children ? <div className="mx-2 flex-shrink-0">{children}</div> : null
+  }
 
   return (
     <div ref={containerRef} className="relative mx-2 flex-shrink-0">
@@ -255,6 +267,7 @@ export function FileSearchBar({
           onKeyDown={handleKeyDown}
         />
       </div>
+      {children}
 
       {/* 结果浮层（绝对定位，不影响布局） */}
       {isOpen && results.length > 0 && (
@@ -265,6 +278,7 @@ export function FileSearchBar({
                 key={`${entry.source}:${entry.path}`}
                 entry={entry}
                 isSelected={index === selectedIndex}
+                showSessionBadge={showSessionBadge}
                 onClick={handleClick}
                 onHover={() => setSelectedIndex(index)}
               />
@@ -280,11 +294,13 @@ export function FileSearchBar({
 function ResultItem({
   entry,
   isSelected,
+  showSessionBadge,
   onClick,
   onHover,
 }: {
   entry: FileIndexEntry
   isSelected: boolean
+  showSessionBadge: boolean
   onClick: (entry: FileIndexEntry) => void
   onHover: () => void
 }): React.ReactElement {
@@ -316,7 +332,7 @@ function ResultItem({
           <span className="text-[11px] font-medium truncate max-w-[90px]">
             {entry.name}
           </span>
-          {entry.source === 'session' && (
+          {showSessionBadge && entry.source === 'session' && (
             <span className="flex-shrink-0 rounded-md bg-muted px-1.5 py-0.5 text-[10px] leading-none text-muted-foreground">会话文件</span>
           )}
           {dirPath && (

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -991,6 +991,11 @@
   z-index: 2;
 }
 
+.file-source-tabbar .app-tab-active::after {
+  left: 12.5%;
+  right: 12.5%;
+}
+
 .main-tabbar .app-tab-inactive:hover {
   background-color: hsl(var(--tab-surface) / 0.42);
 }


### PR DESCRIPTION
## 概述

右侧 Files 面板新增“会话文件 / 项目文件”来源 Tab。选择按 sessionId 单独持久化，新会话默认显示会话文件；文件树、附加文件/目录、搜索结果和项目上传入口均随当前来源筛选。

## 改动

- `apps/electron/src/renderer/atoms/agent-atoms.ts` — 新增按 sessionId 存储的文件来源选择 atom，并在初始化时恢复已保存值。
- `apps/electron/src/renderer/components/agent/SidePanel.tsx` — 增加来源 Tab，按筛选控制文件树、附加资源、项目根异常提示及上传入口；优化首项与 Tab 分割线的间距。
- `apps/electron/src/renderer/components/file-browser/FileSearchBar.tsx` — 支持按来源搜索、隐藏已明确来源的会话 badge，并在项目根不可用时保留来源 Tab 以便切回会话文件。
- `apps/electron/src/renderer/components/file-browser/FileBrowser.tsx` — 支持按调用方控制会话来源 badge。
- `apps/electron/src/renderer/styles/globals.css` — 为文件来源 Tab 使用局部的 75% 宽度活动指示条。

## 测试方法

1. 执行 `bun run typecheck`，验证所有 workspace package 的 TypeScript 类型。
2. 执行 `bun run build:renderer`，验证 renderer production build。
3. 执行 `git diff --check`，验证补丁格式。
4. 检查项目根不可用且项目来源已选中时，来源 Tab 仍可切换到会话文件。

## 备注

- 已完成针对未提交 diff 的代码审查与 Windows 兼容性扫描，未发现新增 Windows 路径、Shell 或平台分支问题。
- 项目根不可用时不显示无效搜索输入，但会保留来源 Tab 作为恢复路径。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)