### PR TITLE
Fix agent island viewed completion state

### DIFF
--- a/apps/electron/src/main/lib/agent-island-service.ts
+++ b/apps/electron/src/main/lib/agent-island-service.ts
@@ -786,19 +786,31 @@ export function initAgentIslandService(deps: AgentIslandServiceDeps): void {
     if (typeof sessionId !== 'string' || sessionId.length === 0) return
     openAgentIslandSession(sessionId)
   })
+
+  ipcMain.handle(AGENT_ISLAND_IPC_CHANNELS.MARK_SESSION_VIEWED, (_event, sessionId: unknown) => {
+    if (typeof sessionId !== 'string' || sessionId.length === 0) return
+    markAgentIslandSessionViewed(sessionId)
+  })
+}
+
+/**
+ * 完成态的未读由主进程管理；主应用确认用户已经看过结果后，在此统一清除。
+ * 错误和需要交互的会话必须保留 attention，不能被普通查看动作吞掉。
+ */
+function markAgentIslandSessionViewed(sessionId: string): void {
+  const session = sessions.get(sessionId)
+  if (session?.phase !== 'completed' || !session.unread) return
+  session.unread = false
+  session.attention = false
+  schedulePush()
 }
 
 function openAgentIslandSession(sessionId: string): void {
   if (!serviceDeps) return
   const session = sessions.get(sessionId)
-  // “完成但未检查”在用户进入对应会话后即视为已检查；异常/阻塞仍保留直到状态改变。
-  if (session?.phase === 'completed' && session.unread) {
-    session.unread = false
-    session.attention = false
-  }
+  markAgentIslandSessionViewed(sessionId)
   serviceDeps.openAgentSession(sessionId, session?.title ?? getTitle(sessionId))
   serviceDeps.showAndFocusMainWindow()
-  schedulePush()
 }
 
 function isExpanded(): boolean {

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -1176,6 +1176,8 @@ export interface ElectronAPI {
     openMainWindow: () => Promise<void>
     /** 打开指定 Agent 会话（聚焦主窗口） */
     openSession: (sessionId: string) => Promise<void>
+    /** 用户已在主应用中主动查看完成会话，清除灵动岛未读状态 */
+    markSessionViewed: (sessionId: string) => Promise<void>
   }
 }
 
@@ -2671,6 +2673,8 @@ const electronAPI: ElectronAPI = {
       ipcRenderer.invoke(AGENT_ISLAND_IPC_CHANNELS.OPEN_MAIN_WINDOW),
     openSession: (sessionId: string) =>
       ipcRenderer.invoke(AGENT_ISLAND_IPC_CHANNELS.OPEN_SESSION, sessionId),
+    markSessionViewed: (sessionId: string) =>
+      ipcRenderer.invoke(AGENT_ISLAND_IPC_CHANNELS.MARK_SESSION_VIEWED, sessionId),
   },
 }
 

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -1149,6 +1149,9 @@ export function useGlobalAgentListeners(): void {
             next.add(data.sessionId)
             return next
           })
+        } else if (!backgroundTasksPending) {
+          // 当前聚焦会话已在主应用可见；同步确认，避免灵动岛把这次完成继续当未读。
+          void window.electronAPI.agentIsland.markSessionViewed(data.sessionId).catch(console.error)
         }
 
         // 标记用户主动打断状态

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -573,9 +573,16 @@ function NotificationsInitializer(): null {
 function DockBadgeInitializer(): null {
   const count = useAtomValue(dockBadgeCountAtom)
   const notificationsEnabled = useAtomValue(notificationsEnabledAtom)
-  const currentSessionId = useAtomValue(currentAgentSessionIdAtom)
+  const tabs = useAtomValue(tabsAtom)
+  const activeTabId = useAtomValue(activeTabIdAtom)
   const setUnviewedCompleted = useSetAtom(unviewedCompletedSessionIdsAtom)
   const badgeCount = notificationsEnabled ? count : 0
+  const activeAgentSessionId = useMemo(() => {
+    const activeTab = activeTabId ? tabs.find((tab) => tab.id === activeTabId) : null
+    return activeTab?.type === 'agent' || activeTab?.type === 'preview'
+      ? activeTab.sessionId
+      : null
+  }, [activeTabId, tabs])
 
   useEffect(() => {
     window.electronAPI.setDockBadgeCount(badgeCount).catch((error) => {
@@ -584,26 +591,27 @@ function DockBadgeInitializer(): null {
   }, [badgeCount])
 
   useEffect(() => {
-    const clearCurrentSessionBadge = (): void => {
-      if (!document.hasFocus() || !currentSessionId) return
-      // 与主进程灵动岛的完成态未读同步，避免用户已在主应用查看结果后仍需去岛上再点一次。
-      void window.electronAPI.agentIsland.markSessionViewed(currentSessionId).catch(console.error)
+    const clearActiveSessionBadge = (): void => {
+      if (!document.hasFocus() || !activeAgentSessionId) return
+      // 以实际激活的 Agent/预览 Tab 为准。Scratch Pad 会保留 currentAgentSessionId，
+      // 不能仅据此把后台会话误判为已查看。
+      void window.electronAPI.agentIsland.markSessionViewed(activeAgentSessionId).catch(console.error)
       setUnviewedCompleted((prev) => {
-        if (!prev.has(currentSessionId)) return prev
+        if (!prev.has(activeAgentSessionId)) return prev
         const next = new Set(prev)
-        next.delete(currentSessionId)
+        next.delete(activeAgentSessionId)
         return next
       })
     }
 
-    clearCurrentSessionBadge()
-    window.addEventListener('focus', clearCurrentSessionBadge)
-    document.addEventListener('visibilitychange', clearCurrentSessionBadge)
+    clearActiveSessionBadge()
+    window.addEventListener('focus', clearActiveSessionBadge)
+    document.addEventListener('visibilitychange', clearActiveSessionBadge)
     return () => {
-      window.removeEventListener('focus', clearCurrentSessionBadge)
-      document.removeEventListener('visibilitychange', clearCurrentSessionBadge)
+      window.removeEventListener('focus', clearActiveSessionBadge)
+      document.removeEventListener('visibilitychange', clearActiveSessionBadge)
     }
-  }, [currentSessionId, setUnviewedCompleted])
+  }, [activeAgentSessionId, setUnviewedCompleted])
 
   return null
 }

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -586,6 +586,8 @@ function DockBadgeInitializer(): null {
   useEffect(() => {
     const clearCurrentSessionBadge = (): void => {
       if (!document.hasFocus() || !currentSessionId) return
+      // 与主进程灵动岛的完成态未读同步，避免用户已在主应用查看结果后仍需去岛上再点一次。
+      void window.electronAPI.agentIsland.markSessionViewed(currentSessionId).catch(console.error)
       setUnviewedCompleted((prev) => {
         if (!prev.has(currentSessionId)) return prev
         const next = new Set(prev)

--- a/packages/shared/src/types/agent-island.ts
+++ b/packages/shared/src/types/agent-island.ts
@@ -165,6 +165,8 @@ export const AGENT_ISLAND_IPC_CHANNELS = {
   OPEN_MAIN_WINDOW: 'agent-island:open-main-window',
   /** renderer → main：请求打开指定 Agent 会话 */
   OPEN_SESSION: 'agent-island:open-session',
+  /** 主应用已主动查看指定完成会话，清除灵动岛未读状态 */
+  MARK_SESSION_VIEWED: 'agent-island:mark-session-viewed',
   /** renderer → main：内联响应权限请求 */
   RESPOND_PERMISSION: 'agent-island:respond-permission',
   /** main → renderer：切换展开（快捷键等外部入口） */


### PR DESCRIPTION
## Summary

- 3d8ec216 fix(agent-island): sync viewed completion state

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)