### PR TITLE
Fix agent island running priority

### DIFF
--- a/apps/electron/src/main/lib/agent-island-priority.ts
+++ b/apps/electron/src/main/lib/agent-island-priority.ts
@@ -1,0 +1,13 @@
+import type { AgentIslandPhase } from '@proma/shared'
+
+/**
+ * Ordering for the island's primary status. A live run takes precedence over
+ * terminal completion notifications, while actionable interaction/errors stay
+ * above both.
+ */
+export function getAgentIslandPhasePriority(phase: AgentIslandPhase): number {
+  if (phase === 'needs-interaction') return 3
+  if (phase === 'error') return 2
+  if (phase === 'running') return 1
+  return 0
+}

--- a/apps/electron/src/main/lib/agent-island-service.ts
+++ b/apps/electron/src/main/lib/agent-island-service.ts
@@ -31,6 +31,7 @@ import { getAgentSessionMeta, listAgentSessions } from './agent-session-manager'
 import { isMacAgentIslandNativeHostReady, publishMacAgentIslandSnapshot } from './mac-agent-island-native-host'
 import { getAgentIslandTodoAttentionKeys, selectAgentIslandTodos } from './agent-island-planning'
 import { selectAgentIslandCompactPlanQuota } from './agent-island-plan-quota'
+import { getAgentIslandPhasePriority } from './agent-island-priority'
 import { listCalendarEvents, listTodos } from './planning-manager'
 import { onPlanningChanged } from './planning-events'
 import { getChannelPlanQuota, listChannels } from './channel-manager'
@@ -423,10 +424,7 @@ function isIslandSession(session: InternalSessionSnapshot, now: number): boolean
 }
 
 function attentionScore(session: InternalSessionSnapshot): number {
-  if (session.phase === 'needs-interaction') return 3
-  if (session.phase === 'error') return 2
-  if (session.phase === 'completed') return 1
-  return 0
+  return getAgentIslandPhasePriority(session.phase)
 }
 
 function compareIslandSessions(a: InternalSessionSnapshot, b: InternalSessionSnapshot): number {


### PR DESCRIPTION
## Summary

- Keep the Agent Island primary status on `running` while another session has an unread completion.
- Preserve higher priority for interaction requests and errors.

## Validation

- `bun run --filter='@proma/electron' build:main`
- Full typecheck remains blocked by pre-existing `AgentSessionMeta.legacyTranscript` errors.

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)