### PR TITLE
fix(electron): 修复 Windows 设置页窗口控制按钮无响应【审核中】

### DIFF
--- a/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
+++ b/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
@@ -8,6 +8,7 @@
 import * as React from "react";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { cn } from "@/lib/utils";
+import { detectIsWindows, WINDOW_CONTROLS_INSET_RIGHT } from "@/lib/platform";
 import {
   Settings,
   Radio,
@@ -171,6 +172,7 @@ export function SettingsPanel({
   const [mainTabs, setMainTabs] = useAtom(tabsAtom);
   const setMainActiveTabId = useSetAtom(activeTabIdAtom);
   const openSession = useOpenSession()
+  const isWindows = React.useMemo(() => detectIsWindows(), [])
 
   /** 统一的退出拦截对话框状态 */
   type PendingAction =
@@ -287,10 +289,18 @@ export function SettingsPanel({
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-content-area text-foreground">
-      <div
-        aria-hidden="true"
-        className="titlebar-drag-region pointer-events-none h-[35px] flex-shrink-0 bg-[hsl(var(--sidebar-surface))]"
-      />
+      {/* 顶部可拖动标题栏区域。背景层保持全宽；drag 层在 Windows 上必须避开右上角的
+          WindowControls 按钮区域（WINDOW_CONTROLS_INSET_RIGHT），否则 OS hitmask 会把
+          按钮点击误判为标题栏点击，导致最小化/最大化/关闭按钮无响应（与 AppShell/TabBar 一致）。 */}
+      <div className="relative h-[35px] flex-shrink-0 bg-[hsl(var(--sidebar-surface))]">
+        <div
+          aria-hidden="true"
+          className={cn(
+            'titlebar-drag-region pointer-events-none absolute left-0 top-0 h-full',
+            isWindows ? WINDOW_CONTROLS_INSET_RIGHT : 'right-0',
+          )}
+        />
+      </div>
 
       {/* 主体：左导航 + 右内容 */}
       <div className="flex flex-1 min-h-0">


### PR DESCRIPTION
## 概述

修复 Windows 平台 bug：用户进入「设置」页面时，右上角最小化/最大化/关闭按钮点击无响应，且窗口无法调整大小。

根因是设置页顶部 35px 的 `titlebar-drag-region` 在 #1341（fix: simplify settings header）简化头部时丢失了对右上角 `WindowControls` 按钮区域的避让逻辑，变成全宽 drag 条。Windows 上 `-webkit-app-region: drag` 区域由 OS 级 WM_NCHITTEST 处理，drag 区域与按钮 hitmask 重叠时 OS 会把按钮单击误判为标题栏点击，导致按钮无响应；主窗口默认最大化后无法点击还原按钮退出最大化，于是表现为「无法调整大小」。项目内其他 drag 区域（AppShell / TabBar / ChatHeader / AgentHeader / PlanningView）均使用 `WINDOW_CONTROLS_INSET_RIGHT` 避让按钮区，唯独 SettingsPanel 遗漏。

## 改动

- `apps/electron/src/renderer/components/settings/SettingsPanel.tsx` — 设置页顶部改为双层结构：外层全宽背景条保持视觉不变；内层 drag 层在 Windows 上应用 `WINDOW_CONTROLS_INSET_RIGHT`（`right-[126px]`）避让右上角按钮区域，非 Windows 保持全宽。新增 `detectIsWindows` / `WINDOW_CONTROLS_INSET_RIGHT` 引用与 `isWindows` 判断。

## 测试方法

1. Windows 上打开应用，进入「设置」页面
2. 验证右上角最小化/最大化/关闭三个按钮均可正常点击
3. 窗口最大化状态下点击「还原」可退出最大化
4. 非最大化状态下拖拽窗口边缘可自由调整大小
5. 点击窗口顶部（避开按钮区域）可拖动窗口
6. macOS / Linux 回归：设置页打开时窗口拖动行为与修复前一致
7. `bun run typecheck`（全量 workspace）通过

## 备注

- 与既有修复 `3f3f171b`（#487，Windows titlebar buttons clickability）采用同一套避让约定（`WINDOW_CONTROLS_INSET_RIGHT = right-[126px]`）
- 主进程 `BrowserWindow` 的 `resizable/maximizable/fullscreenable` 均未被改动，问题纯属渲染层 drag 区域遮挡

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
