### PR TITLE
feat(settings): 设置界面支持 ESC 退出并展示键帽提示【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
+++ b/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
@@ -25,6 +25,7 @@ import {
   HardDrive,
 } from "lucide-react";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { ShortcutKeycaps } from "@/components/shortcuts/ShortcutKeycaps";
 import {
   settingsTabAtom,
   channelFormDirtyAtom,
@@ -219,13 +220,26 @@ export function SettingsPanel({
   }
 
   /** 关闭设置面板时检测是否有未保存内容 */
-  const handleClose = (): void => {
+  const handleClose = React.useCallback((): void => {
     if (activeTab === 'channels' && channelFormDirty) {
       setPendingAction({ type: 'close' })
       return
     }
     onClose?.()
-  }
+  }, [activeTab, channelFormDirty, onClose])
+
+  /** 按 ESC 退出设置面板：window 级监听确保焦点在设置面板内任何位置（含 body）都生效；
+   *  Radix 弹层（Select 下拉/AlertDialog/Popover 等）处理 ESC 时会 preventDefault，
+   *  此时交给弹层自行关闭，不退出设置。 */
+  React.useEffect(() => {
+    const handleWindowKeyDown = (e: KeyboardEvent): void => {
+      if (e.key !== 'Escape') return
+      if (e.defaultPrevented) return
+      handleClose()
+    }
+    window.addEventListener('keydown', handleWindowKeyDown)
+    return () => window.removeEventListener('keydown', handleWindowKeyDown)
+  }, [handleClose])
 
   // 左侧会话点击在渠道表单有未保存内容时，由 useOpenSession 暂存目标并交给此处确认。
   React.useEffect(() => {
@@ -300,10 +314,13 @@ export function SettingsPanel({
           <div className="flex-shrink-0 p-3">
             <button
               onClick={handleClose}
-              className="flex w-full items-center gap-2 rounded-md px-3 py-2.5 text-sm text-muted-foreground transition-colors hover:bg-background/60 hover:text-foreground"
+              className="group flex w-full items-center gap-2 rounded-md px-3 py-2.5 text-sm text-muted-foreground transition-colors hover:bg-background/60 hover:text-foreground"
             >
               <ArrowLeft size={16} />
               <span>返回</span>
+              <span className="ml-auto hidden group-hover:inline-flex">
+                <ShortcutKeycaps accelerator="Esc" />
+              </span>
             </button>
           </div>
         </div>


### PR DESCRIPTION
## 概述

在设置界面中按下 ESC 键即可退出返回主界面，并在底部返回按钮悬浮时展示 ESC 键帽提示，降低用户发现快捷键的成本。

## 改动

- `apps/electron/src/renderer/components/settings/SettingsPanel.tsx` — 核心改动，包含三部分：
  - **ESC 退出逻辑**：在 `SettingsPanel` 挂载期间注册 `window` 级 `keydown` 监听，按下 Escape 时复用统一的 `handleClose()` 关闭设置面板。使用 `e.defaultPrevented` 精确区分 Radix 弹层（Select 下拉、AlertDialog、Popover 等 portal 到 body 的弹层在 ESC 时都会 `preventDefault`，由弹层自行关闭，不会误退出设置）
  - **未保存内容保护**：ESC 走 `handleClose()`，渠道表单有未保存内容时依然弹出确认对话框，与 Cmd+W / 返回按钮行为一致，不会丢失未保存的配置
  - **ESC 键帽提示**：返回按钮添加 `group`，按钮内部右侧用 `hidden group-hover:inline-flex` 控制，仅在悬浮返回键时展示 `Esc` 键帽（复用现有 `ShortcutKeycaps` 组件，与快捷键设置页样式统一），不占布局空间、不改变返回按钮原有外观

## 测试方法

1. 打开设置面板（Cmd+,），按下 ESC，应退出到主界面
2. 打开设置面板后不点击任何元素直接按 ESC（焦点仍在 body），应正常退出
3. 在模型配置页编辑渠道表单（未保存）后按 ESC，应弹出「放弃未保存的更改？」确认框
4. 打开任一设置下拉框（Select）后按 ESC，应只关闭下拉框、不退出设置
5. 鼠标悬浮在左下角「返回」按钮上，应显示 Esc 键帽提示；移开后消失

## 备注

- 窗口级监听在 `SettingsPanel` 卸载时清理，无事件泄漏
- `handleClose` 用 `useCallback` 包装，effect 依赖稳定
- 纯渲染层改动，不涉及数据持久化与主进程