### PR TITLE
Fix agent queued messages in background

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -453,6 +453,9 @@ function createWindow(): void {
       preload: join(__dirname, 'preload.cjs'),
       contextIsolation: true,
       nodeIntegration: false,
+      // 排队消息的自动投递依赖 renderer 消费 STREAM_COMPLETE；窗口被遮挡、最小化或失焦时
+      // 不能让 Chromium 降速该事件循环，否则下一条消息会等到用户重新激活窗口才发送。
+      backgroundThrottling: false,
     },
     ...titleBarOptions,
   })


### PR DESCRIPTION
## Summary

- Disable Chromium renderer background throttling so queued Agent messages continue automatically after a run completes while the app is inactive.

## Test plan

- [x] `bun test apps/electron/src/renderer/lib/agent-message-queue.test.ts`
- [x] `bun run --filter='@proma/electron' build:main`
- [ ] Manual inactive-window regression test

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)