### PR TITLE
【等待审核】fix(tabs): Windows 上面板按钮不再悬浮遮挡预览页面

### DIFF
--- a/apps/electron/src/renderer/components/tabs/TabBar.tsx
+++ b/apps/electron/src/renderer/components/tabs/TabBar.tsx
@@ -228,9 +228,11 @@ function TabBarInner({
   const fadeTimerRef = React.useRef<ReturnType<typeof setTimeout>>()
   const isWindows = React.useMemo(() => detectIsWindows(), [])
 
-  // 文件面板切换（全局共享）：活动 Tab 是 Agent 且面板关闭时，在 TabBar 右上角展示"打开"按钮。
-  // 该按钮的 absolute 定位与 DiffPanelTabBar.PanelRightClose 的 mr-1 mb-[3px] 坐标耦合，
+  // 文件面板切换（全局共享）：活动 Tab 是 Agent 且面板关闭时，在 TabBar 右上角展示“打开”按钮。
+  // 非 Windows：absolute 定位与 DiffPanelTabBar.PanelRightClose 的 mr-1 mb-[3px] 坐标耦合，
   // 若右侧关闭按钮样式变化，这里需同步调整。
+  // Windows：右上角被 WindowControls（126px）占用，按钮收进 TabBar 带内右缘 right-[126px]，
+  // 与面板内关闭按钮（right-4px）位置不同，属有意的平台差异。
   const [isPanelOpen, setSidePanelOpen] = useAtom(agentSidePanelOpenAtom)
   const setShortcutGuideOpen = useSetAtom(shortcutGuideOpenAtom)
   const setFaqDialogOpen = useSetAtom(faqDialogOpenAtom)
@@ -397,6 +399,8 @@ function TabBarInner({
         className={cn(
           "relative flex items-end flex-1 min-w-0 overflow-x-auto scrollbar-none",
           // Windows 始终避开 WindowControls（~126px）；非 Windows 为快捷键地图和文件面板按钮预留空间。
+          // 已知限制：Windows 下多标签溢出并滚动到底时，最右标签右端可能被带内按钮（z-10）遮挡，
+          // 与非 Windows 既有模式同源；如需彻底避免需将按钮改为文档流布局（flex 兄弟），暂不处理。
           isWindows && WINDOW_CONTROLS_PADDING_RIGHT,
           !isWindows && (showOpenPanelButton ? "pr-20" : "pr-10"),
         )}
@@ -457,10 +461,11 @@ function ShortcutGuideButton({
   return (
     <div
       className={cn(
-        "absolute flex items-center gap-1 titlebar-no-drag",
+        "absolute flex items-center gap-1 titlebar-no-drag inset-y-0 items-end pb-[3px] z-10",
+        // Windows 上避开 WindowControls（right-[126px]）；面板按钮显示时再向左让位（126 + 面板按钮 28px + 4px 间距 = 158px）
         isWindows
-          ? cn("top-[37px] h-7 z-[52]", hasPanelButton ? "right-9" : "right-1")
-          : cn("inset-y-0 items-end pb-[3px] z-10", hasPanelButton ? "right-9" : "right-1"),
+          ? (hasPanelButton ? "right-[158px]" : WINDOW_CONTROLS_INSET_RIGHT)
+          : (hasPanelButton ? "right-9" : "right-1"),
       )}
     >
       {/* FAQ 快捷按钮（在快捷键地图左边） */}
@@ -505,7 +510,8 @@ function ShortcutGuideButton({
 
 /** 打开 Agent 文件面板按钮。
  *  非 Windows：inset-y-0 撑满 TabBar，贴右边缘 right-1。
- *  Windows：溢出到 TabBar 下方（top-[37px]），避开 WindowControls，贴右边缘与关闭按钮对齐。 */
+ *  Windows：与非 Windows 一致在 TabBar 带内（inset-y-0 items-end pb-[3px]），
+ *  仅水平位置让出右上角 WindowControls 区域（right-[126px]），不再悬浮遮挡内容区。 */
 function AgentPanelOpenButton({
   isWindows,
   onToggle,
@@ -516,10 +522,8 @@ function AgentPanelOpenButton({
   return (
     <div
       className={cn(
-        "absolute flex titlebar-no-drag",
-        isWindows
-          ? "top-[37px] right-1 h-7 z-[52]"
-          : "inset-y-0 right-1 items-end pb-[3px] z-10",
+        "absolute flex titlebar-no-drag inset-y-0 items-end pb-[3px] z-10",
+        isWindows ? WINDOW_CONTROLS_INSET_RIGHT : "right-1",
       )}
     >
       <Tooltip>


### PR DESCRIPTION
## 概述

Windows 平台「打开文件面板」按钮（AgentPanelOpenButton）与 FAQ/快捷键按钮（ShortcutGuideButton）属同一缺陷族：原先 top-[37px] 悬浮在 TabBar 下方内容区，与 preview 页（DiffTabContent）顶部工具栏按钮重叠。本 PR 将其收进 TabBar 带内（right-[126px]），同时 ShortcutGuideButton 在面板按钮显示时让位到 right-[158px]（126 + 面板按钮 28px + 4px 间距），两按钮带内水平错开、均不遮挡内容区。

## 改动

- `apps/electron/src/renderer/components/tabs/TabBar.tsx`：
  - AgentPanelOpenButton：Windows 定位从悬浮（top-[37px] right-1 z-[52]）改为带内（inset-y-0 items-end pb-[3px] z-10 + WINDOW_CONTROLS_INSET_RIGHT），JSDoc 同步更新
  - ShortcutGuideButton：Windows 分支在面板按钮显示时让位 right-[158px]（否则 right-[126px]），两按钮水平错开 4px 间距
  - 更新失效的坐标耦合注释（Windows 下打开按钮已与面板内关闭按钮位置不同，属有意平台差异）
  - 滚动区注释登记已知限制

## 测试

- `bun run typecheck`：全部 6 包 exit 0
- BDD 自审（2 个独立角度子会话并行）：平台布局/回归 approve、代码质量/一致性 approve
- Playwright 模拟验证（几何数据 + 视觉双确认）：修复前 FAQ+面板按钮均与预览工具栏重叠（28×28）；修复后两按钮都收进 TabBar 带内、与工具栏分离、水平错开（gap 4px）、与 WindowControls 无遮挡；无面板按钮时 FAQ 仍在带内 right-[126px]

## 紧急度

常规

## 备注

- **已知限制同 PR**（多标签溢出滚动到底时最右标签可能被带内按钮遮挡，已在代码注释登记）
- 非 Windows 布局零回归；旧 Windows 悬浮定位（top-[37px]/z-[52]）已彻底清理
- 无关联 upstream issue
