### PR TITLE
feat(updater): install downloaded updates when idle

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -86,11 +86,11 @@ import { createTray, destroyTray, getTray } from './tray'
 import { initializeRuntime } from './lib/runtime-init'
 import { seedDefaultSkills } from './lib/config-paths'
 import { upgradeDefaultSkillsInWorkspaces } from './lib/agent-workspace-manager'
-import { stopAllAgents, killOrphanedClaudeSubprocesses } from './lib/agent-service'
+import { hasActiveAgentSessions, stopAllAgents, killOrphanedClaudeSubprocesses } from './lib/agent-service'
 import { disposePiMcpConnections } from './lib/adapters/pi-mcp-tools'
 import { markRunningDelegationsAsInterrupted } from './lib/agent-session-manager'
 import { stopAllGenerations } from './lib/chat-service'
-import { initAutoUpdater, cleanupUpdater } from './lib/updater/auto-updater'
+import { configureUpdater, initAutoUpdater, cleanupUpdater } from './lib/updater/auto-updater'
 import { startWorkspaceWatcher, stopWorkspaceWatcher } from './lib/workspace-watcher'
 import { startChatToolsWatcher, stopChatToolsWatcher } from './lib/chat-tools-watcher'
 import { getIsQuitting, setQuitting } from './lib/app-lifecycle'
@@ -548,8 +548,9 @@ async function bootstrap(): Promise<void> {
   // 启动 Chat 工具配置文件监听（Agent 创建工具后自动通知渲染进程）
   safeRun('startChatToolsWatcher', startChatToolsWatcher)
 
-  // 生产环境下初始化自动更新
+  // 自动更新仅在生产环境启用，并由主进程统一检测 Agent 是否空闲。
   if (app.isPackaged && mainWindow) {
+    configureUpdater(mainWindow, { hasActiveAgents: hasActiveAgentSessions })
     safeRun('initAutoUpdater', () => initAutoUpdater(mainWindow!))
   }
 

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -2658,6 +2658,11 @@ export class AgentOrchestrator {
     return this.activeSessions.has(sessionId)
   }
 
+  /** 是否存在任意运行中 Agent（含后台运行与外部触发的会话）。 */
+  hasActiveSessions(): boolean {
+    return this.activeSessions.size > 0
+  }
+
   /** 同一个真实本地项目根只能由一个运行中会话执行文件回退。 */
   private hasOtherActiveSessionForLocalProjectRoot(sessionId: string, localProjectRoot: string): boolean {
     for (const activeSessionId of this.activeSessions.keys()) {

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -350,6 +350,11 @@ export function isAgentSessionActive(sessionId: string): boolean {
   return orchestrator.isActive(sessionId)
 }
 
+/** 是否存在任意运行中 Agent，供更新器等全局生命周期服务安全判断。 */
+export function hasActiveAgentSessions(): boolean {
+  return orchestrator.hasActiveSessions()
+}
+
 /** 中止所有活跃的 Agent 会话（应用退出时调用） */
 export function stopAllAgents(): void {
   orchestrator.stopAll()

--- a/apps/electron/src/main/lib/updater/auto-updater.ts
+++ b/apps/electron/src/main/lib/updater/auto-updater.ts
@@ -1,14 +1,15 @@
 /**
  * 自动更新核心模块
  *
- * 检测新版本 → 自动后台下载 → 用户从更新入口确认后重启安装。
- * 仅在打包后的生产环境中工作。
+ * 检测新版本 → 自动后台下载 → 用户选择立即或空闲时重启安装。
+ * 自动更新仅在打包后的生产环境中启用。
  */
 
 import { autoUpdater } from 'electron-updater'
 import { BrowserWindow, app } from 'electron'
 import type { UpdateStatus } from './updater-types'
 import { UPDATER_IPC_CHANNELS } from './updater-types'
+import { createIdleInstallScheduler } from './idle-install-scheduler'
 
 /** 当前更新状态 */
 let currentStatus: UpdateStatus = { status: 'idle' }
@@ -19,10 +20,40 @@ let win: BrowserWindow | null = null
 /** 定时检查定时器 */
 let checkInterval: ReturnType<typeof setInterval> | null = null
 
+/** 由 Agent 服务注入，覆盖所有窗口/后台 Agent 的运行状态。 */
+let hasActiveAgents = (): boolean => false
+
+/**
+ * 用户选择「空闲时更新」后，等待所有 Agent 结束再安装。
+ *
+ * 状态检查留在主进程，避免渲染进程漏掉后台运行或其他窗口中的 Agent。
+ */
+const idleInstallScheduler = createIdleInstallScheduler({
+  canInstall: () => currentStatus.status === 'downloaded' && !hasActiveAgents(),
+  install: () => {
+    console.log('[更新] 当前没有运行中的 Agent，开始安装已下载更新')
+    quitAndInstall()
+  },
+})
+
 /** 更新状态并推送给渲染进程 */
 function setStatus(status: UpdateStatus): void {
   currentStatus = status
+  if (status.status !== 'downloaded') {
+    idleInstallScheduler.cancel()
+  }
   win?.webContents?.send(UPDATER_IPC_CHANNELS.ON_STATUS_CHANGED, status)
+}
+
+/**
+ * 绑定更新器所需的主窗口与 Agent 状态。
+ */
+export function configureUpdater(
+  mainWindow: BrowserWindow,
+  options?: { hasActiveAgents?: () => boolean },
+): void {
+  hasActiveAgents = options?.hasActiveAgents ?? hasActiveAgents
+  win = mainWindow
 }
 
 /** 获取当前更新状态 */
@@ -50,8 +81,29 @@ export async function checkForUpdates(): Promise<void> {
   }
 }
 
+/**
+ * 请求在没有运行中 Agent 时安装已下载的更新。
+ *
+ * @returns 是否已接受请求；仅 downloaded 状态可排队。
+ */
+export function installWhenIdle(): boolean {
+  if (currentStatus.status !== 'downloaded') {
+    console.warn('[更新] 跳过空闲安装：当前没有已下载的更新')
+    return false
+  }
+
+  console.log('[更新] 已请求空闲安装，等待所有 Agent 结束')
+  idleInstallScheduler.request()
+  return true
+}
+
 /** 退出并安装已下载的更新 */
 export function quitAndInstall(): void {
+  if (!app.isPackaged) {
+    console.warn('[更新] 开发环境不支持安装更新')
+    return
+  }
+
   // 移除所有窗口的 close 监听器，避免 preventDefault 阻止退出
   for (const w of BrowserWindow.getAllWindows()) {
     w.removeAllListeners('close')
@@ -69,6 +121,7 @@ export function cleanupUpdater(): void {
     clearInterval(checkInterval)
     checkInterval = null
   }
+  idleInstallScheduler.dispose()
 }
 
 /**
@@ -77,7 +130,7 @@ export function cleanupUpdater(): void {
  * @param mainWindow - 主窗口实例，用于推送更新状态
  */
 export function initAutoUpdater(mainWindow: BrowserWindow): void {
-  win = mainWindow
+  configureUpdater(mainWindow)
 
   autoUpdater.logger = {
     info: (...args: unknown[]) => console.log('[更新-updater]', ...args),
@@ -159,8 +212,9 @@ export function initAutoUpdater(mainWindow: BrowserWindow): void {
       clearInterval(checkInterval)
       checkInterval = null
     }
+    idleInstallScheduler.dispose()
     win = null
   })
 
-  console.log('[更新] 自动更新模块已初始化（自动下载，用户主动确认后安装）')
+  console.log('[更新] 自动更新模块已初始化（自动下载，支持空闲时安装）')
 }

--- a/apps/electron/src/main/lib/updater/auto-updater.ts
+++ b/apps/electron/src/main/lib/updater/auto-updater.ts
@@ -97,20 +97,42 @@ export function installWhenIdle(): boolean {
   return true
 }
 
-/** 退出并安装已下载的更新 */
-export function quitAndInstall(): void {
+/** 取消尚未执行的空闲安装请求。 */
+export function cancelIdleInstall(): void {
+  idleInstallScheduler.cancel()
+  console.log('[更新] 已取消空闲安装请求')
+}
+
+/**
+ * 退出并安装已下载的更新。
+ *
+ * 所有安装入口最终都经过这里：即使调用方绕过空闲调度器，也不会在 Agent
+ * 运行时退出；在真正安装前再次检查一次，避免检查与退出之间启动新 Agent。
+ */
+function quitAndInstall(): void {
   if (!app.isPackaged) {
     console.warn('[更新] 开发环境不支持安装更新')
     return
   }
 
-  // 移除所有窗口的 close 监听器，避免 preventDefault 阻止退出
-  for (const w of BrowserWindow.getAllWindows()) {
-    w.removeAllListeners('close')
+  if (hasActiveAgents()) {
+    console.log('[更新] 检测到运行中的 Agent，改为等待空闲后安装')
+    installWhenIdle()
+    return
   }
 
-  // 延迟调用确保 IPC 响应已发送回渲染进程
+  // 延迟调用确保 IPC 响应已发送回渲染进程；回调内再次检查防止竞态。
   setImmediate(() => {
+    if (hasActiveAgents()) {
+      console.log('[更新] 安装前出现新的运行中 Agent，继续等待空闲')
+      installWhenIdle()
+      return
+    }
+
+    // 移除所有窗口的 close 监听器，避免 preventDefault 阻止退出。
+    for (const w of BrowserWindow.getAllWindows()) {
+      w.removeAllListeners('close')
+    }
     autoUpdater.quitAndInstall(true, true)
   })
 }

--- a/apps/electron/src/main/lib/updater/idle-install-scheduler.test.ts
+++ b/apps/electron/src/main/lib/updater/idle-install-scheduler.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'bun:test'
+import { createIdleInstallScheduler } from './idle-install-scheduler'
+
+describe('空闲更新安装调度器', () => {
+  test('Given 有运行中的 Agent When 请求空闲安装 Then 等待 Agent 结束后才安装一次', () => {
+    let hasRunningAgent = true
+    let installCount = 0
+    let tick: (() => void) | undefined
+    let clearCount = 0
+
+    const scheduler = createIdleInstallScheduler({
+      canInstall: () => !hasRunningAgent,
+      install: () => { installCount += 1 },
+      setIntervalFn: (callback) => {
+        tick = callback
+        return 1 as unknown as ReturnType<typeof setInterval>
+      },
+      clearIntervalFn: () => { clearCount += 1 },
+    })
+
+    scheduler.request()
+    expect(installCount).toBe(0)
+    expect(tick).toBeDefined()
+
+    hasRunningAgent = false
+    tick?.()
+    tick?.()
+
+    expect(installCount).toBe(1)
+    expect(clearCount).toBe(1)
+  })
+
+  test('Given 空闲安装尚未触发 When 用户取消 Then Agent 结束后不安装', () => {
+    let hasRunningAgent = true
+    let installCount = 0
+    let tick: (() => void) | undefined
+
+    const scheduler = createIdleInstallScheduler({
+      canInstall: () => !hasRunningAgent,
+      install: () => { installCount += 1 },
+      setIntervalFn: (callback) => {
+        tick = callback
+        return 1 as unknown as ReturnType<typeof setInterval>
+      },
+      clearIntervalFn: () => {},
+    })
+
+    scheduler.request()
+    scheduler.cancel()
+    hasRunningAgent = false
+    tick?.()
+
+    expect(installCount).toBe(0)
+  })
+
+  test('Given 没有运行中的 Agent When 请求空闲安装 Then 立即安装且不创建轮询', () => {
+    let installCount = 0
+    let scheduled = false
+
+    const scheduler = createIdleInstallScheduler({
+      canInstall: () => true,
+      install: () => { installCount += 1 },
+      setIntervalFn: () => {
+        scheduled = true
+        return 1 as unknown as ReturnType<typeof setInterval>
+      },
+      clearIntervalFn: () => {},
+    })
+
+    scheduler.request()
+
+    expect(installCount).toBe(1)
+    expect(scheduled).toBe(false)
+  })
+})

--- a/apps/electron/src/main/lib/updater/idle-install-scheduler.ts
+++ b/apps/electron/src/main/lib/updater/idle-install-scheduler.ts
@@ -1,0 +1,70 @@
+/**
+ * 空闲安装调度器
+ *
+ * 将「更新已下载」与「所有 Agent 已结束」两个条件串联：只要仍有 Agent
+ * 处于运行状态，就保留请求并定期重试；条件满足后只执行一次安装回调。
+ */
+
+export interface IdleInstallSchedulerOptions {
+  /** 当前是否允许安装更新（例如更新仍处于 downloaded 状态且无活跃 Agent） */
+  canInstall: () => boolean
+  /** 条件满足时执行安装 */
+  install: () => void
+  /** 轮询间隔，默认 1 秒 */
+  intervalMs?: number
+  /** 注入时钟以便测试 */
+  setIntervalFn?: (callback: () => void, intervalMs: number) => ReturnType<typeof setInterval>
+  /** 注入时钟以便测试 */
+  clearIntervalFn?: (timer: ReturnType<typeof setInterval>) => void
+}
+
+export interface IdleInstallScheduler {
+  /** 请求在安全空闲时安装；重复请求不会重复调度。 */
+  request(): void
+  /** 取消尚未执行的空闲安装请求。 */
+  cancel(): void
+  /** 释放定时器。 */
+  dispose(): void
+}
+
+export function createIdleInstallScheduler({
+  canInstall,
+  install,
+  intervalMs = 1_000,
+  setIntervalFn = setInterval,
+  clearIntervalFn = clearInterval,
+}: IdleInstallSchedulerOptions): IdleInstallScheduler {
+  let requested = false
+  let timer: ReturnType<typeof setInterval> | null = null
+
+  const clearTimer = (): void => {
+    if (!timer) return
+    clearIntervalFn(timer)
+    timer = null
+  }
+
+  const attemptInstall = (): void => {
+    if (!requested) return
+    if (!canInstall()) return
+
+    requested = false
+    clearTimer()
+    install()
+  }
+
+  const request = (): void => {
+    if (requested) return
+    requested = true
+    attemptInstall()
+    if (requested && !timer) {
+      timer = setIntervalFn(attemptInstall, intervalMs)
+    }
+  }
+
+  const cancel = (): void => {
+    requested = false
+    clearTimer()
+  }
+
+  return { request, cancel, dispose: cancel }
+}

--- a/apps/electron/src/main/lib/updater/updater-ipc.ts
+++ b/apps/electron/src/main/lib/updater/updater-ipc.ts
@@ -8,10 +8,10 @@ import { ipcMain } from 'electron'
 import { UPDATER_IPC_CHANNELS } from './updater-types'
 import type { UpdateStatus } from './updater-types'
 import {
+  cancelIdleInstall,
   checkForUpdates,
   getUpdateStatus,
   installWhenIdle,
-  quitAndInstall,
 } from './auto-updater'
 
 /** 注册更新 IPC 处理器 */
@@ -33,16 +33,16 @@ export function registerUpdaterIpc(): void {
   )
 
   ipcMain.handle(
-    UPDATER_IPC_CHANNELS.QUIT_AND_INSTALL,
-    (): void => {
-      quitAndInstall()
+    UPDATER_IPC_CHANNELS.INSTALL_WHEN_IDLE,
+    (): boolean => {
+      return installWhenIdle()
     }
   )
 
   ipcMain.handle(
-    UPDATER_IPC_CHANNELS.INSTALL_WHEN_IDLE,
-    (): boolean => {
-      return installWhenIdle()
+    UPDATER_IPC_CHANNELS.CANCEL_IDLE_INSTALL,
+    (): void => {
+      cancelIdleInstall()
     }
   )
 

--- a/apps/electron/src/main/lib/updater/updater-ipc.ts
+++ b/apps/electron/src/main/lib/updater/updater-ipc.ts
@@ -10,6 +10,7 @@ import type { UpdateStatus } from './updater-types'
 import {
   checkForUpdates,
   getUpdateStatus,
+  installWhenIdle,
   quitAndInstall,
 } from './auto-updater'
 
@@ -35,6 +36,13 @@ export function registerUpdaterIpc(): void {
     UPDATER_IPC_CHANNELS.QUIT_AND_INSTALL,
     (): void => {
       quitAndInstall()
+    }
+  )
+
+  ipcMain.handle(
+    UPDATER_IPC_CHANNELS.INSTALL_WHEN_IDLE,
+    (): boolean => {
+      return installWhenIdle()
     }
   )
 

--- a/apps/electron/src/main/lib/updater/updater-types.ts
+++ b/apps/electron/src/main/lib/updater/updater-types.ts
@@ -1,7 +1,7 @@
 /**
  * 自动更新相关类型定义
  *
- * 检测新版本 → 自动下载 → 用户从更新入口确认后重启安装
+ * 检测新版本 → 自动下载 → 用户选择立即或空闲时重启安装
  */
 
 /** 更新状态 */
@@ -32,4 +32,5 @@ export const UPDATER_IPC_CHANNELS = {
   GET_STATUS: 'updater:get-status',
   ON_STATUS_CHANGED: 'updater:status-changed',
   QUIT_AND_INSTALL: 'updater:quit-and-install',
+  INSTALL_WHEN_IDLE: 'updater:install-when-idle',
 } as const

--- a/apps/electron/src/main/lib/updater/updater-types.ts
+++ b/apps/electron/src/main/lib/updater/updater-types.ts
@@ -31,6 +31,6 @@ export const UPDATER_IPC_CHANNELS = {
   CHECK_FOR_UPDATES: 'updater:check',
   GET_STATUS: 'updater:get-status',
   ON_STATUS_CHANGED: 'updater:status-changed',
-  QUIT_AND_INSTALL: 'updater:quit-and-install',
   INSTALL_WHEN_IDLE: 'updater:install-when-idle',
+  CANCEL_IDLE_INSTALL: 'updater:cancel-idle-install',
 } as const

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -881,9 +881,10 @@ export interface ElectronAPI {
       progress?: { percent: number; transferred: number; total: number; bytesPerSecond: number }
       error?: string
     }) => void) => () => void
-    quitAndInstall: () => Promise<void>
     /** 在所有运行中的 Agent 结束后重启并安装更新 */
     installWhenIdle: () => Promise<boolean>
+    /** 取消尚未执行的空闲安装请求 */
+    cancelIdleInstall: () => Promise<void>
   }
 
   // GitHub Release
@@ -2119,8 +2120,8 @@ const electronAPI: ElectronAPI = {
       ipcRenderer.on('updater:status-changed', listener)
       return () => { ipcRenderer.removeListener('updater:status-changed', listener) }
     },
-    quitAndInstall: () => ipcRenderer.invoke('updater:quit-and-install'),
     installWhenIdle: () => ipcRenderer.invoke('updater:install-when-idle'),
+    cancelIdleInstall: () => ipcRenderer.invoke('updater:cancel-idle-install'),
   },
 
   // GitHub Release

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -882,6 +882,8 @@ export interface ElectronAPI {
       error?: string
     }) => void) => () => void
     quitAndInstall: () => Promise<void>
+    /** 在所有运行中的 Agent 结束后重启并安装更新 */
+    installWhenIdle: () => Promise<boolean>
   }
 
   // GitHub Release
@@ -2118,6 +2120,7 @@ const electronAPI: ElectronAPI = {
       return () => { ipcRenderer.removeListener('updater:status-changed', listener) }
     },
     quitAndInstall: () => ipcRenderer.invoke('updater:quit-and-install'),
+    installWhenIdle: () => ipcRenderer.invoke('updater:install-when-idle'),
   },
 
   // GitHub Release

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -814,14 +814,9 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
   }, [setSettingsOpen])
 
   const handleUpdateButtonClick = React.useCallback((): void => {
-    if (updateStatus.status === 'downloaded') {
-      void window.electronAPI.updater?.quitAndInstall()
-      return
-    }
-
     setSettingsTab('about')
     setSettingsOpen(true)
-  }, [setSettingsOpen, setSettingsTab, updateStatus.status])
+  }, [setSettingsOpen, setSettingsTab])
 
   React.useEffect(() => {
     const id = window.setInterval(() => setRelativeTimeNow(Date.now()), 60_000)

--- a/apps/electron/src/renderer/components/settings/AboutSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AboutSettings.tsx
@@ -37,6 +37,7 @@ function UpdateCard(): React.ReactElement | null {
   const available = useAtomValue(updaterAvailableAtom)
   const status = useAtomValue(updateStatusAtom)
   const [checking, setChecking] = React.useState(false)
+  const [idleInstallScheduled, setIdleInstallScheduled] = React.useState(false)
   const [showReleaseNotes, setShowReleaseNotes] = React.useState(false)
   const [release, setRelease] = React.useState<import('@proma/shared').GitHubRelease | null>(null)
 
@@ -58,11 +59,22 @@ function UpdateCard(): React.ReactElement | null {
     window.electronAPI.openExternal(url)
   }
 
-  const handleQuitAndInstall = (): void => {
-    window.electronAPI.updater?.quitAndInstall()
+  const handleInstallWhenIdle = (): void => {
+    void window.electronAPI.updater?.installWhenIdle()
+      .then((scheduled) => setIdleInstallScheduled(scheduled))
+      .catch(() => setIdleInstallScheduled(false))
+  }
+
+  const handleCancelIdleInstall = (): void => {
+    void window.electronAPI.updater?.cancelIdleInstall()
+      .then(() => setIdleInstallScheduled(false))
   }
 
   // 当检测到新版本时，获取完整的 release 信息
+  React.useEffect(() => {
+    if (status.status !== 'downloaded') setIdleInstallScheduled(false)
+  }, [status.status])
+
   React.useEffect(() => {
     if (status.status === 'available' && status.version && !release) {
       window.electronAPI
@@ -91,13 +103,22 @@ function UpdateCard(): React.ReactElement | null {
 
           {/* 操作按钮 */}
           {status.status === 'downloaded' ? (
-            <button
-              onClick={handleQuitAndInstall}
-              className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
-            >
-              <RotateCw className="h-3.5 w-3.5" />
-              立即重启
-            </button>
+            idleInstallScheduled ? (
+              <button
+                onClick={handleCancelIdleInstall}
+                className="inline-flex items-center gap-1.5 rounded-md bg-secondary px-3 py-1.5 text-xs font-medium text-secondary-foreground hover:bg-secondary/80 transition-colors"
+              >
+                取消安排
+              </button>
+            ) : (
+              <button
+                onClick={handleInstallWhenIdle}
+                className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+              >
+                <RotateCw className="h-3.5 w-3.5" />
+                空闲时更新
+              </button>
+            )
           ) : status.status === 'available' ? (
             <button
               onClick={handleGoToDownload}

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -405,7 +405,36 @@ function UpdaterInitializer(): null {
                   .then((scheduled) => {
                     if (!scheduled) {
                       toast.error('更新尚未准备好，请稍后重试')
+                      return
                     }
+
+                    toast.custom((scheduledToastId) => (
+                      <div className="w-[312px] max-w-[calc(100vw-32px)] rounded-xl bg-background/95 p-3 text-foreground shadow-[0_12px_32px_rgba(0,0,0,0.14)] ring-1 ring-black/5 backdrop-blur-xl dark:ring-white/10">
+                        <div className="flex items-center gap-2.5">
+                          <img src={PromaLogo} alt="Proma" className="size-7 rounded-md" />
+                          <div className="min-w-0 flex-1">
+                            <p className="text-sm font-semibold tracking-tight">已安排空闲时更新</p>
+                            <p className="text-xs leading-4 text-muted-foreground">当前任务结束后会自动重启安装。</p>
+                          </div>
+                        </div>
+                        <div className="mt-2 flex justify-end">
+                          <button
+                            type="button"
+                            className="h-7 rounded-md px-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground active:scale-[0.96]"
+                            onClick={() => {
+                              void window.electronAPI.updater?.cancelIdleInstall()
+                              toast.dismiss(scheduledToastId)
+                            }}
+                          >
+                            取消安排
+                          </button>
+                        </div>
+                      </div>
+                    ), {
+                      duration: Infinity,
+                      dismissible: false,
+                      unstyled: true,
+                    })
                   })
                   .catch(() => {
                     toast.error('无法安排空闲更新，请稍后重试')

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -75,6 +75,7 @@ import { appModeAtom } from './atoms/app-mode'
 import type { FeishuBotBridgeState, FeishuBridgeState, DingTalkBotBridgeState, DingTalkBridgeState } from '@proma/shared'
 import { Toaster } from './components/ui/sonner'
 import { toast } from 'sonner'
+import { ArrowUpRight } from 'lucide-react'
 import { diffCapabilities } from '@proma/shared'
 import type { WorkspaceCapabilities } from '@proma/shared'
 import { showCapabilityChangeToasts } from './lib/capabilities-toast'
@@ -82,6 +83,7 @@ import { GlobalShortcuts } from './components/shortcuts/GlobalShortcuts'
 import { TabSwitcher } from './components/tabs/TabSwitcher'
 import { htmlToMarkdown, markdownToHtml } from './lib/markdown-rich-text'
 import { getEnabledClaudeAgentChannelIds } from './lib/agent-channel-selection'
+import { PromaLogo } from './lib/model-logo'
 import { initShortcutRegistry, updateShortcutOverrides } from './lib/shortcut-registry'
 import './styles/globals.css'
 import 'katex/dist/katex.min.css'
@@ -349,11 +351,78 @@ function AgentSettingsInitializer(): null {
  */
 function UpdaterInitializer(): null {
   const setUpdateStatus = useSetAtom(updateStatusAtom)
+  const updateStatus = useAtomValue(updateStatusAtom)
+  const notifiedDownloadVersionRef = useRef<string | null>(null)
 
   useEffect(() => {
     const cleanup = initializeUpdater(setUpdateStatus)
     return cleanup
   }, [setUpdateStatus])
+
+  useEffect(() => {
+    if (updateStatus.status !== 'downloaded') return
+
+    const version = updateStatus.version || '新版本'
+    if (notifiedDownloadVersionRef.current === version) return
+    notifiedDownloadVersionRef.current = version
+    const versionLabel = version.startsWith('v') ? version : `v${version}`
+
+    toast.custom((toastId) => (
+      <div className="w-[344px] max-w-[calc(100vw-32px)] rounded-xl bg-background/95 p-3 text-foreground shadow-[0_12px_32px_rgba(0,0,0,0.14)] ring-1 ring-black/5 backdrop-blur-xl dark:ring-white/10">
+        <div className="flex items-center gap-2.5">
+          <img src={PromaLogo} alt="Proma" className="size-8 rounded-lg" />
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-1.5 text-sm leading-5">
+              <span className="font-semibold tracking-tight">Proma 更新已下载</span>
+              <span className="text-xs text-primary">{versionLabel}</span>
+            </div>
+            <p className="text-xs leading-4 text-muted-foreground">所有 Agent 完成后即可自动安装。</p>
+          </div>
+        </div>
+        <div className="mt-2.5 flex items-center justify-between">
+          <button
+            type="button"
+            className="h-7 rounded-md px-1.5 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground active:scale-[0.96]"
+            onClick={() => toast.dismiss(toastId)}
+          >
+            取消
+          </button>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              className="flex h-7 items-center gap-1 rounded-md px-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground active:scale-[0.96]"
+              onClick={() => { void window.electronAPI.openExternal('https://proma.cool/changelog') }}
+            >
+              查看更新
+              <ArrowUpRight size={13} />
+            </button>
+            <button
+              type="button"
+              className="h-7 rounded-md bg-primary px-2.5 text-xs font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 active:scale-[0.96]"
+              onClick={() => {
+                toast.dismiss(toastId)
+                void window.electronAPI.updater?.installWhenIdle()
+                  .then((scheduled) => {
+                    if (!scheduled) {
+                      toast.error('更新尚未准备好，请稍后重试')
+                    }
+                  })
+                  .catch(() => {
+                    toast.error('无法安排空闲更新，请稍后重试')
+                  })
+              }}
+            >
+              空闲时更新
+            </button>
+          </div>
+        </div>
+      </div>
+    ), {
+      duration: Infinity,
+      dismissible: false,
+      unstyled: true,
+    })
+  }, [updateStatus])
 
   return null
 }

--- a/apps/electron/src/renderer/vite-env.d.ts
+++ b/apps/electron/src/renderer/vite-env.d.ts
@@ -31,9 +31,10 @@ interface UpdaterAPI {
   checkForUpdates: () => Promise<void>
   getStatus: () => Promise<UpdateStatus>
   onStatusChanged: (callback: (status: UpdateStatus) => void) => () => void
-  quitAndInstall: () => Promise<void>
   /** 在所有运行中的 Agent 结束后重启并安装更新 */
   installWhenIdle: () => Promise<boolean>
+  /** 取消尚未执行的空闲安装请求 */
+  cancelIdleInstall: () => Promise<void>
 }
 
 // 附件临时 base64 缓存（用于发送前暂存数据）

--- a/apps/electron/src/renderer/vite-env.d.ts
+++ b/apps/electron/src/renderer/vite-env.d.ts
@@ -32,6 +32,8 @@ interface UpdaterAPI {
   getStatus: () => Promise<UpdateStatus>
   onStatusChanged: (callback: (status: UpdateStatus) => void) => () => void
   quitAndInstall: () => Promise<void>
+  /** 在所有运行中的 Agent 结束后重启并安装更新 */
+  installWhenIdle: () => Promise<boolean>
 }
 
 // 附件临时 base64 缓存（用于发送前暂存数据）


### PR DESCRIPTION
## Summary

- 在更新下载完成后展示持久化的 Proma 品牌 Toast，提供查看更新、取消和空闲时更新操作。
- 仅在所有运行中 Agent 完成后才重启安装，并由主进程统一判断全局 Agent 活跃状态。
- 新增空闲安装调度器及 BDD 测试；移除开发态模拟更新入口。

## Test plan

- [x] `bun test apps/electron/src/main/lib/updater/idle-install-scheduler.test.ts`
- [x] `bun run typecheck`
- [x] `bun run --filter='@proma/electron' build`
- [x] `git diff --check`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)