### PR TITLE
Fix responsive Agent Island compact layout

### DIFF
--- a/apps/electron/native/agent-island/macos-agent-island-helper.swift
+++ b/apps/electron/native/agent-island/macos-agent-island-helper.swift
@@ -192,8 +192,8 @@ final class IslandModel: ObservableObject {
 
 private enum IslandLayout {
   static let horizontalScreenInset: CGFloat = 16
-  static let compactMinimumWidth: CGFloat = 352
-  static let compactNotchSideReserve: CGFloat = 152
+  static let compactMinimumWidth: CGFloat = 368
+  static let compactNotchSideReserve: CGFloat = 168
   static let expandedMinimumWidth: CGFloat = 500
   static let expandedMaximumWidth: CGFloat = 580
   static let expandedScreenWidthRatio: CGFloat = 0.425

--- a/apps/electron/native/agent-island/macos-agent-island-helper.swift
+++ b/apps/electron/native/agent-island/macos-agent-island-helper.swift
@@ -190,6 +190,17 @@ final class IslandModel: ObservableObject {
   }
 }
 
+private enum IslandLayout {
+  static let horizontalScreenInset: CGFloat = 16
+  static let compactMinimumWidth: CGFloat = 352
+  static let compactNotchSideReserve: CGFloat = 152
+  static let expandedMinimumWidth: CGFloat = 500
+  static let expandedMaximumWidth: CGFloat = 580
+  static let expandedScreenWidthRatio: CGFloat = 0.425
+  static let stackedPlanningWidth: CGFloat = 550
+  static let expandedMaximumHeight: CGFloat = 420
+}
+
 struct NotchMetrics {
   let hasNotch: Bool
   let width: CGFloat
@@ -207,8 +218,10 @@ struct NotchMetrics {
       // On a notched Mac this is the physical safe-area height, not a visual
       // approximation. It keeps the compact island contiguous with the cutout.
       height = topInset
-      // Black "ears" make the native panel physically bridge the hardware notch.
-      compactWidth = min(screen.frame.width - 32, max(420, notch + 276))
+      // Keep the physical notch as the visual anchor, but reserve only the
+      // space needed by Proma's compact status and quota badge on small Macs.
+      let availableWidth = max(1, screen.frame.width - IslandLayout.horizontalScreenInset * 2)
+      compactWidth = min(availableWidth, max(IslandLayout.compactMinimumWidth, notch + IslandLayout.compactNotchSideReserve))
     } else {
       hasNotch = false
       width = 0
@@ -356,17 +369,10 @@ struct PlanQuotaCarousel: View {
 struct CompactPlanQuotaBadge: View {
   let quota: CompactPlanQuota
 
-  private func shortLabel(_ window: PlanQuotaWindow) -> String {
-    switch window.windowType {
-    case "5h": return "5h"
-    case "weekly": return "周"
-    default: return window.windowLabel
-    }
-  }
 
   private var detail: String {
     quota.windows.prefix(2).map { window in
-      "\(shortLabel(window)) \(window.remainingLabel ?? "\(Int(window.remainingPercent.rounded()))%")"
+      window.remainingLabel ?? "\(Int(window.remainingPercent.rounded()))%"
     }.joined(separator: " · ")
   }
 
@@ -376,11 +382,6 @@ struct CompactPlanQuotaBadge: View {
         .foregroundStyle(.white.opacity(0.92))
         .lineLimit(1)
         .truncationMode(.tail)
-      if quota.additionalChannelCount > 0 {
-        Text("+\(quota.additionalChannelCount)")
-          .foregroundStyle(Color(red: 0.65, green: 0.73, blue: 1))
-          .fontWeight(.bold)
-      }
     }
     .font(.system(size: 9, weight: .semibold))
     .monospacedDigit()
@@ -415,34 +416,33 @@ struct CompactIslandView: View {
     }
   }
 
-  private var compactLabel: String {
+  private var compactIndicator: (symbol: String, color: Color)? {
     if let session = primarySession {
-      return "Proma · \(phaseText(session.phase))"
+      switch session.phase {
+      case "running": return ("play.circle.fill", Color(red: 0.62, green: 0.72, blue: 1))
+      case "needs-interaction": return ("hand.raised.fill", Color(red: 1, green: 0.66, blue: 0.22))
+      case "completed": return ("checkmark.circle.fill", Color.green.opacity(0.9))
+      case "error": return ("exclamationmark.triangle.fill", Color.red.opacity(0.9))
+      default: return ("circle", Color.white.opacity(0.62))
+      }
     }
     if snapshot.state.idleDashboard {
-      return snapshot.state.recentSessions.isEmpty ? "Proma · 额度概览" : "Proma · 最近会话"
+      return snapshot.state.recentSessions.isEmpty
+        ? ("chart.bar.fill", Color.white.opacity(0.72))
+        : ("clock.arrow.circlepath", Color.white.opacity(0.72))
     }
-    return planningIndicator?.label ?? "工作提醒"
+    return planningIndicator.map { ($0.symbol, $0.color) }
   }
 
   var body: some View {
     Button(action: { action("set-expanded", ["expanded": true]) }) {
       HStack(spacing: 8) {
-        if primarySession == nil, let indicator = planningIndicator {
+        if let indicator = compactIndicator {
           Image(systemName: indicator.symbol)
             .font(.system(size: 11, weight: .semibold))
             .foregroundStyle(indicator.color)
             .frame(width: 14)
-        } else if primarySession == nil {
-          Image(systemName: "bell")
-            .font(.system(size: 10, weight: .semibold))
-            .foregroundStyle(.white.opacity(0.65))
-            .frame(width: 14)
         }
-        Text(compactLabel)
-          .font(.system(size: 10.5, weight: .semibold))
-          .lineLimit(1)
-          .foregroundStyle(.white.opacity(0.92))
         Spacer(minLength: 6)
         if let quota = snapshot.state.compactPlanQuota {
           CompactPlanQuotaBadge(quota: quota)
@@ -476,6 +476,8 @@ struct Metric: View {
 
 struct ExpandedIslandView: View {
   let snapshot: SnapshotMessage
+  let contentWidth: CGFloat
+  let isMeasuring: Bool
   let action: (String, [String: Any]) -> Void
 
   private var primaryPhase: String? { snapshot.state.sessions.first?.phase }
@@ -510,7 +512,11 @@ struct ExpandedIslandView: View {
     }
   }
 
-  var body: some View {
+  private var usesStackedPlanning: Bool {
+    contentWidth < IslandLayout.stackedPlanningWidth
+  }
+
+  private var islandContent: some View {
     VStack(spacing: 0) {
       // 计划是唯一内容时，直接展示可操作的信息卡；不再浪费一行
       // “即将开始”标题。Agent 会话存在时才保留状态头与打开入口。
@@ -586,7 +592,10 @@ struct ExpandedIslandView: View {
         if !displayedSessions.isEmpty {
           Divider().overlay(.white.opacity(0.11))
         }
-        HStack(alignment: .top, spacing: 12) {
+        let planningLayout: AnyLayout = usesStackedPlanning
+          ? AnyLayout(VStackLayout(alignment: .leading, spacing: 12))
+          : AnyLayout(HStackLayout(alignment: .top, spacing: 12))
+        planningLayout {
           if !snapshot.planning.todos.isEmpty {
             Button(action: { action("open-planning", [:]) }) {
               PlanningColumn(title: "接下来待办", symbol: "checklist", count: snapshot.planning.todos.count) {
@@ -631,6 +640,18 @@ struct ExpandedIslandView: View {
       removal: .opacity.combined(with: .move(edge: .bottom))
     ))
     .animation(.easeInOut(duration: 0.36), value: contentMode)
+  }
+
+  var body: some View {
+    if isMeasuring {
+      islandContent
+    } else {
+      ScrollView(.vertical) {
+        islandContent
+      }
+      .scrollIndicators(.hidden)
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
   }
 }
 
@@ -687,7 +708,12 @@ struct IslandRootView: View {
           : Color.black)
         if let snapshot = model.snapshot, snapshot.state.visible {
           if snapshot.state.expanded {
-            ExpandedIslandView(snapshot: snapshot, action: action)
+            ExpandedIslandView(
+              snapshot: snapshot,
+              contentWidth: model.surfaceSize.width,
+              isMeasuring: false,
+              action: action
+            )
               .transition(.opacity.combined(with: .move(edge: .top)))
           } else {
             CompactIslandView(snapshot: snapshot, height: model.compactHeight, action: action)
@@ -730,15 +756,14 @@ struct IslandRootView: View {
 
 @MainActor
 final class IslandController {
-  private static let maximumWidth: CGFloat = 620
-  // Large enough that lower contour clearance, not an arbitrary panel cap,
-  // determines the expanded layout for current 3-session + 4+4 planning data.
-  private static let maximumHeight: CGFloat = 640
-
   private let model = IslandModel()
   private let panel: AgentIslandPanel
   private var screen: NSScreen
   private var latestMessage: SnapshotMessage?
+  // An open island keeps its measured outer height until it closes. New data
+  // remains reachable through the internal scroll view instead of repeatedly
+  // growing/shrinking the panel as Agent state streams in.
+  private var pinnedExpandedHeight: CGFloat?
   private var screenObserver: NSObjectProtocol?
 
   init() {
@@ -782,11 +807,15 @@ final class IslandController {
       && message.state.expanded
       && latestMessage?.state.visible == true
       && message.state.visible
+    if !message.state.visible || !message.state.expanded { pinnedExpandedHeight = nil }
     latestMessage = message
     layout(message, forceModelUpdate: false, animateFrame: animateExpandedResize)
   }
 
-  func close() { panel.orderOut(nil) }
+  func close() {
+    pinnedExpandedHeight = nil
+    panel.orderOut(nil)
+  }
 
   private func refreshForDisplayChange() {
     guard let latestMessage else { return }
@@ -807,8 +836,19 @@ final class IslandController {
     }
 
     let expanded = message.state.expanded
-    let width = expanded ? min(Self.maximumWidth, screen.frame.width - 32) : metrics.compactWidth
-    let height = expanded ? Self.expandedHeight(for: message, width: width) : metrics.height
+    let width = expanded ? Self.expandedWidth(for: screen) : metrics.compactWidth
+    let height: CGFloat
+    if expanded {
+      if let pinnedExpandedHeight, !forceModelUpdate {
+        height = pinnedExpandedHeight
+      } else {
+        let measuredHeight = Self.expandedHeight(for: message, width: width)
+        pinnedExpandedHeight = measuredHeight
+        height = measuredHeight
+      }
+    } else {
+      height = metrics.height
+    }
     let surfaceSize = CGSize(width: width, height: height)
 
     // Best practice from CC Island/Open Vibe Island: fit the NSPanel to the real
@@ -835,17 +875,31 @@ final class IslandController {
     NSScreen.screens.first(where: { NotchMetrics(screen: $0).hasNotch })
   }
 
+  private static func expandedWidth(for screen: NSScreen) -> CGFloat {
+    let availableWidth = max(1, screen.frame.width - IslandLayout.horizontalScreenInset * 2)
+    let preferredWidth = min(
+      IslandLayout.expandedMaximumWidth,
+      screen.frame.width * IslandLayout.expandedScreenWidthRatio
+    )
+    return min(availableWidth, max(IslandLayout.expandedMinimumWidth, preferredWidth))
+  }
+
   private static func expandedHeight(for message: SnapshotMessage, width: CGFloat) -> CGFloat {
-    // Measure the exact same SwiftUI tree used by the visible surface at its
-    // final width. This avoids a second resize after hover while also avoiding
-    // fragile hand-written font/padding arithmetic that can cut off the curve.
+    // Measure the same content tree once when opening (or after a display
+    // change). The rendered version scrolls inside this budget if new items
+    // arrive later, keeping the outer panel stable.
     let measuringView = NSHostingView(rootView:
-      ExpandedIslandView(snapshot: message, action: { _, _ in })
-        .frame(width: width, alignment: .topLeading)
-        .fixedSize(horizontal: false, vertical: true)
+      ExpandedIslandView(
+        snapshot: message,
+        contentWidth: width,
+        isMeasuring: true,
+        action: { _, _ in }
+      )
+      .frame(width: width, alignment: .topLeading)
+      .fixedSize(horizontal: false, vertical: true)
     )
     let height = ceil(measuringView.fittingSize.height)
-    return min(maximumHeight, max(height, 1))
+    return min(IslandLayout.expandedMaximumHeight, max(height, 1))
   }
 
   private static func topFrame(screen: NSScreen, width: CGFloat, height: CGFloat) -> NSRect {

--- a/apps/electron/src/main/lib/agent-island-service.ts
+++ b/apps/electron/src/main/lib/agent-island-service.ts
@@ -215,12 +215,44 @@ function handlePromaEvent(sessionId: string, event: import('@proma/shared').Prom
       }
       break
     }
-    case 'external_run_started':
+    case 'external_run_started': {
+      const session = ensureSession(sessionId)
+      session.startedAt = event.startedAt
+      session.phase = 'running'
+      session.attention = false
+      session.lastActivityAt = Date.now()
+      break
+    }
+    case 'run_started': {
+      const session = ensureSession(sessionId)
+      session.startedAt = event.startedAt
+      session.phase = 'running'
+      session.attention = false
+      session.lastActivityAt = Date.now()
+      break
+    }
     case 'run_resumed': {
       const session = ensureSession(sessionId)
       session.phase = 'running'
       session.attention = false
       session.lastActivityAt = Date.now()
+      break
+    }
+    case 'run_stopped': {
+      const session = sessions.get(sessionId)
+      // A delayed completion from an older run must never clear a newer one.
+      if (!session || (event.startedAt != null && session.startedAt !== event.startedAt)) break
+      // A user cancellation is terminal for the current run, but it is not an
+      // error or a completed result that needs attention. Keep it out of the
+      // island immediately instead of leaving the previous running snapshot.
+      session.phase = 'completed'
+      session.detail = '已中断'
+      session.interactionKind = undefined
+      session.attention = false
+      session.unread = false
+      session.terminalAt = Date.now()
+      session.lastActivityAt = Date.now()
+      pushActivity(session, 'status', '任务已中断')
       break
     }
     case 'retry': {
@@ -734,7 +766,7 @@ function schedulePush(throttleMs = PUSH_THROTTLE_MS): void {
 
 function requiresImmediateAgentIslandPush(payload: AgentStreamPayload): boolean {
   if (payload.kind === 'proma_event') {
-    return ['permission_request', 'ask_user_request', 'exit_plan_mode_request'].includes(payload.event.type)
+    return ['permission_request', 'ask_user_request', 'exit_plan_mode_request', 'run_stopped'].includes(payload.event.type)
   }
   const message = payload.message
   return message.type === 'result' || (message.type === 'assistant' && Boolean((message as import('@proma/shared').SDKAssistantMessage).error))

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -420,12 +420,13 @@ export class AgentOrchestrator {
   private adapter: AgentProviderAdapter
   private eventBus: AgentEventBus
   private activeSessions = new Map<string, number>()
+  private nextRunGeneration = 0
 
   /** 队列消息本地记录（sessionId → UUID 集合，用于防重） */
   private queuedMessageUuids = new Map<string, Set<string>>()
 
-  /** 被用户手动中止的会话集合（在 stop 中标记，catch block 中消费） */
-  private stoppedBySessions = new Set<string>()
+  /** 被用户手动中止的运行代际（在 stop 中标记，在对应运行的终态路径消费）。 */
+  private stoppedBySessions = new Map<string, number>()
 
   /** 运行中会话的当前权限模式（支持运行时动态切换） */
   private sessionPermissionModes = new Map<string, PromaPermissionMode>()
@@ -441,10 +442,10 @@ export class AgentOrchestrator {
    * SDK 在 query.close() 后不一定走异常路径：某些版本会先正常 yield result 再结束迭代。
    * 因此停止标记必须在所有终态路径统一消费，而不能只依赖 catch 块。
    */
-  private consumeStoppedByUser(sessionId: string): boolean {
-    const stoppedByUser = this.stoppedBySessions.has(sessionId)
+  private consumeStoppedByUser(sessionId: string, runGeneration: number): boolean {
+    if (this.stoppedBySessions.get(sessionId) !== runGeneration) return false
     this.stoppedBySessions.delete(sessionId)
-    return stoppedByUser
+    return true
   }
 
   /**
@@ -919,7 +920,6 @@ export class AgentOrchestrator {
       // userMessage 是传给 Agent 的 SDK 文本（@file 路径已解码为真实路径）。
       this.persistUserMessage(sessionId, rawUserMessage ?? userMessage)
       userMessagePersisted = true
-      callbacks.onRunStarted?.({ startedAt: streamStartedAt })
     }
 
     // 0. 并发保护
@@ -1157,8 +1157,9 @@ export class AgentOrchestrator {
     // 2.1 立即抢占会话槽位（在所有同步检查通过后、第一个 await 之前）
     // 防止 buildSdkEnv 等 await 期间并发调用绕过上方的检查，导致多条重复消息写入 JSONL
     // finally 块会通过 generation 匹配来安全清理，不影响正常流程
-    const runGeneration = Date.now()
+    const runGeneration = ++this.nextRunGeneration
     this.activeSessions.set(sessionId, runGeneration)
+    callbacks.onRunStarted?.({ startedAt: streamStartedAt })
 
     const releaseActiveRun = (): void => {
       // 在发送 STREAM_COMPLETE 前释放 active slot，避免渲染进程已进入空闲态、
@@ -1976,7 +1977,7 @@ export class AgentOrchestrator {
 
             // 等待期间如果会话被中止，退出
             if (!this.activeSessions.has(sessionId)) {
-              const wasStoppedByUser = this.consumeStoppedByUser(sessionId)
+              const wasStoppedByUser = this.consumeStoppedByUser(sessionId, runGeneration)
               this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
               try { updateAgentSessionMeta(sessionId, { stoppedByUser: wasStoppedByUser }) } catch { /* 会话可能已删除 */ }
               completeRun(getAgentSessionMessages(sessionId), { stoppedByUser: wasStoppedByUser, startedAt: streamStartedAt })
@@ -2361,7 +2362,7 @@ export class AgentOrchestrator {
             continue
           }
 
-          const wasStoppedByUser = this.consumeStoppedByUser(sessionId)
+          const wasStoppedByUser = this.consumeStoppedByUser(sessionId, runGeneration)
 
           // 正常完成 — 如果之前有可见重试，发送 retry_cleared
           if (!wasStoppedByUser && retryAttemptsScheduled > RETRY_VISIBILITY_THRESHOLD) {
@@ -2411,7 +2412,7 @@ export class AgentOrchestrator {
 
           // 用户主动中止
           if (!this.activeSessions.has(sessionId)) {
-            const wasStoppedByUser = this.consumeStoppedByUser(sessionId)
+            const wasStoppedByUser = this.consumeStoppedByUser(sessionId, runGeneration)
             console.log(`[Agent 编排] 会话 ${sessionId} 已被用户中止`)
             this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
             // 持久化中断状态到会话 meta
@@ -2659,9 +2660,10 @@ export class AgentOrchestrator {
    * 再调用 adapter.abort() 中止底层 SDK 进程。
    */
   stop(sessionId: string): void {
+    const runGeneration = this.activeSessions.get(sessionId)
     this.activeSessions.delete(sessionId)
     this.sessionPermissionModes.delete(sessionId)
-    this.stoppedBySessions.add(sessionId)
+    if (runGeneration != null) this.stoppedBySessions.set(sessionId, runGeneration)
     this.queuedMessageUuids.delete(sessionId)
     this.adapter.abort(sessionId)
     console.log(`[Agent 编排] 已中止会话: ${sessionId}`)

--- a/apps/electron/src/main/lib/agent-service.ts
+++ b/apps/electron/src/main/lib/agent-service.ts
@@ -109,6 +109,21 @@ function getMainRendererWebContents(): WebContents | null {
   return win && !win.webContents.isDestroyed() ? win.webContents : null
 }
 
+function publishRunStopped(
+  sessionId: string,
+  stoppedByUser: boolean | undefined,
+  startedAt: number | undefined,
+): void {
+  if (!stoppedByUser) return
+  eventBus.emit(sessionId, {
+    kind: 'proma_event',
+    event: {
+      type: 'run_stopped',
+      ...(startedAt != null ? { startedAt } : {}),
+    },
+  })
+}
+
 // ===== EventBus IPC 转发中间件 =====
 
 /**
@@ -177,6 +192,7 @@ export async function runAgent(
         }
       },
       onComplete: (messages, opts) => {
+        publishRunStopped(input.sessionId, opts?.stoppedByUser, opts?.startedAt)
         if (!webContents.isDestroyed()) {
           sendAgentStreamComplete(webContents, input, {
             messages,
@@ -189,6 +205,12 @@ export async function runAgent(
             session: getSessionMetaForRenderer(input.sessionId),
           })
         }
+      },
+      onRunStarted: ({ startedAt }) => {
+        eventBus.emit(input.sessionId, {
+          kind: 'proma_event',
+          event: { type: 'run_started', startedAt },
+        })
       },
       onTitleUpdated: (title) => {
         eventBus.emit(input.sessionId, {
@@ -267,6 +289,7 @@ export async function runAgentHeadless(
       },
       onComplete: (messages, opts) => {
         callbacks.onComplete(messages)
+        publishRunStopped(runInput.sessionId, opts?.stoppedByUser, opts?.startedAt)
         // 同步到渲染进程
         if (wc && !wc.isDestroyed()) {
           sendAgentStreamComplete(wc, runInput, {

--- a/apps/electron/src/renderer/components/agent-island/AgentIslandApp.tsx
+++ b/apps/electron/src/renderer/components/agent-island/AgentIslandApp.tsx
@@ -1,10 +1,15 @@
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import {
   ArrowUpRight,
-  Bell,
+  BarChart3,
   CalendarDays,
   ChevronDown,
+  CircleCheck,
+  CirclePlay,
+  Hand,
+  History,
   ListTodo,
+  TriangleAlert,
 } from 'lucide-react'
 import type {
   AgentIslandCompactPlanQuotaSnapshot,
@@ -20,6 +25,14 @@ const COMPACT_SURFACE_HEIGHT = 32
 const SURFACE_WIDTH = 420
 
 type SurfaceMode = 'compact' | 'expanded' | 'collapsing'
+
+const PHASE_LABEL: Record<AgentIslandPhase, string> = {
+  idle: '待命',
+  running: '执行中',
+  'needs-interaction': '待处理',
+  completed: '已完成',
+  error: '需关注',
+}
 
 function useAgentIslandSnapshot(): AgentIslandWindowSnapshot | null {
   const [snapshot, setSnapshot] = useState<AgentIslandWindowSnapshot | null>(null)
@@ -49,12 +62,24 @@ function useAgentIslandSnapshot(): AgentIslandWindowSnapshot | null {
   return snapshot
 }
 
-const PHASE_LABEL: Record<AgentIslandPhase, string> = {
-  idle: '待命',
-  running: '执行中',
-  'needs-interaction': '待处理',
-  completed: '已完成',
-  error: '需关注',
+function getCompactIcon(
+  primarySession: AgentIslandSessionSnapshot | undefined,
+  state: AgentIslandWindowSnapshot['state'],
+  planningIndicator: ReturnType<typeof getPlanningIndicator>,
+): React.ReactNode | null {
+  if (primarySession) {
+    switch (primarySession.phase) {
+      case 'running': return <CirclePlay size={13} />
+      case 'needs-interaction': return <Hand size={13} />
+      case 'completed': return <CircleCheck size={13} />
+      case 'error': return <TriangleAlert size={13} />
+      default: return <CirclePlay size={13} />
+    }
+  }
+  if (state.idleDashboard) {
+    return state.recentSessions.length === 0 ? <BarChart3 size={13} /> : <History size={13} />
+  }
+  return planningIndicator?.icon ?? null
 }
 
 function formatTime(timestamp: number | undefined, allDay = false): string {
@@ -86,16 +111,11 @@ function getPlanningIndicator(snapshot: AgentIslandWindowSnapshot): { icon: Reac
   return { icon: <ListTodo size={13} />, label: '即将到期' }
 }
 
-function compactQuotaWindowLabel(window: AgentIslandCompactPlanQuotaSnapshot['windows'][number]): string {
-  if (window.windowType === '5h') return '5h'
-  if (window.windowType === 'weekly') return '周'
-  return window.windowLabel
-}
 
 function formatCompactPlanQuota(quota: AgentIslandCompactPlanQuotaSnapshot): string {
   return quota.windows
     .slice(0, 2)
-    .map((window) => `${compactQuotaWindowLabel(window)} ${window.remainingLabel ?? `${Math.round(window.remainingPercent)}%`}`)
+    .map((window) => window.remainingLabel ?? `${Math.round(window.remainingPercent)}%`)
     .join(' · ')
 }
 
@@ -108,7 +128,6 @@ function CompactPlanQuota({ quota }: { quota: AgentIslandCompactPlanQuotaSnapsho
   return (
     <span className="island-compact-quota" title={title}>
       <span className="island-compact-quota-value">{detail}</span>
-      {quota.additionalChannelCount > 0 && <span className="island-compact-quota-more">+{quota.additionalChannelCount}</span>}
     </span>
   )
 }
@@ -230,11 +249,7 @@ export function AgentIslandApp(): React.ReactElement {
 
   const primarySession = state.sessions[0]
   const planningIndicator = getPlanningIndicator(snapshot)
-  const compactLabel = primarySession
-    ? `Proma · ${PHASE_LABEL[primarySession.phase]}`
-    : state.idleDashboard
-      ? state.recentSessions.length === 0 ? 'Proma · 额度概览' : 'Proma · 最近会话'
-      : planningIndicator?.label ?? '工作提醒'
+  const compactIcon = getCompactIcon(primarySession, state, planningIndicator)
   const displayedSessions = state.idleDashboard ? state.recentSessions : state.sessions
   const header = getHeaderCopy(primarySession?.phase)
   const showPlanning = !state.idleDashboard && (planning.todos.length > 0 || planning.events.length > 0)
@@ -296,12 +311,7 @@ export function AgentIslandApp(): React.ReactElement {
         </div>
 
         <button className="island-compact-layer" type="button" onClick={() => setExpanded(true)} title="展开">
-          {!primarySession && (
-            <span className="island-compact-icon" aria-hidden="true">
-              {planningIndicator?.icon ?? <Bell size={12} />}
-            </span>
-          )}
-          <span className="island-compact-label">{compactLabel}</span>
+          {compactIcon && <span className="island-compact-icon" aria-hidden="true">{compactIcon}</span>}
           {state.compactPlanQuota && <CompactPlanQuota quota={state.compactPlanQuota} />}
           <ChevronDown className="island-compact-chevron" size={14} aria-hidden="true" />
         </button>

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -607,7 +607,11 @@ export type PromaEvent =
   | { type: 'permission_mode_changed'; mode: PromaPermissionMode }
   | { type: 'title_updated'; title: string }
   | { type: 'external_run_started'; source: AgentExternalRunSource; sessionId: string; title?: string; workspaceId?: string; modelId?: string; startedAt: number; session?: AgentSessionMeta }
+  /** 普通桌面会话已开始执行；startedAt 用于区分同一会话的连续运行。 */
+  | { type: 'run_started'; startedAt: number }
   | { type: 'run_resumed'; sessionId: string }
+  /** 用户主动停止当前执行；startedAt 防止旧运行的终态覆盖新一轮执行。 */
+  | { type: 'run_stopped'; startedAt?: number }
   // 协作子会话阻塞事件上浮
   | { type: 'delegation_blocked'; delegationId: string; blockedEvent: unknown }
   // 自动任务会话被用户接管（毕业）


### PR DESCRIPTION
## Summary
- refine compact and expanded sizing for notched MacBook displays
- replace compact status copy with concise semantic icons and quota values
- clear stale running state after a user stops an Agent run
- widen the compact notch layout to fit dual 100% quota values

## Validation
- `bun run typecheck`
- `bun run scripts/build-agent-island-native.ts`
- `git diff --check`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)