### PR TITLE
fix(oauth): scope provider auth requests through app proxy

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -157,6 +157,7 @@ import { loginCodexOAuth, cancelCodexOAuthLogin } from './lib/codex-oauth-servic
 import { loginXaiOAuth, cancelXaiOAuthLogin } from './lib/xai-oauth-service'
 import { resolvePiReasoningCapability } from './lib/adapters/pi-model-registry'
 import { serializeCodexCredentials, serializeXaiCredentials } from '@proma/shared'
+import type { CodexOAuthDeviceCode, CodexOAuthLoginMethod, XaiOAuthDeviceCode } from '@proma/shared'
 import {
   listConversations,
   createConversation,
@@ -903,6 +904,16 @@ function releaseDirectoryWatcherIfUnreferenced(dirPath: string): void {
   if (!isStillReferenced) unwatchAttachedDirectory(dirPath)
 }
 
+async function withOAuthDeviceCodeQr<T extends CodexOAuthDeviceCode | XaiOAuthDeviceCode>(deviceCode: T): Promise<T> {
+  try {
+    const QRCode = (await import('qrcode')).default
+    return { ...deviceCode, qrCodeData: await QRCode.toDataURL(deviceCode.verificationUri, { width: 240, margin: 1 }) }
+  } catch (error) {
+    console.warn('[OAuth] 生成设备码二维码失败:', error)
+    return deviceCode
+  }
+}
+
 export function registerIpcHandlers(): void {
   console.log('[IPC] 正在注册 IPC 处理器...')
 
@@ -1252,9 +1263,19 @@ export function registerIpcHandlers(): void {
   // apiKey 传给 create/update，channel-manager 加密后存储——与现有 apiKey 明文回传模式一致。
   ipcMain.handle(
     CHANNEL_IPC_CHANNELS.CODEX_OAUTH_LOGIN,
-    async (): Promise<import('@proma/shared').CodexOAuthLoginResult> => {
+    async (event, requestedMethod?: CodexOAuthLoginMethod): Promise<import('@proma/shared').CodexOAuthLoginResult> => {
+      const method: CodexOAuthLoginMethod = requestedMethod === 'device_code' ? 'device_code' : 'browser'
       try {
-        const credentials = await loginCodexOAuth()
+        const credentials = await loginCodexOAuth({
+          method,
+          onDeviceCode: (deviceCode) => {
+            void withOAuthDeviceCodeQr(deviceCode).then((payload) => {
+              if (!event.sender.isDestroyed()) {
+                event.sender.send(CHANNEL_IPC_CHANNELS.CODEX_OAUTH_DEVICE_CODE, payload)
+              }
+            }).catch((error) => console.warn('[OAuth] 发送 Codex device code 失败:', error))
+          },
+        })
         return {
           success: true,
           credentials: serializeCodexCredentials(credentials),
@@ -1284,7 +1305,13 @@ export function registerIpcHandlers(): void {
     async (event): Promise<import('@proma/shared').XaiOAuthLoginResult> => {
       try {
         const credentials = await loginXaiOAuth({
-          onDeviceCode: (deviceCode) => event.sender.send(CHANNEL_IPC_CHANNELS.XAI_OAUTH_DEVICE_CODE, deviceCode),
+          onDeviceCode: (deviceCode) => {
+            void withOAuthDeviceCodeQr(deviceCode).then((payload) => {
+              if (!event.sender.isDestroyed()) {
+                event.sender.send(CHANNEL_IPC_CHANNELS.XAI_OAUTH_DEVICE_CODE, payload)
+              }
+            }).catch((error) => console.warn('[OAuth] 发送 xAI device code 失败:', error))
+          },
         })
         return { success: true, credentials: serializeXaiCredentials(credentials) }
       } catch (error) {

--- a/apps/electron/src/main/lib/adapters/pi-agent-proxy.test.ts
+++ b/apps/electron/src/main/lib/adapters/pi-agent-proxy.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, test } from 'bun:test'
+import { describe, expect, mock, test } from 'bun:test'
 import type { Dispatcher } from 'undici'
 import { buildPiRemoteConnectionSettings } from './pi-agent-adapter'
 import {
   getPiRequestProxyDispatcher,
+  runWithManagedPiRequestProxy,
   runWithPiRequestProxy,
 } from './pi-request-proxy'
 
@@ -53,6 +54,30 @@ describe('Pi request proxy', () => {
     expect(firstSeen).toBe(first)
     expect(secondSeen).toBe(second)
     expect(getPiRequestProxyDispatcher()).toBeUndefined()
+  })
+
+  test('Given a managed proxy dispatcher When the operation resolves Then closes it after leaving its async scope', async () => {
+    const close = mock(() => Promise.resolve())
+    const dispatcher = { close } as unknown as Dispatcher
+
+    await expect(runWithManagedPiRequestProxy(dispatcher, async () => {
+      expect(getPiRequestProxyDispatcher()).toBe(dispatcher)
+      return 'done'
+    })).resolves.toBe('done')
+
+    expect(close).toHaveBeenCalledTimes(1)
+    expect(getPiRequestProxyDispatcher()).toBeUndefined()
+  })
+
+  test('Given a managed proxy dispatcher When the operation fails Then still closes it', async () => {
+    const close = mock(() => Promise.resolve())
+    const dispatcher = { close } as unknown as Dispatcher
+
+    await expect(runWithManagedPiRequestProxy(dispatcher, async () => {
+      throw new Error('OAuth failed')
+    })).rejects.toThrow('OAuth failed')
+
+    expect(close).toHaveBeenCalledTimes(1)
   })
 
   test('Given runtime proxy environment When no explicit URL is provided Then uses it without mutating process environment', () => {

--- a/apps/electron/src/main/lib/adapters/pi-request-proxy.ts
+++ b/apps/electron/src/main/lib/adapters/pi-request-proxy.ts
@@ -93,6 +93,31 @@ export function runWithPiRequestProxy<T>(dispatcher: Dispatcher | undefined, ope
   return requestDispatcherStorage.run(dispatcher, operation)
 }
 
+/**
+ * 在一个受管生命周期内执行 Pi 网络操作。
+ *
+ * OAuth 等短时 Pi 操作也必须使用此入口：内部全局 fetch 会继承当前 async scope 的
+ * dispatcher，且无论成功、取消或抛错均会释放连接池。
+ */
+export async function runWithManagedPiRequestProxy<T>(
+  dispatcher: Dispatcher | undefined,
+  operation: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await runWithPiRequestProxy(dispatcher, operation)
+  } finally {
+    await closePiRequestProxyDispatcher(dispatcher)
+  }
+}
+
+export async function runWithPiRequestProxyScope<T>(
+  options: PiRequestProxyOptions,
+  operation: () => Promise<T>,
+): Promise<T> {
+  installPiRequestProxyFetch()
+  return runWithManagedPiRequestProxy(createPiRequestProxyDispatcher(options), operation)
+}
+
 /** 用于测试及诊断：不会暴露或修改全局 dispatcher。 */
 export function getPiRequestProxyDispatcher(): Dispatcher | undefined {
   return requestDispatcherStorage.getStore()

--- a/apps/electron/src/main/lib/codex-oauth-service.ts
+++ b/apps/electron/src/main/lib/codex-oauth-service.ts
@@ -12,7 +12,8 @@
  */
 
 import { shell } from 'electron'
-import type { CodexOAuthCredentials } from '@proma/shared'
+import type { CodexOAuthCredentials, CodexOAuthDeviceCode, CodexOAuthLoginMethod } from '@proma/shared'
+import { runWithOAuthProxyScope } from './oauth-proxy-scope'
 /** Pi 0.80.10 将 OAuth 流程收敛到 ModelRuntime。保持动态 import，避免 Electron 主包将 Pi runtime 内联。 */
 type PiSdk = typeof import('@earendil-works/pi-coding-agent')
 
@@ -69,8 +70,15 @@ let activeLoginAbort: AbortController | undefined
 export interface CodexLoginCallbacks {
   /** SDK 生成授权 URL 后回调，用于（除自动开浏览器外）通知渲染层展示 URL。 */
   onAuthUrl?: (url: string) => void
+  /** Pi 生成 device code 后回调，供 UI 展示、复制或交给另一台设备扫码。 */
+  onDeviceCode?: (deviceCode: CodexOAuthDeviceCode) => void
   /** 进度消息回调。 */
   onProgress?: (message: string) => void
+}
+
+export interface CodexLoginOptions extends CodexLoginCallbacks {
+  /** 默认系统浏览器；网络受限时可选择 RFC 8628 device-code 流程。 */
+  method?: CodexOAuthLoginMethod
 }
 
 /**
@@ -79,8 +87,9 @@ export interface CodexLoginCallbacks {
  * 成功返回规范化的 OAuth 凭据；用户取消或失败则抛错。
  * 登录期间自动用系统浏览器打开授权页，SDK 内部回调服务（:1455）接收授权码。
  */
-export async function loginCodexOAuth(callbacks?: CodexLoginCallbacks): Promise<CodexOAuthCredentials> {
+export async function loginCodexOAuth(options?: CodexLoginOptions): Promise<CodexOAuthCredentials> {
   const sdk = await loadPiSdk()
+  const method = options?.method ?? 'browser'
 
   // 取消上一个仍在进行的登录流程，避免 :1455 端口占用与并发回调。
   activeLoginAbort?.abort()
@@ -88,31 +97,36 @@ export async function loginCodexOAuth(callbacks?: CodexLoginCallbacks): Promise<
   activeLoginAbort = abort
 
   try {
-    const runtime = await sdk.ModelRuntime.create({
-      credentials: createEphemeralCredentialStore(),
-      allowModelNetwork: false,
+    return await runWithOAuthProxyScope(async () => {
+      const runtime = await sdk.ModelRuntime.create({
+        credentials: createEphemeralCredentialStore(),
+        allowModelNetwork: false,
+      })
+      const credentials = await runtime.login('openai-codex', 'oauth', {
+        signal: abort.signal,
+        prompt: async (prompt) => {
+          if (prompt.type === 'select') return method
+          return new Promise<string>((_resolve, reject) => {
+            prompt.signal?.addEventListener('abort', () => reject(new Error('登录已取消')), { once: true })
+            abort.signal.addEventListener('abort', () => reject(new Error('登录已取消')), { once: true })
+          })
+        },
+        notify: (event) => {
+          if (event.type === 'auth_url') {
+            options?.onAuthUrl?.(event.url)
+            shell.openExternal(event.url).catch((err) => console.error('[Codex OAuth] 打开浏览器失败:', err))
+          } else if (event.type === 'device_code') {
+            console.log(`[Codex OAuth] 请在浏览器中授权（设备码：${event.userCode}）`)
+            options?.onDeviceCode?.({ userCode: event.userCode, verificationUri: event.verificationUri })
+            shell.openExternal(event.verificationUri).catch((err) => console.error('[Codex OAuth] 打开设备授权页面失败:', err))
+          } else if (event.type === 'progress' || event.type === 'info') {
+            console.log(`[Codex OAuth] ${event.message}`)
+            options?.onProgress?.(event.message)
+          }
+        },
+      })
+      return normalizeCredentials(credentials)
     })
-    const credentials = await runtime.login('openai-codex', 'oauth', {
-      signal: abort.signal,
-      prompt: async (prompt) => {
-        // Pi 先要求选择登录方式；Proma v1 固定浏览器授权，回调服务会处理 code。
-        if (prompt.type === 'select') return 'browser'
-        return new Promise<string>((_resolve, reject) => {
-          prompt.signal?.addEventListener('abort', () => reject(new Error('登录已取消')), { once: true })
-          abort.signal.addEventListener('abort', () => reject(new Error('登录已取消')), { once: true })
-        })
-      },
-      notify: (event) => {
-        if (event.type === 'auth_url') {
-          callbacks?.onAuthUrl?.(event.url)
-          shell.openExternal(event.url).catch((err) => console.error('[Codex OAuth] 打开浏览器失败:', err))
-        } else if (event.type === 'progress' || event.type === 'info') {
-          console.log(`[Codex OAuth] ${event.message}`)
-          callbacks?.onProgress?.(event.message)
-        }
-      },
-    })
-    return normalizeCredentials(credentials)
   } finally {
     if (activeLoginAbort === abort) {
       activeLoginAbort = undefined
@@ -133,14 +147,16 @@ export function cancelCodexOAuthLogin(): void {
  */
 export async function refreshCodexOAuth(refreshToken: string): Promise<CodexOAuthCredentials> {
   const sdk = await loadPiSdk()
-  const store = createEphemeralCredentialStore({
-    type: 'oauth',
-    access: '',
-    refresh: refreshToken,
-    expires: 0,
+  return runWithOAuthProxyScope(async () => {
+    const store = createEphemeralCredentialStore({
+      type: 'oauth',
+      access: '',
+      refresh: refreshToken,
+      expires: 0,
+    })
+    const runtime = await sdk.ModelRuntime.create({ credentials: store, allowModelNetwork: false })
+    // getAuth() 走 provider 的标准 refresh 流程，并通过 store 原子更新凭据。
+    await runtime.getAuth('openai-codex')
+    return normalizeCredentials(await store.read())
   })
-  const runtime = await sdk.ModelRuntime.create({ credentials: store, allowModelNetwork: false })
-  // getAuth() 走 provider 的标准 refresh 流程，并通过 store 原子更新凭据。
-  await runtime.getAuth('openai-codex')
-  return normalizeCredentials(await store.read())
 }

--- a/apps/electron/src/main/lib/oauth-proxy-scope.test.ts
+++ b/apps/electron/src/main/lib/oauth-proxy-scope.test.ts
@@ -4,7 +4,7 @@ const getEffectiveProxyUrl = mock<() => Promise<string | undefined>>()
 
 mock.module('./proxy-settings-service', () => ({ getEffectiveProxyUrl }))
 
-const { buildOAuthNoProxy, runWithOAuthProxyScope } = await import('./oauth-proxy-scope')
+const { buildOAuthNoProxy, readNoProxyEnvironment, runWithOAuthProxyScope } = await import('./oauth-proxy-scope')
 const { getPiRequestProxyDispatcher } = await import('./adapters/pi-request-proxy')
 
 afterEach(() => {
@@ -14,6 +14,17 @@ afterEach(() => {
 describe('OAuth proxy scope', () => {
   test('Given a user NO_PROXY list When building OAuth exclusions Then preserves it and includes every loopback host', () => {
     expect(buildOAuthNoProxy('internal.example,localhost')).toBe('internal.example,localhost,127.0.0.1,[::1]')
+  })
+
+  test('Given a NO_PROXY wildcard When building OAuth exclusions Then preserves its all-direct meaning', () => {
+    expect(buildOAuthNoProxy('*')).toBe('*')
+  })
+
+  test('Given both NO_PROXY environment variable spellings When resolving exclusions Then prefers lowercase like Undici', () => {
+    expect(readNoProxyEnvironment({
+      NO_PROXY: 'uppercase.example',
+      no_proxy: 'lowercase.example',
+    })).toBe('lowercase.example')
   })
 
   test('Given an application proxy When running OAuth Then scopes the entire operation to that proxy', async () => {

--- a/apps/electron/src/main/lib/oauth-proxy-scope.test.ts
+++ b/apps/electron/src/main/lib/oauth-proxy-scope.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+
+const getEffectiveProxyUrl = mock<() => Promise<string | undefined>>()
+
+mock.module('./proxy-settings-service', () => ({ getEffectiveProxyUrl }))
+
+const { buildOAuthNoProxy, runWithOAuthProxyScope } = await import('./oauth-proxy-scope')
+const { getPiRequestProxyDispatcher } = await import('./adapters/pi-request-proxy')
+
+afterEach(() => {
+  getEffectiveProxyUrl.mockReset()
+})
+
+describe('OAuth proxy scope', () => {
+  test('Given a user NO_PROXY list When building OAuth exclusions Then preserves it and includes every loopback host', () => {
+    expect(buildOAuthNoProxy('internal.example,localhost')).toBe('internal.example,localhost,127.0.0.1,[::1]')
+  })
+
+  test('Given an application proxy When running OAuth Then scopes the entire operation to that proxy', async () => {
+    getEffectiveProxyUrl.mockResolvedValue('http://127.0.0.1:7890')
+
+    await expect(runWithOAuthProxyScope(async () => {
+      expect(getPiRequestProxyDispatcher()).toBeDefined()
+      return 'token'
+    })).resolves.toBe('token')
+
+    expect(getPiRequestProxyDispatcher()).toBeUndefined()
+  })
+
+  test('Given no configured proxy When running OAuth Then preserves direct networking while retaining loopback exclusions', async () => {
+    getEffectiveProxyUrl.mockResolvedValue(undefined)
+
+    await expect(runWithOAuthProxyScope(async () => {
+      expect(getPiRequestProxyDispatcher()).toBeUndefined()
+      return 'token'
+    })).resolves.toBe('token')
+  })
+})

--- a/apps/electron/src/main/lib/oauth-proxy-scope.ts
+++ b/apps/electron/src/main/lib/oauth-proxy-scope.ts
@@ -4,17 +4,18 @@ import { getEffectiveProxyUrl } from './proxy-settings-service'
 // EnvHttpProxyAgent 以 URL hostname 匹配 IPv6；方括号形式才能正确匹配 http://[::1]/。
 const LOOPBACK_NO_PROXY_HOSTS = ['localhost', '127.0.0.1', '[::1]']
 
-function readNoProxyEnvironment(): string | undefined {
-  for (const [key, value] of Object.entries(process.env)) {
-    if (key.toLowerCase() === 'no_proxy' && value?.trim()) return value
-  }
-  return undefined
+export function readNoProxyEnvironment(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  // 与 EnvHttpProxyAgent 保持相同的 lowercase 优先级。
+  const noProxy = env.no_proxy ?? env.NO_PROXY
+  return noProxy?.trim() || undefined
 }
 
 /**
  * OAuth 的浏览器回调必须直接访问本地 loopback；保留用户已有的 NO_PROXY 规则并补齐它们。
  */
 export function buildOAuthNoProxy(noProxy = readNoProxyEnvironment()): string {
+  if (noProxy?.trim() === '*') return '*'
+
   const hosts = new Set(
     (noProxy ?? '')
       .split(',')

--- a/apps/electron/src/main/lib/oauth-proxy-scope.ts
+++ b/apps/electron/src/main/lib/oauth-proxy-scope.ts
@@ -1,0 +1,39 @@
+import { runWithPiRequestProxyScope } from './adapters/pi-request-proxy'
+import { getEffectiveProxyUrl } from './proxy-settings-service'
+
+// EnvHttpProxyAgent 以 URL hostname 匹配 IPv6；方括号形式才能正确匹配 http://[::1]/。
+const LOOPBACK_NO_PROXY_HOSTS = ['localhost', '127.0.0.1', '[::1]']
+
+function readNoProxyEnvironment(): string | undefined {
+  for (const [key, value] of Object.entries(process.env)) {
+    if (key.toLowerCase() === 'no_proxy' && value?.trim()) return value
+  }
+  return undefined
+}
+
+/**
+ * OAuth 的浏览器回调必须直接访问本地 loopback；保留用户已有的 NO_PROXY 规则并补齐它们。
+ */
+export function buildOAuthNoProxy(noProxy = readNoProxyEnvironment()): string {
+  const hosts = new Set(
+    (noProxy ?? '')
+      .split(',')
+      .map((host) => host.trim())
+      .filter(Boolean),
+  )
+  for (const host of LOOPBACK_NO_PROXY_HOSTS) hosts.add(host)
+  return [...hosts].join(',')
+}
+
+/**
+ * 用 Proma 的全局代理配置执行一段 Pi OAuth 网络操作。
+ *
+ * Pi OAuth 内部使用全局 fetch；受管 scope 通过 AsyncLocalStorage 为该异步链路绑定
+ * dispatcher，并在操作结束后关闭连接池。外部系统浏览器不属于此网络平面。
+ */
+export async function runWithOAuthProxyScope<T>(operation: () => Promise<T>): Promise<T> {
+  return runWithPiRequestProxyScope({
+    proxyUrl: await getEffectiveProxyUrl(),
+    noProxy: buildOAuthNoProxy(),
+  }, operation)
+}

--- a/apps/electron/src/main/lib/proxy-settings-service.test.ts
+++ b/apps/electron/src/main/lib/proxy-settings-service.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'bun:test'
+import { redactProxyUrl } from './proxy-settings-service'
+
+describe('proxy settings logging', () => {
+  test('Given an authenticated proxy URL When formatting it for logs Then redacts both username and password', () => {
+    const value = redactProxyUrl('http://alice:secret@127.0.0.1:7890')
+
+    expect(value).not.toContain('alice')
+    expect(value).not.toContain('secret')
+    expect(value).toContain('127.0.0.1:7890')
+  })
+
+  test('Given a malformed proxy URL When formatting it for logs Then never returns the original value', () => {
+    expect(redactProxyUrl('alice:secret@not a url')).toBe('[invalid proxy URL]')
+  })
+})

--- a/apps/electron/src/main/lib/proxy-settings-service.ts
+++ b/apps/electron/src/main/lib/proxy-settings-service.ts
@@ -19,6 +19,23 @@ const DEFAULT_PROXY_CONFIG: ProxyConfig = {
   manualUrl: '',
 }
 
+/** 代理 URL 可能携带认证信息；日志中绝不能输出其用户名或密码。 */
+export function redactProxyUrl(proxyUrl: string): string {
+  try {
+    const url = new URL(proxyUrl)
+    if (!['http:', 'https:', 'socks:', 'socks4:', 'socks5:'].includes(url.protocol)) {
+      return '[invalid proxy URL]'
+    }
+    if (url.username || url.password) {
+      url.username = '***'
+      url.password = '***'
+    }
+    return url.toString()
+  } catch {
+    return '[invalid proxy URL]'
+  }
+}
+
 /**
  * 读取代理配置
  *
@@ -51,7 +68,10 @@ export async function saveProxySettings(config: ProxyConfig): Promise<void> {
 
   try {
     writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8')
-    console.log('[代理配置] 配置已保存:', config)
+    console.log('[代理配置] 配置已保存:', {
+      ...config,
+      manualUrl: config.manualUrl ? redactProxyUrl(config.manualUrl) : '',
+    })
   } catch (error) {
     console.error('[代理配置] 保存配置失败:', error)
     throw new Error('保存代理配置失败')
@@ -78,7 +98,7 @@ export async function getEffectiveProxyUrl(): Promise<string | undefined> {
   if (config.mode === 'system') {
     const result = await detectSystemProxy()
     if (result.success && result.proxyUrl) {
-      console.log('[代理配置] 使用系统代理:', result.proxyUrl)
+      console.log('[代理配置] 使用系统代理:', redactProxyUrl(result.proxyUrl))
       return result.proxyUrl
     }
     console.log('[代理配置] 系统代理检测失败:', result.message)
@@ -87,7 +107,7 @@ export async function getEffectiveProxyUrl(): Promise<string | undefined> {
 
   // 手动模式
   if (config.manualUrl.trim()) {
-    console.log('[代理配置] 使用手动配置代理:', config.manualUrl)
+    console.log('[代理配置] 使用手动配置代理:', redactProxyUrl(config.manualUrl))
     return config.manualUrl.trim()
   }
 

--- a/apps/electron/src/main/lib/xai-oauth-service.ts
+++ b/apps/electron/src/main/lib/xai-oauth-service.ts
@@ -8,6 +8,7 @@
 
 import { shell } from 'electron'
 import type { XaiOAuthCredentials, XaiOAuthDeviceCode } from '@proma/shared'
+import { runWithOAuthProxyScope } from './oauth-proxy-scope'
 
 type PiSdk = typeof import('@earendil-works/pi-coding-agent')
 type OAuthCredential = XaiOAuthCredentials & { type: 'oauth'; [key: string]: unknown }
@@ -71,32 +72,34 @@ export async function loginXaiOAuth(callbacks?: XaiLoginCallbacks): Promise<XaiO
   activeLoginAbort = abort
 
   try {
-    const runtime = await sdk.ModelRuntime.create({
-      credentials: createEphemeralCredentialStore(),
-      allowModelNetwork: false,
+    return await runWithOAuthProxyScope(async () => {
+      const runtime = await sdk.ModelRuntime.create({
+        credentials: createEphemeralCredentialStore(),
+        allowModelNetwork: false,
+      })
+      const credentials = await runtime.login('xai', 'oauth', {
+        signal: abort.signal,
+        // xAI 的内置 OAuth 直接走 device code，不会向此 callback 提问；保留拒绝路径
+        // 以便上游未来增加交互时不会无限挂起。
+        prompt: async (prompt) => new Promise<string>((_resolve, reject) => {
+          const cancel = () => reject(new Error('登录已取消'))
+          prompt.signal?.addEventListener('abort', cancel, { once: true })
+          abort.signal.addEventListener('abort', cancel, { once: true })
+        }),
+        notify: (event) => {
+          if (event.type === 'device_code') {
+            console.log(`[xAI OAuth] 请在浏览器中授权（设备码：${event.userCode}）`)
+            callbacks?.onDeviceCode?.({ userCode: event.userCode, verificationUri: event.verificationUri })
+            shell.openExternal(event.verificationUri).catch((error) => {
+              console.error('[xAI OAuth] 打开授权页面失败:', error)
+            })
+          } else if (event.type === 'progress' || event.type === 'info') {
+            console.log(`[xAI OAuth] ${event.message}`)
+          }
+        },
+      })
+      return normalizeCredentials(credentials)
     })
-    const credentials = await runtime.login('xai', 'oauth', {
-      signal: abort.signal,
-      // xAI 的内置 OAuth 直接走 device code，不会向此 callback 提问；保留拒绝路径
-      // 以便上游未来增加交互时不会无限挂起。
-      prompt: async (prompt) => new Promise<string>((_resolve, reject) => {
-        const cancel = () => reject(new Error('登录已取消'))
-        prompt.signal?.addEventListener('abort', cancel, { once: true })
-        abort.signal.addEventListener('abort', cancel, { once: true })
-      }),
-      notify: (event) => {
-        if (event.type === 'device_code') {
-          console.log(`[xAI OAuth] 请在浏览器中授权（设备码：${event.userCode}）`)
-          callbacks?.onDeviceCode?.({ userCode: event.userCode, verificationUri: event.verificationUri })
-          shell.openExternal(event.verificationUri).catch((error) => {
-            console.error('[xAI OAuth] 打开授权页面失败:', error)
-          })
-        } else if (event.type === 'progress' || event.type === 'info') {
-          console.log(`[xAI OAuth] ${event.message}`)
-        }
-      },
-    })
-    return normalizeCredentials(credentials)
   } finally {
     if (activeLoginAbort === abort) activeLoginAbort = undefined
   }
@@ -110,13 +113,15 @@ export function cancelXaiOAuthLogin(): void {
 /** 通过 Pi 内置 xAI provider 刷新 token。 */
 export async function refreshXaiOAuth(refreshToken: string): Promise<XaiOAuthCredentials> {
   const sdk = await loadPiSdk()
-  const store = createEphemeralCredentialStore({
-    type: 'oauth',
-    access: '',
-    refresh: refreshToken,
-    expires: 0,
+  return runWithOAuthProxyScope(async () => {
+    const store = createEphemeralCredentialStore({
+      type: 'oauth',
+      access: '',
+      refresh: refreshToken,
+      expires: 0,
+    })
+    const runtime = await sdk.ModelRuntime.create({ credentials: store, allowModelNetwork: false })
+    await runtime.getAuth('xai')
+    return normalizeCredentials(await store.read('xai'))
   })
-  const runtime = await sdk.ModelRuntime.create({ credentials: store, allowModelNetwork: false })
-  await runtime.getAuth('xai')
-  return normalizeCredentials(await store.read('xai'))
 }

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -256,10 +256,13 @@ export interface ElectronAPI {
   getChannelPlanQuota: (channelId: string) => Promise<ChannelPlanQuotaResult>
 
   /** 发起 ChatGPT (Codex) OAuth 登录，返回序列化凭据（作为 apiKey 存储） */
-  codexOAuthLogin: () => Promise<CodexOAuthLoginResult>
+  codexOAuthLogin: (method?: import('@proma/shared').CodexOAuthLoginMethod) => Promise<CodexOAuthLoginResult>
 
   /** 取消进行中的 ChatGPT (Codex) OAuth 登录 */
   codexOAuthCancel: () => Promise<void>
+
+  /** 订阅登录期间，接收 Codex device code 与授权链接。返回取消订阅函数。 */
+  onCodexOAuthDeviceCode: (callback: (deviceCode: import('@proma/shared').CodexOAuthDeviceCode) => void) => () => void
 
   /** 发起 xAI（Grok/X 订阅）OAuth 登录 */
   xaiOAuthLogin: () => Promise<XaiOAuthLoginResult>
@@ -1326,12 +1329,18 @@ const electronAPI: ElectronAPI = {
     return ipcRenderer.invoke(CHANNEL_IPC_CHANNELS.GET_PLAN_QUOTA, channelId)
   },
 
-  codexOAuthLogin: () => {
-    return ipcRenderer.invoke(CHANNEL_IPC_CHANNELS.CODEX_OAUTH_LOGIN)
+  codexOAuthLogin: (method?: import('@proma/shared').CodexOAuthLoginMethod) => {
+    return ipcRenderer.invoke(CHANNEL_IPC_CHANNELS.CODEX_OAUTH_LOGIN, method)
   },
 
   codexOAuthCancel: () => {
     return ipcRenderer.invoke(CHANNEL_IPC_CHANNELS.CODEX_OAUTH_CANCEL)
+  },
+
+  onCodexOAuthDeviceCode: (callback: (deviceCode: import('@proma/shared').CodexOAuthDeviceCode) => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, deviceCode: import('@proma/shared').CodexOAuthDeviceCode) => callback(deviceCode)
+    ipcRenderer.on(CHANNEL_IPC_CHANNELS.CODEX_OAUTH_DEVICE_CODE, listener)
+    return () => ipcRenderer.removeListener(CHANNEL_IPC_CHANNELS.CODEX_OAUTH_DEVICE_CODE, listener)
   },
 
   xaiOAuthLogin: () => {

--- a/apps/electron/src/renderer/components/settings/ChannelForm.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelForm.tsx
@@ -42,6 +42,7 @@ import type {
   ChannelCreateInput,
   ChannelModel,
   ChannelTestResult,
+  CodexOAuthDeviceCode,
   FetchModelsResult,
   ProviderType,
   XaiOAuthDeviceCode,
@@ -237,11 +238,13 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
   const [showBaseUrlRiskDialog, setShowBaseUrlRiskDialog] = React.useState(false)
   const [pendingRiskAction, setPendingRiskAction] = React.useState<'auto-save' | 'create' | 'fetch' | 'save-and-close' | 'test' | null>(null)
   const [codexLoggingIn, setCodexLoggingIn] = React.useState(false)
+  const [codexDeviceCode, setCodexDeviceCode] = React.useState<CodexOAuthDeviceCode | null>(null)
   const [xaiLoggingIn, setXaiLoggingIn] = React.useState(false)
   const [xaiDeviceCode, setXaiDeviceCode] = React.useState<XaiOAuthDeviceCode | null>(null)
 
   const setChannelFormDirty = useSetAtom(channelFormDirtyAtom)
   const lastAgentEligibleRef = React.useRef(channel ? isAgentEligibleChannel(channel) : false)
+  const codexLoggingInRef = React.useRef(false)
   const xaiLoggingInRef = React.useRef(false)
 
   React.useEffect(() => {
@@ -249,8 +252,16 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
   }, [channel])
 
   React.useEffect(() => {
+    codexLoggingInRef.current = codexLoggingIn
+  }, [codexLoggingIn])
+
+  React.useEffect(() => {
     xaiLoggingInRef.current = xaiLoggingIn
   }, [xaiLoggingIn])
+
+  React.useEffect(() => {
+    return window.electronAPI.onCodexOAuthDeviceCode(setCodexDeviceCode)
+  }, [])
 
   React.useEffect(() => {
     return window.electronAPI.onXaiOAuthDeviceCode(setXaiDeviceCode)
@@ -258,6 +269,7 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
 
   // 关闭或放弃表单时取消仍在轮询的 device-code 授权，避免后台孤立请求。
   React.useEffect(() => () => {
+    if (codexLoggingInRef.current) void window.electronAPI.codexOAuthCancel()
     if (xaiLoggingInRef.current) void window.electronAPI.xaiOAuthCancel()
   }, [])
 
@@ -506,12 +518,20 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
     )
   }
 
-  /** 发起 ChatGPT (Codex) OAuth 登录：打开浏览器授权，成功后把凭据写入 apiKey */
-  const handleCodexLogin = async (): Promise<void> => {
+  const handleCancelCodexLogin = (): void => {
+    codexLoggingInRef.current = false
+    void window.electronAPI.codexOAuthCancel()
+    setCodexDeviceCode(null)
+  }
+
+  /** 发起 ChatGPT (Codex) OAuth 登录，默认系统浏览器；网络受限时可改用设备码。 */
+  const handleCodexLogin = async (method: 'browser' | 'device_code' = 'browser'): Promise<void> => {
+    codexLoggingInRef.current = true
     setCodexLoggingIn(true)
+    setCodexDeviceCode(null)
     setTestResult(null)
     try {
-      const result = await window.electronAPI.codexOAuthLogin()
+      const result = await window.electronAPI.codexOAuthLogin(method)
       if (!result.success || !result.credentials) {
         toast.error(result.message ?? 'ChatGPT 登录失败，请重试')
         return
@@ -560,17 +580,20 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
       console.error('[模型配置表单] ChatGPT 登录失败:', error)
       toast.error('ChatGPT 登录失败，请重试')
     } finally {
+      codexLoggingInRef.current = false
       setCodexLoggingIn(false)
     }
   }
 
   const handleCancelXaiLogin = (): void => {
+    xaiLoggingInRef.current = false
     void window.electronAPI.xaiOAuthCancel()
     setXaiDeviceCode(null)
   }
 
   /** 发起 xAI（Grok/X 订阅）OAuth 登录：Pi 打开预填 device-code 浏览器授权页。 */
   const handleXaiLogin = async (): Promise<void> => {
+    xaiLoggingInRef.current = true
     setXaiLoggingIn(true)
     setXaiDeviceCode(null)
     setTestResult(null)
@@ -633,6 +656,7 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
       console.error('[模型配置表单] xAI 登录失败:', error)
       toast.error('xAI 登录失败，请重试')
     } finally {
+      xaiLoggingInRef.current = false
       setXaiLoggingIn(false)
       setXaiDeviceCode(null)
     }
@@ -959,19 +983,41 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
                   variant="outline"
                   size="sm"
                   type="button"
-                  onClick={handleCodexLogin}
+                  onClick={() => void handleCodexLogin('browser')}
                   disabled={codexLoggingIn}
                   className="w-full"
                 >
                   {codexLoggingIn ? <Loader2 size={14} className="animate-spin" /> : <Zap size={14} />}
-                  <span>{codexLoggingIn ? '等待浏览器授权…' : hasRequiredSecret ? '重新登录 ChatGPT' : '用 ChatGPT 登录'}</span>
+                  <span>{codexLoggingIn ? '等待授权完成…' : hasRequiredSecret ? '重新登录 ChatGPT' : '用 ChatGPT 登录'}</span>
                 </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  type="button"
+                  onClick={() => void handleCodexLogin('device_code')}
+                  disabled={codexLoggingIn}
+                  className="w-full text-muted-foreground"
+                >
+                  使用设备码登录（浏览器无法使用系统代理时）
+                </Button>
+                {codexLoggingIn && (
+                  <Button variant="ghost" size="sm" type="button" onClick={handleCancelCodexLogin} className="w-full text-muted-foreground">
+                    取消登录
+                  </Button>
+                )}
+                {codexDeviceCode && (
+                  <div className="rounded-md border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground space-y-2">
+                    <div>在任意可访问网络的浏览器中打开链接，并输入设备码：<span className="font-mono font-medium text-foreground">{codexDeviceCode.userCode}</span></div>
+                    <a href={codexDeviceCode.verificationUri} target="_blank" rel="noreferrer" className="text-primary hover:underline">打开 ChatGPT 授权页面</a>
+                    {codexDeviceCode.qrCodeData && <img src={codexDeviceCode.qrCodeData} alt="ChatGPT 设备码授权二维码" className="h-28 w-28 rounded bg-white p-1" />}
+                  </div>
+                )}
                 {hasRequiredSecret ? (
                   <div className="flex items-center gap-1.5 text-xs text-emerald-600">
                     <CheckCircle2 size={12} className="shrink-0" />
                     <span>已登录 ChatGPT 订阅{codexCredentials?.accountId ? `（账号 ${codexCredentials.accountId.slice(0, 8)}…）` : ''}</span>
                   </div>
-                ) : <div className="text-xs text-muted-foreground">使用 ChatGPT Plus/Pro 订阅登录，通过 OAuth 授权，无需 API Key。授权将在系统浏览器中打开。</div>}
+                ) : <div className="text-xs text-muted-foreground">Proma 会代理 token 请求；系统浏览器授权页仍需使用可访问 OpenAI 的网络。可改用设备码并在另一台设备完成授权。</div>}
               </div>
             ) : isXaiProvider ? (
               <div className="space-y-2">
@@ -992,11 +1038,12 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
                   </Button>
                 )}
                 {xaiDeviceCode && (
-                  <div className="rounded-md border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground space-y-1.5">
+                  <div className="rounded-md border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground space-y-2">
                     <div>若浏览器未自动填入授权码，请输入：<span className="font-mono font-medium text-foreground">{xaiDeviceCode.userCode}</span></div>
                     <a href={xaiDeviceCode.verificationUri} target="_blank" rel="noreferrer" className="text-primary hover:underline">
                       打开 xAI 授权页面
                     </a>
+                    {xaiDeviceCode.qrCodeData && <img src={xaiDeviceCode.qrCodeData} alt="xAI 设备码授权二维码" className="h-28 w-28 rounded bg-white p-1" />}
                   </div>
                 )}
                 {hasRequiredSecret ? (
@@ -1004,7 +1051,7 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
                     <CheckCircle2 size={12} className="shrink-0" />
                     <span>已登录 xAI（Grok）订阅</span>
                   </div>
-                ) : <div className="text-xs text-muted-foreground">使用 SuperGrok 或 X Premium 订阅登录，通过 OAuth 授权，无需 API Key。授权将在系统浏览器中打开。</div>}
+                ) : <div className="text-xs text-muted-foreground">Proma 会代理设备码与 token 请求；授权页由系统浏览器打开。若浏览器无可用代理，可扫码在另一台设备完成授权。</div>}
               </div>
             ) : isZhipuTeamProvider ? (
               <div className="space-y-2">

--- a/docs/plans/2026-08-02-unified-oauth-proxy.md
+++ b/docs/plans/2026-08-02-unified-oauth-proxy.md
@@ -1,0 +1,68 @@
+# Unified OAuth Proxy Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Route every Pi OAuth back-channel request through Proma’s request-scoped application proxy while preserving external-browser OAuth and providing Codex device-code fallback.
+
+**Architecture:** Reuse the existing AsyncLocalStorage dispatcher router for a short-lived OAuth scope rather than copying provider OAuth protocols. The main process resolves the app proxy once per OAuth operation, scopes `ModelRuntime.login()` / `getAuth()` to it, and always closes the dispatcher. Browser authorization remains external; Codex device-code exposes a QR-capable fallback for browsers that cannot use the app proxy.
+
+**Tech Stack:** Electron main/preload/renderer, TypeScript, Bun tests, undici, Pi `ModelRuntime`, qrcode.
+
+---
+
+### Task 1: Add a managed OAuth proxy scope
+
+**Files:**
+- Modify: `apps/electron/src/main/lib/adapters/pi-request-proxy.ts`
+- Create: `apps/electron/src/main/lib/oauth-proxy-scope.ts`
+- Test: `apps/electron/src/main/lib/oauth-proxy-scope.test.ts`
+
+**Step 1:** Write tests that verify the scope resolves the configured proxy, appends loopback hosts to `NO_PROXY`, executes in the Pi scope, and closes on both success and failure.
+
+**Step 2:** Add `runWithPiRequestProxyScope()` around the existing dispatcher lifecycle.
+
+**Step 3:** Add `runWithOAuthProxyScope()` that reads `getEffectiveProxyUrl()`, merges process `NO_PROXY` with `localhost,127.0.0.1,[::1]` (the bracketed IPv6 form required by Undici), and delegates to the managed Pi scope.
+
+**Step 4:** Run `bun test apps/electron/src/main/lib/oauth-proxy-scope.test.ts`.
+
+### Task 2: Route Codex and xAI SDK OAuth through the scope
+
+**Files:**
+- Modify: `apps/electron/src/main/lib/codex-oauth-service.ts`
+- Modify: `apps/electron/src/main/lib/xai-oauth-service.ts`
+
+**Step 1:** Wrap each provider’s `ModelRuntime.login()` and `getAuth()` operation in `runWithOAuthProxyScope()`.
+
+**Step 2:** Preserve the Pi SDK as the OAuth protocol implementation; do not copy device-code, polling, or refresh logic into Proma.
+
+**Step 3:** Add a `device_code` method to Codex login selection and forward its device-code event to a caller callback; retain browser as default.
+
+**Step 4:** Run targeted typecheck/tests.
+
+### Task 3: Surface Codex device-code fallback securely
+
+**Files:**
+- Modify: `packages/shared/src/types/channel.ts`
+- Modify: `apps/electron/src/main/ipc.ts`
+- Modify: `apps/electron/src/preload/index.ts`
+- Modify: `apps/electron/src/renderer/components/settings/ChannelForm.tsx`
+
+**Step 1:** Add typed Codex OAuth method and device-code IPC contracts.
+
+**Step 2:** Let IPC generate a QR data URL only from the device verification URI and send it to the initiating renderer.
+
+**Step 3:** Add a secondary Codex “use device code” action, display short code/URL/QR while polling, and allow cancellation.
+
+**Step 4:** Update wording so users know system-browser connectivity is separate from Proma’s Node proxy.
+
+### Task 4: Verify and review
+
+**Files:**
+- Test: `apps/electron/src/main/lib/oauth-proxy-scope.test.ts`
+- Test: `apps/electron/src/main/lib/adapters/pi-agent-proxy.test.ts`
+
+**Step 1:** Run targeted Bun tests and `bun run typecheck` from `apps/electron`.
+
+**Step 2:** Inspect diff for secret logging, process-wide dispatcher changes, and browser callback proxying.
+
+**Step 3:** Review the final change against the OAuth proxy architecture document and report any remaining browser-network limitation explicitly.

--- a/packages/shared/src/types/channel.ts
+++ b/packages/shared/src/types/channel.ts
@@ -490,6 +490,8 @@ export const CHANNEL_IPC_CHANNELS = {
   CODEX_OAUTH_LOGIN: 'channel:codex-oauth-login',
   /** 取消进行中的 ChatGPT OAuth 登录流程 */
   CODEX_OAUTH_CANCEL: 'channel:codex-oauth-cancel',
+  /** Codex device-code 已就绪（主进程推送给发起登录的渲染窗口） */
+  CODEX_OAUTH_DEVICE_CODE: 'channel:codex-oauth-device-code',
   /** 发起 xAI（Grok/X 订阅）OAuth 登录 */
   XAI_OAUTH_LOGIN: 'channel:xai-oauth-login',
   /** 取消进行中的 xAI OAuth 登录流程 */
@@ -504,6 +506,16 @@ export const CHANNEL_IPC_CHANNELS = {
  * 登录在主进程执行（Pi SDK 的 codex 流程用 Node crypto + 本地回调服务），
  * 成功后返回已加密的凭据 JSON（可直接作为 Channel.apiKey 存储）与展示信息。
  */
+export type CodexOAuthLoginMethod = 'browser' | 'device_code'
+
+/** Pi Codex device-code 登录流程的用户可见信息。 */
+export interface CodexOAuthDeviceCode {
+  userCode: string
+  verificationUri: string
+  /** 可扫码交给另一台可联网设备完成授权。 */
+  qrCodeData?: string
+}
+
 export interface CodexOAuthLoginResult {
   /** 是否登录成功 */
   success: boolean
@@ -531,4 +543,6 @@ export interface XaiOAuthLoginResult {
 export interface XaiOAuthDeviceCode {
   userCode: string
   verificationUri: string
+  /** 可扫码交给另一台可联网设备完成授权。 */
+  qrCodeData?: string
 }


### PR DESCRIPTION
## Summary
- route Codex and xAI login/refresh back-channel requests through a short-lived, request-scoped Pi dispatcher
- retain RFC 8252 external-browser authorization and add a QR-capable Codex device-code fallback for restricted browser networks
- bypass the local OAuth callback on `localhost`, `127.0.0.1`, and `[::1]`; avoid process-wide proxy mutation
- close scoped dispatchers on success and failure, cancel device-code polling on form teardown, and redact proxy credentials from logs

## Validation
- `bun test apps/electron/src/main/lib/oauth-proxy-scope.test.ts`
- `bun test apps/electron/src/main/lib/adapters/pi-agent-proxy.test.ts`
- `bun test apps/electron/src/main/lib/proxy-settings-service.test.ts`
- `bun run typecheck`
- `bun run build:main && bun run build:preload && bun run build:renderer`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)