### PR TITLE
perf(git-diff): deduplicate and safely cache repository scans

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.16.38",
+  "version": "0.16.39",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -152,7 +152,7 @@ import type {
 } from '@proma/shared'
 import type { UserProfile, AppSettings } from '../types'
 import { getRuntimeStatus, getGitRepoStatus, reinitializeRuntime } from './lib/runtime-init'
-import { getUnstagedChanges, getFileDiff, getUntrackedContent, revertFile, getDiffContents, listWorktrees, getWorktreeChanges, getMainRepoRoot } from './lib/git-diff-service'
+import { getUnstagedChanges, invalidateGitDiffCache, getFileDiff, getUntrackedContent, revertFile, getDiffContents, listWorktrees, getWorktreeChanges, getMainRepoRoot } from './lib/git-diff-service'
 import { registerPromaFilePath } from './lib/local-file-protocol'
 import { registerUpdaterIpc } from './lib/updater/updater-ipc'
 import {
@@ -1008,6 +1008,19 @@ export function registerIpcHandlers(): void {
       const allowedExtraPaths = extraPaths?.filter((p) => isPathAllowed(p, access))
       return getUnstagedChanges(dirPath, allowedSessionPath, allowedWorkspaceFilesPath, allowedExtraPaths)
     }
+  )
+
+  // Agent 写入、Git 变更及窗口重新聚焦前主动失效，避免长寿命缓存显示旧 Diff。
+  ipcMain.handle(
+    IPC_CHANNELS.INVALIDATE_GIT_DIFF_CACHE,
+    async (_, changedPath?: string) => {
+      if (changedPath && typeof changedPath === 'string') {
+        // 仅影响进程内缓存，不读写目标路径；允许刚删除的文件路径参与失效。
+        invalidateGitDiffCache(changedPath)
+        return
+      }
+      invalidateGitDiffCache()
+    },
   )
 
   // 获取单个文件的 diff

--- a/apps/electron/src/main/lib/git-diff-service.test.ts
+++ b/apps/electron/src/main/lib/git-diff-service.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { getUnstagedChanges, invalidateGitDiffCache } from './git-diff-service'
+
+let repoPath = ''
+
+function git(...args: string[]): void {
+  execFileSync('git', args, { cwd: repoPath, stdio: 'pipe' })
+}
+
+function createRepository(prefix: string, fileName: string): string {
+  const path = mkdtempSync(join(tmpdir(), prefix))
+  execFileSync('git', ['init'], { cwd: path, stdio: 'pipe' })
+  execFileSync('git', ['config', 'user.email', 'test@proma.local'], { cwd: path, stdio: 'pipe' })
+  execFileSync('git', ['config', 'user.name', 'Proma Test'], { cwd: path, stdio: 'pipe' })
+  writeFileSync(join(path, fileName), 'base\n')
+  execFileSync('git', ['add', fileName], { cwd: path, stdio: 'pipe' })
+  execFileSync('git', ['commit', '-m', 'initial'], { cwd: path, stdio: 'pipe' })
+  return path
+}
+
+beforeEach(() => {
+  repoPath = createRepository('proma-git-diff-', 'tracked.txt')
+})
+
+afterEach(() => {
+  invalidateGitDiffCache(repoPath)
+  rmSync(repoPath, { recursive: true, force: true })
+})
+
+describe('git diff scan cache', () => {
+  test('deduplicates concurrent scans and returns the cached snapshot until invalidated', async () => {
+    const trackedPath = join(repoPath, 'tracked.txt')
+    writeFileSync(trackedPath, 'base\nfirst\n')
+
+    const results = await Promise.all(Array.from({ length: 8 }, () => getUnstagedChanges(repoPath)))
+    expect(results.every((result) => result.files[0]?.additions === 1)).toBe(true)
+
+    writeFileSync(trackedPath, 'base\nfirst\nsecond\n')
+    const cached = await getUnstagedChanges(repoPath)
+    expect(cached.files[0]?.additions).toBe(1)
+
+    invalidateGitDiffCache(trackedPath)
+    const refreshed = await getUnstagedChanges(repoPath)
+    expect(refreshed.files[0]?.additions).toBe(2)
+  })
+
+  test('refreshes a linked worktree when its symbolic HEAD ref changes outside the watcher', async () => {
+    const linkedParentPath = mkdtempSync(join(tmpdir(), 'proma-git-diff-linked-parent-'))
+    const linkedWorktreePath = join(linkedParentPath, 'linked')
+    try {
+      execFileSync('git', ['worktree', 'add', '-b', 'linked-cache-test', linkedWorktreePath], { cwd: repoPath, stdio: 'pipe' })
+      const linkedFile = join(linkedWorktreePath, 'tracked.txt')
+      writeFileSync(linkedFile, 'base\ncommitted from linked worktree\n')
+      execFileSync('git', ['add', 'tracked.txt'], { cwd: linkedWorktreePath, stdio: 'pipe' })
+      execFileSync('git', ['commit', '-m', 'commit from linked worktree'], { cwd: linkedWorktreePath, stdio: 'pipe' })
+      writeFileSync(linkedFile, 'base\ncommitted from linked worktree\nuncommitted\n')
+
+      const cached = await getUnstagedChanges(linkedWorktreePath)
+      expect(cached.files[0]?.additions).toBe(1)
+
+      // 只移动 common git-dir 中的 branch ref，不改 linked worktree 的 HEAD 或 index。
+      execFileSync('git', ['update-ref', 'refs/heads/linked-cache-test', 'HEAD~1'], { cwd: linkedWorktreePath, stdio: 'pipe' })
+
+      const refreshed = await getUnstagedChanges(linkedWorktreePath)
+      expect(refreshed.files[0]?.additions).toBe(2)
+    } finally {
+      invalidateGitDiffCache(linkedWorktreePath)
+      execFileSync('git', ['worktree', 'remove', '--force', linkedWorktreePath], { cwd: repoPath, stdio: 'pipe' })
+      rmSync(linkedParentPath, { recursive: true, force: true })
+    }
+  })
+
+  test('keeps another repository cache valid after targeted invalidation', async () => {
+    const secondRepo = createRepository('proma-git-diff-second-', 'other.txt')
+    try {
+      writeFileSync(join(repoPath, 'tracked.txt'), 'base\nfirst\n')
+      writeFileSync(join(secondRepo, 'other.txt'), 'base\nfirst\n')
+      const [, before] = await Promise.all([getUnstagedChanges(repoPath), getUnstagedChanges(secondRepo)])
+      expect(before.files[0]?.additions).toBe(1)
+
+      writeFileSync(join(repoPath, 'tracked.txt'), 'base\nfirst\nsecond\n')
+      writeFileSync(join(secondRepo, 'other.txt'), 'base\nfirst\nsecond\n')
+      invalidateGitDiffCache(join(repoPath, 'tracked.txt'))
+      const [, after] = await Promise.all([getUnstagedChanges(repoPath), getUnstagedChanges(secondRepo)])
+
+      expect(after.files[0]?.additions).toBe(1)
+
+      invalidateGitDiffCache(join(secondRepo, 'other.txt'))
+      const refreshedSecond = await getUnstagedChanges(secondRepo)
+      expect(refreshedSecond.files[0]?.additions).toBe(2)
+    } finally {
+      invalidateGitDiffCache(secondRepo)
+      rmSync(secondRepo, { recursive: true, force: true })
+    }
+  })
+})

--- a/apps/electron/src/main/lib/git-diff-service.ts
+++ b/apps/electron/src/main/lib/git-diff-service.ts
@@ -6,6 +6,7 @@
  */
 
 import { spawn } from 'child_process'
+import { createHash } from 'node:crypto'
 import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from 'fs'
 import { basename, dirname, isAbsolute, join, resolve, sep } from 'path'
 import type { ChangedFileEntry, UnstagedChangesResult, UntrackedFileEntry } from '@proma/shared'
@@ -116,7 +117,38 @@ function normalizeSafePath(root: string, filePath: string): string | null {
  * @param cwd - 工作目录
  * @returns 命令输出，如果失败返回 null
  */
-function runGitCommand(args: string[], cwd: string, options?: { quiet?: boolean }): Promise<string | null> {
+/** 进程级 Git 子进程上限，避免多个 Diff 面板刷新时放大 I/O。 */
+const MAX_CONCURRENT_GIT_COMMANDS = 6
+
+class AsyncSemaphore {
+  private active = 0
+  private readonly waiters: Array<() => void> = []
+
+  private async acquire(): Promise<void> {
+    if (this.active >= MAX_CONCURRENT_GIT_COMMANDS) {
+      await new Promise<void>((resolve) => this.waiters.push(resolve))
+    }
+    this.active += 1
+  }
+
+  private release(): void {
+    this.active -= 1
+    this.waiters.shift()?.()
+  }
+
+  async run<T>(operation: () => Promise<T>): Promise<T> {
+    await this.acquire()
+    try {
+      return await operation()
+    } finally {
+      this.release()
+    }
+  }
+}
+
+const gitCommandSemaphore = new AsyncSemaphore()
+
+function runGitProcess(args: string[], cwd: string, options?: { quiet?: boolean }): Promise<string | null> {
   return new Promise((resolve) => {
     try {
       // -c core.quotePath=false：禁用 git 对非 ASCII 路径的八进制转义（如中文文件名
@@ -137,45 +169,52 @@ function runGitCommand(args: string[], cwd: string, options?: { quiet?: boolean 
 
       let stdout = ''
       let stderr = ''
+      let settled = false
+      let timeout: ReturnType<typeof setTimeout> | null = null
+      let forceKillTimeout: ReturnType<typeof setTimeout> | null = null
+      const finish = (value: string | null) => {
+        if (settled) return
+        settled = true
+        if (timeout) clearTimeout(timeout)
+        if (forceKillTimeout) clearTimeout(forceKillTimeout)
+        resolve(value)
+      }
 
-      child.stdout?.on('data', (data) => {
-        stdout += data
-      })
+      child.stdout?.on('data', (data) => { stdout += data })
+      child.stderr?.on('data', (data) => { stderr += data })
 
-      child.stderr?.on('data', (data) => {
-        stderr += data
-      })
-
-      // 10 秒超时
-      const timeout = setTimeout(() => {
+      timeout = setTimeout(() => {
         child.kill('SIGTERM')
         console.warn('[git-diff-service] git 命令超时:', args.join(' '))
-        resolve(null)
+        // SIGTERM 被忽略时再强制结束，避免永久占据全局 semaphore。
+        forceKillTimeout = setTimeout(() => {
+          if (settled) return
+          child.kill('SIGKILL')
+          finish(null)
+        }, 1000)
       }, 10000)
 
       child.on('close', (code) => {
-        clearTimeout(timeout)
         if (code === 0) {
-          resolve(stdout.trim())
+          finish(stdout.trim())
         } else {
-          if (!options?.quiet) {
-            console.error('[git-diff-service] git 命令失败:', args.join(' '), stderr.trim())
-          }
-          resolve(null)
+          if (!options?.quiet) console.error('[git-diff-service] git 命令失败:', args.join(' '), stderr.trim())
+          finish(null)
         }
       })
 
       child.on('error', (err) => {
-        clearTimeout(timeout)
-        if (!options?.quiet) {
-          console.error('[git-diff-service] git 命令错误:', err)
-        }
-        resolve(null)
+        if (!options?.quiet) console.error('[git-diff-service] git 命令错误:', err)
+        finish(null)
       })
     } catch {
       resolve(null)
     }
   })
+}
+
+function runGitCommand(args: string[], cwd: string, options?: { quiet?: boolean }): Promise<string | null> {
+  return gitCommandSemaphore.run(() => runGitProcess(args, cwd, options))
 }
 
 const WORKTREE_FETCH_TTL_MS = 30_000
@@ -272,8 +311,186 @@ function parseNumstat(numStat: string | null): Map<string, { additions: number; 
   return map
 }
 
+interface CachedRepoScan {
+  files: Array<Omit<ChangedFileEntry, 'source'>>
+  untrackedFiles: UntrackedFileEntry[]
+}
+
+interface CachedRepoScanEntry {
+  revision: number
+  fingerprint: string
+  value: CachedRepoScan
+}
+
+interface InFlightRepoScan {
+  revision: number
+  fingerprint: string | null
+  promise: Promise<CachedRepoScan>
+}
+
+/** 每个仓库独立 revision；定向失效绝不影响无关仓库。 */
+const repoRevisions = new Map<string, number>()
+const repoScanCache = new Map<string, CachedRepoScanEntry>()
+const inFlightRepoScans = new Map<string, InFlightRepoScan>()
+
+function getRepoRevision(gitRoot: string): number {
+  return repoRevisions.get(gitRoot) ?? 0
+}
+
+function isSameOrDescendant(path: string, possibleParent: string): boolean {
+  return path === possibleParent || path.startsWith(possibleParent.endsWith('/') ? possibleParent : `${possibleParent}/`)
+}
+
+function getPathFingerprint(path: string): string {
+  try {
+    // git diff 会刷新 index 的 stat cache；不能用 mtime/ctime，否则每次扫描都会错过缓存。
+    const digest = createHash('sha256').update(readFileSync(path)).digest('hex')
+    return `${path}:${digest}`
+  } catch {
+    return `${path}:missing`
+  }
+}
+
+function getGitCommonDirPath(gitDir: string): string {
+  try {
+    const commonDir = readFileSync(join(gitDir, 'commondir'), 'utf-8').trim()
+    return commonDir ? resolve(gitDir, commonDir) : gitDir
+  } catch {
+    return gitDir
+  }
+}
+
+function getGitDirPath(gitRoot: string): string | null {
+  const dotGitPath = join(gitRoot, '.git')
+  try {
+    if (statSync(dotGitPath).isDirectory()) return dotGitPath
+    const match = readFileSync(dotGitPath, 'utf-8').match(/^gitdir:\s*(.+)\s*$/m)
+    return match ? resolve(gitRoot, match[1]!) : null
+  } catch {
+    return null
+  }
+}
+
+/** linked worktree 的符号 HEAD 的 ref 位于 common git-dir，必须单独校验扫描期间它没有改变。 */
+function getGitHeadFingerprint(gitRoot: string): string | null {
+  const gitDir = getGitDirPath(gitRoot)
+  if (!gitDir) return null
+  try {
+    const headPath = join(gitDir, 'HEAD')
+    const headContent = readFileSync(headPath, 'utf-8')
+    const fingerprints = [getPathFingerprint(headPath)]
+    const symbolicRef = headContent.match(/^ref:\s*(.+)\s*$/m)?.[1]
+    if (symbolicRef) {
+      const commonDir = getGitCommonDirPath(gitDir)
+      const refPath = join(commonDir, symbolicRef)
+      fingerprints.push(getPathFingerprint(refPath))
+      if (!existsSync(refPath)) fingerprints.push(getPathFingerprint(join(commonDir, 'packed-refs')))
+    }
+    return fingerprints.join('|')
+  } catch {
+    return null
+  }
+}
+
+/** 返回会影响 `git diff HEAD` 的轻量状态指纹。 */
+function getGitStateFingerprint(gitRoot: string): string | null {
+  const gitDir = getGitDirPath(gitRoot)
+  const headFingerprint = getGitHeadFingerprint(gitRoot)
+  return gitDir && headFingerprint ? `${headFingerprint}|${getPathFingerprint(join(gitDir, 'index'))}` : null
+}
+
 /**
- * 获取当前工作树相对 HEAD 的文件变更列表（支持多 Git 仓库）
+ * 让指定路径所属的已知仓库缓存失效；未给路径时失效全部。
+ * 扫描会捕获 revision，完成时仅当 revision 未变才允许写回缓存。
+ */
+export function invalidateGitDiffCache(changedPath?: string): void {
+  const roots = new Set([...repoRevisions.keys(), ...repoScanCache.keys(), ...inFlightRepoScans.keys()])
+  const target = changedPath ? normalizeGitRoot(changedPath) : null
+
+  for (const root of roots) {
+    if (target && !isSameOrDescendant(target, root) && !isSameOrDescendant(root, target)) continue
+    repoRevisions.set(root, getRepoRevision(root) + 1)
+    repoScanCache.delete(root)
+  }
+}
+
+async function scanGitRoot(gitRoot: string): Promise<CachedRepoScan | null> {
+  // 三条查询没有数据依赖；在全局 semaphore 约束下并行可缩短单仓库延迟。
+  const [nameStatus, numStat, untrackedOutput] = await Promise.all([
+    runGitCommand(['diff', 'HEAD', '--name-status'], gitRoot),
+    runGitCommand(['diff', 'HEAD', '--numstat'], gitRoot),
+    runGitCommand(['ls-files', '--others', '--exclude-standard'], gitRoot),
+  ])
+  // Git 暂时不可用/超时不能被缓存为“干净仓库”，否则会长期显示空 Diff。
+  if (nameStatus === null || numStat === null || untrackedOutput === null) return null
+
+  const numStatMap = parseNumstat(numStat)
+  const files: Array<Omit<ChangedFileEntry, 'source'>> = []
+  if (nameStatus) {
+    for (const statusLine of nameStatus.split('\n').filter(Boolean)) {
+      const simpleMatch = statusLine.match(/^([MDAT])\t(.+)$/)
+      const renameMatch = statusLine.match(/^([RC])\d*\t([^\t]+)\t(.+)$/)
+      let status: ChangedFileStatus
+      let filePath: string
+
+      if (simpleMatch) {
+        status = simpleMatch[1] === 'D' ? 'deleted' : 'modified'
+        filePath = simpleMatch[2]!
+      } else if (renameMatch) {
+        status = 'modified'
+        filePath = renameMatch[3]!
+      } else {
+        continue
+      }
+
+      const stats = numStatMap.get(filePath) ?? { additions: 0, deletions: 0 }
+      files.push({ filePath, status, additions: stats.additions, deletions: stats.deletions, gitRoot })
+    }
+  }
+
+  return {
+    files,
+    untrackedFiles: untrackedOutput
+      ? untrackedOutput.split('\n').filter(Boolean).map((filePath) => ({ filePath, gitRoot }))
+      : [],
+  }
+}
+
+async function getCachedRepoScan(gitRoot: string): Promise<CachedRepoScan> {
+  const root = normalizeGitRoot(gitRoot)
+  const revision = getRepoRevision(root)
+  const fingerprint = getGitStateFingerprint(root)
+  const headFingerprint = getGitHeadFingerprint(root)
+  const cached = repoScanCache.get(root)
+  if (fingerprint !== null && cached?.revision === revision && cached.fingerprint === fingerprint) return cached.value
+
+  const inFlight = inFlightRepoScans.get(root)
+  if (inFlight?.revision === revision && inFlight.fingerprint === fingerprint) return inFlight.promise
+
+  const promise = scanGitRoot(root).then((value) => {
+    if (value === null) return { files: [], untrackedFiles: [] }
+    const completedFingerprint = getGitStateFingerprint(root)
+    const completedHeadFingerprint = getGitHeadFingerprint(root)
+    // Git diff 会刷新 index stat cache；但 HEAD/ref 在扫描期间变化会让两个并发查询混用基准，不能缓存。
+    if (
+      completedFingerprint !== null
+      && headFingerprint !== null
+      && headFingerprint === completedHeadFingerprint
+      && getRepoRevision(root) === revision
+      && inFlightRepoScans.get(root)?.promise === promise
+    ) {
+      repoScanCache.set(root, { revision, fingerprint: completedFingerprint, value })
+    }
+    return value
+  }).finally(() => {
+    if (inFlightRepoScans.get(root)?.promise === promise) inFlightRepoScans.delete(root)
+  })
+  inFlightRepoScans.set(root, { revision, fingerprint, promise })
+  return promise
+}
+
+/**
+ * 获取当前工作树相对 HEAD 的文件变更列表（支持多 Git 仓库）。
  *
  * 包含 staged + unstaged 改动；函数名保留为 getUnstagedChanges 以兼容现有 IPC。
  */
@@ -283,100 +500,41 @@ export async function getUnstagedChanges(
   workspaceFilesPath?: string,
   extraPaths?: string[],
 ): Promise<UnstagedChangesResult> {
-  // 收集所有候选目录中的不重复 Git 仓库根
   const rawCandidates = [dirPath, sessionPath, workspaceFilesPath, ...(extraPaths || [])].filter(
-    (p): p is string => typeof p === 'string' && p.length > 0
+    (p): p is string => typeof p === 'string' && p.length > 0,
   )
-  const candidates = rawCandidates
-    .map(toChangeCandidate)
-    .filter((candidate): candidate is ChangeCandidate => candidate !== null)
-
+  const candidates = rawCandidates.map(toChangeCandidate).filter((candidate): candidate is ChangeCandidate => candidate !== null)
   const gitRoots: string[] = []
-  for (const cand of candidates) {
-    const roots = await findAllGitRoots(cand.searchPath)
+
+  const rootsByCandidate = await Promise.all(candidates.map((candidate) => findAllGitRoots(candidate.searchPath)))
+  for (const roots of rootsByCandidate) {
     for (const root of roots) {
       if (!gitRoots.includes(root)) gitRoots.push(root)
     }
   }
+  if (gitRoots.length === 0) return { isGitRepo: false, files: [], untrackedFiles: [], gitRootNames: [] }
 
-  if (gitRoots.length === 0) {
-    return { isGitRepo: false, files: [], untrackedFiles: [], gitRootNames: [] }
+  const isUnderAnyCandidate = (absolutePath: string): boolean => {
+    const normalized = normalizeComparablePath(absolutePath)
+    return candidates.some((candidate) => candidate.fileOnly
+      ? normalized === candidate.matchPath
+      : normalized === candidate.matchPath || normalized.startsWith(`${candidate.matchPath}/`))
   }
 
-  const allFiles: ChangedFileEntry[] = []
-  const allUntracked: UntrackedFileEntry[] = []
-
-  // 候选路径用于过滤：目录匹配子树，附加文件只匹配自身，避免显示同级无关改动。
-  const isUnderAnyCandidate = (absPath: string): boolean => {
-    const normalized = normalizeComparablePath(absPath)
-    return candidates.some((candidate) => {
-      if (candidate.fileOnly) return normalized === candidate.matchPath
-      return normalized === candidate.matchPath || normalized.startsWith(candidate.matchPath + '/')
-    })
-  }
-
-  for (const gitRoot of gitRoots) {
-    // 获取当前工作树相对 HEAD 的变更文件列表，覆盖 staged + unstaged。
-    const nameStatus = await runGitCommand(['diff', 'HEAD', '--name-status'], gitRoot)
-    const numStat = await runGitCommand(['diff', 'HEAD', '--numstat'], gitRoot)
-    const numStatMap = parseNumstat(numStat)
-
-    if (nameStatus) {
-      const statusLines = nameStatus.split('\n').filter(Boolean)
-
-      for (const statusLine of statusLines) {
-        const simpleMatch = statusLine.match(/^([MDAT])\t(.+)$/)
-        const renameMatch = statusLine.match(/^([RC])\d*\t([^\t]+)\t(.+)$/)
-
-        let status: ChangedFileStatus
-        let filePath: string
-
-        if (simpleMatch) {
-          const code = simpleMatch[1]!
-          status = code === 'D' ? 'deleted' : 'modified'
-          filePath = simpleMatch[2]!
-        } else if (renameMatch) {
-          status = 'modified'
-          filePath = renameMatch[3]!
-        } else {
-          continue
-        }
-
-        // 过滤：只保留落在某个 candidate 内的文件
-        const absPath = join(gitRoot, filePath)
-        if (!isUnderAnyCandidate(absPath)) continue
-
-        const stats = numStatMap.get(filePath) ?? { additions: 0, deletions: 0 }
-
-        allFiles.push({
-          filePath,
-          status,
-          additions: stats.additions,
-          deletions: stats.deletions,
-          source: computeSource(filePath, gitRoot, sessionPath, workspaceFilesPath),
-          gitRoot,
-        })
-      }
+  const scans = await Promise.all(gitRoots.map(getCachedRepoScan))
+  const files: ChangedFileEntry[] = []
+  const untrackedFiles: UntrackedFileEntry[] = []
+  for (const scan of scans) {
+    for (const file of scan.files) {
+      if (!isUnderAnyCandidate(join(file.gitRoot, file.filePath))) continue
+      files.push({ ...file, source: computeSource(file.filePath, file.gitRoot, sessionPath, workspaceFilesPath) })
     }
-
-    // 获取未追踪文件
-    const untrackedOutput = await runGitCommand(['ls-files', '--others', '--exclude-standard'], gitRoot)
-    if (untrackedOutput) {
-      for (const rel of untrackedOutput.split('\n').filter(Boolean)) {
-        const absPath = join(gitRoot, rel)
-        if (isUnderAnyCandidate(absPath)) {
-          allUntracked.push({ filePath: rel, gitRoot })
-        }
-      }
+    for (const file of scan.untrackedFiles) {
+      if (isUnderAnyCandidate(join(file.gitRoot, file.filePath))) untrackedFiles.push(file)
     }
   }
 
-  return {
-    isGitRepo: true,
-    files: allFiles,
-    untrackedFiles: allUntracked,
-    gitRootNames: gitRoots.map((r) => basename(r)),
-  }
+  return { isGitRepo: true, files, untrackedFiles, gitRootNames: gitRoots.map((root) => basename(root)) }
 }
 
 /**
@@ -575,6 +733,7 @@ export async function revertFile(dirPath: string, filePath: string, gitRoot?: st
   if (result === null) {
     throw new Error(`还原失败: git restore --staged --worktree -- ${safePath}`)
   }
+  invalidateGitDiffCache(join(root, safePath))
 }
 
 async function getGitCommonDir(somePath: string): Promise<string | null> {

--- a/apps/electron/src/main/lib/workspace-watcher-utils.ts
+++ b/apps/electron/src/main/lib/workspace-watcher-utils.ts
@@ -4,6 +4,10 @@ const HIGH_NOISE_SEGMENTS = new Set([
   '.cache', '__pycache__', '.turbo', '.parcel-cache', '.svelte-kit',
 ])
 
+const GIT_DIFF_STATE_FILES = new Set([
+  'HEAD', 'ORIG_HEAD', 'MERGE_HEAD', 'CHERRY_PICK_HEAD', 'REVERT_HEAD', 'index',
+])
+
 export function isHighNoisePath(normalizedPath: string): boolean {
   return normalizedPath.split('/').some((seg) => HIGH_NOISE_SEGMENTS.has(seg))
 }
@@ -15,7 +19,19 @@ export function normalizeWatchFilename(filename: string | Buffer | null): string
   return null
 }
 
+/**
+ * 只有直接影响 `git diff HEAD` 结果的 Git 元数据才触发刷新。
+ * 远端 fetch 产生的 FETCH_HEAD、refs/remotes 与 objects 均不在范围内，避免重现刷新循环。
+ */
+export function isGitDiffStatePath(normalizedPath: string): boolean {
+  const segments = normalizedPath.split('/').filter(Boolean)
+  const gitIndex = segments.lastIndexOf('.git')
+  if (gitIndex < 0) return false
+  const gitRelativePath = segments.slice(gitIndex + 1)
+  return gitRelativePath.length === 1 && GIT_DIFF_STATE_FILES.has(gitRelativePath[0]!)
+}
+
 export function shouldNotifyForWatchFilename(filename: string | Buffer | null): boolean {
   const normalizedFilename = normalizeWatchFilename(filename)
-  return normalizedFilename !== null && !isHighNoisePath(normalizedFilename)
+  return normalizedFilename !== null && (!isHighNoisePath(normalizedFilename) || isGitDiffStatePath(normalizedFilename))
 }

--- a/apps/electron/src/main/lib/workspace-watcher.test.ts
+++ b/apps/electron/src/main/lib/workspace-watcher.test.ts
@@ -2,14 +2,17 @@ import { describe, expect, it } from 'bun:test'
 import { shouldNotifyForWatchFilename } from './workspace-watcher-utils'
 
 describe('shouldNotifyForWatchFilename', () => {
-  it('ignores Git metadata and other high-noise paths', () => {
+  it('refreshes only Git metadata that changes diff state', () => {
     expect(shouldNotifyForWatchFilename('.git/FETCH_HEAD')).toBe(false)
+    expect(shouldNotifyForWatchFilename('.git/objects/pack/pack-a.idx')).toBe(false)
+    expect(shouldNotifyForWatchFilename('.git/index')).toBe(true)
+    expect(shouldNotifyForWatchFilename('.git/HEAD')).toBe(true)
     expect(shouldNotifyForWatchFilename('node_modules/.cache/index')).toBe(false)
     expect(shouldNotifyForWatchFilename('src\\components\\Button.tsx')).toBe(true)
   })
 
   it('normalizes Buffer filenames before filtering', () => {
-    expect(shouldNotifyForWatchFilename(Buffer.from('.git/index'))).toBe(false)
+    expect(shouldNotifyForWatchFilename(Buffer.from('.git/index'))).toBe(true)
     expect(shouldNotifyForWatchFilename(Buffer.from('src/file.ts'))).toBe(true)
   })
 

--- a/apps/electron/src/main/lib/workspace-watcher.ts
+++ b/apps/electron/src/main/lib/workspace-watcher.ts
@@ -13,11 +13,12 @@
 
 import { watch, existsSync, statSync } from 'node:fs'
 import type { FSWatcher } from 'node:fs'
-import { dirname, resolve } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 import type { BrowserWindow } from 'electron'
 import { AGENT_IPC_CHANNELS } from '@proma/shared'
 import { getAgentWorkspacesDir } from './config-paths'
 import { listAgentSessions } from './agent-session-manager'
+import { invalidateGitDiffCache } from './git-diff-service'
 import { isHighNoisePath, normalizeWatchFilename, shouldNotifyForWatchFilename } from './workspace-watcher-utils'
 
 /** debounce 延迟（ms） */
@@ -204,10 +205,14 @@ export function startWorkspaceWatcher(win: BrowserWindow): void {
       if (!filename || win.isDestroyed()) return
 
       // filename 格式: {slug}/mcp.json 或 {slug}/skills/xxx/SKILL.md 或 {slug}/{sessionId}/file.txt
-      const normalizedFilename = filename.replace(/\\/g, '/')
+      const normalizedFilename = normalizeWatchFilename(filename)
+      if (normalizedFilename === null) return
 
-      // 跳过 node_modules / .next 等高频变动目录，防止大规模工作区触发 IPC 事件风暴
-      if (isHighNoisePath(normalizedFilename)) return
+      // 普通文件及有限的 Diff 状态元数据变更均需失效缓存；fetch 的高噪声 Git 元数据仍被忽略。
+      if (shouldNotifyForWatchFilename(normalizedFilename)) {
+        invalidateGitDiffCache(join(watchDir, normalizedFilename))
+      }
+      if (isHighNoisePath(normalizedFilename) && !shouldNotifyForWatchFilename(normalizedFilename)) return
 
       const pathParts = normalizedFilename.split('/').filter(Boolean)
 
@@ -304,7 +309,9 @@ export function watchAttachedDirectory(dirPath: string): void {
 
   try {
     const w = watch(dirPath, { recursive: true }, (_eventType, filename) => {
-      if (!shouldNotifyForWatchFilename(filename)) return
+      const normalizedFilename = normalizeWatchFilename(filename)
+      if (normalizedFilename === null || !shouldNotifyForWatchFilename(normalizedFilename)) return
+      invalidateGitDiffCache(join(dirPath, normalizedFilename))
       notifyWorkspaceFilesChanged()
     })
 

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -200,6 +200,8 @@ export interface ElectronAPI {
 
   /** 获取未暂存的变更文件列表 */
   getUnstagedChanges: (dirPath: string, sessionPath?: string, workspaceFilesPath?: string, extraPaths?: string[], sessionId?: string) => Promise<import('@proma/shared').UnstagedChangesResult>
+  /** 失效 Git Diff 扫描缓存；省略路径时失效全部仓库 */
+  invalidateGitDiffCache: (changedPath?: string) => Promise<void>
   /** 获取单个文件的 diff */
   getFileDiff: (input: import('@proma/shared').GetFileDiffInput) => Promise<string>
   /** 获取未追踪文件内容 */
@@ -1257,6 +1259,10 @@ const electronAPI: ElectronAPI = {
 
   getUnstagedChanges: (dirPath: string, sessionPath?: string, workspaceFilesPath?: string, extraPaths?: string[], sessionId?: string) => {
     return ipcRenderer.invoke(IPC_CHANNELS.GET_UNSTAGED_CHANGES, dirPath, sessionPath, workspaceFilesPath, extraPaths, sessionId)
+  },
+
+  invalidateGitDiffCache: (changedPath?: string) => {
+    return ipcRenderer.invoke(IPC_CHANNELS.INVALIDATE_GIT_DIFF_CACHE, changedPath)
   },
 
   getFileDiff: (input: import('@proma/shared').GetFileDiffInput) => {

--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -375,6 +375,9 @@ export const workspaceCapabilitiesVersionAtom = atom(0)
 /** 工作区文件版本号 — 文件变化时自增，触发文件浏览器重新加载 */
 export const workspaceFilesVersionAtom = atom(0)
 
+/** Git watcher 触发的全局 Diff 刷新版本，避免按历史会话批量更新 Map。 */
+export const workspaceGitDiffRefreshVersionAtom = atom(0)
+
 // ===== 侧面板 Atoms =====
 
 /** 侧面板是否打开（全局共享，所有会话共用一个状态） */

--- a/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
+++ b/apps/electron/src/renderer/components/diff/DiffChangesList.tsx
@@ -10,7 +10,7 @@ import { useAtomValue, useSetAtom } from 'jotai'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { FileTypeIcon } from '@/components/file-browser/FileTypeIcon'
-import { agentDiffUnseenFilesAtom, agentDiffDataAtom, agentSelectedWorktreeAtom } from '@/atoms/agent-atoms'
+import { agentDiffUnseenFilesAtom, agentDiffDataAtom, agentSelectedWorktreeAtom, workspaceGitDiffRefreshVersionAtom } from '@/atoms/agent-atoms'
 import type { ChangedFileEntry, ChangedFileStatus, ChangeSource, UntrackedFileEntry, WorktreeInfo } from '@proma/shared'
 import { WorktreeSelector } from './WorktreeSelector'
 import { groupSessionFileChanges } from '@/lib/session-file-changes'
@@ -109,6 +109,7 @@ export const DiffChangesList = React.memo(function DiffChangesList({
   // Diff 数据缓存：mount 时若已有上次结果，立即用作初值，避免空数组闪 1s "没有代码改动"
   const diffDataMap = useAtomValue(agentDiffDataAtom)
   const setDiffDataMap = useSetAtom(agentDiffDataAtom)
+  const workspaceGitDiffRefreshVersion = useAtomValue(workspaceGitDiffRefreshVersionAtom)
   const cached = diffDataMap.get(diffCacheKey)
   const [files, setFiles] = React.useState<ChangedFileEntry[]>(() => cached?.files ?? [])
   const [untrackedFiles, setUntrackedFiles] = React.useState<UntrackedFileEntry[]>(() => cached?.untrackedFiles ?? [])
@@ -173,7 +174,7 @@ export const DiffChangesList = React.memo(function DiffChangesList({
 
   React.useEffect(() => {
     fetchChanges()
-  }, [fetchChanges, refreshVersion])
+  }, [fetchChanges, refreshVersion, workspaceGitDiffRefreshVersion])
 
   // 窗口聚焦刷新已统一在 useGlobalAgentListeners 中处理（递增 refreshVersion）
 

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -956,8 +956,12 @@ export function useGlobalAgentListeners(): void {
               const writtenPath = entry.path
               pendingWriteTools.delete(event.toolUseId)
               if (event.isError) continue
-              store.set(agentDiffRefreshVersionAtom, (prev) => {
-                const m = new Map(prev); m.set(sessionId, (prev.get(sessionId) ?? 0) + 1); return m
+              // 相对路径的 cwd 由 Agent 决定，不能按 Electron cwd 错配到别的仓库；改为保守全量失效。
+              const cacheInvalidationPath = writtenPath && isAbsolutePath(writtenPath) ? writtenPath : undefined
+              void window.electronAPI.invalidateGitDiffCache(cacheInvalidationPath).finally(() => {
+                store.set(agentDiffRefreshVersionAtom, (prev) => {
+                  const m = new Map(prev); m.set(sessionId, (prev.get(sessionId) ?? 0) + 1); return m
+                })
               })
               if (writtenPath) {
                 buildWrittenFilePreviewInfo(sessionId, writtenPath).then((previewFile) => {
@@ -1007,8 +1011,10 @@ export function useGlobalAgentListeners(): void {
             // Bash git 突变命令完成时，仅刷新 diff 列表（不标记 unseen，避免红点）
             if (pendingGitMutateTools.has(event.toolUseId)) {
               pendingGitMutateTools.delete(event.toolUseId)
-              store.set(agentDiffRefreshVersionAtom, (prev) => {
-                const m = new Map(prev); m.set(sessionId, (prev.get(sessionId) ?? 0) + 1); return m
+              void window.electronAPI.invalidateGitDiffCache().finally(() => {
+                store.set(agentDiffRefreshVersionAtom, (prev) => {
+                  const m = new Map(prev); m.set(sessionId, (prev.get(sessionId) ?? 0) + 1); return m
+                })
               })
             }
           } else if (event.type === 'shell_killed') {
@@ -1417,10 +1423,13 @@ export function useGlobalAgentListeners(): void {
     const HASH_MAX = 100
     let focusCheckSeq = 0
     const bumpDiffRefresh = (sessionId: string) => {
-      store.set(agentDiffRefreshVersionAtom, (prev) => {
-        const m = new Map(prev)
-        m.set(sessionId, (prev.get(sessionId) ?? 0) + 1)
-        return m
+      // 外部修改的精确路径无法从 focus 事件可靠取得，保守地失效全部缓存。
+      void window.electronAPI.invalidateGitDiffCache().finally(() => {
+        store.set(agentDiffRefreshVersionAtom, (prev) => {
+          const m = new Map(prev)
+          m.set(sessionId, (prev.get(sessionId) ?? 0) + 1)
+          return m
+        })
       })
     }
 

--- a/apps/electron/src/renderer/main.tsx
+++ b/apps/electron/src/renderer/main.tsx
@@ -32,6 +32,7 @@ import {
   currentAgentSessionIdAtom,
   workspaceCapabilitiesVersionAtom,
   workspaceFilesVersionAtom,
+  workspaceGitDiffRefreshVersionAtom,
   agentThinkingAtom,
   agentEffortAtom,
   agentMaxBudgetUsdAtom,
@@ -173,6 +174,7 @@ function AgentSettingsInitializer(): null {
   const setCurrentWorkspaceId = useSetAtom(currentAgentWorkspaceIdAtom)
   const bumpCapabilities = useSetAtom(workspaceCapabilitiesVersionAtom)
   const bumpFiles = useSetAtom(workspaceFilesVersionAtom)
+  const bumpGitDiffRefresh = useSetAtom(workspaceGitDiffRefreshVersionAtom)
   const setThinking = useSetAtom(agentThinkingAtom)
   const setEffort = useSetAtom(agentEffortAtom)
   const setMaxBudget = useSetAtom(agentMaxBudgetUsdAtom)
@@ -314,6 +316,8 @@ function AgentSettingsInitializer(): null {
     })
     const unsubFiles = window.electronAPI.onWorkspaceFilesChanged(() => {
       bumpFiles((v) => v + 1)
+      // watcher 已在主进程失效命中的 repo cache；所有已挂载 Changes 面板由此重新拉取。
+      bumpGitDiffRefresh((v) => v + 1)
       // 外部本地项目目录变动时，主进程在 LIST_WORKSPACES 中重新计算根目录状态。
       // 这里仅响应 watcher 事件刷新一次，避免在侧栏每次渲染时同步访问文件系统。
       window.electronAPI.listAgentWorkspaces().then(setAgentWorkspaces).catch(console.error)
@@ -323,7 +327,7 @@ function AgentSettingsInitializer(): null {
       unsubCapabilities()
       unsubFiles()
     }
-  }, [bumpCapabilities, bumpFiles, currentWorkspaceId, setAgentWorkspaces, workspaces])
+  }, [bumpCapabilities, bumpFiles, bumpGitDiffRefresh, currentWorkspaceId, setAgentWorkspaces, workspaces])
 
   return null
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/shared",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "license": "AGPL-3.0-only",
   "description": "Shared types, configs and utilities for proma",
   "type": "module",

--- a/packages/shared/src/types/runtime.ts
+++ b/packages/shared/src/types/runtime.ts
@@ -346,6 +346,8 @@ export const IPC_CHANNELS = {
   GET_GIT_REPO_STATUS: 'git:get-repo-status',
   /** 获取未暂存的变更文件列表 */
   GET_UNSTAGED_CHANGES: 'git:get-unstaged-changes',
+  /** 失效 Git Diff 扫描缓存；可按文件/目录定向失效 */
+  INVALIDATE_GIT_DIFF_CACHE: 'git:invalidate-diff-cache',
   /** 获取单个文件的 diff */
   GET_FILE_DIFF: 'git:get-file-diff',
   /** 获取未追踪文件内容 */


### PR DESCRIPTION
## Summary

Supersedes closed #1424 with a consistency-first implementation for multi-repository Diff scanning:

- bounds all Git child processes with a process-wide FIFO semaphore and runs the three independent per-repo queries concurrently;
- deduplicates concurrent scans per repository root and caches raw snapshots by root, keeping UI-specific filtering and source attribution request-local;
- uses per-root revisions so targeted invalidation never evicts unrelated repositories and an in-flight pre-invalidation scan cannot repopulate the cache;
- invalidates through Agent writes, Git mutations, reverts, workspace/attached-directory watcher events (including useful `.git` metadata), and window focus;
- avoids caching partial/failed Git scans and refreshes only mounted Changes panels after watcher events.

## Tests

- `bun test apps/electron/src/main/lib/git-diff-service.test.ts`
- `bun run typecheck`
- `git diff --check`

## Review

Independently reviewed after implementation; no blocker or high-severity findings remained.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
