### PR TITLE
feat(onboarding): 首个引导页新增向下滚动提示箭头【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/onboarding/OnboardingView.tsx
+++ b/apps/electron/src/renderer/components/onboarding/OnboardingView.tsx
@@ -18,7 +18,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useAtomValue } from 'jotai'
-import { ChevronRight, ChevronLeft, ChevronsRight, Check } from 'lucide-react'
+import { ChevronRight, ChevronLeft, ChevronsRight, ArrowDown, Check } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { EnvironmentCheckPanel } from '@/components/environment/EnvironmentCheckPanel'
 import { isShellEnvironmentOkAtom } from '@/atoms/environment'
@@ -366,29 +366,61 @@ function GuideFeatureStep({ anchor, title, highlight, paragraphs, nextLabel, onN
 
 type GuideExamplesIntroProps = Omit<GuideFeatureStepProps, 'nextLabel' | 'onNext' | 'onBack' | 'showNavigation'>
 
-function GuideExamplesPage({ intro, nextLabel, onNext, onBack, children }: {
+function GuideExamplesPage({ intro, nextLabel, onNext, onBack, children, showScrollHint = false }: {
   intro: GuideExamplesIntroProps
   nextLabel: string
   onNext: () => void
   onBack: () => void
   children: React.ReactNode
+  /** 首个讲解页显示向下滚动提示，避免底部进度地图被误解为横向翻页。 */
+  showScrollHint?: boolean
 }) {
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const firstPageRef = useRef<HTMLDivElement>(null)
+  const [showHint, setShowHint] = useState(showScrollHint)
+
+  useEffect(() => {
+    if (!showScrollHint) return
+    const container = scrollRef.current
+    const firstPage = firstPageRef.current
+    if (!container || !firstPage) return
+
+    const handleScroll = () => {
+      // 轻微滚动仍保留提示，直到第二页内容真正进入视口。
+      const secondPageStart = firstPage.offsetTop + firstPage.offsetHeight
+      if (container.scrollTop >= secondPageStart - 24) setShowHint(false)
+    }
+    container.addEventListener('scroll', handleScroll, { passive: true })
+    return () => container.removeEventListener('scroll', handleScroll)
+  }, [showScrollHint])
+
   return (
-    <div className="h-full w-full overflow-y-auto">
-      <div className="h-[1100px] lg:h-[calc(100vh-4rem)] lg:min-h-[660px]">
-        <GuideFeatureStep
-          {...intro}
-          nextLabel={nextLabel}
-          onNext={onNext}
-          onBack={onBack}
-          showNavigation={false}
-        />
+    <div className="relative h-full w-full">
+      <div ref={scrollRef} className="h-full w-full overflow-y-auto">
+        <div ref={firstPageRef} className="h-[1100px] lg:h-[calc(100vh-4rem)] lg:min-h-[660px]">
+          <GuideFeatureStep
+            {...intro}
+            nextLabel={nextLabel}
+            onNext={onNext}
+            onBack={onBack}
+            showNavigation={false}
+          />
+        </div>
+
+        <div className="mx-auto w-full max-w-[calc(58vw+504px)] px-6 pb-28 pt-6 md:px-10">
+          {children}
+          <GuideNavigation nextLabel={nextLabel} onNext={onNext} onBack={onBack} />
+        </div>
       </div>
 
-      <div className="mx-auto w-full max-w-[calc(58vw+504px)] px-6 pb-28 pt-6 md:px-10">
-        {children}
-        <GuideNavigation nextLabel={nextLabel} onNext={onNext} onBack={onBack} />
-      </div>
+      {showHint && (
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute bottom-[180px] right-8 z-30 flex h-24 w-24 items-center justify-center rounded-none text-[#1b3f2d] md:right-10"
+        >
+          <ArrowDown className="h-20 w-20" strokeWidth={2.5} />
+        </div>
+      )}
     </div>
   )
 }
@@ -397,6 +429,7 @@ function GuideExamplesPage({ intro, nextLabel, onNext, onBack, children }: {
 function AgentChatGuidePage({ onNext, onBack }: { onNext: () => void; onBack: () => void }) {
   return (
     <GuideExamplesPage
+      showScrollHint
       intro={{
         anchor: { x: 0.073, y: 0.049 },
         arrowMode: 'magnifier',


### PR DESCRIPTION
## 概述

Onboarding 引导流程中，首个讲解页（Agent / Chat 科普页）底部有横向进度地图，容易让用户误以为需要左右滑动翻页。本 PR 在页面右下角增加一个向下的滚动提示箭头，引导用户向下滚动继续浏览，并在第二页内容真正进入视口时自动隐藏。

## 改动

- `apps/electron/src/renderer/components/onboarding/OnboardingView.tsx`
  - `GuideExamplesPage` 新增 `showScrollHint` 开关，默认关闭，仅首个讲解页（Agent / Chat）启用
  - 新增滚动监听：以第一页实际内容高度判断第二页进入视口的时机，届时自动隐藏箭头；第一页内的轻微滚动不会让提示过早消失
  - 箭头为纯视觉提示（`pointer-events-none`、`aria-hidden`），直角方形、深绿色，不影响任何交互与点击

## 测试方法

1. 将 `~/.proma-dev/settings.json` 中 `onboardingCompleted` 设为 `false` 后启动 DEV 客户端
2. 进入引导流程首个讲解页，确认右下角出现向下箭头
3. 在第一页内上下轻微滚动，箭头保持显示；滚动到第二页内容进入视口时箭头自动消失
4. 确认其他讲解页（文件/子会话/自动任务/记忆等）不显示箭头
5. 运行 `bun run --filter='@proma/electron' typecheck` 与 `build:renderer`，均通过

## 备注

- 箭头隐藏后回滚到第一页顶部不会重新出现（设计行为）
- 纯 CSS/React 渲染改动，无平台差异，Windows 兼容
