### PR TITLE
fix(agent): focus input after quoting history

### DIFF
--- a/apps/electron/src/renderer/components/agent/AgentHistorySelectionLayer.tsx
+++ b/apps/electron/src/renderer/components/agent/AgentHistorySelectionLayer.tsx
@@ -18,6 +18,7 @@ import {
 import { quotedSelectionMapAtom } from '@/atoms/preview-atoms'
 import { agentDiffPanelTabAtom, agentSidePanelOpenAtom } from '@/atoms/agent-atoms'
 import { SelectionActionPopover } from '@/components/selection/SelectionActionPopover'
+import { useFocusAgentSessionInput } from '@/hooks/useFocusAgentSessionInput'
 import { SELECTION_ACTION_POPOVER_SELECTOR } from '@/lib/quoted-selection'
 
 const MAX_AGENT_HISTORY_QUOTED_CHARS = 2000
@@ -63,6 +64,7 @@ export function AgentHistorySelectionLayer({
   const setSideChatMap = useSetAtom(agentSideChatMapAtom)
   const setSidePanelOpen = useSetAtom(agentSidePanelOpenAtom)
   const setSidePanelTabMap = useSetAtom(agentDiffPanelTabAtom)
+  const focusAgentSessionInput = useFocusAgentSessionInput()
   const [selection, setSelection] = React.useState<AgentHistorySelection | null>(null)
   const pointerSelectingRef = React.useRef(false)
   const captureTimerRef = React.useRef<number | null>(null)
@@ -209,8 +211,9 @@ export function AgentHistorySelectionLayer({
     })
     window.getSelection()?.removeAllRanges()
     clearSelection()
+    focusAgentSessionInput(sessionId)
     toast.success('已添加到 Agent 引用')
-  }, [clearSelection, selection, sessionId, setQuotedSelectionMap])
+  }, [clearSelection, focusAgentSessionInput, selection, sessionId, setQuotedSelectionMap])
 
   const handleOpenChatTab = React.useCallback(async (): Promise<void> => {
     if (!selection) return


### PR DESCRIPTION
## Summary
- focus the current Agent input after adding a quote from Agent history
- reuse the existing session-aware focus helper used by file previews and the scratch pad

## Testing
- `bun run --filter='@proma/electron' typecheck`
- `bun run --filter='@proma/electron' build:renderer`
- manual: select Agent history text → click “为 Agent 引用” → type directly in the focused input

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)