### PR TITLE
style(ui): 滚动进度条与分屏分割线保持 4px 间距【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx
@@ -356,7 +356,7 @@ export function ScrollMinimap({ items }: ScrollMinimapProps): React.ReactElement
   const thumbTopPct = scrollRange > 0 ? (scrollTop / scrollRange) * (100 - thumbHeightPct) : 0
 
   return (
-    <div className="absolute right-0 top-0 bottom-0 z-30 flex pointer-events-none">
+    <div className="absolute right-1 top-0 bottom-0 z-30 flex pointer-events-none">
       {/* ── 迷你地图悬停区域（面板 + 横杠） ── */}
       <div className="flex items-start h-full">
         {/* 展开面板 */}


### PR DESCRIPTION
## 概述

当右侧草稿（ScratchPad）或预览面板打开、Agent Session 与之并排分屏时，Agent Session 消息区域的滚动进度条（`ScrollMinimap`）以 `absolute right-0` 定位，正好紧贴两侧面板之间的分割线，视觉上显得拥挤、不美观。本次改动将滚动条整体内缩 4px（`right-1`），与分割线之间留出呼吸感。

## 改动

- `apps/electron/src/renderer/components/ai-elements/scroll-minimap.tsx` — 根容器定位从 `right-0` 改为 `right-1`（4px），使滚动进度条与迷你地图横杠整体左移 4px。

## 测试方法

1. 打开一个 Agent 会话并产生足够消息，使滚动条出现
2. 打开右侧草稿（ScratchPad）或预览面板，观察分屏时滚动条与分割线的间距
3. 关闭右侧面板，确认全屏时滚动条位置正常
4. 在 Chat 会话中重复验证（组件共用，两处应一致内缩）

## 备注

- 该组件被 Agent 与 Chat 共用，改动对两处一致生效；Chat 内容区本身有 32px 内边距，不受影响
- typecheck 全部通过（shared / session-core / core / cli / ui / electron 共 6 个包）

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
