### PR TITLE
refactor: finish Pi-only runtime cleanup

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -11,7 +11,7 @@ It is not just another chat box. Proma is meant to become a long-lived Agent wor
 ## What Proma Can Do
 
 - **Chat mode**: multi-model conversations, attachments, image input, Markdown / Mermaid / KaTeX / code highlighting, parallel conversations, system prompts, and context controls.
-- **Agent mode**: two built-in runtimes—Claude Agent SDK and Pi Agent SDK—with workspace isolation, permission modes, file operations, streaming output, plan confirmation, and ask-user interactions. Claude is the default; switch runtimes below the Agent input.
+- **Agent mode**: a unified Pi Agent Runtime with workspace isolation, permission modes, file operations, streaming output, plan confirmation, and ask-user interactions.
 - **Collaboration and tasks**: complex work can be split into traceable collaboration agents and tasks, with calls and results shown in the message stream.
 - **Skills, MCP, and project roots**: each Proma project manages its own Skills and MCP servers. Project files can use a user-selected local project root or a Proma-managed blank-project directory; local project configuration is not imported automatically.
 - **Remote bots**: Lark / Feishu bot bridging is supported, with DingTalk and WeChat bridge entry points also present in the app.
@@ -51,10 +51,9 @@ If your organization plans to deploy Proma for hundreds or thousands of employee
 1. Open Proma and finish the environment check. Agent mode depends on local tooling, especially Git, Node.js / Bun, and a usable shell.
 2. Go to **Settings > Channels**, add at least one AI provider channel, and fill in Base URL, API Key, and model list.
 3. Chat mode can use OpenAI, Anthropic, Google, or OpenAI-compatible channels.
-4. The default Claude Agent Runtime requires an Anthropic or Anthropic-compatible channel, such as Anthropic, DeepSeek, Kimi API, or Kimi Coding Plan.
-5. Switch Claude / Pi directly below the Agent input. Pi can use any enabled model channel.
-6. Go to **Settings > Agent** and choose the default Agent channel, model, and workspace.
-7. Configure memory, web search, or Feishu / DingTalk / WeChat bridges from their corresponding settings tabs if needed.
+4. Agent uses the Pi Runtime and can use any enabled model channel.
+5. Go to **Settings > Agent** and choose the default Agent channel, model, and workspace.
+6. Configure memory, web search, or Feishu / DingTalk / WeChat bridges from their corresponding settings tabs if needed.
 
 ## Choosing A Mode
 
@@ -111,7 +110,7 @@ Proma supports Doubao-powered streaming voice input, both inside Proma and acros
 
 ## Agent Runtime and Providers
 
-Proma uses a single **Pi Agent Runtime**, powered by `@earendil-works/pi-coding-agent`, `pi-agent-core`, and `pi-ai`. Enabled Proma channels are dynamically registered as Pi providers, supporting OpenAI Chat Completions / Responses, Google Generative AI, Anthropic Messages, and compatible endpoints.
+Proma uses a single **Pi Agent Runtime**, powered by `@earendil-works/pi-coding-agent`, `pi-agent-core`, and `pi-ai`. Enabled Proma channels are dynamically registered as Pi providers, supporting OpenAI Chat Completions / Responses, Google Generative AI, Anthropic Messages, and compatible endpoints. Historical Claude transcripts are retained as read-only records: they can be viewed, but not continued, forked, or rewound.
 
 | Channel type | Chat | Pi Agent |
 | --- | --- | --- |
@@ -136,7 +135,7 @@ Proma uses a single **Pi Agent Runtime**, powered by `@earendil-works/pi-coding-
 | Code highlighting | Shiki |
 | Build | Vite + esbuild |
 | Distribution | electron-builder |
-| Agent runtime | Pi: `@earendil-works/pi-* @0.80.3` |
+| Agent runtime | Pi: `@earendil-works/pi-* @0.82.1` |
 
 ## Architecture
 
@@ -172,10 +171,10 @@ The Pi Agent runtime runs as an esbuild external dependency in the main process.
 
 When changing packaging, verify that:
 
-- `build:main` / `watch:main` keep both Agent SDKs external.
+- `build:main` / `watch:main` keep Pi runtime dependencies external.
 - `scripts/sync-runtime-deps.ts` stays aligned with the external runtime dependency list.
-- `electron-builder.yml` retains the `asarUnpack` rules for the Claude binary and Pi native add-ons.
-- After `bun run dist:fast` on a target platform, both Claude and Pi (when enabled) can start, call tools, and resume sessions.
+- `electron-builder.yml` retains the `asarUnpack` rules required by Pi native add-ons.
+- After `bun run dist:fast` on a target platform, verify that Pi Agent can start, call tools, and resume sessions.
 
 See [AGENTS.md](./AGENTS.md) for the full engineering conventions.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Proma 是一个本地优先的 AI 桌面应用，把多模型 Chat、通用 Agen
 ## 现在能做什么
 
 - **Chat 模式**：多模型对话、附件解析、图片输入、Markdown / Mermaid / KaTeX / 代码高亮、并排对话、系统提示词、上下文管理。
-- **Agent 模式**：内置 Claude Agent SDK 与 Pi Agent SDK 两套运行时；支持工作区隔离、权限模式、文件操作、长任务流式输出、计划确认和用户追问。Claude 是默认内核，Pi 可在实验性设置中开启。
+- **Agent 模式**：统一使用 Pi Agent Runtime；支持工作区隔离、权限模式、文件操作、长任务流式输出、计划确认和用户追问。
 - **协作与任务**：复杂任务可拆分为可追踪的协作子 Agent / Task，并在消息流中展示调用过程和结果。
 - **Skills、MCP 与项目根目录**：每个 Proma 项目独立配置 Skills 与 MCP Server。项目文件可使用用户选择的本地项目根目录，也可使用 Proma 托管的空白项目目录；本地项目配置不会被自动导入。
 - **远程机器人**：支持飞书 / Lark 机器人桥接，并已提供钉钉、微信桥接入口，用手机或群聊触发本机 Agent 工作流。
@@ -57,10 +57,9 @@ Proma 是一个本地优先的 AI 桌面应用，把多模型 Chat、通用 Agen
 1. 打开 Proma，先完成环境检查。Agent 模式依赖本机基础环境，尤其是 Git、Node.js / Bun 以及可用的 Shell。
 2. 进入 **设置 > 渠道**，添加至少一个 AI 供应商渠道，填写 Base URL、API Key 和模型列表。
 3. Chat 模式可以使用 OpenAI、Anthropic、Google 或 OpenAI 兼容协议的渠道。
-4. 默认的 Claude Agent Runtime 需要 Anthropic 或 Anthropic 兼容协议渠道，例如 Anthropic、DeepSeek、Kimi API、Kimi Coding Plan。
-5. Agent 输入框下方可直接切换 Claude / Pi 内核；Pi 可使用任意已启用的模型渠道。
-6. 进入 **设置 > Agent**，选择默认 Agent 渠道、模型和工作区。
-7. 如需记忆、联网搜索、飞书 / 钉钉 / 微信桥接，在设置页对应 Tab 中继续配置。
+4. Agent 使用 Pi Runtime，可使用任意已启用的模型渠道。
+5. 进入 **设置 > Agent**，选择默认 Agent 渠道、模型和工作区。
+6. 如需记忆、联网搜索、飞书 / 钉钉 / 微信桥接，在设置页对应 Tab 中继续配置。
 
 ## 模式选择
 
@@ -115,7 +114,7 @@ Proma 支持豆包的流式语音输入功能，并且支持在 Proma 内使用�
 
 ## Agent 运行时与模型渠道
 
-Proma 的 Agent 模式统一使用 **Pi Agent Runtime**，由 `@earendil-works/pi-coding-agent`、`pi-agent-core` 和 `pi-ai` 驱动。已启用的 Proma 渠道会动态注册为 Pi provider，支持 OpenAI Chat Completions / Responses、Google Generative AI、Anthropic Messages 及其兼容端点。
+Proma 的 Agent 模式统一使用 **Pi Agent Runtime**，由 `@earendil-works/pi-coding-agent`、`pi-agent-core` 和 `pi-ai` 驱动。已启用的 Proma 渠道会动态注册为 Pi provider，支持 OpenAI Chat Completions / Responses、Google Generative AI、Anthropic Messages 及其兼容端点。历史 Claude transcript 会保留为只读记录，可查看但不能继续、分叉或回退。
 
 | 渠道类型 | Chat | Pi Agent |
 | --- | --- | --- |
@@ -140,7 +139,7 @@ Proma 的 Agent 模式统一使用 **Pi Agent Runtime**，由 `@earendil-works/p
 | 代码高亮 | Shiki |
 | 构建 | Vite + esbuild |
 | 分发 | electron-builder |
-| Agent Runtime | Pi: `@earendil-works/pi-* @0.80.3` |
+| Agent Runtime | Pi: `@earendil-works/pi-* @0.82.1` |
 
 ## 架构概览
 
@@ -176,10 +175,10 @@ Pi 运行时在主进程中作为 esbuild external 依赖运行。`apps/electron
 
 修改打包配置时，请确认：
 
-- `build:main` / `watch:main` 仍将两套 Agent SDK 标记为 external。
+- `build:main` / `watch:main` 将 Pi runtime 依赖标记为 external。
 - `scripts/sync-runtime-deps.ts` 的 external runtime 清单与实际依赖一致。
-- `electron-builder.yml` 保留 Claude binary 与 Pi native addon 的 `asarUnpack` 规则。
-- 在目标平台测试 `bun run dist:fast` 后，分别验证 Claude 与 Pi（若已启用）可以启动、调用工具和恢复会话。
+- `electron-builder.yml` 保留 Pi native addon 所需的 `asarUnpack` 规则。
+- 在目标平台测试 `bun run dist:fast` 后，验证 Pi Agent 可以启动、调用工具和恢复会话。
 
 更完整的工程约定见 [AGENTS.md](./AGENTS.md)。
 

--- a/apps/electron/src/main/lib/adapters/pi-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/pi-agent-adapter.ts
@@ -16,15 +16,12 @@ import type {
   CodexOAuthCredentials,
   XaiOAuthCredentials,
   AgentQueryInput,
-  ErrorCode,
   JsonSchemaOutputFormat,
   PromaPermissionMode,
   ProviderType,
-  RecoveryAction,
   SendQueuedMessageOptions,
   SDKMessage,
   SDKUserMessageInput,
-  TypedError,
 } from '@proma/shared'
 import {
   calculatePiAutoCompactionReserveTokens,
@@ -32,13 +29,8 @@ import {
   isCodexFastModeSupportedModel,
   resolveReasoningProfile,
 } from '@proma/shared'
-import {
-  THINKING_SIGNATURE_ERROR_MESSAGE,
-  THINKING_SIGNATURE_ERROR_TITLE,
-  isThinkingSignatureError as matchesThinkingSignatureError,
-} from '@proma/shared'
 import type { CanUseToolOptions, PermissionResult } from '../agent-permission-service'
-import { TRANSIENT_NETWORK_PATTERN, isMalformedResponseError } from '../error-patterns'
+import { isPromptTooLongError } from '../agent-error-utils'
 
 import type {
   AgentSession,
@@ -325,33 +317,7 @@ function createAsyncQueue<T>(): AsyncQueue<T> {
   }
 }
 
-const FRIENDLY_ERROR_MESSAGES: Array<{ pattern: RegExp; message: string }> = [
-  {
-    pattern: /api key|unauthorized|invalid.*key|authentication/i,
-    message: '请检查是否选择了正确的 Proma 供应渠道和模型',
-  },
-  {
-    pattern: /validation|schema/i,
-    message: 'API 请求格式校验失败，请重试或开启新会话',
-  },
-]
-
-const MAX_ERROR_MESSAGE_LENGTH = 5000
 const SESSION_READY_TIMEOUT_MS = 60_000
-const PROMPT_TOO_LONG_PATTERNS = [
-  'prompt is too long',
-  'prompt_too_long',
-  'input is too long',
-  'context_length_exceeded',
-  'maximum context length',
-  'context length',
-  'context window',
-  'maximum context',
-  'token limit',
-  'too many tokens',
-  'exceeds the model',
-  'exceed the model',
-] as const
 const SKILL_COMMAND_PATTERN = /\/skill:([A-Za-z0-9][A-Za-z0-9._-]*)/g
 
 function createActivePiSession(): ActivePiSession {
@@ -410,195 +376,6 @@ async function waitForActiveSession(active: ActivePiSession): Promise<AgentSessi
     ])
   } finally {
     if (timer) clearTimeout(timer)
-  }
-}
-
-export function friendlyErrorMessage(raw: string): string {
-  const isLong = raw.length > MAX_ERROR_MESSAGE_LENGTH
-  const sample = isLong ? raw.slice(0, MAX_ERROR_MESSAGE_LENGTH) : raw
-  for (const { pattern, message } of FRIENDLY_ERROR_MESSAGES) {
-    if (pattern.test(sample)) return message
-  }
-  return isLong
-    ? sample + `\n\n[错误详情过长 (${(raw.length / 1024).toFixed(0)}KB)，已截断]`
-    : raw
-}
-
-export function isPromptTooLongError(...messages: Array<string | undefined>): boolean {
-  const text = messages
-    .filter((message): message is string => typeof message === 'string')
-    .join(' ')
-    .toLowerCase()
-  return PROMPT_TOO_LONG_PATTERNS.some((pattern) => text.includes(pattern))
-}
-
-export function isThinkingSignatureError(message: string, originalError?: string): boolean {
-  return matchesThinkingSignatureError(message, originalError)
-}
-
-function stringifyErrorContent(content: unknown): string | undefined {
-  if (typeof content === 'string' && content.trim()) return content
-  if (Array.isArray(content)) {
-    const text = content
-      .map((block) => {
-        if (!block || typeof block !== 'object') return ''
-        const record = block as Record<string, unknown>
-        if (typeof record.text === 'string') return record.text
-        if (typeof record.message === 'string') return record.message
-        return ''
-      })
-      .filter(Boolean)
-      .join('\n')
-      .trim()
-    return text || undefined
-  }
-  if (content && typeof content === 'object') {
-    const record = content as Record<string, unknown>
-    if (typeof record.message === 'string') return record.message
-    if (typeof record.error === 'string') return record.error
-    return JSON.stringify(record)
-  }
-  return undefined
-}
-
-export function extractErrorDetails(error: {
-  error?: { message?: string; errorType?: string }
-  errorMessage?: string
-  errors?: unknown[]
-  message?: { content?: unknown }
-  content?: unknown
-}): {
-  detailedMessage: string
-  originalError?: string
-} {
-  const direct = error.error?.message ?? error.errorMessage
-  if (direct) return { detailedMessage: direct, originalError: direct }
-  const fromMessage = stringifyErrorContent(error.message?.content ?? error.content)
-  if (fromMessage) return { detailedMessage: fromMessage, originalError: fromMessage }
-  const fromErrors = Array.isArray(error.errors)
-    ? error.errors.map((item) => stringifyErrorContent(item)).filter(Boolean).join('\n')
-    : undefined
-  if (fromErrors) return { detailedMessage: fromErrors, originalError: fromErrors }
-  return { detailedMessage: 'Agent 执行失败', originalError: undefined }
-}
-
-/** 各错误码对应的标题与是否可重试（用于构建差异化 TypedError） */
-const ERROR_CODE_META: Partial<Record<ErrorCode, { title: string; canRetry: boolean }>> = {
-  invalid_api_key: { title: '认证失败', canRetry: true },
-  billing_error: { title: '账单错误', canRetry: false },
-  rate_limited: { title: '请求频率限制', canRetry: true },
-  prompt_too_long: { title: '上下文过长', canRetry: false },
-  invalid_request: { title: '请求无效', canRetry: false },
-  service_unavailable: { title: '服务暂时不可用', canRetry: true },
-  service_error: { title: '服务错误', canRetry: true },
-  provider_error: { title: '服务繁忙', canRetry: true },
-  network_error: { title: '网络异常', canRetry: true },
-  invalid_model: { title: '模型不可用', canRetry: false },
-  agent_runtime_not_found: { title: 'Agent 核心未就绪', canRetry: false },
-}
-
-/**
- * 判断错误文本是否为 pi runtime 模块加载失败（打包遗漏依赖 / 安装损坏）。
- *
- * 只匹配明确的 Node 模块解析失败措辞，且要求同时提及 pi 运行时包名，
- * 避免上游错误正文里偶然出现包名字符串就被误判为「核心未就绪」（那会错误地丢失可重试性）。
- */
-export function isRuntimeNotFoundError(text: string): boolean {
-  const isModuleResolutionFailure = /cannot find module|module not found|err_module_not_found|failed to (?:load|resolve)/i.test(text)
-  if (!isModuleResolutionFailure) return false
-  return /pi-coding-agent|pi-agent-core|@earendil-works/i.test(text)
-}
-
-/** 从错误文本中兜底提取 HTTP 状态码（锚定在明确的状态码上下文，避免误匹配正文数字） */
-function extractHttpStatusFromErrorText(...messages: Array<string | undefined>): number | null {
-  const combined = messages.filter(Boolean).join('\n')
-  const patterns = [
-    /API Error:\s*(\d{3})/i,
-    /API error[^:]*:\s+(\d{3})/i,
-    /\b(?:HTTP|status|statusCode)\s*[:=]?\s*(\d{3})\b/i,
-    /\b(\d{3})\s+\{[^}]*"error"/is,
-  ]
-  for (const pattern of patterns) {
-    const match = combined.match(pattern)
-    const statusCode = match?.[1] ? parseInt(match[1], 10) : NaN
-    if (statusCode >= 400 && statusCode < 600) return statusCode
-  }
-  return null
-}
-
-export function mapSDKErrorToTypedError(errorCode: string, message: string, originalError?: string): TypedError {
-  const diagnosticText = `${errorCode}\n${message}\n${originalError ?? ''}`
-
-  // thinking-signature：中途切换模型导致思考标签不互认，需保留专属文案与「在新对话继续」动作
-  if (isThinkingSignatureError(message, originalError)) {
-    return {
-      code: 'thinking_signature_invalid',
-      title: THINKING_SIGNATURE_ERROR_TITLE,
-      message: THINKING_SIGNATURE_ERROR_MESSAGE,
-      actions: [
-        { key: 'n', label: '在新对话继续', action: 'retry_in_new_session' },
-        { key: 'r', label: '重试', action: 'retry' },
-      ],
-      canRetry: true,
-      retryDelayMs: 1000,
-      originalError,
-    }
-  }
-
-  let code: ErrorCode = 'unknown_error'
-  const httpStatus = extractHttpStatusFromErrorText(message, originalError, errorCode)
-  if (isRuntimeNotFoundError(diagnosticText)) {
-    // pi runtime 动态 import 失败（打包遗漏依赖 / 安装损坏），产出定向的「核心未就绪」错误码，
-    // 让 UI 给出「请重新安装」引导，而非泛化的 unknown_error
-    code = 'agent_runtime_not_found'
-  } else if (/api.*key|unauthorized|authentication|invalid.*credential/i.test(diagnosticText)) {
-    code = 'invalid_api_key'
-  } else if (/billing|quota|insufficient_quota|credit|balance|payment|subscription/i.test(diagnosticText)) {
-    code = 'billing_error'
-  } else if (/rate.?limit/i.test(diagnosticText) || httpStatus === 429) {
-    code = 'rate_limited'
-  } else if (isPromptTooLongError(message, originalError, errorCode)) {
-    code = 'prompt_too_long'
-  } else if (isMalformedResponseError(message, originalError)) {
-    // 上游返回无法解析的响应体（网关 HTML 错误页 / SSE 截断 / 脏数据），瞬时异常，可重试
-    code = 'service_error'
-  } else if (TRANSIENT_NETWORK_PATTERN.test(message) || TRANSIENT_NETWORK_PATTERN.test(originalError ?? '')) {
-    code = 'network_error'
-  } else if (/overloaded/i.test(diagnosticText) || httpStatus === 529) {
-    code = 'provider_error'
-  } else if (/service unavailable/i.test(diagnosticText) || httpStatus === 503) {
-    code = 'service_unavailable'
-  } else if (httpStatus === 500 || httpStatus === 502 || (httpStatus != null && httpStatus >= 500)) {
-    // HTTP 5xx（含 500 内部错误 / 502 网关异常）通常为上游瞬时故障，可重试
-    code = 'service_error'
-  } else if (/invalid request|bad request|400|schema|validation/i.test(diagnosticText)) {
-    code = 'invalid_request'
-  } else if (/network|fetch|socket|terminated|ECONNRESET/i.test(diagnosticText)) {
-    code = 'network_error'
-  } else if (/model/i.test(diagnosticText)) {
-    code = 'invalid_model'
-  }
-
-  const meta = ERROR_CODE_META[code] ?? { title: 'Agent 执行失败', canRetry: false }
-  // 认证/渠道配置类错误友好化后文案固定，引导用户直接重新选择模型，而非跳转设置
-  const isInvalidChannelOrModel = /请检查是否选择了正确的 Proma 供应渠道和模型/.test(message)
-
-  const actions: RecoveryAction[] = [
-    isInvalidChannelOrModel
-      ? { key: 'm', label: '重新选择模型', action: 'select_model' }
-      : { key: 's', label: '设置', action: 'settings' },
-    ...(meta.canRetry ? [{ key: 'r', label: '重试', action: 'retry' }] : []),
-    ...(code === 'prompt_too_long' ? [{ key: 'c', label: '压缩上下文', action: 'compact' }] : []),
-  ]
-
-  return {
-    code,
-    title: meta.title,
-    message,
-    actions,
-    canRetry: meta.canRetry,
-    retryDelayMs: meta.canRetry ? 1000 : undefined,
-    originalError,
   }
 }
 

--- a/apps/electron/src/main/lib/adapters/pi-model-registry.ts
+++ b/apps/electron/src/main/lib/adapters/pi-model-registry.ts
@@ -10,7 +10,7 @@ import {
   CODEX_GPT_54_MINI_CONTEXT_WINDOW,
   CODEX_GPT_56_CONTEXT_WINDOW,
   extractZhipuCodingTeamApiToken,
-  inferAgentSdkContextWindow,
+  inferContextWindow,
   inferCodexAlignedGPT5ContextWindow,
   resolveReasoningCapability,
   resolveReasoningProfile,
@@ -441,7 +441,7 @@ export async function resolvePiImageInputCapability(
   provider: ProviderType,
   modelId: string | undefined,
 ): Promise<'supported' | 'unsupported' | 'unknown'> {
-  const resolvedModelId = stripAgentSdkContextSuffix(modelId)
+  const resolvedModelId = stripLegacyAgentSdkContextSuffix(modelId)
   if (!resolvedModelId) return 'unknown'
   const catalogModel = await findPiCatalogModel(provider, resolvedModelId)
   if (!catalogModel) return 'unknown'
@@ -458,7 +458,7 @@ export async function resolvePiReasoningCapability(
   provider: ProviderType,
   modelId: string | undefined,
 ): Promise<ReasoningCapability | undefined> {
-  const resolvedModelId = stripAgentSdkContextSuffix(modelId)
+  const resolvedModelId = stripLegacyAgentSdkContextSuffix(modelId)
   const profile = resolveReasoningProfile({
     modelId: resolvedModelId,
     transport: provider === 'openai-codex' || provider === 'xai'
@@ -485,7 +485,7 @@ async function resolvePiModelDefaults(input: PiAgentQueryOptions): Promise<PiMod
   const isVolcengineGlm52 = (input.provider === 'doubao' || input.provider === 'ark-coding-plan')
     && input.model?.toLowerCase() === 'glm-5.2'
   const catalogContextWindow = catalogModel?.contextWindow ?? DEFAULT_CONTEXT_WINDOW
-  const inferredContextWindow = inferAgentSdkContextWindow(input.model, input.provider) ?? DEFAULT_CONTEXT_WINDOW
+  const inferredContextWindow = inferContextWindow(input.model) ?? DEFAULT_CONTEXT_WINDOW
   return {
     reasoning: catalogModel?.reasoning ?? true,
     thinkingLevelMap: providerSpecificCapabilities?.thinkingLevelMap
@@ -562,7 +562,7 @@ export function resolvePiApiKey(provider: ProviderType, apiKey: string): string 
  * 端点（智谱等）并不识别，带后缀会被判为「模型不存在」（智谱 1211）。
  * pi 模式统一剥离该后缀，保证注册与请求使用干净的模型 ID。
  */
-export function stripAgentSdkContextSuffix(modelId: string | undefined): string | undefined {
+export function stripLegacyAgentSdkContextSuffix(modelId: string | undefined): string | undefined {
   return modelId?.replace(/\[1m\]$/i, '')
 }
 
@@ -622,7 +622,7 @@ export async function buildCodexModel(sdk: PiSdk, input: CodexModelInput) {
     allowModelNetwork: false,
   })
 
-  const resolvedModelId = stripAgentSdkContextSuffix(input.model)
+  const resolvedModelId = stripLegacyAgentSdkContextSuffix(input.model)
   const codexModels = await getCodexCatalogModels()
   const model = (resolvedModelId ? modelRuntime.getModel('openai-codex', resolvedModelId) : undefined)
     ?? (resolvedModelId ? findCatalogModelById(codexModels, resolvedModelId) : undefined)
@@ -662,7 +662,7 @@ export async function buildXaiModel(sdk: PiSdk, input: XaiModelInput) {
     ),
     allowModelNetwork: false,
   })
-  const resolvedModelId = stripAgentSdkContextSuffix(input.model)
+  const resolvedModelId = stripLegacyAgentSdkContextSuffix(input.model)
   const xaiModels = await getXaiCatalogModels()
   const model = (resolvedModelId ? modelRuntime.getModel('xai', resolvedModelId) : undefined)
     ?? (resolvedModelId ? findCatalogModelById(xaiModels, resolvedModelId) : undefined)
@@ -687,8 +687,8 @@ export async function buildModel(sdk: PiSdk, input: PiAgentQueryOptions) {
   }
   const providerName = `proma-${input.provider}-${input.sessionId}`
   const resolvedApiKey = resolvePiApiKey(input.provider, input.apiKey)
-  // pi runtime 统一剥离 `[1m]` 后缀：无论上游从哪条路径传入，注册与查找都用干净 ID。
-  const resolvedModelId = stripAgentSdkContextSuffix(input.model)
+  // pi runtime 统一剥离历史 `[1m]` 后缀：无论上游从哪条路径传入，注册与查找都用干净 ID。
+  const resolvedModelId = stripLegacyAgentSdkContextSuffix(input.model)
   const modelRuntime = await sdk.ModelRuntime.create({ allowModelNetwork: false })
   const api = normalizePiApi(input.provider)
   const modelDefaults = await resolvePiModelDefaults({ ...input, model: resolvedModelId })

--- a/apps/electron/src/main/lib/agent-error-utils.ts
+++ b/apps/electron/src/main/lib/agent-error-utils.ts
@@ -12,10 +12,10 @@ import {
 } from '@proma/shared'
 import { TRANSIENT_NETWORK_PATTERN, isMalformedResponseError } from './error-patterns'
 
-// SDK 错误消息友好化
+// Agent 错误消息友好化
 // ============================================================================
 
-/** 已知 SDK 错误 → 用户友好提示映射 */
+/** 已知 Agent 错误 → 用户友好提示映射 */
 const FRIENDLY_ERROR_MESSAGES: Array<{ pattern: RegExp; message: string }> = [
   {
     pattern: /not logged in|please run \/login/i,
@@ -30,7 +30,7 @@ const FRIENDLY_ERROR_MESSAGES: Array<{ pattern: RegExp; message: string }> = [
 /** 错误消息最大保留长度（超出部分截断，防止存储膨胀） */
 const MAX_ERROR_MESSAGE_LENGTH = 5000
 
-/** 将 SDK 原始错误消息转换为用户友好的提示（无匹配则返回原文） */
+/** 将 Agent 原始错误消息转换为用户友好的提示（无匹配则返回原文） */
 export function friendlyErrorMessage(raw: string): string {
   const isLong = raw.length > MAX_ERROR_MESSAGE_LENGTH
   const sample = isLong ? raw.slice(0, MAX_ERROR_MESSAGE_LENGTH) : raw
@@ -40,35 +40,6 @@ export function friendlyErrorMessage(raw: string): string {
   return isLong
     ? sample + `\n\n[错误详情过长 (${(raw.length / 1024).toFixed(0)}KB)，已截断]`
     : raw
-}
-
-// ============================================================================
-// Terminal reason 白名单
-// ============================================================================
-
-/**
- * 表示"本轮结束但会话应继续"的 terminal_reason 白名单。
- *
- * SDK 0.2.96+ 在 SDKResultMessage 引入 `terminal_reason` 字段后，某些值并不代表
- * 会话真正结束，而是期望 host 保留 stdin 通道、驱动下一轮：
- * - `aborted_streaming` / `aborted_tools`：query.interrupt() 软中断，等队列续轮
- * - `tool_deferred`：工具被延迟执行（配套 result.deferred_tool_use），等异步回填
- * - `hook_stopped` / `stop_hook_prevented`：hook 层面的暂停，host 可继续注入消息
- *
- * 未列在此集合中的 terminal_reason（含 `undefined` 的旧版行为、`completed`、
- * `max_turns`、`prompt_too_long`、各类 error 等）一律按"本轮结束 + 关闭通道"处理。
- */
-export const CONTINUABLE_TERMINAL_REASONS: ReadonlySet<string> = new Set([
-  'aborted_streaming',
-  'aborted_tools',
-  'tool_deferred',
-  'hook_stopped',
-  'stop_hook_prevented',
-])
-
-/** 判断 result.terminal_reason 是否应保留消息通道以等待下一轮 */
-export function shouldKeepChannelOpen(terminalReason: string | undefined): boolean {
-  return terminalReason != null && CONTINUABLE_TERMINAL_REASONS.has(terminalReason)
 }
 
 // ============================================================================
@@ -82,13 +53,17 @@ const PROMPT_TOO_LONG_PATTERNS = [
   'input is too long',
   'context_length_exceeded',
   'maximum context length',
+  'context length',
+  'context window',
+  'maximum context',
+  'too many tokens',
   'token limit',
   'exceeds the model',
 ] as const
 
 /** 检测错误消息是否为 prompt too long 类型 */
-export function isPromptTooLongError(...messages: string[]): boolean {
-  const combined = messages.join(' ').toLowerCase()
+export function isPromptTooLongError(...messages: Array<string | undefined>): boolean {
+  const combined = messages.filter((message): message is string => typeof message === 'string').join(' ').toLowerCase()
   return PROMPT_TOO_LONG_PATTERNS.some((p) => combined.includes(p))
 }
 
@@ -115,8 +90,8 @@ function extractHttpStatusFromErrorText(...messages: string[]): number | null {
   return null
 }
 
-/** 将 SDK 错误映射为 TypedError */
-export function mapSDKErrorToTypedError(
+/** 将 Agent 错误映射为 TypedError */
+export function mapAgentErrorToTypedError(
   errorCode: string,
   detailedMessage: string,
   originalError: string,
@@ -218,7 +193,7 @@ export function mapSDKErrorToTypedError(
   }
 
   // 瞬时网络错误（terminated / ECONNRESET / socket hang up 等）：
-  // assistant.error 路径下，SDK 常常把这类错误标记为 errorType='unknown'，
+  // assistant.error 路径下，Pi adapter 常把这类错误标记为 errorType='unknown'，
   // 这里从 detailedMessage / originalError 兜底匹配，归类为可重试的 network_error。
   const looksLikeNetwork =
     (!errorMap[errorCode]) &&
@@ -240,7 +215,7 @@ export function mapSDKErrorToTypedError(
 
   // 上游响应体解析失败（JSON Parse error: Unable to parse JSON string 等）：
   // 网关返回 HTML 错误页 / SSE 流截断 / 代理注入脏数据导致 SDK 解析非 JSON 体失败，
-  // SDK 常标记为 errorType='unknown'。归类为可重试的 service_error（已在重试白名单内）。
+  // Pi adapter 常标记为 errorType='unknown'。归类为可重试的 service_error（已在重试白名单内）。
   const looksLikeMalformedResponse =
     (!errorMap[errorCode]) &&
     isMalformedResponseError(detailedMessage, originalError)
@@ -248,7 +223,7 @@ export function mapSDKErrorToTypedError(
     return {
       code: 'service_error',
       title: '响应解析失败',
-      message: '上游返回了无法解析的响应，通常为网关瞬时异常，正在重试',
+      message: '上游返回了无法解析的响应，通常为网关瞬时异常，请重试',
       actions: [
         { key: 's', label: '设置', action: 'settings' },
         { key: 'r', label: '重试', action: 'retry' },
@@ -318,40 +293,3 @@ export function mapSDKErrorToTypedError(
     originalError,
   }
 }
-
-/** 从 assistant 错误消息中提取详细信息 */
-export function extractErrorDetails(msg: { error?: { message: string }; message?: { content?: Array<Record<string, unknown>> } }): { detailedMessage: string; originalError: string } {
-  let detailedMessage = msg.error?.message ?? '未知错误'
-  let originalError = msg.error?.message ?? '未知错误'
-
-  try {
-    const content = msg.message?.content
-    if (Array.isArray(content) && content.length > 0) {
-      const textBlock = content.find((block) => block.type === 'text')
-      if (textBlock && 'text' in textBlock && typeof textBlock.text === 'string') {
-        const fullText = textBlock.text
-        originalError = fullText
-
-        const apiErrorMatch = fullText.match(/API Error:\s*\d+\s*(\{.*\})/s)
-        if (apiErrorMatch?.[1]) {
-          try {
-            const apiErrorObj = JSON.parse(apiErrorMatch[1])
-            if (apiErrorObj.error?.message) {
-              detailedMessage = apiErrorObj.error.message
-            }
-          } catch {
-            detailedMessage = fullText
-          }
-        } else {
-          detailedMessage = fullText
-        }
-      }
-    }
-  } catch {
-    // 提取失败，使用原始 error 字段
-  }
-
-  return { detailedMessage, originalError }
-}
-
-// ============================================================================

--- a/apps/electron/src/main/lib/agent-git-attribution.ts
+++ b/apps/electron/src/main/lib/agent-git-attribution.ts
@@ -4,9 +4,7 @@
  * 目标：当 Agent 代用户创建 commit / PR 时，附带可搜索、可关闭的 Proma 标识，
  * 用于产品曝光；同时避免 Co-Authored-By 假冒作者、污染 GitHub contributors。
  *
- * v1（最小版）两层保障：
- * 1. System prompt 指令（Claude / Pi 通用）— 引导 Agent 在 git commit / gh pr 时附加标识
- * 2. Claude SDK session `.claude/settings.json` 的 `attribution` 字段 — 覆盖 SDK 默认 Co-Authored-By
+ * System prompt 指令 — 引导 Agent 在 git commit / gh pr 时附加标识。
  *
  * 后续可增强：canUseTool 对 Bash 的确定性 --trailer / body 注入。
  */
@@ -42,43 +40,6 @@ export function isGitAttributionEnabled(config?: GitAttributionConfig | boolean 
     return config.enabled
   }
   return DEFAULT_GIT_ATTRIBUTION_ENABLED
-}
-
-/**
- * Claude Code settings.json 的 attribution 字段。
- * 空字符串会禁用 SDK 内置 Co-Authored-By / Generated with 归因。
- * @see https://code.claude.com/docs/en/settings#attribution-settings
- */
-export function buildClaudeSdkAttribution(enabled: boolean): { commit: string; pr: string } {
-  if (!enabled) {
-    return { commit: '', pr: '' }
-  }
-  return {
-    commit: PROMA_COMMIT_TRAILER,
-    pr: PROMA_PR_ATTRIBUTION,
-  }
-}
-
-/**
- * 将 Proma attribution 合并进 Claude session 的 settings 对象。
- * @returns 是否发生了变更（调用方可据此决定是否写盘）
- */
-export function applyClaudeSdkAttributionSettings(
-  sdkSettings: Record<string, unknown>,
-  enabled: boolean,
-): boolean {
-  const next = buildClaudeSdkAttribution(enabled)
-  const prev = sdkSettings.attribution
-  const prevObj = prev && typeof prev === 'object' && !Array.isArray(prev)
-    ? (prev as Record<string, unknown>)
-    : null
-
-  if (prevObj?.commit === next.commit && prevObj?.pr === next.pr) {
-    return false
-  }
-
-  sdkSettings.attribution = next
-  return true
 }
 
 /** 注入到 buildSystemPrompt 的 Git/PR 标识规范 */

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -20,7 +20,7 @@ import { join, dirname } from 'node:path'
 import { accessSync, constants, existsSync, mkdirSync, realpathSync } from 'node:fs'
 import type { ToolDefinition } from '@earendil-works/pi-coding-agent'
 import { app } from 'electron'
-import type { AgentSendInput, AgentMessage, AgentGenerateTitleInput, AgentProviderAdapter, AgentSessionMeta, CodexOAuthCredentials, XaiOAuthCredentials, TypedError, RetryAttempt, SDKMessage, SDKAssistantMessage, AgentStreamPayload, RewindSessionResult } from '@proma/shared'
+import type { AgentSendInput, AgentMessage, AgentGenerateTitleInput, AgentProviderAdapter, AgentSessionMeta, CodexOAuthCredentials, XaiOAuthCredentials, TypedError, SDKMessage, SDKAssistantMessage, AgentStreamPayload, RewindSessionResult } from '@proma/shared'
 import {
   PROMA_DEFAULT_PERMISSION_MODE,
   PROMA_PERMISSION_MODE_CONFIG,
@@ -30,15 +30,15 @@ import {
   isPersistableSDKSystemMessage,
   normalizePathForCompare,
   normalizeMcpTransportType,
-  inferAgentSdkContextWindow,
+  inferContextWindow,
   inferReasoningTransport,
   resolveReasoningProfile,
 } from '@proma/shared'
 import type { PromaPermissionMode, AskUserRequest, ExitPlanModeRequest, SDKSystemMessage } from '@proma/shared'
 import type { PiAgentQueryOptions } from './adapters/pi-agent-adapter'
 import { getPiAssistantErrorDetails, hasPiAssistantTextContent, stripPiAssistantError } from './adapters/pi-message-adapter'
-import { friendlyErrorMessage, isPromptTooLongError, isThinkingSignatureError, mapSDKErrorToTypedError, shouldKeepChannelOpen } from './agent-error-utils'
-import { isTransientNetworkError, isMalformedResponseError, isSessionNotFoundError } from './error-patterns'
+import { friendlyErrorMessage, isPromptTooLongError, isThinkingSignatureError, mapAgentErrorToTypedError } from './agent-error-utils'
+import { isSessionNotFoundError } from './error-patterns'
 import { AgentEventBus } from './agent-event-bus'
 import { decryptApiKey, getChannelById, listChannels, persistCodexOAuthCredentials, persistXaiOAuthCredentials, resolveChannelRuntimeApiKey, resolveCodexOAuthCredentials, resolveXaiOAuthCredentials } from './channel-manager'
 import { getAdapter, fetchTitle } from '@proma/core'
@@ -110,124 +110,6 @@ function isMissingActiveQueueChannelError(error: unknown): boolean {
 
 function isPartialSDKMessage(message: SDKMessage): boolean {
   return (message as Record<string, unknown>)._partial === true
-}
-
-/**
- * 从 stderr 中提取 API 错误信息
- *
- * 解析类似这样的错误：
- * "401 {\"error\":{\"message\":\"...\"}}"
- * "API error: 400 Bad Request ..."
- */
-function extractApiError(stderr: string): { statusCode: number; message: string } | null {
-  if (!stderr) return null
-
-  // 模式 1：JSON 错误格式 - "401 {...}"
-  const jsonMatch = stderr.match(/(\d{3})\s+(\{[^}]*"error"[^}]*\})/s)
-  if (jsonMatch) {
-    try {
-      const statusCode = parseInt(jsonMatch[1]!)
-      const errorObj = JSON.parse(jsonMatch[2]!)
-      const message = errorObj.error?.message || errorObj.message || '未知错误'
-      return { statusCode, message }
-    } catch {
-      // JSON 解析失败，继续尝试其他模式
-    }
-  }
-
-  // 模式 2：API error 格式 - "API error (attempt X/Y): 401 401 {...}"
-  const apiErrorMatch = stderr.match(/API error[^:]*:\s+(\d{3})\s+\d{3}\s+(\{.*?\})/s)
-  if (apiErrorMatch) {
-    try {
-      const statusCode = parseInt(apiErrorMatch[1]!)
-      const errorObj = JSON.parse(apiErrorMatch[2]!)
-      const message = errorObj.error?.message || errorObj.message || '未知错误'
-      return { statusCode, message }
-    } catch {
-      // JSON 解析失败
-    }
-  }
-
-  // 模式 3：直接的状态码 + 消息
-  const simpleMatch = stderr.match(/(\d{3})[:\s]+(.+?)(?:\n|$)/i)
-  if (simpleMatch) {
-    const statusCode = parseInt(simpleMatch[1]!)
-    const message = simpleMatch[2]!.trim()
-    if (statusCode >= 400 && statusCode < 600) {
-      return { statusCode, message }
-    }
-  }
-
-  return null
-}
-
-// ===== 自动重试工具函数 =====
-
-/** 可自动重试的 TypedError 错误码 */
-const AUTO_RETRYABLE_ERROR_CODES: ReadonlySet<string> = new Set([
-  'rate_limited',
-  'provider_error',      // overloaded 映射为 provider_error
-  'service_error',
-  'service_unavailable',
-  'network_error',
-])
-
-/** 判断 typed_error 事件是否可自动重试 */
-function isAutoRetryableTypedError(error: TypedError): boolean {
-  return AUTO_RETRYABLE_ERROR_CODES.has(error.code)
-}
-
-/** 判断 catch 块中的 API 错误是否可自动重试（HTTP 429 / 5xx / 已知可恢复错误模式 / 瞬时网络错误） */
-function isAutoRetryableCatchError(
-  apiError: { statusCode: number; message: string } | null,
-  rawErrorMessage?: string,
-  stderr?: string,
-): boolean {
-  if (apiError) {
-    // 529 是 Anthropic 的过载状态码，通常很快恢复；与 429 / 5xx 一并重试。
-    if (apiError.statusCode === 429 || apiError.statusCode >= 500) return true
-  }
-  // 已知的可恢复错误模式（无 HTTP 状态码但可重试）
-  if (rawErrorMessage) {
-    if (rawErrorMessage.includes('context_management')) return true
-  }
-  // 兜底：extractApiError 未识别但 stderr / 错误文本中包含 502 / 529 或 overloaded 关键字时也视为可重试
-  // 502 (Bad Gateway) 通常是上游网关瞬时异常，与 529 一样很快自行恢复
-  const text = `${rawErrorMessage ?? ''}\n${stderr ?? ''}`
-  if (/\b502\b|\b529\b|overloaded/i.test(text)) return true
-  // 瞬时网络错误（terminated / ECONNRESET / socket hang up 等）
-  if (isTransientNetworkError(rawErrorMessage, stderr)) return true
-  // 上游响应体解析失败（JSON Parse error 等）：网关瞬时异常返回非 JSON 体，重试通常即可恢复
-  if (isMalformedResponseError(rawErrorMessage, stderr)) return true
-  return false
-}
-
-/** 最大自动重试次数 */
-const MAX_AUTO_RETRIES = 25
-
-/** 重试可见性阈值：前 N 次重试不通知 UI，避免偶发瞬时波动频繁惊扰用户 */
-const RETRY_VISIBILITY_THRESHOLD = 5
-
-/** 自动重试累计等待预算（毫秒） */
-const MAX_AUTO_RETRY_WAIT_MS = 5 * 60_000
-
-/** 重试单次延迟上限（毫秒） */
-const RETRY_MAX_DELAY_MS = 15_000
-
-/**
- * 计算重试延迟（指数退避 + ±20% jitter）
- *
- * 基础序列：1s, 2s, 4s, 8s, 15s, 15s...（cap = 15s）
- * 叠加 ±20% 随机抖动，避免大量 session 同时重试造成惊群。
- * 累计等待会被限制在 5 分钟以内。
- */
-function getRetryDelayMs(attempt: number, elapsedRetryDelayMs: number): number {
-  const remainingMs = MAX_AUTO_RETRY_WAIT_MS - elapsedRetryDelayMs
-  if (remainingMs <= 0) return 0
-
-  const base = Math.min(1000 * Math.pow(2, attempt - 1), RETRY_MAX_DELAY_MS)
-  const jitter = base * (Math.random() * 0.4 - 0.2)
-  return Math.min(remainingMs, Math.max(0, Math.round(base + jitter)))
 }
 
 /** 默认会话标题（用于判断是否需要自动生成） */
@@ -531,7 +413,6 @@ export class AgentOrchestrator {
    * 因此不清除磁盘 meta：本轮以非 resume 模式恢复，若失败下一轮仍可尝试 resume（#903）。
    * 调用方负责设置本地 existingSdkSessionId = undefined 和流程控制（break/continue）。
    *
-   * @returns lastRetryableError 描述字符串
    */
   private prepareSessionNotFoundRecovery(
     sessionId: string,
@@ -541,8 +422,8 @@ export class AgentOrchestrator {
     workspaceSlug: string | undefined,
     accumulatedMessages: SDKMessage[],
     queryStartedAt: number,
-  ): string {
-    return this.prepareResumeFallbackRecovery(
+  ): void {
+    this.prepareResumeFallbackRecovery(
       sessionId,
       queryOptions,
       contextualMessage,
@@ -551,7 +432,6 @@ export class AgentOrchestrator {
       accumulatedMessages,
       queryStartedAt,
       '检测到 session-not-found（可能为误检），保留 sdkSessionId 并切换到上下文回填模式',
-      'Session 暂不可 resume，切换到上下文回填模式',
     )
   }
 
@@ -576,9 +456,8 @@ export class AgentOrchestrator {
     accumulatedMessages: SDKMessage[],
     queryStartedAt: number,
     logMessage: string,
-    retryReason: string,
     clearPersistedSession = false,
-  ): string {
+  ): void {
     console.log(`[Agent 编排] ${logMessage}`)
     // 先持久化当前已累积的消息，确保 JSONL 文件包含最新内容
     this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
@@ -591,7 +470,6 @@ export class AgentOrchestrator {
     queryOptions.resumeSessionId = undefined
     queryOptions.resumeSessionAt = undefined
     queryOptions.prompt = buildRecoveryPrompt(sessionId, contextualMessage, { agentCwd, workspaceSlug })
-    return retryReason
   }
 
   /**
@@ -705,7 +583,6 @@ export class AgentOrchestrator {
     extensions: { piCustomTools?: ToolDefinition[] } = {},
   ): Promise<void> {
     const { sessionId, userMessage, rawUserMessage, channelId, modelId, workspaceId: requestedWorkspaceId, additionalDirectories, permissionModeOverride, mentionedSkills, mentionedMcpServers, mentionedSessionIds, mentionedTodoIds, mentionedCalendarEventIds, automationContext, retryOfErrorUuid } = input
-    const stderrChunks: string[] = []
     const streamStartedAt = input.startedAt ?? Date.now()
     let userMessagePersisted = false
     let sessionMeta = getAgentSessionMeta(sessionId)
@@ -944,16 +821,6 @@ export class AgentOrchestrator {
     ): void => {
       releaseActiveRun()
       callbacks.onComplete(messages, opts)
-    }
-    // 轻量完成：turn 主体结束但仍有后台任务在飞行。
-    // 关键区别——不调用 releaseActiveRun，保留 activeSessions/activeChannels/sessionPermissionModes，
-    // 以便 ① adapter 保持的通道在任务完成时自动续轮 ② 用户在等待期手动注入消息能复用通道。
-    // UI 侧通过 backgroundTasksPending 进入"空闲可输入"态（spinner 停、输入框启用）。
-    const idleComplete = (
-      messages?: AgentMessage[],
-      opts?: { startedAt?: number; resultSubtype?: string; resultErrors?: string[] },
-    ): void => {
-      callbacks.onComplete(messages, { ...opts, backgroundTasksPending: true })
     }
     const failRun = (
       error: string,
@@ -1409,26 +1276,28 @@ export class AgentOrchestrator {
           .catch((err) => console.error('[Agent 编排] 标题生成未捕获异常:', err))
       }
       const handleSessionId = (sdkSessionId: string, piSessionFile?: string): void => {
-        // 仅在 session_id 真正变化时才持久化。SDK v2 几乎每条消息都会回调 onSessionId，
+        // 仅在 session_id 真正变化时才持久化。Pi 在同一 artifact 的每条消息都可能回调，
         // capturedSdkSessionId 已初始化为 existingSdkSessionId，并在 recovery 时同步重置。
         const isNewSessionId = sdkSessionId !== capturedSdkSessionId
-        const needsPiSessionFile = !!piSessionFile && sessionMeta?.piSessionFile !== piSessionFile
+        const latestSessionMeta = getAgentSessionMeta(sessionId)
+        // recovery 新建 artifact 后，旧 entry bindings 属于另一棵 Pi tree，必须原子替换而非合并。
+        const artifactReplaced = !!piSessionFile && latestSessionMeta?.piSessionFile !== piSessionFile
         capturedSdkSessionId = sdkSessionId
-        if (isNewSessionId || needsPiSessionFile) {
+        if (isNewSessionId || artifactReplaced) {
           try {
             // 用户可在本轮运行中改选下一轮内核；不能让旧 runtime 回填不兼容的 session artifact。
-            const latestSessionMeta = getAgentSessionMeta(sessionId)
             if (latestSessionMeta?.legacyTranscript?.continuationRequired) {
               console.log(`[Agent 编排] 忽略只读历史会话的 session artifact: ${sdkSessionId}`)
             } else {
               updateAgentSessionMeta(sessionId, {
                 sdkSessionId,
                 ...(piSessionFile ? { piSessionFile } : {}),
+                ...(artifactReplaced ? { piEntryBindings: {} } : {}),
               })
-              console.log(`[Agent 编排] 已保存 SDK session_id: ${sdkSessionId}`)
+              console.log(`[Agent 编排] 已保存 Pi session_id: ${sdkSessionId}`)
             }
           } catch (err) {
-            console.error(`[Agent 编排] 保存 SDK session_id 失败:`, err)
+            console.error(`[Agent 编排] 保存 Pi session_id 失败:`, err)
           }
         }
 
@@ -1441,7 +1310,7 @@ export class AgentOrchestrator {
         this.eventBus.emit(sessionId, { kind: 'proma_event', event: { type: 'model_resolved', model: resolvedModel } })
       }
       const handleContextWindow = (cw: number): void => {
-        const inferredWindow = inferAgentSdkContextWindow(modelId, channel.provider)
+        const inferredWindow = inferContextWindow(modelId)
         const contextWindow = Math.max(cw, inferredWindow ?? 0) || cw
         console.log(`[Agent 编排] 缓存 contextWindow: ${contextWindow}`)
         // result 消息里的真实 contextWindow 透传到 renderer，
@@ -1455,7 +1324,7 @@ export class AgentOrchestrator {
       const queryOptions: PiAgentQueryOptions = {
         sessionId,
         prompt: finalPrompt,
-        // pi runtime 不支持 Claude Agent SDK 的 `[1m]` 扩展上下文变体：
+        // 旧持久化模型 ID 可能带 `[1m]` 上下文后缀；Pi runtime 不支持该变体：
         // 智谱等端点不识别 glm-5.2[1m] 这类后缀，会返回 1211「模型不存在」。
         // 因此 pi 分支直接使用用户配置的原始模型 ID，不追加任何 `[1m]`。
         model: selectedModelId,
@@ -1522,83 +1391,13 @@ export class AgentOrchestrator {
 
       console.log(`[Agent 编排] 开始通过 Adapter 遍历事件流...`)
 
-      // 14. 遍历 Adapter 产出的 AgentEvent 流（含自动重试）
-      let lastRetryableError: string | undefined
-      let retryDelayElapsedMs = 0
-      let retryAttemptsScheduled = 0
-      let retrySucceeded = false
-      let skipNextRetryDelay = false
-      let thinkingSignatureRecoveryAttempted = false
-      let promptTooLongRecoveryAttempted = false
-      let invisibleRecoveryAttempts = 0
-      const canAutoRetry = (attempt: number): boolean =>
-        attempt <= MAX_AUTO_RETRIES && retryDelayElapsedMs < MAX_AUTO_RETRY_WAIT_MS
-      // Pi runtime 使用其 session 内的 native retry（agent.continue），能保留已完成的
-      // tool_result；禁止外层以原 prompt 重开 query，但保留 session-not-found 等显式恢复。
-      const canReplayPromptForRetry = (attempt: number): boolean =>
-false && canAutoRetry(attempt)
-
-      const canTryThinkingSignatureRecovery = (attempt: number): boolean =>
-        !thinkingSignatureRecoveryAttempted &&
-        canAutoRetry(attempt) &&
-        !!(existingSdkSessionId || capturedSdkSessionId || queryOptions.resumeSessionId)
-      const canTryPromptTooLongRecovery = (attempt: number): boolean =>
-        !promptTooLongRecoveryAttempted &&
-        canAutoRetry(attempt) &&
-        !!(existingSdkSessionId || capturedSdkSessionId || queryOptions.resumeSessionId)
-
+      // 14. 遍历 Adapter 事件流。Pi adapter 自行处理传输层重试；此处仅允许一次 resume artifact 回退。
+      const MAX_QUERY_ATTEMPTS = 2
       const queryStartedAt = Date.now()
 
-      for (let attempt = 1; attempt <= MAX_AUTO_RETRIES + 1; attempt++) {
-        // 非首次尝试：等待 + 发送重试事件到 UI
-        if (attempt > 1) {
-          if (skipNextRetryDelay) {
-            skipNextRetryDelay = false
-            console.log(`[Agent 编排] 已切换到上下文回填模式，立即重试`)
-          } else {
-            const retryAttempt = Math.max(1, attempt - 1 - invisibleRecoveryAttempts)
-            const delayMs = getRetryDelayMs(retryAttempt, retryDelayElapsedMs)
-            if (delayMs <= 0) {
-              console.log(`[Agent 编排] 自动重试等待预算已耗尽 (${MAX_AUTO_RETRY_WAIT_MS}ms)，停止重试`)
-              break
-            }
-            retryDelayElapsedMs += delayMs
-            retryAttemptsScheduled = retryAttempt
-            const delaySec = delayMs / 1000
-            const attemptData: RetryAttempt = {
-              attempt: retryAttempt,
-              timestamp: Date.now(),
-              reason: lastRetryableError ?? '未知错误',
-              errorMessage: lastRetryableError ?? '',
-              delaySeconds: delaySec,
-            }
-
-            // 前 RETRY_VISIBILITY_THRESHOLD 次重试静默进行，避免偶发瞬时波动频繁惊扰用户
-            if (retryAttempt > RETRY_VISIBILITY_THRESHOLD) {
-              this.eventBus.emit(sessionId, {
-                kind: 'proma_event',
-                event: { type: 'retry', status: 'starting', attempt: retryAttempt, maxAttempts: MAX_AUTO_RETRIES, delaySeconds: delaySec, reason: lastRetryableError ?? '未知错误' },
-              })
-              this.eventBus.emit(sessionId, {
-                kind: 'proma_event',
-                event: { type: 'retry', status: 'attempt', attemptData },
-              })
-            }
-
-            console.log(`[Agent 编排] 第 ${retryAttempt} 次重试${retryAttempt <= RETRY_VISIBILITY_THRESHOLD ? '(静默)' : ''}，等待 ${delaySec}s...`)
-            await new Promise((r) => setTimeout(r, delayMs))
-
-            // 等待期间如果会话被中止，退出
-            if (!this.activeSessions.has(sessionId)) {
-              const wasStoppedByUser = this.consumeStoppedByUser(sessionId, runGeneration)
-              this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
-              try { updateAgentSessionMeta(sessionId, { stoppedByUser: wasStoppedByUser }) } catch { /* 会话可能已删除 */ }
-              completeRun(getAgentSessionMessages(sessionId), { stoppedByUser: wasStoppedByUser, startedAt: streamStartedAt })
-              return
-            }
-          }
-        }
-
+      for (let attempt = 1; attempt <= MAX_QUERY_ATTEMPTS; attempt++) {
+        // 回退会清除 queryOptions.resumeSessionId；新建 Pi artifact 不应再触发 prompt replay。
+        const wasResuming = !!queryOptions.resumeSessionId
         let shouldRetryFromError = false
 
         try {
@@ -1620,9 +1419,6 @@ false && canAutoRetry(attempt)
           // 终止路径失效，需排查。
           let drainTimeoutPromise: Promise<'drain_timeout'> | null = null
           const RESULT_DRAIN_TIMEOUT_MS = 2_000
-          // 后台任务等待态：result 走轻量完成后置 true，下一轮真正开始（收到 assistant/user/task 消息）时
-          // 置回 false 并发 run_resumed，让 UI 从空闲态恢复运行态。
-          let awaitingBackgroundWake = false
           let visibleRunMessageCount = 0
 
           while (true) {
@@ -1660,16 +1456,6 @@ false && canAutoRetry(attempt)
               visibleRunMessageCount += 1
             }
 
-            // 后台任务唤醒：轻量完成后处于等待态，收到新一轮的首条实质消息时
-            // 发 run_resumed，让 UI 从"空闲可输入"恢复到"运行中"。
-            // applyAgentEvent 的流式分支不会重置 running，故必须显式通知。
-            if (awaitingBackgroundWake) {
-              const sub = msg.type === 'system' ? (msg as { subtype?: string }).subtype : undefined
-              if (msg.type === 'assistant' || msg.type === 'user' || sub === 'task_started' || sub === 'task_progress') {
-                awaitingBackgroundWake = false
-                this.eventBus.emit(sessionId, { kind: 'proma_event', event: { type: 'run_resumed', sessionId } })
-              }
-            }
 
             // SDK 权限模式可能在 canUseTool 前直接批准工具（如 bypassPermissions）。
             // 因此计划阶段状态要从实际 tool_use 流里同步，不能只依赖权限回调。
@@ -1695,16 +1481,13 @@ false && canAutoRetry(attempt)
                 if (isPromptTooLongError(detailedMessage, originalError)) {
                   errorCode = 'prompt_too_long'
                 }
-                const typedError = mapSDKErrorToTypedError(errorCode, friendlyErrorMessage(detailedMessage), originalError)
+                const typedError = mapAgentErrorToTypedError(errorCode, friendlyErrorMessage(detailedMessage), originalError)
 
                 // Session 不存在错误：清除 sdkSessionId，切换到上下文回填模式重试
-                if (isSessionNotFoundError(detailedMessage, originalError) && existingSdkSessionId && canAutoRetry(attempt)) {
-                  invisibleRecoveryAttempts += 1
-                  skipNextRetryDelay = true
+                if (isSessionNotFoundError(detailedMessage, originalError) && wasResuming) {
                   existingSdkSessionId = undefined
                   capturedSdkSessionId = undefined
-                  lastRetryableError = this.prepareSessionNotFoundRecovery(sessionId, queryOptions, contextualMessage, agentCwd, workspaceSlug, accumulatedMessages, queryStartedAt)
-                  stderrChunks.length = 0
+                  this.prepareSessionNotFoundRecovery(sessionId, queryOptions, contextualMessage, agentCwd, workspaceSlug, accumulatedMessages, queryStartedAt)
                   shouldRetryFromError = true
                   break
                 }
@@ -1713,14 +1496,11 @@ false && canAutoRetry(attempt)
                 // 先自动清除 SDK resume 关系，改用 Proma 已持久化上下文重跑一次；再失败才展示用户提示。
                 if (
                   typedError.code === THINKING_SIGNATURE_ERROR_CODE &&
-                  canTryThinkingSignatureRecovery(attempt)
+                  wasResuming
                 ) {
-                  thinkingSignatureRecoveryAttempted = true
-                  invisibleRecoveryAttempts += 1
                   existingSdkSessionId = undefined
                   capturedSdkSessionId = undefined
-                  skipNextRetryDelay = true
-                  lastRetryableError = this.prepareResumeFallbackRecovery(
+                  this.prepareResumeFallbackRecovery(
                     sessionId,
                     queryOptions,
                     contextualMessage,
@@ -1729,10 +1509,8 @@ false && canAutoRetry(attempt)
                     accumulatedMessages,
                     queryStartedAt,
                     '检测到 thinking signature 不兼容，清除 sdkSessionId 并切换到上下文回填模式',
-                    '思考签名不兼容，切换到上下文回填模式',
                     true,  // 跨模型签名不兼容是唯一确定永久无效的场景，清除磁盘 sdkSessionId
                   )
-                  stderrChunks.length = 0
                   shouldRetryFromError = true
                   break
                 }
@@ -1741,14 +1519,11 @@ false && canAutoRetry(attempt)
                 // 自动清除 resume 指针，改用 Proma 最近历史回填重跑一次；用于飞书/自动任务等无人值守入口自恢复。
                 if (
                   typedError.code === 'prompt_too_long' &&
-                  canTryPromptTooLongRecovery(attempt)
+                  wasResuming
                 ) {
-                  promptTooLongRecoveryAttempted = true
-                  invisibleRecoveryAttempts += 1
                   existingSdkSessionId = undefined
                   capturedSdkSessionId = undefined
-                  skipNextRetryDelay = true
-                  lastRetryableError = this.prepareResumeFallbackRecovery(
+                  this.prepareResumeFallbackRecovery(
                     sessionId,
                     queryOptions,
                     contextualMessage,
@@ -1757,25 +1532,8 @@ false && canAutoRetry(attempt)
                     accumulatedMessages,
                     queryStartedAt,
                     '检测到上下文过长，清除 sdkSessionId 并切换到上下文回填模式',
-                    '上下文过长，切换到上下文回填模式',
                     true,
                   )
-                  stderrChunks.length = 0
-                  shouldRetryFromError = true
-                  break
-                }
-
-                // 判断是否可自动重试
-                if (isAutoRetryableTypedError(typedError) && canReplayPromptForRetry(attempt)) {
-                  lastRetryableError = typedError.title
-                    ? `${typedError.title}: ${typedError.message}`
-                    : typedError.message
-                  console.log(`[Agent 编排] 可重试错误 (assistant error): ${typedError.code} - ${lastRetryableError}`)
-                  this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
-                  accumulatedMessages.length = 0
-                  // 与 catch 路径（isAutoRetryableCatchError）和思考签名回填路径保持一致：
-                  // 重试前清空已累积的 stderr，避免 25 次重试上限内字符串无限增长
-                  stderrChunks.length = 0
                   shouldRetryFromError = true
                   break
                 }
@@ -1819,14 +1577,6 @@ false && canAutoRetry(attempt)
                 appendSDKMessages(sessionId, [errorSDKMsg])
                 console.log(`[Agent 编排] 已保存 TypedError 消息: ${typedError.code} - ${typedError.title}`)
 
-                // 如果之前有可见重试记录，发送 retry_failed
-                if (retryAttemptsScheduled > RETRY_VISIBILITY_THRESHOLD && lastRetryableError) {
-                  this.eventBus.emit(sessionId, {
-                    kind: 'proma_event',
-                    event: { type: 'retry', status: 'failed', attemptData: { attempt: retryAttemptsScheduled, timestamp: Date.now(), reason: lastRetryableError, errorMessage: typedError.message, delaySeconds: 0 } },
-                  })
-                }
-
                 // 透传归一化后的错误消息到前端，避免 SDK 原始 API Error 直接暴露给用户。
                 this.eventBus.emit(sessionId, { kind: 'sdk_message', message: errorSDKMsg })
                 try { updateAgentSessionMeta(sessionId, {}) } catch { /* 忽略 */ }
@@ -1850,14 +1600,14 @@ false && canAutoRetry(attempt)
                     accumulatedMessages.push(msg)
                   }
                 } else {
-                  // 为结果消息注入渠道信息，确保持久化后能按 Agent SDK 运行窗口计算压缩阈值
+                  // 为结果消息注入渠道信息，确保持久化后能按模型上下文窗口计算压缩阈值
                   if (msg.type === 'result') {
                     if (modelId) {
                       (msg as Record<string, unknown>)._channelModelId = modelId
                     }
                     ;(msg as Record<string, unknown>)._channelProvider = channel.provider
                   }
-                  // 为 assistant 消息注入渠道信息，确保持久化后能正确匹配模型显示名与 Agent SDK 窗口
+                  // 为 assistant 消息注入渠道信息，确保持久化后能正确匹配模型显示名与上下文窗口
                   if (msg.type === 'assistant') {
                     if (modelId) {
                       (msg as Record<string, unknown>)._channelModelId = modelId
@@ -1877,72 +1627,50 @@ false && canAutoRetry(attempt)
             // Turn 结束时：持久化累积消息
             if (msg.type === 'result') {
               capturedResultSubtype = (msg as { subtype?: string }).subtype
-              // SDK 的 SDKResultError 在 errors[] 中携带真实错误原因（error_during_execution 等场景），
-              // 捕获后既用于重试判定，也透传到前端展示具体错误。
+              // Pi result 的 errors[] 携带真实错误原因，透传到前端展示具体错误。
               const rawResultErrors = (msg as { errors?: unknown }).errors
               capturedResultErrors = Array.isArray(rawResultErrors)
                 ? rawResultErrors.filter((e): e is string => typeof e === 'string' && e.trim().length > 0)
                 : undefined
               this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
               accumulatedMessages.length = 0
-              // 软中断 / 延迟工具 / hook 暂停等场景下，adapter 保留 channel
-              // 等待队列或后续消息继续 drive Query，此处跳过 drain 超时以免误关闭事件循环。
-              // 完整白名单见 agent-error-utils.ts 的 CONTINUABLE_TERMINAL_REASONS。
-              const resultTerminalReason = (msg as { terminal_reason?: string }).terminal_reason
-              // adapter 在"本轮结束但仍有后台任务/定时任务在飞行"时打的注解：
-              // 走轻量完成（UI 空闲可输入、host 保留会话），等待 task_notification 自动续轮。
-              const keptOpenForTasks = (msg as Record<string, unknown>)._keepChannelOpenForTasks === true
-              const keepChannelOpen = shouldKeepChannelOpen(resultTerminalReason) || keptOpenForTasks
-              // 分类打点：跟踪线上哪种 terminal_reason 最常见，配合 deferred_tool_use 回填决策
-              const hasDeferredTool = (msg as { deferred_tool_use?: unknown }).deferred_tool_use != null
               console.log(
-                `[Agent 编排] result 到达: sessionId=${sessionId}, subtype=${capturedResultSubtype ?? 'unknown'}, ` +
-                `terminal_reason=${resultTerminalReason ?? 'undefined'}, keepChannelOpen=${keepChannelOpen}` +
-                (keptOpenForTasks ? ', keptOpenForTasks=true' : '') +
-                (hasDeferredTool ? ', hasDeferredTool=true' : '') +
+                `[Agent 编排] result 到达: sessionId=${sessionId}, subtype=${capturedResultSubtype ?? 'unknown'}` +
                 (capturedResultErrors?.length ? `, errors=${JSON.stringify(capturedResultErrors)}` : ''),
               )
-              // error_during_execution 是 SDK 的兜底错误码，以 result（而非 assistant.error / 抛异常）形式到达，
-              // 默认不会触发上面两条重试路径。这里用 errors[] 文本喂给现有的可重试判定（502/529/overloaded/
-              // 网络瞬断 / 响应体解析失败等），命中则进入重试循环，复用统一的退避逻辑。
-              if (
-                capturedResultSubtype === 'error_during_execution' &&
-                capturedResultErrors?.length &&
-                isSessionNotFoundError(capturedResultErrors.join('\n'), stderrChunks.join('\n')) &&
-                existingSdkSessionId &&
-                canAutoRetry(attempt)
-              ) {
-                invisibleRecoveryAttempts += 1
-                skipNextRetryDelay = true
-                existingSdkSessionId = undefined
-                capturedSdkSessionId = undefined
-                lastRetryableError = this.prepareSessionNotFoundRecovery(sessionId, queryOptions, contextualMessage, agentCwd, workspaceSlug, accumulatedMessages, queryStartedAt)
-                stderrChunks.length = 0
-                shouldRetryFromError = true
-                break
+              // Pi 也可能在 result 中报告失效的 resume artifact；仅回退本轮实际 resume 的请求。
+              const resultErrorText = capturedResultErrors?.join('\n')
+              if (resultErrorText && wasResuming) {
+                if (isSessionNotFoundError(resultErrorText)) {
+                  existingSdkSessionId = undefined
+                  capturedSdkSessionId = undefined
+                  this.prepareSessionNotFoundRecovery(sessionId, queryOptions, contextualMessage, agentCwd, workspaceSlug, accumulatedMessages, queryStartedAt)
+                  shouldRetryFromError = true
+                  break
+                }
+                if (isPromptTooLongError(resultErrorText)) {
+                  existingSdkSessionId = undefined
+                  capturedSdkSessionId = undefined
+                  this.prepareResumeFallbackRecovery(
+                    sessionId, queryOptions, contextualMessage, agentCwd, workspaceSlug, accumulatedMessages, queryStartedAt,
+                    '检测到上下文过长，清除 sdkSessionId 并切换到上下文回填模式', true,
+                  )
+                  shouldRetryFromError = true
+                  break
+                }
+                if (isThinkingSignatureError(resultErrorText)) {
+                  existingSdkSessionId = undefined
+                  capturedSdkSessionId = undefined
+                  this.prepareResumeFallbackRecovery(
+                    sessionId, queryOptions, contextualMessage, agentCwd, workspaceSlug, accumulatedMessages, queryStartedAt,
+                    '检测到 thinking signature 不兼容，清除 sdkSessionId 并切换到上下文回填模式', true,
+                  )
+                  shouldRetryFromError = true
+                  break
+                }
               }
-              if (
-                capturedResultSubtype === 'error_during_execution' &&
-                capturedResultErrors?.length &&
-                isAutoRetryableCatchError(null, capturedResultErrors.join('\n')) &&
-                canReplayPromptForRetry(attempt)
-              ) {
-                lastRetryableError = capturedResultErrors[0]
-                console.log(`[Agent 编排] 可重试错误 (result error_during_execution, attempt ${attempt}/${MAX_AUTO_RETRIES}): ${lastRetryableError}`)
-                // 与 assistant.error / catch 重试路径保持一致：清空已累积 stderr，避免重试上限内无限增长
-                stderrChunks.length = 0
-                shouldRetryFromError = true
-                break
-              }
-              if (keptOpenForTasks) {
-                // 轻量完成：UI 置空闲可输入，但 host 保持运行态（不 releaseActiveRun、不 break、不启动 drain 超时），
-                // while 循环继续 park 在 queryIterator.next()，等待后台任务完成时 SDK 自动 yield 的新一轮消息。
-                awaitingBackgroundWake = true
-                idleComplete(getAgentSessionMessages(sessionId), { startedAt: streamStartedAt, resultSubtype: capturedResultSubtype, resultErrors: capturedResultErrors })
-              } else if (!keepChannelOpen && !drainTimeoutPromise) {
-                // 启动 drain 超时安全网：正常情况下 adapter 收到 terminal result 会主动 break
-                // 触发 iterator.return → 下一次 next() 立即返回 done，此 timeout 不会触发。
-                // 仅在极端情况下（adapter 主动终止失效、SDK 行为再次变化）保护事件循环不无限挂起。
+              if (!drainTimeoutPromise) {
+                // Pi adapter 收到终态 result 后会结束 iterator；超时仅保护异常运行时行为。
                 drainTimeoutPromise = new Promise((resolve) =>
                   setTimeout(() => resolve('drain_timeout'), RESULT_DRAIN_TIMEOUT_MS),
                 )
@@ -1975,13 +1703,6 @@ false && canAutoRetry(attempt)
 
           const wasStoppedByUser = this.consumeStoppedByUser(sessionId, runGeneration)
 
-          // 正常完成 — 如果之前有可见重试，发送 retry_cleared
-          if (!wasStoppedByUser && retryAttemptsScheduled > RETRY_VISIBILITY_THRESHOLD) {
-            this.eventBus.emit(sessionId, { kind: 'proma_event', event: { type: 'retry', status: 'cleared' } })
-            console.log(`[Agent 编排] 重试成功，已在第 ${attempt} 次尝试后恢复`)
-          }
-          retrySucceeded = true
-
           // 15. 持久化 assistant 消息
           this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
 
@@ -2009,58 +1730,33 @@ false && canAutoRetry(attempt)
           // 发送完成信号
           completeRun(getAgentSessionMessages(sessionId), { stoppedByUser: wasStoppedByUser, startedAt: streamStartedAt, resultSubtype: capturedResultSubtype, resultErrors: capturedResultErrors })
 
-          break  // 成功完成，退出重试循环
+          return
 
         } catch (error) {
-          // 打印 stderr
-          const fullStderr = stderrChunks.join('').trim()
-          if (fullStderr) {
-            console.error(`[Agent 编排] 完整 stderr 输出 (${fullStderr.length} 字符):`)
-            console.error(fullStderr)
-          } else {
-            console.error(`[Agent 编排] stderr 为空`)
-          }
-
-          // 用户主动中止
           if (!this.activeSessions.has(sessionId)) {
             const wasStoppedByUser = this.consumeStoppedByUser(sessionId, runGeneration)
-            console.log(`[Agent 编排] 会话 ${sessionId} 已被用户中止`)
             this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
-            // 持久化中断状态到会话 meta
             try { updateAgentSessionMeta(sessionId, { stoppedByUser: wasStoppedByUser }) } catch { /* 会话可能已删除 */ }
             completeRun(getAgentSessionMessages(sessionId), { stoppedByUser: wasStoppedByUser, startedAt: streamStartedAt })
             return
           }
 
-          // 从 stderr 提取 API 错误
-          const stderrOutput = stderrChunks.join('').trim()
-          const apiError = extractApiError(stderrOutput)
-          const rawErrorMessage = error instanceof Error ? error.message : ''
-          const catchLooksPromptTooLong = isPromptTooLongError(
-            apiError?.message ?? '',
-            rawErrorMessage,
-            stderrOutput,
-          )
+          const rawErrorMessage = errorMessageOf(error)
+          const catchLooksPromptTooLong = isPromptTooLongError(rawErrorMessage)
 
           // Session 不存在错误：清除 sdkSessionId，切换到上下文回填模式重试
-          if (isSessionNotFoundError(rawErrorMessage, stderrOutput) && existingSdkSessionId && canAutoRetry(attempt)) {
-            invisibleRecoveryAttempts += 1
-            skipNextRetryDelay = true
+          if (isSessionNotFoundError(rawErrorMessage) && wasResuming) {
             existingSdkSessionId = undefined
             capturedSdkSessionId = undefined
-            lastRetryableError = this.prepareSessionNotFoundRecovery(sessionId, queryOptions, contextualMessage, agentCwd, workspaceSlug, accumulatedMessages, queryStartedAt)
-            stderrChunks.length = 0
+            this.prepareSessionNotFoundRecovery(sessionId, queryOptions, contextualMessage, agentCwd, workspaceSlug, accumulatedMessages, queryStartedAt)
             continue  // 进入下一次 retry 循环
           }
 
           // 上下文过长：清除超限 resume 指针，用 Proma 历史回填自动恢复一次。
-          if (catchLooksPromptTooLong && canTryPromptTooLongRecovery(attempt)) {
-            promptTooLongRecoveryAttempted = true
-            invisibleRecoveryAttempts += 1
+          if (catchLooksPromptTooLong && wasResuming) {
             existingSdkSessionId = undefined
             capturedSdkSessionId = undefined
-            skipNextRetryDelay = true
-            lastRetryableError = this.prepareResumeFallbackRecovery(
+            this.prepareResumeFallbackRecovery(
               sessionId,
               queryOptions,
               contextualMessage,
@@ -2069,24 +1765,19 @@ false && canAutoRetry(attempt)
               accumulatedMessages,
               queryStartedAt,
               '检测到上下文过长，清除 sdkSessionId 并切换到上下文回填模式',
-              '上下文过长，切换到上下文回填模式',
               true,
             )
-            stderrChunks.length = 0
             continue  // 进入下一次 retry 循环
           }
 
           // Thinking signature 不兼容：先自动清除 SDK resume 关系并用上下文回填重跑一次。
           if (
-            isThinkingSignatureError(apiError?.message ?? '', rawErrorMessage, stderrOutput) &&
-            canTryThinkingSignatureRecovery(attempt)
+            isThinkingSignatureError(rawErrorMessage) &&
+            wasResuming
           ) {
-            thinkingSignatureRecoveryAttempted = true
-            invisibleRecoveryAttempts += 1
             existingSdkSessionId = undefined
             capturedSdkSessionId = undefined
-            skipNextRetryDelay = true
-            lastRetryableError = this.prepareResumeFallbackRecovery(
+            this.prepareResumeFallbackRecovery(
               sessionId,
               queryOptions,
               contextualMessage,
@@ -2095,28 +1786,13 @@ false && canAutoRetry(attempt)
               accumulatedMessages,
               queryStartedAt,
               '检测到 thinking signature 不兼容，清除 sdkSessionId 并切换到上下文回填模式',
-              '思考签名不兼容，切换到上下文回填模式',
               true,  // 跨模型签名不兼容是唯一确定永久无效的场景，清除磁盘 sdkSessionId
             )
-            stderrChunks.length = 0
-            continue  // 进入下一次 retry 循环
-          }
-
-          // 判断是否可重试
-          if (isAutoRetryableCatchError(apiError, rawErrorMessage, stderrOutput) && canReplayPromptForRetry(attempt)) {
-            lastRetryableError = apiError
-              ? `API Error ${apiError.statusCode}: ${apiError.message}`
-              : (error instanceof Error ? error.message : '未知错误')
-            console.log(`[Agent 编排] 可重试错误 (catch, attempt ${attempt}/${MAX_AUTO_RETRIES}): ${lastRetryableError}`)
-            // 保存部分内容
-            this.persistSDKMessages(sessionId, accumulatedMessages, Date.now() - queryStartedAt)
-            accumulatedMessages.length = 0
-            stderrChunks.length = 0
             continue  // 进入下一次 retry 循环
           }
 
           // 不可重试 — 走原有终止逻辑
-          const errorMessage = error instanceof Error ? error.message : '未知错误'
+          const errorMessage = rawErrorMessage || '未知错误'
           console.error(`[Agent 编排] 执行失败:`, error)
 
           // 保存已累积的部分内容
@@ -2129,28 +1805,14 @@ false && canAutoRetry(attempt)
             }
           }
 
-          let userFacingError: string
-          if (apiError) {
-            userFacingError = friendlyErrorMessage(`API 错误 (${apiError.statusCode}):\n${apiError.message}`)
-          } else {
-            userFacingError = friendlyErrorMessage(errorMessage)
-          }
+          let userFacingError = friendlyErrorMessage(errorMessage)
 
           // 保存错误消息到 JSONL
           try {
             // 检测是否为 prompt too long 错误
-            const isPromptTooLong = isPromptTooLongError(
-              userFacingError,
-              error instanceof Error ? (error.stack ?? error.message) : String(error),
-              stderrOutput,
-            )
-            const isThinkingSignature = isThinkingSignatureError(
-              apiError?.message ?? '',
-              userFacingError,
-              rawErrorMessage,
-              error instanceof Error ? (error.stack ?? error.message) : String(error),
-              stderrOutput,
-            )
+            const errorStack = error instanceof Error ? (error.stack ?? error.message) : String(error)
+            const isPromptTooLong = isPromptTooLongError(userFacingError, errorStack)
+            const isThinkingSignature = isThinkingSignatureError(userFacingError, rawErrorMessage, errorStack)
             const errorCode = isPromptTooLong
               ? 'prompt_too_long'
               : isThinkingSignature
@@ -2196,14 +1858,6 @@ false && canAutoRetry(attempt)
             console.error('[Agent 编排] 保存错误消息失败:', saveError)
           }
 
-          // 如果之前有可见重试记录，发送 retry_failed
-          if (retryAttemptsScheduled > RETRY_VISIBILITY_THRESHOLD && lastRetryableError) {
-            this.eventBus.emit(sessionId, {
-              kind: 'proma_event',
-              event: { type: 'retry', status: 'failed', attemptData: { attempt: retryAttemptsScheduled, timestamp: Date.now(), reason: lastRetryableError, errorMessage: userFacingError, delaySeconds: 0 } },
-            })
-          }
-
           failRun(userFacingError, getAgentSessionMessages(sessionId), { startedAt: streamStartedAt })
 
           // 保留 Pi session ID，确保网络或上游临时失败后的下一轮可继续 resume。
@@ -2215,38 +1869,19 @@ false && canAutoRetry(attempt)
         }
       }
 
-      // 重试循环结束（达到最大次数仍失败）
-      if (!retrySucceeded && lastRetryableError) {
-        const retryFailureMessage = retryDelayElapsedMs >= MAX_AUTO_RETRY_WAIT_MS
-          ? '重试等待已达到 5 分钟后仍然失败'
-          : `重试 ${retryAttemptsScheduled || MAX_AUTO_RETRIES} 次后仍然失败`
-
-        // 仅当重试曾经对用户可见时才发送 retry_failed 事件
-        if (retryAttemptsScheduled > RETRY_VISIBILITY_THRESHOLD) {
-          this.eventBus.emit(sessionId, {
-            kind: 'proma_event',
-            event: { type: 'retry', status: 'failed', attemptData: { attempt: retryAttemptsScheduled || MAX_AUTO_RETRIES, timestamp: Date.now(), reason: lastRetryableError, errorMessage: retryFailureMessage, delaySeconds: 0 } },
-          })
-        }
-
-        // 保存错误消息
-        const retryErrorContent = `${retryFailureMessage}: ${lastRetryableError}`
-        const retryErrorSDKMsg: SDKMessage = {
-          type: 'assistant',
-          message: {
-            content: [{ type: 'text', text: retryErrorContent }],
-          },
-          parent_tool_use_id: null,
-          uuid: randomUUID(),
-          error: { message: retryErrorContent, errorType: 'unknown_error' },
-          _createdAt: Date.now(),
-          _errorCode: 'unknown_error',
-          _errorTitle: '重试失败',
-        } as unknown as SDKMessage
-        appendSDKMessages(sessionId, [retryErrorSDKMsg])
-
-        failRun(`${retryFailureMessage}: ${lastRetryableError}`, getAgentSessionMessages(sessionId), { startedAt: streamStartedAt })
-      }
+      const recoveryFailure = '会话恢复失败，请新建会话继续'
+      const recoveryError: SDKMessage = {
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: recoveryFailure }] },
+        parent_tool_use_id: null,
+        uuid: randomUUID(),
+        error: { message: recoveryFailure, errorType: 'unknown_error' },
+        _createdAt: Date.now(),
+        _errorCode: 'unknown_error',
+        _errorTitle: '会话恢复失败',
+      } as unknown as SDKMessage
+      appendSDKMessages(sessionId, [recoveryError])
+      failRun(recoveryFailure, getAgentSessionMessages(sessionId), { startedAt: streamStartedAt })
 
     } finally {
       // 只在 generation 匹配时才清理，防止旧流的 finally 误删新流的注册

--- a/apps/electron/src/main/lib/agent-session-manager.test.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.test.ts
@@ -12,6 +12,32 @@ let tempHome: string
 const originalHome = process.env.HOME
 const originalPromaDev = process.env.PROMA_DEV
 
+// agent-session-manager loads Pi lazily for fork/rewind, so this focused fake isolates
+// entry-tree semantics without requiring a real Pi session JSONL fixture.
+mock.module('@earendil-works/pi-coding-agent', () => ({
+  SessionManager: {
+    open: (sessionFile: string) => ({
+      createBranchedSession: (entryId: string) => {
+        const branchFile = join(tempHome, `.pi-branch-${entryId}.jsonl`)
+        writeFileSync(branchFile, '', 'utf-8')
+        return branchFile
+      },
+      getSessionFile: () => sessionFile,
+      getSessionId: () => 'pi-test-session',
+      getEntry: (entryId: string) => entryId === 'entry-keep' ? { id: entryId } : undefined,
+    }),
+    forkFrom: (_branchFile: string) => {
+      const forkFile = join(tempHome, '.pi-fork.jsonl')
+      writeFileSync(forkFile, '', 'utf-8')
+      return {
+        getSessionFile: () => forkFile,
+        getSessionId: () => 'pi-fork-session',
+        getEntry: (entryId: string) => entryId === 'entry-keep' ? { id: entryId } : undefined,
+      }
+    },
+  },
+}))
+
 mock.module('electron', () => ({
   app: {
     isPackaged: true,
@@ -374,6 +400,61 @@ describe('Agent 会话引用搜索', () => {
     const results = await manager.searchAgentSessionReferences({ query: '隐藏关键词' })
 
     expect(results).toEqual([])
+  })
+})
+
+describe('Pi entry binding recovery', () => {
+  test('Given Pi branch excludes later entries When fork Then keeps only bindings in the fork artifact', async () => {
+    const piSessionFile = join(tempHome, '.pi-source-fork.jsonl')
+    writeFileSync(piSessionFile, '', 'utf-8')
+    writeAgentSessionsIndex([{
+      id: 'pi-fork-source', title: 'Pi source', workspaceId: 'workspace-a', createdAt: 1, updatedAt: 1,
+      agentRuntime: 'pi', sdkSessionId: 'pi-source-session', piSessionFile,
+      piEntryBindings: {
+        'assistant-keep': 'entry-keep',
+        'assistant-stale': 'entry-stale',
+        'assistant-missing': 'missing-entry',
+      },
+    }])
+    writeAgentSessionJsonl('pi-fork-source', [
+      JSON.stringify({ type: 'user', uuid: 'user-1', message: { content: [{ type: 'text', text: '开始' }] } }),
+      JSON.stringify({ type: 'assistant', uuid: 'assistant-keep', message: { content: [{ type: 'text', text: '保留' }] } }),
+      JSON.stringify({ type: 'assistant', uuid: 'assistant-stale', message: { content: [{ type: 'text', text: '丢弃' }] } }),
+    ])
+
+    const forked = await manager.forkAgentSession({ sessionId: 'pi-fork-source', upToMessageUuid: 'assistant-keep' })
+
+    expect(forked.piEntryBindings).toEqual({ 'assistant-keep': 'entry-keep' })
+    expect(manager.getAgentSessionMeta(forked.id)?.piEntryBindings).toEqual({ 'assistant-keep': 'entry-keep' })
+    expect(forked.piSessionFile && existsSync(forked.piSessionFile)).toBe(true)
+  })
+
+  test('Given rewind excludes transcript and artifact entries When rewinding Then keeps only valid retained assistant bindings', async () => {
+    const piSessionFile = join(tempHome, '.pi-source-rewind.jsonl')
+    writeFileSync(piSessionFile, '', 'utf-8')
+    writeAgentSessionsIndex([{
+      id: 'pi-rewind-source', title: 'Pi rewind', workspaceId: 'workspace-a', createdAt: 1, updatedAt: 1,
+      agentRuntime: 'pi', sdkSessionId: 'pi-source-session', piSessionFile,
+      piEntryBindings: {
+        'assistant-keep': 'entry-keep',
+        'assistant-stale': 'entry-stale',
+        'assistant-alias': 'entry-keep',
+        'assistant-broken': 'missing-entry',
+      },
+    }])
+    writeAgentSessionJsonl('pi-rewind-source', [
+      JSON.stringify({ type: 'user', uuid: 'user-1', message: { content: [{ type: 'text', text: '开始' }] } }),
+      JSON.stringify({ type: 'assistant', uuid: 'assistant-keep', message: { content: [{ type: 'text', text: '保留' }] } }),
+      JSON.stringify({ type: 'user', uuid: 'user-after', message: { content: [{ type: 'text', text: '后续' }] } }),
+      JSON.stringify({ type: 'assistant', uuid: 'assistant-stale', message: { content: [{ type: 'text', text: '丢弃' }] } }),
+    ])
+
+    const retainedCount = await manager.rewindPiAgentSession('pi-rewind-source', 'assistant-keep')
+
+    expect(retainedCount).toBe(2)
+    expect(manager.getAgentSessionMeta('pi-rewind-source')?.piEntryBindings).toEqual({ 'assistant-keep': 'entry-keep' })
+    expect(manager.getAgentSessionSDKMessages('pi-rewind-source').map((message) => (message as { uuid?: string }).uuid))
+      .toEqual(['user-1', 'assistant-keep'])
   })
 })
 

--- a/apps/electron/src/main/lib/agent-session-manager.ts
+++ b/apps/electron/src/main/lib/agent-session-manager.ts
@@ -768,16 +768,21 @@ async function forkPiAgentSession(sourceMeta: AgentSessionMeta, input: ForkSessi
     const forkedManager = sdk.SessionManager.forkFrom(branchFile, destDir ?? sourceDir ?? process.cwd(), sessionDir)
     const piSessionFile = forkedManager.getSessionFile()
     if (!piSessionFile || !existsSync(piSessionFile)) throw new Error('Pi 分叉 artifact 校验失败')
+    // 新 branch 只包含分叉点之前的 entry；不能把源树后续 turn 的映射带入 metadata。
+    const branchBindings = Object.fromEntries(
+      Object.entries(sourceMeta.piEntryBindings ?? {})
+        .filter(([, mappedEntryId]) => Boolean(forkedManager.getEntry(mappedEntryId))),
+    )
 
     updateAgentSessionMeta(newMeta.id, {
       sdkSessionId: forkedManager.getSessionId(),
       piSessionFile,
-      piEntryBindings: { ...(sourceMeta.piEntryBindings ?? {}) },
+      piEntryBindings: branchBindings,
       forkSourceDir: sourceDir,
     })
     newMeta.sdkSessionId = forkedManager.getSessionId()
     newMeta.piSessionFile = piSessionFile
-    newMeta.piEntryBindings = { ...(sourceMeta.piEntryBindings ?? {}) }
+    newMeta.piEntryBindings = branchBindings
 
     if (sourceWorkbenchDir && destWorkbenchDir) copyForkWorkspaceFiles(sourceWorkbenchDir, destWorkbenchDir)
     await copyForkStoredSDKMessages({
@@ -825,8 +830,15 @@ export async function rewindPiAgentSession(sessionId: string, assistantMessageUu
   const branchFile = manager.createBranchedSession(entryId)
   if (!branchFile || !existsSync(branchFile)) throw new Error('Pi 未能生成回退 session artifact')
   const rewindManager = sdk.SessionManager.open(branchFile, join(getSdkConfigDir(), 'sessions'), cwd)
+  const retainedAssistantUuids = new Set(
+    kept.flatMap((message) => {
+      const candidate = message as { uuid?: unknown; type?: unknown }
+      return candidate.type === 'assistant' && typeof candidate.uuid === 'string' ? [candidate.uuid] : []
+    }),
+  )
   const retainedBindings = Object.fromEntries(
-    Object.entries(meta.piEntryBindings ?? {}).filter(([, mappedEntryId]) => Boolean(rewindManager.getEntry(mappedEntryId))),
+    Object.entries(meta.piEntryBindings ?? {}).filter(([messageUuid, mappedEntryId]) =>
+      retainedAssistantUuids.has(messageUuid) && Boolean(rewindManager.getEntry(mappedEntryId))),
   )
 
   writeTextFileAtomic(filePath, truncatedContent)

--- a/apps/electron/src/main/lib/agent-session-usage.ts
+++ b/apps/electron/src/main/lib/agent-session-usage.ts
@@ -20,7 +20,7 @@
  * 避免对整份会话 JSONL 全量 JSON.parse（高频 daily 任务一天可触发数百次）。
  */
 
-import { calculateContextUsageRatio, inferAgentSdkContextWindow, inferContextWindow } from '@proma/shared'
+import { calculateContextUsageRatio, inferContextWindow } from '@proma/shared'
 import type { SDKAssistantMessage, SDKResultMessage } from '@proma/shared'
 import { existsSync, readFileSync } from 'node:fs'
 import { getAgentSessionMessagesPath } from './config-paths'
@@ -82,9 +82,7 @@ export function getSessionContextUsageRatio(sessionId: string): number | undefin
       if (!usage) continue
       const usedTokens = sumUsedTokens(usage)
       const modelId = asst._channelModelId ?? asst.message?.model
-      const contextWindow = asst._channelProvider
-        ? inferAgentSdkContextWindow(modelId, asst._channelProvider)
-        : inferContextWindow(modelId)
+      const contextWindow = inferContextWindow(modelId)
       return calculateContextUsageRatio(usedTokens, contextWindow)
     }
   }
@@ -108,9 +106,7 @@ function pickResultContextWindow(result: SDKResultMessage): number | undefined {
   let best: number | undefined
   for (const [modelId, info] of Object.entries(result.modelUsage)) {
     const fallbackModelId = result._channelModelId ?? modelId
-    const fallbackWindow = result._channelProvider
-      ? inferAgentSdkContextWindow(fallbackModelId, result._channelProvider)
-      : inferContextWindow(fallbackModelId)
+    const fallbackWindow = inferContextWindow(fallbackModelId)
     const win = Math.max(info?.contextWindow ?? 0, fallbackWindow ?? 0) || undefined
     if (win === undefined) continue
     if (best === undefined || win > best) best = win

--- a/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
+++ b/apps/electron/src/renderer/components/agent/SDKMessageRenderer.tsx
@@ -80,7 +80,6 @@ import type {
 import type { AgentPendingFile } from '@proma/shared'
 import {
   getSDKCompactStatus,
-  inferAgentSdkContextWindow,
   inferContextWindow,
   THINKING_SIGNATURE_ERROR_CODE,
   THINKING_SIGNATURE_ERROR_TITLE,
@@ -216,18 +215,14 @@ function extractTurnUsage(turnMessages: SDKMessage[]): { durationMs?: number; us
     if (resultMsg.modelUsage) {
       for (const [modelId, info] of Object.entries(resultMsg.modelUsage)) {
         const fallbackModelId = resultMsg._channelModelId ?? modelId
-        const fallbackWindow = resultMsg._channelProvider
-          ? inferAgentSdkContextWindow(fallbackModelId, resultMsg._channelProvider)
-          : inferContextWindow(fallbackModelId)
+        const fallbackWindow = inferContextWindow(fallbackModelId)
         const candidate = Math.max(info?.contextWindow ?? 0, fallbackWindow ?? 0) || undefined
         if (candidate && (contextWindow === undefined || candidate > contextWindow)) {
           contextWindow = candidate
         }
       }
     } else {
-      contextWindow = resultMsg._channelProvider
-        ? inferAgentSdkContextWindow(resultMsg._channelModelId, resultMsg._channelProvider)
-        : inferContextWindow(resultMsg._channelModelId)
+      contextWindow = inferContextWindow(resultMsg._channelModelId)
     }
     return {
       durationMs,

--- a/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
+++ b/apps/electron/src/renderer/hooks/useGlobalAgentListeners.ts
@@ -66,7 +66,7 @@ import { previewFileMapAtom } from '@/atoms/preview-atoms'
 import type { NotificationSoundType } from '@/types/settings'
 import { toast } from 'sonner'
 import type { AgentStreamEvent, AgentStreamCompletePayload, AgentEvent, AgentStreamPayload, SDKAssistantMessage, SDKUserMessage, SDKSystemMessage, SDKContentBlock, SDKUserContentBlock, PromaEvent, AgentSessionMeta, ProviderType } from '@proma/shared'
-import { inferAgentSdkContextWindow, inferContextWindow } from '@proma/shared'
+import { inferContextWindow } from '@proma/shared'
 import { buildExternalAgentRunActivation, shouldActivateExternalAgentRun } from '@/lib/external-agent-run'
 import { upsertAgentSession, mergeFetchedAgentSessions } from '@/lib/agent-session-list'
 import {
@@ -261,10 +261,7 @@ function payloadToLegacyEvents(payload: AgentStreamPayload): AgentEvent[] {
         // 因为部分端点（如智谱）会在 message.model 里剥掉 [1m] 等规格后缀，
         // 导致 glm-x-preview[1m] 被识别成 glm-x-preview（200K）。
         const modelName = aMsg._channelModelId ?? aMsg.message.model
-        const provider = aMsg._channelProvider
-        const fallbackWindow = provider
-          ? inferAgentSdkContextWindow(modelName, provider)
-          : inferContextWindow(modelName)
+        const fallbackWindow = inferContextWindow(modelName)
         events.push({
           type: 'usage_update',
           usage: {
@@ -319,14 +316,10 @@ function payloadToLegacyEvents(payload: AgentStreamPayload): AgentEvent[] {
       // 多 entry 场景（Task 子 Agent 等）：取最大 contextWindow，
       // 避免子 Agent 的小窗口覆盖主模型的大窗口、导致指示器飘忽。
       let contextWindow: number | undefined
-      const fallbackWindow = rMsg._channelProvider
-        ? inferAgentSdkContextWindow(rMsg._channelModelId, rMsg._channelProvider)
-        : inferContextWindow(rMsg._channelModelId)
+      const fallbackWindow = inferContextWindow(rMsg._channelModelId)
       if (rMsg.modelUsage) {
         for (const [modelId, info] of Object.entries(rMsg.modelUsage)) {
-          const modelFallbackWindow = rMsg._channelProvider
-            ? inferAgentSdkContextWindow(rMsg._channelModelId ?? modelId, rMsg._channelProvider)
-            : inferContextWindow(rMsg._channelModelId ?? modelId)
+          const modelFallbackWindow = inferContextWindow(rMsg._channelModelId ?? modelId)
           const candidate = Math.max(info?.contextWindow ?? 0, modelFallbackWindow ?? 0) || undefined
           if (candidate && (contextWindow === undefined || candidate > contextWindow)) {
             contextWindow = candidate

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -404,7 +404,6 @@ export type ErrorCode =
   | 'agent_provider_not_supported'
   | 'agent_model_unavailable'
   | 'api_key_decrypt_failed'
-  | 'claude_binary_not_found'
   | 'agent_runtime_not_found'
   | 'workspace_not_found'
   | 'local_project_root_unavailable'

--- a/packages/shared/src/utils/context-window.ts
+++ b/packages/shared/src/utils/context-window.ts
@@ -1,13 +1,10 @@
-import type { ProviderType } from '../types/channel'
-
 /**
  * 模型上下文窗口推断 — 单一 source of truth。
  *
  * 1M 上下文已随各家模型转正为默认能力（Anthropic 于 2026-03 对 Opus 4.6 /
  * Sonnet 4.6 起 GA，无需 context-1m beta header；Sonnet 5 / Opus 4.7+ 延续），
- * 故不再下发任何 beta。Claude Agent SDK 仍要求通过 `[1m]` 模型后缀显式选择
- * 扩展上下文（发送请求前会自动剥离），因此前端推断、后端用量统计和 SDK 模型
- * 选择必须共用同一份判定，否则会出现"UI 显示 1M 但实际只 200K"的不一致。
+ * 故不再下发任何 beta。Proma 统一按模型能力推断窗口，前端展示、后端用量统计和运行时注册
+ * 必须共用同一份判定，避免出现"UI 显示 1M 但实际只 200K"的不一致。
  */
 
 /** 默认上下文窗口（无法识别模型时使用） */
@@ -41,8 +38,8 @@ export function inferCodexAlignedGPT5ContextWindow(modelId: string | undefined):
   }
 }
 
-/** 已确认需要显式选择 Claude Agent SDK `[1m]` 变体的模型。 */
-const AGENT_SDK_1M_CONTEXT_RULES = {
+/** 已确认支持 1M 上下文的模型。 */
+const ONE_MILLION_CONTEXT_RULES = {
   // Claude 系列
   claude: [
     'claude-sonnet-4-6',
@@ -75,25 +72,7 @@ const AGENT_SDK_1M_CONTEXT_RULES = {
   ],
 } as const
 
-const AGENT_SDK_1M_CONTEXT_PROVIDER_RULES: Partial<Record<ProviderType, readonly string[]>> = {
-  anthropic: AGENT_SDK_1M_CONTEXT_RULES.claude,
-  deepseek: AGENT_SDK_1M_CONTEXT_RULES.deepseek,
-  'zhipu-coding': AGENT_SDK_1M_CONTEXT_RULES.glm,
-  'zhipu-coding-team': AGENT_SDK_1M_CONTEXT_RULES.glm,
-  minimax: AGENT_SDK_1M_CONTEXT_RULES.minimax,
-  xiaomi: AGENT_SDK_1M_CONTEXT_RULES.mimo,
-  'xiaomi-token-plan': AGENT_SDK_1M_CONTEXT_RULES.mimo,
-  'ark-coding-plan': [
-    ...AGENT_SDK_1M_CONTEXT_RULES.deepseek,
-    ...AGENT_SDK_1M_CONTEXT_RULES.glm,
-    ...AGENT_SDK_1M_CONTEXT_RULES.kimi,
-    ...AGENT_SDK_1M_CONTEXT_RULES.minimax,
-  ],
-  'kimi-api': AGENT_SDK_1M_CONTEXT_RULES.kimi,
-  'kimi-coding': AGENT_SDK_1M_CONTEXT_RULES.kimi,
-}
-
-const AGENT_SDK_1M_CONTEXT_DISPLAY_RULES = Object.values(AGENT_SDK_1M_CONTEXT_RULES).flat()
+const ONE_MILLION_CONTEXT_DISPLAY_RULES = Object.values(ONE_MILLION_CONTEXT_RULES).flat()
 const EXACT_CONTEXT_RULES = new Set(['k3', 'kimi-k3'])
 
 function matchesContextRule(model: string, pattern: string): boolean {
@@ -104,8 +83,8 @@ function matchesContextRule(model: string, pattern: string): boolean {
 }
 
 /**
- * 上下文窗口配置表。仅影响显示推断的模型加在 rules；已实测 Agent SDK 1M
- * 行为的模型加在上方 AGENT_SDK_1M_CONTEXT_RULES，并自动复用于 rules。
+ * 上下文窗口配置表。仅影响显示推断的模型加在 rules；已确认 1M
+ * 能力的模型加在上方 ONE_MILLION_CONTEXT_RULES，并自动复用于 rules。
  *
  * 匹配规则：modelId.toLowerCase() 包含 pattern 即命中（substring match）。
  * exclude 列表优先级最高：命中 exclude 的模型始终返回 DEFAULT_CONTEXT_WINDOW。
@@ -118,10 +97,10 @@ const CONTEXT_WINDOW_CONFIG = {
 
   /** 1M 上下文模型匹配规则 */
   rules: [
-    ...AGENT_SDK_1M_CONTEXT_DISPLAY_RULES,
-    // OpenAI 协议渠道（如 OpenCode Go）使用该真实模型 ID，不应追加 Claude SDK `[1m]` 后缀。
+    ...ONE_MILLION_CONTEXT_DISPLAY_RULES,
+    // OpenAI 协议渠道（如 OpenCode Go）使用该真实模型 ID。
     'kimi-k3',
-    // 已废弃的 MiMo V2 Pro 仅保留历史显示推断，不主动启用 SDK 1M 变体
+    // 已废弃的 MiMo V2 Pro 仅保留历史显示推断
     'mimo-v2-pro',
   ] as const,
 } as const
@@ -148,38 +127,4 @@ export function inferContextWindow(model?: string): number | undefined {
   if (codexAlignedWindow !== undefined) return codexAlignedWindow
   if (supports1MContext(model)) return ONE_MILLION_CONTEXT_WINDOW
   return DEFAULT_CONTEXT_WINDOW
-}
-
-/**
- * 按 Agent SDK 实际启用的窗口推断 contextWindow。
- *
- * 与 resolveAgentSdkModelId 不同，这里只判断模型窗口能力，不判断是否要把
- * `[1m]` 后缀传给 SDK。通用 Anthropic-compatible 端点可能不接受带后缀的
- * 模型名，但这不应把已知 1M 模型的上下文分母降级为 200K。
- */
-export function inferAgentSdkContextWindow(modelId: string | undefined, provider: ProviderType): number | undefined {
-  if (!modelId) return undefined
-  const codexAlignedWindow = inferCodexAlignedGPT5ContextWindow(modelId)
-  if (codexAlignedWindow !== undefined) return codexAlignedWindow
-  return supports1MContext(modelId)
-    || resolveAgentSdkModelId(modelId, provider) !== modelId
-    || /\[1m\]$/i.test(modelId)
-    ? ONE_MILLION_CONTEXT_WINDOW
-    : DEFAULT_CONTEXT_WINDOW
-}
-
-/**
- * 将已确认的 1M Agent 模型转换为 Claude Agent SDK 的扩展上下文变体。
- *
- * `[1m]` 仅用于已验证的内置供应商组合。泛化的 Anthropic-compatible
- * 端点无法保证 SDK 会在请求前剥离后缀，因此必须保留用户配置的真实模型 ID。
- */
-export function resolveAgentSdkModelId(modelId: string, provider: ProviderType): string {
-  if (!modelId || /\[1m\]$/i.test(modelId)) {
-    return modelId
-  }
-  const model = modelId.toLowerCase()
-  const rules = AGENT_SDK_1M_CONTEXT_PROVIDER_RULES[provider]
-  if (!rules?.some((pattern) => matchesContextRule(model, pattern))) return modelId
-  return `${modelId}[1m]`
 }

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -18,8 +18,6 @@ export {
   inferCodexAlignedGPT5ContextWindow,
   supports1MContext,
   inferContextWindow,
-  inferAgentSdkContextWindow,
-  resolveAgentSdkModelId,
 } from './context-window'
 export { calculateContextUsageRatio } from './context-usage'
 export {


### PR DESCRIPTION
## Summary
- remove Claude SDK-era outer prompt replay, stderr parsing, terminal-channel handling, and duplicate Pi error helpers
- keep transport retry inside the Pi adapter; retain one safe historical-context fallback only for a failed resumed artifact
- filter stale Pi entry bindings on fork/rewind and clear bindings when a new Pi artifact replaces the old tree
- make context-window inference runtime-neutral while preserving legacy `[1m]` storage cleanup
- update Chinese and English READMEs for the Pi-only runtime and read-only historical Claude transcripts

## Validation
- `bun run --filter='@proma/shared' typecheck`
- `bun run --filter='@proma/electron' typecheck`
- `bun test apps/electron/src/main/lib/agent-session-manager.test.ts` (17 passed)
- `bun run electron:build`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)