### PR TITLE
feat(file-open): 预览面板增加文件打开方式下拉菜单

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -332,6 +332,21 @@ const KNOWN_EDITORS = [
   'Zed', 'CotEditor', 'IntelliJ IDEA', 'Xcode', 'TextEdit',
 ]
 
+/** macOS 文件打开应用的预置清单（Finder、Terminal 已在菜单中硬编码，此处排除） */
+const KNOWN_FILE_OPEN_APPS_MAC = [
+  { id: 'visual-studio-code', name: 'Visual Studio Code', paths: ['/Applications/Visual Studio Code.app', '{home}/Applications/Visual Studio Code.app'] },
+  { id: 'xcode', name: 'Xcode', paths: ['/Applications/Xcode.app'] },
+  { id: 'android-studio', name: 'Android Studio', paths: ['/Applications/Android Studio.app', '{home}/Applications/Android Studio.app'] },
+]
+
+/** 内置文件打开应用信息（前端用） */
+interface BuiltinOpenApp {
+  id: string
+  name: string
+  path: string
+  iconDataUrl: string
+}
+
 /**
  * 检查路径是否在允许的目录范围内（解析 symlink）
  *
@@ -1087,7 +1102,7 @@ export function registerIpcHandlers(): void {
     }
   )
 
-  // 用系统默认应用打开任意文件（appName 需在 KNOWN_EDITORS 白名单内）
+  // 用系统默认应用打开任意文件（appName 需在 KNOWN_EDITORS 白名单内，或为有效 .app 路径）
   ipcMain.handle(
     IPC_CHANNELS.SYSTEM_OPEN_FILE,
     async (_, filePath: string, appName?: string, access?: FileAccessOptions | string[]): Promise<void> => {
@@ -1101,10 +1116,13 @@ export function registerIpcHandlers(): void {
       if (process.platform === 'darwin') {
         const { spawnSync } = await import('node:child_process')
         if (appName) {
-          if (!KNOWN_EDITORS.includes(appName)) {
+          // 白名单应用名称 或 有效 .app 路径均可
+          const isValidAppPath = appName.endsWith('.app') && appName.includes('/')
+          if (!KNOWN_EDITORS.includes(appName) && !isValidAppPath) {
             console.warn('[IPC] shell:system-open-file 拒绝未知应用:', appName)
             return
           }
+          spawnSync('open', ['-a', appName, absPath], { timeout: 5000 })
           spawnSync('open', ['-a', appName, absPath], { timeout: 5000 })
         } else {
           spawnSync('open', [absPath], { timeout: 5000 })
@@ -1156,6 +1174,51 @@ export function registerIpcHandlers(): void {
         console.warn('[IPC] shell:get-default-app-for-file 失败:', err)
         return null
       }
+    }
+  )
+
+  // 列出当前平台可用的文件打开应用（内置 + 用户自定义）
+  ipcMain.handle(
+    IPC_CHANNELS.LIST_OPEN_APPS,
+    async (): Promise<BuiltinOpenApp[]> => {
+      if (process.platform !== 'darwin') return []
+      const { existsSync } = await import('node:fs')
+      const { homedir } = await import('node:os')
+      const home = homedir()
+      const results: BuiltinOpenApp[] = []
+      for (const app of KNOWN_FILE_OPEN_APPS_MAC) {
+        for (const rawPath of app.paths) {
+          const resolved = rawPath.replace('{home}', home)
+          if (existsSync(resolved)) {
+            // 复用已有图标抓取能力
+            const iconDataUrl = await getAppIconDataUrl(resolved).catch(() => '')
+            results.push({ id: app.id, name: app.name, path: resolved, iconDataUrl })
+            break
+          }
+        }
+      }
+      return results
+    }
+  )
+
+  // 打开系统原生应用选择对话框，返回选中应用的信息
+  ipcMain.handle(
+    IPC_CHANNELS.CHOOSE_OPEN_APP,
+    async (): Promise<{ name: string; path: string; iconDataUrl: string } | null> => {
+      if (process.platform !== 'darwin') return null
+      const { dialog } = await import('electron')
+      const result = await dialog.showOpenDialog({
+        title: '选择用于打开文件的应用',
+        filters: [{ name: '应用', extensions: ['app'] }],
+        properties: ['openFile'],
+      })
+      if (result.canceled || result.filePaths.length === 0) return null
+      const appPath = result.filePaths[0]
+      if (!appPath.endsWith('.app')) return null
+      const base = appPath.split('/').pop() ?? ''
+      const name = base.replace(/\.app$/, '')
+      const iconDataUrl = await getAppIconDataUrl(appPath).catch(() => '')
+      return { name, path: appPath, iconDataUrl }
     }
   )
 

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -779,6 +779,12 @@ export interface ElectronAPI {
   /** 查询本机为该文件类型注册的默认打开应用（含图标 dataURL） */
   getDefaultAppForFile: (filePath: string, access?: import('@proma/shared').FileAccessOptions) => Promise<import('@proma/shared').DefaultAppInfo | null>
 
+  /** 列出当前平台可用的文件打开应用（内置 + 自定义） */
+  listOpenApps: () => Promise<Array<{ id: string; name: string; path: string; iconDataUrl: string }>>
+
+  /** 打开系统原生应用选择对话框 */
+  chooseOpenApp: () => Promise<{ name: string; path: string; iconDataUrl: string } | null>
+
   /** 在系统文件管理器中显示文件 */
   showInFolder: (filePath: string, access?: import('@proma/shared').FileAccessOptions) => Promise<void>
 
@@ -1996,6 +2002,14 @@ const electronAPI: ElectronAPI = {
 
   getDefaultAppForFile: (filePath: string, access?: import('@proma/shared').FileAccessOptions) => {
     return ipcRenderer.invoke(IPC_CHANNELS.GET_DEFAULT_APP_FOR_FILE, filePath, access) as Promise<import('@proma/shared').DefaultAppInfo | null>
+  },
+
+  listOpenApps: () => {
+    return ipcRenderer.invoke(IPC_CHANNELS.LIST_OPEN_APPS)
+  },
+
+  chooseOpenApp: () => {
+    return ipcRenderer.invoke(IPC_CHANNELS.CHOOSE_OPEN_APP)
   },
 
   showInFolder: (filePath: string, access?: import('@proma/shared').FileAccessOptions) => {

--- a/apps/electron/src/renderer/components/diff/DefaultAppOpenDropdown.tsx
+++ b/apps/electron/src/renderer/components/diff/DefaultAppOpenDropdown.tsx
@@ -1,0 +1,220 @@
+/**
+ * DefaultAppOpenDropdown — 预览面板顶部文件打开下拉按钮
+ *
+ * 点击展开/收起菜单，使用原生定位避免 Radix 兼容问题。
+ */
+
+import * as React from 'react'
+import { ChevronDown, ExternalLink, Plus, X, FolderOpen, Terminal } from 'lucide-react'
+import { toast } from 'sonner'
+import { useDefaultAppForFile } from '@/hooks/useDefaultAppForFile'
+import { cn } from '@/lib/utils'
+import type { FileAccessOptions } from '@proma/shared'
+import type { FileOpenAppEntry } from '@/types/settings'
+
+interface DefaultAppOpenDropdownProps {
+  filePath: string
+  access?: FileAccessOptions
+  className?: string
+}
+
+export function DefaultAppOpenDropdown({
+  filePath,
+  access,
+  className,
+}: DefaultAppOpenDropdownProps): React.ReactElement {
+  const defaultAppInfo = useDefaultAppForFile(filePath, access)
+  const [builtinApps, setBuiltinApps] = React.useState<Array<{ id: string; name: string; path: string; iconDataUrl: string }>>([])
+  const [customApps, setCustomApps] = React.useState<FileOpenAppEntry[]>([])
+  const [open, setOpen] = React.useState(false)
+  const btnRef = React.useRef<HTMLButtonElement>(null)
+  const menuRef = React.useRef<HTMLDivElement>(null)
+
+  React.useEffect(() => {
+    let cancelled = false
+    Promise.all([
+      window.electronAPI.listOpenApps().catch(() => [] as typeof builtinApps),
+      window.electronAPI.getSettings().then((s) => s.fileOpenApps ?? []).catch(() => [] as FileOpenAppEntry[]),
+    ]).then(([builtin, custom]) => {
+      if (cancelled) return
+      setBuiltinApps(builtin)
+      setCustomApps(custom)
+    })
+    return () => { cancelled = true }
+  }, [])
+
+  // 点击外部关闭
+  React.useEffect(() => {
+    if (!open) return
+    const handler = (e: MouseEvent) => {
+      if (btnRef.current?.contains(e.target as Node)) return
+      if (menuRef.current?.contains(e.target as Node)) return
+      setOpen(false)
+    }
+    document.addEventListener('mousedown', handler, true)
+    return () => document.removeEventListener('mousedown', handler, true)
+  }, [open])
+
+  const dirPath = React.useMemo(() => {
+    const lastSep = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'))
+    return lastSep > 0 ? filePath.slice(0, lastSep) : filePath
+  }, [filePath])
+
+  const persistCustomApps = React.useCallback((apps: FileOpenAppEntry[]) => {
+    setCustomApps(apps)
+    window.electronAPI.updateSettings({ fileOpenApps: apps }).catch(console.error)
+  }, [])
+
+  const handleDefaultOpen = React.useCallback(() => {
+    setOpen(false)
+    window.electronAPI.systemOpenFile(filePath, undefined, access).catch(console.error)
+  }, [filePath, access])
+
+  const handleOpenWith = React.useCallback((appPath: string) => {
+    setOpen(false)
+    window.electronAPI.systemOpenFile(filePath, appPath, access).catch(console.error)
+  }, [filePath, access])
+
+  const handleChooseOtherApp = React.useCallback(async () => {
+    try {
+      const result = await window.electronAPI.chooseOpenApp()
+      if (!result) return
+      const exists = customApps.some((a) => a.path === result.path)
+        || builtinApps.some((a) => a.path === result.path)
+      if (exists) { toast.info(`${result.name} 已在列表中`); return }
+      setOpen(false)
+      persistCustomApps([...customApps, {
+        id: `custom-${Date.now()}-${result.name}`,
+        name: result.name, path: result.path, iconDataUrl: result.iconDataUrl,
+      }])
+      toast.success(`已添加 ${result.name}`)
+    } catch (err) { console.error('[DefaultAppOpenDropdown] 选择应用失败:', err) }
+  }, [customApps, builtinApps, persistCustomApps])
+
+  const handleRemove = React.useCallback((e: React.MouseEvent, appId: string) => {
+    e.stopPropagation()
+    e.preventDefault()
+    persistCustomApps(customApps.filter((a) => a.id !== appId))
+  }, [customApps, persistCustomApps])
+
+  const defaultName = defaultAppInfo?.name
+
+  return (
+    <div className={cn('relative', className)}>
+      <button
+        ref={btnRef}
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className={cn(
+          'flex items-center gap-1 h-6 px-1.5 shrink-0 text-muted-foreground hover:text-foreground hover:bg-muted/50 rounded transition-colors',
+          open && 'bg-muted/50 text-foreground',
+        )}
+        title={defaultAppInfo ? `用 ${defaultAppInfo.name} 打开` : '选择打开方式'}
+        aria-label="选择打开方式"
+      >
+        {defaultAppInfo ? (
+          <img src={defaultAppInfo.iconDataUrl} alt="" className="size-4 shrink-0" draggable={false} />
+        ) : (
+          <ExternalLink className="size-4 shrink-0" />
+        )}
+        <span className="text-[11px] leading-none truncate max-w-[100px]">
+          {defaultName ?? '默认应用'}
+        </span>
+        <ChevronDown className={cn('size-3 shrink-0 transition-transform duration-150', open && 'rotate-180')} />
+      </button>
+
+      {open && (
+        <div
+          ref={menuRef}
+          className="absolute right-0 top-full mt-1 z-50 min-w-[200px] rounded-md border border-border bg-popover p-1 shadow-md"
+        >
+          {/* 默认应用打开 */}
+          <MenuItem icon={<ExternalLink className="size-3.5 shrink-0" />} onClick={handleDefaultOpen}>
+            用系统默认应用打开
+          </MenuItem>
+
+          {/* Finder */}
+          <MenuItem
+            icon={<FolderOpen className="size-3.5 shrink-0" />}
+            onClick={() => { setOpen(false); window.electronAPI.showInFolder(filePath, access).catch(console.error) }}
+          >
+            在访达中显示
+          </MenuItem>
+
+          {/* 终端 */}
+          <MenuItem
+            icon={<Terminal className="size-3.5 shrink-0" />}
+            onClick={() => { setOpen(false); window.electronAPI.systemOpenFile(dirPath, '/System/Applications/Utilities/Terminal.app', access).catch(console.error) }}
+          >
+            在终端中打开
+          </MenuItem>
+
+          {/* 预置应用 */}
+          {builtinApps.length > 0 && <div className="my-1 h-px bg-border" />}
+          {builtinApps.map((app) => (
+            <MenuItem
+              key={app.id}
+              icon={app.iconDataUrl ? <img src={app.iconDataUrl} alt="" className="size-3.5 shrink-0" draggable={false} /> : <ExternalLink className="size-3.5 shrink-0" />}
+              onClick={() => handleOpenWith(app.path)}
+            >
+              用 {app.name} 打开
+            </MenuItem>
+          ))}
+
+          {/* 自定义应用 */}
+          {customApps.length > 0 && <div className="my-1 h-px bg-border" />}
+          {customApps.map((app) => (
+            <MenuItem
+              key={app.id}
+              icon={app.iconDataUrl ? <img src={app.iconDataUrl} alt="" className="size-3.5 shrink-0" draggable={false} /> : <ExternalLink className="size-3.5 shrink-0" />}
+              onClick={() => handleOpenWith(app.path)}
+              rightAction={
+                <button
+                  type="button"
+                  className="opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-destructive rounded p-0.5 transition-opacity"
+                  onClick={(e) => handleRemove(e, app.id)}
+                  aria-label={`移除 ${app.name}`}
+                >
+                  <X className="size-3" />
+                </button>
+              }
+            >
+              {app.name}
+            </MenuItem>
+          ))}
+
+          {/* 更多应用 */}
+          <div className="my-1 h-px bg-border" />
+          <MenuItem icon={<Plus className="size-3.5 shrink-0" />} onClick={handleChooseOtherApp}>
+            更多应用...
+          </MenuItem>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** 菜单项 */
+function MenuItem({
+  icon,
+  children,
+  onClick,
+  rightAction,
+}: {
+  icon: React.ReactNode
+  children: React.ReactNode
+  onClick: () => void
+  rightAction?: React.ReactNode
+}): React.ReactElement {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs text-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
+    >
+      {icon}
+      <span className="truncate flex-1 text-left">{children}</span>
+      {rightAction}
+    </button>
+  )
+}

--- a/apps/electron/src/renderer/components/diff/PreviewPanel.tsx
+++ b/apps/electron/src/renderer/components/diff/PreviewPanel.tsx
@@ -28,7 +28,7 @@ import { getActiveAccelerator, getAcceleratorDisplay } from '@/lib/shortcut-regi
 import { detectIsWindows } from '@/lib/platform'
 import { cn } from '@/lib/utils'
 import { DiffTabContent } from './DiffTabContent'
-import { DefaultAppOpenButton } from './DefaultAppOpenButton'
+import { DefaultAppOpenDropdown } from './DefaultAppOpenDropdown'
 import { getDefaultAppTargetPath, getPreviewFileAccess } from './preview-open-path'
 
 interface PreviewPanelProps {
@@ -80,7 +80,7 @@ export function PreviewPanel({ sessionId }: PreviewPanelProps): React.ReactEleme
   const renderPreviewActions = (): React.ReactElement => (
     <div className="ml-auto flex items-center gap-0.5 shrink-0">
       {currentFile && (
-        <DefaultAppOpenButton
+        <DefaultAppOpenDropdown
           filePath={defaultAppTargetPath}
           access={defaultAppAccess}
         />

--- a/apps/electron/src/renderer/components/diff/PreviewTabContent.tsx
+++ b/apps/electron/src/renderer/components/diff/PreviewTabContent.tsx
@@ -19,7 +19,7 @@ import {
 } from '@/atoms/tab-atoms'
 import { previewFileMapAtom } from '@/atoms/preview-atoms'
 import { tearOffPreviewToSplit } from './preview-opener'
-import { DefaultAppOpenButton } from './DefaultAppOpenButton'
+import { DefaultAppOpenDropdown } from './DefaultAppOpenDropdown'
 import { DiffTabContent } from './DiffTabContent'
 import { getDefaultAppTargetPath, getPreviewFileAccess } from './preview-open-path'
 
@@ -100,7 +100,7 @@ export function PreviewTabContent({ sessionId }: PreviewTabContentProps): React.
   const defaultAppAccess = getPreviewFileAccess(sessionId, currentFile, sessionPath)
   const toolbarActions = (
     <>
-      <DefaultAppOpenButton
+      <DefaultAppOpenDropdown
         filePath={defaultAppTargetPath}
         access={defaultAppAccess}
       />

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -255,6 +255,8 @@ export interface AppSettings {
   richTextRenderingEnabled?: boolean
   /** Markdown 预览字号档位（默认 'medium'，对应 15px） */
   markdownFontSize?: MarkdownFontSize
+  /** 自定义文件打开应用列表（用于顶部文件浏览器打开菜单） */
+  fileOpenApps?: FileOpenAppEntry[]
   /** 上次是否在 Scratch Pad 页（用于重启恢复） */
   scratchPadActive?: boolean
   /** 应用图标变体 ID（dock + window icon），'default' 或 logo 变体 id */
@@ -281,6 +283,18 @@ export interface AppSettings {
   mainWindowState?: MainWindowState
   /** 独立任务/日程窗口状态（大小、位置、是否最大化） */
   planningWindowState?: MainWindowState
+}
+
+/** 用户自定义文件打开应用条目 */
+export interface FileOpenAppEntry {
+  /** 应用的持久化标识 */
+  id: string
+  /** 应用显示名称 */
+  name: string
+  /** 应用绝对路径（macOS: .app bundle，Windows: .exe） */
+  path: string
+  /** 应用图标的 base64 dataURL */
+  iconDataUrl: string
 }
 
 /** 主窗口大小、位置和最大化状态 */

--- a/packages/shared/src/types/runtime.ts
+++ b/packages/shared/src/types/runtime.ts
@@ -367,6 +367,10 @@ export const IPC_CHANNELS = {
   SCAN_EDITORS: 'shell:scan-editors',
   /** 查询某个文件在本机系统中的默认打开应用信息（带图标） */
   GET_DEFAULT_APP_FOR_FILE: 'shell:get-default-app-for-file',
+  /** 打开系统应用选择对话框，选择用于打开文件的应用 */
+  CHOOSE_OPEN_APP: 'shell:choose-open-app',
+  /** 列出当前平台可用的文件打开应用（内置 + 自定义） */
+  LIST_OPEN_APPS: 'shell:list-open-apps',
   /** 打开独立预览窗口 */
   OPEN_DETACHED_PREVIEW: 'preview:open-detached',
   /** 获取独立预览窗口数据 */


### PR DESCRIPTION
## 背景

预览面板顶部原来只有一个固定的「用默认应用打开」按钮，
每次想用 VS Code / Xcode / 终端等工具打开都得去系统文件管理器改关联。

## 修改内容

### 1. 下拉菜单组件（DefaultAppOpenDropdown）
- 预览面板顶部打开按钮改为单个下拉按钮：左半显示默认应用图标+名称，
  点击弹出菜单；chevron 箭头随展开/收起旋转 180°
- 菜单首项「用系统默认应用打开」，随后是「在访达中显示」「在终端中打开」
- 使用原生定位实现，不依赖 Radix Dropdown，规避组件库事件转发问题

### 2. 预置应用（macOS）
- 支持 VS Code / Xcode / Android Studio，通过 existsSync 只显示已安装项
- Finder、Terminal 作为固定快捷项在菜单中硬编码，避免重复

### 3. 自定义应用
- 「更多应用...」弹出系统原生对话框选择任意 .app，点击即打开
- 新增应用持久化到 settings.json 的 fileOpenApps 字段，重启保留
- 每个自定义应用悬停显示右侧 ×，可单独移除

### 4. 主进程 IPC 与授权
- 新增 shell:list-open-apps（扫描预置应用）、shell:choose-open-app（选择应用）
- system-open-file 在原有白名单基础上放开有效 .app 路径
- 终端打开使用 systemOpenFile + 目录路径并携带 access 授权上下文，
  解决「在终端中打开」越界报错

## 验证方式

- [x] bun test：502 pass（3 个 Electron 预存失败，与本次改动无关）
- [x] bun run electron:build：构建成功
- [x] 手动验证：下拉展开/收起、默认应用打开、预置应用打开、
     自定义应用添加/移除、终端打开目录正常

## 兼容性

- 向后兼容：fileOpenApps 缺省为空数组，老用户不受影响
- 跨平台：非 macOS 返回空预置列表，下拉仍保留默认打开/访达/终端入口
- 未修改 PreviewPanel 与 PreviewTabContent 以外的预览逻辑