### PR TITLE
Fix DeepSeek V4 Pi reasoning effort

### DIFF
--- a/apps/electron/src/main/lib/adapters/pi-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/pi-agent-adapter.ts
@@ -58,6 +58,7 @@ import {
 } from '../agent-runtime-guards'
 import { createPromaAgentsFilesOverride } from './pi-resource-loader-overrides'
 import { createCodexFastModeExtension, withCodexFastModeServiceTier } from './pi-codex-request-settings'
+import { createDeepSeekReasoningRequestExtension } from './pi-deepseek-reasoning-request-settings'
 import { createOpenAIReasoningRequestExtension } from './pi-openai-reasoning-request-settings'
 import { mergeRuntimeEnv, type AgentRuntimeEnv } from '../agent-runtime-env'
 import {
@@ -1475,11 +1476,23 @@ export class PiAgentAdapter implements AgentProviderAdapter {
           transport: inferReasoningTransport(input.provider),
         })
         : undefined
+      const deepSeekReasoningProfile = input.provider === 'deepseek'
+        ? resolveReasoningProfile({
+          modelId: input.model,
+          transport: 'anthropic-messages',
+        })
+        : undefined
       const extensionFactories = [
         ...(openAIReasoningProfile
           ? [createOpenAIReasoningRequestExtension({
               profile: openAIReasoningProfile,
               thinkingLevel: input.openAIThinkingLevel,
+            })]
+          : []),
+        ...(deepSeekReasoningProfile?.encodings['anthropic-messages']?.kind === 'deepseek-output-effort'
+          ? [createDeepSeekReasoningRequestExtension({
+              profile: deepSeekReasoningProfile,
+              thinkingLevel: input.thinkingLevel,
             })]
           : []),
         ...(input.provider === 'openai-codex' && input.codexFastMode

--- a/apps/electron/src/main/lib/adapters/pi-deepseek-reasoning-request-settings.ts
+++ b/apps/electron/src/main/lib/adapters/pi-deepseek-reasoning-request-settings.ts
@@ -1,0 +1,66 @@
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
+import {
+  normalizeReasoningLevel,
+  resolveReasoningProfile,
+  type AgentThinkingLevel,
+  type ReasoningProfile,
+} from '@proma/shared'
+
+type ProviderPayload = Record<string, unknown>
+
+export interface DeepSeekReasoningRequestSettings {
+  profile?: ReasoningProfile
+  thinkingLevel?: AgentThinkingLevel
+}
+
+function isProviderPayload(payload: unknown): payload is ProviderPayload {
+  return typeof payload === 'object' && payload !== null && !Array.isArray(payload)
+}
+
+/**
+ * Rewrites Pi's generic Anthropic extended-thinking body to DeepSeek V4's
+ * Anthropic-compatible protocol. DeepSeek ignores `thinking.budget_tokens`;
+ * strength must be carried by `output_config.effort`.
+ */
+export function injectDeepSeekReasoningLevel(
+  payload: unknown,
+  settings: DeepSeekReasoningRequestSettings,
+): unknown {
+  if (!isProviderPayload(payload)) return payload
+
+  const modelId = typeof payload.model === 'string' ? payload.model : undefined
+  const profile = settings.profile ?? resolveReasoningProfile({
+    modelId,
+    transport: 'anthropic-messages',
+  })
+  const encoding = profile?.encodings['anthropic-messages']
+  if (encoding?.kind !== 'deepseek-output-effort' || !settings.thinkingLevel) return payload
+
+  const normalizedLevel = normalizeReasoningLevel(profile, settings.thinkingLevel)
+  if (!normalizedLevel) return payload
+
+  const { thinking: _upstreamThinking, output_config: _upstreamOutputConfig, ...body } = payload
+  if (normalizedLevel === 'off') {
+    return { ...body, thinking: { type: 'disabled' } }
+  }
+
+  const effort = encoding.effortMap[normalizedLevel]
+  if (typeof effort !== 'string') return payload
+  return {
+    ...body,
+    thinking: { type: 'enabled' },
+    output_config: { effort },
+  }
+}
+
+/** Pi inline extension for DeepSeek V4 Anthropic-compatible reasoning requests. */
+export function createDeepSeekReasoningRequestExtension(
+  settings: DeepSeekReasoningRequestSettings,
+): (pi: ExtensionAPI) => void {
+  return (pi) => {
+    pi.on('before_provider_request', (event) => {
+      const updatedPayload = injectDeepSeekReasoningLevel(event.payload, settings)
+      return updatedPayload === event.payload ? undefined : updatedPayload
+    })
+  }
+}

--- a/apps/electron/src/main/lib/adapters/pi-model-registry.ts
+++ b/apps/electron/src/main/lib/adapters/pi-model-registry.ts
@@ -96,6 +96,11 @@ function compilePiReasoningCapabilities(
         compat: { forceAdaptiveThinking: true },
         thinkingLevelMap,
       }
+    // DeepSeek V4's Anthropic-compatible protocol is not adaptive thinking.
+    // Pi's generic stream emits a legacy budget; the runtime request extension
+    // replaces it with `thinking: enabled` + `output_config.effort`.
+    case 'deepseek-output-effort':
+      return { thinkingLevelMap }
     case 'openai-reasoning-effort':
       return {
         compat: { supportsReasoningEffort: true },

--- a/packages/shared/src/types/reasoning-profile.ts
+++ b/packages/shared/src/types/reasoning-profile.ts
@@ -37,6 +37,7 @@ export function inferReasoningTransport(provider: ProviderType | undefined): Rea
 /** 编译器据此生成 runtime 专属请求参数。 */
 export type ReasoningEncodingKind =
   | 'adaptive-effort'
+  | 'deepseek-output-effort'
   | 'openai-reasoning-effort'
   | 'zai-thinking-effort'
 
@@ -49,7 +50,7 @@ export interface ReasoningEncoding {
 }
 
 export interface ReasoningProfile {
-  id: 'kimi-k3' | 'glm-5.2' | 'openai-reasoning-standard' | 'openai-reasoning-max'
+  id: 'deepseek-v4-flash' | 'deepseek-v4-pro' | 'kimi-k3' | 'glm-5.2' | 'openai-reasoning-standard' | 'openai-reasoning-max'
   levels: readonly AgentThinkingLevel[]
   defaultLevel: AgentThinkingLevel
   normalize(level: AgentThinkingLevel | undefined): AgentThinkingLevel
@@ -83,10 +84,31 @@ export interface ResolveReasoningProfileInput {
   transport: ReasoningTransport
 }
 
+const DEEPSEEK_V4_LEVELS = ['off', 'low', 'high', 'xhigh', 'max'] as const satisfies readonly AgentThinkingLevel[]
 const K3_LEVELS = ['off', 'low', 'high', 'max'] as const satisfies readonly AgentThinkingLevel[]
 const GLM_52_LEVELS = ['off', 'high', 'max'] as const satisfies readonly AgentThinkingLevel[]
 const OPENAI_STANDARD_LEVELS = ['off', 'low', 'medium', 'high', 'xhigh'] as const satisfies readonly AgentThinkingLevel[]
 const OPENAI_MAX_LEVELS = [...OPENAI_STANDARD_LEVELS, 'max'] as const satisfies readonly AgentThinkingLevel[]
+
+// DeepSeek Anthropic compatibility only honors output_config.effort. The official
+// V4 Flash and Pro mappings differ at low and xhigh; off is handled by emitting
+// `thinking: { type: 'disabled' }` rather than an effort value.
+const DEEPSEEK_V4_FLASH_EFFORT_MAP: ReasoningEffortMap = {
+  minimal: null,
+  low: 'low',
+  medium: null,
+  high: 'high',
+  xhigh: 'high',
+  max: 'max',
+}
+const DEEPSEEK_V4_PRO_EFFORT_MAP: ReasoningEffortMap = {
+  minimal: null,
+  low: 'high',
+  medium: null,
+  high: 'high',
+  xhigh: 'max',
+  max: 'max',
+}
 
 const K3_EFFORT_MAP: ReasoningEffortMap = {
   minimal: 'low',
@@ -127,6 +149,25 @@ const OPENAI_MAX_EFFORT_MAP: ReasoningEffortMap = {
   max: 'max',
 }
 
+function normalizeDeepSeekV4Level(level: AgentThinkingLevel | undefined): AgentThinkingLevel {
+  switch (level) {
+    case 'off':
+      return 'off'
+    case 'minimal':
+    case 'low':
+      return 'low'
+    case 'medium':
+    case 'high':
+      return 'high'
+    case 'xhigh':
+      return 'xhigh'
+    case 'max':
+      return 'max'
+    default:
+      return 'high'
+  }
+}
+
 function normalizeK3Level(level: AgentThinkingLevel | undefined): AgentThinkingLevel {
   switch (level) {
     case 'off':
@@ -160,6 +201,26 @@ function normalizeOpenAIStandardLevel(level: AgentThinkingLevel | undefined): Ag
 function normalizeOpenAIMaxLevel(level: AgentThinkingLevel | undefined): AgentThinkingLevel {
   if (level === 'minimal') return 'low'
   return level ?? 'high'
+}
+
+const DEEPSEEK_V4_FLASH_PROFILE: ReasoningProfile = {
+  id: 'deepseek-v4-flash',
+  levels: DEEPSEEK_V4_LEVELS,
+  defaultLevel: 'high',
+  normalize: normalizeDeepSeekV4Level,
+  encodings: {
+    'anthropic-messages': { kind: 'deepseek-output-effort', effortMap: DEEPSEEK_V4_FLASH_EFFORT_MAP },
+  },
+}
+
+const DEEPSEEK_V4_PRO_PROFILE: ReasoningProfile = {
+  id: 'deepseek-v4-pro',
+  levels: DEEPSEEK_V4_LEVELS,
+  defaultLevel: 'high',
+  normalize: normalizeDeepSeekV4Level,
+  encodings: {
+    'anthropic-messages': { kind: 'deepseek-output-effort', effortMap: DEEPSEEK_V4_PRO_EFFORT_MAP },
+  },
 }
 
 const K3_PROFILE: ReasoningProfile = {
@@ -207,6 +268,8 @@ const OPENAI_MAX_PROFILE: ReasoningProfile = {
 }
 
 export const REASONING_PROFILES: readonly ReasoningProfile[] = [
+  DEEPSEEK_V4_FLASH_PROFILE,
+  DEEPSEEK_V4_PRO_PROFILE,
   K3_PROFILE,
   GLM_52_PROFILE,
   OPENAI_STANDARD_PROFILE,
@@ -221,13 +284,17 @@ export function resolveReasoningProfile(input: ResolveReasoningProfileInput): Re
   const isOpenAITransport = input.transport === 'openai-completions' || input.transport === 'openai-responses'
   const isOpenAIReasoningModel = !modelId.endsWith('-chat-latest')
     && (modelId.startsWith('gpt-5') || /^(o1|o3|o4)(?:-|$)/.test(modelId))
-  const profile = /^(?:k3(?:-256k)?|kimi-k3)$/.test(modelId)
-    ? K3_PROFILE
-    : modelId === 'glm-5.2'
-      ? GLM_52_PROFILE
-      : isOpenAITransport && isOpenAIReasoningModel
-        ? /^gpt-5\.6(?:-|$)/.test(modelId) ? OPENAI_MAX_PROFILE : OPENAI_STANDARD_PROFILE
-        : undefined
+  const profile = /^deepseek-v4-flash(?:-|$)/.test(modelId)
+    ? DEEPSEEK_V4_FLASH_PROFILE
+    : /^deepseek-v4-pro(?:-|$)/.test(modelId)
+      ? DEEPSEEK_V4_PRO_PROFILE
+      : /^(?:k3(?:-256k)?|kimi-k3)$/.test(modelId)
+        ? K3_PROFILE
+        : modelId === 'glm-5.2'
+          ? GLM_52_PROFILE
+          : isOpenAITransport && isOpenAIReasoningModel
+            ? /^gpt-5\.6(?:-|$)/.test(modelId) ? OPENAI_MAX_PROFILE : OPENAI_STANDARD_PROFILE
+            : undefined
 
   return profile?.encodings[input.transport] ? profile : undefined
 }


### PR DESCRIPTION
## Summary

- Map Pi DeepSeek V4 thinking levels to the official Anthropic-compatible `output_config.effort` protocol.
- Apply model-specific Flash / Pro mappings and explicitly disable thinking for `off`.

## Validation

- `bun run typecheck`
- `bun run --filter @proma/electron build:main`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)