### PR TITLE
feat(channel): add xAI subscription OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Proma 的 Agent 模式提供两套可切换的内核：
 | OpenAI、OpenAI Responses、Google、智谱 AI、豆包、通义千问 | 支持 | 暂不支持 | 支持 |
 | OpenAI 兼容自定义端点 | 支持 | 暂不支持 | 支持 |
 | ChatGPT 订阅（Codex OAuth） | — | 支持 | 支持 |
+| xAI 订阅（Grok OAuth） | — | — | 支持 |
 
 > Pi Runtime 可在每个 Agent 会话的输入框下方直接切换；切换会开启新的底层 SDK 会话，但不会删除 Proma 中已保存的消息。Pi 会桥接工作区 Skills、用户 MCP Server，以及 Proma 内置的 Automation / Collaboration 工具；不同模型供应商对工具调用、推理和上下文长度的支持仍可能不同。
 

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -154,8 +154,9 @@ import {
   getChannelPlanQuota,
 } from './lib/channel-manager'
 import { loginCodexOAuth, cancelCodexOAuthLogin } from './lib/codex-oauth-service'
+import { loginXaiOAuth, cancelXaiOAuthLogin } from './lib/xai-oauth-service'
 import { resolvePiReasoningCapability } from './lib/adapters/pi-model-registry'
-import { serializeCodexCredentials } from '@proma/shared'
+import { serializeCodexCredentials, serializeXaiCredentials } from '@proma/shared'
 import {
   listConversations,
   createConversation,
@@ -1262,6 +1263,29 @@ export function registerIpcHandlers(): void {
     CHANNEL_IPC_CHANNELS.CODEX_OAUTH_CANCEL,
     async (): Promise<void> => {
       cancelCodexOAuthLogin()
+    }
+  )
+
+  // 发起 xAI（Grok/X 订阅）OAuth device-code 登录。Pi 会通过 device-code 事件给出
+  // 预填的浏览器授权链接；成功后的凭据沿用 Channel.apiKey 加密存储。
+  ipcMain.handle(
+    CHANNEL_IPC_CHANNELS.XAI_OAUTH_LOGIN,
+    async (event): Promise<import('@proma/shared').XaiOAuthLoginResult> => {
+      try {
+        const credentials = await loginXaiOAuth({
+          onDeviceCode: (deviceCode) => event.sender.send(CHANNEL_IPC_CHANNELS.XAI_OAUTH_DEVICE_CODE, deviceCode),
+        })
+        return { success: true, credentials: serializeXaiCredentials(credentials) }
+      } catch (error) {
+        return { success: false, message: error instanceof Error ? error.message : String(error) }
+      }
+    }
+  )
+
+  ipcMain.handle(
+    CHANNEL_IPC_CHANNELS.XAI_OAUTH_CANCEL,
+    async (): Promise<void> => {
+      cancelXaiOAuthLogin()
     }
   )
 

--- a/apps/electron/src/main/lib/adapters/pi-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/pi-agent-adapter.ts
@@ -14,6 +14,7 @@ import type {
   AgentThinkingLevel,
   AgentProviderAdapter,
   CodexOAuthCredentials,
+  XaiOAuthCredentials,
   AgentQueryInput,
   ErrorCode,
   JsonSchemaOutputFormat,
@@ -97,6 +98,8 @@ export interface PiAgentQueryOptions extends AgentQueryInput {
   apiKey: string
   baseUrl?: string
   provider: ProviderType
+  /** OAuth credential coordination key; equals the selected Proma channel id. */
+  channelId?: string
   channelName?: string
   maxTurns?: number
   permissionMode: PromaPermissionMode
@@ -142,6 +145,10 @@ export interface PiAgentQueryOptions extends AgentQueryInput {
   codexOAuthCredentials?: CodexOAuthCredentials
   /** Pi 运行中刷新 OAuth 后，将新凭据回写到 Proma 渠道存储。 */
   onCodexOAuthCredentialsRefreshed?: (credentials: CodexOAuthCredentials) => void | Promise<void>
+  /** xAI OAuth credential store 使用真实 expires 和 refresh，不读取 ~/.pi。 */
+  xaiOAuthCredentials?: XaiOAuthCredentials
+  /** Pi 运行中刷新 xAI OAuth 后，将新凭据回写到 Proma 渠道存储。 */
+  onXaiOAuthCredentialsRefreshed?: (credentials: XaiOAuthCredentials) => void | Promise<void>
   /** 会话级 OpenAI（Codex OAuth / Responses API）思考深度。 */
   openAIThinkingLevel?: AgentThinkingLevel
 }
@@ -1429,7 +1436,7 @@ export class PiAgentAdapter implements AgentProviderAdapter {
         },
         ...buildPiRemoteConnectionSettings(input),
       })
-      const openAIReasoningProfile = (input.provider === 'openai-codex' || input.provider === 'openai-responses')
+      const openAIReasoningProfile = (input.provider === 'openai-codex' || input.provider === 'xai' || input.provider === 'openai-responses')
         ? resolveReasoningProfile({
           modelId: input.model,
           transport: inferReasoningTransport(input.provider),

--- a/apps/electron/src/main/lib/adapters/pi-model-registry.ts
+++ b/apps/electron/src/main/lib/adapters/pi-model-registry.ts
@@ -15,6 +15,7 @@ import {
   resolveReasoningCapability,
   resolveReasoningProfile,
   type CodexOAuthCredentials,
+  type XaiOAuthCredentials,
   type ReasoningCapability,
   type ReasoningTransport,
   type ProviderType,
@@ -27,6 +28,7 @@ import {
 } from '@proma/core'
 import type { Api, KnownProvider, Model } from '@earendil-works/pi-ai/compat'
 import type { PiAgentQueryOptions } from './pi-agent-adapter'
+import { rememberXaiOAuthCredentials, refreshXaiOAuthCredentialsSerial } from '../xai-oauth-credentials'
 import { supportsPiDeveloperRole } from './pi-provider-compat'
 
 type PiSdk = typeof import('@earendil-works/pi-coding-agent')
@@ -126,6 +128,14 @@ export interface CodexModelInput {
   onCodexOAuthCredentialsRefreshed?: (credentials: CodexOAuthCredentials) => void | Promise<void>
 }
 
+/** Pi 内置 xAI provider 所需的最小模型与 OAuth 输入。 */
+export interface XaiModelInput {
+  channelId?: string
+  model?: string
+  xaiOAuthCredentials?: XaiOAuthCredentials
+  onXaiOAuthCredentialsRefreshed?: (credentials: XaiOAuthCredentials) => void | Promise<void>
+}
+
 function createCodexRuntimeCredentialStore(
   initial: CodexOAuthCredentials,
   onRefreshed?: PiAgentQueryOptions['onCodexOAuthCredentialsRefreshed'],
@@ -163,6 +173,60 @@ function createCodexRuntimeCredentialStore(
     },
     async delete(providerId: string): Promise<void> {
       if (providerId === 'openai-codex') credential = undefined
+    },
+  }
+}
+
+type XaiRuntimeCredential = XaiOAuthCredentials & {
+  type: 'oauth'
+  [key: string]: unknown
+}
+
+function createXaiRuntimeCredentialStore(
+  channelId: string,
+  initial: XaiOAuthCredentials,
+  onRefreshed?: PiAgentQueryOptions['onXaiOAuthCredentialsRefreshed'],
+) {
+  let credential: XaiRuntimeCredential | undefined = { type: 'oauth', ...rememberXaiOAuthCredentials(channelId, initial) }
+
+  return {
+    async read(providerId: string): Promise<XaiRuntimeCredential | undefined> {
+      return providerId === 'xai' ? credential : undefined
+    },
+    async list(): Promise<readonly { providerId: string; type: 'oauth' }[]> {
+      return credential ? [{ providerId: 'xai', type: 'oauth' }] : []
+    },
+    async modify(
+      providerId: string,
+      fn: (current: XaiRuntimeCredential | undefined) => Promise<XaiRuntimeCredential | undefined>,
+    ): Promise<XaiRuntimeCredential | undefined> {
+      if (providerId !== 'xai' || !credential) return undefined
+      const previous = credential
+      const refreshed = await refreshXaiOAuthCredentialsSerial(
+        channelId,
+        credential,
+        async (latest) => {
+          const next = await fn({ type: 'oauth', ...latest })
+          if (!next) throw new Error('Pi xAI OAuth 刷新未返回凭据')
+          return { access: next.access, refresh: next.refresh, expires: next.expires }
+        },
+      )
+      credential = { type: 'oauth', ...refreshed }
+      if (
+        previous.access !== credential.access
+        || previous.refresh !== credential.refresh
+        || previous.expires !== credential.expires
+      ) {
+        try {
+          await onRefreshed?.(credential)
+        } catch (error) {
+          console.warn('[Pi xAI OAuth] 刷新后的凭据回写失败，将在下次执行前重试:', error)
+        }
+      }
+      return credential
+    },
+    async delete(providerId: string): Promise<void> {
+      if (providerId === 'xai') credential = undefined
     },
   }
 }
@@ -231,6 +295,7 @@ function loadPiAiCompat(): Promise<PiAiCompat> {
 function normalizePiApi(provider: ProviderType): Api {
   switch (provider) {
     case 'openai':
+    case 'xai':
     case 'opencode-go-openai':
     case 'zhipu':
     case 'doubao':
@@ -253,6 +318,8 @@ function candidatePiProviders(provider: ProviderType): KnownProvider[] {
     case 'openai':
     case 'openai-responses':
       return ['openai']
+    case 'xai':
+      return ['xai']
     case 'deepseek':
       return ['deepseek']
     case 'google':
@@ -322,6 +389,9 @@ async function findPiCatalogModel(provider: ProviderType, modelId: string): Prom
   if (provider === 'openai-codex') {
     return findCatalogModelById(await getCodexCatalogModels(), modelId)
   }
+  if (provider === 'xai') {
+    return findCatalogModelById(await getXaiCatalogModels(), modelId)
+  }
 
   const preferredProviders = candidatePiProviders(provider)
   const { getProviders } = await loadPiAiCompat()
@@ -371,7 +441,7 @@ export async function resolvePiReasoningCapability(
   const resolvedModelId = stripAgentSdkContextSuffix(modelId)
   const profile = resolveReasoningProfile({
     modelId: resolvedModelId,
-    transport: provider === 'openai-codex'
+    transport: provider === 'openai-codex' || provider === 'xai'
       ? 'openai-responses'
       : toReasoningTransport(normalizePiApi(provider)),
   })
@@ -549,9 +619,51 @@ export async function listCodexModels(): Promise<{ id: string; name: string }[]>
   return (await getCodexCatalogModels()).map((m) => ({ id: m.id, name: m.name }))
 }
 
+export async function getXaiCatalogModels(): Promise<PiCatalogModel[]> {
+  const { getModels } = await loadPiAiCompat()
+  return [...getModels('xai')]
+}
+
+/**
+ * 为 xAI（Grok/X 订阅）OAuth 渠道构建 Pi 内置模型。
+ *
+ * xAI 的 device-code token 不等同于 xAI API key，必须注入内存 CredentialStore
+ * 并使用内置 `xai` provider，不能退回 registerProvider() 的 API key 路径。
+ */
+export async function buildXaiModel(sdk: PiSdk, input: XaiModelInput) {
+  if (!input.xaiOAuthCredentials || !input.channelId) {
+    throw new Error('xAI OAuth 凭据或渠道标识缺失，请重新登录')
+  }
+  const modelRuntime = await sdk.ModelRuntime.create({
+    credentials: createXaiRuntimeCredentialStore(
+      input.channelId,
+      input.xaiOAuthCredentials,
+      input.onXaiOAuthCredentialsRefreshed,
+    ),
+    allowModelNetwork: false,
+  })
+  const resolvedModelId = stripAgentSdkContextSuffix(input.model)
+  const xaiModels = await getXaiCatalogModels()
+  const model = (resolvedModelId ? modelRuntime.getModel('xai', resolvedModelId) : undefined)
+    ?? (resolvedModelId ? findCatalogModelById(xaiModels, resolvedModelId) : undefined)
+    ?? modelRuntime.getModels('xai')[0]
+  if (!model) {
+    throw new Error('未找到可用的 xAI（Grok）模型，请确认订阅已授权并升级 Pi 运行时')
+  }
+  return { modelRuntime, model }
+}
+
+/** 列出 Pi SDK 内置的 xAI（Grok）模型 ID，供订阅登录后拉取模型使用。 */
+export async function listXaiModels(): Promise<{ id: string; name: string }[]> {
+  return (await getXaiCatalogModels()).map((m) => ({ id: m.id, name: m.name }))
+}
+
 export async function buildModel(sdk: PiSdk, input: PiAgentQueryOptions) {
   if (input.provider === 'openai-codex') {
     return buildCodexModel(sdk, input)
+  }
+  if (input.provider === 'xai') {
+    return buildXaiModel(sdk, input)
   }
   const providerName = `proma-${input.provider}-${input.sessionId}`
   const resolvedApiKey = resolvePiApiKey(input.provider, input.apiKey)

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -20,7 +20,7 @@ import { join, dirname } from 'node:path'
 import { accessSync, constants, existsSync, mkdirSync, realpathSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { app } from 'electron'
-import type { AgentRuntime, AgentSendInput, AgentMessage, AgentGenerateTitleInput, AgentProviderAdapter, AgentSessionMeta, CodexOAuthCredentials, TypedError, RetryAttempt, SDKMessage, SDKAssistantMessage, AgentStreamPayload, RewindSessionResult, ProviderType } from '@proma/shared'
+import type { AgentRuntime, AgentSendInput, AgentMessage, AgentGenerateTitleInput, AgentProviderAdapter, AgentSessionMeta, CodexOAuthCredentials, XaiOAuthCredentials, TypedError, RetryAttempt, SDKMessage, SDKAssistantMessage, AgentStreamPayload, RewindSessionResult, ProviderType } from '@proma/shared'
 import {
   PROMA_DEFAULT_PERMISSION_MODE,
   PROMA_PERMISSION_MODE_CONFIG,
@@ -43,7 +43,7 @@ import type { PiAgentQueryOptions } from './adapters/pi-agent-adapter'
 import { getPiAssistantErrorDetails, hasPiAssistantTextContent, stripPiAssistantError } from './adapters/pi-message-adapter'
 import { isTransientNetworkError, isMalformedResponseError, isSessionNotFoundError } from './error-patterns'
 import { AgentEventBus } from './agent-event-bus'
-import { decryptApiKey, getChannelById, listChannels, persistCodexOAuthCredentials, resolveChannelRuntimeApiKey, resolveCodexOAuthCredentials } from './channel-manager'
+import { decryptApiKey, getChannelById, listChannels, persistCodexOAuthCredentials, persistXaiOAuthCredentials, resolveChannelRuntimeApiKey, resolveCodexOAuthCredentials, resolveXaiOAuthCredentials } from './channel-manager'
 import { getAdapter, fetchTitle, normalizeAnthropicBaseUrlForSdk, getPromaUserAgent } from '@proma/core'
 import pkg from '../../../package.json' with { type: 'json' }
 import { getFetchFn } from './proxy-fetch'
@@ -630,6 +630,12 @@ export class AgentOrchestrator {
       return null
     }
 
+    if (channel.provider === 'xai') {
+      // xAI subscription uses Pi's provider-specific OAuth transport; title generation's
+      // generic channel adapter only understands API keys, so retain a local deterministic title.
+      return createFallbackTitle(userMessage)
+    }
+
     if (channel.provider === 'openai-codex') {
       const fallbackTitle = createFallbackTitle(userMessage)
       try {
@@ -1063,21 +1069,28 @@ export class AgentOrchestrator {
 
     let apiKey: string
     let codexOAuthCredentials: CodexOAuthCredentials | undefined
+    let xaiOAuthCredentials: XaiOAuthCredentials | undefined
     try {
-      // ChatGPT (Codex) OAuth 渠道必须保留完整凭据给 Pi runtime，才能按真实
-      // expires 刷新；其余渠道只需解密 API Key。
+      // 订阅 OAuth 渠道必须保留完整凭据给 Pi runtime，才能在执行中按真实 expires
+      // 自动刷新；其余渠道只需解密 API Key。
       if (channel.provider === 'openai-codex') {
         codexOAuthCredentials = await resolveCodexOAuthCredentials(channelId)
         apiKey = codexOAuthCredentials.access
+      } else if (channel.provider === 'xai') {
+        xaiOAuthCredentials = await resolveXaiOAuthCredentials(channelId)
+        apiKey = xaiOAuthCredentials.access
       } else {
         apiKey = decryptApiKey(channelId)
       }
     } catch (err) {
-      if (channel.provider === 'openai-codex') {
+      if (channel.provider === 'openai-codex' || channel.provider === 'xai') {
+        const isXai = channel.provider === 'xai'
         reportPreflightError({
           code: 'expired_oauth_token',
-          title: 'ChatGPT 登录已失效',
-          message: '无法刷新 ChatGPT 登录凭据，登录可能已过期或被撤销。请在设置中重新登录 ChatGPT。',
+          title: isXai ? 'xAI 登录已失效' : 'ChatGPT 登录已失效',
+          message: isXai
+            ? '无法刷新 xAI 登录凭据，登录可能已过期或被撤销。请在设置中重新登录 xAI。'
+            : '无法刷新 ChatGPT 登录凭据，登录可能已过期或被撤销。请在设置中重新登录 ChatGPT。',
           actions: [
             { key: 's', label: '打开渠道设置', action: 'open_channel_settings' },
           ],
@@ -1767,6 +1780,7 @@ export class AgentOrchestrator {
         apiKey,
         baseUrl: channel.baseUrl,
         provider: channel.provider,
+        channelId,
         channelName: channel.name,
         proxyUrl,
         runtimeEnv,
@@ -1788,7 +1802,13 @@ export class AgentOrchestrator {
             persistCodexOAuthCredentials(channelId, credentials)
           },
         }),
-        ...((channel.provider === 'openai-codex' || channel.provider === 'openai-responses' || channel.provider === 'openai' || channel.provider === 'custom')
+        ...(xaiOAuthCredentials && {
+          xaiOAuthCredentials,
+          onXaiOAuthCredentialsRefreshed: (credentials: XaiOAuthCredentials) => {
+            persistXaiOAuthCredentials(channelId, credentials)
+          },
+        }),
+        ...((channel.provider === 'openai-codex' || channel.provider === 'xai' || channel.provider === 'openai-responses' || channel.provider === 'openai' || channel.provider === 'custom')
           && resolveReasoningProfile({
             modelId: selectedModelId,
             transport: inferReasoningTransport(channel.provider),

--- a/apps/electron/src/main/lib/channel-manager.ts
+++ b/apps/electron/src/main/lib/channel-manager.ts
@@ -21,6 +21,7 @@ import type {
   ChannelPlanQuotaResult,
   ChannelPlanQuotaWindow,
   CodexOAuthCredentials,
+  XaiOAuthCredentials,
   FetchModelsInput,
   FetchModelsResult,
   ProviderType,
@@ -32,10 +33,15 @@ import {
   parseCodexCredentials,
   serializeCodexCredentials,
   isCodexCredentialExpired,
+  parseXaiCredentials,
+  serializeXaiCredentials,
+  isXaiCredentialExpired,
 } from '@proma/shared'
 import { refreshCodexOAuth } from './codex-oauth-service'
+import { refreshXaiOAuth } from './xai-oauth-service'
+import { refreshXaiOAuthCredentialsSerial, rememberXaiOAuthCredentials } from './xai-oauth-credentials'
 import { parseCodexPlanQuotaResponse } from './codex-plan-quota'
-import { listCodexModels } from './adapters/pi-model-registry'
+import { listCodexModels, listXaiModels } from './adapters/pi-model-registry'
 import { getFetchFn } from './proxy-fetch'
 import { getEffectiveProxyUrl } from './proxy-settings-service'
 import {
@@ -495,6 +501,42 @@ export async function resolveCodexAccessToken(channelId: string): Promise<string
   return (await resolveCodexOAuthCredentials(channelId)).access
 }
 
+/** 保存 Pi 或 Proma 刷新后的完整 xAI OAuth 凭据。 */
+export function persistXaiOAuthCredentials(channelId: string, credentials: XaiOAuthCredentials): void {
+  const channel = getChannelById(channelId)
+  if (!channel || channel.provider !== 'xai') {
+    throw new Error(`xAI 渠道不存在或类型不匹配: ${channelId}`)
+  }
+  updateChannel(channelId, { apiKey: serializeXaiCredentials(credentials) })
+  rememberXaiOAuthCredentials(channelId, credentials, true)
+}
+
+/** 解析 xAI（Grok/X 订阅）凭据，按 expiry 刷新并回写加密渠道存储。 */
+export async function resolveXaiOAuthCredentials(channelId: string): Promise<XaiOAuthCredentials> {
+  const config = readConfig()
+  const channel = config.channels.find((c) => c.id === channelId)
+  if (!channel || channel.provider !== 'xai') {
+    throw new Error('xAI 订阅渠道不存在或类型不匹配')
+  }
+  const credentials = parseXaiCredentials(decryptKey(channel.apiKey))
+  if (!credentials) throw new Error('xAI 登录凭据无效或缺失，请重新登录')
+  if (!isXaiCredentialExpired(credentials)) {
+    return rememberXaiOAuthCredentials(channelId, credentials)
+  }
+
+  const refreshed = await refreshXaiOAuthCredentialsSerial(
+    channelId,
+    credentials,
+    (current) => refreshXaiOAuth(current.refresh),
+  )
+  persistXaiOAuthCredentials(channelId, refreshed)
+  return refreshed
+}
+
+export async function resolveXaiAccessToken(channelId: string): Promise<string> {
+  return (await resolveXaiOAuthCredentials(channelId)).access
+}
+
 /**
  * 解析渠道运行时实际使用的认证 token。
  *
@@ -507,9 +549,9 @@ export async function resolveChannelRuntimeApiKey(channelId: string): Promise<st
     throw new Error(`渠道不存在: ${channelId}`)
   }
 
-  return channel.provider === 'openai-codex'
-    ? resolveCodexAccessToken(channelId)
-    : decryptApiKey(channelId)
+  if (channel.provider === 'openai-codex') return resolveCodexAccessToken(channelId)
+  if (channel.provider === 'xai') return resolveXaiAccessToken(channelId)
+  return decryptApiKey(channelId)
 }
 
 /**
@@ -1614,6 +1656,7 @@ export async function fetchModels(input: FetchModelsInput): Promise<FetchModelsR
       case 'qwen-anthropic':
       case 'qwen-token-plan':
       case 'openai-codex':
+      case 'xai':
         if (provider === 'openai-codex') {
           // ChatGPT (Codex) 走 Pi SDK 内置模型目录，不依赖 baseUrl/apiKey。
           const codexModels = await listCodexModels()
@@ -1621,6 +1664,14 @@ export async function fetchModels(input: FetchModelsInput): Promise<FetchModelsR
             success: true,
             message: `已加载 ${codexModels.length} 个 ChatGPT (Codex) 模型`,
             models: codexModels.map((m) => ({ id: m.id, name: m.name, enabled: true, source: 'fetched' as const })),
+          }
+        }
+        if (provider === 'xai') {
+          const xaiModels = await listXaiModels()
+          return {
+            success: true,
+            message: `已加载 ${xaiModels.length} 个 xAI（Grok）模型`,
+            models: xaiModels.map((m) => ({ id: m.id, name: m.name, enabled: true, source: 'fetched' as const })),
           }
         }
         if (provider === 'deepseek') {

--- a/apps/electron/src/main/lib/chat-service.ts
+++ b/apps/electron/src/main/lib/chat-service.ts
@@ -211,13 +211,14 @@ export async function sendMessage(
     return
   }
 
-  // Codex OAuth uses the ChatGPT-specific Responses protocol, which Chat does
+  // Subscription OAuth uses Pi provider-specific transports, which Chat mode does
   // not currently implement. Keep this guard for historical conversations that
-  // still reference a formerly selectable Codex model.
-  if (channel.provider === 'openai-codex') {
+  // still reference a formerly selectable subscription model.
+  if (channel.provider === 'openai-codex' || channel.provider === 'xai') {
+    const providerName = channel.provider === 'xai' ? 'xAI（Grok OAuth）' : 'ChatGPT 订阅（Codex OAuth）'
     webContents.send(CHAT_IPC_CHANNELS.STREAM_ERROR, {
       conversationId,
-      error: 'Chat 模式暂不支持 ChatGPT 订阅（Codex OAuth），请切换到 Agent 模式使用。',
+      error: `Chat 模式暂不支持 ${providerName}，请切换到 Agent 模式使用。`,
     })
     return
   }

--- a/apps/electron/src/main/lib/xai-oauth-credentials.ts
+++ b/apps/electron/src/main/lib/xai-oauth-credentials.ts
@@ -1,0 +1,62 @@
+/**
+ * 跨 Pi Agent query 的 xAI OAuth refresh 协调器。
+ *
+ * Pi 为每次 query 创建独立 CredentialStore；xAI 可能轮换 refresh token，因此
+ * 必须按 Proma channelId 串行刷新，避免并行会话各自消费旧 refresh token。
+ */
+
+import type { XaiOAuthCredentials } from '@proma/shared'
+
+const inflightCredentialRefreshes = new Map<string, Promise<XaiOAuthCredentials>>()
+const latestCredentialsByChannel = new Map<string, XaiOAuthCredentials>()
+
+/**
+ * 记录最新凭据。持久化写入调用方应传 force=true；新建 query 的旧快照不会覆盖
+ * 已被另一个运行中 query 刷新的凭据。
+ */
+export function rememberXaiOAuthCredentials(
+  channelId: string,
+  credentials: XaiOAuthCredentials,
+  force = false,
+): XaiOAuthCredentials {
+  const existing = latestCredentialsByChannel.get(channelId)
+  if (force || !existing || credentials.expires > existing.expires) {
+    latestCredentialsByChannel.set(channelId, credentials)
+    return credentials
+  }
+  return existing
+}
+
+/**
+ * 用同一个 channelId 串行刷新 xAI OAuth，并让并发调用复用刚换出的凭据。
+ * refresh 回调只会由真正发起刷新的一方执行。
+ */
+export async function refreshXaiOAuthCredentialsSerial(
+  channelId: string,
+  fallback: XaiOAuthCredentials,
+  refresh: (credentials: XaiOAuthCredentials) => Promise<XaiOAuthCredentials>,
+): Promise<XaiOAuthCredentials> {
+  const inflight = inflightCredentialRefreshes.get(channelId)
+  if (inflight) return inflight
+
+  const latest = latestCredentialsByChannel.get(channelId)
+  if (latest
+    && (latest.access !== fallback.access || latest.refresh !== fallback.refresh)
+    && latest.expires > Date.now()) {
+    return latest
+  }
+
+  const refreshPromise = (async () => {
+    const current = latestCredentialsByChannel.get(channelId) ?? fallback
+    const refreshed = await refresh(current)
+    return rememberXaiOAuthCredentials(channelId, refreshed, true)
+  })()
+  inflightCredentialRefreshes.set(channelId, refreshPromise)
+  try {
+    return await refreshPromise
+  } finally {
+    if (inflightCredentialRefreshes.get(channelId) === refreshPromise) {
+      inflightCredentialRefreshes.delete(channelId)
+    }
+  }
+}

--- a/apps/electron/src/main/lib/xai-oauth-service.ts
+++ b/apps/electron/src/main/lib/xai-oauth-service.ts
@@ -1,0 +1,122 @@
+/**
+ * xAI（Grok/X 订阅）OAuth 登录服务。
+ *
+ * 复用 Pi SDK 的内置 xAI device-code OAuth：浏览器打开带预填授权码的 xAI
+ * 授权链接，用户确认后 SDK 轮询换取 access/refresh token。凭据由调用方用
+ * Channel.apiKey + Electron safeStorage 加密持久化；本服务绝不写入 ~/.pi。
+ */
+
+import { shell } from 'electron'
+import type { XaiOAuthCredentials, XaiOAuthDeviceCode } from '@proma/shared'
+
+type PiSdk = typeof import('@earendil-works/pi-coding-agent')
+type OAuthCredential = XaiOAuthCredentials & { type: 'oauth'; [key: string]: unknown }
+
+let piSdkPromise: Promise<PiSdk> | undefined
+let activeLoginAbort: AbortController | undefined
+
+function loadPiSdk(): Promise<PiSdk> {
+  piSdkPromise ??= import('@earendil-works/pi-coding-agent')
+  return piSdkPromise
+}
+
+/** Pi ModelRuntime 所需的最小内存 CredentialStore。 */
+function createEphemeralCredentialStore(initial?: OAuthCredential) {
+  let credential = initial
+  return {
+    async read(providerId: string): Promise<OAuthCredential | undefined> {
+      return providerId === 'xai' ? credential : undefined
+    },
+    async list(): Promise<readonly { providerId: string; type: 'oauth' }[]> {
+      return credential ? [{ providerId: 'xai', type: 'oauth' }] : []
+    },
+    async modify(
+      providerId: string,
+      fn: (current: OAuthCredential | undefined) => Promise<OAuthCredential | undefined>,
+    ): Promise<OAuthCredential | undefined> {
+      if (providerId !== 'xai') return undefined
+      credential = await fn(credential)
+      return credential
+    },
+    async delete(providerId: string): Promise<void> {
+      if (providerId === 'xai') credential = undefined
+    },
+  }
+}
+
+function normalizeCredentials(value: unknown): XaiOAuthCredentials {
+  if (!value || typeof value !== 'object') throw new Error('Pi OAuth 未返回有效 xAI 凭据')
+  const credential = value as Partial<OAuthCredential>
+  if (typeof credential.access !== 'string' || typeof credential.refresh !== 'string' || typeof credential.expires !== 'number') {
+    throw new Error('Pi OAuth 返回的 xAI 凭据缺少 access、refresh 或 expires')
+  }
+  return { access: credential.access, refresh: credential.refresh, expires: credential.expires }
+}
+
+export interface XaiLoginCallbacks {
+  /** 将 device code 推送到 UI，供浏览器未预填时手动填写。 */
+  onDeviceCode?: (deviceCode: XaiOAuthDeviceCode) => void
+}
+
+/**
+ * 通过系统浏览器登录 SuperGrok 或 X Premium。
+ *
+ * Pi 产生 device_code 事件时，verificationUri 已优先使用预填链接；同时把 code
+ * 回传给 UI，确保浏览器未预填时也能完成授权。流程可由 cancelXaiOAuthLogin 中止。
+ */
+export async function loginXaiOAuth(callbacks?: XaiLoginCallbacks): Promise<XaiOAuthCredentials> {
+  const sdk = await loadPiSdk()
+  activeLoginAbort?.abort()
+  const abort = new AbortController()
+  activeLoginAbort = abort
+
+  try {
+    const runtime = await sdk.ModelRuntime.create({
+      credentials: createEphemeralCredentialStore(),
+      allowModelNetwork: false,
+    })
+    const credentials = await runtime.login('xai', 'oauth', {
+      signal: abort.signal,
+      // xAI 的内置 OAuth 直接走 device code，不会向此 callback 提问；保留拒绝路径
+      // 以便上游未来增加交互时不会无限挂起。
+      prompt: async (prompt) => new Promise<string>((_resolve, reject) => {
+        const cancel = () => reject(new Error('登录已取消'))
+        prompt.signal?.addEventListener('abort', cancel, { once: true })
+        abort.signal.addEventListener('abort', cancel, { once: true })
+      }),
+      notify: (event) => {
+        if (event.type === 'device_code') {
+          console.log(`[xAI OAuth] 请在浏览器中授权（设备码：${event.userCode}）`)
+          callbacks?.onDeviceCode?.({ userCode: event.userCode, verificationUri: event.verificationUri })
+          shell.openExternal(event.verificationUri).catch((error) => {
+            console.error('[xAI OAuth] 打开授权页面失败:', error)
+          })
+        } else if (event.type === 'progress' || event.type === 'info') {
+          console.log(`[xAI OAuth] ${event.message}`)
+        }
+      },
+    })
+    return normalizeCredentials(credentials)
+  } finally {
+    if (activeLoginAbort === abort) activeLoginAbort = undefined
+  }
+}
+
+export function cancelXaiOAuthLogin(): void {
+  activeLoginAbort?.abort()
+  activeLoginAbort = undefined
+}
+
+/** 通过 Pi 内置 xAI provider 刷新 token。 */
+export async function refreshXaiOAuth(refreshToken: string): Promise<XaiOAuthCredentials> {
+  const sdk = await loadPiSdk()
+  const store = createEphemeralCredentialStore({
+    type: 'oauth',
+    access: '',
+    refresh: refreshToken,
+    expires: 0,
+  })
+  const runtime = await sdk.ModelRuntime.create({ credentials: store, allowModelNetwork: false })
+  await runtime.getAuth('xai')
+  return normalizeCredentials(await store.read('xai'))
+}

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -20,6 +20,8 @@ import type {
   FetchModelsResult,
   ChannelPlanQuotaResult,
   CodexOAuthLoginResult,
+  XaiOAuthLoginResult,
+  XaiOAuthDeviceCode,
   ConversationMeta,
   ChatMessage,
   ChatSendInput,
@@ -256,6 +258,15 @@ export interface ElectronAPI {
 
   /** 取消进行中的 ChatGPT (Codex) OAuth 登录 */
   codexOAuthCancel: () => Promise<void>
+
+  /** 发起 xAI（Grok/X 订阅）OAuth 登录 */
+  xaiOAuthLogin: () => Promise<XaiOAuthLoginResult>
+
+  /** 取消进行中的 xAI OAuth 登录 */
+  xaiOAuthCancel: () => Promise<void>
+
+  /** 订阅登录期间，接收 xAI device code 与授权链接。返回取消订阅函数。 */
+  onXaiOAuthDeviceCode: (callback: (deviceCode: XaiOAuthDeviceCode) => void) => () => void
 
   // ===== 对话管理相关 =====
 
@@ -1309,6 +1320,20 @@ const electronAPI: ElectronAPI = {
 
   codexOAuthCancel: () => {
     return ipcRenderer.invoke(CHANNEL_IPC_CHANNELS.CODEX_OAUTH_CANCEL)
+  },
+
+  xaiOAuthLogin: () => {
+    return ipcRenderer.invoke(CHANNEL_IPC_CHANNELS.XAI_OAUTH_LOGIN)
+  },
+
+  xaiOAuthCancel: () => {
+    return ipcRenderer.invoke(CHANNEL_IPC_CHANNELS.XAI_OAUTH_CANCEL)
+  },
+
+  onXaiOAuthDeviceCode: (callback: (deviceCode: XaiOAuthDeviceCode) => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, deviceCode: XaiOAuthDeviceCode) => callback(deviceCode)
+    ipcRenderer.on(CHANNEL_IPC_CHANNELS.XAI_OAUTH_DEVICE_CODE, listener)
+    return () => ipcRenderer.removeListener(CHANNEL_IPC_CHANNELS.XAI_OAUTH_DEVICE_CODE, listener)
   },
 
   // 对话管理

--- a/apps/electron/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatInput.tsx
@@ -318,7 +318,7 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
   }, [])
 
   const toolbarItems = React.useMemo<ToolbarItem[]>(() => [
-    { key: 'model', node: <ModelSelector excludedProviders={['openai-codex']} useSharedOpenState /> },
+    { key: 'model', node: <ModelSelector excludedProviders={['openai-codex', 'xai']} useSharedOpenState /> },
     {
       key: 'thinking',
       node: (

--- a/apps/electron/src/renderer/components/settings/ChannelForm.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelForm.tsx
@@ -35,6 +35,7 @@ import {
   isAgentCompatibleProvider,
   parseZhipuTeamCredentials,
   parseCodexCredentials,
+  parseXaiCredentials,
 } from '@proma/shared'
 import type {
   Channel,
@@ -43,6 +44,7 @@ import type {
   ChannelTestResult,
   FetchModelsResult,
   ProviderType,
+  XaiOAuthDeviceCode,
 } from '@proma/shared'
 import {
   normalizeBaseUrl,
@@ -79,7 +81,7 @@ interface ChannelFormProps {
 }
 
 /** 所有可选供应商 */
-const PROVIDER_OPTIONS: ProviderType[] = ['anthropic', 'anthropic-compatible', 'openai', 'openai-responses', 'openai-codex', 'deepseek', 'google', 'kimi-api', 'kimi-coding', 'opencode-go-openai', 'zhipu', 'zhipu-coding', 'zhipu-coding-team', 'ark-coding-plan', 'minimax', 'doubao', 'qwen', 'qwen-anthropic', 'qwen-token-plan', 'xiaomi', 'xiaomi-token-plan', 'custom']
+const PROVIDER_OPTIONS: ProviderType[] = ['anthropic', 'anthropic-compatible', 'openai', 'openai-responses', 'openai-codex', 'xai', 'deepseek', 'google', 'kimi-api', 'kimi-coding', 'opencode-go-openai', 'zhipu', 'zhipu-coding', 'zhipu-coding-team', 'ark-coding-plan', 'minimax', 'doubao', 'qwen', 'qwen-anthropic', 'qwen-token-plan', 'xiaomi', 'xiaomi-token-plan', 'custom']
 
 /** 需要用 messages 端点测试的供应商预设模型 */
 const PROVIDER_TEST_MODEL_PRESETS: Partial<Record<ProviderType, string[]>> = {
@@ -235,13 +237,29 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
   const [showBaseUrlRiskDialog, setShowBaseUrlRiskDialog] = React.useState(false)
   const [pendingRiskAction, setPendingRiskAction] = React.useState<'auto-save' | 'create' | 'fetch' | 'save-and-close' | 'test' | null>(null)
   const [codexLoggingIn, setCodexLoggingIn] = React.useState(false)
+  const [xaiLoggingIn, setXaiLoggingIn] = React.useState(false)
+  const [xaiDeviceCode, setXaiDeviceCode] = React.useState<XaiOAuthDeviceCode | null>(null)
 
   const setChannelFormDirty = useSetAtom(channelFormDirtyAtom)
   const lastAgentEligibleRef = React.useRef(channel ? isAgentEligibleChannel(channel) : false)
+  const xaiLoggingInRef = React.useRef(false)
 
   React.useEffect(() => {
     lastAgentEligibleRef.current = channel ? isAgentEligibleChannel(channel) : false
   }, [channel])
+
+  React.useEffect(() => {
+    xaiLoggingInRef.current = xaiLoggingIn
+  }, [xaiLoggingIn])
+
+  React.useEffect(() => {
+    return window.electronAPI.onXaiOAuthDeviceCode(setXaiDeviceCode)
+  }, [])
+
+  // 关闭或放弃表单时取消仍在轮询的 device-code 授权，避免后台孤立请求。
+  React.useEffect(() => () => {
+    if (xaiLoggingInRef.current) void window.electronAPI.xaiOAuthCancel()
+  }, [])
 
   /** 编辑模式下加载明文 API Key */
   React.useEffect(() => {
@@ -261,14 +279,19 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
 
   const isZhipuTeamProvider = provider === 'zhipu-coding-team'
   const isCodexProvider = provider === 'openai-codex'
+  const isXaiProvider = provider === 'xai'
+  const isSubscriptionProvider = isCodexProvider || isXaiProvider
   const effectiveApiKey = isZhipuTeamProvider ? buildZhipuTeamSecret(zhipuTeamSecret) : apiKey
-  // ChatGPT (Codex)：apiKey state 存的是登录后拿到的凭据 JSON；能解析出有效凭据即视为已登录。
+  // 订阅渠道的 apiKey state 存的是登录后拿到的凭据 JSON；能解析出有效凭据即视为已登录。
   const codexCredentials = isCodexProvider ? parseCodexCredentials(apiKey) : null
+  const xaiCredentials = isXaiProvider ? parseXaiCredentials(apiKey) : null
   const hasRequiredSecret = isZhipuTeamProvider
     ? Boolean(zhipuTeamSecret.apiKey.trim())
     : isCodexProvider
       ? Boolean(codexCredentials)
-      : Boolean(apiKey.trim())
+      : isXaiProvider
+        ? Boolean(xaiCredentials)
+        : Boolean(apiKey.trim())
   const requiresBaseUrlRiskAcknowledgement = isThirdPartyBaseUrl(provider, baseUrl)
     && normalizeBaseUrl(baseUrl) !== acknowledgedBaseUrl
 
@@ -541,10 +564,84 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
     }
   }
 
+  const handleCancelXaiLogin = (): void => {
+    void window.electronAPI.xaiOAuthCancel()
+    setXaiDeviceCode(null)
+  }
+
+  /** 发起 xAI（Grok/X 订阅）OAuth 登录：Pi 打开预填 device-code 浏览器授权页。 */
+  const handleXaiLogin = async (): Promise<void> => {
+    setXaiLoggingIn(true)
+    setXaiDeviceCode(null)
+    setTestResult(null)
+    try {
+      const result = await window.electronAPI.xaiOAuthLogin()
+      if (!result.success || !result.credentials) {
+        toast.error(result.message ?? 'xAI 登录失败，请重试')
+        return
+      }
+      const credentials = result.credentials
+      setApiKey(credentials)
+
+      let xaiModels: ChannelModel[] = []
+      try {
+        const modelsResult = await window.electronAPI.fetchModels({ provider, baseUrl, apiKey: credentials })
+        setFetchResult(modelsResult)
+        if (modelsResult.success && modelsResult.models.length > 0) {
+          xaiModels = modelsResult.models.map((model) => ({ ...model, enabled: true }))
+          setModels(xaiModels)
+        }
+      } catch (modelErr) {
+        console.error('[模型配置表单] 拉取 xAI 模型失败:', modelErr)
+      }
+
+      // OAuth 登录成功即明确保存意图。编辑模式也立即写入，不能依赖 600ms 的
+      // auto-save，避免用户立刻关闭表单而丢失 refresh token。
+      const savedModels = xaiModels.length > 0 ? xaiModels : models
+      if (isEdit && channel) {
+        const saved = await window.electronAPI.updateChannel(channel.id, {
+          name,
+          provider,
+          baseUrl,
+          apiKey: credentials,
+          models: savedModels,
+          enabled,
+        })
+        const eligible = isAgentEligibleChannel(saved)
+        if (eligible !== lastAgentEligibleRef.current) {
+          lastAgentEligibleRef.current = eligible
+          await onAgentEligibilityChange?.(saved, eligible)
+        }
+        toast.success('xAI 登录成功')
+      } else {
+        const input: ChannelCreateInput = {
+          name: name.trim() || PROVIDER_LABELS.xai,
+          provider,
+          baseUrl,
+          apiKey: credentials,
+          models: savedModels,
+          enabled,
+        }
+        const saved = await window.electronAPI.createChannel(input)
+        if (isAgentEligibleChannel(saved)) {
+          await onAgentEligibilityChange?.(saved, true)
+        }
+        toast.success('xAI 渠道已创建')
+        onSaved(saved)
+      }
+    } catch (error) {
+      console.error('[模型配置表单] xAI 登录失败:', error)
+      toast.error('xAI 登录失败，请重试')
+    } finally {
+      setXaiLoggingIn(false)
+      setXaiDeviceCode(null)
+    }
+  }
+
   /** 从供应商 API 拉取可用模型列表。 */
   const fetchAvailableModels = async (): Promise<void> => {
-    // ChatGPT (Codex) 走 SDK 内置目录，不依赖 baseUrl；其余 provider 仍要求 baseUrl。
-    if (!hasRequiredSecret || (!isCodexProvider && !baseUrl.trim())) return
+    // 订阅 provider 走 Pi SDK 内置目录，不依赖 baseUrl；其余 provider 仍要求 baseUrl。
+    if (!hasRequiredSecret || (!isSubscriptionProvider && !baseUrl.trim())) return
 
     setFetchingModels(true)
     setFetchResult(null)
@@ -574,7 +671,7 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
           // ChatGPT (Codex) 是 SDK 内置的少量精选模型，拉取即全部启用，
           // 与登录自动拉取路径（handleCodexLogin）保持一致，避免新模型（如 gpt-5.6 系列）
           // 默认未启用而沉到「可用模型」折叠区，被误认为"拉不到"。
-          if (isCodexProvider) return { ...m, enabled: true }
+          if (isSubscriptionProvider) return { ...m, enabled: true }
           return old ? { ...m, enabled: old.enabled } : { ...m, enabled: false }
         })
         return [...manualKept, ...merged]
@@ -596,7 +693,7 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
 
   /** 测试连接（直接使用表单当前值，无需先保存）。 */
   const testChannelConnection = async (): Promise<void> => {
-    if (!hasRequiredSecret || !baseUrl.trim()) return
+    if (!hasRequiredSecret || !baseUrl.trim() || isSubscriptionProvider) return
 
     setTesting(true)
     setTestResult(null)
@@ -820,8 +917,8 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
             placeholder="例如: My Anthropic"
             required
           />
-          {/* ChatGPT (Codex) 的请求地址由 Pi SDK 内置管理，无需用户填写 */}
-          {!isCodexProvider && (
+          {/* 订阅 provider 的请求地址由 Pi SDK 内置管理，无需用户填写 */}
+          {!isSubscriptionProvider && (
             <SettingsInput
               label={getUrlInputLabel(provider)}
               value={baseUrl}
@@ -835,10 +932,10 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
           <div className="px-4 py-3 space-y-2">
             <div className="flex items-center justify-between">
               <div className="text-sm font-medium text-foreground">
-                {isCodexProvider ? 'ChatGPT 登录' : isZhipuTeamProvider ? '智谱团队版凭证' : 'API Key'}
+                {isCodexProvider ? 'ChatGPT 登录' : isXaiProvider ? 'xAI 登录' : isZhipuTeamProvider ? '智谱团队版凭证' : 'API Key'}
               </div>
-              {/* codex 无 baseUrl/apiKey，测试连接不适用，隐藏测试按钮 */}
-              {!isCodexProvider && (
+              {/* 订阅 OAuth 无标准 API Key 测试路径，隐藏测试按钮 */}
+              {!isSubscriptionProvider && (
                 <Button
                   variant="outline"
                   size="sm"
@@ -866,32 +963,48 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
                   disabled={codexLoggingIn}
                   className="w-full"
                 >
-                  {codexLoggingIn ? (
-                    <Loader2 size={14} className="animate-spin" />
-                  ) : (
-                    <Zap size={14} />
-                  )}
-                  <span>
-                    {codexLoggingIn
-                      ? '等待浏览器授权…'
-                      : hasRequiredSecret
-                        ? '重新登录 ChatGPT'
-                        : '用 ChatGPT 登录'}
-                  </span>
+                  {codexLoggingIn ? <Loader2 size={14} className="animate-spin" /> : <Zap size={14} />}
+                  <span>{codexLoggingIn ? '等待浏览器授权…' : hasRequiredSecret ? '重新登录 ChatGPT' : '用 ChatGPT 登录'}</span>
                 </Button>
                 {hasRequiredSecret ? (
                   <div className="flex items-center gap-1.5 text-xs text-emerald-600">
                     <CheckCircle2 size={12} className="shrink-0" />
-                    <span>
-                      已登录 ChatGPT 订阅
-                      {codexCredentials?.accountId ? `（账号 ${codexCredentials.accountId.slice(0, 8)}…）` : ''}
-                    </span>
+                    <span>已登录 ChatGPT 订阅{codexCredentials?.accountId ? `（账号 ${codexCredentials.accountId.slice(0, 8)}…）` : ''}</span>
                   </div>
-                ) : (
-                  <div className="text-xs text-muted-foreground">
-                    使用 ChatGPT Plus/Pro 订阅登录，通过 OAuth 授权，无需 API Key。授权将在系统浏览器中打开。
+                ) : <div className="text-xs text-muted-foreground">使用 ChatGPT Plus/Pro 订阅登录，通过 OAuth 授权，无需 API Key。授权将在系统浏览器中打开。</div>}
+              </div>
+            ) : isXaiProvider ? (
+              <div className="space-y-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  type="button"
+                  onClick={handleXaiLogin}
+                  disabled={xaiLoggingIn}
+                  className="w-full"
+                >
+                  {xaiLoggingIn ? <Loader2 size={14} className="animate-spin" /> : <Zap size={14} />}
+                  <span>{xaiLoggingIn ? '等待浏览器授权…' : hasRequiredSecret ? '重新登录 xAI' : '用 xAI 登录'}</span>
+                </Button>
+                {xaiLoggingIn && (
+                  <Button variant="ghost" size="sm" type="button" onClick={handleCancelXaiLogin} className="w-full text-muted-foreground">
+                    取消登录
+                  </Button>
+                )}
+                {xaiDeviceCode && (
+                  <div className="rounded-md border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground space-y-1.5">
+                    <div>若浏览器未自动填入授权码，请输入：<span className="font-mono font-medium text-foreground">{xaiDeviceCode.userCode}</span></div>
+                    <a href={xaiDeviceCode.verificationUri} target="_blank" rel="noreferrer" className="text-primary hover:underline">
+                      打开 xAI 授权页面
+                    </a>
                   </div>
                 )}
+                {hasRequiredSecret ? (
+                  <div className="flex items-center gap-1.5 text-xs text-emerald-600">
+                    <CheckCircle2 size={12} className="shrink-0" />
+                    <span>已登录 xAI（Grok）订阅</span>
+                  </div>
+                ) : <div className="text-xs text-muted-foreground">使用 SuperGrok 或 X Premium 订阅登录，通过 OAuth 授权，无需 API Key。授权将在系统浏览器中打开。</div>}
               </div>
             ) : isZhipuTeamProvider ? (
               <div className="space-y-2">
@@ -1028,7 +1141,7 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
             size="sm"
             type="button"
             onClick={handleFetchModels}
-            disabled={fetchingModels || !hasRequiredSecret || (!isCodexProvider && !baseUrl.trim())}
+            disabled={fetchingModels || !hasRequiredSecret || (!isSubscriptionProvider && !baseUrl.trim())}
             className="h-7 text-xs"
           >
             {fetchingModels ? (

--- a/apps/electron/src/renderer/lib/model-logo.ts
+++ b/apps/electron/src/renderer/lib/model-logo.ts
@@ -256,6 +256,7 @@ const PROVIDER_LOGO_MAP: Record<ProviderType, string> = {
   xiaomi: XiaomiLogo,
   'xiaomi-token-plan': XiaomiLogo,
   'openai-codex': OpenAILogo,
+  xai: GrokLogo,
   custom: DefaultLogo,
 }
 

--- a/packages/shared/src/types/channel.ts
+++ b/packages/shared/src/types/channel.ts
@@ -30,6 +30,7 @@ export type ProviderType =
   | 'xiaomi'
   | 'xiaomi-token-plan'
   | 'openai-codex'
+  | 'xai'
   /**
    * OpenAI Chat Completions 的自定义请求地址。
    *
@@ -63,8 +64,9 @@ export const PROVIDER_DEFAULT_URLS: Record<ProviderType, string> = {
   'qwen-token-plan': 'https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic/v1/messages',
   xiaomi: 'https://api.xiaomimimo.com/anthropic',
   'xiaomi-token-plan': 'https://token-plan-cn.xiaomimimo.com/anthropic',
-  // ChatGPT 订阅登录：baseUrl 由 Pi SDK 内部管理（登录后从 OAuth token 派生），无需用户填写。
+  // 订阅登录渠道的 baseUrl 由 Pi SDK 内部管理，无需用户填写。
   'openai-codex': '',
+  xai: '',
   custom: '',
 }
 
@@ -93,6 +95,7 @@ export const PROVIDER_LABELS: Record<ProviderType, string> = {
   xiaomi: '小米 MiMo (API)',
   'xiaomi-token-plan': '小米 MiMo Token Plan',
   'openai-codex': 'ChatGPT 订阅 (Codex)',
+  xai: 'xAI 订阅 (Grok)',
   custom: 'OpenAI Chat Completions（自定义地址）',
 }
 
@@ -238,6 +241,42 @@ export function parseCodexCredentials(secret: string): CodexOAuthCredentials | n
  * 避免边界请求打出去才发现过期。
  */
 export function isCodexCredentialExpired(credentials: CodexOAuthCredentials, skewMs = 60_000): boolean {
+  return Date.now() >= credentials.expires - skewMs
+}
+
+/**
+ * xAI（Grok/X 订阅）OAuth 凭据。
+ *
+ * 与 Codex 一样序列化后放入 Channel.apiKey，并由 Electron safeStorage 加密。
+ * Pi 的内置 xAI provider 使用 access / refresh / expires 来自动续期。
+ */
+export interface XaiOAuthCredentials {
+  access: string
+  refresh: string
+  expires: number
+}
+
+export function serializeXaiCredentials(credentials: XaiOAuthCredentials): string {
+  return JSON.stringify(credentials)
+}
+
+export function parseXaiCredentials(secret: string): XaiOAuthCredentials | null {
+  const trimmed = secret.trim()
+  if (!trimmed) return null
+  try {
+    const parsed = JSON.parse(trimmed) as Partial<XaiOAuthCredentials>
+    if (typeof parsed.access === 'string' && parsed.access
+      && typeof parsed.refresh === 'string' && parsed.refresh
+      && typeof parsed.expires === 'number') {
+      return { access: parsed.access, refresh: parsed.refresh, expires: parsed.expires }
+    }
+  } catch {
+    return null
+  }
+  return null
+}
+
+export function isXaiCredentialExpired(credentials: XaiOAuthCredentials, skewMs = 60_000): boolean {
   return Date.now() >= credentials.expires - skewMs
 }
 
@@ -451,6 +490,12 @@ export const CHANNEL_IPC_CHANNELS = {
   CODEX_OAUTH_LOGIN: 'channel:codex-oauth-login',
   /** 取消进行中的 ChatGPT OAuth 登录流程 */
   CODEX_OAUTH_CANCEL: 'channel:codex-oauth-cancel',
+  /** 发起 xAI（Grok/X 订阅）OAuth 登录 */
+  XAI_OAUTH_LOGIN: 'channel:xai-oauth-login',
+  /** 取消进行中的 xAI OAuth 登录流程 */
+  XAI_OAUTH_CANCEL: 'channel:xai-oauth-cancel',
+  /** xAI device-code 已就绪（主进程推送给发起登录的渲染窗口） */
+  XAI_OAUTH_DEVICE_CODE: 'channel:xai-oauth-device-code',
 } as const
 
 /**
@@ -471,4 +516,19 @@ export interface CodexOAuthLoginResult {
   accountId?: string
   /** 失败或取消时的用户可读原因 */
   message?: string
+}
+
+/** xAI（Grok/X 订阅）OAuth 登录结果。 */
+export interface XaiOAuthLoginResult {
+  success: boolean
+  /** 序列化后的 OAuth 凭据 JSON；由 channel-manager 加密写入 Channel.apiKey。 */
+  credentials?: string
+  /** 失败或取消时的用户可读原因 */
+  message?: string
+}
+
+/** Pi xAI device-code 登录流程的用户可见信息。 */
+export interface XaiOAuthDeviceCode {
+  userCode: string
+  verificationUri: string
 }

--- a/packages/shared/src/types/reasoning-profile.ts
+++ b/packages/shared/src/types/reasoning-profile.ts
@@ -25,6 +25,7 @@ export function inferReasoningTransport(provider: ProviderType | undefined): Rea
       return 'openai-completions'
     case 'openai-codex':
     case 'openai-responses':
+    case 'xai':
       return 'openai-responses'
     case 'google':
       return 'other'


### PR DESCRIPTION
## Summary

- Add xAI (Grok/X subscription) device-code OAuth login backed by Pi's native provider.
- Store and refresh OAuth credentials through Proma's encrypted channel storage.
- Keep this subscription path Agent-only, with model discovery and browser/manual-code UX.

## Validation

- `bun run typecheck`
- Manual Electron development verification
- Pi native `xai` credential-store smoke test

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)