### PR TITLE
【已审核】feat(settings): 设置页面支持独立窗口

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -113,6 +113,7 @@ import { wechatBridge } from './lib/wechat-bridge'
 import { getWeChatConfig } from './lib/wechat-config'
 import { createQuickTaskWindow, toggleQuickTaskWindow, destroyQuickTaskWindow } from './lib/quick-task-window'
 import { destroyPlanningWindow, showPlanningWindow } from './lib/planning-window'
+import { destroySettingsWindow } from './lib/settings-window'
 import { createAgentIslandWindow, destroyAgentIslandWindow, showAgentIslandWindow } from './lib/agent-island-window'
 import { handleNativeAgentIslandEvent, initAgentIslandService, disposeAgentIslandService, publishAgentIslandNow } from './lib/agent-island-service'
 import { disposeMacAgentIslandNativeHost, startMacAgentIslandNativeHost } from './lib/mac-agent-island-native-host'
@@ -735,6 +736,7 @@ app.on('before-quit', () => {
   // 销毁辅助窗口
   destroyQuickTaskWindow()
   destroyPlanningWindow()
+  destroySettingsWindow()
   destroyVoiceDictationWindow()
   // 销毁灵动岛服务与窗口（先关闭 NSPanel helper，避免开发热重载遗留原生面板）
   disposeMacAgentIslandNativeHost()

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -27,6 +27,7 @@ import type {
   VoiceDictationToggleInput,
   MicPermissionResult,
 } from '../types'
+import { OPENABLE_SETTINGS_TABS, type SettingsTab } from '../types'
 import type {
   RuntimeStatus,
   GitRepoStatus,
@@ -1631,12 +1632,39 @@ export function registerIpcHandlers(): void {
   // 更新用户档案
   ipcMain.handle(
     USER_PROFILE_IPC_CHANNELS.UPDATE,
-    async (_, updates: Partial<UserProfile>): Promise<UserProfile> => {
-      return updateUserProfile(updates)
+    async (event, updates: Partial<UserProfile>): Promise<UserProfile> => {
+      const profile = await updateUserProfile(updates)
+      // 广播给其他窗口（如独立设置窗口修改后同步主窗口左下角头像/用户名）
+      BrowserWindow.getAllWindows().forEach((win) => {
+        if (win.webContents.id !== event.sender.id) {
+          win.webContents.send(USER_PROFILE_IPC_CHANNELS.CHANGED, profile)
+        }
+      })
+      return profile
     }
   )
 
   // ===== 应用设置相关 =====
+
+  // 打开或聚焦独立设置窗口（可选携带初始标签页）
+  ipcMain.handle(
+    SETTINGS_IPC_CHANNELS.OPEN_WINDOW,
+    async (_, tab?: unknown): Promise<void> => {
+      const { showSettingsWindow } = await import('./lib/settings-window')
+      showSettingsWindow(typeof tab === 'string' && (OPENABLE_SETTINGS_TABS as readonly string[]).includes(tab) ? (tab as SettingsTab) : undefined)
+    }
+  )
+
+  // 渲染进程确认可关闭设置窗口（弹窗确认后或无未保存内容时调用）
+  ipcMain.handle(
+    SETTINGS_IPC_CHANNELS.CONFIRM_CLOSE,
+    async (event): Promise<void> => {
+      const win = BrowserWindow.fromWebContents(event.sender)
+      if (!win || win.isDestroyed()) return
+      const { confirmSettingsWindowClose } = await import('./lib/settings-window')
+      confirmSettingsWindowClose(win)
+    }
+  )
 
   // 获取应用设置
   ipcMain.handle(

--- a/apps/electron/src/main/lib/settings-window.ts
+++ b/apps/electron/src/main/lib/settings-window.ts
@@ -1,0 +1,211 @@
+import { app, BrowserWindow, screen, shell } from 'electron'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import type { MainWindowState } from '../../types'
+import { getPersistableMainWindowState } from './main-window-lifecycle'
+import { getSettings, updateSettings } from './settings-service'
+import { SETTINGS_IPC_CHANNELS, OPENABLE_SETTINGS_TABS, type SettingsTab } from '../../types'
+
+const DEFAULT_WIDTH = 1280
+const DEFAULT_HEIGHT = 860
+const MIN_WIDTH = 900
+const MIN_HEIGHT = 600
+const SETTINGS_WINDOW_TITLE = 'Proma · 设置'
+
+let settingsWindow: BrowserWindow | null = null
+/** 渲染进程确认可关闭后才置为 true；用于拦截未保存的渠道表单。 */
+let closeConfirmed = false
+/** 窗口状态保存防抖定时器（模块级，destroy 时统一清理） */
+let settingsSaveTimer: ReturnType<typeof setTimeout> | null = null
+
+function getIconPath(): string | undefined {
+  const resourcesDir = join(__dirname, 'resources')
+  const filename = process.platform === 'darwin'
+    ? 'icon.icns'
+    : process.platform === 'win32'
+      ? 'icon.ico'
+      : 'icon.png'
+  const iconPath = join(resourcesDir, filename)
+  return existsSync(iconPath) ? iconPath : undefined
+}
+
+function getInitialBounds(savedState?: MainWindowState): Electron.Rectangle {
+  if (savedState) {
+    return { x: savedState.x, y: savedState.y, width: savedState.width, height: savedState.height }
+  }
+
+  const display = screen.getDisplayNearestPoint(screen.getCursorScreenPoint())
+  const { x, y, width, height } = display.workArea
+  const windowWidth = Math.min(DEFAULT_WIDTH, Math.max(MIN_WIDTH, width - 80))
+  const windowHeight = Math.min(DEFAULT_HEIGHT, Math.max(MIN_HEIGHT, height - 80))
+  return {
+    x: x + Math.round((width - windowWidth) / 2),
+    y: y + Math.round((height - windowHeight) / 2),
+    width: windowWidth,
+    height: windowHeight,
+  }
+}
+
+function ensureWindowOnScreen(win: BrowserWindow): void {
+  const bounds = win.getBounds()
+  const centerX = bounds.x + bounds.width / 2
+  const centerY = bounds.y + bounds.height / 2
+  const visible = screen.getAllDisplays().some((display) => {
+    const area = display.workArea
+    return centerX >= area.x && centerX <= area.x + area.width && centerY >= area.y && centerY <= area.y + area.height
+  })
+  if (visible) return
+
+  const area = screen.getPrimaryDisplay().workArea
+  win.setPosition(
+    area.x + Math.round((area.width - bounds.width) / 2),
+    area.y + Math.round((area.height - bounds.height) / 2),
+  )
+}
+
+function isDevServerNavigation(url: string): boolean {
+  try {
+    return new URL(url).origin === 'http://127.0.0.1:5173'
+  } catch {
+    return false
+  }
+}
+
+function persistSettingsWindowState(win: BrowserWindow): void {
+  const state = getPersistableMainWindowState(win)
+  if (!state) return
+  try {
+    updateSettings({ settingsWindowState: state })
+  } catch (error) {
+    console.error('[设置窗口] 保存窗口状态失败:', error)
+  }
+}
+
+function createSettingsWindow(tab?: SettingsTab): BrowserWindow {
+  const savedState = getSettings().settingsWindowState
+  const isMac = process.platform === 'darwin'
+  const isWindows = process.platform === 'win32'
+  const titleBarOptions = isMac
+    ? {
+        titleBarStyle: 'hiddenInset' as const,
+        trafficLightPosition: { x: 18, y: 18 },
+        vibrancy: 'under-window' as const,
+        visualEffectState: 'followWindow' as const,
+      }
+    : isWindows
+      ? { titleBarStyle: 'hidden' as const }
+      : {}
+  const win = new BrowserWindow({
+    ...getInitialBounds(savedState),
+    minWidth: MIN_WIDTH,
+    minHeight: MIN_HEIGHT,
+    title: SETTINGS_WINDOW_TITLE,
+    icon: getIconPath(),
+    show: false,
+    webPreferences: {
+      preload: join(__dirname, 'preload.cjs'),
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+    ...titleBarOptions,
+  })
+  settingsWindow = win
+  closeConfirmed = false
+  ensureWindowOnScreen(win)
+
+  const query = new URLSearchParams({ window: 'settings' })
+  if (tab) query.set('tab', tab)
+  const isDev = !app.isPackaged
+  if (isDev) {
+    void win.loadURL(`http://127.0.0.1:5173?${query.toString()}`)
+  } else {
+    void win.loadFile(join(__dirname, 'renderer', 'index.html'), { query: Object.fromEntries(query) })
+  }
+
+  win.once('ready-to-show', () => {
+    if (savedState?.isMaximized) win.maximize()
+    win.show()
+    win.focus()
+  })
+
+  const flushState = (): void => {
+    if (settingsSaveTimer) {
+      clearTimeout(settingsSaveTimer)
+      settingsSaveTimer = null
+    }
+    persistSettingsWindowState(win)
+  }
+  const scheduleStateSave = (): void => {
+    if (settingsSaveTimer) clearTimeout(settingsSaveTimer)
+    settingsSaveTimer = setTimeout(() => {
+      settingsSaveTimer = null
+      persistSettingsWindowState(win)
+    }, 500)
+  }
+  win.on('resize', scheduleStateSave)
+  win.on('move', scheduleStateSave)
+  win.on('maximize', scheduleStateSave)
+  win.on('unmaximize', scheduleStateSave)
+  win.on('close', flushState)
+
+  // 拦截关闭：未确认前先请求渲染进程检查未保存内容（渠道表单 dirty），
+  // 渲染进程确认后通过 confirmSettingsWindowClose 再次关闭。
+  // 渲染进程未就绪（仍在加载）或已崩溃时不拦截，避免窗口永远无法关闭。
+  win.on('close', (event) => {
+    if (closeConfirmed || win.webContents.isDestroyed()) return
+    if (win.webContents.isLoading() || win.webContents.isCrashed()) return
+    event.preventDefault()
+    win.webContents.send(SETTINGS_IPC_CHANNELS.REQUEST_CLOSE)
+  })
+
+  win.webContents.on('will-navigate', (event, url) => {
+    if (isDev && isDevServerNavigation(url)) return
+    event.preventDefault()
+    if (url.startsWith('http://') || url.startsWith('https://')) void shell.openExternal(url)
+  })
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    if (url.startsWith('http://') || url.startsWith('https://')) void shell.openExternal(url)
+    return { action: 'deny' }
+  })
+  win.on('closed', () => {
+    if (settingsWindow === win) settingsWindow = null
+  })
+
+  return win
+}
+
+/** 打开单例设置窗口；已存在时恢复、确保可见并聚焦。tab 仅在新建窗口时生效，已存在时通过 IPC 转发切换。 */
+export function showSettingsWindow(tab?: SettingsTab): void {
+  if (!settingsWindow || settingsWindow.isDestroyed()) {
+    createSettingsWindow(tab)
+    return
+  }
+  ensureWindowOnScreen(settingsWindow)
+  if (settingsWindow.isMinimized()) settingsWindow.restore()
+  settingsWindow.show()
+  settingsWindow.focus()
+  // 深链：窗口已存在且 tab 合法时，请求渲染进程切换到对应标签页
+  if (tab && (OPENABLE_SETTINGS_TABS as readonly string[]).includes(tab) && !settingsWindow.webContents.isLoading()) {
+    settingsWindow.webContents.send(SETTINGS_IPC_CHANNELS.TAB_CHANGED, tab)
+  }
+}
+
+/** 渲染进程确认可关闭后调用：放行关闭拦截并真正关闭窗口。 */
+export function confirmSettingsWindowClose(win: BrowserWindow): void {
+  if (settingsWindow !== win) return
+  closeConfirmed = true
+  win.close()
+}
+
+/** 应用退出时销毁窗口，确保状态保存定时器与渲染进程一同释放。 */
+export function destroySettingsWindow(): void {
+  if (!settingsWindow || settingsWindow.isDestroyed()) return
+  persistSettingsWindowState(settingsWindow)
+  if (settingsSaveTimer) {
+    clearTimeout(settingsSaveTimer)
+    settingsSaveTimer = null
+  }
+  settingsWindow.destroy()
+  settingsWindow = null
+  closeConfirmed = false
+}

--- a/apps/electron/src/main/menu.ts
+++ b/apps/electron/src/main/menu.ts
@@ -50,7 +50,8 @@ export function createApplicationMenu(): Menu {
             } catch {
               // 窗口尚未加载页面时沿用主窗口的安全默认行为。
             }
-            if (windowType === 'planning') {
+            if (windowType === 'planning' || windowType === 'settings') {
+              // planning/settings 独立窗口直接关闭；settings 窗口的 close 事件会先询问未保存内容。
               win.close()
               return
             }

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -8,6 +8,7 @@
 import { contextBridge, ipcRenderer, webUtils } from 'electron'
 import { IPC_CHANNELS, CHANNEL_IPC_CHANNELS, CHAT_IPC_CHANNELS, AGENT_IPC_CHANNELS, ENVIRONMENT_IPC_CHANNELS, INSTALLER_IPC_CHANNELS, PROXY_IPC_CHANNELS, GITHUB_RELEASE_IPC_CHANNELS, SYSTEM_PROMPT_IPC_CHANNELS, CHAT_TOOL_IPC_CHANNELS, FEISHU_IPC_CHANNELS, DINGTALK_IPC_CHANNELS, WECHAT_IPC_CHANNELS, AUTOMATION_IPC_CHANNELS, PLANNING_IPC_CHANNELS, AGENT_ISLAND_IPC_CHANNELS } from '@proma/shared'
 import { USER_PROFILE_IPC_CHANNELS, SETTINGS_IPC_CHANNELS, SCRATCH_PAD_IPC_CHANNELS, APP_ICON_IPC_CHANNELS, DOCK_BADGE_IPC_CHANNELS, STORAGE_IPC_CHANNELS } from '../types'
+import type { SettingsTab } from '../types'
 import type {
   RuntimeStatus,
   GitRepoStatus,
@@ -370,6 +371,8 @@ export interface ElectronAPI {
 
   /** 更新用户档案 */
   updateUserProfile: (updates: Partial<UserProfile>) => Promise<UserProfile>
+  /** 订阅用户档案变更（跨窗口同步） */
+  onUserProfileChanged: (callback: (profile: UserProfile) => void) => () => void
 
   // ===== 应用设置相关 =====
 
@@ -1160,6 +1163,15 @@ export interface ElectronAPI {
   // ===== 任务 / 日程（Planning）=====
   /** 打开或聚焦单例独立任务/日程窗口。 */
   openPlanningWindow: () => Promise<void>
+  // ===== 设置（Settings）=====
+  /** 打开或聚焦单例独立设置窗口，可指定初始标签页。 */
+  openSettingsWindow: (tab?: SettingsTab) => Promise<void>
+  /** 订阅主进程的关闭请求（用于未保存内容确认）。 */
+  onSettingsCloseRequested: (callback: () => void) => () => void
+  /** 订阅主进程请求切换到指定标签页（窗口已存在时深链生效） */
+  onSettingsTabRequested: (callback: (tab: SettingsTab) => void) => () => void
+  /** 确认可关闭独立设置窗口。 */
+  confirmSettingsClose: () => Promise<void>
   listTodos: (query?: TodoListQuery) => Promise<Todo[]>
   createTodo: (input: CreateTodoInput) => Promise<Todo>
   /** 在主进程原子地关联项目并创建 Todo 的 Agent 会话。 */
@@ -1485,6 +1497,12 @@ const electronAPI: ElectronAPI = {
 
   updateUserProfile: (updates: Partial<UserProfile>) => {
     return ipcRenderer.invoke(USER_PROFILE_IPC_CHANNELS.UPDATE, updates)
+  },
+
+  onUserProfileChanged: (callback: (profile: UserProfile) => void) => {
+    const listener = (_: unknown, profile: UserProfile): void => callback(profile)
+    ipcRenderer.on(USER_PROFILE_IPC_CHANNELS.CHANGED, listener)
+    return () => { ipcRenderer.removeListener(USER_PROFILE_IPC_CHANNELS.CHANGED, listener) }
   },
 
   // 应用设置
@@ -2677,6 +2695,19 @@ const electronAPI: ElectronAPI = {
 
   // ===== 任务 / 日程（Planning）=====
   openPlanningWindow: () => ipcRenderer.invoke(PLANNING_IPC_CHANNELS.OPEN_WINDOW),
+  // ===== 设置（Settings）=====
+  openSettingsWindow: (tab?: SettingsTab) => ipcRenderer.invoke(SETTINGS_IPC_CHANNELS.OPEN_WINDOW, tab),
+  onSettingsCloseRequested: (callback: () => void) => {
+    const listener = (): void => callback()
+    ipcRenderer.on(SETTINGS_IPC_CHANNELS.REQUEST_CLOSE, listener)
+    return () => { ipcRenderer.removeListener(SETTINGS_IPC_CHANNELS.REQUEST_CLOSE, listener) }
+  },
+  onSettingsTabRequested: (callback: (tab: SettingsTab) => void) => {
+    const listener = (_: unknown, tab: SettingsTab): void => callback(tab)
+    ipcRenderer.on(SETTINGS_IPC_CHANNELS.TAB_CHANGED, listener)
+    return () => { ipcRenderer.removeListener(SETTINGS_IPC_CHANNELS.TAB_CHANGED, listener) }
+  },
+  confirmSettingsClose: () => ipcRenderer.invoke(SETTINGS_IPC_CHANNELS.CONFIRM_CLOSE),
   listTodos: (query?: TodoListQuery) => ipcRenderer.invoke(PLANNING_IPC_CHANNELS.LIST_TODOS, query),
   createTodo: (input: CreateTodoInput) => ipcRenderer.invoke(PLANNING_IPC_CHANNELS.CREATE_TODO, input),
   startTodoAgent: (input: StartTodoAgentInput) => ipcRenderer.invoke(PLANNING_IPC_CHANNELS.START_TODO_AGENT, input),

--- a/apps/electron/src/renderer/atoms/settings-tab.ts
+++ b/apps/electron/src/renderer/atoms/settings-tab.ts
@@ -11,9 +11,10 @@
  */
 
 import { atom } from 'jotai'
-import type { TabType } from './tab-atoms'
+import type { SettingsTab } from '../../types'
 
-export type SettingsTab = 'general' | 'channels' | 'vision-relay' | 'proxy' | 'appearance' | 'about' | 'prompts' | 'tools' | 'bots' | 'tutorial' | 'shortcuts' | 'voice-input' | 'migration' | 'storage'
+/** 设置标签页类型（下沉到 types/settings.ts 共享，供主进程/preload/渲染进程复用） */
+export type { SettingsTab }
 export type ToolSettingsFocus = 'memory' | 'web-search' | 'nano-banana' | 'custom-tools'
 
 /** 当前设置标签页（不持久化，每次打开设置默认显示渠道） */
@@ -22,22 +23,8 @@ export const settingsTabAtom = atom<SettingsTab>('channels')
 /** Chat 工具设置页的目标配置区，用于从内置 MCP 详情直达对应配置 */
 export const toolSettingsFocusAtom = atom<ToolSettingsFocus | null>(null)
 
-/** 设置浮窗是否打开 */
-export const settingsOpenAtom = atom(false)
-
 /** 渠道创建表单是否有未保存内容（用于拦截导航离开） */
 export const channelFormDirtyAtom = atom(false)
 
-/** 外部请求关闭设置面板（如 Cmd+W），SettingsPanel 监听后弹出确认对话框 */
+/** 外部请求关闭设置窗口（如 Cmd+W），SettingsPanel 监听后弹出确认对话框 */
 export const settingsCloseRequestedAtom = atom(false)
-
-/**
- * 从设置工作区离开时暂存的会话导航目标。
- * 渠道表单有未保存内容时，SettingsPanel 确认放弃后再执行该导航。
- */
-export interface SettingsSessionNavigation {
-  type: TabType
-  sessionId: string
-  title: string
-}
-export const settingsPendingSessionNavigationAtom = atom<SettingsSessionNavigation | null>(null)

--- a/apps/electron/src/renderer/components/agent-skills/AgentSkillsView.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/AgentSkillsView.tsx
@@ -23,7 +23,7 @@ import {
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { agentPendingPromptAtom, workspaceCapabilitiesVersionAtom } from '@/atoms/agent-atoms'
 import { agentSkillsTabAtom } from '@/atoms/active-view'
-import { settingsOpenAtom, settingsTabAtom, toolSettingsFocusAtom, type ToolSettingsFocus } from '@/atoms/settings-tab'
+
 import { useProjectActions } from '@/hooks/useProjectActions'
 import { useCreateSession } from '@/hooks/useCreateSession'
 import { LocalProjectBadge } from '@/components/agent/LocalProjectBadge'
@@ -90,9 +90,6 @@ export function AgentSkillsView(): React.ReactElement {
   const data = useAgentSkillsData()
   const bumpCapabilities = useSetAtom(workspaceCapabilitiesVersionAtom)
   const setPendingPrompt = useSetAtom(agentPendingPromptAtom)
-  const setSettingsOpen = useSetAtom(settingsOpenAtom)
-  const setSettingsTab = useSetAtom(settingsTabAtom)
-  const setToolSettingsFocus = useSetAtom(toolSettingsFocusAtom)
   const { workspaces, currentWorkspaceId, selectProject } = useProjectActions()
   const { createAgent } = useCreateSession()
   const currentWorkspace = workspaces.find((workspace) => workspace.id === currentWorkspaceId)
@@ -158,17 +155,10 @@ export function AgentSkillsView(): React.ReactElement {
   }
 
   const configureBuiltinMcp = React.useCallback((serverId: string): void => {
-    const focusMap: Partial<Record<string, ToolSettingsFocus>> = {
-      mem: 'memory',
-      'nano-banana': 'nano-banana',
-    }
-    const focus = focusMap[serverId]
-    if (!focus) return
-    setToolSettingsFocus(focus)
-    setSettingsTab('tools')
-    setSettingsOpen(true)
+    // 独立设置窗口不支持直达内置 MCP 配置区，统一打开 Chat 工具页
+    void window.electronAPI.openSettingsWindow('tools')
     setSelectedBuiltinMcp(null)
-  }, [setSettingsOpen, setSettingsTab, setToolSettingsFocus])
+  }, [setSelectedBuiltinMcp])
 
   const handleClassifySkills = React.useCallback(async (): Promise<void> => {
     if (classifyingSkills) return

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -107,7 +107,7 @@ import {
   finalizeStreamingActivities,
 } from '@/atoms/agent-atoms'
 import type { AgentContextStatus } from '@/atoms/agent-atoms'
-import { settingsOpenAtom } from '@/atoms/settings-tab'
+
 import { longTextPasteAsAttachmentEnabledAtom } from '@/atoms/ui-preferences'
 import { channelsAtom } from '@/atoms/chat-atoms'
 import { todoPlanningGroupsAtom } from '@/atoms/planning-atoms'
@@ -542,7 +542,6 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   const [agentRuntime, setAgentRuntime] = useAtom(agentRuntimeAtom)
   const [agentThinking, setAgentThinking] = useAtom(agentThinkingAtom)
   const agentEffort = useAtomValue(agentEffortAtom)
-  const setSettingsOpen = useSetAtom(settingsOpenAtom)
   const setDraftSessionIds = useSetAtom(draftSessionIdsAtom)
   const globalWorkspaceId = useAtomValue(currentAgentWorkspaceIdAtom)
   // 从会话元数据派生 workspaceId：会话数据已加载时以自身为准，未加载时回退全局 atom
@@ -3156,7 +3155,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
                 <button
                   type="button"
                   className="text-xs underline underline-offset-2 hover:text-foreground transition-colors"
-                  onClick={() => setSettingsOpen(true)}
+                  onClick={() => { void window.electronAPI.openSettingsWindow('channels') }}
                 >
                   前往设置
                 </button>

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -60,7 +60,6 @@ import { automationsAtom, automationFormAtom, automationToDraft } from '@/atoms/
 import { activeViewAtom } from '@/atoms/active-view'
 import { planningTabAtom } from '@/atoms/planning-atoms'
 import { environmentCheckDialogOpenAtom } from '@/atoms/environment'
-import { settingsOpenAtom, settingsTabAtom } from '@/atoms/settings-tab'
 import { useOpenPreview } from '@/components/diff/preview-opener'
 import { getFileParentPath } from '@/lib/file-utils'
 import { parseQuotedSelectionRefs } from '@/lib/quoted-selection'
@@ -1131,8 +1130,6 @@ export function AssistantErrorTail({
   const canRestoreProjectRoot = shouldOfferProjectRootRestore(projectRootStatus)
 
   const setEnvDialogOpen = useSetAtom(environmentCheckDialogOpenAtom)
-  const setSettingsOpen = useSetAtom(settingsOpenAtom)
-  const setSettingsTab = useSetAtom(settingsTabAtom)
   const setModelSelectorOpen = useSetAtom(modelSelectorOpenAtom)
   const [detailsOpen, setDetailsOpen] = React.useState(false)
 
@@ -1156,11 +1153,10 @@ export function AssistantErrorTail({
         setEnvDialogOpen(true)
         break
       case 'open_channel_settings':
-        setSettingsTab('channels')
-        setSettingsOpen(true)
+        void window.electronAPI.openSettingsWindow('channels')
         break
       case 'settings':
-        setSettingsOpen(true)
+        void window.electronAPI.openSettingsWindow()
         break
       case 'select_model':
         setModelSelectorOpen(true)

--- a/apps/electron/src/renderer/components/app-shell/AppShell.tsx
+++ b/apps/electron/src/renderer/components/app-shell/AppShell.tsx
@@ -19,9 +19,7 @@ import { sidebarCollapsedAtom } from '@/atoms/tab-atoms'
 import { automationFormAtom } from '@/atoms/automation-atoms'
 import { activeViewAtom } from '@/atoms/active-view'
 import { interfaceVariantAtom } from '@/atoms/theme'
-import { settingsOpenAtom } from '@/atoms/settings-tab'
 import { WindowControls } from '@/components/WindowControls'
-import { SettingsPanel } from '@/components/settings/SettingsPanel'
 import { detectIsWindows, WINDOW_CONTROLS_INSET_RIGHT } from '@/lib/platform'
 import { cn } from '@/lib/utils'
 
@@ -50,8 +48,6 @@ export function AppShell({ contextValue }: AppShellProps): React.ReactElement {
   const isPanelOpen = useAtomValue(currentSessionSidePanelOpenAtom)
   const automationForm = useAtomValue(automationFormAtom)
   const interfaceVariant = useAtomValue(interfaceVariantAtom)
-  const settingsOpen = useAtomValue(settingsOpenAtom)
-  const setSettingsOpen = useSetAtom(settingsOpenAtom)
   const isClassic = interfaceVariant === 'classic'
   // 定时任务表单打开时隐藏右侧文件面板，让中间区域扩展到全宽（表单内含自己的右栏配置）
   const activeView = useAtomValue(activeViewAtom)
@@ -181,7 +177,7 @@ export function AppShell({ contextValue }: AppShellProps): React.ReactElement {
       <WindowControls />
 
       <div className="shell-bg relative h-screen w-screen overflow-hidden bg-gradient-to-br from-zinc-50 to-zinc-100 dark:from-zinc-950 dark:to-zinc-900">
-        <div className={cn('flex h-full w-full', settingsOpen && 'hidden')} aria-hidden={settingsOpen}>
+        <div className={cn('flex h-full w-full')}>
             {/* 左侧边栏：可折叠，可拖拽调整宽度 */}
             <div className={cn(isClassic ? 'p-2 pr-0' : '', 'relative z-[60] crt-sidebar')}>
               <LeftSidebar width={clampedLeftSidebarWidth} noTransition={isDraggingLeftSidebar} />
@@ -233,12 +229,6 @@ export function AppShell({ contextValue }: AppShellProps): React.ReactElement {
               </div>
             )}
         </div>
-        {settingsOpen && (
-          <div className="absolute inset-0 z-[60]">
-            <SettingsPanel onClose={() => setSettingsOpen(false)} />
-          </div>
-        )}
-
       </div>
     </AppShellProvider>
   )

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -11,7 +11,7 @@
 import * as React from 'react'
 import { useAtom, useSetAtom, useAtomValue, useStore } from 'jotai'
 import { toast } from 'sonner'
-import { Pin, PinOff, Star, Settings, Plus, Trash2, Pencil, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, FolderInput, FolderPlus, GripVertical, Clock, AlarmClock, ChevronRight, Blocks, GitBranch, Download, Loader2, RotateCw } from 'lucide-react'
+import { Pin, PinOff, Star, Settings, Plus, Trash2, Pencil, PanelLeftClose, PanelLeftOpen, ArrowRightLeft, Search, Archive, ArchiveRestore, ArrowLeft, Bot, MessageSquare, MoreHorizontal, FolderOpen, FolderInput, FolderPlus, GripVertical, Clock, AlarmClock, ChevronRight, Blocks, GitBranch, Download, Loader2, RotateCw, GraduationCap } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { ModeSwitcher } from './ModeSwitcher'
@@ -20,7 +20,7 @@ import { UserAvatar } from '@/components/chat/UserAvatar'
 import { activeViewAtom, agentSkillsTabAtom } from '@/atoms/active-view'
 import { automationFormAtom, automationsAtom } from '@/atoms/automation-atoms'
 import { appModeAtom, type AppMode } from '@/atoms/app-mode'
-import { settingsOpenAtom, settingsTabAtom } from '@/atoms/settings-tab'
+
 import {
   conversationsAtom,
   currentConversationIdAtom,
@@ -74,6 +74,8 @@ import {
   sidebarCollapsedAtom,
   closeTab,
   updateTabTitle,
+  openTab,
+  TUTORIAL_TAB_ID,
   sessionViewStateMapAtom,
 } from '@/atoms/tab-atoms'
 import { userProfileAtom } from '@/atoms/user-profile'
@@ -721,9 +723,6 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
   const automations = useAtomValue(automationsAtom)
   const setAutomations = useSetAtom(automationsAtom)
   const automationCount = automations.length
-  const settingsOpen = useAtomValue(settingsOpenAtom)
-  const setSettingsOpen = useSetAtom(settingsOpenAtom)
-  const setSettingsTab = useSetAtom(settingsTabAtom)
   const [conversations, setConversations] = useAtom(conversationsAtom)
   const [currentConversationId, setCurrentConversationId] = useAtom(currentConversationIdAtom)
   const draftSessionIds = useAtomValue(draftSessionIdsAtom)
@@ -812,13 +811,32 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
   const newChatShortcutLabel = getAcceleratorDisplay(getActiveAccelerator('new-session'))
 
   const handleOpenSettings = React.useCallback((): void => {
-    setSettingsOpen(true)
-  }, [setSettingsOpen])
+    void window.electronAPI.openSettingsWindow().catch((error) => {
+      console.error('[设置] 打开独立窗口失败:', error)
+    })
+  }, [])
 
   const handleUpdateButtonClick = React.useCallback((): void => {
-    setSettingsTab('about')
-    setSettingsOpen(true)
-  }, [setSettingsOpen, setSettingsTab])
+    void window.electronAPI.openSettingsWindow('about').catch((error) => {
+      console.error('[设置] 打开独立窗口失败:', error)
+    })
+  }, [])
+
+  const handleOpenTutorial = React.useCallback((): void => {
+    // 教程 Tab 已打开则关闭（toggle），未打开则打开；与 SettingsPanel 的 tutorial 分支逻辑一致
+    const existingTab = tabs.find((t) => t.id === TUTORIAL_TAB_ID)
+    if (existingTab) {
+      const result = closeTab(tabs, activeTabId, TUTORIAL_TAB_ID)
+      setTabs(result.tabs)
+      setActiveTabId(result.activeTabId)
+      return
+    }
+    const result = openTab(tabs, { type: 'tutorial', sessionId: TUTORIAL_TAB_ID, title: 'Proma 使用教程' })
+    setTabs(result.tabs)
+    setActiveTabId(result.activeTabId)
+    setAutomationForm({ open: false, draft: null })
+    setActiveView('conversations')
+  }, [activeTabId, setActiveView, setAutomationForm, setActiveTabId, setTabs, tabs])
 
   React.useEffect(() => {
     const id = window.setInterval(() => setRelativeTimeNow(Date.now()), 60_000)
@@ -1032,6 +1050,9 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       .listAgentSessions()
       .then(setAgentSessions)
       .catch(console.error)
+    // 订阅用户档案变更（独立设置窗口修改后同步到主窗口）
+    const unsubProfile = window.electronAPI.onUserProfileChanged(setUserProfile)
+    return () => unsubProfile()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [setConversations, setUserProfile, setAgentSessions])
 
@@ -1811,7 +1832,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       if (processedQuickSwitchEventsRef.current.has(event)) return
       processedQuickSwitchEventsRef.current.add(event)
       if (event.isComposing) return
-      if (settingsOpen || searchDialogOpen) return
+      if (searchDialogOpen) return
 
       const number = getQuickSwitchNumber(event)
       if (number !== null && hasOnlyPrimaryModifier(event, isMac)) {
@@ -1875,7 +1896,6 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     }
   }, [
     isMac,
-    settingsOpen,
     searchDialogOpen,
     handleSelectAgentSession,
     handleSelectConversation,
@@ -2643,6 +2663,19 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
             <TooltipTrigger asChild>
               <button
                 type="button"
+                aria-label="Proma 教程"
+                onClick={handleOpenTutorial}
+                className="relative size-10 flex items-center justify-center rounded-[12px] transition-colors titlebar-no-drag hover:bg-foreground/5"
+              >
+                <GraduationCap size={18} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="right">Proma 教程</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
                 aria-label="打开设置"
                 onClick={handleOpenSettings}
                 className="relative size-10 flex items-center justify-center rounded-[12px] transition-colors titlebar-no-drag hover:bg-foreground/5"
@@ -3177,6 +3210,14 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
               hideIcon
             />
           )}
+          <button
+            type="button"
+            aria-label="Proma 教程"
+            onClick={handleOpenTutorial}
+            className="relative flex size-7 flex-shrink-0 items-center justify-center rounded-[8px] text-foreground/40 transition-colors hover:bg-foreground/[0.05] hover:text-foreground/70"
+          >
+            <GraduationCap size={16} />
+          </button>
           <button
             type="button"
             aria-label="打开设置"

--- a/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
+++ b/apps/electron/src/renderer/components/automation/AutomationFormView.tsx
@@ -37,7 +37,6 @@ import {
 import { agentWorkspacesAtom, agentSessionsAtom, agentChannelIdsAtom, agentRuntimeAtom, currentAgentWorkspaceIdAtom } from '@/atoms/agent-atoms'
 import { activeSessionIdAtom } from '@/atoms/tab-atoms'
 import { activeViewAtom, agentSkillsTabAtom } from '@/atoms/active-view'
-import { settingsOpenAtom, settingsTabAtom } from '@/atoms/settings-tab'
 import { useOpenSession } from '@/hooks/useOpenSession'
 import { MarkdownRichEditor } from '@/components/diff/MarkdownRichEditor'
 import { LocalProjectBadge } from '@/components/agent/LocalProjectBadge'
@@ -398,8 +397,7 @@ export function AutomationFormView({ standalone = false }: { standalone?: boolea
   const currentAgentWorkspaceId = useAtomValue(currentAgentWorkspaceIdAtom)
   const setActiveView = useSetAtom(activeViewAtom)
   const setAgentSkillsTab = useSetAtom(agentSkillsTabAtom)
-  const setSettingsOpen = useSetAtom(settingsOpenAtom)
-  const setSettingsTab = useSetAtom(settingsTabAtom)
+
   const openSession = useOpenSession()
 
   const [form, setForm] = React.useState<AutomationDraft | null>(null)
@@ -1070,10 +1068,7 @@ export function AutomationFormView({ standalone = false }: { standalone?: boolea
                 <button
                   type="button"
                   className="ml-auto text-xs underline underline-offset-2 hover:text-foreground transition-colors"
-                  onClick={() => {
-                    setSettingsTab('channels')
-                    setSettingsOpen(true)
-                  }}
+                  onClick={() => { void window.electronAPI.openSettingsWindow('channels') }}
                 >
                   前往渠道设置
                 </button>

--- a/apps/electron/src/renderer/components/chat/ToolSelectorPopover.tsx
+++ b/apps/electron/src/renderer/components/chat/ToolSelectorPopover.tsx
@@ -23,7 +23,7 @@ import {
 import { cn } from '@/lib/utils'
 import { Wrench, Brain, Globe, Settings, ImagePlus } from 'lucide-react'
 import { chatToolsAtom, hasActiveToolsAtom } from '@/atoms/chat-tool-atoms'
-import { settingsTabAtom, settingsOpenAtom } from '@/atoms/settings-tab'
+
 import { inputToolbarActiveButtonClass, inputToolbarButtonClass } from '@/components/ai-elements/input-toolbar-styles'
 
 /** 工具 ID 到图标的映射 */
@@ -45,8 +45,6 @@ export function ToolSelectorPopover(): React.ReactElement {
   const tools = useAtomValue(chatToolsAtom)
   const setChatTools = useSetAtom(chatToolsAtom)
   const hasActiveTools = useAtomValue(hasActiveToolsAtom)
-  const setSettingsOpen = useSetAtom(settingsOpenAtom)
-  const setSettingsTab = useSetAtom(settingsTabAtom)
 
   /** 切换工具开关（通过 IPC 更新后端配置，再刷新 atom） */
   const toggleTool = async (toolId: string, currentEnabled: boolean): Promise<void> => {
@@ -62,8 +60,7 @@ export function ToolSelectorPopover(): React.ReactElement {
   /** 跳转到设置页工具 tab */
   const goToToolSettings = (): void => {
     setOpen(false)
-    setSettingsOpen(true)
-    setSettingsTab('tools')
+    void window.electronAPI.openSettingsWindow('tools')
   }
 
   return (

--- a/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
+++ b/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
@@ -8,7 +8,6 @@
 import * as React from "react";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { cn } from "@/lib/utils";
-import { detectIsWindows, WINDOW_CONTROLS_INSET_RIGHT } from "@/lib/platform";
 import {
   Settings,
   Radio,
@@ -20,7 +19,7 @@ import {
   Wrench,
   Bot,
   GraduationCap,
-  ArrowLeft,
+  X,
   Keyboard,
   Mic,
   HardDriveDownload,
@@ -32,16 +31,10 @@ import {
   settingsTabAtom,
   channelFormDirtyAtom,
   settingsCloseRequestedAtom,
-  settingsOpenAtom,
-  settingsPendingSessionNavigationAtom,
-  type SettingsSessionNavigation,
 } from "@/atoms/settings-tab";
 import type { SettingsTab } from "@/atoms/settings-tab";
 import { appModeAtom } from "@/atoms/app-mode";
-import { activeViewAtom } from "@/atoms/active-view";
-import { automationFormAtom } from "@/atoms/automation-atoms";
 import { hasUpdateAtom } from "@/atoms/updater";
-import { tabsAtom, activeTabIdAtom, openTab, TUTORIAL_TAB_ID } from "@/atoms/tab-atoms";
 import { hasEnvironmentIssuesAtom } from "@/atoms/environment";
 import {
   AlertDialog,
@@ -66,7 +59,6 @@ import { ShortcutSettings } from "./ShortcutSettings";
 import { VoiceInputSettings } from "./VoiceInputSettings";
 import { MigrationSettings } from "./MigrationSettings";
 import { StorageSettings } from "./StorageSettings";
-import { useOpenSession } from '@/hooks/useOpenSession'
 
 /** 设置 Tab 定义 */
 interface TabItem {
@@ -162,23 +154,14 @@ export function SettingsPanel({
   const [activeTab, setActiveTab] = useAtom(settingsTabAtom);
   const channelFormDirty = useAtomValue(channelFormDirtyAtom);
   const [closeRequested, setCloseRequested] = useAtom(settingsCloseRequestedAtom);
-  const [pendingSessionNavigation, setPendingSessionNavigation] = useAtom(settingsPendingSessionNavigationAtom);
-  const setSettingsOpen = useSetAtom(settingsOpenAtom);
-  const setActiveView = useSetAtom(activeViewAtom);
-  const setAutomationForm = useSetAtom(automationFormAtom);
   const appMode = useAtomValue(appModeAtom);
   const hasUpdate = useAtomValue(hasUpdateAtom);
   const hasEnvironmentIssues = useAtomValue(hasEnvironmentIssuesAtom);
-  const [mainTabs, setMainTabs] = useAtom(tabsAtom);
-  const setMainActiveTabId = useSetAtom(activeTabIdAtom);
-  const openSession = useOpenSession()
-  const isWindows = React.useMemo(() => detectIsWindows(), [])
 
   /** 统一的退出拦截对话框状态 */
   type PendingAction =
     | { type: 'tab'; tabId: SettingsTab }
     | { type: 'close' }
-    | { type: 'session'; navigation: SettingsSessionNavigation }
     | null
   const [pendingAction, setPendingAction] = React.useState<PendingAction>(null)
   const showNavDialog = pendingAction !== null
@@ -188,13 +171,6 @@ export function SettingsPanel({
     if (!pendingAction) return
     if (pendingAction.type === 'tab') {
       setActiveTab(pendingAction.tabId)
-    } else if (pendingAction.type === 'session') {
-      openSession(
-        pendingAction.navigation.type,
-        pendingAction.navigation.sessionId,
-        pendingAction.navigation.title,
-        { bypassSettingsGuard: true },
-      )
     } else {
       onClose?.()
     }
@@ -206,18 +182,8 @@ export function SettingsPanel({
     setPendingAction(null)
   }
 
-  /** 切换标签页时检测是否有未保存内容，tutorial 特殊处理：打开 New Tab 并关闭设置 */
+  /** 切换标签页时检测是否有未保存内容 */
   const handleTabChange = (tabId: SettingsTab): void => {
-    if (tabId === 'tutorial') {
-      const result = openTab(mainTabs, { type: 'tutorial', sessionId: TUTORIAL_TAB_ID, title: 'Proma 使用教程' })
-      setMainTabs(result.tabs)
-      setMainActiveTabId(result.activeTabId)
-      // Skills/Automations 会全屏覆盖 TabContent；打开教程时先清理表单并回到会话视图。
-      setAutomationForm({ open: false, draft: null })
-      setActiveView('conversations')
-      setSettingsOpen(false)
-      return
-    }
     if (tabId === activeTab) return
     if (activeTab === 'channels' && channelFormDirty) {
       setPendingAction({ type: 'tab', tabId })
@@ -248,13 +214,6 @@ export function SettingsPanel({
     return () => window.removeEventListener('keydown', handleWindowKeyDown)
   }, [handleClose])
 
-  // 左侧会话点击在渠道表单有未保存内容时，由 useOpenSession 暂存目标并交给此处确认。
-  React.useEffect(() => {
-    if (!pendingSessionNavigation) return
-    setPendingAction({ type: 'session', navigation: pendingSessionNavigation })
-    setPendingSessionNavigation(null)
-  }, [pendingSessionNavigation, setPendingSessionNavigation])
-
   // Cmd+W 等外部关闭请求：弹出确认对话框
   React.useEffect(() => {
     if (closeRequested && activeTab === 'channels') {
@@ -263,10 +222,19 @@ export function SettingsPanel({
     }
   }, [closeRequested, activeTab, setCloseRequested])
 
-  // 工具 tab 两种模式都显示，Agent Skills / MCP 独立在侧边栏能力中心管理。
+  // 独立窗口无法打开主窗口 Tab，因此不提供 tutorial（Proma 教程）入口。
   const tabs = React.useMemo(() => {
-    if (appMode === "agent") {
-      return [
+    const allTabs = appMode === "agent"
+      ? [
+        ...BASE_TABS,
+        TOOLS_TAB,
+        VOICE_INPUT_TAB,
+        BOTS_TAB,
+        TUTORIAL_TAB,
+        SHORTCUTS_TAB,
+        ...TAIL_TABS,
+      ]
+      : [
         ...BASE_TABS,
         TOOLS_TAB,
         VOICE_INPUT_TAB,
@@ -275,38 +243,16 @@ export function SettingsPanel({
         SHORTCUTS_TAB,
         ...TAIL_TABS,
       ];
-    }
-    return [
-      ...BASE_TABS,
-      TOOLS_TAB,
-      VOICE_INPUT_TAB,
-      BOTS_TAB,
-      TUTORIAL_TAB,
-      SHORTCUTS_TAB,
-      ...TAIL_TABS,
-    ];
+    return allTabs.filter((tab) => tab.id !== 'tutorial');
   }, [appMode]);
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-content-area text-foreground">
-      {/* 顶部可拖动标题栏区域。背景层保持全宽；drag 层在 Windows 上必须避开右上角的
-          WindowControls 按钮区域（WINDOW_CONTROLS_INSET_RIGHT），否则 OS hitmask 会把
-          按钮点击误判为标题栏点击，导致最小化/最大化/关闭按钮无响应（与 AppShell/TabBar 一致）。 */}
-      <div className="relative h-[35px] flex-shrink-0 bg-[hsl(var(--sidebar-surface))]">
-        <div
-          aria-hidden="true"
-          className={cn(
-            'titlebar-drag-region pointer-events-none absolute left-0 top-0 h-full',
-            isWindows ? WINDOW_CONTROLS_INSET_RIGHT : 'right-0',
-          )}
-        />
-      </div>
-
-      {/* 主体：左导航 + 右内容 */}
+      {/* 主体：左导航 + 右内容（顶部拖拽由 SettingsWindowApp 的透明 drag region 提供） */}
       <div className="flex flex-1 min-h-0">
         {/* 左侧 Tab 导航 */}
         <div className="flex h-full min-h-0 w-[277px] flex-shrink-0 flex-col border-r border-border/80 bg-[hsl(var(--sidebar-surface))] dark:border-border/70">
-          <nav className="flex flex-1 flex-col gap-0.5 overflow-y-auto px-3 pt-5 scrollbar-thin">
+          <nav className="flex flex-1 flex-col gap-0.5 overflow-y-auto px-3 pt-[40px] scrollbar-thin">
             {tabs.map((tab) => (
               <button
                 key={tab.id}
@@ -331,8 +277,8 @@ export function SettingsPanel({
               onClick={handleClose}
               className="group flex w-full items-center gap-2 rounded-md px-3 py-2.5 text-sm text-muted-foreground transition-colors hover:bg-background/60 hover:text-foreground"
             >
-              <ArrowLeft size={16} />
-              <span>返回</span>
+              <X size={16} />
+              <span>关闭</span>
               <span className="ml-auto hidden group-hover:inline-flex">
                 <ShortcutKeycaps accelerator="Esc" />
               </span>
@@ -342,7 +288,7 @@ export function SettingsPanel({
 
         {/* 右侧内容区域 */}
         <ScrollArea className="min-w-0 flex-1 bg-content-area">
-          <div className="mx-auto w-full max-w-[1080px] px-5 py-8 pb-12 sm:px-8">
+          <div className="mx-auto w-full max-w-[1080px] px-5 pt-[40px] pb-12 sm:px-8">
             {renderTabContent(activeTab)}
           </div>
         </ScrollArea>

--- a/apps/electron/src/renderer/components/settings/SettingsWindowApp.tsx
+++ b/apps/electron/src/renderer/components/settings/SettingsWindowApp.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useMemo } from 'react'
+import { useStore, useSetAtom } from 'jotai'
+import { cn } from '@/lib/utils'
+import { SettingsPanel } from './SettingsPanel'
+import { settingsTabAtom, channelFormDirtyAtom, settingsCloseRequestedAtom, type SettingsTab } from '@/atoms/settings-tab'
+import { OPENABLE_SETTINGS_TABS } from '../../../types'
+import { userProfileAtom } from '@/atoms/user-profile'
+import { feishuBotStatesAtom } from '@/atoms/feishu-atoms'
+import { dingtalkBotStatesAtom } from '@/atoms/dingtalk-atoms'
+import { wechatBridgeStateAtom } from '@/atoms/wechat-atoms'
+import { sendWithCmdEnterAtom, shortcutOverridesAtom } from '@/atoms/shortcut-atoms'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { WindowControls } from '@/components/WindowControls'
+import { detectIsWindows, WINDOW_CONTROLS_INSET_RIGHT } from '@/lib/platform'
+
+/** 独立窗口模式：复用设置面板，不挂载聊天与 Agent 工作区。 */
+export function SettingsWindowApp(): React.ReactElement {
+  const store = useStore()
+  const setSettingsTab = useSetAtom(settingsTabAtom)
+  const setUserProfile = useSetAtom(userProfileAtom)
+  const setFeishuBots = useSetAtom(feishuBotStatesAtom)
+  const setDingTalkBots = useSetAtom(dingtalkBotStatesAtom)
+  const setWechatState = useSetAtom(wechatBridgeStateAtom)
+  const setSendWithCmdEnter = useSetAtom(sendWithCmdEnterAtom)
+  const setShortcutOverrides = useSetAtom(shortcutOverridesAtom)
+  const setSettingsCloseRequested = useSetAtom(settingsCloseRequestedAtom)
+  const isWindows = useMemo(() => detectIsWindows(), [])
+
+  useEffect(() => {
+    document.title = 'Proma · 设置'
+    const tab = new URLSearchParams(window.location.search).get('tab')
+    // 有合法 tab 参数时直达对应页（如「关于/更新」）；否则默认显示通用设置
+    if (tab && (OPENABLE_SETTINGS_TABS as readonly string[]).includes(tab)) {
+      setSettingsTab(tab as SettingsTab)
+    } else {
+      setSettingsTab('general')
+    }
+    // 加载已保存的用户档案（主窗口由 LeftSidebar 加载；独立窗口需要自行加载）
+    window.electronAPI.getUserProfile().then(setUserProfile).catch(console.error)
+    // 加载远程连接（BotHub）状态：只读取展示，不订阅/上报（避免主窗口初始化器的副作用）
+    window.electronAPI.getFeishuMultiStatus?.()
+      .then((r) => setFeishuBots(r.bots))
+      .catch(() => {})
+    window.electronAPI.getDingTalkMultiStatus?.()
+      .then((r) => setDingTalkBots(r.bots))
+      .catch(() => {})
+    window.electronAPI.getWeChatStatus?.()
+      .then(setWechatState)
+      .catch(() => {})
+    // 快捷键设置（主窗口由 GlobalShortcuts 加载；独立窗口需要自行加载）
+    window.electronAPI.getSettings().then((settings) => {
+      if (settings.sendWithCmdEnter !== undefined) setSendWithCmdEnter(settings.sendWithCmdEnter)
+      if (settings.shortcutOverrides) setShortcutOverrides(settings.shortcutOverrides)
+    }).catch(console.error)
+    // 主窗口修改档案时同步更新（反向同步）
+    const unsubProfile = window.electronAPI.onUserProfileChanged(setUserProfile)
+    // 窗口已存在时主进程转发的标签页深链
+    const unsubTab = window.electronAPI.onSettingsTabRequested((nextTab) => {
+      if ((OPENABLE_SETTINGS_TABS as readonly string[]).includes(nextTab)) {
+        setSettingsTab(nextTab)
+      }
+    })
+    return () => {
+      unsubProfile()
+      unsubTab()
+    }
+  }, [setSettingsTab, setUserProfile, setFeishuBots, setDingTalkBots, setWechatState, setSendWithCmdEnter, setShortcutOverrides])
+
+  // 主进程在窗口关闭前询问未保存内容：渠道表单 dirty 时交给 SettingsPanel 弹确认，
+  // 确认后由 AlertDialog 的 executePendingAction 调 onClose（confirmSettingsClose）真正关闭。
+  // 读取最新 dirty 状态使用 store.get，避免渲染期 ref 的快照竞态。
+  useEffect(() => {
+    return window.electronAPI.onSettingsCloseRequested(() => {
+      if (store.get(channelFormDirtyAtom)) {
+        setSettingsCloseRequested(true)
+        return
+      }
+      void window.electronAPI.confirmSettingsClose()
+    })
+  }, [setSettingsCloseRequested, store])
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <div className="relative h-screen overflow-hidden shell-bg">
+        {/* 顶部拖拽条：与主窗口 AppShell 一致的透明方案，Windows 上让出右上角按钮区 */}
+        <div
+          className={cn(
+            'titlebar-drag-region fixed top-0 left-0 h-[40px] z-50',
+            isWindows ? WINDOW_CONTROLS_INSET_RIGHT : 'right-0',
+          )}
+        />
+        <WindowControls />
+        <SettingsPanel onClose={() => void window.electronAPI.confirmSettingsClose()} />
+      </div>
+    </TooltipProvider>
+  )
+}

--- a/apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx
+++ b/apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx
@@ -12,7 +12,7 @@
 import { useEffect, useCallback } from 'react'
 import { useAtomValue, useSetAtom, useAtom, useStore } from 'jotai'
 import { appModeAtom } from '@/atoms/app-mode'
-import { settingsOpenAtom, channelFormDirtyAtom, settingsCloseRequestedAtom } from '@/atoms/settings-tab'
+
 import { searchDialogOpenAtom } from '@/atoms/search-atoms'
 import {
   tabsAtom,
@@ -63,9 +63,6 @@ import {
  */
 export function GlobalShortcuts(): null {
   const [appMode, setAppMode] = useAtom(appModeAtom)
-  const [settingsOpen, setSettingsOpen] = useAtom(settingsOpenAtom)
-  const channelFormDirty = useAtomValue(channelFormDirtyAtom)
-  const setSettingsCloseRequested = useSetAtom(settingsCloseRequestedAtom)
   const [searchOpen, setSearchOpen] = useAtom(searchDialogOpenAtom)
   const [shortcutGuideOpen, setShortcutGuideOpen] = useAtom(shortcutGuideOpenAtom)
   const [sidebarCollapsed, setSidebarCollapsed] = useAtom(sidebarCollapsedAtom)
@@ -107,15 +104,6 @@ export function GlobalShortcuts(): null {
       setShortcutGuideOpen(false)
       return
     }
-    if (settingsOpen) {
-      // 渠道表单有未保存内容时，通知 SettingsPanel 弹出确认对话框
-      if (channelFormDirty) {
-        setSettingsCloseRequested(true)
-        return
-      }
-      setSettingsOpen(false)
-      return
-    }
     if (searchOpen) {
       setSearchOpen(false)
       return
@@ -123,7 +111,7 @@ export function GlobalShortcuts(): null {
 
     if (!activeTabId) return
     requestClose(activeTabId)
-  }, [shortcutGuideOpen, setShortcutGuideOpen, settingsOpen, setSettingsOpen, channelFormDirty, setSettingsCloseRequested, searchOpen, setSearchOpen, activeTabId, requestClose])
+  }, [shortcutGuideOpen, setShortcutGuideOpen, searchOpen, setSearchOpen, activeTabId, requestClose])
 
   // 监听菜单 IPC 事件（Cmd+W 被 Electron 菜单拦截后通过 IPC 转发）
   useEffect(() => {
@@ -136,10 +124,14 @@ export function GlobalShortcuts(): null {
 
   // ===== 快捷键 Handler =====
 
-  // Cmd+, → 打开设置
+  // Cmd+, → 打开独立设置窗口
   useShortcut(
     'open-settings',
-    useCallback(() => setSettingsOpen(true), [setSettingsOpen]),
+    useCallback(() => {
+      void window.electronAPI.openSettingsWindow().catch((error) => {
+        console.error('[设置] 打开独立窗口失败:', error)
+      })
+    }, []),
   )
 
   // Cmd+Shift+F / Ctrl+Shift+F → 全局搜索

--- a/apps/electron/src/renderer/hooks/useOpenSession.ts
+++ b/apps/electron/src/renderer/hooks/useOpenSession.ts
@@ -26,11 +26,6 @@ import {
   currentAgentWorkspaceIdAtom,
   unviewedCompletedSessionIdsAtom,
 } from '@/atoms/agent-atoms'
-import {
-  channelFormDirtyAtom,
-  settingsOpenAtom,
-  settingsPendingSessionNavigationAtom,
-} from '@/atoms/settings-tab'
 
 interface OpenSessionOptions {
   bypassSettingsGuard?: boolean
@@ -50,20 +45,9 @@ export function useOpenSession(): OpenSessionFn {
   const agentSessions = useAtomValue(agentSessionsAtom)
   const setCurrentAgentWorkspaceId = useSetAtom(currentAgentWorkspaceIdAtom)
   const setUnviewedCompleted = useSetAtom(unviewedCompletedSessionIdsAtom)
-  const settingsOpen = useAtomValue(settingsOpenAtom)
-  const channelFormDirty = useAtomValue(channelFormDirtyAtom)
-  const setSettingsOpen = useSetAtom(settingsOpenAtom)
-  const setPendingSessionNavigation = useSetAtom(settingsPendingSessionNavigationAtom)
 
   return React.useCallback(
     (type: TabType, sessionId: string, title: string, options?: OpenSessionOptions): void => {
-      if (!options?.bypassSettingsGuard && settingsOpen && channelFormDirty) {
-        setPendingSessionNavigation({ type, sessionId, title })
-        return
-      }
-
-      setSettingsOpen(false)
-
       // 切回 agent 会话时，若该会话上次开着预览 Tab 则一并重建并回到上次视图
       const restore = type === 'agent'
         ? buildOpenTabRestore(
@@ -107,6 +91,6 @@ export function useOpenSession(): OpenSessionFn {
         setCurrentAgentSessionId(null)
       }
     },
-    [tabs, setTabs, setActiveTabId, setAutomationForm, setActiveView, setAppMode, setCurrentConversationId, setCurrentAgentSessionId, agentSessions, setCurrentAgentWorkspaceId, setUnviewedCompleted, settingsOpen, channelFormDirty, setSettingsOpen, setPendingSessionNavigation],
+    [tabs, setTabs, setActiveTabId, setAutomationForm, setActiveView, setAppMode, setCurrentConversationId, setCurrentAgentSessionId, agentSessions, setCurrentAgentWorkspaceId, setUnviewedCompleted],
   )
 }

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -95,10 +95,11 @@ const isVoiceDictationIndicatorWindow = new URLSearchParams(window.location.sear
 const isDetachedPreviewWindow = new URLSearchParams(window.location.search).get('window') === 'detached-preview'
 const isPlanningWindow = new URLSearchParams(window.location.search).get('window') === 'planning'
 const isAgentIslandWindow = new URLSearchParams(window.location.search).get('window') === 'agent-island'
-const isMainWindow = !isQuickTaskWindow && !isVoiceDictationIndicatorWindow && !isDetachedPreviewWindow && !isPlanningWindow && !isAgentIslandWindow
+const isSettingsWindow = new URLSearchParams(window.location.search).get('window') === 'settings'
+const isMainWindow = !isQuickTaskWindow && !isVoiceDictationIndicatorWindow && !isDetachedPreviewWindow && !isPlanningWindow && !isAgentIslandWindow && !isSettingsWindow
 
-// 主窗口和独立规划窗口均由内部面板管理滚动，避免页面本身出现第二层滚动。
-if (isMainWindow || isPlanningWindow) {
+// 主窗口、独立规划窗口和独立设置窗口均由内部面板管理滚动，避免页面本身出现第二层滚动。
+if (isMainWindow || isPlanningWindow || isSettingsWindow) {
   document.documentElement.classList.add('proma-main-window')
 }
 
@@ -169,7 +170,7 @@ function ThemeInitializer(): null {
  *
  * 从主进程加载 Agent 渠道/模型设置并写入 atoms。
  */
-function AgentSettingsInitializer(): null {
+function AgentSettingsInitializer({ quiet = false }: { quiet?: boolean } = {}): null {
   const setAgentChannelId = useSetAtom(agentChannelIdAtom)
   const setAgentModelId = useSetAtom(agentModelIdAtom)
   const setAgentChannelIds = useSetAtom(agentChannelIdsAtom)
@@ -308,8 +309,10 @@ function AgentSettingsInitializer(): null {
       .catch(console.error)
   }, [currentWorkspaceId, workspaces])
 
-  // 订阅主进程文件监听推送
+  // 订阅主进程文件监听推送（quiet：独立设置窗口只加载初始数据，不重复响应能力/文件变更）
   useEffect(() => {
+    if (quiet) return
+
     const unsubCapabilities = window.electronAPI.onCapabilitiesChanged(() => {
       // 查找当前工作区 slug
       const ws = workspaces.find((w) => w.id === currentWorkspaceId)
@@ -338,10 +341,10 @@ function AgentSettingsInitializer(): null {
     })
 
     return () => {
-      unsubCapabilities()
-      unsubFiles()
+      if (unsubCapabilities) unsubCapabilities()
+      if (unsubFiles) unsubFiles()
     }
-  }, [bumpCapabilities, bumpFiles, currentWorkspaceId, setAgentWorkspaces, workspaces])
+  }, [bumpCapabilities, bumpFiles, currentWorkspaceId, quiet, setAgentWorkspaces, workspaces])
 
   return null
 }
@@ -351,7 +354,7 @@ function AgentSettingsInitializer(): null {
  *
  * 订阅主进程推送的更新状态变化事件。
  */
-function UpdaterInitializer(): null {
+function UpdaterInitializer({ quiet = false }: { quiet?: boolean } = {}): null {
   const setUpdateStatus = useSetAtom(updateStatusAtom)
   const updateStatus = useAtomValue(updateStatusAtom)
   const notifiedDownloadVersionRef = useRef<string | null>(null)
@@ -362,7 +365,8 @@ function UpdaterInitializer(): null {
   }, [setUpdateStatus])
 
   useEffect(() => {
-    if (updateStatus.status !== 'downloaded') return
+    // quiet（独立设置窗口）：只维护更新状态供「关于/更新」页展示，不弹下载完成 toast
+    if (quiet || updateStatus.status !== 'downloaded') return
 
     const version = updateStatus.version || '新版本'
     if (notifiedDownloadVersionRef.current === version) return
@@ -682,7 +686,7 @@ function AgentListenersInitializer(): null {
  * 启动时从主进程加载所有工具信息到 atom。
  * 订阅 chat-tools.json 文件变更通知，自动刷新工具列表。
  */
-function ChatToolInitializer(): null {
+function ChatToolInitializer({ quiet = false }: { quiet?: boolean } = {}): null {
   const setChatTools = useSetAtom(chatToolsAtom)
 
   useEffect(() => {
@@ -697,12 +701,13 @@ function ChatToolInitializer(): null {
       window.electronAPI.getChatTools()
         .then((tools) => {
           setChatTools(tools)
-          toast.success('Chat 工具已更新')
+          // quiet（独立设置窗口）：只刷新列表，不重复弹 toast
+          if (!quiet) toast.success('Chat 工具已更新')
         })
         .catch((err: unknown) => console.error('[ChatToolInitializer] 刷新工具列表失败:', err))
     })
     return cleanup
-  }, [setChatTools])
+  }, [setChatTools, quiet])
 
   return null
 }
@@ -1121,6 +1126,22 @@ if (isQuickTaskWindow) {
       <React.StrictMode>
         <ThemeInitializer />
         <AgentIslandApp />
+      </React.StrictMode>
+    )
+  })
+} else if (isSettingsWindow) {
+  import('./components/settings/SettingsWindowApp').then(({ SettingsWindowApp }) => {
+    ReactDOM.createRoot(document.getElementById('root')!).render(
+      <React.StrictMode>
+        <ThemeInitializer />
+        <AgentSettingsInitializer quiet />
+        <NotificationsInitializer />
+        <UiPreferencesInitializer />
+        <UpdaterInitializer quiet />
+        <ChatToolInitializer quiet />
+        <MarkdownFontSizeInitializer />
+        <SettingsWindowApp />
+        <Toaster position="bottom-right" />
       </React.StrictMode>
     )
   })

--- a/apps/electron/src/types/settings.ts
+++ b/apps/electron/src/types/settings.ts
@@ -371,6 +371,8 @@ export interface AppSettings {
   mainWindowState?: MainWindowState
   /** 独立任务/日程窗口状态（大小、位置、是否最大化） */
   planningWindowState?: MainWindowState
+  /** 独立设置窗口状态（大小、位置、是否最大化） */
+  settingsWindowState?: MainWindowState
 }
 
 /** 当前发布的 Onboarding 内容版本。提升该值可让所有用户重新完成新版引导。 */
@@ -399,6 +401,16 @@ export interface PersistedTabSettings {
   activeTabId: string | null
 }
 
+/** 设置标签页类型（设置窗口可打开的全部标签） */
+export type SettingsTab = 'general' | 'channels' | 'vision-relay' | 'proxy' | 'appearance' | 'about' | 'prompts' | 'tools' | 'bots' | 'tutorial' | 'shortcuts' | 'voice-input' | 'migration' | 'storage'
+
+/** 独立设置窗口可直达的标签页白名单（tutorial 依赖主窗口 Tab 系统，不在此列） */
+export const OPENABLE_SETTINGS_TABS: readonly SettingsTab[] = [
+  'general', 'channels', 'vision-relay', 'prompts', 'proxy',
+  'tools', 'bots', 'shortcuts', 'voice-input',
+  'migration', 'storage', 'appearance', 'about',
+] as const
+
 /** 设置 IPC 通道 */
 export const SETTINGS_IPC_CHANNELS = {
   GET: 'settings:get',
@@ -408,6 +420,14 @@ export const SETTINGS_IPC_CHANNELS = {
   ON_SYSTEM_THEME_CHANGED: 'settings:system-theme-changed',
   /** 用户手动切换主题时广播给所有窗口 */
   ON_THEME_SETTINGS_CHANGED: 'settings:theme-settings-changed',
+  /** 打开或聚焦单例独立设置窗口（可携带初始标签页） */
+  OPEN_WINDOW: 'settings:open-window',
+  /** 主进程请求渲染进程确认关闭（用于拦截未保存的渠道表单） */
+  REQUEST_CLOSE: 'settings:request-close',
+  /** 渲染进程确认可以关闭（弹窗确认后或无未保存内容时调用） */
+  CONFIRM_CLOSE: 'settings:confirm-close',
+  /** 主进程请求渲染进程切换到指定标签页（窗口已存在时深链生效） */
+  TAB_CHANGED: 'settings:tab-changed',
 } as const
 
 /** Scratch Pad IPC 通道 */

--- a/apps/electron/src/types/user-profile.ts
+++ b/apps/electron/src/types/user-profile.ts
@@ -22,4 +22,6 @@ export interface UserProfile {
 export const USER_PROFILE_IPC_CHANNELS = {
   GET: 'user-profile:get',
   UPDATE: 'user-profile:update',
+  /** 用户档案变更时广播给所有窗口（跨窗口同步） */
+  CHANGED: 'user-profile:changed',
 } as const


### PR DESCRIPTION
## 概述

把 Proma 的设置页面从主窗口内嵌覆盖面板升级为独立打开的窗口，完全复刻「任务/日程独立窗口」（planning-window）模式：单例 BrowserWindow + 状态持久化 + IPC 四层闭合。侧边栏「设置」、Cmd+, 及所有上下文入口统一转向独立窗口，**内嵌设置面板代码已彻底移除**；设置窗口补齐主窗口同等的数据初始化，并实现用户档案跨窗口双向同步。

## 改动

- `apps/electron/src/main/lib/settings-window.ts`（新增）：单例设置窗口——状态持久化（`settingsWindowState`）、`?window=settings` 入口、可选 `tab` 参数、close 拦截未保存确认（渲染未就绪/崩溃不拦截）、tab 深链（窗口已存在时转发切换）、销毁时清理保存定时器
- `apps/electron/src/types/settings.ts`：`settingsWindowState` + `settings:open-window` / `request-close` / `confirm-close` / `tab-changed` channel；`SettingsTab` 类型与 `OPENABLE_SETTINGS_TABS` 白名单下沉至此（main/preload/renderer 单一来源）
- `apps/electron/src/types/user-profile.ts`：`user-profile:changed` 广播 channel
- `apps/electron/src/main/ipc.ts`：OPEN_WINDOW（白名单校验）+ CONFIRM_CLOSE handler；updateUserProfile 后广播档案变更
- `apps/electron/src/main/index.ts` / `menu.ts`：退出销毁设置窗口；Cmd+W 对设置窗口走关闭拦截
- `apps/electron/src/preload/index.ts`：`openSettingsWindow` / `onSettingsCloseRequested` / `confirmSettingsClose` / `onSettingsTabRequested` / `onUserProfileChanged`
- `apps/electron/src/renderer/main.tsx`：`isSettingsWindow` 分支挂 SettingsWindowApp；共享初始化器（AgentSettings/Updater/ChatTool）支持 `quiet` 标志，设置窗口只加载数据不重复弹 toast/订阅
- `apps/electron/src/renderer/components/settings/SettingsWindowApp.tsx`（新增）：SettingsPanel + WindowControls + 透明拖拽区 + 未保存关闭确认 + 初始化用户档案/桥接状态/快捷键 + 档案反向同步 + tab 深链
- `apps/electron/src/renderer/components/settings/SettingsPanel.tsx`：简化为纯独立窗口面板（移除 tutorial、内嵌「返回/独立窗口」按钮、顶部条）
- `apps/electron/src/renderer/components/app-shell/AppShell.tsx`、`LeftSidebar.tsx`、`shortcuts/GlobalShortcuts.tsx`、`hooks/useOpenSession.ts`：**移除内嵌设置面板全链**（settingsOpenAtom/settingsPendingSessionNavigation 及守卫）；LeftSidebar 保留设置/教程入口 + 订阅档案变更
- 5 个入口组件（AgentView/SDKMessageRenderer/AgentSkillsView/AutomationFormView/ToolSelectorPopover）：全部 → `openSettingsWindow(tab)`

## 测试

- `bun run typecheck` 0 错误
- BDD 自审查通过，全部问题已处理：close 拦截兜底、内嵌面板死代码移除、初始化器 quiet、tab 深链、档案双向同步、白名单单一来源、类型下沉、dirty 读取用 store、saveTimer 清理
- dev 实测：侧边栏设置 → 独立窗口（默认「通用设置」）；状态持久化；Cmd+,/Cmd+W 生效；按钮可点击；未保存关闭确认；教程 toggle；设置窗口各页显示实际值；设置窗口改档案主窗口实时同步

## 紧急度

常规

## 备注

- 独立窗口默认「通用设置」页；带 tab 参数直达；窗口已打开时深链可切换标签页
- 独立窗口隐藏「Proma 教程」页（依赖主窗口 Tab 系统），教程入口在侧边栏设置按钮左侧（单击 toggle）
- 内嵌设置面板已彻底移除（不再有 `setSettingsOpen` 调用点）