### PR TITLE
fix(agent): 图片 @ 引用 chip 支持点击预览【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentMessages.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentMessages.tsx
@@ -721,8 +721,13 @@ export function AgentMessages({ sessionId, sessionModelId, messagesLoaded, persi
     ? allGroups.some((g) => g.type === 'assistant-turn' && liveGroupSet.has(g))
     : (liveMessages != null && liveMessages.some((m) => (m as { type: string }).type === 'assistant'))
 
+  const messageBasePaths = React.useMemo(
+    () => [sessionPath, ...(attachedDirs ?? [])].filter((path): path is string => Boolean(path)),
+    [sessionPath, attachedDirs],
+  )
+
   return (
-    <BasePathsProvider basePaths={attachedDirs}>
+    <BasePathsProvider basePaths={messageBasePaths}>
     <div ref={historySelectionRootRef} className="relative flex min-h-0 flex-1 flex-col">
       <Conversation resize={ready && !transitioning ? 'smooth' : 'instant'} className={ready ? (skipFadeIn ? 'opacity-100' : 'opacity-100 transition-opacity duration-200') : 'opacity-0'}>
         <ScrollPositionManager id={sessionId} ready={ready} />

--- a/apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx
@@ -28,7 +28,7 @@ function existsCacheKey(filePath: string, bases: string[]): string {
 }
 
 /** 图片扩展名 */
-const IMAGE_EXTS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp'])
+const IMAGE_EXTS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp', 'ico'])
 /** 视频扩展名 */
 const VIDEO_EXTS = new Set(['mp4', 'webm', 'mov'])
 /**
@@ -64,6 +64,11 @@ const TRAILING_SEP_RE = /[\\/]+$/
 
 /** Windows 盘符绝对路径前缀（如 C:\ D:/ e:\） */
 const WIN_DRIVE_RE = /^[A-Za-z]:[\\/]/
+
+/** 判断路径是否指向可在内置预览中显示的图片。 */
+export function isImageFilePath(filePath: string): boolean {
+  return IMAGE_EXTS.has(getExtension(filePath.trim()))
+}
 
 /** 从路径提取文件名（同时支持 / 和 \） */
 function getFileName(filePath: string): string {

--- a/apps/electron/src/renderer/components/ai-elements/message.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/message.tsx
@@ -38,7 +38,7 @@ import {
 import { LoadingIndicator } from '@/components/ui/loading-indicator'
 import { CodeBlock, MermaidBlock } from '@proma/ui'
 import { detectLanguage } from '@proma/core'
-import { FilePathChip, isAbsoluteFilePath, isRelativeFilePath } from './file-path-chip'
+import { FilePathChip, isAbsoluteFilePath, isImageFilePath, isRelativeFilePath } from './file-path-chip'
 import type { HTMLAttributes, ComponentProps, ReactNode } from 'react'
 import type { FileAttachment } from '@proma/shared'
 
@@ -274,6 +274,16 @@ function safeDecode(raw: string): string {
   }
 }
 
+/**
+ * 附加 basePaths 上下文 — 用于把会话目录与附加目录穿透到各类文件 chip。
+ */
+const BasePathsContext = React.createContext<string[] | undefined>(undefined)
+
+/** 提供附加目录候选给所有内嵌的 MessageResponse。 */
+export function BasePathsProvider({ basePaths, children }: { basePaths?: string[]; children: React.ReactNode }): React.ReactElement {
+  return <BasePathsContext.Provider value={basePaths}>{children}</BasePathsContext.Provider>
+}
+
 /** 仅在普通文本中转换旧引用，避免改写 inline code、fenced code 和缩进代码块。 */
 export function normalizeNamedReferenceDelimiters(markdown: string): string {
   const normalizeText = (text: string): string => text.replace(
@@ -326,6 +336,14 @@ function MentionChip({ type, value }: { type: MentionType; value: string }): Rea
   const style = MENTION_STYLES[type]
   const Icon = style.icon
   const decoded = safeDecode(value)
+  const contextBasePaths = React.useContext(BasePathsContext)
+
+  // 图片引用原先会以内联图片显示。改为 chip 后仍沿用同一文件预览入口，
+  // 避免用户只能看到文件名而无法查看内容。
+  if (type === 'file' && isImageFilePath(decoded)) {
+    return <FilePathChip filePath={decoded} basePaths={contextBasePaths} />
+  }
+
   const isNamedReference = type === 'session' || type === 'todo' || type === 'calendar_event'
   const [referenceId = '', ...labelParts] = isNamedReference ? decoded.split('::') : [decoded]
   const label = labelParts.length > 0 ? labelParts.join('::') : undefined
@@ -430,17 +448,6 @@ export function remarkPreserveBreaks() {
 
 /** remark 插件函数签名 */
 export type RemarkPluginFn = () => (tree: MdastParent) => void
-
-/**
- * 附加 basePaths 上下文 — 用于把"附加目录候选"穿透到 MarkdownInlineCode 而不必逐层透传 props。
- * AgentMessages 在顶层用 BasePathsProvider 包裹，FilePathChip 渲染时会自动取到。
- */
-const BasePathsContext = React.createContext<string[] | undefined>(undefined)
-
-/** 提供附加目录候选给所有内嵌的 MessageResponse */
-export function BasePathsProvider({ basePaths, children }: { basePaths?: string[]; children: React.ReactNode }): React.ReactElement {
-  return <BasePathsContext.Provider value={basePaths}>{children}</BasePathsContext.Provider>
-}
 
 /**
  * 本轮「文件名 → 绝对路径」映射上下文 — 由 AssistantTurnRenderer 提供，作用域为单个 turn。

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -29,6 +29,8 @@ import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip
 import { cn } from '@/lib/utils'
 import { lowlight } from '@/lib/lowlight'
 import { htmlToMarkdown } from '@/lib/markdown-rich-text'
+import { useOpenPreview } from '@/components/diff/preview-opener'
+import { isImageFilePath } from './file-path-chip'
 import { resolveMentionSuggestionChar } from './mention-utils'
 import { richTextRenderingEnabledAtom } from '@/atoms/ui-preferences'
 import { createFileMentionSuggestion } from '@/components/file-browser/file-mention-suggestion'
@@ -242,6 +244,29 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
   const richTextEnabledRef = useRef(richTextEnabled)
   richTextEnabledRef.current = richTextEnabled
   const isMac = useMemo(() => isMacPlatform(), [])
+  const openPreview = useOpenPreview()
+  const mentionPreviewBasePaths = useMemo(
+    () => Array.from(new Set([workspacePath, ...attachedDirs, ...sessionAttachedDirs].filter(Boolean))) as string[],
+    [workspacePath, attachedDirs, sessionAttachedDirs],
+  )
+
+  const handleImageMentionClick = useCallback((event: MouseEvent): boolean => {
+    const target = event.target
+    if (!(target instanceof Element) || !sessionId) return false
+
+    const mention = target.closest<HTMLElement>('[data-type="mention"][data-mention-previewable="true"]')
+    const filePath = mention?.dataset.id
+    if (!filePath) return false
+
+    event.preventDefault()
+    openPreview(sessionId, {
+      filePath,
+      previewOnly: true,
+      readOnly: true,
+      basePaths: mentionPreviewBasePaths.length > 0 ? mentionPreviewBasePaths : undefined,
+    })
+    return true
+  }, [sessionId, openPreview, mentionPreviewBasePaths])
 
   const forwardSessionQuickSwitchKeyEvent = useCallback((event: React.KeyboardEvent<HTMLDivElement>, type: 'keydown' | 'keyup'): void => {
     const nativeEvent = event.nativeEvent
@@ -404,6 +429,9 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
                   : {}),
                 ...(node.attrs.commandMenuMention ? { 'data-command-menu-mention': 'true' } : {}),
                 ...(isDirectory ? { 'data-mention-is-directory': 'true' } : {}),
+                ...(char === '@' && !isDirectory && isImageFilePath(String(node.attrs.id))
+                  ? { 'data-mention-previewable': 'true' }
+                  : {}),
                 class: chipClass,
               },
               `${char === '@' ? '@' : ''}${label}`,
@@ -431,6 +459,9 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
         }
         return false
       },
+      // TipTap mention 节点由 ProseMirror 直接输出 DOM，不能在这里挂 React onClick。
+      // 仅拦截图片 @ 引用，其余 chip 保持编辑器的原有选择行为。
+      handleClick: (_view, _pos, event) => handleImageMentionClick(event),
       attributes: {
         class: cn(
           'prose dark:prose-invert max-w-none focus:outline-none',
@@ -955,6 +986,12 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
           mask-size: contain;
           mask-repeat: no-repeat;
           flex-shrink: 0;
+        }
+        .mention-chip[data-mention-previewable="true"] {
+          cursor: pointer;
+        }
+        .mention-chip[data-mention-previewable="true"]:hover {
+          background-color: hsl(var(--primary) / 0.16);
         }
         .directory-mention-chip {
           background-color: hsl(var(--primary) / 0.14);

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -249,24 +249,29 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
     () => Array.from(new Set([workspacePath, ...attachedDirs, ...sessionAttachedDirs].filter(Boolean))) as string[],
     [workspacePath, attachedDirs, sessionAttachedDirs],
   )
+  // useEditor 只会在 richTextEnabled 变化时重建，事件处理器必须经 ref 读取异步加载的最新路径。
+  const mentionPreviewBasePathsRef = useRef<string[]>(mentionPreviewBasePaths)
+  mentionPreviewBasePathsRef.current = mentionPreviewBasePaths
 
   const handleImageMentionClick = useCallback((event: MouseEvent): boolean => {
     const target = event.target
-    if (!(target instanceof Element) || !sessionId) return false
+    const activeSessionId = currentSessionIdRef.current
+    if (!(target instanceof Element) || !activeSessionId) return false
 
     const mention = target.closest<HTMLElement>('[data-type="mention"][data-mention-previewable="true"]')
     const filePath = mention?.dataset.id
     if (!filePath) return false
 
     event.preventDefault()
-    openPreview(sessionId, {
+    const basePaths = mentionPreviewBasePathsRef.current
+    openPreview(activeSessionId, {
       filePath,
       previewOnly: true,
       readOnly: true,
-      basePaths: mentionPreviewBasePaths.length > 0 ? mentionPreviewBasePaths : undefined,
+      basePaths: basePaths.length > 0 ? basePaths : undefined,
     })
     return true
-  }, [sessionId, openPreview, mentionPreviewBasePaths])
+  }, [openPreview])
 
   const forwardSessionQuickSwitchKeyEvent = useCallback((event: React.KeyboardEvent<HTMLDivElement>, type: 'keydown' | 'keyup'): void => {
     const nativeEvent = event.nativeEvent


### PR DESCRIPTION
## 概述
Agent 输入框将图片以 `@file` mention chip 展示后，用户无法点击查看图片内容。本 PR 恢复两处图片引用的预览能力：输入框内的图片 `@` chip 与已发送用户消息中的图片 `@file:` chip，均通过既有的文件预览入口打开，并正确保留会话目录、项目目录与附加目录的路径解析上下文。

## 改动
- `apps/electron/src/renderer/components/agent/AgentMessages.tsx` — `BasePathsProvider` 的候选目录现在包含会话工作目录与附加目录，并做 memoize 避免流式渲染期间不必要的重渲染。
- `apps/electron/src/renderer/components/ai-elements/message.tsx` — 图片 `@file:` 引用复用可点击的 `FilePathChip`，并消费上下文中的候选目录；`BasePathsContext` 前移使其对 mention chip 与行内代码路径均生效。
- `apps/electron/src/renderer/components/ai-elements/file-path-chip.tsx` — 新增导出 `isImageFilePath`（统一图片扩展名判定，含 ICO），不再把本地文件名中的 `#`/`?` 当作 URL 分隔符截断扩展名。
- `apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx` — 图片 `@` chip 增加可点击状态；点击时直接使用 TipTap 保存的原始文件路径（不再错误解码 `%20` 等合法文件名），并仅对非目录的图片引用启用预览行为。

## 测试方法
1. 在 Agent 输入框通过 `@` 引用一张图片，确认 chip 可点击并打开图片预览（Tab 或右侧分屏）。
2. 发送消息后，确认已发送消息中的图片 `@file:` chip 可点击预览。
3. 验证含空格的路径、`plot#1.png`、`scan?final.png` 等文件名可正常识别为图片。
4. 确认目录引用（如名为 `assets.png` 的目录）不会被错误当作图片预览。
5. 运行 `bun run --filter='@proma/electron' typecheck`。

## 备注
- 已通过 `bun run --filter='@proma/electron' typecheck` 与图片路径定向检查；全量 `bun test` 中 4 个既有失败来自 Electron mock / OAuth proxy / planning 测试环境，与本改动无关。
- 本改动不涉及主进程 IPC、持久化或数据迁移，Windows 路径处理保持跨平台兼容。