### PR TITLE
Disable Agent Island before macOS 26

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -116,6 +116,7 @@ import { destroyPlanningWindow, showPlanningWindow } from './lib/planning-window
 import { createAgentIslandWindow, destroyAgentIslandWindow, showAgentIslandWindow } from './lib/agent-island-window'
 import { handleNativeAgentIslandEvent, initAgentIslandService, disposeAgentIslandService, publishAgentIslandNow } from './lib/agent-island-service'
 import { disposeMacAgentIslandNativeHost, startMacAgentIslandNativeHost } from './lib/mac-agent-island-native-host'
+import { isMacOS26OrLater } from './lib/macos-version'
 import {
   createVoiceDictationWindow,
   toggleVoiceDictationWindow,
@@ -140,8 +141,13 @@ function activateAgentIslandElectronFallback(reason?: string): void {
   publishAgentIslandNow()
 }
 
-/** macOS 优先使用真刘海 NSPanel；其他平台保持既有 BrowserWindow 体验。 */
+/** macOS 26+ 优先使用真刘海 NSPanel；旧版 macOS 默认不显示灵动岛。 */
 function startAgentIslandSurface(): void {
+  if (process.platform === 'darwin' && !isMacOS26OrLater()) {
+    console.info('[agent-island] 已在 macOS 26 以下禁用')
+    return
+  }
+
   const startedNative = startMacAgentIslandNativeHost({
     onReady: () => {
       console.info('[agent-island] macOS 原生 NSPanel helper 已就绪')

--- a/apps/electron/src/main/lib/macos-version.ts
+++ b/apps/electron/src/main/lib/macos-version.ts
@@ -1,0 +1,9 @@
+import { release } from 'node:os'
+
+// Apple maps macOS 26 to Darwin 25. Future macOS releases use larger Darwin majors.
+const MACOS_26_DARWIN_MAJOR = 25
+
+export function isMacOS26OrLater(darwinRelease = release()): boolean {
+  const darwinMajor = Number.parseInt(darwinRelease.split('.')[0] ?? '', 10)
+  return Number.isFinite(darwinMajor) && darwinMajor >= MACOS_26_DARWIN_MAJOR
+}


### PR DESCRIPTION
## Summary

- 5679d49a fix(agent-island): disable it before macOS 26

## Test plan

- [ ] 本地开发环境验证通过
- [ ] 相关功能无回归

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)