### PR TITLE
feat(agent): surface non-git file changes

### DIFF
--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -11,6 +11,7 @@ import type { AgentSessionMeta, AgentEvent, AgentWorkspace, AgentPendingFile, Re
 import { PROMA_DEFAULT_PERMISSION_MODE } from '@proma/shared'
 import { calculateDockBadgeCount, countPendingRequests } from '@/lib/dock-badge-count'
 import type { AgentQueuedMessage } from '@/lib/agent-message-queue'
+import type { SessionFileChange } from '@/lib/session-file-changes'
 
 /** 活动状态 */
 export type ActivityStatus = 'pending' | 'running' | 'completed' | 'error' | 'backgrounded'
@@ -418,6 +419,15 @@ export const agentDiffUnseenChangesAtom = atom(new Map<string, boolean>())
 
 /** Agent 本轮刚修改但用户尚未查看的文件路径 — 按 session 隔离，Map<sessionId, Set<filePath>> */
 export const agentDiffUnseenFilesAtom = atom(new Map<string, Set<string>>())
+
+/**
+ * 非 Git 目录中由 Agent 成功写入的文件变更，按会话保存。
+ * 这些文件不能生成 Git diff，但应和 Git 改动共享“文件改动”入口。
+ */
+export const agentNonGitFileChangesAtom = atom<Map<string, SessionFileChange[]>>(new Map())
+
+/** 当前 session 的 Agent run ID（即渲染进程生成并传给主进程的 startedAt）。 */
+export const agentFileChangesCurrentRunAtom = atom<Map<string, string>>(new Map())
 
 /**
  * Diff 数据缓存 — 按 session 隔离，存放上一次 IPC 拉取到的未暂存改动结果。

--- a/apps/electron/src/renderer/components/agent/SidePanel.tsx
+++ b/apps/electron/src/renderer/components/agent/SidePanel.tsx
@@ -34,6 +34,8 @@ import {
   workspaceAttachedFilesMapAtom,
   agentPendingFilesAtomFamily,
   agentDiffRefreshVersionAtom,
+  agentNonGitFileChangesAtom,
+  agentFileChangesCurrentRunAtom,
   fileBrowserAutoRevealAtom,
   agentSelectedWorktreeAtom,
 } from '@/atoms/agent-atoms'
@@ -118,7 +120,10 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
   const setFilesVersion = useSetAtom(workspaceFilesVersionAtom)
   const diffRefreshVersionMap = useAtomValue(agentDiffRefreshVersionAtom)
   const diffRefreshVersion = diffRefreshVersionMap.get(sessionId) ?? 0
-  const hasFileChanges = filesVersion > 0
+  const nonGitFileChangesMap = useAtomValue(agentNonGitFileChangesAtom)
+  const nonGitFileChanges = nonGitFileChangesMap.get(sessionId) ?? []
+  const fileChangesCurrentRunMap = useAtomValue(agentFileChangesCurrentRunAtom)
+  const fileChangesCurrentRunId = fileChangesCurrentRunMap.get(sessionId)
 
   // 文件面板必须跟随当前会话归属的项目。仅在会话元数据尚未加载时回退全局选择，
   // 避免用户切换项目列表但仍查看旧会话时读写错误项目根目录。
@@ -487,6 +492,9 @@ export function SidePanel({ sessionId, sessionPath, activeTab, onTabChange, widt
                 onFileClick={handleDiffFileClick}
                 workspaceSlug={workspaceSlug || undefined}
                 worktreeRepoPaths={worktreeRepoPathsMemo}
+                nonGitFileChanges={nonGitFileChanges}
+                currentFileChangeRunId={fileChangesCurrentRunId}
+                onPlainFileClick={handleFilePreview}
               />
             ) : (
               <div className="flex-1 flex items-center justify-center text-muted-foreground text-xs">等待会话初始化...</div>

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -49,6 +49,8 @@ import {
   agentDiffRefreshVersionAtom,
   agentDiffUnseenChangesAtom,
   agentDiffUnseenFilesAtom,
+  agentNonGitFileChangesAtom,
+  agentFileChangesCurrentRunAtom,
   agentDiffDataAtom,
   agentStreamingStatesAtom,
   liveMessagesMapAtom,
@@ -845,6 +847,8 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
   const setDiffRefreshVersion = useSetAtom(agentDiffRefreshVersionAtom)
   const setDiffUnseen = useSetAtom(agentDiffUnseenChangesAtom)
   const setDiffUnseenFiles = useSetAtom(agentDiffUnseenFilesAtom)
+  const setNonGitFileChanges = useSetAtom(agentNonGitFileChangesAtom)
+  const setFileChangesCurrentRun = useSetAtom(agentFileChangesCurrentRunAtom)
   const setDiffData = useSetAtom(agentDiffDataAtom)
   const setStreamingStates = useSetAtom(agentStreamingStatesAtom)
   const setLiveMessagesMap = useSetAtom(liveMessagesMapAtom)
@@ -882,6 +886,8 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     setDiffRefreshVersion(deleteKey)
     setDiffUnseen(deleteKey)
     setDiffUnseenFiles(deleteKey)
+    setNonGitFileChanges(deleteKey)
+    setFileChangesCurrentRun(deleteKey)
     setDiffData(deleteKey)
     setSessionChannelMap(deleteKey)
     setSessionModelMap(deleteKey)
@@ -916,7 +922,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
     sessionExistsAtom.remove(id)
 
     clearPreviewCacheForSession(id)
-  }, [setConvModels, setConvContextLength, setConvThinking, setConvParallel, setConvPromptId, setPreviewPanelOpen, setPreviewFile, setDiffPanelTab, setDiffRefreshVersion, setDiffUnseen, setDiffUnseenFiles, setDiffData, setSessionChannelMap, setSessionModelMap, setSessionPathMap, setSessionViewStateMap, setStreamingStates, setLiveMessagesMap, setSessionPendingFiles, store])
+  }, [setConvModels, setConvContextLength, setConvThinking, setConvParallel, setConvPromptId, setPreviewPanelOpen, setPreviewFile, setDiffPanelTab, setDiffRefreshVersion, setDiffUnseen, setDiffUnseenFiles, setNonGitFileChanges, setFileChangesCurrentRun, setDiffData, setSessionChannelMap, setSessionModelMap, setSessionPathMap, setSessionViewStateMap, setStreamingStates, setLiveMessagesMap, setSessionPendingFiles, store])
 
   const currentWorkspaceSlug = React.useMemo(() => {
     if (!currentWorkspaceId) return null

--- a/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
@@ -5,14 +5,25 @@
  */
 
 import * as React from 'react'
-import { ChevronRight, Search, Undo2, X } from 'lucide-react'
+import { Box, ChevronRight, FolderSearch, Search, Undo2, X } from 'lucide-react'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { FileTypeIcon } from '@/components/file-browser/FileTypeIcon'
 import { agentDiffUnseenFilesAtom, agentDiffDataAtom, agentSelectedWorktreeAtom } from '@/atoms/agent-atoms'
-import type { ChangedFileEntry, ChangeSource, UntrackedFileEntry, WorktreeInfo } from '@proma/shared'
+import type { ChangedFileEntry, ChangedFileStatus, ChangeSource, UntrackedFileEntry, WorktreeInfo } from '@proma/shared'
 import { WorktreeSelector } from './WorktreeSelector'
+import { groupSessionFileChanges } from '@/lib/session-file-changes'
+import type { SessionFileChange } from '@/lib/session-file-changes'
+
+interface GitFileEntry {
+  filePath: string
+  status: ChangedFileStatus
+  additions: number
+  deletions: number
+  source?: ChangeSource
+  gitRoot: string
+}
 
 /** 按目录分组后的数据结构 */
 interface FileGroup {
@@ -20,7 +31,7 @@ interface FileGroup {
   gitRoot: string
   /** 显示用的目录名（仓库的最后一段） */
   dirName: string
-  files: ChangedFileEntry[]
+  files: GitFileEntry[]
   totalAdditions: number
   totalDeletions: number
   sources: ChangeSource[]
@@ -47,6 +58,12 @@ interface DiffChangesListProps {
   workspaceSlug?: string
   /** 用于自动发现 worktree 的仓库候选路径 */
   worktreeRepoPaths?: string[]
+  /** 本会话在非 Git 目录中成功写入的文件 */
+  nonGitFileChanges?: SessionFileChange[]
+  /** 当前 Agent run ID，用于将文件变更划分为本轮和更早 */
+  currentFileChangeRunId?: string
+  /** 点击非 Git 文件时打开纯文件预览 */
+  onPlainFileClick?: (filePath: string) => void
 }
 
 /** 文件来源 badge 的颜色和文案 */
@@ -68,6 +85,9 @@ export const DiffChangesList = React.memo(function DiffChangesList({
   extraPaths,
   workspaceSlug,
   worktreeRepoPaths,
+  nonGitFileChanges = [],
+  currentFileChangeRunId,
+  onPlainFileClick,
 }: DiffChangesListProps): React.ReactElement {
   // Worktree 选择状态（内联 WorktreeSelector）
   const selectedWorktreeMap = useAtomValue(agentSelectedWorktreeAtom)
@@ -184,41 +204,48 @@ export const DiffChangesList = React.memo(function DiffChangesList({
   // 按 Git 仓库分组（在所有 hooks 之后、条件返回之前调用）
   const { fileGroups, matchedFilesCount } = React.useMemo(() => {
     const q = searchQuery.toLowerCase().trim()
-    // 用完整 gitRoot 做 key，避免同名目录冲突
-    const groups = new Map<string, ChangedFileEntry[]>()
-    let matched = 0
-    for (const f of files) {
-      if (q && !f.filePath.toLowerCase().includes(q)) continue
-      const key = f.gitRoot || ''
+    const allFiles: GitFileEntry[] = [
+      ...files,
+      ...untrackedFiles.map((file) => ({
+        ...file,
+        status: 'untracked' as const,
+        additions: 0,
+        deletions: 0,
+      })),
+    ]
+    const filteredFiles = q
+      ? allFiles.filter((file) => file.filePath.toLowerCase().includes(q))
+      : allFiles
+
+    // 用完整 gitRoot 做 key，避免同名目录冲突。
+    const groups = new Map<string, GitFileEntry[]>()
+    for (const file of filteredFiles) {
+      const key = file.gitRoot || ''
       if (!groups.has(key)) groups.set(key, [])
-      groups.get(key)!.push(f)
-      matched++
+      groups.get(key)!.push(file)
     }
     const result: FileGroup[] = [...groups.entries()].map(([gitRoot, groupFiles]) => ({
       gitRoot,
       dirName: gitRoot ? gitRoot.split('/').pop() || gitRoot : '/',
       files: groupFiles,
-      totalAdditions: groupFiles.reduce((sum, f) => sum + f.additions, 0),
-      totalDeletions: groupFiles.reduce((sum, f) => sum + f.deletions, 0),
-      sources: [...new Set(groupFiles.map((f) => f.source))],
+      totalAdditions: groupFiles.reduce((sum, file) => sum + file.additions, 0),
+      totalDeletions: groupFiles.reduce((sum, file) => sum + file.deletions, 0),
+      sources: [...new Set(groupFiles.flatMap((file) => file.source ? [file.source] : []))],
     }))
-    return { fileGroups: result, matchedFilesCount: matched }
-  }, [files, searchQuery])
+    return { fileGroups: result, matchedFilesCount: filteredFiles.length }
+  }, [files, untrackedFiles, searchQuery])
 
-  const filteredUntrackedFiles = React.useMemo(() => {
-    const q = searchQuery.toLowerCase().trim()
-    if (!q) return untrackedFiles
-    return untrackedFiles.filter((f) => f.filePath.toLowerCase().includes(q))
-  }, [untrackedFiles, searchQuery])
-
-  const isEmpty = fileGroups.length === 0 && filteredUntrackedFiles.length === 0
+  const isEmpty = fileGroups.length === 0
   const hasAnyChanges = files.length > 0 || untrackedFiles.length > 0
+  const hasGitChanges = isGitRepo && hasAnyChanges
+  const hasNonGitFileChanges = nonGitFileChanges.length > 0
+  const hasAnyVisibleChanges = hasGitChanges || hasNonGitFileChanges
   const shouldShowSearch = isGitRepo && (hasAnyChanges || searchQuery.length > 0)
-  const shouldShowWorktreeSelector = Boolean(workspaceSlug || (worktreeRepoPaths?.length ?? 0) > 0)
+  const shouldShowWorktreeSelector = isGitRepo && Boolean(workspaceSlug || (worktreeRepoPaths?.length ?? 0) > 0)
 
   return (
     <div className="flex flex-col h-full overflow-y-auto">
-      {/* Worktree 分支选择器 — 空 diff / 非 Git 空态也保留，避免无法切到会话 worktree */}
+      {/* Worktree 分支选择器仅作用于 Git 改动。 */}
       {shouldShowWorktreeSelector && (
         <WorktreeSelector
           sessionId={sessionId}
@@ -245,7 +272,7 @@ export const DiffChangesList = React.memo(function DiffChangesList({
             {searchQuery && (
               <>
                 <span className="text-[10px] text-muted-foreground/50 flex-shrink-0 tabular-nums">
-                  {matchedFilesCount + filteredUntrackedFiles.length}
+                  {matchedFilesCount}
                 </span>
                 <button
                   type="button"
@@ -261,22 +288,28 @@ export const DiffChangesList = React.memo(function DiffChangesList({
         </div>
       )}
 
-      {!isGitRepo && (
+      {hasNonGitFileChanges && (
+        <NonGitChangesList
+          changes={nonGitFileChanges}
+          currentRunId={currentFileChangeRunId}
+          sessionId={sessionId}
+          onFileClick={onPlainFileClick}
+        />
+      )}
+
+      {!hasAnyVisibleChanges && (
         <div className="flex flex-col items-center justify-center h-full text-muted-foreground p-4">
-          <p className="text-[12px] text-center">当前目录不是 Git 仓库</p>
+          <p className="text-[12px] text-center">
+            {isGitRepo ? (hasFetched ? '没有文件改动' : '加载中…') : '当前目录不是 Git 仓库'}
+          </p>
         </div>
       )}
-      {isGitRepo && !hasAnyChanges && (
+      {hasGitChanges && isEmpty && (
         <div className="flex flex-col items-center justify-center h-full text-muted-foreground p-4">
-          <p className="text-[12px] text-center">{hasFetched ? '没有代码改动' : '加载中…'}</p>
+          <p className="text-[12px] text-center">没有匹配的代码改动</p>
         </div>
       )}
-      {isGitRepo && hasAnyChanges && isEmpty && (
-        <div className="flex flex-col items-center justify-center h-full text-muted-foreground p-4">
-          <p className="text-[12px] text-center">没有匹配的文件</p>
-        </div>
-      )}
-      {isGitRepo && hasAnyChanges && !isEmpty && (
+      {hasGitChanges && !isEmpty && (
         <>
           {fileGroups.map((group) => {
             const isCollapsed = collapsedDirs.has(group.gitRoot)
@@ -286,10 +319,10 @@ export const DiffChangesList = React.memo(function DiffChangesList({
                 <button
                   type="button"
                   onClick={() => toggleDir(group.gitRoot)}
-                  className="flex items-center gap-1 w-full px-2 py-2 text-[13px] font-medium text-foreground/60 hover:bg-foreground/[0.04] transition-colors"
+                  className="flex items-center gap-1.5 w-full px-3 py-2 text-[13px] font-medium text-foreground/60 hover:bg-foreground/[0.04] transition-colors"
                 >
                   <ChevronRight
-                    className={cn('size-3 transition-transform', !isCollapsed && 'rotate-90')}
+                    className={cn('size-3.5 transition-transform', !isCollapsed && 'rotate-90')}
                   />
                   <span className="truncate">{group.dirName}</span>
                   {/* 文件夹层级的来源 badges */}
@@ -302,7 +335,7 @@ export const DiffChangesList = React.memo(function DiffChangesList({
                     )
                   })}
                   <span className="ml-auto shrink-0 flex items-center gap-1.5">
-                    <span className="text-foreground/30">{group.files.length} changed files</span>
+                    <span className="text-foreground/30">{group.files.length} files</span>
                     {group.totalAdditions > 0 && <span className="text-foreground/30">+{group.totalAdditions}</span>}
                     {group.totalDeletions > 0 && <span className="text-foreground/30">-{group.totalDeletions}</span>}
                   </span>
@@ -317,8 +350,11 @@ export const DiffChangesList = React.memo(function DiffChangesList({
                       file={file}
                       isSelected={absPath === selectedFilePath || file.filePath === selectedFilePath}
                       isUnseen={unseenFiles.has(absPath)}
-                      onClick={() => { markFileAsSeen(absPath); onFileClick(file.filePath, false, file.gitRoot) }}
-                      onRevert={() => handleRevert(file.filePath, file.gitRoot)}
+                      onClick={() => {
+                        markFileAsSeen(absPath)
+                        onFileClick(file.filePath, file.status === 'untracked', file.gitRoot)
+                      }}
+                      onRevert={file.status === 'untracked' ? undefined : () => handleRevert(file.filePath, file.gitRoot)}
                       dirPath={dirPath}
                     />
                   )
@@ -326,29 +362,125 @@ export const DiffChangesList = React.memo(function DiffChangesList({
               </div>
             )
           })}
-
-          {/* 未追踪文件分组 */}
-          {filteredUntrackedFiles.length > 0 && (
-            <div>
-              <div className="flex items-center px-2 py-2 text-[13px] font-medium text-muted-foreground border-t border-border/30">
-                未追踪文件
-              </div>
-              {filteredUntrackedFiles.map((file) => (
-                <UntrackedFileRow
-                  key={`${file.gitRoot}:${file.filePath}`}
-                  file={file}
-                  onClick={() => onFileClick(file.filePath, true, file.gitRoot)}
-                />
-              ))}
-            </div>
-          )}
         </>
       )}
     </div>
   )
 })
 
-/** 已追踪文件的行 */
+function NonGitChangesList({
+  changes,
+  currentRunId,
+  sessionId,
+  onFileClick,
+}: {
+  changes: SessionFileChange[]
+  currentRunId?: string
+  sessionId: string
+  onFileClick?: (filePath: string) => void
+}): React.ReactElement {
+  const { current, earlier } = groupSessionFileChanges(changes, currentRunId)
+  const hasEarlierChanges = earlier.length > 0
+  const title = hasEarlierChanges
+    ? `本会话文件变更 · ${changes.length}`
+    : `本会话文件变更 · 本轮 · ${current.length}`
+
+  return (
+    <div className="shrink-0 py-1">
+      <div className="flex items-center gap-1.5 px-3 py-2 text-[13px] font-medium text-muted-foreground tabular-nums">
+        <Box className="size-3.5 shrink-0" />
+        <span>{title}</span>
+      </div>
+      {hasEarlierChanges ? (
+        <>
+          {current.length > 0 && <NonGitRunGroup title="本轮" changes={current} sessionId={sessionId} onFileClick={onFileClick} />}
+          <NonGitRunGroup title="更早" changes={earlier} sessionId={sessionId} onFileClick={onFileClick} />
+        </>
+      ) : (
+        <NonGitFileList changes={current} sessionId={sessionId} onFileClick={onFileClick} />
+      )}
+    </div>
+  )
+}
+
+function NonGitRunGroup({
+  title,
+  changes,
+  sessionId,
+  onFileClick,
+}: {
+  title: string
+  changes: SessionFileChange[]
+  sessionId: string
+  onFileClick?: (filePath: string) => void
+}): React.ReactElement {
+  return (
+    <section className="pb-2">
+      <div className="px-3 py-1 text-[11px] font-medium text-muted-foreground tabular-nums">{title} · {changes.length}</div>
+      <NonGitFileList changes={changes} sessionId={sessionId} onFileClick={onFileClick} />
+    </section>
+  )
+}
+
+function NonGitFileList({
+  changes,
+  sessionId,
+  onFileClick,
+}: {
+  changes: SessionFileChange[]
+  sessionId: string
+  onFileClick?: (filePath: string) => void
+}): React.ReactElement {
+  return (
+    <div>
+      {changes.map((change) => {
+        const parts = change.path.split(/[\\/]/)
+        const name = parts.pop() || change.path
+        const parent = getCompactFilePath(parts.filter(Boolean).join('/'))
+        return (
+          <div key={change.path} className="group flex h-9 items-center hover:bg-primary/5 transition-colors">
+            <Tooltip delayDuration={700}>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={() => onFileClick?.(change.path)}
+                  className="flex h-full min-w-0 flex-1 items-center gap-2 px-3 text-left text-sm"
+                >
+                  <FileTypeIcon name={name} isDirectory={false} size={16} />
+                  <span className="min-w-0 flex-1 truncate text-[13px]">{name}</span>
+                  {parent && <span className="max-w-[40%] truncate text-[11px] text-muted-foreground">{parent}</span>}
+                  {change.kind === 'created' && (
+                    <span className="shrink-0 rounded-sm bg-orange-500/10 px-1.5 py-0.5 text-[11px] font-medium text-orange-600 dark:text-orange-400">新建</span>
+                  )}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="left" className="max-w-[400px] break-all">{change.path}</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-label="在文件夹中显示"
+                  onClick={() => window.electronAPI.showInFolder(change.path, { sessionId }).catch(console.error)}
+                  className="mr-1 flex size-8 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-foreground/[0.08] hover:text-foreground"
+                >
+                  <FolderSearch className="size-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="left">在文件夹中显示</TooltipContent>
+            </Tooltip>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function getCompactFilePath(path: string): string {
+  return path.replace(/^\/Users\/[^/]+\//, '~/')
+}
+
+/** Git 文件行：已追踪和未追踪文件共用同一布局。 */
 function FileRow({
   file,
   onClick,
@@ -357,9 +489,9 @@ function FileRow({
   isUnseen,
   dirPath,
 }: {
-  file: ChangedFileEntry
+  file: GitFileEntry
   onClick: () => void
-  onRevert: () => void
+  onRevert?: () => void
   isSelected?: boolean
   isUnseen?: boolean
   dirPath: string
@@ -368,6 +500,7 @@ function FileRow({
   const fileName = parts.pop()!
   const dir = parts.join('/')
   const fullPath = `${file.gitRoot || dirPath}/${file.filePath}`.replace(/\/+/g, '/')
+  const hasLineChanges = file.additions > 0 || file.deletions > 0
 
   return (
     <div
@@ -388,73 +521,6 @@ function FileRow({
       <Tooltip delayDuration={900}>
         <TooltipTrigger asChild>
           <span className="ml-1.5 truncate flex items-baseline gap-1.5 min-w-0">
-            <span className="shrink-0">
-              {fileName}
-              {file.status === 'deleted' && (
-                <span className="ml-1 text-foreground/30 text-[12px]">(已删除)</span>
-              )}
-            </span>
-            {dir && (
-              <span className="text-[11px] text-foreground/30 truncate">{dir}</span>
-            )}
-          </span>
-        </TooltipTrigger>
-        <TooltipContent side="bottom" className="max-w-[400px] break-all">{fullPath}</TooltipContent>
-      </Tooltip>
-
-      {/* +/- 行数 — hover 时隐藏让位给操作按钮 */}
-      <span className="ml-auto shrink-0 flex items-center gap-1.5 text-[13px] group-hover:hidden">
-        {file.additions > 0 && (
-          <span style={{ color: 'rgb(34 197 94)' }}>+{file.additions}</span>
-        )}
-        {file.deletions > 0 && (
-          <span style={{ color: 'rgb(239 68 68)' }}>-{file.deletions}</span>
-        )}
-      </span>
-
-      {/* Hover 操作按钮 */}
-      <span className="ml-auto shrink-0 hidden group-hover:flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span
-              className="p-0.5 rounded hover:bg-foreground/[0.08] text-foreground/40 hover:text-foreground/70 cursor-pointer"
-              onClick={onRevert}
-            >
-              <Undo2 className="size-4" />
-            </span>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">还原文件变更</TooltipContent>
-        </Tooltip>
-      </span>
-    </div>
-  )
-}
-
-/** 未追踪文件的行 */
-function UntrackedFileRow({
-  file,
-  onClick,
-}: {
-  file: UntrackedFileEntry
-  onClick: () => void
-}): React.ReactElement {
-  const filePath = file.filePath
-  const parts = filePath.split('/')
-  const fileName = parts.pop()!
-  const dir = parts.join('/')
-  const fullPath = `${file.gitRoot}/${file.filePath}`.replace(/\/+/g, '/')
-
-  return (
-    <div
-      role="button"
-      tabIndex={0}
-      className="flex items-center w-full px-2 pl-6 h-[36px] text-[14px] hover:bg-foreground/[0.04] transition-colors"
-      onClick={onClick}
-    >
-      <FileTypeIcon name={fileName} isDirectory={false} size={16} />
-      <Tooltip delayDuration={900}>
-        <TooltipTrigger asChild>
-          <span className="ml-1.5 truncate flex items-baseline gap-1.5 min-w-0">
             <span className="shrink-0">{fileName}</span>
             {dir && (
               <span className="text-[11px] text-foreground/30 truncate">{dir}</span>
@@ -463,9 +529,61 @@ function UntrackedFileRow({
         </TooltipTrigger>
         <TooltipContent side="bottom" className="max-w-[400px] break-all">{fullPath}</TooltipContent>
       </Tooltip>
-      <span className="ml-1.5 rounded px-1 py-0.5 text-[12px] leading-none shrink-0 bg-amber-500/10 text-amber-500">
-        新文件
-      </span>
+
+      {hasLineChanges && (
+        <span className="ml-auto shrink-0 flex items-center gap-1.5 text-[13px] tabular-nums group-hover:hidden">
+          {file.additions > 0 && (
+            <span style={{ color: 'rgb(34 197 94)' }}>+{file.additions}</span>
+          )}
+          {file.deletions > 0 && (
+            <span style={{ color: 'rgb(239 68 68)' }}>-{file.deletions}</span>
+          )}
+        </span>
+      )}
+
+      {onRevert && (
+        <span className="ml-auto shrink-0 hidden group-hover:flex items-center gap-1" onClick={(event) => event.stopPropagation()}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="还原文件变更"
+                className="flex size-8 items-center justify-center rounded text-foreground/40 hover:bg-foreground/[0.08] hover:text-foreground/70"
+                onClick={onRevert}
+              >
+                <Undo2 className="size-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">还原文件变更</TooltipContent>
+          </Tooltip>
+        </span>
+      )}
+
+      <GitStatusMarker status={file.status} className={onRevert ? 'ml-2' : 'ml-auto'} />
     </div>
+  )
+}
+
+function GitStatusMarker({
+  status,
+  className,
+}: {
+  status: ChangedFileStatus
+  className?: string
+}): React.ReactElement {
+  const config: Record<ChangedFileStatus, { label: string; description: string; color: string }> = {
+    modified: { label: 'M', description: '已修改', color: 'text-amber-500' },
+    deleted: { label: 'D', description: '已删除', color: 'text-red-500' },
+    untracked: { label: 'U', description: '未追踪', color: 'text-emerald-500' },
+  }
+  const { label, description, color } = config[status]
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className={cn('w-4 shrink-0 text-right text-[12px] font-medium tabular-nums', className, color)}>{label}</span>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">{description}</TooltipContent>
+    </Tooltip>
   )
 }

--- a/apps/electron/src/renderer/components/diff/WorktreeSelector.tsx
+++ b/apps/electron/src/renderer/components/diff/WorktreeSelector.tsx
@@ -105,7 +105,7 @@ export function WorktreeSelector({
 
   const allWorktrees = repoWorktrees.flatMap((rw) => rw.worktrees)
   const selectedWorktree = allWorktrees.find((wt) => wt.path === selectedPath)
-  const displayLabel = selectedWorktree ? selectedWorktree.branch : '会话改动'
+  const displayLabel = selectedWorktree ? selectedWorktree.branch : 'Worktrees'
   const hasMultipleRepos = repoWorktrees.length > 1
 
   if (allWorktrees.length === 0) return <></>

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -45,6 +45,10 @@ import {
   unviewedCompletedSessionIdsAtom,
   agentSessionPathMapAtom,
   agentDiffRefreshVersionAtom,
+  agentDiffPanelTabAtom,
+  agentNonGitFileChangesAtom,
+  agentFileChangesCurrentRunAtom,
+  agentSidePanelOpenAtom,
   askUserDraftsAtom,
 } from '@/atoms/agent-atoms'
 import {
@@ -71,6 +75,7 @@ import {
 } from '@/lib/agent-completion-presence'
 import { getPlanModeChangeFromToolName, updatePlanModeSessionSet } from '@/lib/agent-plan-mode'
 import { buildTodoAgentPrompt } from '@/lib/todo-agent-prompt'
+import { getSessionFileChangeKind, upsertSessionFileChange } from '@/lib/session-file-changes'
 
 /** 触发右侧文件浏览器自动定位的写入类工具集合 */
 const WRITE_TOOLS = new Set(['Write', 'Edit', 'MultiEdit', 'NotebookEdit', 'Update'])
@@ -453,8 +458,16 @@ export function useGlobalAgentListeners(): void {
   const store = useStore()
 
   useEffect(() => {
-    /** 正在执行的写工具：toolUseId → { path, sessionId } */
-    const pendingWriteTools = new Map<string, { path: string; sessionId: string }>()
+    /** 正在执行的写工具；写入前的文件存在性用于区分新建和编辑。 */
+    const pendingWriteTools = new Map<string, {
+      path: string
+      sessionId: string
+      toolName: string
+      existedBefore?: boolean
+      runId: string
+    }>()
+    /** 每轮只自动打开一次文件改动面板，避免连续写入打断用户。 */
+    const autoActivatedChangeTurns = new Map<string, string>()
     /** 正在执行的 git 突变 Bash 命令：toolUseId → sessionId（完成后触发 diff 刷新） */
     const pendingGitMutateTools = new Map<string, string>()
 
@@ -835,6 +848,17 @@ export function useGlobalAgentListeners(): void {
             })
           }
 
+          const activeRunStartedAt = store.get(agentStreamingStatesAtom).get(sessionId)?.startedAt
+          if (activeRunStartedAt != null) {
+            const activeRunId = String(activeRunStartedAt)
+            store.set(agentFileChangesCurrentRunAtom, (prev) => {
+              if (prev.get(sessionId) === activeRunId) return prev
+              const map = new Map(prev)
+              map.set(sessionId, activeRunId)
+              return map
+            })
+          }
+
           // Pi 原生重试成功后仍会沿用同一会话；仅在事件属于当前 stream run 时
           // 清掉过期错误，避免迟到的旧 retry_cleared 掩盖新一轮真实失败。
           if (event.type === 'retry_cleared') {
@@ -844,7 +868,7 @@ export function useGlobalAgentListeners(): void {
             }
           }
 
-          // RightSidePanel 由用户完全控制，Agent 行为不影响其开关状态
+          // 非 Git 文件写入时自动打开“文件改动”；Git Diff 的面板状态仍由用户控制。
 
           // Agent 修改文件时，记入「最近修改」状态，用于 60s 内左侧竖条标记
           if (event.type === 'tool_start' && WRITE_TOOLS.has(event.toolName)) {
@@ -853,7 +877,25 @@ export function useGlobalAgentListeners(): void {
               (input?.file_path as string | undefined)
               ?? (input?.path as string | undefined)
               ?? (input?.notebook_path as string | undefined)
-            pendingWriteTools.set(event.toolUseId, { path: targetPath || '', sessionId })
+            const runId = store.get(agentFileChangesCurrentRunAtom).get(sessionId)
+              ?? String(store.get(agentStreamingStatesAtom).get(sessionId)?.startedAt ?? event.turnId ?? Date.now())
+            const entry = {
+              path: targetPath || '',
+              sessionId,
+              toolName: event.toolName,
+              runId,
+            }
+            pendingWriteTools.set(event.toolUseId, entry)
+            if (typeof targetPath === 'string' && targetPath.length > 0) {
+              void window.electronAPI.resolveAndReadFile(targetPath, { sessionId })
+                .then((file) => {
+                  const pending = pendingWriteTools.get(event.toolUseId)
+                  if (pending) pending.existedBefore = file !== null
+                })
+                .catch(() => {
+                  // 文件不存在和暂时无法读取都按未知处理，避免阻断写入反馈。
+                })
+            }
             if (typeof targetPath === 'string' && targetPath.length > 0) {
               const now = Date.now()
               // 记入「最近修改」状态，用于 60s 内左侧竖条标记
@@ -914,17 +956,18 @@ export function useGlobalAgentListeners(): void {
             store.set(backgroundTasksAtomFamily(sessionId), (prev) =>
               prev.filter((t) => t.toolUseId !== event.toolUseId)
             )
-            // Agent 写类工具完成时，递增 diff 刷新版本号并标记未查看改动
+            // Agent 写类工具成功时刷新 Git diff；非 Git 目录记录为本会话文件变更。
             if (pendingWriteTools.has(event.toolUseId)) {
               const entry = pendingWriteTools.get(event.toolUseId)!
               const writtenPath = entry.path
               pendingWriteTools.delete(event.toolUseId)
+              if (event.isError) continue
               store.set(agentDiffRefreshVersionAtom, (prev) => {
                 const m = new Map(prev); m.set(sessionId, (prev.get(sessionId) ?? 0) + 1); return m
               })
               if (writtenPath) {
                 buildWrittenFilePreviewInfo(sessionId, writtenPath).then((previewFile) => {
-                  if (!previewFile || previewFile.previewOnly || !previewFile.inDiffScope) return
+                  if (!previewFile || !previewFile.inDiffScope) return
 
                   store.set(agentDiffUnseenChangesAtom, (prev) => {
                     const m = new Map(prev); m.set(sessionId, true); return m
@@ -936,6 +979,33 @@ export function useGlobalAgentListeners(): void {
                     m.set(sessionId, s)
                     return m
                   })
+
+                  if (previewFile.previewOnly) {
+                    store.set(agentNonGitFileChangesAtom, (prev) => {
+                      const m = new Map(prev)
+                      const current = m.get(sessionId) ?? []
+                      m.set(sessionId, upsertSessionFileChange(current, {
+                        path: writtenPath,
+                        kind: getSessionFileChangeKind(entry.toolName, entry.existedBefore),
+                        runId: entry.runId,
+                        updatedAt: Date.now(),
+                      }))
+                      return m
+                    })
+
+                    if (
+                      store.get(currentAgentSessionIdAtom) === sessionId
+                      && autoActivatedChangeTurns.get(sessionId) !== entry.runId
+                    ) {
+                      autoActivatedChangeTurns.set(sessionId, entry.runId)
+                      store.set(agentSidePanelOpenAtom, true)
+                      store.set(agentDiffPanelTabAtom, (prev) => {
+                        const m = new Map(prev)
+                        m.set(sessionId, 'changes')
+                        return m
+                      })
+                    }
+                  }
 
                 }).catch(() => { /* 改动提示不应影响流式输出 */ })
               }

--- a/apps/electron/src/renderer/lib/session-file-changes.ts
+++ b/apps/electron/src/renderer/lib/session-file-changes.ts
@@ -1,0 +1,45 @@
+export type SessionFileChangeKind = "created" | "edited";
+
+export interface SessionFileChange {
+  path: string;
+  kind: SessionFileChangeKind;
+  runId: string;
+  updatedAt: number;
+}
+
+export function getSessionFileChangeKind(
+  toolName: string,
+  existedBefore: boolean | undefined,
+): SessionFileChangeKind {
+  if (toolName === "Write" && existedBefore === false) return "created";
+  return "edited";
+}
+
+export function upsertSessionFileChange(
+  changes: readonly SessionFileChange[],
+  next: SessionFileChange,
+): SessionFileChange[] {
+  const index = changes.findIndex((change) => change.path === next.path);
+  if (index < 0) return [next, ...changes];
+
+  const current = changes[index]!;
+  const updated = {
+    ...next,
+    // A file created in this session should remain visibly new after later edits.
+    kind: current.kind === "created" ? "created" : next.kind,
+  };
+  return changes.map((change, changeIndex) =>
+    changeIndex === index ? updated : change,
+  );
+}
+
+export function groupSessionFileChanges(
+  changes: readonly SessionFileChange[],
+  currentRunId: string | undefined,
+): { current: SessionFileChange[]; earlier: SessionFileChange[] } {
+  if (!currentRunId) return { current: [...changes], earlier: [] };
+  return {
+    current: changes.filter((change) => change.runId === currentRunId),
+    earlier: changes.filter((change) => change.runId !== currentRunId),
+  };
+}


### PR DESCRIPTION
## Summary
- Surface files created or edited by the Agent outside Git repositories in the changes panel.
- Group session file changes by the current Agent run and earlier runs, with preview and Finder reveal actions.
- Unify tracked and untracked Git files by directory with VS Code-style U/M/D status markers.

## Validation
- `bun run typecheck`
- `git diff --check`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)