### PR TITLE
feat(agent): 新建项目时继承当前项目配置（MCP / CLAUDE.md / 自定义 Skills）

### DIFF
--- a/apps/electron/src/main/lib/agent-workspace-manager.test.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.test.ts
@@ -152,3 +152,45 @@ describe('Agent 工作区 Skill 扫描', () => {
     expect(skills.map((skill) => skill.slug).sort()).toEqual(expectedSlugs)
   })
 })
+
+describe('Agent 工作区继承配置', () => {
+  test('Given 源工作区配置了 MCP/CLAUDE.md/自定义 Skill When 用 inheritFromWorkspaceId 创建新工作区 Then 复制运行时配置', () => {
+    const source = manager.createAgentWorkspace('Source Workspace')
+    const sourceDir = configPaths.getAgentWorkspacePath(source.slug)
+
+    writeFileSync(
+      join(sourceDir, 'mcp.json'),
+      JSON.stringify({ servers: { demo: { type: 'stdio', command: 'demo-mcp', enabled: true } } }, null, 2),
+      'utf-8',
+    )
+    writeFileSync(join(sourceDir, 'CLAUDE.md'), '# 源项目规则\n', 'utf-8')
+    writeWorkspaceSkill(source.slug, 'my-custom-skill', 'My Custom')
+
+    const target = manager.createAgentWorkspace({ name: 'Inherited Workspace', inheritFromWorkspaceId: source.id })
+    const targetDir = configPaths.getAgentWorkspacePath(target.slug)
+
+    expect(existsSync(join(targetDir, 'mcp.json'))).toBe(true)
+    expect(existsSync(join(targetDir, 'CLAUDE.md'))).toBe(true)
+    expect(existsSync(join(configPaths.getWorkspaceSkillsDir(target.slug), 'my-custom-skill', 'SKILL.md'))).toBe(true)
+  })
+
+  test('Given 源工作区缺少 mcp.json When 继承创建新工作区 Then 不报错并复制其余配置', () => {
+    const source = manager.createAgentWorkspace('Source No Mcp')
+    writeFileSync(join(configPaths.getAgentWorkspacePath(source.slug), 'CLAUDE.md'), '# 规则\n', 'utf-8')
+    writeWorkspaceSkill(source.slug, 'another-custom', 'Another')
+
+    const target = manager.createAgentWorkspace({ name: 'Inherited No Mcp', inheritFromWorkspaceId: source.id })
+    const targetDir = configPaths.getAgentWorkspacePath(target.slug)
+
+    expect(existsSync(join(targetDir, 'mcp.json'))).toBe(false)
+    expect(existsSync(join(targetDir, 'CLAUDE.md'))).toBe(true)
+    expect(existsSync(join(configPaths.getWorkspaceSkillsDir(target.slug), 'another-custom', 'SKILL.md'))).toBe(true)
+  })
+
+  test('Given 继承源 id 不存在 When 创建新工作区 Then 不失败且正常初始化', () => {
+    const target = manager.createAgentWorkspace({ name: 'Bad Inherit', inheritFromWorkspaceId: 'nonexistent-id' })
+
+    expect(existsSync(configPaths.getAgentWorkspacePath(target.slug))).toBe(true)
+    expect(target.slug).not.toBe('')
+  })
+})

--- a/apps/electron/src/main/lib/agent-workspace-manager.ts
+++ b/apps/electron/src/main/lib/agent-workspace-manager.ts
@@ -252,6 +252,66 @@ function copyDefaultSkills(workspaceSlug: string, options: { throwOnError?: bool
   }
 }
 
+/**
+ * 新建工作区时从源工作区继承运行时配置：mcp.json、CLAUDE.md、自定义 Skills。
+ *
+ * 内置 default-skills 由 copyDefaultSkills 初始化，这里只复制源工作区中
+ * 非内置的自定义 Skill（与 default-skills 同名、已退役的跳过）。所有复制
+ * 均为「目标不存在才复制」，不会覆盖新工作区已生成的配置。
+ */
+export function copyInheritedWorkspaceConfig(sourceSlug: string, targetSlug: string): void {
+  const sourceDir = getAgentWorkspacePath(sourceSlug)
+  const targetDir = getAgentWorkspacePath(targetSlug)
+  if (!existsSync(sourceDir)) {
+    console.warn(`[Agent 工作区] 继承配置：源工作区不存在 ${sourceSlug}，跳过`)
+    return
+  }
+
+  // 1. mcp.json（源存在且目标不存在时复制）
+  const srcMcp = join(sourceDir, 'mcp.json')
+  if (existsSync(srcMcp)) {
+    const dstMcp = getWorkspaceMcpPath(targetSlug)
+    if (!existsSync(dstMcp)) {
+      cpSync(srcMcp, dstMcp)
+      console.log(`[Agent 工作区] 已继承 MCP 配置: ${sourceSlug} -> ${targetSlug}`)
+    }
+  }
+
+  // 2. CLAUDE.md
+  const srcClaude = join(sourceDir, 'CLAUDE.md')
+  if (existsSync(srcClaude)) {
+    const dstClaude = join(targetDir, 'CLAUDE.md')
+    if (!existsSync(dstClaude)) {
+      cpSync(srcClaude, dstClaude)
+      console.log(`[Agent 工作区] 已继承 CLAUDE.md: ${sourceSlug} -> ${targetSlug}`)
+    }
+  }
+
+  // 3. 自定义 Skills（跳过 default-skills 同名与已退役）
+  const sourceSkillsDir = getWorkspaceSkillsDir(sourceSlug)
+  if (!existsSync(sourceSkillsDir)) return
+  const defaultSkillNames = new Set(
+    readdirSync(getDefaultSkillsDir(), { withFileTypes: true })
+      .filter((e) => e.isDirectory() && !isRetiredDefaultSkill(e.name))
+      .map((e) => e.name),
+  )
+  const targetSkillsDir = getWorkspaceSkillsDir(targetSlug)
+  mkdirSync(targetSkillsDir, { recursive: true })
+  for (const entry of readdirSync(sourceSkillsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+    if (defaultSkillNames.has(entry.name)) continue
+    const source = join(sourceSkillsDir, entry.name)
+    const target = join(targetSkillsDir, entry.name)
+    if (existsSync(target)) continue
+    try {
+      cpSync(source, target, { recursive: true, filter: skillCopyFilter })
+      console.log(`[Agent 工作区] 已继承自定义 Skill: ${entry.name} (${sourceSlug} -> ${targetSlug})`)
+    } catch (err) {
+      console.warn(`[Agent 工作区] 继承自定义 Skill 失败 (${entry.name}):`, err)
+    }
+  }
+}
+
 export function createAgentWorkspace(input: string | CreateAgentWorkspaceInput): AgentWorkspace {
   const { name, projectRootPath } = typeof input === 'string'
     ? { name: input, projectRootPath: undefined }
@@ -296,6 +356,19 @@ export function createAgentWorkspace(input: string | CreateAgentWorkspaceInput):
     getAgentWorkspacePath(slug)
     ensurePluginManifest(slug, name)
     copyDefaultSkills(slug, { throwOnError: true })
+    // 可选：从已有工作区继承 MCP / CLAUDE.md / 自定义 Skills（复制失败不阻塞创建）
+    if (typeof input !== 'string' && input.inheritFromWorkspaceId) {
+      const sourceWorkspace = index.workspaces.find((w) => w.id === input.inheritFromWorkspaceId)
+      if (sourceWorkspace) {
+        try {
+          copyInheritedWorkspaceConfig(sourceWorkspace.slug, slug)
+        } catch (copyError) {
+          console.warn(`[Agent 工作区] 继承配置失败 (${slug}):`, copyError)
+        }
+      } else {
+        console.warn(`[Agent 工作区] 继承配置：源工作区 id 未找到 ${input.inheritFromWorkspaceId}`)
+      }
+    }
   } catch (error) {
     const workspacesRoot = resolve(getAgentWorkspacesDir())
     const workspaceDir = resolve(join(workspacesRoot, slug))

--- a/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
+++ b/apps/electron/src/renderer/components/agent/WorkspaceSelector.tsx
@@ -78,6 +78,8 @@ export function WorkspaceSelector(): React.ReactElement {
   const [creating, setCreating] = React.useState(false)
   const [newName, setNewName] = React.useState('')
   const createInputRef = React.useRef<HTMLInputElement>(null)
+  /** 新建项目时是否继承当前项目配置（MCP / Skills / CLAUDE.md） */
+  const [inheritConfigOnCreate, setInheritConfigOnCreate] = React.useState(true)
 
   // 重命名状态
   const [editingId, setEditingId] = React.useState<string | null>(null)
@@ -108,7 +110,7 @@ export function WorkspaceSelector(): React.ReactElement {
   }
 
   const handleCreate = async (): Promise<void> => {
-    await createProject(newName)
+    await createProject(newName, { inheritFromWorkspaceId: inheritConfigOnCreate ? currentWorkspaceId ?? undefined : undefined })
     setCreating(false)
   }
 
@@ -377,19 +379,30 @@ export function WorkspaceSelector(): React.ReactElement {
 
           {/* 新建项目输入框 */}
           {creating && (
-            <div className="flex items-center gap-2 px-2 py-[5px]">
-              <FolderOpen size={13} className="flex-shrink-0 text-foreground/40" />
-              <input
-                ref={createInputRef}
-                value={newName}
-                onChange={(e) => setNewName(e.target.value)}
-                onKeyDown={handleCreateKeyDown}
-                onBlur={() => setCreating(false)}
-                placeholder="项目名称..."
-                className="flex-1 min-w-0 bg-transparent text-[13px] text-foreground border-b border-primary/50 outline-none px-0.5"
-                maxLength={50}
-              />
-            </div>
+            <>
+              <div className="flex items-center gap-2 px-2 py-[5px]">
+                <FolderOpen size={13} className="flex-shrink-0 text-foreground/40" />
+                <input
+                  ref={createInputRef}
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  onKeyDown={handleCreateKeyDown}
+                  onBlur={() => setCreating(false)}
+                  placeholder="项目名称..."
+                  className="flex-1 min-w-0 bg-transparent text-[13px] text-foreground border-b border-primary/50 outline-none px-0.5"
+                  maxLength={50}
+                />
+              </div>
+              <label className="flex items-center gap-1.5 px-2 py-[3px] text-[11px] text-foreground/60 cursor-pointer select-none">
+                <input
+                  type="checkbox"
+                  checked={inheritConfigOnCreate}
+                  onChange={(e) => setInheritConfigOnCreate(e.target.checked)}
+                  className="size-3 accent-primary"
+                />
+                复制当前项目配置（MCP / Skills / CLAUDE.md）
+              </label>
+            </>
           )}
         </div>
 

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -756,6 +756,8 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
   const [creatingProject, setCreatingProject] = React.useState(false)
   const [newProjectName, setNewProjectName] = React.useState('')
   const newProjectInputRef = React.useRef<HTMLInputElement>(null)
+  /** 新建项目时是否继承当前项目配置（MCP / Skills / CLAUDE.md） */
+  const [inheritConfigOnCreate, setInheritConfigOnCreate] = React.useState(true)
   const [relativeTimeNow, setRelativeTimeNow] = React.useState(() => Date.now())
   const [userProfile, setUserProfile] = useAtom(userProfileAtom)
   const streamingIds = useAtomValue(streamingConversationIdsAtom)
@@ -1631,7 +1633,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
 
     try {
       const { workspace, session } = await window.electronAPI.createAgentProject(
-        { name: trimmed },
+        { name: trimmed, inheritFromWorkspaceId: inheritConfigOnCreate ? currentWorkspaceId ?? undefined : undefined },
         agentChannelId || undefined,
         agentModelId || undefined,
       )
@@ -2931,22 +2933,33 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
           {/* 下区：项目分组历史 */}
           <div className="px-2 pb-3">
             {creatingProject && (
-              <div className="flex items-center gap-2 px-2 py-1.5 mb-1 rounded-md bg-foreground/[0.04]">
-                <FolderOpen size={14} className="flex-shrink-0 text-foreground/40" />
-                <input
-                  ref={newProjectInputRef}
-                  value={newProjectName}
-                  onChange={(e) => setNewProjectName(e.target.value)}
-                  onKeyDown={handleCreateProjectKeyDown}
-                  onBlur={() => {
-                    setCreatingProject(false)
-                    setNewProjectName('')
-                  }}
-                  placeholder="项目名称..."
-                  className="flex-1 min-w-0 bg-transparent text-[13px] text-foreground border-b border-primary/50 outline-none px-0.5"
-                  maxLength={50}
-                />
-              </div>
+              <>
+                <div className="flex items-center gap-2 px-2 py-1.5 mb-1 rounded-md bg-foreground/[0.04]">
+                  <FolderOpen size={14} className="flex-shrink-0 text-foreground/40" />
+                  <input
+                    ref={newProjectInputRef}
+                    value={newProjectName}
+                    onChange={(e) => setNewProjectName(e.target.value)}
+                    onKeyDown={handleCreateProjectKeyDown}
+                    onBlur={() => {
+                      setCreatingProject(false)
+                      setNewProjectName('')
+                    }}
+                    placeholder="项目名称..."
+                    className="flex-1 min-w-0 bg-transparent text-[13px] text-foreground border-b border-primary/50 outline-none px-0.5"
+                    maxLength={50}
+                  />
+                </div>
+                <label className="flex items-center gap-1.5 px-2 py-1 mb-1 text-[11px] text-foreground/60 cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    checked={inheritConfigOnCreate}
+                    onChange={(e) => setInheritConfigOnCreate(e.target.checked)}
+                    className="size-3 accent-primary"
+                  />
+                  复制当前项目配置（MCP / Skills / CLAUDE.md）
+                </label>
+              </>
             )}
 
             <div className="flex flex-col gap-0.5">

--- a/apps/electron/src/renderer/hooks/useProjectActions.ts
+++ b/apps/electron/src/renderer/hooks/useProjectActions.ts
@@ -25,7 +25,7 @@ interface UseProjectActionsResult {
   /** 切换到指定项目；已是当前项目时无副作用。默认切回对话视图，resetView:false 可保持当前视图（如停留在 Agent 技能） */
   selectProject: (workspaceId: string, opts?: { resetView?: boolean }) => void
   /** 创建并切到新项目；成功返回新项目，失败已 toast 并返回 null */
-  createProject: (name: string, options?: Pick<CreateAgentWorkspaceInput, 'projectRootPath'>) => Promise<AgentWorkspace | null>
+  createProject: (name: string, options?: Pick<CreateAgentWorkspaceInput, 'projectRootPath' | 'inheritFromWorkspaceId'>) => Promise<AgentWorkspace | null>
   /** 选择本地文件夹，并以它作为项目文件根创建项目。 */
   createProjectFromFolder: () => Promise<AgentWorkspace | null>
 }
@@ -51,7 +51,7 @@ export function useProjectActions(): UseProjectActionsResult {
   )
 
   const createProject = React.useCallback(
-    async (name: string, options?: Pick<CreateAgentWorkspaceInput, 'projectRootPath'>): Promise<AgentWorkspace | null> => {
+    async (name: string, options?: Pick<CreateAgentWorkspaceInput, 'projectRootPath' | 'inheritFromWorkspaceId'>): Promise<AgentWorkspace | null> => {
       const trimmed = name.trim()
       if (!trimmed) return null
       if (createInFlightRef.current) return null

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -38,6 +38,8 @@ export interface CreateAgentWorkspaceInput {
   name: string
   /** 可选的用户本地项目根目录 */
   projectRootPath?: string
+  /** 可选：从已有工作区继承运行时配置（MCP 服务器、CLAUDE.md、自定义 Skills） */
+  inheritFromWorkspaceId?: string
 }
 
 /** 创建项目后自动生成的首个 Agent 会话。 */


### PR DESCRIPTION
## 背景

新建工作区时只初始化内置 default-skills，**不会复制 mcp.json、CLAUDE.md 和用户自装的自定义 Skills**。导致配置了 MCP 服务器（如 tolaria、vision）和自装 Skill 的用户，每个新项目都要重新手动配置一遍。

关联 Issue：[#971 新建工作区时未自动复制 default-mcp.json 到工作区 mcp.json](https://github.com/proma-ai/Proma/issues/971)

## 改动

新建项目时支持**从当前（或指定）工作区继承运行时配置**：

1. **shared**：`CreateAgentWorkspaceInput` 新增 `inheritFromWorkspaceId?: string`
2. **manager**：新增 `copyInheritedWorkspaceConfig(sourceSlug, targetSlug)`——复制 mcp.json、CLAUDE.md、自定义 Skills（跳过内置 default-skills 与已退役 Skill；目标已存在不覆盖；复制失败不阻塞创建）
3. **UI**：侧边栏与工作区选择器的新建项目入口新增「复制当前项目配置（MCP / Skills / CLAUDE.md）」勾选项，**默认开启**（继承当前工作区）

## 测试

- `agent-workspace-manager.test.ts` 新增 3 个用例：正常继承（MCP/CLAUDE.md/自定义 Skill 全部复制）、源缺 mcp.json 容错、无效源 id 容错
- 全部 8 个用例通过，`bun run typecheck` 全绿

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
