### PR TITLE
Support drag files and folders from file panel or system to Agent input as references

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -1845,7 +1845,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       })
   }, [addClipboardTextDraft])
 
-  /** 将右侧文件面板拖入的目录附加到会话 */
+  /** 将右侧文件面板拖入的目录附加到会话（保持 Agent 可访问） */
   const addPanelDirectory = React.useCallback(async (dirPath: string): Promise<void> => {
     try {
       const updated = await window.electronAPI.attachDirectory({
@@ -1857,8 +1857,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         map.set(sessionId, updated)
         return map
       })
-      const dirName = dirPath.split(/[\\/]/).pop() || dirPath
-      toast.success(`已附加目录: ${dirName}`)
     } catch (error) {
       console.error('[AgentView] 面板拖拽附加目录失败:', error)
     }
@@ -1883,16 +1881,14 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     setIsDragOver(false)
 
     // 优先识别右侧文件面板的自定义拖拽载荷（会话文件 / 项目文件引用）
+    // 文件与文件夹统一在输入框插入 @file 引用；文件夹同时附加到会话（Agent 可访问）
     const panelItems = getFilePanelDragData(e.dataTransfer)
     if (panelItems && panelItems.length > 0) {
-      const files = panelItems.filter((item) => !item.isDirectory)
-      const dirs = panelItems.filter((item) => item.isDirectory)
-      if (files.length > 0) {
-        // 在输入框光标处插入 @file 引用（与键盘 @ 引用行为一致，跟随输入对话内容）
-        richTextInputRef.current?.insertFileMentions(files)
-      }
-      for (const dir of dirs) {
-        await addPanelDirectory(dir.path)
+      richTextInputRef.current?.insertFileMentions(panelItems)
+      for (const item of panelItems) {
+        if (item.isDirectory) {
+          await addPanelDirectory(item.path)
+        }
       }
       return
     }

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -30,7 +30,7 @@ import { PlanModeDashedBorder } from './PlanModeDashedBorder'
 import { ModelSelector } from '@/components/chat/ModelSelector'
 import { AttachmentPreviewItem } from '@/components/chat/AttachmentPreviewItem'
 import { QuotedSelectionChip } from '@/components/diff/QuotedSelectionChip'
-import { RichTextInput } from '@/components/ai-elements/rich-text-input'
+import { RichTextInput, type RichTextInputHandle } from '@/components/ai-elements/rich-text-input'
 import { SpeechButton } from '@/components/ai-elements/speech-button'
 import { InputToolbarOverflow, type ToolbarItem } from '@/components/ai-elements/InputToolbarOverflow'
 import {
@@ -119,7 +119,7 @@ import { useOpenPreview } from '@/components/diff/preview-opener'
 import type { AgentRuntime, AgentSendInput, AgentPendingFile, AgentThinkingLevel, FileDialogLargeFile, FileDialogResult, ModelOption, ReasoningCapability, SDKMessage, SDKUserMessage, ProviderType } from '@proma/shared'
 import { inferAgentSdkContextWindow, inferContextWindow, inferReasoningTransport, isCodexFastModeSupportedModel, MAX_ATTACHMENT_SIZE, normalizeReasoningCapabilityLevel, normalizeReasoningLevel, resolveReasoningCapability, resolveReasoningProfile } from '@proma/shared'
 import { fileToBase64, formatFileNames, getFileParentPath } from '@/lib/file-utils'
-import { getFilePanelDragData, getMediaTypeFromFilename } from '@/lib/file-panel-drag'
+import { getFilePanelDragData } from '@/lib/file-panel-drag'
 import { buildQuotedSelectionBlock } from '@/lib/quoted-selection'
 import { createClipboardPendingFile, createClipboardTextDraft, makeUniqueAttachmentName } from '@/lib/clipboard-text-attachment'
 import {
@@ -739,6 +739,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
 
   // pendingFiles ref（供 addFilesAsAttachments 读取最新列表，避免闭包旧值）
   const pendingFilesRef = React.useRef(pendingFiles)
+  // RichTextInput 命令接口 ref（右侧文件面板拖入时插入 @file 引用）
+  const richTextInputRef = React.useRef<RichTextInputHandle>(null)
   React.useEffect(() => {
     pendingFilesRef.current = pendingFiles
   }, [pendingFiles])
@@ -1843,25 +1845,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       })
   }, [addClipboardTextDraft])
 
-  /** 将右侧文件面板拖入的文件添加为引用（sourcePath 直接引用原路径，等同于「添加到聊天」） */
-  const addPanelFileReferences = React.useCallback((items: Array<{ path: string; name: string }>): void => {
-    const usedNames: string[] = pendingFilesRef.current.map((f) => f.filename)
-    for (const item of items) {
-      if (pendingFilesRef.current.some((f) => f.sourcePath === item.path)) continue
-      const uniqueFilename = makeUniqueFilename(item.name, usedNames)
-      usedNames.push(uniqueFilename)
-
-      const pending: AgentPendingFile = {
-        id: `pending-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-        filename: uniqueFilename,
-        mediaType: getMediaTypeFromFilename(item.name),
-        size: 0,
-        sourcePath: item.path,
-      }
-      setPendingFiles((prev) => [...prev, pending])
-    }
-  }, [makeUniqueFilename, setPendingFiles])
-
   /** 将右侧文件面板拖入的目录附加到会话 */
   const addPanelDirectory = React.useCallback(async (dirPath: string): Promise<void> => {
     try {
@@ -1905,7 +1888,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       const files = panelItems.filter((item) => !item.isDirectory)
       const dirs = panelItems.filter((item) => item.isDirectory)
       if (files.length > 0) {
-        addPanelFileReferences(files)
+        // 在输入框光标处插入 @file 引用（与键盘 @ 引用行为一致，跟随输入对话内容）
+        richTextInputRef.current?.insertFileMentions(files)
       }
       for (const dir of dirs) {
         await addPanelDirectory(dir.path)
@@ -1971,7 +1955,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       // 无路径信息：回退，所有项按普通文件处理
       addFilesAsAttachments(droppedFiles)
     }
-  }, [sessionId, addFilesAsAttachments, addPanelFileReferences, addPanelDirectory, setAttachedDirsMap])
+  }, [sessionId, addFilesAsAttachments, addPanelDirectory, setAttachedDirsMap])
 
   /** ModelSelector 选择回调 */
   const handleModelSelect = React.useCallback((option: ModelOption): void => {
@@ -3153,6 +3137,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
             )}
 
             <RichTextInput
+              ref={richTextInputRef}
               value={inputContent}
               onChange={setInputContent}
               onSubmit={handleSend}

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -1914,7 +1914,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         // 通过主进程检测目录 vs 文件
         const { directories, files: filePaths } = await window.electronAPI.checkPathsType(paths)
 
-        // 拖拽的文件夹直接附加
+        // 拖拽的文件夹：附加到会话 + 插入可见的文件夹引用（与右侧面板拖拽体验一致）
         for (const dirPath of directories) {
           try {
             const updated = await window.electronAPI.attachDirectory({
@@ -1927,6 +1927,13 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
               return map
             })
             const dirName = dirPath.split('/').pop() || dirPath
+            // 在输入框插入文件夹引用 chip（Agent 通过附加目录可访问）
+            richTextInputRef.current?.insertFileMentions([{
+              path: dirPath,
+              name: dirName,
+              isDirectory: true,
+              scope: 'project',
+            }])
             toast.success(`已附加目录: ${dirName}`)
           } catch (error) {
             console.error('[AgentView] 拖拽附加文件夹失败:', error)

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -119,7 +119,7 @@ import { useOpenPreview } from '@/components/diff/preview-opener'
 import type { AgentRuntime, AgentSendInput, AgentPendingFile, AgentThinkingLevel, FileDialogLargeFile, FileDialogResult, ModelOption, ReasoningCapability, SDKMessage, SDKUserMessage, ProviderType } from '@proma/shared'
 import { inferAgentSdkContextWindow, inferContextWindow, inferReasoningTransport, isCodexFastModeSupportedModel, MAX_ATTACHMENT_SIZE, normalizeReasoningCapabilityLevel, normalizeReasoningLevel, resolveReasoningCapability, resolveReasoningProfile } from '@proma/shared'
 import { fileToBase64, formatFileNames, getFileParentPath } from '@/lib/file-utils'
-import { getFilePanelDragData } from '@/lib/file-panel-drag'
+import { getFilePanelDragData, INSERT_FILE_MENTION_EVENT, type FilePanelDragItem } from '@/lib/file-panel-drag'
 import { buildQuotedSelectionBlock } from '@/lib/quoted-selection'
 import { createClipboardPendingFile, createClipboardTextDraft, makeUniqueAttachmentName } from '@/lib/clipboard-text-attachment'
 import {
@@ -2693,6 +2693,17 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     }
     window.addEventListener('proma:focus-input', handler)
     return () => window.removeEventListener('proma:focus-input', handler)
+  }, [])
+
+  // 监听文件面板三点菜单「引用到 Agent」事件：在输入框插入 @file 引用
+  React.useEffect(() => {
+    const handler = (event: Event): void => {
+      const items = (event as CustomEvent<FilePanelDragItem[]>).detail
+      if (!items || items.length === 0) return
+      richTextInputRef.current?.insertFileMentions(items)
+    }
+    window.addEventListener(INSERT_FILE_MENTION_EVENT, handler)
+    return () => window.removeEventListener(INSERT_FILE_MENTION_EVENT, handler)
   }, [])
 
   const allAskUserRequests = useAtomValue(allPendingAskUserRequestsAtom)

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -1845,8 +1845,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       })
   }, [addClipboardTextDraft])
 
-  /** 将右侧文件面板拖入的目录附加到会话（保持 Agent 可访问） */
-  const addPanelDirectory = React.useCallback(async (dirPath: string): Promise<void> => {
+  /** 将右侧文件面板拖入的目录附加到会话（保持 Agent 可访问）。返回是否成功。 */
+  const addPanelDirectory = React.useCallback(async (dirPath: string): Promise<boolean> => {
     try {
       const updated = await window.electronAPI.attachDirectory({
         sessionId,
@@ -1857,8 +1857,10 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
         map.set(sessionId, updated)
         return map
       })
+      return true
     } catch (error) {
       console.error('[AgentView] 面板拖拽附加目录失败:', error)
+      return false
     }
   }, [sessionId, setAttachedDirsMap])
 
@@ -1881,13 +1883,19 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     setIsDragOver(false)
 
     // 优先识别右侧文件面板的自定义拖拽载荷（会话文件 / 项目文件引用）
-    // 文件与文件夹统一在输入框插入 @file 引用；文件夹同时附加到会话（Agent 可访问）
+    // 文件直接插入引用；文件夹先附加到会话（Agent 可访问），附加成功后才插入引用，
+    // 避免失败时留下 Agent 无法访问的无效引用。
     const panelItems = getFilePanelDragData(e.dataTransfer)
     if (panelItems && panelItems.length > 0) {
-      richTextInputRef.current?.insertFileMentions(panelItems)
-      for (const item of panelItems) {
-        if (item.isDirectory) {
-          await addPanelDirectory(item.path)
+      const files = panelItems.filter((item) => !item.isDirectory)
+      const dirs = panelItems.filter((item) => item.isDirectory)
+      if (files.length > 0) {
+        richTextInputRef.current?.insertFileMentions(files)
+      }
+      for (const dir of dirs) {
+        const ok = await addPanelDirectory(dir.path)
+        if (ok) {
+          richTextInputRef.current?.insertFileMentions([dir])
         }
       }
       return
@@ -1926,7 +1934,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
               map.set(sessionId, updated)
               return map
             })
-            const dirName = dirPath.split('/').pop() || dirPath
+            const dirName = dirPath.split(/[\\/]/).pop() || dirPath
             // 在输入框插入文件夹引用 chip（Agent 通过附加目录可访问）
             richTextInputRef.current?.insertFileMentions([{
               path: dirPath,

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -119,6 +119,7 @@ import { useOpenPreview } from '@/components/diff/preview-opener'
 import type { AgentRuntime, AgentSendInput, AgentPendingFile, AgentThinkingLevel, FileDialogLargeFile, FileDialogResult, ModelOption, ReasoningCapability, SDKMessage, SDKUserMessage, ProviderType } from '@proma/shared'
 import { inferAgentSdkContextWindow, inferContextWindow, inferReasoningTransport, isCodexFastModeSupportedModel, MAX_ATTACHMENT_SIZE, normalizeReasoningCapabilityLevel, normalizeReasoningLevel, resolveReasoningCapability, resolveReasoningProfile } from '@proma/shared'
 import { fileToBase64, formatFileNames, getFileParentPath } from '@/lib/file-utils'
+import { getFilePanelDragData, getMediaTypeFromFilename } from '@/lib/file-panel-drag'
 import { buildQuotedSelectionBlock } from '@/lib/quoted-selection'
 import { createClipboardPendingFile, createClipboardTextDraft, makeUniqueAttachmentName } from '@/lib/clipboard-text-attachment'
 import {
@@ -1842,6 +1843,44 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       })
   }, [addClipboardTextDraft])
 
+  /** 将右侧文件面板拖入的文件添加为引用（sourcePath 直接引用原路径，等同于「添加到聊天」） */
+  const addPanelFileReferences = React.useCallback((items: Array<{ path: string; name: string }>): void => {
+    const usedNames: string[] = pendingFilesRef.current.map((f) => f.filename)
+    for (const item of items) {
+      if (pendingFilesRef.current.some((f) => f.sourcePath === item.path)) continue
+      const uniqueFilename = makeUniqueFilename(item.name, usedNames)
+      usedNames.push(uniqueFilename)
+
+      const pending: AgentPendingFile = {
+        id: `pending-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+        filename: uniqueFilename,
+        mediaType: getMediaTypeFromFilename(item.name),
+        size: 0,
+        sourcePath: item.path,
+      }
+      setPendingFiles((prev) => [...prev, pending])
+    }
+  }, [makeUniqueFilename, setPendingFiles])
+
+  /** 将右侧文件面板拖入的目录附加到会话 */
+  const addPanelDirectory = React.useCallback(async (dirPath: string): Promise<void> => {
+    try {
+      const updated = await window.electronAPI.attachDirectory({
+        sessionId,
+        directoryPath: dirPath,
+      })
+      setAttachedDirsMap((prev) => {
+        const map = new Map(prev)
+        map.set(sessionId, updated)
+        return map
+      })
+      const dirName = dirPath.split(/[\\/]/).pop() || dirPath
+      toast.success(`已附加目录: ${dirName}`)
+    } catch (error) {
+      console.error('[AgentView] 面板拖拽附加目录失败:', error)
+    }
+  }, [sessionId, setAttachedDirsMap])
+
   /** 拖放处理 */
   const handleDragOver = React.useCallback((e: React.DragEvent): void => {
     e.preventDefault()
@@ -1859,6 +1898,20 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     e.preventDefault()
     e.stopPropagation()
     setIsDragOver(false)
+
+    // 优先识别右侧文件面板的自定义拖拽载荷（会话文件 / 项目文件引用）
+    const panelItems = getFilePanelDragData(e.dataTransfer)
+    if (panelItems && panelItems.length > 0) {
+      const files = panelItems.filter((item) => !item.isDirectory)
+      const dirs = panelItems.filter((item) => item.isDirectory)
+      if (files.length > 0) {
+        addPanelFileReferences(files)
+      }
+      for (const dir of dirs) {
+        await addPanelDirectory(dir.path)
+      }
+      return
+    }
 
     const droppedFiles = Array.from(e.dataTransfer.files)
     if (droppedFiles.length === 0) return
@@ -1918,7 +1971,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       // 无路径信息：回退，所有项按普通文件处理
       addFilesAsAttachments(droppedFiles)
     }
-  }, [sessionId, addFilesAsAttachments, setAttachedDirsMap])
+  }, [sessionId, addFilesAsAttachments, addPanelFileReferences, addPanelDirectory, setAttachedDirsMap])
 
   /** ModelSelector 选择回调 */
   const handleModelSelect = React.useCallback((option: ModelOption): void => {

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -538,8 +538,8 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
                     </div>
                   </FileSearchBar>
                   <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin pt-1">
-                    {/* 拖拽引用提示：告知用户可拖拽文件/文件夹到 Agent 输入框 */}
-                    <div className="mx-1 mb-1.5 px-2.5 py-1.5 text-[11px] leading-4 text-muted-foreground/75 rounded-md bg-muted/40 border border-border/50">
+                    {/* 拖拽引用提示：引用块样式，左侧竖线 + 缩进，与下方文件列表内容左对齐 */}
+                    <div className="mb-1.5 ml-4 border-l-2 border-primary/40 pl-2 text-[11px] leading-4 text-foreground/75">
                       支持拖拽文件或文件夹到输入框，实现引用
                     </div>
                     {showProjectFiles && wsAttachedFiles.length > 0 && (
@@ -1268,20 +1268,18 @@ function AttachedDirItem({ entry, depth, selectedPaths, onSelect, refreshVersion
               </button>
             </DropdownMenuTrigger>
               <DropdownMenuContent align="start" className="w-40 z-[9999] min-w-0 p-0.5">
-                {!entry.isDirectory && (
-                  <DropdownMenuItem
-                    className="text-xs py-1 [&>svg]:size-3.5"
-                    onSelect={() => dispatchInsertFileMention([{
-                      path: currentPath,
-                      name: currentName,
-                      isDirectory: entry.isDirectory,
-                      scope,
-                    }])}
-                  >
-                    <MessageSquarePlus />
-                    引用到 Agent
-                  </DropdownMenuItem>
-                )}
+                <DropdownMenuItem
+                  className="text-xs py-1 [&>svg]:size-3.5"
+                  onSelect={() => dispatchInsertFileMention([{
+                    path: currentPath,
+                    name: currentName,
+                    isDirectory: entry.isDirectory,
+                    scope,
+                  }])}
+                >
+                  <MessageSquarePlus />
+                  引用到 Agent
+                </DropdownMenuItem>
                 {onAddToChat && !entry.isDirectory && (
                   <DropdownMenuItem
                     className="text-xs py-1 [&>svg]:size-3.5"

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -44,6 +44,7 @@ import { previewFileMapAtom } from '@/atoms/preview-atoms'
 import { useOpenPreview } from '@/components/diff/preview-opener'
 import { detectIsWindows } from '@/lib/platform'
 import type { FileEntry, AgentPendingFile } from '@proma/shared'
+import { setFilePanelDragData, getMediaTypeFromFilename } from '@/lib/file-panel-drag'
 
 function getPathBasename(filePath: string): string {
   return filePath.split(/[\\/]/).filter(Boolean).pop() || filePath
@@ -58,14 +59,6 @@ function getPathDirname(filePath: string): string {
 function joinPath(parentDir: string, name: string): string {
   const separator = parentDir.includes('\\') && !parentDir.includes('/') ? '\\' : '/'
   return parentDir ? `${parentDir}${separator}${name}` : name
-}
-
-function getMediaTypeFromFilename(filename: string): string {
-  const ext = filename.split('.').pop()?.toLowerCase() ?? ''
-  const imageExts = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp', 'ico'])
-  if (!imageExts.has(ext)) return 'application/octet-stream'
-  const mimeExt = ext === 'jpg' ? 'jpeg' : ext === 'svg' ? 'svg+xml' : ext
-  return `image/${mimeExt}`
 }
 
 interface SidePanelProps {
@@ -668,6 +661,16 @@ function AttachedFilesSection({ title, scope = 'project', showSessionBadge = tru
             key={filePath}
             className="flex items-center gap-1 py-1 pl-2 pr-2 text-sm cursor-pointer hover:bg-accent/50 group mx-2 rounded-lg"
             onClick={() => onFilePreview?.(filePath)}
+            draggable
+            onDragStart={(e) => {
+              e.stopPropagation()
+              setFilePanelDragData(e.dataTransfer, [{
+                path: filePath,
+                name,
+                isDirectory: false,
+                scope,
+              }])
+            }}
           >
             <span className="w-3.5 flex-shrink-0" />
             <FileTypeIcon name={name} isDirectory={false} />
@@ -677,6 +680,7 @@ function AttachedFilesSection({ title, scope = 'project', showSessionBadge = tru
             )}
             <div
               className="flex-shrink-0 mr-1"
+              draggable={false}
               onClick={(e) => e.stopPropagation()}
               onMouseDown={(e) => e.stopPropagation()}
             >
@@ -918,6 +922,16 @@ function AttachedDirTree({ dirPath, onDetach, selectedPaths, onSelect, refreshVe
         )}
         style={{ paddingLeft }}
         onClick={toggleExpand}
+        draggable
+        onDragStart={(e) => {
+          e.stopPropagation()
+          setFilePanelDragData(e.dataTransfer, [{
+            path: dirPath,
+            name: dirName,
+            isDirectory: true,
+            scope,
+          }])
+        }}
       >
         <span
           aria-hidden="true"
@@ -966,7 +980,7 @@ function AttachedDirTree({ dirPath, onDetach, selectedPaths, onSelect, refreshVe
             </div>
           )}
           {children.map((child) => (
-            <AttachedDirItem key={child.path} entry={child} depth={1} selectedPaths={selectedPaths} onSelect={onSelect} refreshVersion={refreshVersion} onAddToChat={onAddToChat} onFilePreview={onFilePreview} allowedPaths={allowedPaths} sessionId={sessionId} revealTarget={revealTarget} revealTs={revealTs} revealAncestors={revealAncestors} />
+            <AttachedDirItem key={child.path} entry={child} depth={1} selectedPaths={selectedPaths} onSelect={onSelect} refreshVersion={refreshVersion} onAddToChat={onAddToChat} onFilePreview={onFilePreview} allowedPaths={allowedPaths} sessionId={sessionId} scope={scope} revealTarget={revealTarget} revealTs={revealTs} revealAncestors={revealAncestors} />
           ))}
         </div>
       )}
@@ -984,6 +998,7 @@ interface AttachedDirItemProps {
   onFilePreview?: (filePath: string) => void
   allowedPaths?: string[]
   sessionId: string
+  scope: 'project' | 'session'
   /** 自动定位目标路径，命中则滚动到中心 */
   revealTarget?: string | null
   /** 自动定位脉冲时间戳，变化时重新触发 */
@@ -992,7 +1007,7 @@ interface AttachedDirItemProps {
   revealAncestors?: Set<string>
 }
 
-function AttachedDirItem({ entry, depth, selectedPaths, onSelect, refreshVersion, onAddToChat, onFilePreview, allowedPaths, sessionId, revealTarget = null, revealTs = 0, revealAncestors }: AttachedDirItemProps): React.ReactElement {
+function AttachedDirItem({ entry, depth, selectedPaths, onSelect, refreshVersion, onAddToChat, onFilePreview, allowedPaths, sessionId, scope, revealTarget = null, revealTs = 0, revealAncestors }: AttachedDirItemProps): React.ReactElement {
   const [expanded, setExpanded] = React.useState(false)
   const [children, setChildren] = React.useState<FileEntry[]>([])
   const [loaded, setLoaded] = React.useState(false)
@@ -1153,6 +1168,16 @@ function AttachedDirItem({ entry, depth, selectedPaths, onSelect, refreshVersion
           zIndex: isSticky ? stickyZIndex : undefined,
         }}
         onClick={handleClick}
+        draggable={!isRenaming}
+        onDragStart={(e) => {
+          e.stopPropagation()
+          setFilePanelDragData(e.dataTransfer, [{
+            path: currentPath,
+            name: currentName,
+            isDirectory: entry.isDirectory,
+            scope,
+          }])
+        }}
       >
         <span
           aria-hidden="true"
@@ -1203,6 +1228,7 @@ function AttachedDirItem({ entry, depth, selectedPaths, onSelect, refreshVersion
         {/* 右侧操作按钮占位 */}
         <div
           className="relative z-10 flex-shrink-0 mr-1"
+          draggable={false}
           onClick={(e) => e.stopPropagation()}
           onMouseDown={(e) => e.stopPropagation()}
         >
@@ -1286,7 +1312,7 @@ function AttachedDirItem({ entry, depth, selectedPaths, onSelect, refreshVersion
             </div>
           )}
           {children.map((child) => (
-            <AttachedDirItem key={child.path} entry={child} depth={depth + 1} selectedPaths={selectedPaths} onSelect={onSelect} refreshVersion={refreshVersion} onAddToChat={onAddToChat} onFilePreview={onFilePreview} allowedPaths={allowedPaths} sessionId={sessionId} revealTarget={revealTarget} revealTs={revealTs} revealAncestors={revealAncestors} />
+            <AttachedDirItem key={child.path} entry={child} depth={depth + 1} selectedPaths={selectedPaths} onSelect={onSelect} refreshVersion={refreshVersion} onAddToChat={onAddToChat} onFilePreview={onFilePreview} allowedPaths={allowedPaths} sessionId={sessionId} scope={scope} revealTarget={revealTarget} revealTs={revealTs} revealAncestors={revealAncestors} />
           ))}
         </div>
       )}

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -44,7 +44,7 @@ import { previewFileMapAtom } from '@/atoms/preview-atoms'
 import { useOpenPreview } from '@/components/diff/preview-opener'
 import { detectIsWindows } from '@/lib/platform'
 import type { FileEntry, AgentPendingFile } from '@proma/shared'
-import { setFilePanelDragData, getMediaTypeFromFilename } from '@/lib/file-panel-drag'
+import { setFilePanelDragData, getMediaTypeFromFilename, dispatchInsertFileMention } from '@/lib/file-panel-drag'
 
 function getPathBasename(filePath: string): string {
   return filePath.split(/[\\/]/).filter(Boolean).pop() || filePath
@@ -538,6 +538,10 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
                     </div>
                   </FileSearchBar>
                   <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin pt-1">
+                    {/* 拖拽引用提示：告知用户可拖拽文件/文件夹到 Agent 输入框 */}
+                    <div className="mx-1 mb-1.5 px-2.5 py-1.5 text-[11px] leading-4 text-muted-foreground/75 rounded-md bg-muted/40 border border-border/50">
+                      支持拖拽文件或文件夹到输入框，实现引用
+                    </div>
                     {showProjectFiles && wsAttachedFiles.length > 0 && (
                       <AttachedFilesSection
                         scope="project"
@@ -696,6 +700,18 @@ function AttachedFilesSection({ title, scope = 'project', showSessionBadge = tru
                   </button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="start" className="w-40 z-[9999] min-w-0 p-0.5">
+                  <DropdownMenuItem
+                    className="text-xs py-1 [&>svg]:size-3.5"
+                    onSelect={() => dispatchInsertFileMention([{
+                      path: filePath,
+                      name,
+                      isDirectory: false,
+                      scope,
+                    }])}
+                  >
+                    <MessageSquarePlus />
+                    引用到 Agent
+                  </DropdownMenuItem>
                   {onAddToChat && (
                     <DropdownMenuItem
                       className="text-xs py-1 [&>svg]:size-3.5"
@@ -1252,6 +1268,20 @@ function AttachedDirItem({ entry, depth, selectedPaths, onSelect, refreshVersion
               </button>
             </DropdownMenuTrigger>
               <DropdownMenuContent align="start" className="w-40 z-[9999] min-w-0 p-0.5">
+                {!entry.isDirectory && (
+                  <DropdownMenuItem
+                    className="text-xs py-1 [&>svg]:size-3.5"
+                    onSelect={() => dispatchInsertFileMention([{
+                      path: currentPath,
+                      name: currentName,
+                      isDirectory: entry.isDirectory,
+                      scope,
+                    }])}
+                  >
+                    <MessageSquarePlus />
+                    引用到 Agent
+                  </DropdownMenuItem>
+                )}
                 {onAddToChat && !entry.isDirectory && (
                   <DropdownMenuItem
                     className="text-xs py-1 [&>svg]:size-3.5"

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -871,7 +871,7 @@ function AttachedDirTree({ dirPath, onDetach, selectedPaths, onSelect, refreshVe
   const [children, setChildren] = React.useState<FileEntry[]>([])
   const [loaded, setLoaded] = React.useState(false)
 
-  const dirName = dirPath.split('/').filter(Boolean).pop() || dirPath
+  const dirName = dirPath.split(/[\\/]/).filter(Boolean).pop() || dirPath
 
   // 计算从 dirPath 到 revealTarget 之间的祖先目录集合（用于子项决定是否自动展开）
   const revealAncestors = React.useMemo(

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -285,6 +285,8 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
         // 禁用内置版本，使用下面单独配置的版本
         link: false,
         underline: false,
+        // 禁用拖拽插入位置指示器（拖入文件/文件夹时出现的横线）
+        dropcursor: false,
         // 纯文本模式：禁用所有格式化扩展，仅保留 Document/Paragraph/Text/HardBreak/History
         ...(richTextEnabled ? {} : {
           blockquote: false,
@@ -347,6 +349,14 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
                     : {}
                 ),
               },
+              // 文件夹引用（右侧文件面板拖入的目录）：渲染为文件夹样式 chip
+              isDirectory: {
+                default: false,
+                parseHTML: (el: HTMLElement) => el.getAttribute('data-mention-is-directory') === 'true',
+                renderHTML: (attrs: Record<string, unknown>) => attrs.isDirectory
+                  ? { 'data-mention-is-directory': 'true' }
+                  : {},
+              },
               // 兼容此前统一命令菜单生成的历史 draft；新节点不再写入此属性。
               commandMenuMention: {
                 default: false,
@@ -370,7 +380,8 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
             const char = resolveMentionSuggestionChar(node.attrs.mentionSuggestionChar, suggestion?.char)
             const label = node.attrs.label ?? node.attrs.id
             const referenceType = node.attrs.referenceType
-            let chipClass = 'mention-chip'
+            const isDirectory = node.attrs.isDirectory === true
+            let chipClass = isDirectory ? 'directory-mention-chip' : 'mention-chip'
             if (referenceType === 'todo') chipClass = 'todo-mention-chip'
             else if (referenceType === 'calendar_event') chipClass = 'calendar-event-mention-chip'
             else if (char === '/') chipClass = 'skill-mention-chip'
@@ -387,6 +398,7 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
                   ? { 'data-mention-reference-type': referenceType }
                   : {}),
                 ...(node.attrs.commandMenuMention ? { 'data-command-menu-mention': 'true' } : {}),
+                ...(isDirectory ? { 'data-mention-is-directory': 'true' } : {}),
                 class: chipClass,
               },
               `${char === '@' ? '@' : ''}${label}`,
@@ -746,6 +758,7 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
               id: item.path,
               label: item.name,
               mentionSuggestionChar: '@',
+              isDirectory: item.isDirectory ?? false,
             },
           })
           .insertContent(' ')
@@ -864,6 +877,30 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
           height: 12px;
           background-color: currentColor;
           mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z'/%3E%3Cpath d='M14 2v4a2 2 0 0 0 2 2h4'/%3E%3C/svg%3E");
+          mask-size: contain;
+          mask-repeat: no-repeat;
+          flex-shrink: 0;
+        }
+        .directory-mention-chip {
+          background-color: hsl(var(--primary) / 0.14);
+          color: hsl(var(--primary));
+          border-radius: 4px;
+          padding: 1px 4px 1px 2px;
+          font-size: 13px;
+          font-weight: 500;
+          white-space: nowrap;
+          display: inline-flex;
+          align-items: center;
+          gap: 2px;
+          vertical-align: baseline;
+        }
+        .directory-mention-chip::before {
+          content: '';
+          display: inline-block;
+          width: 12px;
+          height: 12px;
+          background-color: currentColor;
+          mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z'/%3E%3C/svg%3E");
           mask-size: contain;
           mask-repeat: no-repeat;
           flex-shrink: 0;

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -30,6 +30,7 @@ import { htmlToMarkdown } from '@/lib/markdown-rich-text'
 import { resolveMentionSuggestionChar } from './mention-utils'
 import { richTextRenderingEnabledAtom } from '@/atoms/ui-preferences'
 import { createFileMentionSuggestion } from '@/components/file-browser/file-mention-suggestion'
+import { getFilePanelDragData } from '@/lib/file-panel-drag'
 import {
   createMcpMentionSuggestion,
   createPlanningMentionSuggestion,
@@ -398,6 +399,15 @@ export function RichTextInput({
     content: value || '',
     editable: !disabled,
     editorProps: {
+      // 右侧文件面板拖拽载荷（自定义 MIME）交给外层容器 onDrop 处理，
+      // 阻止 ProseMirror 把 text/plain 路径文本当作普通文本插入。
+      handleDrop: (_view, event) => {
+        if (event.dataTransfer && getFilePanelDragData(event.dataTransfer)) {
+          event.preventDefault()
+          return true
+        }
+        return false
+      },
       attributes: {
         class: cn(
           'prose dark:prose-invert max-w-none focus:outline-none',

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -13,7 +13,7 @@
  * - 自动扩高
  */
 
-import { useState, useEffect, useRef, useMemo, useCallback } from 'react'
+import { useState, useEffect, useRef, useMemo, useCallback, useImperativeHandle, forwardRef } from 'react'
 import { useAtomValue } from 'jotai'
 import { useEditor, EditorContent } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
@@ -30,7 +30,7 @@ import { htmlToMarkdown } from '@/lib/markdown-rich-text'
 import { resolveMentionSuggestionChar } from './mention-utils'
 import { richTextRenderingEnabledAtom } from '@/atoms/ui-preferences'
 import { createFileMentionSuggestion } from '@/components/file-browser/file-mention-suggestion'
-import { getFilePanelDragData } from '@/lib/file-panel-drag'
+import { getFilePanelDragData, type FilePanelDragItem } from '@/lib/file-panel-drag'
 import {
   createMcpMentionSuggestion,
   createPlanningMentionSuggestion,
@@ -146,13 +146,19 @@ interface RichTextInputProps {
   className?: string
 }
 
+/** RichTextInput 对外暴露的命令接口 */
+export interface RichTextInputHandle {
+  /** 在光标处插入文件引用（右侧文件面板拖入时调用） */
+  insertFileMentions: (items: FilePanelDragItem[]) => void
+}
+
 /**
  * 富文本输入组件
  * - 基于 TipTap 的 WYSIWYG 编辑器
  * - 支持 Markdown 快捷输入
  * - 无工具栏，纯净输入体验
  */
-export function RichTextInput({
+export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>(function RichTextInput({
   value,
   onChange,
   onSubmit,
@@ -174,7 +180,7 @@ export function RichTextInput({
   htmlValue,
   onHtmlChange,
   sendWithCmdEnter = false,
-}: RichTextInputProps): React.ReactElement {
+}: RichTextInputProps, ref: React.Ref<RichTextInputHandle>): React.ReactElement {
   const [isExpanded, setIsExpanded] = useState(false)
   const inputIdRef = useRef(`rich-text-input-${Math.random().toString(36).slice(2)}`)
   // 手动折叠状态：用户主动折叠输入框
@@ -725,6 +731,29 @@ export function RichTextInput({
     }
   }, [editor, disabled, autoFocusTrigger])
 
+  // 对外暴露命令接口：右侧文件面板拖入时，在光标处插入 @file 引用 mention。
+  // mention 节点沿用 TipTap Mention 扩展的 attrs（id=路径，label=文件名），
+  // 发送时由 htmlToMarkdown 序列化为 @file:{path}，与键盘 @ 引用行为完全一致。
+  useImperativeHandle(ref, () => ({
+    insertFileMentions(items: FilePanelDragItem[]): void {
+      if (!editor || items.length === 0) return
+      let chain = editor.chain().focus()
+      for (const item of items) {
+        chain = chain
+          .insertContent({
+            type: 'mention',
+            attrs: {
+              id: item.path,
+              label: item.name,
+              mentionSuggestionChar: '@',
+            },
+          })
+          .insertContent(' ')
+      }
+      chain.run()
+    },
+  }), [editor])
+
   // 语音输入回填：优先插入到当前编辑器的光标位置。
   useEffect(() => {
     if (!editor || disabled) return
@@ -951,4 +980,4 @@ export function RichTextInput({
       `}</style>
     </div>
   )
-}
+})

--- a/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
@@ -56,7 +56,7 @@ import {
   STICKY_ROW_BASE_CLASS,
   canBeSticky,
 } from './tree-row-layout'
-import { setFilePanelDragData } from '@/lib/file-panel-drag'
+import { setFilePanelDragData, dispatchInsertFileMention } from '@/lib/file-panel-drag'
 
 /** 计算目标路径相对 rootPath 的祖先目录集合（不含 rootPath 自身、含目标的所有上级） */
 export function computeRevealAncestors(rootPath: string, targetPath: string): Set<string> {
@@ -871,6 +871,20 @@ function FileTreeItem({
               </button>
             </DropdownMenuTrigger>
               <DropdownMenuContent align="start" className="w-40 z-[9999] min-w-0 p-0.5">
+                {!entry.isDirectory && menuSelectedCount === 1 && (
+                  <DropdownMenuItem
+                    className="text-xs py-1 [&>svg]:size-3.5"
+                    onSelect={() => dispatchInsertFileMention([{
+                      path: entry.path,
+                      name: entry.name,
+                      isDirectory: entry.isDirectory,
+                      scope: entry.scope,
+                    }])}
+                  >
+                    <MessageSquarePlus />
+                    引用到 Agent
+                  </DropdownMenuItem>
+                )}
                 {onAddToChat && !entry.isDirectory && menuSelectedCount === 1 && (
                   <DropdownMenuItem
                     className="text-xs py-1 [&>svg]:size-3.5"

--- a/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
@@ -871,7 +871,7 @@ function FileTreeItem({
               </button>
             </DropdownMenuTrigger>
               <DropdownMenuContent align="start" className="w-40 z-[9999] min-w-0 p-0.5">
-                {!entry.isDirectory && menuSelectedCount === 1 && (
+                {menuSelectedCount === 1 && (
                   <DropdownMenuItem
                     className="text-xs py-1 [&>svg]:size-3.5"
                     onSelect={() => dispatchInsertFileMention([{

--- a/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
+++ b/apps/electron/src/renderer/components/file-browser/FileBrowser.tsx
@@ -56,6 +56,7 @@ import {
   STICKY_ROW_BASE_CLASS,
   canBeSticky,
 } from './tree-row-layout'
+import { setFilePanelDragData } from '@/lib/file-panel-drag'
 
 /** 计算目标路径相对 rootPath 的祖先目录集合（不含 rootPath 自身、含目标的所有上级） */
 export function computeRevealAncestors(rootPath: string, targetPath: string): Set<string> {
@@ -654,6 +655,17 @@ function FileTreeItem({
     }
   }
 
+  /** 拖拽到 Agent 输入框：写入面板文件引用载荷 */
+  const handleRowDragStart = React.useCallback((e: React.DragEvent): void => {
+    e.stopPropagation()
+    setFilePanelDragData(e.dataTransfer, [{
+      path: entry.path,
+      name: entry.name,
+      isDirectory: entry.isDirectory,
+      scope: entry.scope,
+    }])
+  }, [entry.path, entry.name, entry.isDirectory, entry.scope])
+
   /** 删除后刷新子目录 */
   const handleRefreshAfterDelete = async (): Promise<void> => {
     if (childrenLoaded) {
@@ -755,6 +767,8 @@ function FileTreeItem({
           zIndex: isSticky ? stickyZIndex : undefined,
         }}
         onClick={handleClick}
+        draggable={!isRenaming}
+        onDragStart={handleRowDragStart}
       >
         <span
           aria-hidden="true"
@@ -833,6 +847,7 @@ function FileTreeItem({
         {/* 右侧操作按钮占位（始终占位，避免行宽跳动） */}
         <div
           className="relative z-10 flex-shrink-0 mr-1"
+          draggable={false}
           onClick={(e) => e.stopPropagation()}
           onMouseDown={(e) => e.stopPropagation()}
         >

--- a/apps/electron/src/renderer/lib/file-panel-drag.ts
+++ b/apps/electron/src/renderer/lib/file-panel-drag.ts
@@ -10,6 +10,12 @@
 
 export const FILE_PANEL_DRAG_MIME = 'application/x-proma-file-panel'
 
+/**
+ * 三点菜单「引用到 Agent」触发的事件名。
+ * detail 携带 FilePanelDragItem[]；AgentView 监听后调用 RichTextInput.insertFileMentions。
+ */
+export const INSERT_FILE_MENTION_EVENT = 'proma:insert-file-mention'
+
 export interface FilePanelDragItem {
   /** 文件绝对路径 */
   path: string
@@ -19,6 +25,10 @@ export interface FilePanelDragItem {
   isDirectory: boolean
   /** 来源范围：项目文件 / 会话文件 */
   scope: 'project' | 'session'
+}
+
+export function dispatchInsertFileMention(items: FilePanelDragItem[]): void {
+  window.dispatchEvent(new CustomEvent(INSERT_FILE_MENTION_EVENT, { detail: items }))
 }
 
 export function setFilePanelDragData(dataTransfer: DataTransfer, items: FilePanelDragItem[]): void {

--- a/apps/electron/src/renderer/lib/file-panel-drag.ts
+++ b/apps/electron/src/renderer/lib/file-panel-drag.ts
@@ -42,9 +42,10 @@ export function getFilePanelDragData(dataTransfer: DataTransfer): FilePanelDragI
   const raw = dataTransfer.getData(FILE_PANEL_DRAG_MIME)
   if (!raw) return null
   try {
-    const parsed = JSON.parse(raw) as FilePanelDragItem[]
+    const parsed = JSON.parse(raw)
     if (!Array.isArray(parsed) || parsed.length === 0) return null
-    return parsed.filter((item) => item && typeof item.path === 'string')
+    const items = parsed.filter(isFilePanelDragItem)
+    return items.length > 0 ? items : null
   } catch {
     return null
   }
@@ -57,4 +58,15 @@ export function getMediaTypeFromFilename(filename: string): string {
   if (!imageExts.has(ext)) return 'application/octet-stream'
   const mimeExt = ext === 'jpg' ? 'jpeg' : ext === 'svg' ? 'svg+xml' : ext
   return `image/${mimeExt}`
+}
+
+function isFilePanelDragItem(item: unknown): item is FilePanelDragItem {
+  if (!item || typeof item !== 'object') return false
+  const candidate = item as Partial<FilePanelDragItem>
+  return (
+    typeof candidate.path === 'string' && candidate.path.length > 0
+    && typeof candidate.name === 'string' && candidate.name.length > 0
+    && typeof candidate.isDirectory === 'boolean'
+    && (candidate.scope === 'project' || candidate.scope === 'session')
+  )
 }

--- a/apps/electron/src/renderer/lib/file-panel-drag.ts
+++ b/apps/electron/src/renderer/lib/file-panel-drag.ts
@@ -1,0 +1,50 @@
+/**
+ * file-panel-drag — 右侧文件面板（会话文件 / 项目文件）拖拽到 Agent 输入框的协议
+ *
+ * 面板中的文件行通过 draggable + dragstart 写入自定义 MIME 载荷，
+ * Agent 输入框 drop 时识别该载荷并把文件作为引用（添加到聊天）加入待发送附件。
+ *
+ * 载荷结构：
+ *   application/x-proma-file-panel → JSON string of FilePanelDragItem[]
+ */
+
+export const FILE_PANEL_DRAG_MIME = 'application/x-proma-file-panel'
+
+export interface FilePanelDragItem {
+  /** 文件绝对路径 */
+  path: string
+  /** 显示名 */
+  name: string
+  /** 是否目录（目录拖入时作为附加目录处理） */
+  isDirectory: boolean
+  /** 来源范围：项目文件 / 会话文件 */
+  scope: 'project' | 'session'
+}
+
+export function setFilePanelDragData(dataTransfer: DataTransfer, items: FilePanelDragItem[]): void {
+  dataTransfer.setData(FILE_PANEL_DRAG_MIME, JSON.stringify(items))
+  // 兜底：同时写入 text/plain，避免部分宿主环境要求必须有文本载荷
+  dataTransfer.setData('text/plain', items.map((i) => i.path).join('\n'))
+  dataTransfer.effectAllowed = 'copy'
+}
+
+export function getFilePanelDragData(dataTransfer: DataTransfer): FilePanelDragItem[] | null {
+  const raw = dataTransfer.getData(FILE_PANEL_DRAG_MIME)
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw) as FilePanelDragItem[]
+    if (!Array.isArray(parsed) || parsed.length === 0) return null
+    return parsed.filter((item) => item && typeof item.path === 'string')
+  } catch {
+    return null
+  }
+}
+
+/** 从文件名推断媒体类型（与 SidePanel 保持一致） */
+export function getMediaTypeFromFilename(filename: string): string {
+  const ext = filename.split('.').pop()?.toLowerCase() ?? ''
+  const imageExts = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp', 'ico'])
+  if (!imageExts.has(ext)) return 'application/octet-stream'
+  const mimeExt = ext === 'jpg' ? 'jpeg' : ext === 'svg' ? 'svg+xml' : ext
+  return `image/${mimeExt}`
+}


### PR DESCRIPTION
## Summary

- df85fc90 feat(agent): external folder drop also inserts visible folder mention
- eeb4d170 feat(agent): folder drag now inserts visible folder mention and attaches to session
- 4dc04702 feat(agent): add drag hint banner and '引用到 Agent' menu item in file panel
- 0169d41f feat(agent): insert file drag as @file mention in input instead of attachment
- ab7c7d68 feat(agent): support drag files from right panel to Agent input as references

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归