### PR TITLE
fix(agent): avoid full session-list refreshes

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -1947,18 +1947,7 @@ export function registerIpcHandlers(): void {
   // 获取 Agent 会话列表
   ipcMain.handle(
     AGENT_IPC_CHANNELS.LIST_SESSIONS,
-    async (): Promise<AgentSessionMeta[]> => {
-      const sessions = listAgentSessions()
-      // 启动所有已有附加目录的文件监听
-      for (const session of sessions) {
-        if (session.attachedDirectories) {
-          for (const dir of session.attachedDirectories) {
-            watchAttachedDirectory(dir)
-          }
-        }
-      }
-      return sessions
-    }
+    async (): Promise<AgentSessionMeta[]> => listAgentSessions()
   )
 
   // 创建 Agent 会话

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -111,6 +111,17 @@ function getMainRendererWebContents(): WebContents | null {
 
 // ===== EventBus IPC 转发中间件 =====
 
+/**
+ * 完成事件只需要侧栏/导航使用的轻量 meta。Pi 的 entry bindings 仅用于主进程
+ * session fork/rewind，传到 renderer 会在长会话完成时徒增 IPC 序列化成本。
+ */
+function getSessionMetaForRenderer(sessionId: string) {
+  const session = getAgentSessionMeta(sessionId)
+  if (!session) return undefined
+  const { piEntryBindings: _piEntryBindings, ...meta } = session
+  return meta
+}
+
 eventBus.use((sessionId, payload, next) => {
   const wc = sessionWebContents.get(sessionId)
   if (wc && !wc.isDestroyed()) {
@@ -174,6 +185,8 @@ export async function runAgent(
             resultSubtype: opts?.resultSubtype,
             resultErrors: opts?.resultErrors,
             backgroundTasksPending: opts?.backgroundTasksPending,
+            // 只读取刚完成的轻量 meta，renderer 可据此增量更新列表，避免再取 5,000+ 条全量会话。
+            session: getSessionMetaForRenderer(input.sessionId),
           })
         }
       },
@@ -263,6 +276,8 @@ export async function runAgentHeadless(
             resultSubtype: opts?.resultSubtype,
             resultErrors: opts?.resultErrors,
             backgroundTasksPending: opts?.backgroundTasksPending,
+            // 只读取刚完成的轻量 meta，renderer 可据此增量更新列表，避免再取 5,000+ 条全量会话。
+            session: getSessionMetaForRenderer(runInput.sessionId),
           })
         }
       },

--- a/apps/electron/src/main/lib/workspace-watcher.ts
+++ b/apps/electron/src/main/lib/workspace-watcher.ts
@@ -17,6 +17,7 @@ import { dirname } from 'node:path'
 import type { BrowserWindow } from 'electron'
 import { AGENT_IPC_CHANNELS } from '@proma/shared'
 import { getAgentWorkspacesDir } from './config-paths'
+import { listAgentSessions } from './agent-session-manager'
 
 /** debounce 延迟（ms） */
 const DEBOUNCE_MS = 300
@@ -100,6 +101,14 @@ function releaseUnavailableDirectoryWatcher(dirPath: string): void {
   console.log('[附加目录监听] 已停止父目录监听:', parentPath)
 }
 
+function restoreAgentSessionAttachedDirectoryWatchers(): void {
+  for (const session of listAgentSessions()) {
+    for (const dirPath of session.attachedDirectories ?? []) {
+      watchAttachedDirectory(dirPath)
+    }
+  }
+}
+
 function watchUnavailableDirectoryParent(dirPath: string): void {
   const parentPath = findNearestExistingDirectory(dirname(dirPath))
   if (!parentPath) {
@@ -147,6 +156,9 @@ function watchUnavailableDirectoryParent(dirPath: string): void {
  */
 export function startWorkspaceWatcher(win: BrowserWindow): void {
   mainWin = win
+  // 会话附加目录只需在启动/监听器重启时恢复一次；LIST_SESSIONS 是高频读取路径，
+  // 不能随每次列表 IPC 再遍历全部会话并触发同步 stat。
+  restoreAgentSessionAttachedDirectoryWatchers()
   const watchDir = getAgentWorkspacesDir()
 
   if (!existsSync(watchDir)) {

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -1151,6 +1151,12 @@ export function useGlobalAgentListeners(): void {
         const backgroundTasksPending = data.backgroundTasksPending === true
         const hasStreamError = store.get(agentStreamErrorsAtom).has(data.sessionId)
 
+        // 主进程随完成事件携带刚落盘的单条 meta；不要为此重新拉取整个会话索引。
+        // 后台任务的轻量完成并未更新会话新鲜度，保留现有列表顺序。
+        if (data.session && !backgroundTasksPending) {
+          store.set(agentSessionsAtom, (prev) => upsertAgentSession(prev, data.session!))
+        }
+
         // 发送桌面通知（仅真正成功完成时播放提示音，错误/中断/异常完成不伪装成完成）
         const completionSession = store.get(agentSessionsAtom)
           .find((session) => session.id === data.sessionId)
@@ -1224,14 +1230,21 @@ export function useGlobalAgentListeners(): void {
           void window.electronAPI.agentIsland.markSessionViewed(data.sessionId).catch(console.error)
         }
 
-        // 标记用户主动打断状态
-        if (data.stoppedByUser) {
-          store.set(stoppedByUserSessionsAtom, (prev: Set<string>) => {
+        // 对齐本次会话的主动打断状态，无需借助全量列表刷新重建整个 Set。
+        store.set(stoppedByUserSessionsAtom, (prev: Set<string>) => {
+          const wasStopped = prev.has(data.sessionId)
+          if (data.stoppedByUser === true && !wasStopped) {
             const next = new Set(prev)
             next.add(data.sessionId)
             return next
-          })
-        }
+          }
+          if (data.stoppedByUser !== true && wasStopped) {
+            const next = new Set(prev)
+            next.delete(data.sessionId)
+            return next
+          }
+          return prev
+        })
 
         // 非正常结束时显示截断提示
         if (data.resultSubtype && data.resultSubtype !== 'success' && !data.stoppedByUser) {
@@ -1300,19 +1313,8 @@ export function useGlobalAgentListeners(): void {
           // 注意：liveMessages 的清理已移至 AgentView 消息加载完成后执行，
           // 与 streamingState 清理同步，避免「实时消息已清 → 持久化消息未到」的空档闪烁
 
-          // 刷新会话列表并同步 stoppedByUser 状态
-          window.electronAPI
-            .listAgentSessions()
-            .then((sessions) => {
-              // 合并而非整体覆盖：避免与并发的 external_run_started 回调互相用
-              // 陈旧快照冲掉对方刚写入的会话（如刚结束 turn 的父会话）。
-              store.set(agentSessionsAtom, (prev) => mergeFetchedAgentSessions(prev, sessions))
-              // 从持久化 meta 对齐 stoppedByUser 状态
-              store.set(stoppedByUserSessionsAtom, new Set<string>(
-                sessions.filter((s) => s.stoppedByUser).map((s) => s.id)
-              ))
-            })
-            .catch(console.error)
+          // 完成事件已携带当前会话 meta，顶部已增量更新列表；全量会话同步仅保留给启动、
+          // 窗口重新聚焦和未知会话等恢复路径，避免完成一个 Agent 就传输整个会话索引。
 
           // 注意：流式状态的完全清除由 AgentView 在消息加载完成后执行，
           // 确保不会出现「气泡消失 → 持久化消息尚未加载」的空档闪烁
@@ -1378,15 +1380,21 @@ export function useGlobalAgentListeners(): void {
     const cleanupTitleUpdated = window.electronAPI.onAgentTitleUpdated(({ sessionId, title }) => {
       // 先使用事件 payload 立即同步标签页，避免依赖会话列表旧快照比较。
       store.set(tabsAtom, (tabs) => updateTabTitle(tabs, sessionId, title))
-      store.set(agentSessionsAtom, (prev) =>
-        prev.map((s) => (s.id === sessionId ? { ...s, title } : s))
-      )
-      // 保留全量刷新语义：外部桥接会复用该事件通知新会话/绑定变化。
+      const existing = store.get(agentSessionsAtom).find((session) => session.id === sessionId)
+      if (existing) {
+        // 标题写入会更新 updatedAt；本地以当前时刻维持与后端一致的“最近会话”排序，
+        // 不再为一行标题变化传输整个会话索引。
+        store.set(agentSessionsAtom, (prev) => upsertAgentSession(prev, {
+          ...existing,
+          title,
+          updatedAt: Date.now(),
+        }))
+        return
+      }
+      // 外部桥接可能先发标题、后发 run-start；仅在本地未知该会话时走恢复性全量同步。
       window.electronAPI
         .listAgentSessions()
-        .then((sessions) => {
-          store.set(agentSessionsAtom, (prev) => mergeFetchedAgentSessions(prev, sessions))
-        })
+        .then((sessions) => store.set(agentSessionsAtom, (prev) => mergeFetchedAgentSessions(prev, sessions)))
         .catch(console.error)
     })
 

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -1213,6 +1213,8 @@ export interface AgentStreamCompletePayload {
   resultErrors?: string[]
   /** 本轮主体结束但仍有后台任务/定时任务在飞行：UI 进入"空闲可输入"态，等待任务完成自动唤醒 */
   backgroundTasksPending?: boolean
+  /** 完成时的最新会话元数据，供 renderer 增量更新列表，避免重新传输全量会话索引。 */
+  session?: AgentSessionMeta
 }
 
 // ===== 文件浏览器 =====


### PR DESCRIPTION
## Summary

- Update Agent session state incrementally on title and stream-complete events instead of reloading the complete session list.
- Restore attached-directory watchers at startup rather than on every session-list request.
- Exclude Pi entry bindings from stream-complete renderer payloads.

## Test plan

- [x] `bun run typecheck`
- [x] `bun test apps/electron/src/renderer/lib/agent-session-list.test.ts`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)