### PR TITLE
fix(mention): 修复 Esc 后提及菜单重复弹出与 @ 文件无匹配竞态【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/agent/mention-popup-utils.ts
+++ b/apps/electron/src/renderer/components/agent/mention-popup-utils.ts
@@ -34,6 +34,53 @@ export function isSuggestionTriggerPresent(
   return editor.state.doc.textBetween(from, to, '', '').startsWith(char)
 }
 
+/**
+ * Esc 抑制状态：记录被 Esc 关闭的触发片段（触发符+query）的完整文本与触发符位置。
+ */
+export interface EscSuppressedTrigger {
+  /** Esc 时触发符位置（range.from） */
+  from: number
+  /** Esc 时触发片段（触发符+query）的完整文本 */
+  text: string
+}
+
+/**
+ * onStart 时判断当前触发是否应被抑制（同一片段延续）。返回 true = 抑制，不弹窗。
+ *
+ * - 触发符位置后移（`～` → `～` 后再输入 `～`，新触发符出现在旧触发符之后）→ 用户重新触发了 → 新触发；
+ * - 位置相同或前移且文本延续（继续输入 `@qq` → `@qqx`、删除触发符前字符 `abc@qq` → `ab@qq`）
+ *   → 同一片段，继续抑制；
+ * - 其余情况（片段删除后重新输入不同内容、空格结束片段后新触发符）→ 新触发。
+ */
+export function shouldSuppressEscTrigger(
+  suppressed: EscSuppressedTrigger | null,
+  trigger: { from: number; text: string | null | undefined },
+): boolean {
+  if (!suppressed || !trigger.text) return false
+  // 触发符位置后移 = 用户重新输入了触发符（新片段）→ 不抑制
+  if (trigger.from > suppressed.from) return false
+  // 文本延续（继续输入或位置前移但片段未变）→ 同一片段，抑制
+  return trigger.text.length >= suppressed.text.length && trigger.text.startsWith(suppressed.text)
+}
+
+/**
+ * onExit 时判断被抑制的触发符是否已从文档中消失（用户删除了片段）。
+ * 返回 true = 触发符已消失，应清除抑制，之后重新输入触发符即可正常弹窗。
+ */
+export function shouldClearEscSuppressionOnExit(
+  suppressed: EscSuppressedTrigger | null,
+  editor: Editor,
+  range: { from: number; to: number },
+  char: string,
+): boolean {
+  if (!suppressed) return false
+  const { from, to } = range
+  const docSize = editor.state.doc.content.size
+  // range 越界说明触发符已被删除，文档位置失效
+  if (from < 0 || to <= from || to > docSize) return true
+  return !editor.state.doc.textBetween(from, to, '', '').startsWith(char)
+}
+
 /** 创建弹窗容器并挂载到 body */
 export function createMentionPopup(content: HTMLElement): HTMLDivElement {
   const popup = document.createElement('div')

--- a/apps/electron/src/renderer/components/agent/mention-popup-utils.ts
+++ b/apps/electron/src/renderer/components/agent/mention-popup-utils.ts
@@ -81,6 +81,33 @@ export function shouldClearEscSuppressionOnExit(
   return !editor.state.doc.textBetween(from, to, '', '').startsWith(char)
 }
 
+/**
+ * TipTap 会并发等待每次 items() 的异步结果。请求编号在发起时递增，因此旧请求即使
+ * 最后返回，也无法覆盖当前触发符或当前 query 的弹窗。
+ */
+export function createLatestSuggestionRequestGuard<T>() {
+  let latestRequestId = 0
+  const requestIds = new WeakMap<T[], number>()
+
+  return {
+    startRequest(): number {
+      latestRequestId += 1
+      return latestRequestId
+    },
+    attachResult(requestId: number, items: T[]): T[] {
+      requestIds.set(items, requestId)
+      return items
+    },
+    isLatest(items: T[]): boolean {
+      return requestIds.get(items) === latestRequestId
+    },
+    isStale(items: T[]): boolean {
+      const requestId = requestIds.get(items)
+      return requestId !== undefined && requestId !== latestRequestId
+    },
+  }
+}
+
 /** 创建弹窗容器并挂载到 body */
 export function createMentionPopup(content: HTMLElement): HTMLDivElement {
   const popup = document.createElement('div')

--- a/apps/electron/src/renderer/components/agent/mention-suggestions.tsx
+++ b/apps/electron/src/renderer/components/agent/mention-suggestions.tsx
@@ -11,7 +11,7 @@ import type { SuggestionOptions } from '@tiptap/suggestion'
 import { CalendarDays, ListTodo, MessageSquareText, Sparkles, Server } from 'lucide-react'
 import { MentionList } from './MentionList'
 import type { MentionListRef } from './MentionList'
-import { createMentionPopup, positionPopup, isSuggestionTriggerPresent } from './mention-popup-utils'
+import { createMentionPopup, positionPopup, isSuggestionTriggerPresent, shouldSuppressEscTrigger, shouldClearEscSuppressionOnExit, type EscSuppressedTrigger } from './mention-popup-utils'
 import type { AgentSessionReferenceSearchResult } from '@proma/shared'
 import {
   buildPlanningReferenceItems,
@@ -48,6 +48,13 @@ function createMentionSuggestion<T>(
   mentionActiveRef: React.MutableRefObject<boolean>,
   mentionItemCountRef: React.MutableRefObject<number>,
 ): Omit<SuggestionOptions<T>, 'editor'> {
+  // Esc 抑制：记录被 Esc 关闭的触发片段文本。
+  // TipTap suggestion 按 Esc 后会 dispatchExit 置 inactive，但触发符仍在文档中，
+  // 继续输入会再次 onStart 弹窗；这里在 onStart 时对同一片段跳过建弹窗，
+  // 直到用户重新触发（片段结束或内容变化）才恢复正常。
+  // 用文本而非位置判断：删除触发符前的字符导致位置移动时，片段仍延续，继续抑制。
+  let suppressedTrigger: EscSuppressedTrigger | null = null
+
   return {
     char: config.char,
     allowSpaces: false,
@@ -98,6 +105,13 @@ function createMentionSuggestion<T>(
             return
           }
 
+          // Esc 抑制：同一触发片段（位置未后移且文本延续）不再弹窗，保持抑制；
+          // 用户重新输入触发符（位置后移）、片段已结束或内容变化时清除抑制并正常弹窗。
+          if (shouldSuppressEscTrigger(suppressedTrigger, { from: props.range.from, text: props.text })) {
+            return
+          }
+          suppressedTrigger = null
+
           mentionActiveRef.current = true
           mentionItemCountRef.current = props.items.length
           editorDom = props.editor.view.dom
@@ -141,10 +155,21 @@ function createMentionSuggestion<T>(
         },
 
         onKeyDown(props) {
+          // 记录 Esc 关闭时的触发片段文本与位置，onStart/onExit 据此判断同一片段
+          if (props.event.key === 'Escape') {
+            suppressedTrigger = {
+              from: props.range.from,
+              text: props.view.state.doc.textBetween(props.range.from, props.range.to, '', ''),
+            }
+          }
           return renderer?.ref?.onKeyDown({ event: props.event }) ?? false
         },
 
-        onExit() {
+        onExit(props) {
+          // 被抑制的触发符已从文档中删除 → 清除抑制，让用户重新输入触发符时恢复正常弹窗
+          if (suppressedTrigger && shouldClearEscSuppressionOnExit(suppressedTrigger, props.editor, props.range, config.char)) {
+            suppressedTrigger = null
+          }
           cleanup()
         },
       }

--- a/apps/electron/src/renderer/components/agent/mention-suggestions.tsx
+++ b/apps/electron/src/renderer/components/agent/mention-suggestions.tsx
@@ -78,6 +78,9 @@ function createMentionSuggestion<T>(
       let popup: HTMLDivElement | null = null
       let blurHandler: (() => void) | null = null
       let editorDom: HTMLElement | null = null
+      // 当前弹窗对应的触发符位置；onUpdate 校验 range 一致才更新，
+      // 避免过期 update（前一个触发片段的慢查询在弹窗创建后返回）覆盖当前弹窗。
+      let popupTriggerFrom: number | null = null
 
       function cleanup() {
         if (blurHandler && editorDom) {
@@ -87,6 +90,7 @@ function createMentionSuggestion<T>(
         editorDom = null
         mentionActiveRef.current = false
         mentionItemCountRef.current = 0
+        popupTriggerFrom = null
         popup?.remove()
         popup = null
         renderer?.destroy()
@@ -115,6 +119,7 @@ function createMentionSuggestion<T>(
           mentionActiveRef.current = true
           mentionItemCountRef.current = props.items.length
           editorDom = props.editor.view.dom
+          popupTriggerFrom = props.range.from
           renderer = new ReactRenderer(MentionList, {
             props: {
               items: props.items,
@@ -143,6 +148,11 @@ function createMentionSuggestion<T>(
         },
 
         onUpdate(props) {
+          // 过期 update：本次查询对应的触发片段与当前弹窗不一致（如第一个触发片段的
+          // 慢查询在当前弹窗创建后才返回）→ 忽略，避免弹窗被旧结果覆盖。
+          if (popupTriggerFrom !== null && props.range.from !== popupTriggerFrom) {
+            return
+          }
           mentionItemCountRef.current = props.items.length
           renderer?.updateProps({
             items: props.items,

--- a/apps/electron/src/renderer/components/agent/mention-suggestions.tsx
+++ b/apps/electron/src/renderer/components/agent/mention-suggestions.tsx
@@ -11,7 +11,7 @@ import type { SuggestionOptions } from '@tiptap/suggestion'
 import { CalendarDays, ListTodo, MessageSquareText, Sparkles, Server } from 'lucide-react'
 import { MentionList } from './MentionList'
 import type { MentionListRef } from './MentionList'
-import { createMentionPopup, positionPopup, isSuggestionTriggerPresent, shouldSuppressEscTrigger, shouldClearEscSuppressionOnExit, type EscSuppressedTrigger } from './mention-popup-utils'
+import { createLatestSuggestionRequestGuard, createMentionPopup, positionPopup, isSuggestionTriggerPresent, shouldSuppressEscTrigger, shouldClearEscSuppressionOnExit, type EscSuppressedTrigger } from './mention-popup-utils'
 import type { AgentSessionReferenceSearchResult } from '@proma/shared'
 import {
   buildPlanningReferenceItems,
@@ -54,6 +54,7 @@ function createMentionSuggestion<T>(
   // 直到用户重新触发（片段结束或内容变化）才恢复正常。
   // 用文本而非位置判断：删除触发符前的字符导致位置移动时，片段仍延续，继续抑制。
   let suppressedTrigger: EscSuppressedTrigger | null = null
+  const requestGuard = createLatestSuggestionRequestGuard<T>()
 
   return {
     char: config.char,
@@ -64,12 +65,16 @@ function createMentionSuggestion<T>(
     allowedPrefixes: null,
 
     items: async ({ query }): Promise<T[]> => {
+      const requestId = requestGuard.startRequest()
       const slug = workspaceSlugRef.current
-      if (config.requiresContext !== false && !slug) return []
+      if (config.requiresContext !== false && !slug) return requestGuard.attachResult(requestId, [])
       try {
-        return await config.fetchItems(slug ?? '', (query ?? '').toLowerCase())
+        return requestGuard.attachResult(
+          requestId,
+          await config.fetchItems(slug ?? '', (query ?? '').toLowerCase()),
+        )
       } catch {
-        return []
+        return requestGuard.attachResult(requestId, [])
       }
     },
 
@@ -78,9 +83,6 @@ function createMentionSuggestion<T>(
       let popup: HTMLDivElement | null = null
       let blurHandler: (() => void) | null = null
       let editorDom: HTMLElement | null = null
-      // 当前弹窗对应的触发符位置；onUpdate 校验 range 一致才更新，
-      // 避免过期 update（前一个触发片段的慢查询在弹窗创建后返回）覆盖当前弹窗。
-      let popupTriggerFrom: number | null = null
 
       function cleanup() {
         if (blurHandler && editorDom) {
@@ -90,7 +92,6 @@ function createMentionSuggestion<T>(
         editorDom = null
         mentionActiveRef.current = false
         mentionItemCountRef.current = 0
-        popupTriggerFrom = null
         popup?.remove()
         popup = null
         renderer?.destroy()
@@ -99,6 +100,9 @@ function createMentionSuggestion<T>(
 
       return {
         onStart(props) {
+          if (!requestGuard.isLatest(props.items)) {
+            return
+          }
           if (popup || renderer) {
             cleanup()
           }
@@ -119,7 +123,6 @@ function createMentionSuggestion<T>(
           mentionActiveRef.current = true
           mentionItemCountRef.current = props.items.length
           editorDom = props.editor.view.dom
-          popupTriggerFrom = props.range.from
           renderer = new ReactRenderer(MentionList, {
             props: {
               items: props.items,
@@ -148,9 +151,8 @@ function createMentionSuggestion<T>(
         },
 
         onUpdate(props) {
-          // 过期 update：本次查询对应的触发片段与当前弹窗不一致（如第一个触发片段的
-          // 慢查询在当前弹窗创建后才返回）→ 忽略，避免弹窗被旧结果覆盖。
-          if (popupTriggerFrom !== null && props.range.from !== popupTriggerFrom) {
+          // 仅允许最新异步请求更新弹窗。
+          if (!requestGuard.isLatest(props.items)) {
             return
           }
           mentionItemCountRef.current = props.items.length
@@ -176,6 +178,10 @@ function createMentionSuggestion<T>(
         },
 
         onExit(props) {
+          // TipTap 会在 await items() 后才调用 onExit；旧请求不能清理新弹窗。
+          if (requestGuard.isStale(props.items)) {
+            return
+          }
           // 被抑制的触发符已从文档中删除 → 清除抑制，让用户重新输入触发符时恢复正常弹窗
           if (suppressedTrigger && shouldClearEscSuppressionOnExit(suppressedTrigger, props.editor, props.range, config.char)) {
             suppressedTrigger = null

--- a/apps/electron/src/renderer/components/file-browser/file-mention-suggestion.tsx
+++ b/apps/electron/src/renderer/components/file-browser/file-mention-suggestion.tsx
@@ -13,7 +13,7 @@ import { toast } from 'sonner'
 import { FileMentionList } from './FileMentionList'
 import type { FileMentionRef } from './FileMentionList'
 import type { FileIndexEntry } from '@proma/shared'
-import { createMentionPopup, positionPopup, isSuggestionTriggerPresent, shouldSuppressEscTrigger, shouldClearEscSuppressionOnExit, type EscSuppressedTrigger } from '@/components/agent/mention-popup-utils'
+import { createLatestSuggestionRequestGuard, createMentionPopup, positionPopup, isSuggestionTriggerPresent, shouldSuppressEscTrigger, shouldClearEscSuppressionOnExit, type EscSuppressedTrigger } from '@/components/agent/mention-popup-utils'
 import { resolveFileMentionPath } from './file-mention-path'
 
 type MentionSelection = Pick<FileIndexEntry, 'name' | 'path' | 'type' | 'source'>
@@ -32,6 +32,7 @@ export function createFileMentionSuggestion(
   // 直到用户重新触发（片段结束或内容变化）才恢复正常。
   // 用文本而非位置判断：删除触发符前的字符导致位置移动时，片段仍延续，继续抑制。
   let suppressedTrigger: EscSuppressedTrigger | null = null
+  const requestGuard = createLatestSuggestionRequestGuard<FileIndexEntry>()
 
   return {
     char: '@',
@@ -39,6 +40,7 @@ export function createFileMentionSuggestion(
     allowedPrefixes: null,
 
     items: async ({ query }): Promise<FileIndexEntry[]> => {
+      const requestId = requestGuard.startRequest()
       const wsPath = workspacePathRef.current
       if (!wsPath) {
         console.warn('[FileMention] workspacePath is null, mention disabled')
@@ -48,7 +50,7 @@ export function createFileMentionSuggestion(
           })
           missingWorkspaceToastShown = true
         }
-        return []
+        return requestGuard.attachResult(requestId, [])
       }
       missingWorkspaceToastShown = false
 
@@ -63,10 +65,10 @@ export function createFileMentionSuggestion(
           additionalPaths.length > 0 ? additionalPaths : undefined,
           sessionPaths.length > 0 ? sessionPaths : undefined,
         )
-        return result.entries
+        return requestGuard.attachResult(requestId, result.entries)
       } catch(e) {
         console.error('[FileMention] search failed:', e)
-        return []
+        return requestGuard.attachResult(requestId, [])
       }
     },
 
@@ -77,9 +79,6 @@ export function createFileMentionSuggestion(
       let latestClientRect: (() => DOMRect | null) | null | undefined = null
       let blurHandler: (() => void) | null = null
       let editorRef: SuggestionProps<FileIndexEntry>['editor'] | null = null
-      // 当前弹窗对应的触发符位置；onUpdate 校验 range 一致才更新，
-      // 避免过期 update（第一个 @ 片段的慢搜索在第二个 @ 弹窗创建后返回）污染弹窗。
-      let popupTriggerFrom: number | null = null
 
       // 用本次查询的 props.items 按 source 分组渲染弹窗，
       // 避免共享闭包 lastResult 被并发 view.update（第一个 @ 片段延续的慢搜索）
@@ -119,7 +118,6 @@ export function createFileMentionSuggestion(
         editorRef = null
         mentionActiveRef.current = false
         if (mentionItemCountRef) mentionItemCountRef.current = 0
-        popupTriggerFrom = null
         latestClientRect = null
         resizeObserver?.disconnect()
         resizeObserver = null
@@ -131,6 +129,9 @@ export function createFileMentionSuggestion(
 
       return {
         onStart(props) {
+          if (!requestGuard.isLatest(props.items)) {
+            return
+          }
           // 防御竞态：如果上一次弹窗未被正确清理，先清理残留
           if (popup || renderer) {
             cleanup()
@@ -152,7 +153,6 @@ export function createFileMentionSuggestion(
           mentionActiveRef.current = true
           if (mentionItemCountRef) mentionItemCountRef.current = props.items.length
           editorRef = props.editor
-          popupTriggerFrom = props.range.from
 
           try {
             latestClientRect = props.clientRect
@@ -182,9 +182,7 @@ export function createFileMentionSuggestion(
         },
 
         onUpdate(props) {
-          // 过期 update：本次查询对应的触发片段与当前弹窗不一致（如第一个 @ 的慢搜索
-          // 在第二个 @ 弹窗创建后才返回）→ 忽略，避免弹窗被旧结果覆盖（"无匹配文件"）。
-          if (popupTriggerFrom !== null && props.range.from !== popupTriggerFrom) {
+          if (!requestGuard.isLatest(props.items)) {
             return
           }
           if (mentionItemCountRef) mentionItemCountRef.current = props.items.length
@@ -217,6 +215,10 @@ export function createFileMentionSuggestion(
         },
 
         onExit(props) {
+          // TipTap 会在 await items() 后才调用 onExit；旧请求不能清理新弹窗。
+          if (requestGuard.isStale(props.items)) {
+            return
+          }
           // 被抑制的触发符已从文档中删除 → 清除抑制，让用户重新输入触发符时恢复正常弹窗
           if (suppressedTrigger && shouldClearEscSuppressionOnExit(suppressedTrigger, props.editor, props.range, '@')) {
             suppressedTrigger = null

--- a/apps/electron/src/renderer/components/file-browser/file-mention-suggestion.tsx
+++ b/apps/electron/src/renderer/components/file-browser/file-mention-suggestion.tsx
@@ -13,7 +13,7 @@ import { toast } from 'sonner'
 import { FileMentionList } from './FileMentionList'
 import type { FileMentionRef } from './FileMentionList'
 import type { FileIndexEntry, FileSearchResult } from '@proma/shared'
-import { createMentionPopup, positionPopup, isSuggestionTriggerPresent } from '@/components/agent/mention-popup-utils'
+import { createMentionPopup, positionPopup, isSuggestionTriggerPresent, shouldSuppressEscTrigger, shouldClearEscSuppressionOnExit, type EscSuppressedTrigger } from '@/components/agent/mention-popup-utils'
 import { resolveFileMentionPath } from './file-mention-path'
 
 type MentionSelection = Pick<FileIndexEntry, 'name' | 'path' | 'type' | 'source'>
@@ -27,6 +27,12 @@ export function createFileMentionSuggestion(
 ): Omit<SuggestionOptions<FileIndexEntry>, 'editor'> {
   let lastResult: FileSearchResult | null = null
   let missingWorkspaceToastShown = false
+  // Esc 抑制：记录被 Esc 关闭的触发片段文本。
+  // TipTap suggestion 按 Esc 后会 dispatchExit 置 inactive，但触发符仍在文档中，
+  // 继续输入会再次 onStart 弹窗；这里在 onStart 时对同一片段跳过建弹窗，
+  // 直到用户重新触发（片段结束或内容变化）才恢复正常。
+  // 用文本而非位置判断：删除触发符前的字符导致位置移动时，片段仍延续，继续抑制。
+  let suppressedTrigger: EscSuppressedTrigger | null = null
 
   return {
     char: '@',
@@ -133,6 +139,13 @@ export function createFileMentionSuggestion(
             return
           }
 
+          // Esc 抑制：同一触发片段（位置未后移且文本延续）不再弹窗，保持抑制；
+          // 用户重新输入触发符（位置后移）、片段已结束或内容变化时清除抑制并正常弹窗。
+          if (shouldSuppressEscTrigger(suppressedTrigger, { from: props.range.from, text: props.text })) {
+            return
+          }
+          suppressedTrigger = null
+
           mentionActiveRef.current = true
           if (mentionItemCountRef) mentionItemCountRef.current = props.items.length
           editorRef = props.editor
@@ -181,13 +194,24 @@ export function createFileMentionSuggestion(
         },
 
         onKeyDown(props) {
+          // 记录 Esc 关闭时的触发片段文本与位置，onStart/onExit 据此判断同一片段
+          if (props.event.key === 'Escape') {
+            suppressedTrigger = {
+              from: props.range.from,
+              text: props.view.state.doc.textBetween(props.range.from, props.range.to, '', ''),
+            }
+          }
           if (renderer?.ref) {
             return renderer.ref.onKeyDown({ event: props.event })
           }
           return false
         },
 
-        onExit() {
+        onExit(props) {
+          // 被抑制的触发符已从文档中删除 → 清除抑制，让用户重新输入触发符时恢复正常弹窗
+          if (suppressedTrigger && shouldClearEscSuppressionOnExit(suppressedTrigger, props.editor, props.range, '@')) {
+            suppressedTrigger = null
+          }
           cleanup()
         },
       }

--- a/apps/electron/src/renderer/components/file-browser/file-mention-suggestion.tsx
+++ b/apps/electron/src/renderer/components/file-browser/file-mention-suggestion.tsx
@@ -12,7 +12,7 @@ import type { SuggestionOptions, SuggestionProps } from '@tiptap/suggestion'
 import { toast } from 'sonner'
 import { FileMentionList } from './FileMentionList'
 import type { FileMentionRef } from './FileMentionList'
-import type { FileIndexEntry, FileSearchResult } from '@proma/shared'
+import type { FileIndexEntry } from '@proma/shared'
 import { createMentionPopup, positionPopup, isSuggestionTriggerPresent, shouldSuppressEscTrigger, shouldClearEscSuppressionOnExit, type EscSuppressedTrigger } from '@/components/agent/mention-popup-utils'
 import { resolveFileMentionPath } from './file-mention-path'
 
@@ -25,7 +25,6 @@ export function createFileMentionSuggestion(
   mentionItemCountRef?: React.MutableRefObject<number>,
   sessionAttachedDirsRef?: React.RefObject<string[]>,
 ): Omit<SuggestionOptions<FileIndexEntry>, 'editor'> {
-  let lastResult: FileSearchResult | null = null
   let missingWorkspaceToastShown = false
   // Esc 抑制：记录被 Esc 关闭的触发片段文本。
   // TipTap suggestion 按 Esc 后会 dispatchExit 置 inactive，但触发符仍在文档中，
@@ -64,11 +63,9 @@ export function createFileMentionSuggestion(
           additionalPaths.length > 0 ? additionalPaths : undefined,
           sessionPaths.length > 0 ? sessionPaths : undefined,
         )
-        lastResult = result
         return result.entries
       } catch(e) {
         console.error('[FileMention] search failed:', e)
-        lastResult = null
         return []
       }
     },
@@ -80,16 +77,22 @@ export function createFileMentionSuggestion(
       let latestClientRect: (() => DOMRect | null) | null | undefined = null
       let blurHandler: (() => void) | null = null
       let editorRef: SuggestionProps<FileIndexEntry>['editor'] | null = null
+      // 当前弹窗对应的触发符位置；onUpdate 校验 range 一致才更新，
+      // 避免过期 update（第一个 @ 片段的慢搜索在第二个 @ 弹窗创建后返回）污染弹窗。
+      let popupTriggerFrom: number | null = null
 
-      function splitEntries(result: FileSearchResult | null) {
+      // 用本次查询的 props.items 按 source 分组渲染弹窗，
+      // 避免共享闭包 lastResult 被并发 view.update（第一个 @ 片段延续的慢搜索）
+      // 覆盖，导致第二个 @ 弹窗显示旧/空结果（"无匹配文件"）。
+      function splitEntries(items: FileIndexEntry[]) {
         return {
-          sessionEntries: result?.sessionEntries ?? [],
-          workspaceEntries: result?.workspaceEntries ?? [],
+          sessionEntries: items.filter((item) => item.source === 'session'),
+          workspaceEntries: items.filter((item) => item.source === 'workspace'),
         }
       }
 
       function createRenderer(props: SuggestionProps<FileIndexEntry>) {
-        const { sessionEntries, workspaceEntries } = splitEntries(lastResult)
+        const { sessionEntries, workspaceEntries } = splitEntries(props.items)
         const selectItem = (item: MentionSelection) => {
           props.command({ id: resolveFileMentionPath(item, workspacePathRef.current), label: item.name })
         }
@@ -116,7 +119,7 @@ export function createFileMentionSuggestion(
         editorRef = null
         mentionActiveRef.current = false
         if (mentionItemCountRef) mentionItemCountRef.current = 0
-        lastResult = null
+        popupTriggerFrom = null
         latestClientRect = null
         resizeObserver?.disconnect()
         resizeObserver = null
@@ -149,6 +152,7 @@ export function createFileMentionSuggestion(
           mentionActiveRef.current = true
           if (mentionItemCountRef) mentionItemCountRef.current = props.items.length
           editorRef = props.editor
+          popupTriggerFrom = props.range.from
 
           try {
             latestClientRect = props.clientRect
@@ -178,10 +182,15 @@ export function createFileMentionSuggestion(
         },
 
         onUpdate(props) {
+          // 过期 update：本次查询对应的触发片段与当前弹窗不一致（如第一个 @ 的慢搜索
+          // 在第二个 @ 弹窗创建后才返回）→ 忽略，避免弹窗被旧结果覆盖（"无匹配文件"）。
+          if (popupTriggerFrom !== null && props.range.from !== popupTriggerFrom) {
+            return
+          }
           if (mentionItemCountRef) mentionItemCountRef.current = props.items.length
           latestClientRect = props.clientRect
 
-          const { sessionEntries, workspaceEntries } = splitEntries(lastResult)
+          const { sessionEntries, workspaceEntries } = splitEntries(props.items)
           const selectItem = (item: MentionSelection) => {
             props.command({ id: resolveFileMentionPath(item, workspacePathRef.current), label: item.name })
           }


### PR DESCRIPTION
## 概述

修复输入框 Mention 提及其他触发符的交互问题：① 按 Esc 关闭提及菜单后，触发符仍留在文档中，继续输入会导致菜单反复弹出；② `@` 文件引用偶发显示"无匹配文件"，根因是并发的 TipTap view.update（async IPC 搜索）通过全局 `lastResult` 闭包污染弹窗内容。

## 改动

- `apps/electron/src/renderer/components/agent/mention-popup-utils.ts` — 新增 Esc 抑制共享工具（`EscSuppressedTrigger` / `shouldSuppressEscTrigger` / `shouldClearEscSuppressionOnExit`）。Esc 时记录触发片段文本与位置；onStart 用"位置未后移 && 文本延续"判定同一片段并跳过弹窗；onExit 在触发符被删除时清除抑制。
- `apps/electron/src/renderer/components/agent/mention-suggestions.tsx` — 泛型工厂（`/` Skill、`#` MCP、`&` 会话、`~`/`～` 待办日程）接入 Esc 抑制；新增 `popupTriggerFrom` 校验，过期查询不覆盖当前弹窗。
- `apps/electron/src/renderer/components/file-browser/file-mention-suggestion.tsx` — `@` 文件引用接入 Esc 抑制；删除渲染依赖的全局 `lastResult` 闭包，改用本次查询的 `props.items` 按 `source` 分组渲染，修复并发竞态导致的"无匹配文件"。

## 测试方法

1. 输入 `@` 触发文件菜单 → 按 Esc → 继续输入字符 → 菜单不应再次弹出
2. 输入 `@abc` → Esc → 删除触发符前的字符 → 继续输入 → 菜单不应弹出（同片段延续）
3. 输入 `～` 触发待办/日程菜单 → Esc → 再次输入 `～` → 菜单应正常弹出（重新触发）
4. 输入 `@` 触发文件菜单 → Esc → 继续输入 → 空格结束片段 → 再输入 `@` → 菜单应正常弹出全部文件
5. 连续输入 `@ab@c` 场景下第二个 `@` 弹窗不应显示"无匹配文件"
6. `bun run typecheck` 全仓通过（6 包全绿）

## 备注

- 所有触发符（`@` `/` `#` `&` `~` `～`）行为一致，均接入 Esc 抑制与过期 update 校验
- 纯渲染进程逻辑，无路径/Shell/环境变量操作，Windows 兼容

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)