### PR TITLE
feat(agent): make Windows shell optional

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proma/electron",
-  "version": "0.16.13",
+  "version": "0.16.14",
   "description": "Proma next gen ai software with general agents - Electron App",
   "main": "dist/main.cjs",
   "author": {

--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -616,9 +616,9 @@ async function bootstrap(): Promise<void> {
   // 协议只接受主进程签发的 opaque token，不解析 renderer 提供的绝对路径。
   protocol.handle('proma-file', handlePromaFileRequest)
 
-  // 初始化运行时环境（Shell 环境 + Bun + Git 检测）
-  // 必须在其他初始化之前执行，确保环境变量正确加载
-  await safeAwait('initializeRuntime', () => initializeRuntime())
+  // 初始化运行时环境。Node.js 仅由 npx / npm 型 MCP 在实际连接时使用，
+  // 或由用户从设置手动检测；启动时不应将其作为 Agent 的前置要求。
+  await safeAwait('initializeRuntime', () => initializeRuntime({ skipNodeDetection: true }))
 
   // 同步默认 Skills 模板到 ~/.proma/default-skills/
   safeRun('seedDefaultSkills', seedDefaultSkills)

--- a/apps/electron/src/main/lib/adapters/pi-agent-adapter.ts
+++ b/apps/electron/src/main/lib/adapters/pi-agent-adapter.ts
@@ -1099,6 +1099,15 @@ function createPromaBashToolOptions(runtimeEnv: AgentRuntimeEnv | undefined): Ba
   }
 }
 
+export function isPiBashToolAvailable(
+  platform: NodeJS.Platform,
+  runtimeEnv: Pick<AgentRuntimeEnv, 'shellKind'> | undefined,
+): boolean {
+  // Pi 的 Windows Bash 工具只能通过 Proma 配置的 Git Bash 或 WSL 执行。
+  // 没有可用 Shell 时，基础 Agent 仍可使用文件与 Proma 工具，但不能暴露一个必然失败的 Bash 工具。
+  return platform !== 'win32' || runtimeEnv?.shellKind === 'git-bash' || runtimeEnv?.shellKind === 'wsl'
+}
+
 function buildBuiltinToolDefinitions(
   sdk: PiSdk,
   cwd: string,
@@ -1107,7 +1116,9 @@ function buildBuiltinToolDefinitions(
 ): ToolDefinition[] {
   const definitions = [
     sdk.createReadToolDefinition(cwd),
-    sdk.createBashToolDefinition(cwd, createPromaBashToolOptions(runtimeEnv)),
+    ...(isPiBashToolAvailable(process.platform, runtimeEnv)
+      ? [sdk.createBashToolDefinition(cwd, createPromaBashToolOptions(runtimeEnv))]
+      : []),
     sdk.createEditToolDefinition(cwd),
     sdk.createWriteToolDefinition(cwd),
     sdk.createGrepToolDefinition(cwd),
@@ -1117,6 +1128,18 @@ function buildBuiltinToolDefinitions(
 
   return definitions.map((tool) =>
     wrapToolWithPermission(tool as unknown as ToolDefinition<TSchema, unknown, unknown>, { canUseTool }) as ToolDefinition)
+}
+
+function appendWindowsBaseModeInstruction(systemPrompt: string, runtimeEnv: AgentRuntimeEnv | undefined): string {
+  if (process.platform !== 'win32' || isPiBashToolAvailable(process.platform, runtimeEnv)) {
+    return systemPrompt
+  }
+
+  return `${systemPrompt}
+
+<runtime_capabilities>
+当前 Windows 设备未配置 Git Bash 或 WSL，因此 Bash 工具不可用。你仍可使用 Read、Write、Edit、Grep、Find、Ls 及 Proma 提供的其他工具完成任务；不要声称已运行命令、测试或 Git 操作。若任务确实需要命令行，请默认调用 InstallWindowsShell 帮助用户安装 Git Bash；该工具会要求用户确认下载并打开官方安装程序。
+</runtime_capabilities>`
 }
 
 function wrapCustomToolDefinitions(
@@ -1306,7 +1329,7 @@ export class PiAgentAdapter implements AgentProviderAdapter {
         additionalSkillPaths: input.additionalSkillPaths ?? [],
         skillsOverride: createPromaSkillsOverride(input.additionalSkillPaths),
         ...(extensionFactories.length > 0 && { extensionFactories }),
-        systemPromptOverride: () => input.systemPrompt,
+        systemPromptOverride: () => appendWindowsBaseModeInstruction(input.systemPrompt, input.runtimeEnv),
       })
       await resourceLoader.reload()
       active.resourceLoader = resourceLoader

--- a/apps/electron/src/main/lib/adapters/pi-builtin-tools.ts
+++ b/apps/electron/src/main/lib/adapters/pi-builtin-tools.ts
@@ -28,6 +28,9 @@ import {
 } from '../automation-scheduler'
 import { getAgentSessionMeta } from '../agent-session-manager'
 import { isBuiltinMcpUserEnabled } from '../builtin-mcp/settings'
+import { downloadInstaller, launchInstaller } from '../installer-downloader'
+import { fetchInstallerManifest, findInstallerSource } from '../installer-manifest'
+import { shouldOfferWindowsShellInstaller } from './windows-shell-installer'
 import { buildPiCollaborationTools } from '../agent-collaboration-tools'
 import { buildPiNanoBananaTools } from '../chat-tools/nano-banana-mcp'
 import { getVisionRelayRouteLabel, inspectImageWithVisionRelay, isVisionRelayConfigured, isVisionRelayEligibleForModel } from '../vision-relay-service'
@@ -83,6 +86,8 @@ export interface PiBuiltinToolsContext {
   allowedRoots?: string[]
   permissionMode?: PromaPermissionMode
   triggeredBy?: 'user' | 'automation' | 'delegation'
+  /** Windows 设备是否已有可供 Pi Bash 使用的 Git Bash 或 WSL。 */
+  windowsShellAvailable?: boolean
 }
 
 function jsonToolResult(payload: unknown): AgentToolResult<unknown> {
@@ -744,6 +749,41 @@ function buildPlanningTools(sdk: PiSdk, ctx: PiBuiltinToolsContext): ToolDefinit
   ] as unknown as ToolDefinition[]
 }
 
+// ===== Windows Shell 安装 =====
+
+function buildWindowsShellInstallerTools(sdk: PiSdk, ctx: PiBuiltinToolsContext): ToolDefinition[] {
+  if (!shouldOfferWindowsShellInstaller(process.platform, ctx.windowsShellAvailable, ctx.triggeredBy)) {
+    return []
+  }
+
+  return [
+    sdk.defineTool({
+      name: 'InstallWindowsShell',
+      label: '安装 Git Bash',
+      description: 'Use this when the user task truly requires command execution but this Windows device has no Git Bash or WSL. It downloads the official Git for Windows installer, verifies it when a checksum is available, and opens the installer. The user must approve this external installation action and complete the Windows installer before retrying Bash work. Do not use merely to inspect files or answer questions.',
+      promptSnippet: 'InstallWindowsShell: install Git for Windows to provide Git Bash when a task truly needs Bash commands.',
+      parameters: Type.Object({}),
+      async execute() {
+        const arch = process.arch === 'arm64' ? 'arm64' : 'x64'
+        const manifest = await fetchInstallerManifest()
+        const source = findInstallerSource(manifest, 'git-for-windows', arch)
+        if (!source) {
+          throw new Error(`未找到当前设备（${arch}）对应的 Git for Windows 安装包`)
+        }
+
+        const result = await downloadInstaller(source, `agent-git-for-windows-${ctx.sessionId}`)
+        await launchInstaller(result.filePath)
+        return jsonToolResult({
+          installer: 'git-for-windows',
+          version: source.version,
+          filePath: result.filePath,
+          message: '已下载并打开 Git for Windows 安装程序。请完成安装后重试原任务；Proma 会在下次运行时自动检测 Git Bash。',
+        })
+      },
+    }),
+  ] as unknown as ToolDefinition[]
+}
+
 // ===== 视觉助手 =====
 
 function buildVisionRelayTools(sdk: PiSdk, ctx: PiBuiltinToolsContext): ToolDefinition[] {
@@ -848,6 +888,13 @@ export async function buildPiBuiltinTools(
     } catch (error) {
       console.error('[Pi 桥接] 注入 collaboration 工具失败:', error)
     }
+  }
+
+  // 未配置 Windows Shell 时，按需提供 Git Bash 安装工具；实际下载与拉起安装器仍经过 Agent 权限确认。
+  try {
+    tools.push(...buildWindowsShellInstallerTools(sdk, ctx))
+  } catch (error) {
+    console.error('[Pi 桥接] 注入 Windows Shell 安装工具失败:', error)
   }
 
   // 视觉助手仅在明确不支持视觉的 DeepSeek V4 用户会话中按需出现。

--- a/apps/electron/src/main/lib/adapters/windows-shell-installer.ts
+++ b/apps/electron/src/main/lib/adapters/windows-shell-installer.ts
@@ -1,0 +1,13 @@
+export type WindowsShellInstallerTrigger = 'user' | 'automation' | 'delegation' | undefined
+
+/**
+ * 仅对没有 Shell 的前台 Windows Agent 提供安装工具。
+ * 后台自动任务和子 Agent 无法可靠地等待用户完成系统安装，必须跳过。
+ */
+export function shouldOfferWindowsShellInstaller(
+  platform: NodeJS.Platform,
+  windowsShellAvailable: boolean | undefined,
+  triggeredBy: WindowsShellInstallerTrigger,
+): boolean {
+  return platform === 'win32' && !windowsShellAvailable && triggeredBy === 'user'
+}

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -704,32 +704,10 @@ export class AgentOrchestrator {
       }
     }
 
-    // 1. Windows 平台：检查 Shell 环境可用性
-    if (process.platform === 'win32') {
-      const runtimeStatus = getRuntimeStatus()
-      const shellStatus = runtimeStatus?.shell
+    // Windows 缺少 Git Bash / WSL 时仍允许启动 Pi Agent。
+    // Pi adapter 会移除 Bash 工具并注入基础模式说明；文件工具、对话和本地 Proma 工具不受影响。
 
-      if (shellStatus && !shellStatus.gitBash?.available && !shellStatus.wsl?.available) {
-        reportPreflightError({
-          code: 'windows_shell_missing',
-          title: 'Windows 环境未就绪',
-          message:
-            '需要 Git Bash 或 WSL 才能运行 Agent。建议安装 Git for Windows（自带 Git Bash），安装完成后点「打开环境检测」刷新状态。',
-          details: [
-            `Git Bash: ${shellStatus.gitBash?.error || '未检测到'}`,
-            `WSL: ${shellStatus.wsl?.error || '未检测到'}`,
-          ],
-          actions: [
-            { key: 'e', label: '打开环境检测', action: 'open_environment_check' },
-            { key: 'g', label: '去官方下载 Git', action: 'open_external', payload: 'https://git-scm.com/download/win' },
-          ],
-          canRetry: false,
-        })
-        return
-      }
-    }
-
-    // 2. 获取渠道信息并解密 API Key
+    // 1. 获取渠道信息并解密 API Key
     const channel = getChannelById(channelId)
     if (!channel) {
       reportPreflightError({
@@ -924,6 +902,7 @@ export class AgentOrchestrator {
         allowedRoots: allAdditionalDirectories,
         permissionMode: permissionModeOverride ?? sessionMeta?.permissionMode ?? PROMA_DEFAULT_PERMISSION_MODE,
         triggeredBy: input.triggeredBy,
+        windowsShellAvailable: process.platform !== 'win32' || runtimeEnv.shellKind != null,
       })
       piBuiltinTools = builtinMcpResult.tools
       const collaborationAvailable = builtinMcpResult.collaborationAvailable

--- a/apps/electron/src/main/lib/installer-downloader.ts
+++ b/apps/electron/src/main/lib/installer-downloader.ts
@@ -36,12 +36,12 @@ function getInstallerDir(): string {
  *
  * @param source 安装包元数据
  * @param key 去重键（前端可据此关联进度事件与取消）
- * @param sender 用于推进度事件的窗口（通常是发起下载的 BrowserWindow）
+ * @param sender 可选的进度事件窗口（通常是发起下载的 BrowserWindow）
  */
 export async function downloadInstaller(
   source: InstallerSource,
   key: string,
-  sender: BrowserWindow,
+  sender?: BrowserWindow,
 ): Promise<InstallerDownloadResult> {
   const dir = getInstallerDir()
   await fsp.mkdir(dir, { recursive: true })
@@ -99,7 +99,7 @@ function downloadToFile(
   filePath: string,
   source: InstallerSource,
   key: string,
-  sender: BrowserWindow,
+  sender: BrowserWindow | undefined,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     let cancelled = false
@@ -224,8 +224,8 @@ function downloadToFile(
   })
 }
 
-function emitProgress(sender: BrowserWindow, payload: InstallerProgressPayload) {
-  if (sender.isDestroyed()) return
+function emitProgress(sender: BrowserWindow | undefined, payload: InstallerProgressPayload) {
+  if (!sender || sender.isDestroyed()) return
   sender.webContents.send(INSTALLER_IPC_CHANNELS.PROGRESS, payload)
 }
 

--- a/apps/electron/src/renderer/components/environment/EnvironmentCheckPanel.tsx
+++ b/apps/electron/src/renderer/components/environment/EnvironmentCheckPanel.tsx
@@ -2,7 +2,7 @@
  * Windows 环境检测面板
  *
  * 展示 Shell 环境（Git Bash / WSL）和 Node.js 的检测结果，
- * 用于 Onboarding Step 2 和设置里的 EnvironmentCheckDialog 复用。
+ * 用于设置里的 EnvironmentCheckDialog，帮助用户按需启用 Shell 与 Node.js 能力。
  */
 
 import * as React from 'react'
@@ -19,7 +19,7 @@ import {
 import { useAtomValue } from 'jotai'
 
 interface EnvironmentCheckPanelProps {
-  /** 首次挂载时是否自动跑一次检测（Onboarding 用），Dialog 场景可设 false */
+  /** 首次挂载时是否自动跑一次检测 */
   autoDetectOnMount?: boolean
 }
 
@@ -69,7 +69,7 @@ export function EnvironmentCheckPanel({
   const gitBashAvailable = shell?.gitBash?.available ?? false
   const wslAvailable = shell?.wsl?.available ?? false
 
-  let shellStatus: 'checking' | 'success' | 'error' = 'error'
+  let shellStatus: 'checking' | 'success' | 'warning' = 'warning'
   let shellStatusText = ''
   if (!runtime) {
     shellStatus = 'checking'
@@ -81,8 +81,8 @@ export function EnvironmentCheckPanel({
     shellStatus = 'success'
     shellStatusText = `WSL ${shell?.wsl?.defaultDistro ?? ''} 已可用`
   } else {
-    shellStatus = 'error'
-    shellStatusText = '未检测到 Git Bash 或 WSL'
+    shellStatus = 'warning'
+    shellStatusText = '未检测到 Git Bash 或 WSL（基础 Agent 仍可用）'
   }
 
   // ----- Node.js 卡片 -----
@@ -108,7 +108,7 @@ export function EnvironmentCheckPanel({
         <div>
           <h3 className="text-sm font-semibold">Windows 环境检测</h3>
           <p className="text-xs text-muted-foreground mt-0.5">
-            Proma 在 Windows 上需要 Git Bash 或 WSL 才能运行 Agent
+            基础 Agent 无需额外环境；Git Bash 或 WSL 可启用 Bash 命令执行
           </p>
         </div>
         <Button
@@ -131,10 +131,10 @@ export function EnvironmentCheckPanel({
         <EnvironmentCheckCard
           name="Shell 环境"
           status={shellStatus}
-          requirement="必需 · Git Bash 或 WSL 任一可用即可"
+          requirement="可选 · 安装 Git Bash 或 WSL 后可使用 Bash 命令"
           statusText={shellStatusText}
           action={
-            shellStatus === 'error'
+            shellStatus === 'warning'
               ? { type: 'download', installerId: 'git-for-windows' }
               : { type: 'none' }
           }
@@ -154,13 +154,12 @@ export function EnvironmentCheckPanel({
       </div>
 
       {!shellOk && runtime && (
-        <div className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-[12px] text-destructive">
-          Shell 环境未就绪：现在发送 Agent 消息会失败。请先安装 Git for Windows
-          （会附带 Git Bash），安装完成后点「重新检测」。
+        <div className="rounded-md border border-yellow-500/30 bg-yellow-500/5 px-3 py-2 text-[12px] text-yellow-700 dark:text-yellow-400">
+          未检测到 Git Bash 或 WSL：仍可使用基础 Agent，但本次不会提供 Bash 命令工具。
         </div>
       )}
 
-      {shellOk && !nodeOk && runtime && (
+      {!nodeOk && runtime && (
         <div className="rounded-md border border-yellow-500/30 bg-yellow-500/5 px-3 py-2 text-[12px] text-yellow-700 dark:text-yellow-400">
           未检测到 Node.js。如果不使用基于 npx 的 MCP 服务器，可以忽略此项。
         </div>

--- a/apps/electron/src/renderer/components/onboarding/OnboardingView.tsx
+++ b/apps/electron/src/renderer/components/onboarding/OnboardingView.tsx
@@ -13,16 +13,11 @@
  *  Step 7：记忆功能科普（图：Agent 技能的记忆页面）
  *  Step 8：侧边回答科普（图：历史选区问答）
  *  Step 9：FAQ 汇总页（按主题分组）
- *  Step 10：Windows 环境检测（仅 Windows，其他平台自动跳过）
  */
 
-import { useEffect, useMemo, useRef, useState } from 'react'
-import { useAtomValue } from 'jotai'
+import { useEffect, useRef, useState } from 'react'
 import { ChevronRight, ChevronLeft, ChevronsRight, Check } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { EnvironmentCheckPanel } from '@/components/environment/EnvironmentCheckPanel'
-import { isShellEnvironmentOkAtom } from '@/atoms/environment'
-import { detectIsWindows } from '@/lib/platform'
 import { CURRENT_ONBOARDING_VERSION } from '../../../types'
 import hopperSeasideWhiteHouse from '@/assets/onboarding/hopper-seaside-white-house.png'
 import guideVisual from '@/assets/onboarding/guide-visual.png'
@@ -39,7 +34,7 @@ import { MemoryGuideExamples } from './MemoryGuideExamples'
 import { SubagentGuideExamples } from './SubagentGuideExamples'
 import { FAQ_GROUPS } from './faq-content'
 
-type OnboardingStep = 'welcome' | 'guide' | 'files' | 'project' | 'automation' | 'memory' | 'sideanswer' | 'subagent' | 'faq' | 'environment'
+type OnboardingStep = 'welcome' | 'guide' | 'files' | 'project' | 'automation' | 'memory' | 'sideanswer' | 'subagent' | 'faq'
 
 interface OnboardingViewProps {
   onComplete: (openTutorial?: boolean) => void
@@ -590,7 +585,7 @@ function FaqPage({ nextLabel, onNext, onBack, highlight }: { nextLabel: string; 
 }
 
 /** 引导步骤标题（欢迎页独立，不在地图中显示） */
-const STEP_LABELS: Array<{ step: Exclude<OnboardingStep, 'welcome' | 'environment'>; label: string }> = [
+const STEP_LABELS: Array<{ step: Exclude<OnboardingStep, 'welcome'>; label: string }> = [
   { step: 'guide', label: 'Agent / Chat' },
   { step: 'project', label: '项目' },
   { step: 'files', label: '文件' },
@@ -607,7 +602,7 @@ const ADVANCED_STEP_LABELS = STEP_LABELS.slice(3)
 /**
  * 底部进度地图：仅显示当前章节的步骤，并保持章节内的宽松间距。
  */
-function ProgressMap({ current }: { current: Exclude<OnboardingStep, 'welcome' | 'environment'> }) {
+function ProgressMap({ current }: { current: Exclude<OnboardingStep, 'welcome'> }) {
   const isBeginner = BEGINNER_STEP_LABELS.some((step) => step.step === current)
   const visibleSteps = isBeginner ? BEGINNER_STEP_LABELS : ADVANCED_STEP_LABELS
   const activeIdx = visibleSteps.findIndex((step) => step.step === current)
@@ -675,9 +670,6 @@ export function OnboardingView({ onComplete, initialStep = 'welcome' }: Onboardi
   const [flash, setFlash] = useState(false)
   const [fading, setFading] = useState(false)
   const [faqBackStep, setFaqBackStep] = useState<'subagent' | 'sideanswer'>('sideanswer')
-  const isWindows = useMemo(() => detectIsWindows(), [])
-  const shellOk = useAtomValue(isShellEnvironmentOkAtom)
-
   const handleFinish = async (openTutorial?: boolean) => {
     await window.electronAPI.updateSettings({
       onboardingCompleted: true,
@@ -719,17 +711,11 @@ export function OnboardingView({ onComplete, initialStep = 'welcome' }: Onboardi
     setFaqBackStep('subagent')
     transitionTo('faq')
   }
-  const handleNextFromFaq = () => {
-    if (isWindows) {
-      transitionTo('environment')
-    } else {
-      handleFinish()
-    }
-  }
+  const handleNextFromFaq = () => handleFinish()
 
   const currentMapIndex = STEP_LABELS.findIndex((item) => item.step === step)
-  const stepIndex = step === 'environment' ? STEP_LABELS.length + 1 : currentMapIndex + 1
-  const totalSteps = STEP_LABELS.length + (isWindows ? 1 : 0)
+  const stepIndex = currentMapIndex + 1
+  const totalSteps = STEP_LABELS.length
 
   return (
     <div className="relative flex h-screen w-full flex-col overflow-hidden bg-[#fbf9f7] md:flex-row">
@@ -981,57 +967,15 @@ export function OnboardingView({ onComplete, initialStep = 'welcome' }: Onboardi
         {step === 'faq' && (
           <FaqPage
             highlight="进阶指南 · 第 5 步"
-            nextLabel={isWindows ? '下一个' : '开始使用'}
+            nextLabel="开始使用"
             onNext={handleNextFromFaq}
             onBack={() => transitionTo(faqBackStep)}
           />
         )}
 
-        {step === 'environment' && isWindows && (
-          <div className="w-full max-w-xl px-6 py-10 md:px-10">
-            {/* 状态徽章 */}
-            <div className="mb-6 flex items-center gap-2.5">
-              <span className="flex h-6 w-6 items-center justify-center rounded-full bg-[#26583d] text-white">
-                <Check size={13} strokeWidth={3} />
-              </span>
-              <span className="text-sm font-medium text-neutral-500">环境检测</span>
-            </div>
-
-            <h2 className="text-2xl font-light tracking-tight text-neutral-900 md:text-3xl">
-              先检查一下环境
-            </h2>
-            <p className="mt-2 text-sm text-neutral-500">
-              Proma 在 Windows 上需要 Git Bash 或 WSL 才能执行命令
-            </p>
-
-            <div className="mt-6 rounded-sm border border-neutral-200 bg-white p-5 shadow-[4px_4px_0_rgba(30,58,95,0.08)]">
-              <EnvironmentCheckPanel autoDetectOnMount />
-            </div>
-
-            <div className="mt-6 flex items-center justify-between">
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => transitionTo('faq')}
-                className="text-neutral-500"
-              >
-                <ChevronLeft className="mr-1 h-4 w-4" />
-                上一个
-              </Button>
-              <div className="flex gap-3">
-                <Button
-                  onClick={() => handleFinish()}
-                  variant={shellOk ? 'default' : 'outline'}
-                >
-                  {shellOk ? '开始使用' : '稍后处理（进入主界面）'}
-                </Button>
-              </div>
-            </div>
-          </div>
-        )}
       </div>
 
-      {step !== 'welcome' && step !== 'environment' && <ProgressMap current={step} />}
+      {step !== 'welcome' && <ProgressMap current={step} />}
 
       {step === 'subagent' && (
         <button

--- a/apps/electron/src/renderer/components/settings/AboutSettings.tsx
+++ b/apps/electron/src/renderer/components/settings/AboutSettings.tsx
@@ -16,10 +16,7 @@ import {
   SettingsSelect,
 } from './primitives'
 import { updateStatusAtom, updaterAvailableAtom, checkForUpdates } from '@/atoms/updater'
-import {
-  environmentCheckResultAtom,
-  hasEnvironmentIssuesAtom,
-} from '@/atoms/environment'
+import { environmentCheckResultAtom } from '@/atoms/environment'
 import { EnvironmentCheckCard } from '@/components/environment/EnvironmentCheckCard'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
@@ -225,7 +222,6 @@ function StatusText({ status, version, error }: {
 
 /** 环境检测卡片 */
 function EnvironmentCard(): React.ReactElement {
-  const hasIssues = useAtomValue(hasEnvironmentIssuesAtom)
   const setEnvironmentResult = useSetAtom(environmentCheckResultAtom)
   const [result, setResult] = React.useState<EnvironmentCheckResult | null>(null)
   const [isChecking, setIsChecking] = React.useState(false)
@@ -257,26 +253,23 @@ function EnvironmentCard(): React.ReactElement {
   // Node.js 检测状态
   const nodejsStatus = !result
     ? 'checking'
-    : result.nodejs.installed && result.nodejs.meetsMinimum
-      ? result.nodejs.meetsRecommended
-        ? 'success'
-        : 'warning'
-      : 'error'
+    : result.nodejs.installed && result.nodejs.meetsMinimum && result.nodejs.meetsRecommended
+      ? 'success'
+      : 'warning'
 
-  // Git 检测状态
+  // Git 仅影响仓库状态、Changes 与 Diff，不阻塞基础 Agent。
   const gitStatus = !result
     ? 'checking'
     : result.git.installed && result.git.meetsRequirement
       ? 'success'
-      : 'error'
+      : 'warning'
 
   return (
     <SettingsCard>
       <div className="p-4 border-b">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <h3 className="text-sm font-medium">环境检测</h3>
-            {hasIssues && <Badge variant="destructive">!</Badge>}
+            <h3 className="text-sm font-medium">可选环境能力</h3>
           </div>
           <button
             onClick={handleCheck}
@@ -292,7 +285,7 @@ function EnvironmentCard(): React.ReactElement {
           </button>
         </div>
         <p className="text-xs text-muted-foreground mt-1">
-          Agent 模式需要 Node.js 和 Git 支持
+          基础 Agent 无需 Node.js 或 Git；按需安装以启用 MCP、Git 变更视图等能力
         </p>
       </div>
 
@@ -302,7 +295,7 @@ function EnvironmentCard(): React.ReactElement {
           name="Node.js"
           status={nodejsStatus}
           version={result?.nodejs.version}
-          requirement="推荐 22 LTS，最低 18 LTS"
+          requirement="可选 · 仅 npx / npm 型 MCP 服务器需要（推荐 22 LTS）"
           action={{
             type: 'openExternal',
             url: result?.nodejs.downloadUrl || 'https://nodejs.org/',
@@ -319,7 +312,7 @@ function EnvironmentCard(): React.ReactElement {
           name="Git"
           status={gitStatus}
           version={result?.git.version}
-          requirement="版本 >= 2.0"
+          requirement="可选 · Git 仓库状态、Changes 与 Diff 功能需要"
           action={{
             type: 'openExternal',
             url: result?.git.downloadUrl || 'https://git-scm.com/',
@@ -399,7 +392,7 @@ function ShellEnvironmentCard(): React.ReactElement | null {
           <div className="flex items-center gap-2">
             <Terminal className="h-4 w-4 text-muted-foreground" />
             <h3 className="text-sm font-medium">Shell 环境（Windows）</h3>
-            {!hasShell && <Badge variant="destructive">!</Badge>}
+            {!hasShell && <Badge variant="secondary">可选</Badge>}
           </div>
           <button
             onClick={handleCheck}
@@ -415,7 +408,7 @@ function ShellEnvironmentCard(): React.ReactElement | null {
           </button>
         </div>
         <p className="text-xs text-muted-foreground mt-1">
-          Agent 模式需要 Git Bash 或 WSL 支持
+          可选：配置 Git Bash 或 WSL 后，Agent 可执行 Bash 命令
         </p>
       </div>
 
@@ -476,12 +469,12 @@ function ShellEnvironmentCard(): React.ReactElement | null {
 
         {/* 无可用环境警告 */}
         {!hasShell && (
-          <Alert variant="destructive">
+          <Alert>
             <AlertCircle className="h-4 w-4" />
             <AlertDescription className="text-xs">
-              <strong>未检测到可用的 Shell 环境！</strong>
+              <strong>未检测到可用的 Shell 环境。</strong>
               <br />
-              Agent 模式需要 Git Bash 或 WSL 才能运行。请安装其中之一后重启应用。
+              基础 Agent 仍可使用；安装 Git Bash 或 WSL 后可启用 Bash 命令执行。
             </AlertDescription>
           </Alert>
         )}


### PR DESCRIPTION
## Summary

- allow Windows Pi Agent sessions to run without Git Bash or WSL
- omit Bash in base mode and offer Git Bash installation when a task requires command execution
- make Node, Git, and Shell setup optional in onboarding and settings

## Test plan

- [x] `bun run typecheck`
- [x] `bun test ./apps/electron/src/main/lib/adapters/pi-agent-bash.test.ts`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)