### PR TITLE
feat(agent-skills): 批量导入 Skill 对话框新增一键全选【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/agent-skills/ImportSkillDialog.tsx
+++ b/apps/electron/src/renderer/components/agent-skills/ImportSkillDialog.tsx
@@ -128,12 +128,38 @@ export function ImportSkillDialog({
     ).length
   }, [selectedWorkspace, selectedKeys])
 
+  // 当前来源项目的全部技能是否都已选中
+  const allSelected = React.useMemo(() => {
+    if (!selectedWorkspace) return false
+    return (
+      selectedWorkspace.skills.length > 0 &&
+      selectedWorkspace.skills.every((s) =>
+        selectedKeys.has(`${selectedWorkspace.workspaceSlug}/${s.slug}`),
+      )
+    )
+  }, [selectedWorkspace, selectedKeys])
+
   const toggleSelection = (sourceSlug: string, skillSlug: string): void => {
     setSelectedKeys((prev) => {
       const next = new Set(prev)
       const key = `${sourceSlug}/${skillSlug}`
       if (next.has(key)) next.delete(key)
       else next.add(key)
+      return next
+    })
+  }
+
+  // 一键全选 / 取消全选当前来源项目的全部技能
+  const handleToggleSelectAll = (): void => {
+    if (!selectedWorkspace) return
+    const workspaceKey = selectedWorkspace.workspaceSlug
+    setSelectedKeys((prev) => {
+      const next = new Set(prev)
+      selectedWorkspace.skills.forEach((s) => {
+        const key = `${workspaceKey}/${s.slug}`
+        if (allSelected) next.delete(key)
+        else next.add(key)
+      })
       return next
     })
   }
@@ -246,10 +272,39 @@ export function ImportSkillDialog({
             <>
               <div className="mb-3 flex items-center justify-between gap-3 text-sm text-muted-foreground">
                 <span className="truncate">{selectedWorkspace.workspaceName}</span>
-                <span className="shrink-0 rounded-md bg-muted px-2 py-1 text-xs font-medium tabular-nums">
-                  {selectedWorkspace.skills.length} 个
-                </span>
+                <div className="flex shrink-0 items-center gap-2">
+                  {/* 全选：勾选框视觉与技能卡片一致，放在计数徽章左侧 */}
+                  <button
+                    type="button"
+                    aria-pressed={allSelected}
+                    disabled={importing}
+                    onClick={handleToggleSelectAll}
+                    className={cn(
+                      'inline-flex items-center gap-1.5 rounded-md text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-60',
+                      allSelected ? 'text-primary' : 'text-foreground hover:text-primary',
+                    )}
+                  >
+                    <span
+                      aria-hidden="true"
+                      className={cn(
+                        'flex size-4 shrink-0 items-center justify-center rounded border transition-colors',
+                        allSelected
+                          ? 'border-primary bg-primary text-primary-foreground'
+                          : 'border-border/80 text-transparent',
+                      )}
+                    >
+                      <Check size={11} />
+                    </span>
+                    {allSelected ? '取消全选' : '全选'}
+                  </button>
+                  <span className="shrink-0 rounded-md bg-muted px-2 py-1 text-xs font-medium tabular-nums">
+                    {selectedCount > 0
+                      ? `已选 ${selectedCount}/${selectedWorkspace.skills.length}`
+                      : `${selectedWorkspace.skills.length} 个`}
+                  </span>
+                </div>
               </div>
+
               <div className="grid gap-3 sm:grid-cols-2">
                 {selectedWorkspace.skills.map((skill) => {
                   const checked = selectedKeys.has(`${selectedWorkspace.workspaceSlug}/${skill.slug}`)


### PR DESCRIPTION
## 概述
在「从其他项目批量导入 Skill」对话框（ImportSkillDialog）中新增一键全选能力：用户选择来源项目后，可一键勾选该项目的全部 Skill，或在已全部勾选时一键取消全选。此前只能逐个点击卡片勾选，当来源项目包含较多 Skill 时操作成本较高。

## 改动
- `apps/electron/src/renderer/components/agent-skills/ImportSkillDialog.tsx` — 新增 `allSelected` memo 用于判断当前来源项目全部技能是否已选中；新增 `handleToggleSelectAll` 函数实现一键全选/取消全选（仅操作当前来源项目 key，不影响其他来源）；UI 上全选按钮置于来源项目名称行右侧、计数徽章左侧，勾选框视觉与技能卡片保持一致，计数徽章在勾选后常驻显示「已选 x/N」。

## 测试方法
1. 打开「Agent 能力中心 → 从其他项目导入 Skill」
2. 选择一个包含多个 Skill 的来源项目
3. 点击「全选」——所有卡片点亮，计数变为「已选 N/N」
4. 点击「取消全选」——全部清空
5. 手动勾选部分技能后点击「全选」——补齐剩余
6. 全选后手动取消一个——按钮回到「全选」，再点可补回
7. 切换来源项目——选中状态自动重置
8. 导入进行中全选按钮禁用

## 备注
- 该改动已通过 `tsc --noEmit` 类型检查，并经独立代码审查（全选状态机逐案验证、Windows 兼容性 SAFE）
- 纯前端渲染层改动，不涉及 IPC / 后端逻辑

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)