### PR TITLE
feat(agent): 外部拖入普通文件改为复制到会话目录后插入 @ 引用

### DIFF
--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -907,7 +907,7 @@ export class AgentOrchestrator {
    * 通过 EventBus 分发 AgentEvent，通过 callbacks 发送控制信号。
    */
   async sendMessage(input: AgentSendInput, callbacks: SessionCallbacks): Promise<void> {
-    const { sessionId, userMessage, channelId, modelId, agentRuntime: inputAgentRuntime, workspaceId: requestedWorkspaceId, additionalDirectories, customMcpServers, permissionModeOverride, mentionedSkills, mentionedMcpServers, mentionedSessionIds, mentionedTodoIds, mentionedCalendarEventIds, automationContext, retryOfErrorUuid } = input
+    const { sessionId, userMessage, rawUserMessage, channelId, modelId, agentRuntime: inputAgentRuntime, workspaceId: requestedWorkspaceId, additionalDirectories, customMcpServers, permissionModeOverride, mentionedSkills, mentionedMcpServers, mentionedSessionIds, mentionedTodoIds, mentionedCalendarEventIds, automationContext, retryOfErrorUuid } = input
     const stderrChunks: string[] = []
     const streamStartedAt = input.startedAt ?? Date.now()
     let userMessagePersisted = false
@@ -915,7 +915,9 @@ export class AgentOrchestrator {
 
     const persistInitialUserMessage = (): void => {
       if (userMessagePersisted) return
-      this.persistUserMessage(sessionId, userMessage)
+      // rawUserMessage 保留展示/持久化用的原始文本（@file 编码原文，remarkMentions 解码显示）；
+      // userMessage 是传给 Agent 的 SDK 文本（@file 路径已解码为真实路径）。
+      this.persistUserMessage(sessionId, rawUserMessage ?? userMessage)
       userMessagePersisted = true
       callbacks.onRunStarted?.({ startedAt: streamStartedAt })
     }

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -1062,7 +1062,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   }, [appendLiveUserMessage, removeLiveUserMessage, sessionId])
 
   const startQueuedMessageRun = React.useCallback(async (
-    text: string,
+    displayText: string,
+    sdkText: string,
     mentions: ReturnType<typeof parseQueuedMessageMentions>,
     channelId: string,
     queuedAdditionalDirectories: string[] = [],
@@ -1087,12 +1088,15 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       return map
     })
 
-    appendOptimisticPersistedMessage(createUserSDKMessage(text, undefined, streamStartedAt))
+    appendOptimisticPersistedMessage(createUserSDKMessage(displayText, undefined, streamStartedAt))
 
     try {
       await window.electronAPI.sendAgentMessage({
         sessionId,
-        userMessage: text,
+        // Agent 侧使用解码后的 SDK 文本（@file 路径还原为真实路径），
+        // 展示/持久化使用 displayText（编码原文，remarkMentions 解码显示）。
+        userMessage: sdkText,
+        rawUserMessage: displayText,
         channelId,
         modelId: agentModelId || undefined,
         agentRuntime: sessionAgentRuntime,
@@ -1159,7 +1163,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       } catch (error) {
         if (isStaleAgentQueueError(error)) {
           console.warn('[AgentView] 检测到陈旧的 Agent 追加通道，改为启动新一轮运行:', error)
-          await startQueuedMessageRun(payload.rawText, payload.mentions, agentChannelId, message.additionalDirectories)
+          await startQueuedMessageRun(payload.rawText, payload.sdkText, payload.mentions, agentChannelId, message.additionalDirectories)
           return
         }
         throw error
@@ -1167,7 +1171,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       return
     }
 
-    await startQueuedMessageRun(payload.rawText, payload.mentions, agentChannelId, message.additionalDirectories)
+    await startQueuedMessageRun(payload.rawText, payload.sdkText, payload.mentions, agentChannelId, message.additionalDirectories)
   }, [
     agentChannelId,
     backgroundWaiting,
@@ -1325,6 +1329,9 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     // 快照当前上下文
     const snapshot = {
       message: pendingPrompt.message,
+      // Agent 侧使用解码后的 SDK 文本（@file 路径还原为真实路径），
+      // 展示/持久化保留编码原文（remarkMentions 解码显示）。
+      sdkMessage: parseQueuedMessageMentions(pendingPrompt.message).cleanedText,
       channelId: agentChannelId,
       modelId: agentModelId || undefined,
       workspaceId: currentWorkspaceId || undefined,
@@ -1365,7 +1372,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       // 发送消息
       const input: AgentSendInput = {
         sessionId,
-        userMessage: snapshot.message,
+        userMessage: snapshot.sdkMessage,
+        rawUserMessage: snapshot.message,
         channelId: snapshot.channelId,
         modelId: snapshot.modelId,
         agentRuntime: sessionAgentRuntime,
@@ -2319,6 +2327,9 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     // 2. 构建最终消息
     const finalMessage = fileReferences + effectiveText
     const mentions = parseQueuedMessageMentions(effectiveText)
+    // Agent 侧使用解码后的 SDK 文本（@file 路径还原为真实路径，Agent 可读取）；
+    // 气泡展示/持久化使用编码原文（remarkMentions 解码显示），与排队路径 rawText/sdkText 分离语义一致。
+    const sdkMessage = fileReferences + mentions.cleanedText
 
     // 清除打断状态（上一轮的打断标记不再显示）
     store.set(stoppedByUserSessionsAtom, (prev: Set<string>) => {
@@ -2366,7 +2377,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
 
     const input: AgentSendInput = {
       sessionId,
-      userMessage: finalMessage,
+      userMessage: sdkMessage,
+      rawUserMessage: finalMessage,
       channelId: agentChannelId,
       modelId: agentModelId || undefined,
       agentRuntime: sessionAgentRuntime,
@@ -2548,11 +2560,13 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
     if (!agentChannelId || streaming) return
 
     // 找到最后一条用户消息
-    const lastUserMessage = [...persistedSDKMessages]
+    const lastUserRawMessage = [...persistedSDKMessages]
       .reverse()
       .map(getUserTextFromSDKMessage)
       .find((text): text is string => text !== null)
-    if (!lastUserMessage) return
+    if (!lastUserRawMessage) return
+    // 重试重发给 Agent 的消息：@file 路径还原为真实路径（持久化存的是编码原文）
+    const lastUserMessage = parseQueuedMessageMentions(lastUserRawMessage).cleanedText
 
     // 与主进程按 UUID 的原子删除同步更新当前 React 状态和 LRU cache，避免旧错误
     // 在下一轮回复开始前仍被页面渲染。旧会话没有 UUID 时保留历史，由主进程幂等处理。

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -2604,7 +2604,9 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
 
     window.electronAPI.sendAgentMessage({
       sessionId,
+      // Agent 侧使用解码后的文本（@file 真实路径）；持久化/展示保留编码原文，避免新历史记录被 \S+ 截断
       userMessage: lastUserMessage,
+      rawUserMessage: lastUserRawMessage,
       channelId: agentChannelId,
       modelId: agentModelId || undefined,
       agentRuntime: sessionAgentRuntime,

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -1949,15 +1949,62 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
           }
         }
 
-        // 普通文件作为附件
+        // 普通文件：复制到会话私有目录后插入 @ 引用（方案 B）
+        // 引用指向会话私有工作目录内的副本路径，Agent 通过会话私有目录即可访问，
+        // 与右侧面板拖拽/键盘 @ 引用保持一致；超大文件或无项目时回退附件逻辑。
         const regularFiles = filePaths.map((p) => pathMap.get(p)!).filter(Boolean)
         if (regularFiles.length > 0) {
-          const fileSourcePaths = new Map<File, string>()
+          const sourcePaths = new Map<File, string>()
           for (const path of filePaths) {
             const file = pathMap.get(path)
-            if (file) fileSourcePaths.set(file, path)
+            if (file) sourcePaths.set(file, path)
           }
-          addFilesAsAttachments(regularFiles, fileSourcePaths)
+
+          const workspace = workspaces.find((w) => w.id === currentWorkspaceId)
+          const canSave = Boolean(workspace?.slug)
+          const savedRefs: Array<{ path: string; name: string }> = []
+          const fallbackFiles: File[] = []
+
+          for (const file of regularFiles) {
+            if (!canSave || file.size > MAX_ATTACHMENT_SIZE) {
+              fallbackFiles.push(file)
+              continue
+            }
+            try {
+              const data = await fileToBase64(file)
+              const saved = await window.electronAPI.saveFilesToAgentSession({
+                workspaceSlug: workspace!.slug,
+                sessionId,
+                files: [{ filename: file.name, data }],
+              })
+              if (saved && saved.length > 0) {
+                const [savedFile] = saved
+                if (savedFile) {
+                  savedRefs.push({ path: savedFile.targetPath, name: savedFile.filename })
+                } else {
+                  fallbackFiles.push(file)
+                }
+              } else {
+                fallbackFiles.push(file)
+              }
+            } catch (error) {
+              console.error('[AgentView] 外部文件复制到会话目录失败:', error)
+              fallbackFiles.push(file)
+            }
+          }
+
+          if (savedRefs.length > 0) {
+            richTextInputRef.current?.insertFileMentions(savedRefs.map((r) => ({
+              path: r.path,
+              name: r.name,
+              isDirectory: false,
+              scope: 'project',
+            })))
+            toast.success(`已引用 ${savedRefs.length} 个文件`)
+          }
+          if (fallbackFiles.length > 0) {
+            addFilesAsAttachments(fallbackFiles, sourcePaths)
+          }
         }
       } catch (error) {
         console.error('[AgentView] 路径检测失败，回退处理:', error)
@@ -1967,7 +2014,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       // 无路径信息：回退，所有项按普通文件处理
       addFilesAsAttachments(droppedFiles)
     }
-  }, [sessionId, addFilesAsAttachments, addPanelDirectory, setAttachedDirsMap])
+  }, [sessionId, addFilesAsAttachments, addPanelDirectory, setAttachedDirsMap, workspaces, currentWorkspaceId])
 
   /** ModelSelector 选择回调 */
   const handleModelSelect = React.useCallback((option: ModelOption): void => {

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -1998,7 +1998,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
               path: r.path,
               name: r.name,
               isDirectory: false,
-              scope: 'project',
+              scope: 'session',
             })))
             toast.success(`已引用 ${savedRefs.length} 个文件`)
           }

--- a/apps/electron/src/renderer/lib/agent-message-queue.test.ts
+++ b/apps/electron/src/renderer/lib/agent-message-queue.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test'
+import { buildQueuedMessageSendPayload, getQueuedMessageDisplayParts, parseQueuedMessageMentions } from './agent-message-queue'
+
+describe('queued message @file mention path decoding (Agent 侧真实路径)', () => {
+  test('decodes percent-encoded @file path back to the real path with spaces', () => {
+    const text = '请查看 @file:%2FUsers%2Fme%2FMy%20report.pdf 这份报告'
+    const result = parseQueuedMessageMentions(text)
+    expect(result.cleanedText).toBe('请查看 @file:/Users/me/My report.pdf 这份报告')
+  })
+
+  test('keeps legacy unencoded @file paths unchanged', () => {
+    const text = '参考 @file:notes/brief.md 内容'
+    const result = parseQueuedMessageMentions(text)
+    expect(result.cleanedText).toBe('参考 @file:notes/brief.md 内容')
+  })
+
+  test('decode does not affect skill / mcp / session mentions removal', () => {
+    const text = '@file:%2FUsers%2Fme%2FMy%20report.pdf /skill:brainstorming #mcp:playwright &session:session-123'
+    const result = parseQueuedMessageMentions(text)
+    expect(result.cleanedText).toBe('@file:/Users/me/My report.pdf')
+    expect(result.mentionedSkills).toEqual(['brainstorming'])
+    expect(result.mentionedMcpServers).toEqual(['playwright'])
+    expect(result.mentionedSessionIds).toEqual(['session-123'])
+  })
+
+  test('buildQueuedMessageSendPayload sdkText contains the real (decoded) file path', () => {
+    const payload = buildQueuedMessageSendPayload({
+      id: 'msg-1',
+      text: '看下 @file:%2FUsers%2Fme%2FMy%20report.pdf',
+      createdAt: Date.now(),
+    })
+    expect(payload.sdkText).toContain('@file:/Users/me/My report.pdf')
+  })
+
+  test('getQueuedMessageDisplayParts shows the full filename for encoded paths with spaces', () => {
+    const parts = getQueuedMessageDisplayParts('看下 @file:%2FUsers%2Fme%2FMy%20report.pdf 这份报告')
+    const fileRef = parts.find((p) => p.type === 'reference' && p.referenceType === 'file')
+    expect(fileRef).toBeDefined()
+    if (fileRef && 'referenceType' in fileRef) {
+      // id 保留协议原始值（编码）；label 是展示层解码后的完整文件名
+      expect(fileRef.id).toBe('%2FUsers%2Fme%2FMy%20report.pdf')
+      expect(fileRef.label).toBe('My report.pdf')
+    }
+  })
+})

--- a/apps/electron/src/renderer/lib/agent-message-queue.ts
+++ b/apps/electron/src/renderer/lib/agent-message-queue.ts
@@ -224,7 +224,17 @@ export function parseQueuedMessageMentions(text: string): ParsedQueuedMessageMen
   }
 
   return {
-    cleanedText: text.replace(REF_PATTERN, '').trim(),
+    cleanedText: text
+      .replace(REF_PATTERN, '')
+      // @file: 路径在 htmlToMarkdown 序列化时已 encodeURIComponent（路径可能含空格），
+      // 这里还原为真实路径，保证 Agent 侧读取的是可访问的完整路径；
+      // 仅当含百分号编码时解码，避免破坏旧的未编码路径。
+      .replace(/@file:([^\s]+)/g, (full, encodedPath: string) =>
+        /%[0-9A-Fa-f]{2}/.test(encodedPath)
+          ? `@file:${decodeReferenceLabel(encodedPath)}`
+          : full
+      )
+      .trim(),
     mentionedSkills,
     mentionedMcpServers,
     mentionedSessionIds,

--- a/apps/electron/src/renderer/lib/markdown-rich-text.test.ts
+++ b/apps/electron/src/renderer/lib/markdown-rich-text.test.ts
@@ -157,7 +157,17 @@ describe('Agent mention serialization', () => {
       '</p>',
     ].join('')))
 
-    expect(markdown).toBe('@file:notes/brief.md /skill:brainstorming #mcp:playwright &session:session-123')
+    expect(markdown).toBe('@file:notes%2Fbrief.md /skill:brainstorming #mcp:playwright &session:session-123')
+  })
+
+  test('encodes file mention paths containing spaces so @file: regex does not truncate them', () => {
+    const markdown = withHtmlDocument(() => htmlToMarkdown([
+      '<p>',
+      '<span data-type="mention" data-id="/Users/me/My report.pdf" data-mention-suggestion-char="@">My report.pdf</span> ',
+      '</p>',
+    ].join('')))
+
+    expect(markdown).toBe('@file:%2FUsers%2Fme%2FMy%20report.pdf')
   })
 
   test('serializes planning selections by reference type rather than the trigger character', () => {

--- a/apps/electron/src/renderer/lib/markdown-rich-text.ts
+++ b/apps/electron/src/renderer/lib/markdown-rich-text.ts
@@ -535,7 +535,9 @@ export function htmlToMarkdown(
           if (suggestionChar === '/') return `/skill:${dataId}`
           if (suggestionChar === '#') return `#mcp:${dataId}`
           if (suggestionChar === '&') return serializeNamedMention('&session', dataId, dataLabel)
-          return `@file:${dataId}`
+          // 路径可能包含空格等字符，必须编码后再嵌入 @file: 协议，
+          // 否则展示层 @file:(\S+) 正则会在空格处截断（remarkMentions / MentionChip / 排队消息均内置解码）。
+          return `@file:${encodeURIComponent(dataId)}`
         }
         return children
       }

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1003,8 +1003,10 @@ export interface WorkspaceCapabilities {
 export interface AgentSendInput {
   /** 会话 ID */
   sessionId: string
-  /** 用户消息内容 */
+  /** 用户消息内容（传给 Agent 的 SDK 文本；@file 引用路径已解码为真实路径） */
   userMessage: string
+  /** 仅用于持久化/展示的原始用户输入（保留 @file 编码原文，省略时回退到 userMessage） */
+  rawUserMessage?: string
   /** 渠道 ID（用于获取 API Key） */
   channelId: string
   /** 模型 ID */


### PR DESCRIPTION
## 背景
此前 PR #1368 实现了「右侧文件面板拖拽 + 键盘 @ 引用」，但外部（Finder）拖入**普通文件**（压缩包、zip 等）仍走「输入框上方附件 chip」（base64 存内存、发送时落盘）。本次统一体验：外部拖入普通文件也变成 `@` 引用渲染，跟随输入对话。

## 改动
1. **外部拖入普通文件 → 复制到会话私有目录 → 插入 `@file` 引用**（AgentView.tsx handleDrop）
   - 引用指向会话私有工作目录内的副本绝对路径，Agent 通过会话私有目录即可访问（collectAttachedDirectories 覆盖）
   - 超大文件（>100MB）/ 无项目 / 保存失败 → 回退原有附件逻辑，不破坏既有能力
   - scope 用 'session'（文件实际在会话私有目录）
2. **修复含空格路径的 @file 引用截断**（markdown-rich-text / agent-message-queue）
   - `htmlToMarkdown` 序列化时 `@file:${encodeURIComponent(path)}`，展示层 `@file:(\S+)` 不再在空格处截断（remarkMentions / MentionChip / 排队消息均内置解码）
   - 发送链路还原真实路径给 Agent（`parseQueuedMessageMentions` 仅对含百分号编码的 `@file` 段解码；旧未编码路径原样保留）
3. **AgentSendInput 新增 `rawUserMessage`**，统一「SDK 用解码路径、持久化/展示用编码原文」分离（orchestrator.sendMessage / 即时发送 / startQueuedMessageRun / 自动发送 / 重试）

## 行为对比
| 场景 | 之前 | 现在 |
|------|------|------|
| 外部拖入普通文件 | 输入框上方附件 chip | 复制到会话目录 + `@文件名` 引用 chip |
| 外部拖入文件夹 | 附加 + @ 引用（已有） | 不变 |
| 含空格路径引用 | 展示截断 | 完整显示 |

## 验证
- 全仓 typecheck 通过
- 渲染构建通过
- 新增测试（含空格路径序列化 / Agent 侧真实路径 / 排队展示完整文件名）27 pass
- gpt-5.6-terra 四轮独立审核，终审通过（可合并）

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)