### PR TITLE
fix(scratch-pad): 草稿末尾保留编辑缓冲区【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
+++ b/apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx
@@ -699,8 +699,8 @@ function ScratchPadEditor({ variant }: ScratchPadEditorProps): React.ReactElemen
 
   const isPane = variant === 'pane'
   const scrollClassName = isPane
-    ? 'flex-1 overflow-auto scrollbar-thin px-4 pt-4 pb-20'
-    : 'flex-1 overflow-auto scrollbar-thin px-8 pt-6 pb-20'
+    ? 'flex-1 overflow-auto scrollbar-thin px-4 pt-4'
+    : 'flex-1 overflow-auto scrollbar-thin px-8 pt-6'
   const contentClassName = isPane ? 'h-full max-w-none' : 'max-w-3xl mx-auto h-full'
   const speechWrapperClassName = isPane
     ? 'absolute left-1/2 -translate-x-1/2 bottom-9 z-20'
@@ -750,7 +750,7 @@ function ScratchPadEditor({ variant }: ScratchPadEditorProps): React.ReactElemen
           {loaded ? (
             <EditorContent
               editor={editor}
-              className="scratch-pad-editor prose prose-sm dark:prose-invert max-w-none h-full [&_.ProseMirror]:min-h-full [&_.ProseMirror]:outline-none [&_.ProseMirror]:text-sm [&_.ProseMirror_p.is-editor-empty:first-child::before]:text-muted-foreground/50 [&_.ProseMirror_p.is-editor-empty:first-child::before]:content-[attr(data-placeholder)] [&_.ProseMirror_p.is-editor-empty:first-child::before]:float-left [&_.ProseMirror_p.is-editor-empty:first-child::before]:pointer-events-none [&_.ProseMirror_p.is-editor-empty:first-child::before]:h-0"
+              className="scratch-pad-editor prose prose-sm dark:prose-invert max-w-none h-full [&_.ProseMirror]:min-h-full [&_.ProseMirror]:pb-[33vh] [&_.ProseMirror]:outline-none [&_.ProseMirror]:text-sm [&_.ProseMirror_p.is-editor-empty:first-child::before]:text-muted-foreground/50 [&_.ProseMirror_p.is-editor-empty:first-child::before]:content-[attr(data-placeholder)] [&_.ProseMirror_p.is-editor-empty:first-child::before]:float-left [&_.ProseMirror_p.is-editor-empty:first-child::before]:pointer-events-none [&_.ProseMirror_p.is-editor-empty:first-child::before]:h-0"
             />
           ) : (
             <div className="min-h-[200px] flex items-center justify-center">


### PR DESCRIPTION
## 概述

草稿页滚动到末尾时，最后有效内容会贴近底部状态栏，缺少继续输入所需的缓冲空间。本 PR 将末尾留白放入 ProseMirror 正文，使文档末尾保留约三分之一视口高度的空白。

## 改动

- `apps/electron/src/renderer/components/scratch-pad/ScratchPadView.tsx` — 移除外层固定 `pb-20`，改为在 ProseMirror 正文末尾添加 `33vh` 的响应式底部 padding；完整草稿页与右侧分屏共用该行为。

## 测试方法

1. 运行 `bun run typecheck`，确认 monorepo 全部包类型检查通过。
2. 运行 `bun run --filter='@proma/electron' build:renderer`，确认 renderer 构建通过且生成 `padding-bottom: 33vh`。
3. 运行 `git diff --check`，确认提交没有空白错误。
4. 审查完整工作树 diff，并完成 Windows 路径、Shell、平台分支、快捷键、打包脚本与依赖变更扫描。

## 备注

- 变更不触及持久化、IPC、平台特定代码或构建配置。
- 建议在实际 Electron 窗口内对长草稿的完整页与右侧分屏各做一次滚动到底的视觉确认。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)