### PR TITLE
fix: apply proxy settings to Tavily and Chrome MCP

### DIFF
--- a/apps/electron/src/main/ipc.ts
+++ b/apps/electron/src/main/ipc.ts
@@ -208,7 +208,8 @@ import {
   downloadInstaller,
   launchInstaller,
 } from './lib/installer-downloader'
-import { getProxySettings, saveProxySettings } from './lib/proxy-settings-service'
+import { getEffectiveProxyUrl, getProxySettings, saveProxySettings } from './lib/proxy-settings-service'
+import { getFetchFn } from './lib/proxy-fetch'
 import { detectSystemProxy } from './lib/system-proxy-detector'
 import {
   listAutomations,
@@ -2834,7 +2835,7 @@ export function registerIpcHandlers(): void {
           return { success: false, message: '请先填写 Tavily API Key' }
         }
         try {
-          const response = await fetch('https://api.tavily.com/search', {
+          const response = await getFetchFn(await getEffectiveProxyUrl())('https://api.tavily.com/search', {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',

--- a/apps/electron/src/main/lib/adapters/pi-mcp-tools.ts
+++ b/apps/electron/src/main/lib/adapters/pi-mcp-tools.ts
@@ -20,6 +20,7 @@ import { Type } from 'typebox'
 
 const DEFAULT_MCP_REQUEST_TIMEOUT_MS = 60_000
 const DEFAULT_MCP_STARTUP_TIMEOUT_MS = 30_000
+const OPTIONAL_MCP_BOOTSTRAP_TIMEOUT_MS = 500
 
 interface PiMcpServerConfig {
   type?: unknown
@@ -30,6 +31,7 @@ interface PiMcpServerConfig {
   headers?: unknown
   startup_timeout_sec?: unknown
   timeout?: unknown
+  required?: unknown
 }
 
 type PiMcpServers = Record<string, Record<string, unknown>>
@@ -42,6 +44,7 @@ interface McpConnection {
   client: Client
   transport: Transport
   tools?: McpToolInfo[]
+  toolsPromise?: Promise<McpToolInfo[]>
 }
 
 interface McpToolBinding {
@@ -202,6 +205,29 @@ function convertMcpResult(result: McpCallToolResult): AgentToolResult<unknown> {
   } as AgentToolResult<unknown>
 }
 
+/**
+ * Optional MCP 服务首次连接在后台继续；首轮消息最多为它等待短暂的 bootstrap 窗口。
+ * 连接完成后，manager 会缓存 tools，后续回合直接复用，不会重复冷启动 stdio 进程。
+ */
+async function listOptionalMcpTools(
+  manager: PiMcpClientManager,
+  serverName: string,
+  config: PiMcpServerConfig,
+): Promise<McpToolInfo[] | undefined> {
+  const toolsPromise = manager.listTools(serverName, config)
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      toolsPromise,
+      new Promise<undefined>((resolve) => {
+        timeout = setTimeout(() => resolve(undefined), OPTIONAL_MCP_BOOTSTRAP_TIMEOUT_MS)
+      }),
+    ])
+  } finally {
+    if (timeout) clearTimeout(timeout)
+  }
+}
+
 class PiMcpClientManager {
   private readonly connections = new Map<string, Promise<McpConnection>>()
 
@@ -227,9 +253,18 @@ class PiMcpClientManager {
   async listTools(serverName: string, config: PiMcpServerConfig): Promise<McpToolInfo[]> {
     const connection = await this.getConnection(serverName, config)
     if (connection.tools) return connection.tools
-    const result = await connection.client.listTools(undefined, { timeout: DEFAULT_MCP_REQUEST_TIMEOUT_MS })
-    connection.tools = result.tools
-    return result.tools
+    if (!connection.toolsPromise) {
+      connection.toolsPromise = connection.client.listTools(undefined, { timeout: DEFAULT_MCP_REQUEST_TIMEOUT_MS })
+        .then((result) => {
+          connection.tools = result.tools
+          return result.tools
+        })
+        .catch((error) => {
+          connection.toolsPromise = undefined
+          throw error
+        })
+    }
+    return await connection.toolsPromise
   }
 
   async callTool(serverName: string, config: PiMcpServerConfig, toolName: string, args: Record<string, unknown>, signal?: AbortSignal): Promise<McpCallToolResult> {
@@ -315,7 +350,13 @@ export async function buildPiMcpTools(mcpServers: PiMcpServers): Promise<ToolDef
   const results = await Promise.allSettled(
     entries.map(async ([serverName, rawConfig]) => {
       const config = rawConfig as PiMcpServerConfig
-      const mcpTools = await manager.listTools(serverName, config)
+      const mcpTools = config.required === false
+        ? await listOptionalMcpTools(manager, serverName, config)
+        : await manager.listTools(serverName, config)
+      if (!mcpTools) {
+        console.info(`[Pi MCP] 可选 MCP 服务器 ${serverName} 尚在后台启动，本回合跳过`)
+        return { serverName, config, mcpTools: [] }
+      }
       return { serverName, config, mcpTools }
     }),
   )

--- a/apps/electron/src/main/lib/agent-orchestrator.ts
+++ b/apps/electron/src/main/lib/agent-orchestrator.ts
@@ -886,7 +886,7 @@ export class AgentOrchestrator {
       // 10. 构建 MCP 服务器配置 + 记忆工具 + 生图工具 + 自定义工具
       const mcpServers = this.buildMcpServers(workspaceSlug)
       if (isBuiltinMcpUserEnabled('chrome-devtools')) {
-        injectChromeDevtoolsMcpServer(mcpServers)
+        injectChromeDevtoolsMcpServer(mcpServers, runtimeEnv.env)
       }
       let piBuiltinTools: unknown[] = []
       let piMcpTools: unknown[] = []

--- a/apps/electron/src/main/lib/builtin-mcp/chrome-devtools.ts
+++ b/apps/electron/src/main/lib/builtin-mcp/chrome-devtools.ts
@@ -40,7 +40,8 @@ export function injectChromeDevtoolsMcpServer(
     // failures (missing npx, first-run package download failure, no Chrome,
     // etc.) must not block the main Agent session.
     required: false,
-    startup_timeout_sec: 60,
+    // Optional MCP 启动在后台进行；5 秒后放弃本次连接并由后续会话重试，不能阻塞 Agent 首包。
+    startup_timeout_sec: 5,
     env: {
       ...(process.env.PATH && { PATH: process.env.PATH }),
       ...(process.env.HOME && { HOME: process.env.HOME }),

--- a/apps/electron/src/main/lib/builtin-mcp/chrome-devtools.ts
+++ b/apps/electron/src/main/lib/builtin-mcp/chrome-devtools.ts
@@ -13,7 +13,22 @@ function npxCommand(): string {
   return process.platform === 'win32' ? 'npx.cmd' : 'npx'
 }
 
-export function injectChromeDevtoolsMcpServer(mcpServers: Record<string, Record<string, unknown>>): void {
+const PROXY_ENV_KEYS = new Set([
+  'HTTP_PROXY', 'HTTPS_PROXY', 'ALL_PROXY', 'NO_PROXY',
+  'http_proxy', 'https_proxy', 'all_proxy', 'no_proxy',
+])
+
+function getProxyEnv(runtimeEnv?: Record<string, string>): Record<string, string> {
+  if (!runtimeEnv) return {}
+  return Object.fromEntries(
+    Object.entries(runtimeEnv).filter(([key]) => PROXY_ENV_KEYS.has(key)),
+  )
+}
+
+export function injectChromeDevtoolsMcpServer(
+  mcpServers: Record<string, Record<string, unknown>>,
+  runtimeEnv?: Record<string, string>,
+): void {
   const name = getBuiltinMcpName('chrome-devtools')
   if (mcpServers[name]) return
 
@@ -33,6 +48,7 @@ export function injectChromeDevtoolsMcpServer(mcpServers: Record<string, Record<
       ...(process.env.TMPDIR && { TMPDIR: process.env.TMPDIR }),
       ...(process.env.TEMP && { TEMP: process.env.TEMP }),
       ...(process.env.TMP && { TMP: process.env.TMP }),
+      ...getProxyEnv(runtimeEnv),
     },
     timeout: 60,
   }

--- a/apps/electron/src/main/lib/proxy-settings-service.ts
+++ b/apps/electron/src/main/lib/proxy-settings-service.ts
@@ -19,6 +19,31 @@ const DEFAULT_PROXY_CONFIG: ProxyConfig = {
   manualUrl: '',
 }
 
+const SYSTEM_PROXY_CACHE_TTL_MS = 30_000
+let systemProxyCache: { expiresAt: number; result: Awaited<ReturnType<typeof detectSystemProxy>> } | undefined
+let pendingSystemProxyDetection: Promise<Awaited<ReturnType<typeof detectSystemProxy>>> | undefined
+
+/**
+ * 系统代理检测可能需要调用 OS 命令。合并并短暂缓存检测，避免网络请求热路径重复触发它。
+ */
+async function getCachedSystemProxy(): Promise<Awaited<ReturnType<typeof detectSystemProxy>>> {
+  const now = Date.now()
+  if (systemProxyCache && systemProxyCache.expiresAt > now) return systemProxyCache.result
+
+  if (!pendingSystemProxyDetection) {
+    pendingSystemProxyDetection = detectSystemProxy()
+      .then((result) => {
+        systemProxyCache = { result, expiresAt: Date.now() + SYSTEM_PROXY_CACHE_TTL_MS }
+        return result
+      })
+      .finally(() => {
+        pendingSystemProxyDetection = undefined
+      })
+  }
+
+  return await pendingSystemProxyDetection
+}
+
 /** 代理 URL 可能携带认证信息；日志中绝不能输出其用户名或密码。 */
 export function redactProxyUrl(proxyUrl: string): string {
   try {
@@ -68,6 +93,7 @@ export async function saveProxySettings(config: ProxyConfig): Promise<void> {
 
   try {
     writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8')
+    systemProxyCache = undefined
     console.log('[代理配置] 配置已保存:', {
       ...config,
       manualUrl: config.manualUrl ? redactProxyUrl(config.manualUrl) : '',
@@ -96,7 +122,7 @@ export async function getEffectiveProxyUrl(): Promise<string | undefined> {
   }
 
   if (config.mode === 'system') {
-    const result = await detectSystemProxy()
+    const result = await getCachedSystemProxy()
     if (result.success && result.proxyUrl) {
       console.log('[代理配置] 使用系统代理:', redactProxyUrl(result.proxyUrl))
       return result.proxyUrl

--- a/apps/electron/src/main/lib/system-proxy-detector.ts
+++ b/apps/electron/src/main/lib/system-proxy-detector.ts
@@ -4,7 +4,25 @@
  * 支持 macOS、Windows、Linux 三个平台的系统代理自动检测。
  */
 
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
 import type { SystemProxyDetectResult } from '@proma/shared'
+
+const execFileAsync = promisify(execFile)
+const SYSTEM_PROXY_COMMAND_TIMEOUT_MS = 3_000
+
+/**
+ * 在不阻塞 Electron 主进程的前提下执行系统代理查询命令。
+ * `execFile` 不经 shell 解析参数，且 timeout 会终止卡住的系统命令。
+ */
+async function runSystemProxyCommand(command: string, args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync(command, args, {
+    encoding: 'utf-8',
+    timeout: SYSTEM_PROXY_COMMAND_TIMEOUT_MS,
+    windowsHide: true,
+  })
+  return stdout
+}
 
 /**
  * 检测系统代理配置
@@ -46,13 +64,10 @@ export async function detectSystemProxy(): Promise<SystemProxyDetectResult> {
  */
 async function detectMacOSProxy(): Promise<SystemProxyDetectResult> {
   try {
-    // 获取主网络服务名称（通常是 Wi-Fi 或以太网）
-    const { execSync } = await import('node:child_process')
-
     // 尝试获取当前活动的网络服务
     let networkService = 'Wi-Fi'
     try {
-      const services = execSync('networksetup -listallnetworkservices', { encoding: 'utf-8' })
+      const services = await runSystemProxyCommand('networksetup', ['-listallnetworkservices'])
       const serviceList = services.split('\n').filter((s) => s && !s.startsWith('*'))
 
       // 优先使用 Wi-Fi，其次是以太网
@@ -89,9 +104,7 @@ async function detectMacOSProxy(): Promise<SystemProxyDetectResult> {
 
     // 优先检查 HTTPS 代理（Secure Web Proxy）
     try {
-      const httpsOutput = execSync(`networksetup -getsecurewebproxy "${networkService}"`, {
-        encoding: 'utf-8',
-      })
+      const httpsOutput = await runSystemProxyCommand('networksetup', ['-getsecurewebproxy', networkService])
       const httpsProxy = parseProxyOutput(httpsOutput)
       if (httpsProxy.enabled && httpsProxy.server && httpsProxy.port) {
         const proxyUrl = `http://${httpsProxy.server}:${httpsProxy.port}`
@@ -106,9 +119,7 @@ async function detectMacOSProxy(): Promise<SystemProxyDetectResult> {
     }
 
     // 回退：检查 HTTP 代理（Web Proxy）
-    const httpOutput = execSync(`networksetup -getwebproxy "${networkService}"`, {
-      encoding: 'utf-8',
-    })
+    const httpOutput = await runSystemProxyCommand('networksetup', ['-getwebproxy', networkService])
     const httpProxy = parseProxyOutput(httpOutput)
     if (httpProxy.enabled && httpProxy.server && httpProxy.port) {
       const proxyUrl = `http://${httpProxy.server}:${httpProxy.port}`
@@ -139,13 +150,13 @@ async function detectMacOSProxy(): Promise<SystemProxyDetectResult> {
  */
 async function detectWindowsProxy(): Promise<SystemProxyDetectResult> {
   try {
-    const { execSync } = await import('node:child_process')
-
     // 读取注册表中的代理设置
-    const regOutput = execSync(
-      'reg query "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings" /v ProxyEnable',
-      { encoding: 'utf-8' }
-    )
+    const regOutput = await runSystemProxyCommand('reg', [
+      'query',
+      'HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
+      '/v',
+      'ProxyEnable',
+    ])
 
     const proxyEnabled = regOutput.includes('0x1')
 
@@ -157,10 +168,12 @@ async function detectWindowsProxy(): Promise<SystemProxyDetectResult> {
     }
 
     // 读取代理服务器地址
-    const serverOutput = execSync(
-      'reg query "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings" /v ProxyServer',
-      { encoding: 'utf-8' }
-    )
+    const serverOutput = await runSystemProxyCommand('reg', [
+      'query',
+      'HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings',
+      '/v',
+      'ProxyServer',
+    ])
 
     // 解析代理服务器地址（格式通常是 "http=host:port;https=host:port" 或直接 "host:port"）
     const match = serverOutput.match(/ProxyServer\s+REG_SZ\s+(.+)/)

--- a/apps/electron/src/main/lib/web-search-service.ts
+++ b/apps/electron/src/main/lib/web-search-service.ts
@@ -8,6 +8,8 @@
  */
 
 import { getToolCredentials, getToolState } from './chat-tool-config'
+import { getFetchFn } from './proxy-fetch'
+import { getEffectiveProxyUrl } from './proxy-settings-service'
 
 const TAVILY_SEARCH_URL = 'https://api.tavily.com/search'
 const TAVILY_EXTRACT_URL = 'https://api.tavily.com/extract'
@@ -124,7 +126,8 @@ async function fetchWithTimeout(url: string, init: RequestInit, timeoutMs = DEFA
   }
 
   try {
-    return await fetch(url, { ...init, signal: controller.signal })
+    const fetchFn = getFetchFn(await getEffectiveProxyUrl())
+    return await fetchFn(url, { ...init, signal: controller.signal })
   } finally {
     clearTimeout(timeout)
     upstreamSignal?.removeEventListener('abort', onAbort)


### PR DESCRIPTION
## Summary
- route Tavily search and its connection test through the configured global proxy
- pass proxy environment variables to the built-in Chrome DevTools MCP npx process
- retain direct networking for the WeChat Bridge

## Validation
- `bun run --filter='@proma/electron' typecheck`
- `bun run --filter='@proma/electron' build:main`

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)