### PR TITLE
feat(settings): 新增 Proma 新手引导重放入口【已审核 PR】

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.16.9",
+  "version": "0.16.10",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/renderer/App.tsx
+++ b/apps/electron/src/renderer/App.tsx
@@ -11,6 +11,8 @@ import { FaqDialog } from './components/shortcuts/FaqDialog'
 import { PlanningReminderRail } from './components/planning/PlanningReminderRail'
 import { conversationsAtom } from './atoms/chat-atoms'
 import { environmentCheckDialogOpenAtom } from './atoms/environment'
+import { onboardingReplayRequestedAtom } from './atoms/onboarding'
+import { settingsOpenAtom, settingsTabAtom } from './atoms/settings-tab'
 import { tabsAtom, activeTabIdAtom, openTab, TUTORIAL_TAB_ID } from './atoms/tab-atoms'
 import { hasCompletedCurrentOnboarding } from '../types'
 import type { AppShellContextType } from './contexts/AppShellContext'
@@ -21,6 +23,8 @@ export default function App(): React.ReactElement {
   const store = useStore()
   const [isLoading, setIsLoading] = React.useState(true)
   const [showOnboarding, setShowOnboarding] = React.useState(false)
+  const [onboardingReplayRequested, setOnboardingReplayRequested] = useAtom(onboardingReplayRequestedAtom)
+  const [isReplayingOnboarding, setIsReplayingOnboarding] = React.useState(false)
 
   // 初始化：检查是否需要显示 Onboarding
   // macOS/Linux 上 SDK 自带 claude native binary 不依赖宿主 Node/Git；
@@ -42,9 +46,26 @@ export default function App(): React.ReactElement {
     initialize()
   }, [])
 
+  // 设置页请求重放时跳过欢迎页，但保留完整的后续 Onboarding 流程。
+  React.useEffect(() => {
+    if (!onboardingReplayRequested || isLoading) return
+
+    setIsReplayingOnboarding(true)
+    setShowOnboarding(true)
+    setOnboardingReplayRequested(false)
+  }, [isLoading, onboardingReplayRequested, setOnboardingReplayRequested])
+
   // 完成 onboarding 回调：创建欢迎对话，可选打开教程 Tab
   const handleOnboardingComplete = async (openTutorial?: boolean) => {
+    const replayingOnboarding = isReplayingOnboarding
     setShowOnboarding(false)
+    setIsReplayingOnboarding(false)
+
+    if (replayingOnboarding) {
+      store.set(settingsTabAtom, 'onboarding')
+      store.set(settingsOpenAtom, true)
+      return
+    }
 
     if (openTutorial) {
       const tabs = store.get(tabsAtom)
@@ -90,7 +111,10 @@ export default function App(): React.ReactElement {
   if (showOnboarding) {
     return (
       <TooltipProvider delayDuration={200}>
-        <OnboardingView onComplete={handleOnboardingComplete} />
+        <OnboardingView
+          initialStep={isReplayingOnboarding ? 'guide' : 'welcome'}
+          onComplete={handleOnboardingComplete}
+        />
         <MigrationImportDialog />
       </TooltipProvider>
     )

--- a/apps/electron/src/renderer/atoms/onboarding.ts
+++ b/apps/electron/src/renderer/atoms/onboarding.ts
@@ -1,0 +1,4 @@
+import { atom } from 'jotai'
+
+/** 设置页请求全屏重放 Onboarding 的一次性 UI 状态。 */
+export const onboardingReplayRequestedAtom = atom(false)

--- a/apps/electron/src/renderer/atoms/settings-tab.ts
+++ b/apps/electron/src/renderer/atoms/settings-tab.ts
@@ -13,7 +13,7 @@
 import { atom } from 'jotai'
 import type { TabType } from './tab-atoms'
 
-export type SettingsTab = 'general' | 'channels' | 'vision-relay' | 'proxy' | 'appearance' | 'about' | 'prompts' | 'tools' | 'bots' | 'tutorial' | 'shortcuts' | 'voice-input' | 'migration' | 'storage'
+export type SettingsTab = 'general' | 'channels' | 'vision-relay' | 'proxy' | 'appearance' | 'about' | 'onboarding' | 'prompts' | 'tools' | 'bots' | 'tutorial' | 'shortcuts' | 'voice-input' | 'migration' | 'storage'
 export type ToolSettingsFocus = 'memory' | 'web-search' | 'nano-banana' | 'custom-tools'
 
 /** 当前设置标签页（不持久化，每次打开设置默认显示渠道） */

--- a/apps/electron/src/renderer/components/onboarding/OnboardingView.tsx
+++ b/apps/electron/src/renderer/components/onboarding/OnboardingView.tsx
@@ -43,6 +43,8 @@ type OnboardingStep = 'welcome' | 'guide' | 'files' | 'project' | 'automation' |
 
 interface OnboardingViewProps {
   onComplete: (openTutorial?: boolean) => void
+  /** 从设置重放时可跳过欢迎页。 */
+  initialStep?: OnboardingStep
 }
 
 /** 图片内归一化锚点（0-1） */
@@ -638,8 +640,8 @@ function ProgressMap({ current }: { current: Exclude<OnboardingStep, 'welcome' |
   )
 }
 
-export function OnboardingView({ onComplete }: OnboardingViewProps) {
-  const [step, setStep] = useState<OnboardingStep>('welcome')
+export function OnboardingView({ onComplete, initialStep = 'welcome' }: OnboardingViewProps) {
+  const [step, setStep] = useState<OnboardingStep>(initialStep)
   const [flash, setFlash] = useState(false)
   const [fading, setFading] = useState(false)
   const [faqBackStep, setFaqBackStep] = useState<'subagent' | 'sideanswer'>('sideanswer')
@@ -999,7 +1001,6 @@ export function OnboardingView({ onComplete }: OnboardingViewProps) {
         )}
       </div>
 
-      {/* ===== 底部进度地图（欢迎页不显示） ===== */}
       {step !== 'welcome' && step !== 'environment' && <ProgressMap current={step} />}
 
       {step === 'subagent' && (

--- a/apps/electron/src/renderer/components/settings/GeneralSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/GeneralSettings.tsx
@@ -410,6 +410,7 @@ export function GeneralSettings(): React.ReactElement {
           />
         </SettingsCard>
       </SettingsSection>
+
     </div>
   )
 }

--- a/apps/electron/src/renderer/components/settings/OnboardingSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/OnboardingSettings.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react'
+import { useSetAtom } from 'jotai'
+import { GraduationCap, RotateCcw } from 'lucide-react'
+import { onboardingReplayRequestedAtom } from '@/atoms/onboarding'
+import { settingsOpenAtom } from '@/atoms/settings-tab'
+import { Button } from '@/components/ui/button'
+import { SettingsCard, SettingsSection } from './primitives'
+
+/** 设置中的二次确认页，避免点击左侧导航后误触直接进入全屏引导。 */
+export function OnboardingSettings(): React.ReactElement {
+  const setReplayRequested = useSetAtom(onboardingReplayRequestedAtom)
+  const setSettingsOpen = useSetAtom(settingsOpenAtom)
+
+  const handleReplay = (): void => {
+    setReplayRequested(true)
+    setSettingsOpen(false)
+  }
+
+  return (
+    <div className="space-y-6">
+      <SettingsSection
+        title="Proma 新手引导"
+        description="重新了解 Proma 的核心工作方式"
+      >
+        <SettingsCard>
+          <div className="flex items-start gap-4 px-4 py-5">
+            <div className="flex size-10 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+              <GraduationCap className="size-5" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <h2 className="text-sm font-medium text-foreground">准备好重新认识 Proma 了吗？</h2>
+              <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                引导会从 Agent 和 Chat 的区别开始，依次介绍项目、文件、子会话、自动任务、记忆、侧边回答和 FAQ。
+              </p>
+            </div>
+            <Button variant="outline" size="sm" onClick={handleReplay} className="shrink-0">
+              <RotateCcw />
+              重放引导
+            </Button>
+          </div>
+        </SettingsCard>
+      </SettingsSection>
+    </div>
+  )
+}

--- a/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
+++ b/apps/electron/src/renderer/components/settings/SettingsPanel.tsx
@@ -66,6 +66,7 @@ import { ShortcutSettings } from "./ShortcutSettings";
 import { VoiceInputSettings } from "./VoiceInputSettings";
 import { MigrationSettings } from "./MigrationSettings";
 import { StorageSettings } from "./StorageSettings";
+import { OnboardingSettings } from "./OnboardingSettings";
 import { useOpenSession } from '@/hooks/useOpenSession'
 
 /** 设置 Tab 定义 */
@@ -104,6 +105,11 @@ const SHORTCUTS_TAB: TabItem = {
   label: "快捷键管理",
   icon: <Keyboard size={16} />,
 };
+const ONBOARDING_TAB: TabItem = {
+  id: "onboarding",
+  label: "Proma 新手引导",
+  icon: <GraduationCap size={16} />,
+};
 const VOICE_INPUT_TAB: TabItem = {
   id: "voice-input",
   label: "语音输入",
@@ -114,6 +120,7 @@ const TAIL_TABS: TabItem[] = [
   { id: "migration", label: "数据迁移", icon: <HardDriveDownload size={16} /> },
   { id: "storage", label: "磁盘管理", icon: <HardDrive size={16} /> },
   { id: "appearance", label: "外观设置", icon: <Palette size={16} /> },
+  ONBOARDING_TAB,
   { id: "about", label: "关于/更新", icon: <Info size={16} /> },
 ];
 
@@ -146,6 +153,8 @@ function renderTabContent(tab: SettingsTab): React.ReactElement {
       return <MigrationSettings />;
     case "storage":
       return <StorageSettings />;
+    case "onboarding":
+      return <OnboardingSettings />;
     default:
       // tutorial 等特殊 tab 由 handleTabChange 拦截打开主区 Tab，不会在此渲染
       return <GeneralSettings />;


### PR DESCRIPTION
## 概述
在 Proma 设置中增加独立的「Proma 新手引导」入口。用户进入设置页后需要再次点击「重放引导」才会启动全屏 onboarding，避免误触；重放从 Agent / Chat 页面开始，结束后返回设置中的引导页面。

## 改动
- `apps/electron/src/renderer/components/settings/SettingsPanel.tsx` — 在「关于/更新」上方增加 Proma 新手引导设置项，并接入对应内容页。
- `apps/electron/src/renderer/components/settings/OnboardingSettings.tsx` — 新增二次确认页和「重放引导」按钮。
- `apps/electron/src/renderer/atoms/settings-tab.ts` — 增加 `onboarding` 设置 Tab 类型。
- `apps/electron/src/renderer/atoms/onboarding.ts` — 增加设置页到 App 的一次性重放请求状态。
- `apps/electron/src/renderer/components/onboarding/OnboardingView.tsx` — 支持通过 `initialStep` 跳过欢迎页，保留原有后续页面和 FAQ 流程。
- `apps/electron/src/renderer/App.tsx` — 消费重放请求；重放完成后重新打开设置并定位到 Proma 新手引导页，避免创建重复欢迎对话。
- `apps/electron/package.json` — patch 版本更新至 `0.16.10`。

## 测试方法
1. `bun run typecheck`
2. `bun run --filter=@proma/electron build:renderer`
3. `bun test apps/electron/src/types/settings.test.ts`
4. `git diff --check`

## 备注
- 首次安装的 onboarding 默认仍从欢迎页开始，原有欢迎对话创建逻辑保持不变。
- 已完成独立代码审查：未发现 Critical 或 Warning 级问题；Windows 兼容性静态检查为 SAFE。

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)