### PR TITLE
Add native planning quick entries

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -47,6 +47,10 @@ function registerProtocolsAndHandlers(): void {
 
   // Windows 文件关联：当用户双击文件时，新实例的参数会通过 second-instance 传给已有实例
   app.on('second-instance', (_event, argv) => {
+    if (hasOpenPlanningArgument(argv)) {
+      showPlanningWindow()
+      return
+    }
     showAndFocusMainWindow()
     const fileArg = argv.find((arg) => arg.endsWith('.proma-backup') || arg.endsWith('.proma-share'))
     if (fileArg) {
@@ -113,6 +117,8 @@ import { wechatBridge } from './lib/wechat-bridge'
 import { getWeChatConfig } from './lib/wechat-config'
 import { createQuickTaskWindow, toggleQuickTaskWindow, destroyQuickTaskWindow } from './lib/quick-task-window'
 import { destroyPlanningWindow, showPlanningWindow } from './lib/planning-window'
+import { configurePlanningQuickEntries } from './lib/planning-quick-entry'
+import { hasOpenPlanningArgument } from './lib/planning-quick-entry-model'
 import { createAgentIslandWindow, destroyAgentIslandWindow, showAgentIslandWindow } from './lib/agent-island-window'
 import { handleNativeAgentIslandEvent, initAgentIslandService, disposeAgentIslandService, publishAgentIslandNow } from './lib/agent-island-service'
 import { disposeMacAgentIslandNativeHost, startMacAgentIslandNativeHost } from './lib/mac-agent-island-native-host'
@@ -560,9 +566,19 @@ async function bootstrap(): Promise<void> {
   // Create main window (will be shown when ready)
   createWindow()
 
+  // 为 Dock、任务栏右键菜单与首次启动参数提供任务/日程的直接入口。
+  safeRun('configurePlanningQuickEntries', () => {
+    configurePlanningQuickEntries({
+      showMainWindow: showAndFocusMainWindow,
+      showPlanningWindow,
+    })
+  })
+  if (hasOpenPlanningArgument(process.argv)) showPlanningWindow()
+
   // Create system tray icon
   createTray({
     showMainWindow: showAndFocusMainWindow,
+    showPlanningWindow,
     openAgentSession: (sessionId, title) => {
       sendToMainWindow(TRAY_IPC_CHANNELS.OPEN_AGENT_SESSION, { sessionId, title })
     },
@@ -618,6 +634,9 @@ async function bootstrap(): Promise<void> {
   )
   safeRun('registerGlobalShortcut:show-main-window', () =>
     registerGlobalShortcut('show-main-window', showAndFocusMainWindow),
+  )
+  safeRun('registerGlobalShortcut:open-planning', () =>
+    registerGlobalShortcut('open-planning', showPlanningWindow),
   )
   safeRun('registerGlobalShortcut:voice-dictation', () =>
     registerGlobalShortcut('voice-dictation', () => {

--- a/apps/electron/src/main/lib/global-shortcut-service.ts
+++ b/apps/electron/src/main/lib/global-shortcut-service.ts
@@ -22,6 +22,7 @@ const registeredAccelerators = new Map<string, string>()
 const GLOBAL_SHORTCUT_DEFAULTS: Record<string, { mac: string; win: string }> = {
   'quick-task': { mac: 'Alt+Space', win: 'Alt+Space' },
   'show-main-window': { mac: 'CommandOrControl+Shift+P', win: 'CommandOrControl+Shift+P' },
+  'open-planning': { mac: 'CommandOrControl+Shift+T', win: 'CommandOrControl+Shift+T' },
   'voice-dictation': { mac: 'Ctrl+`', win: 'Ctrl+`' },
 }
 

--- a/apps/electron/src/main/lib/planning-quick-entry-model.ts
+++ b/apps/electron/src/main/lib/planning-quick-entry-model.ts
@@ -1,0 +1,14 @@
+/** 用于 Windows Jump List 启动独立规划窗口的命令行参数。 */
+export const OPEN_PLANNING_ARGUMENT = '--open-planning'
+
+export function hasOpenPlanningArgument(argv: readonly string[]): boolean {
+  return argv.includes(OPEN_PLANNING_ARGUMENT)
+}
+
+/**
+ * 开发模式需把应用目录传给 Electron 可执行文件；打包版只需传功能参数。
+ */
+export function getPlanningTaskArguments(defaultApp: boolean, appPath: string): string {
+  const appArgument = defaultApp ? `"${appPath}" ` : ''
+  return `${appArgument}${OPEN_PLANNING_ARGUMENT}`
+}

--- a/apps/electron/src/main/lib/planning-quick-entry.ts
+++ b/apps/electron/src/main/lib/planning-quick-entry.ts
@@ -1,0 +1,33 @@
+import { app, Menu } from 'electron'
+import { getPlanningTaskArguments } from './planning-quick-entry-model'
+
+interface PlanningQuickEntryActions {
+  showMainWindow: () => void
+  showPlanningWindow: () => void
+}
+
+/**
+ * 配置操作系统原生入口。两个平台均复用主进程的单例规划窗口，避免产生第二份数据或运行时。
+ */
+export function configurePlanningQuickEntries(actions: PlanningQuickEntryActions): void {
+  if (process.platform === 'darwin' && app.dock) {
+    app.dock.setMenu(Menu.buildFromTemplate([
+      { label: '打开任务/日程', click: actions.showPlanningWindow },
+      { type: 'separator' },
+      { label: '打开 Proma', click: actions.showMainWindow },
+    ]))
+  }
+
+  if (process.platform === 'win32') {
+    app.setUserTasks([
+      {
+        program: process.execPath,
+        arguments: getPlanningTaskArguments(process.defaultApp === true, app.getAppPath()),
+        iconPath: process.execPath,
+        iconIndex: 0,
+        title: '任务/日程',
+        description: '打开 Proma 的任务、日程与定时任务中心',
+      },
+    ])
+  }
+}

--- a/apps/electron/src/main/tray.ts
+++ b/apps/electron/src/main/tray.ts
@@ -10,6 +10,7 @@ let tray: Tray | null = null
 
 export interface TrayActions {
   showMainWindow: () => void
+  showPlanningWindow: () => void
   openAgentSession: (sessionId: string, title: string) => void
   createChatSession: () => void
   createAgentSession: () => void
@@ -43,6 +44,7 @@ function showMainWindow(): void {
 function getDefaultTrayActions(): TrayActions {
   return {
     showMainWindow,
+    showPlanningWindow: showMainWindow,
     openAgentSession: () => showMainWindow(),
     createChatSession: () => showMainWindow(),
     createAgentSession: () => showMainWindow(),
@@ -73,6 +75,11 @@ function buildTrayMenu(actions: TrayActions): Menu {
   const moreItems = model.moreSessions.map((item) => createRecentSessionMenuItem(item, actions))
 
   const template: Electron.MenuItemConstructorOptions[] = [
+    {
+      label: '任务/日程',
+      click: () => actions.showPlanningWindow(),
+    },
+    { type: 'separator' },
     ...(runningItems.length > 0
       ? [
           { label: '运行中', enabled: false },

--- a/apps/electron/src/renderer/components/shortcuts/ShortcutGuideDialog.tsx
+++ b/apps/electron/src/renderer/components/shortcuts/ShortcutGuideDialog.tsx
@@ -48,7 +48,6 @@ const SHORTCUT_DISPLAY_ORDER: Record<ShortcutCategory, readonly string[]> = {
   navigation: [
     'cycle-sessions',
     'quick-switch-session',
-    'open-planning',
     'file-find',
     'global-search',
     'focus-input',
@@ -62,7 +61,7 @@ const SHORTCUT_DISPLAY_ORDER: Record<ShortcutCategory, readonly string[]> = {
     'editor-bold',
     'editor-strikethrough',
   ],
-  global: ['quick-task', 'show-main-window', 'voice-dictation'],
+  global: ['quick-task', 'show-main-window', 'open-planning', 'voice-dictation'],
 }
 
 const CATEGORY_ICONS: Record<ShortcutCategory, React.ComponentType<{ className?: string }>> = {

--- a/apps/electron/src/renderer/lib/shortcut-defaults.ts
+++ b/apps/electron/src/renderer/lib/shortcut-defaults.ts
@@ -124,7 +124,8 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
     description: '打开或聚焦独立的 Todo、日程与定时任务窗口',
     defaultMac: 'Cmd+Shift+T',
     defaultWin: 'Ctrl+Shift+T',
-    category: 'navigation',
+    category: 'global',
+    global: true,
   },
   {
     id: 'file-find',

--- a/apps/electron/src/renderer/lib/shortcut-defaults.ts
+++ b/apps/electron/src/renderer/lib/shortcut-defaults.ts
@@ -26,6 +26,8 @@ export interface ShortcutDefinition {
   category: ShortcutCategory
   /** 是否为全局快捷键（由主进程 globalShortcut 注册） */
   global?: boolean
+  /** 全局注册不可用时，是否仍保留应用内 keydown 回退 */
+  localFallback?: boolean
   /** 是否为只读（仅展示，不可自定义） */
   readonly?: boolean
 }
@@ -126,6 +128,7 @@ export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
     defaultWin: 'Ctrl+Shift+T',
     category: 'global',
     global: true,
+    localFallback: true,
   },
   {
     id: 'file-find',

--- a/apps/electron/src/renderer/lib/shortcut-registry.ts
+++ b/apps/electron/src/renderer/lib/shortcut-registry.ts
@@ -141,8 +141,9 @@ let parsedCache = new Map<string, ParsedAccelerator>()
 function rebuildCache(): void {
   parsedCache = new Map()
   for (const def of DEFAULT_SHORTCUTS) {
-    // 全局快捷键由主进程 globalShortcut 处理，不在渲染进程注册
-    if (def.global) continue
+    // 全局快捷键通常由主进程处理；声明本地回退的组合仍注册 keydown，
+    // 以便系统拒绝全局注册时保留应用内行为。
+    if (def.global && !def.localFallback) continue
     const accel = getActiveAccelerator(def.id)
     // 用户已禁用的快捷键不进入分发缓存
     if (accel === null) continue


### PR DESCRIPTION
## Summary

- Add macOS Dock and Windows taskbar quick actions for the planning window.
- Add a top-level system tray action and promote Cmd/Ctrl+Shift+T to a configurable global shortcut.
- Route cold and warm Windows Jump List launches through the existing single-instance planning window.

## Test plan

- `bun run --filter=@proma/electron build:main` passed.
- `bun run --filter=@proma/electron build:renderer` passed; existing large-chunk warnings remain.
- `bun test` ran 519 tests: 515 passed, 4 failed in existing Electron/proxy/planning-manager environment-sensitive tests.
- Full typecheck remains blocked by pre-existing @proma/shared exports from the shared dependency worktree.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)