### PR TITLE
fix(renderer): 浅色主题选区保留文字颜色【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.16.7",
+  "version": "0.16.8",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/styles/globals.css
+++ b/apps/electron/src/renderer/styles/globals.css
@@ -28,16 +28,15 @@
 
 /* ===== 文字选区颜色 =====
  * 吃 --primary token，多数主题下品牌色自动反映到选区高亮。
- * 但部分主题的 --primary 在暗背景上太暗（如 ocean-dark/forest-dark）或在亮背景上太浅（如云朵舞者），
- * 这些主题在下方单独覆写 ::selection 让对比度回到可读区间。
+ * 只覆盖选区背景，让嵌套的终端、代码块和语法高亮内容保留自身前景色。
+ * 部分主题的 --primary 在暗背景上太暗（如 ocean-dark/forest-dark）或在亮背景上太浅（如云朵舞者），
+ * 这些主题在下方单独覆写 ::selection 的背景色让对比度回到可读区间。
  */
 ::selection {
-  background-color: hsl(var(--primary) / 0.25);
-  color: hsl(var(--foreground));
+  background-color: hsl(var(--primary) / 0.20);
 }
 ::-moz-selection {
-  background-color: hsl(var(--primary) / 0.25);
-  color: hsl(var(--foreground));
+  background-color: hsl(var(--primary) / 0.20);
 }
 
 /* 暗色特殊主题：--primary 太暗，改用 --accent-foreground（明亮的强调文字色）
@@ -60,7 +59,7 @@
 /* 云朵舞者（slate-light）：--primary 是淡杏粉，亮背景下需要更高不透明度才看得见 */
 .theme-slate-light ::selection,
 .theme-slate-light ::-moz-selection {
-  background-color: hsl(var(--primary) / 0.6);
+  background-color: hsl(var(--primary) / 0.50);
 }
 
 /* CRT 终端：亮绿选区 + 黑字 */
@@ -1263,7 +1262,7 @@
   padding: 0;
 }
 
-/* 浅色主题代码块是深底，用偏浅的蓝灰选区承托白字，避免 Shiki token 内联色在选中后变黑。 */
+/* 浅色主题代码块是深底，用偏浅的蓝灰选区承托原有文字与 Shiki 语法色。 */
 :root:not(.dark) :is(
   .code-block-wrapper pre.shiki,
   .tiptap pre
@@ -1272,9 +1271,7 @@
   .code-block-wrapper pre.shiki,
   .tiptap pre
 ) ::selection {
-  background-color: hsl(210 80% 62% / 0.32);
-  color: hsl(0 0% 98%) !important;
-  -webkit-text-fill-color: hsl(0 0% 98%);
+  background-color: hsl(210 80% 68% / 0.32);
 }
 
 :root:not(.dark) :is(
@@ -1285,8 +1282,7 @@
   .code-block-wrapper pre.shiki,
   .tiptap pre
 ) ::-moz-selection {
-  background-color: hsl(210 80% 62% / 0.32);
-  color: hsl(0 0% 98%) !important;
+  background-color: hsl(210 80% 68% / 0.32);
 }
 
 /* 代码行：限制重排范围，GPU 合成优化 */


### PR DESCRIPTION
## 概述

修复浅色主题中 Agent 对话的终端输出、代码块等可选中文本：选区现在只改变背景色，保留内容自身的前景色，避免全局 `--foreground` 覆盖深色输出的浅色文字。同步将浅色选区调整为更柔和的亮度。

## 改动

- `apps/electron/src/renderer/styles/globals.css` — 移除全局和浅色代码块选区的文字颜色覆盖；降低常规与 slate-light 选区背景强度，并让深色代码块使用更亮的蓝灰选区。
- `apps/electron/package.json` — 将 `@proma/electron` 从 `0.16.7` 升至 `0.16.8`。

## 测试方法

1. 运行 `bun run typecheck`，确认全部 workspace 包类型检查通过。
2. 运行 `bun run --filter='@proma/electron' build:renderer`，确认 Vite renderer 构建通过。
3. 在 Chromium 中验证深色终端内容被选中后，前景色仍继承原始浅色文字，只有选区背景改变。
4. 完成 Proma fork 审查及 Windows 路径、Shell、平台分支和打包脚本扫描，未发现本改动引入的兼容性问题。

## 备注

- 分支基于最新 `upstream/main`（`d703cea8`）切出。
- 改动已完成代码审查；当前 diff 仅包含上述两个文件。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)