### PR TITLE
Show active channel quota in collapsed island

### DIFF
--- a/apps/electron/native/agent-island/macos-agent-island-helper.swift
+++ b/apps/electron/native/agent-island/macos-agent-island-helper.swift
@@ -36,6 +36,7 @@ struct AgentState: Codable {
   let sessions: [AgentSession]
   let recentSessions: [AgentSession]
   let idleDashboard: Bool
+  let compactPlanQuota: CompactPlanQuota?
   let totalCount: Int
   let updatedAt: Double
 }
@@ -65,16 +66,25 @@ struct Planning: Codable {
 }
 
 struct PlanQuotaWindow: Codable {
+  let windowType: String?
   let windowLabel: String
   let remainingPercent: Double
   let remainingLabel: String?
 }
 
 struct PlanQuota: Codable, Identifiable {
+  let channelId: String
   let channelName: String
   let planName: String
   let windows: [PlanQuotaWindow]
-  var id: String { "\(channelName):\(planName)" }
+  var id: String { "\(channelId):\(planName)" }
+}
+
+struct CompactPlanQuota: Codable {
+  let channelName: String
+  let planName: String
+  let windows: [PlanQuotaWindow]
+  let additionalChannelCount: Int
 }
 
 struct SnapshotMessage: Codable {
@@ -314,11 +324,15 @@ struct PlanQuotaCarousel: View {
                 .font(.system(size: 10, weight: .semibold))
                 .foregroundStyle(.white.opacity(0.84))
                 .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: 78, alignment: .leading)
               if quota.planName != quota.channelName {
                 Text("· \(quota.planName)")
                   .font(.system(size: 9.5, weight: .medium))
                   .foregroundStyle(.white.opacity(0.44))
                   .lineLimit(1)
+                  .truncationMode(.tail)
+                  .frame(maxWidth: 108, alignment: .leading)
               }
               Spacer(minLength: 8)
               Text(quotaText(quota))
@@ -326,6 +340,7 @@ struct PlanQuotaCarousel: View {
                 .monospacedDigit()
                 .foregroundStyle(.white.opacity(0.9))
                 .lineLimit(1)
+                .layoutPriority(1)
             }
             .frame(height: 16)
           }
@@ -335,6 +350,45 @@ struct PlanQuotaCarousel: View {
         .transition(.opacity)
       }
     }
+  }
+}
+
+struct CompactPlanQuotaBadge: View {
+  let quota: CompactPlanQuota
+
+  private func shortLabel(_ window: PlanQuotaWindow) -> String {
+    switch window.windowType {
+    case "5h": return "5h"
+    case "weekly": return "周"
+    default: return window.windowLabel
+    }
+  }
+
+  private var detail: String {
+    quota.windows.prefix(2).map { window in
+      "\(shortLabel(window)) \(window.remainingLabel ?? "\(Int(window.remainingPercent.rounded()))%")"
+    }.joined(separator: " · ")
+  }
+
+  var body: some View {
+    HStack(spacing: 4) {
+      Text(detail)
+        .foregroundStyle(.white.opacity(0.92))
+        .lineLimit(1)
+        .truncationMode(.tail)
+      if quota.additionalChannelCount > 0 {
+        Text("+\(quota.additionalChannelCount)")
+          .foregroundStyle(Color(red: 0.65, green: 0.73, blue: 1))
+          .fontWeight(.bold)
+      }
+    }
+    .font(.system(size: 9, weight: .semibold))
+    .monospacedDigit()
+    .lineLimit(1)
+    .padding(.horizontal, 6)
+    .padding(.vertical, 4)
+    .background(.white.opacity(0.075), in: RoundedRectangle(cornerRadius: 6))
+    .frame(maxWidth: 142, alignment: .trailing)
   }
 }
 
@@ -393,6 +447,10 @@ struct CompactIslandView: View {
           .lineLimit(1)
           .foregroundStyle(.white.opacity(0.92))
         Spacer(minLength: 6)
+        if let quota = snapshot.state.compactPlanQuota {
+          CompactPlanQuotaBadge(quota: quota)
+            .layoutPriority(1)
+        }
         Image(systemName: "chevron.down")
           .font(.system(size: 9, weight: .semibold))
           .foregroundStyle(.white.opacity(0.46))

--- a/apps/electron/native/agent-island/macos-agent-island-helper.swift
+++ b/apps/electron/native/agent-island/macos-agent-island-helper.swift
@@ -385,9 +385,6 @@ struct CompactPlanQuotaBadge: View {
     .font(.system(size: 9, weight: .semibold))
     .monospacedDigit()
     .lineLimit(1)
-    .padding(.horizontal, 6)
-    .padding(.vertical, 4)
-    .background(.white.opacity(0.075), in: RoundedRectangle(cornerRadius: 6))
     .frame(maxWidth: 142, alignment: .trailing)
   }
 }

--- a/apps/electron/src/main/lib/agent-island-plan-quota.ts
+++ b/apps/electron/src/main/lib/agent-island-plan-quota.ts
@@ -1,0 +1,32 @@
+import type {
+  AgentIslandCompactPlanQuotaSnapshot,
+  AgentIslandPlanQuotaSnapshot,
+} from '@proma/shared'
+
+/**
+ * 收起态只能容纳一个额度摘要：按 Island 会话的语义优先级顺序选择第一个
+ * 支持查询额度的渠道，并保留其余不同渠道的数量供用户识别。
+ */
+export function selectAgentIslandCompactPlanQuota(
+  activeChannelIds: readonly string[],
+  planQuotas: readonly AgentIslandPlanQuotaSnapshot[],
+): AgentIslandCompactPlanQuotaSnapshot | undefined {
+  const quotasByChannelId = new Map(planQuotas.map((quota) => [quota.channelId, quota]))
+  const activeQuotas: AgentIslandPlanQuotaSnapshot[] = []
+  const seenChannelIds = new Set<string>()
+
+  for (const channelId of activeChannelIds) {
+    if (seenChannelIds.has(channelId)) continue
+    seenChannelIds.add(channelId)
+    const quota = quotasByChannelId.get(channelId)
+    if (quota) activeQuotas.push(quota)
+  }
+
+  const [primary] = activeQuotas
+  if (!primary) return undefined
+
+  return {
+    ...primary,
+    additionalChannelCount: activeQuotas.length - 1,
+  }
+}

--- a/apps/electron/src/main/lib/agent-island-service.ts
+++ b/apps/electron/src/main/lib/agent-island-service.ts
@@ -33,6 +33,7 @@ import { getAgentSessionMeta, listAgentSessions } from './agent-session-manager'
 import { createAgentIslandWindow, getAgentIslandWindow, hideAgentIslandWindow, moveAgentIslandWindow, onAgentIslandWindowReady, resizeAgentIslandWindow, showAgentIslandWindow } from './agent-island-window'
 import { isMacAgentIslandNativeHostReady, publishMacAgentIslandSnapshot } from './mac-agent-island-native-host'
 import { getAgentIslandTodoAttentionKeys, selectAgentIslandTodos } from './agent-island-planning'
+import { selectAgentIslandCompactPlanQuota } from './agent-island-plan-quota'
 import { listCalendarEvents, listTodos } from './planning-manager'
 import { onPlanningChanged } from './planning-events'
 import { getChannelPlanQuota, listChannels } from './channel-manager'
@@ -476,6 +477,24 @@ function buildState(now: number): AgentIslandState {
   }
 }
 
+/**
+ * 收起态优先给最需要处理的运行中会话展示额度；会话列表已按语义优先级稳定排序。
+ * 未读完成/错误会话不是“当前渠道”，不应挤占正在运行 Agent 的额度位置。
+ */
+function buildCompactPlanQuota(state: AgentIslandState): AgentIslandState['compactPlanQuota'] {
+  const activeChannelIds = state.sessions
+    .filter((session) => session.phase === 'running' || session.phase === 'needs-interaction')
+    .flatMap((session) => {
+      try {
+        const channelId = getAgentSessionMeta(session.sessionId)?.channelId
+        return channelId ? [channelId] : []
+      } catch {
+        return []
+      }
+    })
+  return selectAgentIslandCompactPlanQuota(activeChannelIds, planQuotas)
+}
+
 function buildPlanningSnapshot(now: number): AgentIslandPlanningSnapshot {
   const today = new Date(now)
   today.setHours(0, 0, 0, 0)
@@ -570,6 +589,7 @@ function pushState(): void {
   const planning = buildPlanningSnapshot(now)
   const planningKeys = getImminentPlanningKeys(now)
   const state = buildState(now)
+  state.compactPlanQuota = buildCompactPlanQuota(state)
   // The idle dashboard is a true home surface: it remains visible even for a
   // new user without any recorded Agent session. Future items do not displace
   // it; only live Agent work or imminent plans take priority.
@@ -620,9 +640,11 @@ async function refreshPlanQuotas(): Promise<void> {
     const next = results.flatMap(({ channel, quota }) => {
       if (!quota.supported || quota.windows.length === 0) return []
       return [{
+        channelId: channel.id,
         channelName: channel.name,
         planName: quota.planName || channel.name,
         windows: quota.windows.map((window) => ({
+          windowType: window.type,
           windowLabel: window.label,
           remainingPercent: window.remainingPercent,
           remainingLabel: window.remainingLabel,

--- a/apps/electron/src/renderer/components/agent-island/AgentIslandApp.tsx
+++ b/apps/electron/src/renderer/components/agent-island/AgentIslandApp.tsx
@@ -7,6 +7,7 @@ import {
   ListTodo,
 } from 'lucide-react'
 import type {
+  AgentIslandCompactPlanQuotaSnapshot,
   AgentIslandPhase,
   AgentIslandPlanQuotaSnapshot,
   AgentIslandSessionSnapshot,
@@ -83,6 +84,33 @@ function getPlanningIndicator(snapshot: AgentIslandWindowSnapshot): { icon: Reac
     return { icon: <CalendarDays size={13} />, label: '即将日程' }
   }
   return { icon: <ListTodo size={13} />, label: '即将到期' }
+}
+
+function compactQuotaWindowLabel(window: AgentIslandCompactPlanQuotaSnapshot['windows'][number]): string {
+  if (window.windowType === '5h') return '5h'
+  if (window.windowType === 'weekly') return '周'
+  return window.windowLabel
+}
+
+function formatCompactPlanQuota(quota: AgentIslandCompactPlanQuotaSnapshot): string {
+  return quota.windows
+    .slice(0, 2)
+    .map((window) => `${compactQuotaWindowLabel(window)} ${window.remainingLabel ?? `${Math.round(window.remainingPercent)}%`}`)
+    .join(' · ')
+}
+
+function CompactPlanQuota({ quota }: { quota: AgentIslandCompactPlanQuotaSnapshot }): React.ReactElement {
+  const detail = formatCompactPlanQuota(quota)
+  const title = [quota.channelName, ...quota.windows.map((window) => (
+    `${window.windowLabel} 剩余 ${window.remainingLabel ?? `${Math.round(window.remainingPercent)}%`}`
+  ))].join(' · ')
+
+  return (
+    <span className="island-compact-quota" title={title}>
+      <span className="island-compact-quota-value">{detail}</span>
+      {quota.additionalChannelCount > 0 && <span className="island-compact-quota-more">+{quota.additionalChannelCount}</span>}
+    </span>
+  )
 }
 
 function PlanQuotaCarousel({ quotas }: { quotas: AgentIslandPlanQuotaSnapshot[] }): React.ReactElement | null {
@@ -273,6 +301,7 @@ export function AgentIslandApp(): React.ReactElement {
             </span>
           )}
           <span className="island-compact-label">{compactLabel}</span>
+          {state.compactPlanQuota && <CompactPlanQuota quota={state.compactPlanQuota} />}
           <ChevronDown className="island-compact-chevron" size={14} aria-hidden="true" />
         </button>
       </div>

--- a/apps/electron/src/renderer/components/agent-island/agent-island.css
+++ b/apps/electron/src/renderer/components/agent-island/agent-island.css
@@ -144,10 +144,7 @@ button {
   flex: 0 1 142px;
   align-items: center;
   gap: 4px;
-  padding: 4px 6px;
-  border-radius: 6px;
   color: rgb(255 255 255 / 0.86);
-  background: rgb(255 255 255 / 0.075);
   font-size: 9px;
   font-weight: 650;
   line-height: 1;

--- a/apps/electron/src/renderer/components/agent-island/agent-island.css
+++ b/apps/electron/src/renderer/components/agent-island/agent-island.css
@@ -80,11 +80,10 @@ button {
   top: 0;
   right: 0;
   left: 0;
-  display: grid;
+  display: flex;
   box-sizing: border-box;
   width: 420px;
   height: 32px;
-  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
   gap: 7px;
   padding: 0 12px;
@@ -128,6 +127,7 @@ button {
 
 .island-compact-label {
   min-width: 0;
+  flex: 1 1 auto;
   overflow: hidden;
   font-size: 10.5px;
   font-weight: 650;
@@ -137,7 +137,41 @@ button {
   white-space: nowrap;
 }
 
+.island-compact-quota {
+  display: inline-flex;
+  min-width: 0;
+  max-width: 142px;
+  flex: 0 1 142px;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 6px;
+  border-radius: 6px;
+  color: rgb(255 255 255 / 0.86);
+  background: rgb(255 255 255 / 0.075);
+  font-size: 9px;
+  font-weight: 650;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.island-compact-quota-value {
+  min-width: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
+  color: rgb(255 255 255 / 0.92);
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.island-compact-quota-more {
+  flex: 0 0 auto;
+  color: #a7baff;
+  font-weight: 750;
+}
+
 .island-compact-chevron {
+  flex: 0 0 auto;
   color: rgb(255 255 255 / 0.48);
 }
 
@@ -222,7 +256,7 @@ button {
   display: grid;
   min-width: 0;
   height: 16px;
-  grid-template-columns: auto auto minmax(0, 1fr);
+  grid-template-columns: minmax(0, 78px) minmax(0, 108px) minmax(0, 1fr);
   align-items: center;
   gap: 5px;
   color: rgb(255 255 255 / 0.85);
@@ -233,6 +267,7 @@ button {
 .island-quota-name,
 .island-quota-plan,
 .island-quota-value {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/packages/shared/src/types/agent-island.ts
+++ b/packages/shared/src/types/agent-island.ts
@@ -74,6 +74,8 @@ export interface AgentIslandState {
   recentSessions: AgentIslandSessionSnapshot[]
   /** 空闲时展示 Plan 额度与最近会话；由主进程按临近事项统一判定。 */
   idleDashboard: boolean
+  /** 收起态展示的当前活跃渠道额度；多渠道时仅保留最高优先级渠道。 */
+  compactPlanQuota?: AgentIslandCompactPlanQuotaSnapshot
   totalCount: number
   updatedAt: number
 }
@@ -106,6 +108,8 @@ export interface AgentIslandPlanningSnapshot {
 
 /** 单个订阅 Plan 限额窗口的展示投影。 */
 export interface AgentIslandPlanQuotaWindowSnapshot {
+  /** 用于收起态压缩为 5h / 周等短标签。 */
+  windowType?: import('./channel').ChannelPlanQuotaWindow['type']
   windowLabel: string
   remainingPercent: number
   remainingLabel?: string
@@ -113,9 +117,16 @@ export interface AgentIslandPlanQuotaWindowSnapshot {
 
 /** 灵动岛展示所需的最小订阅 Plan 额度投影；按渠道聚合，绝不包含凭据。 */
 export interface AgentIslandPlanQuotaSnapshot {
+  /** 渠道 ID 仅用于把运行中的 Agent 会话关联到额度投影，不包含凭据。 */
+  channelId: string
   channelName: string
   planName: string
   windows: AgentIslandPlanQuotaWindowSnapshot[]
+}
+
+/** 收起态的渠道额度摘要；additionalChannelCount 只统计同样可查询额度的其他活跃渠道。 */
+export interface AgentIslandCompactPlanQuotaSnapshot extends AgentIslandPlanQuotaSnapshot {
+  additionalChannelCount: number
 }
 
 /** Electron fallback 窗口的完整投影，和原生 Swift surface 消费同一份状态数据。 */


### PR DESCRIPTION
## Summary

- Show the active Agent channel's supported Plan quota on the collapsed island.
- Use compact `5h` / `周` window labels, summarize other active eligible channels as `+N`, and keep expanded quota labels constrained.
- Apply the same snapshot contract to macOS native UI and the Electron fallback used by Windows.

## Test plan

- [x] `bun test apps/electron/src/main/lib/codex-plan-quota.test.ts`
- [x] `bun run typecheck`
- [x] `bun run --filter=@proma/electron build:main`
- [x] `bun run --filter=@proma/electron build:renderer`
- [x] `bun run --filter=@proma/electron build:agent-island-native`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
