### PR TITLE
feat(sidebar): 恢复「新建会话 + 搜索」并排按钮布局【已审核 PR】

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ dist
 apps/electron/resources/bin/
 # Swift 编译的 macOS 原生灵动岛 helper（构建时生成，按宿主架构分发）
 apps/electron/resources/agent-island/
+# Objective-C++ 编译的 macOS EventKit N-API addon（构建时生成，按宿主架构分发）
+apps/electron/resources/eventkit/
 # bun build --compile 的临时中间产物
 *.bun-build
 

--- a/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
+++ b/apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx
@@ -2535,6 +2535,22 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
             <TooltipTrigger asChild>
               <button
                 type="button"
+                aria-label={mode === 'agent' ? '新建 Agent 会话' : '新建 Chat 对话'}
+                onClick={() => { void (mode === 'agent' ? createAgentSessionInWorkspace() : createChat()) }}
+                className="size-10 flex items-center justify-center rounded-[12px] text-foreground/70 bg-primary/5 hover:bg-primary/10 transition-colors titlebar-no-drag border border-dashed border-[hsl(var(--dashed-border))] hover:border-[hsl(var(--dashed-border-hover))]"
+              >
+                <Plus size={16} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="right">
+              {mode === 'agent' ? '新会话' : '新对话'}
+            </TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
                 aria-label="搜索"
                 onClick={() => setSearchDialogOpen(true)}
                 className="size-10 flex items-center justify-center rounded-[12px] text-foreground/45 sidebar-control-surface hover:text-foreground/70 transition-[background-color,color] duration-150 titlebar-no-drag"
@@ -2687,22 +2703,11 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
       {/* macOS 需要避开左上角红绿灯；边栏覆盖全局标题栏拖拽层，因此留白自身也要可拖拽。 */}
       <div className={cn('w-full flex-shrink-0 titlebar-drag-region', isMac ? 'h-[30px]' : 'h-1')} />
 
-      {/* 模式切换器 + 搜索 + 折叠按钮 */}
+      {/* 模式切换器 + 折叠按钮 */}
       <div className="titlebar-drag-region flex items-start gap-1.5 px-3">
         <div className="flex-1 min-w-0">
           <ModeSwitcher />
         </div>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              onClick={() => setSearchDialogOpen(true)}
-              className="mt-2 size-10 flex-shrink-0 flex items-center justify-center rounded-[10px] text-foreground/40 sidebar-control-surface hover:text-foreground/60 transition-[background-color,color] duration-150 titlebar-no-drag"
-            >
-              <Search size={14} />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">搜索 ({getAcceleratorDisplay(getActiveAccelerator('global-search'))})</TooltipContent>
-        </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>
             <button
@@ -2715,6 +2720,30 @@ export function LeftSidebar({ width, noTransition }: LeftSidebarProps): React.Re
             </button>
           </TooltipTrigger>
           <TooltipContent side="right">收起侧边栏 ({navigator.platform.includes('Mac') ? '⌘B' : 'Ctrl+B'})</TooltipContent>
+        </Tooltip>
+      </div>
+
+      {/* 新对话/新会话按钮 + 搜索按钮 */}
+      <div className="px-3 pt-2 flex items-center gap-1.5">
+        <button
+          type="button"
+          onClick={() => { void (mode === 'agent' ? createAgentSessionInWorkspace() : createChat()) }}
+          className="flex-1 flex items-center gap-2 px-3 py-2 rounded-[10px] text-[13px] font-medium text-foreground/70 bg-primary/5 hover:bg-primary/10 transition-colors duration-100 titlebar-no-drag border border-dashed border-[hsl(var(--dashed-border))] hover:border-[hsl(var(--dashed-border-hover))]"
+        >
+          <Plus size={14} />
+          <span>{mode === 'agent' ? '新会话' : '新对话'}</span>
+        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={() => setSearchDialogOpen(true)}
+              className="flex-shrink-0 size-[36px] flex items-center justify-center rounded-[10px] text-foreground/40 bg-primary/5 hover:bg-primary/10 hover:text-foreground/60 transition-colors duration-100 titlebar-no-drag border border-dashed border-[hsl(var(--dashed-border))] hover:border-[hsl(var(--dashed-border-hover))]"
+            >
+              <Search size={14} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">搜索 ({getAcceleratorDisplay(getActiveAccelerator('global-search'))})</TooltipContent>
         </Tooltip>
       </div>
 


### PR DESCRIPTION
## 概述
恢复约 550 commits 前版本的侧边栏布局：展开态在 ModeSwitcher 下方显示「新对话/新会话 + 搜索」并排按钮，折叠态在高频操作区恢复「新建会话」按钮并与搜索按钮相邻。当前版本将新建会话入口拆散到项目行/对话分组的 hover 按钮中，不易发现，本 PR 将其还原为显眼的一等入口。

## 改动
- `apps/electron/src/renderer/components/app-shell/LeftSidebar.tsx` — 
  - 展开态：顶栏仅保留 ModeSwitcher + 折叠按钮，在下方恢复「新对话/新会话（flex-1，虚线边框）+ 搜索（36px）」整行按钮，样式沿用历史版本（复用 `--dashed-border` 设计 token）
  - 折叠态：高频操作区恢复「新建会话」按钮（Plus 图标），排在搜索按钮之前，与历史版本顺序一致；保留后来的任务/日程按钮
  - Agent 模式新建调用现有 `createAgentSessionInWorkspace()`（当前项目 + 渠道/模型），Chat 模式调用 `createChat()`（当前模型/渠道），不引入新逻辑
- `.gitignore` — 忽略 `apps/electron/resources/eventkit/`：EventKit N-API addon 由 `build:eventkit-native` 按宿主架构构建，是构建产物，不应入库（与已有 `resources/bin/`、`resources/agent-island/` 规则一致）

## 测试方法
1. 展开侧边栏：ModeSwitcher 下方应显示「新对话/新会话 + 搜索」并排按钮
2. 点击新建按钮：Agent 模式创建新 Agent 会话并打开标签页；Chat 模式创建新对话并打开标签页
3. 点击搜索按钮：打开全局搜索对话框，快捷键提示正常
4. 折叠侧边栏：高频操作区依次显示「新建会话 → 搜索 → 任务/日程」
5. `bun run typecheck` 全部 workspace 通过；`bun run --filter '@proma/electron' build:renderer` 构建通过

## 备注
- 本次改动已由 Review-Proma-PR 流程独立审查：无代码质量、回归风险、Windows 兼容性问题（改动不涉及路径/Shell/平台分支）
- 工作区中的 `AGENTS.md` 格式化改动（含一处被破坏的 HTML 实体文本）未包含在本 PR 中，另行处理

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)