### PR TITLE
fix(agent): prevent cursor jumps in long drafts

### DIFF
--- a/apps/electron/src/renderer/atoms/agent-atoms.ts
+++ b/apps/electron/src/renderer/atoms/agent-atoms.ts
@@ -1184,6 +1184,14 @@ export const currentAgentErrorAtom = atom<string | null>((get) => {
  */
 export const agentSessionDraftsAtom = atom<Map<string, string>>(new Map())
 
+/** 明确外部草稿写入的版本号；RichTextInput 用它区分本地回写与强制覆盖。 */
+export const agentSessionDraftSyncVersionsAtom = atom<Map<string, number>>(new Map())
+
+/** 单个 session 的外部草稿同步版本派生 atom。 */
+export const agentSessionDraftSyncVersionAtomFamily = atomFamily((sessionId: string) =>
+  atom((get) => get(agentSessionDraftSyncVersionsAtom).get(sessionId) ?? 0),
+)
+
 /** 单个 session 的 markdown 草稿派生 atom — 按 sessionId 切片订阅 */
 export const agentSessionDraftAtomFamily = atomFamily((sessionId: string) =>
   atom((get) => get(agentSessionDraftsAtom).get(sessionId) ?? ''),

--- a/apps/electron/src/renderer/atoms/chat-atoms.ts
+++ b/apps/electron/src/renderer/atoms/chat-atoms.ts
@@ -6,7 +6,7 @@
  */
 
 import { atom } from 'jotai'
-import { atomWithStorage } from 'jotai/utils'
+import { atomFamily, atomWithStorage } from 'jotai/utils'
 import type { ConversationMeta, ChatMessage, FileAttachment, ChatToolActivity, Channel } from '@proma/shared'
 
 /** 全局渠道列表缓存（启动时加载一次，设置变更时刷新） */
@@ -195,6 +195,14 @@ export const currentChatErrorAtom = atom<string | null>((get) => {
  * 用于在切换对话时保留输入框内容
  */
 export const conversationDraftsAtom = atom<Map<string, string>>(new Map())
+
+/** 明确外部草稿写入的版本号；RichTextInput 用它区分本地回写与强制覆盖。 */
+export const conversationDraftSyncVersionsAtom = atom<Map<string, number>>(new Map())
+
+/** 单个对话的外部草稿同步版本派生 atom。 */
+export const conversationDraftSyncVersionAtomFamily = atomFamily((conversationId: string) =>
+  atom((get) => get(conversationDraftSyncVersionsAtom).get(conversationId) ?? 0),
+)
 
 /** 当前对话的草稿内容（派生读写原子） */
 export const currentConversationDraftAtom = atom(

--- a/apps/electron/src/renderer/components/agent/AgentView.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentView.tsx
@@ -79,6 +79,8 @@ import {
   agentWorkspacesAtom,
   agentStreamErrorsAtom,
   agentSessionDraftsAtom,
+  agentSessionDraftSyncVersionsAtom,
+  agentSessionDraftSyncVersionAtomFamily,
   agentSessionDraftAtomFamily,
   agentSessionDraftHtmlAtom,
   agentSessionDraftHtmlAtomFamily,
@@ -656,8 +658,10 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
   // 按 sessionId 切片订阅 drafts/draftHtml：仅本 session 草稿变化才让 AgentView 重渲染。
   // 输入框每次按键都会写整 Map atom，若直接订阅整 Map，AgentView 跟着每键重渲染。
   const inputContent = useAtomValue(agentSessionDraftAtomFamily(sessionId))
+  const draftSyncVersion = useAtomValue(agentSessionDraftSyncVersionAtomFamily(sessionId))
   const setDraftsMap = useSetAtom(agentSessionDraftsAtom)
-  const setInputContent = React.useCallback((value: string) => {
+  const setDraftSyncVersions = useSetAtom(agentSessionDraftSyncVersionsAtom)
+  const setInputContentFromEditor = React.useCallback((value: string) => {
     setDraftsMap((prev) => {
       const map = new Map(prev)
       if (value.trim() === '') {
@@ -668,6 +672,15 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
       return map
     })
   }, [sessionId, setDraftsMap])
+  // 仅非编辑器自身的写入才要求 RichTextInput 用受控内容覆盖文档。
+  const setInputContent = React.useCallback((value: string) => {
+    setDraftSyncVersions((prev) => {
+      const map = new Map(prev)
+      map.set(sessionId, (map.get(sessionId) ?? 0) + 1)
+      return map
+    })
+    setInputContentFromEditor(value)
+  }, [sessionId, setDraftSyncVersions, setInputContentFromEditor])
   const inputHtmlContent = useAtomValue(agentSessionDraftHtmlAtomFamily(sessionId))
   const setDraftHtmlMap = useSetAtom(agentSessionDraftHtmlAtom)
   const setInputHtmlContent = React.useCallback((html: string) => {
@@ -3228,7 +3241,7 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
             <RichTextInput
               ref={richTextInputRef}
               value={inputContent}
-              onChange={setInputContent}
+              onChange={setInputContentFromEditor}
               onSubmit={handleSend}
               onPasteFiles={handlePasteFiles}
               onPasteLongText={handlePasteLongText}
@@ -3245,6 +3258,8 @@ export function AgentView({ sessionId }: { sessionId: string }): React.ReactElem
               }
               disabled={!agentChannelId || !hasAvailableModel}
               autoFocusTrigger={sessionId}
+              draftScopeKey={sessionId}
+              draftSyncVersion={draftSyncVersion}
               collapsible
               enableMentions
               workspacePath={sessionPath}

--- a/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
+++ b/apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx
@@ -31,6 +31,7 @@ import { lowlight } from '@/lib/lowlight'
 import { htmlToMarkdown } from '@/lib/markdown-rich-text'
 import { useOpenPreview } from '@/components/diff/preview-opener'
 import { isImageFilePath } from './file-path-chip'
+import { consumeLocalDraftEcho, recordLocalDraftEcho } from '@/lib/input-draft-echo'
 import { resolveMentionSuggestionChar } from './mention-utils'
 import { richTextRenderingEnabledAtom } from '@/atoms/ui-preferences'
 import { createFileMentionSuggestion } from '@/components/file-browser/file-mention-suggestion'
@@ -146,6 +147,10 @@ interface RichTextInputProps {
   workspaceSlug?: string | null
   /** 当前 Agent 会话 ID（用于 & 会话引用中排除自身） */
   sessionId?: string | null
+  /** 草稿所属范围；切换范围时强制同步，避免跨会话误认本地回写。 */
+  draftScopeKey?: string | null
+  /** 调用方明确要求用受控值覆盖编辑器时递增；普通本地 echo 不应递增。 */
+  draftSyncVersion?: number
   /** 附加目录路径列表（工作区级，@ 引用时标记为工作区文件） */
   attachedDirs?: string[]
   /** 会话级附加目录路径列表（@ 引用时标记为会话文件） */
@@ -189,6 +194,8 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
   workspacePath,
   workspaceSlug,
   sessionId,
+  draftScopeKey,
+  draftSyncVersion = 0,
   attachedDirs = [],
   sessionAttachedDirs = [],
   htmlValue,
@@ -206,6 +213,9 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
   const lineCheckHandleRef = useRef<number | null>(null)
   // 跟踪编辑器自己设置的值，用于区分外部设置和内部更新
   const lastEditorValueRef = useRef<string>('')
+  // 记录尚未由 props 确认的本地草稿。长文本连续编辑时，React 可能先提交较旧的
+  // value；不能把它当作外部更新而整篇 setContent，否则 selection 会被重映射。
+  const pendingLocalDraftEchoesRef = useRef<string[]>([])
   // 跟踪 IME 输入状态（中文输入法等）
   const isComposingRef = useRef(false)
   // 保持 onSubmit 引用最新
@@ -685,6 +695,7 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
       const html = ed.getHTML()
       if (html === '<p></p>') {
         lastEditorValueRef.current = ''
+        pendingLocalDraftEchoesRef.current = recordLocalDraftEcho(pendingLocalDraftEchoesRef.current, '')
         onChange('')
         onHtmlChangeRef.current?.('')
         if (isExpandedRef.current) {
@@ -697,6 +708,7 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
         // 纯文本模式下跳过 markdown 特殊字符转义，保持用户所见即所得
         const markdown = htmlToMarkdown(html, { skipMarkdownEscape: !richTextEnabled })
         lastEditorValueRef.current = markdown
+        pendingLocalDraftEchoesRef.current = recordLocalDraftEcho(pendingLocalDraftEchoesRef.current, markdown)
         onChange(markdown)
         onHtmlChangeRef.current?.(html)
 
@@ -727,40 +739,66 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
     }
   }, [])
 
-  // 追踪编辑器实例，重建时强制同步（避免 htmlValue 草稿丢失）
+  // 追踪编辑器实例、草稿范围和显式外部同步版本，重建/切换时强制同步。
   const editorInstanceRef = useRef(editor)
-  // 同步外部 value 变化（清空时）
+  const editorDraftScopeKeyRef = useRef(draftScopeKey)
+  const editorDraftSyncVersionRef = useRef(draftSyncVersion)
+  // 同步真正的外部 value 变化。用户编辑生成的受控 value 回写可能延迟且乱序到达；
+  // 这些本地 echo 必须直接忽略，不能整篇 setContent 后让 ProseMirror 重映射光标。
   useEffect(() => {
-    if (editor) {
-      const controllerValue = value
-      const isEditorRecreated = editor !== editorInstanceRef.current
-      editorInstanceRef.current = editor
-      // 如果值是编辑器自己设置的，跳过同步
-      // 但编辑器重建后必须强制同步（即使 value 未变，htmlValue 草稿可能不同）
-      if (!isEditorRecreated && controllerValue === lastEditorValueRef.current) {
+    if (!editor) return
+
+    const controllerValue = value
+    const isEditorRecreated = editor !== editorInstanceRef.current
+    const isDraftScopeChanged = draftScopeKey !== editorDraftScopeKeyRef.current
+    const isExplicitExternalSync = draftSyncVersion !== editorDraftSyncVersionRef.current
+    editorInstanceRef.current = editor
+    editorDraftScopeKeyRef.current = draftScopeKey
+    editorDraftSyncVersionRef.current = draftSyncVersion
+
+    if (isDraftScopeChanged || isExplicitExternalSync) {
+      pendingLocalDraftEchoesRef.current = []
+    } else if (!isEditorRecreated) {
+      const remainingEchoes = consumeLocalDraftEcho(pendingLocalDraftEchoesRef.current, controllerValue)
+      if (remainingEchoes) {
+        // 仅消费一个确定是本地的 echo。即使其文本恰好等于最新草稿，也不能清空队列：
+        // a → ab → a 这样的重复值序列仍可能有旧 ab 在路上。
+        pendingLocalDraftEchoesRef.current = remainingEchoes
         return
       }
 
-      if (controllerValue === '') {
-        editor.commands.clearContent()
-        lastEditorValueRef.current = ''
-        isExpandedRef.current = false
-        setIsExpanded(false)
-        setIsManuallyCollapsed(false)
-      } else if (htmlValue) {
-        // 优先使用 HTML 草稿恢复（保留 mention 等富文本节点）
-        editor.commands.setContent(htmlValue)
-        lastEditorValueRef.current = controllerValue
-      } else {
-        const html = controllerValue
-          .split(/\n\n+/)
-          .map(para => `<p>${para.replace(/\n/g, '<br>')}</p>`)
-          .join('')
-        editor.commands.setContent(html)
-        lastEditorValueRef.current = controllerValue
+      if (pendingLocalDraftEchoesRef.current.length > 0) {
+        // 有本地更新尚未回写时，受控层不带版本的陌生值无法区分来源；调用方必须通过
+        // draftSyncVersion 标记真实外部更新，避免旧值覆盖正在编辑的文档。
+        return
       }
+
+      if (controllerValue === lastEditorValueRef.current) return
     }
-  }, [editor, value])
+
+    // 草稿范围切换、发送清空、队列回填等真正外部更新取代了当前本地编辑，
+    // 旧 echo 已不再有意义，避免日后误匹配。
+    pendingLocalDraftEchoesRef.current = []
+
+    if (controllerValue === '') {
+      editor.commands.clearContent(false)
+      lastEditorValueRef.current = ''
+      isExpandedRef.current = false
+      setIsExpanded(false)
+      setIsManuallyCollapsed(false)
+    } else if (htmlValue) {
+      // 优先使用 HTML 草稿恢复（保留 mention 等富文本节点）。外部同步不应再次触发草稿写回。
+      editor.commands.setContent(htmlValue, { emitUpdate: false })
+      lastEditorValueRef.current = controllerValue
+    } else {
+      const html = controllerValue
+        .split(/\n\n+/)
+        .map(para => `<p>${para.replace(/\n/g, '<br>')}</p>`)
+        .join('')
+      editor.commands.setContent(html, { emitUpdate: false })
+      lastEditorValueRef.current = controllerValue
+    }
+  }, [draftScopeKey, draftSyncVersion, editor, value])
 
   // 同步 disabled 状态
   useEffect(() => {

--- a/apps/electron/src/renderer/components/chat/ChatInput.tsx
+++ b/apps/electron/src/renderer/components/chat/ChatInput.tsx
@@ -40,6 +40,8 @@ import {
 import { getActiveAccelerator, getAcceleratorDisplay } from '@/lib/shortcut-registry'
 import {
   conversationDraftsAtom,
+  conversationDraftSyncVersionsAtom,
+  conversationDraftSyncVersionAtomFamily,
 } from '@/atoms/chat-atoms'
 import type { PendingAttachment } from '@/atoms/chat-atoms'
 import { quotedSelectionMapAtom } from '@/atoms/preview-atoms'
@@ -79,7 +81,9 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
   const setQuotedSelectionMap = useSetAtom(quotedSelectionMapAtom)
   const currentQuotedSelection = quotedSelectionMap.get(conversationId) ?? null
   const content = draftsMap.get(conversationId) ?? ''
-  const setContent = React.useCallback((value: string) => {
+  const draftSyncVersion = useAtomValue(conversationDraftSyncVersionAtomFamily(conversationId))
+  const setDraftSyncVersions = useSetAtom(conversationDraftSyncVersionsAtom)
+  const setContentFromEditor = React.useCallback((value: string) => {
     setDraftsMap((prev) => {
       const map = new Map(prev)
       if (value.trim() === '') {
@@ -90,6 +94,14 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
       return map
     })
   }, [conversationId, setDraftsMap])
+  const setContent = React.useCallback((value: string) => {
+    setDraftSyncVersions((prev) => {
+      const map = new Map(prev)
+      map.set(conversationId, (map.get(conversationId) ?? 0) + 1)
+      return map
+    })
+    setContentFromEditor(value)
+  }, [conversationId, setContentFromEditor, setDraftSyncVersions])
 
   const [selectedModel] = useConversationModel()
   const [thinkingEnabled, setThinkingEnabled] = useConversationThinkingEnabled()
@@ -459,12 +471,14 @@ export function ChatInput({ conversationId, streaming, pendingAttachments, onSet
           {/* TipTap 富文本编辑器 */}
           <RichTextInput
             value={content}
-            onChange={setContent}
+            onChange={setContentFromEditor}
             onSubmit={handleSend}
             onPasteFiles={handlePasteFiles}
             voiceInputId={chatVoiceInputId}
             placeholder={sendWithCmdEnter ? '输入消息... (⌘/Ctrl+Enter 发送，Enter 换行)' : '输入消息... (Enter 发送，Shift+Enter 换行)'}
             autoFocusTrigger={conversationId}
+            draftScopeKey={conversationId}
+            draftSyncVersion={draftSyncVersion}
             sendWithCmdEnter={sendWithCmdEnter}
           />
 

--- a/apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx
+++ b/apps/electron/src/renderer/components/shortcuts/GlobalShortcuts.tsx
@@ -26,6 +26,7 @@ import {
   agentPendingPromptAtom,
   agentSessionDraftHtmlAtom,
   agentSessionDraftsAtom,
+  agentSessionDraftSyncVersionsAtom,
   agentSessionsAtom,
   currentAgentSessionIdAtom,
   agentChannelIdAtom,
@@ -37,6 +38,7 @@ import {
 import {
   chatPendingMessageAtom,
   conversationDraftsAtom,
+  conversationDraftSyncVersionsAtom,
   conversationsAtom,
   currentConversationIdAtom,
   selectedModelAtom,
@@ -431,6 +433,11 @@ export function GlobalShortcuts(): null {
           map.delete(sessionId)
           return map
         })
+        store.set(agentSessionDraftSyncVersionsAtom, (prev) => {
+          const map = new Map(prev)
+          map.set(sessionId, (map.get(sessionId) ?? 0) + 1)
+          return map
+        })
         window.dispatchEvent(new CustomEvent('proma:focus-input'))
         acknowledgeDelivery(true)
         return
@@ -444,6 +451,11 @@ export function GlobalShortcuts(): null {
           const map = new Map(prev)
           const current = map.get(conversationId) ?? ''
           map.set(conversationId, current ? `${current}\n${trimmed}` : trimmed)
+          return map
+        })
+        store.set(conversationDraftSyncVersionsAtom, (prev) => {
+          const map = new Map(prev)
+          map.set(conversationId, (map.get(conversationId) ?? 0) + 1)
           return map
         })
         window.dispatchEvent(new CustomEvent('proma:focus-input'))

--- a/apps/electron/src/renderer/lib/input-draft-echo.ts
+++ b/apps/electron/src/renderer/lib/input-draft-echo.ts
@@ -1,0 +1,19 @@
+/**
+ * Tracks local controlled-input updates until their React props echo back.
+ * A delayed older echo must not be treated as a genuine external replacement.
+ */
+export function recordLocalDraftEcho(pending: readonly string[], value: string): string[] {
+  // 不能截断：一旦丢掉仍在路上的旧 echo，它到达时又会被误判成外部内容，
+  // 重新触发整篇 setContent。受控状态确认最新值后调用方会立即清空此队列。
+  return [...pending, value]
+}
+
+/**
+ * Returns the remaining pending echoes when `value` is local; otherwise null.
+ * Consuming through the matching entry also discards older echoes that have
+ * already reached the controlled component.
+ */
+export function consumeLocalDraftEcho(pending: readonly string[], value: string): string[] | null {
+  const echoIndex = pending.indexOf(value)
+  return echoIndex === -1 ? null : pending.slice(echoIndex + 1)
+}


### PR DESCRIPTION
## Summary

- Ignore delayed local draft echoes instead of replacing the entire TipTap document.
- Keep genuine external draft restores while preventing them from re-emitting updates.

## Validation

- `bun build apps/electron/src/renderer/components/ai-elements/rich-text-input.tsx --no-bundle --external='*'`
- `git diff --check`
- Full typecheck was not run because this worktree has no installed `node_modules` (`tsc` unavailable).

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)