### PR TITLE
fix(ui): 修复经典视图+深色主题下设置面板左侧导航变白【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -1018,6 +1018,10 @@
   --radius: 0.625rem;
   --radius-xl-extra: 4px;
   --radius-2xl-extra: 8px;
+}
+
+/* 经典界面浅色：侧栏使用纯白对齐 upstream；深色下不覆盖，保持主题的深色侧栏 */
+:root.ui-classic:not(.dark) {
   --sidebar-surface: 0 0% 98%;
 }
 


### PR DESCRIPTION
## 概述

修复经典视图（Classic）+ 深色主题组合下，设置界面左侧导航栏显示为白色的问题。此前该场景下设置面板左侧与主侧边栏视觉不一致（主侧边栏为深色，设置面板却为纯白）。

## 改动

- `apps/electron/src/renderer/styles/globals.css` — 将 `:root.ui-classic` 中对 `--sidebar-surface` 的浅色硬编码（`0 0% 98%`）拆出，改为仅在非深色场景生效的 `:root.ui-classic:not(.dark)` 规则；深色下不再覆盖，回落到 `.dark` 主题的深色侧栏值（默认深色 `0 0% 10%`，深色特殊风格使用各自主题色）。

## 测试方法

1. 切换到经典视图（设置 → 外观设置 → 界面风格 → 经典）
2. 切换主题模式为深色，打开设置面板，确认左侧导航栏为深色且与主侧边栏一致
3. 切换到浅色主题，确认左侧导航栏仍为纯白（对齐 upstream 经典视图视觉）
4. 切换深色特殊风格（如森息夜语），确认左侧导航栏跟随主题深色
5. 切换到现代视图，确认设置面板样式无任何变化

## 备注

- 纯 CSS 变量作用域修改，不涉及平台相关逻辑，Windows 兼容性无风险
- 经典视图 + 浅色特殊风格下侧栏仍为纯白（对齐 upstream 行为），与本次修复无关

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
