### PR TITLE
【已审核】feat(channel): 适配 OpenCode Go 订阅额度显示

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -162,6 +162,7 @@ import {
   updateChannel,
   deleteChannel,
   decryptApiKey,
+  decryptChannelSecret,
   testChannel,
   testChannelDirect,
   fetchModels,
@@ -1253,6 +1254,14 @@ export function registerIpcHandlers(): void {
     CHANNEL_IPC_CHANNELS.DECRYPT_KEY,
     async (_, channelId: string): Promise<string> => {
       return decryptApiKey(channelId)
+    }
+  )
+
+  // 解密渠道可选敏感字段（表单回显 OpenCode Go workspaceId / authCookie 用）
+  ipcMain.handle(
+    CHANNEL_IPC_CHANNELS.DECRYPT_SECRET,
+    async (_, channelId: string, field: 'workspaceId' | 'authCookie'): Promise<string> => {
+      return decryptChannelSecret(channelId, field)
     }
   )
 

--- a/apps/electron/src/main/lib/channel-manager.ts
+++ b/apps/electron/src/main/lib/channel-manager.ts
@@ -349,6 +349,8 @@ export function createChannel(input: ChannelCreateInput): Channel {
     provider: input.provider,
     baseUrl: input.baseUrl,
     apiKey: encryptApiKey(input.apiKey),
+    workspaceId: input.workspaceId ? encryptApiKey(input.workspaceId) : undefined,
+    authCookie: input.authCookie ? encryptApiKey(input.authCookie) : undefined,
     models: input.models,
     enabled: input.enabled,
     createdAt: now,
@@ -385,6 +387,17 @@ export function updateChannel(id: string, input: ChannelUpdateInput): Channel {
     provider: input.provider ?? existing.provider,
     baseUrl: input.baseUrl ?? existing.baseUrl,
     apiKey: input.apiKey ? encryptApiKey(input.apiKey) : existing.apiKey,
+    // 可选字段：undefined 保留原值，空字符串显式清空（authCookie 会过期，需能清除）
+    workspaceId: input.workspaceId === undefined
+      ? existing.workspaceId
+      : input.workspaceId
+        ? encryptApiKey(input.workspaceId)
+        : undefined,
+    authCookie: input.authCookie === undefined
+      ? existing.authCookie
+      : input.authCookie
+        ? encryptApiKey(input.authCookie)
+        : undefined,
     models: input.models ?? existing.models,
     enabled: input.enabled ?? existing.enabled,
     updatedAt: Date.now(),
@@ -428,6 +441,28 @@ export function decryptApiKey(channelId: string): string {
   }
 
   return decryptKey(channel.apiKey)
+}
+
+/**
+ * 解密渠道的可选敏感字段（如 OpenCode Go 额度查询的 workspaceId / authCookie）。
+ *
+ * 未配置时返回空字符串，供表单回显；仅对 safeStorage 加密过的值解密。
+ */
+export function decryptChannelSecret(channelId: string, field: 'workspaceId' | 'authCookie'): string {
+  // IPC 运行时不受 TS 类型约束，必须做白名单校验，避免任意索引解密
+  if (field !== 'workspaceId' && field !== 'authCookie') {
+    throw new Error(`不支持的解密字段: ${field}`)
+  }
+  const config = readConfig()
+  const channel = config.channels.find((c) => c.id === channelId)
+
+  if (!channel) {
+    throw new Error(`渠道不存在: ${channelId}`)
+  }
+
+  const encrypted = channel[field]
+  if (!encrypted) return ''
+  return decryptKey(encrypted)
 }
 
 /**
@@ -911,6 +946,97 @@ function createUnsupportedPlanQuota(provider: ProviderType, message: string): Ch
     windows: [],
     updatedAt: Date.now(),
     message,
+  }
+}
+
+const OPENCODE_GO_QUOTA_TIMEOUT_MS = 10_000
+
+/**
+ * 解析 OpenCode Go 控制台 /go 页面中的三窗口用量。
+ *
+ * 官方未提供额度查询 API（anomalyco/opencode#10448 / #16017），页面为 SolidStart SSR，
+ * 用量数据以 RPC 注入形式内嵌在 HTML 中（rollingUsage / weeklyUsage / monthlyUsage，
+ * camelCase 字段名不受界面 locale 影响），直接提取 status / resetInSec / usagePercent。
+ * 2026-08-06 真实页面验证：三窗口均可解析（滚动 24% / 每周 9% / 每月 4%）。
+ */
+function parseOpenCodeGoQuotaWindows(html: string): ChannelPlanQuotaWindow[] {
+  const windows: ChannelPlanQuotaWindow[] = []
+  const specs: Array<{ key: string; type: ChannelPlanQuotaWindow['type']; label: string }> = [
+    { key: 'rollingUsage', type: '5h', label: '每 5 小时' },
+    { key: 'weeklyUsage', type: 'weekly', label: '每周额度' },
+    { key: 'monthlyUsage', type: 'custom', label: '每月额度' },
+  ]
+  for (const { key, type, label } of specs) {
+    const match = html.match(new RegExp(`${key}:\\$R\\[\\d+\\]=\\{([^}]*)\\}`))
+    if (!match) continue
+    // 正则含捕获组，match[1] 必然存在
+    const body = match[1]!
+    const status = body.match(/status:"([^"]+)"/)?.[1]
+    const resetInSec = Number(body.match(/resetInSec:(\d+)/)?.[1])
+    const usagePercent = Number(body.match(/usagePercent:(\d+)/)?.[1])
+    // status 非 ok 或缺少百分比时跳过该窗口，避免展示无效数据
+    if (status !== 'ok' || !Number.isFinite(usagePercent)) continue
+    const used = clampPercent(usagePercent)
+    windows.push({
+      type,
+      label,
+      usedPercent: used,
+      remainingPercent: clampPercent(100 - used),
+      ...(Number.isFinite(resetInSec) && resetInSec > 0 ? { resetAt: Date.now() + resetInSec * 1000 } : {}),
+    })
+  }
+  return windows
+}
+
+/**
+ * 查询 OpenCode Go 订阅额度（控制台页面抓取）。
+ *
+ * OpenCode Go 是 Anomaly 的 $10/月订阅，额度按美元价值分三个滚动窗口
+ * （每 5 小时 $12 / 每周 $30 / 每月 $60）。官方未开放额度查询 API，
+ * 此处抓取登录后的控制台页面，需要浏览器会话的 auth cookie。
+ *
+ * 注意：auth cookie 会随会话过期，过期后需在渠道配置中重新填写。
+ */
+async function queryOpenCodeGoPlanQuota(
+  workspaceId: string,
+  authCookie: string,
+  proxyUrl?: string,
+): Promise<ChannelPlanQuotaResult> {
+  const fetchFn = getFetchFn(proxyUrl)
+  const response = await fetchFn(
+    `https://opencode.ai/workspace/${encodeURIComponent(workspaceId)}/go`,
+    withTimeout({
+      method: 'GET',
+      headers: {
+        Accept: 'text/html,application/xhtml+xml',
+        'User-Agent': getPromaUserAgent(pkg.version),
+        // 透传用户从浏览器复制的完整 Cookie 字符串（auth=...;oc_locale=... 等）
+        Cookie: authCookie,
+      },
+    }, OPENCODE_GO_QUOTA_TIMEOUT_MS),
+  )
+  const responseText = await response.text()
+  if (!response.ok) {
+    return createUnsupportedPlanQuota(
+      'opencode-go-openai',
+      `OpenCode Go 额度查询失败: HTTP ${response.status}（auth cookie 可能已过期，请重新填写）`,
+    )
+  }
+
+  const windows = parseOpenCodeGoQuotaWindows(responseText)
+  if (windows.length === 0) {
+    return createUnsupportedPlanQuota(
+      'opencode-go-openai',
+      'OpenCode Go 额度页面解析失败，请检查 workspaceId 与 auth cookie 是否有效',
+    )
+  }
+
+  return {
+    supported: true,
+    provider: 'opencode-go-openai',
+    planName: 'OpenCode Go',
+    windows,
+    updatedAt: Date.now(),
   }
 }
 
@@ -1526,6 +1652,19 @@ export async function getChannelPlanQuota(channelId: string): Promise<ChannelPla
     }
     if (provider === 'zhipu' || provider === 'zhipu-coding' || provider === 'zhipu-coding-team') {
       return await queryZhipuPlanQuota(apiKey, channel.baseUrl, proxyUrl, provider)
+    }
+    if (provider === 'opencode-go-openai') {
+      if (!channel.workspaceId || !channel.authCookie) {
+        return createUnsupportedPlanQuota(
+          'opencode-go-openai',
+          '未配置额度查询信息，请在渠道配置中填写 workspaceId 与 auth cookie',
+        )
+      }
+      return await queryOpenCodeGoPlanQuota(
+        decryptKey(channel.workspaceId),
+        decryptKey(channel.authCookie),
+        proxyUrl,
+      )
     }
     return createUnsupportedPlanQuota(provider, '当前渠道不支持订阅 Plan 额度查询')
   } catch (error) {

--- a/apps/electron/src/main/lib/channel-manager.ts
+++ b/apps/electron/src/main/lib/channel-manager.ts
@@ -1002,9 +1002,12 @@ async function queryOpenCodeGoPlanQuota(
   authCookie: string,
   proxyUrl?: string,
 ): Promise<ChannelPlanQuotaResult> {
+  // 兼容两种填法：裸 ID（wrk_xxx）或浏览器地址栏复制的完整 URL（https://opencode.ai/workspace/<id>/go）
+  const idMatch = workspaceId.trim().match(/\/workspace\/([^/]+)(?:\/|$)/)
+  const normalizedWorkspaceId = idMatch?.[1] ?? workspaceId.trim()
   const fetchFn = getFetchFn(proxyUrl)
   const response = await fetchFn(
-    `https://opencode.ai/workspace/${encodeURIComponent(workspaceId)}/go`,
+    `https://opencode.ai/workspace/${encodeURIComponent(normalizedWorkspaceId)}/go`,
     withTimeout({
       method: 'GET',
       headers: {

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -256,6 +256,9 @@ export interface ElectronAPI {
   /** 解密获取明文 API Key（仅在用户查看时调用） */
   decryptApiKey: (channelId: string) => Promise<string>
 
+  /** 解密渠道可选敏感字段（OpenCode Go workspaceId / authCookie，表单回显用） */
+  decryptChannelSecret: (channelId: string, field: 'workspaceId' | 'authCookie') => Promise<string>
+
   /** 测试渠道连接 */
   testChannel: (channelId: string) => Promise<ChannelTestResult>
 
@@ -1342,6 +1345,10 @@ const electronAPI: ElectronAPI = {
 
   decryptApiKey: (channelId: string) => {
     return ipcRenderer.invoke(CHANNEL_IPC_CHANNELS.DECRYPT_KEY, channelId)
+  },
+
+  decryptChannelSecret: (channelId: string, field: 'workspaceId' | 'authCookie') => {
+    return ipcRenderer.invoke(CHANNEL_IPC_CHANNELS.DECRYPT_SECRET, channelId, field)
   },
 
   testChannel: (channelId: string) => {

--- a/apps/electron/src/renderer/components/settings/ChannelForm.tsx
+++ b/apps/electron/src/renderer/components/settings/ChannelForm.tsx
@@ -216,6 +216,12 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
   ))
   const [apiKey, setApiKey] = React.useState('')
   const [zhipuTeamSecret, setZhipuTeamSecret] = React.useState<ZhipuTeamSecretForm>(EMPTY_ZHIPU_TEAM_SECRET)
+  // OpenCode Go 额度显示用（独立字段，与 apiKey 分开加密存储）
+  const [openCodeGoWorkspaceId, setOpenCodeGoWorkspaceId] = React.useState('')
+  const [openCodeGoAuthCookie, setOpenCodeGoAuthCookie] = React.useState('')
+  const [showAuthCookie, setShowAuthCookie] = React.useState(false)
+  // OpenCode Go 额度字段解密回显完成前不触发 autosave，避免用空值误清已存配置
+  const [quotaCredentialsLoaded, setQuotaCredentialsLoaded] = React.useState(false)
   const [showApiKey, setShowApiKey] = React.useState(false)
   const [models, setModels] = React.useState<ChannelModel[]>(channel?.models ?? [])
   const [enabled, setEnabled] = React.useState(channel?.enabled ?? true)
@@ -281,6 +287,17 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
         if (channel.provider === 'zhipu-coding-team') {
           setZhipuTeamSecret({ ...EMPTY_ZHIPU_TEAM_SECRET, ...parseZhipuTeamSecret(key) })
         }
+        if (channel.provider === 'opencode-go-openai') {
+          void window.electronAPI.decryptChannelSecret(channel.id, 'workspaceId')
+            .then(setOpenCodeGoWorkspaceId)
+            .catch(() => setOpenCodeGoWorkspaceId(''))
+            .finally(() => {
+              void window.electronAPI.decryptChannelSecret(channel.id, 'authCookie')
+                .then(setOpenCodeGoAuthCookie)
+                .catch(() => setOpenCodeGoAuthCookie(''))
+                .finally(() => setQuotaCredentialsLoaded(true))
+            })
+        }
         setApiKeyLoaded(true)
       }).catch((error) => {
         console.error('[模型配置表单] 解密 API Key 失败:', error)
@@ -290,6 +307,7 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
   }, [isEdit, channel, apiKeyLoaded])
 
   const isZhipuTeamProvider = provider === 'zhipu-coding-team'
+  const isOpenCodeGoProvider = provider === 'opencode-go-openai'
   const isCodexProvider = provider === 'openai-codex'
   const isXaiProvider = provider === 'xai'
   const isSubscriptionProvider = isCodexProvider || isXaiProvider
@@ -328,6 +346,8 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
     currentBaseUrl: string,
     currentApiKey: string,
     currentEnabled: boolean,
+    currentWorkspaceId?: string,
+    currentAuthCookie?: string,
   ) => {
     if (!isEdit || !channel) return
     try {
@@ -336,6 +356,8 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
         provider: currentProvider,
         baseUrl: currentBaseUrl,
         apiKey: currentApiKey || undefined,
+        workspaceId: isOpenCodeGoProvider ? currentWorkspaceId : undefined,
+        authCookie: isOpenCodeGoProvider ? currentAuthCookie : undefined,
         models: currentModels,
         enabled: currentEnabled,
       })
@@ -349,7 +371,7 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
       console.error('[模型配置表单] auto-save 失败:', error)
       toast.error('自动保存失败，请检查后手动重试', { id: 'auto-save-error' })
     }
-  }, [isEdit, channel, onAgentEligibilityChange])
+  }, [isEdit, channel, onAgentEligibilityChange, isOpenCodeGoProvider])
 
   /** 触发防抖 auto-save */
   const scheduleAutoSave = React.useCallback((
@@ -360,13 +382,17 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
     nextApiKey: string,
     nextEnabled: boolean,
     requiresRiskAcknowledgement: boolean,
+    nextWorkspaceId?: string,
+    nextAuthCookie?: string,
   ) => {
     if (!isEdit || !initializedRef.current || requiresRiskAcknowledgement) return
+    // 额度字段未回显完成时跳过，避免空值清空已存配置（'' 有清空语义）
+    if (isOpenCodeGoProvider && !quotaCredentialsLoaded) return
     if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current)
     autoSaveTimerRef.current = setTimeout(() => {
-      doAutoSave(nextModels, nextName, nextProvider, nextBaseUrl, nextApiKey, nextEnabled)
+      doAutoSave(nextModels, nextName, nextProvider, nextBaseUrl, nextApiKey, nextEnabled, nextWorkspaceId, nextAuthCookie)
     }, AUTO_SAVE_DELAY)
-  }, [isEdit, doAutoSave])
+  }, [isEdit, doAutoSave, isOpenCodeGoProvider, quotaCredentialsLoaded])
 
   // API Key 加载完成后标记初始化
   React.useEffect(() => {
@@ -390,9 +416,11 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
       effectiveApiKey,
       enabled,
       requiresBaseUrlRiskAcknowledgement,
+      openCodeGoWorkspaceId,
+      openCodeGoAuthCookie,
     )
     return () => { if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current) }
-  }, [models, name, provider, baseUrl, effectiveApiKey, enabled, requiresBaseUrlRiskAcknowledgement, scheduleAutoSave])
+  }, [models, name, provider, baseUrl, effectiveApiKey, enabled, requiresBaseUrlRiskAcknowledgement, scheduleAutoSave, openCodeGoWorkspaceId, openCodeGoAuthCookie])
 
   // 切换供应商时自动更新 Base URL 与名称，Anthropic 兼容渠道自动添加预设模型
   const handleProviderChange = (newProvider: string): void => {
@@ -415,6 +443,9 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
       setApiKey(zhipuTeamSecret.apiKey)
       setZhipuTeamSecret(EMPTY_ZHIPU_TEAM_SECRET)
     }
+    // 注意：不从 opencode 切走时清空 workspaceId/authCookie state。
+    // 这两个字段有「'' 清空」语义，切走时清空 state 会经 autosave 持久化删除已存凭证；
+    // 非 opencode provider 下 doAutoSave 会传 undefined 保留原值，state 残留无副作用。
     // 预设模型：首次切换到对应 provider 且无模型时自动填充
     if (models.length === 0) {
       if (p === 'deepseek') {
@@ -757,6 +788,8 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
         provider,
         baseUrl,
         apiKey: effectiveApiKey,
+        workspaceId: openCodeGoWorkspaceId,
+        authCookie: openCodeGoAuthCookie,
         models,
         enabled,
       }
@@ -773,7 +806,7 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
     } finally {
       setSaving(false)
     }
-  }, [name, provider, baseUrl, effectiveApiKey, hasRequiredSecret, models, enabled, onAgentEligibilityChange])
+  }, [name, provider, baseUrl, effectiveApiKey, hasRequiredSecret, models, enabled, onAgentEligibilityChange, openCodeGoWorkspaceId, openCodeGoAuthCookie])
 
   /** 显示第三方 Base URL 风险确认。 */
   const requestBaseUrlRiskAcknowledgement = (action: 'auto-save' | 'create' | 'fetch' | 'save-and-close' | 'test' | null): void => {
@@ -1097,6 +1130,69 @@ export function ChannelForm({ channel, onSaved, onAgentEligibilityChange, onCanc
                     智谱组织与项目管理
                   </a>
                   {' '}查看；不填写时使用 API Token 的默认组织与项目上下文查询。
+                </div>
+              </div>
+            ) : isOpenCodeGoProvider ? (
+              <div className="space-y-2">
+                <div className="relative">
+                  <Input
+                    type={showApiKey ? 'text' : 'password'}
+                    value={apiKey}
+                    onChange={(e) => setApiKey(e.target.value)}
+                    placeholder={getApiKeyPlaceholder(provider, isEdit)}
+                    required={!isEdit}
+                    className="pr-10"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowApiKey(!showApiKey)}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-muted-foreground hover:text-foreground transition-colors"
+                    tabIndex={-1}
+                    title={showApiKey ? '隐藏凭证' : '显示凭证'}
+                  >
+                    {showApiKey ? <EyeOff size={16} /> : <Eye size={16} />}
+                  </button>
+                </div>
+                <Input
+                  type="text"
+                  value={openCodeGoWorkspaceId}
+                  onChange={(e) => setOpenCodeGoWorkspaceId(e.target.value)}
+                  placeholder="Workspace ID（可选，额度显示用，控制台 URL 中形如 wrk_xxx）"
+                />
+                <div className="relative">
+                  <Input
+                    type={showAuthCookie ? 'text' : 'password'}
+                    value={openCodeGoAuthCookie}
+                    onChange={(e) => setOpenCodeGoAuthCookie(e.target.value)}
+                    placeholder="Cookie（可选，额度显示用，如 auth=...;oc_locale=...）"
+                    className="pr-10"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowAuthCookie(!showAuthCookie)}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-muted-foreground hover:text-foreground transition-colors"
+                    tabIndex={-1}
+                    title={showAuthCookie ? '隐藏凭证' : '显示凭证'}
+                  >
+                    {showAuthCookie ? <EyeOff size={16} /> : <Eye size={16} />}
+                  </button>
+                </div>
+                <div className="space-y-1 text-xs text-muted-foreground">
+                  <div>额度显示需填写以下两项（可留空，不影响对话功能）：</div>
+                  <div>
+                    · Workspace ID：登录{' '}
+                    <a
+                      className="text-primary hover:underline"
+                      href="https://opencode.ai"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      opencode.ai
+                    </a>
+                    {' '}后从控制台 URL 复制（形如 wrk_xxx）
+                  </div>
+                  <div>· Cookie：浏览器 F12 → Application → Cookies → opencode.ai，复制完整 Cookie 字符串（auth=...;oc_locale=...）</div>
+                  <div>Cookie 会随会话过期，过期后需更新；清空输入框可移除。</div>
                 </div>
               </div>
             ) : (

--- a/apps/electron/src/renderer/lib/channel-plan-quota.ts
+++ b/apps/electron/src/renderer/lib/channel-plan-quota.ts
@@ -4,6 +4,7 @@ const PLAN_QUOTA_PROVIDERS = new Set<ProviderType>([
   'deepseek',
   'kimi-coding',
   'minimax',
+  'opencode-go-openai',
   'zhipu',
   'zhipu-coding',
   'zhipu-coding-team',

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/shared",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "license": "AGPL-3.0-only",
   "description": "Shared types, configs and utilities for proma",
   "type": "module",

--- a/packages/shared/src/types/channel.ts
+++ b/packages/shared/src/types/channel.ts
@@ -310,6 +310,20 @@ export interface Channel {
   baseUrl: string
   /** 加密后的 API Key（base64 编码） */
   apiKey: string
+  /**
+   * OpenCode Go 订阅额度查询用 workspace ID（safeStorage 加密存储）。
+   *
+   * opencode.ai 控制台 URL 中形如 wrk_xxx；官方暂无额度查询 API，
+   * 只能抓取登录后的控制台页面，需配合 authCookie 使用。
+   */
+  workspaceId?: string
+  /**
+   * OpenCode Go 订阅额度查询用 auth cookie（safeStorage 加密存储）。
+   *
+   * 浏览器登录 opencode.ai 后从 DevTools → Application → Cookies 复制的完整 Cookie 字符串；
+   * 会话过期后需在渠道配置中更新。
+   */
+  authCookie?: string
   /** 可用模型列表 */
   models: ChannelModel[]
   /** 是否启用 */
@@ -329,6 +343,10 @@ export interface ChannelCreateInput {
   baseUrl: string
   /** 明文 API Key，主进程会加密后存储 */
   apiKey: string
+  /** 明文 OpenCode Go workspace ID，主进程会加密后存储（可选） */
+  workspaceId?: string
+  /** 明文 OpenCode Go auth cookie，主进程会加密后存储（可选） */
+  authCookie?: string
   models: ChannelModel[]
   enabled: boolean
 }
@@ -342,6 +360,10 @@ export interface ChannelUpdateInput {
   baseUrl?: string
   /** 明文 API Key，为空字符串表示不更新 */
   apiKey?: string
+  /** 明文 OpenCode Go workspace ID，undefined 保留原值，空字符串清空 */
+  workspaceId?: string
+  /** 明文 OpenCode Go auth cookie，undefined 保留原值，空字符串清空 */
+  authCookie?: string
   models?: ChannelModel[]
   enabled?: boolean
 }
@@ -478,6 +500,8 @@ export const CHANNEL_IPC_CHANNELS = {
   DELETE: 'channel:delete',
   /** 解密获取明文 API Key */
   DECRYPT_KEY: 'channel:decrypt-key',
+  /** 解密渠道可选敏感字段（如 OpenCode Go workspaceId / authCookie） */
+  DECRYPT_SECRET: 'channel:decrypt-secret',
   /** 测试渠道连接 */
   TEST: 'channel:test',
   /** 从供应商拉取可用模型列表 */


### PR DESCRIPTION
## 概述

OpenCode Go 是 Anomaly 的 $10/月订阅服务，额度按美元价值分三个滚动窗口（每 5 小时 $12 / 每周 $30 / 每月 $60）。官方目前未提供额度查询 API（anomalyco/opencode#10448 / #16017 均为 OPEN 的 feature request），用量只能通过登录后的 Web 控制台查看。

本 PR 为 `opencode-go-openai` 渠道适配订阅额度显示，复用既有 Plan 额度架构（Codex/Kimi/MiniMax/DeepSeek/智谱同款）：抓取控制台 `/go` 页面，从页面内嵌的 RPC 数据（`rollingUsage` / `weeklyUsage` / `monthlyUsage`，camelCase 字段不受界面 locale 影响）提取三窗口已用百分比与重置倒计时，在模型选择器的渠道徽章中展示（每 5 小时 / 每周 / 每月）。

## 改动

- `packages/shared/src/types/channel.ts`：Channel/CreateInput/UpdateInput 新增可选 `workspaceId`/`authCookie` 字段（safeStorage 加密存储，`undefined` 保留原值、`''` 显式清空）；新增 `DECRYPT_SECRET` IPC 通道常量；版本 0.1.49 → 0.1.50
- `apps/electron/src/main/lib/channel-manager.ts`：`createChannel`/`updateChannel` 加密存储新字段；新增 `decryptChannelSecret`（含运行时字段白名单校验）；新增 `queryOpenCodeGoPlanQuota` + `parseOpenCodeGoQuotaWindows`（解析 SolidStart SSR 内嵌的 RPC 用量数据，`status` 非 ok 时跳过该窗口）；`getChannelPlanQuota` 新增 `opencode-go-openai` 分支；Cookie 透传浏览器复制的完整字符串
- `apps/electron/src/main/ipc.ts`：注册 `DECRYPT_SECRET` handler
- `apps/electron/src/preload/index.ts`：暴露 `decryptChannelSecret`
- `apps/electron/src/renderer/lib/channel-plan-quota.ts`：`PLAN_QUOTA_PROVIDERS` 注册 `opencode-go-openai`
- `apps/electron/src/renderer/components/settings/ChannelForm.tsx`：opencode-go 渠道新增 Workspace ID / Cookie 输入（独立可见性 state、解密回显、回显完成前禁用 autosave 防竞态、切 provider 不清空凭证）

## 测试

- `bun run typecheck` 全包通过（6/6）
- 两轮独立 BDD 自审（collaboration 子会话）通过，修复 1 严重 + 5 中等发现
- **真实凭证端到端实测通过**（2026-08-06）：HTTP 200，三窗口正确解析——每 5 小时已用 24%（约 9 分钟后重置）/ 每周已用 9% / 每月已用 4%

## 紧急度

常规

## 备注

- Cookie 为浏览器会话凭证，会过期，过期后需在渠道配置中更新（清空输入框可移除）
- 解析依赖控制台页面的 RPC 数据结构，数据缺失或 `status` 非 ok 时该窗口跳过，不影响对话功能
- 参考：anomalyco/opencode#10448 / #16017（官方额度 API 请求，落地后可切换数据源）
