### PR TITLE
fix(sidebar): 左侧栏分组标题字号统一为 13px【已审核 PR】

### DIFF
--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -2801,7 +2801,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
           <div className="px-2 pb-3">
             {conversationGroups.map((group) => (
               <div key={group.label} className="mb-1">
-                <div className="ml-[4px] px-1.5 pt-2 pb-1 text-[11px] font-medium text-foreground/40 select-none">
+                <div className="ml-[4px] px-1.5 pt-2 pb-1 text-[13px] font-medium leading-[18px] text-foreground/40 select-none">
                   {group.label}
                 </div>
                 <div className="flex flex-col gap-0.5">
@@ -2903,7 +2903,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
 
           {/* 下区标题：项目历史 */}
           <div className="px-2 pt-2 pb-1 flex items-center justify-between flex-shrink-0">
-            <span className="px-1.5 text-[11px] font-medium text-foreground/40 select-none">项目</span>
+            <span className="px-1.5 text-[13px] font-medium leading-[18px] text-foreground/40 select-none">项目</span>
             <div className="flex items-center gap-0.5">
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -3024,7 +3024,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
               /* Chat 归档：对话按日期分组 */
               conversationGroups.map((group) => (
                 <div key={group.label} className="mb-1">
-                  <div className="px-3 pt-2 pb-1 text-[11px] font-medium text-foreground/40 select-none">
+                  <div className="px-3 pt-2 pb-1 text-[13px] font-medium leading-[18px] text-foreground/40 select-none">
                     {group.label}
                   </div>
                   <div className="flex flex-col gap-0.5">
@@ -3050,7 +3050,7 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
               /* Agent 模式归档：Agent 会话按日期分组，含委派树 */
               archivedAgentSessionTrees.map((group) => (
                 <div key={group.label} className="mb-1">
-                  <div className="px-3 pt-2 pb-1 text-[11px] font-medium text-foreground/40 select-none">
+                  <div className="px-3 pt-2 pb-1 text-[13px] font-medium leading-[18px] text-foreground/40 select-none">
                     {group.label}
                   </div>
                   <div className="flex flex-col gap-0.5">


### PR DESCRIPTION
## 概述

左侧边栏中「置顶」标题使用 13px，而「项目」及日期分组标签（今天/昨天/更早）等其他分组标题使用 11px，视觉上字号不一致。本次改动将左侧栏所有分组标题统一为 13px（`text-[13px] leading-[18px]`），与「置顶」保持一致，使侧边栏分组层级观感更统一。

## 改动

- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 将 4 处分组标题从 `text-[11px]` 统一升级为 `text-[13px] font-medium leading-[18px]`：
  - Chat 模式对话历史日期分组标签（今天/昨天/更早）
  - 「项目」标题
  - Chat 归档视图日期分组标签
  - Agent 模式归档视图日期分组标签

「置顶」「对话」标题原本即为 13px，保持不变。

## 测试方法

1. 启动 Electron 应用，进入 Chat 模式 active 视图
2. 展开左侧栏，对比「置顶」「对话」「项目」及日期分组标题的字号，应全部一致（13px）
3. 切换到 Agent 模式，检查置顶区与项目分组标题同样一致
4. 进入归档视图，确认归档分组标签字号与其余标题一致

## 备注

- 仅改动 Tailwind className，无逻辑变更
- 已通过 `bun run --filter='@proma/electron' typecheck`