### PR TITLE
【等待审核】fix(core): 代码块非法语言标识归一化为 Code

### DIFF
--- a/packages/core/src/highlight/shiki-service.ts
+++ b/packages/core/src/highlight/shiki-service.ts
@@ -86,10 +86,22 @@ const DISPLAY_NAMES: Record<string, string> = {
   plaintext: 'Text', text: 'Text',
 }
 
-/** 获取语言显示名称，未匹配的自动首字母大写 */
+/** 显式文本类语言别名（应显示为 'Text' 而非 'Code'） */
+const TEXT_LANGUAGE_ALIASES = new Set(['text', 'plaintext', 'txt', 'plain'])
+
+/**
+ * 获取语言显示名称，非法/未知标识归一化为 'Code'，显式文本类显示 'Text'
+ *
+ * 非法标识（含引号/空格等特殊字符，或 Shiki 无法识别的语言名）统一回退为 'Code'，
+ * 避免把原始串原样首字母大写后显示为乱码。
+ */
 export function getDisplayName(lang: string): string {
   if (!lang) return 'Code'
-  const key = lang.toLowerCase()
+  const key = lang.toLowerCase().trim()
+  // 非 Shiki 可识别语言（含非法字符或不存在于语言集）→ 归一化为 Code；显式文本别名 → Text
+  if (resolveLanguage(lang) === 'text') {
+    return TEXT_LANGUAGE_ALIASES.has(key) ? 'Text' : 'Code'
+  }
   return DISPLAY_NAMES[key] ?? key.charAt(0).toUpperCase() + key.slice(1)
 }
 


### PR DESCRIPTION
## 概述

代码块的非法语言标识（如 ```""`、```" "` 等含引号/特殊字符的无效标识）在语言标签处被原样首字母大写显示，产生乱码（如空引号 `""` 或引号字符本身），视觉体验异常。

根因：`getDisplayName()` 对任意字符串直接 `toLowerCase()` + 首字母大写返回，不做合法性校验；而高亮侧 `resolveLanguage()` 已正确回退 `text`，造成「高亮正常但标签乱码」的不一致。

修复：`getDisplayName()` 复用与高亮侧同一套 Shiki 语言集校验（`resolveLanguage()`），非法/未知标识统一归一化为 `Code`，显式文本类别名（`text`/`plaintext`/`txt`/`plain`）显示为 `Text`，合法语言显示名保持不变。

## 改动

- `packages/core/src/highlight/shiki-service.ts`（+14/-2）：`getDisplayName()` 增加合法性校验与归一化，新增 `TEXT_LANGUAGE_ALIASES` 常量

## 测试

- `bun run typecheck`（packages/core）通过，0 错误
- 14 个边界用例实测全部通过：
  - 合法语言（javascript/js/c++/c#/ruby/shell/html 等）→ 显示名不变
  - `text`/`plaintext`/`txt`/`plain` → `Text`
  - `""`、`" "`、`"javascript"`、`foo bar`、`{invalid}`、空串/空白 → `Code`
- 两条渲染路径均覆盖：聊天消息 `CodeBlock.tsx` 与 diff 编辑器预览（共用 `getDisplayName`，无需额外改动）

## 紧急度

低

## 备注

Closes #1143