### PR TITLE
feat(planning): Todo 描述草稿式自动保存，关闭不再丢失内容【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/planning/PlanningView.tsx
+++ b/apps/electron/src/renderer/components/planning/PlanningView.tsx
@@ -269,6 +269,7 @@ function TodoWorkspace({ standalone = false }: { standalone?: boolean } = {}): R
     id: string,
     input: Omit<Parameters<typeof window.electronAPI.updateTodo>[0], 'id'>,
     savedField?: 'title' | 'notes',
+    silentNotesSync = false,
   ) => {
     try {
       const updated = await window.electronAPI.updateTodo({ id, ...input })
@@ -285,7 +286,8 @@ function TodoWorkspace({ standalone = false }: { standalone?: boolean } = {}): R
             const notes = updated.notes ?? ''
             detailNotesRef.current = notes
             savedDetailNotesRef.current = notes
-            setDetailNotes(notes)
+            // 自动保存时不回写输入框，避免打断正在输入的内容（主进程会 trim 首尾空白）
+            if (!silentNotesSync) setDetailNotes(notes)
           }
         }
       }
@@ -301,6 +303,80 @@ function TodoWorkspace({ standalone = false }: { standalone?: boolean } = {}): R
       return undefined
     }
   }, [setTodos])
+
+  // —— Todo 标题/描述草稿式自动保存 ——
+  const notesSaveTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [notesSaveState, setNotesSaveState] = React.useState<'saving' | 'saved' | null>(null)
+  const notesSaveStateTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const showNotesSaved = React.useCallback((): void => {
+    if (notesSaveStateTimerRef.current) clearTimeout(notesSaveStateTimerRef.current)
+    notesSaveStateTimerRef.current = setTimeout(() => {
+      notesSaveStateTimerRef.current = null
+      setNotesSaveState(null)
+    }, 2000)
+  }, [])
+
+  const saveDetailNotes = React.useCallback((): void => {
+    if (notesSaveTimerRef.current) {
+      clearTimeout(notesSaveTimerRef.current)
+      notesSaveTimerRef.current = null
+    }
+    const id = selectedTodoIdRef.current
+    if (!id || todoConflict) return
+    const currentTodo = todos.find((todo) => todo.id === id)
+    if (!currentTodo) return
+    const notes = detailNotesRef.current
+    if (notes === savedDetailNotesRef.current) return
+    setNotesSaveState('saving')
+    // silentNotesSync=true：仅同步已保存值，不回写输入框，避免打断正在输入的内容
+    void updateTodo(id, { notes, expectedUpdatedAt: currentTodo.updatedAt }, 'notes', true).then((updated) => {
+      if (updated) {
+        setNotesSaveState('saved')
+        showNotesSaved()
+      } else {
+        setNotesSaveState(null)
+        if (notesSaveStateTimerRef.current) {
+          clearTimeout(notesSaveStateTimerRef.current)
+          notesSaveStateTimerRef.current = null
+        }
+      }
+    })
+  }, [showNotesSaved, todoConflict, todos, updateTodo])
+
+  const saveDetailNotesRef = React.useRef(saveDetailNotes)
+  saveDetailNotesRef.current = saveDetailNotes
+
+  const scheduleNotesAutoSave = React.useCallback((): void => {
+    if (notesSaveTimerRef.current) clearTimeout(notesSaveTimerRef.current)
+    notesSaveTimerRef.current = setTimeout(() => {
+      notesSaveTimerRef.current = null
+      saveDetailNotesRef.current()
+    }, 800)
+  }, [])
+
+  const saveDetailTitle = React.useCallback((): void => {
+    const id = selectedTodoIdRef.current
+    if (!id || todoConflict) return
+    const currentTodo = todos.find((todo) => todo.id === id)
+    if (!currentTodo) return
+    const title = detailTitleRef.current.trim()
+    if (!title || title === currentTodo.title) return
+    void updateTodo(id, { title, expectedUpdatedAt: currentTodo.updatedAt }, 'title')
+  }, [todoConflict, todos, updateTodo])
+
+  React.useEffect(() => {
+    return () => {
+      if (notesSaveTimerRef.current) {
+        clearTimeout(notesSaveTimerRef.current)
+        notesSaveTimerRef.current = null
+      }
+      if (notesSaveStateTimerRef.current) {
+        clearTimeout(notesSaveStateTimerRef.current)
+        notesSaveStateTimerRef.current = null
+      }
+    }
+  }, [])
 
   const reloadTodoDetail = (): void => {
     if (selected) applyTodoDetailDraft(selected)
@@ -528,9 +604,9 @@ function TodoWorkspace({ standalone = false }: { standalone?: boolean } = {}): R
           <div className="min-h-0 flex-1 overflow-y-auto">{visibleTodos.length ? visibleTodos.map((todo) => <TodoListItem key={todo.id} todo={todo} selected={selectedId === todo.id} todayEnd={todayEnd} onSelect={() => setSelectedId(todo.id)} onToggle={() => void completeTodo(todo)} onDelete={() => setTodoPendingDeletion(todo)} />) : <div className="flex h-full min-h-56 items-center justify-center px-8 text-center text-sm text-muted-foreground">这里还没有任务。点击右上角“新建 Todo”或按 ⌘N 即可添加。</div>}</div>
         </div>
 
-        {selected && <PlanningFloatingInspector label="Todo 详情" onClose={() => setSelectedId(null)}><div className="space-y-7 p-5">
+        {selected && <PlanningFloatingInspector label="Todo 详情" onClose={() => { saveDetailNotes(); saveDetailTitle(); setSelectedId(null) }}><div className="space-y-7 p-5">
           {todoConflict && <div className="flex items-center justify-between gap-3 rounded-md border border-amber-500/35 bg-amber-500/10 px-3 py-2 text-xs text-amber-900 dark:text-amber-100"><span>此 Todo 已在其他窗口更新，请重新加载后再编辑。</span><Button type="button" variant="link" size="sm" className="h-auto shrink-0 px-0 text-xs" onClick={reloadTodoDetail}>重新加载</Button></div>}
-          <div className="pr-12"><label className="sr-only" htmlFor="todo-title">任务标题</label><Input id="todo-title" value={detailTitle} onChange={(event) => { detailTitleRef.current = event.target.value; setDetailTitle(event.target.value) }} onBlur={() => { if (!todoConflict && detailTitle.trim() && detailTitle.trim() !== selected.title) void updateTodo(selected.id, { title: detailTitle.trim(), expectedUpdatedAt: todoBaseUpdatedAtRef.current ?? selected.updatedAt }, 'title') }} disabled={todoConflict} className="h-auto border-0 bg-transparent px-0 text-lg font-semibold shadow-none focus-visible:ring-0" /></div><div><label className="mb-2 block text-xs font-medium text-muted-foreground">描述</label><Textarea value={detailNotes} onChange={(event) => { detailNotesRef.current = event.target.value; setDetailNotes(event.target.value) }} onBlur={() => { if (!todoConflict && detailNotes !== (selected.notes ?? '')) void updateTodo(selected.id, { notes: detailNotes, expectedUpdatedAt: todoBaseUpdatedAtRef.current ?? selected.updatedAt }, 'notes') }} placeholder="添加描述…" disabled={todoConflict} className="min-h-64 resize-y overflow-y-auto scrollbar-thin border-0 bg-muted/35 shadow-none focus-visible:ring-2" /></div><DetailSection title="时间"><DetailField label="计划完成时间"><TodoDatePicker value={selected.dueAt} onChange={(dueAt) => void updateTodo(selected.id, { dueAt: dueAt ?? null, expectedUpdatedAt: todoBaseUpdatedAtRef.current ?? selected.updatedAt })} className="h-8 w-full justify-start bg-muted/45 text-xs text-foreground hover:bg-muted" /></DetailField></DetailSection><DetailSection title="组织"><DetailField label="优先级"><Select value={selected.priority} onValueChange={(value) => void updateTodo(selected.id, { priority: value as Todo['priority'], expectedUpdatedAt: todoBaseUpdatedAtRef.current ?? selected.updatedAt })}><SelectTrigger className="h-8 border-0 bg-muted/45 text-xs"><SelectValue /></SelectTrigger><SelectContent><SelectItem value="high">高优先级</SelectItem><SelectItem value="medium">中优先级</SelectItem><SelectItem value="low">低优先级</SelectItem></SelectContent></Select></DetailField><DetailField label="Todo 分组"><Select value={selected.groupId ?? '__none__'} onValueChange={(value) => void updateTodo(selected.id, { groupId: value === '__none__' ? null : value, expectedUpdatedAt: todoBaseUpdatedAtRef.current ?? selected.updatedAt })}><SelectTrigger className="h-8 border-0 bg-muted/45 text-xs"><SelectValue /></SelectTrigger><SelectContent><SelectItem value="__none__">不分组</SelectItem>{groups.map((group) => <SelectItem key={group.id} value={group.id}>{group.name}</SelectItem>)}</SelectContent></Select></DetailField><DetailField label="标签"><div className="flex flex-wrap gap-1">{tags.length ? tags.map((tag) => <button key={tag.id} type="button" onClick={() => void updateTodo(selected.id, { tagIds: selected.tags.some((item) => item.id === tag.id) ? selected.tags.filter((item) => item.id !== tag.id).map((item) => item.id) : [...selected.tags.map((item) => item.id), tag.id], expectedUpdatedAt: todoBaseUpdatedAtRef.current ?? selected.updatedAt })} className={cn('rounded-md px-2 py-1 text-xs transition-colors', selected.tags.some((item) => item.id === tag.id) ? 'bg-primary text-primary-foreground' : 'bg-muted/60 text-muted-foreground hover:bg-muted')}>#{tag.name}</button>) : <span className="text-xs text-muted-foreground">暂无标签</span>}</div></DetailField></DetailSection><DetailSection title="项目与 Agent"><DetailField label="执行项目"><Popover open={projectPickerOpen} onOpenChange={setProjectPickerOpen}><PopoverTrigger asChild><button type="button" disabled={startingTodoId === selected.id || assigningTodoId === selected.id || agentWorkspaces.length === 0} className="flex h-9 w-full items-center gap-2 rounded-md bg-muted/45 px-2 text-left text-xs transition-colors hover:bg-muted disabled:cursor-wait disabled:opacity-60"><span className="min-w-0 flex-1 truncate">{selected.workspaceId ? agentWorkspaces.find((workspace) => workspace.id === selected.workspaceId)?.name ?? '关联项目已不可用' : agentWorkspaces.length ? '选择项目' : '暂无可用项目'}</span><ChevronRight size={14} className="shrink-0 text-muted-foreground" /></button></PopoverTrigger><PopoverContent align="start" className="w-72 overflow-hidden p-1"><p className="px-2 py-1.5 text-xs font-medium text-muted-foreground">选择 Todo 的执行项目</p><div className="max-h-60 overflow-y-auto">{agentWorkspaces.map((workspace) => { const isCurrent = selected.workspaceId === workspace.id; const isAssigning = assigningTodoId === selected.id; return <button key={workspace.id} type="button" disabled={isAssigning} onClick={() => void assignTodoWorkspace(selected, workspace.id)} className={cn('flex min-h-10 w-full items-center gap-2 rounded-md px-2 text-left text-sm transition-colors hover:bg-muted disabled:cursor-wait disabled:opacity-60', isCurrent && 'bg-primary/10')}><span className="min-w-0 flex-1 truncate">{workspace.name}</span><span className={cn('shrink-0 text-xs', isCurrent ? 'text-primary' : 'text-muted-foreground')}>{isAssigning ? '选择中…' : isCurrent ? '当前项目' : '选择'}</span></button> })}</div></PopoverContent></Popover></DetailField><Button type="button" size="sm" className="w-full" disabled={!selected.workspaceId || startingTodoId === selected.id || assigningTodoId === selected.id} onClick={() => { if (selected.workspaceId) void startTodoInWorkspace(selected, selected.workspaceId) }}><Bot size={15} />{startingTodoId === selected.id ? '启动中…' : '开始运行 Agent'}</Button><DetailField label="关联会话">{selected.sessionLinks.length ? <div className="space-y-1">{selected.sessionLinks.map((link) => { const session = agentSessions.find((item) => item.id === link.sessionId); return <button key={link.sessionId} type="button" disabled={!session || standalone} title={standalone && session ? '请在主窗口查看关联会话' : undefined} onClick={() => { if (session && !standalone) openSession('agent', session.id, session.title) }} className={cn('flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors', session && !standalone ? 'bg-muted/45 hover:bg-muted' : 'cursor-not-allowed bg-muted/25 text-muted-foreground/60')}><span className="min-w-0 flex-1 truncate">{session?.title ?? '会话不可用'}</span><time className="shrink-0 tabular-nums text-[11px] text-muted-foreground">{new Date(link.lastTouchedAt).toLocaleDateString('zh-CN', { month: 'numeric', day: 'numeric' })}</time></button> })}</div> : <span className="text-xs text-muted-foreground">尚未由 Agent Session 操作</span>}</DetailField></DetailSection><div className="flex items-center justify-between border-t border-border/60 pt-4"><Button size="sm" variant="ghost" onClick={() => void updateTodo(selected.id, { status: selected.status === 'completed' ? 'open' : 'completed', expectedUpdatedAt: todoBaseUpdatedAtRef.current ?? selected.updatedAt })}>{selected.status === 'completed' ? '恢复任务' : '标记完成'}</Button><Button size="sm" variant="ghost" className="text-destructive hover:text-destructive" onClick={() => setTodoPendingDeletion(selected)}><Trash2 size={14} />删除</Button></div></div></PlanningFloatingInspector>}
+          <div className="pr-12"><label className="sr-only" htmlFor="todo-title">任务标题</label><Input id="todo-title" value={detailTitle} onChange={(event) => { detailTitleRef.current = event.target.value; setDetailTitle(event.target.value) }} onBlur={saveDetailTitle} disabled={todoConflict} className="h-auto border-0 bg-transparent px-0 text-lg font-semibold shadow-none focus-visible:ring-0" /></div><div><label className="mb-2 flex items-center justify-between text-xs font-medium text-muted-foreground"><span>描述</span><span aria-live="polite" className={cn('text-[11px] font-normal text-muted-foreground transition-opacity duration-300', notesSaveState ? 'opacity-100' : 'opacity-0')}>{notesSaveState === 'saving' ? '保存中…' : notesSaveState === 'saved' ? '✓ 已保存' : ''}</span></label><Textarea value={detailNotes} onChange={(event) => { detailNotesRef.current = event.target.value; setDetailNotes(event.target.value); scheduleNotesAutoSave() }} onBlur={saveDetailNotes} placeholder="添加描述…" disabled={todoConflict} className="min-h-64 resize-y overflow-y-auto scrollbar-thin border-0 bg-muted/35 shadow-none focus-visible:ring-2" /></div><DetailSection title="时间"><DetailField label="计划完成时间"><TodoDatePicker value={selected.dueAt} onChange={(dueAt) => void updateTodo(selected.id, { dueAt: dueAt ?? null, expectedUpdatedAt: todoBaseUpdatedAtRef.current ?? selected.updatedAt })} className="h-8 w-full justify-start bg-muted/45 text-xs text-foreground hover:bg-muted" /></DetailField></DetailSection><DetailSection title="组织"><DetailField label="优先级"><Select value={selected.priority} onValueChange={(value) => void updateTodo(selected.id, { priority: value as Todo['priority'], expectedUpdatedAt: todoBaseUpdatedAtRef.current ?? selected.updatedAt })}><SelectTrigger className="h-8 border-0 bg-muted/45 text-xs"><SelectValue /></SelectTrigger><SelectContent><SelectItem value="high">高优先级</SelectItem><SelectItem value="medium">中优先级</SelectItem><SelectItem value="low">低优先级</SelectItem></SelectContent></Select></DetailField><DetailField label="Todo 分组"><Select value={selected.groupId ?? '__none__'} onValueChange={(value) => void updateTodo(selected.id, { groupId: value === '__none__' ? null : value, expectedUpdatedAt: todoBaseUpdatedAtRef.current ?? selected.updatedAt })}><SelectTrigger className="h-8 border-0 bg-muted/45 text-xs"><SelectValue /></SelectTrigger><SelectContent><SelectItem value="__none__">不分组</SelectItem>{groups.map((group) => <SelectItem key={group.id} value={group.id}>{group.name}</SelectItem>)}</SelectContent></Select></DetailField><DetailField label="标签"><div className="flex flex-wrap gap-1">{tags.length ? tags.map((tag) => <button key={tag.id} type="button" onClick={() => void updateTodo(selected.id, { tagIds: selected.tags.some((item) => item.id === tag.id) ? selected.tags.filter((item) => item.id !== tag.id).map((item) => item.id) : [...selected.tags.map((item) => item.id), tag.id], expectedUpdatedAt: todoBaseUpdatedAtRef.current ?? selected.updatedAt })} className={cn('rounded-md px-2 py-1 text-xs transition-colors', selected.tags.some((item) => item.id === tag.id) ? 'bg-primary text-primary-foreground' : 'bg-muted/60 text-muted-foreground hover:bg-muted')}>#{tag.name}</button>) : <span className="text-xs text-muted-foreground">暂无标签</span>}</div></DetailField></DetailSection><DetailSection title="项目与 Agent"><DetailField label="执行项目"><Popover open={projectPickerOpen} onOpenChange={setProjectPickerOpen}><PopoverTrigger asChild><button type="button" disabled={startingTodoId === selected.id || assigningTodoId === selected.id || agentWorkspaces.length === 0} className="flex h-9 w-full items-center gap-2 rounded-md bg-muted/45 px-2 text-left text-xs transition-colors hover:bg-muted disabled:cursor-wait disabled:opacity-60"><span className="min-w-0 flex-1 truncate">{selected.workspaceId ? agentWorkspaces.find((workspace) => workspace.id === selected.workspaceId)?.name ?? '关联项目已不可用' : agentWorkspaces.length ? '选择项目' : '暂无可用项目'}</span><ChevronRight size={14} className="shrink-0 text-muted-foreground" /></button></PopoverTrigger><PopoverContent align="start" className="w-72 overflow-hidden p-1"><p className="px-2 py-1.5 text-xs font-medium text-muted-foreground">选择 Todo 的执行项目</p><div className="max-h-60 overflow-y-auto">{agentWorkspaces.map((workspace) => { const isCurrent = selected.workspaceId === workspace.id; const isAssigning = assigningTodoId === selected.id; return <button key={workspace.id} type="button" disabled={isAssigning} onClick={() => void assignTodoWorkspace(selected, workspace.id)} className={cn('flex min-h-10 w-full items-center gap-2 rounded-md px-2 text-left text-sm transition-colors hover:bg-muted disabled:cursor-wait disabled:opacity-60', isCurrent && 'bg-primary/10')}><span className="min-w-0 flex-1 truncate">{workspace.name}</span><span className={cn('shrink-0 text-xs', isCurrent ? 'text-primary' : 'text-muted-foreground')}>{isAssigning ? '选择中…' : isCurrent ? '当前项目' : '选择'}</span></button> })}</div></PopoverContent></Popover></DetailField><Button type="button" size="sm" className="w-full" disabled={!selected.workspaceId || startingTodoId === selected.id || assigningTodoId === selected.id} onClick={() => { if (selected.workspaceId) void startTodoInWorkspace(selected, selected.workspaceId) }}><Bot size={15} />{startingTodoId === selected.id ? '启动中…' : '开始运行 Agent'}</Button><DetailField label="关联会话">{selected.sessionLinks.length ? <div className="space-y-1">{selected.sessionLinks.map((link) => { const session = agentSessions.find((item) => item.id === link.sessionId); return <button key={link.sessionId} type="button" disabled={!session || standalone} title={standalone && session ? '请在主窗口查看关联会话' : undefined} onClick={() => { if (session && !standalone) openSession('agent', session.id, session.title) }} className={cn('flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors', session && !standalone ? 'bg-muted/45 hover:bg-muted' : 'cursor-not-allowed bg-muted/25 text-muted-foreground/60')}><span className="min-w-0 flex-1 truncate">{session?.title ?? '会话不可用'}</span><time className="shrink-0 tabular-nums text-[11px] text-muted-foreground">{new Date(link.lastTouchedAt).toLocaleDateString('zh-CN', { month: 'numeric', day: 'numeric' })}</time></button> })}</div> : <span className="text-xs text-muted-foreground">尚未由 Agent Session 操作</span>}</DetailField></DetailSection><div className="flex items-center justify-between border-t border-border/60 pt-4"><Button size="sm" variant="ghost" onClick={() => void updateTodo(selected.id, { status: selected.status === 'completed' ? 'open' : 'completed', expectedUpdatedAt: todoBaseUpdatedAtRef.current ?? selected.updatedAt })}>{selected.status === 'completed' ? '恢复任务' : '标记完成'}</Button><Button size="sm" variant="ghost" className="text-destructive hover:text-destructive" onClick={() => setTodoPendingDeletion(selected)}><Trash2 size={14} />删除</Button></div></div></PlanningFloatingInspector>}
       </div>
       <Dialog open={createOpen} onOpenChange={setCreateOpen}>
         <DialogContent className="top-[34%] max-w-xl gap-0 p-3" hideClose>

--- a/apps/electron/src/renderer/components/planning/PlanningView.tsx
+++ b/apps/electron/src/renderer/components/planning/PlanningView.tsx
@@ -270,6 +270,7 @@ function TodoWorkspace({ standalone = false }: { standalone?: boolean } = {}): R
     input: Omit<Parameters<typeof window.electronAPI.updateTodo>[0], 'id'>,
     savedField?: 'title' | 'notes',
     silentNotesSync = false,
+    savedNotesSnapshot?: string,
   ) => {
     try {
       const updated = await window.electronAPI.updateTodo({ id, ...input })
@@ -284,10 +285,14 @@ function TodoWorkspace({ standalone = false }: { standalone?: boolean } = {}): R
           }
           if (savedField === 'notes') {
             const notes = updated.notes ?? ''
-            detailNotesRef.current = notes
+            const hasNewerNotesDraft = savedNotesSnapshot !== undefined && detailNotesRef.current !== savedNotesSnapshot
             savedDetailNotesRef.current = notes
-            // 自动保存时不回写输入框，避免打断正在输入的内容（主进程会 trim 首尾空白）
-            if (!silentNotesSync) setDetailNotes(notes)
+            // 自动保存完成后，只在用户未继续输入时同步草稿 ref；否则保留新草稿并交给下一次保存。
+            if (!hasNewerNotesDraft) {
+              detailNotesRef.current = notes
+              // 自动保存时不回写输入框，避免打断正在输入的内容（主进程会 trim 首尾空白）
+              if (!silentNotesSync) setDetailNotes(notes)
+            }
           }
         }
       }
@@ -306,6 +311,7 @@ function TodoWorkspace({ standalone = false }: { standalone?: boolean } = {}): R
 
   // —— Todo 标题/描述草稿式自动保存 ——
   const notesSaveTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+  const notesSaveInFlightIdsRef = React.useRef(new Set<string>())
   const [notesSaveState, setNotesSaveState] = React.useState<'saving' | 'saved' | null>(null)
   const notesSaveStateTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -323,26 +329,38 @@ function TodoWorkspace({ standalone = false }: { standalone?: boolean } = {}): R
       notesSaveTimerRef.current = null
     }
     const id = selectedTodoIdRef.current
-    if (!id || todoConflict) return
-    const currentTodo = todos.find((todo) => todo.id === id)
-    if (!currentTodo) return
+    const expectedUpdatedAt = todoBaseUpdatedAtRef.current
+    if (!id || !expectedUpdatedAt || todoConflict || notesSaveInFlightIdsRef.current.has(id)) return
     const notes = detailNotesRef.current
     if (notes === savedDetailNotesRef.current) return
+    notesSaveInFlightIdsRef.current.add(id)
+    if (notesSaveStateTimerRef.current) {
+      clearTimeout(notesSaveStateTimerRef.current)
+      notesSaveStateTimerRef.current = null
+    }
     setNotesSaveState('saving')
-    // silentNotesSync=true：仅同步已保存值，不回写输入框，避免打断正在输入的内容
-    void updateTodo(id, { notes, expectedUpdatedAt: currentTodo.updatedAt }, 'notes', true).then((updated) => {
-      if (updated) {
-        setNotesSaveState('saved')
-        showNotesSaved()
-      } else {
+    // 保存时保留草稿快照；请求返回后若用户已继续输入，不覆盖新草稿。
+    void updateTodo(id, { notes, expectedUpdatedAt }, 'notes', true, notes).then((updated) => {
+      notesSaveInFlightIdsRef.current.delete(id)
+      if (selectedTodoIdRef.current !== id) return
+      if (!updated) {
         setNotesSaveState(null)
-        if (notesSaveStateTimerRef.current) {
-          clearTimeout(notesSaveStateTimerRef.current)
-          notesSaveStateTimerRef.current = null
-        }
+        return
       }
+      if (detailNotesRef.current !== savedDetailNotesRef.current) {
+        // 新草稿在本次请求中产生；立即续存，避免 800ms timer 已在请求期间空转后丢失内容。
+        if (!notesSaveTimerRef.current) {
+          notesSaveTimerRef.current = setTimeout(() => {
+            notesSaveTimerRef.current = null
+            saveDetailNotesRef.current()
+          }, 0)
+        }
+        return
+      }
+      setNotesSaveState('saved')
+      showNotesSaved()
     })
-  }, [showNotesSaved, todoConflict, todos, updateTodo])
+  }, [showNotesSaved, todoConflict, updateTodo])
 
   const saveDetailNotesRef = React.useRef(saveDetailNotes)
   saveDetailNotesRef.current = saveDetailNotes


### PR DESCRIPTION
## 概述
修复 Todo 详情面板中描述（notes）只有在失焦（blur）时才保存的问题：此前直接关闭面板（×/Esc/点空白）时，未失焦的描述会静默丢失。本次改为草稿式自动保存——输入停顿 800ms 自动写入，失焦立即保存，关闭面板时强制 flush 未保存的标题与描述。

## 改动
- `apps/electron/src/renderer/components/planning/PlanningView.tsx` — Todo 详情面板的标题/描述保存逻辑重构：
  - 描述输入后 debounce 800ms 自动保存（草稿式），不再依赖 blur 触发
  - 关闭详情面板（×/Esc/点空白）时先 flush 未保存的标题与描述，再执行关闭
  - 自动保存采用 silent 模式不回写输入框，避免打断正在输入的内容（主进程会 trim 首尾空白）
  - 描述标签旁新增「保存中…/✓ 已保存」状态提示，2 秒自动消失，颜色与描述标题一致

## 测试方法
1. 打开 Todo 详情面板，在描述中输入内容，停顿 1 秒后观察「✓ 已保存」提示；切换 Todo 或刷新后内容仍在
2. 输入描述后立即点击 × 或按 Esc 关闭面板，重新打开确认内容已保存
3. 修改标题后直接按 Esc 关闭，重新打开确认标题已保存
4. 输入描述后立即点击列表中的其他 Todo，确认原 Todo 描述已保存
5. 两个窗口打开同一 Todo，其中一个编辑时，确认另一窗口出现「已在其他窗口更新」冲突提示（`expectedUpdatedAt` 版本校验仍生效）

## 备注
- 改动集中在 `TodoWorkspace` 组件内，未触碰主进程存储逻辑
- `bun run typecheck` 通过

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
