### PR TITLE
feat(onboarding): 滚动提示改为正文下方文字行

### DIFF
--- a/apps/electron/src/renderer/components/onboarding/OnboardingView.tsx
+++ b/apps/electron/src/renderer/components/onboarding/OnboardingView.tsx
@@ -18,7 +18,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useAtomValue } from 'jotai'
-import { ChevronRight, ChevronLeft, ChevronsRight, ArrowDown, Check } from 'lucide-react'
+import { ChevronRight, ChevronLeft, ChevronsRight, Check } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { EnvironmentCheckPanel } from '@/components/environment/EnvironmentCheckPanel'
 import { isShellEnvironmentOkAtom } from '@/atoms/environment'
@@ -81,6 +81,8 @@ interface GuideFeatureStepProps {
   magnifierScale?: number
   /** 是否在本讲解区显示上一页/下一页导航 */
   showNavigation?: boolean
+  /** 无导航时在正文下方显示的向下滚动提示；点击可滚到示例区 */
+  onScrollHint?: () => void
 }
 
 interface MagnifierProps {
@@ -216,7 +218,7 @@ function GuideNavigation({ nextLabel, onNext, onBack }: { nextLabel: string; onN
 /**
  * 引导科普页：左侧显示界面截图，从锚点画绿色指针指向右侧讲解区。
  */
-function GuideFeatureStep({ anchor, title, highlight, paragraphs, nextLabel, onNext, onBack, imageSrc = guideVisual, arrowMode = 'none', magnifierOffsetX = 0, magnifierImageOffset = {}, imageRightCrop = 0, magnifierScale = 1, showNavigation = true }: GuideFeatureStepProps) {
+function GuideFeatureStep({ anchor, title, highlight, paragraphs, nextLabel, onNext, onBack, imageSrc = guideVisual, arrowMode = 'none', magnifierOffsetX = 0, magnifierImageOffset = {}, imageRightCrop = 0, magnifierScale = 1, showNavigation = true, onScrollHint }: GuideFeatureStepProps) {
   const imgRef = useRef<HTMLImageElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const [imgRect, setImgRect] = useState<{ x: number; y: number; w: number; h: number } | null>(null)
@@ -361,12 +363,25 @@ function GuideFeatureStep({ anchor, title, highlight, paragraphs, nextLabel, onN
             <GuideNavigation nextLabel={nextLabel} onNext={onNext} onBack={onBack} />
           </div>
         )}
+
+        {/* 无导航的首屏：用一行文字承接阅读动线，说明下方还有内容。 */}
+        {!showNavigation && onScrollHint && (
+          <div className="mt-12 w-full max-w-lg border-t border-[#1b3f2d]/20 pt-5">
+            <button
+              type="button"
+              onClick={onScrollHint}
+              className="text-left text-sm leading-6 text-neutral-500 transition-colors hover:text-[#1b3f2d]"
+            >
+              继续向下滚动，查看这一步的真实示例
+            </button>
+          </div>
+        )}
       </div>
     </div>
   )
 }
 
-type GuideExamplesIntroProps = Omit<GuideFeatureStepProps, 'nextLabel' | 'onNext' | 'onBack' | 'showNavigation'>
+type GuideExamplesIntroProps = Omit<GuideFeatureStepProps, 'nextLabel' | 'onNext' | 'onBack' | 'showNavigation' | 'onScrollHint'>
 
 function GuideExamplesPage({ intro, nextLabel, onNext, onBack, children, showScrollHint = false }: {
   intro: GuideExamplesIntroProps
@@ -374,38 +389,29 @@ function GuideExamplesPage({ intro, nextLabel, onNext, onBack, children, showScr
   onNext: () => void
   onBack: () => void
   children: React.ReactNode
-  /** 首个讲解页显示向下滚动提示，避免底部进度地图被误解为横向翻页。 */
+  /** 首个讲解页在正文下方提示继续向下滚动，避免底部进度地图被误解为横向翻页。 */
   showScrollHint?: boolean
 }) {
   const scrollRef = useRef<HTMLDivElement>(null)
-  const firstPageRef = useRef<HTMLDivElement>(null)
-  const [showHint, setShowHint] = useState(showScrollHint)
 
-  useEffect(() => {
-    if (!showScrollHint) return
+  /** 点击提示推进约一屏，避免与首屏高度、示例区负 margin 耦合。 */
+  const handleScrollHint = () => {
     const container = scrollRef.current
-    const firstPage = firstPageRef.current
-    if (!container || !firstPage) return
-
-    const handleScroll = () => {
-      // 轻微滚动仍保留提示，直到第二页内容真正进入视口。
-      const secondPageStart = firstPage.offsetTop + firstPage.offsetHeight
-      if (container.scrollTop >= secondPageStart - 24) setShowHint(false)
-    }
-    container.addEventListener('scroll', handleScroll, { passive: true })
-    return () => container.removeEventListener('scroll', handleScroll)
-  }, [showScrollHint])
+    if (!container) return
+    container.scrollBy({ top: container.clientHeight * 0.82, behavior: 'smooth' })
+  }
 
   return (
     <div className="relative h-full w-full">
       <div ref={scrollRef} className="h-full w-full overflow-y-auto">
-        <div ref={firstPageRef} className="h-[1100px] lg:h-[calc(100vh-4rem)] lg:min-h-[660px]">
+        <div className="h-[1100px] lg:h-[calc(100vh-4rem)] lg:min-h-[660px]">
           <GuideFeatureStep
             {...intro}
             nextLabel={nextLabel}
             onNext={onNext}
             onBack={onBack}
             showNavigation={false}
+            onScrollHint={showScrollHint ? handleScrollHint : undefined}
           />
         </div>
 
@@ -414,15 +420,6 @@ function GuideExamplesPage({ intro, nextLabel, onNext, onBack, children, showScr
           <GuideNavigation nextLabel={nextLabel} onNext={onNext} onBack={onBack} />
         </div>
       </div>
-
-      {showHint && (
-        <div
-          aria-hidden="true"
-          className="pointer-events-none absolute bottom-[180px] right-8 z-30 flex h-24 w-24 items-center justify-center rounded-none text-[#1b3f2d] md:right-10"
-        >
-          <ArrowDown className="h-20 w-20" strokeWidth={2.5} />
-        </div>
-      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

重做 #1436 引入的首个引导页向下滚动提示。

原实现是一个 80px 的裸 `ArrowDown` 图标绝对定位在右下角，没有文字说明、不可点击，并依赖 `bottom-[180px]` 魔法数字避开底部进度地图，与引导页其余部分的纸感排版语言不一致。

改为在右侧正文下方显示一行可点击文字「继续向下滚动，查看这一步的真实示例」，上方带一条分隔线。

## 设计说明

- **位置**：复用 `showNavigation={false}` 时空置的导航槽位，与其他章节的「上一个 / 下一个」处于同一基线，页面阅读节奏一致；同时天然避开底部进度地图，不需要魔法数字。
- **样式**：分隔线用 `border-[#1b3f2d]/20`，文字 `text-sm text-neutral-500` + hover 转墨绿，沿用 `GuideNavigation` 与 `ChapterMarker` 的既有线条语言，不引入新视觉元素。
- **滚动距离**：点击滚动 `clientHeight * 0.82`，不依赖首屏高度常量，也不受示例区 `-mt-[150px]` 影响。
- **状态精简**：移除 `showHint` state、`firstPageRef` 与 scroll 监听——这行文字随内容一起滚走，不需要监听滚动来隐藏，少一个 listener 和一次 re-render。

净变化 26 insertions / 29 deletions，单文件。

## Test plan

- [x] `bun run typecheck` 全部 6 个 package 通过
- [x] `bun test` 518 pass / 4 fail；4 个失败为 `oauth-proxy-scope` 与 `planning-manager` 的测试隔离问题，单独跑均通过，且已 stash 改动在 `origin/main` baseline 上复现完全相同的 4 个失败，与本 PR 无关
- [x] dev 环境重置 onboarding 实际走查首个引导页，提示位置与点击滚动行为正常
- [ ] 其余四个「首屏 + 示例」章节（文件 / 子会话 / 自动任务 / 记忆）暂未启用该提示，沿用 #1436 的范围，如需一并加上只是各传一个 `showScrollHint`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)
