### PR TITLE
chore: bump version to 0.16.5

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.16.3",
+  "version": "0.16.5",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {


### PR DESCRIPTION
## Summary

- da065d7a chore(release): bump version to 0.16.5

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归