### PR TITLE
fix(agent-island): keep idle dashboard visible

### DIFF
--- a/apps/electron/native/agent-island/macos-agent-island-helper.swift
+++ b/apps/electron/native/agent-island/macos-agent-island-helper.swift
@@ -368,8 +368,8 @@ struct CompactIslandView: View {
     if let session = primarySession {
       return "Proma · \(phaseText(session.phase))"
     }
-    if !snapshot.state.recentSessions.isEmpty {
-      return "Proma · 最近会话"
+    if snapshot.state.idleDashboard {
+      return snapshot.state.recentSessions.isEmpty ? "Proma · 额度概览" : "Proma · 最近会话"
     }
     return planningIndicator?.label ?? "工作提醒"
   }

--- a/apps/electron/src/main/lib/agent-island-service.ts
+++ b/apps/electron/src/main/lib/agent-island-service.ts
@@ -572,11 +572,10 @@ function pushState(): void {
   const planning = buildPlanningSnapshot(now)
   const planningKeys = getImminentPlanningKeys(now)
   const state = buildState(now)
-  // Future items are still available in the planning view, but only imminent
-  // ones should displace the idle Plan + recent-Agent dashboard.
-  state.idleDashboard = state.sessions.length === 0
-    && state.recentSessions.length > 0
-    && planningKeys.length === 0
+  // The idle dashboard is a true home surface: it remains visible even for a
+  // new user without any recorded Agent session. Future items do not displace
+  // it; only live Agent work or imminent plans take priority.
+  state.idleDashboard = state.sessions.length === 0 && planningKeys.length === 0
   const enabled = serviceDeps?.enabled?.() !== false
   state.visible = enabled && isIslandVisible(state, planningKeys)
   state.presentation = state.visible ? (isExpanded() ? 'expanded' : 'compact') : 'hidden'


### PR DESCRIPTION
## Summary

- Keep the idle Agent Island dashboard visible even without historical Agent sessions
- Present an explicit idle compact label for quota-only state

## Test plan

- [x] `bun run typecheck`
- [x] `bun run --filter=@proma/electron build:main`
- [x] `bun run --filter=@proma/electron build:agent-island-native`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)